### PR TITLE
Do not allow saving standalone script without family name and version_year outside of in_development

### DIFF
--- a/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
+++ b/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
@@ -246,6 +246,7 @@ class UnitEditor extends React.Component {
       return;
     } else if (
       !this.props.hasCourse &&
+      this.state.professionalLearningCourse === '' &&
       this.state.publishedState !== PublishedState.in_development &&
       (!this.state.isCourse ||
         this.state.versionYear === '' ||

--- a/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
+++ b/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
@@ -245,6 +245,19 @@ class UnitEditor extends React.Component {
       });
       return;
     } else if (
+      !this.props.hasCourse &&
+      this.state.publishedState !== PublishedState.in_development &&
+      (!this.state.isCourse ||
+        this.state.versionYear === '' ||
+        this.state.familyName === '')
+    ) {
+      this.setState({
+        isSaving: false,
+        error:
+          'Standalone units that are not in development must be a standalone unit with family name and version year.'
+      });
+      return;
+    } else if (
       this.state.isCourse &&
       ((this.state.versionYear !== '' && this.state.familyName === '') ||
         (this.state.versionYear === '' && this.state.familyName !== ''))


### PR DESCRIPTION
Once a unit is out of the in_development published state it should either be in a UnitGroup or be marked as a standalone unit with family_name and version_year so that it can be included in the assignment dropdown appropriately. This PR adds a check in the editor to make sure if the published_state is not in_development all the the correct information is set. One special case here is units that are part of a course that uses the PLC course models. Those are set up differently so we allow them to not have a these settings when not in_development

## Links

[Jira ](https://codedotorg.atlassian.net/browse/PLAT-1631)

## Testing story

- Manually tested a couple scripts
- Added a couple unit tests

## Follow Up

- It would be good to add validations on the back end for this too. https://codedotorg.atlassian.net/browse/PLAT-1716