### PR TITLE
[Google Blockly][Utils] Move isReadOnly to utils

### DIFF
--- a/apps/src/block_utils.js
+++ b/apps/src/block_utils.js
@@ -1080,7 +1080,7 @@ exports.createJsWrapperBlockCreator = function(
           (!window.appOptions || window.appOptions.level.miniToolbox)
         ) {
           var toggle = new Blockly.FieldIcon('+');
-          if (this.blockSpace.isReadOnly()) {
+          if (Blockly.cdoUtils.isWorkspaceReadOnly(this.blockSpace)) {
             toggle.setReadOnly();
           }
 
@@ -1093,7 +1093,7 @@ exports.createJsWrapperBlockCreator = function(
           this.isMiniFlyoutOpen = false;
           // On button click, open/close the horizontal flyout, toggle button text between +/-, and re-render the block.
           Blockly.bindEvent_(toggle.fieldGroup_, 'mousedown', this, () => {
-            if (this.blockSpace.isReadOnly()) {
+            if (Blockly.cdoUtils.isWorkspaceReadOnly(this.blockSpace)) {
               return;
             }
 

--- a/apps/src/blockly/addons/cdoUtils.js
+++ b/apps/src/blockly/addons/cdoUtils.js
@@ -13,5 +13,5 @@ export function getBlockFields(block) {
 }
 
 export function isWorkspaceReadOnly(workspace) {
-  return false; // TODO
+  return false; // TODO - used for feedback
 }

--- a/apps/src/blockly/addons/cdoUtils.js
+++ b/apps/src/blockly/addons/cdoUtils.js
@@ -11,3 +11,7 @@ export function getBlockFields(block) {
   });
   return fields;
 }
+
+export function isWorkspaceReadOnly(workspace) {
+  return false; // TODO
+}

--- a/apps/src/blockly/addons/cdoWorkspaceSvg.js
+++ b/apps/src/blockly/addons/cdoWorkspaceSvg.js
@@ -101,10 +101,6 @@ export default class WorkspaceSvg extends GoogleBlockly.WorkspaceSvg {
     }
   }
 
-  isReadOnly() {
-    return false; // TODO - used for feedback
-  }
-
   resize() {
     super.resize();
 

--- a/apps/src/blockly/cdoBlocklyWrapper.js
+++ b/apps/src/blockly/cdoBlocklyWrapper.js
@@ -231,6 +231,9 @@ function initializeBlocklyWrapper(blocklyInstance) {
     },
     getBlockFields: function(block) {
       return block.getTitles();
+    },
+    isWorkspaceReadOnly: function(workspace) {
+      return workspace.isReadOnly();
     }
   };
   return blocklyWrapper;

--- a/apps/src/code-studio/initApp/loadApp.js
+++ b/apps/src/code-studio/initApp/loadApp.js
@@ -446,7 +446,7 @@ const sourceHandler = {
       let appOptions = getAppOptions();
       if (window.Blockly && Blockly.mainBlockSpace) {
         // If we're readOnly, source hasn't changed at all
-        source = Blockly.mainBlockSpace.isReadOnly()
+        source = Blockly.cdoUtils.isWorkspaceReadOnly(Blockly.mainBlockSpace)
           ? currentLevelSource
           : Blockly.Xml.domToText(
               Blockly.Xml.blockSpaceToDom(Blockly.mainBlockSpace)

--- a/apps/src/feedback.js
+++ b/apps/src/feedback.js
@@ -1495,7 +1495,7 @@ FeedbackUtils.prototype.getUserBlocks_ = function() {
     // If Blockly is in readOnly mode, then all blocks are uneditable
     // so this filter would be useless. Ignore uneditable blocks only if
     // Blockly is in edit mode.
-    if (!Blockly.mainBlockSpace.isReadOnly()) {
+    if (!Blockly.cdoUtils.isWorkspaceReadOnly(Blockly.mainBlockSpace)) {
       blockValid = blockValid && block.isEditable();
     }
     return blockValid;


### PR DESCRIPTION
We have Blockly classes that contain functions that we can pull out as utility functions. To better understand exactly what google Blockly functionality we’re overriding in our wrapper classes, we need to move all utility-type functions out of the classes. 

Acceptance Criteria: 

- Ensure backward compatibility with cdoBlocklyWrapper 
- Update all files to use `isWorkspaceReadOnly` (from cdoUtils) instead of `isReadOnly`
- Remove isReadOnly out of cdoWorkspaceSvg 

QA Notes: 

- [x] Check for regressions in live google blockly V6 labs. 
- [x] Check for regressions in cdo blockly labs


## Links

- jira ticket: [[Google Blockly][Utils] Move isReadOnly to utils](https://codedotorg.atlassian.net/browse/STAR-2175)



## Testing story

Between commits, relevant labs* were loaded with various `console.log` commands in place to make sure the both versions of the functions were returning the same values. No regressions were found. 
*.*Tested Poetry, Flappy, Sprite Lab, Play Lab, and Dance*

## Follow-up work

* Continue moving all utility-type functions out of the Blockly classes.
* Add support for read-only workspaces in Google Blockly labs. (This function has always just returned `false` for Google Blockly labs.)

