### PR TITLE
Migration to add overloaded_by to programming_methods

### DIFF
--- a/dashboard/app/models/programming_method.rb
+++ b/dashboard/app/models/programming_method.rb
@@ -14,6 +14,7 @@
 #  external_link        :string(255)
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
+#  overloaded_by        :string(255)
 #
 # Indexes
 #

--- a/dashboard/db/migrate/20220407200052_add_overloaded_by_to_programming_methods.rb
+++ b/dashboard/db/migrate/20220407200052_add_overloaded_by_to_programming_methods.rb
@@ -1,0 +1,5 @@
+class AddOverloadedByToProgrammingMethods < ActiveRecord::Migration[5.2]
+  def change
+    add_column :programming_methods, :overloaded_by, :string
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_25_185859) do
+ActiveRecord::Schema.define(version: 2022_04_07_200052) do
 
   create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -1411,6 +1411,7 @@ ActiveRecord::Schema.define(version: 2022_03_25_185859) do
     t.string "external_link"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "overloaded_by"
     t.index ["key", "programming_class_id"], name: "index_programming_methods_on_key_and_programming_class_id", unique: true
   end
 


### PR DESCRIPTION
CSA wants the ability to group methods that are overloads of each other. The mock of what that will look like is [here](https://codedotorg.slack.com/archives/C01EF4GJ9GE/p1648591512209809) -- this is just the migration to add a column to handle it. This column will hold the key of the method that should be displayed most prominently.



## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
