### PR TITLE
Unique teacher IDs in list of verified teachers

### DIFF
--- a/dashboard/app/controllers/javabuilder_sessions_controller.rb
+++ b/dashboard/app/controllers/javabuilder_sessions_controller.rb
@@ -111,7 +111,7 @@ class JavabuilderSessionsController < ApplicationController
         teacher.has_pilot_experiment?(CSA_PILOT_FACILITATORS)
       teachers << teacher.id
     end
-    teachers
+    teachers.uniq
   end
 
   def log_token_creation(payload)


### PR DESCRIPTION
Noticed in logging that verified teacher list includes duplicate teacher IDs -- I think this occurs when a student is in multiple sections with the same teacher.