### PR TITLE
The Bad Guys: make featured project images square

### DIFF
--- a/pegasus/sites.v3/code.org/views/featured_project.html
+++ b/pegasus/sites.v3/code.org/views/featured_project.html
@@ -1,6 +1,6 @@
 <div class="col-25 col-rtl-right" style="padding: 10px">
   <a href="%url%" style="font-family: 'Gotham 4r', sans-serif; color: black; text-decoration: none">
-    <div style="border: 2px solid rgb(187, 187, 187); border-radius: 10px; height: 200px; overflow: hidden; text-align: center">
+    <div style="border: 2px solid rgb(187, 187, 187); border-radius: 10px; height: 270px; overflow: hidden; text-align: center">
       <div style="width: 100%; height: 85%; overflow: hidden">
         <img src="%image%" style="width: 100%"/>
       </div>


### PR DESCRIPTION
As used in https://studio.code.org/thebadguys.  

Also affects https://studio.code.org/poetry & https://studio.code.org/helloworld but looks fine on them.

### before (/poetry)

<img width="989" alt="Screen Shot 2022-04-08 at 7 39 34 AM" src="https://user-images.githubusercontent.com/2205926/162324488-382b838b-fd23-44e7-96af-90ec94b5b1fb.png">

### after (/poetry)

<img width="988" alt="Screen Shot 2022-04-08 at 7 39 10 AM" src="https://user-images.githubusercontent.com/2205926/162324513-039794ce-b910-4775-ab3b-ff14fe07f2d4.png">
