### PR TITLE
Explicitly use the Write Connection for Writes inside `app_options`

### DIFF
--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -367,7 +367,14 @@ module LevelsHelper
         end
       if section && section.first_activity_at.nil?
         section.first_activity_at = DateTime.now
-        section.save(validate: false)
+        # app_options is sometimes referenced from
+        # endpoints that are being redirected to the read
+        # connection (ScriptLevel#show, for example), so
+        # make sure that we're using the write connection
+        # here.
+        MultipleDatabasesTransitionHelper.use_writer_connection do
+          section.save(validate: false)
+        end
       end
       @app_options[:experiments] =
         Experiment.get_all_enabled(user: current_user, section: section, script: @script).pluck(:name)


### PR DESCRIPTION
This helper is referenced extensively from within view code, including in at least one view that is currently being pointed at the read replica.

Unfortunately, it also does some incidental writes. Specifically, one which tracks the progress of students in sections:

    ActionView::Template::Error at /s/allthethings/lessons/2/levels/4
    =================================================================

    > Mysql2::Error: UPDATE command denied to user 'reader'@'localhost' for table 'sections'

    app/views/levels/show.html.haml, line 69
    ----------------------------------------

    ``` ruby
       64         - else
       65           = render partial: "levels/#{@level.class.to_s.underscore}"
       66         - unless @level.is_a?(StandaloneVideo) || @level.properties['hide_reference_area']
       67           = render partial: 'levels/reference_area'
       68       - else
    >  69         = render partial: 'levels/blockly'
       70
       71     - if @peer_reviews.present?
       72       = render partial: 'peer_reviews/viewer'
       73
       74   - if tracking_pixel_enabled && @script.try(:hoc?) && (@script_level.try(:chapter) == 1 || @script_level.try(:position) == 1)
    ```

The simple fix is to explicitly direct this write to the writer

## Testing story

Test via DTT; the current one is full of UI test failures because of this

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
