### PR TITLE
App Lab: Check outgoing link's domain more carefully

### DIFF
--- a/apps/src/applab/commands.js
+++ b/apps/src/applab/commands.js
@@ -1609,15 +1609,23 @@ function filterUrl(urlToCheck) {
 
 applabCommands.openUrl = function(opts) {
   if (apiValidateType(opts, 'openUrl', 'url', opts.url, 'string')) {
-    // Studio and code.org links are immediately opened, other links are filtered
-    // Remove protocol from url string if present
+    // studio.code.org and code.org links are immediately opened.
+    // Other links are filtered.
+
     let hostname = opts.url;
+    // First, remove protocol from url string, if present.
     let protocols = ['https://', 'http://', 'www.'];
     protocols.forEach(protocol => {
       if (hostname.startsWith(protocol)) {
         hostname = hostname.slice(protocol.length);
       }
     });
+    // Second, remove path from url string, if present.
+    const pathIndex = hostname.indexOf('/');
+    if (pathIndex !== -1) {
+      hostname = hostname.substr(0, pathIndex);
+    }
+
     if (['studio.code.org', 'code.org'].includes(hostname)) {
       if (opts.url.startsWith('http')) {
         window.open(opts.url);

--- a/apps/src/applab/commands.js
+++ b/apps/src/applab/commands.js
@@ -1618,10 +1618,7 @@ applabCommands.openUrl = function(opts) {
         hostname = hostname.slice(protocol.length);
       }
     });
-    if (
-      hostname.startsWith('studio.code.org') ||
-      hostname.startsWith('code.org')
-    ) {
+    if (['studio.code.org', 'code.org'].includes(hostname)) {
       if (opts.url.startsWith('http')) {
         window.open(opts.url);
       } else {

--- a/apps/test/unit/applab/commandsTest.js
+++ b/apps/test/unit/applab/commandsTest.js
@@ -170,5 +170,7 @@ describe('openUrl', () => {
   it('triggers a call to filterURL for an external link', () => {
     openUrl({url: 'www.google.com'});
     expect($.ajax).to.have.been.calledOnce;
+    openUrl({url: 'code.org.otherdomain.com'});
+    expect($.ajax).to.have.been.calledTwice;
   });
 });


### PR DESCRIPTION
Until now, App Lab checked that outgoing links had a hostname that _started_ with `code.org` or `studio.code.org`.

And code like this would _not_ show a warning that the user would be taken to another site:

```
open("https://code.org.otherdomain.com/");
```

Now, we check for a complete match, so the above code will now show the warning:

<img width="616" alt="Screen Shot 2022-04-08 at 9 09 48 AM" src="https://user-images.githubusercontent.com/2205926/162334318-22a2621d-31cc-426f-9038-26191fd12bb4.png">
