### PR TITLE
Fix published state of fit apprentice script

### DIFF
--- a/dashboard/config/scripts_json/fit2019-apprentice.script_json
+++ b/dashboard/config/scripts_json/fit2019-apprentice.script_json
@@ -13,7 +13,7 @@
     "new_name": null,
     "family_name": "fit2019-apprentice",
     "serialized_at": "2022-01-10 15:56:26 UTC",
-    "published_state": "preview",
+    "published_state": "beta",
     "instruction_type": "teacher_led",
     "instructor_audience": "teacher",
     "participant_audience": "student",


### PR DESCRIPTION
This is a deeper learning course which is showing up in the assignment dropdown currently. Deeper learning courses should not be able to be marked as launched. 

https://codedotorg.slack.com/archives/C02EEGWLHR8/p1649170700421269?thread_ts=1649118338.709159&cid=C02EEGWLHR8

Follow up work to prevent this: https://codedotorg.atlassian.net/browse/PLAT-1724