### PR TITLE
Add schema.rb to the list of files we revert on levelbuilder if there are changes

### DIFF
--- a/bin/content-push
+++ b/bin/content-push
@@ -9,6 +9,7 @@ CONTENT_PATHS = 'dashboard pegasus aws/dms'.freeze
 # Revert any local changes to these files on levelbuilder
 LEVELBUILDER_OMISSIONS = [
   'dashboard/db/schema_cache.yml',
+  'dashboard/db/schema.rb',
 ]
 
 def ask_for_name

--- a/dashboard/db/schema_cache.yml
+++ b/dashboard/db/schema_cache.yml
@@ -28111,6 +28111,19 @@ indexes:
     comment: 
   - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
     table: script_levels
+    name: index_script_levels_on_activity_section_id
+    unique: false
+    columns:
+    - activity_section_id
+    lengths: {}
+    orders: {}
+    opclasses: {}
+    where: 
+    type: 
+    using: :btree
+    comment: 
+  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+    table: script_levels
     name: index_script_levels_on_script_id
     unique: false
     columns:
@@ -28128,19 +28141,6 @@ indexes:
     unique: false
     columns:
     - stage_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where: 
-    type: 
-    using: :btree
-    comment: 
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: script_levels
-    name: index_script_levels_on_activity_section_id
-    unique: false
-    columns:
-    - activity_section_id
     lengths: {}
     orders: {}
     opclasses: {}
@@ -29289,5 +29289,5 @@ database_version: !ruby/object:ActiveRecord::ConnectionAdapters::AbstractAdapter
   version:
   - 5
   - 7
-  - 37
-  full_version_string: 5.7.37
+  - 12
+  full_version_string: 5.7.12

--- a/dashboard/db/schema_cache.yml
+++ b/dashboard/db/schema_cache.yml
@@ -28111,19 +28111,6 @@ indexes:
     comment: 
   - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
     table: script_levels
-    name: index_script_levels_on_activity_section_id
-    unique: false
-    columns:
-    - activity_section_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where: 
-    type: 
-    using: :btree
-    comment: 
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: script_levels
     name: index_script_levels_on_script_id
     unique: false
     columns:
@@ -28141,6 +28128,19 @@ indexes:
     unique: false
     columns:
     - stage_id
+    lengths: {}
+    orders: {}
+    opclasses: {}
+    where: 
+    type: 
+    using: :btree
+    comment: 
+  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+    table: script_levels
+    name: index_script_levels_on_activity_section_id
+    unique: false
+    columns:
+    - activity_section_id
     lengths: {}
     orders: {}
     opclasses: {}
@@ -29289,5 +29289,5 @@ database_version: !ruby/object:ActiveRecord::ConnectionAdapters::AbstractAdapter
   version:
   - 5
   - 7
-  - 12
-  full_version_string: 5.7.12
+  - 37
+  full_version_string: 5.7.37


### PR DESCRIPTION
We have had the DTS fail twice this week because there was a local change to schema.rb on levelbuilder. @davidsbailey [suggested](https://codedotorg.slack.com/archives/C0T0PNTM3/p1649437975834359?thread_ts=1649283507.319039&cid=C0T0PNTM3) to add the file to the list of files on levelbuilder we revert changes. Thats what this PR does. 