### PR TITLE
Add migration to ensure indexes are same on all envs

### DIFF
--- a/dashboard/db/migrate/20220408173143_fix_projects_index.rb
+++ b/dashboard/db/migrate/20220408173143_fix_projects_index.rb
@@ -1,0 +1,9 @@
+class FixProjectsIndex < ActiveRecord::Migration[6.0]
+  def change
+    existing_index = indexes('projects').select {|i| i.name == "storage_apps_project_type_index"}.first
+    if existing_index.lengths.blank?
+      remove_index :projects, :project_type
+      add_index :projects, :project_type, length: 191, name: 'storage_apps_project_type_index'
+    end
+  end
+end

--- a/dashboard/db/migrate/20220408173143_fix_projects_index.rb
+++ b/dashboard/db/migrate/20220408173143_fix_projects_index.rb
@@ -1,9 +1,14 @@
 class FixProjectsIndex < ActiveRecord::Migration[6.0]
-  def change
+  def up
+    return if Rails.env.production?
+
     existing_index = indexes('projects').select {|i| i.name == "storage_apps_project_type_index"}.first
     if existing_index.lengths.blank?
       remove_index :projects, :project_type
       add_index :projects, :project_type, length: 191, name: 'storage_apps_project_type_index'
     end
+  end
+
+  def down
   end
 end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -1438,7 +1438,7 @@ ActiveRecord::Schema.define(version: 2022_04_07_200052) do
     t.boolean "standalone", default: true
     t.integer "remix_parent_id"
     t.boolean "skip_content_moderation"
-    t.index ["project_type"], name: "storage_apps_project_type_index"
+    t.index ["project_type"], name: "storage_apps_project_type_index", length: 191
     t.index ["published_at"], name: "storage_apps_published_at_index"
     t.index ["standalone"], name: "storage_apps_standalone_index"
     t.index ["storage_id"], name: "storage_apps_storage_id_index"

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_07_200052) do
+ActiveRecord::Schema.define(version: 2022_04_08_173143) do
 
   create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Started in slack here: https://codedotorg.slack.com/archives/C0T0PNTM3/p1649283507319039

It was discovered that in some environments the projects table `project_type` index has a length specified and some environments don't. It's unclear what caused this diff, but changing an index in production on a table this large is risky, so we'll align the other environments with what's in production. To do this, we'll check if the index has a specified length, if not, we'll swap out the index for the same index with a specified length.

## Testing story
Tested two scenarios locally:
- If we start with an index that doesn't have length specified, that the migration will swap it out for the right index with length
- If we start with an index that does have length specified, that nothing happens
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
