### PR TITLE
Silence Some New Deprecation Warnings

### DIFF
--- a/dashboard/config/initializers/backtrace_silencers.rb
+++ b/dashboard/config/initializers/backtrace_silencers.rb
@@ -20,6 +20,8 @@ silenced = [
   /update_attributes!? is deprecated and will be removed from Rails 6.1/,
   /Initialization autoloaded the constants/,
   /Class level methods will no longer inherit scoping/,
+  /ActionView::Base instances should be constructed with a lookup context, assignments, and a controller/,
+  /ActionView::Base instances must implement `compiled_method_container`/,
 ]
 
 silenced_expr = Regexp.new(silenced.join('|'))

--- a/dashboard/config/initializers/backtrace_silencers.rb
+++ b/dashboard/config/initializers/backtrace_silencers.rb
@@ -18,6 +18,8 @@ silenced = [
   /NOT conditions will no longer behave as NOR in Rails 6.1. To continue using NOR conditions, NOT each condition individually/,
   /Rails 6.1 will return Content-Type header without modification/,
   /update_attributes!? is deprecated and will be removed from Rails 6.1/,
+  /Initialization autoloaded the constants/,
+  /Class level methods will no longer inherit scoping/,
 ]
 
 silenced_expr = Regexp.new(silenced.join('|'))


### PR DESCRIPTION
Added as part of the upgrade to Rails 6.0, these will need to be addressed as part of the eventual upgrade to 6.1

Thanks Meg for logging these!

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
