### PR TITLE
Stop Silencing Rails 5.2 Deprecation Warnings

### DIFF
--- a/dashboard/config/initializers/backtrace_silencers.rb
+++ b/dashboard/config/initializers/backtrace_silencers.rb
@@ -8,10 +8,6 @@
 
 # In addition to backtrace silencing, we also want to silence annoying deprecations:
 silenced = [
-  # Added in Rails 5.2
-  /Single arity template handlers are deprecated/,
-  /SourceAnnotationExtractor is deprecated! Use Rails::SourceAnnotationExtractor instead/,
-
   # Added in Rails 6.0
   /Uniqueness validator will no longer enforce case sensitive comparison in Rails 6.1/,
   /The asset ".*" is not present in the asset pipeline.Falling back to an asset that may be in the public folder./,


### PR DESCRIPTION
Now that we're upgraded to Rails 6.0

## Testing story

Checked the drone logs from this PR to confirm that we don't see any instances of these warnings:

```bash
$ grep -h "DEPRECATION" logs_code-dot-org_code-dot-org_* | sort -u
DEPRECATION WARNING: ActionView::Base instances must implement `compiled_method_container` or use the class method `with_empty_template_cache` for constructing an ActionView::Base instance that has an empty cache. (called from block in <class:MarkdownHandlerTest> at /drone/src/dashboard/test/config/initializers/markdown_handler_test.rb:14)
DEPRECATION WARNING: ActionView::Base instances must implement `compiled_method_container` or use the class method `with_empty_template_cache` for constructing an ActionView::Base instance that has an empty cache. (called from block in <class:MarkdownHandlerTest> at /drone/src/dashboard/test/config/initializers/markdown_handler_test.rb:42)
DEPRECATION WARNING: ActionView::Base instances must implement `compiled_method_container` or use the class method `with_empty_template_cache` for constructing an ActionView::Base instance that has an empty cache. (called from block in <class:MarkdownHandlerTest> at /drone/src/dashboard/test/config/initializers/markdown_handler_test.rb:7)
DEPRECATION WARNING: ActionView::Base instances should be constructed with a lookup context, assignments, and a controller. (called from new at /drone/src/dashboard/test/config/initializers/markdown_handler_test.rb:14)
DEPRECATION WARNING: ActionView::Base instances should be constructed with a lookup context, assignments, and a controller. (called from new at /drone/src/dashboard/test/config/initializers/markdown_handler_test.rb:42)
DEPRECATION WARNING: ActionView::Base instances should be constructed with a lookup context, assignments, and a controller. (called from new at /drone/src/dashboard/test/config/initializers/markdown_handler_test.rb:7)
DEPRECATION WARNING: Class level methods will no longer inherit scoping from `create!` in Rails 6.1. To continue using the scoped relation, pass it into the block directly. To instead access the full set of models, as Rails 6.1 will, use `Level.default_scoped`. (called from setup_contained_levels at /drone/src/dashboard/app/models/concerns/levels/levels_within_levels.rb:153)
DEPRECATION WARNING: Class level methods will no longer inherit scoping from `create!` in Rails 6.1. To continue using the scoped relation, pass it into the block directly. To instead access the full set of models, as Rails 6.1 will, use `Resource.default_scoped`. (called from generate_key_from_name at /drone/src/dashboard/app/models/resource.rb:159)
DEPRECATION WARNING: Class level methods will no longer inherit scoping from `current_locale` in Rails 6.1. To continue using the scoped relation, pass it into the block directly. To instead access the full set of models, as Rails 6.1 will, use `Video.default_scoped`. (called from block in <class:Video> at /drone/src/dashboard/app/models/video.rb:26)
DEPRECATION WARNING: name is deprecated. Use first_name & last_name instead. (called from block in <class:EnrollmentTest> at /drone/src/dashboard/test/models/pd/enrollment_test.rb:564)
DEPRECATION WARNING: name is deprecated. Use first_name & last_name instead. (called from new at /drone/src/dashboard/app/controllers/pd/workshop_enrollment_controller.rb:88)
DEPRECATION WARNING: School is deprecated. Use school_info or school_name instead. (called from block in <class:DeleteAccountsHelperTest> at /drone/src/dashboard/test/helpers/delete_accounts_helper_test.rb:1370)
DEPRECATION WARNING: School is deprecated. Use school_info or school_name instead. (called from block in <class:DeleteAccountsHelperTest> at /drone/src/dashboard/test/helpers/delete_accounts_helper_test.rb:1375)
DEPRECATION WARNING: School is deprecated. Use school_info or school_name instead. (called from block in <class:EnrollmentTest> at /drone/src/dashboard/test/models/pd/enrollment_test.rb:569)
DEPRECATION WARNING: School is deprecated. Use school_info or school_name instead. (called from new at /drone/src/dashboard/app/controllers/pd/workshop_enrollment_controller.rb:88)
DEPRECATION WARNING: School is deprecated. Use school_info or school_name instead. (called from school at /drone/src/dashboard/app/serializers/api/v1/pd/enrollment_flat_attendance_serializer.rb:10)
DEPRECATION WARNING: The asset "css/algebra_game.css" is not present in the asset pipeline.
DEPRECATION WARNING: The asset "css/artist.css" is not present in the asset pipeline.
DEPRECATION WARNING: The asset "css/artist_k1.css" is not present in the asset pipeline.
DEPRECATION WARNING: The asset "css/basketball.css" is not present in the asset pipeline.
DEPRECATION WARNING: The asset "css/frozen.css" is not present in the asset pipeline.
DEPRECATION WARNING: The asset "css/gumball.css" is not present in the asset pipeline.
DEPRECATION WARNING: The asset "css/iceage.css" is not present in the asset pipeline.
DEPRECATION WARNING: The asset "css/infinity.css" is not present in the asset pipeline.
DEPRECATION WARNING: The asset "css/makerlab.css" is not present in the asset pipeline.
DEPRECATION WARNING: The asset "css/minecraft_adventurer.css" is not present in the asset pipeline.
DEPRECATION WARNING: The asset "css/minecraft_codebuilder.css" is not present in the asset pipeline.
DEPRECATION WARNING: The asset "css/minecraft_designer.css" is not present in the asset pipeline.
DEPRECATION WARNING: The asset "css/minecraft_hero.css" is not present in the asset pipeline.
DEPRECATION WARNING: The asset "css/playlab.css" is not present in the asset pipeline.
DEPRECATION WARNING: The asset "css/playlab_k1.css" is not present in the asset pipeline.
DEPRECATION WARNING: The asset "css/sports.css" is not present in the asset pipeline.
DEPRECATION WARNING: The asset "css/starwarsblocks.css" is not present in the asset pipeline.
DEPRECATION WARNING: The asset "css/starwarsblocks_hour.css" is not present in the asset pipeline.
DEPRECATION WARNING: The asset "css/starwars.css" is not present in the asset pipeline.
```

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
