### PR TITLE
Sprite Upload - Fix Level Animation Load Bug

### DIFF
--- a/shared/middleware/animation_library_api.rb
+++ b/shared/middleware/animation_library_api.rb
@@ -44,6 +44,26 @@ class AnimationLibraryApi < Sinatra::Base
   end
 
   #
+  # GET /api/v1/animation-library/level_animations/<version-id>/<filename>
+  # Retrieve an animation that was uploaded by a levelbuilder (for use in level start_animations)
+  #
+  get %r{/api/v1/animation-library/level_animations/(.+)} do |animation_name|
+    not_found if animation_name.empty?
+
+    begin
+      result = Aws::S3::Bucket.
+        new(ANIMATION_LIBRARY_BUCKET, client: AWS::S3.create_client).
+        object("level_animations/#{animation_name}").
+        get
+      content_type result.content_type
+      cache_for 3600
+      result.body
+    rescue
+      not_found
+    end
+  end
+
+  #
   # POST /api/v1/animation-library/level_animations/<filename>
   # Create Sprite in Level Animations folder
   #


### PR DESCRIPTION
![Screenshot from 2022-04-11 17-20-09](https://user-images.githubusercontent.com/2959170/162853827-888a2070-1cfa-47d5-bb4b-da768cf64b4c.png)
**_Narrator Voice_**: She did, in fact, still need that function.



Hastily deleted a function that looked like a dupe, but is actually useful to get a level_animation when we do not (yet) have the version. So adding back in a function that grabs the most recent image metadata for the filename. Adding back here to enable loading the level_animations. Working sprite selection shown in gift below.

![level_animations](https://user-images.githubusercontent.com/2959170/162854121-2aae8181-edf0-415e-854e-512b37bf7417.gif)
