### PR TITLE
Add programming_classes directory to list of directories allowed by the levelbuilder scoop

### DIFF
--- a/tools/hooks/restrict_levelbuilder_changes.rb
+++ b/tools/hooks/restrict_levelbuilder_changes.rb
@@ -8,6 +8,7 @@ LEVELS_DIR = File.expand_path(REPO_DIR + '/dashboard/config/scripts', __FILE__).
 COURSES_DIR = File.expand_path(REPO_DIR + '/dashboard/config/courses', __FILE__).freeze
 COURSE_OFFERINGS_DIR = File.expand_path(REPO_DIR + '/dashboard/config/course_offerings', __FILE__).freeze
 REFERENCE_GUIDES_DIR = File.expand_path(REPO_DIR + '/dashboard/config/reference_guides', __FILE__).freeze
+PROGRAMMING_CLASSES_DIR = File.expand_path(REPO_DIR + '/dashboard/config/programming_classes', __FILE__).freeze
 PROGRAMMING_ENVIRONMENTS_DIR = File.expand_path(REPO_DIR + '/dashboard/config/programming_environments', __FILE__).freeze
 PROGRAMMING_EXPRESSIONS_DIR = File.expand_path(REPO_DIR + '/dashboard/config/programming_expressions', __FILE__).freeze
 VIDEO_THUMBNAILS_DIR = File.expand_path(REPO_DIR + '/dashboard/public/c/video_thumbnails', __FILE__).freeze
@@ -30,6 +31,6 @@ staged_files = HooksUtils.get_staged_files
 
 staged_files.each do |filename|
   raise "#{ERROR_MESSAGE}\nFile blocked: #{filename}" unless filename.start_with?(
-    BLOCKS_DIR, SHARED_FUNCTIONS_DIR, LIBRARIES_DIR, LEVELS_DIR, COURSES_DIR, COURSE_OFFERINGS_DIR, REFERENCE_GUIDES_DIR, PROGRAMMING_ENVIRONMENTS_DIR, PROGRAMMING_EXPRESSIONS_DIR, VIDEO_THUMBNAILS_DIR, FOORM_DIR
+    BLOCKS_DIR, SHARED_FUNCTIONS_DIR, LIBRARIES_DIR, LEVELS_DIR, COURSES_DIR, COURSE_OFFERINGS_DIR, REFERENCE_GUIDES_DIR, PROGRAMMING_CLASSES_DIR, PROGRAMMING_ENVIRONMENTS_DIR, PROGRAMMING_EXPRESSIONS_DIR, VIDEO_THUMBNAILS_DIR, FOORM_DIR
   ) || ALLOWED_FILES.include?(filename)
 end


### PR DESCRIPTION
Same idea as #44829 and #44910. I tested this by trying to commit `dashboard/config/programming_classes/` on a branch called `levelbuilder` with and without this change. It failed without and worked with this change.



## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
