### PR TITLE
One-off migration to drop temp views in prod

### DIFF
--- a/bin/oneoff/drop_temp_views_from_pegasus
+++ b/bin/oneoff/drop_temp_views_from_pegasus
@@ -4,8 +4,8 @@ require File.expand_path('../../../pegasus/src/env', __FILE__)
 require src_dir 'database'
 require 'optparse'
 
-# To run: bin/oneoff/drop_temp_views_from_pegasus.rb
-# To revert: bin/oneoff/drop_temp_views_from_pegasus.rb --revert
+# To run: bin/oneoff/drop_temp_views_from_pegasus
+# To revert: bin/oneoff/drop_temp_views_from_pegasus --revert
 
 # Parse options
 options = {
@@ -52,6 +52,7 @@ def revert_drop_temp_views_from_pegasus
   pegasus_storage_apps = "#{CDO.pegasus_db_name}__storage_apps".to_sym
   pegasus_user_storage_ids = "#{CDO.pegasus_db_name}__user_storage_ids".to_sym
   dashboard_projects = "#{CDO.dashboard_db_name}__projects".to_sym
+  dashboard_user_project_storage_ids = "#{CDO.dashboard_db_name}__user_project_storage_ids".to_sym
 
   puts "Creating view pegasus.storage_apps"
   DB.create_view(pegasus_storage_apps, DB[dashboard_projects].select_all)

--- a/bin/oneoff/drop_temp_views_from_pegasus.rb
+++ b/bin/oneoff/drop_temp_views_from_pegasus.rb
@@ -1,0 +1,67 @@
+#!/usr/bin/env ruby
+
+require File.expand_path('../../../pegasus/src/env', __FILE__)
+require src_dir 'database'
+require 'optparse'
+
+# To run: bin/oneoff/drop_temp_views_from_pegasus.rb
+# To revert: bin/oneoff/drop_temp_views_from_pegasus.rb --revert
+
+# Parse options
+options = {
+  revert: false,
+}
+
+OptionParser.new do |opts|
+  opts.banner = <<~BANNER
+    Usage: #{File.basename(__FILE__)} [options]
+
+    This drops the temporary views pegasus.storage_apps and pegasus.user_storage_ids from the Pegasus DB
+
+    Options:
+  BANNER
+
+  opts.on('--revert',
+    'Will revert the Database to its previous state (add the views back)'
+  ) do |revert|
+    options[:revert] = revert
+  end
+
+  opts.on('-h', '--help', 'Prints this help message') do
+    puts opts
+    exit
+  end
+end.parse!
+puts "Options: #{options}"
+options.freeze
+
+$revert = options[:revert]
+
+def drop_temp_views_from_pegasus
+  pegasus_storage_apps = "#{CDO.pegasus_db_name}__storage_apps".to_sym
+  pegasus_user_storage_ids = "#{CDO.pegasus_db_name}__user_storage_ids".to_sym
+
+  puts "Dropping view pegasus.storage_apps"
+  DB.drop_view(pegasus_storage_apps)
+
+  puts "Dropping view pegasus.user_storage_ids"
+  DB.drop_view(pegasus_user_storage_ids)
+end
+
+def revert_drop_temp_views_from_pegasus
+  pegasus_storage_apps = "#{CDO.pegasus_db_name}__storage_apps".to_sym
+  pegasus_user_storage_ids = "#{CDO.pegasus_db_name}__user_storage_ids".to_sym
+  dashboard_projects = "#{CDO.dashboard_db_name}__projects".to_sym
+
+  puts "Creating view pegasus.storage_apps"
+  DB.create_view(pegasus_storage_apps, DB[dashboard_projects].select_all)
+
+  puts "Creating view pegasus.user_storage_ids"
+  DB.create_view(pegasus_user_storage_ids, DB[dashboard_user_project_storage_ids].select_all)
+end
+
+if $revert
+  revert_drop_temp_views_from_pegasus
+else
+  drop_temp_views_from_pegasus
+end


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
During the migration of pegasus.storage_apps => dashboard.projects and pegasus.user_storage_ids => dashboard.user_project_storage_ids, views with the old table names pointing to the new table were created as a stop-gap solution to ensure that if there were any queries pointing to the old table names they would still work. Since the migration was run, I have done more auditing and replaced all instances in our codebase pointing to the old table names. Then I worked with infra to turn on query logging for a couple of minutes and determined during that time there were no queries to the old table names. So this PR drops those temporary views in production, now that we believe they are no longer needed.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
- jira ticket: [LP-2272](https://codedotorg.atlassian.net/browse/LP-2272)
<!--
- spec: []()

-->

## Testing story
I tested locally that views were dropped and could be reconstructed by running the migration with `--revert`
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Follow-up work
Once the views have been dropped in production, we'll want to drop them on all other environments (https://github.com/code-dot-org/code-dot-org/pull/45792)
<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
