### PR TITLE
Drop temp pegasus views in non-prod envs

### DIFF
--- a/pegasus/migrations/139_drop_temp_views.rb
+++ b/pegasus/migrations/139_drop_temp_views.rb
@@ -1,0 +1,23 @@
+Sequel.migration do
+  up do
+    pegasus_storage_apps = "#{CDO.pegasus_db_name}__storage_apps".to_sym
+    pegasus_user_storage_ids = "#{CDO.pegasus_db_name}__user_storage_ids".to_sym
+
+    unless [:production].include?(rack_env)
+      DB.drop_view(pegasus_storage_apps)
+      DB.drop_view(pegasus_user_storage_ids)
+    end
+  end
+
+  down do
+    pegasus_storage_apps = "#{CDO.pegasus_db_name}__storage_apps".to_sym
+    pegasus_user_storage_ids = "#{CDO.pegasus_db_name}__user_storage_ids".to_sym
+    dashboard_projects = "#{CDO.dashboard_db_name}__projects".to_sym
+    dashboard_user_project_storage_ids = "#{CDO.dashboard_db_name}__user_project_storage_ids".to_sym
+
+    unless [:production].include?(rack_env)
+      create_view(pegasus_storage_apps, DB[dashboard_projects].select_all)
+      create_view(pegasus_user_storage_ids, DB[dashboard_user_project_storage_ids].select_all)
+    end
+  end
+end


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
For more context see https://github.com/code-dot-org/code-dot-org/pull/45790 (migration for prod). This is the migration to drop the temporary pegasus views on all environments excluding production.

## Links
- jira ticket: [LP-2272](https://codedotorg.atlassian.net/browse/LP-2272)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()

-->

## Testing story
Tested locally that views are dropped when the migration is run and reverting the migration re-creates the views.
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy
Once the one-off has been run in production, this can be released.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
