### PR TITLE
Fix implementation of the `dashboard_read_replica` flag

### DIFF
--- a/dashboard/app/helpers/read_replica_helper.rb
+++ b/dashboard/app/helpers/read_replica_helper.rb
@@ -14,11 +14,11 @@ module ReadReplicaHelper
         Gatekeeper.allows('dashboard_read_replica')
       end
 
-      def lookup_connection_handler(handler_key)
+      def connected_to(database: nil, role: nil, prevent_writes: false, &blk)
         if read_replica?
-          super(handler_key)
+          super
         else
-          super(ActiveRecord::Base.writing_role)
+          super(database: database, role: :writing, prevent_writes: prevent_writes, &blk)
         end
       end
     end


### PR DESCRIPTION
Specifically, address the `The MySQL server is running with the --read-only option so it cannot execute this statement` errors we've been getting when this flag is set on our Staging and Levelbuilder environments.

The root issue here is that the previous implementation was reaching into the Rails internals to override read/write splitting at a point in the process of establishing a connection _after_ some extra protections that Rails added were put in place. Specifically, the `prevent_writes` flag:

https://github.com/rails/rails/blob/0d304eae601f085274b2e2c04316e025b443da62/activerecord/lib/active_record/connection_handling.rb#L119-L123

The solution is to implement this override flag elsewhere in the process.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
