### PR TITLE
Smaller minimum console window

### DIFF
--- a/apps/src/javalab/JavalabPanels.jsx
+++ b/apps/src/javalab/JavalabPanels.jsx
@@ -106,7 +106,8 @@ class JavalabPanels extends React.Component {
 
     const consoleDesiredHeight = this.props.editorColumnHeight - desiredHeight;
 
-    const consoleHeightMin = 200;
+    // Minimum height fits 3 lines of text
+    const consoleHeightMin = 140;
     const consoleHeightMax = window.innerHeight - 200;
 
     let newHeight = Math.max(


### PR DESCRIPTION
Sets minimum console height to the equivalent of 3 lines of text.

[JAVA-311](https://codedotorg.atlassian.net/browse/JAVA-311)

**Before**

![image](https://user-images.githubusercontent.com/25372625/163072286-eab4a9c7-e2be-4499-ac1d-5fbcfbf16a4f.png)

**After**

![image](https://user-images.githubusercontent.com/25372625/163072227-7d608181-6c1a-489e-a3aa-7be84382893d.png)

