### PR TITLE
[Sprite Lab] Add think block

### DIFF
--- a/apps/src/p5lab/drawUtils.js
+++ b/apps/src/p5lab/drawUtils.js
@@ -43,7 +43,7 @@ export function getTextWidth(p5, text, size) {
  * @param {Number} height
  * @param {Number} config.tailSize
  * @param {Number} config.tailTipX
- * @param {Number} config.padding
+ * @param {Number} config.radius
  * @param {String} config.fill
  * @param {Number} config.strokeWeight
  * @param {Number} config.stroke
@@ -58,34 +58,37 @@ export function speechBubble(
   {
     tailSize = 10,
     tailTipX = x,
-    padding = 8,
+    radius = 8,
     fill = 'white',
     strokeWeight = 2,
     stroke = 'gray'
   } = {},
-  style
+  bubbleType
 ) {
   const minX = x - width / 2;
   const minY = y - height - tailSize;
   const maxY = y - tailSize;
+  // The two ellipses that make up the tail can move in relation to the
+  // speech bubble based upon the sprite's X position. We take move the
+  // bubbles from the expected center position to somewhere closer to the
+  // sprite, if the sprite is near the side edges of the canvas.
   const tailTopX = (tailTipX + (minX + width / 2)) / 2;
   const tailBottomX = (tailTipX + tailTopX) / 2;
-
   p5.push();
   p5.stroke(stroke);
   p5.strokeWeight(strokeWeight);
   p5.fill(fill);
-  switch (style) {
+  switch (bubbleType) {
     case 'think':
       // Thought bubbles have more-rounded corners, and trailing bubbles.
-      p5.rect(minX, minY, width, height, padding * 3);
+      p5.rect(minX, minY, width, height, radius * 3);
       p5.ellipse(tailTopX, maxY, tailSize);
       p5.ellipse(tailBottomX, maxY + tailSize, tailSize / 2);
       break;
     case 'say':
     default:
       // Speech bubbles have less-rounded corners and triangular tails.
-      p5.rect(minX, minY, width, height, padding);
+      p5.rect(minX, minY, width, height, radius);
       p5.stroke(fill);
       p5.triangle(tailTipX - tailSize, maxY, tailTipX, maxY, tailTipX, y);
       p5.stroke(stroke);

--- a/apps/src/p5lab/drawUtils.js
+++ b/apps/src/p5lab/drawUtils.js
@@ -24,15 +24,15 @@ export function getTextWidth(p5, text, size) {
 
 /**
  * Draw a speech bubble - a P5 shape comprised of a rectangle
- * with a triangle at the bottom. The x/y values will be the
+ * with a tail at the bottom. The x/y values will be the
  * bottom center of the bubble body, including the height added
- * by the triangle. With the default config values, the triangle
+ * by the tail. With the default config values, the tail
  * will have a size of 10 and align to the center of the bubble body.
- * Other passed config values allow the triangle to be adjusted,
+ * Other passed config values allow the tail to be adjusted,
  * such as when a sprite is close to the edge of the app canvas.
  *
- * Note: The bubble body and triangle stroke outlines will overlap if the width:triangleSize
- * ratio is too low (e.g., the width is too narrow and triangle is too large). Consider
+ * Note: The bubble body and tail stroke outlines will overlap if the width:tailSize
+ * ratio is too low (e.g., the width is too narrow and tail is too large). Consider
  * setting a minimum width or calculating a ratio greater than 5:1 (not exact; just a starting
  * point).
  *
@@ -41,9 +41,9 @@ export function getTextWidth(p5, text, size) {
  * @param {Number} y
  * @param {Number} width
  * @param {Number} height
- * @param {Number} config.triangleSize
- * @param {Number} config.triangleTipX
- * @param {Number} config.rectangleCornerRadius
+ * @param {Number} config.tailSize
+ * @param {Number} config.tailTipX
+ * @param {Number} config.padding
  * @param {String} config.fill
  * @param {Number} config.strokeWeight
  * @param {Number} config.stroke
@@ -56,37 +56,42 @@ export function speechBubble(
   width,
   height,
   {
-    triangleSize = 10,
-    triangleTipX = x,
-    rectangleCornerRadius = 8,
+    tailSize = 10,
+    tailTipX = x,
+    padding = 8,
     fill = 'white',
     strokeWeight = 2,
     stroke = 'gray'
-  } = {}
+  } = {},
+  style
 ) {
   const minX = x - width / 2;
-  const minY = y - height - triangleSize;
-  const maxY = y - triangleSize;
+  const minY = y - height - tailSize;
+  const maxY = y - tailSize;
+  const tailMidX = (tailTipX + (minX + width / 2)) / 2;
+  const tailBottomX = (tailTipX + tailMidX) / 2;
 
   p5.push();
   p5.stroke(stroke);
   p5.strokeWeight(strokeWeight);
   p5.fill(fill);
-  p5.beginShape();
-  p5.rect(minX, minY, width, height, rectangleCornerRadius);
+  p5.rect(minX, minY, width, height, padding);
   p5.stroke(fill);
-  p5.triangle(
-    triangleTipX - triangleSize,
-    maxY,
-    triangleTipX,
-    maxY,
-    triangleTipX,
-    y
-  );
-  p5.stroke(stroke);
-  p5.line(triangleTipX, maxY, triangleTipX, y);
-  p5.line(triangleTipX, y, triangleTipX - triangleSize - 1, maxY);
-  p5.endShape(p5.CLOSE);
+  switch (style) {
+    case 'think':
+      p5.ellipse(tailMidX, maxY, tailSize);
+      p5.stroke(stroke);
+      p5.arc(tailMidX, maxY, tailSize, tailSize, 0, 180);
+      p5.ellipse(tailBottomX, maxY + tailSize, tailSize / 2);
+      break;
+    case 'say':
+    default:
+      p5.triangle(tailTipX - tailSize, maxY, tailTipX, maxY, tailTipX, y);
+      p5.stroke(stroke);
+      p5.line(tailTipX, maxY, tailTipX, y);
+      p5.line(tailTipX, y, tailTipX - tailSize - 1, maxY);
+      break;
+  }
   p5.pop();
 
   return {minX, minY};

--- a/apps/src/p5lab/drawUtils.js
+++ b/apps/src/p5lab/drawUtils.js
@@ -68,8 +68,8 @@ export function speechBubble(
   const minX = x - width / 2;
   const minY = y - height - tailSize;
   const maxY = y - tailSize;
-  const tailMidX = (tailTipX + (minX + width / 2)) / 2;
-  const tailBottomX = (tailTipX + tailMidX) / 2;
+  const tailTopX = (tailTipX + (minX + width / 2)) / 2;
+  const tailBottomX = (tailTipX + tailTopX) / 2;
 
   p5.push();
   p5.stroke(stroke);
@@ -79,10 +79,7 @@ export function speechBubble(
     case 'think':
       // Thought bubbles have more-rounded corners, and trailing bubbles.
       p5.rect(minX, minY, width, height, padding * 3);
-      p5.stroke(fill);
-      p5.ellipse(tailMidX, maxY, tailSize);
-      p5.stroke(stroke);
-      p5.arc(tailMidX, maxY, tailSize, tailSize, 0, 180);
+      p5.ellipse(tailTopX, maxY, tailSize);
       p5.ellipse(tailBottomX, maxY + tailSize, tailSize / 2);
       break;
     case 'say':

--- a/apps/src/p5lab/drawUtils.js
+++ b/apps/src/p5lab/drawUtils.js
@@ -75,10 +75,11 @@ export function speechBubble(
   p5.stroke(stroke);
   p5.strokeWeight(strokeWeight);
   p5.fill(fill);
-  p5.rect(minX, minY, width, height, padding);
-  p5.stroke(fill);
   switch (style) {
     case 'think':
+      // Thought bubbles have more-rounded corners, and trailing bubbles.
+      p5.rect(minX, minY, width, height, padding * 3);
+      p5.stroke(fill);
       p5.ellipse(tailMidX, maxY, tailSize);
       p5.stroke(stroke);
       p5.arc(tailMidX, maxY, tailSize, tailSize, 0, 180);
@@ -86,6 +87,9 @@ export function speechBubble(
       break;
     case 'say':
     default:
+      // Speech bubbles have less-rounded corners and triangular tails.
+      p5.rect(minX, minY, width, height, padding);
+      p5.stroke(fill);
       p5.triangle(tailTipX - tailSize, maxY, tailTipX, maxY, tailTipX, y);
       p5.stroke(stroke);
       p5.line(tailTipX, maxY, tailTipX, y);
@@ -153,7 +157,6 @@ export function validationBar(
   p5.push();
   p5.noStroke();
   p5.fill(color);
-  p5.beginShape();
   p5.rect(x, y, width, height);
   p5.pop();
 }

--- a/apps/src/p5lab/spritelab/CoreLibrary.js
+++ b/apps/src/p5lab/spritelab/CoreLibrary.js
@@ -85,16 +85,17 @@ export default class CoreLibrary {
       return;
     }
 
-    this.speechBubbles.forEach(({text, sprite}) => {
+    this.speechBubbles.forEach(({text, sprite, style}) => {
       this.drawSpeechBubble(
         text,
         sprite.x,
-        sprite.y - Math.round(sprite.getScaledHeight() / 2)
+        sprite.y - Math.round(sprite.getScaledHeight() / 2),
+        style
       );
     });
   }
 
-  drawSpeechBubble(text, x, y) {
+  drawSpeechBubble(text, x, y, style) {
     const padding = 8;
     if (typeof text === 'number') {
       text = text.toString();
@@ -131,34 +132,40 @@ export default class CoreLibrary {
     width = Math.max(width, 50);
     const height = lines.length * textSize + padding * 2;
 
-    let triangleSize = 10;
-    let triangleTipX = x;
-    // The number of pixels used to create the rounded corners of the speech bubble:
-    const rectangleCornerRadius = 8;
+    let tailSize = 10;
+    let tailTipX = x;
 
     // For the calculations below, keep in mind that x and y are located at the horizontal center and the top of the sprite, respectively.
     // In other words, x and y indicate the default position of the bubble's triangular tip.
     y = Math.min(y, APP_HEIGHT);
     const spriteX = x;
-    if (y - height - triangleSize < 1) {
-      triangleSize = Math.max(1, y - height);
-      y = height + triangleSize;
+    if (y - height - tailSize < 1) {
+      tailSize = Math.max(1, y - height);
+      y = height + tailSize;
     }
     if (spriteX - width / 2 < 1) {
-      triangleTipX = Math.max(spriteX, rectangleCornerRadius + triangleSize);
+      tailTipX = Math.max(spriteX, padding + tailSize);
       x = width / 2;
     }
     if (spriteX + width / 2 > APP_WIDTH) {
-      triangleTipX = Math.min(spriteX, APP_WIDTH - rectangleCornerRadius);
+      tailTipX = Math.min(spriteX, APP_WIDTH - padding);
       x = APP_WIDTH - width / 2;
     }
 
     // Draw bubble.
-    const {minY} = drawUtils.speechBubble(this.p5, x, y, width, height, {
-      triangleSize,
-      triangleTipX,
-      rectangleCornerRadius
-    });
+    const {minY} = drawUtils.speechBubble(
+      this.p5,
+      x,
+      y,
+      width,
+      height,
+      {
+        tailSize,
+        tailTipX,
+        padding
+      },
+      style
+    );
 
     // Draw text within bubble.
     drawUtils.multilineText(this.p5, lines, x, minY + padding, textSize, {
@@ -166,7 +173,7 @@ export default class CoreLibrary {
     });
   }
 
-  addSpeechBubble(sprite, text, seconds = null) {
+  addSpeechBubble(sprite, text, seconds = null, style = 'say') {
     // Sprites can only have one speech bubble at a time so first filter out
     // any existing speech bubbles for this sprite
     this.removeSpeechBubblesForSprite(sprite);
@@ -179,7 +186,8 @@ export default class CoreLibrary {
       sprite,
       text,
       removeAt,
-      renderFrame: this.currentFrame()
+      renderFrame: this.currentFrame(),
+      style
     });
     return id;
   }

--- a/apps/src/p5lab/spritelab/CoreLibrary.js
+++ b/apps/src/p5lab/spritelab/CoreLibrary.js
@@ -85,17 +85,17 @@ export default class CoreLibrary {
       return;
     }
 
-    this.speechBubbles.forEach(({text, sprite, style}) => {
+    this.speechBubbles.forEach(({text, sprite, bubbleType}) => {
       this.drawSpeechBubble(
         text,
         sprite.x,
         sprite.y - Math.round(sprite.getScaledHeight() / 2),
-        style
+        bubbleType
       );
     });
   }
 
-  drawSpeechBubble(text, x, y, style) {
+  drawSpeechBubble(text, x, y, bubbleType) {
     const padding = 8;
     if (typeof text === 'number') {
       text = text.toString();
@@ -131,6 +131,7 @@ export default class CoreLibrary {
       drawUtils.getTextWidth(this.p5, longestLine, textSize) + padding * 2;
     width = Math.max(width, 50);
     const height = lines.length * textSize + padding * 2;
+    const radius = padding;
 
     let tailSize = 10;
     let tailTipX = x;
@@ -144,11 +145,11 @@ export default class CoreLibrary {
       y = height + tailSize;
     }
     if (spriteX - width / 2 < 1) {
-      tailTipX = Math.max(spriteX, padding + tailSize);
+      tailTipX = Math.max(spriteX, radius + tailSize);
       x = width / 2;
     }
     if (spriteX + width / 2 > APP_WIDTH) {
-      tailTipX = Math.min(spriteX, APP_WIDTH - padding);
+      tailTipX = Math.min(spriteX, APP_WIDTH - radius);
       x = APP_WIDTH - width / 2;
     }
 
@@ -162,9 +163,9 @@ export default class CoreLibrary {
       {
         tailSize,
         tailTipX,
-        padding
+        radius
       },
-      style
+      bubbleType
     );
 
     // Draw text within bubble.
@@ -173,7 +174,7 @@ export default class CoreLibrary {
     });
   }
 
-  addSpeechBubble(sprite, text, seconds = null, style = 'say') {
+  addSpeechBubble(sprite, text, seconds = null, bubbleType = 'say') {
     // Sprites can only have one speech bubble at a time so first filter out
     // any existing speech bubbles for this sprite
     this.removeSpeechBubblesForSprite(sprite);
@@ -187,7 +188,7 @@ export default class CoreLibrary {
       text,
       removeAt,
       renderFrame: this.currentFrame(),
-      style
+      bubbleType
     });
     return id;
   }

--- a/apps/src/p5lab/spritelab/commands/actionCommands.js
+++ b/apps/src/p5lab/spritelab/commands/actionCommands.js
@@ -12,9 +12,15 @@ function move(coreLibrary, spriteArg, distance) {
   });
 }
 
-function addSpriteSpeechBubble(coreLibrary, spriteArg, text, seconds, style) {
+function addSpriteSpeechBubble(
+  coreLibrary,
+  spriteArg,
+  text,
+  seconds,
+  bubbleType
+) {
   coreLibrary.getSpriteArray(spriteArg)?.forEach(sprite => {
-    coreLibrary.addSpeechBubble(sprite, text, seconds, style);
+    coreLibrary.addSpeechBubble(sprite, text, seconds, bubbleType);
   });
 }
 

--- a/apps/src/p5lab/spritelab/commands/actionCommands.js
+++ b/apps/src/p5lab/spritelab/commands/actionCommands.js
@@ -255,12 +255,16 @@ export const commands = {
     addSpriteSpeechBubble(this, spriteArg, text, 4 /* seconds */, 'say');
   },
 
-  spriteSayTime(spriteArg, text, seconds, style) {
-    addSpriteSpeechBubble(this, spriteArg, text, seconds, style);
+  spriteSayTime(spriteArg, text, seconds) {
+    addSpriteSpeechBubble(this, spriteArg, text, seconds, 'say');
   },
 
   spriteThink(spriteArg, text) {
     addSpriteSpeechBubble(this, spriteArg, text, 4 /* seconds */, 'think');
+  },
+
+  spriteThinkTime(spriteArg, text, seconds) {
+    addSpriteSpeechBubble(this, spriteArg, text, seconds, 'think');
   },
 
   removeTint(spriteArg) {

--- a/apps/src/p5lab/spritelab/commands/actionCommands.js
+++ b/apps/src/p5lab/spritelab/commands/actionCommands.js
@@ -12,9 +12,9 @@ function move(coreLibrary, spriteArg, distance) {
   });
 }
 
-function addSpriteSpeechBubble(coreLibrary, spriteArg, text, seconds) {
+function addSpriteSpeechBubble(coreLibrary, spriteArg, text, seconds, style) {
   coreLibrary.getSpriteArray(spriteArg)?.forEach(sprite => {
-    coreLibrary.addSpeechBubble(sprite, text, seconds);
+    coreLibrary.addSpeechBubble(sprite, text, seconds, style);
   });
 }
 
@@ -252,11 +252,15 @@ export const commands = {
   },
 
   spriteSay(spriteArg, text) {
-    addSpriteSpeechBubble(this, spriteArg, text, 4 /* seconds */);
+    addSpriteSpeechBubble(this, spriteArg, text, 4 /* seconds */, 'say');
   },
 
-  spriteSayTime(spriteArg, text, seconds) {
-    addSpriteSpeechBubble(this, spriteArg, text, seconds);
+  spriteSayTime(spriteArg, text, seconds, style) {
+    addSpriteSpeechBubble(this, spriteArg, text, seconds, style);
+  },
+
+  spriteThink(spriteArg, text) {
+    addSpriteSpeechBubble(this, spriteArg, text, 4 /* seconds */, 'think');
   },
 
   removeTint(spriteArg) {

--- a/dashboard/config/blocks/GamelabJr/gamelab_spriteSayTime.json
+++ b/dashboard/config/blocks/GamelabJr/gamelab_spriteSayTime.json
@@ -2,7 +2,7 @@
   "category": "Sprites",
   "config": {
     "func": "spriteSayTime",
-    "blockText": "{SPRITE}say{TEXT1}for{NUM}seconds",
+    "blockText": "{SPRITE}{STYLE}{TEXT1}for{NUM}seconds",
     "args": [
       {
         "name": "SPRITE",
@@ -16,6 +16,19 @@
         "name": "NUM",
         "type": "Number",
         "field": false
+      },
+      {
+        "name": "STYLE",
+        "options": [
+          [
+            "say",
+            "\"say\""
+          ],
+          [
+            "think",
+            "\"think\""
+          ]
+        ]
       }
     ]
   }

--- a/dashboard/config/blocks/GamelabJr/gamelab_spriteThink.json
+++ b/dashboard/config/blocks/GamelabJr/gamelab_spriteThink.json
@@ -1,0 +1,18 @@
+{
+  "category": "Sprites",
+  "config": {
+    "func": "spriteThink",
+    "blockText": "{SPRITE} think {SPEECH}",
+    "args": [
+      {
+        "name": "SPRITE",
+        "type": "Sprite"
+      },
+      {
+        "name": "SPEECH",
+        "type": "String",
+        "field": true
+      }
+    ]
+  }
+}

--- a/dashboard/config/blocks/GamelabJr/gamelab_spriteThinkTime.json
+++ b/dashboard/config/blocks/GamelabJr/gamelab_spriteThinkTime.json
@@ -1,8 +1,8 @@
 {
   "category": "Sprites",
   "config": {
-    "func": "spriteSayTime",
-    "blockText": "{SPRITE}say{TEXT1}for{NUM}seconds",
+    "func": "spriteThinkTime",
+    "blockText": "{SPRITE}think{TEXT1}for{NUM}seconds",
     "args": [
       {
         "name": "SPRITE",


### PR DESCRIPTION
## Request and Context
A near copy of the “Say” block, the “Think” block will have a similar bubble above the sprite just with the cloud instead of a callout:
![image](https://user-images.githubusercontent.com/43474485/163201061-fa575e8c-473c-45ce-9bc4-855b3d236fc9.png)

This is needed for the Fables CSC activity, as ELA needs internal narrative/motivation of the characters in addition to speaking. 
![image](https://user-images.githubusercontent.com/43474485/163201067-a446f172-1a4a-41ca-b678-f6db70904a7d.png)

## Design Considerations
This is a high priority request to unblock CSC lesson development and piloting. Speech bubbles are currently created on the canvas using p5 primitives. It is easy enough to change the specific design for a speech bubble later on without "breaking anything".

### Thought Bubble Shape
The requested design was for a "cloud" shape, as is often seen in comics. This style was difficult to implement for three main reasons:
* A high level of needed precision when placing curves/arcs/ellipses
* The need for the shape to present well at various widths and heights
* The challenge in producing an "organic"-looking design

`say` and `think` blocks are also used in other Block programming environments, but use a different design style to differentiate between the two.

| Scratch|Tynker | Snap|
|-|-|-|
| <img width="250" alt="image (10)" src="https://user-images.githubusercontent.com/43474485/163202342-a4ced67a-f012-473d-bd6f-5b654d24dd88.png">|<img width="250" alt="image (9)" src="https://user-images.githubusercontent.com/43474485/163202350-5fcfd304-54e4-4581-89d5-55372ab20574.png"> |<img width="250" alt="image (10)" src="https://user-images.githubusercontent.com/43474485/163202367-b0f64a38-051c-4685-b35a-da15ab18b193.png"> |
| <img width="250" alt="image" src="https://user-images.githubusercontent.com/79231656/163229040-f938a7ff-5ce0-435c-bbf8-463bb2c9ba22.png">|<img width="250" alt="image" src="https://user-images.githubusercontent.com/79231656/163229292-5fa274ba-ac1f-4e3d-8e47-c97b77574d6c.png"> | <img width="250" alt="image" src="https://user-images.githubusercontent.com/79231656/163229464-a08ecc85-d848-455c-b788-e88f29e128b8.png">|



There are also examples of speech/thought bubbles that are created by various web developers. In this [list](https://devsnap.me/css-speech-bubbles), only 1 of 25 attempted anything resembling a cloud shape!

## Proposed Solution
1. Create a style of "speech bubble" that is comprised of a rectangle with significantly-rounded corners.
2. Create a `spriteThink` block to mirror the existing `spriteSay` block, introduced in Hello World.
~3. Add a drop-down selector the more advanced `spriteSayTime` block to allow the student to change styles on the fly.~
3. Create a `spriteThinkTime` block to mirror the existing `spriteSayTime` block found in projects/free play.
4. Clean up parts of the code, e.g. refer to a speech bubble's "tail" rather than its "triangle".

#### Current Block Proposal
![image](https://user-images.githubusercontent.com/43474485/163233766-b827e949-0e23-46e8-b462-53b0491e238c.png)

#### Older Block Proposal
<img width="50%" alt="image" src="https://user-images.githubusercontent.com/43474485/163199532-58ad013e-0437-4f6f-a393-1364e49794d2.png"><img width="50%" alt="image" src="https://user-images.githubusercontent.com/43474485/163199261-84bafdfb-0509-48e0-85da-5e1eb17d9e89.png">


## Risks
* ~Once merged, this will also making the option available to all users if the block(s) are available in the toolbox. Today it can be found in the Sprite Lab project level and Hello World free play.~ Thought bubbles will only be available in levels that feature the new blocks.
* Making the proposed changes does *not* break any existing blocks, levels, or project, including those that already use `spriteSayTime`. ~However, once merged, we would be unable to later remove the `think` option from the block without breaking it for any users that used it while it was an option: <br/><img width="50%" alt="image" src="https://user-images.githubusercontent.com/43474485/163198594-40bbaf27-715d-4c7b-b36a-77191000ea5a.png"><br/>
In other words, if it is anticipated that the pilot may lead us to the conclusion that we should not have a `think` option at all, we should use a different solution.~

* It is easy to alter the design of each speech bubble later on, if desired. 

## Links

- jira ticket: [STAR-2210: [Sprite Lab] Add think block](https://codedotorg.atlassian.net/browse/STAR-2210)


## Testing story

The new speech bubble was tested with a range of different string lengths and canvas positions to confirm expected responsiveness:
https://user-images.githubusercontent.com/43474485/163199608-89f87025-f71f-46be-b479-edb843a6fa31.mp4

## Deployment strategy
~I recommend that this can be merged once approved if stakeholders are comfortable with the small risks above. Alternatively, we can explore other options, such as not modifying `spriteSayTime` and instead creating a new block (ie. `spriteThinkTime`).~ All explored risks have been eliminated!

## Follow-up work
Following the pilot, we can consider refining the bubble design, if desired.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
