### PR TITLE
[App Lab] getProperty returns string instead of number for min and max of a slider

### DIFF
--- a/apps/src/applab/designElements/slider.jsx
+++ b/apps/src/applab/designElements/slider.jsx
@@ -179,11 +179,11 @@ export default {
       case 'sliderValue':
         return parseInt(element.value, 10);
       case 'min':
-        return element.min;
+        return parseInt(element.min, 10);
       case 'max':
-        return element.max;
+        return parseInt(element.max, 10);
       case 'step':
-        return element.step;
+        return parseInt(element.step, 10);
       default:
         throw `unknown property name ${name}`;
     }


### PR DESCRIPTION
## Problem
The getProperty block in applab returns a string instead of a number for the min, max and step parameters on a slider element
![image](https://user-images.githubusercontent.com/43474485/163222377-83dc39e6-5833-4df0-930c-28ce613897cf.png)

## Solution
Follow the pattern used for `sliderValue` to parse each string value and return an integer.

![image](https://user-images.githubusercontent.com/43474485/163222122-4b46768c-df00-4313-958d-5ddf62160956.png)

## Links


- jira ticket: [STAR-2086: [App Lab] getProperty returns string instead of number for min and max of a slider](https://codedotorg.atlassian.net/browse/STAR-2086)


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
