### PR TITLE
Fix not being able to save with picked course offering category

### DIFF
--- a/apps/src/lib/levelbuilder/CourseOfferingEditor.jsx
+++ b/apps/src/lib/levelbuilder/CourseOfferingEditor.jsx
@@ -70,9 +70,9 @@ export default function CourseOfferingEditor(props) {
           style={styles.dropdown}
           onChange={e => updateCourseOffering('category', e.target.value)}
         >
-          {Object.values(CourseOfferingCategories).map(category => (
+          {Object.keys(CourseOfferingCategories).map(category => (
             <option key={category} value={category}>
-              {category}
+              {CourseOfferingCategories[category]}
             </option>
           ))}
         </select>


### PR DESCRIPTION
When I was trying to update the category of a course offering I noticed that it would not save because it was trying to set the category to the human readable name instead of the key we use on the backend.
