### PR TITLE
Refactor Programming{Class,Expression,Method}Editor to do setup code only on init

### DIFF
--- a/apps/src/lib/levelbuilder/code-docs-editor/ProgrammingClassEditor.jsx
+++ b/apps/src/lib/levelbuilder/code-docs-editor/ProgrammingClassEditor.jsx
@@ -18,6 +18,9 @@ function useProgrammingClass(initialProgrammingClass) {
     // We remove id and key from state as they should not be modified
     delete copiedClass.id;
     delete copiedClass.key;
+    // Examples and fields don't have obvious unique identifiers so adding
+    // some here. These are required by React when we transform these lists
+    // into sets of components.
     if (copiedClass.examples) {
       copiedClass.examples.forEach(e => (e.key = createUuid()));
     }
@@ -31,7 +34,7 @@ function useProgrammingClass(initialProgrammingClass) {
     initializeProgrammingClass(initialProgrammingClass)
   );
 
-  const updateProgrammingClass = (key, value) => {
+  const setProgrammingClassProperty = (key, value) => {
     setProgrammingClass({...programmingClass, [key]: value});
   };
 
@@ -39,7 +42,7 @@ function useProgrammingClass(initialProgrammingClass) {
     setProgrammingClass(initializeProgrammingClass(newProgrammingClass));
   };
 
-  return [programmingClass, updateProgrammingClass, resetProgrammingClass];
+  return [programmingClass, setProgrammingClassProperty, resetProgrammingClass];
 }
 
 function renderExampleEditor(example, updateFunc) {
@@ -60,7 +63,7 @@ export default function ProgrammingClassEditor({
 }) {
   const [
     programmingClass,
-    updateProgrammingClass,
+    setProgrammingClassProperty,
     resetProgrammingClass
   ] = useProgrammingClass(initialProgrammingClass);
   const [isSaving, setIsSaving] = useState(false);
@@ -119,7 +122,7 @@ export default function ProgrammingClassEditor({
         Display Name
         <input
           value={programmingClass.name}
-          onChange={e => updateProgrammingClass('name', e.target.value)}
+          onChange={e => setProgrammingClassProperty('name', e.target.value)}
           style={styles.textInput}
         />
       </label>
@@ -135,7 +138,9 @@ export default function ProgrammingClassEditor({
         Category
         <select
           value={programmingClass.categoryKey}
-          onChange={e => updateProgrammingClass('categoryKey', e.target.value)}
+          onChange={e =>
+            setProgrammingClassProperty('categoryKey', e.target.value)
+          }
           style={styles.selectInput}
         >
           <option key="none" value={''}>
@@ -158,7 +163,10 @@ export default function ProgrammingClassEditor({
           <input
             value={programmingClass.externalDocumentation}
             onChange={e =>
-              updateProgrammingClass('externalDocumentation', e.target.value)
+              setProgrammingClassProperty(
+                'externalDocumentation',
+                e.target.value
+              )
             }
             style={styles.textInput}
           />
@@ -167,7 +175,7 @@ export default function ProgrammingClassEditor({
           markdown={programmingClass.content}
           label={'Content'}
           handleMarkdownChange={e =>
-            updateProgrammingClass('content', e.target.value)
+            setProgrammingClassProperty('content', e.target.value)
           }
           features={markdownEditorFeatures}
         />
@@ -177,7 +185,7 @@ export default function ProgrammingClassEditor({
           markdown={programmingClass.syntax}
           label={'Syntax'}
           handleMarkdownChange={e =>
-            updateProgrammingClass('syntax', e.target.value)
+            setProgrammingClassProperty('syntax', e.target.value)
           }
           features={markdownEditorFeatures}
         />
@@ -187,7 +195,7 @@ export default function ProgrammingClassEditor({
           markdown={programmingClass.tips}
           label={'Tips'}
           handleMarkdownChange={e =>
-            updateProgrammingClass('tips', e.target.value)
+            setProgrammingClassProperty('tips', e.target.value)
           }
           features={markdownEditorFeatures}
           helpTip="List of tips for using this code documentation"
@@ -196,7 +204,7 @@ export default function ProgrammingClassEditor({
       <CollapsibleEditorSection title="Examples" collapsed>
         <OrderableList
           list={programmingClass.examples || []}
-          setList={list => updateProgrammingClass('examples', list)}
+          setList={list => setProgrammingClassProperty('examples', list)}
           addButtonText="Add Another Example"
           renderItem={renderExampleEditor}
         />
@@ -204,7 +212,7 @@ export default function ProgrammingClassEditor({
       <CollapsibleEditorSection title="Fields" collapsed>
         <OrderableList
           list={programmingClass.fields || []}
-          setList={list => updateProgrammingClass('fields', list)}
+          setList={list => setProgrammingClassProperty('fields', list)}
           addButtonText="Add Another Field"
           renderItem={renderFieldEditor}
         />
@@ -212,7 +220,7 @@ export default function ProgrammingClassEditor({
       <CollapsibleEditorSection title="Methods" collapsed>
         <OrderableList
           list={programmingClass.methods || []}
-          setList={list => updateProgrammingClass('methods', list)}
+          setList={list => setProgrammingClassProperty('methods', list)}
           addButtonText="Add Another Method"
           renderItem={renderMethodNameEditor}
         />

--- a/apps/src/lib/levelbuilder/code-docs-editor/ProgrammingExpressionEditor.jsx
+++ b/apps/src/lib/levelbuilder/code-docs-editor/ProgrammingExpressionEditor.jsx
@@ -18,6 +18,9 @@ function useProgrammingExpression(initialProgrammingExpression) {
     // We remove id and key from state as they should not be modified
     delete copiedExpression.id;
     delete copiedExpression.key;
+    // Examples and parameters don't have obvious unique identifiers so adding
+    // some here. These are required by React when we transform these lists
+    // into sets of components.
     if (copiedExpression.examples) {
       copiedExpression.examples.forEach(e => (e.key = createUuid()));
     }
@@ -63,7 +66,7 @@ export default function ProgrammingExpressionEditor({
 }) {
   const [
     programmingExpression,
-    updateProgrammingExpression
+    setProgrammingExpressionProperty
   ] = useProgrammingExpression(initialProgrammingExpression);
   const [isSaving, setIsSaving] = useState(false);
   const [lastUpdated, setLastUpdated] = useState(null);
@@ -116,7 +119,9 @@ export default function ProgrammingExpressionEditor({
         Display Name
         <input
           value={programmingExpression.name}
-          onChange={e => updateProgrammingExpression('name', e.target.value)}
+          onChange={e =>
+            setProgrammingExpressionProperty('name', e.target.value)
+          }
           style={styles.textInput}
         />
       </label>
@@ -133,7 +138,7 @@ export default function ProgrammingExpressionEditor({
         <select
           value={programmingExpression.categoryKey}
           onChange={e =>
-            updateProgrammingExpression('categoryKey', e.target.value)
+            setProgrammingExpressionProperty('categoryKey', e.target.value)
           }
           style={styles.selectInput}
         >
@@ -157,7 +162,7 @@ export default function ProgrammingExpressionEditor({
           <input
             value={programmingExpression.blockName}
             onChange={e =>
-              updateProgrammingExpression('blockName', e.target.value)
+              setProgrammingExpressionProperty('blockName', e.target.value)
             }
             style={styles.textInput}
           />
@@ -168,7 +173,7 @@ export default function ProgrammingExpressionEditor({
         <select
           value={programmingExpression.videoKey || ''}
           onChange={e =>
-            updateProgrammingExpression('videoKey', e.target.value)
+            setProgrammingExpressionProperty('videoKey', e.target.value)
           }
           style={styles.selectInput}
         >
@@ -182,7 +187,7 @@ export default function ProgrammingExpressionEditor({
       </label>
       <ImageInput
         updateImageUrl={imgUrl =>
-          updateProgrammingExpression('imageUrl', imgUrl)
+          setProgrammingExpressionProperty('imageUrl', imgUrl)
         }
         imageUrl={programmingExpression.imageUrl}
       />
@@ -191,7 +196,7 @@ export default function ProgrammingExpressionEditor({
         <textarea
           value={programmingExpression.shortDescription}
           onChange={e =>
-            updateProgrammingExpression('shortDescription', e.target.value)
+            setProgrammingExpressionProperty('shortDescription', e.target.value)
           }
           style={styles.textInput}
         />
@@ -203,7 +208,7 @@ export default function ProgrammingExpressionEditor({
           <input
             value={programmingExpression.externalDocumentation}
             onChange={e =>
-              updateProgrammingExpression(
+              setProgrammingExpressionProperty(
                 'externalDocumentation',
                 e.target.value
               )
@@ -215,7 +220,7 @@ export default function ProgrammingExpressionEditor({
           markdown={programmingExpression.content}
           label={'Content'}
           handleMarkdownChange={e =>
-            updateProgrammingExpression('content', e.target.value)
+            setProgrammingExpressionProperty('content', e.target.value)
           }
           features={markdownEditorFeatures}
         />
@@ -225,7 +230,7 @@ export default function ProgrammingExpressionEditor({
           markdown={programmingExpression.syntax}
           label={'Syntax'}
           handleMarkdownChange={e =>
-            updateProgrammingExpression('syntax', e.target.value)
+            setProgrammingExpressionProperty('syntax', e.target.value)
           }
           features={markdownEditorFeatures}
         />
@@ -237,7 +242,7 @@ export default function ProgrammingExpressionEditor({
           <textarea
             value={programmingExpression.returnValue}
             onChange={e =>
-              updateProgrammingExpression('returnValue', e.target.value)
+              setProgrammingExpressionProperty('returnValue', e.target.value)
             }
             style={styles.textInput}
           />
@@ -248,7 +253,7 @@ export default function ProgrammingExpressionEditor({
           markdown={programmingExpression.tips}
           label={'Tips'}
           handleMarkdownChange={e =>
-            updateProgrammingExpression('tips', e.target.value)
+            setProgrammingExpressionProperty('tips', e.target.value)
           }
           features={markdownEditorFeatures}
           helpTip="List of tips for using this code documentation"
@@ -257,7 +262,7 @@ export default function ProgrammingExpressionEditor({
       <CollapsibleEditorSection title="Parameters" collapsed>
         <OrderableList
           list={programmingExpression.parameters}
-          setList={list => updateProgrammingExpression('parameters', list)}
+          setList={list => setProgrammingExpressionProperty('parameters', list)}
           addButtonText="Add Another Parameter"
           renderItem={renderParameterEditor}
         />
@@ -265,7 +270,7 @@ export default function ProgrammingExpressionEditor({
       <CollapsibleEditorSection title="Examples" collapsed>
         <OrderableList
           list={programmingExpression.examples || []}
-          setList={list => updateProgrammingExpression('examples', list)}
+          setList={list => setProgrammingExpressionProperty('examples', list)}
           addButtonText="Add Another Example"
           renderItem={renderExampleEditor}
         />

--- a/apps/src/lib/levelbuilder/code-docs-editor/ProgrammingMethodEditor.jsx
+++ b/apps/src/lib/levelbuilder/code-docs-editor/ProgrammingMethodEditor.jsx
@@ -17,6 +17,9 @@ function useProgrammingMethod(initialProgrammingMethod) {
     // We remove id and key from state as they should not be modified
     delete copiedMethod.id;
     delete copiedMethod.key;
+    // Examples and parameters don't have obvious unique identifiers so adding
+    // some here. These are required by React when we transform these lists
+    // into sets of components.
     if (copiedMethod.examples) {
       copiedMethod.examples.forEach(e => (e.key = createUuid()));
     }


### PR DESCRIPTION
According to [React Hooks documentation](https://reactjs.org/docs/hooks-reference.html#lazy-initial-state), complex initialization code can be run once if a function is passed to `useState`. Knowing this, I changed `ProgrammingClassEditor`, `ProgrammingExpressionEditor`, and `ProgrammingMethodEditor` to use this feature for setting keys on serialized lists and removing data we don't want to keep in state. In addition, the Class and Method editors both reset the entire object in state after save is called. I'm reusing the initialization code there so that we have a consistent experience when data is gotten from the server.

`ProgrammingEnvironmentEditor` did not have complex setup logic so I left it as is.



## Testing story

mostly relying on existing unit tests here but I did a quick pass of each of these editors and didn't find any issues



## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
