### PR TITLE
Speculative fix for flaky test in user_test.rb

### DIFF
--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -4204,13 +4204,17 @@ class UserTest < ActiveSupport::TestCase
     user = create :user
     level = create :level
     script = create :script
-    user_level_1 = create :user_level, user: user, level: level, script: script, updated_at: 1.day.ago
-    user_level_2 = create :user_level, user: user, level: level, script: script, updated_at: 1.day.ago
-    user_level_3 = create :user_level, user: user, level: level, script: script, updated_at: 1.day.ago
 
-    result = User.index_user_levels_by_level_id([user_level_1, user_level_2, user_level_3])
+    # Freeze time to ensure all the user levels have the same updated_at timestamp
+    Timecop.freeze do
+      user_level_1 = create :user_level, user: user, level: level, script: script, updated_at: 1.day.ago
+      user_level_2 = create :user_level, user: user, level: level, script: script, updated_at: 1.day.ago
+      user_level_3 = create :user_level, user: user, level: level, script: script, updated_at: 1.day.ago
 
-    assert_equal({level.id => user_level_1}, result)
+      result = User.index_user_levels_by_level_id([user_level_1, user_level_2, user_level_3])
+
+      assert_equal({level.id => user_level_1}, result)
+    end
   end
 
   test 'find_by_email_or_hashed_email returns nil when no user is found' do


### PR DESCRIPTION
The test `test_index_user_levels_by_level_id_returns_first_created_user_level_if_updated_at_is_identical` failed in the DTT today with the output:
```
[0m[1000D[K FAIL["test_index_user_levels_by_level_id_returns_first_created_user_level_if_updated_at_is_identical", "UserTest", 597.216460313648]
 test_index_user_levels_by_level_id_returns_first_created_user_level_if_updated_at_is_identical#UserTest (597.22s)
        --- expected
        +++ actual
        @@ -1 +1 @@
        -{752=>#<UserLevel id: 34, user_id: 274, level_id: 752, attempts: 0, created_at: "2022-04-13 18:23:55", updated_at: "2022-04-12 18:23:55", best_result: nil, script_id: 458, level_source_id: nil, submitted: nil, readonly_answers: nil, unlocked_at: nil, time_spent: nil, deleted_at: nil, properties: nil>}
        +{752=>#<UserLevel id: 35, user_id: 274, level_id: 752, attempts: 0, created_at: "2022-04-13 18:23:56", updated_at: "2022-04-12 18:23:56", best_result: nil, script_id: 458, level_source_id: nil, submitted: nil, readonly_answers: nil, unlocked_at: nil, time_spent: nil, deleted_at: nil, properties: nil>}
        test/models/user_test.rb:4213:in `block in <class:UserTest>'
        test/testing/setup_all_and_teardown_all.rb:36:in `run'
```

Notably, the `updated_at` timestamps are not identical, so my guess that the clock ticked between the creation of the user levels in this test. I believe freezing time should prevent this from happening, but obviously it's very difficult to know 😅 

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
