### PR TITLE
redirect from pegasus to dashboard csf congrats with experiment

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -702,6 +702,8 @@ describe('entry tests', () => {
       './src/sites/code.org/pages/public/yourschool.js',
     'code.org/public/yourschool/thankyou':
       './src/sites/code.org/pages/public/yourschool/thankyou.js',
+    'code.org/views/csf_congrats':
+      './src/sites/code.org/pages/views/csf_congrats.js',
     'code.org/views/regional_partner_search':
       './src/sites/code.org/pages/views/regional_partner_search.js',
     'code.org/views/share_privacy':

--- a/apps/src/sites/code.org/pages/views/csf_congrats.js
+++ b/apps/src/sites/code.org/pages/views/csf_congrats.js
@@ -1,0 +1,9 @@
+import experiments from '@cdo/apps/util/experiments';
+
+const studioCertificate = experiments.isEnabled(experiments.STUDIO_CERTIFICATE);
+
+if (studioCertificate) {
+  const script = document.querySelector('script[data-studio-redirect-url]');
+  const url = script.dataset['studioRedirectUrl'];
+  window.location = url;
+}

--- a/apps/src/sites/studio/pages/congrats/index.js
+++ b/apps/src/sites/studio/pages/congrats/index.js
@@ -27,7 +27,7 @@ $(document).ready(function() {
   let tutorial = '';
   try {
     const params = queryString.parse(window.location.search);
-    certificateId = params['i'].replace(/[^a-z0-9_]/g, '');
+    certificateId = params['i'] && params['i'].replace(/[^a-z0-9_]/g, '');
     tutorial = atob(params['s']).replace(/[^A-Za-z0-9_\- ]/g, '');
   } catch (e) {}
 

--- a/pegasus/sites.v3/code.org/views/csf_congrats.haml
+++ b/pegasus/sites.v3/code.org/views/csf_congrats.haml
@@ -1,3 +1,6 @@
+- studio_redirect_url = CDO.studio_url("/congrats?s=#{Base64.urlsafe_encode64(course)}")
+%script{type: 'text/javascript', src: webpack_asset_path('js/code.org/views/csf_congrats.js'), 'data': {studio_redirect_url: studio_redirect_url}}
+
 %script{type: "text/javascript", src: "/js/csf-congrats.js"}
 %link{:href=>"/shared/css/course-blocks.css", :type=>"text/css", :rel=>"stylesheet"}
 

--- a/pegasus/sites.v3/code.org/views/csf_congrats.haml
+++ b/pegasus/sites.v3/code.org/views/csf_congrats.haml
@@ -1,3 +1,5 @@
+-# this page is being moved to dashboard. pass the new url to the js entry point,
+-# which can use a js experiment to decide whether to redirect to the new url.
 - studio_redirect_url = CDO.studio_url("/congrats?s=#{Base64.urlsafe_encode64(course)}")
 %script{type: 'text/javascript', src: webpack_asset_path('js/code.org/views/csf_congrats.js'), 'data': {studio_redirect_url: studio_redirect_url}}
 


### PR DESCRIPTION
Finishes [PLAT-1734](https://codedotorg.atlassian.net/browse/PLAT-1734). see [congrats page work plan](https://docs.google.com/document/d/1wTObDFZdWS6RzpM3R6wEm04ToY2fM1B5Kb2rUHCNq28/edit#heading=h.h0cd07oasonl).

The strategy I chose was to use javascript on the old csf congrats page to redirect to the new csf congrats page. this makes development a little easier because the same js experiment controls both the csf redirect as well as all the other recent customizations to the dashboard congrats page. here's where we are in the process:

![Screen Shot 2022-04-14 at 10 31 08 AM](https://user-images.githubusercontent.com/8001765/163442473-89cf41ba-dccd-4f48-b8c1-ece78b7c7f8c.png)

the alternative i considered was to make it so that when you complete a csf course, you get sent directly to the dashboard congrats page. this was going to be a little trickier because:
1. there are 4 different places the server sends the congrats url down to the client: 1 in the milestone response, and 3 in the appOptions
2. modifying the urls on the server would mean not being able to use the same js experiment. while this is possible, it creates more work in the short term for setting up the experiment. 

even though the new entry point created in this PR is throwaway work, it feels like less work than setting up a server-side experiment and conditionally modifying the congrats url in 4 places.

## Testing story

we don't seem to have any existing UI test coverage for CSF course certificates. since this page is going away, and I won't really be touching it much again after this PR, those UI tests didn't seem worth investing in. instead, I manually verified:
* without the experiment, the user flow still works the same as before when completing course1
* with the experiment, code.org/congrats/course1 redirects to studio.code.org/congrats with the correct `s` param in the url 

## Future work

after we launch the experiment, we want to follow up by going and updating the server urls to point directly to the dashboard page, without this redirect. this is tracked by [PLAT-1749](https://codedotorg.atlassian.net/browse/PLAT-1749).
