### PR TITLE
Fix docs not being available in production (again)

### DIFF
--- a/dashboard/app/controllers/programming_expressions_controller.rb
+++ b/dashboard/app/controllers/programming_expressions_controller.rb
@@ -7,8 +7,6 @@ class ProgrammingExpressionsController < ApplicationController
   before_action :set_expression_by_keys, only: [:show_by_keys, :docs_show]
   load_and_authorize_resource
 
-  before_action :require_levelbuilder_mode_or_test_env, except: [:search, :show, :show_by_keys]
-
   def index
     @programming_environments = ProgrammingEnvironment.all.map do |env|
       {id: env.id, name: env.name, title: env.title, published: env.published, editPath: edit_programming_environment_path(env.name)}


### PR DESCRIPTION
This line was accidentally added in #45434, I believe due to a bad merge after I let that PR become stale. This line just lists a subset of the exceptions on line 6, so just removing this line and keeping line 6 as is. `docs_show` is the controller action used in production.

I turned off levelbuilder mode locally and verified that this change fixed the issue. I'd love to know a way to test that something works outside of the levelbuilder or test environments more robustly, but I'm not sure how we would do that.



## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
