### PR TITLE
Add code block styling to reference guide and code doc markdown

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -343,6 +343,7 @@ describe('entry tests', () => {
           ['build/package/css/courses.css', 'style/curriculum/courses.scss'],
           ['build/package/css/scripts.css', 'style/curriculum/scripts.scss'],
           ['build/package/css/lessons.css', 'style/curriculum/lessons.scss'],
+          ['build/package/css/markdown.css', 'style/curriculum/markdown.scss'],
           ['build/package/css/levels.css', 'style/curriculum/levels.scss'],
           ['build/package/css/rollups.css', 'style/curriculum/rollups.scss'],
           [

--- a/apps/src/lib/levelbuilder/code-docs-editor/ProgrammingExpressionEditor.jsx
+++ b/apps/src/lib/levelbuilder/code-docs-editor/ProgrammingExpressionEditor.jsx
@@ -99,7 +99,8 @@ export default function ProgrammingExpressionEditor({
   };
 
   const markdownEditorFeatures = {
-    imageUpload: true
+    imageUpload: true,
+    programmingExpression: true
   };
 
   return (

--- a/apps/src/lib/levelbuilder/lesson-editor/FindProgrammingExpressionDialog.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/FindProgrammingExpressionDialog.jsx
@@ -217,5 +217,5 @@ export class FindProgrammingExpressionDialog extends Component {
 }
 
 export default connect(state => ({
-  programmingEnvironments: state.levelSearchingInfo.programmingEnvironments
+  programmingEnvironments: state?.levelSearchingInfo?.programmingEnvironments
 }))(FindProgrammingExpressionDialog);

--- a/apps/src/lib/levelbuilder/reference-guide-editor/ReferenceGuideEditor.jsx
+++ b/apps/src/lib/levelbuilder/reference-guide-editor/ReferenceGuideEditor.jsx
@@ -109,7 +109,7 @@ export default function ReferenceGuideEditor(props) {
           setReferenceGuide({...referenceGuide, content: e.target.value})
         }
         markdown={referenceGuide.content || ''}
-        features={{imageUpload: true}}
+        features={{imageUpload: true, programmingExpression: true}}
       />
       <SaveBar
         handleSave={save}

--- a/apps/src/sites/studio/pages/programming_expressions/edit.js
+++ b/apps/src/sites/studio/pages/programming_expressions/edit.js
@@ -6,9 +6,13 @@ import ExpandableImageDialog from '@cdo/apps/templates/lessonOverview/Expandable
 import instructionsDialog from '@cdo/apps/redux/instructionsDialog';
 import {getStore, registerReducers} from '@cdo/apps/redux';
 import {Provider} from 'react-redux';
+import reducers, {
+  initLevelSearching
+} from '@cdo/apps/lib/levelbuilder/lesson-editor/activitiesEditorRedux';
 
 $(document).ready(() => {
   registerReducers({
+    ...reducers,
     instructionsDialog
   });
   const store = getStore();
@@ -16,6 +20,9 @@ $(document).ready(() => {
   const programmingExpression = getScriptData('programmingExpression');
   const environmentCategories = getScriptData('environmentCategories');
   const videoOptions = getScriptData('videoOptions');
+  const levelSearchingInfo = getScriptData('levelSearchingInfo');
+  store.dispatch(initLevelSearching(levelSearchingInfo));
+
   ReactDOM.render(
     <Provider store={store}>
       <>

--- a/apps/src/sites/studio/pages/reference_guides/edit.js
+++ b/apps/src/sites/studio/pages/reference_guides/edit.js
@@ -5,10 +5,14 @@ import ReferenceGuideEditor from '@cdo/apps/lib/levelbuilder/reference-guide-edi
 import instructionsDialog from '@cdo/apps/redux/instructionsDialog';
 import {getStore, registerReducers} from '@cdo/apps/redux';
 import {Provider} from 'react-redux';
+import reducers, {
+  initLevelSearching
+} from '@cdo/apps/lib/levelbuilder/lesson-editor/activitiesEditorRedux';
 
 $(() => {
   // instructionsDialog reducer is needed for the ExpandableImageDialog
   registerReducers({
+    ...reducers,
     instructionsDialog
   });
   const store = getStore();
@@ -17,6 +21,9 @@ $(() => {
   const referenceGuides = getScriptData('referenceGuides');
   const updateUrl = getScriptData('updateUrl');
   const editAllUrl = getScriptData('editAllUrl');
+  const levelSearchingInfo = getScriptData('levelSearchingInfo');
+  store.dispatch(initLevelSearching(levelSearchingInfo));
+
   ReactDOM.render(
     <Provider store={store}>
       <ReferenceGuideEditor

--- a/apps/style/curriculum/reference_guides.scss
+++ b/apps/style/curriculum/reference_guides.scss
@@ -1,5 +1,6 @@
 @import 'color';
 @import 'font';
+@import "markdown";
 
 .page-content {
   display: flex;

--- a/dashboard/app/views/programming_expressions/edit.html.haml
+++ b/dashboard/app/views/programming_expressions/edit.html.haml
@@ -1,3 +1,10 @@
+%link{href: asset_path('css/markdown.css'), rel: 'stylesheet', type: 'text/css'}
 %script{src: webpack_asset_path('js/programming_expressions/edit.js'),
-  data: {programmingExpression: @programming_expression.summarize_for_edit.to_json, environmentCategories: @environment_categories.to_json, videoOptions: Video.all.where(locale: 'en-US').map {|v| {key: v.key, name: v.localized_name}}.to_json}}
+  data: {
+    programmingExpression: @programming_expression.summarize_for_edit.to_json,
+    environmentCategories: @environment_categories.to_json,
+    videoOptions: Video.all.where(locale: 'en-US').map {|v| {key: v.key, name: v.localized_name}}.to_json,
+    levelSearchingInfo: {programmingEnvironments: ProgrammingEnvironment.all.map(&:summarize_for_lesson_edit)}.to_json
+  }
+}
 #edit-container

--- a/dashboard/app/views/programming_expressions/show.html.haml
+++ b/dashboard/app/views/programming_expressions/show.html.haml
@@ -1,4 +1,5 @@
 //%script{src: webpack_asset_path('js/googleblockly.js')}
+%link{href: asset_path('css/markdown.css'), rel: 'stylesheet', type: 'text/css'}
 %link{href: asset_path('css/curriculum_navigation.css'), rel: 'stylesheet', type: 'text/css'}
 - content_for(:head) do
   = tag 'meta', name: 'description', content: @programming_expression.syntax

--- a/dashboard/app/views/reference_guides/edit.html.haml
+++ b/dashboard/app/views/reference_guides/edit.html.haml
@@ -4,7 +4,8 @@
     referenceGuide: @reference_guide.summarize_for_edit.to_json,
     referenceGuides: @reference_guides.to_json,
     updateUrl: @update_url.to_json,
-    editAllUrl: @edit_all_url.to_json
+    editAllUrl: @edit_all_url.to_json,
+    levelSearchingInfo: {programmingEnvironments: ProgrammingEnvironment.all.map(&:summarize_for_lesson_edit)}.to_json
   }}
 
 #show-container


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Adds the markdown.scss rules to edit and show pages for ref guides and code docs.
Enables the programming expression feature on the markdown editors.

This changes the styling from the default markdown code to the block style that was seen in curriculumbuilder.
This doesn't automatically update the existing content, tess will be coordinating a manual pass to do that.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [PLAT-1743](https://codedotorg.atlassian.net/browse/PLAT-1743)

## Testing story

Manual testing, no UI tests for either page yet, but making a note to add a test for this when those are created.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Screenshots

Reference guides:
edit
![image](https://user-images.githubusercontent.com/82416901/163462888-695b6c6a-ddf3-4a63-952d-13261aa5f6af.png)
show
![image](https://user-images.githubusercontent.com/82416901/163462937-c9dc5170-6fe7-45c8-a969-a0efb28b7ee0.png)

Code docs:
edit
![image](https://user-images.githubusercontent.com/82416901/163463128-66a7fab8-5dfc-40ca-9056-6517a8327270.png)
show
![image](https://user-images.githubusercontent.com/82416901/163463167-1add2093-f523-4657-b9b2-3af708f08b32.png)

Dialog:
![image](https://user-images.githubusercontent.com/82416901/163464110-410f874c-1111-40f4-aefa-8e2a7b37b584.png)
