### PR TITLE
Fixing i18n serialization for single items

### DIFF
--- a/dashboard/lib/services/i18n/curriculum_sync_utils/sync_in.rb
+++ b/dashboard/lib/services/i18n/curriculum_sync_utils/sync_in.rb
@@ -21,7 +21,10 @@ module Services
 
             # prepare data
             data = ScriptCrowdinSerializer.new(script).as_json.compact
-            data.delete(:crowdin_key) # don't need this for top-level data
+            # The JSON object will have the script's crowdin_key as the top level key, but we don't
+            # need that, so we will discard the crowdin_key and set data to be the object it is
+            # pointing to.
+            data = data.first[1] unless data.first.nil?
 
             # we expect that some migrated scripts won't have any lesson plan content
             # at all; that's fine, we can just skip those.


### PR DESCRIPTION
## Context
Our Curriculum has many database models supporting it, such as scripts, lessons, lesson_activities, vocabulary, etc. A lot of these models have content we want to translate. We translate them by querying the database for all Scripts and related data, and then serialize it into a JSON file. We then upload the JSON file to Crowdin. Later we download the translated JSON and deserialize it so our website can access the translations.

When we convert the data into a JSON format, we use a human readable `crowdin_key` instead of database primary_key so that translators have more relevant context about what they are translating. Sometimes this key is a unique name or a URL.

## Issue
The i18n sync-out step was failing to parse JSON serializations of Curriculum models in our database. The root cause ended up being that the sync-in was serializing the data into a JSON structure which the sync-out couldn't parse. In particular the sync-in didn't know how to serialize objects which have a one-to-one relationship. As of a few weeks ago, our system only ever dealt with one-to-many relationships. However, recently we started adding models which have a one-to-one relationship.

This PR fixes the issue by serializing every object, not just "collections" of objects. You can see this in the diff where the code in `CrowdinCollectionSerializer` is moved to `CrowdinSerializer`. Now `CrowdinCollectionSerializer` simply combines all the correctly serialized object.

Below are examples of the expectations and actual data which caused the issue:

### Expected Structure/Pattern
```JSON
"model_name": {
  "crowdin_key": {
    "description": "Acquire and use…",
    "model_name": {
      "crowdin_key": {
        "name": "Common Core…"
      }
    }
  }
}
```
### Expected JSON
```JSON
"standards": {
  "ccela/11-12.L.6": {
    "description": "Acquire and use…",
    "framework": {
      "ccela": {
        "name": "Common Core…"
      }
    }
  }
}
```
### Actual JSON
```JSON
"standards": {
  "ccela/11-12.L.6": {
    "description": "Acquire and use…",
    "framework": {
      "name": "Common Core…"
    }
  }
}
```
Note how the `framework` doesn't have the `crowdin_key` "ccela". Since this doesn't match the structure we expect, the parsing fails.

## Links
* [JIRA](https://codedotorg.atlassian.net/browse/FND-1976)

## Testing story
Ran the sync-in and out locally. Compared the results before and after this change.

## Deployment strategy
* After this is merged, I will run a fresh i18n sync in & up.
* After the fixed sync-in data is uploaded to crowdin, I will reapply translation memory for the affected files since the keys will have changed for some strings and we don't want to lose those translations.
* After the translations are reapplied, I will run the i18n sync down & out.
