### PR TITLE
cloning bubble choice levels copies children of child levels

### DIFF
--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -667,7 +667,7 @@ class Level < ApplicationRecord
 
       level
     rescue Exception => e
-      raise e, "Failed to clone #{name} as #{new_name}. Message: #{e.message}"
+      raise e, "Failed to clone #{name} as #{new_name}. Message: #{e.message}", e.backtrace
     end
   end
 

--- a/dashboard/test/models/level_test.rb
+++ b/dashboard/test/models/level_test.rb
@@ -959,6 +959,43 @@ class LevelTest < ActiveSupport::TestCase
     assert_equal contained_level_2_copy, level_2_copy.contained_levels.last
   end
 
+  test 'clone with suffix copies child levels of bubble choice sublevels' do
+    template_level = create :level, name: 'template level', start_blocks: '<xml>template</xml>'
+    level_1 = create :level, name: 'level 1'
+    level_1.project_template_level_name = template_level.name
+    level_1.save!
+
+    contained_level = create :level, name: 'contained level', type: 'FreeResponse'
+    level_2 = create :level, name: 'level 2'
+    level_2.contained_level_names = [contained_level.name]
+    level_2.save!
+
+    dsl_text = <<~DSL
+      name 'bubble choice'
+      sublevels
+      level 'level 1'
+      level 'level 2'
+    DSL
+
+    bubble_choice = BubbleChoice.create_from_level_builder({}, {name: 'bubble choice', type: 'BubbleChoice', dsl_text: dsl_text})
+    bubble_choice.stubs(:dsl_text).returns(dsl_text)
+    File.stubs(:write)
+    assert_equal bubble_choice.sublevels.first.name, 'level 1'
+    assert_equal bubble_choice.sublevels.last.name, 'level 2'
+
+    bubble_choice_copy = bubble_choice.clone_with_suffix('copy')
+
+    level_1_copy = bubble_choice_copy.sublevels.first
+    assert_equal level_1_copy.name, 'level 1_copy'
+    template_level_copy = level_1_copy.project_template_level
+    assert_equal template_level_copy.name, 'template level_copy'
+
+    level_2_copy = bubble_choice_copy.sublevels.last
+    assert_equal level_2_copy.name, 'level 2_copy'
+    contained_level_copy = level_2_copy.contained_levels.first
+    assert_equal contained_level_copy.name, 'contained level_copy'
+  end
+
   test 'clone with suffix copies level concept difficulty' do
     level_1 = create :level, name: 'level 1'
     level_1.assign_attributes(


### PR DESCRIPTION
This is part of [PLAT-1717](https://codedotorg.atlassian.net/browse/PLAT-1717) and [LP-2287](https://codedotorg.atlassian.net/browse/LP-2287). For notes on how this fits in, see [deeply nested levels notes](https://docs.google.com/document/d/1SrpcFrNAhglSR7leO5nxuYOK7_Jnn0Zd3QA8WDcPg4k/edit).


## Testing story

This PR just adds tests showing that when a contained level or a project template level is associated with the sublevel of a bubble choice level, then all of the levels get copied when cloning.
