### PR TITLE
Update pegasus migration to drop temp views if they do not exist

### DIFF
--- a/pegasus/migrations/139_drop_temp_views.rb
+++ b/pegasus/migrations/139_drop_temp_views.rb
@@ -4,8 +4,27 @@ Sequel.migration do
     pegasus_user_storage_ids = "#{CDO.pegasus_db_name}__user_storage_ids".to_sym
 
     unless [:production].include?(rack_env)
-      DB.drop_view(pegasus_storage_apps)
-      DB.drop_view(pegasus_user_storage_ids)
+      begin
+        DB.drop_view(pegasus_storage_apps)
+      rescue Sequel::DatabaseError => e
+        is_unknown_table_error = e.message.include? "Unknown table"
+        if is_unknown_table_error
+          CDO.log.warn "Temporary view for storage apps doesn't exist"
+        else
+          raise e
+        end
+      end
+
+      begin
+        DB.drop_view(pegasus_user_storage_ids)
+      rescue Sequel::DatabaseError => e
+        is_unknown_table_error = e.message.include? "Unknown table"
+        if is_unknown_table_error
+          CDO.log.warn "Temporary view for user_storage_ids doesn't exist"
+        else
+          raise e
+        end
+      end
     end
   end
 


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
On `pegasus_unittest` database we do not have temporary views (not super sure why), so I need to update the migration to handle that case. The idea is that merging this change won't effect environments where the migration has already been run and then we can re-start the test build and hopefully at the next attempt to run the migration it'll work for `pegasus_unittest`.

## Testing story
I tested locally that if the views had been dropped that the old version of the migration would fail, and that the updated version would pass:

Old migration:
![Screen Shot 2022-04-14 at 4 35 11 PM](https://user-images.githubusercontent.com/24235215/163493458-f4876de1-dce0-4a66-8d81-a56df1022722.png)
New migration:
![Screen Shot 2022-04-14 at 4 35 33 PM](https://user-images.githubusercontent.com/24235215/163493478-4db59fac-2150-4ab3-8d72-2cd407fb14d2.png)

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
