### PR TITLE
Get sublevel progress for sublevel contained levels

### DIFF
--- a/dashboard/app/helpers/users_helper.rb
+++ b/dashboard/app/helpers/users_helper.rb
@@ -378,7 +378,8 @@ module UsersHelper
 
     # get progress for sublevels to save in levels hash
     level.sublevels.each do |sublevel|
-      ul = user_levels_by_level.try(:[], sublevel.id)
+      level_for_progress = BubbleChoice.level_for_progress_for_sublevel(sublevel)
+      ul = user_levels_by_level.try(:[], level_for_progress.id)
       feedback = teacher_feedback_by_level.try(:[], sublevel.id)
       sublevel_progress = get_level_progress(user.id, ul, feedback&.review_state, script_level, paired_user_levels, include_timestamp)
       next unless sublevel_progress

--- a/dashboard/test/helpers/users_helper_test.rb
+++ b/dashboard/test/helpers/users_helper_test.rb
@@ -310,19 +310,23 @@ class UsersHelperTest < ActionView::TestCase
 
     # Create BubbleChoice level with sublevels, script_level, and user_levels.
     sublevel1 = create :level, name: 'choice_1'
+    sublevel1_contained_level = create :level, name: "choice_1 contained"
+    sublevel1.contained_level_names = [sublevel1_contained_level.name]
+    sublevel1.save!
+
     sublevel2 = create :level, name: 'choice_2'
     level = create :bubble_choice_level, sublevels: [sublevel1, sublevel2]
     create :script_level, script: script, levels: [level], lesson: lesson
 
     # for user_1
-    sublevel1_user_level = create :user_level, user: user_1, level: sublevel1, script: script, best_result: ActivityConstants::BEST_PASS_RESULT, time_spent: 180
+    sublevel1_user_level = create :user_level, user: user_1, level: sublevel1_contained_level, script: script, best_result: ActivityConstants::BEST_PASS_RESULT, time_spent: 180
     sublevel2_user_level = create :user_level, user: user_1, level: sublevel2, script: script, best_result: 20, time_spent: 300
 
     sublevel1_last_progress = UserLevel.find(sublevel1_user_level.id).updated_at.to_i
     sublevel2_last_progress = UserLevel.find(sublevel2_user_level.id).updated_at.to_i
 
     # for user_2
-    sublevel1_user_level_2 = create :user_level, user: user_2, level: sublevel1, script: script, best_result: ActivityConstants::BEST_PASS_RESULT, time_spent: 180
+    sublevel1_user_level_2 = create :user_level, user: user_2, level: sublevel1_contained_level, script: script, best_result: ActivityConstants::BEST_PASS_RESULT, time_spent: 180
     sublevel2_user_level_2 = create :user_level, user: user_2, level: sublevel2, script: script, best_result: 20, time_spent: 300
     create :teacher_feedback, student: user_2, teacher: teacher, level: sublevel2, script: script, review_state: TeacherFeedback::REVIEW_STATES.keepWorking
 

--- a/dashboard/test/models/levels/bubble_choice_test.rb
+++ b/dashboard/test/models/levels/bubble_choice_test.rb
@@ -346,7 +346,7 @@ DSL
     student = create :student
 
     sublevel1 = create :level, name: 'choice_1', display_name: 'Choice 1!', thumbnail_url: 'some-fake.url/kittens.png', bubble_choice_description: 'Choose me!'
-    sublevel1_contained_level = create :level, name: 'sublevel contained level'
+    sublevel1_contained_level = create :level, name: 'Choice 1 contained'
     sublevel1.contained_level_names = [sublevel1_contained_level.name]
 
     sublevel2 = create :level, name: 'choice_2', short_instructions: 'A short instruction'


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Fixes displaying progress for bubble choice sublevels with contained levels. 
In header:
![Screen Shot 2022-04-15 at 4 45 07 PM](https://user-images.githubusercontent.com/24235215/163653092-16a4292a-e157-4caa-adaa-a7e09f57dfef.png)
On teacher dashboard progress table:
![Screen Shot 2022-04-18 at 10 10 43 AM](https://user-images.githubusercontent.com/24235215/163845352-c6d02536-b665-41bf-b3c1-e5c54fb97eda.png)

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
- jira ticket: [LP-2287](https://codedotorg.atlassian.net/browse/LP-2287)
<!--
- spec: []()

-->

## Testing story
Tested locally on level page, looking at teacher panel and teacher section progress table. Also added unit tests
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
