### PR TITLE
Put PL categories at the top of the list if they are available

### DIFF
--- a/lib/cdo/shared_constants/curriculum/shared_course_constants.rb
+++ b/lib/cdo/shared_constants/curriculum/shared_course_constants.rb
@@ -60,6 +60,9 @@ module SharedCourseConstants
 
   # All the categories options used to group course offerings in the assignment dropdown
   COURSE_OFFERING_CATEGORIES = OpenStruct.new(
+    pl_self_paced: 'Self-Paced Professional Learning',
+    pl_virtual: 'Virtual Professional Learning',
+    pl_other: 'Other Professional Learning',
     full_course: 'Full Courses',
     csf: 'CS Fundamentals',
     csc: 'CS Connections',
@@ -68,9 +71,6 @@ module SharedCourseConstants
     csf_international: 'CS Fundamentals International',
     math: 'Math',
     twenty_hour: '20-hour',
-    other: 'Other',
-    pl_self_paced: 'Self-Paced Professional Learning',
-    pl_virtual: 'Virtual Professional Learning',
-    pl_other: 'Other Professional Learning'
+    other: 'Other'
   ).freeze
 end


### PR DESCRIPTION
Reorders the Course Offering Categories list which is used as the order of the categories in the dropdown. This will result in the PL offerings showing at the top of the list in the assignment dropdown when PL offerings are available.

This is in response to bug bash feedback on creating PL sections.
[ENG Plan](https://docs.google.com/document/d/1V61xONU0-mleMEEdHWNxhvZtYIPRCB31mT_hbUXusCQ/edit#)
[Product Spec](https://docs.google.com/document/d/1qZpc90daxQiiqpcQUiUiGV2tQoaYEQUzOA72UZzBlVE/edit#heading=h.7j0u06e8a26f)
