### PR TITLE
Migrate course_structure to a permanent table

### DIFF
--- a/aws/redshift/views/course_structure.sql
+++ b/aws/redshift/views/course_structure.sql
@@ -1,6 +1,6 @@
-drop view if exists analysis.course_structure;
-create view analysis.course_structure as
-select 
+DROP table analysis.course_structure;
+create table analysis.course_structure as
+(select 
   cn.course_name_short,
   cn.course_name_long,
   sn.script_name_short,
@@ -12,24 +12,28 @@ select
   sc.name script_name, 
   st.id stage_id, 
   st.name stage_name, 
-  case when lockable = 1 AND has_lesson_plan = 0 then st.absolute_position else st.relative_position end stage_number,
-  lsl.level_id, 
+  case when lockable = 1 then st.absolute_position else st.relative_position end stage_number, 
+  case when sl.script_id = '26' and lsl.level_id = '14633' then '1' else lsl.level_id end as level_id, --------------------- hard coded error correction, level_script_levels defines the first level of this script as id# 14,633 when user_levels defines this level as #1
   le.name level_name, 
   sl.position as level_number,
-  case when json_extract_path_text(sl.properties, 'challenge') = 'true' then 1 else 0 end as challenge,
+  --case when json_extract_path_text(sl.properties, 'challenge') = 'true' then 1 else 0 end as challenge,
   case when sl.assessment = 1 then 1 else 0 end as assessment,
-  case when json_extract_path_text(le.properties, 'mini_rubric') = 'true' then 1 else 0 end as mini_rubric
+  --case when json_extract_path_text(le.properties, 'mini_rubric') = 'true' then 1 else 0 end as mini_rubric
+  case when json_extract_path_text(sc.properties, 'curriculum_umbrella') = '' then 'other'
+  else lower(json_extract_path_text(sc.properties, 'curriculum_umbrella')) end as course_name_true,
+  rank () over (partition by sl.script_id order by stage_number, sl.position) level_script_order,
+  le.updated_at as updated_at
 from dashboard_production.levels_script_levels lsl
   join dashboard_production.script_levels sl on sl.id = lsl.script_level_id
   join dashboard_production.stages st on st.id = sl.stage_id
   join dashboard_production.levels le on le.id = lsl.level_id
   join dashboard_production.scripts sc on sc.id = sl.script_id
   left join dashboard_production.course_scripts cs on cs.script_id = sc.id
-  left join dashboard_production.courses c on c.id = cs.course_id
+  left join dashboard_production.unit_groups c on c.id = cs.course_id
   left join analysis.course_names cn on cn.versioned_course_id = c.id
   left join analysis.script_names sn on sn.versioned_script_id = sc.id
-order by script_id, stage_number, level_number
-with no schema binding;
+  );
+
 
 GRANT ALL PRIVILEGES ON analysis.course_structure TO GROUP admin;
 GRANT SELECT ON analysis.course_structure TO GROUP reader, GROUP reader_pii;


### PR DESCRIPTION
The course structure view has reached a point of complexity where joining it to business logic yields significant performance issues.  As such, we are converting the view to a permanent table to optimize performance, but, as a result, we will no longer have the procedure stored in redshift.  We are updating the code here to reflect the most recent version of the table in the analytics database.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
