### PR TITLE
Add get_summary_by_name to programming_environments_controller

### DIFF
--- a/dashboard/app/controllers/programming_environments_controller.rb
+++ b/dashboard/app/controllers/programming_environments_controller.rb
@@ -4,7 +4,7 @@ class ProgrammingEnvironmentsController < ApplicationController
 
   before_action :require_levelbuilder_mode_or_test_env, except: [:index, :show, :docs_show, :docs_index]
   before_action :set_programming_environment, except: [:index, :docs_index, :new, :create, :docs_show]
-  authorize_resource
+  authorize_resource except: [:get_summary_by_name]
 
   def index
     @programming_environments = ProgrammingEnvironment.where(published: true).order(:name).map(&:summarize_for_index)
@@ -93,6 +93,12 @@ class ProgrammingEnvironmentsController < ApplicationController
     render(status: 200, plain: "Destroyed #{@programming_environment.name}")
   rescue => e
     render(status: :not_acceptable, plain: e.message)
+  end
+
+  def get_summary_by_name
+    return render :not_found unless @programming_environment
+    programming_environment_categories = @programming_environment.categories_for_get
+    return render json: programming_environment_categories
   end
 
   private

--- a/dashboard/app/controllers/programming_environments_controller.rb
+++ b/dashboard/app/controllers/programming_environments_controller.rb
@@ -2,9 +2,9 @@ class ProgrammingEnvironmentsController < ApplicationController
   include ProxyHelper
   EXPIRY_TIME = 30.minutes
 
-  before_action :require_levelbuilder_mode_or_test_env, except: [:index, :show, :docs_show, :docs_index]
+  before_action :require_levelbuilder_mode_or_test_env, except: [:index, :show, :docs_show, :docs_index, :get_summary_by_name]
   before_action :set_programming_environment, except: [:index, :docs_index, :new, :create, :docs_show]
-  authorize_resource except: [:get_summary_by_name]
+  authorize_resource
 
   def index
     @programming_environments = ProgrammingEnvironment.where(published: true).order(:name).map(&:summarize_for_index)
@@ -97,8 +97,8 @@ class ProgrammingEnvironmentsController < ApplicationController
 
   def get_summary_by_name
     return render :not_found unless @programming_environment
-    programming_environment_categories = @programming_environment.categories_for_get
-    return render json: programming_environment_categories
+    return head :forbidden unless can?(:get_summary_by_name, @programming_environment)
+    return render json: @programming_environment.categories_for_get
   end
 
   private

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -78,7 +78,7 @@ class Ability
       can? :update, level
     end
 
-    can [:read, :docs_show, :docs_index], ProgrammingEnvironment do |environment|
+    can [:read, :docs_show, :docs_index, :get_summary_by_name], ProgrammingEnvironment do |environment|
       environment.published || user.permission?(UserPermission::LEVELBUILDER)
     end
 

--- a/dashboard/app/models/programming_environment.rb
+++ b/dashboard/app/models/programming_environment.rb
@@ -134,4 +134,8 @@ class ProgrammingEnvironment < ApplicationRecord
   def categories_for_navigation
     categories.select(&:should_be_in_navigation?).map(&:summarize_for_navigation)
   end
+
+  def categories_for_get
+    categories.select(&:should_be_in_navigation?).map(&:summarize_for_get)
+  end
 end

--- a/dashboard/app/models/programming_environment_category.rb
+++ b/dashboard/app/models/programming_environment_category.rb
@@ -57,6 +57,15 @@ class ProgrammingEnvironmentCategory < ApplicationRecord
     }
   end
 
+  def summarize_for_get
+    {
+      key: key,
+      name: name,
+      color: color,
+      docs: programming_classes.map(&:summarize_for_show) + programming_expressions.map(&:summarize_for_show)
+    }
+  end
+
   def should_be_in_navigation?
     !programming_classes.empty? || !programming_expressions.empty?
   end

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -361,6 +361,8 @@ Dashboard::Application.routes.draw do
     end
   end
 
+  get 'get_summary_by_name/:name', to: 'programming_environments#get_summary_by_name'
+
   resources :programming_methods, only: [:edit, :update]
 
   resources :standards, only: [] do

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -361,7 +361,7 @@ Dashboard::Application.routes.draw do
     end
   end
 
-  get 'get_summary_by_name/:name', to: 'programming_environments#get_summary_by_name'
+  get '/programming_environments/get_summary_by_name/:name', to: 'programming_environments#get_summary_by_name'
 
   resources :programming_methods, only: [:edit, :update]
 

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -354,14 +354,15 @@ Dashboard::Application.routes.draw do
   end
 
   resources :programming_environments, only: [:index, :new, :create, :edit, :update, :show, :destroy], param: 'name' do
+    member do
+      get :get_summary_by_name
+    end
     resources :programming_expressions, param: 'programming_expression_key', constraints: {programming_expression_key: /#{CurriculumHelper::KEY_CHAR_RE}+/} do
       member do
         get :show, to: 'programming_expressions#show_by_keys'
       end
     end
   end
-
-  get '/programming_environments/get_summary_by_name/:name', to: 'programming_environments#get_summary_by_name'
 
   resources :programming_methods, only: [:edit, :update]
 

--- a/dashboard/test/controllers/programming_environments_controller_test.rb
+++ b/dashboard/test/controllers/programming_environments_controller_test.rb
@@ -224,7 +224,7 @@ class ProgrammingEnvironmentsControllerTest < ActionController::TestCase
   end
 
   test 'can get summary by name' do
-    programming_environment = create :programming_environment, name: 'test-environment'
+    programming_environment = create :programming_environment, name: 'test-environment', published: true
     programming_category = create :programming_environment_category, name: 'test-category', programming_environment_id: programming_environment.id
     programming_class = create :programming_class, name: 'test-class', programming_environment_category_id: programming_category.id, programming_environment_id: programming_environment.id
     get :get_summary_by_name, params: {name: programming_environment.name}
@@ -278,5 +278,15 @@ class ProgrammingEnvironmentsControllerTest < ActionController::TestCase
     test_user_gets_response_for :index, user: :student, response: :success
     test_user_gets_response_for :index, user: :teacher, response: :success
     test_user_gets_response_for :index, user: :levelbuilder, response: :success
+
+    test_user_gets_response_for :get_summary_by_name, params: -> {{name: @published_programming_environment.name}}, user: nil, response: :success, name: 'signed out user can get summary of published programming environment'
+    test_user_gets_response_for :get_summary_by_name, params: -> {{name: @published_programming_environment.name}}, user: :student, response: :success, name: 'student can get summary of published programming environment'
+    test_user_gets_response_for :get_summary_by_name, params: -> {{name: @published_programming_environment.name}}, user: :teacher, response: :success, name: 'teacher can get summary of published programming environment'
+    test_user_gets_response_for :get_summary_by_name, params: -> {{name: @published_programming_environment.name}}, user: :levelbuilder, response: :success, name: 'levelbuilder can get summary of published programming environment'
+
+    test_user_gets_response_for :get_summary_by_name, params: -> {{name: @unpublished_programming_environment.name}}, user: nil, response: :forbidden, name: 'signed out user cannot get summary of unpublished programming environment'
+    test_user_gets_response_for :get_summary_by_name, params: -> {{name: @unpublished_programming_environment.name}}, user: :student, response: :forbidden, name: 'student cannot get summary of unpublished programming environment'
+    test_user_gets_response_for :get_summary_by_name, params: -> {{name: @unpublished_programming_environment.name}}, user: :teacher, response: :forbidden, name: 'teacher cannot get summary of unpublished programming environment'
+    test_user_gets_response_for :get_summary_by_name, params: -> {{name: @published_programming_environment.name}}, user: :levelbuilder, response: :success, name: 'levelbuilder can get summary of unpublished programming environment'
   end
 end

--- a/dashboard/test/controllers/programming_environments_controller_test.rb
+++ b/dashboard/test/controllers/programming_environments_controller_test.rb
@@ -223,6 +223,18 @@ class ProgrammingEnvironmentsControllerTest < ActionController::TestCase
     refute_nil ProgrammingEnvironment.find_by_name('test-environment')
   end
 
+  test 'can get summary by name' do
+    programming_environment = create :programming_environment, name: 'test-environment'
+    programming_category = create :programming_environment_category, name: 'test-category', programming_environment_id: programming_environment.id
+    programming_class = create :programming_class, name: 'test-class', programming_environment_category_id: programming_category.id, programming_environment_id: programming_environment.id
+    get :get_summary_by_name, params: {name: programming_environment.name}
+    assert_response :ok
+    response = JSON.parse(@response.body)
+    assert_equal 1, response.length
+    assert_equal programming_category.name, response[0]["name"]
+    assert_equal programming_class.name, response[0]["docs"][0]["name"]
+  end
+
   class AccessTests < ActionController::TestCase
     setup do
       File.stubs(:write)


### PR DESCRIPTION
To show code docs in the instruction panel we need a new route to get a json summary of the all the classes and categories in a given programming environment. This PR adds a new route `get_summary_by_name` which returns that json summary.

## Links

- jira ticket: [JAVA-549](https://codedotorg.atlassian.net/browse/JAVA-549)

## Testing story
Tested via a unit test. This route is not currently used.

## Follow-up work
Use this route in the new documentation tab.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
