### PR TITLE
Using the correct asset path for fontawesome

### DIFF
--- a/dashboard/app/controllers/offline_controller.rb
+++ b/dashboard/app/controllers/offline_controller.rb
@@ -20,7 +20,7 @@ class OfflineController < ApplicationController
     bird_asset_paths = bird_paths.map {|path| helpers.asset_path(path)}
 
     # Load fonts distributed by dashboard
-    font_paths = Dir.glob('*.*', base: 'public/fonts').map {|path| "/assets/#{path}"}
+    font_asset_paths = Dir.glob('*.*', base: 'public/fonts').map {|path| helpers.asset_path(path)}
 
     level_paths = (1..13).map {|n| "/s/express-2021/lessons/1/levels/#{n}"}
 
@@ -62,7 +62,7 @@ class OfflineController < ApplicationController
         helpers.asset_path("blockly/media/1x1.gif"),
         '/favicon.ico',
         '/shared/css/hamburger.css'
-      ].concat(bird_asset_paths, font_paths, level_paths)
+      ].concat(bird_asset_paths, font_asset_paths, level_paths)
     }
   end
 


### PR DESCRIPTION
We use FontAwesome to create icons in our UI. I noticed in production that the “Less” button was a square instead of the usual “up” arrow when a student is on a level while in **offline** mode.
Broken icon | Working icon
-- | --
![image](https://user-images.githubusercontent.com/1372238/164107851-385a1519-9e7e-46e5-8272-c132bb1c29ab.png)  |  ![image](https://user-images.githubusercontent.com/1372238/164107868-fe3a7930-557a-4258-a68b-15fe42c36dc5.png)

The special font was missing because our offline asset manifest (*offline-files.json*) had the wrong path to the *fontawesome-webfont.woff2* file. Since this is an "asset" manages by the dashboard server, it has a hash in the filename which is dynamically generated. The fix is to use the dashboard helper libraries which know where the file is.

On the production server I ran `ActionController::Base.helpers.asset_path('fontawesome-webfont.woff2')` and got the result `"/assets/fontawesome-webfont-2adefcbc041e7d18fcf2d417879dc5a09997aa64d675b7a3c4b6ce33da13f3fe.woff2"` which is the file path we are looking for.

## Links
* [JIRA](https://codedotorg.atlassian.net/browse/FND-1981)

## Testing story
* Manually tested that localhost offline experience still works.
* Manually used the helper library on a production server to make sure the path is correct.
