### PR TITLE
optimize seeding of dsl-defined levels

### DIFF
--- a/dashboard/app/dsl/base_dsl.rb
+++ b/dashboard/app/dsl/base_dsl.rb
@@ -12,11 +12,6 @@ class BaseDSL
     self.class.to_s.tap {|s| s.slice!('DSL')}.underscore
   end
 
-  def self.parse_file(filename, name=nil)
-    text = File.read(filename)
-    parse(text, filename, name)
-  end
-
   def self.parse(str, filename, name=nil)
     object = new
     object.name(name) if name.present?

--- a/dashboard/app/dsl/bubble_choice_dsl.rb
+++ b/dashboard/app/dsl/bubble_choice_dsl.rb
@@ -33,10 +33,6 @@ class BubbleChoiceDSL < ContentDSL
     @hash[:sublevels] << name
   end
 
-  def self.parse_file(filename)
-    super(filename, File.basename(filename, '.bubble_choice'))
-  end
-
   def self.serialize(level)
     new_dsl = "name '#{escape(level.name)}'"
     new_dsl += "\neditor_experiment '#{level.editor_experiment}'" if level.editor_experiment.present?

--- a/dashboard/app/dsl/level_group_dsl.rb
+++ b/dashboard/app/dsl/level_group_dsl.rb
@@ -107,8 +107,4 @@ class LevelGroupDSL < LevelDSL
     end
     new_dsl
   end
-
-  def self.parse_file(filename)
-    super(filename, File.basename(filename, '.level_group'))
-  end
 end

--- a/dashboard/app/models/levels/bubble_choice.rb
+++ b/dashboard/app/models/levels/bubble_choice.rb
@@ -206,9 +206,9 @@ class BubbleChoice < DSLDefined
     level
   end
 
-  def self.setup(data)
+  def self.setup(data, md5)
     sublevel_names = data[:properties].delete(:sublevels)
-    level = super(data)
+    level = super(data, md5)
     level.setup_sublevels(sublevel_names)
     level
   end

--- a/dashboard/app/models/levels/dsl_defined.rb
+++ b/dashboard/app/models/levels/dsl_defined.rb
@@ -98,8 +98,8 @@ class DSLDefined < Level
   end
 
   # Use DSL class to parse string
-  def self.parse(str, filename, name=nil)
-    dsl_class.parse(str, filename, name)
+  def self.parse(str, filename)
+    dsl_class.parse(str, filename)
   end
 
   def self.create_from_level_builder(params, level_params, old_name = nil)

--- a/dashboard/app/models/levels/dsl_defined.rb
+++ b/dashboard/app/models/levels/dsl_defined.rb
@@ -84,11 +84,11 @@ class DSLDefined < Level
     end
   end
 
-  def self.setup(data)
+  def self.setup(data, md5)
     level = find_or_create_by({name: data[:name]})
     level.send(:write_attribute, 'properties', {})
 
-    level.update!(name: data[:name], game_id: Game.find_by(name: to_s).id, properties: data[:properties])
+    level.update!(name: data[:name], game_id: Game.find_by(name: to_s).id, properties: data[:properties], md5: md5)
 
     level
   end

--- a/dashboard/app/models/levels/dsl_defined.rb
+++ b/dashboard/app/models/levels/dsl_defined.rb
@@ -84,7 +84,7 @@ class DSLDefined < Level
     end
   end
 
-  def self.setup(data, md5)
+  def self.setup(data, md5=nil)
     level = find_or_create_by({name: data[:name]})
     level.send(:write_attribute, 'properties', {})
 
@@ -116,7 +116,10 @@ class DSLDefined < Level
         raise "Renaming of DSLDefined levels is not allowed: '#{old_name}' --> '#{data[:name]}'"
       end
 
-      level = setup data
+      # prevent levelbuilder from reseeding this level during the next deploy.
+      md5 = Digest::MD5.hexdigest(text)
+
+      level = setup data, md5
 
       # Save updated level data to external files
       if Rails.application.config.levelbuilder_mode

--- a/dashboard/app/models/levels/dsl_defined.rb
+++ b/dashboard/app/models/levels/dsl_defined.rb
@@ -98,8 +98,8 @@ class DSLDefined < Level
   end
 
   # Use DSL class to parse string
-  def self.parse(str, filename)
-    dsl_class.parse(str, filename)
+  def self.parse(str, filename, name=nil)
+    dsl_class.parse(str, filename, name)
   end
 
   def self.create_from_level_builder(params, level_params, old_name = nil)

--- a/dashboard/app/models/levels/dsl_defined.rb
+++ b/dashboard/app/models/levels/dsl_defined.rb
@@ -97,11 +97,6 @@ class DSLDefined < Level
     "#{self}DSL".constantize
   end
 
-  # Use DSL class to parse file
-  def self.parse_file(filename, name=nil)
-    parse(File.read(filename), filename, name)
-  end
-
   # Use DSL class to parse string
   def self.parse(str, filename, name=nil)
     dsl_class.parse(str, filename, name)

--- a/dashboard/app/models/levels/level_group.rb
+++ b/dashboard/app/models/levels/level_group.rb
@@ -116,8 +116,8 @@ class LevelGroup < DSLDefined
     end
   end
 
-  def self.setup(data)
-    level = super(data)
+  def self.setup(data, md5)
+    level = super(data, md5)
 
     levels_and_texts_by_page = data[:pages].map do |page|
       page[:levels].map do |level_name|

--- a/dashboard/lib/tasks/seed.rake
+++ b/dashboard/lib/tasks/seed.rake
@@ -243,7 +243,8 @@ namespace :seed do
       dsls_glob.each do |filename|
         dsl_class = DSL_TYPES.detect {|type| filename.include?(".#{type.underscore}")}.try(:constantize)
         begin
-          data, _i18n = dsl_class.parse_file(filename)
+          contents = File.read(filename)
+          data, _i18n = dsl_class.parse(contents, filename)
           dsl_class.setup data
         rescue Exception
           puts "Error parsing #{filename}"

--- a/dashboard/test/controllers/levels_controller_test.rb
+++ b/dashboard/test/controllers/levels_controller_test.rb
@@ -686,7 +686,8 @@ class LevelsControllerTest < ActionController::TestCase
 
   test "should load file contents when editing a dsl defined level" do
     level_path = 'config/scripts/test_demo_level.external'
-    data, _ = External.parse_file level_path
+    contents = File.read(level_path)
+    data, _ = External.parse(contents, level_path)
     External.setup data
 
     level = Level.find_by_name 'Test Demo Level'
@@ -698,7 +699,8 @@ class LevelsControllerTest < ActionController::TestCase
 
   test "should load encrypted file contents when editing a dsl defined level with the wrong encryption key" do
     level_path = 'config/scripts/test_external_markdown.external'
-    data, _ = External.parse_file level_path
+    contents = File.read(level_path)
+    data, _ = External.parse(contents, level_path)
     External.setup data
     CDO.stubs(:properties_encryption_key).returns("thisisafakekeyyyyyyyyyyyyyyyyyyyyy")
     level = Level.find_by_name 'Test External Markdown'


### PR DESCRIPTION
skips seeding dsl-defined levels which have not changed since the last time they were seeded, shaving ~5 minutes off of seeding in local development:

before:
```
Dave-MBP:~/src/cdo/dashboard (staging)$ rake seed:dsls
Finished seed:dsls (5 minutes and 12 seconds)
```

after:
```
Dave-MBP:~/src/cdo/dashboard (optimize-dsl-level-seed)$ rake seed:dsls  
Finished seed:dsls (29 seconds)
```

this should also shave similar times off seeding in deploys to staging, test, production,  levelbuilder, where most of these levels are already seeded -- however it won't shave time off of drone runs or initial setup of a development environment.

All of the real work is done in afa819f639d31f0927b85e7e8ea514d86b3bd0e5 -- the other commits are all for refactoring or to make sure nothing else breaks.

the strategy is copied from what we already do for custom levels (those defined in `.level` files): https://github.com/code-dot-org/code-dot-org/blob/ee0da25a97dc8ebd8cf4604188799ea90258983b/dashboard/lib/level_loader.rb#L119-L125

## Testing story

the UI tests in the [latest drone run](https://drone.cdn-code.org/code-dot-org/code-dot-org/17696/2/4) provide good test coverage that various dsl-defined levels are still working properly when seeded from scratch.

I also manually verified that edits to dsl-defined level files are picked up and propagated into the database during the next run of `rake seed:dsls`.
