### PR TITLE
Add page and route for creating new reference guides

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -670,6 +670,7 @@ describe('entry tests', () => {
       './src/sites/studio/pages/programming_expressions/edit.js',
     'programming_methods/edit':
       './src/sites/studio/pages/programming_methods/edit.js',
+    'reference_guides/new': './src/sites/studio/pages/reference_guides/new.js',
     'reference_guides/edit':
       './src/sites/studio/pages/reference_guides/edit.js',
     'reference_guides/edit_all':

--- a/apps/src/lib/levelbuilder/reference-guide-editor/NewReferenceGuideForm.jsx
+++ b/apps/src/lib/levelbuilder/reference-guide-editor/NewReferenceGuideForm.jsx
@@ -11,7 +11,6 @@ const NewReferenceGuideForm = props => {
       <h1>New Reference Guide</h1>
       <label>
         Key
-        <input name="key" required />
         <HelpTip>
           <p>
             The reference guide key is used in URLs and cannot be updated once
@@ -19,6 +18,7 @@ const NewReferenceGuideForm = props => {
             Also 'new' and 'edit' are reserved.
           </p>
         </HelpTip>
+        <input className="input" name="key" required />
       </label>
       <br />
       <button className="btn btn-primary" type="submit">

--- a/apps/src/lib/levelbuilder/reference-guide-editor/NewReferenceGuideForm.jsx
+++ b/apps/src/lib/levelbuilder/reference-guide-editor/NewReferenceGuideForm.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import RailsAuthenticityToken from '@cdo/apps/lib/util/RailsAuthenticityToken';
+import HelpTip from '@cdo/apps/lib/ui/HelpTip';
+
+const NewReferenceGuideForm = props => {
+  const {baseUrl} = props;
+  return (
+    <form action={baseUrl} method="post">
+      <RailsAuthenticityToken />
+      <h1>New Reference Guide</h1>
+      <label>
+        Key
+        <input name="key" required />
+        <HelpTip>
+          <p>
+            The reference guide key is used in URLs and cannot be updated once
+            set. A slug can only contain lowercase letters, numbers, and dashes.
+            Also 'new' and 'edit' are reserved.
+          </p>
+        </HelpTip>
+      </label>
+      <br />
+      <button className="btn btn-primary" type="submit">
+        Save Changes
+      </button>
+    </form>
+  );
+};
+NewReferenceGuideForm.propTypes = {
+  baseUrl: PropTypes.string.isRequired
+};
+
+export default NewReferenceGuideForm;

--- a/apps/src/lib/levelbuilder/reference-guide-editor/NewReferenceGuideForm.jsx
+++ b/apps/src/lib/levelbuilder/reference-guide-editor/NewReferenceGuideForm.jsx
@@ -10,12 +10,12 @@ const NewReferenceGuideForm = props => {
       <RailsAuthenticityToken />
       <h1>New Reference Guide</h1>
       <label>
-        Key
+        Slug
         <HelpTip>
           <p>
-            The reference guide key is used in URLs and cannot be updated once
-            set. A slug can only contain lowercase letters, numbers, and dashes.
-            Also 'new' and 'edit' are reserved.
+            The reference guide slug is used in URLs and cannot be updated once
+            set. A slug can only contain lowercase letters, numbers, and dashes,
+            and 'new' and 'edit' are reserved.
           </p>
         </HelpTip>
         <input className="input" name="key" required />

--- a/apps/src/lib/levelbuilder/reference-guide-editor/ReferenceGuideEditAll.jsx
+++ b/apps/src/lib/levelbuilder/reference-guide-editor/ReferenceGuideEditAll.jsx
@@ -175,6 +175,7 @@ export default function ReferenceGuideEditAll(props) {
           className="create-btn"
           icon={<FontAwesome icon="plus" />}
           iconBefore={true}
+          href={`${baseUrl}/new`}
           text="Create New Guide"
         />
       </div>

--- a/apps/src/sites/studio/pages/reference_guides/new.js
+++ b/apps/src/sites/studio/pages/reference_guides/new.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import getScriptData from '@cdo/apps/util/getScriptData';
+import NewReferenceGuideForm from '@cdo/apps/lib/levelbuilder/reference-guide-editor/NewReferenceGuideForm';
+
+$(document).ready(() => {
+  const baseUrl = getScriptData('baseUrl');
+  ReactDOM.render(
+    <NewReferenceGuideForm baseUrl={baseUrl} />,
+    document.getElementById('form')
+  );
+});

--- a/apps/test/unit/lib/levelbuilder/reference-guide-editor/NewReferenceGuideFormTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/reference-guide-editor/NewReferenceGuideFormTest.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import {expect} from '../../../../util/reconfiguredChai';
+import NewReferenceGuideForm from '@cdo/apps/lib/levelbuilder/reference-guide-editor/NewReferenceGuideForm';
+
+describe('NewReferenceGuide', () => {
+  it('renders form', () => {
+    const wrapper = shallow(<NewReferenceGuideForm baseUrl={'hello/world'} />);
+
+    expect(wrapper.find('input').props().required).to.be.true;
+    expect(wrapper.find('form').props().action).to.equal('hello/world');
+  });
+});

--- a/dashboard/app/controllers/reference_guides_controller.rb
+++ b/dashboard/app/controllers/reference_guides_controller.rb
@@ -34,6 +34,7 @@ class ReferenceGuidesController < ApplicationController
 
   # DELETE /courses/:course_name/guides/:key
   def destroy
+    @reference_guide.remove_serialization
     @reference_guide.destroy
   end
 

--- a/dashboard/app/controllers/reference_guides_controller.rb
+++ b/dashboard/app/controllers/reference_guides_controller.rb
@@ -25,6 +25,28 @@ class ReferenceGuidesController < ApplicationController
     redirect_to course_reference_guide_path(params[:course_course_name], first_child_key)
   end
 
+  # GET /courses/:course_name/guides/new
+  def new
+    @base_url = course_reference_guides_path(params[:course_course_name])
+  end
+
+  # POST /courses/:course_name/guides
+  def create
+    course_version_id = find_matching_course_version(params[:course_course_name])&.id
+    reference_guide = ReferenceGuide.new(
+      key: params[:key],
+      display_name: params[:key],
+      course_version_id: course_version_id,
+      position: 0
+    )
+    if reference_guide.save
+      reference_guide.write_serialization
+      redirect_to edit_course_reference_guide_path(params[:course_course_name], reference_guide.key)
+    else
+      render :not_acceptable, json: reference_guide.errors
+    end
+  end
+
   # PATCH /courses/:course_name/guides/:key
   def update
     @reference_guide.update!(reference_guide_params.except(:key, :course_course_name))

--- a/dashboard/app/helpers/curriculum_helper.rb
+++ b/dashboard/app/helpers/curriculum_helper.rb
@@ -1,6 +1,6 @@
 module CurriculumHelper
   KEY_CHAR_RE = /[A-Za-z0-9\-\_\.]/
-  RESERVED_KEYS = ['edit']
+  RESERVED_KEYS = ['edit', 'new']
 
   def validate_key_format
     if RESERVED_KEYS.include?(key)

--- a/dashboard/app/models/reference_guide.rb
+++ b/dashboard/app/models/reference_guide.rb
@@ -56,6 +56,12 @@ class ReferenceGuide < ApplicationRecord
     File.write(file_path, JSON.pretty_generate(object_to_serialize))
   end
 
+  def remove_serialization
+    return unless Rails.application.config.levelbuilder_mode
+    file_path = Rails.root.join("config/reference_guides/#{course_offering_version}/#{key}.json")
+    File.delete(file_path)
+  end
+
   # runs through all seed files, creating and deleting records to match the seed files
   def self.seed_all
     # collect all existing ids

--- a/dashboard/app/views/reference_guides/new.html.haml
+++ b/dashboard/app/views/reference_guides/new.html.haml
@@ -1,3 +1,4 @@
+%link{href: asset_path('css/reference_guides.css'), rel: 'stylesheet', type: 'text/css'}
 %script{src: webpack_asset_path('js/reference_guides/new.js'),
         data: {baseUrl: @base_url.to_json}}
 #form

--- a/dashboard/app/views/reference_guides/new.html.haml
+++ b/dashboard/app/views/reference_guides/new.html.haml
@@ -1,0 +1,4 @@
+%script{src: webpack_asset_path('js/reference_guides/new.js'),
+        data: {baseUrl: @base_url.to_json}}
+#form
+

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -304,11 +304,7 @@ Dashboard::Application.routes.draw do
       get 'get_rollup_resources'
     end
 
-    resources :reference_guides, only: [:show, :update, :destroy, :index], param: 'key', path: 'guides' do
-      member do
-        get 'edit'
-      end
-    end
+    resources :reference_guides, param: 'key', path: 'guides'
   end
 
   # CSP 20-21 lockable lessons with lesson plan redirects

--- a/dashboard/test/controllers/reference_guides_controller_test.rb
+++ b/dashboard/test/controllers/reference_guides_controller_test.rb
@@ -79,6 +79,7 @@ class ReferenceGuidesControllerTest < ActionController::TestCase
     editable_reference_guide = create :reference_guide, course_version: @unit_group.course_version
 
     sign_in @levelbuilder
+    File.expects(:delete).with {|filename, _| filename.to_s.end_with? "#{editable_reference_guide.key}.json"}.once
 
     post :destroy, params: {
       course_course_name: editable_reference_guide.course_offering_version,

--- a/dashboard/test/controllers/reference_guides_controller_test.rb
+++ b/dashboard/test/controllers/reference_guides_controller_test.rb
@@ -102,6 +102,26 @@ class ReferenceGuidesControllerTest < ActionController::TestCase
     assert_redirected_to "/courses/#{@reference_guide_subcategory.course_offering_version}/guides/#{@reference_guide_subcategory.key}"
   end
 
+  test 'data is passed to new' do
+    sign_in @levelbuilder
+
+    get :new, params: {
+      course_course_name: @reference_guide.course_offering_version
+    }
+    assert_response :ok
+  end
+
+  test 'create results in new reference guide' do
+    key = 'new-ref-guide'
+
+    sign_in @levelbuilder
+    File.expects(:write).with {|filename, _| filename.to_s.end_with? "#{key}.json"}.once
+
+    assert_creates(ReferenceGuide) do
+      post :create, params: {key: key, course_course_name: @unit_group.name}
+    end
+  end
+
   test_user_gets_response_for :show, params: -> {{course_course_name: @reference_guide.course_offering_version, key: 'unknown_ref_guide'}}, user: :student, response: :not_found
 
   # everyone can see basic reference guides
@@ -121,6 +141,12 @@ class ReferenceGuidesControllerTest < ActionController::TestCase
   test_user_gets_response_for :edit_all, params: -> {{course_course_name: @reference_guide.course_offering_version}}, user: :student, response: :forbidden
   test_user_gets_response_for :edit_all, params: -> {{course_course_name: @reference_guide.course_offering_version}}, user: :teacher, response: :forbidden
   test_user_gets_response_for :edit_all, params: -> {{course_course_name: @reference_guide.course_offering_version}}, user: :levelbuilder, response: :success
+
+  # new page is levelbuilder only
+  test_user_gets_response_for :new, params: -> {{course_course_name: @reference_guide.course_offering_version}}, user: nil, response: :redirect
+  test_user_gets_response_for :new, params: -> {{course_course_name: @reference_guide.course_offering_version}}, user: :student, response: :forbidden
+  test_user_gets_response_for :new, params: -> {{course_course_name: @reference_guide.course_offering_version}}, user: :teacher, response: :forbidden
+  test_user_gets_response_for :new, params: -> {{course_course_name: @reference_guide.course_offering_version}}, user: :levelbuilder, response: :success
 
   # pilot reference guides are restricted
   test_user_gets_response_for :show, name: 'not signed-in cannot view pilot ref guide',


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Adds a new ref guide form with just a key input that creates a blank ref guide and redirects to the edit page.
Also updates delete to make sure it deletes the seed file.


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- spec: [product spec](https://docs.google.com/document/d/1VZGle7QA-06ZNNxy2SkvA8Msrok8pyN7fuq5hzek888/edit)
- jira ticket: [PLAT-1719](https://codedotorg.atlassian.net/browse/PLAT-1719)

## Testing story

Added unit tests, manually tested

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

Use this to create overview pages

## Screenshots
![image](https://user-images.githubusercontent.com/82416901/164299265-45c695ce-518d-4efd-8ec4-11b79914289b.png)
