### PR TITLE
Add localhost.hourofcode.com to the allowed hosts in development envi…

### DIFF
--- a/dashboard/config/environments/development.rb
+++ b/dashboard/config/environments/development.rb
@@ -23,6 +23,7 @@ Dashboard::Application.configure do
   if config.respond_to?(:hosts)
     config.hosts << "localhost-studio.code.org"
     config.hosts << "localhost.code.org"
+    config.hosts << "localhost.hourofcode.com"
   end
 
   # Do not eager load code on boot.


### PR DESCRIPTION
When trying to navigate to localhost.hourofcode.com, I got the following Rails error

![blocked_host](https://user-images.githubusercontent.com/86268316/164320781-54037eae-3a55-45e9-81df-3ba0fa86949c.png)

A quick google search revealed that this is a Rails 6 thing, and has an equally [quick fix](https://www.fngtps.com/2019/rails6-blocked-host/). localhost.hourofcode.com works fine now!
