### PR TITLE
fix editing of encrypted levels

### DIFF
--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -141,7 +141,9 @@ class LevelsController < ApplicationController
   # GET /levels/1/edit
   def edit
     # Make sure that the encrypted property is a boolean
-    @level.properties['encrypted'] = @level.properties['encrypted'].to_bool if @level.properties['encrypted']
+    if @level.properties['encrypted']&.is_a?(String)
+      @level.properties['encrypted'] = @level.properties['encrypted'].to_bool
+    end
     @in_script = @level.script_levels.any?
     @standalone = ProjectsController::STANDALONE_PROJECTS.values.map {|h| h[:name]}.include?(@level.name)
     fb = FirebaseHelper.new('shared')

--- a/dashboard/test/controllers/levels_controller_test.rb
+++ b/dashboard/test/controllers/levels_controller_test.rb
@@ -635,6 +635,19 @@ class LevelsControllerTest < ActionController::TestCase
     assert_redirected_to "/"
   end
 
+  test 'can edit encrypted level' do
+    Rails.application.config.stubs(:levelbuilder_mode).returns true
+    sign_in @levelbuilder
+    level = create :multi, encrypted: true
+
+    get :edit, params: {id: level.id}
+    assert_response :success
+
+    level.update!(encrypted: 'true')
+    get :edit, params: {id: level.id}
+    assert_response :success
+  end
+
   test "should not create level if not levelbuilder" do
     [@not_admin, @admin].each do |user|
       sign_in user


### PR DESCRIPTION
One of the problems Ken ran into recently is that after lesson copy failed, when he tried to manually copy the level `csp-7-exam1-mod_2021` instead, he got an error page with this message:
![Screen Shot 2022-04-20 at 4 11 11 PM](https://user-images.githubusercontent.com/8001765/164341981-166f1ca4-7f29-42e6-b317-87d93dc66761.png)

this PR fixes the error, and adds a unit test to confirm the fix.

## Testing story

new unit test