### PR TITLE
Add two UI Test only PL Courses

### DIFF
--- a/dashboard/lib/tasks/seed.rake
+++ b/dashboard/lib/tasks/seed.rake
@@ -70,7 +70,9 @@ namespace :seed do
     'ui-test-script-in-course-2019',
     'ui-test-versioned-script-2017',
     'ui-test-versioned-script-2019',
-    'ui-test-csa-family-script'
+    'ui-test-csa-family-script',
+    'ui-test-teacher-pl-course',
+    'ui-test-facilitator-pl-course'
   ].map {|script| "test/ui/config/scripts_json/#{script}.script_json"}.freeze
   UI_TEST_SCRIPTS = SPECIAL_UI_TEST_SCRIPTS + [
     '20-hour',
@@ -291,7 +293,7 @@ namespace :seed do
   end
 
   timed_task course_offerings_ui_tests: :environment do
-    %w(ui-test-course ui-test-csa-family-script).each do |course_offering_name|
+    %w(ui-test-course ui-test-csa-family-script ui-test-teacher-pl-course ui-test-facilitator-pl-course).each do |course_offering_name|
       CourseOffering.seed_record("test/ui/config/course_offerings/#{course_offering_name}.json")
     end
   end

--- a/dashboard/test/ui/config/course_offerings/ui-test-facilitator-pl-course.json
+++ b/dashboard/test/ui/config/course_offerings/ui-test-facilitator-pl-course.json
@@ -1,0 +1,7 @@
+{
+  "key": "ui-test-facilitator-pl-course",
+  "display_name": "Facilitator PL Course",
+  "category": "pl_other",
+  "is_featured": false,
+  "assignable": true
+}

--- a/dashboard/test/ui/config/course_offerings/ui-test-teacher-pl-course.json
+++ b/dashboard/test/ui/config/course_offerings/ui-test-teacher-pl-course.json
@@ -1,0 +1,7 @@
+{
+  "key": "ui-test-teacher-pl-course",
+  "display_name": "Teacher PL Course",
+  "category": "pl_other",
+  "is_featured": false,
+  "assignable": true
+}

--- a/dashboard/test/ui/config/scripts_json/ui-test-facilitator-pl-course.script_json
+++ b/dashboard/test/ui/config/scripts_json/ui-test-facilitator-pl-course.script_json
@@ -1,0 +1,80 @@
+{
+  "script": {
+    "name": "ui-test-facilitator-pl-course",
+    "wrapup_video_id": null,
+    "login_required": false,
+    "properties": {
+      "is_course": true,
+      "is_migrated": true,
+      "version_year": "unversioned"
+    },
+    "new_name": null,
+    "family_name": "ui-test-facilitator-pl-course",
+    "serialized_at": "2022-04-20 20:08:14 UTC",
+    "published_state": "stable",
+    "instruction_type": "teacher_led",
+    "instructor_audience": "plc_reviewer",
+    "participant_audience": "facilitator",
+    "seeding_key": {
+      "script.name": "ui-test-facilitator-pl-course"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "ui-test-facilitator-pl-course"
+      }
+    }
+  ],
+  "lessons": [
+
+  ],
+  "lesson_activities": [
+
+  ],
+  "activity_sections": [
+
+  ],
+  "script_levels": [
+
+  ],
+  "levels_script_levels": [
+
+  ],
+  "resources": [
+
+  ],
+  "lessons_resources": [
+
+  ],
+  "scripts_resources": [
+
+  ],
+  "scripts_student_resources": [
+
+  ],
+  "vocabularies": [
+
+  ],
+  "lessons_vocabularies": [
+
+  ],
+  "lessons_programming_expressions": [
+
+  ],
+  "objectives": [
+
+  ],
+  "lessons_standards": [
+
+  ],
+  "lessons_opportunity_standards": [
+
+  ]
+}

--- a/dashboard/test/ui/config/scripts_json/ui-test-teacher-pl-course.script_json
+++ b/dashboard/test/ui/config/scripts_json/ui-test-teacher-pl-course.script_json
@@ -1,0 +1,80 @@
+{
+  "script": {
+    "name": "ui-test-teacher-pl-course",
+    "wrapup_video_id": null,
+    "login_required": false,
+    "properties": {
+      "is_course": true,
+      "is_migrated": true,
+      "version_year": "unversioned"
+    },
+    "new_name": null,
+    "family_name": "ui-test-teacher-pl-course",
+    "serialized_at": "2022-04-20 20:08:14 UTC",
+    "published_state": "stable",
+    "instruction_type": "teacher_led",
+    "instructor_audience": "facilitator",
+    "participant_audience": "teacher",
+    "seeding_key": {
+      "script.name": "ui-test-teacher-pl-course"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "ui-test-teacher-pl-course"
+      }
+    }
+  ],
+  "lessons": [
+
+  ],
+  "lesson_activities": [
+
+  ],
+  "activity_sections": [
+
+  ],
+  "script_levels": [
+
+  ],
+  "levels_script_levels": [
+
+  ],
+  "resources": [
+
+  ],
+  "lessons_resources": [
+
+  ],
+  "scripts_resources": [
+
+  ],
+  "scripts_student_resources": [
+
+  ],
+  "vocabularies": [
+
+  ],
+  "lessons_vocabularies": [
+
+  ],
+  "lessons_programming_expressions": [
+
+  ],
+  "objectives": [
+
+  ],
+  "lessons_standards": [
+
+  ],
+  "lessons_opportunity_standards": [
+
+  ]
+}


### PR DESCRIPTION
We are going to be adding a new UI test for creating pl sections and assigning pl courses. There are currently no launched PL courses and even if there were it would be best to use something that is consistent and will not change. This PR adds two new UI Test Only PL Courses (participant audience of teacher and facilitator) to be used in UI tests. These will only be seeded for UI tests.