### PR TITLE
Put new/moved ref guides at the end of list of siblings

### DIFF
--- a/dashboard/app/controllers/reference_guides_controller.rb
+++ b/dashboard/app/controllers/reference_guides_controller.rb
@@ -37,7 +37,7 @@ class ReferenceGuidesController < ApplicationController
       key: params[:key],
       display_name: params[:key],
       course_version_id: course_version_id,
-      position: 0
+      position: (find_last_child(course_version_id, nil)&.position || 0) + 1
     )
     if reference_guide.save
       reference_guide.write_serialization
@@ -49,7 +49,16 @@ class ReferenceGuidesController < ApplicationController
 
   # PATCH /courses/:course_name/guides/:key
   def update
-    @reference_guide.update!(reference_guide_params.except(:key, :course_course_name))
+    new_attributes = reference_guide_params.except(:key, :course_course_name)
+    # when updating the parent, move the reference guide to the end of that list of children
+    # so that it receives a unique position among its siblings
+    if @reference_guide.parent_reference_guide_key != new_attributes[:parent_reference_guide_key] && !new_attributes[:position]
+      new_attributes[:position] = (find_last_child(
+        @reference_guide.course_version_id,
+        new_attributes[:parent_reference_guide_key]
+        )&.position || 0) + 1
+    end
+    @reference_guide.update!(new_attributes)
     @reference_guide.write_serialization
     render json: @reference_guide.summarize_for_edit.to_json
   end
@@ -67,6 +76,13 @@ class ReferenceGuidesController < ApplicationController
   end
 
   private
+
+  def find_last_child(course_version_id, parent_key)
+    ReferenceGuide.
+      where(course_version_id: course_version_id, parent_reference_guide_key: parent_key).
+      order('position').
+      last
+  end
 
   def find_reference_guide
     course_version_id = find_matching_course_version(params[:course_course_name])&.id


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Currently, when new guides are added, their position is initialized to 0, which is usually the same as the first ref guide, and since we move guides around by swapping position values, we can't have any duplicate values. So this ensures we always set a unique value to the position field when creating new guides (or moving guides to new parents, which runs into the same issue).

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [PLAT-1719](https://codedotorg.atlassian.net/browse/PLAT-1719)

## Testing story

Tested locally, added tests