### PR TITLE
Allow reordering and deleting published activities with no levels

### DIFF
--- a/apps/src/lib/levelbuilder/lesson-editor/ActivityCard.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ActivityCard.jsx
@@ -93,6 +93,12 @@ class ActivityCard extends Component {
       allowMajorCurriculumChanges
     } = this.props;
 
+    let levelsInActivity = 0;
+    activity.activitySections.forEach(activitySection => {
+      levelsInActivity += activitySection.scriptLevels.length;
+    });
+    console.log(activity);
+
     return (
       <div className="uitest-activity-card">
         <div
@@ -129,7 +135,7 @@ class ActivityCard extends Component {
                   <span style={{fontSize: 10}}>{'(mins)'}</span>
                 </label>
               </div>
-              {allowMajorCurriculumChanges && (
+              {(allowMajorCurriculumChanges || levelsInActivity === 0) && (
                 <OrderControls
                   name={activity.displayName || 'Unnamed Activity'}
                   move={this.handleMoveActivity}

--- a/apps/src/lib/levelbuilder/lesson-editor/ActivityCard.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ActivityCard.jsx
@@ -97,7 +97,6 @@ class ActivityCard extends Component {
     activity.activitySections.forEach(activitySection => {
       levelsInActivity += activitySection.scriptLevels.length;
     });
-    console.log(activity);
 
     return (
       <div className="uitest-activity-card">

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/ActivityCardTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/ActivityCardTest.jsx
@@ -61,6 +61,56 @@ describe('ActivityCard', () => {
     expect(wrapper.find('button').length).to.equal(1);
   });
 
+  it('show OrderControls when not allowed to make major curriculum changes but there are no levels in activity', () => {
+    const activityWithNoLevels = {
+      key: 'activity-1',
+      displayName: 'Main Activity',
+      position: 1,
+      duration: 20,
+      activitySections: [
+        {
+          key: 'section-3',
+          position: 1,
+          displayName: 'Making programs',
+          duration: 10,
+          remarks: true,
+          scriptLevels: [],
+          text: 'Simple text',
+          tips: []
+        },
+        {
+          key: 'section-1',
+          position: 2,
+          displayName: '',
+          duration: 0,
+          remarks: false,
+          scriptLevels: [],
+          text: 'Details about this section',
+          tips: [
+            {
+              key: 'tip-1',
+              type: 'teachingTip',
+              markdown: 'Teaching tip content'
+            },
+            {
+              key: 'tip-2',
+              type: 'discussionGoal',
+              markdown: 'Discussion Goal content'
+            }
+          ]
+        }
+      ]
+    };
+    const wrapper = shallow(
+      <ActivityCard
+        {...defaultProps}
+        allowMajorCurriculumChanges={false}
+        activity={activityWithNoLevels}
+      />
+    );
+    expect(wrapper.find('OrderControls').length).to.equal(1);
+  });
+
   it('hides OrderControls when not allowed to make major curriculum changes', () => {
     const wrapper = shallow(
       <ActivityCard {...defaultProps} allowMajorCurriculumChanges={false} />


### PR DESCRIPTION
Allow deleting and reordering of activities in published lessons that have do not have any levels.

<img width="728" alt="Screen Shot 2022-04-22 at 10 25 01 AM" src="https://user-images.githubusercontent.com/208083/164735239-2ba387e9-d425-405c-90dc-1f69b0f266ea.png">
<img width="783" alt="Screen Shot 2022-04-22 at 10 24 54 AM" src="https://user-images.githubusercontent.com/208083/164735250-72315cc6-0b8f-402d-b6f9-97196ac8f535.png">

## Links

[Slack](https://codedotorg.slack.com/archives/C02EEGWLHR8/p1650581645001669)

## Testing story

- New unit test