### PR TITLE
Make sure get selected unit if its not the last in the list

### DIFF
--- a/apps/src/redux/unitSelectionRedux.js
+++ b/apps/src/redux/unitSelectionRedux.js
@@ -20,11 +20,14 @@ const getSelectedUnit = state => {
     return null;
   }
 
-  let script;
+  let unit;
   state.unitSelection.coursesWithProgress.forEach(course => {
-    script = course.units.find(unit => scriptId === unit.id);
+    const tempUnit = course.units.find(unit => scriptId === unit.id);
+    if (tempUnit) {
+      unit = tempUnit;
+    }
   });
-  return script;
+  return unit;
 };
 
 export const getSelectedScriptName = state => {

--- a/apps/test/unit/redux/unitSelectionReduxTest.js
+++ b/apps/test/unit/redux/unitSelectionReduxTest.js
@@ -20,11 +20,11 @@ describe('unitSelectionRedux', () => {
     it('returns the script name of the selected script', () => {
       const state = {
         unitSelection: {
-          scriptId: 9,
+          scriptId: 5,
           coursesWithProgress: fakeCoursesWithProgress
         }
       };
-      assert.equal(getSelectedScriptName(state), 'flappy');
+      assert.equal(getSelectedScriptName(state), 'csd1-2018');
     });
 
     it('returns null if no script is selected', () => {


### PR DESCRIPTION
Eyes test caught that the name of the unit selected in the unit selector dropdown was not showing correctly on the progress tab. This was because as we looped through the list of courses we would reset the found unit to undefined if it was not in the last course in the list. Now we don't set the unit unless we find it to prevent this issue. 

<img width="572" alt="Screen Shot 2022-04-22 at 11 15 51 AM" src="https://user-images.githubusercontent.com/208083/164743834-f16791ed-9630-44ed-a776-8c1cd69c8d5b.png">

## Testing story

- Updated tests to not always use the last script in the list