### PR TITLE
fix sublevel name collisions during level group copy

### DIFF
--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -653,7 +653,7 @@ class Level < ApplicationRecord
     level = Level.find_by_name(new_name)
     if level
       return level if allow_existing
-      new_name = Level.next_unused_name(prefix, suffix)
+      new_name = next_unused_name_for_copy(suffix)
     end
 
     begin
@@ -686,11 +686,16 @@ class Level < ApplicationRecord
     end
   end
 
-  # Returns the first level name of the form "<prefix>_copy<num>_<suffix>" which
+  COPY_SUFFIX_LENGTH = 8 # '_copy999'.length
+
+  # Returns the first level name of the form "<base_name>_copy<num>_<suffix>" which
   # is not already used by another level.
-  # @param [String] prefix
   # @param [String] suffix
-  def self.next_unused_name(prefix, suffix)
+  def next_unused_name_for_copy(suffix)
+    # Make sure we don't go over the 70 character limit.
+    max_index = 70 - COPY_SUFFIX_LENGTH - suffix.length - 1
+    prefix = base_name[0..max_index]
+
     i = 1
     loop do
       new_name = "#{prefix}_copy#{i}#{suffix}"

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -646,7 +646,8 @@ class Level < ApplicationRecord
     max_index = 70 - suffix.length - 1
     new_name = "#{base_name[0..max_index]}#{suffix}"
 
-    return Level.find_by_name(new_name) if Level.find_by_name(new_name)
+    level = Level.find_by_name(new_name)
+    return level if level
 
     begin
       level = clone_with_name(new_name, editor_experiment: editor_experiment)

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -662,11 +662,9 @@ class Level < ApplicationRecord
       update_params = {name_suffix: suffix}
       update_params[:editor_experiment] = editor_experiment if editor_experiment
 
-      # The clone_child_levels method does not work adequately for LevelGroup
-      # levels because the update_params it returns do not include an updated
-      # copy of levels_and_texts_per_page, nor does it rewrite the .level_group
-      # file. instead, it relies on LevelGroup#clone_sublevels_with_suffix to
-      # take care of these.
+      # Cloning of level group sublevels is handled by
+      # LevelGroup.clone_sublevels_with_suffix. In order to be able to customize
+      # that cloning logic, we must skip initially cloning child levels here.
       unless is_a? LevelGroup
         child_params_to_update = Level.clone_child_levels(level, new_suffix, editor_experiment: editor_experiment)
         update_params.merge!(child_params_to_update)

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -655,8 +655,15 @@ class Level < ApplicationRecord
       update_params = {name_suffix: suffix}
       update_params[:editor_experiment] = editor_experiment if editor_experiment
 
-      child_params_to_update = Level.clone_child_levels(level, new_suffix, editor_experiment: editor_experiment)
-      update_params.merge!(child_params_to_update)
+      # The clone_child_levels method does not work adequately for LevelGroup
+      # levels because the update_params it returns do not include an updated
+      # copy of levels_and_texts_per_page, nor does it rewrite the .level_group
+      # file. instead, it relies on LevelGroup#clone_sublevels_with_suffix to
+      # take care of these.
+      unless is_a? LevelGroup
+        child_params_to_update = Level.clone_child_levels(level, new_suffix, editor_experiment: editor_experiment)
+        update_params.merge!(child_params_to_update)
+      end
 
       level.update!(update_params)
 

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -668,7 +668,7 @@ class Level < ApplicationRecord
 
       level
     rescue Exception => e
-      raise e, "Failed to clone #{name} as #{new_name}. Message: #{e.message}", e.backtrace
+      raise e, "Failed to clone Level #{name.inspect} as #{new_name.inspect}. Message:\n#{e.message}", e.backtrace
     end
   end
 

--- a/dashboard/app/models/levels/level_group.rb
+++ b/dashboard/app/models/levels/level_group.rb
@@ -180,7 +180,7 @@ class LevelGroup < DSLDefined
       level.rewrite_dsl_file(LevelGroupDSL.serialize(level))
       level
     rescue Exception => e
-      raise e, "Failed to clone #{name} as #{new_name}. Message: #{e.message}"
+      raise e, "Failed to clone LevelGroup #{name.inspect} as #{new_name.inspect}. Message:\n#{e.message}", e.backtrace
     end
   end
 

--- a/dashboard/app/models/levels/level_group.rb
+++ b/dashboard/app/models/levels/level_group.rb
@@ -190,7 +190,7 @@ class LevelGroup < DSLDefined
   # e.g. [[Multi<id:1>, Match<id:2>],[External<id:4>,FreeResponse<id:4>]]
   def clone_sublevels_with_suffix(old_levels_and_texts_by_page, new_suffix)
     new_levels_and_texts_by_page = old_levels_and_texts_by_page.map do |levels_and_texts|
-      levels_and_texts.map {|level| level.clone_with_suffix(new_suffix)}
+      levels_and_texts.map {|level| level.clone_with_suffix(new_suffix, allow_existing: false)}
     end
     update_levels_and_texts_by_page(new_levels_and_texts_by_page)
   end

--- a/dashboard/app/models/parent_levels_child_level.rb
+++ b/dashboard/app/models/parent_levels_child_level.rb
@@ -36,7 +36,7 @@
 class ParentLevelsChildLevel < ApplicationRecord
   belongs_to :parent_level, class_name: 'Level'
   belongs_to :child_level, class_name: 'Level'
-  validates_uniqueness_of :child_level, scope: :parent_level
+  validates_uniqueness_of :child_level, scope: :parent_level, message: ->(plcl, _data) {"child_level #{plcl.child_level&.name&.dump} is already taken for parent_level #{plcl.parent_level&.name&.dump}"}
 
   default_scope {order(position: :asc)}
 

--- a/dashboard/test/models/level_group_test.rb
+++ b/dashboard/test/models/level_group_test.rb
@@ -271,6 +271,46 @@ MARKDOWN
     assert_equal 'level1_copy', page.levels.first.name
   end
 
+  test 'clone with suffix when sublevel names conflict after stripping version year' do
+    level_group_input_dsl = <<~DSL
+      name 'my level group'
+      page
+      level 'conflicting-level-a-2018'
+      level 'conflicting-level-b-2019'
+
+    DSL
+    expected_copy_dsl = <<~DSL.strip
+      name 'my level group_copy'
+
+      page
+      level 'conflicting-level-a_copy'
+      level 'conflicting-level-b_copy'
+    DSL
+
+    # Create the sublevels.
+    create :free_response, name: 'conflicting-level-a-2018'
+    create :free_response, name: 'conflicting-level-b-2019'
+
+    # Create the level_group.
+    level_group = LevelGroup.create_from_level_builder({}, {name: 'my_level_group', dsl_text: level_group_input_dsl})
+    File.stubs(:exist?).with {|filepath| filepath.basename.to_s == 'my_level_group.level_group'}.returns(true)
+    File.stubs(:read).with {|filepath| filepath.basename.to_s == 'my_level_group.level_group'}.returns(level_group_input_dsl)
+
+    File.stubs(:write).with do |filepath, actual_dsl|
+      filepath.basename.to_s == 'my_level_group_copy.level_group' &&
+        actual_dsl == expected_copy_dsl
+    end.once
+
+    # Copy the level group and all its sub levels.
+    level_group_copy = level_group.clone_with_suffix('_copy')
+
+    # Verify the result
+    assert_equal 'my level group_copy', level_group_copy.name
+    assert_equal 1, level_group_copy.pages.count
+    page = level_group_copy.pages.first
+    assert_equal ['conflicting-level-a_copy', 'conflicting-level-b_copy'], page.levels.map(&:name)
+  end
+
   # Test that clone_with_suffix performs a deep copy of a LevelGroup, and the
   # copy has the correct dsl text.
   test 'clone level group with suffix' do

--- a/dashboard/test/models/level_group_test.rb
+++ b/dashboard/test/models/level_group_test.rb
@@ -275,21 +275,21 @@ MARKDOWN
     level_group_input_dsl = <<~DSL
       name 'my level group'
       page
-      level 'conflicting-level-a-2018'
-      level 'conflicting-level-b-2019'
+      level 'conflicting-level-2018'
+      level 'conflicting-level-2019'
 
     DSL
     expected_copy_dsl = <<~DSL.strip
-      name 'my level group_copy'
+      name 'my level group_2020'
 
       page
-      level 'conflicting-level-a_copy'
-      level 'conflicting-level-b_copy'
+      level 'conflicting-level_2020'
+      level 'conflicting-level_copy1_2020'
     DSL
 
     # Create the sublevels.
-    create :free_response, name: 'conflicting-level-a-2018'
-    create :free_response, name: 'conflicting-level-b-2019'
+    create :free_response, name: 'conflicting-level-2018'
+    create :free_response, name: 'conflicting-level-2019'
 
     # Create the level_group.
     level_group = LevelGroup.create_from_level_builder({}, {name: 'my_level_group', dsl_text: level_group_input_dsl})
@@ -297,18 +297,18 @@ MARKDOWN
     File.stubs(:read).with {|filepath| filepath.basename.to_s == 'my_level_group.level_group'}.returns(level_group_input_dsl)
 
     File.stubs(:write).with do |filepath, actual_dsl|
-      filepath.basename.to_s == 'my_level_group_copy.level_group' &&
+      filepath.basename.to_s == 'my_level_group_2020.level_group' &&
         actual_dsl == expected_copy_dsl
     end.once
 
     # Copy the level group and all its sub levels.
-    level_group_copy = level_group.clone_with_suffix('_copy')
+    level_group_copy = level_group.clone_with_suffix('_2020')
 
     # Verify the result
-    assert_equal 'my level group_copy', level_group_copy.name
+    assert_equal 'my level group_2020', level_group_copy.name
     assert_equal 1, level_group_copy.pages.count
     page = level_group_copy.pages.first
-    assert_equal ['conflicting-level-a_copy', 'conflicting-level-b_copy'], page.levels.map(&:name)
+    assert_equal ['conflicting-level_2020', 'conflicting-level_copy1_2020'], page.levels.map(&:name)
   end
 
   # Test that clone_with_suffix performs a deep copy of a LevelGroup, and the

--- a/dashboard/test/models/level_test.rb
+++ b/dashboard/test/models/level_test.rb
@@ -1232,12 +1232,24 @@ class LevelTest < ActiveSupport::TestCase
     assert_not level_with_contained.can_have_feedback_review_state?
   end
 
-  test 'next_unused_name' do
-    assert_equal 'unused_copy1_2020', Level.next_unused_name('unused', '_2020')
+  test 'next_unused_name_for_copy finds next available level name' do
+    level = create :level, name: 'my-level'
+    assert_equal 'my-level_copy1_2020', level.next_unused_name_for_copy('_2020')
 
     create :level, name: 'my-level_copy1_2020'
     create :level, name: 'my-level_copy2_2020'
     create :level, name: 'my-level_copy4_2020'
-    assert_equal 'my-level_copy3_2020', Level.next_unused_name('my-level', '_2020')
+    assert_equal 'my-level_copy3_2020', level.next_unused_name_for_copy('_2020')
+  end
+
+  test 'next_unused_name_for_copy returns name under the maximum length' do
+    long_name = 'abcdefghij123456789012345678901234567890123456789012345678901234567890'
+    assert_equal 70, long_name.length
+    level = create :level, name: long_name
+    next_name = level.next_unused_name_for_copy('_2020')
+
+    # the maximum is 70. allow a little extra room for longer numbers.
+    assert next_name.length <= 68
+    assert next_name.match /_copy1_2020$/
   end
 end

--- a/dashboard/test/models/level_test.rb
+++ b/dashboard/test/models/level_test.rb
@@ -1087,6 +1087,21 @@ class LevelTest < ActiveSupport::TestCase
     assert_equal 'new-level-editors', new_level.editor_experiment
   end
 
+  test 'clone with suffix uses existing levels when level names match' do
+    existing_level = create :level, name: 'old level_2020'
+    old_level = create :level, name: 'old level'
+    new_level = old_level.clone_with_suffix('_2020')
+    assert_equal existing_level, new_level
+  end
+
+  test 'clone with suffix does not use exactly levels when allow_existing is false' do
+    existing_level = create :level, name: 'old level_2020'
+    old_level = create :level, name: 'old level'
+    new_level = old_level.clone_with_suffix('_2020', allow_existing: false)
+    refute_equal existing_level, new_level
+    assert_equal 'old level_copy1_2020', new_level.name
+  end
+
   test 'contained_level_names filters blank names before validation' do
     level = build :level
     create :level, name: 'real_name'

--- a/dashboard/test/models/level_test.rb
+++ b/dashboard/test/models/level_test.rb
@@ -1231,4 +1231,13 @@ class LevelTest < ActiveSupport::TestCase
 
     assert_not level_with_contained.can_have_feedback_review_state?
   end
+
+  test 'next_unused_name' do
+    assert_equal 'unused_copy1_2020', Level.next_unused_name('unused', '_2020')
+
+    create :level, name: 'my-level_copy1_2020'
+    create :level, name: 'my-level_copy2_2020'
+    create :level, name: 'my-level_copy4_2020'
+    assert_equal 'my-level_copy3_2020', Level.next_unused_name('my-level', '_2020')
+  end
 end


### PR DESCRIPTION
## Background

Finishes [PLAT-1764](https://codedotorg.atlassian.net/browse/PLAT-1764). After adding some details to the error logging, here is the error when copying the lesson https://levelbuilder-studio.code.org/s/csp7-2021/lessons/11 using the suffix `dave`:
```
Failed to clone LevelGroup "CSP Unit 7 AP-Style Assessment _2021" as "CSP Unit 7 AP-Style Assessment _dave". Message:
Failed to clone Level "CSP Unit 7 AP-Style Assessment _2021" as "CSP Unit 7 AP-Style Assessment _dave". Message:
Validation failed: Child level child_level "csp-7-exam1-mod_dave" is already taken for parent_level "CSP Unit 7 AP-Style Assessment _dave"
```
The lesson contains a single level group, and the problem is that we are trying to add the same level as a child of the new level group twice. this happens because we [strip old version year suffixes](https://github.com/code-dot-org/code-dot-org/blob/a5053af23b6edda8cd60ba5ff8970b496de26277/dashboard/app/models/levels/level.rb#L802-L809) before we add the new suffix, so these two level names end up colliding:
* `csp-7-exam1-mod-2020_2021`
* `csp-7-exam1-mod_2022`

ordinarily, when trying to clone a level to a name that exists already, we'll simply reuse the existing level. however, in this case, because they are both children of the same LevelGroup, we hit this validation error: https://github.com/code-dot-org/code-dot-org/blob/bc75047f27d933e1807676c9b9103e86989ac1ed/dashboard/app/models/parent_levels_child_level.rb#L39

## Description

This PR solves the problem by making it so that whenever we deep copy a level group via `clone_with_suffix`, we make sure to always create a new copy of each sublevel, rather than ever using an existing level name. The work for this is mostly contained in b580e7a973d67a1008d7a159b767ccedf47a0abf -- the other commits are for refactoring and keeping other things from breaking.

In order to accomplish this, the other noteworthy change here is to stop calling `Level.clone_child_levels` for level group levels (2b3103bf182f4648299a5691b46c3333673f17e1), which was duplicating some of the work of copying child levels. See comments in that commit (and in a5053af23b6edda8cd60ba5ff8970b496de26277) for context.

## Testing story

added new unit tests. also verified the problem lesson can now successfully be copied.

## Follow-up work

Dave to work with Tess to share out this change in behavior to curriculum writers.