### PR TITLE
Bump @code-dot-org/piskel to 0.13.0-cdo.9

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -61,7 +61,7 @@
     "@code-dot-org/ml-activities": "0.0.26",
     "@code-dot-org/ml-playground": "0.0.39",
     "@code-dot-org/p5.play": "^1.3.20-cdo",
-    "@code-dot-org/piskel": "0.13.0-cdo.8",
+    "@code-dot-org/piskel": "0.13.0-cdo.9",
     "@code-dot-org/redactable-markdown": "0.4.0",
     "@react-bootstrap/pagination": "^1.0.0",
     "@storybook/addon-actions": "^4.1.16",

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -1688,10 +1688,10 @@
     opentype.js "^0.4.9"
     reqwest "^1.1.5"
 
-"@code-dot-org/piskel@0.13.0-cdo.8":
-  version "0.13.0-cdo.8"
-  resolved "https://registry.yarnpkg.com/@code-dot-org/piskel/-/piskel-0.13.0-cdo.8.tgz#085226f893790d36c56bef010659f2144093c6a9"
-  integrity sha512-cVfDjshCctXNtCU+VKKf2RZGXABkal59K06ZTBhfBWd7qAJGx6BL1yeRx4iO8tsKrSK425rNrXiIHO+IDLEV5A==
+"@code-dot-org/piskel@0.13.0-cdo.9":
+  version "0.13.0-cdo.9"
+  resolved "https://registry.yarnpkg.com/@code-dot-org/piskel/-/piskel-0.13.0-cdo.9.tgz#84b8ad23bd73e2821229061fa1bcb52e461236de"
+  integrity sha512-BhbuhlxFkXd3+OmnaK9DGIOY+v6qMLH3UJmkBBAF9SEh88mb+MMvT/vXT8Txv1b4/RrnXZJD1nEMUsya5gx3vQ==
   dependencies:
     messageformat "^2.3.0"
 


### PR DESCRIPTION
Bumps @code-dot-org/piskel to 0.13.0-cdo.9 ([version comparison](https://github.com/code-dot-org/piskel/compare/v0.13.0-cdo.8...v0.13.0-cdo.)). New version includes very small change to remove unsupported browser alert for Safari: https://github.com/code-dot-org/piskel/pull/53

## Links

[Jira Ticket](https://codedotorg.atlassian.net/browse/STAR-1892)
