### PR TITLE
allowing teachers to additionally leave Clever and Google managed sections

### DIFF
--- a/apps/src/templates/studioHomepages/SectionsAsStudentTable.jsx
+++ b/apps/src/templates/studioHomepages/SectionsAsStudentTable.jsx
@@ -116,19 +116,17 @@ class SectionsAsStudentTable extends React.Component {
               </td>
               {canLeave && (
                 <td style={{...styles.col, ...styles.leaveCol}}>
-                  {!/^(C|G)-/.test(section.code) && (
-                    <Button
-                      __useDeprecatedTag
-                      style={{marginLeft: 5}}
-                      text={i18n.leaveSection()}
-                      onClick={this.onLeave.bind(
-                        this,
-                        section.code,
-                        section.name
-                      )}
-                      color={Button.ButtonColor.gray}
-                    />
-                  )}
+                  <Button
+                    __useDeprecatedTag
+                    style={{marginLeft: 5}}
+                    text={i18n.leaveSection()}
+                    onClick={this.onLeave.bind(
+                      this,
+                      section.code,
+                      section.name
+                    )}
+                    color={Button.ButtonColor.gray}
+                  />
                 </td>
               )}
             </tr>


### PR DESCRIPTION
Jira: https://codedotorg.atlassian.net/browse/FND-1971

This PR removes the condition on section codes in "Joined Sections," such that teachers can now leave any section, including Google- and Clever-managed sections.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
