### PR TITLE
Javalab: Display throttling/authorizer error messages

### DIFF
--- a/apps/src/javalab/JavabuilderConnection.js
+++ b/apps/src/javalab/JavabuilderConnection.js
@@ -149,7 +149,7 @@ export default class JavabuilderConnection {
     // only do so once we've sent a message. This is a bit of a hack, but this should only
     // happen if our token was somehow valid for the initial Javabuilder HTTP request and
     // then became invalid when establishing the WebSocket connection.
-    this.sendMessage('connected');
+    this.sendMessage(WebSocketMessageType.CONNECTED);
     this.miniApp?.onCompile?.();
   }
 

--- a/apps/src/javalab/constants.js
+++ b/apps/src/javalab/constants.js
@@ -20,7 +20,8 @@ export const WebSocketMessageType = {
   DEBUG: 'DEBUG',
   STATUS: 'STATUS',
   TEST_RESULT: 'TEST_RESULT',
-  AUTHORIZER: 'AUTHORIZER'
+  AUTHORIZER: 'AUTHORIZER',
+  CONNECTED: 'CONNECTED'
 };
 
 export const JavabuilderExceptionType = {

--- a/dashboard/app/controllers/javabuilder_sessions_controller.rb
+++ b/dashboard/app/controllers/javabuilder_sessions_controller.rb
@@ -60,10 +60,13 @@ class JavabuilderSessionsController < ApplicationController
   private
 
   def upload_project_files_and_render(session_id, project_files, encoded_payload)
-    success = JavalabFilesHelper.upload_project_files(project_files, request.host, encoded_payload)
-    success ?
-      render(json: {token: encoded_payload, session_id: session_id}) :
-      render(status: :internal_server_error, json: {error: "Error uploading sources."})
+    response = JavalabFilesHelper.upload_project_files(project_files, request.host, encoded_payload)
+    if response
+      return render(json: {token: encoded_payload, session_id: session_id}) if response.code == '200'
+      return render(status: response.code, json: response.body)
+    else
+      return render(status: :internal_server_error, json: {error: "Error uploading sources."})
+    end
   end
 
   def get_encoded_payload(additional_payload)

--- a/dashboard/app/helpers/javalab_files_helper.rb
+++ b/dashboard/app/helpers/javalab_files_helper.rb
@@ -9,9 +9,9 @@ module JavalabFilesHelper
     response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == 'https') do |http|
       http.request(upload_request)
     end
-    response.code == '200'
+    return response
   rescue StandardError
-    false
+    nil
   end
 
   # Get all files related to the project at the given channel id as a hash.

--- a/dashboard/test/controllers/javabuilder_sessions_controller_test.rb
+++ b/dashboard/test/controllers/javabuilder_sessions_controller_test.rb
@@ -13,7 +13,8 @@ class JavabuilderSessionsControllerTest < ActionController::TestCase
     JavalabFilesHelper.stubs(:get_project_files).returns({})
     JavalabFilesHelper.stubs(:get_project_files_with_override_sources).returns({})
     JavalabFilesHelper.stubs(:get_project_files_with_override_validation).returns({})
-    JavalabFilesHelper.stubs(:upload_project_files).returns(true)
+    put_response = Net::HTTPResponse.new(nil, '200', nil)
+    JavalabFilesHelper.stubs(:upload_project_files).returns(put_response)
   end
 
   test_user_gets_response_for :get_access_token,
@@ -156,7 +157,7 @@ class JavabuilderSessionsControllerTest < ActionController::TestCase
   end
 
   test 'returns error if upload fails' do
-    JavalabFilesHelper.stubs(:upload_project_files).returns(false)
+    JavalabFilesHelper.stubs(:upload_project_files).returns(nil)
     levelbuilder = create :levelbuilder
     sign_in(levelbuilder)
     get :get_access_token, params: {channelId: @fake_channel_id, levelId: 261, executionType: 'RUN', miniAppType: 'console'}


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

This allows us to interpret and display authorizer error messages from Javalab. In the case of errors that occur when trying to make the put sources request, this is fairly straightforward; if we get back an error response, we pass it on to Javalab which in turn pulls out the error message key and translates it.

For errors that occur when making the websocket connection, this is a little bit more convoluted. Unfortunately, we can't get back the full error message from Javabuilder when opening the connection, as the browser doesn't parse the error response body. Instead, Javabuilder allows us to successfully connect, but then sends a message containing the authorization error body. To do this though, Javalab first needs to send a message to Javabuilder once the connection has opened so that Javabuilder is notified that the connection has been made. See [this PR](https://github.com/code-dot-org/javabuilder/pull/281) for more details.

![Screen Shot 2022-04-22 at 11 04 57 AM](https://user-images.githubusercontent.com/85528507/165157265-f3e6f52b-e1a9-4af9-9103-a020c4d18c9c.png)

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Tested using localhost against dev Javabuilder

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
