### PR TITLE
The Bad Guys promo followup work

### DIFF
--- a/apps/src/templates/projects/ProjectsPromo.jsx
+++ b/apps/src/templates/projects/ProjectsPromo.jsx
@@ -6,7 +6,7 @@ import color from '@cdo/apps/util/color';
 import DCDO from '@cdo/apps/dcdo';
 
 const ProjectsPromo = () => {
-  if (!!DCDO.get('thebadguys-promotion', false)) {
+  if (!!DCDO.get('thebadguys-projects-page', false)) {
     return (
       <TwoColumnActionBlock
         imageUrl={pegasus(

--- a/pegasus/cache/i18n/en-US.yml
+++ b/pegasus/cache/i18n/en-US.yml
@@ -369,6 +369,7 @@
   homepage_slot_text_blurb_students_courses: "Explore our courses"
   homepage_slot_text_link_codestudio: "Try Code Studio"
   homepage_slot_text_link_local: "Find a local class"
+  homepage_slot_text_link_thebadguys: "Code with The Bad Guys"
   homepage_slot_text_link_othercourses: "Other online courses"
   homepage_slot_text_title_educators: "Educators"
   homepage_slot_text_blurb_educators: "Teach your students"

--- a/pegasus/sites.v3/code.org/public/badguys.redirect
+++ b/pegasus/sites.v3/code.org/public/badguys.redirect
@@ -1,0 +1,1 @@
+/thebadguys

--- a/pegasus/src/homepage.rb
+++ b/pegasus/src/homepage.rb
@@ -342,8 +342,8 @@ class Homepage
                 url: CDO.studio_url("/")
               },
               {
-                text: "homepage_slot_text_link_local",
-                url: "/learn/local"
+                text: "homepage_slot_text_link_thebadguys",
+                url: "/thebadguys"
               },
               {
                 text: "homepage_slot_text_link_othercourses",


### PR DESCRIPTION
Increase the visibility of The Bad Guys project on the site after the homepage banner was removed.

**Related PR w/ DCDO fix:** https://github.com/code-dot-org/code-dot-org/pull/46019

1. Show The Bad Guys banner on the [Projects page](https://studio.code.org/projects/public) without showing The Bad Guys banner on the homepage when the DCDO flag `"thebadguys-projects-page"` is set to `true`. Previously, both banners were set with the DCDO flag `"thebadguys-promotion"` from [this PR](https://github.com/code-dot-org/code-dot-org/pull/45672). 

With flag:
<img width="1008" alt="161881533-2b952d49-d566-4f09-a857-8f4a4edcf733" src="https://user-images.githubusercontent.com/9256643/165188800-f17a12f5-d8ec-4523-bb76-8e5b99fb4e2a.png">

Without flag:
<img width="1005" alt="161881520-154313bc-5da5-4eb7-a11c-af5e916bae34" src="https://user-images.githubusercontent.com/9256643/165188912-c97e711b-b3c2-41f3-b4b2-c99da8737590.png">

2. Add a link on the [homepage](https://code.org/) in the Students section
<img width="269" alt="Screen Shot 2022-04-25 at 4 19 12 PM" src="https://user-images.githubusercontent.com/9256643/165189907-1c2a0855-4190-47de-a21c-88be7f52a5fa.png">