### PR TITLE
Remove Some Pre-Rails-5 Logic

### DIFF
--- a/dashboard/app/controllers/api/v1/peer_review_submissions_controller.rb
+++ b/dashboard/app/controllers/api/v1/peer_review_submissions_controller.rb
@@ -37,10 +37,9 @@ class Api::V1::PeerReviewSubmissionsController < ApplicationController
           # constrained by our join to the set of users submitting for peer review, which is below
           # 500 as of August 2019, and the total number of peer_reviews rows being examined post-join
           # does not exceed 20,000 at this time.
-          # sanitize_sql_like will be public in Rails 5.2+
           reviews.
             joins(:submitter).
-            where("users.name LIKE ?", "%#{PeerReview.send(:sanitize_sql_like, user_query)}%")
+            where("users.name LIKE ?", "%#{PeerReview.sanitize_sql_like(user_query)}%")
         end
     end
 

--- a/dashboard/app/controllers/application_controller.rb
+++ b/dashboard/app/controllers/application_controller.rb
@@ -94,9 +94,10 @@ class ApplicationController < ActionController::Base
   def prevent_caching
     # Rails has some logic to normalize the cache-control header that varies
     # from version to version. Ideally, we would include 'no-cache' here but
-    # that causes Rails 5.2 to remove 'must-revalidate' which causes issues
-    # on older mobile Safari browsers. See Rails logic at
-    # https://github.com/rails/rails/blob/v5.2.4.4/actionpack/lib/action_dispatch/http/cache.rb#L185
+    # that causes Rails (starting in 5.2, still true as of 6.0) to remove
+    # 'must-revalidate' which causes issues on older mobile Safari browsers.
+    # See Rails logic at
+    # https://github.com/rails/rails/blob/v6.0.4.4/actionpack/lib/action_dispatch/http/cache.rb#L184
     response.headers["Cache-Control"] = "no-store, max-age=0, must-revalidate"
     response.headers["Pragma"] = "no-cache"
     response.headers["Expires"] = "Fri, 01 Jan 1990 00:00:00 GMT"


### PR DESCRIPTION
Specifically, logic that we had in place prior to the upgrade to Rails 5 which we no longer need following the several upgrades we've had since.

Also update the comment for one piece of logic which we DO still need.

## Testing Story

Relying on existing unit tests to verify that this will not result in any functional changes

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
