### PR TITLE
improve error message when lesson key is not unique

### DIFF
--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -85,7 +85,9 @@ class Lesson < ApplicationRecord
   # absolute_position of 3 but a relative_position of 1
   acts_as_list scope: :script, column: :absolute_position
 
-  validates_uniqueness_of :key, scope: :script_id
+  validates_uniqueness_of :key, scope: :script_id, message: ->(object, _data) do
+    "lesson with key #{object.key.inspect} is already taken within unit #{object.script&.name.inspect}"
+  end
 
   include CodespanOnlyMarkdownHelper
 

--- a/dashboard/test/models/lesson_test.rb
+++ b/dashboard/test/models/lesson_test.rb
@@ -1201,12 +1201,23 @@ class LessonTest < ActiveSupport::TestCase
       assert_equal 2, copied_lesson.relative_position
     end
 
-    test 'unit cannot have two lessons with the same name' do
+    test 'unit cannot have two lessons with the same key' do
       unit = create :script, :with_lessons, name: 'unit-name'
       e = assert_raises do
         unit.lessons.last.update!(key: unit.lessons.first.key)
       end
       assert_includes e.message, "lesson with key \"#{unit.lessons.first.key}\" is already taken within unit \"unit-name\""
+    end
+
+    test 'cannot clone lesson when lesson name is already taken' do
+      create :lesson, lesson_group: @destination_lesson_group, key: 'conflicting-key'
+      @destination_script.reload
+      # cloning uses the original lesson name as the new lesson key
+      @original_lesson.update!(name: 'conflicting-key')
+      e = assert_raises do
+        @original_lesson.copy_to_unit(@destination_script)
+      end
+      assert_includes e.message, "lesson with key \"conflicting-key\" is already taken within unit \"#{@destination_script.name}\""
     end
 
     test "creates lesson group if script has none" do

--- a/dashboard/test/models/lesson_test.rb
+++ b/dashboard/test/models/lesson_test.rb
@@ -1201,6 +1201,14 @@ class LessonTest < ActiveSupport::TestCase
       assert_equal 2, copied_lesson.relative_position
     end
 
+    test 'unit cannot have two lessons with the same name' do
+      unit = create :script, :with_lessons, name: 'unit-name'
+      e = assert_raises do
+        unit.lessons.last.update!(key: unit.lessons.first.key)
+      end
+      assert_includes e.message, "lesson with key \"#{unit.lessons.first.key}\" is already taken within unit \"unit-name\""
+    end
+
     test "creates lesson group if script has none" do
       @destination_script.lesson_groups = []
 


### PR DESCRIPTION
Finishes [PLAT-1756](https://codedotorg.atlassian.net/browse/PLAT-1756).

### before
![Screen Shot 2022-04-27 at 12 12 19 PM](https://user-images.githubusercontent.com/8001765/165602003-fa9f24b3-2835-4f8e-baf9-9d1cc83ee3c3.png)

### after
![Screen Shot 2022-04-27 at 12 15 06 PM](https://user-images.githubusercontent.com/8001765/165602445-f221413d-dd1a-4454-b3fb-86d56dd9e9ba.png)

it's a little weird that it says "key lesson with key ...." because the first "key" is redundant / out of place. this is due to a quirk of how activerecord validations work that we've generally lived with for levelbuilder error messages, but I'm open to suggestions for how to improve it.

## Testing story

* manual verification shown in screenshots
* unit tests for both `lesson.update!` and `lesson.copy_to_unit`