### PR TITLE
start serializing lesson name in LessonCrowdinSerializer

### DIFF
--- a/dashboard/lib/services/i18n/curriculum_sync_utils/serializers.rb
+++ b/dashboard/lib/services/i18n/curriculum_sync_utils/serializers.rb
@@ -139,11 +139,8 @@ module Services
       end
 
       class LessonCrowdinSerializer < CrowdinSerializer
-        # Note that we don't include "name" here, because that's already
-        # handled by existing logic. We could in the future consider moving
-        # that (and possibly script stuff, too) out of whereever it exists
-        # and into this logic.
         attributes(
+          :name,
           :overview,
           :preparation,
           :purpose,


### PR DESCRIPTION
Starts [PLAT-1528](https://codedotorg.atlassian.net/browse/PLAT-1528). First step for getting lesson names out of scripts.en.yml.

## Testing story

My plan for verification is to merge this PR, wait for the next i18n sync + down/out PR, then look at a file like `dashboard/config/locales/lessons.es-MX.json` to see that at least one lesson name translation has been added there.

## Follow-up work

see jira ticket for next steps.