### PR TITLE
Change page size for section_level_progress

### DIFF
--- a/apps/src/templates/sectionProgress/sectionProgressLoader.js
+++ b/apps/src/templates/sectionProgress/sectionProgressLoader.js
@@ -20,7 +20,7 @@ import {getStore} from '@cdo/apps/redux';
 import _ from 'lodash';
 import logToCloud from '@cdo/apps/logToCloud';
 
-const NUM_STUDENTS_PER_PAGE = 50;
+const NUM_STUDENTS_PER_PAGE = 20;
 
 export function loadScriptProgress(scriptId, sectionId) {
   const state = getStore().getState().sectionProgress;

--- a/apps/test/unit/templates/sectionProgress/sectionProgressLoaderTest.js
+++ b/apps/test/unit/templates/sectionProgress/sectionProgressLoaderTest.js
@@ -24,7 +24,7 @@ const timeInSeconds = 321;
 const serverProgressResponse = {
   pagination: {
     page: 1,
-    per: 50,
+    per: 20,
     total_pages: 1
   },
   student_last_updates: {
@@ -331,7 +331,7 @@ describe('sectionProgressLoader.loadScript', () => {
               sections: {
                 [selectedSectionId]: {}
               },
-              selectedStudents: new Array(60)
+              selectedStudents: new Array(30) // this is 1.5 * NUM_STUDENTS_PER_PAGE in sectionProgressLoaders
             }
           };
         },


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Changes the page size from 50 to 20. We're getting reports of the progress table not loading, from testing the requests made to the related endpoints we're seeing timeouts after 30 seconds. Hitting the endpoints directly and changing the page size to a smaller amount allows the results to load in a reasonable amount of time.


## Testing story
Tested on production at https://studio.code.org/dashboardapi/section_level_progress/3890631?script_id=512&page=1&per=50
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
