### PR TITLE
Isolate the cookie scripts to only load on code.org/cookies and houro…

### DIFF
--- a/shared/haml/hoc_onetrust_cookie_scripts.haml
+++ b/shared/haml/hoc_onetrust_cookie_scripts.haml
@@ -1,11 +1,11 @@
 -# OneTrust Cookies Consent Notice scripts for hourofcode.com
 - cookie_script_env = DCDO.get('onetrust_cookie_scripts', 'off')
-- if cookie_script_env == 'production'
+- if cookie_script_env == 'production' && request.path == '/cookies'
   %script{src: 'https://cdn.cookielaw.org/consent/7c79c547-a2fc-4998-9b21-0c7a5e67e345/OtAutoBlock.js', type: 'text/javascript'}
   %script{src: 'https://cdn.cookielaw.org/scripttemplates/otSDKStub.js', type: 'text/javascript', charset: 'UTF-8', 'data-domain-script' => '7c79c547-a2fc-4998-9b21-0c7a5e67e345'}
   :javascript
     function OptanonWrapper() { }
-- elsif cookie_script_env == 'test'
+- elsif cookie_script_env == 'test' && request.path == '/cookies'
   %script{src: 'https://cdn.cookielaw.org/consent/7c79c547-a2fc-4998-9b21-0c7a5e67e345-test/OtAutoBlock.js', type: 'text/javascript'}
   %script{src: 'https://cdn.cookielaw.org/scripttemplates/otSDKStub.js', type: 'text/javascript', charset: 'UTF-8', 'data-domain-script' => '7c79c547-a2fc-4998-9b21-0c7a5e67e345-test'}
   :javascript

--- a/shared/haml/onetrust_cookie_scripts.haml
+++ b/shared/haml/onetrust_cookie_scripts.haml
@@ -1,11 +1,11 @@
 -# OneTrust Cookies Consent Notice scripts for code.org
 - cookie_script_env = DCDO.get('onetrust_cookie_scripts', 'off')
-- if cookie_script_env == 'production'
+- if cookie_script_env == 'production' && request.path == "/cookies"
   %script{src: 'https://cdn.cookielaw.org/consent/27cca70a-7db3-4852-9ef0-a6660fd0977d/OtAutoBlock.js', type: 'text/javascript'}
   %script{src: 'https://cdn.cookielaw.org/scripttemplates/otSDKStub.js', type: 'text/javascript', charset: 'UTF-8', 'data-domain-script' => '27cca70a-7db3-4852-9ef0-a6660fd0977d'}
   :javascript
     function OptanonWrapper() { }
-- elsif cookie_script_env == 'test'
+- elsif cookie_script_env == 'test' && request.path == "/cookies"
   %script{src: 'https://cdn.cookielaw.org/consent/27cca70a-7db3-4852-9ef0-a6660fd0977d-test/OtAutoBlock.js', type: 'text/javascript'}
   %script{src: 'https://cdn.cookielaw.org/scripttemplates/otSDKStub.js', type: 'text/javascript', charset: 'UTF-8', 'data-domain-script' => '27cca70a-7db3-4852-9ef0-a6660fd0977d-test'}
   :javascript


### PR DESCRIPTION
After deploying the OneTrust cookie scripts and turning the DCDO flag on in production, we were alerted to a high rate of javascript errors on some pages and quickly flipped the flag back off. Unfortunately we haven't been able to reproduce the issue on any other environment, so let's try restricting the cookie scripts to only loading on the `/cookies` pages, so we can attempt to reproduce it again in production on a not-yet-public page.

## Links

- Slack conversation: [https://codedotorg.slack.com/archives/C0T0PNTM3/p1650651553908389](https://codedotorg.slack.com/archives/C0T0PNTM3/p1650651553908389)
