### PR TITLE
Javalab: file name dialog polish

### DIFF
--- a/apps/src/javalab/NameFileDialog.jsx
+++ b/apps/src/javalab/NameFileDialog.jsx
@@ -24,6 +24,20 @@ export default class NameFileDialog extends Component {
     };
   }
 
+  componentDidUpdate(prevProps) {
+    if (!prevProps.isOpen && this.props.isOpen) {
+      this.textInput.setSelectionRange(0, 0);
+    }
+  }
+
+  onKeyDown = event => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      event.stopPropagation();
+      this.props.handleSave(this.textInput.value);
+    }
+  };
+
   render() {
     const {
       isOpen,
@@ -70,6 +84,8 @@ export default class NameFileDialog extends Component {
               ...styles.dialogInput,
               ...(displayTheme === DisplayTheme.DARK && styles.darkDialog)
             }}
+            onKeyDown={this.onKeyDown}
+            autoFocus
           />
           <div>
             <button


### PR DESCRIPTION
When creating a new file or renaming an existing file:
- Automatically move the cursor to the beginning of the input element (particularly relevant for new files, where we auto-populate the .java extension).
- Pressing enter after entering input closes the dialog and saves your changes.

**Before**

<img width="603" alt="image" src="https://user-images.githubusercontent.com/25372625/165391732-f2c973c1-6146-4275-a23f-bcf4543e9eea.png">

**After**

<img width="604" alt="image" src="https://user-images.githubusercontent.com/25372625/165391640-80251d56-cbde-486f-b931-298aff336953.png">

## Links

- Jira: [PP-86](https://codedotorg.atlassian.net/browse/PP-86)

## Testing story

Tested manually that I was able to create and rename files appropriately.