### PR TITLE
Bottom controls in code review groups dialog should stick to the bottom on scroll

### DIFF
--- a/apps/src/componentLibrary/StylizedBaseDialog.jsx
+++ b/apps/src/componentLibrary/StylizedBaseDialog.jsx
@@ -90,7 +90,11 @@ export default function StylizedBaseDialog(props) {
   ];
 
   return (
-    <BaseDialog {...passThroughProps()} useUpdatedStyles>
+    <BaseDialog
+      {...passThroughProps()}
+      useUpdatedStyles
+      useFlexbox={props.stickyHeaderFooter}
+    >
       {props.title && (
         <>
           <div style={styles.container}>{renderTitle()}</div>
@@ -100,7 +104,8 @@ export default function StylizedBaseDialog(props) {
       <div
         style={{
           ...styles.container,
-          ...(styles.body[props.type] || {})
+          ...(styles.body[props.type] || {}),
+          overflowY: props.stickyHeaderFooter && 'auto'
         }}
       >
         {props.body ? props.body : props.children}
@@ -141,7 +146,8 @@ StylizedBaseDialog.propTypes = {
   handleConfirmation: PropTypes.func,
   handleClose: PropTypes.func.isRequired,
   handleCancellation: PropTypes.func,
-  type: PropTypes.oneOf(Object.keys(DialogStyle))
+  type: PropTypes.oneOf(Object.keys(DialogStyle)),
+  stickyHeaderFooter: PropTypes.bool
 };
 
 StylizedBaseDialog.defaultProps = {

--- a/apps/src/templates/BaseDialog.jsx
+++ b/apps/src/templates/BaseDialog.jsx
@@ -27,6 +27,7 @@ export default class BaseDialog extends React.Component {
     children: PropTypes.node,
     fixedWidth: PropTypes.number,
     fixedHeight: PropTypes.number,
+    useFlexbox: PropTypes.bool,
     bodyId: PropTypes.string,
     bodyClassName: PropTypes.string,
     style: PropTypes.object,
@@ -121,6 +122,13 @@ export default class BaseDialog extends React.Component {
         overflowY: overflowY,
         borderRadius: 4
       };
+      if (this.props.useFlexbox) {
+        modalBodyStyle = {
+          ...modalBodyStyle,
+          display: 'flex',
+          flexDirection: 'column'
+        };
+      }
       bodyStyle = {
         ...bodyStyle,
         width: this.props.fixedWidth || BASE_DIALOG_WIDTH,

--- a/apps/src/templates/manageStudents/CodeReviewGroupsDialog.jsx
+++ b/apps/src/templates/manageStudents/CodeReviewGroupsDialog.jsx
@@ -150,6 +150,7 @@ export default function CodeReviewGroupsDialog({
         footerJustification="space-between"
         confirmationButtonText={i18n.confirmChanges()}
         disableConfirmationButton={!groupsHaveChanged}
+        stickyHeaderFooter={true}
       >
         {renderModalBody()}
       </StylizedBaseDialog>


### PR DESCRIPTION
This adds some extra CSS to BaseDialog and StylizedBaseDialog to create a dialog UI where the middle portion scrolls but the header and footer remain fixed. It does feels like a bit a special case (especially adding the `useFlexbox` prop in BaseDialog) but BaseDialog already has quite a bit of branching/special case style logic so it would be a lot to overhaul it in a meaningful way right now.

JIRA: https://codedotorg.atlassian.net/browse/JAVA-382

![Screen Shot 2022-04-26 at 3 57 29 PM](https://user-images.githubusercontent.com/85528507/165406521-6bca26cf-13af-409a-96d1-7a5f9ea1b07f.png)

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Tested locally, used Chrome devtools to emulate a couple different screen size variants.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
