### PR TITLE
Add Crowdin Client V2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -355,3 +355,5 @@ gem 'pry'
 
 # Google's Compact Language Detector
 gem 'cld'
+
+gem 'crowdin-api', '~> 1.2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -357,6 +357,9 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
+    crowdin-api (1.2.1)
+      open-uri (>= 0.1.0, < 0.2.0)
+      rest-client (>= 2.0.0, < 2.1.0)
     css_parser (1.10.0)
       addressable
     cucumber (3.1.1)
@@ -614,6 +617,7 @@ GEM
     omniauth-rails_csrf_protection (0.1.2)
       actionpack (>= 4.2)
       omniauth (>= 1.3.1)
+    open-uri (0.1.0)
     open_uri_redirections (0.2.1)
     openid_connect (1.0.3)
       activemodel
@@ -950,6 +954,7 @@ DEPENDENCIES
   codecov
   colorize
   composite_primary_keys (~> 12.0)
+  crowdin-api (~> 1.2.1)
   cucumber
   daemons
   dalli

--- a/bin/i18n/sync-down.rb
+++ b/bin/i18n/sync-down.rb
@@ -43,7 +43,7 @@ def sync_down
         options[:locale_subdir] = "hourofcode"
       end
 
-      utils = Crowdin::Utils.new(project, options)
+      utils = Crowdin::LegacyUtils.new(project, options)
 
       puts "Fetching list of changed files"
       elapsed = with_elapsed {utils.fetch_changes}

--- a/lib/cdo/aws/s3_packaging.rb
+++ b/lib/cdo/aws/s3_packaging.rb
@@ -197,7 +197,7 @@ class S3Packaging
       # https://github.com/aws/aws-sdk-ruby/issues/1149
       url = Aws::S3::Bucket.new(BUCKET_NAME, credentials: 0).object(s3_key).public_url
       File.open(package, 'wb') do |file|
-        IO.copy_stream open(url), file
+        IO.copy_stream URI.open(url), file
       rescue OpenURI::HTTPError
         raise Aws::S3::Errors::NoSuchKey.new(nil, file.path)
       end

--- a/lib/cdo/crowdin/client_extentions.rb
+++ b/lib/cdo/crowdin/client_extentions.rb
@@ -1,0 +1,151 @@
+require 'crowdin-api'
+
+#
+# Add functionalities to the Crowdin::Client class in the crowdin-api gem.
+#
+module Crowdin
+  module ClientExtensions
+    # Project Id is at https://crowdin.com/project/<project_name>/tools/api
+    # Project source language is at https://crowdin.com/project/<project_name>/settings
+    CDO_PROJECTS = {
+      codeorg: {
+        id: 26074,
+        source_language: 'enus'
+      },
+      'hour-of-code': {
+        id: 55536,
+        source_language: 'en'
+      },
+      'codeorg-markdown': {
+        id: 314545,
+        source_language: 'en'
+      },
+      'codeorg-restricted': {
+        id: 464582,
+        source_language: 'en'
+      }
+    }
+
+    # Maximum number of items to retrieve from Crowdin in an API call
+    MAX_ITEMS_COUNT = 500
+
+    # Send requests to Crowdin in a loop until the number of items retrieved
+    # is less than an expected limit.
+    #
+    # @param query [Hash] query string params used in the requests
+    # @yieldparam query [Hash] updated query string params
+    # @yieldreturn [Array] the response from Crowdin
+    # @return [Array] all responses from Crowdin
+    #
+    def request_loop(query)
+      raise 'Missing block' unless block_given?
+
+      results = []
+      loop do
+        # yield to the given block to do real work
+        response = yield query
+        raise 'Crowdin request failed!' if response.is_a?(String) && response.match?('Something went wrong')
+
+        puts "Offset = #{query[:offset]}. Response size = #{response['data'].size}"
+        results.concat(response['data'])
+        query[:offset] += response['data'].size
+        break if response['data'].size < query[:limit]
+      end
+
+      results
+    end
+
+    # Download a list of all Crowdin's supported languages.
+    #
+    # @param limit [Number] maximum number of items to retrieve in an API call
+    # @return [Array<Hash>] array of all languages
+    #
+    def download_languages(limit = MAX_ITEMS_COUNT)
+      query = {
+        limit: limit,
+        offset: 0
+      }
+
+      languages = request_loop(query) do
+        list_languages(query)
+      end
+
+      puts "Downloaded #{languages.size} languages"
+      languages.map do |language|
+        language['data']
+      end
+    end
+
+    # Download all translations that were create for a project in a language
+    # by a user during a time period.
+    #
+    # E.g. download_translations('codeorg','it','Tomedes','2021-11-01','2022-01-01')
+    #
+    # @param project_name [String, Symbol]
+    # @param crowdin_language_id [String]
+    # @param user_name [String]
+    # @param start_date [String]
+    # @param end_date [String]
+    # @param limit [Number]
+    # @return Array<Hash> array of translations
+    #
+    def download_translations(project_name, crowdin_language_id, user_name, start_date, end_date, limit = MAX_ITEMS_COUNT)
+      query = {
+        croql: "user=@user:\"#{user_name}\" and updated>='#{start_date}' and updated<'#{end_date}'",
+        limit: limit,
+        offset: 0
+      }
+
+      project_id = CDO_PROJECTS.dig(project_name.to_sym, :id)
+      translations = request_loop(query) do
+        list_language_translations(crowdin_language_id, query, project_id)
+      end
+
+      puts "Downloaded #{translations.size} translations"
+      translations.map do |translation|
+        translation['data']['crowdin_language_id'] = crowdin_language_id
+        translation['data']
+      end
+    end
+
+    # Download all source strings that have translations created for a project
+    # in a language by a user during a time period.
+    #
+    # E.g. download_source_strings('codeorg','it','Tomedes','2021-11-01','2022-01-01')
+    #
+    # @param project_name [String, Symbol]
+    # @param crowdin_language_id [String]
+    # @param user_name [String]
+    # @param start_date [String]
+    # @param end_date [String]
+    # @param limit [Number]
+    # @return Array<Hash> array of source strings
+    #
+    def download_source_strings(project_name, crowdin_language_id, user_name, start_date, end_date, limit = MAX_ITEMS_COUNT)
+      query = {
+        croql: "count of translations where (" \
+          "language=@language:\"#{crowdin_language_id}\" and " \
+          "user=@user:\"#{user_name}\" and " \
+          "updated>='#{start_date}' and " \
+          "updated<'#{end_date}'" \
+          ") > 0",
+        limit: limit,
+        offset: 0
+      }
+
+      project_id = CDO_PROJECTS.dig(project_name.to_sym, :id)
+      source_strings = request_loop(query) do
+        list_strings(query, project_id)
+      end
+
+      puts "Downloaded #{source_strings.size} source strings"
+      source_strings.map do |string|
+        string['data']
+      end
+    end
+  end
+
+  class Client
+    include ClientExtensions
+  end
+end

--- a/lib/cdo/crowdin/legacy_utils.rb
+++ b/lib/cdo/crowdin/legacy_utils.rb
@@ -7,7 +7,7 @@ module Crowdin
   # @see https://support.crowdin.com/api/api-integration-setup/#rate-limits
   MAX_THREADS = 10
 
-  class Utils
+  class LegacyUtils
     attr_reader :project
     attr_reader :files_to_download_json
     attr_reader :files_to_sync_out_json

--- a/lib/cdo/web_purify.rb
+++ b/lib/cdo/web_purify.rb
@@ -31,7 +31,7 @@ module WebPurify
       "&format=json"
     result = JSON.
       parse(
-        open(
+        URI.open(
           url,
           open_timeout: DCDO.get('webpurify_tcp_connect_timeout', 5),
           read_timeout: DCDO.get('webpurify_http_read_timeout', 10)

--- a/lib/test/cdo/crowdin/test_client_extensions.rb
+++ b/lib/test/cdo/crowdin/test_client_extensions.rb
@@ -9,24 +9,64 @@ class CrowdinClientExtensionsTest < Minitest::Test
   end
 
   def test_download_languages
-    # An array of stubbed responses, one for each call.
+    # Download 1 record per API call
+    limit = 1
+    # An array of stubbed responses, one for each API call.
     fake_responses = [
       {'data' => [{'data' => {'id' => 'language1'}}]},
       {'data' => [{'data' => {'id' => 'language2'}}]},
-      {'data' => [{'data' => {'id' => 'language3'}}]},
+      # this response should stop the downloading loop
       {'data' => []}
     ]
     @crowdin_client.stubs(:list_languages).returns(*fake_responses)
 
-    results = @crowdin_client.download_languages(1)
+    results = @crowdin_client.download_languages(limit)
+    assert_equal fake_responses.size - 1, results.size
+  end
 
-    # Expected results = [{id => ..}, {id => ...}, ...]
-    expected_results = fake_responses.map do |response|
-      response['data'].map do |language|
-        language['data']
-      end
-    end.flatten
+  def test_download_translations
+    # Download 1 record per API call
+    limit = 1
+    # An array of stubbed responses, one for each API call.
+    fake_responses = [
+      {'data' => [{'data' => {'stringId' => 1, 'translationId' => 1}}]},
+      {'data' => [{'data' => {'stringId' => 2, 'translationId' => 2}}]},
+      # this response should stop the downloading loop
+      {'data' => []}
+    ]
+    @crowdin_client.stubs(:list_language_translations).returns(*fake_responses)
 
-    assert_equal expected_results, results
+    results = @crowdin_client.download_translations(
+      'project_name',
+      'crowdin_language_id',
+      'user_name',
+      'start_date',
+      'end_date',
+      limit
+    )
+    assert_equal fake_responses.size - 1, results.size
+  end
+
+  def test_download_source_strings
+    # Download 1 record per API call
+    limit = 1
+    # An array of stubbed responses, one for each API call.
+    fake_responses = [
+      {'data' => [{'data' => {'id' => 1, 'text' => 'string1'}}]},
+      {'data' => [{'data' => {'id' => 2, 'text' => 'string2'}}]},
+      # this response should stop the downloading loop
+      {'data' => []}
+    ]
+    @crowdin_client.stubs(:list_strings).returns(*fake_responses)
+
+    results = @crowdin_client.download_source_strings(
+      'project_name',
+      'crowdin_language_id',
+      'user_name',
+      'start_date',
+      'end_date',
+      limit
+    )
+    assert_equal fake_responses.size - 1, results.size
   end
 end

--- a/lib/test/cdo/crowdin/test_client_extensions.rb
+++ b/lib/test/cdo/crowdin/test_client_extensions.rb
@@ -1,0 +1,32 @@
+require_relative '../../test_helper'
+require_relative '../../../cdo/crowdin/client_extentions'
+
+class CrowdinClientExtensionsTest < Minitest::Test
+  def setup
+    @crowdin_client = Crowdin::Client.new do |config|
+      config.api_token = 'fake_token'
+    end
+  end
+
+  def test_download_languages
+    # An array of stubbed responses, one for each call.
+    fake_responses = [
+      {'data' => [{'data' => {'id' => 'language1'}}]},
+      {'data' => [{'data' => {'id' => 'language2'}}]},
+      {'data' => [{'data' => {'id' => 'language3'}}]},
+      {'data' => []}
+    ]
+    @crowdin_client.stubs(:list_languages).returns(*fake_responses)
+
+    results = @crowdin_client.download_languages(1)
+
+    # Expected results = [{id => ..}, {id => ...}, ...]
+    expected_results = fake_responses.map do |response|
+      response['data'].map do |language|
+        language['data']
+      end
+    end.flatten
+
+    assert_equal expected_results, results
+  end
+end

--- a/lib/test/cdo/crowdin/test_legacy_utils.rb
+++ b/lib/test/cdo/crowdin/test_legacy_utils.rb
@@ -1,5 +1,5 @@
 require_relative '../../test_helper'
-require 'cdo/crowdin/utils'
+require_relative '../../../cdo/crowdin/legacy_utils'
 require 'tempfile'
 
 class MockCrowdinProject < Minitest::Mock
@@ -30,7 +30,7 @@ class MockCrowdinProject < Minitest::Mock
   end
 end
 
-class CrowdinUtilsTest < Minitest::Test
+class CrowdinLegacyUtilsTest < Minitest::Test
   def setup
     @mock_project = MockCrowdinProject.new
 
@@ -41,7 +41,7 @@ class CrowdinUtilsTest < Minitest::Test
       locales_dir: Dir.mktmpdir("locales"),
       logger: Logger.new('/dev/null')
     }
-    @utils = Crowdin::Utils.new(@mock_project, @options)
+    @utils = Crowdin::LegacyUtils.new(@mock_project, @options)
     @latest_crowdin_etags = {
       "i1-8n" => {
         "/foo.bar" => MockCrowdinProject::LATEST_ETAG_VALUE,

--- a/lib/test/cdo/test_azure_content_moderator.rb
+++ b/lib/test/cdo/test_azure_content_moderator.rb
@@ -28,14 +28,14 @@ class AzureContentModeratorTest < Minitest::Test
   def test_checks_jpg_image
     expect_firehose_log_request
     expect_firehose_log_result
-    image_data = open('https://studio.code.org/notfound.jpg')
+    image_data = URI.open('https://studio.code.org/notfound.jpg')
     assert_equal :everyone, @acm.rate_image(image_data, 'image/jpeg')
   end
 
   def test_checks_png_image
     expect_firehose_log_request
     expect_firehose_log_result
-    image_data = open('https://code.org/images/infographics/fit-800/diversity-courses-updated-05-23.png')
+    image_data = URI.open('https://code.org/images/infographics/fit-800/diversity-courses-updated-05-23.png')
     assert_equal :everyone, @acm.rate_image(image_data, 'image/png')
   end
 
@@ -46,14 +46,14 @@ class AzureContentModeratorTest < Minitest::Test
       json['ImageUrl'] == test_image_url &&
         stream == :analysis
     end
-    image_data = open('https://code.org/images/infographics/fit-800/diversity-courses-updated-05-23.png')
+    image_data = URI.open('https://code.org/images/infographics/fit-800/diversity-courses-updated-05-23.png')
     assert_equal :everyone, @acm.rate_image(image_data, 'image/png', test_image_url)
   end
 
   def test_raise_on_image_too_small
     expect_firehose_log_request
     # This image is smaller than the Azure content moderator's minimum size.
-    image_data = open('https://code.org/images/icons/medium-monogram-white.png')
+    image_data = URI.open('https://code.org/images/icons/medium-monogram-white.png')
     assert_raises AzureContentModerator::RequestFailed do
       @acm.rate_image(image_data, 'image/png')
     end


### PR DESCRIPTION
[FND-1955](https://codedotorg.atlassian.net/browse/FND-1955) Add the Crowdin Ruby Client and extend it to support downloading all languages, translations and source strings.

## Links
- Crowdin V2 API https://support.crowdin.com/api/v2/ 
- Crowdin Client in Ruby https://github.com/crowdin/crowdin-api-client-ruby
- CrowdIn query language (CroQL) https://support.crowdin.com/croql/

## Testing story
- Unit tests & manual tests.

## PR Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
