### PR TITLE
[Fit and Finish] SpriteLab Educate Videos Fix

### DIFF
--- a/pegasus/sites.v3/code.org/public/educate/spritelab.haml
+++ b/pegasus/sites.v3/code.org/public/educate/spritelab.haml
@@ -45,8 +45,8 @@ video_player: true
   - spritelab_videos << { id: 'CSF_SpriteLabIntro_CDEF', category_title: 'Making Your First Projects', code: 'l0B0gDuHHC8', download_path: 'https://videos.code.org/levelbuilder/introducingspritelab_sm-mp4.mp4', studio_stage: '/s/coursee-2021/lessons/2/levels/3' }
   - spritelab_videos << { id: 'CSF_Spritelab_MakeSprite_CDEF', code: 'nHq7_-Kpgc8', download_path: 'https://videos.code.org/levelbuilder/howtomakeasprite_sm-mp4.mp4', studio_stage: '/s/coursee-2021/lessons/2/levels/7' }
   - spritelab_videos << { id: 'CDEF_Video_SpritesInAction', code: 'vsjoWjyQLRU', download_path: 'https://videos.code.org/levelbuilder/spritesinaction_sm-mp4.mp4', studio_stage: '/s/coursee-2021/lessons/3/levels/3' }
-  - spritelab_videos << { id: '	csf21pilot_events', code: '_RxDeRPwJ-g', download_path: 'https://videos.code.org/levelbuilder/video-1-sprites-in-action_v2_small_20mb-mp4.mp4', studio_stage: '/s/coursef-2021/lessons/3/levels/3' }
-  - spritelab_videos << { id: '	csf21pilot_prompts', code: '3TQ6ybjSm6c', download_path: 'https://videos.code.org/levelbuilder/video-2-sprite-lab-text-and-prompts_v2_small_20mb-mp4.mp4', studio_stage: '/s/coursef-2021/lessons/7/levels/3' }
+  - spritelab_videos << { id: 'csf21pilot_events', code: '_RxDeRPwJ-g', download_path: 'https://videos.code.org/levelbuilder/video-1-sprites-in-action_v2_small_20mb-mp4.mp4', studio_stage: '/s/coursef-2021/lessons/3/levels/3' }
+  - spritelab_videos << { id: 'csf21pilot_prompts', code: '3TQ6ybjSm6c', download_path: 'https://videos.code.org/levelbuilder/video-2-sprite-lab-text-and-prompts_v2_small_20mb-mp4.mp4', studio_stage: '/s/coursef-2021/lessons/7/levels/3' }
   - spritelab_videos << { id: 'csf_lots_of_sprites', code: '5yWt5o0zwAM', download_path: 'https://videos.code.org/levelbuilder/video-3-sprite-lab-lots-of-sprites-v2_small_20mb-mp4.mp4', studio_stage: 's/coursef-2021/lessons/20/levels/2/sublevel/1' }
 
   - spritelab_videos.each do |video|


### PR DESCRIPTION
There was a typo in the Pegasus docs preventing two of the six videos from opening in the dialog and playing. This change removes the spaces that were the typos.

Before:
![befora](https://user-images.githubusercontent.com/2959170/165588291-a83e93be-443b-4082-945a-97eb09526e0c.gif)


After:
![aftera](https://user-images.githubusercontent.com/2959170/165588305-fcac2ee0-d21c-4587-8c95-f7d26c5b4e2f.gif)
