### PR TITLE
Make code.org homepage donate button more noticeable

### DIFF
--- a/pegasus/sites.v3/code.org/public/css/donors.css
+++ b/pegasus/sites.v3/code.org/public/css/donors.css
@@ -70,12 +70,10 @@ table td {
   width: 100%;
   font-size: 24px;
   font-weight: 900;
-  margin: 0px;
+  margin: 0 0 12px 0;
   padding: 0px;
   text-align: center;
   color: #4d575f;
-  position: absolute;
-  top: 0px;
   font-family: 'Gotham 4r', sans-serif;
 }
 

--- a/pegasus/sites.v3/code.org/public/css/donors.css
+++ b/pegasus/sites.v3/code.org/public/css/donors.css
@@ -53,7 +53,7 @@ table td {
 }
 
 #donorslider {
-  background-color: #cfc9de;
+  background-color: white;
   margin-top: 20px;
   padding-top: 10px;
   margin-bottom: 0px;
@@ -68,33 +68,33 @@ table td {
 
 #donorslider h1 {
   width: 100%;
-  font-size: 20px;
+  font-size: 24px;
+  font-weight: 900;
   margin: 0px;
   padding: 0px;
   text-align: center;
-  color: white;
+  color: #4d575f;
   position: absolute;
   top: 0px;
   font-family: 'Gotham 4r', sans-serif;
 }
 
 #donorslider .donor-slider {
+  text-align: center;
+  font-size: 13px;
+}
+
+#donorslider .donor-button {
   color: white;
   text-align: center;
   font-size: 13px;
 }
 
-#donorlinks {
-  text-align: right;
-  position: absolute;
-  width: 100%;
-}
-
-#donorlinks a {
-  color: white;
-}
-
 #donorslider .donor-slider a {
-  color: white; 
+  color: #4d575f;
   font-family: 'Gotham 4r', sans-serif;
+}
+
+#donorslider .donor-button button {
+  margin: 12px 8px;
 }

--- a/pegasus/sites.v3/code.org/views/donor_slider.haml
+++ b/pegasus/sites.v3/code.org/views/donor_slider.haml
@@ -13,13 +13,6 @@
       %h1
         = I18n.t(:homepage_header_donors)
 
-      #donorlinks.desktop-feature
-        %a{href: "/about/donors"}
-          = I18n.t(:homepage_donors_seall)
-        &nbsp; &nbsp; &nbsp;
-        %a{href: "/donate"}
-          = I18n.t(:homepage_donors_donate)
-
     .donor-slider
       - diamond_supporters.each_with_index do |supporter|
         %a{:href=>supporter[:url_s], :target=> "_blank"}
@@ -33,3 +26,7 @@
             = "#{supporter[:name_s]}"
           - else
             = "#{supporter[:name_s]}, "
+    
+    .donor-button
+      %button{onclick: "window.location.href = '/donate'"}
+        = I18n.t(:homepage_donors_donate)

--- a/pegasus/sites.v3/code.org/views/donor_slider.haml
+++ b/pegasus/sites.v3/code.org/views/donor_slider.haml
@@ -28,5 +28,5 @@
             = "#{supporter[:name_s]}, "
     
     .donor-button
-      %button{onclick: "window.location.href = '/donate'"}
+      %button{role: "link", onclick: "window.location.href = '/donate'"}
         = I18n.t(:homepage_donors_donate)

--- a/pegasus/sites.v3/code.org/views/donor_slider.haml
+++ b/pegasus/sites.v3/code.org/views/donor_slider.haml
@@ -9,7 +9,7 @@
 
 #donorslider
   .container_responsive
-    #donorheader{style: "position:relative; height:40px"}
+    .donor-header
       %h1
         = I18n.t(:homepage_header_donors)
 


### PR DESCRIPTION
**What:** Added more visible donor button and updated styling on the code.org homepage.

**Why**: For a more engaging and user friendly donor button, and also to fix multiline headers in mobile view dimensions. These are more common for other languages. 

## Links
- spec: [mock](https://codedotorg.atlassian.net/jira/software/c/projects/PP/boards/61/backlog?view=detail&selectedIssue=PP-143&issueLimit=100)
- jira ticket: [PP-143](https://codedotorg.atlassian.net/browse/PP-143)


## Testing story
- Visited the homepage on my local machine
- Tested locally using other languages
- Tested locally with other view dimensions

Multiline header before:
![Screen Shot 2022-04-27 at 5 14 28 PM](https://user-images.githubusercontent.com/48133820/165640081-e6d83f8b-f97a-4cc5-84b5-253cb11783c5.png)

Multiline header after:
<img width="1219" alt="Screen Shot 2022-04-27 at 5 05 19 PM" src="https://user-images.githubusercontent.com/48133820/165640100-2bf19586-3275-4ebf-ac29-9518dc7fc3d2.png">

New implementation:
<img width="1176" alt="Screen Shot 2022-04-27 at 6 36 45 PM" src="https://user-images.githubusercontent.com/48133820/165648199-01a21167-dc6c-4ad5-a0bc-57a82538230a.png">


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
