### PR TITLE
The Bad Guys promo Projects page banner fix

### DIFF
--- a/lib/dynamic_config/dcdo.rb
+++ b/lib/dynamic_config/dcdo.rb
@@ -43,6 +43,7 @@ class DCDOBase < DynamicConfigBase
       'frontend-i18n-tracking': DCDO.get('frontend-i18n-tracking', false),
       'clearerSignUpUserType': DCDO.get('clearerSignUpUserType', false),
       'thebadguys-promotion': DCDO.get('thebadguys-promotion', false),
+      'thebadguys-projects-page': DCDO.get('thebadguys-projects-page', false),
       'code_review_v2': DCDO.get('code_review_v2', false)
     }
   end


### PR DESCRIPTION
**Bug fix!** Forgot to add the DCDO flag to `dcdo.rb` // Related PR: https://github.com/code-dot-org/code-dot-org/pull/45981

Show The Bad Guys banner on the [Projects page](https://studio.code.org/projects/public) without showing The Bad Guys banner on the homepage when the DCDO flag `"thebadguys-projects-page"` is set to `true`. Previously, both banners were set with the DCDO flag `"thebadguys-promotion"` from https://github.com/code-dot-org/code-dot-org/pull/45672.

With flag:
<img width="1008" alt="165188800-f17a12f5-d8ec-4523-bb76-8e5b99fb4e2a" src="https://user-images.githubusercontent.com/9256643/165595514-b280b76f-f33d-4328-9cff-bfc1e8df8b07.png">

Without flag:
<img width="1005" alt="165188912-c97e711b-b3c2-41f3-b4b2-c99da8737590" src="https://user-images.githubusercontent.com/9256643/165595536-d52e029a-9a5b-4647-bfa7-f04fcb8a280c.png">

