### PR TITLE
[Google Blockly] Fix svgResize for v7

### DIFF
--- a/apps/src/blockly/addons/cdoUtils.js
+++ b/apps/src/blockly/addons/cdoUtils.js
@@ -12,6 +12,10 @@ export function getBlockFields(block) {
   return fields;
 }
 
+export function workspaceSvgResize(workspace) {
+  return Blockly.svgResize(workspace);
+}
+
 export function isWorkspaceReadOnly(workspace) {
   return false; // TODO - used for feedback
 }

--- a/apps/src/blockly/cdoBlocklyWrapper.js
+++ b/apps/src/blockly/cdoBlocklyWrapper.js
@@ -243,6 +243,9 @@ function initializeBlocklyWrapper(blocklyInstance) {
     },
     setHSV: function(block, h, s, v) {
       block.setHSV(h, s, v);
+    },
+    workspaceSvgResize: function(workspace) {
+      return workspace.blockSpaceEditor.svgResize();
     }
   };
   return blocklyWrapper;

--- a/apps/src/templates/instructions/utils.js
+++ b/apps/src/templates/instructions/utils.js
@@ -76,7 +76,7 @@ export function shrinkBlockSpaceContainer(blockSpace, withPadding) {
   // and shrink it, triggering a blockspace resize when we do so
   container.style.height = height + 'px';
   container.style.width = width + 'px';
-  blockSpace.blockSpaceEditor.svgResize();
+  Blockly.cdoUtils.workspaceSvgResize(blockSpace);
 }
 
 /**


### PR DESCRIPTION
In order to move Bounce to v7, we need to make sure that embedded blocks in hints and instructions are rendered correctly.

## Current appearance with cdo Blockly (working)
<img width="1003" alt="image" src="https://user-images.githubusercontent.com/43474485/165628195-ddce5fd4-ba51-4562-9bb4-41b2d2632388.png">

## Error with Google Blockly 
using `?blocklyVersion=Google`
<img width="379" alt="image" src="https://user-images.githubusercontent.com/43474485/165628316-b1843821-310f-4c8d-90f6-dd39a37bf9bd.png">

## Fixed
<img width="811" alt="image" src="https://user-images.githubusercontent.com/43474485/165628452-64081c8b-d5f9-47c6-bf77-a77867eb9dc9.png">

Checked for regressions in Sprite Lab, Poetry and Dance using levels that include embedded blocks in instructions and/or hints.