### PR TITLE
[Java Lab] Allow click away from file dropdown

### DIFF
--- a/apps/src/javalab/JavalabEditorTabMenu.jsx
+++ b/apps/src/javalab/JavalabEditorTabMenu.jsx
@@ -2,12 +2,13 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import JavalabDropdown from './components/JavalabDropdown';
 import javalabMsg from '@cdo/javalab/locale';
+import onClickOutside from 'react-onclickoutside';
 
 /**
  * A menu with a set of clickable links that calls the cancel handler if you
  * click outside the menu or the cancel button.
  */
-export default class JavalabEditorTabMenu extends Component {
+class JavalabEditorTabMenu extends Component {
   static propTypes = {
     cancelTabMenu: PropTypes.func.isRequired,
     renameFromTabMenu: PropTypes.func.isRequired,
@@ -20,6 +21,10 @@ export default class JavalabEditorTabMenu extends Component {
 
   state = {
     dropdownOpen: false
+  };
+
+  handleClickOutside = () => {
+    this.props.cancelTabMenu();
   };
 
   dropdownElements = () => {
@@ -103,3 +108,5 @@ export default class JavalabEditorTabMenu extends Component {
     return <JavalabDropdown>{this.dropdownElements()}</JavalabDropdown>;
   }
 }
+
+export default onClickOutside(JavalabEditorTabMenu);


### PR DESCRIPTION
Fit and finish hackathon. Uses `react-onclickoutside` to close the dropdown.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

JIRA: https://codedotorg.atlassian.net/browse/PP-89

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
