### PR TITLE
Course Version selector can handle multi-line strings

### DIFF
--- a/apps/src/templates/teacherDashboard/AssignmentVersionMenuHeader.jsx
+++ b/apps/src/templates/teacherDashboard/AssignmentVersionMenuHeader.jsx
@@ -16,7 +16,9 @@ const style = {
     fontSize: 16,
     fontWeight: 'bold',
     height: rowHeight,
-    color: 'white'
+    color: color.white,
+    display: 'flex',
+    alignItems: 'center'
   },
   selectedColumn: {
     ...cellStyle,

--- a/apps/src/templates/teacherDashboard/AssignmentVersionMenuItem.jsx
+++ b/apps/src/templates/teacherDashboard/AssignmentVersionMenuItem.jsx
@@ -84,14 +84,15 @@ export const columnWidths = {
 export const rowHeight = 35;
 
 export const cellStyle = {
-  display: 'inline-block',
-  marginTop: 9
+  display: 'inline-block'
 };
 
 const style = {
   wrapper: {
     fontSize: 16,
-    height: rowHeight
+    minHeight: rowHeight,
+    display: 'flex',
+    alignItems: 'center'
   },
   selectedColumn: {
     ...cellStyle,
@@ -109,6 +110,7 @@ const style = {
     width: columnWidths.status
   },
   recommended: {
+    display: 'inline-block',
     borderRadius: 5,
     padding: 8,
     backgroundColor: color.cyan,


### PR DESCRIPTION
Fixed the CSS styling of the Course Version Select to support menu items which have multi-line content (due to long strings in non-English langauges).

## Screenshots
Before | After
--- | ---
![image](https://user-images.githubusercontent.com/1372238/165604714-015a73ae-6037-472c-83ae-1a5245401066.png) | ![image](https://user-images.githubusercontent.com/1372238/165605106-4ad84392-f7f9-468c-9203-c0f8b367a6ef.png)

## Links
* [JIRA](https://codedotorg.atlassian.net/browse/PP-123)

## Testing story
* Manually tested on http://localhost-studio.code.org:3000/s/express-2021/lang/sk-sk in Chrome and Firefox
