### PR TITLE
show validation error when level clone fails from extra links box

### DIFF
--- a/dashboard/app/views/levels/_admin.html.haml
+++ b/dashboard/app/views/levels/_admin.html.haml
@@ -46,6 +46,7 @@
                 = text_field_tag :name, @level.name
                 = hidden_field_tag :authenticity_token, form_authenticity_token
                 = submit_tag 'Clone'
+              .validation-error{style: 'color: red;'}
             - content_for(:head) do
               %script{src: webpack_asset_path('js/levelbuilder.js')}
             :javascript


### PR DESCRIPTION
Finishes [PP-129](https://codedotorg.atlassian.net/browse/PP-129).

### before

no error message when name is taken

![Screen Shot 2022-04-27 at 1 08 56 PM](https://user-images.githubusercontent.com/8001765/165622714-58a54987-d7c2-42ba-990d-c72d27597dde.png)

### after

![Screen Shot 2022-04-27 at 1 08 37 PM](https://user-images.githubusercontent.com/8001765/165622728-509c7934-ff05-4a7f-ac95-5405d4c54097.png)

## Testing story

manual verification shown in screenshots