### PR TITLE
add button to copy lesson plan in extra links box on teacher lesson plan page

### DIFF
--- a/apps/src/lib/levelbuilder/CloneLessonDialogButton.jsx
+++ b/apps/src/lib/levelbuilder/CloneLessonDialogButton.jsx
@@ -1,5 +1,6 @@
 import React, {useState} from 'react';
 import PropTypes from 'prop-types';
+import Button, {ButtonColor} from '@cdo/apps/templates/Button';
 import CloneLessonDialog from '@cdo/apps/lib/levelbuilder/unit-editor/CloneLessonDialog';
 
 export default function CloneLessonDialogButton(props) {
@@ -12,9 +13,12 @@ export default function CloneLessonDialogButton(props) {
   const lessonId = isOpen ? props.lessonId : undefined;
   return (
     <div>
-      <button type="button" onClick={onClick}>
-        {props.buttonText}
-      </button>
+      <Button
+        color={ButtonColor.white}
+        text={props.buttonText}
+        style={styles.button}
+        onClick={onClick}
+      />
       <CloneLessonDialog
         lessonId={lessonId}
         lessonName={props.lessonName}
@@ -28,4 +32,12 @@ CloneLessonDialogButton.propTypes = {
   lessonId: PropTypes.number.isRequired,
   lessonName: PropTypes.string.isRequired,
   buttonText: PropTypes.string.isRequired
+};
+
+const styles = {
+  button: {
+    height: 23,
+    padding: 5,
+    margin: 0
+  }
 };

--- a/apps/src/lib/levelbuilder/CloneLessonDialogButton.jsx
+++ b/apps/src/lib/levelbuilder/CloneLessonDialogButton.jsx
@@ -13,7 +13,7 @@ export default function CloneLessonDialogButton(props) {
   return (
     <div>
       <button type="button" onClick={onClick}>
-        Copy
+        {props.buttonText}
       </button>
       <CloneLessonDialog
         lessonId={lessonId}
@@ -26,5 +26,6 @@ export default function CloneLessonDialogButton(props) {
 
 CloneLessonDialogButton.propTypes = {
   lessonId: PropTypes.number.isRequired,
-  lessonName: PropTypes.string.isRequired
+  lessonName: PropTypes.string.isRequired,
+  buttonText: PropTypes.string.isRequired
 };

--- a/apps/src/lib/levelbuilder/CloneLessonDialogButton.jsx
+++ b/apps/src/lib/levelbuilder/CloneLessonDialogButton.jsx
@@ -1,0 +1,30 @@
+import React, {useState} from 'react';
+import PropTypes from 'prop-types';
+import CloneLessonDialog from '@cdo/apps/lib/levelbuilder/unit-editor/CloneLessonDialog';
+
+export default function CloneLessonDialogButton(props) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleClose = () => setIsOpen(false);
+
+  const onClick = () => setIsOpen(true);
+
+  const lessonId = isOpen ? props.lessonId : undefined;
+  return (
+    <div>
+      <button type="button" onClick={onClick}>
+        Copy
+      </button>
+      <CloneLessonDialog
+        lessonId={lessonId}
+        lessonName={props.lessonName}
+        handleClose={handleClose}
+      />
+    </div>
+  );
+}
+
+CloneLessonDialogButton.propTypes = {
+  lessonId: PropTypes.number.isRequired,
+  lessonName: PropTypes.string.isRequired
+};

--- a/apps/src/sites/studio/pages/lessons/show.js
+++ b/apps/src/sites/studio/pages/lessons/show.js
@@ -20,12 +20,14 @@ import {
 import {setViewType, ViewType} from '@cdo/apps/code-studio/viewAsRedux';
 import {tooltipifyVocabulary} from '@cdo/apps/utils';
 import {prepareBlocklyForEmbedding} from '@cdo/apps/templates/utils/embeddedBlocklyUtils';
+import CloneLessonDialogButton from '@cdo/apps/lib/levelbuilder/CloneLessonDialogButton';
 
 $(document).ready(function() {
   prepareBlockly();
   displayLessonOverview();
   prepareExpandableImageDialog();
   tooltipifyVocabulary();
+  renderCopyLessonButton();
 });
 
 function prepareBlockly() {
@@ -138,3 +140,19 @@ function prepareExpandableImageDialog() {
     container
   );
 }
+
+const renderCopyLessonButton = () => {
+  const element = document.getElementById('copy-lesson-button');
+
+  // this will only be present for levelbuilders, in the extra links box
+  if (element) {
+    const lessonData = getScriptData('lesson');
+    const lessonId = lessonData['id'];
+    const lessonName = lessonData['displayName'];
+
+    ReactDOM.render(
+      <CloneLessonDialogButton lessonId={lessonId} lessonName={lessonName} />,
+      element
+    );
+  }
+};

--- a/apps/src/sites/studio/pages/lessons/show.js
+++ b/apps/src/sites/studio/pages/lessons/show.js
@@ -151,7 +151,11 @@ const renderCopyLessonButton = () => {
     const lessonName = lessonData['displayName'];
 
     ReactDOM.render(
-      <CloneLessonDialogButton lessonId={lessonId} lessonName={lessonName} />,
+      <CloneLessonDialogButton
+        lessonId={lessonId}
+        lessonName={lessonName}
+        buttonText="Copy"
+      />,
       element
     );
   }

--- a/apps/test/unit/lib/levelbuilder/CloneLessonDialogButtonTest.js
+++ b/apps/test/unit/lib/levelbuilder/CloneLessonDialogButtonTest.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import CloneLessonDialogButton from '@cdo/apps/lib/levelbuilder/CloneLessonDialogButton';
+import {expect} from '../../../util/reconfiguredChai';
+
+describe('CloneLessonDialogButton', () => {
+  let defaultProps;
+
+  beforeEach(() => {
+    defaultProps = {
+      lessonId: 123,
+      lessonName: 'Lesson One',
+      buttonText: 'Make a Copy'
+    };
+  });
+
+  it('renders a closed CloneLessonDialog initially', () => {
+    const wrapper = shallow(<CloneLessonDialogButton {...defaultProps} />);
+
+    const button = wrapper.find('Button');
+    expect(button.prop('text')).to.equal('Make a Copy');
+
+    const dialog = wrapper.find('CloneLessonDialog');
+    // this indicates that the dialog is closed
+    expect(dialog.prop('lessonId')).to.be.undefined;
+    expect(dialog.prop('lessonName')).to.equal('Lesson One');
+  });
+});

--- a/apps/test/unit/lib/levelbuilder/CloneLessonDialogButtonTest.js
+++ b/apps/test/unit/lib/levelbuilder/CloneLessonDialogButtonTest.js
@@ -25,4 +25,15 @@ describe('CloneLessonDialogButton', () => {
     expect(dialog.prop('lessonId')).to.be.undefined;
     expect(dialog.prop('lessonName')).to.equal('Lesson One');
   });
+
+  it('renders an open CloneLessonDialog after button is clicked', () => {
+    const wrapper = shallow(<CloneLessonDialogButton {...defaultProps} />);
+
+    const button = wrapper.find('Button');
+    button.simulate('click');
+
+    const dialog = wrapper.find('CloneLessonDialog');
+    expect(dialog.prop('lessonId')).to.equal(123);
+    expect(dialog.prop('lessonName')).to.equal('Lesson One');
+  });
 });

--- a/dashboard/app/views/lessons/show.html.haml
+++ b/dashboard/app/views/lessons/show.html.haml
@@ -16,6 +16,8 @@
     %ul
       - if Rails.application.config.levelbuilder_mode
         %li= link_to "Edit", @lesson.get_uncached_edit_path
+        %li
+          #copy-lesson-button
       - else
         %li= link_to 'Edit on levelbuilder', URI.join("https://levelbuilder-studio.code.org/", script_lesson_path(@lesson.script, @lesson)).to_s
 


### PR DESCRIPTION
Finishes [PP-107](https://codedotorg.atlassian.net/browse/PP-107).

https://user-images.githubusercontent.com/8001765/165638819-f782a7af-e846-4ab2-a65a-37061c166323.mov


## Testing story

* new unit tests cover the new component
* manually verified it is working end to end, as shown in the screenshots
* manually verified that lesson pages still load without levelbuilder permissions

drone status: GREEN
* UI tests: GREEN: https://drone.cdn-code.org/code-dot-org/code-dot-org/18038
* unit tests: GREEN
  * apps tests failed in in 6:11: https://drone.cdn-code.org/code-dot-org/code-dot-org/18038/1/3
  * apps tests failed in 7:09: https://drone.cdn-code.org/code-dot-org/code-dot-org/18091/1/3 
  * apps tests passed in https://drone.cdn-code.org/code-dot-org/code-dot-org/18136