### PR TITLE
fix edit-on-levelbuilder link when viewing sublevels

### DIFF
--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -128,11 +128,11 @@ class ScriptLevelsController < ApplicationController
 
     # In the case of puzzle_page or sublevel_position, send param through to be included in the
     # generation of the script level path.
-    extra_params = {}
+    @extra_params = {}
     if @script_level.long_assessment?
-      extra_params[:puzzle_page] = params[:puzzle_page] ? params[:puzzle_page] : 1
+      @extra_params[:puzzle_page] = params[:puzzle_page] ? params[:puzzle_page] : 1
     end
-    extra_params[:sublevel_position] = params[:sublevel_position] if @script_level.bubble_choice?
+    @extra_params[:sublevel_position] = params[:sublevel_position] if @script_level.bubble_choice?
 
     can_view_version = @script_level&.script&.can_view_version?(current_user, locale: locale)
     override_redirect = VersionRedirectOverrider.override_unit_redirect?(session, @script_level&.script)
@@ -146,7 +146,7 @@ class ScriptLevelsController < ApplicationController
       return
     end
 
-    if request.path != (canonical_path = build_script_level_path(@script_level, extra_params))
+    if request.path != (canonical_path = build_script_level_path(@script_level, @extra_params))
       canonical_path << "?#{request.query_string}" unless request.query_string.empty?
       redirect_to canonical_path, status: :moved_permanently
       return

--- a/dashboard/app/views/levels/_admin.html.haml
+++ b/dashboard/app/views/levels/_admin.html.haml
@@ -73,7 +73,7 @@
             = link_to '[E]', edit_level_path(project_template_level)
 
       - elsif @script_level
-        %li= link_to 'edit on levelbuilder', URI.join("https://levelbuilder-studio.code.org/", build_script_level_path(@script_level)).to_s
+        %li= link_to 'edit on levelbuilder', URI.join("https://levelbuilder-studio.code.org/", build_script_level_path(@script_level, @extra_params)).to_s
 
     This level is in #{@level.script_levels.count} scripts:
     %ul


### PR DESCRIPTION
Finishes [PP-68](https://codedotorg.atlassian.net/browse/PP-68). In addition to fixing the "edit on levelbuilder" link for bubble choice sublevels:

| before | after |
|---|---|
| ![Screen Shot 2022-04-27 at 3 54 13 PM](https://user-images.githubusercontent.com/8001765/165645082-2e5fb746-7805-4463-81c8-251e6bb1482f.png) | ![Screen Shot 2022-04-27 at 3 56 06 PM](https://user-images.githubusercontent.com/8001765/165645099-08a55d83-ff20-4019-9c89-6f66a9d52a4b.png) |

it also fixes the behavior when viewing a page number greater than 1 in a levelgroup:

| before | after |
|---|---|
| ![Screen Shot 2022-04-27 at 4 04 08 PM](https://user-images.githubusercontent.com/8001765/165645504-857b8940-5a6a-4c6b-bdb2-33fde96f8568.png) | ![Screen Shot 2022-04-27 at 4 03 27 PM](https://user-images.githubusercontent.com/8001765/165645512-f3f6d8ea-ba37-42f9-9d48-af04ece408d0.png) |

## Testing story

manually verified as shown in screenshots. lots of existing tests covering the script level page to ensure that the non-levelbuilder view did not somehow break. 

