### PR TITLE
Replace dropdown with a search bar in the foorm editors

### DIFF
--- a/apps/src/code-studio/pd/foorm/editor/components/FoormEntityLoadButtons.jsx
+++ b/apps/src/code-studio/pd/foorm/editor/components/FoormEntityLoadButtons.jsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import {connect} from 'react-redux';
 import PropTypes from 'prop-types';
-import {Button, DropdownButton, MenuItem} from 'react-bootstrap';
+import {Button} from 'react-bootstrap';
+import loadable from '@cdo/apps/util/loadable';
+const VirtualizedSelect = loadable(() =>
+  import('@cdo/apps/templates/VirtualizedSelect')
+);
 import SingleCheckbox from '../../../form_components/SingleCheckbox';
 import {
   setLastSaved,
@@ -62,21 +66,9 @@ class FoormEntityLoadButtons extends React.Component {
             a['text'].localeCompare(b['text']) ||
             a['metadata']['version'] - b['metadata']['version']
         )
-        .map((entity, i) => {
-          return this.renderMenuItem(
-            () => this.props.onSelect(entity['metadata']),
-            entity['text'],
-            i
-          );
+        .map(entity => {
+          return {metadata: entity['metadata'], label: entity['text']};
         })
-    );
-  }
-
-  renderMenuItem(clickHandler, textToDisplay, key) {
-    return (
-      <MenuItem key={key} eventKey={key} onClick={clickHandler}>
-        {textToDisplay}
-      </MenuItem>
     );
   }
 
@@ -96,21 +88,22 @@ class FoormEntityLoadButtons extends React.Component {
   render() {
     return (
       <div>
-        <DropdownButton
-          id="load_config"
-          title={`Load ${this.props.foormEntityName}...`}
-          className="btn"
-          disabled={this.props.isDisabled}
-        >
-          {this.getDropdownOptions()}
-        </DropdownButton>
-        <Button
-          onClick={() => this.initializeEmptyCodeMirror()}
-          className="btn"
-          disabled={this.props.isDisabled}
-        >
-          {`New ${this.props.foormEntityName}`}
-        </Button>
+        <div className="load-buttons-top-row">
+          <VirtualizedSelect
+            options={this.getDropdownOptions()}
+            className="load-buttons-search"
+            cache={false}
+            onChange={entity => this.props.onSelect(entity.metadata)}
+            placeholder={`Search for ${this.props.foormEntityName}`}
+          />
+          <Button
+            onClick={() => this.initializeEmptyCodeMirror()}
+            className="load-buttons-new"
+            disabled={this.props.isDisabled}
+          >
+            {`New ${this.props.foormEntityName}`}
+          </Button>
+        </div>
         {this.props.showVersionFilterToggle && (
           <SingleCheckbox
             name="latestVersionsOnly"

--- a/apps/src/code-studio/pd/foorm/editor/components/FoormEntityLoadButtons.jsx
+++ b/apps/src/code-studio/pd/foorm/editor/components/FoormEntityLoadButtons.jsx
@@ -36,7 +36,8 @@ class FoormEntityLoadButtons extends React.Component {
   };
 
   state = {
-    latestVersionsOnly: true
+    latestVersionsOnly: true,
+    selectedOption: null
   };
 
   shouldShowLatestVersionsOnly() {
@@ -93,7 +94,13 @@ class FoormEntityLoadButtons extends React.Component {
             options={this.getDropdownOptions()}
             className="load-buttons-search"
             cache={false}
-            onChange={entity => this.props.onSelect(entity.metadata)}
+            value={this.state.selectedOption}
+            onChange={option => {
+              this.setState({selectedOption: option});
+              if (option) {
+                this.props.onSelect(option.metadata);
+              }
+            }}
             placeholder={`Search for ${this.props.foormEntityName}`}
           />
           <Button

--- a/apps/style/code-studio/foorm_editor.scss
+++ b/apps/style/code-studio/foorm_editor.scss
@@ -29,3 +29,15 @@ div[role=dialog] {
     }
   }
 }
+
+.load-buttons-top-row {
+  display: flex;
+}
+
+.load-buttons-new {
+  margin-top: 0;
+}
+
+.load-buttons-search {
+  width: 60%;
+}

--- a/apps/test/unit/code-studio/pd/foorm/FoormEntityLoadButtonsTest.js
+++ b/apps/test/unit/code-studio/pd/foorm/FoormEntityLoadButtonsTest.js
@@ -1,27 +1,13 @@
 import React from 'react';
-import {mount} from 'enzyme';
+import {shallow} from 'enzyme';
 import {assert} from 'chai';
 
-import {
-  stubRedux,
-  restoreRedux,
-  getStore,
-  registerReducers
-} from '@cdo/apps/redux';
-import {Provider} from 'react-redux';
-import foorm from '../../../../../src/code-studio/pd/foorm/editor/foormEditorRedux';
-import {DropdownButton, MenuItem} from 'react-bootstrap';
-import FoormEntityLoadButtons from '../../../../../src/code-studio/pd/foorm/editor/components/FoormEntityLoadButtons';
-import SingleCheckbox from '../../../../../src/code-studio/pd/form_components/SingleCheckbox';
+import {UnconnectedFoormEntityLoadButtons as FoormEntityLoadButtons} from '@cdo/apps/code-studio/pd/foorm/editor/components/FoormEntityLoadButtons';
+import SingleCheckbox from '@cdo/apps/code-studio/pd/form_components/SingleCheckbox';
 
 describe('FoormEntityLoadButtons', () => {
-  let defaultProps, store, wrapper;
+  let defaultProps, wrapper;
   beforeEach(() => {
-    stubRedux();
-    registerReducers({foorm});
-
-    store = getStore();
-
     defaultProps = {
       foormEntities: [
         {
@@ -44,18 +30,12 @@ describe('FoormEntityLoadButtons', () => {
     };
   });
 
-  afterEach(() => {
-    restoreRedux();
-  });
-
   it('filters and sorts menu items by default with toggle', () => {
-    wrapper = mount(
-      <Provider store={store}>
-        <FoormEntityLoadButtons
-          {...defaultProps}
-          showVersionFilterToggle={true}
-        />
-      </Provider>
+    wrapper = shallow(
+      <FoormEntityLoadButtons
+        {...defaultProps}
+        showVersionFilterToggle={true}
+      />
     );
 
     const expectedOrder = [
@@ -65,27 +45,21 @@ describe('FoormEntityLoadButtons', () => {
     ];
 
     assert.equal(
-      wrapper
-        .find(DropdownButton)
-        .at(0)
-        .find(MenuItem).length,
+      wrapper.find('.load-buttons-search').prop('options').length,
       3
     );
     wrapper
-      .find(DropdownButton)
-      .at(0)
-      .find(MenuItem)
-      .every((menuItem, i) => assert.equal(menuItem.text(), expectedOrder[i]));
+      .find('.load-buttons-search')
+      .prop('options')
+      .every((menuItem, i) => assert.equal(menuItem.label, expectedOrder[i]));
   });
 
   it("sorts, but doesn't filter menu items when toggled off", () => {
-    wrapper = mount(
-      <Provider store={store}>
-        <FoormEntityLoadButtons
-          {...defaultProps}
-          showVersionFilterToggle={true}
-        />
-      </Provider>
+    wrapper = shallow(
+      <FoormEntityLoadButtons
+        {...defaultProps}
+        showVersionFilterToggle={true}
+      />
     );
 
     wrapper
@@ -102,27 +76,21 @@ describe('FoormEntityLoadButtons', () => {
     ];
 
     assert.equal(
-      wrapper
-        .find(DropdownButton)
-        .at(0)
-        .find(MenuItem).length,
+      wrapper.find('.load-buttons-search').prop('options').length,
       4
     );
     wrapper
-      .find(DropdownButton)
-      .at(0)
-      .find(MenuItem)
-      .every((menuItem, i) => assert.equal(menuItem.text(), expectedOrder[i]));
+      .find('.load-buttons-search')
+      .prop('options')
+      .every((menuItem, i) => assert.equal(menuItem.label, expectedOrder[i]));
   });
 
   it("sorts, but doesn't filter menu items with no toggle", () => {
-    wrapper = mount(
-      <Provider store={store}>
-        <FoormEntityLoadButtons
-          {...defaultProps}
-          showVersionFilterToggle={false}
-        />
-      </Provider>
+    wrapper = shallow(
+      <FoormEntityLoadButtons
+        {...defaultProps}
+        showVersionFilterToggle={false}
+      />
     );
 
     const expectedOrder = [
@@ -133,16 +101,12 @@ describe('FoormEntityLoadButtons', () => {
     ];
 
     assert.equal(
-      wrapper
-        .find(DropdownButton)
-        .at(0)
-        .find(MenuItem).length,
+      wrapper.find('.load-buttons-search').prop('options').length,
       4
     );
     wrapper
-      .find(DropdownButton)
-      .at(0)
-      .find(MenuItem)
-      .every((menuItem, i) => assert.equal(menuItem.text(), expectedOrder[i]));
+      .find('.load-buttons-search')
+      .prop('options')
+      .every((menuItem, i) => assert.equal(menuItem.label, expectedOrder[i]));
   });
 });

--- a/apps/test/unit/code-studio/pd/foorm/FoormEntityLoadButtonsTest.js
+++ b/apps/test/unit/code-studio/pd/foorm/FoormEntityLoadButtonsTest.js
@@ -4,9 +4,12 @@ import {assert} from 'chai';
 
 import {UnconnectedFoormEntityLoadButtons as FoormEntityLoadButtons} from '@cdo/apps/code-studio/pd/foorm/editor/components/FoormEntityLoadButtons';
 import SingleCheckbox from '@cdo/apps/code-studio/pd/form_components/SingleCheckbox';
+import {Button} from 'react-bootstrap';
+import sinon from 'sinon';
 
 describe('FoormEntityLoadButtons', () => {
-  let defaultProps, wrapper;
+  let defaultProps, wrapper, showCodeMirrorStub;
+  showCodeMirrorStub = sinon.stub();
   beforeEach(() => {
     defaultProps = {
       foormEntities: [
@@ -26,7 +29,15 @@ describe('FoormEntityLoadButtons', () => {
           metadata: {name: 'c_library', version: 0},
           text: 'c_library, version 0'
         }
-      ]
+      ],
+      showCodeMirror: showCodeMirrorStub,
+      resetCodeMirror: () => {},
+      resetSelectedData: () => {},
+      setLastSaved: () => {},
+      setSaveError: () => {},
+      setHasJSONError: () => {},
+      setHasLintError: () => {},
+      setLastSavedQuestions: () => {}
     };
   });
 
@@ -108,5 +119,11 @@ describe('FoormEntityLoadButtons', () => {
       .find('.load-buttons-search')
       .prop('options')
       .every((menuItem, i) => assert.equal(menuItem.label, expectedOrder[i]));
+  });
+
+  it('shows blank editor on new library click', () => {
+    wrapper.find(Button).prop('onClick')();
+
+    sinon.assert.calledOnce(showCodeMirrorStub);
   });
 });


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Fit and finish!

Replaces the boring old dropdown with a fancy new autocomplete search bar for the foorm editors. Works across all foorm editors (form, library). Automatically updates with filtered list when toggling the "only show latest" checkbox.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
https://studio.code.org/foorm/forms/editor
https://studio.code.org/foorm/libraries/editor
- jira ticket: [PP-137](https://codedotorg.atlassian.net/browse/PP-137)

## Testing story

Manual testing and updated the unit tests

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Screenshots
before:
![image](https://user-images.githubusercontent.com/82416901/165645330-b9b9ba64-74e3-4076-aa8e-9dc6b76bbbf5.png)

after:
![image](https://user-images.githubusercontent.com/82416901/165646969-f60fb6c0-59d6-440d-add6-66cfbbc474a5.png)

![image](https://user-images.githubusercontent.com/82416901/165646691-e75cfdb9-b15e-451d-8b74-2bf97fd0c252.png)
