### PR TITLE
Spruce up code.org/translate

### DIFF
--- a/pegasus/sites.v3/code.org/views/target_languages.haml
+++ b/pegasus/sites.v3/code.org/views/target_languages.haml
@@ -1,5 +1,6 @@
 #language{:style=>'padding-left: 20px; margin: 0;'}
   - Languages.get_crowdin_languages.each do |properties|
+    - next if properties[:crowdin_code_s] == 'in-TL'
     %div{:style => 'width: 100%;'}
       .col-16{:style=>'float: left;'}
         %div{:style => 'height: 130px; width: 130px; margin-right: 0p'}

--- a/pegasus/sites.v3/code.org/views/target_languages.haml
+++ b/pegasus/sites.v3/code.org/views/target_languages.haml
@@ -1,11 +1,9 @@
-#language{:style=>'padding-left: 20px; margin: 0;'}
+#language{:style=>'background-color: #f3f3f3; padding: 10px; display: flex; justify-content: center; flex-wrap: wrap'}
   - Languages.get_crowdin_languages.each do |properties|
     - next if properties[:crowdin_code_s] == 'in-TL'
-    %div{:style => 'width: 100%;'}
-      .col-16{:style=>'float: left;'}
-        %div{:style => 'height: 130px; width: 130px; margin-right: 0p'}
-          - project_url = "http://crowdin.com/project/codeorg/#{properties[:crowdin_code_s]}"
-          - image_url = "/images/flags/#{properties[:crowdin_code_s]}.png"
-          %a{:href=>project_url, :style=>'text-decoration: none;'}
-            %img{:src=>image_url, :style=>'max-width: 130px; max-height: 130px;'}
-            %br{:style=>'clear: both;'}= properties[:crowdin_name_s]
+    - project_url = "http://crowdin.com/project/codeorg/#{properties[:crowdin_code_s]}"
+    - image_url = "/images/flags/#{properties[:crowdin_code_s]}.png"
+    %div{:style => 'text-align: center; height: 180px; width: 125px'}
+      %a{:href=>project_url, :style=>'text-decoration: none'}
+        %img{:src=>image_url, :style=>'height: 60px; margin: auto'}
+        %p{:style => 'width: 100%'}= properties[:crowdin_name_s]


### PR DESCRIPTION
Some minor fixes to the code.org/translate page
- Remove the `I18n Pseudo Language`. This is not a real language.
- Make it so the different language tiles don't overlap.
- Add a very light grey background behind the languages/flags so flags with white edges are easier to see.

__ | Screenshot
---|---
Before | ![Before Screenshot](https://user-images.githubusercontent.com/1372238/165647436-cf99e103-326a-45eb-82ca-442682b019ec.png)
After | ![After Screenshot](https://user-images.githubusercontent.com/1372238/165647486-6dd85597-6769-43be-9b73-31cf3f5863f8.png)

## Links
* [JIRA](https://codedotorg.atlassian.net/browse/PP-150)

## Testing story
* Manually tested on http://localhost.code.org:3000/translate