### PR TITLE
Do not generate pdfs for in development and pilot courses

### DIFF
--- a/dashboard/lib/services/curriculum_pdfs.rb
+++ b/dashboard/lib/services/curriculum_pdfs.rb
@@ -100,7 +100,7 @@ module Services
 
       return false unless rack_env?(:staging)
       return false unless script_data['properties'].fetch('is_migrated', false)
-      return false if script_data['published_state'] == SharedCourseConstants::PUBLISHED_STATE.in_development
+      return false if [SharedCourseConstants::PUBLISHED_STATE.pilot, SharedCourseConstants::PUBLISHED_STATE.in_development].include?(script_data['published_state'])
       return false if script_data['properties'].fetch('use_legacy_lesson_plans', false)
       return false if DCDO.get('disable_curriculum_pdf_generation', false)
 
@@ -112,14 +112,9 @@ module Services
       !timestamps_equal(new_timestamp, existing_timestamp)
     end
 
-    # We do not want to generate an overview pdf in a couple cases:
-    # 1) There are no lesson plans in the unit
-    # 2) The unit's published state is in-development or pilot. This is because
-    # we rely on being able to see the unit overview page as a signed out user
-    # in order to generate the overview pdf. When a course is in-development or pilot
-    # signed out users can not see the unit overview page
+    # Do no generate the overview pdf is there are no lesson plans
     def self.should_generate_overview_pdf?(unit)
-      !(unit.unit_without_lesson_plans? || [SharedCourseConstants::PUBLISHED_STATE.pilot, SharedCourseConstants::PUBLISHED_STATE.in_development].include?(unit.get_published_state))
+      !unit.unit_without_lesson_plans?
     end
 
     # Do no generate the resources pdf is there are no lesson plans since

--- a/dashboard/lib/services/curriculum_pdfs.rb
+++ b/dashboard/lib/services/curriculum_pdfs.rb
@@ -89,7 +89,11 @@ module Services
     #    process themselves.
     # 2. Is the script one for which we care about PDFs? Right now, we only
     #    want to generate PDFs for "migrated" scripts.
-    # 3. Is the script actually being updated? The overall seed process is
+    # 3. Is the unit able to be seen by a signed out user?
+    #    We rely on being able to see the unit overview page as a signed out user
+    #    in order to generate the overview pdf. When a course is in-development or pilot
+    #    signed out users can not see the unit overview page
+    # 4. Is the script actually being updated? The overall seed process is
     #    indiscriminate, and will happily re-seed content even without
     #    changes. This is fine for database upserts, but we want to be more
     #    cautious with the more-expensive PDFs generation process.

--- a/dashboard/lib/services/curriculum_pdfs.rb
+++ b/dashboard/lib/services/curriculum_pdfs.rb
@@ -100,6 +100,7 @@ module Services
 
       return false unless rack_env?(:staging)
       return false unless script_data['properties'].fetch('is_migrated', false)
+      return false if script_data['published_state'] == SharedCourseConstants::PUBLISHED_STATE.in_development
       return false if script_data['properties'].fetch('use_legacy_lesson_plans', false)
       return false if DCDO.get('disable_curriculum_pdf_generation', false)
 

--- a/dashboard/test/lib/services/curriculum_pdfs_test.rb
+++ b/dashboard/test/lib/services/curriculum_pdfs_test.rb
@@ -60,6 +60,25 @@ module Services
       refute Services::CurriculumPdfs.generate_pdfs?(script_data)
     end
 
+    test 'will not generate a PDF if unit is in development published state' do
+      CDO.stubs(:rack_env).returns(:staging)
+      script = create(:script)
+      script_data = {
+        'properties' => {
+          'is_migrated' => true,
+        },
+        'serialized_at' => Time.now.getutc,
+        'name' => script.name,
+        'published_state' => SharedCourseConstants::PUBLISHED_STATE.in_development
+      }
+
+      script_data = JSON.parse(script_data.to_json)
+
+      refute Services::CurriculumPdfs.generate_pdfs?(script_data)
+      script_data['published_state'] = SharedCourseConstants::PUBLISHED_STATE.beta
+      assert Services::CurriculumPdfs.generate_pdfs?(script_data)
+    end
+
     test 'will not generate a overview PDF when unit does not have lesson plans' do
       CDO.stubs(:rack_env).returns(:staging)
       unit_with_lesson_plans = create(:script, is_migrated: true, published_state: SharedCourseConstants::PUBLISHED_STATE.beta)

--- a/dashboard/test/lib/services/curriculum_pdfs_test.rb
+++ b/dashboard/test/lib/services/curriculum_pdfs_test.rb
@@ -75,7 +75,13 @@ module Services
       script_data = JSON.parse(script_data.to_json)
 
       refute Services::CurriculumPdfs.generate_pdfs?(script_data)
+      script_data['published_state'] = SharedCourseConstants::PUBLISHED_STATE.pilot
+      refute Services::CurriculumPdfs.generate_pdfs?(script_data)
       script_data['published_state'] = SharedCourseConstants::PUBLISHED_STATE.beta
+      assert Services::CurriculumPdfs.generate_pdfs?(script_data)
+      script_data['published_state'] = SharedCourseConstants::PUBLISHED_STATE.preview
+      assert Services::CurriculumPdfs.generate_pdfs?(script_data)
+      script_data['published_state'] = SharedCourseConstants::PUBLISHED_STATE.stable
       assert Services::CurriculumPdfs.generate_pdfs?(script_data)
     end
 
@@ -91,35 +97,6 @@ module Services
 
       assert Services::CurriculumPdfs.should_generate_overview_pdf?(unit_with_lesson_plans)
       refute Services::CurriculumPdfs.should_generate_overview_pdf?(unit_without_lesson_plans)
-    end
-
-    test 'will not generate a overview PDF when unit is in pilot or in-development published state' do
-      CDO.stubs(:rack_env).returns(:staging)
-      pilot_unit = create(:script, is_migrated: true, published_state: SharedCourseConstants::PUBLISHED_STATE.pilot)
-      pilot_lg = create(:lesson_group, script: pilot_unit)
-      create(:lesson, script: pilot_unit, lesson_group: pilot_lg, has_lesson_plan: true)
-
-      in_development_unit = create(:script, is_migrated: true, published_state: SharedCourseConstants::PUBLISHED_STATE.in_development)
-      in_development_lg = create(:lesson_group, script: in_development_unit)
-      create(:lesson, script: in_development_unit, lesson_group: in_development_lg, has_lesson_plan: true)
-
-      beta_unit = create(:script, is_migrated: true, published_state: SharedCourseConstants::PUBLISHED_STATE.beta)
-      beta_lg = create(:lesson_group, script: beta_unit)
-      create(:lesson, script: beta_unit, lesson_group: beta_lg, has_lesson_plan: true)
-
-      preview_unit = create(:script, is_migrated: true, published_state: SharedCourseConstants::PUBLISHED_STATE.preview)
-      preview_lg = create(:lesson_group, script: preview_unit)
-      create(:lesson, script: preview_unit, lesson_group: preview_lg, has_lesson_plan: true)
-
-      stable_unit = create(:script, is_migrated: true, published_state: SharedCourseConstants::PUBLISHED_STATE.stable)
-      stable_lg = create(:lesson_group, script: stable_unit)
-      create(:lesson, script: stable_unit, lesson_group: stable_lg, has_lesson_plan: true)
-
-      refute Services::CurriculumPdfs.should_generate_overview_pdf?(pilot_unit)
-      refute Services::CurriculumPdfs.should_generate_overview_pdf?(in_development_unit)
-      assert Services::CurriculumPdfs.should_generate_overview_pdf?(beta_unit)
-      assert Services::CurriculumPdfs.should_generate_overview_pdf?(preview_unit)
-      assert Services::CurriculumPdfs.should_generate_overview_pdf?(stable_unit)
     end
 
     test 'will only generate a resources PDF when unit has lesson plans' do


### PR DESCRIPTION
Do not generate any PDFs for in_development or pilot courses. There are two reasons for this:

1. There is a lot of change that happens while in one of these two states which requires a lot of resources.
2. We currently require a signed out user to be able to view the pages in order to be able to make PDFs. Signed out users can not see the course in either of these states.

## Links

[Jira](https://codedotorg.atlassian.net/browse/PLAT-1704)

## Testing story

- Updated/Added unit tests