### PR TITLE
Move new video link to the top of the page

### DIFF
--- a/dashboard/app/views/videos/index.html.haml
+++ b/dashboard/app/views/videos/index.html.haml
@@ -1,4 +1,9 @@
 %h1 Listing videos
+
+- if can? :create, Video
+  %div= link_to t('crud.new_model', model: Video.model_name.human), new_video_path
+  &nbsp;
+
 %table
   %thead
     %tr
@@ -21,6 +26,3 @@
         %td= link_to('Download', video.download)
         - if can? :update, video
           %td= link_to t('crud.edit'), edit_video_path(video)
-%br/
-- if can? :create, Video
-  = link_to t('crud.new_model', model: Video.model_name.human), new_video_path


### PR DESCRIPTION
Finishes https://codedotorg.atlassian.net/browse/PP-130.

This simply moves the "New Video" link to the top of /videos so that a user doesn't have to scroll all the way to the bottom of the page to add a new video.

Now:
![Screen Shot 2022-04-28 at 12 13 31 PM](https://user-images.githubusercontent.com/46464143/165828865-526496a2-7e55-4998-9641-871f2cd5de13.png)


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
