### PR TITLE
Hide libraries from hidden (archived) sections

### DIFF
--- a/dashboard/app/controllers/api/v1/section_libraries_controller.rb
+++ b/dashboard/app/controllers/api/v1/section_libraries_controller.rb
@@ -2,12 +2,14 @@ class Api::V1::SectionLibrariesController < Api::V1::JsonApiController
   before_action :authenticate_user!
   check_authorization unless: :no_sections?
 
-  # gets the libraries from all members of all sections I am a part of
+  # gets the libraries from all members of all active sections I am a part of
   # GET api/v1/section_libraries
   def index
     sections = current_user.sections + current_user.sections_as_student
+    active_sections = sections.select {|section| !section.hidden}
+
     libraries = []
-    sections.each do |section|
+    active_sections.each do |section|
       authorize! :list_projects, section
       libraries += ProjectsList.fetch_section_libraries(section)
     end

--- a/dashboard/app/models/sections/section.rb
+++ b/dashboard/app/models/sections/section.rb
@@ -434,7 +434,7 @@ class Section < ApplicationRecord
     end
   end
 
-  # One of the contstraints for teachers looking for discount codes is that they
+  # One of the constraints for teachers looking for discount codes is that they
   # have a section in which 10+ students have made progress on 5+ levels in both
   # csd2 and csd3
   # Note: This code likely belongs in CircuitPlaygroundDiscountCodeApplication


### PR DESCRIPTION
Hide libraries from sections that have been archived (ie, hidden).

Archived sections/associated libraries used to appear in this dropdown, but do not any more after this change.

<img width="1671" alt="image" src="https://user-images.githubusercontent.com/25372625/165835078-8ebebbfc-02eb-4333-bfde-37dcf2cd458b.png">

## Links

- jira ticket: [PP-43](https://codedotorg.atlassian.net/browse/PP-43?atlOrigin=eyJpIjoiMzI0MTYyMTZiNWFjNDYyMDk2Mzg0NTM4MDgyMDM1MTciLCJwIjoiamlyYS1zbGFjay1pbnQifQ)

## Testing story

Tested manually that after archiving a section, the section and associated libraries no longer shows up in the dropdown of sections/libraries available to me.