### PR TITLE
Clear pilot experiment when unit added to unit group

### DIFF
--- a/dashboard/app/models/unit_group.rb
+++ b/dashboard/app/models/unit_group.rb
@@ -240,7 +240,7 @@ class UnitGroup < ApplicationRecord
     new_units_objects.each_with_index do |unit, index|
       unit_group_unit = UnitGroupUnit.find_or_create_by!(unit_group: self, script: unit) do |ugu|
         ugu.position = index + 1
-        unit.update!(published_state: nil, instruction_type: nil, participant_audience: nil, instructor_audience: nil, is_course: false)
+        unit.update!(published_state: nil, instruction_type: nil, participant_audience: nil, instructor_audience: nil, is_course: false, pilot_experiment: nil)
         unit.course_version.destroy if unit.course_version
       end
       unit_group_unit.update!(position: index + 1)

--- a/dashboard/app/models/unit_group.rb
+++ b/dashboard/app/models/unit_group.rb
@@ -242,6 +242,9 @@ class UnitGroup < ApplicationRecord
         ugu.position = index + 1
         unit.update!(published_state: nil, instruction_type: nil, participant_audience: nil, instructor_audience: nil, is_course: false, pilot_experiment: nil)
         unit.course_version.destroy if unit.course_version
+
+        unit.reload
+        unit.write_script_json
       end
       unit_group_unit.update!(position: index + 1)
     end

--- a/dashboard/test/models/unit_group_test.rb
+++ b/dashboard/test/models/unit_group_test.rb
@@ -313,7 +313,6 @@ class UnitGroupTest < ActiveSupport::TestCase
     end
 
     test "set published state to nil for new UnitGroupUnits" do
-      File.stubs(:write).with {|filename, _| filename.to_s == "#{Rails.root}/config/scripts_json/unit1.script_json"}.once
       unit_group = create :unit_group
 
       unit1 = create(:script, name: 'unit1')
@@ -337,7 +336,6 @@ class UnitGroupTest < ActiveSupport::TestCase
     end
 
     test "set instructor and participant audience to nil for new UnitGroupUnits" do
-      File.stubs(:write).with {|filename, _| filename.to_s == "#{Rails.root}/config/scripts_json/unit1.script_json"}.once
       unit_group = create :unit_group
 
       unit1 = create(:script, name: 'unit1')
@@ -363,7 +361,6 @@ class UnitGroupTest < ActiveSupport::TestCase
     end
 
     test "set instruction type to nil for new UnitGroupUnits" do
-      File.stubs(:write).with {|filename, _| filename.to_s == "#{Rails.root}/config/scripts_json/unit1.script_json"}.once
       unit_group = create :unit_group
 
       unit1 = create(:script, name: 'unit1')

--- a/dashboard/test/models/unit_group_test.rb
+++ b/dashboard/test/models/unit_group_test.rb
@@ -299,6 +299,8 @@ class UnitGroupTest < ActiveSupport::TestCase
     end
 
     test "set pilot experiment to nil for new UnitGroupUnits" do
+      File.stubs(:write).with {|filename, _| filename.to_s == "#{Rails.root}/config/scripts_json/unit1.script_json"}.once
+
       unit_group = create :unit_group
 
       unit1 = create(:script, name: 'unit1', published_state: 'pilot', pilot_experiment: 'unit-going-to-unit-group-pilot')
@@ -311,6 +313,7 @@ class UnitGroupTest < ActiveSupport::TestCase
     end
 
     test "set published state to nil for new UnitGroupUnits" do
+      File.stubs(:write).with {|filename, _| filename.to_s == "#{Rails.root}/config/scripts_json/unit1.script_json"}.once
       unit_group = create :unit_group
 
       unit1 = create(:script, name: 'unit1')
@@ -334,6 +337,7 @@ class UnitGroupTest < ActiveSupport::TestCase
     end
 
     test "set instructor and participant audience to nil for new UnitGroupUnits" do
+      File.stubs(:write).with {|filename, _| filename.to_s == "#{Rails.root}/config/scripts_json/unit1.script_json"}.once
       unit_group = create :unit_group
 
       unit1 = create(:script, name: 'unit1')
@@ -359,6 +363,7 @@ class UnitGroupTest < ActiveSupport::TestCase
     end
 
     test "set instruction type to nil for new UnitGroupUnits" do
+      File.stubs(:write).with {|filename, _| filename.to_s == "#{Rails.root}/config/scripts_json/unit1.script_json"}.once
       unit_group = create :unit_group
 
       unit1 = create(:script, name: 'unit1')

--- a/dashboard/test/models/unit_group_test.rb
+++ b/dashboard/test/models/unit_group_test.rb
@@ -298,6 +298,18 @@ class UnitGroupTest < ActiveSupport::TestCase
       refute unit1.course_version
     end
 
+    test "set pilot experiment to nil for new UnitGroupUnits" do
+      unit_group = create :unit_group
+
+      unit1 = create(:script, name: 'unit1', published_state: 'pilot', pilot_experiment: 'unit-going-to-unit-group-pilot')
+
+      unit_group.update_scripts(['unit1'])
+
+      unit1.reload
+      assert_nil unit1.published_state
+      assert_nil unit1.pilot_experiment
+    end
+
     test "set published state to nil for new UnitGroupUnits" do
       unit_group = create :unit_group
 


### PR DESCRIPTION
I noticed when setting up the adhoc for PL Sections bug bash that some of the self-paced-pl-csa units which had been added to a unit group still had the pilot_experiment set on them from before they were added to the unit group. However their published state was not pilot. We clear the published state when adding a unit to a unit group but not the pilot experiment. This PR will fix that.

## Links

[Jira](https://codedotorg.atlassian.net/browse/PLAT-1753)

## Testing story

- Unit Test