### PR TITLE
Fix bug where background would show when deleting last sprite in spritelab

### DIFF
--- a/apps/src/p5lab/AnimationTab/AnimationListItem.jsx
+++ b/apps/src/p5lab/AnimationTab/AnimationListItem.jsx
@@ -38,7 +38,7 @@ class AnimationListItem extends React.Component {
     children: PropTypes.node,
     style: PropTypes.object,
     allAnimationsSingleFrame: PropTypes.bool.isRequired,
-    spriteLab: PropTypes.bool.isRequired,
+    isSpriteLab: PropTypes.bool.isRequired,
     labType: PropTypes.string.isRequired
   };
 
@@ -89,7 +89,7 @@ class AnimationListItem extends React.Component {
   };
 
   deleteAnimation = () => {
-    this.props.deleteAnimation(this.props.animationKey);
+    this.props.deleteAnimation(this.props.animationKey, this.props.isSpriteLab);
   };
 
   setAnimationLooping = looping => {
@@ -207,7 +207,7 @@ class AnimationListItem extends React.Component {
           isSelected={this.props.isSelected}
           singleFrameAnimation={this.props.allAnimationsSingleFrame}
         />
-        {!this.props.spriteLab && animationName}
+        {!this.props.isSpriteLab && animationName}
         {this.props.isSelected && (
           <ListItemButtons
             onFrameDelayChanged={this.setAnimationFrameDelay}
@@ -294,15 +294,15 @@ export default connect(
     columnWidth: state.animationTab.columnSizes[0],
     allAnimationsSingleFrame:
       state.pageConstants.allAnimationsSingleFrame || false,
-    spriteLab: state.pageConstants.isBlockly
+    isSpriteLab: state.pageConstants.isBlockly
   }),
   dispatch => {
     return {
       cloneAnimation(animationKey) {
         dispatch(cloneAnimation(animationKey));
       },
-      deleteAnimation(animationKey) {
-        dispatch(deleteAnimation(animationKey));
+      deleteAnimation(animationKey, isSpriteLab) {
+        dispatch(deleteAnimation(animationKey, isSpriteLab));
       },
       selectAnimation(animationKey) {
         dispatch(selectAnimation(animationKey));

--- a/apps/src/p5lab/ErrorDialogStack.jsx
+++ b/apps/src/p5lab/ErrorDialogStack.jsx
@@ -22,7 +22,8 @@ class ErrorDialogStack extends React.Component {
     errors: PropTypes.arrayOf(PropTypes.object).isRequired,
     dismissError: PropTypes.func.isRequired,
     deleteAnimation: PropTypes.func,
-    animationList: PropTypes.object
+    animationList: PropTypes.object,
+    isSpriteLab: PropTypes.bool.isRequired
   };
 
   handleDeleteChoice(key) {
@@ -40,7 +41,7 @@ class ErrorDialogStack extends React.Component {
       },
       {includeUserId: true}
     );
-    this.props.deleteAnimation(key);
+    this.props.deleteAnimation(key, this.props.isSpriteLab);
     this.props.dismissError();
   }
 
@@ -125,7 +126,8 @@ export default connect(
   function propsFromStore(state) {
     return {
       errors: state.errorDialogStack,
-      animationList: state.animationList
+      animationList: state.animationList,
+      isSpriteLab: state.pageConstants.isBlockly
     };
   },
   function propsFromDispatch(dispatch) {
@@ -133,8 +135,8 @@ export default connect(
       dismissError: function() {
         dispatch(actions.dismissError());
       },
-      deleteAnimation: function(key) {
-        dispatch(animationActions.deleteAnimation(key));
+      deleteAnimation: function(key, isSpriteLab) {
+        dispatch(animationActions.deleteAnimation(key, isSpriteLab));
       }
     };
   }

--- a/apps/src/p5lab/redux/animationList.js
+++ b/apps/src/p5lab/redux/animationList.js
@@ -362,26 +362,29 @@ export function setInitialAnimationList(
       type: SET_INITIAL_ANIMATION_LIST,
       animationList: serializedAnimationList
     });
-    let index = 0;
+    let key = serializedAnimationList.orderedKeys[0];
     // If we're in spritelab, we need to make sure we don't set the selected animation to a background
     if (isSpriteLab) {
-      while (
-        index < serializedAnimationList.orderedKeys.length &&
-        (
-          serializedAnimationList.propsByKey[
-            serializedAnimationList.orderedKeys[index]
-          ].categories || []
-        ).includes('backgrounds')
-      ) {
-        index = index + 1;
-      }
+      const filteredOrderedKeys = getOrderedKeysWithoutBackgrounds(
+        serializedAnimationList
+      );
+      key = filteredOrderedKeys[0];
     }
-    dispatch(selectAnimation(serializedAnimationList.orderedKeys[index] || ''));
+    dispatch(selectAnimation(key || ''));
     serializedAnimationList.orderedKeys.forEach(key => {
       dispatch(loadAnimationFromSource(key));
     });
   };
 }
+
+const getOrderedKeysWithoutBackgrounds = serializedAnimationList => {
+  return serializedAnimationList.orderedKeys.filter(animKey => {
+    const animProps = serializedAnimationList.propsByKey[animKey];
+    return (
+      !animProps.categories || !animProps.categories.includes('backgrounds')
+    );
+  });
+};
 
 export function addBlankAnimation() {
   // To avoid special cases and saving tons of blank animations to our server,
@@ -608,9 +611,14 @@ export function editAnimation(key, props) {
  * @param {!AnimationKey} key
  * @returns {function}
  */
-export function deleteAnimation(key) {
+export function deleteAnimation(key, isSpriteLab = false) {
   return (dispatch, getState) => {
-    const orderedKeys = getState().animationList.orderedKeys;
+    const animationList = getState().animationList;
+    let orderedKeys = animationList.orderedKeys;
+    // If we're in spritelab, we need to make sure we don't set the selected animation to a background
+    if (isSpriteLab) {
+      orderedKeys = getOrderedKeysWithoutBackgrounds(animationList);
+    }
     const currentSelectionIndex = orderedKeys.indexOf(key);
     let keyToSelect =
       currentSelectionIndex === 0 ? 1 : currentSelectionIndex - 1;

--- a/apps/test/unit/p5lab/ErrorDialogStackTest.js
+++ b/apps/test/unit/p5lab/ErrorDialogStackTest.js
@@ -64,6 +64,7 @@ describe('ErrorDialogStack', function() {
             dismissError={() => {}}
             deleteAnimation={() => {}}
             animationList={undefined}
+            isSpriteLab={false}
           />
         );
         expect(dialog.text()).to.contain(
@@ -81,6 +82,7 @@ describe('ErrorDialogStack', function() {
             dismissError={() => {}}
             deleteAnimation={() => {}}
             animationList={undefined}
+            isSpriteLab={false}
           />
         );
         expect(dialog.text()).to.not.contain(

--- a/apps/test/unit/p5lab/redux/animationListTest.js
+++ b/apps/test/unit/p5lab/redux/animationListTest.js
@@ -371,6 +371,20 @@ describe('animationList', function() {
       store.dispatch(deleteAnimation(key0));
       expect(store.getState().animationTab.selectedAnimation).to.equal('');
     });
+
+    it('deleting an animation deselects when there are no other non-background animations in the spritelab animationList', function() {
+      const key0 = 'animation_1';
+      const key1 = 'animation_2';
+      let animationList = createAnimationList(2);
+      animationList.propsByKey[key1].categories = ['backgrounds'];
+      let store = createStore(
+        combineReducers({animationList: reducer, animationTab}),
+        {}
+      );
+      store.dispatch(setInitialAnimationList(animationList));
+      store.dispatch(deleteAnimation(key0, true));
+      expect(store.getState().animationTab.selectedAnimation).to.equal('');
+    });
   });
 
   describe('action: clone animation', function() {


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

When initially loading the list of animations, we skip over any background animations when deciding which one to select first, so do the same when deleting.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [PP-50](https://codedotorg.atlassian.net/browse/PP-50)

## Testing story

added a unit test, and manually tested.
not sure how to test the error boundary dialog effectively, but the changes there are minimal
