### PR TITLE
allow save, publish and return to BubbleChoice sublevels

### DIFF
--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -144,7 +144,9 @@ class LevelsController < ApplicationController
     if @level.properties['encrypted']&.is_a?(String)
       @level.properties['encrypted'] = @level.properties['encrypted'].to_bool
     end
-    @in_script = @level.script_levels.any?
+    bubble_choice_parents = BubbleChoice.parent_levels(@level.name)
+    any_parent_in_script = bubble_choice_parents.any? {|pl| pl.script_levels.any?}
+    @in_script = @level.script_levels.any? || any_parent_in_script
     @standalone = ProjectsController::STANDALONE_PROJECTS.values.map {|h| h[:name]}.include?(@level.name)
     fb = FirebaseHelper.new('shared')
     @dataset_library_manifest = fb.get_library_manifest


### PR DESCRIPTION
Finishes [PP-160](https://codedotorg.atlassian.net/browse/PP-160). the logic for this was already implemented here, and just needed to be enabled: https://github.com/code-dot-org/code-dot-org/blob/a4c41a4888a80415cf9bcf7abd36c3d327397daf/dashboard/app/views/levels/edit.html.haml#L68-L78

## screenshots

| before | after | 
|---|---|
| ![Screen Shot 2022-04-28 at 4 11 45 PM](https://user-images.githubusercontent.com/8001765/165862331-90b719d3-cf20-41b3-b505-fa3a7daca5be.png) | ![Screen Shot 2022-04-28 at 4 11 56 PM](https://user-images.githubusercontent.com/8001765/165862343-8883c161-4183-4b10-9f77-017f03494089.png) |

## Testing story

manual verification shown in screenshots