### PR TITLE
Create + User menus always line up with left side of buttons

### DIFF
--- a/shared/css/user-menu.scss
+++ b/shared/css/user-menu.scss
@@ -34,17 +34,16 @@
   }
 
   .user_options, .create_options {
-    left: 0px;
     top: 50px;
   }
 
   .help_contents {
-    right: 0px;
     top: 58px;
   }
 
   .user_options, .create_options, .help_contents {
     position: absolute;
+    right: 0px;
     background-color: $white;
     border: 1px solid $charcoal;
 

--- a/shared/css/user-menu.scss
+++ b/shared/css/user-menu.scss
@@ -3,6 +3,7 @@
 .user_menu, .create_menu, .help_button {
   user-select: none;
   height: 38px;
+  position: relative;
 
   .create_button, .display_name, .pairing_name {
     max-width: 120px;
@@ -31,10 +32,19 @@
       
     }
   }
+
+  .user_options, .create_options {
+    left: 0px;
+    top: 50px;
+  }
+
+  .help_contents {
+    right: 0px;
+    top: 58px;
+  }
+
   .user_options, .create_options, .help_contents {
     position: absolute;
-    top: 55px;
-    right: 71px;
     background-color: $white;
     border: 1px solid $charcoal;
 


### PR DESCRIPTION
Position the user_options and create_options menus relative to their respective buttons, so they are always left-aligned even as the User button width stretches from longer names.

## Links
- jira ticket: [PP-108](https://codedotorg.atlassian.net/browse/PP-108)

## Result
![create_menu_fix](https://user-images.githubusercontent.com/86268316/165983128-7e31affe-f5df-410f-934c-9cfd9c2dc45c.gif)

Edit: the dropdowns are now right-aligned instead of left-aligned, but will still always line up with their respective buttons.
![right-align-dropdown](https://user-images.githubusercontent.com/86268316/166552363-866ee31f-46c2-4d29-be7f-6b0f7c613fa8.png)
