### PR TITLE
Change the color of the header bar on levelbuilder

### DIFF
--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -348,6 +348,13 @@ img.video_thumbnail {
   }
 }
 
+.levelbuilder-header {
+  .header {
+    background-color: $purple;
+  }
+}
+
+
 #language_dir.rtl #pageheader-wrapper {
   .create_options {
     direction: rtl;

--- a/dashboard/app/views/layouts/_header.html.haml
+++ b/dashboard/app/views/layouts/_header.html.haml
@@ -5,15 +5,11 @@
   script_level = local_assigns[:script_level]
   level = local_assigns[:level]
   lesson = local_assigns[:lesson]
-  full_width = local_assigns[:full_width]
-
-  show_bug_links = script_level || (level && level.try(:is_project_level))
 
   user_type = nil
 
   header_class = 'header-wrapper'
-  header_class = header_class + (show_bug_links ? ' feedback-bug-links' : '')
-  header_class = header_class + (script_level || level ? ' hide_on_mobile' : '')
+  header_class = header_class + (rack_env?(:levelbuilder) ? ' levelbuilder-header' : '')
 
   if current_user
     if current_user.teacher?


### PR DESCRIPTION
Content editors have been saying that it is confusing to tell if you are on levelbuilder or production. I thought a different header bar color would make it clearer. 

<img width="1356" alt="Screen Shot 2022-04-29 at 1 25 38 PM" src="https://user-images.githubusercontent.com/208083/165993430-8ad74f19-ef37-49b4-925b-e05320e92b57.png">
