### PR TITLE
Replace resource/vocab markdown in more fields in activity section

### DIFF
--- a/dashboard/test/models/lesson_test.rb
+++ b/dashboard/test/models/lesson_test.rb
@@ -971,12 +971,13 @@ class LessonTest < ActiveSupport::TestCase
       assert_equal @original_lesson.programming_expressions, copied_lesson.programming_expressions
     end
 
-    test "resource markdown is updated when cloning lesson" do
+    test "resource markdown is updated in activity sections when cloning lesson" do
       resource_in_lesson = create :resource, key: 'original_key', name: 'resource1', course_version: @original_course_version, lessons: [@original_lesson]
       resource_not_in_lesson = create :resource, name: 'resource2', course_version: @original_course_version, lessons: []
 
       lesson_activity = create :lesson_activity, lesson: @original_lesson
       create :activity_section, lesson_activity: lesson_activity, description: "Resource 1: [r #{Services::GloballyUniqueIdentifiers.build_resource_key(resource_in_lesson)}]. Resource 2: [r #{Services::GloballyUniqueIdentifiers.build_resource_key(resource_not_in_lesson)}]."
+      create :activity_section, lesson_activity: lesson_activity, tips: [{'markdown': "Resource 1: [r #{Services::GloballyUniqueIdentifiers.build_resource_key(resource_in_lesson)}]"}, {markdown: "description without resource"}]
 
       @destination_script.expects(:write_script_json).once
       copied_lesson = @original_lesson.copy_to_unit(@destination_script)
@@ -988,7 +989,9 @@ class LessonTest < ActiveSupport::TestCase
       refute_nil copied_resource1
       copied_resource2 = @destination_course_version.resources.find_by_name('resource2')
       refute_nil copied_resource2
-      assert_equal @destination_script.lessons.last.lesson_activities.last.activity_sections.last.description, "Resource 1: [r #{Services::GloballyUniqueIdentifiers.build_resource_key(copied_resource1)}]. Resource 2: [r #{Services::GloballyUniqueIdentifiers.build_resource_key(copied_resource2)}]."
+      assert_equal @destination_script.lessons.last.lesson_activities.last.activity_sections.first.description, "Resource 1: [r #{Services::GloballyUniqueIdentifiers.build_resource_key(copied_resource1)}]. Resource 2: [r #{Services::GloballyUniqueIdentifiers.build_resource_key(copied_resource2)}]."
+      assert_equal 2, @destination_script.lessons.last.lesson_activities.last.activity_sections.last.tips.length
+      assert_equal ["Resource 1: [r #{Services::GloballyUniqueIdentifiers.build_resource_key(copied_resource1)}]", "description without resource"], @destination_script.lessons.last.lesson_activities.last.activity_sections.last.tips.map {|t| t['markdown']}
     end
 
     test "preparation resource markdown is updated when cloning lesson" do
@@ -1011,7 +1014,7 @@ class LessonTest < ActiveSupport::TestCase
       assert_equal @destination_script.lessons.last.preparation, "Resource 1: [r #{Services::GloballyUniqueIdentifiers.build_resource_key(copied_resource1)}]. Resource 2: [r #{Services::GloballyUniqueIdentifiers.build_resource_key(copied_resource2)}]."
     end
 
-    test "vocabulary markdown is updated when cloning lesson" do
+    test "vocabulary markdown is updated in activity sections when cloning lesson" do
       vocabulary_in_lesson = create :vocabulary, key: 'original_key', word: 'vocabulary one', course_version: @original_course_version, lessons: [@original_lesson]
       vocabulary_not_in_lesson = create :vocabulary, word: 'vocabulary two', course_version: @original_course_version, lessons: []
 
@@ -1028,6 +1031,25 @@ class LessonTest < ActiveSupport::TestCase
       copied_vocabulary2 = @destination_course_version.vocabularies.find_by_word('vocabulary two')
       refute_nil copied_vocabulary2
       assert_equal @destination_script.lessons.last.lesson_activities.last.activity_sections.last.description, "Vocab 1: [v #{Services::GloballyUniqueIdentifiers.build_vocab_key(copied_vocabulary1)}]. Vocab 2: [v #{Services::GloballyUniqueIdentifiers.build_vocab_key(copied_vocabulary2)}]."
+    end
+
+    test "student overview vocab markdown is updated when cloning lesson" do
+      vocabulary_in_lesson = create :vocabulary, key: 'original_key', word: 'vocabulary one', course_version: @original_course_version, lessons: [@original_lesson]
+      vocabulary_not_in_lesson = create :vocabulary, word: 'vocabulary two', course_version: @original_course_version, lessons: []
+
+      @original_lesson.student_overview = "Vocab 1: [v #{Services::GloballyUniqueIdentifiers.build_vocab_key(vocabulary_in_lesson)}]. Vocab 2: [v #{Services::GloballyUniqueIdentifiers.build_vocab_key(vocabulary_not_in_lesson)}]."
+      @original_lesson.save!
+
+      @destination_script.expects(:write_script_json).once
+      copied_lesson = @original_lesson.copy_to_unit(@destination_script)
+      assert_equal @destination_script, copied_lesson.script
+      assert_equal 1, copied_lesson.vocabularies.length
+
+      copied_vocabulary1 = @destination_course_version.vocabularies.find_by_word('vocabulary one')
+      refute_nil copied_vocabulary1
+      copied_vocabulary2 = @destination_course_version.vocabularies.find_by_word('vocabulary two')
+      refute_nil copied_vocabulary2
+      assert_equal @destination_script.lessons.last.student_overview, "Vocab 1: [v #{Services::GloballyUniqueIdentifiers.build_vocab_key(copied_vocabulary1)}]. Vocab 2: [v #{Services::GloballyUniqueIdentifiers.build_vocab_key(copied_vocabulary2)}]."
     end
 
     test "variants are removed when cloning lesson into another script" do


### PR DESCRIPTION
Reported by [Dan](https://codedotorg.slack.com/archives/C02EEGWLHR8/p1651182397491359?thread_ts=1650912638.349809&cid=C02EEGWLHR8).

Also refactor so it's a been cleaner. I didn't add more tests because there are tests covering both of these new loops but I can add some tests if folks think it's necessary. I'm not sure how valuable it is to test the replace logic for all seven fields we're running these functions on.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
