### PR TITLE
Java Lab: Give exemplar access to pilot users

### DIFF
--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -420,6 +420,12 @@ class Ability
       end
     end
 
+    # Allow pilot users to have access to run override_sources java lab code, which is how we run exemplars.
+    # TODO: Change this to authorized_instructors once we have throttling in place.
+    if user.persisted? && (user.has_pilot_experiment?(CSA_PILOT) || user.has_pilot_experiment?(CSA_PILOT_FACILITATORS))
+      can :get_access_token_with_override_sources, :javabuilder_session
+    end
+
     # This action allows levelbuilders to work on exemplars and validation in levelbuilder
     if user.persisted? && user.permission?(UserPermission::LEVELBUILDER)
       can [:get_access_token_with_override_sources, :get_access_token_with_override_validation], :javabuilder_session


### PR DESCRIPTION
In order to enable review of next year's exemplars, give access to the `get_access_token_with_override_sources` route to users with CSA pilot or CSA pilot facilitator permission. This enables these users to run exemplar code--viewing the code is controlled separately and already works for verified instructors. We will update this to be all verified instructors once throttling is in place.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
