### PR TITLE
Create /project_commits endpoint to fetch all the commits of a project

### DIFF
--- a/dashboard/app/controllers/project_versions_controller.rb
+++ b/dashboard/app/controllers/project_versions_controller.rb
@@ -1,9 +1,9 @@
 class ProjectVersionsController < ApplicationController
+  before_action :authenticate_user!, except: [:project_commits]
+
   # POST /project_versions
   def create
-    user_storage_id, project_id = storage_decrypt_channel_id(params[:storage_id])
-    project_owner = User.find_by(id: user_id_for_storage_id(user_storage_id))
-    return render :forbidden unless can?(:create, project_owner, project_id)
+    _, project_id = storage_decrypt_channel_id(params[:storage_id])
     project_version = ProjectVersion.new(project_id: project_id, object_version_id: params[:version_id], comment: params[:comment])
     if project_version.save
       return head :ok

--- a/dashboard/app/controllers/project_versions_controller.rb
+++ b/dashboard/app/controllers/project_versions_controller.rb
@@ -21,7 +21,7 @@ class ProjectVersionsController < ApplicationController
     user_storage_id, project_id = storage_decrypt_channel_id(params[:channel_id])
     project_owner = User.find_by(id: user_id_for_storage_id(user_storage_id))
     return render :not_acceptable unless project_owner
-    return render :forbidden unless can?(:project_commits, project_owner, project_id)
+    return render :forbidden unless can?(:project_commits, ProjectVersion.new, project_owner, project_id)
     commits = ProjectVersion.where(project_id: project_id).order(created_at: :desc)
     commits = commits.map do |commit|
       {

--- a/dashboard/app/controllers/project_versions_controller.rb
+++ b/dashboard/app/controllers/project_versions_controller.rb
@@ -1,5 +1,5 @@
 class ProjectVersionsController < ApplicationController
-  before_action :authenticate_user!, except: [:project_commits]
+  before_action :authenticate_user!
 
   # POST /project_versions
   def create
@@ -22,7 +22,7 @@ class ProjectVersionsController < ApplicationController
     project_owner = User.find_by(id: user_id_for_storage_id(user_storage_id))
     return render :not_acceptable unless project_owner
     return render :forbidden unless can?(:project_commits, ProjectVersion.new, project_owner, project_id)
-    commits = ProjectVersion.where(project_id: project_id).where.not(comment: '').order(created_at: :desc)
+    commits = ProjectVersion.where(project_id: project_id).where.not(comment: '').order(created_at: :asc)
     project_expired_date = 1.year.ago
     commits = commits.map do |commit|
       {

--- a/dashboard/app/controllers/project_versions_controller.rb
+++ b/dashboard/app/controllers/project_versions_controller.rb
@@ -16,4 +16,18 @@ class ProjectVersionsController < ApplicationController
     headers['csrf-token'] = form_authenticity_token
     return head :ok
   end
+
+  def project_commits
+    _, project_id = storage_decrypt_channel_id(params[:storage_id])
+    commits = ProjectVersion.where(project_id: project_id)
+    commits = commits.map do |commit|
+      {
+        createdAt: commit.created_at,
+        comment: commit.comment,
+        projectVersion: commit.object_version_id,
+        isVersionExpired: commit.created_at < 1.year.ago
+      }
+    end
+    render :ok, json: commits.to_json
+  end
 end

--- a/dashboard/app/controllers/project_versions_controller.rb
+++ b/dashboard/app/controllers/project_versions_controller.rb
@@ -22,13 +22,14 @@ class ProjectVersionsController < ApplicationController
     project_owner = User.find_by(id: user_id_for_storage_id(user_storage_id))
     return render :not_acceptable unless project_owner
     return render :forbidden unless can?(:project_commits, ProjectVersion.new, project_owner, project_id)
-    commits = ProjectVersion.where(project_id: project_id).order(created_at: :desc)
+    commits = ProjectVersion.where(project_id: project_id).where.not(comment: '').order(created_at: :desc)
+    project_expired_date = 1.year.ago
     commits = commits.map do |commit|
       {
         createdAt: commit.created_at,
         comment: commit.comment,
         projectVersion: commit.object_version_id,
-        isVersionExpired: commit.created_at < 1.year.ago
+        isVersionExpired: commit.created_at < project_expired_date
       }
     end
     render :ok, json: commits.to_json

--- a/dashboard/app/controllers/project_versions_controller.rb
+++ b/dashboard/app/controllers/project_versions_controller.rb
@@ -18,8 +18,9 @@ class ProjectVersionsController < ApplicationController
   end
 
   def project_commits
-    _, project_id = storage_decrypt_channel_id(params[:storage_id])
-    commits = ProjectVersion.where(project_id: project_id)
+    user_storage_id, project_id = storage_decrypt_channel_id(params[:channel_id])
+    return render :forbidden unless user_storage_id == current_user.user_storage_id
+    commits = ProjectVersion.where(project_id: project_id).order(created_at: :desc)
     commits = commits.map do |commit|
       {
         createdAt: commit.created_at,

--- a/dashboard/app/helpers/project_version_helper.rb
+++ b/dashboard/app/helpers/project_version_helper.rb
@@ -1,4 +1,6 @@
 module ProjectVersionHelper
+  # We delete old versions after one year, unless they are the current version
+  # See https://s3.console.aws.amazon.com/s3/management/cdo-v3-sources/lifecycle/
   PROJECT_TTL = 1.year
 
   def version_expired?(version_date)

--- a/dashboard/app/helpers/project_version_helper.rb
+++ b/dashboard/app/helpers/project_version_helper.rb
@@ -1,0 +1,7 @@
+module ProjectVersionHelper
+  PROJECT_TTL = 1.year
+
+  def version_expired?(version_date)
+    version_date < (Date.today - PROJECT_TTL)
+  end
+end

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -117,16 +117,16 @@ class Ability
       can :project_comments, CodeReviewComment do |_, project_owner, project_id|
         CodeReviewComment.user_can_review_project?(project_owner, user, project_id)
       end
-      can :project_commits, ProjectVersion do |project_owner, project_id|
+      can :create, ReviewableProject do |_, project_owner|
+        ReviewableProject.user_can_mark_project_reviewable?(project_owner, user)
+      end
+      can :destroy, ReviewableProject, user_id: user.id
+      can :project_commits, ProjectVersion do |_, project_owner, project_id|
         CodeReviewComment.user_can_review_project?(project_owner, user, project_id)
       end
       can :create, ProjectVersion do |project_owner|
         current_user.id == project_owner&.id
       end
-      can :create, ReviewableProject do |_, project_owner|
-        ReviewableProject.user_can_mark_project_reviewable?(project_owner, user)
-      end
-      can :destroy, ReviewableProject, user_id: user.id
       can :create, Pd::RegionalPartnerProgramRegistration, user_id: user.id
       can :read, Pd::Session
       can :manage, Pd::Enrollment, user_id: user.id

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -124,9 +124,6 @@ class Ability
       can :project_commits, ProjectVersion do |_, project_owner, project_id|
         CodeReviewComment.user_can_review_project?(project_owner, user, project_id)
       end
-      can :create, ProjectVersion do |project_owner|
-        current_user.id == project_owner&.id
-      end
       can :create, Pd::RegionalPartnerProgramRegistration, user_id: user.id
       can :read, Pd::Session
       can :manage, Pd::Enrollment, user_id: user.id

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -117,6 +117,12 @@ class Ability
       can :project_comments, CodeReviewComment do |_, project_owner, project_id|
         CodeReviewComment.user_can_review_project?(project_owner, user, project_id)
       end
+      can :project_commits, ProjectVersion do |project_owner, project_id|
+        CodeReviewComment.user_can_review_project?(project_owner, user, project_id)
+      end
+      can :create, ProjectVersion do |project_owner|
+        current_user.id == project_owner&.id
+      end
       can :create, ReviewableProject do |_, project_owner|
         ReviewableProject.user_can_mark_project_reviewable?(project_owner, user)
       end

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -960,6 +960,7 @@ Dashboard::Application.routes.draw do
 
   resources :project_versions, only: [:create]
   get 'project_versions/get_token', to: 'project_versions#get_token'
+  get 'project_commits/:storage_id', to: 'project_versions#project_commits'
 
   resources :reviewable_projects, only: [:create, :destroy]
   get 'reviewable_projects/for_level', to: 'reviewable_projects#for_level'

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -960,7 +960,7 @@ Dashboard::Application.routes.draw do
 
   resources :project_versions, only: [:create]
   get 'project_versions/get_token', to: 'project_versions#get_token'
-  get 'project_commits/:storage_id', to: 'project_versions#project_commits'
+  get 'project_commits/:channel_id', to: 'project_versions#project_commits'
 
   resources :reviewable_projects, only: [:create, :destroy]
   get 'reviewable_projects/for_level', to: 'reviewable_projects#for_level'

--- a/dashboard/test/controllers/project_versions_controller_test.rb
+++ b/dashboard/test/controllers/project_versions_controller_test.rb
@@ -13,4 +13,26 @@ class ProjectVersionsControllerTest < ActionController::TestCase
     assert_not_nil project_version
     assert_equal 'This is a comment', project_version.comment
   end
+
+  test "can fetch project versions" do
+    student = create :student
+    sign_in student
+
+    fake_storage_id = 123
+    fake_project_id = 654
+    fake_channel_id = 'abcdef'
+    User.any_instance.stubs(:user_storage_id).returns fake_storage_id
+    @controller.expects(:storage_decrypt_channel_id).with(fake_channel_id).returns([fake_storage_id, fake_project_id])
+
+    create :project_version, project_id: fake_project_id, comment: "First comment", created_at: 2.days.ago
+    create :project_version, project_id: fake_project_id, comment: "Second comment", created_at: 1.day.ago
+    create :project_version, project_id: fake_project_id, comment: "Third comment"
+
+    get :project_commits, params: {channel_id: fake_channel_id}
+    assert_response :ok
+
+    returned_commits = JSON.parse(@response.body)
+    assert_equal 3, returned_commits.length
+    assert_equal ['Third comment', 'Second comment', 'First comment'], returned_commits.map {|c| c['comment']}
+  end
 end

--- a/dashboard/test/controllers/project_versions_controller_test.rb
+++ b/dashboard/test/controllers/project_versions_controller_test.rb
@@ -41,6 +41,28 @@ class ProjectVersionsControllerTest < ActionController::TestCase
     assert_equal ['Third comment', 'Second comment', 'First comment'], returned_commits.map {|c| c['comment']}
   end
 
+  test "versions more than a year old have isVersionExpired set to true" do
+    student = create :student
+    sign_in student
+
+    fake_storage_id = 123
+    fake_project_id = 654
+    fake_channel_id = 'abcdef'
+    @controller.expects(:user_id_for_storage_id).with(fake_storage_id).returns(student.id)
+    @controller.expects(:storage_decrypt_channel_id).with(fake_channel_id).returns([fake_storage_id, fake_project_id])
+
+    create :project_version, project_id: fake_project_id, comment: "First comment", created_at: 2.years.ago
+    create :project_version, project_id: fake_project_id, comment: "Second comment", created_at: 2.days.ago
+
+    get :project_commits, params: {channel_id: fake_channel_id}
+    assert_response :ok
+
+    returned_commits = JSON.parse(@response.body)
+    assert_equal 2, returned_commits.length
+    refute returned_commits.first['isVersionExpired']
+    assert returned_commits.last['isVersionExpired']
+  end
+
   test "can fetch project versions of students project if their teacher" do
     teacher = create :teacher
     section = create :section, user: teacher
@@ -62,11 +84,13 @@ class ProjectVersionsControllerTest < ActionController::TestCase
   test "can fetch project versions of another students project if in the same code review group" do
     section = create :section, code_review_expires_at: 1.year.from_now
     group = create :code_review_group, section: section
+
     project_owner_student = create :student
     follower1 = create :follower, section: section, student_user: project_owner_student
     create :code_review_group_member, code_review_group: group, follower: follower1
+
     student_reviewer = create :student
-    follower2 = create :follower, section: section, student_user: project_owner_student
+    follower2 = create :follower, section: section, student_user: student_reviewer
     create :code_review_group_member, code_review_group: group, follower: follower2
     sign_in student_reviewer
 
@@ -81,5 +105,31 @@ class ProjectVersionsControllerTest < ActionController::TestCase
 
     get :project_commits, params: {channel_id: fake_channel_id}
     assert_response :ok
+  end
+
+  test "cannot fetch project versions of a user who isnt in the same code review group" do
+    section = create :section, code_review_expires_at: 1.year.from_now
+    project_owner_student = create :student
+    group1 = create :code_review_group, section: section
+    follower1 = create :follower, section: section, student_user: project_owner_student
+    create :code_review_group_member, code_review_group: group1, follower: follower1
+
+    student_reviewer = create :student
+    group2 = create :code_review_group, section: section
+    follower2 = create :follower, section: section, student_user: student_reviewer
+    create :code_review_group_member, code_review_group: group2, follower: follower2
+    sign_in student_reviewer
+
+    fake_storage_id = 123
+    fake_project_id = 654
+    fake_channel_id = 'abcdef'
+    @controller.expects(:user_id_for_storage_id).with(fake_storage_id).returns(project_owner_student.id)
+    @controller.expects(:storage_decrypt_channel_id).with(fake_channel_id).returns([fake_storage_id, fake_project_id])
+    create :reviewable_project, user_id: project_owner_student.id, project_id: fake_project_id
+
+    create :project_version, project_id: fake_project_id, comment: "Third comment"
+
+    get :project_commits, params: {channel_id: fake_channel_id}
+    assert_response :not_found
   end
 end

--- a/dashboard/test/controllers/project_versions_controller_test.rb
+++ b/dashboard/test/controllers/project_versions_controller_test.rb
@@ -33,7 +33,7 @@ class ProjectVersionsControllerTest < ActionController::TestCase
 
     returned_commits = JSON.parse(@response.body)
     assert_equal 3, returned_commits.length
-    assert_equal ['Third comment', 'Second comment', 'First comment'], returned_commits.map {|c| c['comment']}
+    assert_equal ['First comment', 'Second comment', 'Third comment'], returned_commits.map {|c| c['comment']}
   end
 
   test "versions more than a year old have isVersionExpired set to true" do
@@ -54,8 +54,8 @@ class ProjectVersionsControllerTest < ActionController::TestCase
 
     returned_commits = JSON.parse(@response.body)
     assert_equal 2, returned_commits.length
-    refute returned_commits.first['isVersionExpired']
-    assert returned_commits.last['isVersionExpired']
+    refute returned_commits.last['isVersionExpired']
+    assert returned_commits.first['isVersionExpired']
   end
 
   test "can fetch project versions and blank comments are filtered out" do
@@ -77,7 +77,7 @@ class ProjectVersionsControllerTest < ActionController::TestCase
 
     returned_commits = JSON.parse(@response.body)
     assert_equal 2, returned_commits.length
-    assert_equal ['Third comment', 'First comment'], returned_commits.map {|c| c['comment']}
+    assert_equal ['First comment', 'Third comment'], returned_commits.map {|c| c['comment']}
   end
 
   test "can fetch project versions of students project if their teacher" do

--- a/dashboard/test/controllers/project_versions_controller_test.rb
+++ b/dashboard/test/controllers/project_versions_controller_test.rb
@@ -5,16 +5,11 @@ class ProjectVersionsControllerTest < ActionController::TestCase
     student = create :student
     sign_in student
 
-    fake_storage_id = 123
-    fake_project_id = 654
-    fake_channel_id = 'abcdef'
-    @controller.expects(:user_id_for_storage_id).with(fake_storage_id).returns(student.id)
-    @controller.expects(:storage_decrypt_channel_id).with(fake_channel_id).returns([fake_storage_id, fake_project_id])
-
+    @controller.expects(:storage_decrypt_channel_id).with("abcdef").returns([123, 654])
     assert_creates(ProjectVersion) do
-      post :create, params: {storage_id: fake_channel_id, version_id: 'fghj', comment: 'This is a comment'}
+      post :create, params: {storage_id: 'abcdef', version_id: 'fghj', comment: 'This is a comment'}
     end
-    project_version = ProjectVersion.find_by(project_id: fake_project_id, object_version_id: 'fghj')
+    project_version = ProjectVersion.find_by(project_id: 654, object_version_id: 'fghj')
     assert_not_nil project_version
     assert_equal 'This is a comment', project_version.comment
   end

--- a/dashboard/test/controllers/project_versions_controller_test.rb
+++ b/dashboard/test/controllers/project_versions_controller_test.rb
@@ -5,11 +5,16 @@ class ProjectVersionsControllerTest < ActionController::TestCase
     student = create :student
     sign_in student
 
-    @controller.expects(:storage_decrypt_channel_id).with("abcdef").returns([123, 654])
+    fake_storage_id = 123
+    fake_project_id = 654
+    fake_channel_id = 'abcdef'
+    @controller.expects(:user_id_for_storage_id).with(fake_storage_id).returns(student.id)
+    @controller.expects(:storage_decrypt_channel_id).with(fake_channel_id).returns([fake_storage_id, fake_project_id])
+
     assert_creates(ProjectVersion) do
-      post :create, params: {storage_id: 'abcdef', version_id: 'fghj', comment: 'This is a comment'}
+      post :create, params: {storage_id: fake_channel_id, version_id: 'fghj', comment: 'This is a comment'}
     end
-    project_version = ProjectVersion.find_by(project_id: 654, object_version_id: 'fghj')
+    project_version = ProjectVersion.find_by(project_id: fake_project_id, object_version_id: 'fghj')
     assert_not_nil project_version
     assert_equal 'This is a comment', project_version.comment
   end
@@ -21,7 +26,7 @@ class ProjectVersionsControllerTest < ActionController::TestCase
     fake_storage_id = 123
     fake_project_id = 654
     fake_channel_id = 'abcdef'
-    User.any_instance.stubs(:user_storage_id).returns fake_storage_id
+    @controller.expects(:user_id_for_storage_id).with(fake_storage_id).returns(student.id)
     @controller.expects(:storage_decrypt_channel_id).with(fake_channel_id).returns([fake_storage_id, fake_project_id])
 
     create :project_version, project_id: fake_project_id, comment: "First comment", created_at: 2.days.ago

--- a/dashboard/test/controllers/project_versions_controller_test.rb
+++ b/dashboard/test/controllers/project_versions_controller_test.rb
@@ -58,6 +58,28 @@ class ProjectVersionsControllerTest < ActionController::TestCase
     assert returned_commits.last['isVersionExpired']
   end
 
+  test "can fetch project versions and blank comments are filtered out" do
+    student = create :student
+    sign_in student
+
+    fake_storage_id = 123
+    fake_project_id = 654
+    fake_channel_id = 'abcdef'
+    @controller.expects(:user_id_for_storage_id).with(fake_storage_id).returns(student.id)
+    @controller.expects(:storage_decrypt_channel_id).with(fake_channel_id).returns([fake_storage_id, fake_project_id])
+
+    create :project_version, project_id: fake_project_id, comment: "First comment", created_at: 2.days.ago
+    create :project_version, project_id: fake_project_id, comment: "", created_at: 1.day.ago
+    create :project_version, project_id: fake_project_id, comment: "Third comment"
+
+    get :project_commits, params: {channel_id: fake_channel_id}
+    assert_response :ok
+
+    returned_commits = JSON.parse(@response.body)
+    assert_equal 2, returned_commits.length
+    assert_equal ['Third comment', 'First comment'], returned_commits.map {|c| c['comment']}
+  end
+
   test "can fetch project versions of students project if their teacher" do
     teacher = create :teacher
     section = create :section, user: teacher

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -1575,6 +1575,12 @@ FactoryGirl.define do
     association :script
   end
 
+  factory :project_version do
+    sequence(:project_id)
+    sequence(:object_version_id)
+    comment 'a commit comment'
+  end
+
   factory :teacher_score do
     association :user_level
     association :teacher


### PR DESCRIPTION
Creates an endpoint to get all the commits for a given project. I decided to name this route /project_commits as that seemed be more descriptive, but I'm happy to change it.

This route is only accessible by the user themself, a teacher of that user, or anyone who can review that particular project. 

Example return value:
```
[{"createdAt":"2022-05-03T03:37:16.000Z","comment":"Created Painter","projectVersion":"LsUQzjTcgibAYTutGsvqPr1TZfBxKCvk","isVersionExpired":false}]
```

## Links

[jira](https://codedotorg.atlassian.net/browse/LP-2319)
[spec](https://docs.google.com/document/d/1ZtvE5fZPbndZsT3gGLc1ZuH7WcdSRdCj1Tc09EwCQJ4/edit)

## Testing story

mostly unit tests, some manual testing in the browser



## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
