### PR TITLE
use get_localized_property to fetch translated lesson descriptions

### DIFF
--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -272,9 +272,9 @@ class Lesson < ApplicationRecord
     lesson_summary = Rails.cache.fetch("#{cache_key}/lesson_summary/#{I18n.locale}/#{include_bonus_levels}") do
       cached_levels = include_bonus_levels ? cached_script_levels : cached_script_levels.reject(&:bonus)
 
-      description_student = I18n.t('description_student', scope: [:data, :script, :name, script.name, :lessons, key], smart: true, default: '')
+      description_student = get_localized_property('student_overview')
       description_student = render_codespan_only_markdown(description_student) unless script.is_migrated?
-      description_teacher = I18n.t('description_teacher', scope: [:data, :script, :name, script.name, :lessons, key], smart: true, default: '')
+      description_teacher = get_localized_property('overview')
       description_teacher = render_codespan_only_markdown(description_teacher) unless script.is_migrated?
 
       lesson_data = {

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -272,9 +272,9 @@ class Lesson < ApplicationRecord
     lesson_summary = Rails.cache.fetch("#{cache_key}/lesson_summary/#{I18n.locale}/#{include_bonus_levels}") do
       cached_levels = include_bonus_levels ? cached_script_levels : cached_script_levels.reject(&:bonus)
 
-      description_student = get_localized_property('student_overview')
+      description_student = get_localized_property('student_overview') || ''
       description_student = render_codespan_only_markdown(description_student) unless script.is_migrated?
-      description_teacher = get_localized_property('overview')
+      description_teacher = get_localized_property('overview') || ''
       description_teacher = render_codespan_only_markdown(description_teacher) unless script.is_migrated?
 
       lesson_data = {


### PR DESCRIPTION
Step 4a from [PLAT-1528](https://codedotorg.atlassian.net/browse/PLAT-1528). I didn't have to wait for translations (step 3) because these description/overview fields have been translated (and in some cases, already [used](https://github.com/code-dot-org/code-dot-org/blob/5b26ad1f99dcc78158e972982ea3fa5cb026d146/dashboard/app/models/lesson.rb#L488)) from the beginning.

lesson descriptions which have been translated using the new system can be found here: https://github.com/code-dot-org/code-dot-org/blob/f507434e179b79cb8cb0c6db14f7ae5e3eb4fb5a/dashboard/config/locales/lessons.es-MX.json

## Screenshots

### teacher description, english (unchanged)

![Screen Shot 2022-05-03 at 12 54 06 PM](https://user-images.githubusercontent.com/8001765/166558969-fe39f833-d797-4fc1-8da7-48bdf61cf0ca.png)

### teacher description, spanish (unchanged)
![Screen Shot 2022-05-03 at 1 10 51 PM](https://user-images.githubusercontent.com/8001765/166558907-f60fe99f-c3e1-42fd-8d68-ae7a88196c0b.png)

### student description, spanish

there weren't any scripts that are both translated and have `include_student_lesson_plans` set. so in order to get this screenshot, I temporarily set `include_student_lesson_plans` on the script:

![Screen Shot 2022-05-03 at 1 09 30 PM](https://user-images.githubusercontent.com/8001765/166558930-c1fe13ae-16ef-48be-ac43-571405b7fe23.png)

## Testing story

Manually verified as shown in screenshots above. 

