### PR TITLE
Update markdown in purpose in clone and other improvements

### DIFF
--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -91,6 +91,8 @@ class Lesson < ApplicationRecord
 
   include CodespanOnlyMarkdownHelper
 
+  MARKDOWN_FIELDS = %w(overview student_overview preparation assessment_opportunities purpose)
+
   def self.update_lessons_in_migrated_unit(unit, lesson_group, raw_lessons, counters)
     raw_lessons.map do |raw_lesson|
       lesson = fetch_lesson(raw_lesson, unit)
@@ -173,6 +175,16 @@ class Lesson < ApplicationRecord
   # user-facing rendering. Currently does localization and markdown
   # preprocessing, could in the future be expanded to do more.
   def render_property(property_name)
+    unless MARKDOWN_FIELDS.include?(property_name)
+      Honeybadger.notify(
+        error_message: "Rendering #{property_name} which is not in MARKDOWN_FIELDS",
+        error_class: "Lesson.render_property",
+        context: {
+          property_name: property_name,
+          markdown_fields: MARKDOWN_FIELDS
+        }
+      )
+    end
     result = get_localized_property(property_name)
     result = Services::MarkdownPreprocessor.process(result || '')
     return result
@@ -826,7 +838,7 @@ class Lesson < ApplicationRecord
       "[v #{new_vocab ? Services::GloballyUniqueIdentifiers.build_vocab_key(new_vocab) : Services::GloballyUniqueIdentifiers.build_vocab_key(vocab)}]"
     end
 
-    %w(overview student_overview preparation assessment_opportunities).each do |field|
+    MARKDOWN_FIELDS.each do |field|
       next unless copied_lesson.try(field)
       Services::MarkdownPreprocessor.sub_resource_links!(copied_lesson.try(field), update_resource_link_on_clone)
       Services::MarkdownPreprocessor.sub_vocab_definitions!(copied_lesson.try(field), update_vocab_definition_on_clone)


### PR DESCRIPTION
- Add `purpose` as a field to update the markdown of on clone
- Move the list of fields to a global variable
- If we try to render a field that isn't in that list, create a Honeybadger error. This is a slight modification on [Dave's idea](https://github.com/code-dot-org/code-dot-org/pull/46142#discussion_r864396182), but I was concerned about raising on this critical pathway. Definitely open to conversation here!



## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
