### PR TITLE
Load jQuery before loading the OneTrust cookie scripts

### DIFF
--- a/shared/haml/hoc_onetrust_cookie_scripts.haml
+++ b/shared/haml/hoc_onetrust_cookie_scripts.haml
@@ -1,11 +1,13 @@
 -# OneTrust Cookies Consent Notice scripts for hourofcode.com
 - cookie_script_env = DCDO.get('onetrust_cookie_scripts', 'off')
 - if cookie_script_env == 'production' && request.path == '/cookies'
+  %script{:src=>'/js/jquery.min.js'}
   %script{src: 'https://cdn.cookielaw.org/consent/7c79c547-a2fc-4998-9b21-0c7a5e67e345/OtAutoBlock.js', type: 'text/javascript'}
   %script{src: 'https://cdn.cookielaw.org/scripttemplates/otSDKStub.js', type: 'text/javascript', charset: 'UTF-8', 'data-domain-script' => '7c79c547-a2fc-4998-9b21-0c7a5e67e345'}
   :javascript
     function OptanonWrapper() { }
 - elsif cookie_script_env == 'test' && request.path == '/cookies'
+  %script{:src=>'/js/jquery.min.js'}
   %script{src: 'https://cdn.cookielaw.org/consent/7c79c547-a2fc-4998-9b21-0c7a5e67e345-test/OtAutoBlock.js', type: 'text/javascript'}
   %script{src: 'https://cdn.cookielaw.org/scripttemplates/otSDKStub.js', type: 'text/javascript', charset: 'UTF-8', 'data-domain-script' => '7c79c547-a2fc-4998-9b21-0c7a5e67e345-test'}
   :javascript

--- a/shared/haml/onetrust_cookie_scripts.haml
+++ b/shared/haml/onetrust_cookie_scripts.haml
@@ -1,11 +1,13 @@
 -# OneTrust Cookies Consent Notice scripts for code.org
 - cookie_script_env = DCDO.get('onetrust_cookie_scripts', 'off')
 - if cookie_script_env == 'production' && request.path == "/cookies"
+  %script{:src=>'/js/jquery.min.js'}
   %script{src: 'https://cdn.cookielaw.org/consent/27cca70a-7db3-4852-9ef0-a6660fd0977d/OtAutoBlock.js', type: 'text/javascript'}
   %script{src: 'https://cdn.cookielaw.org/scripttemplates/otSDKStub.js', type: 'text/javascript', charset: 'UTF-8', 'data-domain-script' => '27cca70a-7db3-4852-9ef0-a6660fd0977d'}
   :javascript
     function OptanonWrapper() { }
 - elsif cookie_script_env == 'test' && request.path == "/cookies"
+  %script{:src=>'/js/jquery.min.js'}
   %script{src: 'https://cdn.cookielaw.org/consent/27cca70a-7db3-4852-9ef0-a6660fd0977d-test/OtAutoBlock.js', type: 'text/javascript'}
   %script{src: 'https://cdn.cookielaw.org/scripttemplates/otSDKStub.js', type: 'text/javascript', charset: 'UTF-8', 'data-domain-script' => '27cca70a-7db3-4852-9ef0-a6660fd0977d-test'}
   :javascript


### PR DESCRIPTION
In our production environment, the OneTrust scripts are being loaded before jQuery. An iframe that gets loaded by OneTrust ends up detecting that jquery.min is not loaded on the page, and loads its own copy. When our copy of jquery.min is then loaded, the duplicate scripts cause jquery to crash.

If we force jQuery to load before the OneTrust scripts, the OneTrust iframe will not attempt to load a duplicate copy of jQuery, which should resolve the problem. Unfortunately this only happens in production and is not reproducible in any pre-prod environment, so we are keeping this change scoped to just the `/cookies` page for safe testing.