### PR TITLE
Allow no authorization when accessing libraries if all sections hidden

### DIFF
--- a/dashboard/app/controllers/api/v1/section_libraries_controller.rb
+++ b/dashboard/app/controllers/api/v1/section_libraries_controller.rb
@@ -1,13 +1,10 @@
 class Api::V1::SectionLibrariesController < Api::V1::JsonApiController
   before_action :authenticate_user!
-  check_authorization unless: :no_sections?
+  check_authorization unless: :no_active_sections?
 
   # gets the libraries from all members of all active sections I am a part of
   # GET api/v1/section_libraries
   def index
-    sections = current_user.sections + current_user.sections_as_student
-    active_sections = sections.select {|section| !section.hidden}
-
     libraries = []
     active_sections.each do |section|
       authorize! :list_projects, section
@@ -18,7 +15,12 @@ class Api::V1::SectionLibrariesController < Api::V1::JsonApiController
 
   private
 
-  def no_sections?
-    current_user.sections.empty? && current_user.sections_as_student.empty?
+  def no_active_sections?
+    active_sections.empty?
+  end
+
+  def active_sections
+    sections = current_user.sections + current_user.sections_as_student
+    sections.select {|section| !section.hidden}
   end
 end

--- a/dashboard/test/controllers/api/v1/section_libraries_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/section_libraries_controller_test.rb
@@ -17,4 +17,13 @@ class Api::V1::SectionLibrariesControllerTest < ActionController::TestCase
     get :index
     assert_response :success
   end
+
+  test 'student in hidden section can list libraries' do
+    hidden_section = create(:section, hidden: true)
+    student = create(:follower, section: hidden_section).student_user
+
+    sign_in student
+    get :index
+    assert_response :success
+  end
 end


### PR DESCRIPTION
Saw [Honeybadger errors](https://app.honeybadger.io/projects/3240/faults/85292347) where we were expecting authorization to happen when students are trying to access libraries if all of their sections are hidden. This is unnecessary, so allowing no auth in this case.

## Testing story

Tested manually as a student by accessing libraries when I was in a) only hidden, b) hidden and non-hidden, and c) all non-hidden sections. Also added a unit test to cover this case.