### PR TITLE
Render react elements instead of iframe for reference guides in map levels

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -649,6 +649,7 @@
   "discountCodeSchoolConfirm": "Before you can receive your code, please verify the school at which you teach:",
   "dismiss": "Dismiss",
   "documentation": "Documentation",
+  "documentationBug": "Found a bug in the documentation? Let us know at [documentation@code.org](mailto:documentation@code.org)",
   "done": "Done",
   "dontForget": "Don't forget",
   "download": "Download",

--- a/apps/src/sites/studio/pages/levels/_curriculum_reference.js
+++ b/apps/src/sites/studio/pages/levels/_curriculum_reference.js
@@ -1,12 +1,26 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
 import $ from 'jquery';
 import {registerGetResult} from '@cdo/apps/code-studio/levels/codeStudioLevels';
 import {onContinue} from '@cdo/apps/code-studio/levels/postOnContinue';
+import getScriptData from '@cdo/apps/util/getScriptData';
+import ReferenceGuide from '@cdo/apps/templates/referenceGuides/ReferenceGuide';
 
 $(document).ready(() => {
   registerGetResult();
 
   // handle click on continue (results in navigating to next puzzle)
   $('.submitButton').click(onContinue);
+
+  const refGuideElement = document.getElementById('reference-guide');
+
+  if (refGuideElement) {
+    const referenceGuide = getScriptData('referenceGuide');
+    ReactDOM.render(
+      <ReferenceGuide referenceGuide={referenceGuide} />,
+      refGuideElement
+    );
+  }
 });
 
 /**

--- a/apps/src/sites/studio/pages/levels/_curriculum_reference.js
+++ b/apps/src/sites/studio/pages/levels/_curriculum_reference.js
@@ -17,7 +17,10 @@ $(document).ready(() => {
   if (refGuideElement) {
     const referenceGuide = getScriptData('referenceGuide');
     ReactDOM.render(
-      <ReferenceGuide referenceGuide={referenceGuide} />,
+      <>
+        <h1>{referenceGuide.display_name}</h1>
+        <ReferenceGuide referenceGuide={referenceGuide} />
+      </>,
       refGuideElement
     );
   }

--- a/apps/src/templates/CopyrightInfo.jsx
+++ b/apps/src/templates/CopyrightInfo.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
+import i18n from '@cdo/locale';
+
+const CopyrightInfo = () => (
+  <div>
+    <a href="https://creativecommons.org/">
+      <img src="https://curriculum.code.org/static/img/creativeCommons-by-nc-sa.png" />
+    </a>
+    <SafeMarkdown
+      markdown={i18n.licenseMaterials({link: 'https://code.org/contact'})}
+    />
+  </div>
+);
+
+export default CopyrightInfo;

--- a/apps/src/templates/lessonOverview/LessonOverview.jsx
+++ b/apps/src/templates/lessonOverview/LessonOverview.jsx
@@ -26,6 +26,7 @@ import StyledCodeBlock from './StyledCodeBlock';
 import VerifiedResourcesNotification from '@cdo/apps/templates/courseOverview/VerifiedResourcesNotification';
 import {PublishedState} from '@cdo/apps/generated/curriculum/sharedCourseConstants';
 import FontAwesome from '../FontAwesome';
+import CopyrightInfo from '@cdo/apps/templates/CopyrightInfo';
 
 class LessonOverview extends Component {
   static propTypes = {
@@ -317,14 +318,7 @@ class LessonOverview extends Component {
         {this.props.activities.map(activity => (
           <Activity activity={activity} key={activity.key} />
         ))}
-        <div>
-          <a href="https://creativecommons.org/">
-            <img src="https://curriculum.code.org/static/img/creativeCommons-by-nc-sa.png" />
-          </a>
-          <SafeMarkdown
-            markdown={i18n.licenseMaterials({link: 'https://code.org/contact'})}
-          />
-        </div>
+        <CopyrightInfo />
       </div>
     );
   }

--- a/apps/src/templates/referenceGuides/ReferenceGuide.jsx
+++ b/apps/src/templates/referenceGuides/ReferenceGuide.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import EnhancedSafeMarkdown from '@cdo/apps/templates/EnhancedSafeMarkdown';
+import {Link} from '@dsco_/link';
+
+const referenceGuideShape = PropTypes.shape({
+  content: PropTypes.string
+});
+
+export default function ReferenceGuide({referenceGuide}) {
+  return (
+    <div>
+      <EnhancedSafeMarkdown markdown={referenceGuide.content} />
+      <p>
+        Found a bug in the documentation? Let us know at{' '}
+        <Link href={`mailto:documentation@code.org`}>
+          documentation@code.org
+        </Link>
+      </p>
+    </div>
+  );
+}
+
+ReferenceGuide.propTypes = {
+  referenceGuide: referenceGuideShape.isRequired
+};

--- a/apps/src/templates/referenceGuides/ReferenceGuide.jsx
+++ b/apps/src/templates/referenceGuides/ReferenceGuide.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import EnhancedSafeMarkdown from '@cdo/apps/templates/EnhancedSafeMarkdown';
-import {Link} from '@dsco_/link';
+import i18n from '@cdo/locale';
+import CopyrightInfo from '@cdo/apps/templates/CopyrightInfo';
 
 const referenceGuideShape = PropTypes.shape({
   content: PropTypes.string
@@ -11,12 +12,8 @@ export default function ReferenceGuide({referenceGuide}) {
   return (
     <div>
       <EnhancedSafeMarkdown markdown={referenceGuide.content} />
-      <p>
-        Found a bug in the documentation? Let us know at{' '}
-        <Link href={`mailto:documentation@code.org`}>
-          documentation@code.org
-        </Link>
-      </p>
+      <EnhancedSafeMarkdown markdown={i18n.documentationBug()} />
+      <CopyrightInfo />
     </div>
   );
 }

--- a/apps/src/templates/referenceGuides/ReferenceGuideView.jsx
+++ b/apps/src/templates/referenceGuides/ReferenceGuideView.jsx
@@ -1,13 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import EnhancedSafeMarkdown from '@cdo/apps/templates/EnhancedSafeMarkdown';
 import {
   NavigationBar,
   NavigationCategory,
   NavigationItem
 } from '@cdo/apps/templates/NavigationBar';
 import {organizeReferenceGuides} from '@cdo/apps/util/referenceGuideHelpers';
-import {Link} from '@dsco_/link';
+import ReferenceGuide from '@cdo/apps/templates/referenceGuides/ReferenceGuide';
 
 const referenceGuideShape = PropTypes.shape({
   display_name: PropTypes.string,
@@ -63,15 +62,7 @@ export default function ReferenceGuideView({
             </NavigationCategory>
           ))}
         </NavigationBar>
-        <div>
-          <EnhancedSafeMarkdown markdown={referenceGuide.content} />
-          <p>
-            Found a bug in the documentation? Let us know at{' '}
-            <Link href={`mailto:documentation@code.org`}>
-              documentation@code.org
-            </Link>
-          </p>
-        </div>
+        <ReferenceGuide referenceGuide={referenceGuide} />
       </div>
     </>
   );

--- a/apps/test/unit/templates/referenceGuides/ReferenceGuidesViewTest.js
+++ b/apps/test/unit/templates/referenceGuides/ReferenceGuidesViewTest.js
@@ -39,8 +39,8 @@ describe('ReferenceGuideView', () => {
         baseUrl={'fgsfds'}
       />
     );
-    expect(wrapper.findOne('EnhancedSafeMarkdown').props.markdown).to.equal(
-      referenceGuide.content
+    expect(wrapper.findOne('ReferenceGuide').props.referenceGuide).to.equal(
+      referenceGuide
     );
   });
 

--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -130,10 +130,6 @@ class LevelsController < ApplicationController
       @total_level_count = @level.levels.length
     end
 
-    if @level.reference_guide_level?
-      @reference_guide = @level.reference_guide
-    end
-
     view_options(
       full_width: true,
       small_footer: @game.uses_small_footer? || @level.enable_scrolling?,

--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -130,6 +130,10 @@ class LevelsController < ApplicationController
       @total_level_count = @level.levels.length
     end
 
+    if @level.reference_guide_level?
+      @reference_guide = @level.reference_guide
+    end
+
     view_options(
       full_width: true,
       small_footer: @game.uses_small_footer? || @level.enable_scrolling?,

--- a/dashboard/app/controllers/reference_guides_controller.rb
+++ b/dashboard/app/controllers/reference_guides_controller.rb
@@ -18,7 +18,7 @@ class ReferenceGuidesController < ApplicationController
   # GET /courses/:course_name/guides
   def index
     # redirect to the show page for the first guide within a category
-    course_version_id = find_matching_course_version(params[:course_course_name])&.id
+    course_version_id = CurriculumHelper.find_matching_course_version(params[:course_course_name])&.id
     first_category_key = ReferenceGuide.where(course_version_id: course_version_id, parent_reference_guide_key: nil).
       order('position').first&.key
     first_child_key = ReferenceGuide.where(course_version_id: course_version_id, parent_reference_guide_key: first_category_key).
@@ -33,7 +33,7 @@ class ReferenceGuidesController < ApplicationController
 
   # POST /courses/:course_name/guides
   def create
-    course_version_id = find_matching_course_version(params[:course_course_name])&.id
+    course_version_id = CurriculumHelper.find_matching_course_version(params[:course_course_name])&.id
     reference_guide = ReferenceGuide.new(
       key: params[:key],
       display_name: params[:key],
@@ -83,7 +83,7 @@ class ReferenceGuidesController < ApplicationController
   end
 
   def find_reference_guide
-    course_version_id = find_matching_course_version(params[:course_course_name])&.id
+    course_version_id = CurriculumHelper.find_matching_course_version(params[:course_course_name])&.id
     unless course_version_id
       flash[:alert] = 'No matching course version found.'
       render :not_found
@@ -96,7 +96,7 @@ class ReferenceGuidesController < ApplicationController
   end
 
   def find_reference_guides
-    course_version = find_matching_course_version(params[:course_course_name])
+    course_version = CurriculumHelper.find_matching_course_version(params[:course_course_name])
     authorize! :read, course_version.content_root
     unless course_version&.id
       flash[:alert] = 'No matching course version found.'

--- a/dashboard/app/controllers/vocabularies_controller.rb
+++ b/dashboard/app/controllers/vocabularies_controller.rb
@@ -50,7 +50,7 @@ class VocabulariesController < ApplicationController
 
   # GET /courses/:course_name/vocab/edit
   def edit
-    @course_version = find_matching_course_version(params[:course_name])
+    @course_version = CurriculumHelper.find_matching_course_version(params[:course_name])
     @vocabularies = @course_version.vocabularies.order(:word).map(&:summarize_for_edit)
   end
 

--- a/dashboard/app/helpers/curriculum_helper.rb
+++ b/dashboard/app/helpers/curriculum_helper.rb
@@ -27,7 +27,7 @@ module CurriculumHelper
   end
 
   # retrieves the matching UnitGroup or Script associated with a course version and offering
-  def find_matching_course_version(course_name)
+  def self.find_matching_course_version(course_name)
     matching_unit_group = UnitGroup.find_by_name(course_name)
     return matching_unit_group.course_version if matching_unit_group
     matching_standalone_course = Script.find_by_name(course_name)

--- a/dashboard/app/models/levels/curriculum_reference.rb
+++ b/dashboard/app/models/levels/curriculum_reference.rb
@@ -35,6 +35,8 @@ class CurriculumReference < Level
     allow_blank: true
   }
 
+  REFERENCE_GUIDE_REGEX = /^\/courses\/(?<course_name>.+)\/guides\/(?<key>.+)\/?/
+
   def self.create_from_level_builder(params, level_params)
     create!(
       level_params.merge(
@@ -52,7 +54,17 @@ class CurriculumReference < Level
     properties['reference']
   end
 
+  def reference_guide
+    matches = REFERENCE_GUIDE_REGEX.match(href)
+    return nil unless matches
+    ReferenceGuide.find_by_course_name_and_key(matches[:course_name], matches[:key])
+  end
+
   def concept_level?
     true
+  end
+
+  def reference_guide_level?
+    return true if REFERENCE_GUIDE_REGEX.match(href)
   end
 end

--- a/dashboard/app/models/reference_guide.rb
+++ b/dashboard/app/models/reference_guide.rb
@@ -62,6 +62,12 @@ class ReferenceGuide < ApplicationRecord
     File.delete(file_path)
   end
 
+  def self.find_by_course_name_and_key(course_name, key)
+    course_version_id = CurriculumHelper.find_matching_course_version(course_name)&.id
+    return nil unless course_version_id
+    ReferenceGuide.find_by_course_version_id_and_key(course_version_id, key)
+  end
+
   # runs through all seed files, creating and deleting records to match the seed files
   def self.seed_all
     # collect all existing ids

--- a/dashboard/app/views/levels/_curriculum_reference.haml
+++ b/dashboard/app/views/levels/_curriculum_reference.haml
@@ -1,11 +1,14 @@
 - level ||= @level
 
 - content_for(:head) do
-  %script{src: webpack_asset_path('js/levels/_curriculum_reference.js')}
+  %script{src: webpack_asset_path('js/levels/_curriculum_reference.js'), data: {referenceGuide: @reference_guide&.summarize_for_show.to_json}}
 
 .curriculum-reference
   %div{style: "overflow: hidden"}
-    #iframe-loading.loading
-    %iframe{id: 'curriculum-reference', width: '100%', frameborder: 0, src: level.href, onload: 'window.curriculumReference.onload()', style: "display: none;" }
+    - if level.reference_guide_level?
+      #reference-guide
+    - else
+      #iframe-loading.loading
+      %iframe{id: 'curriculum-reference', width: '100%', frameborder: 0, src: level.href, onload: 'window.curriculumReference.onload()', style: "display: none;" }
     %a.btn.btn-large.btn-primary.next-lesson.submitButton.pull-right= t('continue')
   = render partial: 'levels/teacher_markdown', locals: {data: level.properties}

--- a/dashboard/app/views/levels/_curriculum_reference.haml
+++ b/dashboard/app/views/levels/_curriculum_reference.haml
@@ -1,7 +1,7 @@
 - level ||= @level
 
 - content_for(:head) do
-  %script{src: webpack_asset_path('js/levels/_curriculum_reference.js'), data: {referenceGuide: @reference_guide&.summarize_for_show.to_json}}
+  %script{src: webpack_asset_path('js/levels/_curriculum_reference.js'), data: {referenceGuide: level.reference_guide&.summarize_for_show.to_json}}
 
 .curriculum-reference
   %div{style: "overflow: hidden"}

--- a/dashboard/test/models/curriculum_reference_test.rb
+++ b/dashboard/test/models/curriculum_reference_test.rb
@@ -6,4 +6,13 @@ class CurriculumReferenceTest < ActiveSupport::TestCase
     assert_equal '/docs/csd/maker_leds/index.html', level.reference
     assert_equal '/docs/csd/maker_leds/index.html', level.href
   end
+
+  test 'knows it is a reference guide' do
+    unit_group = create :unit_group, family_name: 'bogus-course', version_year: '2022', name: 'bogus-course-2022'
+    CourseOffering.add_course_offering(unit_group)
+    ref_guide = create :reference_guide, key: 'key', course_version: unit_group.course_version
+    level = create(:curriculum_reference, reference: "/courses/#{ref_guide.course_offering_version}/guides/#{ref_guide.key}")
+    assert level.reference_guide_level?
+    assert_equal ref_guide, level.reference_guide
+  end
 end

--- a/dashboard/test/models/reference_guide_test.rb
+++ b/dashboard/test/models/reference_guide_test.rb
@@ -51,4 +51,11 @@ class ReferenceGuideTest < ActiveSupport::TestCase
     category = create :reference_guide, key: 'category_page', course_version_id: guide.course_version_id
     assert_equal [guide], category.children
   end
+
+  test "reference guides can be found by course_version_name and key" do
+    unit_group = create :unit_group, family_name: 'bogus-course', version_year: '2022', name: 'bogus-course-2022'
+    CourseOffering.add_course_offering(unit_group)
+    guide = create :reference_guide, key: 'page', course_version: unit_group.course_version
+    assert_equal guide, ReferenceGuide.find_by_course_name_and_key(guide.course_offering_version, guide.key)
+  end
 end


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Conditionally renders a reference guide react element instead of the old iframe for concept maps.

Not sure if this is the best way to structure things, but its the way that works most easily with the existing stuff. Potentially another route would be to create a new Level type for reference guides?

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- spec: [product spec](https://docs.google.com/document/d/1VZGle7QA-06ZNNxy2SkvA8Msrok8pyN7fuq5hzek888/edit)
- jira ticket: [PLAT-1694](https://codedotorg.atlassian.net/browse/PLAT-1694)

## Testing story
Tested manually, plus some unit tests

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Screenshots
levels_controller map level
![image](https://user-images.githubusercontent.com/82416901/167009121-d3fe86a4-c479-466c-b4a7-c5dd1d97a71c.png)

script_levels_controller map level
![image](https://user-images.githubusercontent.com/82416901/167009054-222829f5-8466-4973-8b91-d7e1c92e37ee.png)

reference guide view page
![image](https://user-images.githubusercontent.com/82416901/167009344-44b66f7e-849b-402f-a14e-647feae36b49.png)

compare to old iframe concept map:
(we don't have the creative commons license included at the bottom, but that can be part of a separate change to add to all of them)
![image](https://user-images.githubusercontent.com/82416901/167009690-59bb57fc-b583-4123-95a9-4986fd10cda1.png)
