### PR TITLE
[Google Blockly] Remove canDisconnectFromParent block attribute

### DIFF
--- a/apps/src/blockly/addons/cdoBlockSvg.js
+++ b/apps/src/blockly/addons/cdoBlockSvg.js
@@ -4,8 +4,6 @@ import BlockSvgUnused from './blockSvgUnused';
 export default class BlockSvg extends GoogleBlockly.BlockSvg {
   constructor(workspace, prototypeName, opt_id) {
     super(workspace, prototypeName, ++Blockly.uidCounter_); // Use counter instead of randomly generated IDs
-
-    this.canDisconnectFromParent_ = true;
   }
 
   addUnusedBlockFrame(helpClickFunc) {
@@ -35,10 +33,6 @@ export default class BlockSvg extends GoogleBlockly.BlockSvg {
     return true;
   }
 
-  setCanDisconnectFromParent(canDisconnect) {
-    this.canDisconnectFromParent_ = canDisconnect;
-  }
-
   dispose() {
     super.dispose();
     this.removeUnusedBlockFrame();
@@ -46,13 +40,6 @@ export default class BlockSvg extends GoogleBlockly.BlockSvg {
 
   isUserVisible() {
     return false; // TODO - used for EXTRA_TOP_BLOCKS_FAIL feedback
-  }
-
-  onMouseDown_(e) {
-    if (!Blockly.utils.isRightButton(e) && !this.canDisconnectFromParent_) {
-      return;
-    }
-    super.onMouseDown_(e);
   }
 
   render(opt_bubble) {

--- a/apps/src/blockly/addons/cdoXml.js
+++ b/apps/src/blockly/addons/cdoXml.js
@@ -2,17 +2,6 @@ export default function initializeBlocklyXml(blocklyWrapper) {
   // Clear xml namespace
   blocklyWrapper.utils.xml.NAME_SPACE = '';
 
-  // Aliasing Google's blockToDom() so that we can override it, but still be able
-  // to call Google's blockToDom() in the override function.
-  blocklyWrapper.Xml.originalBlockToDom = blocklyWrapper.Xml.blockToDom;
-  blocklyWrapper.Xml.blockToDom = function(block) {
-    const blockXml = blocklyWrapper.Xml.originalBlockToDom(block);
-    if (!block.canDisconnectFromParent_) {
-      blockXml.setAttribute('can_disconnect_from_parent', false);
-    }
-    return blockXml;
-  };
-
   // Aliasing Google's domToBlockHeadless_() so that we can override it, but still be able
   // to call Google's domToBlockHeadless_() in the override function.
   blocklyWrapper.Xml.originalDomToBlockHeadless_ =
@@ -42,20 +31,6 @@ export default function initializeBlocklyXml(blocklyWrapper) {
       block
         .getField('NAME')
         .setValue(`unknown block: ${xmlBlock.getAttribute('type')}`);
-    }
-    return block;
-  };
-
-  // Aliasing Google's domToBlock() so that we can override it, but still be able
-  // to call Google's domToBlock() in the override function.
-  blocklyWrapper.Xml.originalDomToBlock = blocklyWrapper.Xml.domToBlock;
-  blocklyWrapper.Xml.domToBlock = function(xmlBlock, workspace) {
-    const block = blocklyWrapper.Xml.originalDomToBlock(xmlBlock, workspace);
-    const can_disconnect_from_parent = xmlBlock.getAttribute(
-      'can_disconnect_from_parent'
-    );
-    if (can_disconnect_from_parent) {
-      block.canDisconnectFromParent_ = can_disconnect_from_parent === 'true';
     }
     return block;
   };


### PR DESCRIPTION
This is a follow-up and clean-up task related to:
* https://github.com/code-dot-org/code-dot-org/pull/45223

We have already removed the `can_disconnect_from_parent` attribute from all levels that use Google Blockly. We can now deprecate the setting more fully. This will also help us continue to pave the way towards v7.

## Links


- jira ticket: [STAR-2156: [Google Blockly] Deprecate "lock to parent" - update all Poetry levels as needed](https://codedotorg.atlassian.net/browse/STAR-2156)
