### PR TITLE
stub script json file writes

### DIFF
--- a/dashboard/test/controllers/courses_controller_test.rb
+++ b/dashboard/test/controllers/courses_controller_test.rb
@@ -643,6 +643,7 @@ class CoursesControllerTest < ActionController::TestCase
   test "update: cannot change course version for unit groups" do
     sign_in @levelbuilder
     Rails.application.config.stubs(:levelbuilder_mode).returns true
+    File.stubs(:write)
     unit_group = create :unit_group
     unit_group.update!(name: 'csp-2017')
     script = create :script, is_migrated: true, published_state: SharedCourseConstants::PUBLISHED_STATE.beta
@@ -706,6 +707,7 @@ class CoursesControllerTest < ActionController::TestCase
   test "edit: does not work for plc_course" do
     sign_in @levelbuilder
     Rails.application.config.stubs(:levelbuilder_mode).returns true
+    File.stubs(:write)
     create :plc_course, name: 'plc-course'
 
     assert_raises ActiveRecord::ReadOnlyRecord do
@@ -716,6 +718,7 @@ class CoursesControllerTest < ActionController::TestCase
   test "edit: renders edit page for regular courses" do
     sign_in @levelbuilder
     Rails.application.config.stubs(:levelbuilder_mode).returns true
+    File.stubs(:write)
     create :unit_group, name: 'csp'
 
     get :edit, params: {course_name: 'csp'}
@@ -726,6 +729,7 @@ class CoursesControllerTest < ActionController::TestCase
 
   test "get_rollup_resources return rollups for a unit with code, resources, standards, and vocab" do
     Rails.application.config.stubs(:levelbuilder_mode).returns true
+    File.stubs(:write)
     sign_in(@levelbuilder)
 
     course_version = create :course_version, content_root: @unit_group_migrated
@@ -745,6 +749,7 @@ class CoursesControllerTest < ActionController::TestCase
 
   test "get_rollup_resources doesn't return rollups if no lesson in a unit has the associated object" do
     Rails.application.config.stubs(:levelbuilder_mode).returns true
+    File.stubs(:write)
     sign_in(@levelbuilder)
 
     course_version = create :course_version, content_root: @unit_group_migrated

--- a/dashboard/test/models/unit_group_test.rb
+++ b/dashboard/test/models/unit_group_test.rb
@@ -3,7 +3,15 @@ require 'test_helper'
 class UnitGroupTest < ActiveSupport::TestCase
   self.use_transactional_test_case = true
 
+  setup do
+    File.stubs(:write)
+  end
+
   class CachingTests < ActiveSupport::TestCase
+    setup do
+      File.stubs(:write)
+    end
+
     def populate_cache_and_disconnect_db
       UnitGroup.stubs(:should_cache?).returns true
       @@course_cache ||= UnitGroup.course_cache_to_cache
@@ -37,6 +45,10 @@ class UnitGroupTest < ActiveSupport::TestCase
   end
 
   class NameValidationTests < ActiveSupport::TestCase
+    setup do
+      File.stubs(:write)
+    end
+
     test "should allow valid unit_group names" do
       create(:unit_group, name: 'valid-name')
     end
@@ -266,6 +278,10 @@ class UnitGroupTest < ActiveSupport::TestCase
   end
 
   class UpdateScriptsTests < ActiveSupport::TestCase
+    setup do
+      File.stubs(:write)
+    end
+
     test "add UnitGroupUnits" do
       unit_group = create :unit_group
 
@@ -733,6 +749,8 @@ class UnitGroupTest < ActiveSupport::TestCase
 
   class SelectCourseScriptTests < ActiveSupport::TestCase
     setup do
+      File.stubs(:write)
+
       @unit_group = create(:unit_group, name: 'my-unit-group')
 
       @course_teacher = create :teacher
@@ -828,6 +846,8 @@ class UnitGroupTest < ActiveSupport::TestCase
 
   class RedirectCourseUrl < ActiveSupport::TestCase
     setup do
+      File.stubs(:write)
+
       @csp_2017 = create(:unit_group, name: 'csp-2017', family_name: 'csp', version_year: '2017')
     end
 
@@ -875,6 +895,8 @@ class UnitGroupTest < ActiveSupport::TestCase
 
   class CanViewVersion < ActiveSupport::TestCase
     setup do
+      File.stubs(:write)
+
       @student = create :student
       @teacher = create :teacher
       @facilitator = create :facilitator
@@ -947,6 +969,7 @@ class UnitGroupTest < ActiveSupport::TestCase
 
   class LatestVersionTests < ActiveSupport::TestCase
     setup do
+      File.stubs(:write)
       @csp_2017 = create(:unit_group, name: 'csp-2017', family_name: 'csp', version_year: '2017', published_state: SharedCourseConstants::PUBLISHED_STATE.stable)
       @csp_2018 = create(:unit_group, name: 'csp-2018', family_name: 'csp', version_year: '2018', published_state: SharedCourseConstants::PUBLISHED_STATE.stable)
       create(:unit_group, name: 'csp-2019', family_name: 'csp', version_year: '2019', published_state: SharedCourseConstants::PUBLISHED_STATE.preview)
@@ -971,6 +994,7 @@ class UnitGroupTest < ActiveSupport::TestCase
 
   class ProgressTests < ActiveSupport::TestCase
     setup do
+      File.stubs(:write)
       @csp_2017 = create(:unit_group, name: 'csp-2017', family_name: 'csp', version_year: '2017')
       @csp1_2017 = create(:script, name: 'csp1-2017')
       @csp2_2017 = create(:script, name: 'csp2-2017')


### PR DESCRIPTION

some tests for course / unit group were generating files with names like unit3.script_json, on the test machine and when run locally:
![Screen Shot 2022-05-05 at 2 47 44 PM](https://user-images.githubusercontent.com/8001765/167031089-a27b238f-6a51-4c42-b151-92042031eef5.png)

this PR fixes the instances of this which I could find.

## Testing story

running the following no longer generates stray script_json files:
```
Dave-MBP:~/src/cdo/dashboard (stub-script-json-file-writes)$ bundle exec spring testunit test/models/unit_group_test.rb test/controllers/courses_controller_test.rb
```
