### PR TITLE
Stop limiting the cookie scripts to only the /cookies page

### DIFF
--- a/shared/haml/hoc_onetrust_cookie_scripts.haml
+++ b/shared/haml/hoc_onetrust_cookie_scripts.haml
@@ -1,12 +1,12 @@
 -# OneTrust Cookies Consent Notice scripts for hourofcode.com
 - cookie_script_env = DCDO.get('onetrust_cookie_scripts', 'off')
-- if cookie_script_env == 'production' && request.path == '/cookies'
+- if cookie_script_env == 'production'
   %script{:src=>'/js/jquery.min.js'}
   %script{src: 'https://cdn.cookielaw.org/consent/7c79c547-a2fc-4998-9b21-0c7a5e67e345/OtAutoBlock.js', type: 'text/javascript'}
   %script{src: 'https://cdn.cookielaw.org/scripttemplates/otSDKStub.js', type: 'text/javascript', charset: 'UTF-8', 'data-domain-script' => '7c79c547-a2fc-4998-9b21-0c7a5e67e345'}
   :javascript
     function OptanonWrapper() { }
-- elsif cookie_script_env == 'test' && request.path == '/cookies'
+- elsif cookie_script_env == 'test'
   %script{:src=>'/js/jquery.min.js'}
   %script{src: 'https://cdn.cookielaw.org/consent/7c79c547-a2fc-4998-9b21-0c7a5e67e345-test/OtAutoBlock.js', type: 'text/javascript'}
   %script{src: 'https://cdn.cookielaw.org/scripttemplates/otSDKStub.js', type: 'text/javascript', charset: 'UTF-8', 'data-domain-script' => '7c79c547-a2fc-4998-9b21-0c7a5e67e345-test'}

--- a/shared/haml/onetrust_cookie_scripts.haml
+++ b/shared/haml/onetrust_cookie_scripts.haml
@@ -1,12 +1,12 @@
 -# OneTrust Cookies Consent Notice scripts for code.org
 - cookie_script_env = DCDO.get('onetrust_cookie_scripts', 'off')
-- if cookie_script_env == 'production' && request.path == "/cookies"
+- if cookie_script_env == 'production'
   %script{:src=>'/js/jquery.min.js'}
   %script{src: 'https://cdn.cookielaw.org/consent/27cca70a-7db3-4852-9ef0-a6660fd0977d/OtAutoBlock.js', type: 'text/javascript'}
   %script{src: 'https://cdn.cookielaw.org/scripttemplates/otSDKStub.js', type: 'text/javascript', charset: 'UTF-8', 'data-domain-script' => '27cca70a-7db3-4852-9ef0-a6660fd0977d'}
   :javascript
     function OptanonWrapper() { }
-- elsif cookie_script_env == 'test' && request.path == "/cookies"
+- elsif cookie_script_env == 'test'
   %script{:src=>'/js/jquery.min.js'}
   %script{src: 'https://cdn.cookielaw.org/consent/27cca70a-7db3-4852-9ef0-a6660fd0977d-test/OtAutoBlock.js', type: 'text/javascript'}
   %script{src: 'https://cdn.cookielaw.org/scripttemplates/otSDKStub.js', type: 'text/javascript', charset: 'UTF-8', 'data-domain-script' => '27cca70a-7db3-4852-9ef0-a6660fd0977d-test'}


### PR DESCRIPTION
Our fix of loading jQuery before the cookie scripts has resolved the errors we were seeing on the `/cookies` page. Now we can remove that limitation and see how it works on the rest of the site.
