### PR TITLE
Specify (non-production) database instance class via template parameter

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -13,6 +13,9 @@ Parameters:
     Type: String
     Default: master
     MaxLength: 16
+  DBInstanceType:
+    Type: String
+    Default: db.r5.large
 <% end -%>
 <% if frontends -%>
   DaemonInstanceType:

--- a/aws/cloudformation/components/database.yml.erb
+++ b/aws/cloudformation/components/database.yml.erb
@@ -20,7 +20,7 @@
       # Use same ParameterGroup for writer and all readers so that any reader can be promoted to writer during a Failover.
       DBParameterGroupName: !Ref AuroraWriterDBParameters
       DBClusterIdentifier: !Ref AuroraCluster
-      DBInstanceClass: db.r4.large
+      DBInstanceClass: !Ref DBInstanceType
       DBSubnetGroupName: !ImportValue VPC-DBSubnetGroup
       Engine: aurora-mysql
       # We will usually do engine version updates manually, so don't specify an EngineVersion for the DBInstance.


### PR DESCRIPTION
Fix forward for #45907 
This template specified `db.r4.large` as the database instance type for all non-production environments, but these instances had been manually upgraded to `db.r5.large` (and for the test writer: `db.r5.2xlarge`). Because of this CloudFormation Stack Drift, the previous Pull Request was triggering downgrades of the database instances.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
