### PR TITLE
Revert "Default to a Larger Database Instance Class"

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -15,7 +15,7 @@ Parameters:
     MaxLength: 16
   DBInstanceType:
     Type: String
-    Default: db.r5.2xlarge
+    Default: db.r5.large
 <% end -%>
 <% if frontends -%>
   DaemonInstanceType:


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#46213

`db.r5.*` are not available in `us-east-1e` where one of the two db instances for `test` and `levelbuilder` are deployed.