### PR TITLE
Revert "Specify (non-production) database instance class via template parameter"

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -13,9 +13,6 @@ Parameters:
     Type: String
     Default: master
     MaxLength: 16
-  DBInstanceType:
-    Type: String
-    Default: db.r5.large
 <% end -%>
 <% if frontends -%>
   DaemonInstanceType:

--- a/aws/cloudformation/components/database.yml.erb
+++ b/aws/cloudformation/components/database.yml.erb
@@ -20,7 +20,7 @@
       # Use same ParameterGroup for writer and all readers so that any reader can be promoted to writer during a Failover.
       DBParameterGroupName: !Ref AuroraWriterDBParameters
       DBClusterIdentifier: !Ref AuroraCluster
-      DBInstanceClass: !Ref DBInstanceType
+      DBInstanceClass: db.r4.large
       DBSubnetGroupName: !ImportValue VPC-DBSubnetGroup
       Engine: aurora-mysql
       # We will usually do engine version updates manually, so don't specify an EngineVersion for the DBInstance.


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#46211

`db.r5.*` are not available in `us-east-1e` where one of the two db instances for `test` and `levelbuilder` are deployed.