### PR TITLE
Revert "Configure Non-Production Databases to Use Same Settings as Production"

### DIFF
--- a/aws/cloudformation/components/database.yml.erb
+++ b/aws/cloudformation/components/database.yml.erb
@@ -2,7 +2,7 @@
     Type: AWS::RDS::DBCluster
     Properties:
       DBClusterIdentifier: !Sub "${AWS::StackName}-cluster"
-      DBClusterParameterGroupName: !Ref AuroraClusterDBParameters # Resource name generated from db_parameters.yml.erb.
+      DBClusterParameterGroupName: !Ref AuroraClusterDBParameters
       Engine: aurora-mysql
       # We will usually do engine version updates manually, since updating this requires replacement, so this value may be out of sync with cluster.
       EngineVersion: 5.7.12
@@ -16,9 +16,6 @@
     Type: AWS::RDS::DBInstance
     Properties:
       DBInstanceIdentifier: !Sub "${AWS::StackName}-<%=i%>"
-      # Resource name generated from db_parameters.yml.erb
-      # Use same ParameterGroup for writer and all readers so that any reader can be promoted to writer during a Failover.
-      DBParameterGroupName: !Ref AuroraWriterDBParameters
       DBClusterIdentifier: !Ref AuroraCluster
       DBInstanceClass: db.r4.large
       DBSubnetGroupName: !ImportValue VPC-DBSubnetGroup
@@ -26,16 +23,12 @@
       # We will usually do engine version updates manually, so don't specify an EngineVersion for the DBInstance.
 <% end -%>
 
-<%
-  YAML.load(erb_file(aws_dir('cloudformation/db_parameters.yml.erb'))).each do |key, values|
--%>
-  <%=key%>DBParameters:
-    Type: AWS::RDS::DB<%=key.match('Cluster')%>ParameterGroup
+  AuroraClusterDBParameters:
+    Type: AWS::RDS::DBClusterParameterGroup
     Properties:
-      Description: !Sub "<%=key.titleize%> DB Parameters for ${AWS::StackName}."
+      Description: !Sub "Aurora DB Cluster Parameters for ${AWS::StackName}."
       Family: aurora-mysql5.7
-      Parameters: <%=values.compact.to_json%>
-<%end -%>
+      Parameters: {'innodb_monitor_enable': 'all'}
 
 <% db_secrets = [nil, 'application-writer', 'readonly'].map do |user| -%>
   DatabaseSecret<%=secret = user&.underscore&.camelcase%>:

--- a/aws/cloudformation/db_parameters.yml.erb
+++ b/aws/cloudformation/db_parameters.yml.erb
@@ -28,6 +28,9 @@ AuroraCluster: &aurora
   # https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_flush_log_at_trx_commit
   innodb_flush_log_at_trx_commit: 0
 
+  # IAM role ARN used to select data into AWS S3.
+  aurora_select_into_s3_role: {'Fn::GetAtt': [AuroraS3Role, Arn]}
+
 # System variables for the Aurora DB writer.
 AuroraWriter:
   # Prevent an slow query from degrading instance or cluster performance.


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#45907

`db.r5.*` are not available in `us-east-1e` where one of the two db instances for `test` and `levelbuilder` are deployed. Fix forward Pull Requests for this Pull Request were attempting to set db instance class to something in the r5 family.