### PR TITLE
Bump UI test version to Chrome 87

### DIFF
--- a/dashboard/test/ui/browsers.json
+++ b/dashboard/test/ui/browsers.json
@@ -4,7 +4,7 @@
   {
     "name": "Chrome",
     "browserName": "chrome",
-    "version": "75",
+    "version": "87",
     "platform": "Windows 7",
     "screenResolution": "1280x1024",
     "extendedDebugging": true

--- a/dashboard/test/ui/features/star_labs/blocklayout.feature
+++ b/dashboard/test/ui/features/star_labs/blocklayout.feature
@@ -8,12 +8,12 @@ Background:
 Scenario: Auto-placing malformed start blocks
   When I've initialized the workspace with an auto-positioned flappy puzzle with extra newlines
   Then block "18" is near offset "16, 16"
-  And block "21" is near offset "16, 114"
+  And block "21" is near offset "16, 108"
 
 Scenario: Auto-placing blocks
   When I've initialized the workspace with an auto-positioned flappy puzzle
   Then block "18" is near offset "16, 16"
-  And block "21" is near offset "16, 114"
+  And block "21" is near offset "16, 108"
 
 Scenario: Auto-placing blocks with XML positioning
   Given I am on "http://studio.code.org/s/allthethings/lessons/5/levels/4?noautoplay=true"

--- a/dashboard/test/ui/features/step_definitions/check_finish_button.rb
+++ b/dashboard/test/ui/features/step_definitions/check_finish_button.rb
@@ -23,7 +23,7 @@ free_play_level_urls = {
 When /^I check that the (blockly|droplet|minecraft) free play level for "([^"]*)" shows the finish button for (small|mobile) screens/i do |level_type, level_name, screen_type|
   individual_steps <<-STEPS
     And I set up the #{level_type} free play level for "#{level_name}"
-    #{screen_type == 'small' ? 'And I change the browser window size to 1366 by 600' : ''}
+    #{screen_type == 'small' ? 'And I change the browser window size to 1366 by 636' : ''}
     #{level_type == 'minecraft' ? 'And I wait until the Minecraft game is loaded' : ''}
     And I press "runButton"
     And I check that selector "button:contains('Finish')" is in the viewport


### PR DESCRIPTION
According to https://code.org/educate/it, Chrome 87 is the lowest version of Chrome we support. We should be at least testing this -- Chrome 75 is nearly 3 years old!

It's worth noting that this version bump adds an info bar warning that Chrome is being controlled by test software. I manually tested a couple eyes tests and they do not have this bar in the baselines and only two UI tests failed. I manually fixed those two but going forward, we'll have to keep this infobar in mind.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
