### PR TITLE
Implement "Only Multi and FreeResponse can be Contained" as a Rails Validation

### DIFF
--- a/dashboard/app/models/concerns/levels/levels_within_levels.rb
+++ b/dashboard/app/models/concerns/levels/levels_within_levels.rb
@@ -151,9 +151,6 @@ module Levels
       # otherwise, update contained levels to match
       levels_child_levels.contained.destroy_all
       Level.where(name: contained_level_names).each do |contained_level|
-        unless ['Multi', 'FreeResponse'].include? contained_level.type
-          raise ArgumentError, "cannot add contained level of type #{contained_level.type}"
-        end
         ParentLevelsChildLevel.create!(
           child_level: contained_level,
           kind: ParentLevelsChildLevel::CONTAINED,

--- a/dashboard/app/models/parent_levels_child_level.rb
+++ b/dashboard/app/models/parent_levels_child_level.rb
@@ -50,4 +50,18 @@ class ParentLevelsChildLevel < ApplicationRecord
   VALID_KINDS.each do |kind|
     scope kind, -> {where(kind: kind)}
   end
+
+  validate :validate_child_level_type
+  def validate_child_level_type
+    if kind == CONTAINED
+      unless %w(Multi FreeResponse).include?(child_level.type)
+        error_message = "cannot add contained level of type #{child_level.type}"
+        errors.add(:child_level_id, error_message)
+
+        # Explicitly surface this error to the associated parent level, to make
+        # it visible to levelbuilders.
+        parent_level.errors.add(:child_level, error_message)
+      end
+    end
+  end
 end

--- a/dashboard/app/models/parent_levels_child_level.rb
+++ b/dashboard/app/models/parent_levels_child_level.rb
@@ -58,9 +58,9 @@ class ParentLevelsChildLevel < ApplicationRecord
         error_message = "cannot add contained level of type #{child_level.type}"
         errors.add(:child_level_id, error_message)
 
-        # Explicitly surface this error to the associated parent level, to make
-        # it visible to levelbuilders.
-        parent_level.errors.add(:child_level, error_message)
+        # Explicitly surface this error to the associated parent level if
+        # possible, to make it visible to levelbuilders.
+        parent_level&.errors&.add(:child_level, error_message)
       end
     end
   end

--- a/dashboard/test/models/concerns/levels/levels_within_levels_test.rb
+++ b/dashboard/test/models/concerns/levels/levels_within_levels_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class LevelsWithinLevelsTest < ActiveSupport::TestCase
   test 'cannot delete levels that other levels reference as children' do
-    child = create(:level, parent_levels: [create(:level)])
+    child = create(:multi, parent_levels: [create(:level)])
 
     refute child.destroy
 
@@ -12,7 +12,7 @@ class LevelsWithinLevelsTest < ActiveSupport::TestCase
   end
 
   test 'can delete levels that other levels reference as parents' do
-    child = create(:level)
+    child = create(:free_response)
     parent = create(:level, child_levels: [child])
 
     assert parent.destroy
@@ -22,7 +22,7 @@ class LevelsWithinLevelsTest < ActiveSupport::TestCase
   end
 
   test 'deleting a parent level will also remove associations' do
-    child = create(:level)
+    child = create(:multi)
     parent = create(:level, child_levels: [child])
     assert child.levels_parent_levels.present?
 
@@ -54,7 +54,7 @@ class LevelsWithinLevelsTest < ActiveSupport::TestCase
   test 'scoped parent/child relationships' do
     parent = create :level
 
-    contained = create :level
+    contained = create :free_response
     ParentLevelsChildLevel.create(
       parent_level: parent,
       child_level: contained,
@@ -140,16 +140,16 @@ class LevelsWithinLevelsTest < ActiveSupport::TestCase
 
   test 'clone_child_levels clones child levels' do
     parent = create :level
-    child = create :level, name: 'child_level'
-    ParentLevelsChildLevel.create(parent_level: parent, child_level: child)
+    child = create :free_response, name: 'child_level'
+    assert ParentLevelsChildLevel.create(parent_level: parent, child_level: child)
     Level.clone_child_levels(parent, '_test_clone')
     assert_equal 'child_level_test_clone', parent.reload.child_levels.first.name
   end
 
   test 'clone_child_levels returns update params' do
     parent = create :level
-    child = create :level, name: 'child_level'
-    ParentLevelsChildLevel.create(
+    child = create :free_response, name: 'child_level'
+    assert ParentLevelsChildLevel.create(
       parent_level: parent,
       child_level: child,
       kind: ParentLevelsChildLevel::CONTAINED

--- a/dashboard/test/models/concerns/levels/levels_within_levels_test.rb
+++ b/dashboard/test/models/concerns/levels/levels_within_levels_test.rb
@@ -134,10 +134,8 @@ class LevelsWithinLevelsTest < ActiveSupport::TestCase
 
     # cannot add contained levels of other types
     bogus_contained = create :match
-    e = assert_raises do
-      level.update!(contained_level_names: [bogus_contained.name])
-    end
-    assert_includes e.message, 'cannot add contained level of type Match'
+    refute level.update(contained_level_names: [bogus_contained.name])
+    assert_includes level.errors.full_messages.first, 'cannot add contained level of type Match'
   end
 
   test 'clone_child_levels clones child levels' do


### PR DESCRIPTION
Rather than a manually-raised error.

## Testing story

Updated existing tests to conform both to new requirement and new implementation.

## Deployment strategy

Note this PR is (currently) based on https://github.com/code-dot-org/code-dot-org/pull/45846 rather than staging

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
