### PR TITLE
Make kodea pd script not a PLC course

### DIFF
--- a/dashboard/config/scripts_json/kodea-pd-2021.script_json
+++ b/dashboard/config/scripts_json/kodea-pd-2021.script_json
@@ -7,7 +7,6 @@
       "is_course": true,
       "is_migrated": true,
       "pilot_experiment": "csf-online-pd-kodea",
-      "professional_learning_course": "K5 Support",
       "version_year": "2021"
     },
     "new_name": null,


### PR DESCRIPTION
The script kodea-pd-2021 should not be a PLC course since it uses the normal assignment set up through a pilot to be assigned and it does not use any peer reviews. This reviews the `professional_learning_course` setting from the script and should fix the build issue in staging.

<img width="1721" alt="Screen Shot 2022-05-07 at 2 45 18 PM" src="https://user-images.githubusercontent.com/208083/167267716-0560c005-3c56-4cd6-a792-683f5af00fec.png">

I ran `bundle exec rake build` locally to test that it would build