### PR TITLE
Make sure the convert to hash is saved

### DIFF
--- a/dashboard/app/controllers/courses_controller.rb
+++ b/dashboard/app/controllers/courses_controller.rb
@@ -26,7 +26,7 @@ class CoursesController < ApplicationController
       @course_families_course_types << [cf, {instruction_type: ug.instruction_type, instructor_audience: ug.instructor_audience, participant_audience: ug.participant_audience}]
     end
 
-    @course_families_course_types.to_h
+    @course_families_course_types = @course_families_course_types.to_h
   end
 
   def index

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -103,7 +103,7 @@ class ScriptsController < ApplicationController
       @unit_families_course_types << [cf, {instruction_type: unit.instruction_type, instructor_audience: unit.instructor_audience, participant_audience: unit.participant_audience}]
     end
 
-    @unit_families_course_types.compact.to_h
+    @unit_families_course_types = @unit_families_course_types.compact.to_h
   end
 
   def create


### PR DESCRIPTION
I broke the create page for unit group and unit in https://github.com/code-dot-org/code-dot-org/pull/46084 because I did not save the conversion to hash. This meant the page could not find the course type information. This fixes that.

Also logged a jira item to create UI tests for these pages that will catch this in the future: https://codedotorg.atlassian.net/browse/PLAT-1798

