### PR TITLE
Delete Non-Production Database Instances in us-east-1e

### DIFF
--- a/aws/cloudformation/components/database.yml.erb
+++ b/aws/cloudformation/components/database.yml.erb
@@ -11,7 +11,10 @@
       VpcSecurityGroupIds: [!ImportValue VPC-DBSecurityGroup]
       DBSubnetGroupName: !ImportValue VPC-DBSubnetGroup
 
-<% 2.times do |i| %>
+<%
+  # Integer range identifying each of the DB Instances to provision in the cluster.
+  DB_INSTANCE_RANGE=(1..1)
+  DB_INSTANCE_RANGE.each do |i| %>
   Aurora<%=i%>:
     Type: AWS::RDS::DBInstance
     Properties:
@@ -69,7 +72,8 @@
       PermissionsBoundary: !ImportValue IAM-DevPermissions
   DBProxyTargetGroup:
     Type: AWS::RDS::DBProxyTargetGroup
-    DependsOn: [Aurora0, Aurora1]
+    # List of Database Instance Logical IDs that must be provisioned before this RDS Proxy TargetGroup (Aurora0,Aurora1)
+    DependsOn: [<%=DB_INSTANCE_RANGE.map {|i| "Aurora#{i}"}.join(',')%>]
     Properties:
       DBProxyName: !Ref DBProxy
       DBClusterIdentifiers: [!Ref AuroraCluster]


### PR DESCRIPTION
We want to standardize our database instances to all be in the `db.r5` family. AWS Aurora randomly placed the `test-0` and `levelbuilder-0` database instances for the `test` and `levelbuilder` clusters in `us-east-1e` because that is one of the Availability Zones within our Database Subnet Group. `us-east-1e` does not support `db.r5` instance types, so delete the `Aurora0` Resource. We will follow up with a change that re-provisions `Aurora0` (`test-0` and `levelbuilder-0`) with a `db.r5` instance class and hopefully force Aurora to provision it in one of the other Availability Zones in our Database Subnet Group.

Deleting one of the two instances in the cluster does NOT delete the cluster (also all our clusters have Deletion Protection enabled, as well).

This is a new technical approach to #46213, which had to be reverted.


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

```
bundle exec rake stack:validate RAILS_ENV=test VERBOSE=true

Pending update for stack `test`:
Remove Aurora0 [AWS::RDS::DBInstance]
```

## Deployment strategy

1. Merge this Pull Request to deploy to `staging` and `test`
2. Manually invoke a release to `levelbuilder`
3. Merge #46253 to deploy it to `staging` and `test`
4. Manually invoke a release to `levelbuilder`
5. Re-Open Staging


## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  3.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
