### PR TITLE
Recreate Reader Database Instance in Non-Production Environments

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -13,6 +13,9 @@ Parameters:
     Type: String
     Default: master
     MaxLength: 16
+  DBInstanceType:
+    Type: String
+    Default: db.r5.2xlarge
 <% end -%>
 <% if frontends -%>
   DaemonInstanceType:

--- a/aws/cloudformation/components/database.yml.erb
+++ b/aws/cloudformation/components/database.yml.erb
@@ -20,7 +20,7 @@
     Properties:
       DBInstanceIdentifier: !Sub "${AWS::StackName}-<%=i%>"
       DBClusterIdentifier: !Ref AuroraCluster
-      DBInstanceClass: db.r5.2xlarge
+      DBInstanceClass: !Ref DBInstanceType
       DBSubnetGroupName: !ImportValue VPC-DBSubnetGroup
       Engine: aurora-mysql
       # We will usually do engine version updates manually, so don't specify an EngineVersion for the DBInstance.

--- a/aws/cloudformation/components/database.yml.erb
+++ b/aws/cloudformation/components/database.yml.erb
@@ -13,14 +13,14 @@
 
 <%
   # Integer range identifying each of the DB Instances to provision in the cluster.
-  DB_INSTANCE_RANGE=(1..1)
+  DB_INSTANCE_RANGE=(0..1)
   DB_INSTANCE_RANGE.each do |i| %>
   Aurora<%=i%>:
     Type: AWS::RDS::DBInstance
     Properties:
       DBInstanceIdentifier: !Sub "${AWS::StackName}-<%=i%>"
       DBClusterIdentifier: !Ref AuroraCluster
-      DBInstanceClass: db.r4.large
+      DBInstanceClass: db.r5.2xlarge
       DBSubnetGroupName: !ImportValue VPC-DBSubnetGroup
       Engine: aurora-mysql
       # We will usually do engine version updates manually, so don't specify an EngineVersion for the DBInstance.


### PR DESCRIPTION
Follow up to #46247 
Re-create the `staging-0`, `test-0`, and `levelbuilder-0` database instances. Hopefully `test-0` and `levelbuilder-0` will be created in a different Availability Zone from `us-east-1e` so they can be provisioned with `db.r5` instance types.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
