### PR TITLE
Dont emit warnings for sass dependencies

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -332,7 +332,8 @@ describe('entry tests', () => {
         // dart-sass: Only the "expanded" and "compressed" values of outputStyle are supported.
         outputStyle: 'expanded',
         includePaths: ['node_modules', '../shared/css/'],
-        implementation: sass
+        implementation: sass,
+        quietDeps: true
       },
       files: _.fromPairs(
         [

--- a/apps/webpack.js
+++ b/apps/webpack.js
@@ -138,7 +138,11 @@ var baseConfig = {
           {loader: 'css-loader'},
           {
             loader: 'sass-loader',
-            options: {includePaths: [scssIncludePath], implementation: sass}
+            options: {
+              includePaths: [scssIncludePath],
+              implementation: sass,
+              quietDeps: true
+            }
           }
         ]
       },


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

A quick change to add this config value and prevent warnings from stuff like bootstrap that is old and cannot be updated by us.
https://sass-lang.com/documentation/js-api/interfaces/LegacySharedOptions#quietDeps

![image](https://user-images.githubusercontent.com/82416901/167504485-b51dbe4f-1206-4926-bc25-b92d97c5f227.png)
