### PR TITLE
Revert "Revert "Configure Non-Production Databases to Use Same Settings as Production""

### DIFF
--- a/aws/cloudformation/components/database.yml.erb
+++ b/aws/cloudformation/components/database.yml.erb
@@ -2,7 +2,7 @@
     Type: AWS::RDS::DBCluster
     Properties:
       DBClusterIdentifier: !Sub "${AWS::StackName}-cluster"
-      DBClusterParameterGroupName: !Ref AuroraClusterDBParameters
+      DBClusterParameterGroupName: !Ref AuroraClusterDBParameters # Resource name generated from db_parameters.yml.erb.
       Engine: aurora-mysql
       # We will usually do engine version updates manually, since updating this requires replacement, so this value may be out of sync with cluster.
       EngineVersion: 5.7.12
@@ -19,6 +19,9 @@
     Type: AWS::RDS::DBInstance
     Properties:
       DBInstanceIdentifier: !Sub "${AWS::StackName}-<%=i%>"
+      # Resource name generated from db_parameters.yml.erb
+      # Use same ParameterGroup for writer and all readers so that any reader can be promoted to writer during a Failover.
+      DBParameterGroupName: !Ref AuroraWriterDBParameters
       DBClusterIdentifier: !Ref AuroraCluster
       DBInstanceClass: !Ref DBInstanceType
       DBSubnetGroupName: !ImportValue VPC-DBSubnetGroup
@@ -26,12 +29,16 @@
       # We will usually do engine version updates manually, so don't specify an EngineVersion for the DBInstance.
 <% end -%>
 
-  AuroraClusterDBParameters:
-    Type: AWS::RDS::DBClusterParameterGroup
+<%
+  YAML.load(erb_file(aws_dir('cloudformation/db_parameters.yml.erb'))).each do |key, values|
+-%>
+  <%=key%>DBParameters:
+    Type: AWS::RDS::DB<%=key.match('Cluster')%>ParameterGroup
     Properties:
-      Description: !Sub "Aurora DB Cluster Parameters for ${AWS::StackName}."
+      Description: !Sub "<%=key.titleize%> DB Parameters for ${AWS::StackName}."
       Family: aurora-mysql5.7
-      Parameters: {'innodb_monitor_enable': 'all'}
+      Parameters: <%=values.compact.to_json%>
+<%end -%>
 
 <% db_secrets = [nil, 'application-writer', 'readonly'].map do |user| -%>
   DatabaseSecret<%=secret = user&.underscore&.camelcase%>:

--- a/aws/cloudformation/db_parameters.yml.erb
+++ b/aws/cloudformation/db_parameters.yml.erb
@@ -28,9 +28,6 @@ AuroraCluster: &aurora
   # https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_flush_log_at_trx_commit
   innodb_flush_log_at_trx_commit: 0
 
-  # IAM role ARN used to select data into AWS S3.
-  aurora_select_into_s3_role: {'Fn::GetAtt': [AuroraS3Role, Arn]}
-
 # System variables for the Aurora DB writer.
 AuroraWriter:
   # Prevent an slow query from degrading instance or cluster performance.


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#46220

The issues with Stack Drift and `db.r5` instances not being available in `us-east-1e` have been resolved with #46247 and #46253 