### PR TITLE
Create local header option

### DIFF
--- a/config.yml.erb
+++ b/config.yml.erb
@@ -417,6 +417,10 @@ proxy: false # If true, generated URLs will not include explicit port numbers in
 # Run dashboard-server with the level editing interface enabled (for admins)
 levelbuilder_mode:
 
+# Use different color header for local environment than the one on production to
+# make it easier to tell the difference
+use_local_header_color:
+
 default_hoc_mode: post-hoc  # overridden by 'hoc_mode' DCDO param, except in :test
 default_hoc_launch: ''      # overridden by 'hoc_launch' DCDO param, except in :test
 

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -354,6 +354,12 @@ img.video_thumbnail {
   }
 }
 
+.local-header {
+  .header {
+    background-color: $orange;
+  }
+}
+
 
 #language_dir.rtl #pageheader-wrapper {
   .create_options {

--- a/dashboard/app/views/layouts/_header.html.haml
+++ b/dashboard/app/views/layouts/_header.html.haml
@@ -10,6 +10,7 @@
 
   header_class = 'header-wrapper'
   header_class = header_class + (rack_env?(:levelbuilder) ? ' levelbuilder-header' : '')
+    header_class = header_class + (CDO.use_local_header_color ? ' local-header' : '')
 
   if current_user
     if current_user.teacher?

--- a/locals.yml.default
+++ b/locals.yml.default
@@ -14,6 +14,10 @@ dashboard_enable_pegasus: true
 # Run dashboard-server with the level editing interface enabled (for admins)
 #levelbuilder_mode: true
 
+# Use different color header for local environment than the one on production to
+# make it easier to tell the difference
+#use_local_header_color: true
+
 # Keeps from taking eyes snapshots when running feature files
 #disable_all_eyes_running: true
 


### PR DESCRIPTION
Add an option in locals.yml to set `use_local_header_color` to make the header orange on local development. 

![Screen Shot 2022-05-10 at 1 16 24 PM](https://user-images.githubusercontent.com/208083/167685516-334cc0b1-ca25-4f1a-b4db-2e9213c891a0.png)
