### PR TITLE
Remove Non-Latin-Characters Apps Test

### DIFF
--- a/apps/test/unit/templates/sectionAssessments/SubmissionStatusAssessmentsTableTest.js
+++ b/apps/test/unit/templates/sectionAssessments/SubmissionStatusAssessmentsTableTest.js
@@ -263,19 +263,6 @@ describe('SubmissionStatusAssessmentsTable', () => {
         .text()
     ).to.equal('7/10/2018 20:52:05');
 
-    const rtlAndNonLatinWrapper = mount(
-      <SubmissionStatusAssessmentsTable
-        studentOverviewData={studentOverviewData}
-        localeCode={'ar-SA'}
-      />
-    );
-    expect(
-      rtlAndNonLatinWrapper
-        .find('.timestampCell')
-        .first()
-        .text()
-    ).to.equal('٢٧‏/١‏/١٤٤٠ هـ في ٨:٥٢:٠٥ م');
-
     // localeCode will undefined by default here, but it defaults to null in
     // redux; so, make sure we explicitly test that particular falsy value
     const nullLocaleWrapper = mount(


### PR DESCRIPTION
I only added it in https://github.com/code-dot-org/code-dot-org/pull/46081 originally out of a surplus of thoroughness, but the fancy characters are causing weird failures in the DTT:

    FAILED TESTS:
      unit tests
	SubmissionStatusAssessmentsTable
	  âœ– renders localized submission timestamps
	    HeadlessChrome 0.0.0 (Linux 0.0.0)
	  AssertionError: expected 'Ù¢Ù§â€/Ù¡â€/Ù¡Ù¤Ù¤Ù  Ù‡Ù€ Ù¨:Ù¥Ù¢:Ù Ù¥ Ù…' to equal 'Ù¢Ù§â€/Ù¡â€/Ù¡Ù¤Ù¤Ù  Ù‡Ù€ ÙÙŠ Ù¨:Ù¥Ù¢:Ù Ù¥ Ù…'

	  + expected - actual

	  -Ù¢Ù§â€/Ù¡â€/Ù¡Ù¤Ù¤Ù  Ù‡Ù€ Ù¨:Ù¥Ù¢:Ù Ù¥ Ù…
	  +Ù¢Ù§â€/Ù¡â€/Ù¡Ù¤Ù¤Ù  Ù‡Ù€ ÙÙŠ Ù¨:Ù¥Ù¢:Ù Ù¥ Ù…


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
