### PR TITLE
Adding programming classes to the code documentation table

### DIFF
--- a/apps/src/lib/levelbuilder/code-docs-editor/ProgrammingExpressionsTable.jsx
+++ b/apps/src/lib/levelbuilder/code-docs-editor/ProgrammingExpressionsTable.jsx
@@ -69,7 +69,7 @@ export default function ProgrammingExpressionsTable({
     );
   };
 
-  const fetchExpressions = (environmentId, categoryId, resultType, page) => {
+  const fetchResults = (environmentId, categoryId, resultType, page) => {
     const data = {};
     if (environmentId !== DEFAULT_VALUE) {
       data.programmingEnvironmentId = environmentId;
@@ -79,7 +79,7 @@ export default function ProgrammingExpressionsTable({
     }
     data.page = page;
     const url =
-      `/${resultType}/get_filtered_expressions?` + queryString.stringify(data);
+      `/${resultType}/get_filtered_results?` + queryString.stringify(data);
     let success = false;
     fetch(url)
       .then(response => {
@@ -108,7 +108,7 @@ export default function ProgrammingExpressionsTable({
     }).then(response => {
       if (response.ok) {
         setItemToDelete(null);
-        fetchExpressions(
+        fetchResults(
           selectedEnvironment,
           selectedCategory,
           selectedResultType,
@@ -121,7 +121,7 @@ export default function ProgrammingExpressionsTable({
   };
 
   useEffect(() => {
-    fetchExpressions(
+    fetchResults(
       selectedEnvironment,
       selectedCategory,
       selectedResultType,
@@ -192,6 +192,7 @@ export default function ProgrammingExpressionsTable({
             setCurrentPage(1);
           }}
           value={selectedResultType}
+          style={{marginRight: 7}}
         >
           {RESULT_TYPES.map(resultType => (
             <option key={resultType.id} value={resultType.id}>
@@ -241,7 +242,7 @@ export default function ProgrammingExpressionsTable({
                 `/${selectedResultType}/${itemToDelete.id}`,
                 () => {
                   setItemToDelete(null);
-                  fetchExpressions(
+                  fetchResults(
                     selectedEnvironment,
                     selectedCategory,
                     selectedResultType,
@@ -261,7 +262,7 @@ export default function ProgrammingExpressionsTable({
             categoriesForSelect={allCategories}
             onClose={() => {
               setItemToClone(null);
-              fetchExpressions(
+              fetchResults(
                 selectedEnvironment,
                 selectedCategory,
                 selectedResultType,

--- a/apps/test/unit/lib/levelbuilder/code-docs-editor/ProgrammingExpressionsTableTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/code-docs-editor/ProgrammingExpressionsTableTest.jsx
@@ -12,7 +12,7 @@ describe('ProgrammingExpressionsTable', () => {
     fetchStub = sinon.stub(window, 'fetch');
     returnData = {
       numPages: 2,
-      expressions: [
+      results: [
         {
           id: 1,
           key: 'button',
@@ -98,19 +98,23 @@ describe('ProgrammingExpressionsTable', () => {
     fetchStub.restore();
   });
 
-  it('renders dropdowns with environments and categories', () => {
+  it('renders dropdowns with resultType, environments and categories', () => {
     const wrapper = shallow(<ProgrammingExpressionsTable {...defaultProps} />);
-    expect(wrapper.find('select').length).to.equal(2);
+    expect(wrapper.find('select').length).to.equal(3);
   });
 
   it('renders dropdowns with environments and categories', () => {
     const wrapper = shallow(<ProgrammingExpressionsTable {...defaultProps} />);
-    expect(wrapper.find('select').length).to.equal(2);
-    const environmentSelector = wrapper.find('select').first();
+    expect(wrapper.find('select').length).to.equal(3);
+
+    const resultTypeSelector = wrapper.find('select').first();
+    expect(resultTypeSelector.find('option').length).to.equal(2);
+
+    const environmentSelector = wrapper.find('select').at(1);
     expect(environmentSelector.find('option').length).to.equal(4);
     expect(environmentSelector.props().value).to.equal('all');
 
-    const categorySelector = wrapper.find('select').at(1);
+    const categorySelector = wrapper.find('select').at(2);
     expect(categorySelector.find('option').length).to.equal(4);
     expect(categorySelector.props().value).to.equal('all');
   });
@@ -118,10 +122,23 @@ describe('ProgrammingExpressionsTable', () => {
   it('updates category dropdown when environment is selected', () => {
     const wrapper = shallow(<ProgrammingExpressionsTable {...defaultProps} />);
 
-    const environmentSelector = wrapper.find('select').at(0);
+    const environmentSelector = wrapper.find('select').at(1);
     environmentSelector.simulate('change', {target: {value: 1}});
 
-    const categorySelector = wrapper.find('select').at(1);
+    const categorySelector = wrapper.find('select').at(2);
+    expect(categorySelector.find('option').length).to.equal(2);
+  });
+
+  it('updates resultType dropdown when resultType is selected', () => {
+    const wrapper = shallow(<ProgrammingExpressionsTable {...defaultProps} />);
+
+    const resultTypeSelector = wrapper.find('select').at(0);
+    resultTypeSelector.simulate('change', {target: {value: 1}});
+
+    const environmentSelector = wrapper.find('select').at(1);
+    environmentSelector.simulate('change', {target: {value: 1}});
+
+    const categorySelector = wrapper.find('select').at(2);
     expect(categorySelector.find('option').length).to.equal(2);
   });
 
@@ -137,7 +154,7 @@ describe('ProgrammingExpressionsTable', () => {
       // A reactabular table has a Header and a Body
       expect(wrapper.findAll('Header').length).to.equal(1);
       expect(wrapper.findAll('Body').length).to.equal(1);
-      expect(wrapper.findOne('Body').props.rows).to.eql(returnData.expressions);
+      expect(wrapper.findOne('Body').props.rows).to.eql(returnData.results);
     });
   });
 

--- a/apps/test/unit/lib/levelbuilder/code-docs-editor/ProgrammingExpressionsTableTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/code-docs-editor/ProgrammingExpressionsTableTest.jsx
@@ -144,7 +144,7 @@ describe('ProgrammingExpressionsTable', () => {
 
   it('shows table with programming expressions after load', () => {
     fetchStub
-      .withArgs('/programming_expressions/get_filtered_expressions?page=1')
+      .withArgs('/programming_expressions/get_filtered_results?page=1')
       .returns(Promise.resolve({ok: true, json: () => returnData}));
     const wrapper = isolateComponent(
       <ProgrammingExpressionsTable {...defaultProps} />
@@ -160,7 +160,7 @@ describe('ProgrammingExpressionsTable', () => {
 
   it('loads data but doesnt show expressions if hidden is true', () => {
     fetchStub
-      .withArgs('/programming_expressions/get_filtered_expressions?page=1')
+      .withArgs('/programming_expressions/get_filtered_results?page=1')
       .returns(Promise.resolve({ok: true, json: () => returnData}));
     const wrapper = isolateComponent(
       <ProgrammingExpressionsTable {...defaultProps} hidden />
@@ -175,7 +175,7 @@ describe('ProgrammingExpressionsTable', () => {
 
   it('shows confirmation dialog before destroying expression', () => {
     fetchStub
-      .withArgs('/programming_expressions/get_filtered_expressions?page=1')
+      .withArgs('/programming_expressions/get_filtered_results?page=1')
       .returns(Promise.resolve({ok: true, json: () => returnData}));
     const wrapper = mount(<ProgrammingExpressionsTable {...defaultProps} />);
     return new Promise(resolve => setImmediate(resolve)).then(() => {
@@ -195,7 +195,7 @@ describe('ProgrammingExpressionsTable', () => {
 
   it('shows clone dialog to clone expression', () => {
     fetchStub
-      .withArgs('/programming_expressions/get_filtered_expressions?page=1')
+      .withArgs('/programming_expressions/get_filtered_results?page=1')
       .returns(Promise.resolve({ok: true, json: () => returnData}));
     const wrapper = mount(<ProgrammingExpressionsTable {...defaultProps} />);
     return new Promise(resolve => setImmediate(resolve)).then(() => {

--- a/dashboard/app/controllers/programming_classes_controller.rb
+++ b/dashboard/app/controllers/programming_classes_controller.rb
@@ -21,8 +21,29 @@ class ProgrammingClassesController < ApplicationController
   end
 
   def edit
+    @programming_class = ProgrammingClass.find_by_id(params[:id])
     return render :not_found unless @programming_class
     @environment_categories = @programming_class.programming_environment.categories.map {|c| {key: c.key, name: c.name}}
+  end
+
+  # GET /programming_classes/get_filtered_expressions
+  # Possible filters:
+  # - programmingEnvironmentId
+  # - categoryId
+  # - page (1 indexed)
+  def get_filtered_expressions
+    return render(status: :not_acceptable, json: {error: 'Page is required'}) unless params[:page]
+
+    @programming_classes = ProgrammingClass.all
+    @programming_classes = @programming_classes.where(programming_environment_id: params[:programmingEnvironmentId]) if params[:programmingEnvironmentId]
+    @programming_classes = @programming_classes.where(programming_environment_category_id: params[:categoryId]) if params[:categoryId]
+
+    results_per_page = 20
+    total_classes = @programming_classes.length
+    num_pages = (total_classes / results_per_page.to_f).ceil
+
+    @programming_classes = @programming_classes.page(params[:page]).per(results_per_page)
+    render json: {numPages: num_pages, results: @programming_classes.map(&:summarize_for_all_code_docs)}
   end
 
   def update
@@ -56,6 +77,16 @@ class ProgrammingClassesController < ApplicationController
   def show
     return render :not_found unless @programming_class
     @programming_environment_categories = @programming_class.programming_environment.categories_for_navigation
+  end
+
+  def destroy
+    return render :not_found unless @programming_class
+    begin
+      @programming_class.destroy
+      render(status: 200, plain: "Destroyed #{@programming_class.name}")
+    rescue
+      render(status: :not_acceptable, plain: @programming_class.errors.full_messages.join('. '))
+    end
   end
 
   private

--- a/dashboard/app/controllers/programming_classes_controller.rb
+++ b/dashboard/app/controllers/programming_classes_controller.rb
@@ -27,12 +27,12 @@ class ProgrammingClassesController < ApplicationController
     @environment_categories = @programming_class.programming_environment.categories.map {|c| {key: c.key, name: c.name}}
   end
 
-  # GET /programming_classes/get_filtered_expressions
+  # GET /programming_classes/get_filtered_results
   # Possible filters:
   # - programmingEnvironmentId
   # - categoryId
   # - page (1 indexed)
-  def get_filtered_expressions
+  def get_filtered_results
     return render(status: :not_acceptable, json: {error: 'Page is required'}) unless params[:page]
 
     @programming_classes = ProgrammingClass.all

--- a/dashboard/app/controllers/programming_classes_controller.rb
+++ b/dashboard/app/controllers/programming_classes_controller.rb
@@ -1,4 +1,5 @@
 class ProgrammingClassesController < ApplicationController
+  include Rails.application.routes.url_helpers
   before_action :require_levelbuilder_mode_or_test_env
   load_and_authorize_resource
 

--- a/dashboard/app/controllers/programming_expressions_controller.rb
+++ b/dashboard/app/controllers/programming_expressions_controller.rb
@@ -16,12 +16,12 @@ class ProgrammingExpressionsController < ApplicationController
     end
   end
 
-  # GET /programming_expressions/get_filtered_expressions
+  # GET /programming_expressions/get_filtered_results
   # Possible filters:
   # - programmingEnvironmentId
   # - categoryId
   # - page (1 indexed)
-  def get_filtered_expressions
+  def get_filtered_results
     return render(status: :not_acceptable, json: {error: 'Page is required'}) unless params[:page]
 
     @programming_expressions = ProgrammingExpression.all

--- a/dashboard/app/controllers/programming_expressions_controller.rb
+++ b/dashboard/app/controllers/programming_expressions_controller.rb
@@ -33,7 +33,7 @@ class ProgrammingExpressionsController < ApplicationController
     num_pages = (total_expressions / results_per_page.to_f).ceil
 
     @programming_expressions = @programming_expressions.page(params[:page]).per(results_per_page)
-    render json: {numPages: num_pages, expressions: @programming_expressions.map(&:summarize_for_all_code_docs)}
+    render json: {numPages: num_pages, results: @programming_expressions.map(&:summarize_for_all_code_docs)}
   end
 
   # GET /programming_expressions/search

--- a/dashboard/app/models/programming_class.rb
+++ b/dashboard/app/models/programming_class.rb
@@ -23,6 +23,7 @@
 #
 class ProgrammingClass < ApplicationRecord
   include CurriculumHelper
+  include Rails.application.routes.url_helpers
 
   belongs_to :programming_environment
   belongs_to :programming_environment_category
@@ -119,7 +120,7 @@ class ProgrammingClass < ApplicationRecord
       environmentId: programming_environment.id,
       environmentTitle: programming_environment.title,
       categoryName: programming_environment_category&.name,
-      editPath: file_path
+      editPath: edit_programming_class_url(self)
     }
   end
 

--- a/dashboard/app/models/programming_class.rb
+++ b/dashboard/app/models/programming_class.rb
@@ -111,6 +111,18 @@ class ProgrammingClass < ApplicationRecord
     }
   end
 
+  def summarize_for_all_code_docs
+    {
+      id: id,
+      key: key,
+      name: name,
+      environmentId: programming_environment.id,
+      environmentTitle: programming_environment.title,
+      categoryName: programming_environment_category&.name,
+      editPath: file_path
+    }
+  end
+
   def summarize_for_show
     {
       id: id,

--- a/dashboard/app/models/programming_class.rb
+++ b/dashboard/app/models/programming_class.rb
@@ -32,6 +32,8 @@ class ProgrammingClass < ApplicationRecord
   validates_uniqueness_of :key, scope: :programming_environment_id, case_sensitive: false
   validate :validate_key_format
 
+  after_destroy :remove_serialization
+
   def self.properties_from_file(path, content)
     expression_config = JSON.parse(content)
 

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -336,7 +336,7 @@ Dashboard::Application.routes.draw do
     end
   end
 
-  resources :programming_classes, only: [:new, :create, :edit, :update, :show] do
+  resources :programming_classes, only: [:new, :create, :edit, :update, :show, :destroy] do
     collection do
       get :get_filtered_expressions
     end

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -338,7 +338,7 @@ Dashboard::Application.routes.draw do
 
   resources :programming_classes, only: [:new, :create, :edit, :update, :show, :destroy] do
     collection do
-      get :get_filtered_expressions
+      get :get_filtered_results
     end
     member do
       post :clone
@@ -348,7 +348,7 @@ Dashboard::Application.routes.draw do
   resources :programming_expressions, only: [:index, :new, :create, :edit, :update, :show, :destroy] do
     collection do
       get :search
-      get :get_filtered_expressions
+      get :get_filtered_results
     end
     member do
       post :clone

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -336,7 +336,14 @@ Dashboard::Application.routes.draw do
     end
   end
 
-  resources :programming_classes, only: [:new, :create, :edit, :update, :show]
+  resources :programming_classes, only: [:new, :create, :edit, :update, :show] do
+    collection do
+      get :get_filtered_expressions
+    end
+    member do
+      post :clone
+    end
+  end
 
   resources :programming_expressions, only: [:index, :new, :create, :edit, :update, :show, :destroy] do
     collection do

--- a/dashboard/test/controllers/programming_classes_controller_test.rb
+++ b/dashboard/test/controllers/programming_classes_controller_test.rb
@@ -165,4 +165,65 @@ class ProgrammingClassesControllerTest < ActionController::TestCase
     test_user_gets_response_for :show, params: -> {{id: @unpublished_programming_class.id}}, user: :teacher, response: :forbidden, name: 'test_teacher_calling_get_show_for_unpublished_class_should_receive_forbidden'
     test_user_gets_response_for :show, params: -> {{id: @unpublished_programming_class.id}}, user: :levelbuilder, response: :success, name: 'test_levelbuilder_calling_get_show_for_unpublished_class_should_receive_success'
   end
+
+  class FilterTests < ActionController::TestCase
+    setup do
+      ProgrammingEnvironment.all.destroy_all
+      @programming_environment1 = create :programming_environment
+      @programming_environment2 = create :programming_environment
+      [@programming_environment1, @programming_environment2].each do |programming_environment|
+        3.times do
+          category = create :programming_environment_category, programming_environment: programming_environment
+          4.times do
+            create :programming_class, programming_environment: programming_environment, programming_environment_category: category
+          end
+        end
+      end
+
+      @levelbuilder = create :levelbuilder
+    end
+
+    test 'get_filtered_results returns not_acceptable if no page providewd' do
+      sign_in @levelbuilder
+
+      get :get_filtered_results, params: {}
+      assert_response :not_acceptable
+    end
+
+    test 'get_filtered_results returns paged results' do
+      sign_in @levelbuilder
+
+      get :get_filtered_results, params: {page: 1}
+      assert_response :ok
+      response = JSON.parse(@response.body)
+      assert_equal 2, response['numPages']
+      assert_equal 20, response['results'].length
+
+      get :get_filtered_results, params: {page: 2}
+      assert_response :ok
+      response = JSON.parse(@response.body)
+      assert_equal 2, response['numPages']
+      assert_equal 4, response['results'].length
+    end
+
+    test 'get_filtered_results only returns expressions in environment if specified' do
+      sign_in @levelbuilder
+
+      get :get_filtered_results, params: {programmingEnvironmentId: @programming_environment1.id, page: 1}
+      assert_response :ok
+      response = JSON.parse(@response.body)
+      assert_equal 1, response['numPages']
+      assert_equal 12, response['results'].length
+    end
+
+    test 'get_filtered_results only returns expressions in category if specified' do
+      sign_in @levelbuilder
+
+      get :get_filtered_results, params: {programmingEnvironmentId: @programming_environment2.id, categoryId: @programming_environment2.categories.first.id, page: 1}
+      assert_response :ok
+      response = JSON.parse(@response.body)
+      assert_equal 1, response['numPages']
+      assert_equal 4, response['results'].length
+    end
+  end
 end

--- a/dashboard/test/controllers/programming_expressions_controller_test.rb
+++ b/dashboard/test/controllers/programming_expressions_controller_test.rb
@@ -248,20 +248,20 @@ class ProgrammingExpressionsControllerTest < ActionController::TestCase
       assert_response :not_acceptable
     end
 
-    test 'get_filtered_results returns paged expressions' do
+    test 'get_filtered_results returns paged results' do
       sign_in @levelbuilder
 
       get :get_filtered_results, params: {page: 1}
       assert_response :ok
       response = JSON.parse(@response.body)
       assert_equal 2, response['numPages']
-      assert_equal 20, response['expressions'].length
+      assert_equal 20, response['results'].length
 
       get :get_filtered_results, params: {page: 2}
       assert_response :ok
       response = JSON.parse(@response.body)
       assert_equal 2, response['numPages']
-      assert_equal 4, response['expressions'].length
+      assert_equal 4, response['results'].length
     end
 
     test 'get_filtered_results only returns expressions in environment if specified' do
@@ -271,7 +271,7 @@ class ProgrammingExpressionsControllerTest < ActionController::TestCase
       assert_response :ok
       response = JSON.parse(@response.body)
       assert_equal 1, response['numPages']
-      assert_equal 12, response['expressions'].length
+      assert_equal 12, response['results'].length
     end
 
     test 'get_filtered_results only returns expressions in category if specified' do
@@ -281,7 +281,7 @@ class ProgrammingExpressionsControllerTest < ActionController::TestCase
       assert_response :ok
       response = JSON.parse(@response.body)
       assert_equal 1, response['numPages']
-      assert_equal 4, response['expressions'].length
+      assert_equal 4, response['results'].length
     end
   end
 

--- a/dashboard/test/controllers/programming_expressions_controller_test.rb
+++ b/dashboard/test/controllers/programming_expressions_controller_test.rb
@@ -241,43 +241,43 @@ class ProgrammingExpressionsControllerTest < ActionController::TestCase
       @levelbuilder = create :levelbuilder
     end
 
-    test 'get_filtered_expressions returns not_acceptable if no page providewd' do
+    test 'get_filtered_results returns not_acceptable if no page providewd' do
       sign_in @levelbuilder
 
-      get :get_filtered_expressions, params: {}
+      get :get_filtered_results, params: {}
       assert_response :not_acceptable
     end
 
-    test 'get_filtered_expressions returns paged expressions' do
+    test 'get_filtered_results returns paged expressions' do
       sign_in @levelbuilder
 
-      get :get_filtered_expressions, params: {page: 1}
+      get :get_filtered_results, params: {page: 1}
       assert_response :ok
       response = JSON.parse(@response.body)
       assert_equal 2, response['numPages']
       assert_equal 20, response['expressions'].length
 
-      get :get_filtered_expressions, params: {page: 2}
+      get :get_filtered_results, params: {page: 2}
       assert_response :ok
       response = JSON.parse(@response.body)
       assert_equal 2, response['numPages']
       assert_equal 4, response['expressions'].length
     end
 
-    test 'get_filtered_expressions only returns expressions in environment if specified' do
+    test 'get_filtered_results only returns expressions in environment if specified' do
       sign_in @levelbuilder
 
-      get :get_filtered_expressions, params: {programmingEnvironmentId: @programming_environment1.id, page: 1}
+      get :get_filtered_results, params: {programmingEnvironmentId: @programming_environment1.id, page: 1}
       assert_response :ok
       response = JSON.parse(@response.body)
       assert_equal 1, response['numPages']
       assert_equal 12, response['expressions'].length
     end
 
-    test 'get_filtered_expressions only returns expressions in category if specified' do
+    test 'get_filtered_results only returns expressions in category if specified' do
       sign_in @levelbuilder
 
-      get :get_filtered_expressions, params: {programmingEnvironmentId: @programming_environment2.id, categoryId: @programming_environment2.categories.first.id, page: 1}
+      get :get_filtered_results, params: {programmingEnvironmentId: @programming_environment2.id, categoryId: @programming_environment2.categories.first.id, page: 1}
       assert_response :ok
       response = JSON.parse(@response.body)
       assert_equal 1, response['numPages']


### PR DESCRIPTION
This PR pulls programming classes into the programming expressions code docs table. The default table loads with programming expressions, and you can select programming classes instead from the dropdown. 

Currently, the edit and destroy buttons are enabled, and the clone button is disabled (the method to clone a class will be future work).

<img width="931" alt="Screen Shot 2022-05-11 at 4 45 38 PM" src="https://user-images.githubusercontent.com/37230822/167965351-a14bb51f-abdb-423c-b0fd-c9d6ed5fa51d.png">


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/LP-2331

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
