### PR TITLE
Revert "Bump UI test version to Chrome 87"

### DIFF
--- a/dashboard/test/ui/browsers.json
+++ b/dashboard/test/ui/browsers.json
@@ -4,7 +4,7 @@
   {
     "name": "Chrome",
     "browserName": "chrome",
-    "version": "87",
+    "version": "75",
     "platform": "Windows 7",
     "screenResolution": "1280x1024",
     "extendedDebugging": true

--- a/dashboard/test/ui/features/star_labs/blocklayout.feature
+++ b/dashboard/test/ui/features/star_labs/blocklayout.feature
@@ -8,12 +8,12 @@ Background:
 Scenario: Auto-placing malformed start blocks
   When I've initialized the workspace with an auto-positioned flappy puzzle with extra newlines
   Then block "18" is near offset "16, 16"
-  And block "21" is near offset "16, 108"
+  And block "21" is near offset "16, 114"
 
 Scenario: Auto-placing blocks
   When I've initialized the workspace with an auto-positioned flappy puzzle
   Then block "18" is near offset "16, 16"
-  And block "21" is near offset "16, 108"
+  And block "21" is near offset "16, 114"
 
 Scenario: Auto-placing blocks with XML positioning
   Given I am on "http://studio.code.org/s/allthethings/lessons/5/levels/4?noautoplay=true"

--- a/dashboard/test/ui/features/step_definitions/check_finish_button.rb
+++ b/dashboard/test/ui/features/step_definitions/check_finish_button.rb
@@ -23,7 +23,7 @@ free_play_level_urls = {
 When /^I check that the (blockly|droplet|minecraft) free play level for "([^"]*)" shows the finish button for (small|mobile) screens/i do |level_type, level_name, screen_type|
   individual_steps <<-STEPS
     And I set up the #{level_type} free play level for "#{level_name}"
-    #{screen_type == 'small' ? 'And I change the browser window size to 1366 by 636' : ''}
+    #{screen_type == 'small' ? 'And I change the browser window size to 1366 by 600' : ''}
     #{level_type == 'minecraft' ? 'And I wait until the Minecraft game is loaded' : ''}
     And I press "runButton"
     And I check that selector "button:contains('Finish')" is in the viewport


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#46232. Some weird eyes diffs occurred, such as https://eyes.applitools.com/app/test-results/00000251750079195828/00000251750079154935/steps/1?accountId=mG4DoRfv0ntEgI3XIYBulrKxlZqrHtGwbP3V103ojvLFU110&mode=step-editor, which would be good to investigate