### PR TITLE
Auto export of EIR teacher data to a google sheet

### DIFF
--- a/bin/cron/eir_teachers_to_gdrive
+++ b/bin/cron/eir_teachers_to_gdrive
@@ -1,0 +1,59 @@
+#!/usr/bin/env ruby
+require_relative 'only_one'
+abort 'Script already running' unless only_one_running?(__FILE__)
+
+require_relative '../../dashboard/config/environment'
+require 'cdo/google/sheet'
+
+#
+# Uses a Google Cloud service account to write enrollment data for EIR workshops into
+# a spreadsheet in Google Drive (with permissions locked down to our organization).
+#
+
+EARLIEST_WORKSHOP_END_DATE = Date.new(2022, 5, 1)
+
+def get_rows
+  # Seed results array with a header row
+  results = [
+    [
+      "First Name",
+      "Last Name",
+      "Email",
+      "Alternate Email",
+      "District Name",
+      "School",
+      "Scholarship Status"
+    ]
+  ]
+
+  # We want to export all teachers enrolled in CSP 5-day summer workshops who have scholarship_status = yes_eir
+
+  potential_workshops = Pd::Workshop.
+    where(course: Pd::SharedWorkshopConstants::COURSE_CSP, subject: Pd::SharedWorkshopConstants::SUBJECT_SUMMER_WORKSHOP).
+    scheduled_end_on_or_after(EARLIEST_WORKSHOP_END_DATE).
+    pluck(:id)
+
+  Pd::Enrollment.
+    where(pd_workshop_id: potential_workshops).
+    joins('INNER JOIN pd_scholarship_infos ON pd_scholarship_infos.user_id = pd_enrollments.user_id AND pd_scholarship_infos.scholarship_status = "yes_eir"').
+    find_each do |enrollment|
+      results << [
+        enrollment.first_name,
+        enrollment.last_name,
+        enrollment.email,
+        enrollment.application&.form_data_hash&.[]('alternateEmail'),
+        enrollment.school_info&.school_district_name,
+        enrollment.school_name,
+        enrollment.scholarship_status
+      ]
+    end
+
+  results
+end
+
+def main
+  sheet = Google::Sheet.new CDO.eir_teacher_enrollments_gsheet_key
+  sheet.export(tab_name: 'EIR Teacher Tracker', rows: get_rows)
+end
+
+main

--- a/config.yml.erb
+++ b/config.yml.erb
@@ -465,6 +465,7 @@ image_optim: <%=chef_managed && !ci_test%>
 enrollments_summer_2020_gsheet_key:
 csf_workshop_attendance_gsheet_key: !Secret
 applications_2022_2023_gsheet_key:
+eir_teacher_enrollments_gsheet_key: !Secret
 
 # Referenced in Chef config, but not sure if they are still used anywhere?
 # TODO: verify these are intentionally no longer used and remove references from Chef config.

--- a/config/development.yml.erb
+++ b/config/development.yml.erb
@@ -37,6 +37,7 @@ custom_error_response: false
 
 # Used for exporting the workshop data to a gsheet
 applications_2022_2023_gsheet_key: !Secret
+eir_teacher_enrollments_gsheet_key: !Secret
 
 # Used for decoding certain protected level sources
 properties_encryption_key: !Secret

--- a/config/production.yml.erb
+++ b/config/production.yml.erb
@@ -29,6 +29,7 @@ use_pusher:                             true
 # Used for the exporting teacher enrollment data to a gsheet
 enrollments_summer_2020_gsheet_key: !Secret
 applications_2022_2023_gsheet_key: !Secret
+eir_teacher_enrollments_gsheet_key: !Secret
 
 # Amazon Future Engineer integration
 afe_pardot_form_handler_url: !Secret

--- a/cookbooks/cdo-apps/templates/default/crontab.erb
+++ b/cookbooks/cdo-apps/templates/default/crontab.erb
@@ -100,6 +100,7 @@
       cronjob at:'0 */2 * * *', do:deploy_dir('bin', 'cron', 'teacher_applications_to_gdrive')
       cronjob at:'30 */2 * * *', do:deploy_dir('bin', 'cron', 'summer_workshops_to_gdrive')
       cronjob at:'0 12 * * *', do:deploy_dir('bin', 'cron', 'csf_workshop_attendance_to_gdrive')
+      cronjob at:'0 13 * * *', do:deploy_dir('bin', 'cron', 'eir_teachers_to_gdrive')
       cronjob at:'0 7 * * *', do:deploy_dir('bin', 'cron', 'stop_inactive_adhoc_instances')
       cronjob at:'0 10 * * *', do:deploy_dir('bin', 'cron', 'redshift_rollups')
       cronjob at:'1 7 * * 6', do:deploy_dir('bin', 'cron', 'cleanup_workshop_attendance_codes')

--- a/dashboard/app/models/pd/enrollment.rb
+++ b/dashboard/app/models/pd/enrollment.rb
@@ -342,6 +342,11 @@ class Pd::Enrollment < ApplicationRecord
     self.application_id = application_id
   end
 
+  def application
+    return nil unless application_id
+    Pd::Application::ApplicationBase.find_by(id: application_id)
+  end
+
   # Removes the name and email information stored within this Pd::Enrollment.
   def clear_data
     write_attribute :name, nil


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Adds an auto export cronjob to collect EIR teachers who are enrolled in workshops and have EIR scholarship status.

This doesn't feel like the most efficient way to to the query but it'll only run once a day at 6am. Open to ideas for improving it tho

## Links


- the: [sheet](https://docs.google.com/spreadsheets/d/1rOC1OcGpYA7_wWWjOOpu4U_u9dFMwU7Y9kce4iS9tDM/edit#gid=783593287)
- jira ticket: [PLAT-1750](https://codedotorg.atlassian.net/browse/PLAT-1750)

## Testing story

Tested script with local data
![image](https://user-images.githubusercontent.com/82416901/167929607-fb2b1c2a-ff72-4746-b17f-97237c97e6df.png)
![image](https://user-images.githubusercontent.com/82416901/167929630-47f85709-1591-42f6-a602-69731f8af87d.png)
