### PR TITLE
Fix Google sign in silent takeover

### DIFF
--- a/dashboard/app/controllers/omniauth_callbacks_controller.rb
+++ b/dashboard/app/controllers/omniauth_callbacks_controller.rb
@@ -358,9 +358,13 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     # OAuth providers do not necessarily provide student email addresses, so we
     # want to perform silent takeover on these accounts, but *only if* the
     # student hasn't made progress with the initial account
+    auth_options_emails = user.migrated? ?
+      user.authentication_options.select {|ao| !ao.hashed_email.blank? && ao.hashed_email} :
+      []
     user.persisted? && user.oauth_student? &&
       user.email.blank? && user.hashed_email.blank? &&
-      !user.has_activity?
+      # Also *all* AuthenticationOption's emails are blank
+      auth_options_emails.blank? && !user.has_activity?
   end
 
   # Looks for an existing user with an email address matching the oauth credentials.

--- a/dashboard/app/controllers/omniauth_callbacks_controller.rb
+++ b/dashboard/app/controllers/omniauth_callbacks_controller.rb
@@ -358,13 +358,11 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     # OAuth providers do not necessarily provide student email addresses, so we
     # want to perform silent takeover on these accounts, but *only if* the
     # student hasn't made progress with the initial account
-    auth_options_emails = user.migrated? ?
-      user.authentication_options.select {|ao| !ao.hashed_email.blank? && ao.hashed_email} :
-      []
+    has_auth_email = user.migrated? && user.authentication_options.any? {|ao| ao.hashed_email.present?}
     user.persisted? && user.oauth_student? &&
       user.email.blank? && user.hashed_email.blank? &&
       # Also *all* AuthenticationOption's emails are blank
-      auth_options_emails.blank? && !user.has_activity?
+      !has_auth_email && !user.has_activity?
   end
 
   # Looks for an existing user with an email address matching the oauth credentials.

--- a/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
+++ b/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
@@ -968,8 +968,6 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
     user = create(:student, :migrated_imported_from_clever, uid: uid)
     user.authentication_options << create(:google_authentication_option, user: user, email: email, authentication_id: uid)
     user.save
-    # user.authentication_options.each {|x| puts x.id, x.credential_type, x.created_at, x.deleted_at}
-    # google_classroom_section = google_classroom_student.sections_as_student.find {|s| s.login_type == Section::LOGIN_TYPE_GOOGLE_CLASSROOM}
     auth = generate_auth_user_hash(provider: 'google_oauth2', uid: uid, user_type: User::TYPE_STUDENT, email: email)
     @request.env['omniauth.auth'] = auth
     @request.env['omniauth.params'] = {}
@@ -978,9 +976,6 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
       get :google_oauth2
     end
     user.reload
-    #puts ''
-    #puts ''
-    #user.authentication_options.each {|x| puts x.id, x.credential_type, x.created_at, x.deleted_at}
     assert_equal 'migrated', user.provider
     auth_option_count = user.authentication_options.count
     assert_equal 2, auth_option_count

--- a/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
+++ b/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
@@ -977,6 +977,8 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
     end
     user.reload
     assert_equal 'migrated', user.provider
+    # No more authentication_options should be created or deleted. The
+    # two created before login should be the only existing ones.
     auth_option_count = user.authentication_options.count
     assert_equal 2, auth_option_count
     assert_equal user.id, signed_in_user_id

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -321,6 +321,16 @@ FactoryGirl.define do
         end
       end
 
+      trait :migrated_imported_from_clever do
+        clever_sso_provider
+        without_email
+        after(:create) do |user|
+          section = create :section, login_type: Section::LOGIN_TYPE_CLEVER
+          create :follower, student_user: user, section: section
+          user.reload
+        end
+      end
+
       trait :without_email do
         email ''
         hashed_email nil


### PR DESCRIPTION
**Context**: There's been [investigation](https://codedotorg.atlassian.net/browse/FND-1035?focusedCommentId=20998) on whether we can refactor our User account creation to have them migrated/multiauth by default. A result of that investigation was needing to address and fix the scenarios in which accounts were still currently failing to migrate. If this wasn't addressed and we moved forward with refactoring, those accounts would instead fail to be created in general.

**What**: This change has our `allows_section_takeover` function check **all** of the currently signing in OAuth `User`'s emails. Before the update we only looked at the `email`/`hashed_email` field on the `User` record, and the email fields on the `primary_contact_info`(which is the chronologically first `AuthenticationOption`). Now we check **all** of the associated `AuthenticationOption`'s emails.

**Why**: The intention is to fix Google OAuth's known sign in issue where a User calls silent takeover on itself. After we confirm a [`User` exists with the given **OAuth credentials**](https://github.com/code-dot-org/code-dot-org/blob/fnd-2029-update-allows-section-takeover-conditions/dashboard/app/controllers/omniauth_callbacks_controller.rb#L60) and passes `allows_section_takeover`, silent takeover is triggered. Silent takeover looks for another `User` by the **OAuth response email**. `allows_section_takeover` was previously failing to account for the other emails a `User` might have, and [the lookup](https://github.com/code-dot-org/code-dot-org/blob/fnd-2029-update-allows-section-takeover-conditions/dashboard/app/controllers/omniauth_callbacks_controller.rb#L382) was finding the exact same User. Silent takeover was then being ran on the same `User` it was being called by.

The result was the existing `User` record being soft deleted, and a new `AuthenticationOption` being created and associated to it. When an end-user tried to log in again, we would create a new `User` that would fail to "migrate" because there were conflicts with the new `AuthenticationOption`(duplicate `authentication_id`s) that is floating in limbo. 

## Links

- jira ticket: [FND-2029](https://codedotorg.atlassian.net/browse/FND-2029)

## Testing story

- Locally created a Clever User and associated a `google_oauth2` AuthenticationOption as well. Then logged in via Google to confirm that silent takeover wouldn't be triggered after the fix.
- Confirmed removing the fix triggers silent takeover.
- Locally ran the unit test creating the same scenario before and after the logic fix.

## Follow-up work

Continue to monitor if unmigrated `google_oauth2` Users are still be created after merge.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
