### PR TITLE
Update `webmock` to >= 3.8.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,7 +82,7 @@ group :development, :test do
   gem 'ruby-prof'
   gem 'vcr', require: false
   # For unit testing.
-  gem 'webmock', require: false
+  gem 'webmock', '~> 3.8', require: false
 
   gem 'codecov', require: false
   gem 'fakeredis', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -352,8 +352,8 @@ GEM
       activerecord (~> 6.0.0)
     concurrent-ruby (1.1.9)
     connection_pool (2.2.1)
-    crack (0.4.3)
-      safe_yaml (~> 1.0.0)
+    crack (0.4.5)
+      rexml
     crass (1.0.6)
     css_parser (1.10.0)
       addressable
@@ -484,7 +484,7 @@ GEM
       sysexits (~> 1.1)
     hammerspace (0.1.7)
       gnista (~> 1.0.1)
-    hashdiff (0.3.7)
+    hashdiff (1.0.1)
     hashery (2.1.2)
     hashie (3.6.0)
     highline (1.6.21)
@@ -782,7 +782,6 @@ GEM
     ruby_parser (3.18.1)
       sexp_processor (~> 4.16)
     rubyzip (1.2.2)
-    safe_yaml (1.0.4)
     sass (3.4.22)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
@@ -900,10 +899,10 @@ GEM
       activesupport
       httpclient (>= 2.4)
       multi_json
-    webmock (3.3.0)
-      addressable (>= 2.3.6)
+    webmock (3.14.0)
+      addressable (>= 2.8.0)
       crack (>= 0.3.2)
-      hashdiff
+      hashdiff (>= 0.4.0, < 2.0.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -1088,7 +1087,7 @@ DEPENDENCIES
   vcr
   web-console
   webdrivers (~> 3.0)
-  webmock
+  webmock (~> 3.8)
   xxhash
   youtube-dl.rb
 


### PR DESCRIPTION
Since that's the earliest version that supports Ruby 2.7: https://github.com/bblimke/webmock/blob/master/CHANGELOG.md#380

## Testing story

Relying on existing unit tests to verify that this library used for testing continues to work.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
