### PR TITLE
Fix Unhandled Deprecation Warning

### DIFF
--- a/lib/cdo/poste.rb
+++ b/lib/cdo/poste.rb
@@ -182,7 +182,7 @@ module Poste
       @@renderer ||= begin
         require 'cdo/markdown/handler'
         Cdo::Markdown::Handler.register
-        ActionView::Base.new
+        ActionView::Base.with_empty_template_cache.empty
       end
     end
   end


### PR DESCRIPTION
Specifically:

    DEPRECATION WARNING: ActionView::Base instances must implement `compiled_method_container` or use the class method `with_empty_template_cache` for constructing an ActionView::Base instance that has an empty cache. (called from render_header at /home/elijah/code-dot-org/lib/cdo/poste.rb:159)

Added in Rails 6. The simple fix is to update the initialization pattern we're using here just like [we already did for ActionViewSinatra](https://github.com/code-dot-org/code-dot-org/commit/0632ec9648f801ee6a755df818c461b3f1e1020e#diff-ef6518d2be237575cba7f239f5c384328bba8a1abba707f44a3166248d4416bf)

## Testing Story

Relying on existing unit tests. Note that currently in staging, we see deprecation warnings when running pegasus tests because of this. With this change, we expect to no longer see those deprecation warnings.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
