### PR TITLE
Update `pdf-reader` gem to 2.9.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -170,7 +170,7 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    Ascii85 (1.0.2)
+    Ascii85 (1.1.0)
     StreetAddress (1.0.6)
     acme-client (2.0.5)
       faraday (~> 0.9, >= 0.9.1)
@@ -633,8 +633,8 @@ GEM
       activerecord (>= 4.0, < 6.1)
     parser (3.1.2.0)
       ast (~> 2.4.1)
-    pdf-reader (1.4.0)
-      Ascii85 (~> 1.0.0)
+    pdf-reader (2.9.2)
+      Ascii85 (~> 1.0)
       afm (~> 0.2.1)
       hashery (~> 2.0)
       ruby-rc4
@@ -856,7 +856,7 @@ GEM
     tilt (2.0.10)
     timecop (0.8.1)
     trailblazer-option (0.1.1)
-    ttfunk (1.4.0)
+    ttfunk (1.7.0)
     twilio-ruby (5.40.1)
       faraday (>= 0.9, < 2.0)
       jwt (>= 1.5, <= 2.5)


### PR DESCRIPTION
To silence the deprecation warning `/home/elijah/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/pdf-reader-1.4.0/lib/pdf/reader/object_hash.rb:81: warning: constant ::Fixnum is deprecated`

## Testing story

Relying on existing unit tests. As far as I can tell, this is exclusively used in Pegasus' PDFMergerTest:

https://github.com/code-dot-org/code-dot-org/blob/15170a4c23c27ac8e34e5f887f70bac899f4eace/pegasus/test/test_pdf_merger.rb#L7

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
