### PR TITLE
Java Lab: add dashboard assets flag

### DIFF
--- a/dashboard/app/controllers/javabuilder_sessions_controller.rb
+++ b/dashboard/app/controllers/javabuilder_sessions_controller.rb
@@ -74,9 +74,9 @@ class JavabuilderSessionsController < ApplicationController
     level_id = params[:levelId]
     options = params[:options]
     execution_type = params[:executionType]
-    use_dashboard_sources = 'false'
     mini_app_type = params[:miniAppType]
     options = options ? options.to_json : '{}'
+    can_access_dashboard_assets = !rack_env?(:development)
 
     # Set the IAT a little in the past to account for time drift between environments
     issued_at_time = (Time.now - 5.seconds).to_i
@@ -91,9 +91,9 @@ class JavabuilderSessionsController < ApplicationController
       level_id: level_id,
       execution_type: execution_type,
       mini_app_type: mini_app_type,
-      use_dashboard_sources: use_dashboard_sources,
       options: options,
-      verified_teachers: teacher_list
+      verified_teachers: teacher_list,
+      can_access_dashboard_assets: can_access_dashboard_assets
     }.merge(additional_payload)
 
     log_token_creation(payload)


### PR DESCRIPTION
Part 1 of consolidating the `canAccessDashboardAssets` and `isIntegrationTest` properties on Javabuilder. These properties actually cover the same logic, whether the instance of Javabuilder should talk to some code.org instance. This property will false for localhost code.org connections to (non-local) Javabuilder and automated tests of Javabuilder. We currently set `canAccessDashboardAssets` based on the [dashboard hostname](https://github.com/code-dot-org/javabuilder/blob/02f0abdddec0cba2a0637d09275070ef130cad5e/org-code-javabuilder/lib/src/main/java/org/code/javabuilder/LambdaRequestHandler.java#L120). Up next we will always set it based on this authorizer parameter, so integration tests can also set this parameter.

As part of this I also removed `use_dashboard_sources` because it is no longer used.
## Links

- jira ticket: [JAVA-589](https://codedotorg.atlassian.net/browse/JAVA-589)

## Testing story
Tested against a dev instance of Javabuilder and the property was sent correctly. The property is not used yet, that will come as a follow-up. The property is ignored (and will continue to be ignored) on a local instance of Javabuilder, as local Javabuilder can talk to local dashboard.


## Follow-up work
Use this property on the Javabuilder side.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
