### PR TITLE
Create a MethodSummaryTable

### DIFF
--- a/apps/src/templates/codeDocs/MethodSummaryTable.jsx
+++ b/apps/src/templates/codeDocs/MethodSummaryTable.jsx
@@ -15,7 +15,7 @@ export default function MethodSummaryTable({
     <table style={{...tableLayoutStyles.table, width: '100%'}}>
       <tbody>
         {methods.map(method => (
-          <tr>
+          <tr key={method.key}>
             <td style={styles.method}>
               <h3>
                 {method.name}

--- a/apps/src/templates/codeDocs/MethodSummaryTable.jsx
+++ b/apps/src/templates/codeDocs/MethodSummaryTable.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import EnhancedSafeMarkdown from '@cdo/apps/templates/EnhancedSafeMarkdown';
+import FontAwesome from '@cdo/apps/templates/FontAwesome';
+import color from '@cdo/apps/util/color';
+import {tableLayoutStyles} from '@cdo/apps/templates/tables/tableConstants';
+import {TextLink} from '@dsco_/link';
+
+export default function MethodSummaryTable({
+  methods,
+  programmingClassLink,
+  openLinkInNewTab = false
+}) {
+  return (
+    <table style={{...tableLayoutStyles.table, width: '100%'}}>
+      <tbody>
+        {methods.map(method => (
+          <tr>
+            <td style={styles.method}>
+              <h3>
+                {method.name}
+                {programmingClassLink && (
+                  <>
+                    {' '}
+                    <TextLink
+                      href={`${programmingClassLink}#method-${method.key}`}
+                      openInNewTab={openLinkInNewTab}
+                      icon={<FontAwesome icon="external-link" />}
+                    />
+                  </>
+                )}
+              </h3>
+              {method.content && (
+                <EnhancedSafeMarkdown markdown={method.content} />
+              )}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+MethodSummaryTable.propTypes = {
+  methods: PropTypes.arrayOf(PropTypes.object).isRequired,
+  programmingClassLink: PropTypes.string,
+  openLinkInNewTab: PropTypes.bool
+};
+
+const styles = {
+  method: {
+    borderStyle: 'solid',
+    borderWidth: 1,
+    borderColor: color.lighter_gray,
+    padding: 5
+  }
+};

--- a/apps/test/unit/templates/codeDocs/MethodSummaryTableTest.jsx
+++ b/apps/test/unit/templates/codeDocs/MethodSummaryTableTest.jsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import {expect} from '../../../util/reconfiguredChai';
+import MethodSummaryTable from '@cdo/apps/templates/codeDocs/MethodSummaryTable';
+
+describe('MethodSummaryTable', () => {
+  let defaultMethods;
+
+  beforeEach(() => {
+    defaultMethods = [
+      {
+        key: 'turnleft',
+        name: 'turnLeft()',
+        content: 'A description about what this method does'
+      },
+      {
+        key: 'step',
+        name: 'step(int steps)',
+        content: 'A description about what this method and parameter does'
+      }
+    ];
+  });
+
+  it('shows a table with the provided methods', () => {
+    const wrapper = shallow(
+      <MethodSummaryTable
+        methods={defaultMethods}
+        programmingClassLink="/docs/ide/java/classes/testclass"
+      />
+    );
+    const methodTable = wrapper.find('table').at(0);
+    expect(methodTable).to.not.be.null;
+    expect(methodTable.find('td').length).to.equal(2);
+  });
+
+  it('show the markdown content for each method', () => {
+    const wrapper = shallow(
+      <MethodSummaryTable
+        methods={defaultMethods}
+        programmingClassLink="/docs/ide/java/classes/testclass"
+      />
+    );
+    expect(wrapper.find('EnhancedSafeMarkdown').length).to.equal(2);
+    expect(
+      wrapper
+        .find('EnhancedSafeMarkdown')
+        .at(0)
+        .props().markdown
+    ).to.equal('A description about what this method does');
+    expect(
+      wrapper
+        .find('EnhancedSafeMarkdown')
+        .at(1)
+        .props().markdown
+    ).to.equal('A description about what this method and parameter does');
+  });
+
+  it('shows a link to the method', () => {
+    const wrapper = shallow(
+      <MethodSummaryTable
+        methods={defaultMethods}
+        programmingClassLink="/docs/ide/java/classes/testclass"
+      />
+    );
+    expect(wrapper.find('TextLink').length).to.equal(2);
+    expect(
+      wrapper
+        .find('TextLink')
+        .at(0)
+        .props().href
+    ).to.include('/docs/ide/java/classes/testclass');
+    expect(
+      wrapper
+        .find('TextLink')
+        .at(1)
+        .props().href
+    ).to.include('/docs/ide/java/classes/testclass');
+  });
+});


### PR DESCRIPTION
Adds a MethodSummaryTable. For now, this will be used in the instructions panel but may eventually be added to the programming class page. In the mock, part of the name was hyperlinked, which would've been difficult, so I added an icon link here. I'm not sure what the best icon would be so I'm open to suggestions!

<img width="756" alt="Screen Shot 2022-05-12 at 3 33 40 PM" src="https://user-images.githubusercontent.com/46464143/168178551-8aec32c0-663e-4b24-93f0-c50246e530e6.png">

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
