### PR TITLE
Fix Java Lab unauthorized message bug

### DIFF
--- a/apps/src/javalab/JavabuilderConnection.js
+++ b/apps/src/javalab/JavabuilderConnection.js
@@ -345,7 +345,7 @@ export default class JavabuilderConnection {
 
   displayUnauthorizedMessage(error) {
     const body = error.responseJSON;
-    if (body.type === WebSocketMessageType.AUTHORIZER) {
+    if (body && body.type === WebSocketMessageType.AUTHORIZER) {
       this.onAuthorizerMessage(body.value, body.detail);
       return;
     }


### PR DESCRIPTION
For general unauthorized messages there is no responseJSON because the failure comes from the initial get token request. Without this fix unauthorized users would see `Connecting...` followed by nothing because we hit an undefined error. Add a null check to ensure that we show the right unauthorized message to users.

## Testing story
Tested locally

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
