### PR TITLE
Fix reference guide help and tips display

### DIFF
--- a/dashboard/app/views/reference_guides/show.html.haml
+++ b/dashboard/app/views/reference_guides/show.html.haml
@@ -1,5 +1,8 @@
 %link{href: asset_path('css/reference_guides.css'), rel: 'stylesheet', type: 'text/css'}
 %link{href: asset_path('css/curriculum_navigation.css'), rel: 'stylesheet', type: 'text/css'}
+-# this header is used by instructions/NetworkResourceLink to display a nice string
+- content_for :head do
+  %meta{:name => "description", :content => @reference_guide.display_name}
 %script{src: webpack_asset_path('js/reference_guides/show.js'),
   data: {referenceGuide: @reference_guide.summarize_for_show.to_json, referenceGuides: @reference_guides.to_json, baseUrl: @base_url.to_json}}
 


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

The NetworkedResourceLink fetches the url and looks for a meta description tag. This tag needs to be in the head since we don't render the page fully.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [PLAT-1352](https://codedotorg.atlassian.net/browse/PLAT-1352)

## Testing story

Tested manually locally using map_reference and reference_links in level help and tips.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Screenshots

before:
![image](https://user-images.githubusercontent.com/82416901/168341351-bfbeb4cb-64c6-4016-bd9b-42321787e2eb.png)

after:
![image](https://user-images.githubusercontent.com/82416901/168341366-e7c77120-e10f-46cf-912d-bdf729ce9465.png)
