### PR TITLE
require longer high-memory use before alarming

### DIFF
--- a/aws/cloudformation/components/alarms.yml.erb
+++ b/aws/cloudformation/components/alarms.yml.erb
@@ -25,7 +25,7 @@
       ComparisonOperator: GreaterThanThreshold
       Dimensions:
         - {Name: InstanceId, Value: !Ref <%=daemon%>}
-      EvaluationPeriods: 5
+      EvaluationPeriods: 7
       MetricName: MemoryUtilization
       Namespace: 'System/Linux'
       Period: 60


### PR DESCRIPTION
Since the Rails 6 upgrade, we have seen high memory use on the daemon server (and frontend servers, to some extent) This has caused us to float close to triggering the `autoscale-prod_daemon_high_memory_utilization` alarm, and finally triggering it last night.

Better solutions will take some effort to complete, so in the meantime this PR increases the requirements for triggering the alarm from 5 consecutive data points to 7, therefore requiring 7 consecutive minutes of >87% memory utilization.

Better solutions include:
- increase the daemon server instance size
- optimizing cron jobs to be more efficient
- optimizing rails code in general
- transitioning from cron jobs to ecs tasks

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
