### PR TITLE
JavalabEditor initial cleanup

### DIFF
--- a/apps/src/javalab/JavalabEditor.jsx
+++ b/apps/src/javalab/JavalabEditor.jsx
@@ -7,9 +7,7 @@ import {
   sourceVisibilityUpdated,
   sourceValidationUpdated,
   renameFile,
-  removeFile,
-  setRenderedHeight,
-  setEditorColumnHeight
+  removeFile
 } from './javalabRedux';
 import {DisplayTheme} from './DisplayTheme';
 import PropTypes from 'prop-types';
@@ -92,8 +90,6 @@ class JavalabEditor extends React.Component {
     handleClearPuzzle: PropTypes.func.isRequired,
 
     // populated by redux
-    setRenderedHeight: PropTypes.func.isRequired,
-    setEditorColumnHeight: PropTypes.func.isRequired,
     setSource: PropTypes.func,
     sourceVisibilityUpdated: PropTypes.func,
     sourceValidationUpdated: PropTypes.func,
@@ -892,8 +888,6 @@ export default connect(
       dispatch(sourceTextUpdated(filename, text)),
     renameFile: (oldFilename, newFilename) =>
       dispatch(renameFile(oldFilename, newFilename)),
-    removeFile: filename => dispatch(removeFile(filename)),
-    setRenderedHeight: height => dispatch(setRenderedHeight(height)),
-    setEditorColumnHeight: height => dispatch(setEditorColumnHeight(height))
+    removeFile: filename => dispatch(removeFile(filename))
   })
 )(Radium(JavalabEditor));

--- a/apps/src/javalab/JavalabEditor.jsx
+++ b/apps/src/javalab/JavalabEditor.jsx
@@ -623,7 +623,7 @@ class JavalabEditor extends React.Component {
       zIndex: 1000
     };
     return (
-      <div style={this.props.style} ref={ref => (this.tabContainer = ref)}>
+      <div style={this.props.style}>
         <PaneHeader hasFocus>
           <PaneButton
             id="javalab-editor-create-file"

--- a/apps/src/javalab/JavalabEditor.jsx
+++ b/apps/src/javalab/JavalabEditor.jsx
@@ -35,7 +35,7 @@ import javalabMsg from '@cdo/javalab/locale';
 import {CompileStatus} from './constants';
 import {makeEnum} from '@cdo/apps/utils';
 import ProjectTemplateWorkspaceIcon from '../templates/ProjectTemplateWorkspaceIcon';
-import VersionHistoryWithCommits from '@cdo/apps/templates/VersionHistoryWithCommits';
+import VersionHistoryWithCommitsDialog from '@cdo/apps/templates/VersionHistoryWithCommitsDialog';
 
 const MIN_HEIGHT = 100;
 // This is the height of the "editor" header and the file tabs combined
@@ -44,7 +44,8 @@ const Dialog = makeEnum(
   'RENAME_FILE',
   'DELETE_FILE',
   'CREATE_FILE',
-  'COMMIT_FILES'
+  'COMMIT_FILES',
+  'VERSION_HISTORY'
 );
 const DEFAULT_FILE_NAME = '.java';
 const EDITOR_LOAD_PAUSE_MS = 100;
@@ -254,10 +255,6 @@ class JavalabEditor extends React.Component {
       }
     };
   };
-
-  handleVersionHistory() {
-    this.setState({versionHistoryOpen: true});
-  }
 
   updateVisibility(key, isVisible) {
     this.props.sourceVisibilityUpdated(this.state.fileMetadata[key], isVisible);
@@ -602,8 +599,7 @@ class JavalabEditor extends React.Component {
       contextTarget,
       renameFileError,
       newFileError,
-      compileStatus,
-      versionHistoryOpen
+      compileStatus
     } = this.state;
     const {
       onCommitCode,
@@ -628,14 +624,6 @@ class JavalabEditor extends React.Component {
     };
     return (
       <div style={this.props.style} ref={ref => (this.tabContainer = ref)}>
-        {versionHistoryOpen && (
-          <VersionHistoryWithCommits
-            handleClearPuzzle={handleClearPuzzle}
-            isProjectTemplateLevel={isProjectTemplateLevel}
-            onClose={() => this.setState({versionHistoryOpen: false})}
-            isOpen={versionHistoryOpen}
-          />
-        )}
         <PaneHeader hasFocus>
           <PaneButton
             id="javalab-editor-create-file"
@@ -663,7 +651,7 @@ class JavalabEditor extends React.Component {
             label={msg.showVersionsHeader()}
             headerHasFocus
             isRtl={false}
-            onClick={() => this.handleVersionHistory()}
+            onClick={() => this.setState({openDialog: Dialog.VERSION_HISTORY})}
             isDisabled={isReadOnlyWorkspace}
           />
           <PaneButton
@@ -822,6 +810,12 @@ class JavalabEditor extends React.Component {
           }
           handleCommit={onCommitCode}
           compileStatus={compileStatus}
+        />
+        <VersionHistoryWithCommitsDialog
+          handleClearPuzzle={handleClearPuzzle}
+          isProjectTemplateLevel={isProjectTemplateLevel}
+          onClose={() => this.setState({openDialog: null})}
+          isOpen={openDialog === Dialog.VERSION_HISTORY}
         />
       </div>
     );

--- a/apps/src/javalab/JavalabEditor.jsx
+++ b/apps/src/javalab/JavalabEditor.jsx
@@ -811,12 +811,14 @@ class JavalabEditor extends React.Component {
           handleCommit={onCommitCode}
           compileStatus={compileStatus}
         />
-        <VersionHistoryWithCommitsDialog
-          handleClearPuzzle={handleClearPuzzle}
-          isProjectTemplateLevel={isProjectTemplateLevel}
-          onClose={() => this.setState({openDialog: null})}
-          isOpen={openDialog === Dialog.VERSION_HISTORY}
-        />
+        {openDialog === Dialog.VERSION_HISTORY && (
+          <VersionHistoryWithCommitsDialog
+            handleClearPuzzle={handleClearPuzzle}
+            isProjectTemplateLevel={isProjectTemplateLevel}
+            onClose={() => this.setState({openDialog: null})}
+            isOpen={openDialog === Dialog.VERSION_HISTORY}
+          />
+        )}
       </div>
     );
   }

--- a/apps/src/templates/VersionHistoryWithCommitsDialog.jsx
+++ b/apps/src/templates/VersionHistoryWithCommitsDialog.jsx
@@ -14,7 +14,7 @@ const DEFAULT_FILE_NAME = 'main.json';
 /**
  * A component for viewing project version history.
  */
-export default class VersionHistoryWithCommits extends React.Component {
+export default class VersionHistoryWithCommitsDialog extends React.Component {
   static propTypes = {
     handleClearPuzzle: PropTypes.func.isRequired,
     isProjectTemplateLevel: PropTypes.bool.isRequired,

--- a/apps/test/unit/templates/VersionHistoryWithCommitsDialogTest.jsx
+++ b/apps/test/unit/templates/VersionHistoryWithCommitsDialogTest.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {mount} from 'enzyme';
 import sinon from 'sinon';
 import {assert, expect} from '../../util/reconfiguredChai';
-import VersionHistoryWithCommits from '@cdo/apps/templates/VersionHistoryWithCommits';
+import VersionHistoryWithCommitsDialog from '@cdo/apps/templates/VersionHistoryWithCommitsDialog';
 import {sources as sourcesApi} from '@cdo/apps/clientApi';
 import * as utils from '@cdo/apps/utils';
 import project from '@cdo/apps/code-studio/initApp/project';
@@ -26,7 +26,7 @@ const FAKE_VERSION_LIST_RESPONSE = {
   ])
 };
 
-describe('VersionHistoryWithCommits', () => {
+describe('VersionHistoryWithCommitsDialog', () => {
   let wrapper;
 
   beforeEach(() => {
@@ -53,7 +53,7 @@ describe('VersionHistoryWithCommits', () => {
       sourcesApi.ajax.restore();
     });
 
-    testVersionHistoryWithCommits({
+    testVersionHistoryWithCommitsDialog({
       props: {
         handleClearPuzzle: () => {},
         isProjectTemplateLevel: false,
@@ -76,7 +76,7 @@ describe('VersionHistoryWithCommits', () => {
     });
   });
 
-  function testVersionHistoryWithCommits({
+  function testVersionHistoryWithCommitsDialog({
     props,
     finishVersionHistoryLoad,
     failVersionHistoryLoad,
@@ -85,7 +85,7 @@ describe('VersionHistoryWithCommits', () => {
     failRestoreVersion
   }) {
     it('renders loading spinner at first', () => {
-      wrapper = mount(<VersionHistoryWithCommits {...props} />);
+      wrapper = mount(<VersionHistoryWithCommitsDialog {...props} />);
       assert(
         wrapper.containsMatchingElement(
           <i className="fa fa-spinner fa-spin" style={{fontSize: '32px'}} />
@@ -94,13 +94,13 @@ describe('VersionHistoryWithCommits', () => {
     });
 
     it('renders an error on failed version history load', () => {
-      wrapper = mount(<VersionHistoryWithCommits {...props} />);
+      wrapper = mount(<VersionHistoryWithCommitsDialog {...props} />);
       failVersionHistoryLoad();
       expect(wrapper.text()).to.include('An error occurred.');
     });
 
     it('renders a version list on successful version history load', () => {
-      wrapper = mount(<VersionHistoryWithCommits {...props} />);
+      wrapper = mount(<VersionHistoryWithCommitsDialog {...props} />);
       // Call third argument, the success handler
       finishVersionHistoryLoad();
 
@@ -117,7 +117,7 @@ describe('VersionHistoryWithCommits', () => {
     });
 
     it('attempts to restore a chosen version when clicking restore button', () => {
-      wrapper = mount(<VersionHistoryWithCommits {...props} />);
+      wrapper = mount(<VersionHistoryWithCommitsDialog {...props} />);
       finishVersionHistoryLoad();
       expect(restoreSpy()).not.to.have.been.called;
 
@@ -129,7 +129,7 @@ describe('VersionHistoryWithCommits', () => {
     });
 
     it('renders an error on failed restore', () => {
-      wrapper = mount(<VersionHistoryWithCommits {...props} />);
+      wrapper = mount(<VersionHistoryWithCommitsDialog {...props} />);
       finishVersionHistoryLoad();
       wrapper
         .find('Button')
@@ -141,7 +141,7 @@ describe('VersionHistoryWithCommits', () => {
     });
 
     it('reloads the page on successful restore', () => {
-      wrapper = mount(<VersionHistoryWithCommits {...props} />);
+      wrapper = mount(<VersionHistoryWithCommitsDialog {...props} />);
       finishVersionHistoryLoad();
       wrapper
         .find('Button')
@@ -154,7 +154,7 @@ describe('VersionHistoryWithCommits', () => {
     });
 
     it('shows a confirmation after clicking Start Over', () => {
-      wrapper = mount(<VersionHistoryWithCommits {...props} />);
+      wrapper = mount(<VersionHistoryWithCommitsDialog {...props} />);
       finishVersionHistoryLoad();
 
       // Click "Start Over"
@@ -175,7 +175,7 @@ describe('VersionHistoryWithCommits', () => {
     });
 
     it('goes back to version list after cancelling Start Over', () => {
-      wrapper = mount(<VersionHistoryWithCommits {...props} />);
+      wrapper = mount(<VersionHistoryWithCommitsDialog {...props} />);
       finishVersionHistoryLoad();
 
       // Click "Start Over"
@@ -206,7 +206,7 @@ describe('VersionHistoryWithCommits', () => {
 
     it('shows a confirmation with template project warning', () => {
       wrapper = mount(
-        <VersionHistoryWithCommits {...props} isProjectTemplateLevel />
+        <VersionHistoryWithCommitsDialog {...props} isProjectTemplateLevel />
       );
       finishVersionHistoryLoad();
 
@@ -234,7 +234,7 @@ describe('VersionHistoryWithCommits', () => {
 
         handleClearPuzzle = sinon.stub().returns(Promise.resolve());
         wrapper = mount(
-          <VersionHistoryWithCommits
+          <VersionHistoryWithCommitsDialog
             {...props}
             handleClearPuzzle={handleClearPuzzle}
           />


### PR DESCRIPTION
More detail to come on some bigger proposed refactoring of JavalabEditor, but first, a few pieces of quick cleanup. They are:
- Remove unused layout management Redux action creators
- Remove unused ref (tabContainer)
- Make the commit history dialog (from a code perspective, not a UI perspective) look more like other dialogs in JavalabEditor (with a rename to make it more clear that it is a dialog), and manage its open/closed state in the same way we manage open/closed for other dialogs.

## Testing story

Tested manually that the version history dialog continued to work as I loaded existing versions/commits and added a new commit. Also tested able to resize console/editor.