### PR TITLE
Replace "color" import with "color.scss"

### DIFF
--- a/apps/style/JsDebuggerUi.scss
+++ b/apps/style/JsDebuggerUi.scss
@@ -1,5 +1,5 @@
 // Style rules associated with our visual debugger for the JSInterpreter.
-@import "color";
+@import "color.scss";
 @import "mixins";
 @import "style-constants";
 

--- a/apps/style/applab/style.scss
+++ b/apps/style/applab/style.scss
@@ -1,6 +1,6 @@
 @use "sass:math";
 
-@import "color";
+@import "color.scss";
 @import "mixins";
 @import "style-constants";
 @import "../JsDebuggerUi.scss";

--- a/apps/style/code-studio/leveltype_widget.scss
+++ b/apps/style/code-studio/leveltype_widget.scss
@@ -1,5 +1,5 @@
 @import "codemirror/lib/codemirror";
-@import "color";
+@import "color.scss";
 
 #odoDivBin {
   background: $light_teal;

--- a/apps/style/code-studio/pd.scss
+++ b/apps/style/code-studio/pd.scss
@@ -1,4 +1,4 @@
-@import "color";
+@import "color.scss";
 @import "bootstrap-sass/assets/stylesheets/bootstrap/mixins/buttons";
 @import "bootstrap-sass/assets/stylesheets/bootstrap/variables";
 @import "mixins";

--- a/apps/style/code-studio/plc/teacher_dashboard.scss
+++ b/apps/style/code-studio/plc/teacher_dashboard.scss
@@ -1,4 +1,4 @@
-@import "color";
+@import "color.scss";
 
 .module_assignments {
   display: flex;

--- a/apps/style/common.scss
+++ b/apps/style/common.scss
@@ -1,6 +1,6 @@
 @use "sass:math";
 
-@import "color";
+@import "color.scss";
 @import "font";
 @import "curriculum/markdown";
 @import "responsive-visualization";

--- a/apps/style/craft/style.scss
+++ b/apps/style/craft/style.scss
@@ -2,7 +2,7 @@
 
 $root: '/blockly/media/craft/'; //TODO: Parameterize for asset pipeline
 
-@import 'color';
+@import 'color.scss';
 @import '../common';
 @import 'font';
 

--- a/apps/style/curriculum/_pdf_printing.scss
+++ b/apps/style/curriculum/_pdf_printing.scss
@@ -1,4 +1,4 @@
-@import 'color';
+@import 'color.scss';
 @import 'style/aniGif';
 
 @media screen {

--- a/apps/style/curriculum/navigation.scss
+++ b/apps/style/curriculum/navigation.scss
@@ -1,4 +1,4 @@
-@import 'color';
+@import 'color.scss';
 @import 'font';
 
 .nav-bar {

--- a/apps/style/curriculum/reference_guides.scss
+++ b/apps/style/curriculum/reference_guides.scss
@@ -1,4 +1,4 @@
-@import 'color';
+@import 'color.scss';
 @import 'font';
 @import "markdown";
 

--- a/apps/style/dance/style.scss
+++ b/apps/style/dance/style.scss
@@ -1,7 +1,7 @@
 $root: '/blockly/media/dance/'; //TODO: Parameterize for asset pipeline
 
 @import 'font';
-@import 'color';
+@import 'color.scss';
 @import 'mixins';
 @import '../VisualizationOverlay.scss';
 

--- a/apps/style/gamelab/style.scss
+++ b/apps/style/gamelab/style.scss
@@ -1,7 +1,7 @@
 $root: '/blockly/media/gamelab/'; //TODO: Parameterize for asset pipeline
 
 @import 'font';
-@import 'color';
+@import 'color.scss';
 @import 'mixins';
 @import "../JsDebuggerUi.scss";
 @import '../VisualizationOverlay.scss';

--- a/apps/style/javalab/style.scss
+++ b/apps/style/javalab/style.scss
@@ -1,4 +1,4 @@
-@import 'color';
+@import 'color.scss';
 
 .container {
   width: 95%;

--- a/apps/style/netsim/style.scss
+++ b/apps/style/netsim/style.scss
@@ -1,6 +1,6 @@
 $root: '/blockly/media/turtle/'; //TODO: Parameterize for asset pipeline
 
-@import 'color';
+@import 'color.scss';
 @import 'font';
 
 $alabaster: #fafafa;

--- a/apps/style/studio/style.scss
+++ b/apps/style/studio/style.scss
@@ -1,7 +1,7 @@
 $root: '/blockly/media/studio/'; //TODO: Parameterize for asset pipeline
 
 @import 'font';
-@import 'color';
+@import 'color.scss';
 @import '../VisualizationOverlay';
 
 #svgStudio {

--- a/apps/style/weblab/style.scss
+++ b/apps/style/weblab/style.scss
@@ -1,4 +1,4 @@
-@import "color";
+@import "color.scss";
 @import "mixins";
 @import "style-constants";
 

--- a/shared/css/buttons.scss
+++ b/shared/css/buttons.scss
@@ -1,4 +1,4 @@
-@import 'color';
+@import 'color.scss';
 @import 'font';
 
 @mixin button-with-color($color) {

--- a/shared/css/cookie-banner.scss
+++ b/shared/css/cookie-banner.scss
@@ -1,4 +1,4 @@
-@import 'color';
+@import 'color.scss';
 @import 'font';
 
 #cookie-banner {

--- a/shared/css/course-blocks.scss
+++ b/shared/css/course-blocks.scss
@@ -1,4 +1,4 @@
-@import 'color';
+@import 'color.scss';
 @import 'font';
 
 /* HEADERS */

--- a/shared/css/course-explorer.scss
+++ b/shared/css/course-explorer.scss
@@ -1,4 +1,4 @@
-@import 'color';
+@import 'color.scss';
 @import 'font';
 
 //colors

--- a/shared/css/details-polyfill.scss
+++ b/shared/css/details-polyfill.scss
@@ -1,4 +1,4 @@
-@import 'color';
+@import 'color.scss';
 
 details {
   summary {

--- a/shared/css/hamburger.scss
+++ b/shared/css/hamburger.scss
@@ -1,4 +1,4 @@
-@import 'color';
+@import 'color.scss';
 @import 'font';
 
 

--- a/shared/css/header.scss
+++ b/shared/css/header.scss
@@ -5,7 +5,7 @@
  *= require user-menu
  */
 
-@import 'color';
+@import 'color.scss';
 
 #pageheader-wrapper {
   padding-top: 0;

--- a/shared/css/user-menu.scss
+++ b/shared/css/user-menu.scss
@@ -1,4 +1,4 @@
-@import 'color';
+@import 'color.scss';
 @import 'font';
 .user_menu, .create_menu, .help_button {
   user-select: none;

--- a/shared/css/warning-banner.scss
+++ b/shared/css/warning-banner.scss
@@ -1,4 +1,4 @@
-@import 'color';
+@import 'color.scss';
 @import 'font';
 
 #warning-banner {


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Replace all instances of `@import "color"` with `@import "color.scss"` (single and double quotes) to preserve consistency and prevent build errors due to dart-sass upgrade.
This skips the 'dashboard/app/assets' directory, since that was giving style warnings (these files were not causing build issues): 
```/home/objelisks/code-dot-org/dashboard/app/assets/stylesheets/application.scss:31:9 [W] ImportPath: Imported partial 'color.scss' should be written as 'color'```

Still unsure of the root cause here. Only a subset of these files actually cause issues at build time, but I'm replacing all of them in order to keep some consistency. It is only color.scss that ever causes any problems. The only thing special about that file that I can find is that we run `convertScssToJs.js` on that file, but that doesn't look like it would affect anything about the import.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- dart-sass: [upgrade](https://github.com/code-dot-org/code-dot-org/pull/46235)

## Testing story

ran `yarn build` `yarn storybook` and `yarn test`

