### PR TITLE
Remove Unused `sdoc` Dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -110,11 +110,6 @@ group :development, :test do
   gem 'pdf-reader', require: false
 end
 
-group :doc do
-  # bundle exec rake doc:rails generates the API under doc/api.
-  gem 'sdoc', require: false
-end
-
 # Needed for unit testing, and also for /rails/mailers email previews.
 gem 'factory_girl_rails', group: [:development, :staging, :test, :adhoc]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -715,8 +715,6 @@ GEM
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
-    rdoc (4.2.2)
-      json (~> 1.4)
     recaptcha (4.6.3)
       json
     redcarpet (3.3.4)
@@ -799,9 +797,6 @@ GEM
     scss_lint (0.49.0)
       rake (>= 0.9, < 12)
       sass (~> 3.4.20)
-    sdoc (0.4.1)
-      json (~> 1.7, >= 1.7.7)
-      rdoc (~> 4.0)
     selenium-webdriver (3.141.0)
       childprocess (~> 0.5)
       rubyzip (~> 1.2, >= 1.2.2)
@@ -1062,7 +1057,6 @@ DEPENDENCIES
   scenic
   scenic-mysql_adapter
   scss_lint
-  sdoc
   selenium-webdriver (= 3.141.0)
   sequel
   shotgun


### PR DESCRIPTION
I can't find anywhere we use the `sdoc` gem, the `doc` bundle group, the `doc:rails` rake command, or whatever "doc/api" refers to.

The `sdoc` gem also pins us to version `~> 1.7` of the `json` gem, which is hampering our ability to upgrade to Ruby 2.7. Removing this unused dependency to clear that up.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
