### PR TITLE
translate lesson name using get_localized_property

### DIFF
--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -230,14 +230,14 @@ class Lesson < ApplicationRecord
     # using legacy lesson plans, remove this condition and consolidate with
     # localized_name_for_lesson_show.
     if script.lessons.many? || (script.is_migrated && !script.use_legacy_lesson_plans)
-      I18n.t "data.script.name.#{script.name}.lessons.#{key}.name"
+      get_localized_property(:name) || ''
     else
       I18n.t "data.script.name.#{script.name}.title"
     end
   end
 
   def localized_name_for_lesson_show
-    I18n.t "data.script.name.#{script.name}.lessons.#{key}.name"
+    get_localized_property(:name) || ''
   end
 
   def localized_lesson_plan

--- a/dashboard/test/controllers/activities_controller_test.rb
+++ b/dashboard/test/controllers/activities_controller_test.rb
@@ -898,7 +898,7 @@ class ActivitiesControllerTest < ActionController::TestCase
 
     # find localized test strings for custom lesson names in script
     assert response.key?('lesson_changing'), "No key 'lesson_changing' in response #{response.inspect}"
-    assert_equal('milestone-lesson-1', response['lesson_changing']['previous']['name'])
+    assert_equal('Milestone Lesson 1', response['lesson_changing']['previous']['name'])
   end
 
   test 'milestone post respects level_id for active level' do

--- a/dashboard/test/controllers/script_levels_controller_test.rb
+++ b/dashboard/test/controllers/script_levels_controller_test.rb
@@ -1022,7 +1022,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
       lesson_position: @custom_s2_l1.lesson,
       id: @custom_s2_l1.position
     }
-    assert_equal 'laurel-lesson-2 #1 | custom-script-laurel - Code.org [test]',
+    assert_equal 'Laurel Lesson 2 #1 | custom-script-laurel - Code.org [test]',
       Nokogiri::HTML(@response.body).css('title').text.strip
   end
 

--- a/dashboard/test/helpers/script_levels_helper_test.rb
+++ b/dashboard/test/helpers/script_levels_helper_test.rb
@@ -52,7 +52,7 @@ class ScriptLevelsHelperTest < ActionView::TestCase
     stubs(:current_user).returns(nil)
     script = Script.find_by_name(Script::COURSE4_NAME)
     script_level = script.get_script_level_by_relative_position_and_puzzle_position 3, 1, false
-    assert_equal 'Lesson 3: ' + I18n.t("data.script.name.#{script.name}.lessons.#{script_level.lesson.key}.name"), script_level.lesson.summarize[:title]
+    assert_equal "Lesson 3: #{script_level.lesson.name}", script_level.lesson.summarize[:title]
   end
 
   test 'show lesson position in header for default script' do

--- a/dashboard/test/models/lesson_test.rb
+++ b/dashboard/test/models/lesson_test.rb
@@ -431,6 +431,7 @@ class LessonTest < ActiveSupport::TestCase
       purpose: 'example purpose'
     )
 
+    lesson.expects(:get_localized_property).with(:name)
     lesson.expects(:get_localized_property).with(:overview)
     lesson.expects(:get_localized_property).with(:purpose)
     lesson.expects(:get_localized_property).with(:preparation)


### PR DESCRIPTION
Step 4b from [PLAT-1528](https://codedotorg.atlassian.net/browse/PLAT-1528). Starts using `get_localized_property` to translate lesson name, which reads from `lessons.*.json` instead of `scripts.*.yml`.

## Testing story

manually verified that the following page still shows correct translations for lesson names in italian: http://localhost-studio.code.org:3000/s/express-2017?no_redirect=1 . the foundations team also confirmed in [slack](https://codedotorg.slack.com/archives/CFTFD6BPV/p1651912432506029?thread_ts=1651701437.075929&cid=CFTFD6BPV) that all lesson name translations should now be available for displaying by this method.

## Follup up work

this looks possible to do in a follow up PR now: https://github.com/code-dot-org/code-dot-org/blob/3fd30c540f4fc4f39eb0b11bb5c9c17a9414173e/dashboard/app/models/lesson.rb#L229-L231 

working on it in https://github.com/code-dot-org/code-dot-org/pull/46393