### PR TITLE
abandoned - Remove lesson name cruft

### DIFF
--- a/dashboard/app/controllers/lessons_controller.rb
+++ b/dashboard/app/controllers/lessons_controller.rb
@@ -135,8 +135,6 @@ class LessonsController < ApplicationController
       # available to lessons in migrated scripts, which only need to be
       # serialized using the new json format.
       @lesson.script.write_script_json
-
-      Script.merge_and_write_i18n(@lesson.i18n_hash, @lesson.script.name, log_event_type: 'write_lesson')
     end
 
     render json: @lesson.summarize_for_lesson_edit

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -230,14 +230,14 @@ class Lesson < ApplicationRecord
     # using legacy lesson plans, remove this condition and consolidate with
     # localized_name_for_lesson_show.
     if script.lessons.many? || (script.is_migrated && !script.use_legacy_lesson_plans)
-      I18n.t "data.script.name.#{script.name}.lessons.#{key}.name"
+      get_localized_property(:name) || ''
     else
       I18n.t "data.script.name.#{script.name}.title"
     end
   end
 
   def localized_name_for_lesson_show
-    I18n.t "data.script.name.#{script.name}.lessons.#{key}.name"
+    get_localized_property(:name) || ''
   end
 
   def localized_lesson_plan

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -223,16 +223,6 @@ class Lesson < ApplicationRecord
   end
 
   def localized_name
-    # The behavior to show the script title instead of the lesson name in
-    # single-lesson scripts is deprecated.
-    if script.lessons.many?
-      localized_name_for_lesson_show
-    else
-      I18n.t "data.script.name.#{script.name}.title"
-    end
-  end
-
-  def localized_name_for_lesson_show
     get_localized_property(:name) || ''
   end
 
@@ -448,7 +438,7 @@ class Lesson < ApplicationRecord
       lockable: lockable,
       key: key,
       duration: total_lesson_duration,
-      displayName: localized_name_for_lesson_show,
+      displayName: localized_name,
       overview: render_property(:overview),
       announcements: announcements,
       purpose: render_property(:purpose),

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -225,12 +225,8 @@ class Lesson < ApplicationRecord
   def localized_name
     # The behavior to show the script title instead of the lesson name in
     # single-lesson scripts is deprecated.
-    #
-    # TODO(dave): once all scripts with exactly one lesson are migrated and no longer
-    # using legacy lesson plans, remove this condition and consolidate with
-    # localized_name_for_lesson_show.
-    if script.lessons.many? || (script.is_migrated && !script.use_legacy_lesson_plans)
-      get_localized_property(:name) || ''
+    if script.lessons.many?
+      localized_name_for_lesson_show
     else
       I18n.t "data.script.name.#{script.name}.title"
     end

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -542,21 +542,6 @@ class Lesson < ApplicationRecord
     }
   end
 
-  # Returns a hash representing i18n strings in scripts.en.yml which may need
-  # to be updated after this object was updated. Currently, this only updates
-  # the lesson name and overviews.
-  def i18n_hash
-    {
-      script.name => {
-        'lessons' => {
-          key => {
-            'name' => name
-          }
-        }
-      }
-    }
-  end
-
   # For a given set of students, determine when the given lesson is locked for
   # each student.
   # The design of a lockable lesson is that there is (optionally) some number of
@@ -907,7 +892,6 @@ class Lesson < ApplicationRecord
     copied_lesson.standards = standards
     copied_lesson.opportunity_standards = opportunity_standards
 
-    Script.merge_and_write_i18n(copied_lesson.i18n_hash, destination_unit.name)
     destination_unit.fix_script_level_positions
     destination_unit.write_script_json
     copied_lesson

--- a/dashboard/test/controllers/activities_controller_test.rb
+++ b/dashboard/test/controllers/activities_controller_test.rb
@@ -898,7 +898,7 @@ class ActivitiesControllerTest < ActionController::TestCase
 
     # find localized test strings for custom lesson names in script
     assert response.key?('lesson_changing'), "No key 'lesson_changing' in response #{response.inspect}"
-    assert_equal('milestone-lesson-1', response['lesson_changing']['previous']['name'])
+    assert_equal('Milestone Lesson 1', response['lesson_changing']['previous']['name'])
   end
 
   test 'milestone post respects level_id for active level' do

--- a/dashboard/test/controllers/lessons_controller_test.rb
+++ b/dashboard/test/controllers/lessons_controller_test.rb
@@ -37,12 +37,7 @@ class LessonsControllerTest < ActionController::TestCase
         'script' => {
           'name' => {
             @script.name => {
-              'title' => @script_title,
-              'lessons' => {
-                @lesson.name => {
-                  'name' => @lesson_name
-                }
-              }
+              'title' => @script_title
             }
           }
         }
@@ -288,12 +283,7 @@ class LessonsControllerTest < ActionController::TestCase
         'script' => {
           'name' => {
             script.name => {
-              'title' => @script_title,
-              'lessons' => {
-                solo_lesson_in_script.key => {
-                  'name' => @lesson_name
-                }
-              }
+              'title' => @script_title
             }
           }
         }

--- a/dashboard/test/controllers/lessons_controller_test.rb
+++ b/dashboard/test/controllers/lessons_controller_test.rb
@@ -289,9 +289,7 @@ class LessonsControllerTest < ActionController::TestCase
         }
       }
     }
-
     I18n.backend.store_translations 'en-US', custom_i18n
-    assert_equal @lesson_name, solo_lesson_in_script.localized_name
 
     get :show, params: {
       script_id: script.name,

--- a/dashboard/test/controllers/lessons_controller_test.rb
+++ b/dashboard/test/controllers/lessons_controller_test.rb
@@ -691,11 +691,6 @@ class LessonsControllerTest < ActionController::TestCase
 
     # Just make sure the new lesson name appears somewhere in the new file contents.
     File.stubs(:write).with do |filename, data|
-      filename.end_with?('scripts.en.yml') && data.include?(@update_params[:name])
-    end.once
-
-    # Just make sure the new lesson name appears somewhere in the new file contents.
-    File.stubs(:write).with do |filename, data|
       filename.end_with?('.script_json') && data.include?(@update_params[:name])
     end.once
 

--- a/dashboard/test/controllers/script_levels_controller_test.rb
+++ b/dashboard/test/controllers/script_levels_controller_test.rb
@@ -1022,7 +1022,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
       lesson_position: @custom_s2_l1.lesson,
       id: @custom_s2_l1.position
     }
-    assert_equal 'laurel-lesson-2 #1 | custom-script-laurel - Code.org [test]',
+    assert_equal 'Laurel Lesson 2 #1 | custom-script-laurel - Code.org [test]',
       Nokogiri::HTML(@response.body).css('title').text.strip
   end
 

--- a/dashboard/test/helpers/script_levels_helper_test.rb
+++ b/dashboard/test/helpers/script_levels_helper_test.rb
@@ -52,7 +52,7 @@ class ScriptLevelsHelperTest < ActionView::TestCase
     stubs(:current_user).returns(nil)
     script = Script.find_by_name(Script::COURSE4_NAME)
     script_level = script.get_script_level_by_relative_position_and_puzzle_position 3, 1, false
-    assert_equal 'Lesson 3: ' + I18n.t("data.script.name.#{script.name}.lessons.#{script_level.lesson.key}.name"), script_level.lesson.summarize[:title]
+    assert_equal "Lesson 3: #{script_level.lesson.name}", script_level.lesson.summarize[:title]
   end
 
   test 'show lesson position in header for default script' do

--- a/dashboard/test/models/lesson_test.rb
+++ b/dashboard/test/models/lesson_test.rb
@@ -503,25 +503,6 @@ class LessonTest < ActiveSupport::TestCase
     assert_equal 30, levels_data[:duration]
   end
 
-  test 'i18n_hash has correct value' do
-    script = create :script, name: 'dummy-script'
-    lesson_group = create :lesson_group, script: script
-    lesson = create :lesson, lesson_group: lesson_group, script: script, key: 'dummy-key', name: 'Dummy Name'
-    lesson.student_overview = 'student overview'
-    lesson.overview = 'teacher overview'
-
-    expected_i18n = {
-      'dummy-script' => {
-        'lessons' => {
-          'dummy-key' => {
-            'name' => 'Dummy Name',
-          }
-        }
-      }
-    }
-    assert_equal expected_i18n, lesson.i18n_hash
-  end
-
   test 'seeding_key' do
     lesson_group = create :lesson_group
     script = lesson_group.script
@@ -1127,7 +1108,6 @@ class LessonTest < ActiveSupport::TestCase
       create :vocabulary, word: 'word one', course_version: @original_course_version, lessons: [@original_lesson]
 
       @destination_script.expects(:write_script_json).once
-      Script.expects(:merge_and_write_i18n).once
       destination_resource = create :resource, name: 'resource1', course_version: @destination_course_version
       destination_vocab = create :vocabulary, word: 'word one', course_version: @destination_course_version
       copied_lesson = @original_lesson.copy_to_unit(@destination_script)
@@ -1138,7 +1118,6 @@ class LessonTest < ActiveSupport::TestCase
 
     test "dots are stripped from cloned lesson key" do
       @destination_script.expects(:write_script_json).once
-      Script.expects(:merge_and_write_i18n).once
       @original_lesson.update!(name: 'Problem.Lesson.')
       copied_lesson = @original_lesson.copy_to_unit(@destination_script)
       assert_equal 'ProblemLesson', copied_lesson.key
@@ -1168,7 +1147,6 @@ class LessonTest < ActiveSupport::TestCase
       destination_script.expects(:write_script_json).once
       course_version_resource_count = course_version.resources.count
       course_version_vocab_count = course_version.vocabularies.count
-      Script.expects(:merge_and_write_i18n).once
       copied_lesson = original_lesson.copy_to_unit(destination_script)
       course_version.reload
 
@@ -1192,7 +1170,6 @@ class LessonTest < ActiveSupport::TestCase
       create :lesson_group, script: destination_script
 
       destination_script.expects(:write_script_json).once
-      Script.expects(:merge_and_write_i18n).once
       copied_lesson = original_lesson.copy_to_unit(destination_script)
 
       assert_equal destination_script, copied_lesson.script
@@ -1213,7 +1190,6 @@ class LessonTest < ActiveSupport::TestCase
         activity_section: existing_activity_section, activity_section_position: 1
 
       @destination_script.expects(:write_script_json).once
-      Script.expects(:merge_and_write_i18n).once
       copied_lesson = @original_lesson.copy_to_unit(@destination_script)
       @destination_script.reload
 
@@ -1258,7 +1234,6 @@ class LessonTest < ActiveSupport::TestCase
       create :lesson, script: @destination_script, lesson_group: @destination_lesson_group, has_lesson_plan: false, lockable: true, absolute_position: 3, relative_position: 1
 
       @destination_script.expects(:write_script_json).once
-      Script.expects(:merge_and_write_i18n).once
       copied_lesson = @original_lesson.copy_to_unit(@destination_script)
       @destination_script.reload
       assert_equal @destination_script, copied_lesson.script
@@ -1276,7 +1251,6 @@ class LessonTest < ActiveSupport::TestCase
       create :lesson, script: @destination_script, lesson_group: @destination_lesson_group, has_lesson_plan: false, lockable: true, absolute_position: 3, relative_position: 1
 
       @destination_script.expects(:write_script_json).once
-      Script.expects(:merge_and_write_i18n).once
       copied_lesson = @original_lesson.copy_to_unit(@destination_script)
       @destination_script.reload
       assert_equal @destination_script, copied_lesson.script
@@ -1307,7 +1281,7 @@ class LessonTest < ActiveSupport::TestCase
       @destination_script.lesson_groups = []
 
       @destination_script.expects(:write_script_json).once
-      Script.expects(:merge_and_write_i18n).twice
+      Script.expects(:merge_and_write_i18n).once
       copied_lesson = @original_lesson.copy_to_unit(@destination_script)
       assert_equal 1, @destination_script.lesson_groups.count
       assert_equal 1, @destination_script.lessons.count

--- a/dashboard/test/models/lesson_test.rb
+++ b/dashboard/test/models/lesson_test.rb
@@ -431,6 +431,7 @@ class LessonTest < ActiveSupport::TestCase
       purpose: 'example purpose'
     )
 
+    lesson.expects(:get_localized_property).with(:name)
     lesson.expects(:get_localized_property).with(:overview)
     lesson.expects(:get_localized_property).with(:purpose)
     lesson.expects(:get_localized_property).with(:preparation)


### PR DESCRIPTION
clean up some tech debt by consolidating `localized_name` and `localized_name_for_lesson_show`, per instructions in these comments: https://github.com/code-dot-org/code-dot-org/blob/d5806396231ca93f850e93b6ce4a092183bfe9aa/dashboard/app/models/lesson.rb#L229-L231

The background is that we did most of the work to eliminate the unwanted behavior, but forgot to do this one last step. See https://github.com/code-dot-org/code-dot-org/pull/42604 for more background. This PR finishes step 5 from the list of work items in that PR, which looks like it got missed when https://codedotorg.atlassian.net/browse/PLAT-858 was resolved.

## Testing story

In order to verify that the precondition of "once all scripts with exactly one lesson are migrated and no longer using legacy lesson plans", I searched the DB for all scripts with `use_legacy_lesson_plans` and only one lesson. I found two:
```
[development] dashboard > scripts = Script.all.select(&:use_legacy_lesson_plans).select {|s| s.lessons.count == 1}.map(&:name)
=> ["csd-post-survey-2018", "csp-post-survey-2018"]
```
in order to proceed anyway (even though the precondition was not strictly met), I wanted to convince myself that there would not be a change in behavior for these two scripts. to do that, I manually verified for these scripts that the user-facing text would not change for their lesson's display name, because the script display name already equals the lesson display name (at least in english).
