### PR TITLE
stop writing lesson names to scripts.en.yml

### DIFF
--- a/dashboard/app/controllers/lessons_controller.rb
+++ b/dashboard/app/controllers/lessons_controller.rb
@@ -135,8 +135,6 @@ class LessonsController < ApplicationController
       # available to lessons in migrated scripts, which only need to be
       # serialized using the new json format.
       @lesson.script.write_script_json
-
-      Script.merge_and_write_i18n(@lesson.i18n_hash, @lesson.script.name, log_event_type: 'write_lesson')
     end
 
     render json: @lesson.summarize_for_lesson_edit

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -554,21 +554,6 @@ class Lesson < ApplicationRecord
     }
   end
 
-  # Returns a hash representing i18n strings in scripts.en.yml which may need
-  # to be updated after this object was updated. Currently, this only updates
-  # the lesson name and overviews.
-  def i18n_hash
-    {
-      script.name => {
-        'lessons' => {
-          key => {
-            'name' => name
-          }
-        }
-      }
-    }
-  end
-
   # For a given set of students, determine when the given lesson is locked for
   # each student.
   # The design of a lockable lesson is that there is (optionally) some number of
@@ -919,7 +904,6 @@ class Lesson < ApplicationRecord
     copied_lesson.standards = standards
     copied_lesson.opportunity_standards = opportunity_standards
 
-    Script.merge_and_write_i18n(copied_lesson.i18n_hash, destination_unit.name)
     destination_unit.fix_script_level_positions
     destination_unit.write_script_json
     copied_lesson

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1652,14 +1652,6 @@ class Script < ApplicationRecord
     Services::MarkdownPreprocessor.sub_resource_links!(data['description_audience'], resource_markdown_replacement_proc) if data['description_audience']
     Services::MarkdownPreprocessor.sub_vocab_definitions!(data['description_audience'], vocab_markdown_replacement_proc) if data['description_audience']
 
-    data['lessons'] = {}
-    lessons.each do |lesson|
-      lesson_data = {
-        'name' => lesson.name,
-      }
-      data['lessons'][lesson.key] = lesson_data
-    end
-
     {'en' => {'data' => {'script' => {'name' => {new_name => data}}}}}
   end
 

--- a/dashboard/test/controllers/lessons_controller_test.rb
+++ b/dashboard/test/controllers/lessons_controller_test.rb
@@ -37,12 +37,7 @@ class LessonsControllerTest < ActionController::TestCase
         'script' => {
           'name' => {
             @script.name => {
-              'title' => @script_title,
-              'lessons' => {
-                @lesson.name => {
-                  'name' => @lesson_name
-                }
-              }
+              'title' => @script_title
             }
           }
         }
@@ -288,12 +283,7 @@ class LessonsControllerTest < ActionController::TestCase
         'script' => {
           'name' => {
             script.name => {
-              'title' => @script_title,
-              'lessons' => {
-                solo_lesson_in_script.key => {
-                  'name' => @lesson_name
-                }
-              }
+              'title' => @script_title
             }
           }
         }

--- a/dashboard/test/controllers/lessons_controller_test.rb
+++ b/dashboard/test/controllers/lessons_controller_test.rb
@@ -691,11 +691,6 @@ class LessonsControllerTest < ActionController::TestCase
 
     # Just make sure the new lesson name appears somewhere in the new file contents.
     File.stubs(:write).with do |filename, data|
-      filename.end_with?('scripts.en.yml') && data.include?(@update_params[:name])
-    end.once
-
-    # Just make sure the new lesson name appears somewhere in the new file contents.
-    File.stubs(:write).with do |filename, data|
       filename.end_with?('.script_json') && data.include?(@update_params[:name])
     end.once
 

--- a/dashboard/test/models/lesson_test.rb
+++ b/dashboard/test/models/lesson_test.rb
@@ -503,25 +503,6 @@ class LessonTest < ActiveSupport::TestCase
     assert_equal 30, levels_data[:duration]
   end
 
-  test 'i18n_hash has correct value' do
-    script = create :script, name: 'dummy-script'
-    lesson_group = create :lesson_group, script: script
-    lesson = create :lesson, lesson_group: lesson_group, script: script, key: 'dummy-key', name: 'Dummy Name'
-    lesson.student_overview = 'student overview'
-    lesson.overview = 'teacher overview'
-
-    expected_i18n = {
-      'dummy-script' => {
-        'lessons' => {
-          'dummy-key' => {
-            'name' => 'Dummy Name',
-          }
-        }
-      }
-    }
-    assert_equal expected_i18n, lesson.i18n_hash
-  end
-
   test 'seeding_key' do
     lesson_group = create :lesson_group
     script = lesson_group.script
@@ -1127,7 +1108,6 @@ class LessonTest < ActiveSupport::TestCase
       create :vocabulary, word: 'word one', course_version: @original_course_version, lessons: [@original_lesson]
 
       @destination_script.expects(:write_script_json).once
-      Script.expects(:merge_and_write_i18n).once
       destination_resource = create :resource, name: 'resource1', course_version: @destination_course_version
       destination_vocab = create :vocabulary, word: 'word one', course_version: @destination_course_version
       copied_lesson = @original_lesson.copy_to_unit(@destination_script)
@@ -1138,7 +1118,6 @@ class LessonTest < ActiveSupport::TestCase
 
     test "dots are stripped from cloned lesson key" do
       @destination_script.expects(:write_script_json).once
-      Script.expects(:merge_and_write_i18n).once
       @original_lesson.update!(name: 'Problem.Lesson.')
       copied_lesson = @original_lesson.copy_to_unit(@destination_script)
       assert_equal 'ProblemLesson', copied_lesson.key
@@ -1168,7 +1147,6 @@ class LessonTest < ActiveSupport::TestCase
       destination_script.expects(:write_script_json).once
       course_version_resource_count = course_version.resources.count
       course_version_vocab_count = course_version.vocabularies.count
-      Script.expects(:merge_and_write_i18n).once
       copied_lesson = original_lesson.copy_to_unit(destination_script)
       course_version.reload
 
@@ -1192,7 +1170,6 @@ class LessonTest < ActiveSupport::TestCase
       create :lesson_group, script: destination_script
 
       destination_script.expects(:write_script_json).once
-      Script.expects(:merge_and_write_i18n).once
       copied_lesson = original_lesson.copy_to_unit(destination_script)
 
       assert_equal destination_script, copied_lesson.script
@@ -1213,7 +1190,6 @@ class LessonTest < ActiveSupport::TestCase
         activity_section: existing_activity_section, activity_section_position: 1
 
       @destination_script.expects(:write_script_json).once
-      Script.expects(:merge_and_write_i18n).once
       copied_lesson = @original_lesson.copy_to_unit(@destination_script)
       @destination_script.reload
 
@@ -1258,7 +1234,6 @@ class LessonTest < ActiveSupport::TestCase
       create :lesson, script: @destination_script, lesson_group: @destination_lesson_group, has_lesson_plan: false, lockable: true, absolute_position: 3, relative_position: 1
 
       @destination_script.expects(:write_script_json).once
-      Script.expects(:merge_and_write_i18n).once
       copied_lesson = @original_lesson.copy_to_unit(@destination_script)
       @destination_script.reload
       assert_equal @destination_script, copied_lesson.script
@@ -1276,7 +1251,6 @@ class LessonTest < ActiveSupport::TestCase
       create :lesson, script: @destination_script, lesson_group: @destination_lesson_group, has_lesson_plan: false, lockable: true, absolute_position: 3, relative_position: 1
 
       @destination_script.expects(:write_script_json).once
-      Script.expects(:merge_and_write_i18n).once
       copied_lesson = @original_lesson.copy_to_unit(@destination_script)
       @destination_script.reload
       assert_equal @destination_script, copied_lesson.script
@@ -1307,7 +1281,7 @@ class LessonTest < ActiveSupport::TestCase
       @destination_script.lesson_groups = []
 
       @destination_script.expects(:write_script_json).once
-      Script.expects(:merge_and_write_i18n).twice
+      Script.expects(:merge_and_write_i18n).once
       copied_lesson = @original_lesson.copy_to_unit(@destination_script)
       assert_equal 1, @destination_script.lesson_groups.count
       assert_equal 1, @destination_script.lessons.count

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -2093,8 +2093,7 @@ class ScriptTest < ActiveSupport::TestCase
                   'description_short' => "Description short: Resource: [r #{copied_resource.key}/familyb/2001]. Vocab: [v #{copied_vocab.key}/familyb/2001].",
                   'description_audience' => "Description audience: Resource: [r #{copied_resource.key}/familyb/2001]. Vocab: [v #{copied_vocab.key}/familyb/2001].",
                   'description' => "Description: Resource: [r #{copied_resource.key}/familyb/2001]. Vocab: [v #{copied_vocab.key}/familyb/2001].",
-                  'student_description' => "Student description: Resource: [r #{copied_resource.key}/familyb/2001]. Vocab: [v #{copied_vocab.key}/familyb/2001].",
-                  'lessons' => {}
+                  'student_description' => "Student description: Resource: [r #{copied_resource.key}/familyb/2001]. Vocab: [v #{copied_vocab.key}/familyb/2001]."
                 }
               }
             }


### PR DESCRIPTION
Depends on https://github.com/code-dot-org/code-dot-org/pull/46392. Step 5b of [PLAT-1528](https://codedotorg.atlassian.net/browse/PLAT-1528). Stops writing lesson names to scripts.en.yml. Also removes some stubbed translation data in unit tests which should no longer be needed.

## Testing story

Mostly relying on existing test coverage. Also manually verified that updating a lesson name in levelbuilder mode locally causes the name to show up in the .script_json file, but not in scripts.en.yml.

This drone run has passing unit tests: https://drone.cdn-code.org/code-dot-org/code-dot-org/19148 and the UI test failures look flaky.  I'll wait for a fully green run before merging.

## Deployment strategy

I'll wait for a few deploys after https://github.com/code-dot-org/code-dot-org/pull/46392 (just merged) ships before merging this PR. that way, if that PR needs to be reverted, we'll still have kept scripts.en.yml up to date with any new changes to lesson names, so we won't be missing any data when we revert.