### PR TITLE
increasing wait time to 1 second

### DIFF
--- a/dashboard/test/ui/features/foundations/footer.feature
+++ b/dashboard/test/ui/features/foundations/footer.feature
@@ -40,7 +40,7 @@ Feature: Checking the footer appearance
     Given I am on "http://studio.code.org/s/mc/lessons/1/levels/14?noautoplay=true"
     And I wait for the page to fully load
 
-    And I wait for 0.5 seconds
+    And I wait for 1 second
     When I open my eyes to test "Desktop Minecraft puzzle using dark small footer"
     Then I see no difference for "small footer"
 

--- a/dashboard/test/ui/features/star_labs/artist_autorun.feature
+++ b/dashboard/test/ui/features/star_labs/artist_autorun.feature
@@ -5,7 +5,7 @@ Scenario: Autorun Eyes Test
   Given I am on "http://studio.code.org/s/allthethings/lessons/3/levels/9"
   And I wait to see "#runButton"
   And I close the instructions overlay if it exists
-  And I wait for 0.5 seconds
+  And I wait for 1 second
   And I open my eyes to test "artist autorun"
   Then I see no difference for "square already drawn"
   When I drag block "2" to block "12"

--- a/dashboard/test/ui/features/star_labs/unused_blocks.feature
+++ b/dashboard/test/ui/features/star_labs/unused_blocks.feature
@@ -5,7 +5,7 @@ Scenario: Solve a level with unused blocks
   Given I am on "http://studio.code.org/s/allthethings/lessons/4/levels/4?noautoplay=true"
   And I rotate to landscape
   And I wait for the page to fully load
-  And I wait for 0.5 seconds
+  And I wait for 1 second
   When I open my eyes to test "Unused Blocks"
 
   # Drag a block into the middle of the workspace


### PR DESCRIPTION
Adding a half second didn't completely take care of flakiness, but seemed to be the right direction (two of the three passed the first time, leading us to update the baselines). Trying 1 second instead in all places to see if it makes a difference.

## Links

This is a followup to https://github.com/code-dot-org/code-dot-org/pull/46387

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
