### PR TITLE
fix: move loadCompletionPage() to componentDidMount()

### DIFF
--- a/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerEligibility.jsx
+++ b/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerEligibility.jsx
@@ -189,6 +189,14 @@ export default class AmazonFutureEngineerEligibility extends React.Component {
     });
   };
 
+  componentDidMount = () => {
+    let {formData} = this.state;
+
+    if (formData.schoolEligible && formData.consentAFE && formData.signedIn) {
+      this.loadCompletionPage();
+    }
+  }
+
   loadCompletionPage = async () => {
     let {submissionAccepted} = getSessionData();
     let {submissionSent} = this.state;
@@ -234,7 +242,6 @@ export default class AmazonFutureEngineerEligibility extends React.Component {
     }
 
     if (formData.schoolEligible && formData.consentAFE && formData.signedIn) {
-      this.loadCompletionPage();
       return (
         <div>
           <h2>Your request is being processed</h2>


### PR DESCRIPTION
setting the state (which loadCompletionPage() does) is unsafe in render(). this pull request moves loadCompletionPage() in amazonFutureEngineerEligibility.tsx to componentDidMount(), which is much safer. componentDidMount() updates immediately after render(), so setting the state won't cause a loop where a state change will cause render() to fire, and render() will cause the state to update.

there may be a better way to do this since I don't know everything about react, but this should solve a potential problem.