### PR TITLE
[Blockly] Revert dropdown test

### DIFF
--- a/dashboard/test/ui/features/star_labs/dropdown.feature
+++ b/dashboard/test/ui/features/star_labs/dropdown.feature
@@ -1,16 +1,17 @@
 Feature: Dropdowns work as expected
 
 Background:
-  Given I am on "http://studio.code.org/s/sports/lessons/1/levels/5?noautoplay=true"
+  Given I am on "http://studio.code.org/s/playlab/lessons/1/levels/8?noautoplay=true"
 
 Scenario: Drag a dropdown and select a different option.
   When I rotate to landscape
   And I wait for the page to fully load
   And I dismiss the login reminder
-  And I drag Google Blockly block "7" to offset "250, 100"
-  And I press dropdown number 0
+  And I drag block "1" to offset "300, 250"
+  And I press dropdown number 45
   Then the dropdown is visible
-  Then I select item 2 from the dropdown
+  Then I select item 1 from the dropdown
   And I wait for 1 seconds
   Then the dropdown is hidden
-  And the dropdown field has text "whistle ▼"
+  And the dropdown field has text "remove ▼"
+  

--- a/dashboard/test/ui/features/step_definitions/dropdown.rb
+++ b/dashboard/test/ui/features/step_definitions/dropdown.rb
@@ -33,8 +33,9 @@ Then /^I select item (\d+) from the dropdown$/ do |n|
 end
 
 Then /^the dropdown field has text "(.*?)"$/ do |text|
-  # This step definition is only used in dropdown.feature, where the relevant dropdown is on first block in the DOM.
-  element_has_text(".blocklyEditableText:first", text)
+  id_selector = get_id_selector
+  # This step definition is only used in dropdown.feature, where the relevant dropdown is on the 15th block.
+  element_has_text("[#{id_selector}='15'] .blocklyEditableText", text)
 end
 
 And /^I press the image dropdown$/ do


### PR DESCRIPTION
Reverts `star_labs/dropdown.feature` to a previous working state.

Slack thread: https://codedotorg.slack.com/archives/C1B3PNDL7/p1652895030155639

Now passing **iPhone_star_labs_dropdown**: https://app.saucelabs.com/tests/5b87ddf974384df4a6b5c84944bc8bf1


<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
