### PR TITLE
Revert "translate lesson name using get_localized_property"

### DIFF
--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -230,14 +230,14 @@ class Lesson < ApplicationRecord
     # using legacy lesson plans, remove this condition and consolidate with
     # localized_name_for_lesson_show.
     if script.lessons.many? || (script.is_migrated && !script.use_legacy_lesson_plans)
-      get_localized_property(:name) || ''
+      I18n.t "data.script.name.#{script.name}.lessons.#{key}.name"
     else
       I18n.t "data.script.name.#{script.name}.title"
     end
   end
 
   def localized_name_for_lesson_show
-    get_localized_property(:name) || ''
+    I18n.t "data.script.name.#{script.name}.lessons.#{key}.name"
   end
 
   def localized_lesson_plan

--- a/dashboard/test/controllers/activities_controller_test.rb
+++ b/dashboard/test/controllers/activities_controller_test.rb
@@ -898,7 +898,7 @@ class ActivitiesControllerTest < ActionController::TestCase
 
     # find localized test strings for custom lesson names in script
     assert response.key?('lesson_changing'), "No key 'lesson_changing' in response #{response.inspect}"
-    assert_equal('Milestone Lesson 1', response['lesson_changing']['previous']['name'])
+    assert_equal('milestone-lesson-1', response['lesson_changing']['previous']['name'])
   end
 
   test 'milestone post respects level_id for active level' do

--- a/dashboard/test/controllers/script_levels_controller_test.rb
+++ b/dashboard/test/controllers/script_levels_controller_test.rb
@@ -1022,7 +1022,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
       lesson_position: @custom_s2_l1.lesson,
       id: @custom_s2_l1.position
     }
-    assert_equal 'Laurel Lesson 2 #1 | custom-script-laurel - Code.org [test]',
+    assert_equal 'laurel-lesson-2 #1 | custom-script-laurel - Code.org [test]',
       Nokogiri::HTML(@response.body).css('title').text.strip
   end
 

--- a/dashboard/test/helpers/script_levels_helper_test.rb
+++ b/dashboard/test/helpers/script_levels_helper_test.rb
@@ -52,7 +52,7 @@ class ScriptLevelsHelperTest < ActionView::TestCase
     stubs(:current_user).returns(nil)
     script = Script.find_by_name(Script::COURSE4_NAME)
     script_level = script.get_script_level_by_relative_position_and_puzzle_position 3, 1, false
-    assert_equal "Lesson 3: #{script_level.lesson.name}", script_level.lesson.summarize[:title]
+    assert_equal 'Lesson 3: ' + I18n.t("data.script.name.#{script.name}.lessons.#{script_level.lesson.key}.name"), script_level.lesson.summarize[:title]
   end
 
   test 'show lesson position in header for default script' do

--- a/dashboard/test/models/lesson_test.rb
+++ b/dashboard/test/models/lesson_test.rb
@@ -431,7 +431,6 @@ class LessonTest < ActiveSupport::TestCase
       purpose: 'example purpose'
     )
 
-    lesson.expects(:get_localized_property).with(:name)
     lesson.expects(:get_localized_property).with(:overview)
     lesson.expects(:get_localized_property).with(:purpose)
     lesson.expects(:get_localized_property).with(:preparation)


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#46392 because it broke translations in arabic. see [slack](https://codedotorg.slack.com/archives/C02EEGWLHR8/p1652903215921779)