### PR TITLE
start translating allthethings script

### DIFF
--- a/lib/cdo/script_constants.rb
+++ b/lib/cdo/script_constants.rb
@@ -288,7 +288,8 @@ module ScriptConstants
     VIGENERE = 'vigenere'.freeze,
     K5_ONLINEPD_2019 = 'k5-onlinepd-2019'.freeze,
     K5_ONLINEPD = 'K5-OnlinePD'.freeze,
-    KODEA_PD_2021 = 'kodea-pd-2021'.freeze
+    KODEA_PD_2021 = 'kodea-pd-2021'.freeze,
+    ALLTHETHINGS = 'allthethings'.freeze
   ]
 
   DEFAULT_VERSION_YEAR = '2017'


### PR DESCRIPTION
https://github.com/code-dot-org/code-dot-org/pull/46392 broke eyes tests because allthethings is not on the list of scripts to be translated. the solution is to start translating allthethings. see discussion in [slack](https://codedotorg.slack.com/archives/CFTFD6BPV/p1652905692352069?thread_ts=1651701437.075929&cid=CFTFD6BPV) for why this is ok.

## Follow up work

once this goes through 1-2 curriculum syncs, it should be safe to merge https://github.com/code-dot-org/code-dot-org/pull/46409.