### PR TITLE
Revert "update gemfile lock for m1 compatibility"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -433,7 +433,7 @@ GEM
       http-cookie (~> 1.0.0)
     faraday_middleware (0.14.0)
       faraday (>= 0.7.4, < 1.0)
-    ffi (1.15.4)
+    ffi (1.10.0)
     firebase (0.2.6)
       httpclient
       json
@@ -530,7 +530,7 @@ GEM
     launchy (2.4.3)
       addressable (~> 2.3)
     le (2.7.2)
-    libv8-node (15.14.0.0)
+    libv8 (8.4.255.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -551,8 +551,8 @@ GEM
     mini_magick (4.9.5)
     mini_mime (1.1.1)
     mini_portile2 (2.6.1)
-    mini_racer (0.4.0)
-      libv8-node (~> 15.14.0.0)
+    mini_racer (0.3.1)
+      libv8 (~> 8.4.255)
     minitest (5.14.4)
     minitest-around (0.4.1)
       minitest (~> 5.0)


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#46003

Getting an error during build in staging and test

```
LoadError: /var/lib/gems/2.5.0/extensions/x86_64-linux/2.5.0/mini_racer-0.4.0/mini_racer_extension.so: undefined symbol: _ZNSt7__cxx1119basic_ostringstreamIcSt11char_traitsIcESaIcEEC1Ev
```