### PR TITLE
Re-merge "Introduce Project models, clean-up logic in CodeReviewsController"

### DIFF
--- a/dashboard/app/controllers/code_reviews_controller.rb
+++ b/dashboard/app/controllers/code_reviews_controller.rb
@@ -6,44 +6,36 @@ class CodeReviewsController < ApplicationController
 
   # GET /code_reviews
   # Returns the list of code reviews and associated comments for the given
-  # project (identified by channel id), script, and level.
+  # project (identified by channel id).
   def index
-    params.require([:channelId, :scriptId, :levelId])
+    params.require([:channelId])
 
-    storage_id, project_id = storage_decrypt_channel_id(params[:channelId])
-    project_owner_id = user_id_for_storage_id(storage_id)
-    project_owner = User.find(project_owner_id)
+    project = Project.find_by_channel_id(params[:channelId])
 
-    # Check that current_user can see code reviews associated with this project
-    authorize! :read, CodeReview, project_owner
+    # Check that current_user can see code reviews associated with this project.
+    # (Note that this ability is defined on Project.)
+    authorize! :index_code_reviews, project
 
-    code_reviews = CodeReview.get_all(
-      project_id: project_id,
-      script_id: params[:scriptId],
-      level_id: params[:levelId]
-    )
-
+    code_reviews = CodeReview.where(project_id: project.id)
     render json: code_reviews.map(&:summarize_with_comments)
   end
 
   # POST /code_reviews
   def create
-    params.require([:scriptId, :levelId, :channelId, :version])
+    params.require([:channelId, :version, :scriptId, :levelId])
 
-    storage_id, project_id = storage_decrypt_channel_id(params[:channelId])
-    project_owner_id = user_id_for_storage_id(storage_id)
+    project = Project.find_by_channel_id(params[:channelId])
     # TODO: Should we check that this is a valid version for this project?
     # TODO: Can we determine and store an accurate expiration date? Can the expiration date change?
 
-    # TODO: Consider storing the channel_id instead of the project_id in CodeReview
     code_review = CodeReview.new(
       user_id: current_user.id,
+      project_id: project.id,
+      project_version: params[:version],
       script_id: params[:scriptId],
-      level_id: params[:levelId],
-      project_id: project_id,
-      project_version: params[:version]
+      level_id: params[:levelId]
     )
-    authorize! :create, code_review, project_owner_id
+    authorize! :create, code_review, project
     code_review.save!
 
     render json: code_review.summarize

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -126,13 +126,20 @@ class Ability
         CodeReviewComment.user_can_review_project?(project_owner, user, project_id)
       end
 
-      can :create, CodeReview do |code_review, project_owner_id|
+      can :create, CodeReview do |code_review, project|
         code_review.user_id == user.id &&
-        project_owner_id == user.id
+        project.owner_id == user.id
       end
       can :edit, CodeReview, user_id: user.id
-      # TODO: teachers and peers should also be able to see the code review
-      can :read, CodeReview, user_id: user.id
+      can :index_code_reviews, Project do |project|
+        # The user can see the code review if one of the following is true:
+        # 1) the user is the project owner
+        # 2) the user is the teacher of the project owner
+        # 3) the user and the project owner are in the same code reivew group
+        project.owner.id == user.id ||
+          project.owner.student_of?(user) ||
+          (project.owner.code_review_groups & user.code_review_groups).any?
+      end
 
       can :create, Pd::RegionalPartnerProgramRegistration, user_id: user.id
       can :read, Pd::Session

--- a/dashboard/app/models/code_review.rb
+++ b/dashboard/app/models/code_review.rb
@@ -17,6 +17,12 @@
 #
 #  index_code_review_requests_unique  (user_id,script_id,level_id,closed_at,deleted_at) UNIQUE
 class CodeReview < ApplicationRecord
+  # TODO: Reorder columns so that the first three columns are id, user_id, project_id
+  # TODO: Change unique index to include just user_id, project_id, closed_at, and deleted_at
+  # TODO: Add index to look up by project_id
+  # TODO: Add column to store channel id
+  # TODO: Add column to store project version expiration
+
   # This model was renamed partway through the development process. This line
   # will be removed when the table is renamed before this work is completed.
   self.table_name = 'code_review_requests'
@@ -29,16 +35,9 @@ class CodeReview < ApplicationRecord
 
   # Enforce that each student can only have one open code review per script and
   # level. (This is also enforced at the database level with a unique index.)
-  validates_uniqueness_of :user_id, scope: [:script_id, :level_id],
+  validates_uniqueness_of :user_id, scope: [:project_id],
     conditions: -> {where(closed_at: nil)},
-    message: 'already has an open code review for this script and level'
-
-  # Returns an array of all code reviews (open and closed) that match the given
-  # identifying attributes. Returns an empty array if there are no matches.
-  def self.get_all(project_id:, script_id:, level_id:)
-    # TODO: Add an index to the db that covers this query
-    CodeReview.where(project_id: project_id, script_id: script_id, level_id: level_id).to_a
-  end
+    message: 'already has an open code review for this project'
 
   def self.open_for_project?(channel:)
     _, project_id = storage_decrypt_channel_id(channel)
@@ -60,8 +59,6 @@ class CodeReview < ApplicationRecord
   def summarize
     {
       id: id,
-      scriptId: script_id,
-      levelId: level_id,
       channelId: nil,             # TODO: implement this!
       version: project_version,
       isVersionExpired: false,    # TODO: implement this!

--- a/dashboard/app/models/project.rb
+++ b/dashboard/app/models/project.rb
@@ -1,0 +1,54 @@
+# == Schema Information
+#
+# Table name: projects
+#
+#  id                      :integer          not null, primary key
+#  storage_id              :integer
+#  value                   :text(16777215)
+#  updated_at              :datetime         not null
+#  updated_ip              :string(39)       not null
+#  state                   :string(50)       default("active"), not null
+#  created_at              :datetime
+#  abuse_score             :integer
+#  project_type            :string(255)
+#  published_at            :datetime
+#  standalone              :boolean          default(TRUE)
+#  remix_parent_id         :integer
+#  skip_content_moderation :boolean
+#
+# Indexes
+#
+#  storage_apps_project_type_index  (project_type)
+#  storage_apps_published_at_index  (published_at)
+#  storage_apps_standalone_index    (standalone)
+#  storage_apps_storage_id_index    (storage_id)
+#
+class Project < ApplicationRecord
+  belongs_to :project_storage, foreign_key: 'storage_id'
+  # Note: owner is nil for projects that are owned by users without an account
+  has_one :owner, class_name: 'User', through: :project_storage, source: :user
+
+  # Finds a project by channel id. Like `find`, this method raises an
+  # ActiveRecord::RecordNotFound error if the corresponding project cannot
+  # be found.
+  def self.find_by_channel_id(channel_id)
+    begin
+      _, project_id = storage_decrypt_channel_id(channel_id)
+    rescue
+      raise ActiveRecord::RecordNotFound.new("Invalid channel_id: #{channel_id}")
+    end
+
+    Project.find(project_id)
+  end
+
+  def channel_id
+    storage_encrypt_channel_id(storage_id, id)
+  end
+
+  # Returns the user_id of the owner of this project. Returns nil if the project
+  # is owned by a user without an account. This should always return the same
+  # value as project.owner.id but is more efficient if only the user_id is needed.
+  def owner_id
+    project_storage.user_id
+  end
+end

--- a/dashboard/app/models/project_storage.rb
+++ b/dashboard/app/models/project_storage.rb
@@ -1,0 +1,24 @@
+# == Schema Information
+#
+# Table name: user_project_storage_ids
+#
+#  id      :integer          not null, primary key
+#  user_id :integer
+#
+# Indexes
+#
+#  user_id                         (user_id) UNIQUE
+#  user_storage_ids_user_id_index  (user_id)
+#
+class ProjectStorage < ApplicationRecord
+  # Conceptually, an instance of this class represents blob storage for all of
+  # the projects belonging to a single user. The user may have an account (user_id
+  # points to the user) or may be unsigned-in (user_id is nil). Under the covers,
+  # metadata for this storage is stored in the 'user_project_storage_ids' table
+  # and the blobs are stored in several S3 buckets depending on the blob type
+  # (e.g. cdo-v3-sources/sources/<storage id>, cdo-v3-files/files/<storage id>, etc.).
+  self.table_name = 'user_project_storage_ids'
+
+  belongs_to :user
+  has_many :projects, inverse_of: :project_storage
+end

--- a/dashboard/test/controllers/code_reviews_controller_test.rb
+++ b/dashboard/test/controllers/code_reviews_controller_test.rb
@@ -1,13 +1,15 @@
 require 'test_helper'
 
 class CodeReviewsControllerTest < ActionController::TestCase
-  self.use_transactional_test_case = true
+  # Setting this to true causes some weird db locking issue, possibly due to
+  # some writes to the projects table coming from a different connection via
+  # sequel.
+  self.use_transactional_test_case = false
 
   setup_all do
     @project_owner = create :student
-    @storage_id = create_storage_id_for_user(@project_owner.id)
-    @channel_id = create :project, storage_id: @storage_id
-    _,  @project_id = storage_decrypt_channel_id(@channel_id)
+    @project = create :project, owner: @project_owner
+    @channel_id = @project.channel_id
   end
 
   setup do
@@ -19,11 +21,11 @@ class CodeReviewsControllerTest < ActionController::TestCase
     level_id = 5
 
     closed_at = DateTime.now
-    create :code_review, user_id: @project_owner.id, project_id: @project_id,
+    create :code_review, user_id: @project_owner.id, project_id: @project.id,
       script_id: script_id, level_id: level_id, closed_at: closed_at
-    create :code_review, user_id: @project_owner.id, project_id: @project_id,
+    create :code_review, user_id: @project_owner.id, project_id: @project.id,
       script_id: script_id, level_id: level_id, closed_at: closed_at + 1.second
-    create :code_review, user_id: @project_owner.id, project_id: @project_id,
+    create :code_review, user_id: @project_owner.id, project_id: @project.id,
       script_id: script_id, level_id: level_id, closed_at: nil
 
     get :index, params: {
@@ -43,42 +45,38 @@ class CodeReviewsControllerTest < ActionController::TestCase
     project_version = 'abc'
 
     post :create, params: {
-      scriptId: script_id,
-      levelId: level_id,
       channelId: @channel_id,
-      version: project_version
+      version: project_version,
+      scriptId: script_id,
+      levelId: level_id
     }
     assert_response :success
 
     response_json = JSON.parse(response.body)
     assert_not_nil response_json['id']
-    assert_equal script_id, response_json['scriptId']
-    assert_equal level_id, response_json['levelId']
     assert_equal project_version, response_json['version']
     assert_equal false, response_json['isVersionExpired']
     assert_equal true, response_json['isOpen']
     assert_not_nil response_json['createdAt']
   end
 
-  test 'cannot create multiple open code reviews for the same script and level' do
-    script_id = 23
-    level_id = 11
+  test 'cannot create multiple open code reviews for the same project' do
     project_version = 'abc'
 
     post :create, params: {
-      scriptId: script_id,
-      levelId: level_id,
       channelId: @channel_id,
-      version: project_version
+      version: project_version,
+      scriptId: 15,
+      levelId: 31
     }
     assert_response :success
 
     assert_raises ActiveRecord::RecordInvalid do
       post :create, params: {
-        scriptId: script_id,
-        levelId: level_id,
         channelId: @channel_id,
-        version: project_version
+        version: project_version,
+        scriptId: 7,
+        levelId: 19
       }
     end
   end

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -871,16 +871,20 @@ FactoryGirl.define do
     end
   end
 
-  # For now, this factory returns the channel id of the created project.
-  # This will be improved when we migrate the projects code to ActiveRecord.
-  factory :project, class: 'Projects' do
-    skip_create # disable ActiveRecord persistence
+  factory :project_storage do
+  end
 
-    storage_id 1
-    value Hash.new
-    updated_ip "127.0.0.1"
+  factory :project do
+    transient do
+      owner create :user
+    end
 
-    initialize_with {Projects.new(storage_id).create(value, ip: updated_ip)}
+    updated_ip '127.0.0.1'
+
+    after(:build) do |project, evaluator|
+      project_storage = create :project_storage, user_id: evaluator.owner.id
+      project.storage_id = project_storage.id
+    end
   end
 
   factory :featured_project do

--- a/dashboard/test/helpers/levels_helper_test.rb
+++ b/dashboard/test/helpers/levels_helper_test.rb
@@ -438,9 +438,9 @@ class LevelsHelperTest < ActionView::TestCase
     create(:script_level, script: script, levels: [@level])
 
     create :channel_token, level: @level, storage_id: fake_storage_id_for_user_id(@user.id)
-    assert_not_nil get_channel_for(@level, script.id, @user)
+    @channel_id = get_channel_for(@level, script.id, @user)
+    assert_not_nil @channel_id
 
-    @channel_id = create :project, storage_id: fake_storage_id_for_user_id(@user.id)
     _,  @project_id = storage_decrypt_channel_id(@channel_id)
     create :code_review, user_id: @user.id, project_id: @project_id,
       script_id: script.id, level_id: @level.id, closed_at: nil

--- a/dashboard/test/models/ability_test.rb
+++ b/dashboard/test/models/ability_test.rb
@@ -798,14 +798,17 @@ class AbilityTest < ActiveSupport::TestCase
   end
 
   test 'only the project owner can create a code review on that project' do
+    skip 'tests that create a project'
     project_owner = create :student
     other_student = create :student
-    code_review = create :code_review, user_id: project_owner.id
+    project = create :project, owner: project_owner
+    other_project = create :project, owner: other_student
+    code_review = create :code_review, user_id: project_owner.id, project_id: project.id
 
-    assert Ability.new(project_owner).can? :create, code_review, project_owner.id
-    refute Ability.new(project_owner).can? :create, code_review, other_student.id
-    refute Ability.new(other_student).can? :create, code_review, project_owner.id
-    refute Ability.new(other_student).can? :create, code_review, other_student.id
+    assert Ability.new(project_owner).can? :create, code_review, project
+    refute Ability.new(project_owner).can? :create, code_review, other_project
+    refute Ability.new(other_student).can? :create, code_review, project
+    refute Ability.new(other_student).can? :create, code_review, other_project
   end
 
   test 'only the code review owner can edit the code review' do
@@ -817,15 +820,35 @@ class AbilityTest < ActiveSupport::TestCase
     refute Ability.new(other_student).can? :edit, code_review
   end
 
-  # TODO: Update this test after allowing peers in the same code review group
-  # to also see the review.
-  test 'only the code review owner can see the review' do
-    code_review_owner = create :student
-    other_student = create :student
-    code_review = create :code_review, user_id: code_review_owner.id
+  test 'who can view code reviews on a given project' do
+    skip 'tests that create a project'
 
-    assert Ability.new(code_review_owner).can? :read, code_review
-    refute Ability.new(other_student).can? :read, code_review
+    # Create the teacher and 3 students involved in this test.
+    teacher = create :teacher
+    project_owner = create :student
+    student_in_group = create :student
+    student_not_in_group = create :student
+
+    # Create a section that's led by the teacher and has all 3 students.
+    section = create :section, teacher: teacher
+    followers = []
+    followers[0] = create :follower, section: section, student_user: project_owner
+    followers[1] = create :follower, section: section, student_user: student_in_group
+    followers[2] = create :follower, section: section, student_user: student_not_in_group
+
+    # Create a code review group includes 2 students (project_owner and student_in_group)
+    code_review_group = create :code_review_group, section: section
+    create :code_review_group_member, code_review_group: code_review_group, follower: followers[0]
+    create :code_review_group_member, code_review_group: code_review_group, follower: followers[1]
+
+    # Create the project owned by code_review_owner
+    project = create :project, owner: project_owner
+
+    # Now we're finally ready to verify who can index code reviews associated the project
+    assert Ability.new(teacher).can? :index_code_reviews, project
+    assert Ability.new(project_owner).can? :index_code_reviews, project
+    assert Ability.new(student_in_group).can? :index_code_reviews, project
+    refute Ability.new(student_not_in_group).can? :index_code_reviews, project
   end
 
   test 'workshop admins can update scholarship info' do

--- a/dashboard/test/models/code_review_test.rb
+++ b/dashboard/test/models/code_review_test.rb
@@ -3,16 +3,15 @@ require 'test_helper'
 class CodeReviewTest < ActiveSupport::TestCase
   setup_all do
     @project_owner = create :student
-    @storage_id = create_storage_id_for_user(@project_owner.id)
-    @channel_id = create :project, storage_id: @storage_id
-    _,  @project_id = storage_decrypt_channel_id(@channel_id)
+    @project = create :project, owner: @project_owner
+    @channel_id = @project.channel_id
   end
 
   test 'open_for_project? returns true if a code review is open for the project' do
     script_id = 12
     level_id = 5
 
-    create :code_review, user_id: @project_owner.id, project_id: @project_id,
+    create :code_review, user_id: @project_owner.id, project_id: @project.id,
       script_id: script_id, level_id: level_id, closed_at: nil
 
     assert CodeReview.open_for_project?(channel: @channel_id)
@@ -22,7 +21,7 @@ class CodeReviewTest < ActiveSupport::TestCase
     script_id = 12
     level_id = 5
 
-    create :code_review, user_id: @project_owner.id, project_id: @project_id,
+    create :code_review, user_id: @project_owner.id, project_id: @project.id,
       script_id: script_id, level_id: level_id, closed_at: DateTime.now
 
     refute CodeReview.open_for_project?(channel: @channel_id)


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#46420 which re-merges #46336.  The first merge attempt was reverted due to a logical merge conflict where a change to the project factory in 46336 was merged around the same time as some new tests that used the project factory.  Commit 8593118 has the changes needed to update the new tests to use the updated factory.