### PR TITLE
JavaLab: fix layout when no instructions shown

### DIFF
--- a/apps/src/javalab/JavalabView.jsx
+++ b/apps/src/javalab/JavalabView.jsx
@@ -128,20 +128,24 @@ class JavalabView extends React.Component {
   };
 
   isLeftSideVisible = () => {
-    const {longInstructions, hasContainedLevels} = this.props;
     // It's possible that a console level without instructions won't have
     // anything to show on the left side.
     return (
-      this.props.viewMode !== CsaViewMode.CONSOLE ||
-      hasInstructions(null, longInstructions, hasContainedLevels)
+      this.props.viewMode !== CsaViewMode.CONSOLE || this.hasInstructions()
     );
+  };
+
+  hasInstructions = () => {
+    const {longInstructions, hasContainedLevels} = this.props;
+    return hasInstructions(null, longInstructions, hasContainedLevels);
   };
 
   renderVisualization = width => {
     const {visualization} = this.props;
     if (visualization) {
+      const previewStyle = this.hasInstructions() ? styles.preview : {};
       return (
-        <div id="visualization-container" style={styles.preview}>
+        <div id="visualization-container" style={previewStyle}>
           {visualization}
         </div>
       );


### PR DESCRIPTION
I noticed (during a cool presentation by @sanchitmalhotra126) that some JavaLab levels have no instructions, and there was a small gap where they would normally be shown.  

Now, if there are no instructions, the layout is fixed, and the gap is gone.

Follow-up to #41688.

### before

<img width="1512" alt="Screen Shot 2022-05-19 at 3 23 14 PM" src="https://user-images.githubusercontent.com/2205926/169216278-a94334ea-51a0-4caa-9247-2b411a1511ba.png">

### after

<img width="1512" alt="Screen Shot 2022-05-19 at 3 25 54 PM" src="https://user-images.githubusercontent.com/2205926/169216740-14d47f22-26be-41e9-8dbb-0be0008107f8.png">

