### PR TITLE
Use link tags for buttons that go to /donate

### DIFF
--- a/pegasus/sites.v3/code.org/views/donor_slider.haml
+++ b/pegasus/sites.v3/code.org/views/donor_slider.haml
@@ -28,5 +28,6 @@
             = "#{supporter[:name_s]}, "
     
     .donor-button
-      %button{role: "link", onclick: "window.location.href = '/donate'"}
-        = I18n.t(:homepage_donors_donate)
+      %a{href: "/donate"}
+        %button
+          = I18n.t(:homepage_donors_donate)

--- a/pegasus/sites.v3/code.org/views/homepage_supporters.haml
+++ b/pegasus/sites.v3/code.org/views/homepage_supporters.haml
@@ -10,8 +10,9 @@
       Amazon • The Ballmer Group • Coinbase • Google.org • Charlie Lee • Microsoft • Spiegel Family Fund • Vista Equity Partners
 
     .donor-button
-      %button{role: "link", onclick: "window.location.href = '/donate'"}
-        = I18n.t(:homepage_donors_donate)
+      %a{href: "/donate"}
+        %button
+          = I18n.t(:homepage_donors_donate)
 
     %a{:href=>'/about/supporters'}
       = I18n.t(:homepage_donors_seall)


### PR DESCRIPTION
This is a proposal to use regular `<a>` links to go to `/donate` for the button at the button of the signed-out code.org/ homepage, and at the bottom of a course-specific certificate page (e.g. https://code.org/congrats/coursea-2019).

It's a follow-up to the discussion at https://github.com/code-dot-org/code-dot-org/pull/46018#pullrequestreview-955623071.

My reasoning is that, by using JS to do the navigation, we lose some useful functionality, but it's not clear we gain any.  Specifically, we lose the ability to right-click a link and choose "Open in new tab", to shift-click to open in a new tab automatically, in Chrome we no longer get a preview of the destination URL when hovering over it, and I presume we lose the ability of search engine spiders to see where the link goes, which would drop our SEO for the donate page.  And on the other hand, I tested with macOS' VoiceOver in Safari, and the link is handled the same whether it has the JS or just a link tag.

I think there is some debate about whether it's good to have a `<button>` tag, and I've seen other sites simply emulate a button appearance in CSS for such links, but I wasn't sure what to do about that.

Happy to debate this change; just wanted to share this PR as a proposal.