### PR TITLE
Reinforce Custom JSON Parsing Logic

### DIFF
--- a/lib/cdo/secrets.rb
+++ b/lib/cdo/secrets.rb
@@ -144,18 +144,22 @@ module Cdo
       raise
     end
 
-    # If +value+ is JSON, parse it and cast to a string.
+    # If +value+ is JSON, parse it.
     #
-    # If +value+ is a JSON object (rather than a scalar), also wrap in
-    # ActiveSupport::OrderedOptions so property-method lookup chains are
-    # possible (e.g., secrets.secret.key).
+    # If +value+ is a JSON array, return it.
+    #
+    # If +value+ is a JSON object, wrap in ActiveSupport::OrderedOptions so
+    # property-method lookup chains are possible (e.g., secrets.secret.key).
+    #
+    # Otherwise, cast the value to a string.
     #
     # @param value[String]
-    # @return [ActiveSupport::OrderedOptions, String]
+    # @return [Array, ActiveSupport::OrderedOptions, String]
     def parse_json(value)
       parsed = JSON.parse(value)
-      return parsed.to_s unless parsed.is_a?(Hash)
-      return ActiveSupport::OrderedOptions[parsed.symbolize_keys]
+      return parsed if parsed.is_a?(Array)
+      return ActiveSupport::OrderedOptions[parsed.symbolize_keys] if parsed.is_a?(Hash)
+      return parsed.to_s
     rescue JSON::ParserError, TypeError
       value
     end

--- a/lib/cdo/secrets.rb
+++ b/lib/cdo/secrets.rb
@@ -144,12 +144,18 @@ module Cdo
       raise
     end
 
-    # If +value+ is JSON, parse and wrap in ActiveSupport::OrderedOptions so
-    # property-method lookup chains are possible (e.g., secrets.secret.key).
+    # If +value+ is JSON, parse it and cast to a string.
+    #
+    # If +value+ is a JSON object (rather than a scalar), also wrap in
+    # ActiveSupport::OrderedOptions so property-method lookup chains are
+    # possible (e.g., secrets.secret.key).
+    #
     # @param value[String]
     # @return [ActiveSupport::OrderedOptions, String]
     def parse_json(value)
-      ActiveSupport::OrderedOptions[JSON.parse(value).symbolize_keys]
+      parsed = JSON.parse(value)
+      return parsed.to_s unless parsed.is_a?(Hash)
+      return ActiveSupport::OrderedOptions[parsed.symbolize_keys]
     rescue JSON::ParserError, TypeError
       value
     end


### PR DESCRIPTION
We've got some custom JSON-parsing logic in our AWS Secrets Manager interface. Specifically, custom logic which in addition to wrapping parsed JSON Objects in fancy Ruby accessor helpers will nicely handle values which cannot be parsed to JSON by simply returning them directly.

Unfortunately, the current version of the JSON gem we're using does not support parsing scalar values:

```
[development] dashboard > JSON.parse("123")
Traceback (most recent call last):
        1: from (irb):1
JSON::ParserError (784: unexpected token at '123')
[development] dashboard > JSON.parse("1.0")
Traceback (most recent call last):
        1: from (irb):2
JSON::ParserError (784: unexpected token at '1.0')
```

I'm not sure why this is; this behavior is (as far as I can find) undocumented and entirely undesirable. The version of the JSON gem to which we'd like to upgrade as part of the Ruby 2.7 upgrade has the expected behavior:

```
[development] dashboard > JSON.parse("123")
=> 123
[development] dashboard > JSON.parse("1.0")
=> 1.0
[development] dashboard >
```

Which for the most part is a good thing, but does break the behavior here. I'm not entirely sure of the best way to preserve the existing behavior; or, indeed, if we even _want_ to preserve the existing behavior. Open to suggestions!

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

- [`json` gem changelog](https://github.com/flori/json/blob/master/CHANGES.md)

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Relying on existing unit tests. In particular, see https://github.com/code-dot-org/code-dot-org/blob/a79e7cbeddf48e792cab64d43f3308566afdf0c5/lib/test/cdo/test_secrets.rb#L70-L73

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
