### PR TITLE
Attempt to fix flaky eyes tests involving top instructions

### DIFF
--- a/dashboard/test/ui/features/foundations/footer.feature
+++ b/dashboard/test/ui/features/foundations/footer.feature
@@ -2,10 +2,10 @@ Feature: Checking the footer appearance
 
   @eyes
   Scenario: Desktop puzzle using light small footer
+    When I open my eyes to test "Desktop puzzle using light small footer"
     Given I am on "http://studio.code.org/s/allthethings/lessons/2/levels/1?noautoplay=true"
     And I wait for the page to fully load
 
-    When I open my eyes to test "Desktop puzzle using light small footer"
     Then I see no difference for "small footer"
 
     When I press the first ".copyright-link" element
@@ -37,11 +37,10 @@ Feature: Checking the footer appearance
 
   @eyes
   Scenario: Desktop Minecraft puzzle using dark small footer
+    When I open my eyes to test "Desktop Minecraft puzzle using dark small footer"
     Given I am on "http://studio.code.org/s/mc/lessons/1/levels/14?noautoplay=true"
     And I wait for the page to fully load
 
-    And I wait for 1 second
-    When I open my eyes to test "Desktop Minecraft puzzle using dark small footer"
     Then I see no difference for "small footer"
 
     When I press the first ".copyright-link" element
@@ -52,6 +51,7 @@ Feature: Checking the footer appearance
 
   @eyes
   Scenario: Desktop Star Wars share small footer
+    When I open my eyes to test "Desktop Star Wars share small footer"
     Given I am on "http://studio.code.org/s/starwars/lessons/1/levels/15?noautoplay=true"
     And I wait for the page to fully load
     And I press "runButton"
@@ -61,7 +61,6 @@ Feature: Checking the footer appearance
     And I navigate to the share URL
     And I wait until element ".small-footer-base" is visible
 
-    When I open my eyes to test "Desktop Star Wars share small footer"
     Then I see no difference for "small footer"
 
     When I open the small footer menu
@@ -87,6 +86,7 @@ Feature: Checking the footer appearance
   # TODO: Fix and re-enable (find #sharing-dialog-copy-button element)
   @eyes @skip
   Scenario: Desktop Minecraft share small footer
+    When I open my eyes to test "Desktop Minecraft share small footer"
     Given I am on "http://studio.code.org/s/mc/lessons/1/levels/14?noautoplay=true"
     And I wait for the page to fully load
     And I press "runButton"
@@ -94,7 +94,6 @@ Feature: Checking the footer appearance
     And I navigate to the share URL
     And I wait until element ".small-footer-base" is visible
 
-    When I open my eyes to test "Desktop Minecraft share small footer"
     Then I see no difference for "small footer"
 
     When I open the small footer menu
@@ -125,12 +124,12 @@ Feature: Checking the footer appearance
 
   @eyes @as_student
   Scenario: Desktop Applab share small footer
+    When I open my eyes to test "Desktop Applab share small footer"
     Given I start a new Applab project
     And I navigate to the shared version of my project
     And I wait until element ".small-footer-base" is visible
     And I wait for 2 seconds
 
-    When I open my eyes to test "Desktop Applab share small footer"
     Then I see no difference for "small footer"
 
     When I open the small footer menu
@@ -143,6 +142,7 @@ Feature: Checking the footer appearance
 
   @eyes_mobile @skip
   Scenario: Mobile Star Wars share small footer
+    When I open my eyes to test "Mobile Star Wars share small footer"
     Given I am on "http://studio.code.org/s/starwars/lessons/1/levels/15?noautoplay=true"
     And I rotate to landscape
     And I wait for the page to fully load
@@ -159,7 +159,6 @@ Feature: Checking the footer appearance
     # pin-to-home-screen popup go away
     And I wait for 10 seconds
 
-    When I open my eyes to test "Mobile Star Wars share small footer"
     Then I see no difference for "small footer"
 
     When I open the small footer menu
@@ -173,6 +172,7 @@ Feature: Checking the footer appearance
   # TODO: Fix and re-enable (find #sharing-dialog-copy-button element)
   @eyes_mobile @skip
   Scenario: Mobile Minecraft share small footer
+    When I open my eyes to test "Mobile Minecraft share small footer"
     Given I am on "http://studio.code.org/s/mc/lessons/1/levels/14?noautoplay=true"
     And I rotate to landscape
     And I wait for the page to fully load
@@ -187,7 +187,6 @@ Feature: Checking the footer appearance
     # pin-to-home-screen popup go away
     And I wait for 10 seconds
 
-    When I open my eyes to test "Mobile Minecraft share small footer"
     Then I see no difference for "small footer"
 
     When I open the small footer menu
@@ -200,6 +199,7 @@ Feature: Checking the footer appearance
 
   @eyes_mobile @as_student
   Scenario: Mobile Applab share small footer
+    When I open my eyes to test "Mobile Applab share small footer"
     Given I am on "http://studio.code.org/home"
     And I rotate to landscape
     And I start a new Applab project
@@ -211,7 +211,6 @@ Feature: Checking the footer appearance
     # pin-to-home-screen popup go away
     And I wait for 20 seconds
 
-    When I open my eyes to test "Mobile Applab share small footer"
     Then I see no difference for "small footer"
 
     When I open the small footer menu

--- a/dashboard/test/ui/features/star_labs/artist_autorun.feature
+++ b/dashboard/test/ui/features/star_labs/artist_autorun.feature
@@ -2,11 +2,10 @@
 Feature: Artist Autorun
 
 Scenario: Autorun Eyes Test
+  When I open my eyes to test "artist autorun"
   Given I am on "http://studio.code.org/s/allthethings/lessons/3/levels/9"
   And I wait to see "#runButton"
   And I close the instructions overlay if it exists
-  And I wait for 1 second
-  And I open my eyes to test "artist autorun"
   Then I see no difference for "square already drawn"
   When I drag block "2" to block "12"
   And I drag block "6" to block "17"

--- a/dashboard/test/ui/features/star_labs/unused_blocks.feature
+++ b/dashboard/test/ui/features/star_labs/unused_blocks.feature
@@ -2,11 +2,10 @@ Feature: Unused Blocks
 
 @eyes
 Scenario: Solve a level with unused blocks
+  When I open my eyes to test "Unused Blocks"
   Given I am on "http://studio.code.org/s/allthethings/lessons/4/levels/4?noautoplay=true"
   And I rotate to landscape
   And I wait for the page to fully load
-  And I wait for 1 second
-  When I open my eyes to test "Unused Blocks"
 
   # Drag a block into the middle of the workspace
   When I drag block "1" to offset "200, 200"


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Attempting to fix some flaky eyes tests by moving the `I open my eyes` step to the top of some tests.  Hopefully, this will set the size of the window before the page is loaded.  See more details in [this Slack thread](https://codedotorg.slack.com/archives/C0T0PNTM3/p1652977537898829).

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
