### PR TITLE
Direct users to new code docs urls

### DIFF
--- a/apps/src/lib/levelbuilder/code-docs-editor/ProgrammingClassEditor.jsx
+++ b/apps/src/lib/levelbuilder/code-docs-editor/ProgrammingClassEditor.jsx
@@ -93,8 +93,7 @@ export default function ProgrammingClassEditor({
       })
       .then(json => {
         if (shouldCloseAfterSave) {
-          // TODO: update this when we have a show page for classes
-          navigateToHref('/');
+          navigateToHref(programmingClass.showUrl);
         } else {
           setLastUpdated(Date.now());
           setError(null);
@@ -230,7 +229,7 @@ export default function ProgrammingClassEditor({
         isSaving={isSaving}
         lastSaved={lastUpdated}
         error={error}
-        handleView={() => navigateToHref('/')}
+        handleView={() => navigateToHref(programmingClass.showUrl)}
       />
     </div>
   );

--- a/dashboard/app/models/programming_class.rb
+++ b/dashboard/app/models/programming_class.rb
@@ -110,7 +110,8 @@ class ProgrammingClass < ApplicationRecord
       tips: tips || '',
       syntax: syntax || '',
       externalDocumentation: external_documentation || '',
-      categoryKey: programming_environment_category&.key || ''
+      categoryKey: programming_environment_category&.key || '',
+      showUrl: programming_environment_programming_class_path(programming_environment.name, key)
     }
   end
 
@@ -149,7 +150,7 @@ class ProgrammingClass < ApplicationRecord
       key: key,
       name: name,
       syntax: syntax,
-      link: "/programming_classes/#{id}"
+      link: programming_environment_programming_class_path(programming_environment.name, key)
     }
   end
 

--- a/dashboard/app/models/programming_expression.rb
+++ b/dashboard/app/models/programming_expression.rb
@@ -143,15 +143,19 @@ class ProgrammingExpression < ApplicationRecord
     record.id
   end
 
-  def documentation_path
+  def cb_documentation_path
     "/docs/#{programming_environment.name}/#{key}/"
   end
 
   def studio_documentation_path
+    programming_environment_programming_expression_path(programming_environment.name, key)
+  end
+
+  def documentation_path
     if DCDO.get('use-studio-code-docs', false)
-      documentation_path
+      studio_documentation_path
     else
-      programming_environment_programming_expression_path(programming_environment.name, key)
+      cb_documentation_path
     end
   end
 


### PR DESCRIPTION
Follow up to #46126. Now that we have CSA docs URLs, we should use them! Plus, we should be sending users to the new expressions URL when possible after launch.




## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
