### PR TITLE
Clone reference guides with scripts

### DIFF
--- a/dashboard/app/models/reference_guide.rb
+++ b/dashboard/app/models/reference_guide.rb
@@ -62,9 +62,9 @@ class ReferenceGuide < ApplicationRecord
     File.delete(file_path)
   end
 
-  def copy_to_course_version(course_version)
+  def copy_to_course_version(destination_course_version)
     copied_ref_guide = ReferenceGuide.find_or_create_by(
-      course_version_id: course_version.id,
+      course_version_id: destination_course_version.id,
       key: key
     ) do |created_ref_guide|
       created_ref_guide.update!(

--- a/dashboard/app/models/reference_guide.rb
+++ b/dashboard/app/models/reference_guide.rb
@@ -62,6 +62,21 @@ class ReferenceGuide < ApplicationRecord
     File.delete(file_path)
   end
 
+  def copy_to_course_version(course_version)
+    copied_ref_guide = ReferenceGuide.find_or_create_by(
+      course_version_id: course_version.id,
+      key: key
+    ) do |created_ref_guide|
+      created_ref_guide.update!(
+        parent_reference_guide_key: parent_reference_guide_key,
+        display_name: display_name,
+        content: content,
+        position: position
+      )
+    end
+    copied_ref_guide.write_serialization
+  end
+
   def self.find_by_course_name_and_key(course_name, key)
     course_version_id = CurriculumHelper.find_matching_course_version(course_name)&.id
     return nil unless course_version_id

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1162,7 +1162,7 @@ class Script < ApplicationRecord
       raise 'Can not have both a destination unit group and a destination professional learning course.'
     end
 
-    source_course_version = course_version || unit_group&.course_version
+    source_course_version = get_course_version
     destination_unit_group = destination_unit_group_name ?
       UnitGroup.find_by_name(destination_unit_group_name) :
       nil

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1162,6 +1162,7 @@ class Script < ApplicationRecord
       raise 'Can not have both a destination unit group and a destination professional learning course.'
     end
 
+    source_course_version = course_version || unit_group&.course_version
     destination_unit_group = destination_unit_group_name ?
       UnitGroup.find_by_name(destination_unit_group_name) :
       nil
@@ -1203,6 +1204,10 @@ class Script < ApplicationRecord
 
         lesson_groups.each do |original_lesson_group|
           original_lesson_group.copy_to_unit(copied_unit, new_level_suffix)
+        end
+
+        source_course_version&.reference_guides&.each do |reference_guide|
+          reference_guide.copy_to_course_version(destination_unit_group.course_version)
         end
 
         if destination_professional_learning_course.nil?

--- a/dashboard/test/controllers/reference_guides_controller_test.rb
+++ b/dashboard/test/controllers/reference_guides_controller_test.rb
@@ -53,7 +53,7 @@ class ReferenceGuidesControllerTest < ActionController::TestCase
 
     show_data = css_select('script[data-referenceguides]').first.attribute('data-referenceguides').to_s
 
-    assert_equal [@reference_guide.summarize_for_index, @reference_guide_subcategory.summarize_for_index].to_json, show_data
+    assert_equal @unit_group.course_version.reference_guides.map(&:summarize_for_index).to_json, show_data
   end
 
   test 'ref guide is updated through update route' do

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -2140,6 +2140,16 @@ class ScriptTest < ActiveSupport::TestCase
       assert_equal @unit_in_course.student_resources[0], cloned_unit.student_resources[0]
     end
 
+    test 'can copy reference guides' do
+      Rails.application.config.stubs(:levelbuilder_mode).returns true
+      ReferenceGuide.any_instance.expects(:write_serialization).once
+      File.stubs(:write)
+      @unit_in_course.unit_group.course_version.reference_guides = [create(:reference_guide)]
+      cloned_unit = @unit_in_course.clone_migrated_unit('coursename3-2021', destination_unit_group_name: @unit_group.name)
+      assert_equal cloned_unit.unit_group, @unit_group
+      assert_equal 1, @unit_group.course_version.reference_guides.count
+    end
+
     test 'can copy a script without a course version' do
       source_unit = create :script, is_course: true, is_migrated: true
       lesson = create :lesson, script: source_unit


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Adds logic to the script cloning process to clone reference guides to the destination course_version if they haven't been created there already.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [PLAT-1167](https://codedotorg.atlassian.net/browse/PLAT-1167)

## Testing story

tested locally, ensuring script runs without errors and that cloning another script into the same unit group doesn't cause errors
```
Script.find_by_name('csp1-2022').clone_migrated_unit('test2-2022', destination_unit_group_name: 'csd-2021')
Script.find_by_name('test2-2022').unit_group.course_version.reference_guides.count
> 93
Script.find_by_name('csp2-2022').clone_migrated_unit('test3-2022', destination_unit_group_name: 'csd-2021')
```
and checked that json files were created

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->
