### PR TITLE
[Bounce] Fix bounce_setPaddleDropdown for default skin

### DIFF
--- a/apps/src/bounce/blocks.js
+++ b/apps/src/bounce/blocks.js
@@ -527,7 +527,7 @@ exports.install = function(blockly, blockInstallOptions) {
   };
 
   blockly.Blocks.bounce_setPaddleDropdown.VALUES = skin.paddles.map(paddle => [
-    skin[paddle].paddle,
+    skin[paddle].paddle || skin[paddle],
     `"${paddle}"`
   ]);
 


### PR DESCRIPTION
The default toolbox for all Bounce levels (used by levelbuilders) includes the `bounce_setPaddleDropdown` block which was created when we created the "sports" and "basketball" skins:
<img width="194" alt="image" src="https://user-images.githubusercontent.com/43474485/169546653-eb01e732-1808-448e-be32-bd802060ad50.png">
In the default Bounce skin, this block is not shown to students because one "paddle" is available. However, it does show up to levelbuilders editing toolbox and start blocks as an unknown block:

<img width="388" alt="image" src="https://user-images.githubusercontent.com/43474485/169545854-4caae5f6-48d2-41d6-b20b-4843433f2171.png">

Unknown blocks are not currently supported with Google Blockly v7. When attempting to load the toolbox or start blocks editor while on v7, the site crashes:

<img width="476" alt="image" src="https://user-images.githubusercontent.com/43474485/169546212-062f58c3-2524-49f6-8822-918ea7993039.png">

In the other skins, we create an array of URLs paired with string identifiers. In the default skin, we just have a single URL. We can specify to use the default paddle image URL if the other method comes back as undefined. This allows the block to render correctly in the default skin:

<img width="266" alt="image" src="https://user-images.githubusercontent.com/43474485/169545763-a4cfc58a-b9a0-445d-a349-d28872d5859f.png">


## Links

- jira ticket: [STAR-2301: [Bounce] Fix bounce_setPaddleDropdown for default skin](https://codedotorg.atlassian.net/browse/STAR-2301)