### PR TITLE
Add educate/it to i18n sync

### DIFF
--- a/bin/i18n/sync-in.rb
+++ b/bin/i18n/sync-in.rb
@@ -497,6 +497,7 @@ def localize_markdown_content
     curriculum/unplugged.md.partial
     educate/csc.md.partial
     educate/curriculum/csf-transition-guide.md
+    educate/it.md
     helloworld.md.partial
     hourofcode/artist.md.partial
     hourofcode/flappy.md.partial

--- a/pegasus/sites.v3/code.org/public/educate/it.md
+++ b/pegasus/sites.v3/code.org/public/educate/it.md
@@ -14,17 +14,57 @@ theme: responsive
 - All other content, such as K-5 courses (Computer Science Fundamentals) and Hour of Code activities are compatible on iPads and Chromebooks in addition to all other modern tablets and laptop or desktop computers.
 - Looking for mobile device support details? Read below.
 
-## Supported Browsers and Platforms
+## Minimum Supported Browsers and Platforms
 
-Code.org takes a tiered approach to the level of support we provide for different browsers and platforms to ensure we are building a stellar experience for most of our users, and an acceptable experience for the rest. We support the following combinations of operating systems and browsers:
+<table>
+ <tr>
+  <td style="vertical-align: top; border-color: transparent;">
+      <table>
+        <th>
+          Browser
+        </th>
+        <tr>
+          <td>Chrome 87.x</td>
+        </tr>
+        <tr>
+          <td>Safari 13.x</td>
+        </tr>
+        <tr>
+          <td>Mobile Safari 11.x</td>
+        </tr>
+        <tr>
+          <td>Edge 87.x</td>
+        </tr>
+        <tr>
+          <td>Firefox 91.x</td>
+        </tr>
+      </table>    
+  </td>
+  <td style="vertical-align: top; border-color: transparent;">
+      <table>
+        <th>
+          Operating System
+        </th>
+        <tr>
+          <td>macOS 10.13</td>
+        </tr>
+        <tr>
+          <td>iOS 11.x</td>
+        </tr>
+        <tr>
+          <td>Windows 7</td>
+        </tr>
+        <tr>
+          <td>Android 6</td>
+        </tr>
+        <tr>
+          <td>ChromeOS (Chromebooks)</td>
+        </tr>
+      </table>
+  </td>
+ </tr>
+</table>
 
-| **Browser**                   | **Operating System**                                                                                               |
-|-------------------------------|--------------------------------------------------------------------------------------------------------------------|
-| Chrome 87.x and higher        | Windows 7 and higher <br><br> macOS 10.13 and higher <br><br> Android 6 and higher <br><br> ChromeOS (Chromebooks) |
-| Safari 13.x and higher        | macOS 10.13 and higher                                                                                             |
-| Mobile Safari 11.x and higher | iOS 11.x and higher                                                                                                |
-| Edge 87.x and higher          | Windows 10 and higher                                                                                              |
-| Firefox 91.x and higher       | Windows 7 and higher                                                                                               |
 
 ## Sites to Unblock
 

--- a/pegasus/sites.v3/code.org/public/educate/it.md
+++ b/pegasus/sites.v3/code.org/public/educate/it.md
@@ -18,7 +18,7 @@ theme: responsive
 
 <table>
  <tr>
-  <td style="vertical-align: top; border-color: transparent;">
+  <td style="vertical-align: top; border-color: transparent; padding: 0px 12px 0px 0px;">
       <table>
         <th>
           Browser
@@ -40,10 +40,10 @@ theme: responsive
         </tr>
       </table>    
   </td>
-  <td style="vertical-align: top; border-color: transparent;">
+  <td style="vertical-align: top; border-color: transparent; padding: 0px 0px 0px 0px;">
       <table>
         <th>
-          Operating System
+          Platform
         </th>
         <tr>
           <td>macOS 10.13</td>


### PR DESCRIPTION
**What**: Add our `it.md` markdown file to our sync-in step and update the minimum requirements table to be more translatable.

**Why**: This will introduce the https://code.org/educate/it markdown page to our translation pipeline on the next sync. The table is now uses HTML to support more intricate styling([link to discussion](https://codedotorg.slack.com/archives/C0SUN2SSF/p1653410282123389)).

## Links

- jira ticket: [FND-1966](https://codedotorg.atlassian.net/browse/FND-1966)

## Testing story

Confirmed changes locally

![Screen Shot 2022-05-27 at 11 21 41 AM](https://user-images.githubusercontent.com/48133820/170739536-ce9c6664-6c28-4674-a1c5-3a6aa7c13657.png)


<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
