### PR TITLE
Truncate code review tables with project IDs

### DIFF
--- a/shared/test/common_test_helper.rb
+++ b/shared/test/common_test_helper.rb
@@ -40,7 +40,7 @@ VCR.configure do |c|
 end
 
 # Truncate database tables to ensure repeatable tests.
-DASHBOARD_TEST_TABLES = %w(channel_tokens user_project_storage_ids projects).freeze
+DASHBOARD_TEST_TABLES = %w(channel_tokens user_project_storage_ids projects code_review_comments reviewable_projects project_versions).freeze
 DASHBOARD_TEST_TABLES.each do |table|
   DASHBOARD_DB[table.to_sym].truncate
 end.freeze


### PR DESCRIPTION
We've had a couple eyes failures in the past month related to not correctly clearing code review tables after having reset project data. ([thread 1](https://codedotorg.slack.com/archives/CA3KCSGTD/p1653310391835479), [thread 2](https://codedotorg.slack.com/archives/C0T0PNTM3/p1650576869433069)).

This PR is a speculative fix -- it adds code review tables that use a project ID to the list of tables that are truncated when the projects tables are truncated -- this was a suggestion Dave had in the second thread that I missed when it was made about a month ago. This code is not expected to be run against the `dashboard_test` database at all, so its not clear that this will solve the issue.

## Testing story

I didn't test this, but truncating these tables manually resolved these issues for ~a month, until the projects table was reset on 5/20 (I'm not sure why it was reset at this point).

## Follow-up work

I wonder if this line could be removed entirely with the work that's been done to move project tables to dashboard -- reading the original PR, it looks like this code is in place to work around tables being split across pegasus and dashboard:

https://github.com/code-dot-org/code-dot-org/pull/18239

I'll also manually truncate these tables on test once this is merged.