### PR TITLE
Add a version year to csd6-2022 to fix honeybadger error

### DIFF
--- a/dashboard/config/scripts_json/csd6-2022.script_json
+++ b/dashboard/config/scripts_json/csd6-2022.script_json
@@ -23,6 +23,7 @@
       "show_calendar": true,
       "student_detail_progress_view": true,
       "tts": true,
+      "version_year": "2022",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,


### PR DESCRIPTION
Quick fix for https://app.honeybadger.io/projects/3240/faults/85583508. When I updated this logic, I forgot to account for no version_year because this is the first year the maker unit doesn't have a version year. There's a better fix to determine the version year from course version, but this was quicker to do right now.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
