### PR TITLE
Add Google Optimize to Pegasus

### DIFF
--- a/pegasus/sites.v3/code.org/views/theme_common_head_before.haml
+++ b/pegasus/sites.v3/code.org/views/theme_common_head_before.haml
@@ -9,7 +9,7 @@
 %link{rel:'shortcut icon', href:'/images/favicon.ico'}
 %link{rel:'apple-touch-icon', href:'/images/apple-touch-icon-precomposed.png'}
 
-%script{src:'https://cdn.optimizely.com/js/12977480133.js'}
+%script{src:'www.googleoptimize.com/optimize.js?id=OPT-KBX3C3L'}
 
 =view :fonts
 -if @header['style_min'] && request.site == 'code.org'

--- a/pegasus/sites/all/views/page.haml
+++ b/pegasus/sites/all/views/page.haml
@@ -2,7 +2,7 @@
 %html
   %head
     -if request.site == 'code.org'
-      %script{src: "https://cdn.optimizely.com/js/12977480133.js"}
+      %script{src: "https://www.googleoptimize.com/optimize.js?id=OPT-KBX3C3L"}
 
     -# Add social networking meta properties.
     - header['social'].each_pair do |property, content|


### PR DESCRIPTION
Replace Optimizely w/ Google Optimize on Pegasus so Marketing can run tests on the Code.org site. 

Reference: [Trello card](https://trello.com/c/HydARABR/36-add-google-optimize-to-pegasus)