### PR TITLE
Add New Rails 6.0 Configurations

### DIFF
--- a/dashboard/config/application.rb
+++ b/dashboard/config/application.rb
@@ -23,6 +23,8 @@ Bundler.require(:default, Rails.env)
 
 module Dashboard
   class Application < Rails::Application
+    config.load_defaults 6.0
+
     unless CDO.chef_managed
       # Only Chef-managed environments run an HTTP-cache service alongside the Rack app.
       # For other environments (development / CI), run the HTTP cache from Rack middleware.

--- a/dashboard/config/application.rb
+++ b/dashboard/config/application.rb
@@ -23,8 +23,6 @@ Bundler.require(:default, Rails.env)
 
 module Dashboard
   class Application < Rails::Application
-    config.load_defaults 6.0
-
     unless CDO.chef_managed
       # Only Chef-managed environments run an HTTP-cache service alongside the Rack app.
       # For other environments (development / CI), run the HTTP cache from Rack middleware.

--- a/dashboard/config/initializers/application_controller_renderer.rb
+++ b/dashboard/config/initializers/application_controller_renderer.rb
@@ -1,0 +1,8 @@
+# Be sure to restart your server when you modify this file.
+
+# ActiveSupport::Reloader.to_prepare do
+#   ApplicationController.renderer.defaults.merge!(
+#     http_host: 'example.org',
+#     https: false
+#   )
+# end

--- a/dashboard/config/initializers/assets.rb
+++ b/dashboard/config/initializers/assets.rb
@@ -1,0 +1,12 @@
+# Be sure to restart your server when you modify this file.
+
+# Version of your assets, change this if you want to expire all your assets.
+Rails.application.config.assets.version = '1.0'
+
+# Add additional assets to the asset load path.
+# Rails.application.config.assets.paths << Emoji.images_path
+
+# Precompile additional assets.
+# application.js, application.css, and all non-JS/CSS in the app/assets
+# folder are already added.
+# Rails.application.config.assets.precompile += %w( admin.js admin.css )

--- a/dashboard/config/initializers/content_security_policy.rb
+++ b/dashboard/config/initializers/content_security_policy.rb
@@ -1,0 +1,28 @@
+# Be sure to restart your server when you modify this file.
+
+# Define an application-wide content security policy
+# For further information see the following documentation
+# https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
+
+# Rails.application.config.content_security_policy do |policy|
+#   policy.default_src :self, :https
+#   policy.font_src    :self, :https, :data
+#   policy.img_src     :self, :https, :data
+#   policy.object_src  :none
+#   policy.script_src  :self, :https
+#   policy.style_src   :self, :https
+
+#   # Specify URI for violation reports
+#   # policy.report_uri "/csp-violation-report-endpoint"
+# end
+
+# If you are using UJS then enable automatic nonce generation
+# Rails.application.config.content_security_policy_nonce_generator = -> request { SecureRandom.base64(16) }
+
+# Set the nonce only to specific directives
+# Rails.application.config.content_security_policy_nonce_directives = %w(script-src)
+
+# Report CSP violations to a specified URI
+# For further information see the following documentation:
+# https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only
+# Rails.application.config.content_security_policy_report_only = true

--- a/dashboard/config/initializers/cookies_serializer.rb
+++ b/dashboard/config/initializers/cookies_serializer.rb
@@ -1,0 +1,5 @@
+# Be sure to restart your server when you modify this file.
+
+# Specify a serializer for the signed and encrypted cookie jars.
+# Valid options are :json, :marshal, and :hybrid.
+Rails.application.config.action_dispatch.cookies_serializer = :marshal

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -16,8 +16,18 @@
 #
 # This would use the information in config/locales/es.yml.
 #
+# The following keys must be escaped otherwise they will not be retrieved by
+# the default I18n backend:
+#
+# true, false, on, off, yes, no
+#
+# Instead, surround them with single quotes.
+#
+# en:
+#   'true': 'foo'
+#
 # To learn more, please read the Rails Internationalization guide
-# available at http://guides.rubyonrails.org/i18n.html.
+# available at https://guides.rubyonrails.org/i18n.html.
 
 en:
   errors:


### PR DESCRIPTION
Specifically, I ran `bundle exec bin/rails app:update` to generate all the changes that Rails thinks we should make, and reduced that down to just the subset of those we want. What I ended up with was:

1. Two new Rails configuration values; `Rails.application.config.assets.version` and `Rails.application.config.action_dispatch.cookies_serializer`
2. Some placeholder Rails initialization files. We aren't currently using any of the functionality referenced in the `application_controller_renderer` or `content_security_policy` files, but it's useful to have them there to make it clear where we should go to configure that functionality in the future. It is a little weird to have these files just lying around not doing anything until then, but it is consistent with how Rails expects us to manage this directory. See existing https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/config/initializers/mime_types.rb and https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/config/initializers/inflections.rb for example
3. More-verbose comment in the default i18n file. Always worth calling out yaml's oddities

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
