### PR TITLE
Droplet: create a socket for known blocks

### DIFF
--- a/apps/src/dropletUtils.js
+++ b/apps/src/dropletUtils.js
@@ -3,7 +3,6 @@ import color from './util/color';
 import {singleton as studioApp} from './StudioApp';
 import {globalFunctions} from './dropletUtilsGlobalFunctions';
 import dontMarshalApi from './dontMarshalApi';
-import experiments from '@cdo/apps/util/experiments';
 
 /**
  * @name DropletBlock
@@ -989,9 +988,7 @@ export function generateDropletModeOptions(config) {
     lockZeroParamFunctions: config.level.lockZeroParamFunctions,
     lockFunctionDropIntoKnownParams: config.lockFunctionDropIntoKnownParams,
     paramButtonsForUnknownFunctions: true,
-    createSocketForKnownBlock: experiments.isEnabled(
-      experiments.DROPLET_CREATE_SOCKET_FOR_KNOWN_BLOCK
-    )
+    createSocketForKnownBlock: true
   };
 }
 

--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -38,7 +38,6 @@ experiments.OPT_IN_EMAIL_REG_PARTNER = 'optInEmailRegPartner';
 experiments.JAVALAB_UNIT_TESTS = 'javalabUnitTests';
 experiments.STUDIO_CERTIFICATE = 'studioCertificate';
 experiments.JAVALAB_DOCUMENTATION = 'javalabDocumentation';
-experiments.DROPLET_CREATE_SOCKET_FOR_KNOWN_BLOCK = 'createSocketForKnownBlock';
 
 /**
  * This was a gamified version of the finish dialog, built in 2018,

--- a/apps/test/unit/dropletUtilsTest.js
+++ b/apps/test/unit/dropletUtilsTest.js
@@ -133,7 +133,7 @@ const BASE_DROPLET_CONFIG = Object.freeze({
     }
   },
   paramButtonsForUnknownFunctions: true,
-  createSocketForKnownBlock: false
+  createSocketForKnownBlock: true
 });
 
 describe('dropletUtils', () => {


### PR DESCRIPTION
Exit the experiment and turn on the functionality built in https://github.com/code-dot-org/code-dot-org/pull/45868 for all users.
