### PR TITLE
[Google Blockly] update domToBlockHeadless_ override to use domToBlock

### DIFF
--- a/apps/src/blockly/addons/cdoXml.js
+++ b/apps/src/blockly/addons/cdoXml.js
@@ -2,12 +2,11 @@ export default function initializeBlocklyXml(blocklyWrapper) {
   // Clear xml namespace
   blocklyWrapper.utils.xml.NAME_SPACE = '';
 
-  // Aliasing Google's domToBlockHeadless_() so that we can override it, but still be able
-  // to call Google's domToBlockHeadless_() in the override function.
-  blocklyWrapper.Xml.originalDomToBlockHeadless_ =
-    blocklyWrapper.Xml.domToBlockHeadless_;
-  // Override domToBlockHeadless_ so that we can gracefully handle unknown blocks.
-  blocklyWrapper.Xml.domToBlockHeadless_ = function(
+  // Aliasing Google's domToBlock() so that we can override it, but still be able
+  // to call Google's domToBlock() in the override function.
+  blocklyWrapper.Xml.originalDomToBlock = blocklyWrapper.Xml.domToBlock;
+  // Override domToBlock so that we can gracefully handle unknown blocks.
+  blocklyWrapper.Xml.domToBlock = function(
     xmlBlock,
     workspace,
     parentConnection,
@@ -15,14 +14,14 @@ export default function initializeBlocklyXml(blocklyWrapper) {
   ) {
     let block;
     try {
-      block = blocklyWrapper.Xml.originalDomToBlockHeadless_(
+      block = blocklyWrapper.Xml.originalDomToBlock(
         xmlBlock,
         workspace,
         parentConnection,
         connectedToParentNext
       );
     } catch (e) {
-      block = blocklyWrapper.Xml.originalDomToBlockHeadless_(
+      block = blocklyWrapper.Xml.originalDomToBlock(
         blocklyWrapper.Xml.textToDom('<block type="unknown" />'),
         workspace,
         parentConnection,


### PR DESCRIPTION
## Problem

Our Blockly labs need to continue to support creating "unknown blocks", so we need to avoid regressions to this feature when updating to newer versions of Google Blockly. This is an especially critical feature for labs where levelbuilders are able to define their own blocks or work with levels that make use of block pools (e.g. Poetry, Dance, Sprite Lab).
For example, Poetry includes the GameLabJr (aka Sprite Lab) block pool, even though some blocks, such as mini-toolbox pointers, are not supported. These Sprite Lab blocks are still made available in the default toolbox for editing start and toolbox blocks for a Poetry level.

![image](https://user-images.githubusercontent.com/43474485/170059931-95312753-bdaf-4f40-9c6a-afe9d1ebbd3c.png)

Currently, we do this by overriding `domToBlockHeadless`, something we will be able to continue once we bump to v7.

## Proposed Solution
It looks like `domToBlock` can actually replace `domToBlockHeadless_` and that we _are_ able to override `domToBlock`. We can update our override to instead use `domToBlock` and maintain all functionality. 🎉 

## Alternative Solution
The other option here was to wait until the Blockly team made available a new API that would allow us to move this code to an `onError` function that would be able to be passed directly into `domToWorkspace`. (See spec linked in bullets below)

## Links

- jira ticket: [STAR-2110: [Google Blockly] Confirm if domToBlock can replace domToBlockHeadless](https://codedotorg.atlassian.net/browse/STAR-2110)
- documentation for `domToBlock`: [Namespace: Xml  |  Blockly  |  Google Developers](https://developers.google.com/blockly/reference/js/Blockly.Xml?hl=en#.domToBlock)
- Google Blockly API Spec: [XML onError - Google Docs](https://docs.google.com/document/d/1f6t4KqFjrb6CNGA06AZZfLs7gITOYCGNPmW7qg-MQY8/edit#)

## Testing story

Tested for regressions in Poetry, Bounce, and Flappy (none found). Staging today uses Blockly version 6.20210701.0. I confirmed that this also works as expected with version 7.20211209.1!