### PR TITLE
Implement from_peers endpoint for code reviews

### DIFF
--- a/dashboard/app/controllers/code_reviews_controller.rb
+++ b/dashboard/app/controllers/code_reviews_controller.rb
@@ -2,7 +2,7 @@ class CodeReviewsController < ApplicationController
   before_action :authenticate_user!
 
   # Make sure we don't forget to authorize each action
-  check_authorization
+  check_authorization except: [:from_peers]
 
   # GET /code_reviews
   # Returns the list of code reviews and associated comments for the given
@@ -58,5 +58,41 @@ class CodeReviewsController < ApplicationController
     end
 
     render json: code_review.summarize_with_comments
+  end
+
+  # GET /code_reviews/from_peers
+  # Returns the list of open code reviews for the given script and level
+  # from peers in the user's code review groups.
+  def from_peers
+    params.require([:scriptId, :levelId])
+
+    code_reviews = CodeReview.open_reviews.where(
+      user_id: peer_user_ids(current_user),
+      level_id: params[:levelId],
+      script_id: params[:scriptId]
+    ).includes(:owner)
+
+    return render json: code_reviews.map(&:summarize_for_peer)
+  end
+
+  # Returns the user ids of the students that are in the same code review group
+  # as the given user.
+  def peer_user_ids(student)
+    # Get the Follower objects for the current user that are in sections where
+    # code review is enabled. There is at most one per section that the student
+    # is in and usually just zero or one since the student is unlikely to be in
+    # more than one section that has code review enabled.
+    followeds = student.
+      followeds.
+      includes(:section).
+      select {|followed| followed.section.code_review_enabled?}
+
+    # For each Follower object, get the user_ids of the other members in the
+    # code review group; combine the results and return as a single array.
+    followeds.
+      map {|followed| followed.code_review_group&.followers&.pluck(:student_user_id)}.
+      compact.
+      flatten.
+      select {|user_id| user_id != student.id}
   end
 end

--- a/dashboard/app/models/code_review.rb
+++ b/dashboard/app/models/code_review.rb
@@ -77,8 +77,7 @@ class CodeReview < ApplicationRecord
     )
   end
 
-  # Information returned to a peer who can comment on this review
-  def summarize_for_peer
+  def summarize_owner_info
     {
       ownerId: owner.id,
       ownerName: owner.name,

--- a/dashboard/app/models/code_review_group.rb
+++ b/dashboard/app/models/code_review_group.rb
@@ -11,7 +11,6 @@
 # Indexes
 #
 #  index_code_review_groups_on_section_id  (section_id)
-#  TODO: Add index on follower_id
 #
 class CodeReviewGroup < ApplicationRecord
   # use dependent: :delete_all here because code_review_group_members is a join table and has no id column.

--- a/dashboard/app/models/code_review_group.rb
+++ b/dashboard/app/models/code_review_group.rb
@@ -11,9 +11,11 @@
 # Indexes
 #
 #  index_code_review_groups_on_section_id  (section_id)
+#  TODO: Add index on follower_id
 #
 class CodeReviewGroup < ApplicationRecord
   # use dependent: :delete_all here because code_review_group_members is a join table and has no id column.
   has_many :members, class_name: 'CodeReviewGroupMember', dependent: :delete_all
+  has_many :followers, through: :members
   belongs_to :section
 end

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -973,7 +973,7 @@ Dashboard::Application.routes.draw do
   end
 
   resources :code_reviews, only: [:index, :create, :update] do
-    get :from_peers, on: :collection
+    get :peers_with_open_reviews, on: :collection
   end
 
   resources :code_review_notes, only: [:create]

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -972,7 +972,9 @@ Dashboard::Application.routes.draw do
     end
   end
 
-  resources :code_reviews, only: [:index, :create, :update]
+  resources :code_reviews, only: [:index, :create, :update] do
+    get :from_peers, on: :collection
+  end
 
   resources :code_review_notes, only: [:create]
 

--- a/dashboard/test/controllers/code_reviews_controller_test.rb
+++ b/dashboard/test/controllers/code_reviews_controller_test.rb
@@ -109,7 +109,7 @@ class CodeReviewsControllerTest < ActionController::TestCase
     assert_response :bad_request
   end
 
-  test 'from_peers returns correct data' do
+  test 'peers_with_open_reviews returns correct data' do
     script_id = 91
     level_id = 161
 
@@ -127,7 +127,7 @@ class CodeReviewsControllerTest < ActionController::TestCase
     create :code_review, user_id: peer.id, script_id: script_id, level_id: level_id
 
     sign_in student
-    get :from_peers, params: {
+    get :peers_with_open_reviews, params: {
       scriptId: script_id,
       levelId: level_id
     }

--- a/dashboard/test/controllers/code_reviews_controller_test.rb
+++ b/dashboard/test/controllers/code_reviews_controller_test.rb
@@ -108,4 +108,93 @@ class CodeReviewsControllerTest < ActionController::TestCase
     }
     assert_response :bad_request
   end
+
+  test 'from_peers returns correct data' do
+    script_id = 91
+    level_id = 161
+
+    student = create :student
+    peer = create :student
+
+    section = create :section, code_review_expires_at: Time.now.utc + 1.day
+    student_follower = create :follower, section: section, student_user: student
+    peer_follower = create :follower, section: section, student_user: peer
+
+    code_review_group = create :code_review_group, section: section
+    create :code_review_group_member, follower: student_follower, code_review_group: code_review_group
+    create :code_review_group_member, follower: peer_follower, code_review_group: code_review_group
+
+    create :code_review, user_id: peer.id, script_id: script_id, level_id: level_id
+
+    sign_in student
+    get :from_peers, params: {
+      scriptId: script_id,
+      levelId: level_id
+    }
+    assert_response :success
+
+    response_json = JSON.parse(response.body)
+    assert_equal 1, response_json.length
+    assert_equal peer.id, response_json[0]['ownerId']
+    assert_equal peer.name, response_json[0]['ownerName']
+  end
+
+  test 'peer_user_ids returns students in code review group' do
+    # Test includes 6 students
+    #   students[0] - student we will query, in section and code review group
+    #   students[1] - student in same section and code review group
+    #   students[2] - student in same section and code review group
+    #   students[3] - student in same section but different code review group
+    #   students[4] - student in same section but not in a code review group
+    #   students[5] - student not in section
+
+    students = []
+    6.times do |i|
+      students[i] = create :student
+    end
+
+    section = create :section, code_review_expires_at: Time.now.utc + 1.day
+    followers = []
+    5.times do |i|
+      followers[i] = create :follower, section: section, student_user: students[i]
+    end
+
+    code_review_group = create :code_review_group, section: section
+    3.times do |i|
+      create :code_review_group_member, follower: followers[i], code_review_group: code_review_group
+    end
+
+    other_code_review_group = create :code_review_group, section: section
+    create :code_review_group_member, follower: followers[3], code_review_group: other_code_review_group
+
+    assert_equal [students[1].id, students[2].id], @controller.peer_user_ids(students[0])
+  end
+
+  test 'peer_user_ids returns empty array for student not in a section' do
+    student = create :student
+    assert_empty @controller.peer_user_ids(student)
+  end
+
+  test 'peer_user_ids returns empty array for student not in a code review group' do
+    student = create :student
+    section = create :section, code_review_expires_at: Time.now.utc + 1.day
+    create :follower, section: section, student_user: student
+
+    assert_empty @controller.peer_user_ids(student)
+  end
+
+  test 'peer_user_ids does not return peers in code review group where code review is not enabled' do
+    student = create :student
+    peer = create :student
+
+    section = create :section, code_review_expires_at: Time.now.utc - 1.day
+    student_follower = create :follower, section: section, student_user: student
+    peer_follower = create :follower, section: section, student_user: peer
+
+    code_review_group = create :code_review_group, section: section
+    create :code_review_group_member, follower: student_follower, code_review_group: code_review_group
+    create :code_review_group_member, follower: peer_follower, code_review_group: code_review_group
+
+    assert_empty @controller.peer_user_ids(student)
+  end
 end


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Implement the from_peers endpoint for code reviews which retrieves the open code reviews for peers in the same code review group.  This involved several tables/models and I've tried to strike a balance between reducing the number of potential n+1 queries, the complexity of any single query, joining over too many domains, and code maintainability.

We're meeting with Mike this morning to figure out if we want to query for open code reviews by script id + level id, script id  + level project id, or perhaps something else.  Some updates may be needed pending the outcome of that meeting, but should not affect `peer_user_ids` which is the most interesting part of this change.

If you're curious, here are the queries that are made as a result of the `peer_user_ids` call:
```
  Follower Load (6.7ms)  SELECT `followers`.* FROM `followers` WHERE `followers`.`deleted_at` IS NULL AND `followers`.`student_user_id` = 7 ORDER BY followers.id
  Section Load (4.6ms)  SELECT `sections`.* FROM `sections` WHERE `sections`.`deleted_at` IS NULL AND `sections`.`id` IN (2, 3, 8)
  CodeReviewGroup Load [NO INDEX] (5.7ms)  SELECT `code_review_groups`.* FROM `code_review_groups` INNER JOIN `code_review_group_members` ON `code_review_groups`.`id` = `code_review_group_members`.`code_review_group_id` WHERE `code_review_group_members`.`follower_id` = 13 LIMIT 1
   (5.9ms)  SELECT `followers`.`student_user_id` FROM `followers` INNER JOIN `code_review_group_members` ON `followers`.`id` = `code_review_group_members`.`follower_id` WHERE `followers`.`deleted_at` IS NULL AND `code_review_group_members`.`code_review_group_id` = 1
```

Calling the controller method issues an additional two queries to get the CodeReviewGroup objects and User objects.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- tech spec: [doc](https://docs.google.com/document/d/1ZtvE5fZPbndZsT3gGLc1ZuH7WcdSRdCj1Tc09EwCQJ4/edit)
- jira ticket: [LP-2326](https://codedotorg.atlassian.net/browse/LP-2326)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
