### PR TITLE
[Google Blockly] Locally define SPRITE object

### DIFF
--- a/apps/src/blockly/addons/cdoTrashcan.js
+++ b/apps/src/blockly/addons/cdoTrashcan.js
@@ -77,12 +77,17 @@ export default class CdoTrashcan extends GoogleBlockly.DeleteArea {
       },
       bodyClipPath
     );
+    const SPRITE = {
+      width: 96,
+      height: 124,
+      url: 'sprites.png'
+    };
     const body = Blockly.utils.dom.createSvgElement(
       Blockly.utils.Svg.IMAGE,
       {
-        width: Blockly.SPRITE.width,
+        width: SPRITE.width,
         x: -SPRITE_LEFT,
-        height: Blockly.SPRITE.height,
+        height: SPRITE.height,
         y: -SPRITE_TOP,
         'clip-path': 'url(#blocklyTrashBodyClipPath)'
       },
@@ -108,9 +113,9 @@ export default class CdoTrashcan extends GoogleBlockly.DeleteArea {
     this.svgLid_ = Blockly.utils.dom.createSvgElement(
       Blockly.utils.Svg.IMAGE,
       {
-        width: Blockly.SPRITE.width,
+        width: SPRITE.width,
         x: -SPRITE_LEFT,
-        height: Blockly.SPRITE.height,
+        height: SPRITE.height,
         y: -SPRITE_TOP,
         'clip-path': 'url(#blocklyTrashLidClipPath)'
       },


### PR DESCRIPTION
Starting in v8, `Blockly.SPRITE` will no longer be available externally. The Blockly team recommended just stub it with the values we need. This `SPRITE` constant is used to create the trashcan animation.

Some context is available here:
- https://github.com/google/blockly/pull/5897

This doesn't feel like a risky change. I confirmed there are no regressions in Google Blockly labs using v6, v7, and v8. Once merged, this will make it simpler to bump to v8!