### PR TITLE
Fix principal approvals

### DIFF
--- a/dashboard/app/controllers/api/v1/pd/application/teacher_applications_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/application/teacher_applications_controller.rb
@@ -20,12 +20,16 @@ module Api::V1::Pd::Application
       end
 
       status = params[:status]
+      previous_status = @application.status
       if status
         @application.status = status
       end
 
       if @application.save
         render json: @application, status: :ok
+
+        # send confirmation email only if user is submitting their application for the first time
+        on_successful_create if previous_status == 'incomplete' && status == 'unreviewed'
       else
         return render json: {errors: @application.errors.full_messages}, status: :bad_request
       end

--- a/dashboard/app/models/pd/application/teacher_application.rb
+++ b/dashboard/app/models/pd/application/teacher_application.rb
@@ -1178,10 +1178,8 @@ module Pd::Application
     # Called after the application is created. Do any manipulation needed for the form data
     # hash here, as well as send emails
     def on_successful_create
-      on_completed_app unless status == 'incomplete'
-    end
+      return if status == 'incomplete'
 
-    def on_completed_app
       queue_email :confirmation, deliver_now: true
       auto_score!
       unless regional_partner&.applications_principal_approval == RegionalPartner::SELECTIVE_APPROVAL

--- a/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
@@ -143,15 +143,11 @@ module Api::V1::Pd::Application
     end
 
     test 'updates course hours, autoscores, and queues email once application is submitted' do
-      Pd::Application::TeacherApplicationMailer.expects(:confirmation).never
-      Pd::Application::TeacherApplicationMailer.expects(:principal_approval).never
-
       application_hash = build :pd_teacher_application_hash_common, :csp,
                                cs_how_many_minutes: 45,
                                cs_how_many_days_per_week: 5,
                                cs_how_many_weeks_per_year: 30
       application = create :pd_teacher_application, form_data_hash: application_hash, user: @applicant, status: 'incomplete'
-      refute TEACHER_APPLICATION_CLASS.last.response_scores # do not score until submit
 
       Pd::Application::TeacherApplicationMailer.expects(:confirmation).once.
         with(instance_of(TEACHER_APPLICATION_CLASS)).

--- a/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
@@ -138,7 +138,7 @@ module Api::V1::Pd::Application
 
       sign_in @applicant
       put :create, params: {form_data_hash: @test_params, status: 'incomplete'}
-      refute TEACHER_APPLICATION_CLASS.last.response_scores # do not score until submit
+      refute TEACHER_APPLICATION_CLASS.last.response_scores
       assert_response :created
     end
 
@@ -160,6 +160,7 @@ module Api::V1::Pd::Application
       put :update, params: {id: application.id, form_data: application_hash, status: 'unreviewed'}
       assert_equal 112, TEACHER_APPLICATION_CLASS.last.sanitize_form_data_hash[:cs_total_course_hours]
       assert JSON.parse(TEACHER_APPLICATION_CLASS.last.response_scores).any?
+      assert_response :ok
     end
 
     test 'can submit an empty form if application is incomplete' do

--- a/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
@@ -132,17 +132,36 @@ module Api::V1::Pd::Application
       put :create, params: @test_params
     end
 
-    test 'updates course hours computation and autoscores on successful create' do
-      application_hash = build(
-        TEACHER_APPLICATION_HASH_FACTORY,
-        cs_how_many_minutes: 45,
-        cs_how_many_days_per_week: 5,
-        cs_how_many_weeks_per_year: 30
-      )
+    test 'does not send emails or autoscore on successful create if application status is incomplete' do
+      Pd::Application::TeacherApplicationMailer.expects(:confirmation).never
+      Pd::Application::TeacherApplicationMailer.expects(:principal_approval).never
 
       sign_in @applicant
-      put :create, params: {form_data: application_hash}
+      put :create, params: {form_data_hash: @test_params, status: 'incomplete'}
+      refute TEACHER_APPLICATION_CLASS.last.response_scores # do not score until submit
+      assert_response :created
+    end
 
+    test 'updates course hours, autoscores, and queues email once application is submitted' do
+      Pd::Application::TeacherApplicationMailer.expects(:confirmation).never
+      Pd::Application::TeacherApplicationMailer.expects(:principal_approval).never
+
+      application_hash = build :pd_teacher_application_hash_common, :csp,
+                               cs_how_many_minutes: 45,
+                               cs_how_many_days_per_week: 5,
+                               cs_how_many_weeks_per_year: 30
+      application = create :pd_teacher_application, form_data_hash: application_hash, user: @applicant, status: 'incomplete'
+      refute TEACHER_APPLICATION_CLASS.last.response_scores # do not score until submit
+
+      Pd::Application::TeacherApplicationMailer.expects(:confirmation).once.
+        with(instance_of(TEACHER_APPLICATION_CLASS)).
+        returns(mock {|mail| mail.expects(:deliver_now)})
+      Pd::Application::TeacherApplicationMailer.expects(:principal_approval).once.
+        with(instance_of(TEACHER_APPLICATION_CLASS)).
+        returns(mock {|mail| mail.expects(:deliver_now)})
+
+      sign_in @applicant
+      put :update, params: {id: application.id, form_data: application_hash, status: 'unreviewed'}
       assert_equal 112, TEACHER_APPLICATION_CLASS.last.sanitize_form_data_hash[:cs_total_course_hours]
       assert JSON.parse(TEACHER_APPLICATION_CLASS.last.response_scores).any?
     end
@@ -152,15 +171,6 @@ module Api::V1::Pd::Application
       put :create, params: {status: 'incomplete'}
 
       assert_equal 'incomplete', TEACHER_APPLICATION_CLASS.last.status
-      assert_response :created
-    end
-
-    test 'does not update course hours nor autoscore on successful create if application status is incomplete' do
-      Pd::Application::TeacherApplication.expects(:auto_score).never
-      Pd::Application::TeacherApplication.expects(:queue_email).never
-
-      sign_in @applicant
-      put :create, params: {status: 'incomplete'}
       assert_response :created
     end
 

--- a/dashboard/test/models/pd/application/teacher_application_test.rb
+++ b/dashboard/test/models/pd/application/teacher_application_test.rb
@@ -797,6 +797,7 @@ module Pd::Application
         # Updates the application with principal's responses and run auto_score! again
         application.on_successful_principal_approval_create(principal_approval)
 
+        # Written as a conditional to address Minitest 6 deprecation: `DEPRECATED: Use assert_nil if expecting nil`
         if test_case[:meet_requirement]
           assert application.response_scores_hash[:meets_minimum_criteria_scores][:replace_existing],
                  "Test case index #{index} failed"

--- a/dashboard/test/models/pd/application/teacher_application_test.rb
+++ b/dashboard/test/models/pd/application/teacher_application_test.rb
@@ -797,9 +797,13 @@ module Pd::Application
         # Updates the application with principal's responses and run auto_score! again
         application.on_successful_principal_approval_create(principal_approval)
 
-        assert_equal test_case[:meet_requirement],
-          application.response_scores_hash[:meets_minimum_criteria_scores][:replace_existing],
-          "Test case index #{index} failed"
+        if test_case[:meet_requirement]
+          assert application.response_scores_hash[:meets_minimum_criteria_scores][:replace_existing],
+                 "Test case index #{index} failed"
+        else
+          refute application.response_scores_hash[:meets_minimum_criteria_scores][:replace_existing],
+                 "Test case index #{index} failed"
+        end
       end
     end
 
@@ -835,6 +839,8 @@ module Pd::Application
         application.queue_email :principal_approval, deliver_now: true
         assert_equal incomplete, application.reload.principal_approval_state
       end
+
+      refute application.reload.principal_approval_not_required
 
       # even if it's not required, when an email was sent display incomplete
       application.update!(principal_approval_not_required: true)


### PR DESCRIPTION
This addresses a problem where principal approval emails weren't being sent when an application that was previously saved (status 'incomplete') was then submitted (status 'unreviewed'). Now, when the `update` method is triggered, it checks the original status and the new status––it sends emails (and auto scores) if it's going from incomplete to unreviewed.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
