### PR TITLE
[Poem Art] Add contest winner poem to English set

### DIFF
--- a/apps/src/p5lab/poetry/PoemSelector.jsx
+++ b/apps/src/p5lab/poetry/PoemSelector.jsx
@@ -185,7 +185,11 @@ function PoemSelector(props) {
   const getPoemOptions = () => {
     const options = Object.keys(POEMS)
       .map(poemKey => getPoem(poemKey))
-      .filter(poem => !poem.locale || poem.locale === appOptions.locale)
+      .filter(
+        poem =>
+          !poem.locales ||
+          poem.locales.some(locale => locale === appOptions.locale)
+      )
       .sort((a, b) => (a.title > b.title ? 1 : -1))
       .map(poem => ({value: poem.key, label: poem.title}));
     // Add option to create your own poem to the top of the dropdown.

--- a/apps/src/p5lab/poetry/PoemSelector.jsx
+++ b/apps/src/p5lab/poetry/PoemSelector.jsx
@@ -185,11 +185,7 @@ function PoemSelector(props) {
   const getPoemOptions = () => {
     const options = Object.keys(POEMS)
       .map(poemKey => getPoem(poemKey))
-      .filter(
-        poem =>
-          !poem.locales ||
-          poem.locales.some(locale => locale === appOptions.locale)
-      )
+      .filter(poem => !poem.locales || poem.locales.includes(appOptions.locale))
       .sort((a, b) => (a.title > b.title ? 1 : -1))
       .map(poem => ({value: poem.key, label: poem.title}));
     // Add option to create your own poem to the top of the dropdown.

--- a/apps/src/p5lab/poetry/constants.js
+++ b/apps/src/p5lab/poetry/constants.js
@@ -28,10 +28,10 @@ export const PALETTES = {
 
 // Notes:
 // - author is not translated.
-// - Poems are shown in all languages, unless there is a locale attribute, in which case
-//   the poem is shown in the dropdown only for users with that current locale.
-// - If the locale attribute is set, then title is used and is not translated.
-// - If the locale attribute is set, then linesSplit is used and is not translated.
+// - Poems are shown in all languages, unless there is a locales attribute, in which case
+//   the poem is shown in the dropdown only for users with a current locale that matches.
+// - If the locales attribute is set, then title is used and is not translated.
+// - If the locales attribute is set, then linesSplit is used and is not translated.
 export const POEMS = {
   hafez: {author: 'Hafez'},
   field: {author: 'Eugene Field'},
@@ -62,7 +62,7 @@ export const POEMS = {
   lomeli2: {author: 'Caia Lomeli'},
   frost: {author: 'Robert Frost'},
   cb: {
-    locale: 'en_us',
+    locales: ['en_us', 'en_gb'],
     author: 'C. B.',
     title: 'My City',
     linesSplit: [
@@ -79,7 +79,7 @@ export const POEMS = {
     ]
   },
   rusinek1: {
-    locale: 'pl_pl',
+    locales: ['pl_pl'],
     author: 'Michał Rusinek, Wierszyki domowe, Znak, 2021',
     title: 'WIESZAKI',
     linesSplit: [
@@ -99,7 +99,7 @@ export const POEMS = {
     ]
   },
   rusinek2: {
-    locale: 'pl_pl',
+    locales: ['pl_pl'],
     author: 'Michał Rusinek, Wierszyki domowe, Znak, 2021',
     title: 'PRYSZNIC',
     linesSplit: [
@@ -115,7 +115,7 @@ export const POEMS = {
     ]
   },
   rusinek3: {
-    locale: 'pl_pl',
+    locales: ['pl_pl'],
     author: 'Michał Rusinek, Wierszyki domowe, Znak, 2021',
     title: 'TOSTER',
     linesSplit: [
@@ -141,7 +141,7 @@ export const POEMS = {
     ]
   },
   rusinek4: {
-    locale: 'pl_pl',
+    locales: ['pl_pl'],
     author: 'Michał Rusinek, Wierszyki domowe, Znak, 2021',
     title: 'WAZON',
     linesSplit: [
@@ -152,7 +152,7 @@ export const POEMS = {
     ]
   },
   rusinek5: {
-    locale: 'pl_pl',
+    locales: ['pl_pl'],
     author: 'Michał Rusinek, Wierszyki domowe, Znak, 2021',
     title: 'SŁOIKI',
     linesSplit: [

--- a/apps/src/p5lab/poetry/constants.js
+++ b/apps/src/p5lab/poetry/constants.js
@@ -29,7 +29,8 @@ export const PALETTES = {
 // Notes:
 // - author is not translated.
 // - Poems are shown in all languages, unless there is a locales attribute, in which case
-//   the poem is shown in the dropdown only for users with a current locale that matches.
+//   the poem is shown in the dropdown only for users with a current locale that is included
+//   in the array.
 // - If the locales attribute is set, then title is used and is not translated.
 // - If the locales attribute is set, then linesSplit is used and is not translated.
 export const POEMS = {

--- a/apps/src/p5lab/poetry/constants.js
+++ b/apps/src/p5lab/poetry/constants.js
@@ -61,6 +61,23 @@ export const POEMS = {
   lomeli1: {author: 'Caia Lomeli'},
   lomeli2: {author: 'Caia Lomeli'},
   frost: {author: 'Robert Frost'},
+  cb: {
+    locale: 'en_us',
+    author: 'C. B.',
+    title: 'My City',
+    linesSplit: [
+      'My city.',
+      'I love the smell of the donuts',
+      'on Avenue 6.',
+      'The sound of the cats screeching',
+      'at five in the morning.',
+      'The feeling of my favorite song playing',
+      'over and over again.',
+      'When I go to a new city',
+      'with different smells, sounds, and feelings,',
+      'I’ll still remember everything my city had.'
+    ]
+  },
   rusinek1: {
     locale: 'pl_pl',
     author: 'Michał Rusinek, Wierszyki domowe, Znak, 2021',

--- a/apps/src/p5lab/poetry/constants.js
+++ b/apps/src/p5lab/poetry/constants.js
@@ -63,7 +63,7 @@ export const POEMS = {
   lomeli2: {author: 'Caia Lomeli'},
   frost: {author: 'Robert Frost'},
   cb: {
-    locales: ['en_us', 'en_gb'],
+    locales: ['en_us'],
     author: 'C. B.',
     title: 'My City',
     linesSplit: [

--- a/apps/src/p5lab/poetry/poem.js
+++ b/apps/src/p5lab/poetry/poem.js
@@ -7,7 +7,7 @@ export function getPoem(key) {
   }
   return {
     key: key,
-    locale: POEMS[key].locale,
+    locales: POEMS[key].locales,
     author: POEMS[key].author,
     title: POEMS[key].title || msg[`${key}Title`](),
     lines: POEMS[key].linesSplit || msg[`${key}Lines`]().split('\n')


### PR DESCRIPTION
This adds one new poem, listed in the selector only when the site is in English ~or English (UK) DBG~. 
It replaces the `locale` (string) attribute with the `locales` (array) attribute.

## Links

- jira ticket: [STAR-2302: [Poem Art] Add contest winner poem to English set [DUE 6/3]](https://codedotorg.atlassian.net/browse/STAR-2302)


## Testing story
We also have poems that are only displayed if the page is in Polish. I checked the selector and compared the list across both English locales, as well as Polish, and Spanish (for a control).

- Tested that "My City" shows in ~both~ English locale, but not otherwise.
- Tested that poems like "WIESZAKI" show correctly in Polish, but not otherwise.
- Tested that none of the hard-coded poems show in Spanish.

![image](https://user-images.githubusercontent.com/43474485/170121700-73775046-4c51-4e62-ae36-0a6a994af428.png)
![image](https://user-images.githubusercontent.com/43474485/170121844-67157331-22c7-42c9-a291-f43f0d9f8a31.png)
![image](https://user-images.githubusercontent.com/43474485/170121549-42510264-7589-46b6-9850-fc3a665b5979.png)
