### PR TITLE
[Migration] Code Review Notes: make commenter nullable

### DIFF
--- a/dashboard/app/models/code_review_note.rb
+++ b/dashboard/app/models/code_review_note.rb
@@ -4,7 +4,7 @@
 #
 #  id                     :bigint           not null, primary key
 #  code_review_request_id :integer          not null
-#  commenter_id           :integer          not null
+#  commenter_id           :integer
 #  is_resolved            :boolean          not null
 #  comment                :text(16777215)   not null
 #  deleted_at             :datetime
@@ -14,6 +14,7 @@
 # Indexes
 #
 #  index_code_review_notes_on_code_review_request_id  (code_review_request_id)
+#
 class CodeReviewNote < ApplicationRecord
   # TODO: This model will be renamed to CodeReviewComment once the old models are
   # removed.
@@ -25,7 +26,7 @@ class CodeReviewNote < ApplicationRecord
   def summarize
     {
       id: id,
-      commenterName: commenter.name,    # TODO: handle deleted user
+      commenterName: commenter&.name,
       comment: comment,
       isResolved: is_resolved,
       createdAt: created_at

--- a/dashboard/db/migrate/20220524212716_allow_null_code_review_note_commenter.rb
+++ b/dashboard/db/migrate/20220524212716_allow_null_code_review_note_commenter.rb
@@ -1,0 +1,9 @@
+class AllowNullCodeReviewNoteCommenter < ActiveRecord::Migration[6.0]
+  def up
+    change_column :code_review_notes, :commenter_id, :integer, null: true
+  end
+
+  def down
+    change_column :code_review_notes, :commenter_id, :integer, null: false
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_21_224748) do
+ActiveRecord::Schema.define(version: 2022_05_24_212716) do
 
   create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -311,7 +311,7 @@ ActiveRecord::Schema.define(version: 2022_04_21_224748) do
 
   create_table "code_review_notes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci", force: :cascade do |t|
     t.integer "code_review_request_id", null: false
-    t.integer "commenter_id", null: false
+    t.integer "commenter_id"
     t.boolean "is_resolved", null: false
     t.text "comment", size: :medium, null: false
     t.datetime "deleted_at"


### PR DESCRIPTION
If a user is deleted we will set the commenter id for any code review notes they wrote to be null. Allow this column to be null.

As part of this I also fixed the summarize method to not assume the commenter exists since it was a 1 character change.
## Links

- spec: [Code Review](https://docs.google.com/document/d/1ZtvE5fZPbndZsT3gGLc1ZuH7WcdSRdCj1Tc09EwCQJ4/edit)
- jira ticket: [LP-2313](https://codedotorg.atlassian.net/browse/LP-2313)

## Testing story
Tested that the migration works and can be rolled back. Also verified it is now possible to create a comment with a null commenter.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
