### PR TITLE
Cache programming classes 

### DIFF
--- a/dashboard/app/controllers/programming_classes_controller.rb
+++ b/dashboard/app/controllers/programming_classes_controller.rb
@@ -121,6 +121,6 @@ class ProgrammingClassesController < ApplicationController
   end
 
   def set_class_by_keys
-    @programming_class = ProgrammingEnvironment.find_by_name(params[:programming_environment_name])&.programming_classes&.find_by_key(params[:programming_class_key])
+    @programming_class = ProgrammingClass.get_from_cache(params[:programming_environment_name], params[:programming_class_key])
   end
 end

--- a/dashboard/app/controllers/programming_environments_controller.rb
+++ b/dashboard/app/controllers/programming_environments_controller.rb
@@ -3,7 +3,7 @@ class ProgrammingEnvironmentsController < ApplicationController
   EXPIRY_TIME = 30.minutes
 
   before_action :require_levelbuilder_mode_or_test_env, except: [:index, :show, :docs_show, :docs_index, :get_summary_by_name]
-  before_action :set_programming_environment, only: [:edit, :update, :destroy, :get_summary_by_name]
+  before_action :set_programming_environment, only: [:edit, :update, :destroy]
   authorize_resource
 
   def index
@@ -98,6 +98,7 @@ class ProgrammingEnvironmentsController < ApplicationController
   end
 
   def get_summary_by_name
+    @programming_environment = ProgrammingEnvironment.get_from_cache(params[:name])
     return render :not_found unless @programming_environment
     return head :forbidden unless can?(:get_summary_by_name, @programming_environment)
     return render json: @programming_environment.categories_for_get

--- a/dashboard/app/models/programming_class.rb
+++ b/dashboard/app/models/programming_class.rb
@@ -168,7 +168,6 @@ class ProgrammingClass < ApplicationRecord
   def self.get_from_cache(programming_environment_name, key)
     cache_key = "programming_class/#{programming_environment_name}/#{key}"
     Rails.cache.fetch(cache_key, force: !Script.should_cache?) do
-      puts 'cache miss'
       env = ProgrammingEnvironment.find_by_name(programming_environment_name)
       ProgrammingClass.includes([:programming_environment, :programming_environment_category, :programming_methods]).find_by(programming_environment_id: env.id, key: key)
     end

--- a/dashboard/app/models/programming_class.rb
+++ b/dashboard/app/models/programming_class.rb
@@ -165,6 +165,15 @@ class ProgrammingClass < ApplicationRecord
     methods
   end
 
+  def self.get_from_cache(programming_environment_name, key)
+    cache_key = "programming_class/#{programming_environment_name}/#{key}"
+    Rails.cache.fetch(cache_key, force: !Script.should_cache?) do
+      puts 'cache miss'
+      env = ProgrammingEnvironment.find_by_name(programming_environment_name)
+      ProgrammingClass.includes([:programming_environment, :programming_environment_category, :programming_methods]).find_by(programming_environment_id: env.id, key: key)
+    end
+  end
+
   private
 
   def parsed_examples

--- a/dashboard/app/models/programming_environment.rb
+++ b/dashboard/app/models/programming_environment.rb
@@ -139,7 +139,9 @@ class ProgrammingEnvironment < ApplicationRecord
   end
 
   def categories_for_get
-    categories.select(&:should_be_in_navigation?).map(&:summarize_for_get)
+    Rails.cache.fetch("programming_environment/#{name}/categories_for_get", force: !Script.should_cache?) do
+      categories.select(&:should_be_in_navigation?).map(&:summarize_for_get)
+    end
   end
 
   def self.get_published_environments_from_cache

--- a/dashboard/app/models/programming_method.rb
+++ b/dashboard/app/models/programming_method.rb
@@ -85,7 +85,7 @@ class ProgrammingMethod < ApplicationRecord
       examples: parsed_examples,
       syntax: syntax,
       externalLink: external_link,
-      overloads: ProgrammingMethod.where(programming_class_id: programming_class_id, overload_of: key).map(&:summarize_for_show)
+      overloads: get_overloads.map(&:summarize_for_show)
     }
   end
 
@@ -115,6 +115,12 @@ class ProgrammingMethod < ApplicationRecord
       errors.add(:overload_of, "Overloaded method cannot have overload_of be non-blank") unless overload.overload_of.blank?
     else
       errors.add(:overload_of, "Overload method must exist")
+    end
+  end
+
+  def get_overloads
+    Rails.cache.fetch("programming_methods/#{id}/get_overloads", force: !Script.should_cache?) do
+      ProgrammingMethod.where(programming_class_id: programming_class_id, overload_of: key).to_a
     end
   end
 end

--- a/dashboard/test/integration/curriculum_docs_test.rb
+++ b/dashboard/test/integration/curriculum_docs_test.rb
@@ -139,6 +139,13 @@ class CurriculumDocsTest < ActionDispatch::IntegrationTest
       end
       assert_response :success
     end
+
+    test "environment get_summary_by_name should cache all queries" do
+      assert_cached_queries(0) do
+        get get_summary_by_name_programming_environment_path(@programming_environment.name)
+      end
+      assert_response :success
+    end
   end
 
   class CodeDocsQueryCountTest < CurriculumDocsTest
@@ -174,6 +181,13 @@ class CurriculumDocsTest < ActionDispatch::IntegrationTest
     test "signed out class show query count" do
       assert_queries(10) do
         get programming_environment_programming_class_path(@programming_environment.name, @programming_class.key)
+      end
+      assert_response :success
+    end
+
+    test "environment get_summary_by_name query count" do
+      assert_queries(6) do
+        get get_summary_by_name_programming_environment_path(@programming_environment.name)
       end
       assert_response :success
     end

--- a/dashboard/test/integration/curriculum_docs_test.rb
+++ b/dashboard/test/integration/curriculum_docs_test.rb
@@ -110,6 +110,7 @@ class CurriculumDocsTest < ActionDispatch::IntegrationTest
       programming_environment_category = create :programming_environment_category, programming_environment: @programming_environment
       @programming_expression = create :programming_expression, programming_environment: @programming_environment, programming_environment_category: programming_environment_category
       @programming_class = create :programming_class, programming_environment: @programming_environment, programming_environment_category: programming_environment_category
+      create :programming_method, programming_class: @programming_class
     end
 
     test "environment index should cache all queries" do
@@ -155,6 +156,7 @@ class CurriculumDocsTest < ActionDispatch::IntegrationTest
       programming_environment_category = create :programming_environment_category, programming_environment: @programming_environment
       @programming_expression = create :programming_expression, programming_environment: @programming_environment, programming_environment_category: programming_environment_category
       @programming_class = create :programming_class, programming_environment: @programming_environment, programming_environment_category: programming_environment_category
+      create :programming_method, programming_class: @programming_class
     end
 
     test "signed out environment index query count" do
@@ -179,14 +181,14 @@ class CurriculumDocsTest < ActionDispatch::IntegrationTest
     end
 
     test "signed out class show query count" do
-      assert_queries(10) do
+      assert_queries(11) do
         get programming_environment_programming_class_path(@programming_environment.name, @programming_class.key)
       end
       assert_response :success
     end
 
     test "environment get_summary_by_name query count" do
-      assert_queries(6) do
+      assert_queries(7) do
         get get_summary_by_name_programming_environment_path(@programming_environment.name)
       end
       assert_response :success

--- a/dashboard/test/integration/curriculum_docs_test.rb
+++ b/dashboard/test/integration/curriculum_docs_test.rb
@@ -109,6 +109,7 @@ class CurriculumDocsTest < ActionDispatch::IntegrationTest
       @programming_environment = create :programming_environment
       programming_environment_category = create :programming_environment_category, programming_environment: @programming_environment
       @programming_expression = create :programming_expression, programming_environment: @programming_environment, programming_environment_category: programming_environment_category
+      @programming_class = create :programming_class, programming_environment: @programming_environment, programming_environment_category: programming_environment_category
     end
 
     test "environment index should cache all queries" do
@@ -131,6 +132,13 @@ class CurriculumDocsTest < ActionDispatch::IntegrationTest
       end
       assert_response :success
     end
+
+    test "class show should cache all queries" do
+      assert_cached_queries(0) do
+        get programming_environment_programming_class_path(@programming_environment.name, @programming_class.key)
+      end
+      assert_response :success
+    end
   end
 
   class CodeDocsQueryCountTest < CurriculumDocsTest
@@ -139,6 +147,7 @@ class CurriculumDocsTest < ActionDispatch::IntegrationTest
       @programming_environment = create :programming_environment
       programming_environment_category = create :programming_environment_category, programming_environment: @programming_environment
       @programming_expression = create :programming_expression, programming_environment: @programming_environment, programming_environment_category: programming_environment_category
+      @programming_class = create :programming_class, programming_environment: @programming_environment, programming_environment_category: programming_environment_category
     end
 
     test "signed out environment index query count" do
@@ -149,15 +158,22 @@ class CurriculumDocsTest < ActionDispatch::IntegrationTest
     end
 
     test "signed out environment show query count" do
-      assert_queries(9) do
+      assert_queries(8) do
         get programming_environment_path(@programming_environment.name)
       end
       assert_response :success
     end
 
     test "signed out expression show query count" do
-      assert_queries(10) do
+      assert_queries(9) do
         get programming_environment_programming_expression_path(@programming_environment.name, @programming_expression.key)
+      end
+      assert_response :success
+    end
+
+    test "signed out class show query count" do
+      assert_queries(10) do
+        get programming_environment_programming_class_path(@programming_environment.name, @programming_class.key)
       end
       assert_response :success
     end


### PR DESCRIPTION
Follows the same pattern as in #46118 to cache ProgrammingClass pages. These pages should be static once they hit production, so there's no reason to hit the database each time. I also added caching for programming_environments#get_summary_by_name while I was here.


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
