### PR TITLE
Add code_reviews table

### DIFF
--- a/dashboard/db/migrate/20220525175523_create_code_reviews.rb
+++ b/dashboard/db/migrate/20220525175523_create_code_reviews.rb
@@ -1,0 +1,24 @@
+class CreateCodeReviews < ActiveRecord::Migration[6.0]
+  def change
+    create_table :code_reviews do |t|
+      t.integer :user_id, null: false
+      t.integer :project_id, null: false
+      t.integer :script_id, null: false
+      t.integer :level_id, null: false
+      t.integer :project_level_id, null: false
+      t.string :project_version, null: false
+      t.datetime :project_version_expires_at
+      t.integer :storage_id, null: false
+      t.datetime :closed_at
+      t.datetime :deleted_at
+
+      t.timestamps
+
+      t.index [:user_id, :project_id, :closed_at, :deleted_at],
+        name: 'index_code_reviews_unique', unique: true
+      t.index [:project_id, :deleted_at]
+      t.index [:user_id, :script_id, :project_level_id, :closed_at, :deleted_at],
+        name: 'index_code_reviews_for_peer_lookup'
+    end
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_24_212716) do
+ActiveRecord::Schema.define(version: 2022_05_25_175523) do
 
   create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -331,6 +331,24 @@ ActiveRecord::Schema.define(version: 2022_05_24_212716) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["user_id", "script_id", "level_id", "closed_at", "deleted_at"], name: "index_code_review_requests_unique", unique: true
+  end
+
+  create_table "code_reviews", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.integer "project_id", null: false
+    t.integer "script_id", null: false
+    t.integer "level_id", null: false
+    t.integer "project_level_id", null: false
+    t.string "project_version", null: false
+    t.datetime "project_version_expires_at"
+    t.integer "storage_id", null: false
+    t.datetime "closed_at"
+    t.datetime "deleted_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["project_id", "deleted_at"], name: "index_code_reviews_on_project_id_and_deleted_at"
+    t.index ["user_id", "project_id", "closed_at", "deleted_at"], name: "index_code_reviews_unique", unique: true
+    t.index ["user_id", "script_id", "project_level_id", "closed_at", "deleted_at"], name: "index_code_reviews_for_peer_lookup"
   end
 
   create_table "concepts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|


### PR DESCRIPTION
This is a rename and iteration of the code_review_requests table (which will be removed in a future clean-up migration).  It will be connected to the CodeReview model in the #46530 .  (This means that any code reviews created using the v2 UI up to this point will be lost, but this is ok since the feature is not yet live.)

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

[tech spec](https://docs.google.com/document/d/1ZtvE5fZPbndZsT3gGLc1ZuH7WcdSRdCj1Tc09EwCQJ4/edit)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
