### PR TITLE
Code review disabled message, disable open review button

### DIFF
--- a/apps/i18n/javalab/en_us.json
+++ b/apps/i18n/javalab/en_us.json
@@ -19,6 +19,7 @@
   "closeReview": "Close review",
   "codeEditingDisabled": "Code editing is disabled while your project is in review",
   "codeReview": "Code Review",
+  "codeReviewDisabledMessage": "Code review is disabled. Your teacher must place you in a code review group to enable this feature.",
   "commentProfanityFound": "Your comment contains inappropriate language, so it will not be saved. Please update your comment to remove the {wordCount, plural, one {word} other {words}} \"{words}\".",
   "commentUpdateError": "There was an error processing your request, please try again.",
   "commit": "Commit",

--- a/apps/src/templates/instructions/CommitsAndReviewTab.jsx
+++ b/apps/src/templates/instructions/CommitsAndReviewTab.jsx
@@ -174,14 +174,25 @@ const CommitsAndReviewTab = props => {
             closeReview={handleCloseReview}
           />
           {!openReviewData && (
-            <div style={styles.openCodeReview}>
+            <div style={styles.timelineAligned}>
               <Button
                 icon="comment"
                 onClick={handleOpenReview}
                 text={javalabMsg.startReview()}
                 color={Button.ButtonColor.blue}
+                disabled={!codeReviewEnabled}
               />
               {openReviewError && <CodeReviewError />}
+            </div>
+          )}
+          {!codeReviewEnabled && (
+            <div
+              style={{
+                ...styles.timelineAligned,
+                ...styles.reviewDisabledMsg
+              }}
+            >
+              {javalabMsg.codeReviewDisabledMessage()}
             </div>
           )}
         </>
@@ -251,7 +262,13 @@ const styles = {
     fontSize: 13,
     margin: 0
   },
-  openCodeReview: {
+  timelineAligned: {
     marginLeft: '30px'
+  },
+  reviewDisabledMsg: {
+    padding: '12px 6px',
+    fontStyle: 'italic',
+    color: color.charcoal,
+    lineHeight: '22px'
   }
 };

--- a/apps/test/unit/templates/instructions/CommitsAndReviewTabTest.jsx
+++ b/apps/test/unit/templates/instructions/CommitsAndReviewTabTest.jsx
@@ -55,4 +55,15 @@ describe('CommitsAndReviewTab', () => {
     const wrapper = setUp();
     expect(wrapper.find(CodeReviewTimeline)).to.have.length(1);
   });
+
+  it('disables the open review button when prop codeReviewEnabled is false', () => {
+    const wrapper = setUp({codeReviewEnabled: false});
+    const openReviewButton = wrapper.find(Button).at(1);
+    expect(openReviewButton.props().disabled).to.be.true;
+  });
+
+  it('displays code review disabled message when prop codeReviewEnabled is false', () => {
+    const wrapper = setUp({codeReviewEnabled: false});
+    expect(wrapper.contains(javalabMsg.codeReviewDisabledMessage())).to.be.true;
+  });
 });


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Added disabled messaging:
![Screen Shot 2022-05-25 at 3 31 03 PM](https://user-images.githubusercontent.com/24235215/170380372-2133eb6b-29bd-4786-b960-8b8f740179ff.png)

It's worth noting there's more logic about who can see/do what on a code review in this open PR https://github.com/code-dot-org/code-dot-org/pull/46424

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
- jira ticket: [LP-2375](https://codedotorg.atlassian.net/browse/LP-2375)
<!--
- spec: []()

-->

## Testing story
Tested locally, added a couple unit tests
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
