### PR TITLE
Adding experiment cookie for the onetrust experience

### DIFF
--- a/cookbooks/cdo-varnish/libraries/http_cache.rb
+++ b/cookbooks/cdo-varnish/libraries/http_cache.rb
@@ -15,6 +15,8 @@ class HttpCache
     'language_',
     # Offline experiment flag, to allow users into the pilot
     'offline_pilot',
+    # Experiment flag used to debug the onetrust cookie experience.
+    'onetrust_cookie_scripts',
     # Page mode, for A/B experiments and feature-flag rollouts.
     'pm'
   ].freeze

--- a/shared/haml/onetrust_cookie_scripts.haml
+++ b/shared/haml/onetrust_cookie_scripts.haml
@@ -1,13 +1,14 @@
 -# OneTrust Cookies Consent Notice scripts for code.org
 - cookie_script_env = DCDO.get('onetrust_cookie_scripts', 'off')
+-# If the user has a cookie to override this, use it. This is for testing purposes.
+- cookie_script_env_override = request.cookies['onetrust_cookie_scripts']
+- cookie_script_env = cookie_script_env_override if cookie_script_env_override.present?
 - if cookie_script_env == 'production'
-  %script{:src=>"#{CDO.code_org_url}/js/jquery.min.js"}
   %script{src: 'https://cdn.cookielaw.org/consent/27cca70a-7db3-4852-9ef0-a6660fd0977d/OtAutoBlock.js', type: 'text/javascript'}
   %script{src: 'https://cdn.cookielaw.org/scripttemplates/otSDKStub.js', type: 'text/javascript', charset: 'UTF-8', 'data-domain-script' => '27cca70a-7db3-4852-9ef0-a6660fd0977d'}
   :javascript
     function OptanonWrapper() { }
 - elsif cookie_script_env == 'test'
-  %script{:src=>"#{CDO.code_org_url}/js/jquery.min.js"}
   %script{src: 'https://cdn.cookielaw.org/consent/27cca70a-7db3-4852-9ef0-a6660fd0977d-test/OtAutoBlock.js', type: 'text/javascript'}
   %script{src: 'https://cdn.cookielaw.org/scripttemplates/otSDKStub.js', type: 'text/javascript', charset: 'UTF-8', 'data-domain-script' => '27cca70a-7db3-4852-9ef0-a6660fd0977d-test'}
   :javascript


### PR DESCRIPTION
The OneTrust Cookie Banner has been throwing errors when we turn it on in production. We are still struggling to reproduce it on localhost. This PR lets us hide the feature behind a browser cookie so we can reproduce the errors on our production servers while not affecting other users.

I also removed the import of the jquery libraries since that was an experiment from our previous push to production.

## Testing story
* Created a `onetrust_cookie_scripts` cookie in my browser and set the value to "test". I confirmed it loaded the "test" OneTrust scripts. 
