### PR TITLE
Use Net::HTTP instead of DataPackage::Package to download worldwide Covid19 data

### DIFF
--- a/bin/cron/applab_datasets/covid19
+++ b/bin/cron/applab_datasets/covid19
@@ -57,8 +57,8 @@ def get_us_covid19_data
 end
 
 def get_world_covid19_data
-  package = DataPackage::Package.new('https://datahub.io/core/covid-19/datapackage.json')
-  resource = package.resources.find {|r| r['name'] == "countries-aggregated_csv"}
+  package = JSON.parse(Net::HTTP.get_response(URI('https://datahub.io/core/covid-19/datapackage.json')).body)
+  resource = package['resources'].find {|r| r['name'] == "countries-aggregated_csv"}
   return unless resource
   response = Net::HTTP.get_response(URI(resource['path']))
   return unless response.code == '200'


### PR DESCRIPTION
Fixes [this Honeybadger error](https://app.honeybadger.io/projects/45435/faults/85632045). The worldwide Covid19 dataset failed to update last night because the data can no longer be downloaded as a `DataPackage::Package` (I'm not sure why). We can instead use the same URI to download the data using `Net::HTTP`. I already ran the script locally and confirmed that the dataset was properly updated in Applab on production.

## Links

- [Honeybadger error](https://app.honeybadger.io/projects/45435/faults/85632045)
