### PR TITLE
Use the correct path to redirect to the environment show page

### DIFF
--- a/dashboard/app/controllers/programming_environments_controller.rb
+++ b/dashboard/app/controllers/programming_environments_controller.rb
@@ -78,7 +78,7 @@ class ProgrammingEnvironmentsController < ApplicationController
     if DCDO.get('use-studio-code-docs', false)
       @programming_environment = ProgrammingEnvironment.get_from_cache(params[:programming_environment_name])
       return render :not_found unless @programming_environment
-      redirect_to(programming_environments_path(@programming_environment.name))
+      redirect_to(programming_environment_path(@programming_environment.name))
     else
       render_proxied_url(
         "https://curriculum.code.org/docs/#{params[:programming_environment_name]}/",


### PR DESCRIPTION
localhost-studio.code.org:3000/docs/applab was redirecting to localhost-studio.code.org:3000/docs/ide.applab. [This helpful stackoverflow post](https://stackoverflow.com/questions/5674116/path-helpers-generate-paths-with-dots-instead-of-slashes) pointed me at the fact that I was using the plural in the URL helper, which was causing the error.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
