### PR TITLE
Configure non-production database clusters to match production cluster.

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -16,6 +16,9 @@ Parameters:
   DBInstanceType:
     Type: String
     Default: db.r5.2xlarge
+  DBBackupRetention:
+    Type: Number
+    Default: 5
 <% end -%>
 <% if frontends -%>
   DaemonInstanceType:

--- a/aws/cloudformation/components/database.yml.erb
+++ b/aws/cloudformation/components/database.yml.erb
@@ -8,9 +8,16 @@
       EngineVersion: 5.7.12
       MasterUsername: !Sub "{{resolve:secretsmanager:${DatabaseSecret}:SecretString:username}}"
       MasterUserPassword: !Sub "{{resolve:secretsmanager:${DatabaseSecret}:SecretString:password}}"
+      EnableIAMDatabaseAuthentication: true
       VpcSecurityGroupIds: [!ImportValue VPC-DBSecurityGroup]
       DBSubnetGroupName: !ImportValue VPC-DBSubnetGroup
-
+      EnableCloudwatchLogsExports:
+        - general
+        - audit
+        - error
+        - slowquery
+      DeletionProtection: true
+      BackupRetentionPeriod: !Ref DBBackupRetention
 <%
   # Integer range identifying each of the DB Instances to provision in the cluster.
   DB_INSTANCE_RANGE=(0..1)


### PR DESCRIPTION
There are a few configuration settings on the staging/test/levelbuilder/adhoc Aurora database clusters that are properties of the cluster Resource and not configured via ParameterGroups (see #45907 ). Update them to match what has been manually configured on the production cluster.
## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

None of the Properties being modified on this Resource trigger Replacement or Interruption of the cluster:
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbcluster.html

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
