### PR TITLE
Update generate missing pdfs

### DIFF
--- a/dashboard/lib/services/curriculum_pdfs.rb
+++ b/dashboard/lib/services/curriculum_pdfs.rb
@@ -22,7 +22,7 @@ require 'dynamic_config/dcdo'
 # - unit calendar
 # - four rollup pages for unit, unit group, one for each of:
 #   - vocab
-#   - resouces
+#   - resources
 #   - standards
 #   - programming expressions
 #
@@ -99,6 +99,9 @@ module Services
     #    cautious with the more-expensive PDFs generation process.
     #
     # In addition, we support manually disabling this feature with DCDO
+    #
+    # IMPORTANT: If you make updates to this method make sure to update the rake task for
+    # generate_missing_pdfs as well.
     def self.generate_pdfs?(script_data)
       return true if DEBUG
 

--- a/dashboard/lib/tasks/curriculum_pdfs.rake
+++ b/dashboard/lib/tasks/curriculum_pdfs.rake
@@ -1,6 +1,8 @@
 namespace :curriculum_pdfs do
   def get_pdf_enabled_scripts
     Script.all.select do |script|
+      return false if [SharedCourseConstants::PUBLISHED_STATE.pilot, SharedCourseConstants::PUBLISHED_STATE.in_development].include?(script.published_state)
+      return false unless script.use_legacy_lesson_plans
       script.is_migrated && script.seeded_from.present?
     end
   end
@@ -47,13 +49,13 @@ namespace :curriculum_pdfs do
           any_pdf_generated = true
         end
 
-        unless Services::CurriculumPdfs.script_overview_pdf_exists_for?(script)
+        if !Services::CurriculumPdfs.script_overview_pdf_exists_for?(script) && should_generate_overview_pdf?(script)
           puts "Generating missing Script Overview PDF for #{script.name}"
           Services::CurriculumPdfs.generate_script_overview_pdf(script, dir)
           any_pdf_generated = true
         end
 
-        unless Services::CurriculumPdfs.script_resources_pdf_exists_for?(script)
+        if !Services::CurriculumPdfs.script_resources_pdf_exists_for?(script) && should_generate_resource_pdf?(script)
           puts "Generating missing Script Resources PDF for #{script.name}"
           Services::CurriculumPdfs.generate_script_resources_pdf(script, dir)
           any_pdf_generated = true


### PR DESCRIPTION
Update `generate_missing_pdfs` rake task to skip scripts that have a `published_state` of `in_development`or `pilot`. Or if `use_legacy_lesson_plans` is true for a script. 

In addition we only generate overview or resources pdfs if a unit has lesson plans. 

## Links

https://codedotorg.atlassian.net/browse/PLAT-1846
https://codedotorg.atlassian.net/browse/PLAT-1847

## Testing story

**How do a test this locally?**