### PR TITLE
Show an error message if a project isn't found

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1549,6 +1549,7 @@
   "projectGroupPlaylabViewMore": "View more Play Lab projects",
   "projectLastUpdated": "Last updated",
   "projectName": "Project Name",
+  "projectNotFound": "This project cannot be found. It could have been deleted or removed from the gallery.",
   "projectPromoButton": "View Project Ideas",
   "projectPromoDescription": "Take a look at our Project Ideas page for starter projects in Sprite Lab, Game Lab, App Lab, and Web Lab. These include project descriptions, tips, and demo projects you can remix to make your own!",
   "projectPromoDescriptionThebadguys": "Make a story or animation starring Ms. Tarantula, Mr. Wolf, Mr. Shark, and the rest of the gang from the new movie The Bad Guys! Recreate your favorite parts of the film, or make something totally unique — it's all up to you!",

--- a/apps/src/code-studio/components/AbuseError.jsx
+++ b/apps/src/code-studio/components/AbuseError.jsx
@@ -15,8 +15,7 @@ export default class AbuseError extends React.Component {
       contact_us: PropTypes.string.isRequired
     }).isRequired,
     className: PropTypes.string,
-    style: PropTypes.object,
-    textStyle: PropTypes.object
+    style: PropTypes.object
   };
 
   render() {

--- a/apps/src/code-studio/components/AbuseExclamation.jsx
+++ b/apps/src/code-studio/components/AbuseExclamation.jsx
@@ -1,96 +1,40 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import AbuseError from './AbuseError';
+import AlertExclamation from './AlertExclamation';
 
-/**
- * A big blue box with an exclamation mark on the left and our abuse text on
- * the right.
- */
-export default class AbuseExclamation extends React.Component {
-  static propTypes = {
-    i18n: PropTypes.shape({
-      tos: PropTypes.string.isRequired,
-      contact_us: PropTypes.string.isRequired,
-      edit_project: PropTypes.string.isRequired,
-      go_to_code_studio: PropTypes.string.isRequired
-    }).isRequired,
-    isOwner: PropTypes.bool.isRequired
+export default function AbuseExclamation({i18n, isOwner}) {
+  let finalLink, finalLinkText;
+  if (isOwner) {
+    finalLink = 'edit';
+    finalLinkText = i18n.edit_project;
+  } else {
+    finalLink = 'https://studio.code.org';
+    finalLinkText = i18n.go_to_code_studio;
+  }
+
+  const textStyle = {
+    fontSize: 18,
+    lineHeight: '24px',
+    padding: 5
   };
 
-  render() {
-    const cyan = '#0094ca';
-    const style = {
-      backgroundColor: cyan,
-      color: 'white',
-      maxWidth: 600,
-      margin: '0 auto',
-      marginTop: 20,
-      borderRadius: 15
-    };
-
-    const circleStyle = {
-      width: 100,
-      height: 100,
-      background: 'gold',
-      borderRadius: 50,
-      MozBorderRadius: 50,
-      WebkitBorderRadius: 50,
-      margin: 20,
-      position: 'relative'
-    };
-
-    const exclamationStyle = {
-      fontSize: 80,
-      position: 'absolute',
-      top: '50%',
-      left: '50%',
-      transform: 'translate(-50%, -50%)'
-    };
-
-    const bodyStyle = {
-      paddingLeft: 0,
-      paddingTop: 10,
-      paddingBottom: 10,
-      paddingRight: 20
-    };
-
-    const textStyle = {
-      fontSize: 18,
-      lineHeight: '24px',
-      padding: 5
-    };
-
-    let finalLink, finalLinkText;
-    if (this.props.isOwner) {
-      finalLink = 'edit';
-      finalLinkText = this.props.i18n.edit_project;
-    } else {
-      finalLink = 'https://studio.code.org';
-      finalLinkText = this.props.i18n.go_to_code_studio;
-    }
-
-    return (
-      <table style={style}>
-        <tbody>
-          <tr>
-            <td>
-              <div style={circleStyle}>
-                <div style={exclamationStyle}>!</div>
-              </div>
-            </td>
-            <td style={bodyStyle}>
-              <AbuseError
-                i18n={this.props.i18n}
-                className="exclamation-abuse"
-                textStyle={textStyle}
-              />
-              <p className="exclamation-abuse" style={textStyle}>
-                <a href={finalLink}>{finalLinkText}</a>
-              </p>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    );
-  }
+  return (
+    <AlertExclamation>
+      <AbuseError i18n={i18n} className="exclamation-abuse" />
+      <p className="exclamation-abuse" style={textStyle}>
+        <a href={finalLink}>{finalLinkText}</a>
+      </p>
+    </AlertExclamation>
+  );
 }
+
+AbuseExclamation.propTypes = {
+  i18n: PropTypes.shape({
+    tos: PropTypes.string.isRequired,
+    contact_us: PropTypes.string.isRequired,
+    edit_project: PropTypes.string.isRequired,
+    go_to_code_studio: PropTypes.string.isRequired
+  }).isRequired,
+  isOwner: PropTypes.bool.isRequired
+};

--- a/apps/src/code-studio/components/AlertExclamation.jsx
+++ b/apps/src/code-studio/components/AlertExclamation.jsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import color from '@cdo/apps/util/color';
+
+/**
+ * A big blue box with an exclamation mark on the left and text on the right.
+ */
+export default function AlertExclamation({children}) {
+  return (
+    <table style={styles.tableStyle}>
+      <tbody>
+        <tr>
+          <td>
+            <div style={styles.circleStyle}>
+              <div style={styles.exclamationStyle}>!</div>
+            </div>
+          </td>
+          <td style={styles.bodyStyle}>{children}</td>
+        </tr>
+      </tbody>
+    </table>
+  );
+}
+
+AlertExclamation.propTypes = {
+  children: PropTypes.node.isRequired
+};
+
+const styles = {
+  tableStyle: {
+    backgroundColor: color.cyan,
+    color: 'white',
+    maxWidth: 600,
+    margin: '0 auto',
+    marginTop: 20,
+    borderRadius: 15
+  },
+  circleStyle: {
+    width: 100,
+    height: 100,
+    background: 'gold',
+    borderRadius: 50,
+    MozBorderRadius: 50,
+    WebkitBorderRadius: 50,
+    margin: 20,
+    position: 'relative'
+  },
+  exclamationStyle: {
+    fontSize: 80,
+    position: 'absolute',
+    top: '50%',
+    left: '50%',
+    transform: 'translate(-50%, -50%)'
+  },
+  bodyStyle: {
+    paddingLeft: 0,
+    paddingTop: 10,
+    paddingBottom: 10,
+    paddingRight: 20
+  }
+};

--- a/apps/src/code-studio/components/styles.scss
+++ b/apps/src/code-studio/components/styles.scss
@@ -1,7 +1,7 @@
 // Styles for ToggleSwitch that cannot be handled with Radium
 // Only add an outline around the toggle when it is tabbed over, not clicked on.
 .toggle-input:focus > .toggle-display {
-  outline: 1px solid #949ca2
+  outline: 1px solid #949ca2;
 }
 
 .toggle-input:focus:not(:focus-visible) > .toggle-display {

--- a/apps/src/code-studio/initApp/clientApi.js
+++ b/apps/src/code-studio/initApp/clientApi.js
@@ -130,9 +130,11 @@ var base = {
       .done(function(data, textStatus, jqXHR) {
         callback(null, data, jqXHR);
       })
-      .fail(function(request, status, error) {
-        var err = new Error('status: ' + status + '; error: ' + error);
-        callback(err, undefined /*data*/, undefined /*jqXHR*/, request);
+      .fail(function(response, status, error) {
+        var err = new Error('status: ' + status + '; error: ' + error, {
+          cause: response.status
+        });
+        callback(err, undefined /*data*/, undefined /*jqXHR*/, response);
       });
   },
 

--- a/apps/src/code-studio/initApp/clientApi.js
+++ b/apps/src/code-studio/initApp/clientApi.js
@@ -131,9 +131,7 @@ var base = {
         callback(null, data, jqXHR);
       })
       .fail(function(response, status, error) {
-        var err = new Error('status: ' + status + '; error: ' + error, {
-          cause: response.status
-        });
+        var err = new Error('status: ' + status + '; error: ' + error);
         callback(err, undefined /*data*/, undefined /*jqXHR*/, response);
       });
   },

--- a/apps/src/code-studio/initApp/loadApp.js
+++ b/apps/src/code-studio/initApp/loadApp.js
@@ -9,6 +9,7 @@ import {
 } from '@cdo/apps/code-studio/headerRedux';
 import {files} from '@cdo/apps/clientApi';
 var renderAbusive = require('./renderAbusive');
+import renderNotFound from './renderNotFound';
 var userAgentParser = require('./userAgentParser');
 var clientState = require('../clientState');
 import getScriptData from '../../util/getScriptData';
@@ -239,26 +240,34 @@ function tryToUploadShareImageToS3({image, level}) {
  */
 function loadProjectAndCheckAbuse(appOptions) {
   return new Promise((resolve, reject) => {
-    project.load().then(() => {
-      if (project.hideBecauseAbusive()) {
-        renderAbusive(project, msg.tosLong({url: 'http://code.org/tos'}));
-        return;
-      }
-      if (project.hideBecausePrivacyViolationOrProfane()) {
-        renderAbusive(project, msg.policyViolation());
-        return;
-      }
-      if (project.getSharingDisabled()) {
-        renderAbusive(
-          project,
-          msg.sharingDisabled({
-            sign_in_url: 'https://studio.code.org/users/sign_in'
-          })
-        );
-        return;
-      }
-      resolve(appOptions);
-    });
+    project
+      .load()
+      .then(() => {
+        if (project.hideBecauseAbusive()) {
+          renderAbusive(project, msg.tosLong({url: 'http://code.org/tos'}));
+          return;
+        }
+        if (project.hideBecausePrivacyViolationOrProfane()) {
+          renderAbusive(project, msg.policyViolation());
+          return;
+        }
+        if (project.getSharingDisabled()) {
+          renderAbusive(
+            project,
+            msg.sharingDisabled({
+              sign_in_url: 'https://studio.code.org/users/sign_in'
+            })
+          );
+          return;
+        }
+        resolve(appOptions);
+      })
+      .catch(() => {
+        if (project.notFound()) {
+          renderNotFound(project);
+          return;
+        }
+      });
   });
 }
 

--- a/apps/src/code-studio/initApp/loadApp.js
+++ b/apps/src/code-studio/initApp/loadApp.js
@@ -9,7 +9,7 @@ import {
 } from '@cdo/apps/code-studio/headerRedux';
 import {files} from '@cdo/apps/clientApi';
 var renderAbusive = require('./renderAbusive');
-import renderNotFound from './renderNotFound';
+import renderProjectNotFound from './renderProjectNotFound';
 var userAgentParser = require('./userAgentParser');
 var clientState = require('../clientState');
 import getScriptData from '../../util/getScriptData';
@@ -263,8 +263,8 @@ function loadProjectAndCheckAbuse(appOptions) {
         resolve(appOptions);
       })
       .catch(() => {
-        if (project.notFound()) {
-          renderNotFound(project);
+        if (project.channelNotFound()) {
+          renderProjectNotFound(project);
           return;
         }
       });

--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -100,6 +100,7 @@ let initialSaveComplete = false;
 let initialCaptureComplete = false;
 let thumbnailChanged = false;
 let thumbnailPngBlob = null;
+let loadResponseCode = null;
 
 /**
  * Current state of our sources API data
@@ -499,6 +500,10 @@ var projects = (module.exports = {
     const isEditOrViewPage = pageAction === 'edit' || pageAction === 'view';
 
     return hasEditPermissions && isEditOrViewPage;
+  },
+
+  notFound() {
+    return loadResponseCode >= 400 && loadResponseCode < 500;
   },
 
   __TestInterface: {
@@ -1691,18 +1696,7 @@ var projects = (module.exports = {
       // Load the project ID, if one exists
       return this.fetchChannel(pathInfo.channelId)
         .catch(err => {
-          if (err.message.includes('error: Not Found')) {
-            // Project not found. Redirect to the most recent project of this
-            // type, or a new project of this type if none exists.
-            const newPath = utils
-              .currentLocation()
-              .pathname.split('/')
-              .slice(PathPart.START, PathPart.APP + 1)
-              .join('/');
-            utils.navigateToHref(newPath);
-          }
-          // Reject even after navigation, to allow unit tests which stub
-          // navigateToHref to confirm that navigation has happened.
+          loadResponseCode = err.cause;
           return Promise.reject(err);
         })
         .then(this.fetchSource.bind(this))

--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -100,7 +100,7 @@ let initialSaveComplete = false;
 let initialCaptureComplete = false;
 let thumbnailChanged = false;
 let thumbnailPngBlob = null;
-let loadResponseCode = null;
+let fetchChannelResponseCode = null;
 
 /**
  * Current state of our sources API data
@@ -502,8 +502,8 @@ var projects = (module.exports = {
     return hasEditPermissions && isEditOrViewPage;
   },
 
-  notFound() {
-    return loadResponseCode >= 400 && loadResponseCode < 500;
+  channelNotFound() {
+    return fetchChannelResponseCode >= 400 && fetchChannelResponseCode < 500;
   },
 
   __TestInterface: {
@@ -1696,9 +1696,9 @@ var projects = (module.exports = {
       // Load the project ID, if one exists
       return this.fetchChannel(pathInfo.channelId)
         .catch(err => {
-          loadResponseCode = err.cause;
           return Promise.reject(err);
         })
+
         .then(this.fetchSource.bind(this))
         .then(() => {
           if (current.isOwner && pathInfo.action === 'view') {
@@ -1818,9 +1818,10 @@ var projects = (module.exports = {
    */
   fetchChannel(channelId) {
     return new Promise((resolve, reject) => {
-      channels.fetch(channelId, (err, data) =>
-        err ? reject(err) : resolve(data)
-      );
+      channels.fetch(channelId, (err, data, jqXhr, response) => {
+        fetchChannelResponseCode = response?.status;
+        err ? reject(err) : resolve(data);
+      });
     }).catch(err => {
       this.logError_(
         'load-channel-error',

--- a/apps/src/code-studio/initApp/renderNotFound.js
+++ b/apps/src/code-studio/initApp/renderNotFound.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import AlertExclamation from '../components/AlertExclamation';
+import msg from '@cdo/locale';
+
+export function NotFoundAlert() {
+  return (
+    <AlertExclamation>
+      <div className="exclamation-abuse">
+        <p style={styles.text}>{msg.projectNotFound()}</p>
+        <p style={styles.text}>
+          <a href="https://studio.code.org">{msg.goToCodeStudio()}</a>
+        </p>
+      </div>
+    </AlertExclamation>
+  );
+}
+
+/**
+ * Renders our AbuseExclamation component, and potentially updates admin box
+ * @param {project.js} project
+ * @param {string} tosText
+ */
+export default (project, tosText) => {
+  ReactDOM.render(<NotFoundAlert />, document.getElementById('codeApp'));
+};
+
+const styles = {
+  text: {
+    fontSize: 18,
+    lineHeight: '24px',
+    padding: 5
+  }
+};

--- a/apps/src/code-studio/initApp/renderProjectNotFound.js
+++ b/apps/src/code-studio/initApp/renderProjectNotFound.js
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom';
 import AlertExclamation from '../components/AlertExclamation';
 import msg from '@cdo/locale';
 
-export function NotFoundAlert() {
+export function ProjectNotFoundAlert() {
   return (
     <AlertExclamation>
       <div className="exclamation-abuse">
@@ -22,7 +22,7 @@ export function NotFoundAlert() {
  * @param {string} tosText
  */
 export default (project, tosText) => {
-  ReactDOM.render(<NotFoundAlert />, document.getElementById('codeApp'));
+  ReactDOM.render(<ProjectNotFoundAlert />, document.getElementById('codeApp'));
 };
 
 const styles = {

--- a/apps/test/unit/code-studio/components/AbuseExclamationTest.jsx
+++ b/apps/test/unit/code-studio/components/AbuseExclamationTest.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import {expect} from '../../../util/reconfiguredChai';
+import AbuseExclamation from '@cdo/apps/code-studio/components/AbuseExclamation';
+
+describe('AbuseExclamation', () => {
+  it('renders AbuseExclamation components', () => {
+    const wrapper = shallow(
+      <AbuseExclamation
+        i18n={{
+          tos: 'terms of service',
+          contact_us: 'contact us',
+          edit_project: 'edit project',
+          go_to_code_studio: 'go to code studio'
+        }}
+        isOwner
+      />
+    );
+    expect(wrapper.find('AbuseError').length).to.equal(1);
+    expect(wrapper.find('AlertExclamation').length).to.equal(1);
+  });
+
+  it('shows edit link if isOwner is true', () => {
+    const wrapper = shallow(
+      <AbuseExclamation
+        i18n={{
+          tos: 'terms of service',
+          contact_us: 'contact us',
+          edit_project: 'edit project',
+          go_to_code_studio: 'go to code studio'
+        }}
+        isOwner
+      />
+    );
+    expect(wrapper.find('a').text()).to.contain('edit project');
+  });
+
+  it('shows code studio link if isOwener is false', () => {
+    const wrapper = shallow(
+      <AbuseExclamation
+        i18n={{
+          tos: 'terms of service',
+          contact_us: 'contact us',
+          edit_project: 'edit project',
+          go_to_code_studio: 'go to code studio'
+        }}
+        isOwner={false}
+      />
+    );
+    expect(wrapper.find('a').text()).to.contain('go to code studio');
+  });
+});

--- a/apps/test/unit/code-studio/components/AlertExclamationTest.jsx
+++ b/apps/test/unit/code-studio/components/AlertExclamationTest.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import {expect} from '../../../util/reconfiguredChai';
+import AlertExclamation from '@cdo/apps/code-studio/components/AlertExclamation';
+
+describe('AlertExclamation', () => {
+  it('renders children in table', () => {
+    const wrapper = shallow(
+      <AlertExclamation>
+        <div id="unit-test-child-div" />
+      </AlertExclamation>
+    );
+    expect(wrapper.find('table').length).to.equal(1);
+    expect(wrapper.find('table').find('#unit-test-child-div').length).to.equal(
+      1
+    );
+    expect(wrapper.text()).contains('!');
+  });
+});

--- a/apps/test/unit/code-studio/initApp/projectTest.js
+++ b/apps/test/unit/code-studio/initApp/projectTest.js
@@ -775,7 +775,7 @@ describe('project.js', () => {
 
       it('fails when channel not found', done => {
         project.load().catch(() => {
-          expect(project.notFound()).to.be.true;
+          expect(project.channelNotFound()).to.be.true;
           done();
         });
       });

--- a/apps/test/unit/code-studio/initApp/projectTest.js
+++ b/apps/test/unit/code-studio/initApp/projectTest.js
@@ -773,12 +773,9 @@ describe('project.js', () => {
         });
       });
 
-      it('redirects to new project when channel not found', done => {
+      it('fails when channel not found', done => {
         project.load().catch(() => {
-          expect(utils.navigateToHref).to.have.been.calledOnce;
-          expect(utils.navigateToHref.firstCall.args[0]).to.equal(
-            '/projects/artist'
-          );
+          expect(project.notFound()).to.be.true;
           done();
         });
       });

--- a/apps/test/unit/code-studio/initApp/renderNotFoundTest.js
+++ b/apps/test/unit/code-studio/initApp/renderNotFoundTest.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import {expect} from '../../../util/reconfiguredChai';
+import {NotFoundAlert} from '@cdo/apps/code-studio/initApp/renderNotFound';
+
+describe('NotFoundAlert', () => {
+  it('renders AlertExclamation with message', () => {
+    const wrapper = shallow(<NotFoundAlert />);
+    expect(wrapper.find('AlertExclamation').length).to.equal(1);
+    expect(wrapper.find('a').text()).to.include('Go to Code Studio');
+  });
+});

--- a/apps/test/unit/code-studio/initApp/renderProjectNotFoundTest.js
+++ b/apps/test/unit/code-studio/initApp/renderProjectNotFoundTest.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import {shallow} from 'enzyme';
 import {expect} from '../../../util/reconfiguredChai';
-import {NotFoundAlert} from '@cdo/apps/code-studio/initApp/renderNotFound';
+import {ProjectNotFoundAlert} from '@cdo/apps/code-studio/initApp/renderProjectNotFound';
 
-describe('NotFoundAlert', () => {
+describe('ProjectNotFoundAlert', () => {
   it('renders AlertExclamation with message', () => {
-    const wrapper = shallow(<NotFoundAlert />);
+    const wrapper = shallow(<ProjectNotFoundAlert />);
     expect(wrapper.find('AlertExclamation').length).to.equal(1);
     expect(wrapper.find('a').text()).to.include('Go to Code Studio');
   });


### PR DESCRIPTION
Original PR here: https://github.com/code-dot-org/code-dot-org/pull/46046. It was reverted a couple of times due to failures in the staging and test environments. After some investigation, I believe it was failing in those environments due to me using a feature that was introduced in Chrome 93.

I removed that feature (the `cause` field of `Error`) and moved up setting the response code for fetching the channel. I also renamed this field and the component that shows the error message so that we can use this same approach when a version isn't found (we may want a different error message to show to the user in that case).

Message users will see when a project is not found:
<img width="700" alt="Screen Shot 2022-06-03 at 8 13 43 AM" src="https://user-images.githubusercontent.com/46464143/171918000-84770fa4-e7c5-4ab6-83b0-985abd5843c0.png">
 