### PR TITLE
Maker Firehose Error Temporary Resolution - Remove dataJson Too Long

### DIFF
--- a/apps/src/lib/kits/maker/boards/circuitPlayground/CircuitPlaygroundBoard.js
+++ b/apps/src/lib/kits/maker/boards/circuitPlayground/CircuitPlaygroundBoard.js
@@ -27,7 +27,6 @@ import {
   BOARD_TYPE
 } from '../../util/boardUtils';
 import {isChromeOS, serialPortType} from '../../util/browserChecks';
-import firehoseClient from '@cdo/apps/lib/util/firehose';
 import {SERIAL_BAUD} from '@cdo/apps/lib/kits/maker/util/boardUtils';
 
 // Polyfill node's process.hrtime for the browser, gets used by johnny-five.
@@ -60,7 +59,6 @@ export default class CircuitPlaygroundBoard extends EventEmitter {
 
     /** @private {SerialPort} serial port controller */
     this.serialPort_ = null;
-    this.logWithFirehose('serial-port-constructor-set-to-null');
 
     /** @private {five.Board} A johnny-five board controller */
     this.fiveBoard_ = null;
@@ -120,10 +118,6 @@ export default class CircuitPlaygroundBoard extends EventEmitter {
     });
     board.once('ready', () => {
       this.serialPort_ = serialPort;
-      this.logWithFirehose(
-        'serial-port-set',
-        JSON.stringify({serialPort, name})
-      );
 
       this.fiveBoard_ = board;
       this.fiveBoard_.samplingInterval(100);
@@ -262,10 +256,8 @@ export default class CircuitPlaygroundBoard extends EventEmitter {
         // node serialport in the Code.org Maker App.
         if (this.serialPort_ && typeof this.serialPort_.close === 'function') {
           this.serialPort_.close();
-          this.logWithFirehose('serial-port-closed');
         }
         this.serialPort_ = null;
-        this.logWithFirehose('serial-port-cleared');
         resolve();
       }, 50);
     });
@@ -299,9 +291,6 @@ export default class CircuitPlaygroundBoard extends EventEmitter {
      */
     if (this.serialPort_) {
       this.serialPort_.queue = [];
-      this.logWithFirehose('serial-port-queue-cleared');
-    } else {
-      this.logWithFirehose('serial-port-undefined');
     }
 
     if (this.prewiredComponents_) {
@@ -394,17 +383,6 @@ export default class CircuitPlaygroundBoard extends EventEmitter {
    */
   boardConnected() {
     return !!this.fiveBoard_;
-  }
-
-  logWithFirehose(eventString, dataJson = null) {
-    firehoseClient.putRecord(
-      {
-        study: 'maker-serial-port',
-        study_group: 'serial-port-lifecycle',
-        event: eventString
-      },
-      {includeUserId: true}
-    );
   }
 
   /**

--- a/apps/src/lib/kits/maker/boards/circuitPlayground/CircuitPlaygroundBoard.js
+++ b/apps/src/lib/kits/maker/boards/circuitPlayground/CircuitPlaygroundBoard.js
@@ -402,7 +402,6 @@ export default class CircuitPlaygroundBoard extends EventEmitter {
         study: 'maker-serial-port',
         study_group: 'serial-port-lifecycle',
         event: eventString
-        //data_json: dataJson
       },
       {includeUserId: true}
     );

--- a/apps/src/lib/kits/maker/boards/circuitPlayground/CircuitPlaygroundBoard.js
+++ b/apps/src/lib/kits/maker/boards/circuitPlayground/CircuitPlaygroundBoard.js
@@ -401,8 +401,8 @@ export default class CircuitPlaygroundBoard extends EventEmitter {
       {
         study: 'maker-serial-port',
         study_group: 'serial-port-lifecycle',
-        event: eventString,
-        data_json: dataJson
+        event: eventString
+        //data_json: dataJson
       },
       {includeUserId: true}
     );


### PR DESCRIPTION
Firehose logging was experiencing a lot of errors. Suresh investigated and found that this log in the Maker App had a data_json that was too long and causing errors. This is from an error investigation that I believe has been resolved, but until that can be confirmed, I am temporarily moving forward with removing the data_json to mitigate the error.

cc: @sureshc @breville 