### PR TITLE
wait for congrats certificate image to load before taking eyes snapshot

### DIFF
--- a/dashboard/test/ui/features/hour_of_code/hour_of_code_finish.feature
+++ b/dashboard/test/ui/features/hour_of_code/hour_of_code_finish.feature
@@ -67,6 +67,7 @@ Scenario: congrats certificate pages
   When I am on "http://code.org/api/hour/finish/flappy"
   And I wait until current URL contains "/congrats"
   And I wait to see element with ID "uitest-certificate"
+  And I wait for image "#uitest-certificate img" to load
   And I see no difference for "uncustomized flappy certificate"
 
   When I type "Robo Coder" into "#name"
@@ -77,6 +78,7 @@ Scenario: congrats certificate pages
   When I am on "http://code.org/api/hour/finish/oceans"
   And I wait until current URL contains "/congrats"
   And I wait to see element with ID "uitest-certificate"
+  And I wait for image "#uitest-certificate img" to load
   And I see no difference for "uncustomized oceans certificate"
 
   When I type "Robo Coder" into "#name"

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -828,6 +828,11 @@ Then /^I click an image "([^"]*)"$/ do |path|
   @browser.execute_script("$('img[src*=\"#{path}\"]').click();")
 end
 
+Then /^I wait for image "([^"]*)" to load$/ do |selector|
+  wait = Selenium::WebDriver::Wait.new(timeout: DEFAULT_WAIT_TIMEOUT)
+  wait.until {@browser.execute_script("return $('#{selector}').prop('complete');")}
+end
+
 Then /^I see jquery selector (.*)$/ do |selector|
   exists = @browser.execute_script("return $(\"#{selector}\").length != 0;")
   expect(exists).to eq(true)


### PR DESCRIPTION
Finishes https://codedotorg.atlassian.net/browse/PLAT-1744. I copied the approach from here: https://github.com/code-dot-org/code-dot-org/blob/53c4d1dc5cdca5ed3ce42cb737f8bb8ad3b9f14f/dashboard/test/ui/features/step_definitions/authoredHints.rb#L18

## Testing story

on the certificate page, I manually verified that the command `$('#uitest-certificate img').prop('complete')` returns `false` while the image is loading and `true` afterward. the drone run will also run the new test steps.