### PR TITLE
[Google Blockly] Address Blockly.bindEvent_ deprecation 

### DIFF
--- a/apps/src/block_utils.js
+++ b/apps/src/block_utils.js
@@ -1092,36 +1092,41 @@ exports.createJsWrapperBlockCreator = function(
           // Block.isMiniFlyoutOpen is used in the blockly repo to track whether or not the horizontal flyout is open.
           this.isMiniFlyoutOpen = false;
           // On button click, open/close the horizontal flyout, toggle button text between +/-, and re-render the block.
-          Blockly.bindEvent_(toggle.fieldGroup_, 'mousedown', this, () => {
-            if (Blockly.cdoUtils.isWorkspaceReadOnly(this.blockSpace)) {
-              return;
-            }
+          Blockly.cdoUtils.bindBrowserEvent(
+            toggle.fieldGroup_,
+            'mousedown',
+            this,
+            () => {
+              if (Blockly.cdoUtils.isWorkspaceReadOnly(this.blockSpace)) {
+                return;
+              }
 
-            if (this.isMiniFlyoutOpen) {
-              toggle.setValue('+');
-            } else {
-              toggle.setValue('-');
-            }
-            this.isMiniFlyoutOpen = !this.isMiniFlyoutOpen;
-            this.render();
-            // If the mini flyout just opened, make sure mini-toolbox blocks are updated with the right thumbnails.
-            // This has to happen after render() because some browsers don't render properly if the elements are not
-            // visible. The root cause is that getComputedTextLength returns 0 if a text element is not visible, so
-            // the thumbnail image overlaps the label in Firefox, Edge, and IE.
-            if (this.isMiniFlyoutOpen) {
-              let miniToolboxBlocks = this.miniFlyout.blockSpace_.topBlocks_;
-              let rootInputBlocks = this.getConnections_(true /* all */)
-                .filter(function(connection) {
-                  return connection.type === Blockly.INPUT_VALUE;
-                })
-                .map(function(connection) {
-                  return connection.targetBlock();
+              if (this.isMiniFlyoutOpen) {
+                toggle.setValue('+');
+              } else {
+                toggle.setValue('-');
+              }
+              this.isMiniFlyoutOpen = !this.isMiniFlyoutOpen;
+              this.render();
+              // If the mini flyout just opened, make sure mini-toolbox blocks are updated with the right thumbnails.
+              // This has to happen after render() because some browsers don't render properly if the elements are not
+              // visible. The root cause is that getComputedTextLength returns 0 if a text element is not visible, so
+              // the thumbnail image overlaps the label in Firefox, Edge, and IE.
+              if (this.isMiniFlyoutOpen) {
+                let miniToolboxBlocks = this.miniFlyout.blockSpace_.topBlocks_;
+                let rootInputBlocks = this.getConnections_(true /* all */)
+                  .filter(function(connection) {
+                    return connection.type === Blockly.INPUT_VALUE;
+                  })
+                  .map(function(connection) {
+                    return connection.targetBlock();
+                  });
+                miniToolboxBlocks.forEach(function(block, index) {
+                  block.shadowBlockValue_(rootInputBlocks[index]);
                 });
-              miniToolboxBlocks.forEach(function(block, index) {
-                block.shadowBlockValue_(rootInputBlocks[index]);
-              });
+              }
             }
-          });
+          );
 
           this.appendDummyInput()
             .appendField(toggle, 'toggle')

--- a/apps/src/blockly/addons/blockSvgUnused.js
+++ b/apps/src/blockly/addons/blockSvgUnused.js
@@ -133,16 +133,21 @@ export default class BlockSvgUnused {
 
     // We bind to mousedown rather than click so we can interrupt the drag
     // that would otherwise be initiated.
-    Blockly.bindEvent_(this.frameHelp_, 'mousedown', this, function(e) {
-      if (Blockly.utils.isRightButton(e)) {
-        // Right-click.
-        return;
-      }
+    Blockly.cdoUtils.bindBrowserEvent(
+      this.frameHelp_,
+      'mousedown',
+      this,
+      function(e) {
+        if (Blockly.utils.isRightButton(e)) {
+          // Right-click.
+          return;
+        }
 
-      this.helpClickFunc_(e);
-      e.stopPropagation();
-      e.preventDefault();
-    });
+        this.helpClickFunc_(e);
+        e.stopPropagation();
+        e.preventDefault();
+      }
+    );
   }
 
   render(svgGroup) {

--- a/apps/src/blockly/addons/cdoUtils.js
+++ b/apps/src/blockly/addons/cdoUtils.js
@@ -45,6 +45,16 @@ export function workspaceSvgResize(workspace) {
   return Blockly.svgResize(workspace);
 }
 
+export function bindBrowserEvent(element, name, thisObject, func, useCapture) {
+  return Blockly.browserEvents.bind(
+    element,
+    name,
+    thisObject,
+    func,
+    useCapture
+  );
+}
+
 export function isWorkspaceReadOnly(workspace) {
   return false; // TODO - used for feedback
 }

--- a/apps/src/blockly/cdoBlocklyWrapper.js
+++ b/apps/src/blockly/cdoBlocklyWrapper.js
@@ -249,6 +249,9 @@ function initializeBlocklyWrapper(blocklyInstance) {
     },
     workspaceSvgResize: function(workspace) {
       return workspace.blockSpaceEditor.svgResize();
+    },
+    bindBrowserEvent: function(element, name, thisObject, func, useCapture) {
+      return Blockly.bindEvent_(element, name, thisObject, func, useCapture);
     }
   };
   return blocklyWrapper;

--- a/apps/src/blockly/googleBlocklyWrapper.js
+++ b/apps/src/blockly/googleBlocklyWrapper.js
@@ -74,12 +74,12 @@ function initializeBlocklyWrapper(blocklyInstance) {
   blocklyWrapper.wrapReadOnlyProperty('ALIGN_LEFT');
   blocklyWrapper.wrapReadOnlyProperty('ALIGN_RIGHT');
   blocklyWrapper.wrapReadOnlyProperty('applab_locale');
-  blocklyWrapper.wrapReadOnlyProperty('bindEvent_');
   blocklyWrapper.wrapReadOnlyProperty('blockRendering');
   blocklyWrapper.wrapReadOnlyProperty('Block');
   blocklyWrapper.wrapReadOnlyProperty('BlockFieldHelper');
   blocklyWrapper.wrapReadOnlyProperty('Blocks');
   blocklyWrapper.wrapReadOnlyProperty('BlockSvg');
+  blocklyWrapper.wrapReadOnlyProperty('browserEvents');
   blocklyWrapper.wrapReadOnlyProperty('common_locale');
   blocklyWrapper.wrapReadOnlyProperty('ComponentManager');
   blocklyWrapper.wrapReadOnlyProperty('Connection');
@@ -305,7 +305,7 @@ function initializeBlocklyWrapper(blocklyInstance) {
   blocklyWrapper.WorkspaceSvg.prototype.addUnusedBlocksHelpListener = function(
     helpClickFunc
   ) {
-    blocklyWrapper.bindEvent_(
+    blocklyWrapper.browserEvents.bind(
       blocklyWrapper.mainBlockSpace.getCanvas(),
       blocklyWrapper.BlockSpace.EVENTS.RUN_BUTTON_CLICKED,
       blocklyWrapper.mainBlockSpace,

--- a/apps/src/dance/blocks.js
+++ b/apps/src/dance/blocks.js
@@ -199,7 +199,7 @@ export default {
 
         if (Blockly.useModalFunctionEditor) {
           var editLabel = new Blockly.FieldIcon(Blockly.Msg.FUNCTION_EDIT);
-          Blockly.bindEvent_(
+          Blockly.cdoUtils.bindBrowserEvent(
             editLabel.fieldGroup_,
             'mousedown',
             this,

--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -500,7 +500,7 @@ export default {
 
         if (allowBehaviorEditing) {
           var editLabel = new Blockly.FieldIcon(Blockly.Msg.FUNCTION_EDIT);
-          Blockly.bindEvent_(
+          Blockly.cdoUtils.bindBrowserEvent(
             editLabel.fieldGroup_,
             'mousedown',
             this,

--- a/apps/src/sharedFunctionalBlocks.js
+++ b/apps/src/sharedFunctionalBlocks.js
@@ -492,7 +492,7 @@ function installCondForType(blockly, generator, type) {
       Blockly.cdoUtils.setHSV(this, ...Blockly.FunctionalTypeColors[type]);
 
       var plusField = new Blockly.FieldIcon('+');
-      Blockly.bindEvent_(
+      Blockly.cdoUtils.bindBrowserEvent(
         plusField.getRootElement(),
         'mousedown',
         this,
@@ -549,7 +549,7 @@ function installCondForType(blockly, generator, type) {
 
       if (this.pairs_.length > 1) {
         var minusField = new Blockly.FieldIcon('-');
-        Blockly.bindEvent_(
+        Blockly.cdoUtils.bindBrowserEvent(
           minusField.getRootElement(),
           'mousedown',
           this,

--- a/apps/test/unit/blockly/googleBlocklyWrapperTest.js
+++ b/apps/test/unit/blockly/googleBlocklyWrapperTest.js
@@ -30,7 +30,6 @@ describe('Google Blockly Wrapper', () => {
       'ALIGN_LEFT',
       'ALIGN_RIGHT',
       'applab_locale',
-      'bindEvent_',
       'blockRendering',
       'Block',
       'BlockFieldHelper',


### PR DESCRIPTION
Blockly.bindEvent_ was deprecated for Google Blockly on December 2021 and will be deleted on December 2022. v7 Google Blockly and later adds a warning to the console when it is detected. This was spotted by @jamescodeorg during last week's Blockly bug bash!

We can add a new function to cdoUtils so that our Google Blockly wrapper uses the recommended Blockly.browserEvents.bind, while using the existing method with cdo Blockly.

```
react_devtools_backend.js:40Blockly.bindEvent_ was deprecated on December 2021 and will be deleted on December 2022. Use Blockly.browserEvents.bind instead.
```

This just eliminates the console warning. Tested in both types of Blockly labs.

- jira ticket: [STAR-2315: [Google Blockly] Address Blockly.bindEvent_ deprecation](https://codedotorg.atlassian.net/browse/STAR-2315)
