### PR TITLE
Stop Using Deprecated `URI.escape`

### DIFF
--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -715,14 +715,14 @@ module LevelsHelper
     # These would ideally also go in _javascript_strings.html right now, but it can't
     # deal with params.
     {
-      thank_you: URI.escape(I18n.t('footer.thank_you')),
+      thank_you: CGI.escape(I18n.t('footer.thank_you')),
       help_from_html: I18n.t('footer.help_from_html'),
-      art_from_html: URI.escape(I18n.t('footer.art_from_html', current_year: Time.now.year)),
-      code_from_html: URI.escape(I18n.t('footer.code_from_html')),
+      art_from_html: CGI.escape(I18n.t('footer.art_from_html', current_year: Time.now.year)),
+      code_from_html: CGI.escape(I18n.t('footer.code_from_html')),
       powered_by_aws: I18n.t('footer.powered_by_aws'),
-      trademark: URI.escape(I18n.t('footer.trademark', current_year: Time.now.year)),
+      trademark: CGI.escape(I18n.t('footer.trademark', current_year: Time.now.year)),
       built_on_github: I18n.t('footer.built_on_github'),
-      google_copyright: URI.escape(I18n.t('footer.google_copyright'))
+      google_copyright: CGI.escape(I18n.t('footer.google_copyright'))
     }
   end
 

--- a/lib/cdo/contact_rollups/v2/pardot.rb
+++ b/lib/cdo/contact_rollups/v2/pardot.rb
@@ -270,7 +270,7 @@ class PardotV2
   # @param email [String]
   # @return [Array<String>]
   def self.retrieve_pardot_ids_by_email(email)
-    doc = post_with_auth_retry "#{PROSPECT_READ_URL}/#{URI.escape(email)}"
+    doc = post_with_auth_retry "#{PROSPECT_READ_URL}/#{URI.encode_www_form_component(email)}"
     doc.xpath('//prospect/id').map(&:text)
   rescue StandardError => e
     # If the input email does not exist, Pardot will response with

--- a/lib/cdo/slack.rb
+++ b/lib/cdo/slack.rb
@@ -166,7 +166,7 @@ class Slack
   def self.snippet(room, text)
     # omit leading '#' when passing channel names to this API
     channel = CHANNEL_MAP[room] || room
-    result = post_to_slack("https://slack.com/api/files.upload?channels=#{channel}&content=#{URI.escape(text)}")
+    result = post_to_slack("https://slack.com/api/files.upload?channels=#{channel}&content=#{URI.encode_www_form_component(text)}")
     return !!result
   end
 

--- a/lib/test/cdo/contact_rollups/test_pardot_v2.rb
+++ b/lib/test/cdo/contact_rollups/test_pardot_v2.rb
@@ -441,7 +441,7 @@ class PardotV2Test < Minitest::Test
 
   def test_delete_prospects_by_email_finds_matching_pardot_ids
     email = 'test@domain.com'
-    read_prospect_url = "#{PardotV2::PROSPECT_READ_URL}/#{email}"
+    read_prospect_url = "#{PardotV2::PROSPECT_READ_URL}/#{URI.encode_www_form_component(email)}"
     pardot_response = create_xml_from_heredoc <<~XML
       <rsp stat="ok" version="1.0">
         <prospect>
@@ -459,7 +459,7 @@ class PardotV2Test < Minitest::Test
 
   def test_delete_prospects_by_email_sends_deletion_requests
     email = 'test@domain.com'
-    read_prospect_url = "#{PardotV2::PROSPECT_READ_URL}/#{email}"
+    read_prospect_url = "#{PardotV2::PROSPECT_READ_URL}/#{URI.encode_www_form_component(email)}"
     pardot_response = create_xml_from_heredoc <<~XML
       <rsp stat="ok" version="1.0">
         <prospect>

--- a/shared/middleware/helpers/firebase_helper.rb
+++ b/shared/middleware/helpers/firebase_helper.rb
@@ -52,7 +52,7 @@ class FirebaseHelper
   end
 
   def escape_table_name(table_name)
-    return URI.escape(table_name).gsub('.', '%252E')
+    return CGI.escape(table_name).gsub('.', '%252E')
   end
 
   def unescape_table_name(table_name)

--- a/shared/test/test_files.rb
+++ b/shared/test/test_files.rb
@@ -24,8 +24,8 @@ class FilesTest < FilesApiTestBase
     file_data = 'fake-file-data'
     old_filename = @api.randomize_filename 'old_file.html'
     new_filename = @api.randomize_filename 'new_file.html'
-    delete_all_file_versions old_filename, URI.escape(old_filename),
-      new_filename, URI.escape(new_filename)
+    delete_all_file_versions old_filename, CGI.escape(old_filename),
+      new_filename, CGI.escape(new_filename)
     delete_all_manifest_versions
     post_file_data @api, old_filename, file_data, 'test/html'
 
@@ -51,8 +51,8 @@ class FilesTest < FilesApiTestBase
     file_data = 'fake-file-data'
     old_filename = @api.randomize_filename 'old_file.html'
     new_filename = @api.randomize_filename 'new_file.html'
-    delete_all_file_versions old_filename, URI.escape(old_filename),
-      new_filename, URI.escape(new_filename)
+    delete_all_file_versions old_filename, CGI.escape(old_filename),
+      new_filename, CGI.escape(new_filename)
     delete_all_manifest_versions
     post_file_data @api, old_filename, file_data, 'test/html'
 
@@ -79,7 +79,7 @@ class FilesTest < FilesApiTestBase
     file_data = 'fake-file-data'
     old_filename = @api.randomize_filename 'old_file.html'
     new_filename = "long_filename#{'_' * 512}.html"
-    delete_all_file_versions old_filename, URI.escape(old_filename)
+    delete_all_file_versions old_filename, CGI.escape(old_filename)
     delete_all_manifest_versions
     post_file_data @api, old_filename, file_data, 'test/html'
 
@@ -713,7 +713,7 @@ class FilesTest < FilesApiTestBase
     assert_fileinfo_equal(expected_image_info, dest_file_infos[0])
     assert_fileinfo_equal(expected_sound_info, dest_file_infos[1])
 
-    dest_api.get_object(URI.escape(image_filename))
+    dest_api.get_object(CGI.escape(image_filename))
     assert successful?
     assert_equal image_body, last_response.body
 
@@ -722,7 +722,7 @@ class FilesTest < FilesApiTestBase
     assert_equal sound_body, last_response.body
 
     # abuse score didn't carry over
-    assert_equal 0, FileBucket.new.get_abuse_score(dest_channel_id, URI.escape(image_filename.downcase))
+    assert_equal 0, FileBucket.new.get_abuse_score(dest_channel_id, CGI.escape(image_filename.downcase))
     assert_equal 0, FileBucket.new.get_abuse_score(dest_channel_id, escaped_sound_filename.downcase)
 
     assert_newrelic_metrics %w(
@@ -732,11 +732,11 @@ class FilesTest < FilesApiTestBase
       Custom/ListRequests/FileBucket/BucketHelper.copy_files
     )
 
-    src_api.delete_object(URI.escape(image_filename))
-    src_api.delete_object(URI.escape(escaped_sound_filename))
+    src_api.delete_object(CGI.escape(image_filename))
+    src_api.delete_object(CGI.escape(escaped_sound_filename))
     delete_all_manifest_versions
-    dest_api.delete_object(URI.escape(image_filename))
-    dest_api.delete_object(URI.escape(escaped_sound_filename))
+    dest_api.delete_object(CGI.escape(image_filename))
+    dest_api.delete_object(CGI.escape(escaped_sound_filename))
     delete_channel(dest_channel_id)
   end
 


### PR DESCRIPTION
This method is obsolete, and Ruby starting in 2.7 will warn us about that. In advance of the upgrade to 2.7, we go through and replace all existing uses of this method with modern alternatives.

I _believe_ I correctly identified which of the recommended alternatives we should use in which case, but please double-check me!

See https://ruby-doc.org/stdlib-2.5.1/libdoc/uri/rdoc/URI/Escape.html#method-i-escape

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
