### PR TITLE
[Google Blockly] Crash when displaying hints

### DIFF
--- a/apps/src/templates/ReadOnlyBlockSpace.jsx
+++ b/apps/src/templates/ReadOnlyBlockSpace.jsx
@@ -48,7 +48,7 @@ export default class ReadOnlyBlockSpace extends React.Component {
 
   componentDidUpdate() {
     if (this.state.blockSpace) {
-      Blockly.svgResize(this.state.blockSpace);
+      Blockly.cdoUtils.workspaceSvgResize(this.state.blockSpace);
     }
   }
 

--- a/apps/src/templates/ReadOnlyBlockSpace.jsx
+++ b/apps/src/templates/ReadOnlyBlockSpace.jsx
@@ -48,7 +48,7 @@ export default class ReadOnlyBlockSpace extends React.Component {
 
   componentDidUpdate() {
     if (this.state.blockSpace) {
-      this.state.blockSpace.blockSpaceEditor.svgResize();
+      Blockly.svgResize(this.state.blockSpace);
     }
   }
 


### PR DESCRIPTION
## Problem
At last week's Blockly bug bash, @maureensturgeon  and @sanchitmalhotra126 discovered that certain hints were causing a crash when viewed. Specifically, this was happening on our adhoc as well as production for hints in Flappy and Bounce that are displayed _after_ a student fails the level (as opposed to hints that are always available). This is only happening with Google Blockly. If Flappy or Bounce are loaded on production with `?blocklyVersion=cdo`, the crash does not occur.

## Explanation
This specific case was missed when testing the following:
* https://github.com/code-dot-org/code-dot-org/pull/46024

`svgResize` was moved to `cdoUtils` for both the Google and cdo Blockly wrappers. We should be using `cdoUtils.workspaceSvgResize(workspace)` in either version of Blockly now.

## Before
**Flappy:** 
![image](https://user-images.githubusercontent.com/43474485/171430561-2f2342a6-a653-4ca8-8d3e-97398ea9d5bf.png)


**Bounce:**
![image](https://user-images.githubusercontent.com/43474485/171430611-034bb68d-d63d-4c88-8a79-608b542e0db1.png)


## After
**Flappy:**
![image](https://user-images.githubusercontent.com/43474485/171430675-89568947-b1d8-4bfe-9158-1898d54e5385.png)

**Bounce:**
![image](https://user-images.githubusercontent.com/43474485/171430739-bea6ebbe-45f3-4257-b7b7-9b4207da69dc.png)

Note that this type of hint is not use in other Google Blockly labs (ie. Poetry) at this time.

I also forced Bounce to run using cdo Blockly and found no regressions:
![image](https://user-images.githubusercontent.com/43474485/171431206-93ff4fe1-6668-48d5-a8f5-1baafc0c3dbe.png)
(at `/s/sports/lessons/1/levels/4?blocklyVersion=cdo`)

## Links

- jira ticket: [STAR-2308: [Google Blockly] Crash when displaying hints](https://codedotorg.atlassian.net/browse/STAR-2308)

