### PR TITLE
Instructions: Truncate Tabs

### DIFF
--- a/apps/src/templates/instructions/InlineAudio.jsx
+++ b/apps/src/templates/instructions/InlineAudio.jsx
@@ -318,7 +318,8 @@ const styles = {
 
   wrapper: {
     marginLeft: '3px',
-    marginRight: '3px'
+    marginRight: '3px',
+    display: 'flex'
   },
 
   button: {

--- a/apps/src/templates/instructions/InstructionsTab.jsx
+++ b/apps/src/templates/instructions/InstructionsTab.jsx
@@ -41,14 +41,16 @@ export default class InstructionsTab extends Component {
         : styles.text)
     };
     return (
-      <a
-        className={this.props.className}
-        onClick={this.props.onClick}
-        style={combinedStyle}
-        title={this.props.text}
-      >
-        {this.props.text}
-      </a>
+      <div style={styles.tabWrapper}>
+        <a
+          className={this.props.className}
+          onClick={this.props.onClick}
+          style={combinedStyle}
+          title={this.props.text}
+        >
+          {this.props.text}
+        </a>
+      </div>
     );
   }
 }
@@ -61,9 +63,7 @@ const styles = {
     paddingBottom: 4,
     fontWeight: 'bold',
     cursor: 'pointer',
-    whiteSpace: 'nowrap',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis'
+    whiteSpace: 'nowrap'
   },
   tabRtl: {
     marginLeft: 5,
@@ -72,7 +72,9 @@ const styles = {
     paddingBottom: 4,
     fontWeight: 'bold',
     cursor: 'pointer',
-    whiteSpace: 'nowrap',
+    whiteSpace: 'nowrap'
+  },
+  tabWrapper: {
     overflow: 'hidden',
     textOverflow: 'ellipsis'
   },

--- a/apps/src/templates/instructions/InstructionsTab.jsx
+++ b/apps/src/templates/instructions/InstructionsTab.jsx
@@ -45,6 +45,7 @@ export default class InstructionsTab extends Component {
         className={this.props.className}
         onClick={this.props.onClick}
         style={combinedStyle}
+        title={this.props.text}
       >
         {this.props.text}
       </a>
@@ -57,17 +58,23 @@ const styles = {
     marginRight: 5,
     paddingLeft: 10,
     paddingRight: 10,
-    paddingBottom: 6,
+    paddingBottom: 4,
     fontWeight: 'bold',
-    cursor: 'pointer'
+    cursor: 'pointer',
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis'
   },
   tabRtl: {
     marginLeft: 5,
     paddingLeft: 10,
     paddingRight: 10,
-    paddingBottom: 6,
+    paddingBottom: 4,
     fontWeight: 'bold',
-    cursor: 'pointer'
+    cursor: 'pointer',
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis'
   },
   text: {
     color: color.charcoal

--- a/apps/src/templates/instructions/TopInstructionsHeader.jsx
+++ b/apps/src/templates/instructions/TopInstructionsHeader.jsx
@@ -227,7 +227,8 @@ const styles = {
     paddingTop: 6,
     width: '100%',
     boxSizing: 'border-box',
-    display: 'flex'
+    display: 'flex',
+    minWidth: 100
   },
   helpTabsLtr: {
     float: 'left',

--- a/apps/src/templates/instructions/TopInstructionsHeader.jsx
+++ b/apps/src/templates/instructions/TopInstructionsHeader.jsx
@@ -196,11 +196,14 @@ function TopInstructionsHeader(props) {
 
 const styles = {
   paneHeaderOverride: {
-    color: color.default_text
+    color: color.default_text,
+    display: 'flex',
+    width: '100%',
+    justifyContent: 'space-between'
   },
   audioRTL: {
     wrapper: {
-      float: 'left'
+      order: 5
     }
   },
   audio: {
@@ -217,11 +220,14 @@ const styles = {
   },
   audioLTR: {
     wrapper: {
-      float: 'right'
+      order: 5
     }
   },
   helpTabs: {
-    paddingTop: 6
+    paddingTop: 6,
+    width: '100%',
+    boxSizing: 'border-box',
+    display: 'flex'
   },
   helpTabsLtr: {
     float: 'left',


### PR DESCRIPTION
99% a copy over of [this PR](https://github.com/code-dot-org/code-dot-org/pull/41914) from @breville, with one css update to ensure the audio button stays visible. 

This PR fixes the behavior where if the tabs on the instructions panel header were too large for the available space, one of two things would happen
- If the audio button was in the header (because text to speech was available), then no tabs would appear at all.
- If the audio button was not in the header, the first n tabs that fit in the header would show up, then the other tabs would not be visible (they were overflowing into a second row)

Now the tabs will truncate with ellipses, and have a tooltip with the full name. This isn't an ideal solution as for Java Lab now most of the time the tabs will be truncated, and sometimes the truncated version isn't very helpful. For example `Review` becomes `Revi...`. However, it is a major improvement over no tabs or invisible tabs. 

This change should only cause visible changes to Java Lab, as the instructions panel is much smaller there. The only change to other labs is if you hover over a tab name you now get a tooltip, or if you have a very narrow browser window.

### Screenshots

View with 4 tabs (Instructions, Help & Tips, Review, For Teachers Only)  

![Screen Shot 2022-06-01 at 10 54 59 AM](https://user-images.githubusercontent.com/33666587/171471086-119beb38-e730-4b62-89a7-44dd9b137b6f.png)

A different set of 4 tabs (Instructions, Help & Tips, Documentation, Review)  
![Screen Shot 2022-06-01 at 10 55 27 AM](https://user-images.githubusercontent.com/33666587/171471034-15bcf714-8aa9-4860-8000-3d463db3aab9.png)

View with 3 tabs (Instructions, Help & Tips, Review)  
![Screen Shot 2022-06-01 at 10 55 13 AM](https://user-images.githubusercontent.com/33666587/171471069-91aae4ab-aaa9-4d22-858d-37cf59aad460.png)


We can likely get rid of the help & tips tab in place of documentation once that tab is out of experiment mode, as currently help & tips links to documentation.

## Links
- [slack thread](https://codedotorg.slack.com/archives/C01EF4GJ9GE/p1654029237504789)


## Testing story
Tested locally

## Follow-up work
Some proposed better solutions that would require more dev time:
- replace the tabs with a tab library
- if there are too many tabs, have a dropdown instead of tabs

