### PR TITLE
[Applab] Log libraries versions errors to Firehose

### DIFF
--- a/apps/src/code-studio/components/libraries/LibraryClientApi.js
+++ b/apps/src/code-studio/components/libraries/LibraryClientApi.js
@@ -74,6 +74,7 @@ export default class LibraryClientApi {
               study: 'applab_library_versions',
               event: event,
               data_json: JSON.stringify({
+                error: error.message,
                 channelId: this.channelId,
                 pathname: location.pathname
               })

--- a/apps/src/code-studio/components/libraries/LibraryClientApi.js
+++ b/apps/src/code-studio/components/libraries/LibraryClientApi.js
@@ -1,5 +1,6 @@
 /* globals fetch */
 import clientApi from '@cdo/apps/code-studio/initApp/clientApi';
+import firehoseClient from '@cdo/apps/lib/util/firehose';
 
 const LIBRARY_NAME = 'library.json';
 export default class LibraryClientApi {
@@ -56,7 +57,7 @@ export default class LibraryClientApi {
     );
   }
 
-  fetchLatestVersionId(onSuccess, onError) {
+  fetchLatestVersionId(onSuccess, onError, event = 'unknown') {
     this.libraryApi.fetch(
       this.channelId + '/' + LIBRARY_NAME + '/versions',
       (error, data) => {
@@ -66,6 +67,20 @@ export default class LibraryClientApi {
           });
           onSuccess(mostRecent.versionId);
         } else {
+          // Log to Firehose on error using "event" as context.
+          // See https://codedotorg.atlassian.net/browse/STAR-2140 for details.
+          firehoseClient.putRecord(
+            {
+              study: 'applab_library_versions',
+              event: event,
+              data_json: JSON.stringify({
+                channelId: this.channelId,
+                pathname: location.pathname
+              })
+            },
+            {includeUserId: true}
+          );
+
           onError(error);
         }
       }

--- a/apps/src/code-studio/components/libraries/LibraryManagerDialog.jsx
+++ b/apps/src/code-studio/components/libraries/LibraryManagerDialog.jsx
@@ -154,7 +154,7 @@ export class LibraryManagerDialog extends React.Component {
     }
   };
 
-  fetchLatestLibrary = (channelId, callback) => {
+  fetchLatestLibrary = (channelId, callback, event) => {
     const {cachedClassLibraries} = this.state;
     const cachedLibrary = cachedClassLibraries.find(
       library => library.channelId === channelId
@@ -186,7 +186,8 @@ export class LibraryManagerDialog extends React.Component {
           },
           errorCallback
         ),
-      errorCallback
+      errorCallback,
+      event
     );
   };
 
@@ -207,8 +208,10 @@ export class LibraryManagerDialog extends React.Component {
     }
 
     const onUpdate = channelId => {
-      this.fetchLatestLibrary(channelId, lib =>
-        this.viewCode(lib, DisplayLibraryMode.UPDATE)
+      this.fetchLatestLibrary(
+        channelId,
+        lib => this.viewCode(lib, DisplayLibraryMode.UPDATE),
+        'update' /* event */
       );
     };
 
@@ -248,10 +251,18 @@ export class LibraryManagerDialog extends React.Component {
           key={library.channel}
           library={library}
           onAdd={() =>
-            this.fetchLatestLibrary(library.channel, this.addLibraryToProject)
+            this.fetchLatestLibrary(
+              library.channel,
+              this.addLibraryToProject,
+              'add' /* event */
+            )
           }
           onViewCode={() =>
-            this.fetchLatestLibrary(library.channel, this.viewCode)
+            this.fetchLatestLibrary(
+              library.channel,
+              this.viewCode,
+              'view' /* event */
+            )
           }
         />
       );
@@ -384,7 +395,11 @@ export class LibraryManagerDialog extends React.Component {
               style={styles.add}
               onClick={() => {
                 this.setState({isLoading: true});
-                this.fetchLatestLibrary(importLibraryId, this.addLibraryById);
+                this.fetchLatestLibrary(
+                  importLibraryId,
+                  this.addLibraryById,
+                  'import' /* event */
+                );
               }}
               type="button"
               disabled={!importLibraryId}


### PR DESCRIPTION
Adding some logging to hopefully give us some insight around how to fix the following:

We've gotten an influx of Honeybadger errors where calls to `GET /v3/libraries/:channel_id/library.json/versions` 500s because `:channel_id` is invalid. In every error instance I could find, the channel was invalid because we're sending the library name to that endpoint instead of an actual channel ID. Example ([link to Honeybadger instance](https://app.honeybadger.io/projects/3240/faults/37286091/01G3XYBTRH3NSHP0WEQXG3DFWH#notice-summary)):

<img width="1129" alt="Screen Shot 2022-06-01 at 3 33 38 PM" src="https://user-images.githubusercontent.com/9812299/171512751-c437935c-bff1-4295-928d-65a12f97edaf.png">

'repeat' is the name of the library. I wasn't able to reproduce this issue myself from the CSP curriculum (unites 6-9 deal with libraries) or from an Applab project. Honeybadger doesn't report where the request was made from, which is why frontend logging is needed. 

This logging will tell us the following so we can then hopefully reproduce:
- The action that triggered this request (importing from an ID, adding from a classmate, updating an already-imported library, or viewing the code for a library)
- The pathname that triggered this request (was it a ScriptLevel? an Applab project?)
- The user

## Links

- [STAR-2140](https://codedotorg.atlassian.net/browse/STAR-2140)