### PR TITLE
Update `sinatra` gem to 2.2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,10 +21,7 @@ gem 'sprockets-rails'
 # (see: http://guides.rubyonrails.org/4_2_release_notes.html#respond-with-class-level-respond-to)
 gem 'responders', '~> 3.0'
 
-# Pinning sinatra to 2.0.2, since '~> 2.0.2' actually lands us on 2.0.5, which
-# breaks some firebase URIs. See
-# https://github.com/code-dot-org/code-dot-org/pull/31614
-gem 'sinatra', '2.0.2', require: 'sinatra/base'
+gem 'sinatra', '~> 2.2.0'
 
 gem 'mysql2', '>= 0.4.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -568,7 +568,8 @@ GEM
     multi_test (0.1.2)
     multi_xml (0.5.5)
     multipart-post (2.1.1)
-    mustermann (1.0.3)
+    mustermann (1.1.1)
+      ruby2_keywords (~> 0.0.1)
     mysql2 (0.5.2)
     nakayoshi_fork (0.0.4)
     naturally (2.1.0)
@@ -657,7 +658,7 @@ GEM
       pusher-signature (~> 0.1.8)
     pusher-signature (0.1.8)
     racc (1.5.2)
-    rack (2.2.3)
+    rack (2.2.3.1)
     rack-cache (1.6.1)
       rack (>= 0.4)
     rack-mini-profiler (1.0.0)
@@ -673,7 +674,7 @@ GEM
       ruby-openid (>= 2.1.8)
     rack-parser (0.7.0)
       rack
-    rack-protection (2.0.2)
+    rack-protection (2.2.0)
       rack
     rack-ssl-enforcer (0.2.9)
     rack-test (1.1.0)
@@ -778,6 +779,7 @@ GEM
     ruby-prof (0.15.9)
     ruby-progressbar (1.10.1)
     ruby-rc4 (0.1.5)
+    ruby2_keywords (0.0.5)
     ruby_dep (1.3.1)
     ruby_parser (3.18.1)
       sexp_processor (~> 4.16)
@@ -811,10 +813,10 @@ GEM
       faraday (~> 0.9)
       jwt (>= 1.5, < 3.0)
       multi_json (~> 1.10)
-    sinatra (2.0.2)
+    sinatra (2.2.0)
       mustermann (~> 1.0)
-      rack (~> 2.0)
-      rack-protection (= 2.0.2)
+      rack (~> 2.2)
+      rack-protection (= 2.2.0)
       tilt (~> 2.0)
     spring (2.0.1)
       activesupport (>= 4.2)
@@ -1058,7 +1060,7 @@ DEPENDENCIES
   selenium-webdriver (= 3.141.0)
   sequel
   shotgun
-  sinatra (= 2.0.2)
+  sinatra (~> 2.2.0)
   sort_alphabetical!
   spring
   spring-commands-testunit

--- a/shared/middleware/helpers/firebase_helper.rb
+++ b/shared/middleware/helpers/firebase_helper.rb
@@ -16,7 +16,7 @@ class FirebaseHelper
   # @return [String] A representation of the table (its columns and its data) as a CSV string.
   def table_as_csv(table_name)
     response = @firebase.get(
-      "/v3/channels/#{@channel_id}/storage/tables/#{table_name}/records"
+      "/v3/channels/#{@channel_id}/storage/tables/#{escape_table_name(table_name)}/records"
     )
     records = response.body || []
 


### PR DESCRIPTION
So we can get Ruby 2.7 support, added in 2.0.8 and 2.1.0

Also add a missing `escape_table_name` call. See https://github.com/code-dot-org/code-dot-org/pull/25507, https://github.com/code-dot-org/code-dot-org/pull/31614, and https://github.com/code-dot-org/code-dot-org/commit/308e048ceb467e4beae82edf33740b5995ba01a2 for context

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
