### PR TITLE
Clean up documentation in the instructions panel

### DIFF
--- a/apps/src/templates/codeDocs/MethodSummaryTable.jsx
+++ b/apps/src/templates/codeDocs/MethodSummaryTable.jsx
@@ -32,8 +32,7 @@ export default function MethodSummaryTable({methods}) {
 }
 
 MethodSummaryTable.propTypes = {
-  methods: PropTypes.arrayOf(PropTypes.object).isRequired,
-  includeLink: PropTypes.bool
+  methods: PropTypes.arrayOf(PropTypes.object).isRequired
 };
 
 const styles = {

--- a/apps/src/templates/codeDocs/MethodWithOverloads.jsx
+++ b/apps/src/templates/codeDocs/MethodWithOverloads.jsx
@@ -10,7 +10,8 @@ import color from '@cdo/apps/util/color';
 export function SingleMethod({
   method,
   programmingEnvironmentName,
-  programmingEnvironmentLanguage
+  programmingEnvironmentLanguage,
+  isSmallWindow
 }) {
   return (
     <div id={`method-${method.key}`}>
@@ -29,6 +30,7 @@ export function SingleMethod({
           <ParametersTable
             parameters={method.parameters}
             programmingEnvironmentLanguage={programmingEnvironmentLanguage}
+            isSmallWindow={isSmallWindow}
           />
         </div>
       )}
@@ -61,7 +63,8 @@ export function SingleMethod({
 export function MethodOverloadSection({
   overloads,
   programmingEnvironmentName,
-  programmingEnvironmentLanguage
+  programmingEnvironmentLanguage,
+  isSmallWindow
 }) {
   const [isOpen, setIsOpen] = useState(true);
   const icon = isOpen ? 'caret-down' : 'caret-up';
@@ -82,6 +85,7 @@ export function MethodOverloadSection({
               method={overload}
               programmingEnvironmentName={programmingEnvironmentName}
               programmingEnvironmentLanguage={programmingEnvironmentLanguage}
+              isSmallWindow={isSmallWindow}
             />
           ))}
         </div>
@@ -93,7 +97,8 @@ export function MethodOverloadSection({
 export default function MethodWithOverloads({
   method,
   programmingEnvironmentName,
-  programmingEnvironmentLanguage
+  programmingEnvironmentLanguage,
+  isSmallWindow
 }) {
   return (
     <div style={styles.container}>
@@ -101,12 +106,14 @@ export default function MethodWithOverloads({
         method={method}
         programmingEnvironmentName={programmingEnvironmentName}
         programmingEnvironmentLanguage={programmingEnvironmentLanguage}
+        isSmallWindow={isSmallWindow}
       />
       {method.overloads?.length > 0 && (
         <MethodOverloadSection
           overloads={method.overloads}
           programmingEnvironmentName={programmingEnvironmentName}
           programmingEnvironmentLanguage={programmingEnvironmentLanguage}
+          isSmallWindow={isSmallWindow}
         />
       )}
     </div>
@@ -127,19 +134,22 @@ const methodShape = PropTypes.shape({
 SingleMethod.propTypes = {
   method: methodShape.isRequired,
   programmingEnvironmentName: PropTypes.string,
-  programmingEnvironmentLanguage: PropTypes.string
+  programmingEnvironmentLanguage: PropTypes.string,
+  isSmallWindow: PropTypes.bool
 };
 
 MethodOverloadSection.propTypes = {
   overloads: PropTypes.arrayOf(methodShape),
   programmingEnvironmentName: PropTypes.string,
-  programmingEnvironmentLanguage: PropTypes.string
+  programmingEnvironmentLanguage: PropTypes.string,
+  isSmallWindow: PropTypes.bool
 };
 
 MethodWithOverloads.propTypes = {
   method: methodShape.isRequired,
   programmingEnvironmentName: PropTypes.string,
-  programmingEnvironmentLanguage: PropTypes.string
+  programmingEnvironmentLanguage: PropTypes.string,
+  isSmallWindow: PropTypes.bool
 };
 
 const styles = {

--- a/apps/src/templates/codeDocs/MethodWithOverloads.jsx
+++ b/apps/src/templates/codeDocs/MethodWithOverloads.jsx
@@ -159,7 +159,8 @@ const styles = {
     borderWidth: 1,
     borderRadius: 5,
     padding: 5,
-    marginBottom: 10
+    marginBottom: 10,
+    minWidth: 'fit-content'
   },
   openOverloadHeader: {
     backgroundColor: color.lightest_gray,

--- a/apps/src/templates/codeDocs/ParametersTable.jsx
+++ b/apps/src/templates/codeDocs/ParametersTable.jsx
@@ -19,23 +19,29 @@ const requiredFormatter = required => {
   }
 };
 
-const descriptionFormatter = description => {
-  if (description) {
-    return (
-      <div style={{padding: 10}}>
-        <EnhancedSafeMarkdown markdown={description} />
-      </div>
-    );
-  } else {
-    return null;
-  }
-};
-
 export default function ParametersTable({
   parameters,
-  programmingEnvironmentLanguage
+  programmingEnvironmentLanguage,
+  isSmallWindow
 }) {
+  const descriptionFormatter = description => {
+    if (description) {
+      const padding = isSmallWindow ? '0px 0px 0px 5px' : 10;
+      return (
+        <div style={{padding: padding}}>
+          <EnhancedSafeMarkdown markdown={description} />
+        </div>
+      );
+    } else {
+      return null;
+    }
+  };
+
   const hideRequiredColumn = programmingEnvironmentLanguage === 'java';
+  let cellStyle = tableLayoutStyles.cell;
+  if (isSmallWindow) {
+    cellStyle = {...cellStyle, ...styles.smallCell};
+  }
   const columns = [
     {
       property: 'name',
@@ -50,7 +56,7 @@ export default function ParametersTable({
         }
       },
       cell: {
-        props: {style: tableLayoutStyles.cell}
+        props: {style: cellStyle}
       }
     },
     {
@@ -66,7 +72,7 @@ export default function ParametersTable({
         }
       },
       cell: {
-        props: {style: tableLayoutStyles.cell}
+        props: {style: cellStyle}
       }
     },
     {
@@ -86,7 +92,7 @@ export default function ParametersTable({
         formatters: [requiredFormatter],
         props: {
           style: {
-            ...tableLayoutStyles.cell,
+            ...cellStyle,
             ...(hideRequiredColumn && {display: 'none'})
           }
         }
@@ -106,7 +112,7 @@ export default function ParametersTable({
       },
       cell: {
         formatters: [descriptionFormatter],
-        props: {style: tableLayoutStyles.cell}
+        props: {style: cellStyle}
       }
     }
   ];
@@ -125,7 +131,8 @@ export default function ParametersTable({
 
 ParametersTable.propTypes = {
   parameters: PropTypes.arrayOf(PropTypes.object),
-  programmingEnvironmentLanguage: PropTypes.string
+  programmingEnvironmentLanguage: PropTypes.string,
+  isSmallWindow: PropTypes.bool
 };
 
 const styles = {
@@ -138,5 +145,9 @@ const styles = {
   },
   table: {
     width: '100%'
+  },
+  smallCell: {
+    padding: 5,
+    fontSize: 13
   }
 };

--- a/apps/src/templates/codeDocs/ProgrammingClassOverview.jsx
+++ b/apps/src/templates/codeDocs/ProgrammingClassOverview.jsx
@@ -11,7 +11,8 @@ export default function ProgrammingClassOverview({
   programmingClass,
   programmingEnvironmentName,
   programmingEnvironmentLanguage,
-  includeMethodSummary
+  includeMethodSummary,
+  isSmallWindow
 }) {
   return (
     <div style={{width: '100%'}}>
@@ -99,6 +100,7 @@ export default function ProgrammingClassOverview({
               method={method}
               programmingEnvironmentName={programmingEnvironmentName}
               programmingEnvironmentLanguage={programmingEnvironmentLanguage}
+              isSmallWindow={isSmallWindow}
             />
           ))}
         </div>
@@ -121,5 +123,6 @@ ProgrammingClassOverview.propTypes = {
   programmingClass: programmingClassShape.isRequired,
   programmingEnvironmentName: PropTypes.string,
   programmingEnvironmentLanguage: PropTypes.string,
-  includeMethodSummary: PropTypes.bool
+  includeMethodSummary: PropTypes.bool,
+  isSmallWindow: PropTypes.bool
 };

--- a/apps/src/templates/instructions/DocumentationTab.jsx
+++ b/apps/src/templates/instructions/DocumentationTab.jsx
@@ -97,6 +97,7 @@ export const UnconnectedDocumentationTab = function({
           <ProgrammingClassOverview
             programmingClass={classMap[keyToShow].doc}
             includeMethodSummary={true}
+            isSmallWindow={true}
           />
         </>
       )}


### PR DESCRIPTION
For wide parameter tables and code snippets there were some overflow issues for code docs in the instructions panel:

Table overflow
<img width="404" alt="Screen Shot 2022-06-01 at 1 32 05 PM" src="https://user-images.githubusercontent.com/33666587/171514743-29e937a4-c5c6-4470-8dcf-812e49595cb1.png">

Snippet Overflow
<img width="395" alt="Screen Shot 2022-06-01 at 1 32 18 PM" src="https://user-images.githubusercontent.com/33666587/171514762-ccfc8d9a-c04f-4554-afd3-9329062b0b15.png">

To fix this I made two changes:
- Add a small window parameter to method details that is used to shrink the padding and the font size for the parameter table. This makes it so the table is more likely to fit in the window and requires less scrolling.
- Update the width of the container for method details to have `min-width: fit-content`, so the border will go around any content larger than the window. The instructions panel scrolls so the user can see the rest of the text if the scroll (or resize the panel).

The same methods after:
Table overflow: shrinking the padding let the entire table fit
![Screen Shot 2022-06-01 at 3 41 03 PM](https://user-images.githubusercontent.com/33666587/171514969-a9efaf9b-0ab8-4191-a603-54baf2e57958.png)

Snippet overflow: we extend the size of the border to fit all the text:
![Screen Shot 2022-06-01 at 3 41 18 PM](https://user-images.githubusercontent.com/33666587/171514973-f38ce1bb-5ae9-4244-981b-c412b653e058.png)

## Links
- jira ticket: [JAVA-616](https://codedotorg.atlassian.net/browse/JAVA-616)


## Testing story
Tested locally. This doesn't change anything for the main docs page.

