### PR TITLE
only load firebase when editing applab level

### DIFF
--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -148,8 +148,10 @@ class LevelsController < ApplicationController
     any_parent_in_script = bubble_choice_parents.any? {|pl| pl.script_levels.any?}
     @in_script = @level.script_levels.any? || any_parent_in_script
     @standalone = ProjectsController::STANDALONE_PROJECTS.values.map {|h| h[:name]}.include?(@level.name)
-    fb = FirebaseHelper.new('shared')
-    @dataset_library_manifest = fb.get_library_manifest
+    if @level.is_a? Applab
+      fb = FirebaseHelper.new('shared')
+      @dataset_library_manifest = fb.get_library_manifest
+    end
   end
 
   use_reader_connection_for_route(:get_rubric)


### PR DESCRIPTION
Finishes [PLAT-1453](https://codedotorg.atlassian.net/browse/PLAT-1453).

## Testing story

* manually verified that applab level edit page still loads, and that the list of datasets still loads: 
![Screen Shot 2022-06-01 at 4 35 45 PM](https://user-images.githubusercontent.com/8001765/171518541-e3918104-6185-48a8-8c4c-25dae33bf5bc.png)

* verified by code inspection that the only level type we need this data for is applab: https://github.com/code-dot-org/code-dot-org/blob/86a6102f236dfc4d906c6774afd2a647e5bfadf4/dashboard/app/views/levels/editors/_applab.html.haml#L24
