### PR TITLE
always use migrated teacher resources for migrated units

### DIFF
--- a/apps/src/code-studio/components/progress/UnitOverviewTopRow.jsx
+++ b/apps/src/code-studio/components/progress/UnitOverviewTopRow.jsx
@@ -126,8 +126,6 @@ class UnitOverviewTopRow extends React.Component {
       courseVersionId
     } = this.props;
 
-    const useMigratedTeacherResources = isMigrated && !teacherResources.length;
-
     const pdfDropdownOptions = this.compilePdfDropdownOptions();
 
     // Adjust styles if locale is RTL
@@ -177,14 +175,13 @@ class UnitOverviewTopRow extends React.Component {
         <div style={styles.resourcesRow}>
           {!professionalLearningCourse &&
             viewAs === ViewType.Instructor &&
-            ((!useMigratedTeacherResources && teacherResources.length > 0) ||
-              (useMigratedTeacherResources &&
-                migratedTeacherResources.length > 0)) && (
+            ((!isMigrated && teacherResources.length > 0) ||
+              (isMigrated && migratedTeacherResources.length > 0)) && (
               <ResourcesDropdown
                 resources={teacherResources}
                 migratedResources={migratedTeacherResources}
                 unitId={scriptId}
-                useMigratedResources={useMigratedTeacherResources}
+                useMigratedResources={isMigrated}
               />
             )}
           {pdfDropdownOptions.length > 0 && viewAs === ViewType.Instructor && (

--- a/apps/test/unit/code-studio/components/progress/UnitOverviewTopRowTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/UnitOverviewTopRowTest.jsx
@@ -217,57 +217,6 @@ describe('UnitOverviewTopRow', () => {
         )
       ).to.be.true;
     });
-
-    it('renders legacy resources instead of migrated resources on migrated script', () => {
-      const wrapper = shallow(
-        <UnitOverviewTopRow
-          {...defaultProps}
-          viewAs={ViewType.Instructor}
-          isMigrated={true}
-          teacherResources={[
-            {
-              type: ResourceType.curriculum,
-              link: 'https://example.com/a'
-            },
-            {
-              type: ResourceType.vocabulary,
-              link: 'https://example.com/b'
-            }
-          ]}
-          migratedTeacherResources={[
-            {
-              id: 1,
-              key: 'curriculum',
-              name: 'Curriculum',
-              url: 'https://example.com/a'
-            },
-            {
-              id: 2,
-              key: 'vocabulary',
-              name: 'Vocabulary',
-              url: 'https://example.com/b'
-            }
-          ]}
-        />
-      );
-      expect(
-        wrapper.containsMatchingElement(
-          <ResourcesDropdown
-            resources={[
-              {
-                type: ResourceType.curriculum,
-                link: 'https://example.com/a'
-              },
-              {
-                type: ResourceType.vocabulary,
-                link: 'https://example.com/b'
-              }
-            ]}
-            useMigratedResources={false}
-          />
-        )
-      ).to.be.true;
-    });
   });
 
   it('renders the unit calendar when showCalendar true for instructor', () => {


### PR DESCRIPTION
Continues [PLAT-1680](https://codedotorg.atlassian.net/browse/PLAT-1680). See [work plan](https://docs.google.com/document/d/1yIL2Z7aqFTdbCi24-RpUhPO_B3wRdsiKRTB1EEs17EY/edit#heading=h.1l25aiwflbrc).

now that migrated teacher resources have had time to be translated, we no longer need to temporarily show unmigrated teacher resources on migrated units.

## screenshots

![Screen Shot 2022-06-01 at 5 13 40 PM](https://user-images.githubusercontent.com/8001765/171522285-c2c8d245-0321-4e4f-aeba-9eda759b121e.png)

## Testing story

manually verified that all teacher resources in CSF 2020 are translated into es-MX (see screenshot for example).
