### PR TITLE
Revert "Instructions: Truncate Tabs"

### DIFF
--- a/apps/src/templates/instructions/InlineAudio.jsx
+++ b/apps/src/templates/instructions/InlineAudio.jsx
@@ -318,8 +318,7 @@ const styles = {
 
   wrapper: {
     marginLeft: '3px',
-    marginRight: '3px',
-    display: 'flex'
+    marginRight: '3px'
   },
 
   button: {

--- a/apps/src/templates/instructions/InstructionsTab.jsx
+++ b/apps/src/templates/instructions/InstructionsTab.jsx
@@ -41,16 +41,13 @@ export default class InstructionsTab extends Component {
         : styles.text)
     };
     return (
-      <div style={styles.tabWrapper}>
-        <a
-          className={this.props.className}
-          onClick={this.props.onClick}
-          style={combinedStyle}
-          title={this.props.text}
-        >
-          {this.props.text}
-        </a>
-      </div>
+      <a
+        className={this.props.className}
+        onClick={this.props.onClick}
+        style={combinedStyle}
+      >
+        {this.props.text}
+      </a>
     );
   }
 }
@@ -60,23 +57,17 @@ const styles = {
     marginRight: 5,
     paddingLeft: 10,
     paddingRight: 10,
-    paddingBottom: 4,
+    paddingBottom: 6,
     fontWeight: 'bold',
-    cursor: 'pointer',
-    whiteSpace: 'nowrap'
+    cursor: 'pointer'
   },
   tabRtl: {
     marginLeft: 5,
     paddingLeft: 10,
     paddingRight: 10,
-    paddingBottom: 4,
+    paddingBottom: 6,
     fontWeight: 'bold',
-    cursor: 'pointer',
-    whiteSpace: 'nowrap'
-  },
-  tabWrapper: {
-    overflow: 'hidden',
-    textOverflow: 'ellipsis'
+    cursor: 'pointer'
   },
   text: {
     color: color.charcoal

--- a/apps/src/templates/instructions/TopInstructionsHeader.jsx
+++ b/apps/src/templates/instructions/TopInstructionsHeader.jsx
@@ -196,14 +196,11 @@ function TopInstructionsHeader(props) {
 
 const styles = {
   paneHeaderOverride: {
-    color: color.default_text,
-    display: 'flex',
-    width: '100%',
-    justifyContent: 'space-between'
+    color: color.default_text
   },
   audioRTL: {
     wrapper: {
-      order: 5
+      float: 'left'
     }
   },
   audio: {
@@ -220,15 +217,11 @@ const styles = {
   },
   audioLTR: {
     wrapper: {
-      order: 5
+      float: 'right'
     }
   },
   helpTabs: {
-    paddingTop: 6,
-    width: '100%',
-    boxSizing: 'border-box',
-    display: 'flex',
-    minWidth: 100
+    paddingTop: 6
   },
   helpTabsLtr: {
     float: 'left',


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#46612
This caused some unexpected eyes diffs, specifically around a background music header button not fully displaying anymore, and a line disappeared from under the tab.