### PR TITLE
Safeguard against requesting starter_assets when Level has none

### DIFF
--- a/dashboard/app/controllers/level_starter_assets_controller.rb
+++ b/dashboard/app/controllers/level_starter_assets_controller.rb
@@ -22,7 +22,8 @@ class LevelStarterAssetsController < ApplicationController
   # Returns requested file body as an IO stream.
   def file
     friendly_name = "#{params[:filename]}.#{params[:format]}"
-    starter_assets = @level&.project_template_level&.starter_assets || @level.starter_assets
+    starter_assets = @level&.project_template_level&.starter_assets || @level&.starter_assets
+    return head :not_found if starter_assets.nil_or_empty?
     uuid_name = starter_assets[friendly_name]
     file_obj = get_object(uuid_name)
     content_type = file_content_type(File.extname(uuid_name))

--- a/dashboard/test/controllers/level_starter_assets_controller_test.rb
+++ b/dashboard/test/controllers/level_starter_assets_controller_test.rb
@@ -103,6 +103,15 @@ class LevelStarterAssetsControllerTest < ActionController::TestCase
     assert_equal 'inline', response.headers['Content-Disposition']
   end
 
+  test 'file: returns 404 if level has no starter assets' do
+    LevelStarterAssetsController.any_instance.expects(:get_object).never
+    level = create(:applab, starter_assets: nil)
+
+    get :file, params: {level_name: level.name, filename: 'ty', format: 'png'}
+
+    assert_response :not_found
+  end
+
   test 'upload: forbidden for non-levelbuilders' do
     sign_in create(:student)
     post :upload, params: {level_name: create(:applab).name, files: []}


### PR DESCRIPTION
[Fixes this Honeybadger error](https://app.honeybadger.io/projects/3240/faults/81278125/01G400YBBSDT3VKWGT8A6WHKWA#notice-summary) which occurred when a levelbuilder would remix a curriculum level that has starter assets (i.e., images that are automatically loaded into the level). Starter assets only work with curriculum levels (e.g., `level.starter_assets`), so when a Level is remixed to a project, the starter assets aren't transferred to the project because the "level" is something like `New App Lab Project.level`. We can extend the starter assets feature to work with the projects system, so I've logged follow-up work for that (if it's something curriculum needs/wants).

## Links

- [STAR-2107](https://codedotorg.atlassian.net/browse/STAR-2107)
- [Honeybadger error](https://app.honeybadger.io/projects/3240/faults/81278125/01G400YBBSDT3VKWGT8A6WHKWA#notice-summary)

## Testing story

Added unit test.

## Follow-up work

[STAR-2321](https://codedotorg.atlassian.net/browse/STAR-2321) - Determine curriculum needs and refactor starter assets feature to work for exemplar projects if needed.