### PR TITLE
Display only the new review tab for code review v2 experiment

### DIFF
--- a/apps/src/templates/instructions/TopInstructions.jsx
+++ b/apps/src/templates/instructions/TopInstructions.jsx
@@ -51,7 +51,7 @@ export const TabType = {
   DOCUMENTATION: 'documentation',
   REVIEW: 'review',
   TEACHER_ONLY: 'teacher-only',
-  COMMITS_AND_REVIEW: 'commits-and-review'
+  REVIEW_V2: 'review-v2'
 };
 
 // Minecraft-specific styles
@@ -137,9 +137,10 @@ class TopInstructions extends Component {
       this.props.readOnlyWorkspace &&
       window.location.search.includes('user_id');
 
-    const teacherViewingStudentTab = this.props.displayReviewTab
-      ? TabType.REVIEW
-      : TabType.COMMENTS;
+    const teacherViewingStudentTab =
+      this.props.displayReviewTab && !experiments.isEnabled('code_review_v2')
+        ? TabType.REVIEW
+        : TabType.COMMENTS;
 
     this.state = {
       // We don't want to start in the comments tab for CSF since its hidden
@@ -608,7 +609,7 @@ class TopInstructions extends Component {
         ? styles.csfBody
         : containerStyle || styles.body,
       isMinecraft && craftStyles.instructionsBody,
-      tabSelected === TabType.COMMITS_AND_REVIEW && styles.commitAndReview
+      tabSelected === TabType.REVIEW_V2 && styles.commitAndReview
     ];
 
     // Only display the help tab when there are one or more videos or
@@ -619,16 +620,19 @@ class TopInstructions extends Component {
     const displayHelpTab =
       (levelVideos && levelVideos.length > 0) || levelResourcesAvailable;
 
-    // If we're displaying the review tab (for CSA peer review) the teacher can leave feedback in that tab,
+    const displayReviewV1Tab =
+      displayReviewTab && !experiments.isEnabled('code_review_v2');
+
+    const displayReviewV2Tab =
+      displayReviewTab && experiments.isEnabled('code_review_v2');
+
+    // If we're displaying the v1 review tab (for CSA peer review) the teacher can leave feedback in that tab,
     // in that case we hide the feedback tab (unless there's a rubric) to avoid confusion about
     // where the teacher should leave feedback
     const displayFeedbackTab =
       !!rubric ||
-      (!displayReviewTab && teacherViewingStudentWork) ||
+      (!displayReviewV1Tab && teacherViewingStudentWork) ||
       (this.isViewingAsStudent && !!latestFeedback);
-
-    const displayCommitsAndReviewTab =
-      displayReviewTab && experiments.isEnabled('code_review_v2');
 
     // Teacher is viewing students work and in the Feedback Tab
     const teacherOnly =
@@ -675,8 +679,8 @@ class TopInstructions extends Component {
           displayFeedback={displayFeedbackTab}
           levelHasRubric={!!rubric}
           displayDocumentationTab={displayDocumentationTab}
-          displayReviewTab={displayReviewTab}
-          displayCommitsAndReviewTab={displayCommitsAndReviewTab}
+          displayReviewTab={displayReviewV1Tab}
+          displayReviewV2Tab={displayReviewV2Tab}
           isViewingAsTeacher={this.isViewingAsTeacher}
           hasBackgroundMusic={hasBackgroundMusic}
           fetchingData={fetchingData}
@@ -690,9 +694,7 @@ class TopInstructions extends Component {
             this.handleTabClick(TabType.DOCUMENTATION)
           }
           handleReviewTabClick={() => this.handleTabClick(TabType.REVIEW)}
-          handleCommitsAndReviewTabClick={() =>
-            this.handleTabClick(TabType.COMMITS_AND_REVIEW)
-          }
+          handleReviewV2TabClick={() => this.handleTabClick(TabType.REVIEW_V2)}
           handleTeacherOnlyTabClick={this.handleTeacherOnlyTabClick}
           collapsible={this.props.collapsible}
           handleClickCollapser={this.handleClickCollapser}
@@ -717,7 +719,7 @@ class TopInstructions extends Component {
             {!fetchingData && (
               <TeacherFeedbackTab
                 teacherViewingStudentWork={teacherViewingStudentWork}
-                displayReviewTab={displayReviewTab}
+                displayReviewTab={displayReviewV1Tab}
                 visible={tabSelected === TabType.COMMENTS}
                 rubric={rubric}
                 innerRef={ref => (this.commentTab = ref)}
@@ -734,7 +736,7 @@ class TopInstructions extends Component {
             {tabSelected === TabType.REVIEW && (
               <ReviewTab ref={ref => (this.reviewTab = ref)} />
             )}
-            {tabSelected === TabType.COMMITS_AND_REVIEW && (
+            {tabSelected === TabType.REVIEW_V2 && (
               <CommitsAndReviewTab
                 ref={ref => (this.commitsAndReviewTab = ref)}
                 onLoadComplete={this.forceTabResizeToMaxOrAvailableHeight}

--- a/apps/src/templates/instructions/TopInstructionsHeader.jsx
+++ b/apps/src/templates/instructions/TopInstructionsHeader.jsx
@@ -21,7 +21,7 @@ function TopInstructionsHeader(props) {
     levelHasRubric,
     displayDocumentationTab,
     displayReviewTab,
-    displayCommitsAndReviewTab,
+    displayReviewV2Tab,
     isViewingAsTeacher,
     hasBackgroundMusic,
     fetchingData,
@@ -31,7 +31,7 @@ function TopInstructionsHeader(props) {
     handleCommentTabClick,
     handleDocumentationTabClick,
     handleReviewTabClick,
-    handleCommitsAndReviewTabClick,
+    handleReviewV2TabClick,
     handleTeacherOnlyTabClick,
     handleClickCollapser,
     isMinecraft,
@@ -145,12 +145,13 @@ function TopInstructionsHeader(props) {
               isRtl={isRtl}
             />
           )}
-          {displayCommitsAndReviewTab && (
+          {displayReviewV2Tab && (
             <InstructionsTab
-              className="uitest-commitsAndReviewTab"
-              onClick={handleCommitsAndReviewTabClick}
-              selected={tabSelected === TabType.COMMITS_AND_REVIEW}
+              className="uitest-reviewV2Tab"
+              onClick={handleReviewV2TabClick}
+              selected={tabSelected === TabType.REVIEW_V2}
               text={i18n.review()}
+              teacherOnly={teacherOnly}
               isMinecraft={isMinecraft}
               isRtl={isRtl}
             />
@@ -269,7 +270,7 @@ TopInstructionsHeader.propTypes = {
   levelHasRubric: PropTypes.bool,
   displayDocumentationTab: PropTypes.bool,
   displayReviewTab: PropTypes.bool,
-  displayCommitsAndReviewTab: PropTypes.bool,
+  displayReviewV2Tab: PropTypes.bool,
   isViewingAsTeacher: PropTypes.bool,
   hasBackgroundMusic: PropTypes.bool.isRequired,
   fetchingData: PropTypes.bool,
@@ -279,7 +280,7 @@ TopInstructionsHeader.propTypes = {
   handleCommentTabClick: PropTypes.func.isRequired,
   handleDocumentationTabClick: PropTypes.func.isRequired,
   handleReviewTabClick: PropTypes.func.isRequired,
-  handleCommitsAndReviewTabClick: PropTypes.func.isRequired,
+  handleReviewV2TabClick: PropTypes.func.isRequired,
   handleTeacherOnlyTabClick: PropTypes.func.isRequired,
   handleClickCollapser: PropTypes.func.isRequired,
   isMinecraft: PropTypes.bool.isRequired,

--- a/apps/src/templates/instructions/teacherFeedback/TeacherFeedbackTab.jsx
+++ b/apps/src/templates/instructions/teacherFeedback/TeacherFeedbackTab.jsx
@@ -19,7 +19,7 @@ const TeacherFeedbackTab = ({
   teacher,
   innerRef
 }) => {
-  // If the teacher is viewing student work and there is no review tab (CSA peer review)
+  // If the teacher is viewing student work and there is no review tab (CSA peer review v1)
   // then the teacher is able to leave feedback for the student (editable feedback)
   const renderEditableFeedback = teacherViewingStudentWork && !displayReviewTab;
 

--- a/apps/test/unit/templates/instructions/TopInstructionsHeaderTest.jsx
+++ b/apps/test/unit/templates/instructions/TopInstructionsHeaderTest.jsx
@@ -21,7 +21,7 @@ const DEFAULT_PROPS = {
   fetchingData: false,
   handleDocumentationClick: () => {},
   handleInstructionTabClick: () => {},
-  handleCommitsAndReviewTabClick: () => {},
+  handleReviewV2TabClick: () => {},
   handleHelpTabClick: () => {},
   handleCommentTabClick: () => {},
   handleDocumentationTabClick: () => {},

--- a/apps/test/unit/templates/instructions/TopInstructionsTest.jsx
+++ b/apps/test/unit/templates/instructions/TopInstructionsTest.jsx
@@ -257,7 +257,7 @@ describe('TopInstructions', () => {
           .be.false;
       });
 
-      it('passes displayCommitsAndReviewTab false if displayReviewTab is false', () => {
+      it('passes displayReviewV2Tab false if displayReviewTab is false', () => {
         const wrapper = shallow(
           <TopInstructions
             {...DEFAULT_PROPS}
@@ -266,12 +266,11 @@ describe('TopInstructions', () => {
           />
         );
 
-        expect(
-          wrapper.find(TopInstructionsHeader).props().displayCommitsAndReviewTab
-        ).to.be.false;
+        expect(wrapper.find(TopInstructionsHeader).props().displayReviewV2Tab)
+          .to.be.false;
       });
 
-      it('passes displayCommitsAndReviewTab false if the code_review_v2 experiment is not enabled', () => {
+      it('passes displayReviewTab=true and displayReviewV2Tab=false if the code_review_v2 experiment is not enabled', () => {
         sinon
           .stub(experiments, 'isEnabled')
           .withArgs('code_review_v2')
@@ -285,9 +284,34 @@ describe('TopInstructions', () => {
           />
         );
 
-        expect(
-          wrapper.find(TopInstructionsHeader).props().displayCommitsAndReviewTab
-        ).to.be.false;
+        expect(wrapper.find(TopInstructionsHeader).props().displayReviewTab).to
+          .be.true;
+
+        expect(wrapper.find(TopInstructionsHeader).props().displayReviewV2Tab)
+          .to.be.false;
+
+        experiments.isEnabled.restore();
+      });
+
+      it('passes displayReviewTab=false and displayReviewV2Tab=true if the code_review_v2 experiment is enabled', () => {
+        sinon
+          .stub(experiments, 'isEnabled')
+          .withArgs('code_review_v2')
+          .returns(true);
+
+        const wrapper = shallow(
+          <TopInstructions
+            {...DEFAULT_PROPS}
+            viewAs={ViewType.Participant}
+            displayReviewTab={true}
+          />
+        );
+
+        expect(wrapper.find(TopInstructionsHeader).props().displayReviewTab).to
+          .be.false;
+
+        expect(wrapper.find(TopInstructionsHeader).props().displayReviewV2Tab)
+          .to.be.true;
 
         experiments.isEnabled.restore();
       });


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Now, when `code_review_v2` is enabled, we will only see the new code review tab instead of the old and new code review tabs. Also, I've re-introduced the feedback tab when `code_review_v2` in enabled.

With code_review_v2 enabled:
![Screen Shot 2022-06-02 at 3 05 14 PM](https://user-images.githubusercontent.com/24235215/171746178-6681f38a-aef4-4320-9049-881dec40cb28.png)

With code_review_v2 disabled:
![Screen Shot 2022-06-02 at 3 10 06 PM](https://user-images.githubusercontent.com/24235215/171746730-f6e5aa1e-3635-4cb9-b72f-65ff127bb037.png)


Some background on the feedback tab choice: for CSA code review v1, we decided to hide the teacher feedback tab since it could be confusing to teachers whether they should leave their feedback on the feedback or the review tab. Now since the experiences on the two tabs have diverged a bit more - the code review tab is a more formal code review and teacher comments are public to other peers as part of the code review, it makes sense for teachers to have a place for private feedback, which is what they can do on the feedback tab.

## Testing story
Tested locally, updated unit tests
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
