### PR TITLE
Code Review - remove expiration logic and fix eyeball links

### DIFF
--- a/apps/src/templates/instructions/codeReviewV2/CodeReviewTimelineCommit.jsx
+++ b/apps/src/templates/instructions/codeReviewV2/CodeReviewTimelineCommit.jsx
@@ -8,7 +8,7 @@ import javalabMsg from '@cdo/javalab/locale';
 import {commitShape} from '@cdo/apps/templates/instructions/codeReviewV2/shapes';
 
 const CodeReviewTimelineCommit = ({commit, isLastElementInTimeline}) => {
-  const {createdAt, comment, projectVersion, isVersionExpired} = commit;
+  const {createdAt, comment, projectVersion} = commit;
   const formattedDate = moment(createdAt).format('M/D/YYYY [at] h:mm A');
 
   return (
@@ -16,7 +16,6 @@ const CodeReviewTimelineCommit = ({commit, isLastElementInTimeline}) => {
       type={codeReviewTimelineElementType.COMMIT}
       isLast={isLastElementInTimeline}
       projectVersionId={projectVersion}
-      isProjectVersionExpired={isVersionExpired}
     >
       <div style={styles.wrapper}>
         <div style={styles.header}>{javalabMsg.commit()}</div>

--- a/apps/src/templates/instructions/codeReviewV2/CodeReviewTimelineElement.jsx
+++ b/apps/src/templates/instructions/codeReviewV2/CodeReviewTimelineElement.jsx
@@ -185,6 +185,8 @@ const styles = {
   }
 };
 
+export const UnconnectedCodeReviewTimelineElement = CodeReviewTimelineElement;
+
 export default connect(state => ({
   viewAsCodeReviewer: state.pageConstants.isCodeReviewing
 }))(CodeReviewTimelineElement);

--- a/apps/src/templates/instructions/codeReviewV2/CodeReviewTimelineElement.jsx
+++ b/apps/src/templates/instructions/codeReviewV2/CodeReviewTimelineElement.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {connect} from 'react-redux';
 import {TextLink} from '@dsco_/link';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
 import color from '@cdo/apps/util/color';
@@ -25,10 +26,14 @@ const CodeReviewTimelineElement = ({
   type,
   isLast,
   projectVersionId,
+  viewAsCodeReviewer,
   children
 }) => {
   const versionLink =
     location.origin + location.pathname + '?version=' + projectVersionId;
+
+  // You can only see previous versions of your own project
+  const displayEyeball = !viewAsCodeReviewer && !!projectVersionId;
 
   if (type === codeReviewTimelineElementType.CREATED) {
     return (
@@ -49,8 +54,7 @@ const CodeReviewTimelineElement = ({
     return (
       <div style={styles.element}>
         <div style={styles.eyeColumn}>
-          {/* TODO only display version to owner */}
-          {!!projectVersionId && <EyeballLink versionHref={versionLink} />}
+          {displayEyeball && <EyeballLink versionHref={versionLink} />}
         </div>
         <div style={styles.timeline}>
           <TimelineDot color={color.dark_charcoal} hasCheck={true} />
@@ -65,8 +69,7 @@ const CodeReviewTimelineElement = ({
     return (
       <div style={styles.element}>
         <div style={{...styles.eyeColumn, ...styles.reviewEye}}>
-          {/* TODO only display version to owner */}
-          {!!projectVersionId && <EyeballLink versionHref={versionLink} />}
+          {displayEyeball && <EyeballLink versionHref={versionLink} />}
         </div>
         <div style={styles.codeReviewTimeline}>
           <div>{children}</div>
@@ -182,4 +185,6 @@ const styles = {
   }
 };
 
-export default CodeReviewTimelineElement;
+export default connect(state => ({
+  viewAsCodeReviewer: state.pageConstants.isCodeReviewing
+}))(CodeReviewTimelineElement);

--- a/apps/src/templates/instructions/codeReviewV2/CodeReviewTimelineElement.jsx
+++ b/apps/src/templates/instructions/codeReviewV2/CodeReviewTimelineElement.jsx
@@ -15,20 +15,18 @@ export const codeReviewTimelineElementType = {
 // 1. CREATED - this is the node that represents the first element on the timeline, it has a line extending below
 //    it unless it is also the only element in the timeline. Otherwise this node does not vary from project to project.
 // 2. COMMIT - this represents a commit to the project. It will display an eyeball on the left which links to the
-//    project version if the project version is present and not expired. It also handles a child which represents
+//    project version if the project version is present. It also handles a child which represents
 //    the specific content in the commit. If it is the last element in the timeline, it will not have a line extending
 //    down from it.
 // 3. CODE_REVIEW - this represnts a code review request and comments made. It will display an eyeball to the left
-//    which links to the project version if it is present and not expired. It takes a child which should be the actual
+//    which links to the project version if it is present. It takes a child which should be the actual
 //    code review component. If it is the last element in the timeline it will not have a line extending below it.
 const CodeReviewTimelineElement = ({
   type,
   isLast,
   projectVersionId,
-  isProjectVersionExpired,
   children
 }) => {
-  const displayVersion = !isProjectVersionExpired && !!projectVersionId;
   const versionLink =
     location.origin + location.pathname + '?version=' + projectVersionId;
 
@@ -51,7 +49,8 @@ const CodeReviewTimelineElement = ({
     return (
       <div style={styles.element}>
         <div style={styles.eyeColumn}>
-          {displayVersion && <EyeballLink versionHref={versionLink} />}
+          {/* TODO only display version to owner */}
+          {!!projectVersionId && <EyeballLink versionHref={versionLink} />}
         </div>
         <div style={styles.timeline}>
           <TimelineDot color={color.dark_charcoal} hasCheck={true} />
@@ -66,7 +65,8 @@ const CodeReviewTimelineElement = ({
     return (
       <div style={styles.element}>
         <div style={{...styles.eyeColumn, ...styles.reviewEye}}>
-          {displayVersion && <EyeballLink versionHref={versionLink} />}
+          {/* TODO only display version to owner */}
+          {!!projectVersionId && <EyeballLink versionHref={versionLink} />}
         </div>
         <div style={styles.codeReviewTimeline}>
           <div>{children}</div>
@@ -82,7 +82,6 @@ CodeReviewTimelineElement.propTypes = {
     .isRequired,
   isLast: PropTypes.bool,
   projectVersionId: PropTypes.string,
-  isProjectVersionExpired: PropTypes.bool,
   children: PropTypes.node
 };
 

--- a/apps/src/templates/instructions/codeReviewV2/CodeReviewTimelineReview.jsx
+++ b/apps/src/templates/instructions/codeReviewV2/CodeReviewTimelineReview.jsx
@@ -23,16 +23,7 @@ const CodeReviewTimelineReview = ({
   deleteCodeReviewComment,
   currentUserId
 }) => {
-  const {
-    id,
-    createdAt,
-    isOpen,
-    version,
-    isVersionExpired,
-    ownerId,
-    ownerName,
-    comments
-  } = review;
+  const {id, createdAt, isOpen, version, ownerId, ownerName, comments} = review;
   const [displayCloseError, setDisplayCloseError] = useState(false);
   const formattedDate = moment(createdAt).format('M/D/YYYY [at] h:mm A');
 
@@ -48,7 +39,6 @@ const CodeReviewTimelineReview = ({
       type={codeReviewTimelineElementType.CODE_REVIEW}
       isLast={isLastElementInTimeline}
       projectVersionId={version}
-      isProjectVersionExpired={isVersionExpired}
     >
       <div style={styles.wrapper}>
         <div style={styles.header}>

--- a/apps/src/templates/instructions/codeReviewV2/shapes.js
+++ b/apps/src/templates/instructions/codeReviewV2/shapes.js
@@ -4,7 +4,6 @@ export const commitShape = PropTypes.shape({
   createdAt: PropTypes.string.isRequired,
   comment: PropTypes.string.isRequired,
   projectVersion: PropTypes.string.isRequired,
-  isVersionExpired: PropTypes.bool,
   timelineElementType: PropTypes.string.isRequired
 });
 
@@ -21,7 +20,6 @@ export const reviewShape = PropTypes.shape({
   createdAt: PropTypes.string,
   isOpen: PropTypes.bool,
   version: PropTypes.string,
-  isVersionExpired: PropTypes.bool,
   timelineElementType: PropTypes.string.isRequired,
   ownerName: PropTypes.string,
   comments: PropTypes.arrayOf(reviewCommentShape)

--- a/apps/test/unit/templates/instructions/codeReviewV2/CodeReviewDataApiTest.js
+++ b/apps/test/unit/templates/instructions/codeReviewV2/CodeReviewDataApiTest.js
@@ -9,22 +9,19 @@ const fakeCommitData = [
     id: 1,
     createdAt: '2022-03-04T04:58:42.000Z',
     comment: 'First commit',
-    projectVersion: 'asdfjkl',
-    isVersionExpired: false
+    projectVersion: 'asdfjkl'
   },
   {
     id: 2,
     createdAt: '2022-03-13T04:58:42.000Z',
     comment: 'Second commit',
-    projectVersion: 'lkjfds',
-    isVersionExpired: false
+    projectVersion: 'lkjfds'
   },
   {
     id: 3,
     createdAt: '2022-03-20T04:58:42.000Z',
     comment: 'Third commit',
-    projectVersion: 'wlkjdujx',
-    isVersionExpired: false
+    projectVersion: 'wlkjdujx'
   }
 ];
 
@@ -34,7 +31,6 @@ const fakeReviewData = [
     createdAt: '2022-03-15T04:58:42.000Z',
     isOpen: false,
     projectVersion: 'asdfjkl',
-    isVersionExpired: false,
     comments: [
       {
         id: 123,
@@ -57,7 +53,6 @@ const fakeReviewData = [
     createdAt: '2022-03-31T04:58:42.000Z',
     isOpen: true,
     projectVersion: 'qweruiop',
-    isVersionExpired: false,
     comments: [
       {
         id: 123,

--- a/apps/test/unit/templates/instructions/codeReviewV2/CodeReviewTimelineCommitTest.jsx
+++ b/apps/test/unit/templates/instructions/codeReviewV2/CodeReviewTimelineCommitTest.jsx
@@ -14,7 +14,6 @@ const DEFAULT_PROPS = {
     createdAt: '2022-03-31T04:58:42.000Z',
     comment: 'This is a comment from your teacher',
     projectVersion: 'asdfjkl',
-    isVersionExpired: false,
     timelineElementType: timelineElementType.commit
   },
   isLastElementInTimeline: false
@@ -34,7 +33,7 @@ describe('CodeReviewTimelineCommit', () => {
     );
   });
 
-  it('passes isLastElementInTimeline, projectVersion and isVersionExpired to CodeReviewTimelineElement', () => {
+  it('passes isLastElementInTimeline and projectVersion to CodeReviewTimelineElement', () => {
     const wrapper = setUp();
     const timelineElementProps = wrapper
       .find(CodeReviewTimelineElement)
@@ -42,7 +41,6 @@ describe('CodeReviewTimelineCommit', () => {
     expect(timelineElementProps.projectVersionId).to.equal(
       DEFAULT_PROPS.commit.projectVersion
     );
-    expect(timelineElementProps.isProjectVersionExpired).to.equal(false);
     expect(timelineElementProps.isLast).to.equal(false);
   });
 

--- a/apps/test/unit/templates/instructions/codeReviewV2/CodeReviewTimelineElementTest.jsx
+++ b/apps/test/unit/templates/instructions/codeReviewV2/CodeReviewTimelineElementTest.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import {shallow} from 'enzyme';
 import {expect} from '../../../../util/reconfiguredChai';
-import CodeReviewTimelineElement, {
+import {
+  UnconnectedCodeReviewTimelineElement as CodeReviewTimelineElement,
   codeReviewTimelineElementType
 } from '@cdo/apps/templates/instructions/codeReviewV2/CodeReviewTimelineElement';
 import color from '@cdo/apps/util/color';
@@ -10,7 +11,8 @@ import javalabMsg from '@cdo/javalab/locale';
 const DEFAULT_PROPS = {
   type: codeReviewTimelineElementType.CREATED,
   isLast: false,
-  projectVersionId: 'asdfjkl'
+  projectVersionId: 'asdfjkl',
+  viewAsCodeReviewer: false
 };
 
 const setUp = (overrideProps = {}, child) => {
@@ -59,10 +61,11 @@ describe('CodeReviewTimelineElement', () => {
   });
 
   describe('Commit', () => {
-    it('displays an eyeball link if there is a version', () => {
+    it('displays an eyeball link if there is a version and viewAsCodeReviewer is false', () => {
       const wrapper = setUp({
         type: codeReviewTimelineElementType.COMMIT,
-        projectVersionId: 'asdfjkl'
+        projectVersionId: 'asdfjkl',
+        viewAsCodeReviewer: false
       });
       expect(wrapper.find('EyeballLink')).to.have.length(1);
     });
@@ -70,7 +73,17 @@ describe('CodeReviewTimelineElement', () => {
     it('hides eyeball link if there is not a version', () => {
       const wrapper = setUp({
         type: codeReviewTimelineElementType.COMMIT,
-        projectVersionId: null
+        projectVersionId: null,
+        viewAsCodeReviewer: false
+      });
+      expect(wrapper.find('EyeballLink')).to.have.length(0);
+    });
+
+    it('hides eyeball link if viewAsCodeReviewer is true', () => {
+      const wrapper = setUp({
+        type: codeReviewTimelineElementType.COMMIT,
+        projectVersionId: 'asdfjkl',
+        viewAsCodeReviewer: true
       });
       expect(wrapper.find('EyeballLink')).to.have.length(0);
     });

--- a/apps/test/unit/templates/instructions/codeReviewV2/CodeReviewTimelineElementTest.jsx
+++ b/apps/test/unit/templates/instructions/codeReviewV2/CodeReviewTimelineElementTest.jsx
@@ -10,8 +10,7 @@ import javalabMsg from '@cdo/javalab/locale';
 const DEFAULT_PROPS = {
   type: codeReviewTimelineElementType.CREATED,
   isLast: false,
-  projectVersionId: 'asdfjkl',
-  isProjectVersionExpired: false
+  projectVersionId: 'asdfjkl'
 };
 
 const setUp = (overrideProps = {}, child) => {
@@ -60,11 +59,10 @@ describe('CodeReviewTimelineElement', () => {
   });
 
   describe('Commit', () => {
-    it('displays an eyeball link if there is a version and it is not expired', () => {
+    it('displays an eyeball link if there is a version', () => {
       const wrapper = setUp({
         type: codeReviewTimelineElementType.COMMIT,
-        projectVersionId: 'asdfjkl',
-        isProjectVersionExpired: false
+        projectVersionId: 'asdfjkl'
       });
       expect(wrapper.find('EyeballLink')).to.have.length(1);
     });
@@ -73,15 +71,6 @@ describe('CodeReviewTimelineElement', () => {
       const wrapper = setUp({
         type: codeReviewTimelineElementType.COMMIT,
         projectVersionId: null
-      });
-      expect(wrapper.find('EyeballLink')).to.have.length(0);
-    });
-
-    it('hides eyeball link if the version is expired', () => {
-      const wrapper = setUp({
-        type: codeReviewTimelineElementType.COMMIT,
-        projectVersionId: 'asdfjkl',
-        isProjectVersionExpired: true
       });
       expect(wrapper.find('EyeballLink')).to.have.length(0);
     });
@@ -116,11 +105,10 @@ describe('CodeReviewTimelineElement', () => {
   });
 
   describe('Code review', () => {
-    it('displays an eyeball link if there is a version and it is not expired', () => {
+    it('displays an eyeball link if there is a version', () => {
       const wrapper = setUp({
         type: codeReviewTimelineElementType.CODE_REVIEW,
-        projectVersionId: 'asdfjkl',
-        isProjectVersionExpired: false
+        projectVersionId: 'asdfjkl'
       });
       expect(wrapper.find('EyeballLink')).to.have.length(1);
     });
@@ -129,15 +117,6 @@ describe('CodeReviewTimelineElement', () => {
       const wrapper = setUp({
         type: codeReviewTimelineElementType.CODE_REVIEW,
         projectVersionId: null
-      });
-      expect(wrapper.find('EyeballLink')).to.have.length(0);
-    });
-
-    it('hides eyeball link if the version is expired', () => {
-      const wrapper = setUp({
-        type: codeReviewTimelineElementType.CODE_REVIEW,
-        projectVersionId: 'asdfjkl',
-        isProjectVersionExpired: true
       });
       expect(wrapper.find('EyeballLink')).to.have.length(0);
     });

--- a/apps/test/unit/templates/instructions/codeReviewV2/CodeReviewTimelineReviewTest.jsx
+++ b/apps/test/unit/templates/instructions/codeReviewV2/CodeReviewTimelineReviewTest.jsx
@@ -2,7 +2,9 @@ import React from 'react';
 import {shallow} from 'enzyme';
 import {expect} from '../../../../util/reconfiguredChai';
 import {UnconnectedCodeReviewTimelineReview as CodeReviewTimelineReview} from '@cdo/apps/templates/instructions/codeReviewV2/CodeReviewTimelineReview';
-import {codeReviewTimelineElementType} from '@cdo/apps/templates/instructions/codeReviewV2/CodeReviewTimelineElement';
+import CodeReviewTimelineElement, {
+  codeReviewTimelineElementType
+} from '@cdo/apps/templates/instructions/codeReviewV2/CodeReviewTimelineElement';
 import javalabMsg from '@cdo/javalab/locale';
 import Comment from '@cdo/apps/templates/instructions/codeReviewV2/Comment';
 import CodeReviewCommentEditor from '@cdo/apps/templates/instructions/codeReviewV2/CodeReviewCommentEditor';
@@ -55,7 +57,7 @@ const setUp = (overrideProps = {}) => {
 describe('CodeReviewTimelineReview', () => {
   it('renders a CodeReviewTimelineElement with type code_review, expected isLast', () => {
     const wrapper = setUp({isLastElementInTimeline: true});
-    const timelineElement = wrapper.find('CodeReviewTimelineElement');
+    const timelineElement = wrapper.find(CodeReviewTimelineElement);
     expect(timelineElement.props().type).to.equal(
       codeReviewTimelineElementType.CODE_REVIEW
     );
@@ -64,7 +66,7 @@ describe('CodeReviewTimelineReview', () => {
 
   it('passes project version to CodeReviewTimelineElement', () => {
     const wrapper = setUp();
-    const timelineElement = wrapper.find('CodeReviewTimelineElement');
+    const timelineElement = wrapper.find(CodeReviewTimelineElement);
     expect(timelineElement.props().projectVersionId).to.equal('asdfjkl');
   });
 

--- a/apps/test/unit/templates/instructions/codeReviewV2/CodeReviewTimelineReviewTest.jsx
+++ b/apps/test/unit/templates/instructions/codeReviewV2/CodeReviewTimelineReviewTest.jsx
@@ -15,7 +15,6 @@ const DEFAULT_REVIEW = {
   createdAt: '2022-03-31T04:58:42.000Z',
   isOpen: true,
   version: 'asdfjkl',
-  isVersionExpired: false,
   timelineElementType: timelineElementType.review,
   ownerId: 2,
   ownerName: 'Jerry',
@@ -67,17 +66,6 @@ describe('CodeReviewTimelineReview', () => {
     const wrapper = setUp();
     const timelineElement = wrapper.find('CodeReviewTimelineElement');
     expect(timelineElement.props().projectVersionId).to.equal('asdfjkl');
-  });
-
-  it('passes version expired to CodeReviewTimelineElement', () => {
-    let wrapper = setUp();
-    let timelineElement = wrapper.find('CodeReviewTimelineElement');
-    expect(timelineElement.props().isProjectVersionExpired).to.be.false;
-
-    const expiredVersionReview = {...DEFAULT_REVIEW, isVersionExpired: true};
-    wrapper = setUp({review: expiredVersionReview});
-    timelineElement = wrapper.find('CodeReviewTimelineElement');
-    expect(timelineElement.props().isProjectVersionExpired).to.be.true;
   });
 
   it('displays your code review header if you are the owner of the review', () => {

--- a/apps/test/unit/templates/instructions/codeReviewV2/CodeReviewTimelineTest.jsx
+++ b/apps/test/unit/templates/instructions/codeReviewV2/CodeReviewTimelineTest.jsx
@@ -16,7 +16,6 @@ const DEFAULT_PROPS = {
       createdAt: '2022-03-04T04:58:42.000Z',
       comment: 'First commit',
       projectVersion: 'asdfjkl',
-      isVersionExpired: false,
       timelineElementType: timelineElementType.commit
     },
     {
@@ -24,7 +23,6 @@ const DEFAULT_PROPS = {
       createdAt: '2022-03-15T04:58:42.000Z',
       isOpen: false,
       version: 'asdfjkl',
-      isVersionExpired: false,
       timelineElementType: timelineElementType.review,
       comments: [
         {
@@ -48,7 +46,6 @@ const DEFAULT_PROPS = {
       createdAt: '2022-03-20T04:58:42.000Z',
       comment: 'Second commit (after review)',
       projectVersion: 'lkjfds',
-      isVersionExpired: false,
       timelineElementType: timelineElementType.commit
     }
   ],

--- a/dashboard/app/controllers/project_versions_controller.rb
+++ b/dashboard/app/controllers/project_versions_controller.rb
@@ -30,8 +30,7 @@ class ProjectVersionsController < ApplicationController
       {
         createdAt: commit.created_at,
         comment: commit.comment,
-        projectVersion: commit.object_version_id,
-        isVersionExpired: version_expired?(commit.created_at)
+        projectVersion: commit.object_version_id
       }
     end
     render :ok, json: commits.to_json

--- a/dashboard/app/controllers/project_versions_controller.rb
+++ b/dashboard/app/controllers/project_versions_controller.rb
@@ -1,8 +1,6 @@
 class ProjectVersionsController < ApplicationController
   before_action :authenticate_user!
 
-  include ProjectVersionHelper
-
   # POST /project_versions
   def create
     _, project_id = storage_decrypt_channel_id(params[:storage_id])

--- a/dashboard/app/helpers/project_version_helper.rb
+++ b/dashboard/app/helpers/project_version_helper.rb
@@ -1,9 +1,0 @@
-module ProjectVersionHelper
-  # We delete old versions after one year, unless they are the current version
-  # See https://s3.console.aws.amazon.com/s3/management/cdo-v3-sources/lifecycle/
-  PROJECT_TTL = 1.year
-
-  def version_expired?(version_date)
-    version_date < (Date.today - PROJECT_TTL)
-  end
-end

--- a/dashboard/app/models/code_review.rb
+++ b/dashboard/app/models/code_review.rb
@@ -61,7 +61,6 @@ class CodeReview < ApplicationRecord
       id: id,
       channelId: nil,             # TODO: implement this!
       version: project_version,
-      isVersionExpired: false,    # TODO: implement this!
       isOpen: open?,
       createdAt: created_at,
     }.merge!(summarize_owner_info)

--- a/dashboard/app/models/code_review.rb
+++ b/dashboard/app/models/code_review.rb
@@ -2,18 +2,19 @@
 #
 # Table name: code_reviews
 #
-#  id               :bigint           not null, primary key
-#  user_id          :integer          not null
-#  project_id       :integer          not null
-#  script_id        :integer          not null
-#  level_id         :integer          not null
-#  project_level_id :integer          not null
-#  project_version  :string(255)      not null
-#  storage_id       :integer          not null
-#  closed_at        :datetime
-#  deleted_at       :datetime
-#  created_at       :datetime         not null
-#  updated_at       :datetime         not null
+#  id                         :bigint           not null, primary key
+#  user_id                    :integer          not null
+#  project_id                 :integer          not null
+#  script_id                  :integer          not null
+#  level_id                   :integer          not null
+#  project_level_id           :integer          not null
+#  project_version            :string(255)      not null
+#  project_version_expires_at :datetime
+#  storage_id                 :integer          not null
+#  closed_at                  :datetime
+#  deleted_at                 :datetime
+#  created_at                 :datetime         not null
+#  updated_at                 :datetime         not null
 #
 # Indexes
 #

--- a/dashboard/app/models/code_review.rb
+++ b/dashboard/app/models/code_review.rb
@@ -2,19 +2,18 @@
 #
 # Table name: code_reviews
 #
-#  id                         :bigint           not null, primary key
-#  user_id                    :integer          not null
-#  project_id                 :integer          not null
-#  script_id                  :integer          not null
-#  level_id                   :integer          not null
-#  project_level_id           :integer          not null
-#  project_version            :string(255)      not null
-#  project_version_expires_at :datetime
-#  storage_id                 :integer          not null
-#  closed_at                  :datetime
-#  deleted_at                 :datetime
-#  created_at                 :datetime         not null
-#  updated_at                 :datetime         not null
+#  id               :bigint           not null, primary key
+#  user_id          :integer          not null
+#  project_id       :integer          not null
+#  script_id        :integer          not null
+#  level_id         :integer          not null
+#  project_level_id :integer          not null
+#  project_version  :string(255)      not null
+#  storage_id       :integer          not null
+#  closed_at        :datetime
+#  deleted_at       :datetime
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
 #
 # Indexes
 #

--- a/dashboard/db/migrate/20220603175343_code_review_remove_expires_at.rb
+++ b/dashboard/db/migrate/20220603175343_code_review_remove_expires_at.rb
@@ -1,0 +1,5 @@
+class CodeReviewRemoveExpiresAt < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :code_reviews, :project_version_expires_at
+  end
+end

--- a/dashboard/db/migrate/20220603175343_code_review_remove_expires_at.rb
+++ b/dashboard/db/migrate/20220603175343_code_review_remove_expires_at.rb
@@ -1,5 +1,0 @@
-class CodeReviewRemoveExpiresAt < ActiveRecord::Migration[6.0]
-  def change
-    remove_column :code_reviews, :project_version_expires_at
-  end
-end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_25_230111) do
+ActiveRecord::Schema.define(version: 2022_06_03_175343) do
 
   create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -340,7 +340,6 @@ ActiveRecord::Schema.define(version: 2022_05_25_230111) do
     t.integer "level_id", null: false
     t.integer "project_level_id", null: false
     t.string "project_version", null: false
-    t.datetime "project_version_expires_at"
     t.integer "storage_id", null: false
     t.datetime "closed_at"
     t.datetime "deleted_at"
@@ -2206,17 +2205,6 @@ ActiveRecord::Schema.define(version: 2022_05_25_230111) do
     t.index ["word", "definition"], name: "index_vocabularies_on_word_and_definition", type: :fulltext
   end
 
-  add_foreign_key "ap_school_codes", "schools"
-  add_foreign_key "census_inaccuracy_investigations", "census_overrides"
-  add_foreign_key "census_inaccuracy_investigations", "census_submissions"
-  add_foreign_key "census_inaccuracy_investigations", "users"
-  add_foreign_key "census_overrides", "schools"
-  add_foreign_key "census_submission_form_maps", "census_submissions"
-  add_foreign_key "census_summaries", "schools"
-  add_foreign_key "circuit_playground_discount_applications", "schools"
-  add_foreign_key "hint_view_requests", "users"
-  add_foreign_key "ib_school_codes", "schools"
-  add_foreign_key "level_concept_difficulties", "levels"
   add_foreign_key "other_curriculum_offerings", "schools"
   add_foreign_key "pd_application_emails", "pd_applications"
   add_foreign_key "pd_application_tags_applications", "pd_application_tags"

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_03_175343) do
+ActiveRecord::Schema.define(version: 2022_05_25_230111) do
 
   create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -320,7 +320,7 @@ ActiveRecord::Schema.define(version: 2022_06_03_175343) do
     t.index ["code_review_request_id"], name: "index_code_review_notes_on_code_review_request_id"
   end
 
-  create_table "code_review_requests", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "code_review_requests", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "script_id", null: false
     t.integer "level_id", null: false
@@ -333,7 +333,7 @@ ActiveRecord::Schema.define(version: 2022_06_03_175343) do
     t.index ["user_id", "script_id", "level_id", "closed_at", "deleted_at"], name: "index_code_review_requests_unique", unique: true
   end
 
-  create_table "code_reviews", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "code_reviews", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "project_id", null: false
     t.integer "script_id", null: false
@@ -345,6 +345,7 @@ ActiveRecord::Schema.define(version: 2022_06_03_175343) do
     t.datetime "deleted_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.datetime "project_version_expires_at"
     t.index ["project_id", "deleted_at"], name: "index_code_reviews_on_project_id_and_deleted_at"
     t.index ["user_id", "project_id", "closed_at", "deleted_at"], name: "index_code_reviews_unique", unique: true
     t.index ["user_id", "script_id", "project_level_id", "closed_at", "deleted_at"], name: "index_code_reviews_for_peer_lookup"
@@ -474,7 +475,7 @@ ActiveRecord::Schema.define(version: 2022_06_03_175343) do
     t.index ["name"], name: "index_courses_on_name"
   end
 
-  create_table "data_docs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "data_docs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "key", null: false
     t.string "name"
     t.text "content"

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -320,7 +320,7 @@ ActiveRecord::Schema.define(version: 2022_05_25_230111) do
     t.index ["code_review_request_id"], name: "index_code_review_notes_on_code_review_request_id"
   end
 
-  create_table "code_review_requests", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "code_review_requests", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "script_id", null: false
     t.integer "level_id", null: false
@@ -333,19 +333,19 @@ ActiveRecord::Schema.define(version: 2022_05_25_230111) do
     t.index ["user_id", "script_id", "level_id", "closed_at", "deleted_at"], name: "index_code_review_requests_unique", unique: true
   end
 
-  create_table "code_reviews", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "code_reviews", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "project_id", null: false
     t.integer "script_id", null: false
     t.integer "level_id", null: false
     t.integer "project_level_id", null: false
     t.string "project_version", null: false
+    t.datetime "project_version_expires_at"
     t.integer "storage_id", null: false
     t.datetime "closed_at"
     t.datetime "deleted_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.datetime "project_version_expires_at"
     t.index ["project_id", "deleted_at"], name: "index_code_reviews_on_project_id_and_deleted_at"
     t.index ["user_id", "project_id", "closed_at", "deleted_at"], name: "index_code_reviews_unique", unique: true
     t.index ["user_id", "script_id", "project_level_id", "closed_at", "deleted_at"], name: "index_code_reviews_for_peer_lookup"
@@ -475,7 +475,7 @@ ActiveRecord::Schema.define(version: 2022_05_25_230111) do
     t.index ["name"], name: "index_courses_on_name"
   end
 
-  create_table "data_docs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "data_docs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "key", null: false
     t.string "name"
     t.text "content"
@@ -2206,6 +2206,17 @@ ActiveRecord::Schema.define(version: 2022_05_25_230111) do
     t.index ["word", "definition"], name: "index_vocabularies_on_word_and_definition", type: :fulltext
   end
 
+  add_foreign_key "ap_school_codes", "schools"
+  add_foreign_key "census_inaccuracy_investigations", "census_overrides"
+  add_foreign_key "census_inaccuracy_investigations", "census_submissions"
+  add_foreign_key "census_inaccuracy_investigations", "users"
+  add_foreign_key "census_overrides", "schools"
+  add_foreign_key "census_submission_form_maps", "census_submissions"
+  add_foreign_key "census_summaries", "schools"
+  add_foreign_key "circuit_playground_discount_applications", "schools"
+  add_foreign_key "hint_view_requests", "users"
+  add_foreign_key "ib_school_codes", "schools"
+  add_foreign_key "level_concept_difficulties", "levels"
   add_foreign_key "other_curriculum_offerings", "schools"
   add_foreign_key "pd_application_emails", "pd_applications"
   add_foreign_key "pd_application_tags_applications", "pd_application_tags"

--- a/dashboard/test/controllers/code_reviews_controller_test.rb
+++ b/dashboard/test/controllers/code_reviews_controller_test.rb
@@ -49,7 +49,6 @@ class CodeReviewsControllerTest < ActionController::TestCase
     response_json = JSON.parse(response.body)
     assert_not_nil response_json['id']
     assert_equal project_version, response_json['version']
-    assert_equal false, response_json['isVersionExpired']
     assert_equal true, response_json['isOpen']
     assert_not_nil response_json['createdAt']
   end

--- a/dashboard/test/controllers/project_versions_controller_test.rb
+++ b/dashboard/test/controllers/project_versions_controller_test.rb
@@ -36,28 +36,6 @@ class ProjectVersionsControllerTest < ActionController::TestCase
     assert_equal ['First comment', 'Second comment', 'Third comment'], returned_commits.map {|c| c['comment']}
   end
 
-  test "versions more than a year old have isVersionExpired set to true" do
-    student = create :student
-    sign_in student
-
-    fake_storage_id = 123
-    fake_project_id = 654
-    fake_channel_id = 'abcdef'
-    @controller.expects(:user_id_for_storage_id).with(fake_storage_id).returns(student.id)
-    @controller.expects(:storage_decrypt_channel_id).with(fake_channel_id).returns([fake_storage_id, fake_project_id])
-
-    create :project_version, project_id: fake_project_id, comment: "First comment", created_at: 2.years.ago
-    create :project_version, project_id: fake_project_id, comment: "Second comment", created_at: 2.days.ago
-
-    get :project_commits, params: {channel_id: fake_channel_id}
-    assert_response :ok
-
-    returned_commits = JSON.parse(@response.body)
-    assert_equal 2, returned_commits.length
-    refute returned_commits.last['isVersionExpired']
-    assert returned_commits.first['isVersionExpired']
-  end
-
   test "can fetch project versions and blank comments are filtered out" do
     student = create :student
     sign_in student


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
- Removes references to expired version logic for code review, instead we're going to create an error page for project versions that could not be found
- Removes project expires at column from code review table
- Hides eyeball link to old versions on code reviews other than your own

Your own code review:
![Screen Shot 2022-06-03 at 11 00 26 AM](https://user-images.githubusercontent.com/24235215/171920590-006205ca-f1bc-4540-ab47-64f049b84782.png)

Peers code review:
![Screen Shot 2022-06-03 at 11 01 02 AM](https://user-images.githubusercontent.com/24235215/171920685-6c323ccf-34f0-443b-92bd-7fc9c9378fda.png)

Background on expiration changes: it's difficult to reliably tell if a version has expired, so we've decided that instead we are going to make a better error page for expired versions and leave links as available forever. The chances of a student looking back on a code review from over a year ago and clicking on an old version of the code is very unlikely anyway, and if they do, they will get an error page. 

## Links
- jira ticket: [LP-2393](https://codedotorg.atlassian.net/browse/LP-2393)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()

-->

## Testing story
Tested locally, updated unit tests
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy
Deployed behind code_review_v2 flag

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
