### PR TITLE
allow 60 seconds before read timeout on levelbuilder

### DIFF
--- a/lib/cdo/aws/cloudfront.rb
+++ b/lib/cdo/aws/cloudfront.rb
@@ -177,7 +177,8 @@ module AWS
               Id: app_name == proxy ? 'cdo' : app_name,
               CustomOriginConfig: {
                 OriginProtocolPolicy: 'match-viewer',
-                OriginSSLProtocols: %w(TLSv1.2 TLSv1.1)
+                OriginSSLProtocols: %w(TLSv1.2 TLSv1.1),
+                OriginReadTimeout: rack_env?(:levelbuilder) ? 60 : 30
               },
               DomainName: origin,
               OriginPath: '',


### PR DESCRIPTION
Finishes [PLAT-1728](https://codedotorg.atlassian.net/browse/PLAT-1728) and [INF-633](https://codedotorg.atlassian.net/browse/INF-633). 

The solution proposed here is to increase the timeout for all requests from CloudFront to the levelbuilder origin from 30 to 60 seconds. See [slack](https://codedotorg.slack.com/archives/C03CK49G9/p1654201379159019) for consensus on this solution.

Documentation: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-distribution-customoriginconfig.html#cfn-cloudfront-distribution-customoriginconfig-originreadtimeout

## Testing story

In order to validate this change, I made a temporary modification to get a different config value in the adhoc environment:
```diff
diff --git a/lib/cdo/aws/cloudfront.rb b/lib/cdo/aws/cloudfront.rb
index e8fc6b9310d..79419c7926b 100644
--- a/lib/cdo/aws/cloudfront.rb
+++ b/lib/cdo/aws/cloudfront.rb
@@ -178,7 +178,7 @@ module AWS
               CustomOriginConfig: {
                 OriginProtocolPolicy: 'match-viewer',
                 OriginSSLProtocols: %w(TLSv1.2 TLSv1.1),
-                OriginReadTimeout: rack_env?(:levelbuilder) ? 60 : 30
+                OriginReadTimeout: rack_env?(:adhoc) ? 55 : 33
               },
               DomainName: origin,
               OriginPath: '',
```

validation output:
```
Dave-MBP:~/src/cdo2 (levelbuilder-read-timeout)$ bundle exec rake adhoc:cdn:validate RAILS_ENV=adhoc VERBOSE=1
...
"CustomOriginConfig":{"OriginProtocolPolicy":"match-viewer","OriginSSLProtocols":["TLSv1.2","TLSv1.1"],"OriginReadTimeout":55}
...
```

Then I deployed the adhoc via
```
Dave-MBP:~/src/cdo2 (levelbuilder-read-timeout)$ bundle exec rake adhoc:cdn:start RAILS_ENV=adhoc
```
and verified that the new setting appeared in the cloudfront distribution origin config for dashboard:
 
![Screen Shot 2022-06-03 at 10 04 18 AM](https://user-images.githubusercontent.com/8001765/171913452-51ddfbc3-0e93-4288-93b9-29a0c3a9a1e0.png)

Finally I reverted to the original code which will only set the increased timeout on levelbuilder.