### PR TITLE
Clean up work ahead of moving front end to user instructor and participant

### DIFF
--- a/dashboard/app/controllers/home_controller.rb
+++ b/dashboard/app/controllers/home_controller.rb
@@ -184,7 +184,7 @@ class HomeController < ApplicationController
       @homepage_data[:joined_student_sections] = current_user&.sections_as_student_participant&.map(&:summarize_without_students)
       @homepage_data[:joined_pl_sections] = current_user&.sections_as_pl_participant&.map(&:summarize_without_students)
       @homepage_data[:announcement] = DCDO.get('announcement_override', nil)
-      @homepage_data[:hiddenScripts] = current_user.get_hidden_script_ids
+      @homepage_data[:hiddenScripts] = current_user.get_hidden_unit_ids
       @homepage_data[:showCensusBanner] = show_census_banner
       @homepage_data[:showNpsSurvey] = show_nps_survey?
       @homepage_data[:showFinishTeacherApplication] = has_incomplete_application?

--- a/dashboard/app/helpers/users_helper.rb
+++ b/dashboard/app/helpers/users_helper.rb
@@ -117,7 +117,16 @@ module UsersHelper
   #   }
   # }
   def summarize_user_progress(unit, user = current_user, exclude_level_progress = false)
-    user_data = user_summary(user)
+    user_data = {}
+    if user
+      user_data[:disableSocialShare] = true if user.under_13?
+      user_data[:lockableAuthorized] = user.teacher? ? user.verified_instructor? : user.student_of_verified_instructor?
+      user_data[:isTeacher] = true if user.teacher?
+      user_data[:isVerifiedInstructor] = true if user.verified_instructor?
+      user_data[:linesOfCode] = user.total_lines
+      user_data[:linesOfCodeText] = I18n.t('nav.popup.lines', lines: user_data[:linesOfCode])
+    end
+
     merge_unit_progress(user_data, user, unit, exclude_level_progress)
 
     if unit.has_peer_reviews?
@@ -144,20 +153,6 @@ module UsersHelper
     return attempted_ids.max_by {|id| level_progress[id][:result]} unless attempted_ids.empty?
 
     return ids[0]
-  end
-
-  # Some summary user data we include in user_progress requests
-  def user_summary(user)
-    user_data = {}
-    if user
-      user_data[:disableSocialShare] = true if user.under_13?
-      user_data[:lockableAuthorized] = user.teacher? ? user.verified_instructor? : user.student_of_verified_instructor?
-      user_data[:isTeacher] = true if user.teacher?
-      user_data[:isVerifiedInstructor] = true if user.verified_instructor?
-      user_data[:linesOfCode] = user.total_lines
-      user_data[:linesOfCodeText] = I18n.t('nav.popup.lines', lines: user_data[:linesOfCode])
-    end
-    user_data
   end
 
   # Get level progress for a set of users within this unit.

--- a/dashboard/app/helpers/users_helper.rb
+++ b/dashboard/app/helpers/users_helper.rb
@@ -263,7 +263,7 @@ module UsersHelper
   # @return [Hash<Integer, Hash>]
   #   a map from level_id to a progress summary for the level.
   private def merge_user_progress_by_level(
-    unit:,
+    script:,
     user:,
     user_levels_by_level:,
     teacher_feedback_by_level:,
@@ -271,10 +271,10 @@ module UsersHelper
     include_timestamp: false
   )
     progress = {}
-    unit.script_levels.each do |sl|
+    script.script_levels.each do |sl|
       sl.level_ids.each do |level_id|
         level = Level.cache_find(level_id)
-        level_for_progress = level.get_level_for_progress(user, unit)
+        level_for_progress = level.get_level_for_progress(user, script)
         ul = user_levels_by_level.try(:[], level_for_progress.id)
 
         feedback = teacher_feedback_by_level.try(:[], level_for_progress.id)

--- a/dashboard/app/helpers/users_helper.rb
+++ b/dashboard/app/helpers/users_helper.rb
@@ -128,7 +128,6 @@ module UsersHelper
     end
 
     merge_unit_progress(user_data, user, unit, exclude_level_progress)
-
     if unit.has_peer_reviews?
       user_data[:peerReviewsPerformed] = PeerReview.get_peer_review_summaries(user, unit).try(:map) do |summary|
         summary.merge(url: summary.key?(:id) ? peer_review_path(summary[:id]) : script_pull_review_path(unit))

--- a/dashboard/app/helpers/users_helper.rb
+++ b/dashboard/app/helpers/users_helper.rb
@@ -105,7 +105,7 @@ module UsersHelper
     )
   end
 
-  # Summarize a user and their progress within a certain script.
+  # Summarize a user and their progress within a certain unit.
   # Example return value:
   # {
   #   "linesOfCode": 34,
@@ -116,17 +116,17 @@ module UsersHelper
   #     "135": {"status": "perfect", "result": 100}
   #   }
   # }
-  def summarize_user_progress(script, user = current_user, exclude_level_progress = false)
+  def summarize_user_progress(unit, user = current_user, exclude_level_progress = false)
     user_data = user_summary(user)
-    merge_script_progress(user_data, user, script, exclude_level_progress)
+    merge_unit_progress(user_data, user, unit, exclude_level_progress)
 
-    if script.has_peer_reviews?
-      user_data[:peerReviewsPerformed] = PeerReview.get_peer_review_summaries(user, script).try(:map) do |summary|
-        summary.merge(url: summary.key?(:id) ? peer_review_path(summary[:id]) : script_pull_review_path(script))
+    if unit.has_peer_reviews?
+      user_data[:peerReviewsPerformed] = PeerReview.get_peer_review_summaries(user, unit).try(:map) do |summary|
+        summary.merge(url: summary.key?(:id) ? peer_review_path(summary[:id]) : script_pull_review_path(unit))
       end
     end
 
-    user_data[:current_lesson] = user.next_unpassed_progression_level(script)&.lesson&.id unless exclude_level_progress || script.script_levels.empty?
+    user_data[:current_lesson] = user.next_unpassed_progression_level(unit)&.lesson&.id unless exclude_level_progress || unit.script_levels.empty?
 
     user_data.compact
   end
@@ -160,9 +160,9 @@ module UsersHelper
     user_data
   end
 
-  # Get level progress for a set of users within this script.
+  # Get level progress for a set of users within this unit.
   # @param [Enumerable<User>] users
-  # @param [Script] script
+  # @param [Script] unit
   # @return [Hash]
   # Example return value (where 1 and 2 are userIds and 135 and 136 are levelIds):
   #   {
@@ -175,13 +175,13 @@ module UsersHelper
   #       "136": {"status": "perfect", "result": 100}
   #     }
   #   }
-  def script_progress_for_users(users, script)
-    user_levels = User.user_levels_by_user_by_level(users, script)
-    teacher_feedbacks = teacher_feedbacks_by_student_by_level(users, script)
+  def script_progress_for_users(users, unit)
+    user_levels = User.user_levels_by_user_by_level(users, unit)
+    teacher_feedbacks = teacher_feedbacks_by_student_by_level(users, unit)
     paired_user_levels_by_user = PairedUserLevel.pairs_by_user(users)
     progress_by_user = users.inject({}) do |progress, user|
       progress[user.id] = merge_user_progress_by_level(
-        script: script,
+        script: unit,
         user: user,
         user_levels_by_level: user_levels[user.id],
         teacher_feedback_by_level: teacher_feedbacks[user.id],
@@ -198,9 +198,9 @@ module UsersHelper
   end
 
   # Retrieve all teacher feedback for the designated set of users in the given
-  # script, with a single query.
+  # unit, with a single query.
   # @param [Enumerable<User>] users
-  # @param [Script] script
+  # @param [Script] unit
   # @return [Hash] TeacherFeedbacks by user id by level id
   # Example return value (where 1,2,3 are user ids and 101, 102 are level ids):
   # {
@@ -214,10 +214,10 @@ module UsersHelper
   #   },
   #   3: {}
   # }
-  private def teacher_feedbacks_by_student_by_level(users, script)
+  private def teacher_feedbacks_by_student_by_level(users, unit)
     initial_hash = Hash[users.map {|user| [user.id, {}]}]
     TeacherFeedback.
-      get_latest_feedbacks_received(users.map(&:id), nil, script.id).
+      get_latest_feedbacks_received(users.map(&:id), nil, unit.id).
       group_by(&:student_id).
       inject(initial_hash) do |memo, (student_id, teacher_feedbacks)|
         memo[student_id] = teacher_feedbacks.index_by(&:level_id)
@@ -225,26 +225,26 @@ module UsersHelper
       end
   end
 
-  # Merge the progress for the specified script and user into the user_data result hash.
-  private def merge_script_progress(user_data, user, script, exclude_level_progress = false)
+  # Merge the progress for the specified unit and user into the user_data result hash.
+  private def merge_unit_progress(user_data, user, unit, exclude_level_progress = false)
     return user_data unless user
 
-    if script.old_professional_learning_course?
+    if unit.old_professional_learning_course?
       user_data[:professionalLearningCourse] = true
-      unit_assignment = Plc::EnrollmentUnitAssignment.find_by(user: user, plc_course_unit: script.plc_course_unit)
+      unit_assignment = Plc::EnrollmentUnitAssignment.find_by(user: user, plc_course_unit: unit.plc_course_unit)
       if unit_assignment
         user_data[:focusAreaLessonIds] = unit_assignment.focus_area_lesson_ids
-        user_data[:changeFocusAreaPath] = script_preview_assignments_path script
+        user_data[:changeFocusAreaPath] = script_preview_assignments_path unit
       end
     end
 
     unless exclude_level_progress
-      user_levels_by_level = user.user_levels_by_level(script)
-      teacher_feedback_by_level = teacher_feedbacks_by_student_by_level([user], script)
+      user_levels_by_level = user.user_levels_by_level(unit)
+      teacher_feedback_by_level = teacher_feedbacks_by_student_by_level([user], unit)
       paired_user_levels = PairedUserLevel.pairs(user_levels_by_level.values.map(&:id))
-      user_data[:completed] = Policies::ScriptActivity.completed?(user, script)
+      user_data[:completed] = Policies::ScriptActivity.completed?(user, unit)
       user_data[:progress] = merge_user_progress_by_level(
-        script: script,
+        script: unit,
         user: user,
         user_levels_by_level: user_levels_by_level,
         teacher_feedback_by_level: teacher_feedback_by_level[user.id],
@@ -255,8 +255,8 @@ module UsersHelper
     user_data
   end
 
-  # Merges and summarizes a user's level progress for a particular script.
-  # @param [Script] script
+  # Merges and summarizes a user's level progress for a particular unit.
+  # @param [Script] unit
   # @param [User] user
   # @param [Hash<Integer, UserLevel>] user_levels_by_level
   #   A map from level id to UserLevel instance for the provided user, passed
@@ -269,7 +269,7 @@ module UsersHelper
   # @return [Hash<Integer, Hash>]
   #   a map from level_id to a progress summary for the level.
   private def merge_user_progress_by_level(
-    script:,
+    unit:,
     user:,
     user_levels_by_level:,
     teacher_feedback_by_level:,
@@ -277,10 +277,10 @@ module UsersHelper
     include_timestamp: false
   )
     progress = {}
-    script.script_levels.each do |sl|
+    unit.script_levels.each do |sl|
       sl.level_ids.each do |level_id|
         level = Level.cache_find(level_id)
-        level_for_progress = level.get_level_for_progress(user, script)
+        level_for_progress = level.get_level_for_progress(user, unit)
         ul = user_levels_by_level.try(:[], level_for_progress.id)
 
         feedback = teacher_feedback_by_level.try(:[], level_for_progress.id)
@@ -442,10 +442,10 @@ module UsersHelper
   end
 
   # @return [Float] The percentage, between 0.0 and 100.0, of the levels in the
-  #   script that were passed or perfected.
-  def percent_complete_total(script, user = current_user)
-    summary = summarize_user_progress(script, user)
-    levels = script.script_levels.map(&:level)
+  #   unit that were passed or perfected.
+  def percent_complete_total(unit, user = current_user)
+    summary = summarize_user_progress(unit, user)
+    levels = unit.script_levels.map(&:level)
     completed = levels.count do |l|
       sum = summary[:progress][l.id]; sum && %w(perfect passed).include?(sum[:status])
     end

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1605,7 +1605,7 @@ class Script < ApplicationRecord
   #   For teachers, this will be a hash mapping from section id to a list of hidden
   #   script ids for that section, filtered so that the only script id which appears
   #   is the current script id. This mirrors the output format of
-  #   User#get_hidden_script_ids, and satisfies the input format of
+  #   User#get_hidden_unit_ids, and satisfies the input format of
   #   initializeHiddenScripts in hiddenLessonRedux.js.
   def section_hidden_unit_info(user)
     return {} unless user&.teacher?

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1346,7 +1346,7 @@ class User < ApplicationRecord
   #   For teachers, this will be a hash mapping from section id to a list of hidden
   #   script ids for that section.
   #   For students this will just be a list of script ids that are hidden for them.
-  def get_hidden_script_ids(unit_group = nil)
+  def get_hidden_unit_ids(unit_group = nil)
     return [] if !teacher? && unit_group.nil?
 
     teacher? ? get_teacher_hidden_ids(false) : get_student_hidden_ids(unit_group.id, false)

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1328,7 +1328,7 @@ class User < ApplicationRecord
     unit_group = unit.try(:unit_group)
     return false unless unit_group
 
-    get_student_hidden_ids(unit_group.id, false).include?(unit.id)
+    get_participant_hidden_ids(unit_group.id, false).include?(unit.id)
   end
 
   # @return {Hash<string,number[]>|number[]}
@@ -1339,7 +1339,7 @@ class User < ApplicationRecord
     unit = Script.get_from_cache(unit_name)
     return [] if unit.nil?
 
-    teacher? ? get_instructor_hidden_ids(true) : get_student_hidden_ids(unit.id, true)
+    teacher? ? get_instructor_hidden_ids(true) : get_participant_hidden_ids(unit.id, true)
   end
 
   # @return {Hash<string,number[]>|number[]}
@@ -1349,7 +1349,7 @@ class User < ApplicationRecord
   def get_hidden_unit_ids(unit_group = nil)
     return [] if !teacher? && unit_group.nil?
 
-    teacher? ? get_instructor_hidden_ids(false) : get_student_hidden_ids(unit_group.id, false)
+    teacher? ? get_instructor_hidden_ids(false) : get_participant_hidden_ids(unit_group.id, false)
   end
 
   def student?
@@ -2547,7 +2547,7 @@ class User < ApplicationRecord
   # @param {boolean} hidden_lessons - True if we're looking for hidden lessons, false
   #   if we're looking for hidden units.
   # @return {number[]} Set of lesson/unit ids that should be hidden
-  def get_student_hidden_ids(assign_id, hidden_lessons)
+  def get_participant_hidden_ids(assign_id, hidden_lessons)
     sections = sections_as_student
     return [] if sections.empty?
 

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1318,38 +1318,38 @@ class User < ApplicationRecord
     end
   end
 
-  # Is the given script hidden for this user (based on the sections that they are in)
-  def unit_hidden?(script)
+  # Is the given unit hidden for this user (based on the sections that they are in)
+  def unit_hidden?(unit)
     return false if try(:teacher?)
 
     return false if sections_as_student.empty?
 
-    # Can't hide a script that isn't part of a course
-    unit_group = script.try(:unit_group)
+    # Can't hide a unit that isn't part of a course
+    unit_group = unit.try(:unit_group)
     return false unless unit_group
 
-    get_student_hidden_ids(unit_group.id, false).include?(script.id)
+    get_student_hidden_ids(unit_group.id, false).include?(unit.id)
   end
 
   # @return {Hash<string,number[]>|number[]}
   #   For teachers, this will be a hash mapping from section id to a list of hidden
   #   lesson ids for that section.
   #   For students this will just be a list of lesson ids that are hidden for them.
-  def get_hidden_lesson_ids(script_name)
-    script = Script.get_from_cache(script_name)
-    return [] if script.nil?
+  def get_hidden_lesson_ids(unit_name)
+    unit = Script.get_from_cache(unit_name)
+    return [] if unit.nil?
 
-    teacher? ? get_teacher_hidden_ids(true) : get_student_hidden_ids(script.id, true)
+    teacher? ? get_instructor_hidden_ids(true) : get_student_hidden_ids(unit.id, true)
   end
 
   # @return {Hash<string,number[]>|number[]}
   #   For teachers, this will be a hash mapping from section id to a list of hidden
-  #   script ids for that section.
-  #   For students this will just be a list of script ids that are hidden for them.
+  #   unit ids for that section.
+  #   For students this will just be a list of unit ids that are hidden for them.
   def get_hidden_unit_ids(unit_group = nil)
     return [] if !teacher? && unit_group.nil?
 
-    teacher? ? get_teacher_hidden_ids(false) : get_student_hidden_ids(unit_group.id, false)
+    teacher? ? get_instructor_hidden_ids(false) : get_student_hidden_ids(unit_group.id, false)
   end
 
   def student?
@@ -2168,12 +2168,12 @@ class User < ApplicationRecord
       sections.find {|section| section.script_id == script.id}
   end
 
-  def lesson_extras_enabled?(script)
-    return false unless script.lesson_extras_available?
+  def lesson_extras_enabled?(unit)
+    return false unless unit.lesson_extras_available?
     return true if teacher?
 
     sections_as_student.any? do |section|
-      section.script_id == script.id && section.lesson_extras
+      section.script_id == unit.id && section.lesson_extras
     end
   end
 
@@ -2521,32 +2521,32 @@ class User < ApplicationRecord
     return sections.flat_map(&:section_hidden_lessons).pluck(:stage_id)
   end
 
-  def hidden_script_ids(sections)
+  def hidden_unit_ids(sections)
     return sections.flat_map(&:section_hidden_scripts).pluck(:script_id)
   end
 
   # This method will extract a list of hidden ids by section. The type of ids depends
-  # on the input. If hidden_lessons is true, id is expected to be a script id and
+  # on the input. If hidden_lessons is true, id is expected to be a unit id and
   # we look for lessons that are hidden. If hidden_lessons is false, id is expected
-  # to be a course_id, and we look for hidden scripts.
+  # to be a course_id, and we look for hidden units.
   # @param {boolean} hidden_lessons - True if we're looking for hidden lessons, false
-  #   if we're looking for hidden scripts.
+  #   if we're looking for hidden units.
   # @return {Hash<string,number[]>
-  def get_teacher_hidden_ids(hidden_lessons)
+  def get_instructor_hidden_ids(hidden_lessons)
     # If we're a teacher, we want to go through each of our sections and return
-    # a mapping from section id to hidden lessons/scripts in that section
+    # a mapping from section id to hidden lessons/units in that section
     hidden_by_section = {}
     sections.each do |section|
-      hidden_by_section[section.id] = hidden_lessons ? hidden_lesson_ids([section]) : hidden_script_ids([section])
+      hidden_by_section[section.id] = hidden_lessons ? hidden_lesson_ids([section]) : hidden_unit_ids([section])
     end
     hidden_by_section
   end
 
   # This method method will go through each of the sections in which we're a member
-  # and determine which lessons/scripts should be hidden
+  # and determine which lessons/units should be hidden
   # @param {boolean} hidden_lessons - True if we're looking for hidden lessons, false
-  #   if we're looking for hidden scripts.
-  # @return {number[]} Set of lesson/script ids that should be hidden
+  #   if we're looking for hidden units.
+  # @return {number[]} Set of lesson/unit ids that should be hidden
   def get_student_hidden_ids(assign_id, hidden_lessons)
     sections = sections_as_student
     return [] if sections.empty?
@@ -2557,14 +2557,14 @@ class User < ApplicationRecord
     end
 
     if assigned_sections.empty?
-      # if we have no sections matching this assignment, we consider a lesson/script
+      # if we have no sections matching this assignment, we consider a lesson/unit
       # hidden if any of our sections hides it
-      return (hidden_lessons ? hidden_lesson_ids(sections) : hidden_script_ids(sections)).uniq
+      return (hidden_lessons ? hidden_lesson_ids(sections) : hidden_unit_ids(sections)).uniq
     else
-      # if we do have sections matching this assignment, we consider a lesson/script
+      # if we do have sections matching this assignment, we consider a lesson/unit
       # hidden only if it is hidden in every one of the sections the student belongs
       # to that match this assignment
-      all_ids = hidden_lessons ? hidden_lesson_ids(assigned_sections) : hidden_script_ids(assigned_sections)
+      all_ids = hidden_lessons ? hidden_lesson_ids(assigned_sections) : hidden_unit_ids(assigned_sections)
 
       counts = all_ids.each_with_object(Hash.new(0)) {|id, hash| hash[id] += 1}
       return counts.select {|_, val| val == assigned_sections.length}.keys

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1319,7 +1319,7 @@ class User < ApplicationRecord
   end
 
   # Is the given script hidden for this user (based on the sections that they are in)
-  def script_hidden?(script)
+  def unit_hidden?(script)
     return false if try(:teacher?)
 
     return false if sections_as_student.empty?

--- a/dashboard/app/views/courses/show.html.haml
+++ b/dashboard/app/views/courses/show.html.haml
@@ -9,7 +9,7 @@
 - data[:sections] = @sections_with_assigned_info || []
 - data[:is_teacher] = @current_user.try(:teacher?) || false
 - data[:is_verified_instructor] = @current_user.try(:verified_instructor?) || false
-- data[:hidden_scripts] = @current_user.try(:get_hidden_script_ids, unit_group)
+- data[:hidden_scripts] = @current_user.try(:get_hidden_unit_ids, unit_group)
 - data[:show_version_warning] = unit_group.has_older_version_progress?(@current_user) && !unit_group.has_dismissed_version_warning?(@current_user)
 - data[:show_redirect_warning] = redirect_warning
 - data[:redirect_to_course_url] = unit_group.redirect_to_course_url(@current_user)

--- a/dashboard/app/views/scripts/show.html.haml
+++ b/dashboard/app/views/scripts/show.html.haml
@@ -14,7 +14,7 @@
 = render partial: 'shared/check_admin'
 = render partial: 'shared/emulate_print_media'
 
-- if @current_user.try(:script_hidden?, @script)
+- if @current_user.try(:unit_hidden?, @script)
   = render partial: 'hidden_script'
 - else
   #landingpage

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -404,7 +404,6 @@ Dashboard::Application.routes.draw do
     get 'reset', to: 'script_levels#reset'
     get 'next', to: 'script_levels#next'
     get 'hidden_lessons', to: 'script_levels#hidden_lesson_ids'
-    get 'hidden_stages', to: 'script_levels#hidden_lesson_ids' #TODO: Remove once launched
     post 'toggle_hidden', to: 'script_levels#toggle_hidden'
 
     member do

--- a/dashboard/test/controllers/script_levels_controller_test.rb
+++ b/dashboard/test/controllers/script_levels_controller_test.rb
@@ -1730,7 +1730,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     assert_equal expected, hidden
   end
 
-  def put_student_in_section(student, teacher, script)
+  def  put_participant_in_section(student, teacher, script)
     section = create :section, user_id: teacher.id, script_id: script.id
     Follower.create!(section_id: section.id, student_user_id: student.id, user: teacher)
     section
@@ -1741,7 +1741,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     student = create :student
     sign_in teacher
 
-    section = put_student_in_section(student, teacher, @custom_script)
+    section = put_participant_in_section(student, teacher, @custom_script)
     lesson1 = @custom_script.lessons[0]
     assert @custom_script.hideable_lessons
 
@@ -1771,7 +1771,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     student = create :student
     sign_in teacher
 
-    section = put_student_in_section(student, teacher, @custom_script)
+    section = put_participant_in_section(student, teacher, @custom_script)
     assert @custom_script.hideable_lessons
 
     # start with no hidden scripts
@@ -1799,7 +1799,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     student = create :student
     sign_in teacher
 
-    section = put_student_in_section(student, teacher, script)
+    section = put_participant_in_section(student, teacher, script)
     refute script.hideable_lessons
 
     post :toggle_hidden, params: {
@@ -1818,7 +1818,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     student = create :student
     sign_in teacher
 
-    section = put_student_in_section(student, other_teacher, @custom_script)
+    section = put_participant_in_section(student, other_teacher, @custom_script)
     lesson1 = @custom_script.lessons[0]
     assert @custom_script.hideable_lessons
 
@@ -1851,7 +1851,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     student = create :student
     sign_in teacher
 
-    section = put_student_in_section(student, other_teacher, @custom_script)
+    section = put_participant_in_section(student, other_teacher, @custom_script)
 
     post :toggle_hidden, params: {
       script_id: @custom_script.id,

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -4095,17 +4095,17 @@ class UserTest < ActiveSupport::TestCase
       assert_equal expected, teacher.get_hidden_unit_ids(@unit_group)
     end
 
-    test "script_hidden?" do
+    test "unit_hidden?" do
       teacher = create :teacher
       student = create :student
       section = put_student_in_section(student, teacher, @script, @unit_group)
       SectionHiddenScript.create(section_id: section.id, script_id: @script.id)
 
       # returns true for student
-      assert_equal true, student.script_hidden?(@script)
+      assert_equal true, student.unit_hidden?(@script)
 
       # returns false for teacher
-      assert_equal false, teacher.script_hidden?(@script)
+      assert_equal false, teacher.unit_hidden?(@script)
     end
   end
 

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -3830,9 +3830,9 @@ class UserTest < ActiveSupport::TestCase
       @script3.reload
     end
 
-    def put_student_in_section(student, teacher, script, unit_group=nil)
-      section = create :section, user_id: teacher.id, script_id: script.try(:id), course_id: unit_group.try(:id)
-      Follower.create!(section_id: section.id, student_user_id: student.id, user: teacher)
+    def put_participant_in_section(participant, instructor, script, unit_group=nil, participant_type='student')
+      section = create :section, user_id: instructor.id, script_id: script.try(:id), course_id: unit_group.try(:id), participant_type: participant_type
+      Follower.create!(section_id: section.id, student_user_id: participant.id, user: instructor)
       section
     end
 
@@ -3880,7 +3880,7 @@ class UserTest < ActiveSupport::TestCase
 
       # Hide the second lesson
       SectionHiddenLesson.create(
-        section_id: put_student_in_section(student, teacher, script).id,
+        section_id: put_participant_in_section(student, teacher, script).id,
         stage_id: script.lessons[1].id
       )
 
@@ -3905,7 +3905,7 @@ class UserTest < ActiveSupport::TestCase
 
       # Hide the first lesson
       SectionHiddenLesson.create(
-        section_id: put_student_in_section(student, teacher, script).id,
+        section_id: put_participant_in_section(student, teacher, script).id,
         stage_id: script.lessons.first.id
       )
 
@@ -3917,8 +3917,8 @@ class UserTest < ActiveSupport::TestCase
     test "user in two sections, both attached to script" do
       student = create :student
 
-      section1 = put_student_in_section(student, @teacher, @script)
-      section2 = put_student_in_section(student, @teacher, @script)
+      section1 = put_participant_in_section(student, @teacher, @script)
+      section2 = put_participant_in_section(student, @teacher, @script)
 
       hide_lessons_in_sections(section1, section2)
 
@@ -3934,8 +3934,8 @@ class UserTest < ActiveSupport::TestCase
     test "user in two sections, both attached to course" do
       student = create :student
 
-      section1 = put_student_in_section(student, @teacher, @script, @unit_group)
-      section2 = put_student_in_section(student, @teacher, @script, @unit_group)
+      section1 = put_participant_in_section(student, @teacher, @script, @unit_group)
+      section2 = put_participant_in_section(student, @teacher, @script, @unit_group)
 
       hide_scripts_in_sections(section1, section2)
 
@@ -3956,8 +3956,8 @@ class UserTest < ActiveSupport::TestCase
     test "user in two sections, both attached to course but no script" do
       student = create :student
 
-      section1 = put_student_in_section(student, @teacher, nil, @unit_group)
-      section2 = put_student_in_section(student, @teacher, nil, @unit_group)
+      section1 = put_participant_in_section(student, @teacher, nil, @unit_group)
+      section2 = put_participant_in_section(student, @teacher, nil, @unit_group)
 
       hide_scripts_in_sections(section1, section2)
 
@@ -3979,8 +3979,8 @@ class UserTest < ActiveSupport::TestCase
       student = create :student
 
       unattached_script = create(:script)
-      section1 = put_student_in_section(student, @teacher, unattached_script)
-      section2 = put_student_in_section(student, @teacher, unattached_script)
+      section1 = put_participant_in_section(student, @teacher, unattached_script)
+      section2 = put_participant_in_section(student, @teacher, unattached_script)
 
       hide_lessons_in_sections(section1, section2)
 
@@ -3997,8 +3997,8 @@ class UserTest < ActiveSupport::TestCase
       student = create :student
 
       unattached_script = create(:script)
-      section1 = put_student_in_section(student, @teacher, unattached_script)
-      section2 = put_student_in_section(student, @teacher, unattached_script)
+      section1 = put_participant_in_section(student, @teacher, unattached_script)
+      section2 = put_participant_in_section(student, @teacher, unattached_script)
 
       hide_scripts_in_sections(section1, section2)
 
@@ -4009,8 +4009,8 @@ class UserTest < ActiveSupport::TestCase
     test "user in two sections, one attached to script one not" do
       student = create :student
 
-      attached_section = put_student_in_section(student, @teacher, @script)
-      unattached_section = put_student_in_section(student, @teacher, create(:script))
+      attached_section = put_participant_in_section(student, @teacher, @script)
+      unattached_section = put_participant_in_section(student, @teacher, create(:script))
 
       hide_lessons_in_sections(attached_section, unattached_section)
 
@@ -4026,8 +4026,8 @@ class UserTest < ActiveSupport::TestCase
     test "user in two sections, one attached to course one not" do
       student = create :student
 
-      attached_section = put_student_in_section(student, @teacher, @script, @unit_group)
-      unattached_section = put_student_in_section(student, @teacher, create(:script))
+      attached_section = put_participant_in_section(student, @teacher, @script, @unit_group)
+      unattached_section = put_participant_in_section(student, @teacher, create(:script))
 
       hide_scripts_in_sections(attached_section, unattached_section)
 
@@ -4046,9 +4046,9 @@ class UserTest < ActiveSupport::TestCase
       teacher_teacher = create :teacher
       student = create :student
 
-      teacher_owner_section = put_student_in_section(student, teacher, @script)
-      teacher_owner_section2 = put_student_in_section(student, teacher, @script)
-      teacher_member_section = put_student_in_section(teacher, teacher_teacher, @script)
+      teacher_owner_section = put_participant_in_section(student, teacher, @script)
+      teacher_owner_section2 = put_participant_in_section(student, teacher, @script)
+      teacher_member_section = put_participant_in_section(teacher, teacher_teacher, @script)
 
       # lesson 1 is hidden in the first section owned by the teacher
       SectionHiddenLesson.create(section_id: teacher_owner_section.id, stage_id: @lesson1.id)
@@ -4073,9 +4073,9 @@ class UserTest < ActiveSupport::TestCase
       teacher_teacher = create :teacher
       student = create :student
 
-      teacher_owner_section = put_student_in_section(student, teacher, @script, @unit_group)
-      teacher_owner_section2 = put_student_in_section(student, teacher, @script, @unit_group)
-      teacher_member_section = put_student_in_section(teacher, teacher_teacher, @script, @unit_group)
+      teacher_owner_section = put_participant_in_section(student, teacher, @script, @unit_group)
+      teacher_owner_section2 = put_participant_in_section(student, teacher, @script, @unit_group)
+      teacher_member_section = put_participant_in_section(teacher, teacher_teacher, @script, @unit_group)
 
       # lesson 1 is hidden in the first section owned by the teacher
       SectionHiddenScript.create(section_id: teacher_owner_section.id, script_id: @script.id)
@@ -4098,7 +4098,7 @@ class UserTest < ActiveSupport::TestCase
     test "unit_hidden?" do
       teacher = create :teacher
       student = create :student
-      section = put_student_in_section(student, teacher, @script, @unit_group)
+      section = put_participant_in_section(student, teacher, @script, @unit_group)
       SectionHiddenScript.create(section_id: section.id, script_id: @script.id)
 
       # returns true for student

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -3940,17 +3940,17 @@ class UserTest < ActiveSupport::TestCase
       hide_scripts_in_sections(section1, section2)
 
       # when attached to course, we should hide only if hidden in every section
-      assert_equal [@script.id], student.get_hidden_script_ids(@unit_group)
+      assert_equal [@script.id], student.get_hidden_unit_ids(@unit_group)
 
       # ignore any archived sections
       section2.hidden = true
       section2.save!
       student.reload
-      assert_equal [@script.id, @script2.id], student.get_hidden_script_ids(@unit_group)
+      assert_equal [@script.id, @script2.id], student.get_hidden_unit_ids(@unit_group)
       section1.hidden = true
       section1.save!
       student.reload
-      assert_equal [], student.get_hidden_script_ids(@unit_group)
+      assert_equal [], student.get_hidden_unit_ids(@unit_group)
     end
 
     test "user in two sections, both attached to course but no script" do
@@ -3962,17 +3962,17 @@ class UserTest < ActiveSupport::TestCase
       hide_scripts_in_sections(section1, section2)
 
       # when attached to course, we should hide only if hidden in every section
-      assert_equal [@script.id], student.get_hidden_script_ids(@unit_group)
+      assert_equal [@script.id], student.get_hidden_unit_ids(@unit_group)
 
       # ignore any archived sections
       section2.hidden = true
       section2.save!
       student.reload
-      assert_equal [@script.id, @script2.id], student.get_hidden_script_ids(@unit_group)
+      assert_equal [@script.id, @script2.id], student.get_hidden_unit_ids(@unit_group)
       section1.hidden = true
       section1.save!
       student.reload
-      assert_equal [], student.get_hidden_script_ids(@unit_group)
+      assert_equal [], student.get_hidden_unit_ids(@unit_group)
     end
 
     test "user in two sections, neither attached to script" do
@@ -4003,7 +4003,7 @@ class UserTest < ActiveSupport::TestCase
       hide_scripts_in_sections(section1, section2)
 
       # when not attached to course, we should hide when hidden in any section
-      assert_equal [@script.id, @script2.id, @script3.id], student.get_hidden_script_ids(@unit_group)
+      assert_equal [@script.id, @script2.id, @script3.id], student.get_hidden_unit_ids(@unit_group)
     end
 
     test "user in two sections, one attached to script one not" do
@@ -4032,7 +4032,7 @@ class UserTest < ActiveSupport::TestCase
       hide_scripts_in_sections(attached_section, unattached_section)
 
       # only the scripts hidden in the attached section are considered hidden
-      assert_equal [@script.id, @script2.id], student.get_hidden_script_ids(@unit_group)
+      assert_equal [@script.id, @script2.id], student.get_hidden_unit_ids(@unit_group)
     end
 
     test "user in no sections" do
@@ -4092,7 +4092,7 @@ class UserTest < ActiveSupport::TestCase
         teacher_owner_section.id => [@script.id],
         teacher_owner_section2.id => [@script.id, @script2.id]
       }
-      assert_equal expected, teacher.get_hidden_script_ids(@unit_group)
+      assert_equal expected, teacher.get_hidden_unit_ids(@unit_group)
     end
 
     test "script_hidden?" do


### PR DESCRIPTION
Prep work ahead of https://github.com/code-dot-org/code-dot-org/pull/46357. Renames a bunch of stuff that that PR will touch.  There is definitely more renaming in this area but gave it a best effort especially with script to unit.

script -> unit
teacher -> instructor
student -> participant
