### PR TITLE
Use correct state variable to toggle resolve state

### DIFF
--- a/apps/src/templates/instructions/codeReviewV2/Comment.jsx
+++ b/apps/src/templates/instructions/codeReviewV2/Comment.jsx
@@ -79,7 +79,7 @@ function Comment({
   };
 
   const handleToggleResolved = () => {
-    const newIsResolvedStatus = !comment.isResolved;
+    const newIsResolvedStatus = !isCommentResolved;
     onResolveStateToggle(
       comment.id,
       newIsResolvedStatus,


### PR DESCRIPTION
The `resolve` field in a comment doesn't actually get updated when a comment is resolved/unresolved. This means that, after the first toggle, the data was stale. This field was already being set as state on the component, so this PR just switches to using that.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
