### PR TITLE
Use project level id when determining whether a user can view code as a code reviewer

### DIFF
--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -212,13 +212,16 @@ class Ability
           end
 
           # Code review V2
+          project_level_id = level_to_view.project_template_level.try(:id) ||
+            level_to_view.id
+
           if user != user_to_assume &&
             !user_to_assume.student_of?(user) &&
             can?(:code_review, user_to_assume) &&
             CodeReview.open_reviews.find_by(
               user_id: user_to_assume.id,
               script_id: script_level.script_id,
-              level_id: level_to_view&.id # TODO replace with project level id
+              project_level_id: project_level_id
             )
             can_view_as_user_for_code_review = true
           end

--- a/dashboard/test/models/ability_test.rb
+++ b/dashboard/test/models/ability_test.rb
@@ -686,6 +686,25 @@ class AbilityTest < ActiveSupport::TestCase
     assert Ability.new(peer_reviewer).can? :view_as_user_for_code_review, javalab_script_level, project_owner
   end
 
+  test 'student in same CSA code review enabled section and code review group as student seeking code review (v2) can view as peer' do
+    # We enable read only access to other student work only on Javalab levels
+    javalab_script_level = create :script_level,
+      levels: [create(:javalab)]
+
+    project_owner = create :student
+    peer_reviewer = create :student
+    section = create :section, code_review_expires_at: Time.now.utc + 1.day
+    put_students_in_section_and_code_review_group([project_owner, peer_reviewer], section)
+    create :code_review,
+      user_id: project_owner.id,
+      script_id: javalab_script_level.script_id,
+      level_id: javalab_script_level.levels[0].id,
+      project_level_id: javalab_script_level.levels[0].id
+
+    assert Ability.new(peer_reviewer).can? :view_as_user, javalab_script_level, project_owner
+    assert Ability.new(peer_reviewer).can? :view_as_user_for_code_review, javalab_script_level, project_owner
+  end
+
   test 'student in same CSA code review enabled section and code review group as student seeking code review can view as peer on bubble choice level' do
     javalab_sublevel = create(:javalab)
     bubble_choice_level = create :bubble_choice_level, sublevels: [javalab_sublevel]
@@ -705,6 +724,31 @@ class AbilityTest < ActiveSupport::TestCase
     assert Ability.new(peer_reviewer).can? :view_as_user_for_code_review, bubble_choice_script_level, project_owner, javalab_sublevel
   end
 
+  test 'student in same CSA code review enabled section and code review group as student seeking code review (v2) can view as peer on level with project template' do
+    # Create two javalab levels that share the same project template level.
+    # The first one will be used to create the code review and the second one
+    # will be used to check the ability.
+    script = create :script
+    template_level = create :javalab
+    javalab_level_1 = create :javalab, project_template_level_name: template_level.name
+    javalab_level_2 = create :javalab, project_template_level_name: template_level.name
+    javalab_script_level_2 = create :script_level, script: script,
+      levels: [javalab_level_2]
+
+    project_owner = create :student
+    peer_reviewer = create :student
+    section = create :section, code_review_expires_at: Time.now.utc + 1.day
+    put_students_in_section_and_code_review_group([project_owner, peer_reviewer], section)
+    create :code_review,
+      user_id: project_owner.id,
+      script_id: script.id,
+      level_id: javalab_level_1.id,
+      project_level_id: template_level.id
+
+    assert Ability.new(peer_reviewer).can? :view_as_user, javalab_script_level_2, project_owner
+    assert Ability.new(peer_reviewer).can? :view_as_user_for_code_review, javalab_script_level_2, project_owner
+  end
+
   test 'student in same CSA code review enabled section and code review group as student seeking code review (v2) can view as peer on bubble choice level' do
     javalab_sublevel = create(:javalab)
     bubble_choice_level = create :bubble_choice_level, sublevels: [javalab_sublevel]
@@ -719,7 +763,7 @@ class AbilityTest < ActiveSupport::TestCase
       user_id: project_owner.id,
       script_id: bubble_choice_script_level.script_id,
       level_id: javalab_sublevel.id,
-      closed_at: nil
+      project_level_id: javalab_sublevel.id
 
     assert Ability.new(peer_reviewer).can? :view_as_user, bubble_choice_script_level, project_owner, javalab_sublevel
     assert Ability.new(peer_reviewer).can? :view_as_user_for_code_review, bubble_choice_script_level, project_owner, javalab_sublevel


### PR DESCRIPTION
When determining if a user can view the level page as a code reviewer, retrieve the code review information by project level id instead of level id.  This should have been done as part of #46563. 

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [LP-2396](https://codedotorg.atlassian.net/browse/LP-2396)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
