### PR TITLE
Adding oneoff script to remove etag records which match a given string

### DIFF
--- a/bin/i18n/oneoff/remove_etags.rb
+++ b/bin/i18n/oneoff/remove_etags.rb
@@ -1,0 +1,13 @@
+#!/usr/bin/env ruby
+require 'json'
+
+# The first argument should be a string which will match the keys of the etags you want to remove.
+files_to_remove = ARGV.first
+etags_file_path = '../crowdin/codeorg_etags.json'
+etags_file = File.read(etags_file_path)
+etags_json = JSON.parse(etags_file)
+etags_json.each do |locale, records|
+  etags_json[locale] = records.select {|file, _| !file.include?(files_to_remove)}
+end
+puts "Removed '#{files_to_remove}' etags from #{etags_file_path}"
+File.write(etags_file_path, JSON.pretty_generate(etags_json))


### PR DESCRIPTION
The i18n sync down tries to skip downloading files from Crowdin if there are no changes. It does this by recording what it has downloaded in the past in an `etags.json` file. At some point, the etag download record got out of sync with what is actually checked into github. I wrote this oneoff script to let us remove specific entries from the etag files so the next i18n sync down will download the files.

## Testing story
Ran locally using `bundle exec bin/i18n/remove_etag.rb curriculum_content`