### PR TITLE
rework cdoFieldVariable

### DIFF
--- a/apps/src/block_utils.js
+++ b/apps/src/block_utils.js
@@ -1,5 +1,7 @@
 import _ from 'lodash';
 import xml from './xml';
+import CdoFieldVariable from './blockly/addons/cdoFieldVariable';
+import {BlocklyVersion} from '@cdo/apps/constants';
 
 const ATTRIBUTES_TO_CLEAN = ['uservisible', 'deletable', 'movable'];
 const DEFAULT_COLOR = [184, 1.0, 0.74];
@@ -729,6 +731,11 @@ const STANDARD_INPUT_TYPES = {
   },
   [VARIABLE_INPUT]: {
     addInput(blockly, block, inputConfig, currentInputRow) {
+      const FieldVariableClass =
+        Blockly.version === BlocklyVersion.CDO
+          ? Blockly.FieldVariable
+          : CdoFieldVariable;
+
       // Make sure the variable name gets declared at the top of the program
       block.getVars = function() {
         return {
@@ -764,7 +771,7 @@ const STANDARD_INPUT_TYPES = {
       // Add the variable field to the block
       currentInputRow
         .appendField(inputConfig.label)
-        .appendField(new Blockly.FieldVariable(null), inputConfig.name);
+        .appendField(new FieldVariableClass(null), inputConfig.name);
     },
     generateCode(block, inputConfig) {
       return Blockly.JavaScript.translateVarName(

--- a/apps/src/blockly/addons/cdoFieldVariable.js
+++ b/apps/src/blockly/addons/cdoFieldVariable.js
@@ -51,11 +51,12 @@ export default class FieldVariable extends GoogleBlockly.FieldVariable {
       }
     }
   }
+  menuGenerator_ = newDropdownCreate;
 }
 
-FieldVariable.originalDropdownCreate = FieldVariable.dropdownCreate;
-FieldVariable.dropdownCreate = function() {
-  const options = FieldVariable.originalDropdownCreate.call(this);
+const originalDropdownCreate = FieldVariable.dropdownCreate;
+const newDropdownCreate = function() {
+  const options = originalDropdownCreate.call(this);
 
   // Remove the last two options (Delete and Rename)
   options.pop();

--- a/apps/src/blockly/googleBlocklyWrapper.js
+++ b/apps/src/blockly/googleBlocklyWrapper.js
@@ -157,7 +157,14 @@ function initializeBlocklyWrapper(blocklyInstance) {
   blocklyWrapper.blockly_.FieldButton = CdoFieldButton;
   blocklyWrapper.blockly_.FieldDropdown = CdoFieldDropdown;
   blocklyWrapper.blockly_.FieldImageDropdown = CdoFieldImageDropdown;
-  blocklyWrapper.blockly_.FieldVariable = CdoFieldVariable;
+
+  // Fix built-in block
+  blocklyWrapper.blockly_.fieldRegistry.unregister('field_variable');
+  blocklyWrapper.blockly_.fieldRegistry.register(
+    'field_variable',
+    CdoFieldVariable
+  );
+
   blocklyWrapper.blockly_.FunctionEditor = FunctionEditor;
   blocklyWrapper.blockly_.Trashcan = CdoTrashcan;
 


### PR DESCRIPTION
## Problem
During a recent Blockly v8 bug bash, it was noticed by Jessie and Amy that clicking the options in the dropdowns for variable fields opened up the alert dialog rather than our "rename variable" dialog:
**Unexpected:**
<img width="599" alt="image" src="https://user-images.githubusercontent.com/43474485/172188534-e04b5cbe-5073-437b-abdc-51672f06a61c.png">
**Expected:**
<img width="504" alt="image" src="https://user-images.githubusercontent.com/43474485/172188594-62038f24-a9da-40e1-ad90-d2dfc39617cd.png">
The reason that the wrong dialog was used is because we normally override Blockly's dropdown options with our own.  For a variable `i`, instead of the options `Rename variable...` and `Delete the 'i' variable`, we would typically have `Rename this variable` and `Rename all i`.
This customization happens in `apps/src/blockly/addons/cdoFieldVariable.js`, but no longer works with v7 (or newer) Google Blockly.





## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
