### PR TITLE
remove legacy teacher resources from all unit groups

### DIFF
--- a/dashboard/config/courses/csd-2017.course
+++ b/dashboard/config/courses/csd-2017.course
@@ -15,16 +15,6 @@
   "properties": {
     "family_name": "csd",
     "has_verified_resources": true,
-    "teacher_resources": [
-      [
-        "curriculum",
-        "https://curriculum.code.org/csd-1718/"
-      ],
-      [
-        "teacherForum",
-        "https://forum.code.org/c/csd"
-      ]
-    ],
     "version_year": "2017"
   },
   "resources": [

--- a/dashboard/config/courses/csd-2018.course
+++ b/dashboard/config/courses/csd-2018.course
@@ -16,16 +16,6 @@
   "properties": {
     "family_name": "csd",
     "has_verified_resources": true,
-    "teacher_resources": [
-      [
-        "curriculum",
-        "https://curriculum.code.org/csd-18/"
-      ],
-      [
-        "teacherForum",
-        "https://forum.code.org/c/csd"
-      ]
-    ],
     "version_year": "2018"
   },
   "resources": [

--- a/dashboard/config/courses/csd-2019.course
+++ b/dashboard/config/courses/csd-2019.course
@@ -15,16 +15,6 @@
   "properties": {
     "family_name": "csd",
     "has_verified_resources": true,
-    "teacher_resources": [
-      [
-        "curriculum",
-        "https://curriculum.code.org/csd-19/"
-      ],
-      [
-        "teacherForum",
-        "https://forum.code.org/c/csd"
-      ]
-    ],
     "version_year": "2019"
   },
   "resources": [

--- a/dashboard/config/courses/csd-2020.course
+++ b/dashboard/config/courses/csd-2020.course
@@ -15,16 +15,6 @@
   "properties": {
     "family_name": "csd",
     "has_verified_resources": true,
-    "teacher_resources": [
-      [
-        "curriculum",
-        "https://curriculum.code.org/csd-20/"
-      ],
-      [
-        "teacherForum",
-        "https://forum.code.org/c/csd"
-      ]
-    ],
     "version_year": "2020"
   },
   "resources": [

--- a/dashboard/config/courses/csp-2017.course
+++ b/dashboard/config/courses/csp-2017.course
@@ -30,20 +30,6 @@
   "properties": {
     "family_name": "csp",
     "has_verified_resources": true,
-    "teacher_resources": [
-      [
-        "curriculum",
-        "https://curriculum.code.org/csp/"
-      ],
-      [
-        "teacherForum",
-        "http://forum.code.org/c/csp"
-      ],
-      [
-        "professionalLearning",
-        "https://studio.code.org/courses/CSP%20Support"
-      ]
-    ],
     "version_year": "2017"
   },
   "resources": [

--- a/dashboard/config/courses/csp-2018.course
+++ b/dashboard/config/courses/csp-2018.course
@@ -18,16 +18,6 @@
   "properties": {
     "family_name": "csp",
     "has_verified_resources": true,
-    "teacher_resources": [
-      [
-        "curriculum",
-        "https://curriculum.code.org/csp-18"
-      ],
-      [
-        "teacherForum",
-        "https://forum.code.org/c/csp"
-      ]
-    ],
     "version_year": "2018"
   },
   "resources": [

--- a/dashboard/config/courses/csp-2019.course
+++ b/dashboard/config/courses/csp-2019.course
@@ -17,16 +17,6 @@
   "properties": {
     "family_name": "csp",
     "has_verified_resources": true,
-    "teacher_resources": [
-      [
-        "curriculum",
-        "https://curriculum.code.org/csp-19"
-      ],
-      [
-        "teacherForum",
-        "https://forum.code.org/c/csp"
-      ]
-    ],
     "version_year": "2019"
   },
   "resources": [


### PR DESCRIPTION
Follow-on to https://github.com/code-dot-org/code-dot-org/pull/46651. That PR removed legacy teacher resources from .script_json files. This PR removes them from .course files.

note that not all teacher resources in csd are translated, as seen in the example below.

## screenshots

csd-2019 in es-MX, before / after

![Screen Shot 2022-06-23 at 2 48 32 PM](https://user-images.githubusercontent.com/8001765/175410518-6b9aa9af-ec54-4fb5-bc5d-3707362e4b7c.png)


## Testing story

* `rake seed:courses` is passing locally. after running it, no `UnitGroup` has `teacher_resources`
* manual testing to confirm translations are working locally (see screenshot)
