### PR TITLE
Maureen/lp 2390 code review teacher experience

### DIFF
--- a/apps/src/javalab/JavalabView.jsx
+++ b/apps/src/javalab/JavalabView.jsx
@@ -229,7 +229,9 @@ class JavalabView extends React.Component {
                 displayReviewTab
                 initialSelectedTab={
                   queryParams(VIEWING_CODE_REVIEW_URL_PARAM) === 'true'
-                    ? TabType.REVIEW
+                    ? experiments.isEnabled('code_review_v2')
+                      ? TabType.REVIEW_V2
+                      : TabType.REVIEW
                     : null
                 }
                 explicitHeight={height}

--- a/apps/src/templates/instructions/codeReviewV2/CodeReviewTimelineReview.jsx
+++ b/apps/src/templates/instructions/codeReviewV2/CodeReviewTimelineReview.jsx
@@ -19,7 +19,6 @@ const CodeReviewTimelineReview = ({
   addCodeReviewComment,
   closeReview,
   toggleResolveComment,
-  viewAsCodeReviewer,
   deleteCodeReviewComment,
   currentUserId
 }) => {
@@ -81,11 +80,11 @@ const CodeReviewTimelineReview = ({
           comments.map(comment => {
             return (
               <Comment
+                isViewingAsCodeReviewOwner={ownerId === currentUserId}
                 comment={comment}
                 key={`code-review-comment-${comment.id}`}
                 onResolveStateToggle={toggleResolveComment}
                 onDelete={deleteCodeReviewComment}
-                viewAsCodeReviewer={viewAsCodeReviewer}
               />
             );
           })}
@@ -104,7 +103,6 @@ const CodeReviewTimelineReview = ({
 export const UnconnectedCodeReviewTimelineReview = CodeReviewTimelineReview;
 
 export default connect(state => ({
-  viewAsCodeReviewer: state.pageConstants.isCodeReviewing,
   currentUserId: state.currentUser?.userId
 }))(CodeReviewTimelineReview);
 
@@ -114,7 +112,6 @@ CodeReviewTimelineReview.propTypes = {
   addCodeReviewComment: PropTypes.func.isRequired,
   closeReview: PropTypes.func.isRequired,
   toggleResolveComment: PropTypes.func.isRequired,
-  viewAsCodeReviewer: PropTypes.bool,
   deleteCodeReviewComment: PropTypes.func.isRequired,
   currentUserId: PropTypes.number
 };

--- a/apps/src/templates/instructions/codeReviewV2/CodeReviewTimelineReview.jsx
+++ b/apps/src/templates/instructions/codeReviewV2/CodeReviewTimelineReview.jsx
@@ -80,7 +80,7 @@ const CodeReviewTimelineReview = ({
           comments.map(comment => {
             return (
               <Comment
-                isViewingAsCodeReviewOwner={ownerId === currentUserId}
+                viewingAsOwner={ownerId === currentUserId}
                 comment={comment}
                 key={`code-review-comment-${comment.id}`}
                 onResolveStateToggle={toggleResolveComment}

--- a/apps/src/templates/instructions/codeReviewV2/CodeReviewTimelineReview.jsx
+++ b/apps/src/templates/instructions/codeReviewV2/CodeReviewTimelineReview.jsx
@@ -34,6 +34,8 @@ const CodeReviewTimelineReview = ({
     );
   };
 
+  const viewingAsOwner = ownerId === currentUserId;
+
   return (
     <CodeReviewTimelineElement
       type={codeReviewTimelineElementType.CODE_REVIEW}
@@ -47,7 +49,7 @@ const CodeReviewTimelineReview = ({
           </div>
           <div style={styles.title}>
             <div style={styles.codeReviewTitle}>
-              {ownerId === currentUserId
+              {viewingAsOwner
                 ? javalabMsg.codeReviewForYou()
                 : javalabMsg.codeReviewForStudent({student: ownerName})}
             </div>
@@ -55,7 +57,7 @@ const CodeReviewTimelineReview = ({
               {javalabMsg.openedDate({date: formattedDate})}
             </div>
           </div>
-          {isOpen && !viewAsCodeReviewer && (
+          {isOpen && viewingAsOwner && (
             <div>
               <Button
                 icon="close"
@@ -68,7 +70,7 @@ const CodeReviewTimelineReview = ({
             </div>
           )}
         </div>
-        {isOpen && !viewAsCodeReviewer && (
+        {isOpen && viewingAsOwner && (
           <div style={styles.codeWorkspaceDisabledMsg}>
             <span style={styles.note}>{javalabMsg.noteWorthy()}</span>
             &nbsp;
@@ -87,7 +89,7 @@ const CodeReviewTimelineReview = ({
               />
             );
           })}
-        {isOpen && viewAsCodeReviewer && (
+        {isOpen && !viewingAsOwner && (
           <CodeReviewCommentEditor
             addCodeReviewComment={(commentText, onSuccess, onFailure) =>
               addCodeReviewComment(commentText, id, onSuccess, onFailure)

--- a/apps/src/templates/instructions/codeReviewV2/Comment.jsx
+++ b/apps/src/templates/instructions/codeReviewV2/Comment.jsx
@@ -21,7 +21,7 @@ function Comment({
   onDelete,
   viewAsTeacher,
   currentUserId,
-  isViewingAsCodeReviewOwner
+  viewingAsOwner
 }) {
   const isMounted = useRef(false);
   const [isCommentResolved, setIsCommentResolved] = useState(
@@ -102,7 +102,7 @@ function Comment({
         iconClass: hideResolved ? 'eye' : 'eye-slash'
       });
     }
-    if (isViewingAsCodeReviewOwner) {
+    if (viewingAsOwner) {
       // Code owners can resolve/unresolve comment
       // TODO: Allow teachers to resolve/unresolve comments too
       menuItems.push({
@@ -229,7 +229,7 @@ Comment.propTypes = {
   comment: reviewCommentShape.isRequired,
   onResolveStateToggle: PropTypes.func.isRequired,
   onDelete: PropTypes.func.isRequired,
-  isViewingAsCodeReviewOwner: PropTypes.bool.isRequired,
+  viewingAsOwner: PropTypes.bool.isRequired,
   // Populated by Redux
   viewAsTeacher: PropTypes.bool,
   currentUserId: PropTypes.number

--- a/apps/src/templates/instructions/codeReviewV2/Comment.jsx
+++ b/apps/src/templates/instructions/codeReviewV2/Comment.jsx
@@ -5,7 +5,7 @@ import moment from 'moment';
 import javalabMsg from '@cdo/javalab/locale';
 import color from '@cdo/apps/util/color';
 import msg from '@cdo/locale';
-import {commentShape} from '@cdo/apps/templates/instructions/codeReview/commentShape';
+import {reviewCommentShape} from '@cdo/apps/templates/instructions/codeReviewV2/shapes';
 import InlineDropdownMenu from '@cdo/apps/templates/InlineDropdownMenu';
 import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
 import Spinner from '@cdo/apps/code-studio/pd/components/spinner';
@@ -19,9 +19,9 @@ function Comment({
   comment,
   onResolveStateToggle,
   onDelete,
-  viewAsCodeReviewer,
   viewAsTeacher,
-  currentUserId
+  currentUserId,
+  isViewingAsCodeReviewOwner
 }) {
   const isMounted = useRef(false);
   const [isCommentResolved, setIsCommentResolved] = useState(
@@ -102,7 +102,7 @@ function Comment({
         iconClass: hideResolved ? 'eye' : 'eye-slash'
       });
     }
-    if (!viewAsCodeReviewer) {
+    if (isViewingAsCodeReviewOwner) {
       // Code owners can resolve/unresolve comment
       // TODO: Allow teachers to resolve/unresolve comments too
       menuItems.push({
@@ -226,10 +226,10 @@ function Comment({
 }
 
 Comment.propTypes = {
-  comment: commentShape.isRequired,
+  comment: reviewCommentShape.isRequired,
   onResolveStateToggle: PropTypes.func.isRequired,
   onDelete: PropTypes.func.isRequired,
-  viewAsCodeReviewer: PropTypes.bool.isRequired,
+  isViewingAsCodeReviewOwner: PropTypes.bool.isRequired,
   // Populated by Redux
   viewAsTeacher: PropTypes.bool,
   currentUserId: PropTypes.number

--- a/apps/src/templates/instructions/codeReviewV2/shapes.js
+++ b/apps/src/templates/instructions/codeReviewV2/shapes.js
@@ -7,16 +7,18 @@ export const commitShape = PropTypes.shape({
   timelineElementType: PropTypes.string.isRequired
 });
 
-const reviewCommentShape = PropTypes.shape({
-  id: PropTypes.number,
-  commentText: PropTypes.string,
-  name: PropTypes.string,
-  timestampString: PropTypes.string,
-  isResolved: PropTypes.bool
+export const reviewCommentShape = PropTypes.shape({
+  id: PropTypes.number.isRequired,
+  comment: PropTypes.string,
+  commenterName: PropTypes.string.isRequired,
+  commenterId: PropTypes.number.isRequired,
+  createdAt: PropTypes.string,
+  isResolved: PropTypes.bool,
+  isFromTeacher: PropTypes.bool
 });
 
 export const reviewShape = PropTypes.shape({
-  id: PropTypes.number,
+  id: PropTypes.number.isRequired,
   createdAt: PropTypes.string,
   isOpen: PropTypes.bool,
   version: PropTypes.string,

--- a/apps/test/unit/templates/instructions/codeReviewV2/CodeReviewTimelineReviewTest.jsx
+++ b/apps/test/unit/templates/instructions/codeReviewV2/CodeReviewTimelineReviewTest.jsx
@@ -23,16 +23,18 @@ const DEFAULT_REVIEW = {
   comments: [
     {
       id: 123,
-      commentText: 'Great work on this!',
-      name: 'Steve',
-      timestampString: '2022-03-31T04:58:42.000Z',
+      comment: 'Great work on this!',
+      commenterName: 'Steve',
+      commenterId: 987,
+      createdAt: '2022-03-31T04:58:42.000Z',
       isResolved: false
     },
     {
       id: 124,
-      commentText: 'Could you add more comments?',
-      name: 'Karen',
-      timestampString: '2022-03-31T04:58:42.000Z',
+      comment: 'Could you add more comments?',
+      commenterName: 'Karen',
+      commenterId: 654,
+      createdAt: '2022-03-31T04:58:42.000Z',
       isResolved: false
     }
   ]
@@ -45,7 +47,6 @@ const DEFAULT_PROPS = {
   closeReview: () => {},
   toggleResolveComment: () => {},
   deleteCodeReviewComment: () => {},
-  viewAsCodeReviewer: false,
   currentUserId: 1
 };
 
@@ -85,8 +86,9 @@ describe('CodeReviewTimelineReview', () => {
     ).to.be.true;
   });
 
-  it('displays the close button if the code review is not closed', () => {
-    const wrapper = setUp();
+  it('displays the close button if the code review is open and viewing as owner', () => {
+    const review = {...DEFAULT_REVIEW, isOpen: true, ownerId: 1};
+    const wrapper = setUp({review: review, currentUserId: 1});
     const closeButton = wrapper.find('Button');
     expect(closeButton).to.have.length(1);
     expect(closeButton.props().text).to.equal(javalabMsg.closeReview());
@@ -98,7 +100,12 @@ describe('CodeReviewTimelineReview', () => {
       .callsFake((successCallback, failureCallback) => {
         successCallback();
       });
-    const wrapper = setUp({closeReview: closeReviewStub});
+    const review = {...DEFAULT_REVIEW, isOpen: true, ownerId: 1};
+    const wrapper = setUp({
+      review: review,
+      currentUserId: 1,
+      closeReview: closeReviewStub
+    });
     const closeButton = wrapper.find('Button');
     closeButton.simulate('click');
 
@@ -113,7 +120,12 @@ describe('CodeReviewTimelineReview', () => {
       .callsFake((successCallback, failureCallback) => {
         failureCallback();
       });
-    const wrapper = setUp({closeReview: closeReviewStub});
+    const review = {...DEFAULT_REVIEW, isOpen: true, ownerId: 1};
+    const wrapper = setUp({
+      review: review,
+      currentUserId: 1,
+      closeReview: closeReviewStub
+    });
     const closeButton = wrapper.find('Button');
     closeButton.simulate('click');
 
@@ -128,9 +140,9 @@ describe('CodeReviewTimelineReview', () => {
     expect(wrapper.find('Button')).to.have.length(0);
   });
 
-  it('hides the close button if not viewAsCodeReviewer', () => {
-    const review = {...DEFAULT_REVIEW, isOpen: true};
-    const wrapper = setUp({review: review, viewAsCodeReviewer: true});
+  it('hides the close button if the current user is not the owner of the review', () => {
+    const review = {...DEFAULT_REVIEW, isOpen: true, ownerId: 1};
+    const wrapper = setUp({review: review, currentUserId: 2});
     expect(wrapper.find('Button')).to.have.length(0);
   });
 
@@ -139,8 +151,9 @@ describe('CodeReviewTimelineReview', () => {
     expect(wrapper.find(Comment)).to.have.length(2);
   });
 
-  it('displays code review disabled note if the review is not closed and not viewing as reviewer', () => {
-    const wrapper = setUp();
+  it('displays code review disabled note if the review is open and viewing as owner', () => {
+    const review = {...DEFAULT_REVIEW, isOpen: true, ownerId: 1};
+    const wrapper = setUp({review: review, currentUserId: 1});
     expect(wrapper.contains(javalabMsg.codeEditingDisabled())).to.be.true;
   });
 
@@ -150,15 +163,15 @@ describe('CodeReviewTimelineReview', () => {
     expect(wrapper.contains(javalabMsg.codeEditingDisabled())).to.be.false;
   });
 
-  it('hides code review disabled note if viewing as reviewer', () => {
-    const review = {...DEFAULT_REVIEW, isOpen: true};
-    const wrapper = setUp({review: review, viewAsCodeReviewer: true});
+  it('hides code review disabled note if as not the owner', () => {
+    const review = {...DEFAULT_REVIEW, isOpen: true, ownerId: 1};
+    const wrapper = setUp({review: review, currentUserId: 2});
     expect(wrapper.contains(javalabMsg.codeEditingDisabled())).to.be.false;
   });
 
-  it('displays CodeReviewCommentEditor if the review is open and viewing as reviewer', () => {
-    const review = {...DEFAULT_REVIEW, isOpen: true};
-    const wrapper = setUp({review: review, viewAsCodeReviewer: true});
+  it('displays CodeReviewCommentEditor if the review is open and viewing as not the owner', () => {
+    const review = {...DEFAULT_REVIEW, isOpen: true, ownerId: 1};
+    const wrapper = setUp({review: review, currentUserId: 2});
     expect(wrapper.find(CodeReviewCommentEditor)).to.have.length(1);
   });
 
@@ -169,12 +182,13 @@ describe('CodeReviewTimelineReview', () => {
   });
 
   // By design, the user will not leave notes on their own code review
-  it('hides the CodeReviewCommentEditor if the review is open but not viewing as reviewer', () => {
+  it('hides the CodeReviewCommentEditor if the review is open and viewing as the owner', () => {
     const review = {
       ...DEFAULT_REVIEW,
-      isOpen: true
+      isOpen: true,
+      ownerId: 1
     };
-    const wrapper = setUp({review: review, viewAsCodeReviewer: false});
+    const wrapper = setUp({review: review, currentUserId: 1});
     expect(wrapper.find(CodeReviewCommentEditor)).to.have.length(0);
   });
 });

--- a/apps/test/unit/templates/instructions/codeReviewV2/CodeReviewTimelineTest.jsx
+++ b/apps/test/unit/templates/instructions/codeReviewV2/CodeReviewTimelineTest.jsx
@@ -27,16 +27,18 @@ const DEFAULT_PROPS = {
       comments: [
         {
           id: 123,
-          commentText: 'Great work on this!',
-          name: 'Steve',
-          timestampString: '2022-03-31T04:58:42.000Z',
+          comment: 'Great work on this!',
+          commenterName: 'Steve',
+          commenterId: 987,
+          createdAt: '2022-03-31T04:58:42.000Z',
           isResolved: false
         },
         {
           id: 124,
-          commentText: 'Could you add more comments?',
-          name: 'Karen',
-          timestampString: '2022-03-31T04:58:42.000Z',
+          comment: 'Could you add more comments?',
+          commenterName: 'Karen',
+          commenterId: 654,
+          createdAt: '2022-03-31T04:58:42.000Z',
           isResolved: false
         }
       ]


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
- Fixes teacher experience, so they're able to comment and are unable to close a students review or resolve comments. Previously we were checking the param `viewAsCodeReviewer` to determine if we should the code review experience, but for a teacher this param is not true, so the teacher was seeing the student experience. I've updated it so it checks if the current user is the owner of the code review to determine whether we show the owner or reviewer experience.
- Fixes logic for which tab to show for code_review_v2. Previously, when the param viewingCodeReview was true we were defaulting to the old code review tab even when the code review feature was enabled, this has been fixed.
- Changes the proptype shape for comments, it was still for the code review v1 comment shape, we had forgotten to update it. As a result of it being changed, I needed to update some tests that were using the wrong shape.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
- jira ticket: [LP-2390](https://codedotorg.atlassian.net/browse/LP-2390)
<!--
- spec: []()

-->

## Testing story
Tested locally, updated unit tests
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
