### PR TITLE
Code Review V2: bug bash style fixes

### DIFF
--- a/apps/src/templates/instructions/CommitsAndReviewTab.jsx
+++ b/apps/src/templates/instructions/CommitsAndReviewTab.jsx
@@ -282,7 +282,7 @@ const styles = {
   },
   header: {
     display: 'flex',
-    flexWrap: 'wrap-reverse',
+    flexWrap: 'wrap',
     justifyContent: 'space-between',
     margin: '5px 0'
   },

--- a/apps/src/templates/instructions/codeReviewV2/CodeReviewTimelineReview.jsx
+++ b/apps/src/templates/instructions/codeReviewV2/CodeReviewTimelineReview.jsx
@@ -126,7 +126,7 @@ const styles = {
   icon: {
     marginRight: '5px',
     backgroundColor: 'lightgrey',
-    width: '30px',
+    minWidth: '30px',
     height: '30px',
     borderRadius: '100%',
     fontSize: '22px',

--- a/apps/src/templates/instructions/codeReviewV2/CodeReviewTimelineReview.jsx
+++ b/apps/src/templates/instructions/codeReviewV2/CodeReviewTimelineReview.jsx
@@ -140,7 +140,8 @@ const styles = {
   },
   title: {
     flexGrow: 1,
-    fontStyle: 'italic'
+    fontStyle: 'italic',
+    marginRight: '10px'
   },
   codeReviewTitle: {
     fontFamily: '"Gotham 5r", sans-serif',
@@ -155,7 +156,7 @@ const styles = {
   date: {
     fontSize: '12px',
     marginBottom: '10px',
-    lineHeight: '12px'
+    lineHeight: '15px'
   },
   codeWorkspaceDisabledMsg: {
     textAlign: 'center',

--- a/apps/src/templates/instructions/codeReviewV2/Comment.jsx
+++ b/apps/src/templates/instructions/codeReviewV2/Comment.jsx
@@ -212,10 +212,7 @@ function Comment({
             ...(isCommentResolved && styles.lessVisibleBackgroundColor)
           }}
         >
-          <SafeMarkdown
-            markdown={commentText}
-            className="code-custom-background"
-          />
+          <SafeMarkdown markdown={commentText} className="comment-content" />
         </div>
       )}
       {displayError && (

--- a/apps/src/templates/instructions/codeReviewV2/comment.scss
+++ b/apps/src/templates/instructions/codeReviewV2/comment.scss
@@ -1,4 +1,9 @@
-.code-custom-background {
+.comment-content {
+  & > * {
+    margin: 0;
+  }
+
+  // gray background for block formatted code comments
   pre {
     background-color: rgba(255, 255, 255, 0.5);
   }


### PR DESCRIPTION
Makes a few small, unrelated styling improvements identified during the code review V2 bug bash. They are:

- wrapping refresh button below project list button, instead of above
- keeping circular gray circle (rather than oval) in background of bubble icon when resizing review area
- prevent "close review" button from overflowing the review title
- center comment text (or code block) vertically within comment

**After (before in Jira ticket)**

<img width="237" alt="image" src="https://user-images.githubusercontent.com/25372625/172435115-966c6573-45ec-4e01-9e76-27df72379822.png">

<img width="374" alt="image" src="https://user-images.githubusercontent.com/25372625/172435362-423b1e4b-7b6d-4137-8c6f-ce294a8d5cd1.png">

## Links

- jira ticket: [LP-2394](https://codedotorg.atlassian.net/browse/LP-2394)

## Testing story

Tested manually (chrome/mac) that these updates looked good on my machine.