### PR TITLE
[Spritelab] Close WorkspaceAlert for execution error on reset

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -1046,7 +1046,7 @@ StudioApp.prototype.toggleRunReset = function(button) {
 
   if (showRun) {
     if (this.editDuringRunAlert !== undefined) {
-      ReactDOM.unmountComponentAtNode(this.editDuringRunAlert);
+      this.closeAlert(this.editDuringRunAlert);
       this.editDuringRunAlert = undefined;
     }
     getStore().dispatch(setIsEditWhileRun(false));
@@ -3117,7 +3117,7 @@ StudioApp.prototype.displayWorkspaceAlert = function(
       type: type,
       onClose: () => {
         onClose();
-        ReactDOM.unmountComponentAtNode(container[0]);
+        this.closeAlert(container[0]);
       },
       isBlockly: this.usingBlockly_,
       displayBottom: bottom
@@ -3151,9 +3151,7 @@ StudioApp.prototype.displayPlayspaceAlert = function(type, alertContents) {
   var renderElement = container[0];
 
   let alertProps = {
-    onClose: () => {
-      ReactDOM.unmountComponentAtNode(renderElement);
-    },
+    onClose: () => this.closeAlert(renderElement),
     type: type
   };
 
@@ -3166,6 +3164,14 @@ StudioApp.prototype.displayPlayspaceAlert = function(type, alertContents) {
 
   const playspaceAlert = React.createElement(Alert, alertProps, alertContents);
   ReactDOM.render(playspaceAlert, renderElement);
+};
+
+/**
+ * Remove an alert from the DOM. This is just an alias for ReactDOM.unmountComponentAtNode.
+ * @param {Node} alert
+ */
+StudioApp.prototype.closeAlert = function(alert) {
+  ReactDOM.unmountComponentAtNode(alert);
 };
 
 /**

--- a/apps/src/p5lab/P5Lab.js
+++ b/apps/src/p5lab/P5Lab.js
@@ -1470,7 +1470,10 @@ export default class P5Lab {
       }
     }
 
-    this.reactToExecutionError(this.JSInterpreter.executionError?.message);
+    if (this.JSInterpreter.executionError) {
+      this.reactToExecutionError(this.JSInterpreter.executionError.message);
+    }
+
     this.completeRedrawIfDrawComplete();
   }
 

--- a/apps/src/p5lab/spritelab/SpriteLab.js
+++ b/apps/src/p5lab/spritelab/SpriteLab.js
@@ -77,6 +77,7 @@ export default class SpriteLab extends P5Lab {
   reset() {
     super.reset();
     getStore().dispatch(clearPrompts());
+    this.clearExecutionErrorWorkspaceAlert();
     this.preview();
   }
 
@@ -92,14 +93,15 @@ export default class SpriteLab extends P5Lab {
   }
 
   /**
-   * If there is an executionError, create a WorkspaceAlert.
+   * If there is an executionError while the program is running, display a WorkspaceAlert.
    * We do this because Sprite Lab has no user-facing console.
    */
   reactToExecutionError(msg) {
     if (!msg) {
       return;
     }
-    studioApp().displayWorkspaceAlert(
+
+    this.executionErrorWorkspaceAlert = studioApp().displayWorkspaceAlert(
       'error',
       React.createElement(
         'div',
@@ -110,6 +112,15 @@ export default class SpriteLab extends P5Lab {
       ),
       true /* bottom */
     );
+  }
+
+  clearExecutionErrorWorkspaceAlert() {
+    if (!this.executionErrorWorkspaceAlert) {
+      return;
+    }
+
+    studioApp().closeAlert(this.executionErrorWorkspaceAlert);
+    this.executionErrorWorkspaceAlert = undefined;
   }
 
   onPromptAnswer(variableName, value) {

--- a/apps/src/p5lab/spritelab/SpriteLab.js
+++ b/apps/src/p5lab/spritelab/SpriteLab.js
@@ -93,7 +93,7 @@ export default class SpriteLab extends P5Lab {
   }
 
   /**
-   * If there is an executionError while the program is running, display a WorkspaceAlert.
+   * If there is an executionError, display a WorkspaceAlert.
    * We do this because Sprite Lab has no user-facing console.
    */
   reactToExecutionError(msg) {


### PR DESCRIPTION
This is a minor update to how we alert users about execution errors in Spritelab. We weren't removing executionError alerts, so alerts began stacking. Now, every time you run or reset the program (e.g., the program state is reset), we clear the previous executionError alert if one exists.


## Links

- [STAR-2165](https://codedotorg.atlassian.net/browse/STAR-2165)