### PR TITLE
Show an error message when a project version isn't found

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -2168,7 +2168,7 @@
   "versionHistory_initialVersion_label": "Initial version",
   "versionHistory_header": "Version History",
   "versionHistory_versionLabel": "Version from {timestamp}",
-  "versionNotFound": "This version of this project cannot be found or has expired.",
+  "versionNotFound": "This version of this project cannot be found or is no longer available.",
   "video": "Video",
   "videos": "Videos",
   "view": "View",

--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -2168,6 +2168,7 @@
   "versionHistory_initialVersion_label": "Initial version",
   "versionHistory_header": "Version History",
   "versionHistory_versionLabel": "Version from {timestamp}",
+  "versionNotFound": "This version of this project cannot be found or has expired.",
   "video": "Video",
   "videos": "Videos",
   "view": "View",

--- a/apps/src/code-studio/initApp/loadApp.js
+++ b/apps/src/code-studio/initApp/loadApp.js
@@ -10,6 +10,7 @@ import {
 import {files} from '@cdo/apps/clientApi';
 var renderAbusive = require('./renderAbusive');
 import renderProjectNotFound from './renderProjectNotFound';
+import renderVersionNotFound from './renderVersionNotFound';
 var userAgentParser = require('./userAgentParser');
 var clientState = require('../clientState');
 import getScriptData from '../../util/getScriptData';
@@ -264,7 +265,10 @@ function loadProjectAndCheckAbuse(appOptions) {
       })
       .catch(() => {
         if (project.channelNotFound()) {
-          renderProjectNotFound(project);
+          renderProjectNotFound();
+          return;
+        } else if (project.sourceNotFound()) {
+          renderVersionNotFound();
           return;
         }
       });

--- a/apps/src/code-studio/initApp/renderVersionNotFound.js
+++ b/apps/src/code-studio/initApp/renderVersionNotFound.js
@@ -3,11 +3,11 @@ import ReactDOM from 'react-dom';
 import AlertExclamation from '../components/AlertExclamation';
 import msg from '@cdo/locale';
 
-export function ProjectNotFoundAlert() {
+export function VersionNotFoundAlert() {
   return (
     <AlertExclamation>
       <div className="exclamation-abuse">
-        <p style={styles.text}>{msg.projectNotFound()}</p>
+        <p style={styles.text}>{msg.versionNotFound()}</p>
         <p style={styles.text}>
           <a href="https://studio.code.org">{msg.goToCodeStudio()}</a>
         </p>
@@ -17,7 +17,7 @@ export function ProjectNotFoundAlert() {
 }
 
 export default () => {
-  ReactDOM.render(<ProjectNotFoundAlert />, document.getElementById('codeApp'));
+  ReactDOM.render(<VersionNotFoundAlert />, document.getElementById('codeApp'));
 };
 
 const styles = {

--- a/apps/test/unit/code-studio/initApp/projectTest.js
+++ b/apps/test/unit/code-studio/initApp/projectTest.js
@@ -774,6 +774,7 @@ describe('project.js', () => {
       });
 
       it('fails when channel not found', done => {
+        stubGetChannelsWithNotFound(server);
         project.load().catch(() => {
           expect(project.channelNotFound()).to.be.true;
           done();
@@ -789,6 +790,22 @@ describe('project.js', () => {
         stubGetChannels(server);
         stubGetMainJsonWithError(server);
         project.load().catch(() => done());
+      });
+
+      it('fails when sources request fails', done => {
+        stubGetChannels(server);
+        stubGetMainJsonWithError(server);
+        project.load().catch(() => done());
+      });
+
+      it('fails when sources not found', done => {
+        stubGetChannels(server);
+        stubGetSourcesWithNotFound(server);
+        project.load().catch(() => {
+          expect(project.channelNotFound()).to.be.false;
+          expect(project.sourceNotFound()).to.be.true;
+          done();
+        });
       });
     });
 
@@ -1103,6 +1120,18 @@ function stubGetChannelsWithError(server) {
   });
 }
 
+function stubGetChannelsWithNotFound(server) {
+  server.respondWith('GET', /\/v3\/channels\/.*/, xhr => {
+    xhr.respond(
+      404,
+      {
+        'Content-Type': 'application/json'
+      },
+      'channel `channel_id` not found'
+    );
+  });
+}
+
 function stubGetChannels(server) {
   server.respondWith('GET', /\/v3\/channels\/.*/, xhr => {
     xhr.respond(
@@ -1169,6 +1198,18 @@ function stubGetMainJsonWithError(server) {
   server.respondWith('GET', /\/v3\/sources\/.*\/main\.json/, xhr =>
     xhr.error()
   );
+}
+
+function stubGetSourcesWithNotFound(server) {
+  server.respondWith('GET', /\/v3\/sources\/.*\/main\.json/, xhr => {
+    xhr.respond(
+      404,
+      {
+        'Content-Type': 'application/json'
+      },
+      'source for `channel_id` not found'
+    );
+  });
 }
 
 function stubPutMainJson(server) {

--- a/apps/test/unit/code-studio/initApp/renderVersionNotFoundTest.js
+++ b/apps/test/unit/code-studio/initApp/renderVersionNotFoundTest.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import {expect} from '../../../util/reconfiguredChai';
+import {VersionNotFoundAlert} from '@cdo/apps/code-studio/initApp/renderVersionNotFound';
+
+describe('VersionNotFoundAlert', () => {
+  it('renders AlertExclamation with message', () => {
+    const wrapper = shallow(<VersionNotFoundAlert />);
+    expect(wrapper.find('AlertExclamation').length).to.equal(1);
+    expect(wrapper.find('a').text()).to.include('Go to Code Studio');
+  });
+});


### PR DESCRIPTION
Adds an error message when the source of a project can't be found, such as when an invalid version is requested. This works on both a standalone project and a project back level.

Very open to feedback on what this error message should say or where it should link to:
![Screen Shot 2022-06-08 at 11 22 22 AM](https://user-images.githubusercontent.com/46464143/172723911-10c95d0c-dd5f-488c-ba18-2389fac46b26.png)




## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
