### PR TITLE
Clean up environment-specific instructions in SETUP.md

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -21,26 +21,12 @@ You can do Code.org development using OSX, Ubuntu, or Windows (running Ubuntu in
 
 3. `cd code-dot-org`
 
-4. For Apple Silicon (M1), make these changes to your [Gemfile.lock](Gemfile.lock) file to switch from `libv8` to `libv8-node` and upgrade `mini_racer`. These changes should not be committed and will unfortunately clutter your `git status`.
-
-   ```text
-   ...
-   libv8-node (15.14.0.0)
-   ...
-   mini_racer (0.4.0)
-     libv8-node (~> 15.14.0.0)
-   ...
-   ```
-
 5. `gem install bundler -v 1.17.3`
-
-6. `export LIBRARY_PATH=$LIBRARY_PATH:/opt/homebrew/opt/openssl/lib/`
 
 7. `rbenv rehash`
 
 8. `bundle install`
     - This step often fails to due environment-specific issues. Look in the [Bundle Install Tips](#bundle-install-tips) section below for steps to resolve many common issues.
-    - For Apple Silicon (M1), you may need to update **ffi** via `bundle update ffi`
 
 9. `bundle exec rake install:hooks`
     <details>
@@ -69,7 +55,7 @@ You can do Code.org development using OSX, Ubuntu, or Windows (running Ubuntu in
     - `ALTER DATABASE dashboard_test CHARACTER SET utf8 COLLATE utf8_unicode_ci;`
 
 12. `bundle exec rake build`
-    - This may fail if your are on a Mac and your OSX XCode Command Line Tools were not installed properly. See Bundle Install Tips for more information.
+    - This may fail if your are on a Mac and your OSX XCode Command Line Tools were not installed properly. See [Bundle Install Tips](#bundle-install-tips) for more information.
 
 13. (Optional, Code.org engineers only) Setup AWS - Ask a Code.org engineer how to complete this step
     - Some functionality will not work on your local site without this, for example, some project-backed level types such as <https://studio.code.org/projects/gamelab>. This setup is only available to Code.org engineers for now, but it is recommended for Code.org engineers.
@@ -155,9 +141,21 @@ These steps are for OSX devices, including Apple Macbooks running on [Apple Sili
 
 15. Install **OpenSSL**
     1. Run `brew install openssl`
-    2. Following the instructions in the output, run a form of `exportLIBRARY_PATH=$LIBRARY_PATH:/usr/local/opt/openssl/lib/`
+    2. Following the instructions in the output, run a form of `export LIBRARY_PATH=$LIBRARY_PATH:/usr/local/opt/openssl/lib/`
 
 16. Install [Google Chrome](https://www.google.com/chrome/), needed for some local app tests.
+
+4. For Apple Silicon (M1), make these changes to your [Gemfile.lock](Gemfile.lock) file to switch from `libv8` to `libv8-node` and upgrade `mini_racer`. These changes should not be committed and will unfortunately clutter your `git status`.
+
+   ```text
+   ...
+   libv8-node (15.14.0.0)
+   ...
+   mini_racer (0.4.0)
+     libv8-node (~> 15.14.0.0)
+   ...
+   ```
+
 
 Return to the [Overview](#overview) to continue installation. Note that there are additional steps for Apple Silicon (M1) when it comes to `bundle install` and `bundle exec rake ...` commands, which are noted in their respective steps.
 
@@ -304,6 +302,8 @@ Note: Virtual Machine Users should check the [Alternative note](#alternative-use
     1. Use the rbenv-doctor from the [`rbenv` installation instructions](https://github.com/rbenv/rbenv#basic-github-checkout) to verify rbenv is set up correctly:
         1. `curl -fsSL https://github.com/rbenv/rbenv-installer/raw/main/bin/rbenv-doctor | bash`
     1. If there are any errors (they appear red), follow the [`rbenv` installation instructions] (https://github.com/rbenv/rbenv#basic-github-checkout) to properly configure `rbenv`, following steps for **Ubuntu Desktop** so that config changes go into `.bashrc`.
+    1. **Note:** Ubuntu 22.04 ships with versions of `libssl` and `openssl` that are incompatible with `ruby-build`; see https://github.com/rbenv/ruby-build/discussions/1940 for context
+        1. As a result, attempts to run `rbenv install` will fail. To resolve, compile a valid version of `openssl` locally and direct `rbenv` to configure ruby to use it as described here: https://github.com/rbenv/ruby-build/discussions/1940#discussioncomment-2663209
 1. Install Ruby 2.5.0 with rbenv
     1. `rbenv install 2.5.0`
     1. If your PATH is missing `~/.rbenv/shims`, the next two commands might not work. Edit your .bashrc to include the following line:

--- a/SETUP.md
+++ b/SETUP.md
@@ -17,18 +17,18 @@ You can do Code.org development using OSX, Ubuntu, or Windows (running Ubuntu in
      yarn --version  # --> 1.22.5
      ```
 
-2. If using SSH (recommended): `git clone git@github.com:code-dot-org/code-dot-org.git` , if using HTTPS: `git clone https://github.com/code-dot-org/code-dot-org.git`
+1. If using SSH (recommended): `git clone git@github.com:code-dot-org/code-dot-org.git` , if using HTTPS: `git clone https://github.com/code-dot-org/code-dot-org.git`
 
-3. `cd code-dot-org`
+1. `cd code-dot-org`
 
-5. `gem install bundler -v 1.17.3`
+1. `gem install bundler -v 1.17.3`
 
-7. `rbenv rehash`
+1. `rbenv rehash`
 
-8. `bundle install`
+1. `bundle install`
     - This step often fails to due environment-specific issues. Look in the [Bundle Install Tips](#bundle-install-tips) section below for steps to resolve many common issues.
 
-9. `bundle exec rake install:hooks`
+1. `bundle exec rake install:hooks`
     <details>
       <summary>Troubleshoot: `rake aborted! Gem::LoadError: You have already activated...` </summary>
 
@@ -46,25 +46,25 @@ You can do Code.org development using OSX, Ubuntu, or Windows (running Ubuntu in
 
     </details>
 
-10. `bundle exec rake install`
+1. `bundle exec rake install`
     - This can take a long time, ~30 minutes or more. The most expensive are the "seeding" tasks, where your local DB is populated from data in the repository. Some of the seeding rake tasks can take several minutes. The longest one, `seed:scripts`, can take > 10 minutes, but it should at least print out progress as it goes.
 
-11. fix your database charset and collation to match our servers
+1. fix your database charset and collation to match our servers
     - `bin/dashboard-sql`
     - `ALTER DATABASE dashboard_development CHARACTER SET utf8 COLLATE utf8_unicode_ci;`
     - `ALTER DATABASE dashboard_test CHARACTER SET utf8 COLLATE utf8_unicode_ci;`
 
-12. `bundle exec rake build`
+1. `bundle exec rake build`
     - This may fail if your are on a Mac and your OSX XCode Command Line Tools were not installed properly. See [Bundle Install Tips](#bundle-install-tips) for more information.
 
-13. (Optional, Code.org engineers only) Setup AWS - Ask a Code.org engineer how to complete this step
+1. (Optional, Code.org engineers only) Setup AWS - Ask a Code.org engineer how to complete this step
     - Some functionality will not work on your local site without this, for example, some project-backed level types such as <https://studio.code.org/projects/gamelab>. This setup is only available to Code.org engineers for now, but it is recommended for Code.org engineers.
 
-14. Run the website `bin/dashboard-server`
+1. Run the website `bin/dashboard-server`
 
-15. Visit <http://localhost-studio.code.org:3000/> to verify it is running.
+1. Visit <http://localhost-studio.code.org:3000/> to verify it is running.
 
-16. Install necessary plugins described in the [Editor configuration](#editor-configuration) section below.
+1. Install necessary plugins described in the [Editor configuration](#editor-configuration) section below.
 
 After setup, read about our [code styleguide](./STYLEGUIDE.md), our [test suites](./TESTING.md), or find more docs on [the wiki](https://github.com/code-dot-org/code-dot-org/wiki/For-Developers).
 
@@ -76,30 +76,30 @@ These steps are for OSX devices, including Apple Macbooks running on [Apple Sili
 
 1. Open your Terminal. These steps assume you are using **zsh**, the default shell for OSX.
 
-2. Optionally configure your **zsh** experience.
+1. Optionally configure your **zsh** experience.
    1. Either install [oh-my-zsh](https://ohmyz.sh/) and add the [git-prompt](https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/git-prompt) plugin, or install the plugin directly without oh-my-zsh as described under the [OS X Catalina](#os-x-catalina) instructions.
 
-3. Install/Update **Xcode Command Line Tools** via `xcode-select --install`
+1. Install/Update **Xcode Command Line Tools** via `xcode-select --install`
 
-4. Install [Homebrew](https://brew.sh/), a macOS package manager
+1. Install [Homebrew](https://brew.sh/), a macOS package manager
 
-5. Install [Redis](https://redis.io/) via `brew install redis`
+1. Install [Redis](https://redis.io/) via `brew install redis`
 
-6. Install [MySql 5.7](https://dev.mysql.com/doc/refman/5.7/en/) via `brew install mysql@5.7`
+1. Install [MySql 5.7](https://dev.mysql.com/doc/refman/5.7/en/) via `brew install mysql@5.7`
    1. Set up your local MySQL server
       1. Force link 5.7 version via `brew link mysql@5.7 --force`
       2. Start mysql with `brew services start mysql@5.7`, which uses [Homebrew services](https://github.com/Homebrew/homebrew-services) to manage things for you.
 
-7. Install the **Java 8 JSK**
+1. Install the **Java 8 JSK**
    1. Either explicitly via `brew cask install adoptopenjdk/openjdk/adoptopenjdk8` or for M1 in Rosetta, `brew install --cask adoptopenjdk/openjdk/adoptopenjdk8`
    2. Or by installing [sdkman](https://sdkman.io/) and installing a suitable JDK. Similar to **rbenv** and **nvm**, **sdkman** allows you to switch between versions of Java.
       1. Different versions will be available depending on your system architecture, use `sdk list java` to identify a Java 8 JDK available for ARM architecture.
       2. `sdk install java <version identifier>` to install a version
       3. `sdk default java <installed version>` to ensure it is the default for future shells.
 
-8. Install **rbenv** via `brew install rbenv`
+1. Install **rbenv** via `brew install rbenv`
 
-9. Install **Ruby 2.5.0**
+1. Install **Ruby 2.5.0**
     1. For non-M1 systems, `rbenv install 2.5.0` should be sufficient
     2. For Apple Silicon, special configuration is required to set *libffi* options correctly. The following is a single line to execute.
 
@@ -107,7 +107,7 @@ These steps are for OSX devices, including Apple Macbooks running on [Apple Sili
       export optflags="-Wno-error=implicit-function-declaration"; export LDFLAGS="-L/opt/homebrew/opt/libffi/lib"; export CPPFLAGS="-I/opt/homebrew/opt/libffi/include"; export PKG_CONFIG_PATH="/opt/homebrew/opt/libffi/lib/pkgconfig" | rbenv install 2.5.0
       ```
 
-10. *(Optional)* Install **pdftk**, which is not available as a standard Homebrew formula. Skipping this will cause some PDF related tests to fail. See <https://leancrew.com/all-this/2017/01/pdftk/> and <https://github.com/turforlag/homebrew-cervezas/pull/1> for more information about pdftk on macOS.
+1. *(Optional)* Install **pdftk**, which is not available as a standard Homebrew formula. Skipping this will cause some PDF related tests to fail. See <https://leancrew.com/all-this/2017/01/pdftk/> and <https://github.com/turforlag/homebrew-cervezas/pull/1> for more information about pdftk on macOS.
 
     ```sh
     curl -O https://raw.githubusercontent.com/zph/homebrew-cervezas/master/pdftk.rb
@@ -115,11 +115,11 @@ These steps are for OSX devices, including Apple Macbooks running on [Apple Sili
     rm ./pdftk.rb
     ```
 
-11. Install an assortment of additional packages via `brew install enscript gs imagemagick ruby-build coreutils sqlite parallel tidy-html5`
+1. Install an assortment of additional packages via `brew install enscript gs imagemagick ruby-build coreutils sqlite parallel tidy-html5`
 
-12. [Check your rmagick version](#rmagick)
+1. [Check your rmagick version](#rmagick)
 
-13. Install [Node Version Manager](https://github.com/nvm-sh/nvm) and install Node
+1. Install [Node Version Manager](https://github.com/nvm-sh/nvm) and install Node
     1. Install NVM via `brew install nvm`
 
     2. Running `nvm install` or `nvm use` within the project directory will install and use the version specified in [.nvmrc](.nvmrc)
@@ -137,15 +137,15 @@ These steps are for OSX devices, including Apple Macbooks running on [Apple Sili
        nvm use && nvm alias default $(cat ./.nvmrc)
        ```
 
-14. Install **yarn** via `npm install -g yarn@1.22.5`
+1. Install **yarn** via `npm install -g yarn@1.22.5`
 
-15. Install **OpenSSL**
+1. Install **OpenSSL**
     1. Run `brew install openssl`
     2. Following the instructions in the output, run a form of `export LIBRARY_PATH=$LIBRARY_PATH:/usr/local/opt/openssl/lib/`
 
-16. Install [Google Chrome](https://www.google.com/chrome/), needed for some local app tests.
+1. Install [Google Chrome](https://www.google.com/chrome/), needed for some local app tests.
 
-4. For Apple Silicon (M1), make these changes to your [Gemfile.lock](Gemfile.lock) file to switch from `libv8` to `libv8-node` and upgrade `mini_racer`. These changes should not be committed and will unfortunately clutter your `git status`.
+1. For Apple Silicon (M1), make these changes to your [Gemfile.lock](Gemfile.lock) file to switch from `libv8` to `libv8-node` and upgrade `mini_racer`. These changes should not be committed and will unfortunately clutter your `git status`.
 
    ```text
    ...
@@ -254,9 +254,9 @@ Return to the [Overview](#overview) to continue installation. Note that there ar
         ```
         ulimit -n 8192
         ```
-    2. close and reopen your current terminal window
-    3. make sure that `ulimit -n` returns 8192
-14. Install the Xcode Command Line Tools:
+    1. close and reopen your current terminal window
+    1. make sure that `ulimit -n` returns 8192
+1. Install the Xcode Command Line Tools:
     1. `xcode-select --install`
 
     <details>
@@ -265,9 +265,9 @@ Return to the [Overview](#overview) to continue installation. Note that there ar
       If it complains `xcode-select: error: command line tools are already installed, use "Software Update" to install updates`, check to make sure XCode is downloaded and up to date manually.
     </details>
 
-15. Install the Java 8 JDK: `brew install --cask adoptopenjdk/openjdk/adoptopenjdk8`. More info [here](http://www.oracle.com/technetwork/java/javase/downloads/index.html).
+1. Install the Java 8 JDK: `brew install --cask adoptopenjdk/openjdk/adoptopenjdk8`. More info [here](http://www.oracle.com/technetwork/java/javase/downloads/index.html).
 
-16. [Download](https://www.google.com/chrome/) and install Google Chrome, if you have not already. This is needed in order to be able to run apps tests locally.
+1. [Download](https://www.google.com/chrome/) and install Google Chrome, if you have not already. This is needed in order to be able to run apps tests locally.
 
 ### Ubuntu 18.04 ([Download iso][ubuntu-iso-url])
 


### PR DESCRIPTION
Specifically:

- The "general" instructions section had several M1-mac-specific instructions in it; move them into the mac-specific section
- Add instructions for an Ubuntu 22.04-specific issue

Also, we were manually maintaining the numbers of the steps in code, which makes refactoring like this more tedious. By instead using a consistent notation, we can let Markdown handle the numbering for us. Because the numbering change is somewhat noisy, I recommend reviewing this PR commit-by-commit:

- https://github.com/code-dot-org/code-dot-org/pull/46750/commits/df60816758562bd111ca7138f0ca9caa4f6d82a5
- https://github.com/code-dot-org/code-dot-org/pull/46750/commits/dca352f9b1f9d6341c0af6a6adba3fba78b33422

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
