### PR TITLE
use URI.open to fetch video thumbnail

### DIFF
--- a/dashboard/app/models/video.rb
+++ b/dashboard/app/models/video.rb
@@ -97,7 +97,7 @@ class Video < ApplicationRecord
 
     path = dashboard_dir('public', 'c', 'video_thumbnails', "#{key}.jpg")
     url = "http://img.youtube.com/vi/#{youtube_code}/mqdefault.jpg"
-    IO.copy_stream(open(url), path)
+    IO.copy_stream(URI.open(url), path)
   end
 
   def youtube_url(args={})


### PR DESCRIPTION
FInishes https://codedotorg.atlassian.net/browse/PLAT-1877. levelbuilders were getting this error when they tried to upload videos:

<img width="1021" alt="image (5)" src="https://user-images.githubusercontent.com/8001765/172714893-dce0566b-67d8-4c19-b9d0-2526dcfe9612.png">

see [slack](https://codedotorg.slack.com/archives/C036XVC3CBF/p1654719465230829) for more details.

It looks like the rails upgrade broke video uploading because we were relying on `open` to open a URL rather than a file. explained here: https://stackoverflow.com/a/65939036

## Testing story

manually verified that creating a new video at localhost-studio.code.org:3000/videos/new was broken before, and this fixes it