### PR TITLE
Re-apply `better_errors`, `rambling-trie`, and `honeybadger` Gem Updates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,7 +72,7 @@ group :development, :test do
 
   gem 'active_record_query_trace'
   gem 'benchmark-ips'
-  gem 'better_errors'
+  gem 'better_errors', '>= 2.7.0'
   gem 'binding_of_caller'
   gem 'brakeman'
   gem 'haml-rails' # haml (instead of erb) generators
@@ -169,7 +169,7 @@ gem 'nokogiri', '>= 1.10.0'
 
 gem 'highline', '~> 1.6.21'
 
-gem 'honeybadger' # error monitoring
+gem 'honeybadger', '>= 4.5.6' # error monitoring
 
 gem 'newrelic_rpm', group: [:staging, :development, :production], # perf/error/etc monitoring
   # Ref:
@@ -291,7 +291,7 @@ gem 'octokit'
 
 # Used to create a prefix trie of student names within a section
 gem 'full-name-splitter', github: 'pahanix/full-name-splitter'
-gem 'rambling-trie'
+gem 'rambling-trie', '>= 2.1.1'
 
 gem 'omniauth-openid'
 gem 'omniauth-openid-connect', github: 'wjordan/omniauth-openid-connect', ref: 'cdo'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -321,9 +321,9 @@ GEM
     backports (3.11.3)
     bcrypt (3.1.13)
     benchmark-ips (2.7.2)
-    better_errors (2.1.1)
+    better_errors (2.9.1)
       coderay (>= 1.0.0)
-      erubis (>= 2.6.6)
+      erubi (>= 1.0.0)
       rack (>= 0.9.0)
     bindata (2.4.10)
     binding_of_caller (0.8.0)
@@ -489,7 +489,7 @@ GEM
     hashery (2.1.2)
     hashie (3.6.0)
     highline (1.6.21)
-    honeybadger (4.5.1)
+    honeybadger (4.12.1)
     html2haml (2.2.0)
       erubis (~> 2.7.0)
       haml (>= 4.0, < 6)
@@ -714,7 +714,7 @@ GEM
     rainbow (3.0.0)
     raindrops (0.19.0)
     rake (11.3.0)
-    rambling-trie (1.0.0)
+    rambling-trie (2.2.1)
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
@@ -937,7 +937,7 @@ DEPENDENCIES
   aws-sdk-secretsmanager
   bcrypt (= 3.1.13)
   benchmark-ips
-  better_errors
+  better_errors (>= 2.7.0)
   binding_of_caller
   bootstrap-sass (~> 2.3.2.2)
   brakeman
@@ -974,7 +974,7 @@ DEPENDENCIES
   haml_lint
   hammerspace
   highline (~> 1.6.21)
-  honeybadger
+  honeybadger (>= 4.5.6)
   httparty
   image_optim!
   image_optim_pack (~> 0.5.0)!
@@ -1033,7 +1033,7 @@ DEPENDENCIES
   rack_csrf
   rails (= 6.0.4.1)
   rails-controller-testing (~> 1.0.5)
-  rambling-trie
+  rambling-trie (>= 2.1.1)
   recaptcha
   redcarpet (~> 3.3.4)
   redis (~> 3.3.3)


### PR DESCRIPTION
My first pass involved just updating in `Gemfile.lock` the specific pinned versions, since the `Gemfile` entries for these gems were nonspecific. Unfortunately, that led to issues during the deploy to production. We're still not sure exactly why, but Chef installed the old versions of the gems (as specified by just the `Gemfile` and not the `Gemfile.lock`) and then failed when it couldn't find the new versions of the gems (as specified by the `Gemfile.lock`).

This time, I updated the Gemfile to explicitly indicate which versions of these gems we care about for Ruby 2.7 compatibility, then ran

    bundle update better_errors honeybadger rambling-trie

## Links

- https://github.com/code-dot-org/code-dot-org/pull/46630
- https://github.com/code-dot-org/code-dot-org/pull/46629
- https://github.com/code-dot-org/code-dot-org/pull/46604

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
