### PR TITLE
Preserve url params for eye links for teacher experience

### DIFF
--- a/apps/src/templates/instructions/codeReviewV2/CodeReviewTimelineElement.jsx
+++ b/apps/src/templates/instructions/codeReviewV2/CodeReviewTimelineElement.jsx
@@ -29,8 +29,12 @@ const CodeReviewTimelineElement = ({
   viewAsCodeReviewer,
   children
 }) => {
-  const versionLink =
-    location.origin + location.pathname + '?version=' + projectVersionId;
+  let versionLink = location.origin + location.pathname;
+  if (location.search) {
+    versionLink += `${location.search}&version=${projectVersionId}`;
+  } else {
+    versionLink += `?version=${projectVersionId}`;
+  }
 
   // You can only see previous versions of your own project
   const displayEyeball = !viewAsCodeReviewer && !!projectVersionId;


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
I realized that the teacher is able to see the eyeball links for previous versions of the project when looking at their student, this is actually ok since it was requested as a P2 feature by Mike. The problem with the experience right now is that the url params are lost when the link is generated so the teacher doesn't load the right section/student. The changes in this PR keep the existing url params and include them in the link to the old version of the project.

## Testing story
Tested locally
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
