### PR TITLE
Migrate unit group teacher resources

### DIFF
--- a/bin/curriculum/migrate_teacher_resources.rb
+++ b/bin/curriculum/migrate_teacher_resources.rb
@@ -51,7 +51,10 @@ def migrate_resources_for_unit_groups
     next unless course_version
     unit_group.resources =
       unit_group.teacher_resources.map {|tr| create_resource_from_teacher_resource(tr, course_version.id)}
-    unit_group.teacher_resources = []
+
+    # do not remove legacy teacher resources yet. keep serving the legacy
+    # teacher resources until migrated teacher resources have been translated.
+
     unit_group.save!
     puts "Migrated teacher resources for #{unit_group.name}"
   end

--- a/dashboard/config/courses/csd-2017.course
+++ b/dashboard/config/courses/csd-2017.course
@@ -28,7 +28,28 @@
     "version_year": "2017"
   },
   "resources": [
-
+    {
+      "name": "Curriculum",
+      "url": "https://curriculum.code.org/csd-1718/",
+      "key": "curriculum",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "curriculum"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csd",
+      "key": "teacher_forum_6",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum_6"
+      }
+    }
   ],
   "student_resources": [
 

--- a/dashboard/config/courses/csd-2018.course
+++ b/dashboard/config/courses/csd-2018.course
@@ -29,7 +29,28 @@
     "version_year": "2018"
   },
   "resources": [
-
+    {
+      "name": "Curriculum",
+      "url": "https://curriculum.code.org/csd-18/",
+      "key": "curriculum",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "curriculum"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csd",
+      "key": "teacher_forum_6",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum_6"
+      }
+    }
   ],
   "student_resources": [
 

--- a/dashboard/config/courses/csd-2019.course
+++ b/dashboard/config/courses/csd-2019.course
@@ -28,7 +28,28 @@
     "version_year": "2019"
   },
   "resources": [
-
+    {
+      "name": "Curriculum",
+      "url": "https://curriculum.code.org/csd-19/",
+      "key": "curriculum",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "curriculum"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csd",
+      "key": "teacher_forum",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum"
+      }
+    }
   ],
   "student_resources": [
 

--- a/dashboard/config/courses/csd-2020.course
+++ b/dashboard/config/courses/csd-2020.course
@@ -28,7 +28,28 @@
     "version_year": "2020"
   },
   "resources": [
-
+    {
+      "name": "Curriculum",
+      "url": "https://curriculum.code.org/csd-20/",
+      "key": "curriculum",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "curriculum"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csd",
+      "key": "teacher_forum",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum"
+      }
+    }
   ],
   "student_resources": [
 

--- a/dashboard/config/courses/csp-2017.course
+++ b/dashboard/config/courses/csp-2017.course
@@ -47,7 +47,39 @@
     "version_year": "2017"
   },
   "resources": [
-
+    {
+      "name": "Curriculum",
+      "url": "https://curriculum.code.org/csp/",
+      "key": "curriculum",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "curriculum"
+      }
+    },
+    {
+      "name": "Professional Learning",
+      "url": "https://studio.code.org/courses/CSP%20Support",
+      "key": "professional_learning_5",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "professional_learning_5"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "http://forum.code.org/c/csp",
+      "key": "teacher_forum_6",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum_6"
+      }
+    }
   ],
   "student_resources": [
 

--- a/dashboard/config/courses/csp-2018.course
+++ b/dashboard/config/courses/csp-2018.course
@@ -31,7 +31,28 @@
     "version_year": "2018"
   },
   "resources": [
-
+    {
+      "name": "Curriculum",
+      "url": "https://curriculum.code.org/csp-18",
+      "key": "curriculum",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "curriculum"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csp",
+      "key": "teacher_forum_6",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum_6"
+      }
+    }
   ],
   "student_resources": [
 

--- a/dashboard/config/courses/csp-2019.course
+++ b/dashboard/config/courses/csp-2019.course
@@ -30,7 +30,28 @@
     "version_year": "2019"
   },
   "resources": [
-
+    {
+      "name": "Curriculum",
+      "url": "https://curriculum.code.org/csp-19",
+      "key": "curriculum",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "curriculum"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csp",
+      "key": "teacher_forum_6",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum_6"
+      }
+    }
   ],
   "student_resources": [
 


### PR DESCRIPTION
In finishing migrating teacher resources for units, I completely forgot about unit groups. This PR starts the process of migrating teacher resources for unit groups.

to keep track of this, I added a new section to the [work plan](https://docs.google.com/document/d/1yIL2Z7aqFTdbCi24-RpUhPO_B3wRdsiKRTB1EEs17EY/edit#) called "migrate teacher resources for unit groups".

## Testing story

This isn't a particularly risky step, so I just manually checked that translated teacher resources on https://localhost-studio.code.org:3000/courses/csd-2021 were still loading properly in es-MX.

