### PR TITLE
Remove radium and l18n styling on VerticalImageResourceCard

### DIFF
--- a/apps/src/templates/VerticalImageResourceCard.jsx
+++ b/apps/src/templates/VerticalImageResourceCard.jsx
@@ -21,7 +21,6 @@ class VerticalImageResourceCard extends Component {
     buttonText: PropTypes.string.isRequired,
     link: PropTypes.string.isRequired,
     image: PropTypes.string.isRequired,
-    isRtl: PropTypes.bool.isRequired,
     MCShareLink: PropTypes.string,
     jumbo: PropTypes.bool,
     hasAdjustableHeight: PropTypes.bool
@@ -33,7 +32,6 @@ class VerticalImageResourceCard extends Component {
       description,
       link,
       buttonText,
-      isRtl,
       jumbo,
       MCShareLink,
       image,
@@ -49,7 +47,6 @@ class VerticalImageResourceCard extends Component {
       ? {...styles.jumboImage, ...imageHeight}
       : {...styles.image, ...imageHeight};
 
-    const localeStyle = isRtl ? styles.rtl : styles.ltr;
     const descriptionStyle = hasAdjustableHeight
       ? styles.description
       : {...styles.description, ...styles.descriptionHeight};
@@ -86,20 +83,20 @@ class VerticalImageResourceCard extends Component {
     const imgSrc = filenameToImgUrl[image];
 
     return (
-      <div style={[cardStyle, localeStyle]}>
+      <div style={[cardStyle]}>
         <div style={imageStyle}>
           <a href={link}>
             <img src={imgSrc} alt={title} />
           </a>
         </div>
         <div>
-          <div style={[styles.text, styles.title, localeStyle]}>{title}</div>
-          <div style={[styles.text, descriptionStyle, localeStyle]}>
+          <div style={[styles.text, styles.title]}>{title}</div>
+          <div style={[styles.text, descriptionStyle]}>
             {description}
             {MCShareLink && (
               <input
                 type="text"
-                style={[styles.text, styles.shareLink, localeStyle]}
+                style={[styles.text, styles.shareLink]}
                 value={MCShareLink}
                 onChange={() => {}}
                 onClick={e => e.target.select()}
@@ -111,7 +108,7 @@ class VerticalImageResourceCard extends Component {
             href={link}
             color={Button.ButtonColor.gray}
             text={buttonText}
-            style={[styles.button, localeStyle]}
+            style={[styles.button]}
           />
         </div>
       </div>
@@ -180,13 +177,6 @@ const styles = {
     marginTop: 5,
     padding: 5,
     width: 258
-  },
-  ltr: {
-    float: 'left'
-  },
-  rtl: {
-    float: 'right',
-    textAlign: 'right'
   }
 };
 

--- a/apps/src/templates/VerticalImageResourceCard.jsx
+++ b/apps/src/templates/VerticalImageResourceCard.jsx
@@ -1,7 +1,5 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
-import Radium from 'radium';
-import {connect} from 'react-redux';
 import {pegasus} from '@cdo/apps/lib/util/urlHelpers';
 import color from '../util/color';
 import Button from './Button';
@@ -83,20 +81,20 @@ class VerticalImageResourceCard extends Component {
     const imgSrc = filenameToImgUrl[image];
 
     return (
-      <div style={[cardStyle]}>
+      <div style={cardStyle}>
         <div style={imageStyle}>
           <a href={link}>
             <img src={imgSrc} alt={title} />
           </a>
         </div>
         <div>
-          <div style={[styles.text, styles.title]}>{title}</div>
-          <div style={[styles.text, descriptionStyle]}>
+          <div style={{...styles.text, ...styles.title}}>{title}</div>
+          <div style={{...styles.text, ...descriptionStyle}}>
             {description}
             {MCShareLink && (
               <input
                 type="text"
-                style={[styles.text, styles.shareLink]}
+                style={{...styles.text, ...styles.shareLink}}
                 value={MCShareLink}
                 onChange={() => {}}
                 onClick={e => e.target.select()}
@@ -180,6 +178,4 @@ const styles = {
   }
 };
 
-export default connect(state => ({
-  isRtl: state.isRtl
-}))(Radium(VerticalImageResourceCard));
+export default VerticalImageResourceCard;


### PR DESCRIPTION
I was getting funky styling on `VerticalImageResourceCard.jsx` coming from the `float: left` style, used for localization. Rather than connecting state and using the `isRtl` prop, I'm letting the browser do it for me (see https://github.com/code-dot-org/code-dot-org/pull/44135#discussion_r779014636 for more discussion on this).

Also removed Radium.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

I tested this locally. Here are screenshots comparing to production (note that the row container does NOT have correct RTL styling in production).


<img width="516" alt="Screen Shot 2022-06-09 at 10 40 14 AM" src="https://user-images.githubusercontent.com/9142121/172889290-7307caa0-455c-4866-98e9-bba83fd80438.png">
<img width="517" alt="Screen Shot 2022-06-09 at 10 39 44 AM" src="https://user-images.githubusercontent.com/9142121/172889363-4dc0c8b9-1e4e-4cc0-ae8c-2813a9cc8fc9.png">
<img width="1043" alt="Screen Shot 2022-06-09 at 10 39 30 AM" src="https://user-images.githubusercontent.com/9142121/172889409-b56bb721-03da-43c9-ac57-0f1b0d173a31.png">
<img width="1042" alt="Screen Shot 2022-06-09 at 10 39 00 AM" src="https://user-images.githubusercontent.com/9142121/172889413-d253d799-0b38-4cec-9c87-da0dc5fe83fd.png">

Production (incorrect float on component –– will create a ticket for this)
<img width="499" alt="Screen Shot 2022-06-09 at 10 31 26 AM" src="https://user-images.githubusercontent.com/9142121/172889449-8a7da2c6-0f73-4d78-8cdf-a82765fb5db3.png">

Other production screenshots:
<img width="831" alt="image" src="https://user-images.githubusercontent.com/9142121/172908542-c5602841-cc9b-4066-92bc-37ba9cd92c97.png">
<img width="813" alt="image" src="https://user-images.githubusercontent.com/9142121/172908643-8e080841-4e6f-44ae-99f4-aa8339f973bb.png">
<img width="453" alt="image" src="https://user-images.githubusercontent.com/9142121/172908686-2a421215-2441-4a0c-b1b4-3178fed26712.png">


<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
