### PR TITLE
Add NewRelic log when user clicks "Continue with Facebook"

### DIFF
--- a/dashboard/app/views/devise/shared/_oauth_links.haml
+++ b/dashboard/app/views/devise/shared/_oauth_links.haml
@@ -32,3 +32,10 @@
   if (!!window.MakerBridge) {
     $('.with-google_oauth2').prop({'disabled': true, 'title': 'Please use the ‘Log in with Google’ button in the toolbar at the top of the Maker App. If you do not see a ‘Log in with Google’ button, please download the latest Maker App version.'});
   }
+
+  var facebookButton = document.getElementsByClassName('oauth-sign-in with-facebook')[0];
+  if (facebookButton && !!window.newrelic) {
+    facebookButton.addEventListener('click', function (e) {
+      window.newrelic.addPageAction('clickedContinueWithFacebook');
+    })
+  }


### PR DESCRIPTION
**What:** Added [NewRelic event log](https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/add-page-action/) when ever someone clicks on the "Continue with Facebook" button on our [sign in page](https://studio.code.org/users/sign_in).

**Why:** Currently (6/9/22), the Facebook sign in functionality is broken and this is an attempt to gauge how much impact this has by getting an idea of how many users are attempting to log in via Facebook. This should be reverted after we gain that insight.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [FND-2047](https://codedotorg.atlassian.net/browse/FND-2047)


## Testing story

Tested locally by adding a breakpoint within the click event listener for the Facebook button. Unfortunately there is not a good way to test the entire functionality because we [only load newrelic in production](https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/logToCloud.js#L31).

By calling the same method on production within the browser console, I confirmed that an event was logged in NewRelic.

<img width="777" alt="Screen Shot 2022-06-09 at 4 35 55 PM" src="https://user-images.githubusercontent.com/48133820/172949428-e5f1bf28-4cec-4336-a338-e2ee9ac00add.png">


## Follow-up work

- Make sure that events start flowing into NewRelic once this is deployed.
- Revert this after we gain the necessary data points we're looking for.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
