### PR TITLE
Pass workshop_id to foorm surveys

### DIFF
--- a/apps/src/code-studio/pd/foorm/editor/components/FoormEntityEditor.jsx
+++ b/apps/src/code-studio/pd/foorm/editor/components/FoormEntityEditor.jsx
@@ -37,6 +37,7 @@ class FoormEntityEditor extends React.Component {
     this.state = {
       livePreviewStatus: PREVIEW_ON,
       num_facilitators: 2,
+      workshop_id: 1,
       workshop_course: 'CS Principles',
       workshop_subject: '5-day Summer',
       regional_partner_name: 'Regional Partner A',
@@ -117,6 +118,14 @@ class FoormEntityEditor extends React.Component {
       <div style={styles.options}>
         <div>
           <form>
+            <label>
+              workshop_id <br />
+              <input
+                type="text"
+                value={this.state.workshop_id}
+                onChange={e => this.setState({workshop_id: e.target.value})}
+              />
+            </label>
             <label>
               workshop_course <br />
               <input
@@ -244,6 +253,7 @@ class FoormEntityEditor extends React.Component {
                 foormData={{
                   facilitators: this.state.facilitators,
                   num_facilitators: this.state.num_facilitators,
+                  workshop_id: this.state.workshop_id,
                   workshop_course: this.state.workshop_course,
                   workshop_subject: this.state.workshop_subject,
                   regional_partner_name: this.state.regional_partner_name,

--- a/dashboard/app/controllers/foorm_preview_controller.rb
+++ b/dashboard/app/controllers/foorm_preview_controller.rb
@@ -47,6 +47,7 @@ class FoormPreviewController < ApplicationController
           facilitator_position: 3
         }
       ],
+      workshop_id: params[:workshopId] || 1,
       workshop_course: params[:workshopCourse] || "Summer Course",
       workshop_subject: params[:workshopSubject] || "Sample Subject",
       regional_partner_name: params[:regionalPartnerName] || "Regional Partner A",

--- a/dashboard/app/controllers/pd/workshop_daily_survey_controller.rb
+++ b/dashboard/app/controllers/pd/workshop_daily_survey_controller.rb
@@ -315,6 +315,7 @@ module Pd
 
       return {
         Pd::WorkshopSurveyFoormConstants::FACILITATORS => facilitator_data,
+        workshop_id: workshop.id,
         workshop_course: workshop.course,
         workshop_subject: workshop.subject,
         regional_partner_name: regional_partner_name,


### PR DESCRIPTION
Passes in `workshop_id` as another variable to be used in foorm surveys to allow RED to be able to make conditional logic based on workshop ID. 

Also updated the preview area to list workshop_id as a variable.

![Screen Shot 2022-06-13 at 5 46 16 PM](https://user-images.githubusercontent.com/208083/173450727-d6e76019-e753-4113-8ae2-11eb37b35882.png)


## Links

[Jira](https://codedotorg.atlassian.net/browse/PLAT-1873)

## Testing story

- Updated the foorm for academic year workshop surveys locally to add an element that would show the `workshop_id` on screen
![Screen Shot 2022-06-13 at 5 42 48 PM](https://user-images.githubusercontent.com/208083/173450238-6a4b2ded-e229-4857-a9ba-b05484cd8d4e.png)
- Found a teacher who was enrolled in a academic year workshop for CSD
- Went to http://localhost-studio.code.org:3000/pd/workshop_post_survey?enrollmentCode=FQXVKTXLXL where the code was the enrollment code for that teacher for that workshop
- Checked that the correct `workshop_id` showed in the box on the screen
![Screen Shot 2022-06-13 at 5 44 09 PM](https://user-images.githubusercontent.com/208083/173450430-bd255001-437c-4894-a3f6-d4ec32cd0b91.png)


