### PR TITLE
Adding extra certificate links for Korean students

### DIFF
--- a/apps/src/templates/certificates/Congrats.jsx
+++ b/apps/src/templates/certificates/Congrats.jsx
@@ -4,6 +4,8 @@ import Certificate from './Certificate';
 import StudentsBeyondHoc from './StudentsBeyondHoc';
 import TeachersBeyondHoc from './TeachersBeyondHoc';
 import styleConstants from '../../styleConstants';
+import {pegasus} from '@cdo/apps/lib/util/urlHelpers';
+import color from '../../util/color';
 
 export default function Congrats(props) {
   /**
@@ -21,6 +23,40 @@ export default function Congrats(props) {
       mc: 'pre2017Minecraft',
       oceans: 'oceans'
     }[tutorial] || 'other');
+  /**
+   * Renders links to certificate alternatives when there is a special event going on.
+   * @param {string} language The language code related to the special event i.e. 'en', 'es', 'ko', etc
+   * @param {string} tutorial The type of tutorial the student finished i.e. 'dance', 'oceans', etc
+   * @returns {HTMLElement} HTML for rendering the extra certificate links.
+   */
+  const renderExtraCertificateLinks = (language, tutorial) => {
+    let extraLinkUrl, extraLinkText;
+    // https://codedotorg.atlassian.net/browse/FND-2048
+    // In order to remove the certificate links remove or comment the following section -------------------------------
+    if (language === 'ko') {
+      if (/oceans/.test(tutorial)) {
+        extraLinkUrl = pegasus('/files/online-coding-party-2021-oceans.pdf');
+        extraLinkText =
+          '온라인 코딩 파티 인증서 받으러 가기! (과학기술정보통신부 인증)';
+      } else if (/dance/.test(tutorial)) {
+        extraLinkUrl = pegasus('/files/online-coding-party-2021-dance.pdf');
+        extraLinkText =
+          '온라인 코딩 파티 인증서 받으러 가기! (과학기술정보통신부 인증)';
+      }
+    }
+    // End of section to be removed or commented ----------------------------------------------------------------------
+    if (!extraLinkUrl || !extraLinkText) {
+      // There are no extra links to render.
+      return;
+    }
+    return (
+      <div style={styles.extraLinkContainer}>
+        <a href={extraLinkUrl} target={'_blank'} style={styles.extraLink}>
+          {extraLinkText}
+        </a>
+      </div>
+    );
+  };
 
   const {
     tutorial,
@@ -46,7 +82,9 @@ export default function Congrats(props) {
         randomDonorName={randomDonorName}
         under13={under13}
         showStudioCertificate={showStudioCertificate}
-      />
+      >
+        {renderExtraCertificateLinks(language, tutorial)}
+      </Certificate>
       {userType === 'teacher' && isEnglish && <TeachersBeyondHoc />}
       <StudentsBeyondHoc
         completedTutorialType={tutorialType}
@@ -80,5 +118,13 @@ const styles = {
     maxWidth: styleConstants['content-width'],
     marginLeft: 'auto',
     marginRight: 'auto'
+  },
+  extraLinkContainer: {
+    clear: 'both',
+    paddingTop: 20
+  },
+  extraLink: {
+    color: color.teal,
+    fontSize: 14
   }
 };


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Our Korean partner once again wants us to surface a link to their special certificate for Korean students, starting June 13th. This PR adds a link to custom certificates on the Congrats! page for Korean students who complete the AI for Oceans or the Dance Party tutorials.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
Previous PR [#43846](https://github.com/code-dot-org/code-dot-org/pull/4384)
Jira TIcket: [FND-2040](https://codedotorg.atlassian.net/browse/FND-2040)
<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->
Completed dance party, oceans, and Minecraft tutorials. Verified link is on dance and oceans pages in Korean only.
- Verified link is not present for Minecraft.
- Clicked the custom certificate links and verified the correct PDF was opened in a new tab.

**Dance Party**
Note the link below the certificate image.
<img width="987" alt="screenshoot_danceparty_ko_link" src="https://user-images.githubusercontent.com/66776217/172970717-c5f23a39-520b-476b-ae2b-2b8f828c1007.png">

**AI for Oceans**
Note the link below the certificate image.
<img width="987" alt="screanshoot_ocean_ko_link" src="https://user-images.githubusercontent.com/66776217/172970727-eb581de1-8b2d-431b-aa12-cf329230783e.png">

**Minecraft**
Note there is NO link below the certificate image.
<img width="987" alt="screanshoot_mincraft_ko_link" src="https://user-images.githubusercontent.com/66776217/172970739-328b7e05-37c8-48d7-8e4b-4e0b50fef655.png">

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
