### PR TITLE
Future proof workshop survey

### DIFF
--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -824,17 +824,17 @@ class Pd::Workshop < ApplicationRecord
     PRE_SURVEY_BY_COURSE.key? course
   end
 
-  def pre_survey_course_name
-    PRE_SURVEY_BY_COURSE[course].try(:[], :course_name)
+  def pre_survey_course_offering_name
+    PRE_SURVEY_BY_COURSE[course].try(:[], :course_offering_name)
   end
 
   def pre_survey_course
     return nil unless pre_survey?
-    UnitGroup.find_by_name! pre_survey_course_name
+    UnitGroup.latest_stable_version(pre_survey_course_offering_name)
   rescue ActiveRecord::RecordNotFound
     # Raise a RuntimeError if the course name is not found, so we'll be notified in Honeybadger
     # Otherwise the RecordNotFound error will result in a 404, and we won't know.
-    raise "No course found for name #{pre_survey_course_name}"
+    raise "No course found for course offering key #{pre_survey_course_offering_name}"
   end
 
   # @return an array of tuples, each in the format:

--- a/dashboard/app/models/pd/workshop_constants.rb
+++ b/dashboard/app/models/pd/workshop_constants.rb
@@ -106,12 +106,12 @@ module Pd
     }.freeze
 
     # Pre-survey data, arranged by course, consisting of:
-    #  - course_name : the name of the Course object associated with that workshop.
+    #  - course_offering_name : the name of the course offering associated with that workshop.
     # Only courses with a pre-survey will have an entry here
     PRE_SURVEY_BY_COURSE = {
-      COURSE_CSD => {course_name: 'csd-2020'},
-      COURSE_CSP => {course_name: 'csp-2020'},
-      COURSE_CSA => {course_name: 'csa-2020'}
+      COURSE_CSD => {course_offering_name: 'csd'},
+      COURSE_CSP => {course_offering_name: 'csp'},
+      COURSE_CSA => {course_offering_name: 'csa'}
     }.freeze
   end
 end

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -1066,7 +1066,8 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
   end
 
   test 'pre_survey_units_and_lessons' do
-    unit_group = create :unit_group, name: 'pd-workshop-pre-survey-test'
+    unit_group = create :unit_group, name: 'pd-workshop-pre-survey-test-1991', family_name: 'pd-workshop-pre-survey-test', version_year: '1991'
+    CourseOffering.add_course_offering(unit_group)
     next_position = 1
     add_unit = ->(unit_name, lesson_names) do
       create(:script, name: unit_name).tap do |script|
@@ -1083,6 +1084,7 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     workshop = build :workshop
     workshop.expects(:pre_survey?).returns(true).twice
     workshop.stubs(:pre_survey_course_offering_name).returns('pd-workshop-pre-survey-test')
+    UnitGroup.expects(:latest_stable_version).with('pd-workshop-pre-survey-test').returns(unit_group)
 
     expected = [
       ['pre-survey-unit-1', ['Lesson 1: Unit 1 - Lesson 1', 'Lesson 2: Unit 1 - Lesson 2']],
@@ -1104,15 +1106,15 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     # With valid course name
     workshop.stubs(:pre_survey?).returns(true)
     workshop.stubs(:pre_survey_course_offering_name).returns(course_name)
-    UnitGroup.expects(:find_by_name!).with(course_name).returns(mock_course)
+    UnitGroup.expects(:latest_stable_version).with(course_name).returns(mock_course)
     assert_equal mock_course, workshop.pre_survey_course
 
     # With invalid course name
-    UnitGroup.expects(:find_by_name!).with(course_name).raises(ActiveRecord::RecordNotFound)
+    UnitGroup.expects(:latest_stable_version).with(course_name).raises(ActiveRecord::RecordNotFound)
     e = assert_raises RuntimeError do
       workshop.pre_survey_course
     end
-    assert_equal "No course found for name #{course_name}", e.message
+    assert_equal "No course found for course offering key #{course_name}", e.message
   end
 
   test 'friendly date range same month' do

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -1082,7 +1082,7 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
 
     workshop = build :workshop
     workshop.expects(:pre_survey?).returns(true).twice
-    workshop.stubs(:pre_survey_course_name).returns('pd-workshop-pre-survey-test')
+    workshop.stubs(:pre_survey_course_offering_name).returns('pd-workshop-pre-survey-test')
 
     expected = [
       ['pre-survey-unit-1', ['Lesson 1: Unit 1 - Lesson 1', 'Lesson 2: Unit 1 - Lesson 2']],
@@ -1103,7 +1103,7 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
 
     # With valid course name
     workshop.stubs(:pre_survey?).returns(true)
-    workshop.stubs(:pre_survey_course_name).returns(course_name)
+    workshop.stubs(:pre_survey_course_offering_name).returns(course_name)
     UnitGroup.expects(:find_by_name!).with(course_name).returns(mock_course)
     assert_equal mock_course, workshop.pre_survey_course
 


### PR DESCRIPTION
Each year around the time we mark courses as `stable` we have to update a hard coded list of the current years courses for workshops to use to show teachers their pre-survey. Instead of having to update this list every year we should be able to check for the latest stable course which will automatically get updated each year when we mark the new courses as stable. 

## Links

https://codedotorg.atlassian.net/browse/PLAT-1863

## Testing story

- Updated existing unit tests