### PR TITLE
Fix flaky Java Lab test

### DIFF
--- a/dashboard/test/ui/features/learning_platform/level_types/contained_levels.feature
+++ b/dashboard/test/ui/features/learning_platform/level_types/contained_levels.feature
@@ -79,6 +79,8 @@ Scenario: Javalab with free response contained level
   And I see no difference for "answer entered" using stitch mode "none"
   Then I press "runButton"
   And I see no difference for "level run" using stitch mode "none"
+  # Wait until we see at least one message on the console, this means the program saved.
+  And I wait until element ".javalab-console" contains text "[JAVALAB]"
 
   # At this point, we should have submitted our result to the server, do
   # a reload and make sure we have the submission


### PR DESCRIPTION
We were getting a pop-up during this test because the code hadn't had time to save yet. Ensure we see at least one console message before reloading the page, as that will mean the code has saved.

## Links
- [slack conversation](https://codedotorg.slack.com/archives/C01EF4GJ9GE/p1654813246307439)
- jira ticket: [JAVA-625](https://codedotorg.atlassian.net/browse/JAVA-625)

## Testing story
I wasn't able to reproduce the flakiness locally, but the test still passed after adding this wait step. 
