### PR TITLE
Add states to INFERRED_NO_EXCLUSION_LIST

### DIFF
--- a/dashboard/app/models/census/state_cs_offering.rb
+++ b/dashboard/app/models/census/state_cs_offering.rb
@@ -179,7 +179,15 @@ class Census::StateCsOffering < ApplicationRecord
   # indication that the school doesn't teach cs. We aren't as confident
   # that the state data is complete for the following states so we do
   # not want to treat the lack of data as a no for those.
-  INFERRED_NO_EXCLUSION_LIST = [].freeze
+  INFERRED_NO_EXCLUSION_LIST = %w(
+    AK
+    CO
+    DC
+    HI
+    ME
+    MI
+    MN
+  ).freeze
 
   def self.infer_no(state_code)
     INFERRED_NO_EXCLUSION_LIST.exclude? state_code.upcase

--- a/dashboard/test/models/census/census_summary_test.rb
+++ b/dashboard/test/models/census/census_summary_test.rb
@@ -257,7 +257,8 @@ class Census::CensusSummaryTest < ActiveSupport::TestCase
       :with_one_year_ago_teaches_yes,
       :with_two_years_ago_teaches_yes,
       :with_three_years_ago_teaches_yes,
-      school_year: school_year
+      school_year: school_year,
+      state: 'WA'
     validate_summary(school, school_year, "NO")
   end
 


### PR DESCRIPTION
A few states only gathered data for certain schools this year and the access report is showing them as "NO" instead of "HISTORICAL_YES". I got the list of states to exclude from inferring no from @Sam-Hutchins..

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
