### PR TITLE
Fix positions of script levels in script level tests

### DIFF
--- a/dashboard/test/helpers/script_levels_helper_test.rb
+++ b/dashboard/test/helpers/script_levels_helper_test.rb
@@ -18,6 +18,7 @@ class ScriptLevelsHelperTest < ActionView::TestCase
         create_list(:script_level, 3, lesson: lesson, script: script)
       end
     end
+    script.fix_script_level_positions
 
     create(:section, user: @teacher, script: script)
     @section = create(:section, user: @teacher, script: script)

--- a/dashboard/test/helpers/script_levels_helper_test.rb
+++ b/dashboard/test/helpers/script_levels_helper_test.rb
@@ -9,9 +9,6 @@ class ScriptLevelsHelperTest < ActionView::TestCase
     @teacher = create(:teacher)
     @student = create(:student)
     script = create(:script, lesson_extras_available: true)
-    create(:section, user: @teacher, script: script)
-    @section = create(:section, user: @teacher, script: script)
-    create(:follower, section: @section, student_user: @student)
 
     # give our test script a more-complex internal hierarchy than the one
     # provided by the factory, so we can test a variety of script_level and
@@ -21,6 +18,10 @@ class ScriptLevelsHelperTest < ActionView::TestCase
         create_list(:script_level, 3, lesson: lesson, script: script)
       end
     end
+
+    create(:section, user: @teacher, script: script)
+    @section = create(:section, user: @teacher, script: script)
+    create(:follower, section: @section, student_user: @student)
   end
 
   test 'tracking_pixel_url' do

--- a/dashboard/test/helpers/script_levels_helper_test.rb
+++ b/dashboard/test/helpers/script_levels_helper_test.rb
@@ -8,18 +8,8 @@ class ScriptLevelsHelperTest < ActionView::TestCase
   setup do
     @teacher = create(:teacher)
     @student = create(:student)
-    script = create(:script, lesson_extras_available: true)
-
-    # give our test script a more-complex internal hierarchy than the one
-    # provided by the factory, so we can test a variety of script_level and
-    # lesson relative positions.
-    script.lesson_groups << create(:lesson_group) do |lesson_group|
-      create_list(:lesson, 3, lesson_group: lesson_group) do |lesson|
-        create_list(:script_level, 3, lesson: lesson, script: script)
-      end
-    end
+    script = create(:script, :with_levels, lessons_count: 3, levels_count: 3, lesson_extras_available: true)
     script.fix_script_level_positions
-
     create(:section, user: @teacher, script: script)
     @section = create(:section, user: @teacher, script: script)
     create(:follower, section: @section, student_user: @student)

--- a/dashboard/test/helpers/script_levels_helper_test.rb
+++ b/dashboard/test/helpers/script_levels_helper_test.rb
@@ -9,7 +9,6 @@ class ScriptLevelsHelperTest < ActionView::TestCase
     @teacher = create(:teacher)
     @student = create(:student)
     script = create(:script, :with_levels, lessons_count: 3, levels_count: 3, lesson_extras_available: true)
-    script.fix_script_level_positions
     create(:section, user: @teacher, script: script)
     @section = create(:section, user: @teacher, script: script)
     create(:follower, section: @section, student_user: @student)


### PR DESCRIPTION
Speculative fix for flaky failures mentioned [here](https://codedotorg.slack.com/archives/C0T0PNTM3/p1654879583283279) and [here](https://codedotorg.slack.com/archives/C03CM903Y/p1633448777438800?thread_ts=1633448555.438400&cid=C03CM903Y): 
```
===========================[0m[1000D[K FAIL["test_do_not_get_End-of-Lesson_experience_for_last_script_level", "ScriptLevelsHelperTest", 118.26589268818498]
 test_do_not_get_End-of-Lesson_experience_for_last_script_level#ScriptLevelsHelperTest (118.27s)
        Expected true to not be truthy.
        test/helpers/script_levels_helper_test.rb:109:in `block in <class:ScriptLevelsHelperTest>'
        test/testing/setup_all_and_teardown_all.rb:36:in `run'
```

When I ran the tests locally, I noticed that `script.script_levels.last` was different than `script.lessons.last.script_levels.last`, and the wrong path was taken through `script_level_solved_response`. The problem appeared to be caused by a mismatch between the many different position values for script levels.

After cleaning up how we generate the script levels, the same test now takes the expected path through `script_level_solved_response`.

## Testing story

Speculative fix for flaky tests. tests are passing for me locally and in drone. I don't have definitive evidence that this will fix the flakiness, but since the test is now executing a more expected codepath, it seems like this has a good chance of eliminating the flakiness.
