### PR TITLE
Simplify header when viewing level page as a peer doing code review

### DIFF
--- a/apps/src/code-studio/components/header/HeaderMiddle.jsx
+++ b/apps/src/code-studio/components/header/HeaderMiddle.jsx
@@ -16,6 +16,7 @@ const lessonProgressExtraWidth = 10;
 class HeaderMiddle extends React.Component {
   static propTypes = {
     projectInfoOnly: PropTypes.bool,
+    scriptNameOnly: PropTypes.bool,
     appLoadStarted: PropTypes.bool,
     appLoaded: PropTypes.bool,
     scriptNameData: PropTypes.object,
@@ -78,6 +79,7 @@ class HeaderMiddle extends React.Component {
   static getWidths(
     width,
     projectInfoOnly,
+    scriptNameOnly,
     projectInfoDesiredWidth,
     scriptNameDesiredWidth,
     lessonProgressDesiredWidth,
@@ -90,6 +92,18 @@ class HeaderMiddle extends React.Component {
       return {
         projectInfo: Math.floor(Math.min(projectInfoDesiredWidth, width)),
         scriptName: 0,
+        progress: 0,
+        popup: 0,
+        finish: 0
+      };
+    }
+
+    if (scriptNameOnly) {
+      return {
+        projectInfo: 0,
+        scriptName: Math.floor(
+          Math.min(scriptNameDesiredWidth + scriptNameExtraWidth, width)
+        ),
         progress: 0,
         popup: 0,
         finish: 0
@@ -179,6 +193,7 @@ class HeaderMiddle extends React.Component {
     const widths = HeaderMiddle.getWidths(
       this.state.width,
       this.props.projectInfoOnly,
+      this.props.scriptNameOnly,
       this.state.projectInfoDesiredWidth,
       this.state.scriptNameDesiredWidth,
       this.state.lessonProgressDesiredWidth,

--- a/apps/src/code-studio/header.js
+++ b/apps/src/code-studio/header.js
@@ -139,6 +139,17 @@ header.buildProjectInfoOnly = function() {
   );
 };
 
+// When viewing the level page in code review mode, we want to show only the
+// lesson information (which is displayed by the ScriptName component).
+header.buildScriptNameOnly = function(scriptNameData) {
+  ReactDOM.render(
+    <Provider store={getStore()}>
+      <HeaderMiddle scriptNameData={scriptNameData} scriptNameOnly={true} />
+    </Provider>,
+    document.querySelector('.header_level')
+  );
+};
+
 // When the page is cached, this function is called to retrieve and set the
 // sign-in button or user menu in the DOM.
 header.buildUserMenu = function() {

--- a/apps/test/unit/code-studio/components/header/HeaderMiddleTest.js
+++ b/apps/test/unit/code-studio/components/header/HeaderMiddleTest.js
@@ -10,6 +10,7 @@ describe('HeaderMiddle', () => {
     const widths = HeaderMiddle.getWidths(
       700,    // width,
       false,  // projectInfoOnly,
+      false,  // scriptNameOnly,
       0,      // projectInfoDesiredWidth,
       200,    // scriptNameDesiredWidth,
       350,    // lessonProgressDesiredWidth,
@@ -31,6 +32,7 @@ describe('HeaderMiddle', () => {
     const widths = HeaderMiddle.getWidths(
       350,    // width,
       false,  // projectInfoOnly,
+      false,  // scriptNameOnly,
       0,      // projectInfoDesiredWidth,
       200,    // scriptNameDesiredWidth,
       350,    // lessonProgressDesiredWidth,
@@ -52,6 +54,7 @@ describe('HeaderMiddle', () => {
     const widths = HeaderMiddle.getWidths(
       700,    // width,
       false,  // projectInfoOnly,
+      false,  // scriptNameOnly,
       200,    // projectInfoDesiredWidth,
       200,    // scriptNameDesiredWidth,
       350,    // lessonProgressDesiredWidth,
@@ -73,6 +76,7 @@ describe('HeaderMiddle', () => {
     const widths = HeaderMiddle.getWidths(
       350,    // width,
       false,  // projectInfoOnly,
+      false,  // scriptNameOnly,
       200,    // projectInfoDesiredWidth,
       200,    // scriptNameDesiredWidth,
       350,    // lessonProgressDesiredWidth,
@@ -94,6 +98,7 @@ describe('HeaderMiddle', () => {
     const widths = HeaderMiddle.getWidths(
       700,    // width,
       true,   // projectInfoOnly,
+      false,  // scriptNameOnly,
       400,    // projectInfoDesiredWidth,
       0,      // scriptNameDesiredWidth,
       0,      // lessonProgressDesiredWidth,
@@ -113,6 +118,7 @@ describe('HeaderMiddle', () => {
     const widths = HeaderMiddle.getWidths(
       350,    // width,
       true,   // projectInfoOnly,
+      false,  // scriptNameOnly,
       400,    // projectInfoDesiredWidth,
       0,      // scriptNameDesiredWidth,
       0,      // lessonProgressDesiredWidth,
@@ -123,6 +129,46 @@ describe('HeaderMiddle', () => {
 
     assert.equal(widths.projectInfo, 350);
     assert.equal(widths.scriptName, 0);
+    assert.equal(widths.progress, 0);
+    assert.equal(widths.popup, 0);
+    assert.equal(widths.finish, 0);
+  });
+
+  it('widths for script name only when wide', () => {
+    const widths = HeaderMiddle.getWidths(
+      700,    // width,
+      false,  // projectInfoOnly,
+      true,   // scriptNameOnly,
+      0,      // projectInfoDesiredWidth,
+      400,    // scriptNameDesiredWidth,
+      0,      // lessonProgressDesiredWidth,
+      0,      // numScriptLessons,
+      0,      // finishDesiredWidth,
+      false   // showFinish
+    );
+
+    assert.equal(widths.projectInfo, 0);
+    assert.equal(widths.scriptName, 410);
+    assert.equal(widths.progress, 0);
+    assert.equal(widths.popup, 0);
+    assert.equal(widths.finish, 0);
+  });
+
+  it('widths for script name only when narrow', () => {
+    const widths = HeaderMiddle.getWidths(
+      350,    // width,
+      false,  // projectInfoOnly,
+      true,   // scriptNameOnly,
+      0,      // projectInfoDesiredWidth,
+      400,    // scriptNameDesiredWidth,
+      0,      // lessonProgressDesiredWidth,
+      0,      // numScriptLessons,
+      0,      // finishDesiredWidth,
+      false   // showFinish
+    );
+
+    assert.equal(widths.projectInfo, 0);
+    assert.equal(widths.scriptName, 350);
     assert.equal(widths.progress, 0);
     assert.equal(widths.popup, 0);
     assert.equal(widths.finish, 0);

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -413,6 +413,7 @@ class ScriptLevelsController < ApplicationController
       @user = user_to_view
 
       if can?(:view_as_user_for_code_review, @script_level, user_to_view, sublevel_to_view)
+        @is_code_reviewing = true
         view_options(is_code_reviewing: true)
       end
     end

--- a/dashboard/app/views/layouts/_header.html.haml
+++ b/dashboard/app/views/layouts/_header.html.haml
@@ -42,7 +42,7 @@
   header_contents_options[:loc_prefix] = "nav.header."
   header_contents_options[:page_mode] = request.cookies['pm']
 
-  should_show_progress = script_level || @lesson_extras
+  should_show_progress = (script_level || @lesson_extras) && !@is_code_reviewing
 
   sign_in_user = current_user || user_type && OpenStruct.new(
     id: nil,
@@ -131,6 +131,12 @@
       href: script_path(@script, section_id: section_id, user_id: user_id),
       smallText: small_text
     }
+  elsif @is_code_reviewing
+    script_name_data = {
+      name: script_level.lesson.localized_title,
+      href: '#',  # When viewing peer code, link should do nothing
+      smallText: false
+    }
   end
 
 - if should_show_progress
@@ -149,6 +155,12 @@
       #{!script_level}
     )
     //]]>
+
+- elsif @is_code_reviewing
+  :javascript
+    dashboard.header.buildScriptNameOnly(
+      #{script_name_data.to_json}
+    )
 
 - elsif level
   :javascript


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

When a peer is doing a code review, we want to hide the share/remix buttons as well as the level bubbles and mini-view drop-down.  It now looks like this: 

<img width="1125" alt="Screen Shot 2022-06-13 at 8 57 13 AM" src="https://user-images.githubusercontent.com/71532552/173395656-876fd3f7-55ed-407d-824d-e497011f24a5.png">

This was implemented by extending the existing pattern to show only the "project info" (which shows the share/remix buttons on the level page) in the header to also support showing only the "script name" component (which shows the lesson information on a level page).  We may want to refactor this logic at some point to consolidate cases and pass data to the header components in a more conventional way.

Note that with the addition of the code review feature (prior to this change), the meaning of the `user_id` query parameter was expanded from "teacher viewing a student's work" to "a user viewing another user's work".  There are now at least two such cases:
1. teacher viewing student work
2. peer viewing another student's work (for code review)

Case 2 was already distinguished on the front-end by `appOptions.isCodeReviewing`.  This change adds `@is_code_reviewing` to distinguish case 2 in the back-end controller code path.  (We may want to consider renaming or consolidating these flags in a future PR for better clarity.)

## Links


<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [LP-2401](https://codedotorg.atlassian.net/browse/LP-2401)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  6.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
