### PR TITLE
Add custom serializer remove remark-slate

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -269,7 +269,6 @@
     "reactabular-sticky": "^8.14.0",
     "reactabular-virtualized": "^8.18.0",
     "rehype-stringify": "^7.0.0",
-    "remark-slate": "^1.8.6",
     "rosie": "^2.0.1",
     "selectize": "^0.12.4",
     "slate": "^0.81.0",

--- a/apps/src/templates/instructions/codeReviewV2/CodeReviewCommentEditor.jsx
+++ b/apps/src/templates/instructions/codeReviewV2/CodeReviewCommentEditor.jsx
@@ -1,8 +1,13 @@
 import React, {useCallback, useMemo, useState} from 'react';
 import PropTypes from 'prop-types';
 import {Editable, withReact, Slate} from 'slate-react';
-import {Editor, Transforms, createEditor, Element as SlateElement} from 'slate';
-import {serialize} from 'remark-slate';
+import {
+  Editor,
+  Transforms,
+  createEditor,
+  Text,
+  Element as SlateElement
+} from 'slate';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
 import Button from '@cdo/apps/templates/Button';
 import color from '@cdo/apps/util/color';
@@ -23,10 +28,25 @@ const CodeReviewCommentEditor = ({addCodeReviewComment}) => {
   );
 
   const onChange = value => {
-    console.log(value);
     const markdownValue = value.map(v => serialize(v)).join('');
-    console.log(markdownValue);
     setCommentText(markdownValue);
+  };
+
+  const serialize = node => {
+    if (Text.isText(node)) {
+      return node.text;
+    }
+
+    const children = node.children.map(n => serialize(n)).join('');
+
+    switch (node.type) {
+      case 'code_block':
+        return `\`\`\`\n${children}\n\`\`\`\n`;
+      case 'paragraph':
+        return `${children}\n`;
+      default:
+        return children;
+    }
   };
 
   const handleSubmit = () => {

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -2435,11 +2435,6 @@
     "@svgr/plugin-svgo" "^4.0.3"
     loader-utils "^1.1.0"
 
-"@types/escape-html@^1.0.0":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@types/escape-html/-/escape-html-1.0.2.tgz#072b7b13784fb3cee9c2450c22f36405983f5e3c"
-  integrity sha512-gaBLT8pdcexFztLSPRtriHeXY/Kn4907uOCZ4Q3lncFBkheAWOuNt53ypsF8szgxbEJ513UeBzcf4utN0EzEwA==
-
 "@types/hoist-non-react-statics@^3.3.0":
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
@@ -6357,7 +6352,7 @@ es6-shim@latest:
   version "0.35.1"
   resolved "https://registry.yarnpkg.com/es6-shim/-/es6-shim-0.35.1.tgz#a23524009005b031ab4a352ac196dfdfd1144ab7"
 
-escape-html@^1.0.3, escape-html@~1.0.3:
+escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
 
@@ -13794,14 +13789,6 @@ remark-rehype@^4.0.0:
   resolved "https://registry.yarnpkg.com/remark-rehype/-/remark-rehype-4.0.0.tgz#b9c8ae687e311eead584742439e028497b7aebe8"
   dependencies:
     mdast-util-to-hast "^4.0.0"
-
-remark-slate@^1.8.6:
-  version "1.8.6"
-  resolved "https://registry.yarnpkg.com/remark-slate/-/remark-slate-1.8.6.tgz#a5b4dc1c83ab6cf59a064d425976fc26bdb43b6e"
-  integrity sha512-1Gmt5MGw25MRVP+0xTXqw9JQDWfRNWujD4YFCPg036a9DZYhn7mLFjM6jreHB+9hKa6RCMOm5thiXznAmdn8Ug==
-  dependencies:
-    "@types/escape-html" "^1.0.0"
-    escape-html "^1.0.3"
 
 remark-stringify@^6.0.0:
   version "6.0.4"


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
remark-slate wasn't working for serializing the slate editor, the resulting value was including html and the text was being html escaped. Since we're only supporting a few types of nodes it was relatively easy to create a custom serializer.

Before:
![Screen Shot 2022-06-13 at 3 21 04 PM](https://user-images.githubusercontent.com/24235215/173456412-c7ac873b-cf2b-4156-a53f-1d31e941cb84.png)
After:
![Screen Shot 2022-06-13 at 3 22 04 PM](https://user-images.githubusercontent.com/24235215/173456697-ec2075b4-3782-4b38-9aed-be4874585734.png)


Before:
![Screen Shot 2022-06-13 at 3 22 39 PM](https://user-images.githubusercontent.com/24235215/173456846-d1fe6d1e-bdc5-4e16-9fde-88f54492796c.png)

After:
![Screen Shot 2022-06-13 at 3 23 42 PM](https://user-images.githubusercontent.com/24235215/173457135-0c47f995-d7b5-4682-8fb1-273f1d1c5c21.png)

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
