### PR TITLE
Fix version issues - Code review V2

### DIFF
--- a/apps/src/templates/instructions/codeReviewV2/CodeReviewTimelineElement.jsx
+++ b/apps/src/templates/instructions/codeReviewV2/CodeReviewTimelineElement.jsx
@@ -5,6 +5,8 @@ import {TextLink} from '@dsco_/link';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
 import color from '@cdo/apps/util/color';
 import javalabMsg from '@cdo/javalab/locale';
+import {stringifyQueryParams} from '@cdo/apps/utils';
+import {queryParams} from '@cdo/apps/code-studio/utils';
 
 export const codeReviewTimelineElementType = {
   CREATED: 'created',
@@ -29,12 +31,11 @@ const CodeReviewTimelineElement = ({
   viewAsCodeReviewer,
   children
 }) => {
-  let versionLink = location.origin + location.pathname;
-  if (location.search) {
-    versionLink += `${location.search}&version=${projectVersionId}`;
-  } else {
-    versionLink += `?version=${projectVersionId}`;
-  }
+  const params = queryParams();
+  params['version'] = projectVersionId;
+
+  const versionLink =
+    location.origin + location.pathname + stringifyQueryParams(params);
 
   // You can only see previous versions of your own project
   const displayEyeball = !viewAsCodeReviewer && !!projectVersionId;

--- a/apps/src/templates/instructions/codeReviewV2/CodeReviewTimelineReview.jsx
+++ b/apps/src/templates/instructions/codeReviewV2/CodeReviewTimelineReview.jsx
@@ -12,6 +12,7 @@ import Comment from '@cdo/apps/templates/instructions/codeReviewV2/Comment';
 import CodeReviewCommentEditor from '@cdo/apps/templates/instructions/codeReviewV2/CodeReviewCommentEditor';
 import {reviewShape} from '@cdo/apps/templates/instructions/codeReviewV2/shapes';
 import CodeReviewError from '@cdo/apps/templates/instructions/codeReviewV2/CodeReviewError';
+import {queryParams} from '@cdo/apps/code-studio/utils';
 
 const CodeReviewTimelineReview = ({
   review,
@@ -25,6 +26,8 @@ const CodeReviewTimelineReview = ({
   const {id, createdAt, isOpen, version, ownerId, ownerName, comments} = review;
   const [displayCloseError, setDisplayCloseError] = useState(false);
   const formattedDate = moment(createdAt).format('M/D/YYYY [at] h:mm A');
+
+  const isViewingOldVersion = !!queryParams('version');
 
   const handleCloseCodeReview = () => {
     closeReview(
@@ -56,7 +59,7 @@ const CodeReviewTimelineReview = ({
               {javalabMsg.openedDate({date: formattedDate})}
             </div>
           </div>
-          {isOpen && viewingAsOwner && (
+          {isOpen && viewingAsOwner && !isViewingOldVersion && (
             <div>
               <Button
                 icon="close"
@@ -91,7 +94,7 @@ const CodeReviewTimelineReview = ({
         {comments?.length === 0 && !isOpen && (
           <span>{javalabMsg.noFeedbackGiven()}</span>
         )}
-        {isOpen && !viewingAsOwner && (
+        {isOpen && !viewingAsOwner && !isViewingOldVersion && (
           <CodeReviewCommentEditor
             addCodeReviewComment={(commentText, onSuccess, onFailure) =>
               addCodeReviewComment(commentText, id, onSuccess, onFailure)

--- a/apps/test/unit/templates/instructions/codeReviewV2/CodeReviewTimelineElementTest.jsx
+++ b/apps/test/unit/templates/instructions/codeReviewV2/CodeReviewTimelineElementTest.jsx
@@ -7,6 +7,8 @@ import {
 } from '@cdo/apps/templates/instructions/codeReviewV2/CodeReviewTimelineElement';
 import color from '@cdo/apps/util/color';
 import javalabMsg from '@cdo/javalab/locale';
+import sinon from 'sinon';
+import * as utils from '@cdo/apps/code-studio/utils';
 
 const DEFAULT_PROPS = {
   type: codeReviewTimelineElementType.CREATED,
@@ -67,7 +69,32 @@ describe('CodeReviewTimelineElement', () => {
         projectVersionId: 'asdfjkl',
         viewAsCodeReviewer: false
       });
-      expect(wrapper.find('EyeballLink')).to.have.length(1);
+      const eyeballLink = wrapper.find('EyeballLink');
+      expect(eyeballLink).to.have.length(1);
+      expect(eyeballLink.props().versionHref.includes('version=asdfjkl')).to.be
+        .true;
+    });
+
+    it('has expected params in eyeball link', () => {
+      // Params existing in the url should be included and version param is overridden if one already exists in the url
+      sinon.stub(utils, 'queryParams').returns({
+        user_id: 123,
+        section_id: 456,
+        version: 'viewingOldVersion'
+      });
+      const wrapper = setUp({
+        type: codeReviewTimelineElementType.COMMIT,
+        projectVersionId: 'asdfjkl',
+        viewAsCodeReviewer: false
+      });
+      const eyeballLink = wrapper.find('EyeballLink');
+      expect(eyeballLink.props().versionHref.includes('version=asdfjkl')).to.be
+        .true;
+      expect(eyeballLink.props().versionHref.includes('user_id=123')).to.be
+        .true;
+      expect(eyeballLink.props().versionHref.includes('section_id=456')).to.be
+        .true;
+      utils.queryParams.restore();
     });
 
     it('hides eyeball link if there is not a version', () => {

--- a/apps/test/unit/templates/instructions/codeReviewV2/CodeReviewTimelineReviewTest.jsx
+++ b/apps/test/unit/templates/instructions/codeReviewV2/CodeReviewTimelineReviewTest.jsx
@@ -11,6 +11,7 @@ import CodeReviewCommentEditor from '@cdo/apps/templates/instructions/codeReview
 import {timelineElementType} from '@cdo/apps/templates/instructions/codeReviewV2/CodeReviewDataApi';
 import sinon from 'sinon';
 import CodeReviewError from '@cdo/apps/templates/instructions/codeReviewV2/CodeReviewError';
+import * as utils from '@cdo/apps/code-studio/utils';
 
 const DEFAULT_REVIEW = {
   id: 1,
@@ -146,6 +147,15 @@ describe('CodeReviewTimelineReview', () => {
     expect(wrapper.find('Button')).to.have.length(0);
   });
 
+  it('hides the close button if viewing an older version of the project', () => {
+    sinon.stub(utils, 'queryParams').returns('versionParam');
+    // Viewing own project with open code review
+    const review = {...DEFAULT_REVIEW, isOpen: true, ownerId: 1};
+    const wrapper = setUp({review: review, currentUserId: 1});
+    expect(wrapper.find('Button')).to.have.length(0);
+    utils.queryParams.restore();
+  });
+
   it('displays Comments for each comment', () => {
     const wrapper = setUp();
     expect(wrapper.find(Comment)).to.have.length(2);
@@ -197,5 +207,14 @@ describe('CodeReviewTimelineReview', () => {
     };
     const wrapper = setUp({review: review, currentUserId: 1});
     expect(wrapper.find(CodeReviewCommentEditor)).to.have.length(0);
+  });
+
+  // Note: teachers can view older version of student projects
+  it('hides the CodeReviewCommentEditor if viewing an older version of the project', () => {
+    sinon.stub(utils, 'queryParams').returns('versionParam');
+    const review = {...DEFAULT_REVIEW, isOpen: true, ownerId: 1};
+    const wrapper = setUp({review: review, currentUserId: 2});
+    expect(wrapper.find(CodeReviewCommentEditor)).to.have.length(0);
+    utils.queryParams.restore();
   });
 });


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Adds several fixes for viewing a project version with code review:
- When links for old versions are generated replaces rather than appends the `version` param in the url
- When viewing an old version, do not allow closing an open code review or adding a comment, since this experience should be readonly

Viewing old version of your own project with open code review (can not close):
![Screen Shot 2022-06-14 at 1 55 01 PM](https://user-images.githubusercontent.com/24235215/173687031-7907aa00-fd76-49e9-839c-d122fdd92e48.png)

## Links
- jira ticket: [LP-2405](https://codedotorg.atlassian.net/browse/LP-2405)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()

-->

## Testing story
Unit tested & local testing
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Follow-up work
We need to re-think which tabs display in the Top Instructions when you're viewing an older version of a project (https://codedotorg.atlassian.net/browse/LP-2408)
<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
