### PR TITLE
Java Lab: disable file dropdown in read only mode

### DIFF
--- a/apps/src/javalab/JavalabEditor.jsx
+++ b/apps/src/javalab/JavalabEditor.jsx
@@ -753,7 +753,7 @@ class JavalabEditor extends React.Component {
                       }}
                       onClick={e => this.toggleTabMenu(tabKey, e)}
                       className="no-focus-outline"
-                      disabled={activeTabKey !== tabKey}
+                      disabled={isReadOnlyWorkspace || activeTabKey !== tabKey}
                     >
                       <FontAwesome
                         icon={

--- a/apps/src/javalab/JavalabEditor.jsx
+++ b/apps/src/javalab/JavalabEditor.jsx
@@ -749,7 +749,8 @@ class JavalabEditor extends React.Component {
                         ...styles.fileMenuToggleButton,
                         ...(displayTheme === DisplayTheme.DARK &&
                           styles.darkFileMenuToggleButton),
-                        ...(activeTabKey !== tabKey && {visibility: 'hidden'})
+                        ...((isReadOnlyWorkspace ||
+                          activeTabKey !== tabKey) && {visibility: 'hidden'})
                       }}
                       onClick={e => this.toggleTabMenu(tabKey, e)}
                       className="no-focus-outline"


### PR DESCRIPTION
Disable the edit/delete file dropdown while in readonly mode in Java Lab. We decided to hide the button while in readonly mode:

### Read Only Mode
![Screen Shot 2022-06-14 at 1 54 40 PM](https://user-images.githubusercontent.com/33666587/173687310-fedad840-f20f-4a34-a1e2-c2f5b7312bd3.png)

### Normal Mode
![Screen Shot 2022-06-14 at 1 54 58 PM](https://user-images.githubusercontent.com/33666587/173687287-c9456c68-0ba6-4adc-8e0c-3f69c80034da.png)


## Links

- jira ticket: [LP-2404](https://codedotorg.atlassian.net/browse/LP-2404)

## Testing story
Tested locally.

