### PR TITLE
Support sass files in pegasus/sites.v3/code.org/public/css

### DIFF
--- a/pegasus/router.rb
+++ b/pegasus/router.rb
@@ -20,8 +20,6 @@ require 'cdo/rack/upgrade_insecure_requests'
 require_relative 'helper_modules/dashboard'
 require 'dynamic_config/dcdo'
 require 'active_support/core_ext/hash'
-require 'sass'
-require 'sass/plugin'
 require 'haml'
 
 if rack_env?(:production)
@@ -110,9 +108,6 @@ class Documents < Sinatra::Base
       settings.template_extnames +
       settings.exclude_extnames +
       ['.fetch']
-    Sass::Plugin.options[:cache_location] = pegasus_dir('cache', '.sass-cache')
-    Sass::Plugin.options[:css_location] = pegasus_dir('cache', 'css')
-    Sass::Plugin.options[:template_location] = shared_dir('css')
     set :mustermann_opts, check_anchors: false, ignore_unknown_options: true
 
     # Haml/Temple engine doesn't recognize the `path` option

--- a/shared/middleware/shared_resources.rb
+++ b/shared/middleware/shared_resources.rb
@@ -18,8 +18,9 @@ class SharedResources < Sinatra::Base
 
   configure do
     Sass::Plugin.options[:cache_location] = pegasus_dir('cache', '.sass-cache')
-    Sass::Plugin.options[:css_location] = pegasus_dir('cache', 'css')
-    Sass::Plugin.options[:template_location] = shared_dir('css')
+    css_location = pegasus_dir('cache', 'css')
+    Sass::Plugin.add_template_location(shared_dir('css'), css_location)
+    Sass::Plugin.add_template_location(sites_v3_dir('code.org/public/css'), css_location)
 
     set :image_extnames, ['.png', '.jpeg', '.jpg', '.gif']
     set :javascript_extnames, ['.js']


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Support sass files in `pegasus/sites.v3/code.org/public/css`.  Note that this uses our existing pattern that relies on the [sass gem](https://github.com/sass/ruby-sass/) which is past end-of-life.

Including Dave, Brendan, and Infra because this area is unfamiliar to me and hopefully someone will stop me if I'm doing something bad.  :-)

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [LP-2388](https://codedotorg.atlassian.net/browse/LP-2388)
- [Commit](https://github.com/code-dot-org/code-dot-org/commit/30a12ad2b5e4a49fa5f36ecd829a703ef2286fe1) that originally added sass support for `/shared/css`

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
