### PR TITLE
Temporary fix for parent checkbox on sign-up page in es-ES

### DIFF
--- a/dashboard/config/locales/es-ES.yml
+++ b/dashboard/config/locales/es-ES.yml
@@ -248,8 +248,7 @@ es:
     share_teacher_email_reg_partner_preference_no: 'No'
     share_teacher_email_reg_partner_preference_required: Debes especificar una preferencia
       de correo electrónico.
-    parent_account_checkbox: Som rodič/zákonný zástupca, ktorý sa prihlasuje v mene
-      svojho dieťaťa
+    parent_account_checkbox: Soy padre o tutor registrándose en lugar de mi hijo
     parent_account_email_progress_permission: Môžeme vám poslať e-mail s príležitostnými
       aktualizáciami o pokroku a projektoch vášho dieťaťa a aktualizáciami o kurze
       a informatike? [(Pozrite si naše pravidlá ochrany osobných údajov)]%{privacy_policy_url}


### PR DESCRIPTION
Mario noticed that the parent checkbox was not in Spanish. 
![image](https://user-images.githubusercontent.com/2933346/173706973-4b2c05b7-8198-4205-bc59-4c860e6a24f8.png)

[We fixed the string in Crowdin](https://crowdin.com/translate/codeorg/40/enus-es#2370940), but since this string is on the sign up page, it's more visible and should be corrected temporarily in this way while we wait for the next sync down/out.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
