### PR TITLE
fix moving and editing of enrollments

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/EnrollmentsPanel.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/EnrollmentsPanel.jsx
@@ -160,12 +160,13 @@ export default class EnrollmentsPanel extends React.Component {
       });
     } else {
       this.setState(state => {
-        state.selectedEnrollments.push({
+        const selectedEnrollments = state.selectedEnrollments.concat({
           id: enrollment.id,
           email: enrollment.email,
           first_name: enrollment.first_name,
           last_name: enrollment.last_name
         });
+        return {selectedEnrollments};
       });
     }
   };

--- a/apps/src/code-studio/pd/workshop_dashboard/EnrollmentsPanel.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/EnrollmentsPanel.jsx
@@ -70,7 +70,13 @@ export default class EnrollmentsPanel extends React.Component {
   };
 
   handleClickChangeEnrollments = event => {
-    this.setState({enrollmentChangeDialogOpen: event.target.name});
+    const name = event.target.name;
+    if (
+      name === MOVE_ENROLLMENT_BUTTON_NAME ||
+      name === EDIT_ENROLLMENT_NAME_BUTTON_NAME
+    ) {
+      this.setState({enrollmentChangeDialogOpen: name});
+    }
   };
 
   handleChangeEnrollmentsCanceled = () => {

--- a/apps/test/unit/code-studio/pd/workshop_dashboard/EnrollmentsPanelTest.jsx
+++ b/apps/test/unit/code-studio/pd/workshop_dashboard/EnrollmentsPanelTest.jsx
@@ -157,7 +157,6 @@ describe('EnrollmentsPanel', () => {
 
     // Select the first enrollment
     wrapper.instance().handleClickSelect(enrollments[0]);
-    wrapper.update();
     assert.deepEqual(
       [_.pick(enrollments[0], ['id', 'email', 'first_name', 'last_name'])],
       wrapper.state('selectedEnrollments')
@@ -209,7 +208,6 @@ describe('EnrollmentsPanel', () => {
 
     // Select the first enrollment
     wrapper.instance().handleClickSelect(enrollments[0]);
-    wrapper.update();
     assert.deepEqual(
       [_.pick(enrollments[0], ['id', 'email', 'first_name', 'last_name'])],
       wrapper.state('selectedEnrollments')


### PR DESCRIPTION
Finishes a long lost work item [PLAT-1386](https://codedotorg.atlassian.net/browse/PLAT-1386) to make it so that you can actually select enrollments and move or rename them.

### problem 1

 avoiding this annoying workaround:

https://user-images.githubusercontent.com/8001765/173941315-ad45b20b-c5a5-4376-9eaf-e2c8f745edf7.mov

now it works like this:

https://user-images.githubusercontent.com/8001765/173941413-4a4a63e7-ceda-4726-a668-748bb280b218.mov

The problem is that the original code was not following the [contract for set state](https://reactjs.org/docs/react-component.html#setstate), and was breaking the rule which says that you should never modify react state directly.

### problem 2

also fixes this problem:

https://user-images.githubusercontent.com/8001765/173957967-47fa402e-0318-4671-8018-32118f88dc9a.mov

which had this annoying workaround, which avoids using the mouse by typing: tab, tab, [number], tab, enter: 

https://user-images.githubusercontent.com/8001765/173957584-2f1a1ec5-165e-431f-95cc-81e74de5fb17.mov

a similar problem / workaround existed for editing name.

now it works like this:

https://user-images.githubusercontent.com/8001765/173957599-bdbda68f-33fc-4b0d-98c6-ed0fb553cf6c.mov

this one is a bit more mysterious. I noticed that `handleClickChangeEnrollments` was getting called with `event.target.value == ''` when I click as shown in the first screenshot. I didn't see anything wrong with how `handleClickChangeEnrollments` was configured, so I opted to solve this by locking down the implementation of `handleClickChangeEnrollments` so that it could only be used to open the dialog, never to close it.

## Testing story

* manual verification shown in screenshots
* removed workarounds from existing unit tests
