### PR TITLE
Revert "Simplify header when viewing level page as a peer doing code review"

### DIFF
--- a/apps/src/code-studio/components/header/HeaderMiddle.jsx
+++ b/apps/src/code-studio/components/header/HeaderMiddle.jsx
@@ -16,7 +16,6 @@ const lessonProgressExtraWidth = 10;
 class HeaderMiddle extends React.Component {
   static propTypes = {
     projectInfoOnly: PropTypes.bool,
-    scriptNameOnly: PropTypes.bool,
     appLoadStarted: PropTypes.bool,
     appLoaded: PropTypes.bool,
     scriptNameData: PropTypes.object,
@@ -79,7 +78,6 @@ class HeaderMiddle extends React.Component {
   static getWidths(
     width,
     projectInfoOnly,
-    scriptNameOnly,
     projectInfoDesiredWidth,
     scriptNameDesiredWidth,
     lessonProgressDesiredWidth,
@@ -92,18 +90,6 @@ class HeaderMiddle extends React.Component {
       return {
         projectInfo: Math.floor(Math.min(projectInfoDesiredWidth, width)),
         scriptName: 0,
-        progress: 0,
-        popup: 0,
-        finish: 0
-      };
-    }
-
-    if (scriptNameOnly) {
-      return {
-        projectInfo: 0,
-        scriptName: Math.floor(
-          Math.min(scriptNameDesiredWidth + scriptNameExtraWidth, width)
-        ),
         progress: 0,
         popup: 0,
         finish: 0
@@ -193,7 +179,6 @@ class HeaderMiddle extends React.Component {
     const widths = HeaderMiddle.getWidths(
       this.state.width,
       this.props.projectInfoOnly,
-      this.props.scriptNameOnly,
       this.state.projectInfoDesiredWidth,
       this.state.scriptNameDesiredWidth,
       this.state.lessonProgressDesiredWidth,

--- a/apps/src/code-studio/header.js
+++ b/apps/src/code-studio/header.js
@@ -139,17 +139,6 @@ header.buildProjectInfoOnly = function() {
   );
 };
 
-// When viewing the level page in code review mode, we want to show only the
-// lesson information (which is displayed by the ScriptName component).
-header.buildScriptNameOnly = function(scriptNameData) {
-  ReactDOM.render(
-    <Provider store={getStore()}>
-      <HeaderMiddle scriptNameData={scriptNameData} scriptNameOnly={true} />
-    </Provider>,
-    document.querySelector('.header_level')
-  );
-};
-
 // When the page is cached, this function is called to retrieve and set the
 // sign-in button or user menu in the DOM.
 header.buildUserMenu = function() {

--- a/apps/test/unit/code-studio/components/header/HeaderMiddleTest.js
+++ b/apps/test/unit/code-studio/components/header/HeaderMiddleTest.js
@@ -10,7 +10,6 @@ describe('HeaderMiddle', () => {
     const widths = HeaderMiddle.getWidths(
       700,    // width,
       false,  // projectInfoOnly,
-      false,  // scriptNameOnly,
       0,      // projectInfoDesiredWidth,
       200,    // scriptNameDesiredWidth,
       350,    // lessonProgressDesiredWidth,
@@ -32,7 +31,6 @@ describe('HeaderMiddle', () => {
     const widths = HeaderMiddle.getWidths(
       350,    // width,
       false,  // projectInfoOnly,
-      false,  // scriptNameOnly,
       0,      // projectInfoDesiredWidth,
       200,    // scriptNameDesiredWidth,
       350,    // lessonProgressDesiredWidth,
@@ -54,7 +52,6 @@ describe('HeaderMiddle', () => {
     const widths = HeaderMiddle.getWidths(
       700,    // width,
       false,  // projectInfoOnly,
-      false,  // scriptNameOnly,
       200,    // projectInfoDesiredWidth,
       200,    // scriptNameDesiredWidth,
       350,    // lessonProgressDesiredWidth,
@@ -76,7 +73,6 @@ describe('HeaderMiddle', () => {
     const widths = HeaderMiddle.getWidths(
       350,    // width,
       false,  // projectInfoOnly,
-      false,  // scriptNameOnly,
       200,    // projectInfoDesiredWidth,
       200,    // scriptNameDesiredWidth,
       350,    // lessonProgressDesiredWidth,
@@ -98,7 +94,6 @@ describe('HeaderMiddle', () => {
     const widths = HeaderMiddle.getWidths(
       700,    // width,
       true,   // projectInfoOnly,
-      false,  // scriptNameOnly,
       400,    // projectInfoDesiredWidth,
       0,      // scriptNameDesiredWidth,
       0,      // lessonProgressDesiredWidth,
@@ -118,7 +113,6 @@ describe('HeaderMiddle', () => {
     const widths = HeaderMiddle.getWidths(
       350,    // width,
       true,   // projectInfoOnly,
-      false,  // scriptNameOnly,
       400,    // projectInfoDesiredWidth,
       0,      // scriptNameDesiredWidth,
       0,      // lessonProgressDesiredWidth,
@@ -129,46 +123,6 @@ describe('HeaderMiddle', () => {
 
     assert.equal(widths.projectInfo, 350);
     assert.equal(widths.scriptName, 0);
-    assert.equal(widths.progress, 0);
-    assert.equal(widths.popup, 0);
-    assert.equal(widths.finish, 0);
-  });
-
-  it('widths for script name only when wide', () => {
-    const widths = HeaderMiddle.getWidths(
-      700,    // width,
-      false,  // projectInfoOnly,
-      true,   // scriptNameOnly,
-      0,      // projectInfoDesiredWidth,
-      400,    // scriptNameDesiredWidth,
-      0,      // lessonProgressDesiredWidth,
-      0,      // numScriptLessons,
-      0,      // finishDesiredWidth,
-      false   // showFinish
-    );
-
-    assert.equal(widths.projectInfo, 0);
-    assert.equal(widths.scriptName, 410);
-    assert.equal(widths.progress, 0);
-    assert.equal(widths.popup, 0);
-    assert.equal(widths.finish, 0);
-  });
-
-  it('widths for script name only when narrow', () => {
-    const widths = HeaderMiddle.getWidths(
-      350,    // width,
-      false,  // projectInfoOnly,
-      true,   // scriptNameOnly,
-      0,      // projectInfoDesiredWidth,
-      400,    // scriptNameDesiredWidth,
-      0,      // lessonProgressDesiredWidth,
-      0,      // numScriptLessons,
-      0,      // finishDesiredWidth,
-      false   // showFinish
-    );
-
-    assert.equal(widths.projectInfo, 0);
-    assert.equal(widths.scriptName, 350);
     assert.equal(widths.progress, 0);
     assert.equal(widths.popup, 0);
     assert.equal(widths.finish, 0);

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -413,7 +413,6 @@ class ScriptLevelsController < ApplicationController
       @user = user_to_view
 
       if can?(:view_as_user_for_code_review, @script_level, user_to_view, sublevel_to_view)
-        @is_code_reviewing = true
         view_options(is_code_reviewing: true)
       end
     end

--- a/dashboard/app/views/layouts/_header.html.haml
+++ b/dashboard/app/views/layouts/_header.html.haml
@@ -42,7 +42,7 @@
   header_contents_options[:loc_prefix] = "nav.header."
   header_contents_options[:page_mode] = request.cookies['pm']
 
-  should_show_progress = (script_level || @lesson_extras) && !@is_code_reviewing
+  should_show_progress = script_level || @lesson_extras
 
   sign_in_user = current_user || user_type && OpenStruct.new(
     id: nil,
@@ -131,12 +131,6 @@
       href: script_path(@script, section_id: section_id, user_id: user_id),
       smallText: small_text
     }
-  elsif @is_code_reviewing
-    script_name_data = {
-      name: script_level.lesson.localized_title,
-      href: '#',  # When viewing peer code, link should do nothing
-      smallText: false
-    }
   end
 
 - if should_show_progress
@@ -155,12 +149,6 @@
       #{!script_level}
     )
     //]]>
-
-- elsif @is_code_reviewing
-  :javascript
-    dashboard.header.buildScriptNameOnly(
-      #{script_name_data.to_json}
-    )
 
 - elsif level
   :javascript


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#46830

I was able to reproduce the issue that teachers are experiencing in PL this morning and reverting this PR fixes the issue.

Issue:
![Screen Shot 2022-06-16 at 9 17 48 AM](https://user-images.githubusercontent.com/24235215/174117963-4a24b5cc-cda8-4f9e-bc17-8c76effc9ccb.png)

