### PR TITLE
Fix Chef installation & configuration of Amazon CloudWatch Agent

### DIFF
--- a/cookbooks/cdo-cloudwatch-agent/recipes/default.rb
+++ b/cookbooks/cdo-cloudwatch-agent/recipes/default.rb
@@ -3,13 +3,35 @@
 # Recipe:: default
 #
 
-aws_cloudwatch_agent 'default' do
+aws_cloudwatch_agent 'install' do
   action [:install]
 end
 
 template 'amazon-cloudwatch-agent.json' do
   path "/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json"
   source "amazon-cloudwatch-agent.json.erb"
+end
+
+# Copy and modify logic from the :config action in the aws_cloudwatch Chef cookbook.
+# The aws_cloudwatch Chef cookbook searches Standard Out from the Cloud Watch Agent's config-translator tool
+# to verify that the input JSON configuration file we generated via ERB was valid.
+# https://github.com/gp42/aws_cloudwatch/blob/0d324a15739e3700cf017bcff599dd6da53e331e/libraries/agent_installer.rb#L115-L132
+# A recent change that Amazon made to the config-translator tool (cmd/config-translator/translator.go) results in this
+# information being written to Standard Error instead:
+# https://github.com/aws/amazon-cloudwatch-agent/compare/v1.247350.0...v1.247352.0#diff-028b81b5a43fcd35fb7f55829f899ae5ab854d4c214e36898e620699da6892ec
+# We use `2>&1` to redirect Standard Error to Standard Out to be certain the input configuration file we generated
+# via ERB is valid. This is important, because without a valid configuration file, the CloudWatch Agent uses an
+# internal default configuration file, which would result in us losing (not publishing) certain Metrics and Logs to
+# the AWS CloudWatch service.
+script 'amazon-cloudwatch-agent-config-translator' do
+  action :run
+  interpreter "bash"
+
+  code <<-EOH
+    res="$(sudo /opt/aws/amazon-cloudwatch-agent/bin/config-translator --input #{json_path} --output #{agent_tom_path} --mode auto --config #{common_path} 2>&1)"
+    echo "$res" | grep 'Valid Json input schema.'
+    exit $?
+  EOH
 end
 
 aws_cloudwatch_agent 'restart' do

--- a/cookbooks/cdo-cloudwatch-agent/recipes/default.rb
+++ b/cookbooks/cdo-cloudwatch-agent/recipes/default.rb
@@ -8,6 +8,10 @@ aws_cloudwatch_agent 'default' do
 end
 
 template 'amazon-cloudwatch-agent.json' do
-  path "/opt/aws/amazon-cloudwatch-agent/etc"
+  path "/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json"
   source "amazon-cloudwatch-agent.json.erb"
+end
+
+aws_cloudwatch_agent 'restart' do
+  action [:restart]
 end

--- a/cookbooks/cdo-cloudwatch-agent/recipes/default.rb
+++ b/cookbooks/cdo-cloudwatch-agent/recipes/default.rb
@@ -4,6 +4,15 @@
 #
 
 aws_cloudwatch_agent 'default' do
-  action      [:install, :configure, :restart]
+  action [:install]
   json_config 'amazon-cloudwatch-agent.json.erb'
+end
+
+template 'amazon-cloudwatch-agent.json' do
+  path "/opt/aws/amazon-cloudwatch-agent/etc/"
+  source "amazon-cloudwatch-agent.json.erb"
+end
+
+aws_cloudwatch_agent 'default' do
+  actiom [:restart]
 end

--- a/cookbooks/cdo-cloudwatch-agent/recipes/default.rb
+++ b/cookbooks/cdo-cloudwatch-agent/recipes/default.rb
@@ -5,14 +5,4 @@
 
 aws_cloudwatch_agent 'default' do
   action [:install]
-  json_config 'amazon-cloudwatch-agent.json.erb'
-end
-
-template 'amazon-cloudwatch-agent.json' do
-  path "/opt/aws/amazon-cloudwatch-agent/etc/"
-  source "amazon-cloudwatch-agent.json.erb"
-end
-
-aws_cloudwatch_agent 'default' do
-  actiom [:restart]
 end

--- a/cookbooks/cdo-cloudwatch-agent/recipes/default.rb
+++ b/cookbooks/cdo-cloudwatch-agent/recipes/default.rb
@@ -27,8 +27,12 @@ script 'amazon-cloudwatch-agent-config-translator' do
   action :run
   interpreter "bash"
 
+  JSON_PATH = '/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json'.freeze
+  AGENT_TOM_PATH = '/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.toml'.freeze
+  COMMON_PATH = '/opt/aws/amazon-cloudwatch-agent/etc/common-config.toml'.freeze
+
   code <<-EOH
-    res="$(sudo /opt/aws/amazon-cloudwatch-agent/bin/config-translator --input #{json_path} --output #{agent_tom_path} --mode auto --config #{common_path} 2>&1)"
+    res="$(sudo /opt/aws/amazon-cloudwatch-agent/bin/config-translator --input #{JSON_PATH} --output #{AGENT_TOM_PATH} --mode auto --config #{COMMON_PATH} 2>&1)"
     echo "$res" | grep 'Valid Json input schema.'
     exit $?
   EOH

--- a/cookbooks/cdo-cloudwatch-agent/recipes/default.rb
+++ b/cookbooks/cdo-cloudwatch-agent/recipes/default.rb
@@ -6,3 +6,8 @@
 aws_cloudwatch_agent 'default' do
   action [:install]
 end
+
+template 'amazon-cloudwatch-agent.json' do
+  path "/opt/aws/amazon-cloudwatch-agent/etc"
+  source "amazon-cloudwatch-agent.json.erb"
+end


### PR DESCRIPTION
https://codedotorg.atlassian.net/browse/INF-671

Provisioning new “FrontEnd” and “Daemon” servers stopped working in late May / early June 2022 due to errors while executing our `cdo-cloudwatch-agent` Cookbook. The root cause of the issue is that Amazon published an updated release of its CloudWatch Agent package that inadvertently writes some types of information to Standard Error instead of Standard Out, and the 3rd party Chef Supermarket Cookbook we’re using to install this package reads Standard Out to verify that the CloudWatch Agent configuration file we’ve provided is valid.

We were invoking the `:install`, `:configure`, and `:restart` actions in the `aws_cloudwatch_agent` cookbook. We now implement the `:configure` action ourselves with a small variation to redirect Standard Error to Standard Out during the configuration process.

## Testing story

Successfully provisioned an adhoc on this feature branch and verified in the Chef Client debug log that CloudWatch Agent is being installed, configured, and started successfully. Verified that the CloudWatch Agent is correctly running on the adhoc and publishing Metrics to the CloudWatch service.

![374FC533-425F-48C2-B965-04DA2E618774](https://user-images.githubusercontent.com/2157034/175362272-ee43708f-5d89-4b62-8f70-4bbfc0464b36.jpeg)


## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
