### PR TITLE
added hover action to expand/collapse buttons and removed onclick on Watcher tab in Game/App lab

### DIFF
--- a/apps/src/lib/tools/jsdebugger/JsDebugger.jsx
+++ b/apps/src/lib/tools/jsdebugger/JsDebugger.jsx
@@ -12,6 +12,7 @@ import dom from '../../../dom';
 import commonStyles from '../../../commonStyles';
 import styleConstants from '../../../styleConstants';
 import Watchers from '../../../templates/watchers/Watchers';
+import color from '../../../util/color';
 import PaneHeader, {
   PaneSection,
   PaneButton
@@ -467,11 +468,14 @@ class JsDebugger extends React.Component {
           >
             {i18n.debugConsoleHeader()}
           </span>
-          <FontAwesome
-            icon={this.state.open ? 'chevron-circle-down' : 'chevron-circle-up'}
-            style={styles.showHideIcon}
-            onClick={this.slideToggle}
-          />
+          <span style={styles.showHideIcon}>
+            <FontAwesome
+              icon={
+                this.state.open ? 'chevron-circle-down' : 'chevron-circle-up'
+              }
+              onClick={this.slideToggle}
+            />
+          </span>
           {this.props.debugButtons && (
             <PaneSection id="debug-commands-header">
               <FontAwesome
@@ -631,7 +635,7 @@ const styles = {
     fontSize: 18,
     ':hover': {
       cursor: 'pointer',
-      color: 'white'
+      color: color.white
     }
   },
   showDebugWatchIcon: {

--- a/apps/src/lib/tools/jsdebugger/JsDebugger.jsx
+++ b/apps/src/lib/tools/jsdebugger/JsDebugger.jsx
@@ -527,15 +527,16 @@ class JsDebugger extends React.Component {
                   : {}
               }
             >
-              <FontAwesome
-                id="hide-toolbox-icon"
-                style={styles.showDebugWatchIcon}
-                icon={
-                  this.state.watchersHidden
-                    ? 'chevron-circle-left'
-                    : 'chevron-circle-right'
-                }
-              />
+              <span style={styles.showDebugWatchIcon}>
+                <FontAwesome
+                  id="hide-watcher"
+                  icon={
+                    this.state.watchersHidden
+                      ? 'chevron-circle-left'
+                      : 'chevron-circle-right'
+                  }
+                />
+              </span>
               <span style={styles.noUserSelect} className="header-text">
                 {this.state.watchersHidden
                   ? i18n.debugShowWatchHeader()

--- a/apps/src/lib/tools/jsdebugger/JsDebugger.jsx
+++ b/apps/src/lib/tools/jsdebugger/JsDebugger.jsx
@@ -502,21 +502,6 @@ class JsDebugger extends React.Component {
               ref={debugWatchHeader =>
                 (this._debugWatchHeader = debugWatchHeader)
               }
-              onClick={() => {
-                // reset resizer-overridden styles
-                // (remove once resize logic migrated to React)
-                if (!this.state.watchersHidden) {
-                  const resetResizeEvent = document.createEvent('Event');
-                  resetResizeEvent.initEvent(
-                    'resetWatchersResizableElements',
-                    true,
-                    true
-                  );
-                  document.dispatchEvent(resetResizeEvent);
-                }
-
-                this.setState({watchersHidden: !this.state.watchersHidden});
-              }}
               style={
                 this.state.watchersHidden
                   ? {
@@ -527,7 +512,23 @@ class JsDebugger extends React.Component {
                   : {}
               }
             >
-              <span style={styles.showDebugWatchIcon}>
+              <span
+                style={styles.showDebugWatchIcon}
+                onClick={() => {
+                  // reset resizer-overridden styles
+                  // (remove once resize logic migrated to React)
+                  if (!this.state.watchersHidden) {
+                    const resetResizeEvent = document.createEvent('Event');
+                    resetResizeEvent.initEvent(
+                      'resetWatchersResizableElements',
+                      true,
+                      true
+                    );
+                    document.dispatchEvent(resetResizeEvent);
+                  }
+                  this.setState({watchersHidden: !this.state.watchersHidden});
+                }}
+              >
                 <FontAwesome
                   id="hide-watcher"
                   icon={


### PR DESCRIPTION
## Summary of changes:
-Added color change hover action to expand/collapse buttons on bottom of page (Debug console and Watcher area)
Although the Jira ticket specified a black hover color, I chose to change color to white since the code already included the color change to white on hover action for both buttons. Added a span around the the two icons allowed color of icons and pointer change to occur.
-Although not in Jira ticket, I also removed onclick on Watcher tab so that onclick for Watcher area active only on expand/collapse button.
Video of changes: https://youtu.be/MEGaCbvkpqs

jira ticket: https://codedotorg.atlassian.net/browse/STAR-2326?atlOrigin=eyJpIjoiMDQ1YWJjZWJmYTFlNDk1NDhjYjYyNjU2ZGQ4YTE0YTYiLCJwIjoiaiJ9

## Follow-up work
Noticed that for Toolbox area at top of page, onclick/hover is active on Show Toolbox (when Toolbox is collapsed) but not on Toolbox (when Toolbox is expanded). 
Originally, The Watchers tab had onclick whether it was expanded (displaying 'Watchers') or collapsed (displaying 'Show Watchers'). However, the hover action for pointer was not on the 'Show Watchers' as it is on the Show Toolbox.
Next task could be to add hover pointer for 'Show Watchers' label.





