### PR TITLE
Added 'Verified Teacher' string and label added in account settings...

### DIFF
--- a/dashboard/app/views/devise/registrations/edit.html.haml
+++ b/dashboard/app/views/devise/registrations/edit.html.haml
@@ -15,6 +15,9 @@
   - email_mismatch = current_user.errors.delete(:email_mismatch)
   - current_user.reload if email_mismatch.present?
   = render "devise/shared/error_messages", resource: resource
+  - if current_user.permission?(UserPermission::AUTHORIZED_TEACHER)
+    .field
+      = f.label t('activerecord.attributes.user.verified_teacher'), class: "label-bold", style: 'color:green;'
   %div
   .field
     = f.label :name, class: "label-bold"

--- a/dashboard/app/views/devise/registrations/edit.html.haml
+++ b/dashboard/app/views/devise/registrations/edit.html.haml
@@ -17,7 +17,7 @@
   = render "devise/shared/error_messages", resource: resource
   - if current_user.permission?(UserPermission::AUTHORIZED_TEACHER)
     .field
-      = f.label t('activerecord.attributes.user.verified_teacher'), class: "label-bold", style: 'color:green;'
+      = f.label '✔ '+t('activerecord.attributes.user.verified_teacher'), class: "label-bold", style: 'color:green;'
   %div
   .field
     = f.label :name, class: "label-bold"

--- a/dashboard/app/views/devise/registrations/edit.html.haml
+++ b/dashboard/app/views/devise/registrations/edit.html.haml
@@ -17,7 +17,7 @@
   = render "devise/shared/error_messages", resource: resource
   - if current_user.permission?(UserPermission::AUTHORIZED_TEACHER)
     .field
-      = f.label '✔ '+t('activerecord.attributes.user.verified_teacher'), class: "label-bold", style: 'color:green;'
+      = f.label '✔ '+t('activerecord.attributes.user.verified_teacher'), class: 'label-bold', style: 'color:green; text-transform: capitalize';
   %div
   .field
     = f.label :name, class: "label-bold"

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -58,6 +58,7 @@ en:
         personal_email_markdown: "Personal email address [(click here if you don't have an email address)](%{url})"
         username: 'Username'
         password: 'Password'
+        verified_teacher: 'Verified Teacher'
         password_confirmation: 'Password confirmation'
         current_password: 'Current password'
         locale: 'Language'


### PR DESCRIPTION
… for verified teachers.

Our Customer Support manager has asked if we can add some sort of explicit indicator on the Account Settings page, clearly stating "Verified! " or similar, to reduce confusion. Sometimes we verify folks, but their provided email address (under their [Code.org](http://code.org/) account) isn’t a real working accessible inbox, so they’re verified, but they don’t receive our email letting them know. In general, there’s no indicator on the site stating “you are verified.”


**_Acceptance criteria_**

_Add “Verified teacher” to the i18n sync_
- String added in [en.yml](https://github.com/code-dot-org/code-dot-org/tree/staging/dashboard/config/locales/en.yml) file.

_A green checkmark icon (not an interactive component) and the string “Verified teacher” appear below the “Edit Account Details” title on http://studio.code.org/users/edit if the User has an authorized_teacher UserPermission._
- Verified Teacher green label appears in the account settings page for teacher with authorized_teacher permission.

## Links
- jira ticket: [FND-2045](https://codedotorg.atlassian.net/browse/FND-2045)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: [FND-2045](https://codedotorg.atlassian.net/browse/FND-2045)
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->
**Test Performed**
Account settings has been tested locally for the following scenarios:
- Account with no Permissions.
<img width="978" alt="Captura de Pantalla 2022-06-16 a la(s) 10 28 22 a m" src="https://user-images.githubusercontent.com/66776217/174106836-ca73eab1-e146-4edd-8c9e-4eab38fde6d4.png">
<img width="978" alt="Captura de Pantalla 2022-06-16 a la(s) 10 28 34 a m" src="https://user-images.githubusercontent.com/66776217/174107191-cad35c2c-5c4c-49ba-9fbb-7d7ff3fad1d6.png">

- Account with authorized_teacher permission.
<img width="978" alt="Captura de Pantalla 2022-06-16 a la(s) 10 27 26 a m" src="https://user-images.githubusercontent.com/66776217/174106913-542e7087-531d-4877-a174-923370bc61ff.png">
<img width="978" alt="Captura de Pantalla 2022-06-16 a la(s) 1 26 58 p m" src="https://user-images.githubusercontent.com/66776217/174140351-8108fb2e-165a-404b-b04e-c3a28664385e.png">

- Account with other than authorized_teacher permissions.
<img width="978" alt="Captura de Pantalla 2022-06-16 a la(s) 10 28 50 a m" src="https://user-images.githubusercontent.com/66776217/174106945-aef17855-bd72-4b56-9af6-6545ef4763f6.png">
<img width="978" alt="Captura de Pantalla 2022-06-16 a la(s) 10 29 01 a m" src="https://user-images.githubusercontent.com/66776217/174107317-c7167808-5f4c-43bf-969f-2577308bb3e4.png">

- Account with multiple permissions included authorized_teacher.
<img width="978" alt="Captura de Pantalla 2022-06-16 a la(s) 10 30 29 a m" src="https://user-images.githubusercontent.com/66776217/174106999-0da01aca-7e53-49ad-ba80-1a2058769fba.png">
<img width="978" alt="Captura de Pantalla 2022-06-16 a la(s) 1 26 58 p m" src="https://user-images.githubusercontent.com/66776217/174140464-3d7079a2-b2d2-40c5-a762-9d4ac959b186.png">

All tests were successful.

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
