### PR TITLE
Revert "Revert "Simplify header when viewing level page as a peer doing code review""

### DIFF
--- a/apps/src/code-studio/components/TeacherContentToggle.js
+++ b/apps/src/code-studio/components/TeacherContentToggle.js
@@ -25,7 +25,8 @@ class TeacherContentToggle extends React.Component {
     hiddenLessonsInitialized: PropTypes.bool.isRequired,
     sectionsAreLoaded: PropTypes.bool.isRequired,
     isHiddenLesson: PropTypes.bool.isRequired,
-    isLockedLesson: PropTypes.bool.isRequired
+    isLockedLesson: PropTypes.bool.isRequired,
+    isCodeReviewing: PropTypes.bool
   };
 
   componentDidMount() {
@@ -55,7 +56,8 @@ class TeacherContentToggle extends React.Component {
       sectionsAreLoaded,
       isLockedLesson,
       isHiddenLesson,
-      isBlocklyOrDroplet
+      isBlocklyOrDroplet,
+      isCodeReviewing
     } = this.props;
 
     const frameStyle = {
@@ -70,10 +72,14 @@ class TeacherContentToggle extends React.Component {
     };
     let hasOverlayFrame = isLockedLesson || isHiddenLesson;
 
-    if (viewAs === ViewType.Participant) {
+    if (viewAs === ViewType.Participant && !isCodeReviewing) {
+      // When a teacher is code reviewing another teacher, we load a different header experience
+      // so that we don't expose progress between peers. Section data is not loaded in this teacher-as-student
+      // viewing another teacher experience
+      const sectionsAreLoading = !sectionsAreLoaded && !isCodeReviewing;
       // Keep this hidden until we've made our async calls for hidden_lessons and
       // locked lessons, so that we don't flash content before hiding it
-      if (!hiddenLessonsInitialized || !sectionsAreLoaded || hasOverlayFrame) {
+      if (!hiddenLessonsInitialized || sectionsAreLoading || hasOverlayFrame) {
         contentStyle.visibility = 'hidden';
       }
     }
@@ -148,7 +154,8 @@ export const mapStateToProps = state => {
     sectionsAreLoaded: state.teacherSections.sectionsAreLoaded,
     hiddenLessonsInitialized: state.hiddenLesson.hiddenLessonsInitialized,
     isHiddenLesson,
-    isLockedLesson
+    isLockedLesson,
+    isCodeReviewing: state.pageConstants?.isCodeReviewing
   };
 };
 

--- a/apps/src/code-studio/components/TeacherContentToggle.js
+++ b/apps/src/code-studio/components/TeacherContentToggle.js
@@ -138,7 +138,7 @@ export const mapStateToProps = state => {
     );
   } else if (!state.verifiedInstructor.isVerified) {
     // if not-authorized teacher
-    isLockedLesson = state.progress.lessons.some(
+    isLockedLesson = state.progress.lessons?.some(
       lesson => lesson.id === currentLessonId && lesson.lockable
     );
   }

--- a/apps/src/code-studio/components/TeacherContentToggle.js
+++ b/apps/src/code-studio/components/TeacherContentToggle.js
@@ -72,7 +72,7 @@ class TeacherContentToggle extends React.Component {
     };
     let hasOverlayFrame = isLockedLesson || isHiddenLesson;
 
-    if (viewAs === ViewType.Participant && !isCodeReviewing) {
+    if (viewAs === ViewType.Participant) {
       // When a teacher is code reviewing another teacher, we load a different header experience
       // so that we don't expose progress between peers. Section data is not loaded in this teacher-as-student
       // viewing another teacher experience

--- a/apps/src/code-studio/components/header/HeaderMiddle.jsx
+++ b/apps/src/code-studio/components/header/HeaderMiddle.jsx
@@ -16,6 +16,7 @@ const lessonProgressExtraWidth = 10;
 class HeaderMiddle extends React.Component {
   static propTypes = {
     projectInfoOnly: PropTypes.bool,
+    scriptNameOnly: PropTypes.bool,
     appLoadStarted: PropTypes.bool,
     appLoaded: PropTypes.bool,
     scriptNameData: PropTypes.object,
@@ -78,6 +79,7 @@ class HeaderMiddle extends React.Component {
   static getWidths(
     width,
     projectInfoOnly,
+    scriptNameOnly,
     projectInfoDesiredWidth,
     scriptNameDesiredWidth,
     lessonProgressDesiredWidth,
@@ -90,6 +92,18 @@ class HeaderMiddle extends React.Component {
       return {
         projectInfo: Math.floor(Math.min(projectInfoDesiredWidth, width)),
         scriptName: 0,
+        progress: 0,
+        popup: 0,
+        finish: 0
+      };
+    }
+
+    if (scriptNameOnly) {
+      return {
+        projectInfo: 0,
+        scriptName: Math.floor(
+          Math.min(scriptNameDesiredWidth + scriptNameExtraWidth, width)
+        ),
         progress: 0,
         popup: 0,
         finish: 0
@@ -179,6 +193,7 @@ class HeaderMiddle extends React.Component {
     const widths = HeaderMiddle.getWidths(
       this.state.width,
       this.props.projectInfoOnly,
+      this.props.scriptNameOnly,
       this.state.projectInfoDesiredWidth,
       this.state.scriptNameDesiredWidth,
       this.state.lessonProgressDesiredWidth,

--- a/apps/src/code-studio/components/progress/teacherPanel/TeacherPanel.jsx
+++ b/apps/src/code-studio/components/progress/teacherPanel/TeacherPanel.jsx
@@ -320,7 +320,7 @@ export default connect(
     );
 
     let lessonNames = {};
-    state.progress.lessons.forEach(lesson => {
+    state.progress.lessons?.forEach(lesson => {
       lessonNames[lesson.id] = lesson.name;
     });
 

--- a/apps/src/code-studio/header.js
+++ b/apps/src/code-studio/header.js
@@ -139,6 +139,17 @@ header.buildProjectInfoOnly = function() {
   );
 };
 
+// When viewing the level page in code review mode, we want to show only the
+// lesson information (which is displayed by the ScriptName component).
+header.buildScriptNameOnly = function(scriptNameData) {
+  ReactDOM.render(
+    <Provider store={getStore()}>
+      <HeaderMiddle scriptNameData={scriptNameData} scriptNameOnly={true} />
+    </Provider>,
+    document.querySelector('.header_level')
+  );
+};
+
 // When the page is cached, this function is called to retrieve and set the
 // sign-in button or user menu in the DOM.
 header.buildUserMenu = function() {

--- a/apps/src/sites/studio/pages/levels/_teacher_panel.js
+++ b/apps/src/sites/studio/pages/levels/_teacher_panel.js
@@ -40,8 +40,14 @@ function initPage() {
   }
 
   // If a teacher is peer-reviewing another teacher in a workshop, don't render
-  // the teacher panel, as it doesn't make sense in that context
-  if (!window.appOptions.isCodeReviewing) {
+  // the teacher panel, as it doesn't make sense in that context.
+  // We need to check for presence of appOptions since some pages such as /extras
+  // (lesson extras page) do not set appOptions.
+  const shouldRenderTeacherPanel = window.appOptions
+    ? !window.appOptions.isCodeReviewing
+    : true;
+
+  if (shouldRenderTeacherPanel) {
     renderTeacherPanel(
       store,
       teacherPanelData.script_id,

--- a/apps/src/sites/studio/pages/levels/_teacher_panel.js
+++ b/apps/src/sites/studio/pages/levels/_teacher_panel.js
@@ -14,6 +14,7 @@ import {
   setUserRoleInCourse,
   CourseRoles
 } from '@cdo/apps/templates/currentUserRedux';
+import {queryParams} from '@cdo/apps/code-studio/utils';
 
 $(document).ready(initPage);
 
@@ -34,16 +35,20 @@ function initPage() {
   }
 
   if (teacherPanelData.is_instructor) {
-    store.dispatch(setViewType(ViewType.Instructor));
+    store.dispatch(setViewType(queryParams('viewAs') || ViewType.Instructor));
     store.dispatch(setUserRoleInCourse(CourseRoles.Instructor));
   }
 
-  renderTeacherPanel(
-    store,
-    teacherPanelData.script_id,
-    teacherPanelData.script_name,
-    teacherPanelData.page_type
-  );
+  // If a teacher is peer-reviewing another teacher in a workshop, don't render
+  // the teacher panel, as it doesn't make sense in that context
+  if (!window.appOptions.isCodeReviewing) {
+    renderTeacherPanel(
+      store,
+      teacherPanelData.script_id,
+      teacherPanelData.script_name,
+      teacherPanelData.page_type
+    );
+  }
 }
 
 function renderTeacherContentToggle(store) {

--- a/apps/test/unit/code-studio/components/header/HeaderMiddleTest.js
+++ b/apps/test/unit/code-studio/components/header/HeaderMiddleTest.js
@@ -10,6 +10,7 @@ describe('HeaderMiddle', () => {
     const widths = HeaderMiddle.getWidths(
       700,    // width,
       false,  // projectInfoOnly,
+      false,  // scriptNameOnly,
       0,      // projectInfoDesiredWidth,
       200,    // scriptNameDesiredWidth,
       350,    // lessonProgressDesiredWidth,
@@ -31,6 +32,7 @@ describe('HeaderMiddle', () => {
     const widths = HeaderMiddle.getWidths(
       350,    // width,
       false,  // projectInfoOnly,
+      false,  // scriptNameOnly,
       0,      // projectInfoDesiredWidth,
       200,    // scriptNameDesiredWidth,
       350,    // lessonProgressDesiredWidth,
@@ -52,6 +54,7 @@ describe('HeaderMiddle', () => {
     const widths = HeaderMiddle.getWidths(
       700,    // width,
       false,  // projectInfoOnly,
+      false,  // scriptNameOnly,
       200,    // projectInfoDesiredWidth,
       200,    // scriptNameDesiredWidth,
       350,    // lessonProgressDesiredWidth,
@@ -73,6 +76,7 @@ describe('HeaderMiddle', () => {
     const widths = HeaderMiddle.getWidths(
       350,    // width,
       false,  // projectInfoOnly,
+      false,  // scriptNameOnly,
       200,    // projectInfoDesiredWidth,
       200,    // scriptNameDesiredWidth,
       350,    // lessonProgressDesiredWidth,
@@ -94,6 +98,7 @@ describe('HeaderMiddle', () => {
     const widths = HeaderMiddle.getWidths(
       700,    // width,
       true,   // projectInfoOnly,
+      false,  // scriptNameOnly,
       400,    // projectInfoDesiredWidth,
       0,      // scriptNameDesiredWidth,
       0,      // lessonProgressDesiredWidth,
@@ -113,6 +118,7 @@ describe('HeaderMiddle', () => {
     const widths = HeaderMiddle.getWidths(
       350,    // width,
       true,   // projectInfoOnly,
+      false,  // scriptNameOnly,
       400,    // projectInfoDesiredWidth,
       0,      // scriptNameDesiredWidth,
       0,      // lessonProgressDesiredWidth,
@@ -123,6 +129,46 @@ describe('HeaderMiddle', () => {
 
     assert.equal(widths.projectInfo, 350);
     assert.equal(widths.scriptName, 0);
+    assert.equal(widths.progress, 0);
+    assert.equal(widths.popup, 0);
+    assert.equal(widths.finish, 0);
+  });
+
+  it('widths for script name only when wide', () => {
+    const widths = HeaderMiddle.getWidths(
+      700,    // width,
+      false,  // projectInfoOnly,
+      true,   // scriptNameOnly,
+      0,      // projectInfoDesiredWidth,
+      400,    // scriptNameDesiredWidth,
+      0,      // lessonProgressDesiredWidth,
+      0,      // numScriptLessons,
+      0,      // finishDesiredWidth,
+      false   // showFinish
+    );
+
+    assert.equal(widths.projectInfo, 0);
+    assert.equal(widths.scriptName, 410);
+    assert.equal(widths.progress, 0);
+    assert.equal(widths.popup, 0);
+    assert.equal(widths.finish, 0);
+  });
+
+  it('widths for script name only when narrow', () => {
+    const widths = HeaderMiddle.getWidths(
+      350,    // width,
+      false,  // projectInfoOnly,
+      true,   // scriptNameOnly,
+      0,      // projectInfoDesiredWidth,
+      400,    // scriptNameDesiredWidth,
+      0,      // lessonProgressDesiredWidth,
+      0,      // numScriptLessons,
+      0,      // finishDesiredWidth,
+      false   // showFinish
+    );
+
+    assert.equal(widths.projectInfo, 0);
+    assert.equal(widths.scriptName, 350);
     assert.equal(widths.progress, 0);
     assert.equal(widths.popup, 0);
     assert.equal(widths.finish, 0);

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -413,6 +413,7 @@ class ScriptLevelsController < ApplicationController
       @user = user_to_view
 
       if can?(:view_as_user_for_code_review, @script_level, user_to_view, sublevel_to_view)
+        @is_code_reviewing = true
         view_options(is_code_reviewing: true)
       end
     end

--- a/dashboard/app/views/layouts/_header.html.haml
+++ b/dashboard/app/views/layouts/_header.html.haml
@@ -42,7 +42,7 @@
   header_contents_options[:loc_prefix] = "nav.header."
   header_contents_options[:page_mode] = request.cookies['pm']
 
-  should_show_progress = script_level || @lesson_extras
+  should_show_progress = (script_level || @lesson_extras) && !@is_code_reviewing
 
   sign_in_user = current_user || user_type && OpenStruct.new(
     id: nil,
@@ -131,6 +131,12 @@
       href: script_path(@script, section_id: section_id, user_id: user_id),
       smallText: small_text
     }
+  elsif @is_code_reviewing
+    script_name_data = {
+      name: script_level.lesson.localized_title,
+      href: '#',  # When viewing peer code, link should do nothing
+      smallText: false
+    }
   end
 
 - if should_show_progress
@@ -149,6 +155,12 @@
       #{!script_level}
     )
     //]]>
+
+- elsif @is_code_reviewing
+  :javascript
+    dashboard.header.buildScriptNameOnly(
+      #{script_name_data.to_json}
+    )
 
 - elsif level
   :javascript


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#46879

Unblocks page load when the teacher is viewing as a participant in code review.

The problem: when a student is viewing a peer, we've decided not to load progress/header bubbles because it would expose a student's progress (and potentially feedback) to their peers. By removing the logic associated with loading progress for the header, we stopped loading progress and section data which was expected by the teacher panel. It's worth re-thinking if this is the right pattern. It would be nice if the teacher panel was a fully independent component and could load all of the data it needed itself. LP started working on this effort last year, but there is still more work to do here. (https://codedotorg.atlassian.net/browse/LP-2411) Additionally, it doesn't make sense for teachers to be rendering the teacher panel if they're in the PL experience. My understanding is that if the teacher is in a section which is assigned to the course, when they're on a level in that course they will not see the teacher panel. The errors that teachers were experiencing in PL this week had to do with logic in the rendering of the teacher panel, so it's likely something isn't working as expected in this area.

I was able to manually test the fix by creating a section for teachers, logging in as the teachers and attempting to do a code review. In Chrome, I saw errors in the console and in Safari I was seeing a full blank screen. The changes in this PR allow the code review to load without errors.