### PR TITLE
Extend wait time for flaky UI tests - ml_hoc.feature

### DIFF
--- a/dashboard/test/ui/features/hour_of_code/ml/ml_hoc.feature
+++ b/dashboard/test/ui/features/hour_of_code/ml/ml_hoc.feature
@@ -15,7 +15,7 @@ Feature: Oceans ML HoC
 
     # Sorting Screen
     Then I click selector "button:contains(Run)" once I see it
-    And I wait for 3 seconds
+    And I wait for 30 seconds
     Then I click selector "button:contains(Continue)" once I see it
 
     # Pond Screen
@@ -38,6 +38,7 @@ Feature: Oceans ML HoC
 
     # Sorting Screen
     Then I click selector "button:contains(Run)" once I see it
+    And I wait for 30 seconds
     Then I click selector "button:contains(Continue)" once I see it
 
     # Pond Screen
@@ -55,6 +56,7 @@ Feature: Oceans ML HoC
 
     # Sorting Screen
     Then I click selector "button:contains(Run)" once I see it
+    And I wait for 30 seconds
     Then I click selector "button:contains(Continue)" once I see it
 
     # Pond Screen
@@ -72,6 +74,7 @@ Feature: Oceans ML HoC
 
     # Sorting Screen
     Then I click selector "button:contains(Run)" once I see it
+    And I wait for 30 seconds
     Then I click selector "button:contains(Continue)" once I see it
 
     # Pond Screen


### PR DESCRIPTION
Similar to:
* https://github.com/code-dot-org/code-dot-org/pull/46655

The `ml_hoc.feature` ui tests have been consistently flaky over the past few months. I can consistent passing to occur on Chrome by extending the wait time for each test during the "Sorting Screen" portion of the activity.

Slack thread: https://codedotorg.slack.com/archives/C1B3PNDL7/p1655326262846249