### PR TITLE
Expanding sync-out to support all Lessons which have unique relative position

### DIFF
--- a/dashboard/lib/services/i18n/curriculum_sync_utils/sync_out.rb
+++ b/dashboard/lib/services/i18n/curriculum_sync_utils/sync_out.rb
@@ -58,16 +58,22 @@ module Services
           if result.key?(:lessons)
             rekeyed_lessons = result[:lessons].map do |lesson_url, lesson_data|
               route_params = Rails.application.routes.recognize_path(lesson_url)
-              lesson = Lesson.joins(:script).
-                find_by(
+              # Filter for only lessons which are "numbered".
+              # Only these lessons guarantee that their relative position is unique.
+              lessons = Lesson.joins(:script).
+                where(
                   "scripts.name": route_params[:script_id],
                   relative_position: route_params[:position].to_i,
-                  has_lesson_plan: true
-                )
-              unless lesson.present?
-                STDERR.puts "could not find lesson for url #{lesson_url.inspect}"
+                ).select(&:numbered_lesson?)
+              if lessons.count == 0
+                STDERR.puts "Could not find lesson for url #{lesson_url.inspect}"
                 next
               end
+              if lessons.count > 1
+                STDERR.puts "More than one lesson found for url #{lesson_url.inspect}. This should be investigated."
+                next
+              end
+              lesson = lessons.first
               [Services::GloballyUniqueIdentifiers.build_lesson_key(lesson), lesson_data]
             end
             result[:lessons] = rekeyed_lessons.compact.to_h


### PR DESCRIPTION
We got a report that some lessons did not have their `name` attribute available for translation. In particular, all the `allthethings` lessons were missing from the `lessons.*.json` files. After some investigation, I found that we were only translating lessons which have the attribute `has_lesson_plan`. We filter for only these lessons because our translation system requires that they have a consistent `relative_position` attribute. The `relative_position` is the lesson's "number" you see when viewing a URL on our website, for example https://studio.code.org/s/allthethings/lessons/4. After some digging I found that there is another attribute, `lockable` which also determines if the relative_position is constant. This `lockable` and `has_lesson_plan` business logic, is covered by the `numbered_lesson?` method, so this PR moves to relying on that.

Changes:
* Uses `lesson.numbered_lesson?` to determine which lessons we translate.
* Added some sanity checking to make sure there truly is only one lesson for a given relative_position.

## Links
* [JIRA](https://codedotorg.atlassian.net/browse/FND-2036)

## Testing story
Applied this change and ran the full i18n-sync on the `i18n-dev` server. The `lessons.*.json` files now contain the lesson names for `allthethings`, `20-hour`, and other lessons.
