### PR TITLE
Update `Gemfile.lock` after changes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -530,7 +530,6 @@ GEM
     kgio (2.11.3)
     launchy (2.4.3)
       addressable (~> 2.3)
-    le (2.7.2)
     libv8 (8.4.255.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/46747, which removed the `le` gem and one of the references to it from `Gemfile.lock`, but not _all_ references.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
