### PR TITLE
Fixing path to etag file

### DIFF
--- a/bin/i18n/oneoff/remove_etags.rb
+++ b/bin/i18n/oneoff/remove_etags.rb
@@ -3,7 +3,7 @@ require 'json'
 
 # The first argument should be a string which will match the keys of the etags you want to remove.
 files_to_remove = ARGV.first
-etags_file_path = '../crowdin/codeorg_etags.json'
+etags_file_path = './bin/i18n/crowdin/codeorg_etags.json'
 etags_file = File.read(etags_file_path)
 etags_json = JSON.parse(etags_file)
 etags_json.each do |locale, records|


### PR DESCRIPTION
I tried running this script on the `i18n-dev` server and it failed to find the etag file. This PR fixes the path.

## Testing
* Tested this change on the `i18n-dev` server and successfully ran the script