### PR TITLE
Normalize Mailer Preview Tests

### DIFF
--- a/dashboard/test/mailers/previews/pd_facilitator_application_mailer_preview.rb
+++ b/dashboard/test/mailers/previews/pd_facilitator_application_mailer_preview.rb
@@ -1,5 +1,5 @@
 # This can be viewed on non-production environments at /rails/mailers/pd/teacher_application_mailer
-class Pd::FacilitatorApplicationMailerPreview < ActionMailer::Preview
+class PdFacilitatorApplicationMailerPreview < ActionMailer::Preview
   include FactoryGirl::Syntax::Methods
   include Pd::Application::ActiveApplicationModels
 

--- a/dashboard/test/mailers/previews/pd_fit_weekend_registration_mailer_preview.rb
+++ b/dashboard/test/mailers/previews/pd_fit_weekend_registration_mailer_preview.rb
@@ -1,4 +1,4 @@
-class Pd::FitWeekendRegistrationMailerPreview < ActionMailer::Preview
+class PdFitWeekendRegistrationMailerPreview < ActionMailer::Preview
   include FactoryGirl::Syntax::Methods
 
   def confirmation_accept

--- a/dashboard/test/mailers/previews/pd_regional_partner_mini_contact_mailer_preview.rb
+++ b/dashboard/test/mailers/previews/pd_regional_partner_mini_contact_mailer_preview.rb
@@ -1,5 +1,5 @@
 # This can be viewed on non-production environments at /rails/mailers/pd/regional_partner_mini_contact_mailer
-class Pd::RegionalPartnerMiniContactMailerPreview < ActionMailer::Preview
+class PdRegionalPartnerMiniContactMailerPreview < ActionMailer::Preview
   include FactoryGirl::Syntax::Methods
 
   def contact_receipt_with_partner

--- a/dashboard/test/mailers/previews/pd_teacher_application_mailer_preview.rb
+++ b/dashboard/test/mailers/previews/pd_teacher_application_mailer_preview.rb
@@ -1,5 +1,5 @@
 # This can be viewed on non-production environments at /rails/mailers/pd/teacher_application_mailer
-class Pd::TeacherApplicationMailerPreview < ActionMailer::Preview
+class PdTeacherApplicationMailerPreview < ActionMailer::Preview
   include FactoryGirl::Syntax::Methods
   include Pd::Application::ActiveApplicationModels
 

--- a/dashboard/test/mailers/previews/pd_workshop_mailer_preview.rb
+++ b/dashboard/test/mailers/previews/pd_workshop_mailer_preview.rb
@@ -1,5 +1,5 @@
 # This can be viewed on non-production environments at /rails/mailers/pd/workshop_mailer
-class Pd::WorkshopMailerPreview < ActionMailer::Preview
+class PdWorkshopMailerPreview < ActionMailer::Preview
   include FactoryGirl::Syntax::Methods
 
   DEFAULT_COURSE = Pd::Workshop::COURSE_ECS

--- a/dashboard/test/mailers/previews/traverse_mail_previews_test.rb
+++ b/dashboard/test/mailers/previews/traverse_mail_previews_test.rb
@@ -4,11 +4,7 @@ class TraverseMailPreviewsTest < ActiveSupport::TestCase
   test 'Verify all mailers can be run' do
     classes = Dir['./test/mailers/previews/*_preview.rb'].map do |file|
       require file
-      if file.scan(/\/pd_([\w_]+).rb/).empty?
-        Object.const_get(file.scan(/\/([\w_]+).rb/).first.first.camelize)
-      else
-        Object.const_get('Pd::' + file.scan(/\/pd_([\w_]+).rb/).first.first.camelize)
-      end
+      Object.const_get(file.scan(/\/([\w_]+).rb/).first.first.camelize)
     end
 
     classes.each do |klass|


### PR DESCRIPTION
Specifically, remove the pseudo-module we're emulating here for the `Pd::` namespace, as well as the namespace itself.

This is in the hopes of eventually enabling the Zeitwerk code loader.  Alternatively, if we really want to keep the namespace we could move this code into a new `pd/` directory and update the test to traverse that subdirectory as well as its current one; but I think this simple solution is preferable.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
