### PR TITLE
[micro:bit] Remove firmware test 

### DIFF
--- a/apps/src/lib/kits/maker/boards/microBit/MicroBitBoard.js
+++ b/apps/src/lib/kits/maker/boards/microBit/MicroBitBoard.js
@@ -11,7 +11,6 @@ import ExternalLed from './ExternalLed';
 import ExternalButton from './ExternalButton';
 import CapacitiveTouchSensor from './CapacitiveTouchSensor';
 import {isChromeOS, serialPortType} from '../../util/browserChecks';
-import {MICROBIT_FIRMWARE_VERSION} from './MicroBitConstants';
 
 /**
  * Controller interface for BBC micro:bit board using
@@ -97,15 +96,6 @@ export default class MicroBitBoard extends EventEmitter {
     return Promise.resolve()
       .then(() => this.openSerialPort())
       .then(serialPort => this.boardClient_.connectBoard(serialPort))
-      .then(() => {
-        if (
-          this.boardClient_.firmwareVersion.includes(MICROBIT_FIRMWARE_VERSION)
-        ) {
-          return Promise.resolve();
-        } else {
-          return Promise.reject('Incorrect firmware detected');
-        }
-      })
       .catch(err => Promise.reject(err));
   }
 

--- a/apps/test/unit/lib/kits/maker/boards/microBit/MicroBitBoardTest.js
+++ b/apps/test/unit/lib/kits/maker/boards/microBit/MicroBitBoardTest.js
@@ -5,8 +5,7 @@ import sinon from 'sinon';
 import {itImplementsTheMakerBoardInterface} from '../MakerBoardTest';
 import {
   MB_COMPONENT_COUNT,
-  MB_COMPONENTS,
-  MICROBIT_FIRMWARE_VERSION
+  MB_COMPONENTS
 } from '@cdo/apps/lib/kits/maker/boards/microBit/MicroBitConstants';
 import ExternalLed from '@cdo/apps/lib/kits/maker/boards/microBit/ExternalLed';
 import ExternalButton from '@cdo/apps/lib/kits/maker/boards/microBit/ExternalButton';
@@ -16,7 +15,6 @@ function boardSetupAndStub(board) {
   stubOpenSerialPort(board);
   sinon.stub(board.boardClient_, 'connectBoard').callsFake(() => {
     board.boardClient_.myPort = {write: () => {}};
-    board.boardClient_.firmwareVersion = `Long String Includes ${MICROBIT_FIRMWARE_VERSION}`;
     sinon.stub(board.boardClient_.myPort, 'write');
   });
 }


### PR DESCRIPTION
Report from micro:bit partners that maker/setup was not working and was failing at this step. Quotes from email correspondence below:
```The problems seems to be here:
return e.boardClient_.firmwareVersion.includes(c.MICROBIT_FIRMWARE_VERSION) ? Promise.resolve() : Promise.reject("Incorrect firmware detected")

I'm assuming [this](https://github.com/code-dot-org/code-dot-org/blob/72c85bdd1a65ebfa25632122168c9da2e17d7a1a/apps/src/lib/kits/maker/boards/microBit/MicroBitBoard.js#L102) is the source.  When it's executing, the  `e.boardClient_. firmwareVersion` is the empty string (""). So of course it fails!
```

and 

```An error in the firmware check appears be the hangup.  I used the debugger and changed the value of MICROBIT_FIRMWARE_VERSION used for comparison to be "" (empty string). .  After that I was able to get a primitive app to run and report updates to accelerometer values.  So....seems pretty likely that the hangup is all due to the initial firmware version check process.```

This appears to be a race condition, since I (EPeach) can't repro this locally and we haven't had reports from people on our team who've tested this. Since we are still in pre-Beta release, I'm going to remove this check for now and add a Jira ticket to track re-adding this check. The only downside to removing this is that we now aren't able to identify if people have incorrect firmware. Since this is pre-Beta and this error is blocking our partners, I think this is appropriate to remove.