### PR TITLE
always use migrated teacher resources for unit groups

### DIFF
--- a/apps/src/sites/studio/pages/courses/show.js
+++ b/apps/src/sites/studio/pages/courses/show.js
@@ -117,9 +117,7 @@ function showCourseOverview() {
         redirectToCourseUrl={scriptData.redirect_to_course_url}
         showAssignButton={courseSummary.show_assign_button}
         userId={userId}
-        useMigratedResources={
-          courseSummary.is_migrated && !teacherResources.length
-        }
+        useMigratedResources
       />
     </Provider>,
     document.getElementById('course_overview')


### PR DESCRIPTION
We have fully moved onto migrated teacher resources for _units_. This is the next step for moving onto migrated teacher resources for _unit groups_. For more details, see [work plan](https://docs.google.com/document/d/1yIL2Z7aqFTdbCi24-RpUhPO_B3wRdsiKRTB1EEs17EY/edit#). 

## Screenshots

We don't officially support translations of any unit groups into other languages today, however we do happen to have some translated teacher resources on csd-2021. I used that unit group to verify that any translations we are currently showing on prod will continue to be translated after this change. The screenshot also shows that we are now using migrated resources:

![Screen Shot 2022-06-22 at 9 25 49 PM](https://user-images.githubusercontent.com/8001765/175209128-02124148-ffdf-4c0e-8199-d707dde236b8.png)

The edit page already uses migrated resources because of this line: https://github.com/code-dot-org/code-dot-org/blob/302d29eb468700759ac7035b9f6e34fd873c073c/apps/src/sites/studio/pages/courses/edit.js#L84

![Screen Shot 2022-06-22 at 9 32 26 PM](https://user-images.githubusercontent.com/8001765/175210013-078df717-d54f-444b-9c30-0d8321037ec1.png)

## Testing story

relying on existing tests to make sure I didn't break anything. also manually verified as shown in screenshots.

## Follow-up work

The next step is to remove all unmigrated teacher resources from unit groups. For more details, see [work plan](https://docs.google.com/document/d/1yIL2Z7aqFTdbCi24-RpUhPO_B3wRdsiKRTB1EEs17EY/edit#). 
