### PR TITLE
[Minecraft] Remove video levels from CourseD (2022) lesson 13

### DIFF
--- a/dashboard/config/scripts_json/coursed-2022.script_json
+++ b/dashboard/config/scripts_json/coursed-2022.script_json
@@ -15,7 +15,7 @@
     },
     "new_name": null,
     "family_name": "coursed",
-    "serialized_at": "2022-05-20 16:08:20 UTC",
+    "serialized_at": "2022-06-22 18:44:06 UTC",
     "published_state": "preview",
     "instruction_type": "teacher_led",
     "instructor_audience": "teacher",
@@ -6488,31 +6488,6 @@
       "assessment": false,
       "properties": {
         "level_keys": [
-          "coursed_looking_ahead_minecraft_intro"
-        ],
-        "progression": "Video: Learn the Basics of Computer Science"
-      },
-      "bonus": false,
-      "seeding_key": {
-        "script_level.level_keys": [
-          "coursed_looking_ahead_minecraft_intro"
-        ],
-        "lesson.key": "Looking Ahead with Minecraft",
-        "lesson_group.key": "csf_conditionals",
-        "script.name": "coursed-2022",
-        "activity_section.key": "33686a06-d5bc-4529-8795-2dff33211d3b"
-      },
-      "level_keys": [
-        "coursed_looking_ahead_minecraft_intro"
-      ]
-    },
-    {
-      "chapter": 102,
-      "position": 2,
-      "activity_section_position": 1,
-      "assessment": false,
-      "properties": {
-        "level_keys": [
           "Overworld Move to Sheep2022"
         ]
       },
@@ -6531,8 +6506,8 @@
       ]
     },
     {
-      "chapter": 103,
-      "position": 3,
+      "chapter": 102,
+      "position": 2,
       "activity_section_position": 2,
       "assessment": false,
       "properties": {
@@ -6555,8 +6530,8 @@
       ]
     },
     {
-      "chapter": 104,
-      "position": 4,
+      "chapter": 103,
+      "position": 3,
       "activity_section_position": 3,
       "assessment": false,
       "properties": {
@@ -6579,8 +6554,8 @@
       ]
     },
     {
-      "chapter": 105,
-      "position": 5,
+      "chapter": 104,
+      "position": 4,
       "activity_section_position": 4,
       "assessment": false,
       "properties": {
@@ -6603,32 +6578,8 @@
       ]
     },
     {
-      "chapter": 106,
-      "position": 6,
-      "activity_section_position": 1,
-      "assessment": false,
-      "properties": {
-        "level_keys": [
-          "coursed_looking_ahead_minecraft_repeat_loops"
-        ]
-      },
-      "bonus": false,
-      "seeding_key": {
-        "script_level.level_keys": [
-          "coursed_looking_ahead_minecraft_repeat_loops"
-        ],
-        "lesson.key": "Looking Ahead with Minecraft",
-        "lesson_group.key": "csf_conditionals",
-        "script.name": "coursed-2022",
-        "activity_section.key": "749a46b8-fc1f-4727-85bb-0e225b727c26"
-      },
-      "level_keys": [
-        "coursed_looking_ahead_minecraft_repeat_loops"
-      ]
-    },
-    {
-      "chapter": 107,
-      "position": 7,
+      "chapter": 105,
+      "position": 5,
       "activity_section_position": 1,
       "assessment": false,
       "properties": {
@@ -6652,8 +6603,8 @@
       ]
     },
     {
-      "chapter": 108,
-      "position": 8,
+      "chapter": 106,
+      "position": 6,
       "activity_section_position": 2,
       "assessment": false,
       "properties": {
@@ -6677,8 +6628,8 @@
       ]
     },
     {
-      "chapter": 109,
-      "position": 9,
+      "chapter": 107,
+      "position": 7,
       "activity_section_position": 3,
       "assessment": false,
       "properties": {
@@ -6702,8 +6653,8 @@
       ]
     },
     {
-      "chapter": 110,
-      "position": 10,
+      "chapter": 108,
+      "position": 8,
       "activity_section_position": 4,
       "assessment": false,
       "properties": {
@@ -6727,8 +6678,8 @@
       ]
     },
     {
-      "chapter": 111,
-      "position": 11,
+      "chapter": 109,
+      "position": 9,
       "activity_section_position": 5,
       "assessment": false,
       "properties": {
@@ -6752,8 +6703,8 @@
       ]
     },
     {
-      "chapter": 112,
-      "position": 12,
+      "chapter": 110,
+      "position": 10,
       "activity_section_position": 6,
       "assessment": false,
       "properties": {
@@ -6777,32 +6728,8 @@
       ]
     },
     {
-      "chapter": 113,
-      "position": 13,
-      "activity_section_position": 1,
-      "assessment": false,
-      "properties": {
-        "level_keys": [
-          "coursed_looking_ahead_minecraft_if_statements"
-        ]
-      },
-      "bonus": false,
-      "seeding_key": {
-        "script_level.level_keys": [
-          "coursed_looking_ahead_minecraft_if_statements"
-        ],
-        "lesson.key": "Looking Ahead with Minecraft",
-        "lesson_group.key": "csf_conditionals",
-        "script.name": "coursed-2022",
-        "activity_section.key": "2ef8d43a-13d4-41ee-8d7f-3aa952ae04de"
-      },
-      "level_keys": [
-        "coursed_looking_ahead_minecraft_if_statements"
-      ]
-    },
-    {
-      "chapter": 114,
-      "position": 14,
+      "chapter": 111,
+      "position": 11,
       "activity_section_position": 1,
       "assessment": false,
       "properties": {
@@ -6827,8 +6754,8 @@
       ]
     },
     {
-      "chapter": 115,
-      "position": 15,
+      "chapter": 112,
+      "position": 12,
       "activity_section_position": 2,
       "assessment": false,
       "properties": {
@@ -6853,8 +6780,8 @@
       ]
     },
     {
-      "chapter": 116,
-      "position": 16,
+      "chapter": 113,
+      "position": 13,
       "activity_section_position": 3,
       "assessment": false,
       "properties": {
@@ -6878,33 +6805,8 @@
       ]
     },
     {
-      "chapter": 117,
-      "position": 17,
-      "activity_section_position": 1,
-      "assessment": false,
-      "properties": {
-        "level_keys": [
-          "coursed_looking_ahead_minecraft_congratulations"
-        ],
-        "progression": "Video: Congratulations"
-      },
-      "bonus": false,
-      "seeding_key": {
-        "script_level.level_keys": [
-          "coursed_looking_ahead_minecraft_congratulations"
-        ],
-        "lesson.key": "Looking Ahead with Minecraft",
-        "lesson_group.key": "csf_conditionals",
-        "script.name": "coursed-2022",
-        "activity_section.key": "c892041f-8717-4cbf-b00b-9d0b5faaf3f5"
-      },
-      "level_keys": [
-        "coursed_looking_ahead_minecraft_congratulations"
-      ]
-    },
-    {
-      "chapter": 118,
-      "position": 18,
+      "chapter": 114,
+      "position": 14,
       "activity_section_position": 1,
       "assessment": false,
       "properties": {
@@ -6928,8 +6830,8 @@
       ]
     },
     {
-      "chapter": 119,
-      "position": 19,
+      "chapter": 115,
+      "position": 15,
       "activity_section_position": 1,
       "assessment": false,
       "properties": {
@@ -6953,8 +6855,8 @@
       ]
     },
     {
-      "chapter": 120,
-      "position": 20,
+      "chapter": 116,
+      "position": 16,
       "activity_section_position": 2,
       "assessment": false,
       "properties": {
@@ -6978,7 +6880,7 @@
       ]
     },
     {
-      "chapter": 121,
+      "chapter": 117,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -7003,7 +6905,7 @@
       ]
     },
     {
-      "chapter": 122,
+      "chapter": 118,
       "position": 2,
       "activity_section_position": 1,
       "assessment": false,
@@ -7028,7 +6930,7 @@
       ]
     },
     {
-      "chapter": 123,
+      "chapter": 119,
       "position": 3,
       "activity_section_position": 1,
       "assessment": false,
@@ -7053,7 +6955,7 @@
       ]
     },
     {
-      "chapter": 124,
+      "chapter": 120,
       "position": 4,
       "activity_section_position": 2,
       "assessment": false,
@@ -7078,7 +6980,7 @@
       ]
     },
     {
-      "chapter": 125,
+      "chapter": 121,
       "position": 5,
       "activity_section_position": 3,
       "assessment": false,
@@ -7103,7 +7005,7 @@
       ]
     },
     {
-      "chapter": 126,
+      "chapter": 122,
       "position": 6,
       "activity_section_position": 4,
       "assessment": false,
@@ -7128,7 +7030,7 @@
       ]
     },
     {
-      "chapter": 127,
+      "chapter": 123,
       "position": 7,
       "activity_section_position": 5,
       "assessment": false,
@@ -7153,7 +7055,7 @@
       ]
     },
     {
-      "chapter": 128,
+      "chapter": 124,
       "position": 8,
       "activity_section_position": 1,
       "assessment": false,
@@ -7178,7 +7080,7 @@
       ]
     },
     {
-      "chapter": 129,
+      "chapter": 125,
       "position": 9,
       "activity_section_position": 1,
       "assessment": false,
@@ -7203,7 +7105,7 @@
       ]
     },
     {
-      "chapter": 130,
+      "chapter": 126,
       "position": 10,
       "activity_section_position": 1,
       "assessment": false,
@@ -7228,7 +7130,7 @@
       ]
     },
     {
-      "chapter": 131,
+      "chapter": 127,
       "position": 11,
       "activity_section_position": 1,
       "assessment": false,
@@ -7254,7 +7156,7 @@
       ]
     },
     {
-      "chapter": 132,
+      "chapter": 128,
       "position": 12,
       "activity_section_position": 1,
       "assessment": false,
@@ -7279,7 +7181,7 @@
       ]
     },
     {
-      "chapter": 133,
+      "chapter": 129,
       "position": 13,
       "activity_section_position": 2,
       "assessment": false,
@@ -7304,7 +7206,7 @@
       ]
     },
     {
-      "chapter": 134,
+      "chapter": 130,
       "position": 14,
       "activity_section_position": 1,
       "assessment": false,
@@ -7329,7 +7231,7 @@
       ]
     },
     {
-      "chapter": 135,
+      "chapter": 131,
       "position": 15,
       "activity_section_position": 2,
       "assessment": false,
@@ -7354,7 +7256,7 @@
       ]
     },
     {
-      "chapter": 136,
+      "chapter": 132,
       "position": 16,
       "activity_section_position": 1,
       "assessment": false,
@@ -7379,7 +7281,7 @@
       ]
     },
     {
-      "chapter": 137,
+      "chapter": 133,
       "position": 17,
       "activity_section_position": 2,
       "assessment": false,
@@ -7404,7 +7306,7 @@
       ]
     },
     {
-      "chapter": 138,
+      "chapter": 134,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -7429,7 +7331,7 @@
       ]
     },
     {
-      "chapter": 139,
+      "chapter": 135,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -7454,7 +7356,7 @@
       ]
     },
     {
-      "chapter": 140,
+      "chapter": 136,
       "position": 3,
       "activity_section_position": 3,
       "assessment": false,
@@ -7479,7 +7381,7 @@
       ]
     },
     {
-      "chapter": 141,
+      "chapter": 137,
       "position": 4,
       "activity_section_position": 1,
       "assessment": false,
@@ -7504,7 +7406,7 @@
       ]
     },
     {
-      "chapter": 142,
+      "chapter": 138,
       "position": 5,
       "activity_section_position": 1,
       "assessment": false,
@@ -7529,7 +7431,7 @@
       ]
     },
     {
-      "chapter": 143,
+      "chapter": 139,
       "position": 6,
       "activity_section_position": 1,
       "assessment": false,
@@ -7554,7 +7456,7 @@
       ]
     },
     {
-      "chapter": 144,
+      "chapter": 140,
       "position": 7,
       "activity_section_position": 2,
       "assessment": false,
@@ -7579,7 +7481,7 @@
       ]
     },
     {
-      "chapter": 145,
+      "chapter": 141,
       "position": 8,
       "activity_section_position": 3,
       "assessment": false,
@@ -7604,7 +7506,7 @@
       ]
     },
     {
-      "chapter": 146,
+      "chapter": 142,
       "position": 9,
       "activity_section_position": 4,
       "assessment": false,
@@ -7629,7 +7531,7 @@
       ]
     },
     {
-      "chapter": 147,
+      "chapter": 143,
       "position": 10,
       "activity_section_position": 1,
       "assessment": false,
@@ -7655,7 +7557,7 @@
       ]
     },
     {
-      "chapter": 148,
+      "chapter": 144,
       "position": 11,
       "activity_section_position": 1,
       "assessment": false,
@@ -7680,7 +7582,7 @@
       ]
     },
     {
-      "chapter": 149,
+      "chapter": 145,
       "position": 12,
       "activity_section_position": 2,
       "assessment": false,
@@ -7705,7 +7607,7 @@
       ]
     },
     {
-      "chapter": 150,
+      "chapter": 146,
       "position": 13,
       "activity_section_position": 1,
       "assessment": false,
@@ -7730,7 +7632,7 @@
       ]
     },
     {
-      "chapter": 151,
+      "chapter": 147,
       "position": 14,
       "activity_section_position": 1,
       "assessment": false,
@@ -7755,7 +7657,7 @@
       ]
     },
     {
-      "chapter": 152,
+      "chapter": 148,
       "position": 15,
       "activity_section_position": 1,
       "assessment": false,
@@ -7780,7 +7682,7 @@
       ]
     },
     {
-      "chapter": 153,
+      "chapter": 149,
       "position": 16,
       "activity_section_position": 2,
       "assessment": false,
@@ -7805,7 +7707,7 @@
       ]
     },
     {
-      "chapter": 154,
+      "chapter": 150,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -7830,7 +7732,7 @@
       ]
     },
     {
-      "chapter": 155,
+      "chapter": 151,
       "position": 2,
       "activity_section_position": 1,
       "assessment": false,
@@ -7855,7 +7757,7 @@
       ]
     },
     {
-      "chapter": 156,
+      "chapter": 152,
       "position": 3,
       "activity_section_position": 1,
       "assessment": false,
@@ -7880,7 +7782,7 @@
       ]
     },
     {
-      "chapter": 157,
+      "chapter": 153,
       "position": 4,
       "activity_section_position": 1,
       "assessment": false,
@@ -7905,7 +7807,7 @@
       ]
     },
     {
-      "chapter": 158,
+      "chapter": 154,
       "position": 5,
       "activity_section_position": 2,
       "assessment": false,
@@ -7930,7 +7832,7 @@
       ]
     },
     {
-      "chapter": 159,
+      "chapter": 155,
       "position": 6,
       "activity_section_position": 3,
       "assessment": false,
@@ -7955,7 +7857,7 @@
       ]
     },
     {
-      "chapter": 160,
+      "chapter": 156,
       "position": 7,
       "activity_section_position": 4,
       "assessment": false,
@@ -7980,7 +7882,7 @@
       ]
     },
     {
-      "chapter": 161,
+      "chapter": 157,
       "position": 8,
       "activity_section_position": 5,
       "assessment": false,
@@ -8005,7 +7907,7 @@
       ]
     },
     {
-      "chapter": 162,
+      "chapter": 158,
       "position": 9,
       "activity_section_position": 1,
       "assessment": false,
@@ -8031,7 +7933,7 @@
       ]
     },
     {
-      "chapter": 163,
+      "chapter": 159,
       "position": 10,
       "activity_section_position": 1,
       "assessment": false,
@@ -8056,7 +7958,7 @@
       ]
     },
     {
-      "chapter": 164,
+      "chapter": 160,
       "position": 11,
       "activity_section_position": 1,
       "assessment": false,
@@ -8081,7 +7983,7 @@
       ]
     },
     {
-      "chapter": 165,
+      "chapter": 161,
       "position": 12,
       "activity_section_position": 1,
       "assessment": false,
@@ -8106,7 +8008,7 @@
       ]
     },
     {
-      "chapter": 166,
+      "chapter": 162,
       "position": 13,
       "activity_section_position": 2,
       "assessment": false,
@@ -8131,7 +8033,7 @@
       ]
     },
     {
-      "chapter": 167,
+      "chapter": 163,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -8156,7 +8058,7 @@
       ]
     },
     {
-      "chapter": 168,
+      "chapter": 164,
       "position": 2,
       "activity_section_position": 1,
       "assessment": false,
@@ -9384,18 +9286,6 @@
     },
     {
       "seeding_key": {
-        "level.key": "coursed_looking_ahead_minecraft_intro",
-        "script_level.level_keys": [
-          "coursed_looking_ahead_minecraft_intro"
-        ],
-        "lesson.key": "Looking Ahead with Minecraft",
-        "lesson_group.key": "csf_conditionals",
-        "script.name": "coursed-2022",
-        "activity_section.key": "33686a06-d5bc-4529-8795-2dff33211d3b"
-      }
-    },
-    {
-      "seeding_key": {
         "level.key": "Overworld Move to Sheep2022",
         "script_level.level_keys": [
           "Overworld Move to Sheep2022"
@@ -9440,18 +9330,6 @@
         "lesson_group.key": "csf_conditionals",
         "script.name": "coursed-2022",
         "activity_section.key": "419b0732-9e07-4ab2-8c48-0fb798dfdfde"
-      }
-    },
-    {
-      "seeding_key": {
-        "level.key": "coursed_looking_ahead_minecraft_repeat_loops",
-        "script_level.level_keys": [
-          "coursed_looking_ahead_minecraft_repeat_loops"
-        ],
-        "lesson.key": "Looking Ahead with Minecraft",
-        "lesson_group.key": "csf_conditionals",
-        "script.name": "coursed-2022",
-        "activity_section.key": "749a46b8-fc1f-4727-85bb-0e225b727c26"
       }
     },
     {
@@ -9528,18 +9406,6 @@
     },
     {
       "seeding_key": {
-        "level.key": "coursed_looking_ahead_minecraft_if_statements",
-        "script_level.level_keys": [
-          "coursed_looking_ahead_minecraft_if_statements"
-        ],
-        "lesson.key": "Looking Ahead with Minecraft",
-        "lesson_group.key": "csf_conditionals",
-        "script.name": "coursed-2022",
-        "activity_section.key": "2ef8d43a-13d4-41ee-8d7f-3aa952ae04de"
-      }
-    },
-    {
-      "seeding_key": {
         "level.key": "Underground Avoiding Lava2022",
         "script_level.level_keys": [
           "Underground Avoiding Lava2022"
@@ -9572,18 +9438,6 @@
         "lesson_group.key": "csf_conditionals",
         "script.name": "coursed-2022",
         "activity_section.key": "4d4e1c44-ff30-4ba6-bdcc-67dc52d3c85a"
-      }
-    },
-    {
-      "seeding_key": {
-        "level.key": "coursed_looking_ahead_minecraft_congratulations",
-        "script_level.level_keys": [
-          "coursed_looking_ahead_minecraft_congratulations"
-        ],
-        "lesson.key": "Looking Ahead with Minecraft",
-        "lesson_group.key": "csf_conditionals",
-        "script.name": "coursed-2022",
-        "activity_section.key": "c892041f-8717-4cbf-b00b-9d0b5faaf3f5"
       }
     },
     {


### PR DESCRIPTION
## Problem

We recently got a ZenDesk [ticket](https://codeorg.zendesk.com/agent/tickets/388407) demonstrating that Minecraft lessons in Course D are not working as expected. This breaking change occurred when the curriculum team did work to pull embedded videos out to separate levels. Unfortunately, the way this activity was built requires that specific levels fall in a hard-coded order that cannot be changed. [STAR-2333](https://codedotorg.atlassian.net/browse/STAR-2333)

Because the lesson is currently broken, and about to be marked "Recommended", the desired change is to manually revert the levels to how they appeared in 2021 courses and older - ie. remove the separate video levels and instead make sure the video autoplay within the actual Minecraft levels.

## Risks

Unfortunately, changes to level order like this are likely to break progress for students. This is unavoidable because the lesson is currently broken. Fortunately, this lesson has seen very low traffic from students in the time since the course was marked "Preview":
![image](https://user-images.githubusercontent.com/43474485/175119935-f440266a-5536-41a5-9db7-0b53b817e7f4.png)
[Google Analytics](https://analytics.google.com/analytics/web/#/report/content-pages/a37745279w66217109p68074336/_u.date00=20220523&_u.date01=20220622&explorer-table.filter=coursed-2022~2Flessons~2F13~2Flevels~2F&explorer-table.plotKeys=%5B%5D&explorer-table.rowCount=100&explorer-graphOptions.selected=analytics.nthMonth&explorer-table-tableMode.selected=data&explorer-table-dataTable.sortColumnName=analytics.pageviews&explorer-table-dataTable.sortDescending=true/)

Elijah brought up that there may also be risks to translations.

## Proposed Solution

After meeting with Emma from the curriculum team and Dave from EPT, we agreed that it made sense to revert the level changes, despite the risks. Because the script is in "Preview" mode, it requires engineering work to undo the changes.

### Process used:
1. On levelbuilder, Emma ensured that all videos in the actual Minecraft levels were set to autoplay as they had originally done.
2. Locally, I manually set the `published_state` state of `coursed-2022` to "in_development".
3. Locally, using the levelbuilder UI, I removed the four unwanted standalone video levels and set the course back to "Preview".

Once merged, Emma will update the lesson plan and resources such as slide decks as needed.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->


- Slack Threads: 
  -  [#curriculum-team](https://codedotorg.slack.com/archives/CFGAVL2CA/p1655910691438459) 
  - [#ed-programs-tools](https://codedotorg.slack.com/archives/C02EEGWLHR8/p1655916730940669)
- jira ticket: [STAR-2328: [Minecraft] Tree not removable, unless failure first](https://codedotorg.atlassian.net/browse/STAR-2328)
- ZenDesk Ticket: [Bug in Course coursed-2022 lesson 13 Puzzle 3htt...](https://codeorg.zendesk.com/agent/tickets/388407)
- Google Analytics: [Traffic to `coursed-2022/lessons/13/levels/` since May 23](https://analytics.google.com/analytics/web/#/report/content-pages/a37745279w66217109p68074336/_u.date00=20220523&_u.date01=20220622&explorer-table.filter=coursed-2022~2Flessons~2F13~2Flevels~2F&explorer-table.plotKeys=%5B%5D&explorer-table.rowCount=100&explorer-graphOptions.selected=analytics.nthMonth&explorer-table-tableMode.selected=data&explorer-table-dataTable.sortColumnName=analytics.pageviews&explorer-table-dataTable.sortDescending=true/)

## Follow-up work

Emma to confirm lesson plan and resources align to level order before final publishing date. Corrections to be made via levelbuilder.

[STAR-2333: [Minecraft] Adventurer levels cannot be re-ordered](https://codedotorg.atlassian.net/browse/STAR-2333)

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
