### PR TITLE
Destroy instead of delete followers to delete code review group members

### DIFF
--- a/dashboard/app/models/code_review_group_member.rb
+++ b/dashboard/app/models/code_review_group_member.rb
@@ -22,6 +22,6 @@ class CodeReviewGroupMember < ApplicationRecord
   belongs_to :code_review_group
 
   def name
-    return follower.student_user.name
+    follower&.student_user&.name || ''
   end
 end

--- a/dashboard/app/models/follower.rb
+++ b/dashboard/app/models/follower.rb
@@ -23,7 +23,7 @@ class Follower < ApplicationRecord
   belongs_to :section, optional: true
   has_one :user, through: :section
   belongs_to :student_user, class_name: 'User', optional: true
-  has_one :code_review_group_member, dependent: :delete
+  has_one :code_review_group_member, dependent: :destroy
   has_one :code_review_group, through: :code_review_group_member
 
   accepts_nested_attributes_for :student_user

--- a/dashboard/app/models/sections/section.rb
+++ b/dashboard/app/models/sections/section.rb
@@ -284,7 +284,7 @@ class Section < ApplicationRecord
   # Follower is determined by the controller so that it can authorize first.
   # Optionally email the teacher.
   def remove_student(student, follower, options)
-    follower.delete
+    follower.destroy
 
     if student.sections_as_student.empty?
       if student.under_13?


### PR DESCRIPTION
Our controller action to delete followers used Rails `delete`, which skips callbacks. We rely on callbacks to destroy code review group members when a follower is deleted, so I moved us to use `destroy` (I believe this is more standard anyway).

I don't see any usages where we'd be explicitly choosing to using delete instead of destroy. I don't see any other callbacks when a follower is deleted, and I looked at the PR where this logic was added originally and don't see any mention of choosing explicitly to use delete over destroy.

## Testing story

I tested manually in the console that running `follower.delete` did not delete associated code review group member records, but running `follower.destroy` did.

## Follow-up work

It's possible that existing groups where a follower has been deleted will face continued issues. Given we only have one report at this moment (which I've fixed manually), I'm inclined to just wait and see. 