### PR TITLE
[WebSerial] Emit disconnect event if device is lost

### DIFF
--- a/apps/src/lib/kits/maker/WebSerialPortWrapper.js
+++ b/apps/src/lib/kits/maker/WebSerialPortWrapper.js
@@ -1,6 +1,8 @@
 import {EventEmitter} from 'events';
 import {SERIAL_BAUD} from '@cdo/apps/lib/kits/maker/util/boardUtils';
 
+const DEVICE_LOST_ERROR_CODE = 19;
+
 export default class WebSerialPortWrapper extends EventEmitter {
   constructor(port) {
     super();
@@ -37,7 +39,7 @@ export default class WebSerialPortWrapper extends EventEmitter {
       .then(async () => {
         this.portOpen = true;
         this.emit('open');
-        while (this.port.readable.locked) {
+        while (this.port.readable?.locked) {
           try {
             const {value, done} = await this.reader.read();
             if (done) {
@@ -46,6 +48,10 @@ export default class WebSerialPortWrapper extends EventEmitter {
             this.emit('data', Buffer.from(value));
           } catch (e) {
             console.error(e);
+
+            if (e.code === DEVICE_LOST_ERROR_CODE) {
+              this.emit('disconnect');
+            }
           }
         }
       });


### PR DESCRIPTION
This change makes it so that we can recover gracefully if the device is disconnected while a user's Applab app is running.

When the device is disconnected while the app is running...
- **Before:** Nothing happens
- **After:** The app is reset and we attempt to reconnect when the app is run again

It's hard to tell what's going on in this video because you can't see me disconnecting and reconnecting the device, but here's an explanation:
1. Connect the device
2. Run the app
3. Disconnect the device (unplug the board from my USB port), which resets the app
6. Run the app
7. We attempt to reconnect, but no device is found
8. Reset the app
9. Plug the device in
10. Run the app
11. We attempt to reconnect, and I select the plugged in board
12. App runs as expected

https://user-images.githubusercontent.com/9812299/175129877-174d92e5-5ef9-43bf-b5f9-dc35f81a1726.mov



## Links

- [STAR-2256](https://codedotorg.atlassian.net/browse/STAR-2256)