### PR TITLE
Add new curriculum offering to census

### DIFF
--- a/dashboard/app/models/census/other_curriculum_offering.rb
+++ b/dashboard/app/models/census/other_curriculum_offering.rb
@@ -24,8 +24,9 @@ class Census::OtherCurriculumOffering < ApplicationRecord
 
   SUPPORTED_PROVIDERS = %w(
     BootUp
-    TEALS
     PLTW
+    SkillsStruck
+    TEALS
   ).freeze
 
   def self.seed_from_csv(provider_code, school_year, filename, dry_run = false)


### PR DESCRIPTION
We're adding a new curriculum offering to the census called `SkillsStruck`. I've already created the folder in S3, though there's nothing in there yet. This processing is pretty robust in handling errors, so this should be a safe change. (Or at least should fail in staging before production.)

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
