### PR TITLE
Remove `StreetAddress` Gem Dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -311,8 +311,6 @@ gem 'auto_strip_attributes', '~> 2.1'
 # Used to sort UTF8 strings properly
 gem 'sort_alphabetical', github: 'grosser/sort_alphabetical'
 
-gem 'StreetAddress', require: "street_address"
-
 gem 'recaptcha', require: 'recaptcha/rails'
 
 gem 'loofah', ' ~> 2.2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -171,7 +171,6 @@ GEM
   remote: https://rubygems.org/
   specs:
     Ascii85 (1.1.0)
-    StreetAddress (1.0.6)
     acme-client (2.0.5)
       faraday (~> 0.9, >= 0.9.1)
     acmesmith (2.3.1)
@@ -908,7 +907,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  StreetAddress
   acmesmith (~> 2.3.1)
   active_model_serializers (~> 0.10.10)
   active_record_query_trace

--- a/bin/oneoff/census/ap-data/dedupe-ap-school-codes.rb
+++ b/bin/oneoff/census/ap-data/dedupe-ap-school-codes.rb
@@ -1,7 +1,6 @@
 #!/usr/bin/env ruby
 
 require_relative '../../../../dashboard/config/environment'
-require 'street_address'
 
 class CodeMatch
   attr_accessor :ap_name

--- a/bin/oneoff/census/ap-data/map-ap-school-data.rb
+++ b/bin/oneoff/census/ap-data/map-ap-school-data.rb
@@ -1,6 +1,19 @@
 #!/usr/bin/env ruby
 
 require_relative '../../../../dashboard/config/environment'
+
+# This script depends on the StreetAddress gem; because it's the only thing in
+# our codebase that does and because these scripts are only included here for
+# posterity not for actual use, we don't currently install that gem.
+#
+# As-is, attempting to run this script will fail with the error:
+#
+#     cannot load such file -- street_address (LoadError)
+#
+# To restore, add the following line back to the Gemfile:
+#
+#     gem 'StreetAddress', require: "street_address"
+#
 require 'street_address'
 
 ap_data_by_address = {}

--- a/bin/oneoff/census/ap-data/merge-ap-school-codes.rb
+++ b/bin/oneoff/census/ap-data/merge-ap-school-codes.rb
@@ -1,7 +1,6 @@
 #!/usr/bin/env ruby
 
 require_relative '../../../../dashboard/config/environment'
-require 'street_address'
 
 CENSUS_BUCKET_NAME = "cdo-census".freeze
 


### PR DESCRIPTION
Right now, the only thing in our codebase which uses this dependency is a single one-off script only included in the codebase for posterity.

I've added a comment to the file explaining how to restore the dependency, but left the `require` call in place.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
