### PR TITLE
Deflake test by not saving answer user levels to variable

### DIFF
--- a/dashboard/test/controllers/api/v1/assessments_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/assessments_controller_test.rb
@@ -319,13 +319,13 @@ class Api::V1::AssessmentsControllerTest < ActionController::TestCase
     ]
 
     # create user_level for level_group
-    user_level = create :user_level, user: @student_1, best_result: 100, script: script, level: level1, submitted: true
+    level_group_user_level = create :user_level, user: @student_1, best_result: 100, script: script, level: level1, submitted: true
 
     # create user_levels for sublevels
     student_answers.each do |level_and_answer|
       level, answer = level_and_answer
       level_source = create :level_source, level: level, data: answer
-      user_level = create :user_level, user: @student_1, script: script, level: level, level_source: level_source
+      create :user_level, user: @student_1, script: script, level: level, level_source: level_source
     end
 
     # Call the controller method.
@@ -350,7 +350,7 @@ class Api::V1::AssessmentsControllerTest < ActionController::TestCase
               "match_correct" => 0,
               "match_count" => 0,
               "submitted" => true,
-              "timestamp" => user_level[:updated_at],
+              "timestamp" => level_group_user_level[:updated_at],
               "level_results" => [
                 {"type" => "Multi", "student_result" => [2, 3], "status" => "correct",},
                 {"type" => "Multi", "student_result" => [3], "status" => "incorrect",}


### PR DESCRIPTION
Same fix as https://github.com/code-dot-org/code-dot-org/pull/45638. I checked briefly to see if there are any other tests that might have the same issue and couldn't find any.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
