### PR TITLE
Consider numbered_lessons? during curriculum sync-in

### DIFF
--- a/dashboard/lib/services/i18n/curriculum_sync_utils/serializers.rb
+++ b/dashboard/lib/services/i18n/curriculum_sync_utils/serializers.rb
@@ -161,7 +161,10 @@ module Services::I18n::CurriculumSyncUtils
     end
 
     class ScriptCrowdinSerializer < CrowdinSerializer
-      has_many :lessons, serializer: LessonCrowdinSerializer
+      # Optional `only_numbered_lessons` scope to avoid `relative_position` conflicts between Lessons
+      has_many :lessons, serializer: LessonCrowdinSerializer do
+        scope[:only_numbered_lessons] ? object.lessons.select(&:numbered_lesson?) : object.lessons
+      end
       has_many :resources, serializer: ResourceCrowdinSerializer
       has_many :student_resources, serializer: ResourceCrowdinSerializer
 

--- a/dashboard/lib/services/i18n/curriculum_sync_utils/sync_in.rb
+++ b/dashboard/lib/services/i18n/curriculum_sync_utils/sync_in.rb
@@ -20,7 +20,9 @@ module Services
             next unless ScriptConstants.i18n? script.name
 
             # prepare data
-            data = Serializers::ScriptCrowdinSerializer.new(script).as_json.compact
+            # Select only lessons that pass `numbered_lesson?` for consistent `relative_position` values
+            # throughout our translation pipeline
+            data = Serializers::ScriptCrowdinSerializer.new(script, scope: {only_numbered_lessons: true}).as_json.compact
             # The JSON object will have the script's crowdin_key as the top level key, but we don't
             # need that, so we will discard the crowdin_key and set data to be the object it is
             # pointing to.


### PR DESCRIPTION
**What:** Added `only_numbered_lessons` scope to our `ScriptCrowdinSerializer` and utilize it when running our curriculum sync-in.

**Why:** This is the sync-in counterpart to the [sync-out fix](https://github.com/code-dot-org/code-dot-org/pull/46903) we also implemented. Without filtering out lessons that pass `numbered_lesson?`, we were unintentionally syncing lessons we didn't want into our pipeline. More explicit details can be found in [that PR](https://github.com/code-dot-org/code-dot-org/pull/46903). The added scope was made optional to future proof in case of functionality that serialized our curriculum, but did not want to take advantage of this logic.

## Links

- [sync-out PR](https://github.com/code-dot-org/code-dot-org/pull/46903)
- [slack thread](https://codedotorg.slack.com/archives/CFTFD6BPV/p1654277976117479)

## Testing story

Locally ran the sync-in with and without the change. The first three lessons here are not [`numbered_lesson?`s](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/models/lesson.rb#L164), and were replaced with the valid lessons that **are**.

Before:
<img width="705" alt="Screen Shot 2022-06-23 at 10 23 57 AM" src="https://user-images.githubusercontent.com/48133820/175335812-044d81d2-c951-404a-9291-34de68b04dcd.png">

After:
<img width="705" alt="Screen Shot 2022-06-22 at 5 20 28 PM" src="https://user-images.githubusercontent.com/48133820/175335230-0f164fdd-9325-44b7-b6be-902c280677f8.png">


## Follow-up work

A full fresh sync needs to be run

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
