### PR TITLE
Add script to remove authorized teacher permissions from students

### DIFF
--- a/bin/oneoff/remove_authorized_teacher_permissions_from_students
+++ b/bin/oneoff/remove_authorized_teacher_permissions_from_students
@@ -1,0 +1,20 @@
+#!/usr/bin/env ruby
+
+require_relative '../../dashboard/config/environment'
+
+DRY_RUN = true
+
+authorized_teacher_student_permissions = UserPermission.where(permission: UserPermission::AUTHORIZED_TEACHER).left_joins(:user).where('users.user_type': 'student')
+
+removed_permissions = 0
+
+authorized_teacher_student_permissions.each do |permission|
+  user = permission.user
+  next unless user.student?
+  next unless permission.permission = UserPermission::AUTHORIZED_TEACHER
+  permission.destroy! unless DRY_RUN
+  puts "Removed authorized teacher permission from student account #{user.id}"
+  removed_permissions += 1
+end
+
+puts "Removed authorized teacher permissions from #{removed_permissions} student accounts"

--- a/bin/oneoff/remove_authorized_teacher_permissions_from_students
+++ b/bin/oneoff/remove_authorized_teacher_permissions_from_students
@@ -11,7 +11,6 @@ removed_permissions = 0
 authorized_teacher_student_permissions.each do |permission|
   user = permission.user
   next unless user.student?
-  next unless permission.permission = UserPermission::AUTHORIZED_TEACHER
   permission.destroy! unless DRY_RUN
   puts "Removed authorized teacher permission from student account #{user.id}"
   removed_permissions += 1


### PR DESCRIPTION
Adds a small script to remove authorized teacher permissions from student accounts. My plan is to wait until this hits production, run it with `DRY_RUN = true`, verify the right users are affected (there are 273 as of today), then run it again with `DRY_RUN = false`.

I tested the sql that is generated from the active record query on the production reporting database and it took 0.25 seconds to run, so I believe this script to be safe to run on production.

## Links

[jira](https://codedotorg.atlassian.net/browse/LP-2214)

## Testing story

I tested this out with one user in this state on my local machine and it worked as expected.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
