### PR TITLE
Java Lab: show warning for mismatched mini app message

### DIFF
--- a/apps/i18n/javalab/en_us.json
+++ b/apps/i18n/javalab/en_us.json
@@ -140,6 +140,8 @@
   "unauthorizedJavabuilderConnectionTeacher": "To run your code in Java Lab, you need to become \"verified\" or join a CSA section owned by a verified teacher. Please see [this article](https://support.code.org/hc/en-us/articles/115001550131) for details on how to become verified.",
   "unauthorizedJavabuilderConnectionStudent": "To run your code in Java Lab, you need to be assigned to a CSA section and your teacher needs to be \"verified.\" Ask your teacher for help and try again. Your teacher can find more details in [this article.](https://support.code.org/hc/en-us/articles/115001550131)",
   "unknownError": "Oops. We hit an error on our side. Try running your program again. If this error continues, contact us at support@code.org. Be sure to include the connection ID {connectionId} in your message.\n{type}",
+  "unsupportedNeighborhoodMessage": "[WARNING] Unsupported message receieved. Neighborhood projects are not supported on this level.",
+  "unsupportedTheaterMessage": "[WARNING] Unsupported message receieved. Theater projects are not supported on this level.",
   "userBlocked": "You have run your code too many times and your account has been locked. Contact support@code.org to unlock your account.",
   "youHaveProjectsToReview": "You have projects to review...",
   "yourPeer": "your peer"

--- a/apps/i18n/javalab/en_us.json
+++ b/apps/i18n/javalab/en_us.json
@@ -140,8 +140,8 @@
   "unauthorizedJavabuilderConnectionTeacher": "To run your code in Java Lab, you need to become \"verified\" or join a CSA section owned by a verified teacher. Please see [this article](https://support.code.org/hc/en-us/articles/115001550131) for details on how to become verified.",
   "unauthorizedJavabuilderConnectionStudent": "To run your code in Java Lab, you need to be assigned to a CSA section and your teacher needs to be \"verified.\" Ask your teacher for help and try again. Your teacher can find more details in [this article.](https://support.code.org/hc/en-us/articles/115001550131)",
   "unknownError": "Oops. We hit an error on our side. Try running your program again. If this error continues, contact us at support@code.org. Be sure to include the connection ID {connectionId} in your message.\n{type}",
-  "unsupportedNeighborhoodMessage": "[WARNING] Unsupported message receieved. Neighborhood projects are not supported on this level.",
-  "unsupportedTheaterMessage": "[WARNING] Unsupported message receieved. Theater projects are not supported on this level.",
+  "unsupportedNeighborhoodMessage": "[WARNING] Level type mismatch: Neighborhood projects are not supported on a non-Neighborhood level.",
+  "unsupportedTheaterMessage": "[WARNING] Level type mismatch: Theater projects are not supported on a non-Theater level.",
   "userBlocked": "You have run your code too many times and your account has been locked. Contact support@code.org to unlock your account.",
   "youHaveProjectsToReview": "You have projects to review...",
   "yourPeer": "your peer"

--- a/apps/src/javalab/JavabuilderConnection.js
+++ b/apps/src/javalab/JavabuilderConnection.js
@@ -3,7 +3,8 @@ import {
   StatusMessageType,
   STATUS_MESSAGE_PREFIX,
   ExecutionType,
-  AuthorizerSignalType
+  AuthorizerSignalType,
+  CsaViewMode
 } from './constants';
 import {handleException} from './javabuilderExceptionHandler';
 import project from '@cdo/apps/code-studio/initApp/project';
@@ -246,7 +247,19 @@ export default class JavabuilderConnection {
         this.onNewlineMessage();
         break;
       case WebSocketMessageType.NEIGHBORHOOD:
+        if (this.miniAppType === CsaViewMode.NEIGHBORHOOD) {
+          this.miniApp.handleSignal(data);
+        } else {
+          this.onUnsupportedNeighborhoodMessage();
+        }
+        break;
       case WebSocketMessageType.THEATER:
+        if (this.miniAppType === CsaViewMode.THEATER) {
+          this.miniApp.handleSignal(data);
+        } else {
+          this.onUnsupportedTheaterMessage();
+        }
+        break;
       case WebSocketMessageType.PLAYGROUND:
         this.miniApp.handleSignal(data);
         break;
@@ -308,6 +321,16 @@ export default class JavabuilderConnection {
 
   onTimeout() {
     this.setIsRunning(false);
+  }
+
+  onUnsupportedNeighborhoodMessage() {
+    this.onOutputMessage(javalabMsg.unsupportedNeighborhoodMessage());
+    this.onNewlineMessage();
+  }
+
+  onUnsupportedTheaterMessage() {
+    this.onOutputMessage(javalabMsg.unsupportedTheaterMessage());
+    this.onNewlineMessage();
   }
 
   // Send a message across the websocket connection to Javabuilder

--- a/apps/src/javalab/JavabuilderConnection.js
+++ b/apps/src/javalab/JavabuilderConnection.js
@@ -43,6 +43,8 @@ export default class JavabuilderConnection {
     this.currentUser = currentUser;
     this.onMarkdownLog = onMarkdownLog;
     this.csrfToken = csrfToken;
+    this.seenUnsupportedNeighborhoodMessage = false;
+    this.seenUnsupportedTheaterMessage = false;
   }
 
   // Get the access token to connect to javabuilder and then open the websocket connection.
@@ -324,13 +326,19 @@ export default class JavabuilderConnection {
   }
 
   onUnsupportedNeighborhoodMessage() {
-    this.onOutputMessage(javalabMsg.unsupportedNeighborhoodMessage());
-    this.onNewlineMessage();
+    if (!this.seenUnsupportedNeighborhoodMessage) {
+      this.onOutputMessage(javalabMsg.unsupportedNeighborhoodMessage());
+      this.onNewlineMessage();
+      this.seenUnsupportedNeighborhoodMessage = true;
+    }
   }
 
   onUnsupportedTheaterMessage() {
-    this.onOutputMessage(javalabMsg.unsupportedTheaterMessage());
-    this.onNewlineMessage();
+    if (!this.seenUnsupportedTheaterMessage) {
+      this.onOutputMessage(javalabMsg.unsupportedTheaterMessage());
+      this.onNewlineMessage();
+      this.seenUnsupportedTheaterMessage = true;
+    }
   }
 
   // Send a message across the websocket connection to Javabuilder
@@ -348,6 +356,8 @@ export default class JavabuilderConnection {
   }
 
   handleExecutionFinished() {
+    this.seenUnsupportedNeighborhoodMessage = false;
+    this.seenUnsupportedTheaterMessage = false;
     switch (this.executionType) {
       case ExecutionType.RUN:
         this.setIsRunning(false);


### PR DESCRIPTION
If we see a neighborhood message on a non-neighborhood level or a theater message on a non-theater level, output a warning message. Only output a warning message for the first unsupported message of a given type that we see, to avoid cluttering the console. This will help avoid confusion if a user tries to run code on an unsupported level type, which is especially likely for neighborhood if the code is shared.

Theater warning:
![Screen Shot 2022-06-23 at 9 54 32 AM](https://user-images.githubusercontent.com/33666587/175353677-e68a7c9f-e847-41e5-a844-043404a68a4a.png)

Neighborhood warning:
![Screen Shot 2022-06-23 at 9 54 41 AM](https://user-images.githubusercontent.com/33666587/175353647-fe815fc4-589a-4c87-8b34-0211f3b18081.png)

## Links
- jira ticket: [JAVA-341](https://codedotorg.atlassian.net/browse/JAVA-341)

## Testing story
Tested locally
