### PR TITLE
Error messages on failed Backpack import

### DIFF
--- a/apps/i18n/javalab/en_us.json
+++ b/apps/i18n/javalab/en_us.json
@@ -77,6 +77,7 @@
   "feedbackBeginningPeer": "This is the beginning of feedback for {peerName}'s project.",
   "illegalMethodAccess": "You tried to access a method that is blocked by our security policy.\n{cause}",
   "fileImportError": "One or more file names are reserved by Java Lab and cannot be imported into this project. Files unable to be imported:",
+  "fileImportServerError": "We encountered an error importing one or more of your files. Please try again. Files unable to be imported:",
   "fileImportWarning": "You have one or more duplicate file names between this project and your selected backpack files. Duplicate file names are:",
   "fileImportWarningConfirm": "Do you want to replace these files with the files from your backpack?",
   "fileLoadError": "There was an error loading the file {filename}.",

--- a/apps/src/code-studio/components/backpack/BackpackClientApi.js
+++ b/apps/src/code-studio/components/backpack/BackpackClientApi.js
@@ -33,7 +33,7 @@ export default class BackpackClientApi {
       this.channelId + '/' + filename,
       (error, data) => {
         if (error) {
-          onError(error);
+          onError();
         } else {
           onSuccess(data);
         }

--- a/apps/src/javalab/Backpack.jsx
+++ b/apps/src/javalab/Backpack.jsx
@@ -24,8 +24,9 @@ class Backpack extends Component {
     isButtonDisabled: PropTypes.bool.isRequired,
     onImport: PropTypes.func.isRequired,
     // populated by redux
-    backpackApi: PropTypes.object,
-    sources: PropTypes.object,
+    backpackApi: PropTypes.object.isRequired,
+    sources: PropTypes.object.isRequired,
+    validation: PropTypes.object.isRequired,
     backpackEnabled: PropTypes.bool
   };
 
@@ -113,7 +114,7 @@ class Backpack extends Component {
     let hiddenFilenamesUsed = [];
     let visibleFilenamesUsed = [];
     const {selectedFiles} = this.state;
-    const {sources} = this.props;
+    const {sources, validation} = this.props;
 
     selectedFiles.forEach(filename => {
       const source = sources[filename];
@@ -123,6 +124,10 @@ class Backpack extends Component {
         } else {
           hiddenFilenamesUsed.push(filename);
         }
+      }
+
+      if (Object.keys(validation).includes(filename)) {
+        hiddenFilenamesUsed.push(filename);
       }
     });
 
@@ -445,5 +450,6 @@ export const UnconnectedBackpack = Backpack;
 export default connect(state => ({
   backpackApi: state.javalab.backpackApi,
   sources: state.javalab.sources,
+  validation: state.javalab.validation,
   backpackEnabled: state.javalab.backpackEnabled
 }))(onClickOutside(Radium(UnconnectedBackpack)));

--- a/apps/test/unit/javalab/BackpackTest.js
+++ b/apps/test/unit/javalab/BackpackTest.js
@@ -112,7 +112,7 @@ describe('Java Lab Backpack Test', () => {
   });
 
   it('no dialog shown if there are no duplicate file names', () => {
-    const wrapper = shallow(<Backpack {...{...defaultProps}} />);
+    const wrapper = shallow(<Backpack {...defaultProps} />);
     // set state to something that should be cleared by expandDropdown
     wrapper.instance().setState({
       dropdownOpen: true,

--- a/apps/test/unit/javalab/BackpackTest.js
+++ b/apps/test/unit/javalab/BackpackTest.js
@@ -21,7 +21,9 @@ describe('Java Lab Backpack Test', () => {
       isButtonDisabled: false,
       onImport: () => {},
       backpackApi: backpackApiStub,
-      backpackEnabled: true
+      backpackEnabled: true,
+      sources: {},
+      validation: {}
     };
   });
 
@@ -110,10 +112,7 @@ describe('Java Lab Backpack Test', () => {
   });
 
   it('no dialog shown if there are no duplicate file names', () => {
-    const otherProps = {
-      sources: {}
-    };
-    const wrapper = shallow(<Backpack {...{...defaultProps, ...otherProps}} />);
+    const wrapper = shallow(<Backpack {...{...defaultProps}} />);
     // set state to something that should be cleared by expandDropdown
     wrapper.instance().setState({
       dropdownOpen: true,


### PR DESCRIPTION
Error on server error and when importing a file with a name that conflicts with a validation file from the backpack.

**Validation name conflict**
<img width="1043" alt="image" src="https://user-images.githubusercontent.com/25372625/175397275-cca859ff-a155-4854-8156-0fcf0ba5e256.png">

**Server error**
<img width="1055" alt="image" src="https://user-images.githubusercontent.com/25372625/175397597-7fccfcb0-547a-453b-9dab-751adf85b122.png">


## Links

- jira ticket: [JAVA-351](https://codedotorg.atlassian.net/browse/JAVA-351)

## Testing story

Tested manually that I received appropriate error dialogs when trying to import validation files, support files, and encountered a stubbed server error. I also was able to import files that didn't meet any of these criteria successfully.