### PR TITLE
Hide PL superhero banners

### DIFF
--- a/pegasus/sites.v3/code.org/views/professional_learning_marketing_banner.haml
+++ b/pegasus/sites.v3/code.org/views/professional_learning_marketing_banner.haml
@@ -1,4 +1,5 @@
-- if request.locale == "en-US"
+- display_professional_learning_banners = false
+- if request.locale == "en-US" && display_professional_learning_banners
   = inline_css 'professional_learning_marketing_banner.css'
   - header_text = 'Help students become superheroes!'
   - text = "Our Professional Learning program helps #{audience_text} teach computer science!"

--- a/shared/css/professional_learning_marketing_banner.scss
+++ b/shared/css/professional_learning_marketing_banner.scss
@@ -46,6 +46,7 @@ $dark_blue_background_colour: #0d4172;
   }
 
   .professional-learning-banner-desktop.homepage {
+    display: none; // banner is currently hidden
 
     .text-wrapper {
       left: 3.5vw;
@@ -84,6 +85,7 @@ $dark_blue_background_colour: #0d4172;
     margin: 0 auto;
     position: relative;
     width: 100%;
+    display: none; // banner is currently hidden
 
     .banner {
       text-align: center;

--- a/shared/css/professional_learning_marketing_banner.scss
+++ b/shared/css/professional_learning_marketing_banner.scss
@@ -21,6 +21,7 @@ $dark_blue_background_colour: #0d4172;
 
 .homepage-professional-learning-banner {
   margin-bottom: 30px;
+  display: none; // banner is currently hidden
 
   a {
     font-family: "Gotham 4r", sans-serif;
@@ -46,7 +47,6 @@ $dark_blue_background_colour: #0d4172;
   }
 
   .professional-learning-banner-desktop.homepage {
-    display: none; // banner is currently hidden
 
     .text-wrapper {
       left: 3.5vw;
@@ -85,7 +85,6 @@ $dark_blue_background_colour: #0d4172;
     margin: 0 auto;
     position: relative;
     width: 100%;
-    display: none; // banner is currently hidden
 
     .banner {
       text-align: center;

--- a/shared/css/professional_learning_marketing_banner.scss
+++ b/shared/css/professional_learning_marketing_banner.scss
@@ -21,7 +21,6 @@ $dark_blue_background_colour: #0d4172;
 
 .homepage-professional-learning-banner {
   margin-bottom: 30px;
-  display: none; // banner is currently hidden
 
   a {
     font-family: "Gotham 4r", sans-serif;


### PR DESCRIPTION
Hide the Professional Learning superhero banners with the ability to put them back in the future using `display_professional_learning_banners = false` 

Related PR: https://github.com/code-dot-org/code-dot-org/pull/44847 • [Trello card](https://docs.google.com/document/d/1AuDWioXNlDHGwbIb0HCORfhtug3HeqG7EGFC9CW7HiI/edit#) • [Google Doc](https://docs.google.com/document/d/1AuDWioXNlDHGwbIb0HCORfhtug3HeqG7EGFC9CW7HiI/edit#heading=h.pvhpv7g1iser)

**Pages affected:** 
- https://code.org/
- https://code.org/educate/professional-learning/middle-high
- https://code.org/educate/curriculum/middle-school
- https://code.org/educate/curriculum/high-school
- https://code.org/yourschool
- https://code.org/administrators