### PR TITLE
Run the Crowdin translation validator tool daily

### DIFF
--- a/bin/i18n/translation_monitor/config_helper.rb
+++ b/bin/i18n/translation_monitor/config_helper.rb
@@ -16,7 +16,7 @@ module ConfigHelper
   # explicitly specified. See the +merge_default_params+ function in this module.
   #   start_date: e.g. 2022-01-01 (yyyy-mm-dd). See https://developer.crowdin.com/croql/
   #   end_date: e.g. 2022-06-23
-  #   write_to_file: if true, the tool will write outputs to the local file system
+  #   write_to_file: if true, the tool will write the translations, source strings, and translation errors to the local file system
   #   write_to_gsheet: if true, the tool will write translation errors to Google Sheet
   #   translations_json: output JSON file for translations downloaded from Crowdin
   #   source_strings_json: output JSON file for source strings downloaded from Crowdin

--- a/bin/i18n/translation_monitor/config_helper.rb
+++ b/bin/i18n/translation_monitor/config_helper.rb
@@ -16,6 +16,8 @@ module ConfigHelper
   # explicitly specified. See the +merge_default_params+ function in this module.
   #   start_date: e.g. 2022-01-01 (yyyy-mm-dd). See https://developer.crowdin.com/croql/
   #   end_date: e.g. 2022-06-23
+  #   write_to_file: if true, the tool will write outputs to the local file system
+  #   write_to_gsheet: if true, the tool will write translation errors to Google Sheet
   #   translations_json: output JSON file for translations downloaded from Crowdin
   #   source_strings_json: output JSON file for source strings downloaded from Crowdin
   #   errors_json: output JSON file for translation errors
@@ -28,6 +30,8 @@ module ConfigHelper
   OPTIONAL_CONFIG_PARAMS = %w[
     start_date
     end_date
+    write_to_file
+    write_to_gsheet
     translations_json
     source_strings_json
     errors_json

--- a/bin/i18n/translation_monitor/configs/crowdin_validator_config.json
+++ b/bin/i18n/translation_monitor/configs/crowdin_validator_config.json
@@ -1,8 +1,8 @@
 {
   "limit": null,
   "shared_data": {
-    "write_to_file": true,
     "write_to_gsheet": true,
+    "write_to_file": false,
     "start_date": "2021-11-01"
   },
   "data": [

--- a/experimental/i18n-dev.crontab
+++ b/experimental/i18n-dev.crontab
@@ -48,3 +48,6 @@ HOME=/home/ubuntu
 
 # Update string translation status to Redshift
 0 0 * * * cd /home/ubuntu/code-dot-org && (bundle exec ./bin/i18n/translation_status/update_translation_status.rb | ./bin/i18n/slack_log) 2>&1 | ./bin/i18n/slack_error
+
+# Run the Crowdin translation validator tool
+30 0 * * * cd /home/ubuntu/code-dot-org && (bundle exec bin/i18n/translation_monitor/run_crowdin_validator.rb | ./bin/i18n/slack_log) 2>&1 | ./bin/i18n/slack_error


### PR DESCRIPTION
The tool will run daily at [00:30am](https://crontab.guru/#30_0_*_*_*). We have several scripts that run at minute 0, so I choose 30 to avoid unnecessary conflicts.

Also, turn off the `write_to_file` config to avoid creating too many files on the i18n-dev server. It can still be turned on for debugging purpose. 

**Note**: The tool will need the following credential files to talk to Crowdin and Google drive. They exist on the `i18n-dev` machine but not in git. 
* bin/i18n/translation_monitor/configs/crowdin_v2_credential.json
    ```
    { "api_token": "..." }
    ```
* bin/i18n/translation_monitor/configs/google_drive_credential.json
    ```
    {
      "type": "service_account",
      "project_id": "...",
      "private_key_id": "...",
      "private_key": "...",
      "client_email": "i18n-logging@....iam.gserviceaccount.com",
      "client_id": "...",
      "auth_uri": "https://accounts.google.com/o/oauth2/auth",
      "token_uri": "https://oauth2.googleapis.com/token",
      "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
      "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/..."
    }
    ```