### PR TITLE
Improve accuracy of the core translation validation

### DIFF
--- a/bin/i18n/test/translation_monitor/test_core_validator.rb
+++ b/bin/i18n/test/translation_monitor/test_core_validator.rb
@@ -22,8 +22,10 @@ class CoreValidatorTest < Minitest::Test
     assert_nil validate_redacted_blocks('[A][0]')
     assert_nil validate_redacted_blocks('[A][0][B][1]')
     assert_nil validate_redacted_blocks('[A][0] [B][1]')
+    assert_nil validate_redacted_blocks('[A][0]  [B][1]  [C][2]')
     assert_nil validate_redacted_blocks('[][0][][1]')
     assert_nil validate_redacted_blocks('[][0] [][1]')
+    assert_nil validate_redacted_blocks("[][0]  [][1]  [][2]")
 
     # invalid cases
     refute_nil validate_redacted_blocks('[A] [0]')

--- a/bin/i18n/test/translation_monitor/test_core_validator.rb
+++ b/bin/i18n/test/translation_monitor/test_core_validator.rb
@@ -48,7 +48,7 @@ class CoreValidatorTest < Minitest::Test
     assert_nil validate_language("", 'any_language_code')
 
     # invalid cases
-    refute_nil validate_language("இது தமிழில் ஒரு வாக்கியம்", 'it')
+    refute_nil validate_language("இது தமிழில் ஒரு சோதனை வாக்கியம்", 'it')
     refute_nil validate_language("ini adalah kalimat dalam bahasa indonesia", 'es')
   end
 end

--- a/bin/i18n/test/translation_monitor/test_core_validator.rb
+++ b/bin/i18n/test/translation_monitor/test_core_validator.rb
@@ -9,6 +9,9 @@ class CoreValidatorTest < Minitest::Test
     assert_nil validate_markdown_link('[text](url)')
     assert_nil validate_markdown_link('[.](http://go.somewhere)')
 
+    # a valid special case
+    assert_nil validate_markdown_link("[][0] (this is just an explanation)")
+
     # invalid cases
     refute_nil validate_markdown_link('[text] (url)')
     refute_nil validate_markdown_link("[text]\t(url)")
@@ -19,11 +22,15 @@ class CoreValidatorTest < Minitest::Test
     assert_nil validate_redacted_blocks('[A][0]')
     assert_nil validate_redacted_blocks('[A][0][B][1]')
     assert_nil validate_redacted_blocks('[A][0] [B][1]')
+    assert_nil validate_redacted_blocks('[][0][][1]')
+    assert_nil validate_redacted_blocks('[][0] [][1]')
 
     # invalid cases
     refute_nil validate_redacted_blocks('[A] [0]')
     refute_nil validate_redacted_blocks("[A]\t[0]")
-    refute_nil validate_redacted_blocks("[] []")
+    refute_nil validate_redacted_blocks("[] [0]")
+    refute_nil validate_redacted_blocks("[]\t[0]")
+    refute_nil validate_redacted_blocks('[] []')
   end
 
   def test_validate_language

--- a/bin/i18n/translation_monitor/core_validator.rb
+++ b/bin/i18n/translation_monitor/core_validator.rb
@@ -12,7 +12,8 @@ module CoreValidator
   #
   def validate_markdown_link(str)
     return if str.nil? || str.empty?
-    str.match?(/\[.*\]\s+\(.*\)/) ? 'cannot have space between [] and () block' : nil
+    remainder = remove_valid_redacted_blocks(str)
+    remainder.match?(/\[.*\]\s+\(.*\)/) ? 'cannot have space between [] and () block' : nil
   end
 
   # Redacted string should not have space(s) between two [] blocks.
@@ -23,12 +24,15 @@ module CoreValidator
   #
   def validate_redacted_blocks(str)
     return if str.nil? || str.empty?
-    # delete all valid redacted blocks
-    valid_blocks_pattern = /\[\w+\]\[\d+\]/
-    remainder = str.gsub(valid_blocks_pattern, '')
-
+    remainder = remove_valid_redacted_blocks(str)
     invalid_blocks_pattern = /\[.*\]\s+\[.*\]/
     remainder.match?(invalid_blocks_pattern) ? 'cannot have space between 2 [] blocks' : nil
+  end
+
+  def remove_valid_redacted_blocks(str)
+    # A valid redacted blocks could be [][0] or [something][0] or [another thing][0]
+    valid_blocks_pattern = /\[[\w\s]*\]\[\d+\]/
+    str.gsub(valid_blocks_pattern, '')
   end
 
   # Check if a string is in a certain language.

--- a/bin/i18n/translation_monitor/core_validator.rb
+++ b/bin/i18n/translation_monitor/core_validator.rb
@@ -46,13 +46,17 @@ module CoreValidator
   #
   def validate_language(str, language_code)
     # Enforce a minimum string length since language detection is not accurate for short strings.
-    return if str.nil? || str.size < 20
+    return if str.nil? || count_words(str) < 5
 
     # Ignore 'unknown' language. Also ignore 'en' because of high false-positive rate.
-    ignored_language_codes = %w[un en]
+    ignored_language_codes = %w[un en xxx]
 
     detected_language = CLD.detect_language(str)[:code]
     return if ignored_language_codes.include?(detected_language) || language_code == detected_language
     "language looks like '#{detected_language}' instead of '#{language_code}'"
+  end
+
+  def count_words(str)
+    str.strip.split(/\s+/).size
   end
 end


### PR DESCRIPTION
Specific improvements:
* Don't try to detect language for a string that has less than 5 words
* Distinguish invalid markdown link from redacted blocks followed by parenthesis (e.g. "[Asimo by Honda][0] (3:58)"). 

Add a few small test cases. 