### PR TITLE
Updated remaining Maker blocks to use new CP Express pin #s as defaul…

### DIFF
--- a/apps/src/lib/kits/maker/dropletConfig.js
+++ b/apps/src/lib/kits/maker/dropletConfig.js
@@ -87,7 +87,7 @@ function getMakerBlocks(boardType) {
       parent: api,
       category: MAKER_CATEGORY,
       paletteParams: ['pin', 'mode'],
-      params: ['13', '"output"'],
+      params: [defaultPin, '"output"'],
       dropdown: {1: ['"output"', '"input"', '"analog"']}
     },
     {
@@ -95,7 +95,7 @@ function getMakerBlocks(boardType) {
       parent: api,
       category: MAKER_CATEGORY,
       paletteParams: ['pin', 'value'],
-      params: ['13', '1'],
+      params: [defaultPin, '1'],
       dropdown: {1: ['1', '0']}
     },
     {
@@ -105,14 +105,14 @@ function getMakerBlocks(boardType) {
       type: 'value',
       nativeIsAsync: true,
       paletteParams: ['pin'],
-      params: ['"D4"']
+      params: [defaultPin]
     },
     {
       func: 'analogWrite',
       parent: api,
       category: MAKER_CATEGORY,
       paletteParams: ['pin', 'value'],
-      params: ['5', '150']
+      params: [defaultPin, '150']
     },
     {
       func: 'analogRead',
@@ -121,7 +121,7 @@ function getMakerBlocks(boardType) {
       type: 'value',
       nativeIsAsync: true,
       paletteParams: ['pin'],
-      params: ['5']
+      params: [defaultPin]
     },
     {
       func: 'boardConnected',


### PR DESCRIPTION
## Summary

- FYI - created an updated PR to reflect that there was only 1 commit (not 6 as indicated in prior PR).
- Some of the Maker blocks were updated to default values for new Circuit Playground Express pin numbers (createLed and createButton) but updated the remaining Maker blocks to use default values for new CP Express pin numbers (pinMode, digitalWrite, analogWrite, digitalRead, analogRead)
- Continuation of this ticket: https://codedotorg.atlassian.net/browse/STAR-1695

- Video before/after: 
https://user-images.githubusercontent.com/107423305/175551036-435fafcc-ec1b-4bd0-9274-3e7d2d57dba6.mp4

- Screenshot before: 
![image](https://user-images.githubusercontent.com/107423305/175550708-fb2fb892-026b-4e41-b550-bedccd51f886.png)

- Screenshot after:
![image](https://user-images.githubusercontent.com/107423305/175550805-c8017f32-15d6-4cb5-9096-29aae9ffebfd.png)

## Links

- jira ticket: https://codedotorg.atlassian.net/browse/STAR-2204
