### PR TITLE
Misc. proofreader work

### DIFF
--- a/bin/i18n/translation_monitor/configs/crowdin_validator_config.json
+++ b/bin/i18n/translation_monitor/configs/crowdin_validator_config.json
@@ -8,13 +8,224 @@
   "data": [
     {
       "project_name": "codeorg",
+      "crowdin_language_id": "ar",
+      "user_names": ["Tomedes", "Tomedes_TEP", "Tomedes_Trans"]
+    },
+    {
+      "project_name": "codeorg",
+      "crowdin_language_id": "cs",
+      "user_names": ["Tomedes", "Tomedes_TEP", "Tomedes_Trans"]
+    },
+    {
+      "project_name": "codeorg",
+      "crowdin_language_id": "de",
+      "user_names": ["Tomedes", "Tomedes_TEP", "Tomedes_Trans"]
+    },
+    {
+      "project_name": "codeorg",
+      "crowdin_language_id": "el",
+      "user_names": ["Tomedes", "Tomedes_TEP", "Tomedes_Trans"]
+    },
+    {
+      "project_name": "codeorg",
+      "crowdin_language_id": "es-ES",
+      "user_names": ["Tomedes", "Tomedes_TEP", "Tomedes_Trans"]
+    },
+    {
+      "project_name": "codeorg",
       "crowdin_language_id": "es-MX",
-      "user_name": "Tomedes"
+      "user_names": ["Tomedes", "Tomedes_TEP", "Tomedes_Trans"]
+    },
+    {
+      "project_name": "codeorg",
+      "crowdin_language_id": "fr",
+      "user_names": ["Tomedes", "Tomedes_TEP", "Tomedes_Trans"]
+    },
+    {
+      "project_name": "codeorg",
+      "crowdin_language_id": "hi",
+      "user_names": ["Tomedes", "Tomedes_TEP", "Tomedes_Trans"]
+    },
+    {
+      "project_name": "codeorg",
+      "crowdin_language_id": "hu",
+      "user_names": ["Tomedes", "Tomedes_TEP", "Tomedes_Trans"]
+    },
+    {
+      "project_name": "codeorg",
+      "crowdin_language_id": "id",
+      "user_names": ["Tomedes", "Tomedes_TEP", "Tomedes_Trans"]
     },
     {
       "project_name": "codeorg",
       "crowdin_language_id": "it",
-      "user_name": "translatebyhumans"
+      "user_names": ["Tomedes", "Tomedes_TEP", "Tomedes_Trans"]
+    },
+    {
+      "project_name": "codeorg",
+      "crowdin_language_id": "ja",
+      "user_names": ["Tomedes", "Tomedes_TEP", "Tomedes_Trans"]
+    },
+    {
+      "project_name": "codeorg",
+      "crowdin_language_id": "kn",
+      "user_names": ["Tomedes", "Tomedes_TEP", "Tomedes_Trans"]
+    },
+    {
+      "project_name": "codeorg",
+      "crowdin_language_id": "ko",
+      "user_names": ["Tomedes", "Tomedes_TEP", "Tomedes_Trans"]
+    },
+    {
+      "project_name": "codeorg",
+      "crowdin_language_id": "mr",
+      "user_names": ["Tomedes", "Tomedes_TEP", "Tomedes_Trans"]
+    },
+    {
+      "project_name": "codeorg",
+      "crowdin_language_id": "ms",
+      "user_names": ["Tomedes", "Tomedes_TEP", "Tomedes_Trans"]
+    },
+    {
+      "project_name": "codeorg",
+      "crowdin_language_id": "ta",
+      "user_names": ["Tomedes", "Tomedes_TEP", "Tomedes_Trans"]
+    },
+    {
+      "project_name": "codeorg",
+      "crowdin_language_id": "tl",
+      "user_names": ["Tomedes", "Tomedes_TEP", "Tomedes_Trans"]
+    },
+    {
+      "project_name": "codeorg",
+      "crowdin_language_id": "tr",
+      "user_names": ["Tomedes", "Tomedes_TEP", "Tomedes_Trans"]
+    },
+    {
+      "project_name": "codeorg",
+      "crowdin_language_id": "vi",
+      "user_names": ["Tomedes", "Tomedes_TEP", "Tomedes_Trans"]
+    },
+    {
+      "project_name": "codeorg",
+      "crowdin_language_id": "zh-CN",
+      "user_names": ["Tomedes", "Tomedes_TEP", "Tomedes_Trans"]
+    },
+    {
+      "project_name": "codeorg",
+      "crowdin_language_id": "zh-TW",
+      "user_names": ["Tomedes", "Tomedes_TEP", "Tomedes_Trans"]
+    },
+
+    {
+      "project_name": "hour-of-code",
+      "crowdin_language_id": "ar",
+      "user_names": ["Tomedes", "Tomedes_TEP", "Tomedes_Trans"]
+    },
+    {
+      "project_name": "hour-of-code",
+      "crowdin_language_id": "cs",
+      "user_names": ["Tomedes", "Tomedes_TEP", "Tomedes_Trans"]
+    },
+    {
+      "project_name": "hour-of-code",
+      "crowdin_language_id": "de",
+      "user_names": ["Tomedes", "Tomedes_TEP", "Tomedes_Trans"]
+    },
+    {
+      "project_name": "hour-of-code",
+      "crowdin_language_id": "el",
+      "user_names": ["Tomedes", "Tomedes_TEP", "Tomedes_Trans"]
+    },
+    {
+      "project_name": "hour-of-code",
+      "crowdin_language_id": "es-ES",
+      "user_names": ["Tomedes", "Tomedes_TEP", "Tomedes_Trans"]
+    },
+    {
+      "project_name": "hour-of-code",
+      "crowdin_language_id": "es-MX",
+      "user_names": ["Tomedes", "Tomedes_TEP", "Tomedes_Trans"]
+    },
+    {
+      "project_name": "hour-of-code",
+      "crowdin_language_id": "fr",
+      "user_names": ["Tomedes", "Tomedes_TEP", "Tomedes_Trans"]
+    },
+    {
+      "project_name": "hour-of-code",
+      "crowdin_language_id": "hi",
+      "user_names": ["Tomedes", "Tomedes_TEP", "Tomedes_Trans"]
+    },
+    {
+      "project_name": "hour-of-code",
+      "crowdin_language_id": "hu",
+      "user_names": ["Tomedes", "Tomedes_TEP", "Tomedes_Trans"]
+    },
+    {
+      "project_name": "hour-of-code",
+      "crowdin_language_id": "id",
+      "user_names": ["Tomedes", "Tomedes_TEP", "Tomedes_Trans"]
+    },
+    {
+      "project_name": "hour-of-code",
+      "crowdin_language_id": "it",
+      "user_names": ["Tomedes", "Tomedes_TEP", "Tomedes_Trans"]
+    },
+    {
+      "project_name": "hour-of-code",
+      "crowdin_language_id": "ja",
+      "user_names": ["Tomedes", "Tomedes_TEP", "Tomedes_Trans"]
+    },
+    {
+      "project_name": "hour-of-code",
+      "crowdin_language_id": "kn",
+      "user_names": ["Tomedes", "Tomedes_TEP", "Tomedes_Trans"]
+    },
+    {
+      "project_name": "hour-of-code",
+      "crowdin_language_id": "ko",
+      "user_names": ["Tomedes", "Tomedes_TEP", "Tomedes_Trans"]
+    },
+    {
+      "project_name": "hour-of-code",
+      "crowdin_language_id": "mr",
+      "user_names": ["Tomedes", "Tomedes_TEP", "Tomedes_Trans"]
+    },
+    {
+      "project_name": "hour-of-code",
+      "crowdin_language_id": "ms",
+      "user_names": ["Tomedes", "Tomedes_TEP", "Tomedes_Trans"]
+    },
+    {
+      "project_name": "hour-of-code",
+      "crowdin_language_id": "ta",
+      "user_names": ["Tomedes", "Tomedes_TEP", "Tomedes_Trans"]
+    },
+    {
+      "project_name": "hour-of-code",
+      "crowdin_language_id": "tl",
+      "user_names": ["Tomedes", "Tomedes_TEP", "Tomedes_Trans"]
+    },
+    {
+      "project_name": "hour-of-code",
+      "crowdin_language_id": "tr",
+      "user_names": ["Tomedes", "Tomedes_TEP", "Tomedes_Trans"]
+    },
+    {
+      "project_name": "hour-of-code",
+      "crowdin_language_id": "vi",
+      "user_names": ["Tomedes", "Tomedes_TEP", "Tomedes_Trans"]
+    },
+    {
+      "project_name": "hour-of-code",
+      "crowdin_language_id": "zh-CN",
+      "user_names": ["Tomedes", "Tomedes_TEP", "Tomedes_Trans"]
+    },
+    {
+      "project_name": "hour-of-code",
+      "crowdin_language_id": "zh-TW",
+      "user_names": ["Tomedes", "Tomedes_TEP", "Tomedes_Trans"]
     }
   ]
 }

--- a/bin/i18n/translation_monitor/data_io_helper.rb
+++ b/bin/i18n/translation_monitor/data_io_helper.rb
@@ -49,7 +49,7 @@ module DataIOHelper
   # @param spreadsheet_name [String]
   # @param sheet_name [String]
   # @credential_json [String] Google credential json file
-  def append_to_gsheet(rows_with_headers, spreadsheet_name, sheet_name, credential_json)
+  def append_to_gsheet(rows_with_headers, spreadsheet_name, sheet_name, credential_json, overwrite = false)
     raise 'Input params cannot be nil or empty!' if rows_with_headers.nil? || spreadsheet_name.empty? || sheet_name.empty? || credential_json.empty?
     @gdrive_session ||= GoogleDrive::Session.from_service_account_key(credential_json)
 
@@ -60,8 +60,13 @@ module DataIOHelper
     worksheet ||= spreadsheet.add_worksheet(sheet_name, 200)
 
     # Delete new data headers if the worksheet already has data
-    rows_with_headers.shift if worksheet.num_rows > 0
-    worksheet.insert_rows(worksheet.num_rows + 1, rows_with_headers)
+    if overwrite
+      worksheet.delete_rows(1, worksheet.num_rows)
+      worksheet.update_cells(1, 1, rows_with_headers)
+    else
+      rows_with_headers.shift if worksheet.num_rows > 0
+      worksheet.insert_rows(worksheet.num_rows + 1, rows_with_headers)
+    end
     worksheet.save
   end
 end

--- a/bin/i18n/translation_monitor/data_io_helper.rb
+++ b/bin/i18n/translation_monitor/data_io_helper.rb
@@ -59,11 +59,11 @@ module DataIOHelper
     worksheet = spreadsheet.worksheet_by_title(sheet_name)
     worksheet ||= spreadsheet.add_worksheet(sheet_name, 200)
 
-    # Delete new data headers if the worksheet already has data
     if overwrite
       worksheet.delete_rows(1, worksheet.num_rows)
       worksheet.update_cells(1, 1, rows_with_headers)
     else
+      # Delete new data headers if the worksheet already has data
       rows_with_headers.shift if worksheet.num_rows > 0
       worksheet.insert_rows(worksheet.num_rows + 1, rows_with_headers)
     end


### PR DESCRIPTION
This PR contains 2 main changes

1. Allow overwriting a gsheet instead of just appending. This is helpful when we need to reprocess all data due to bugs.

2. Add configs to validate translation mades by Tomedes (3 accounts `Tomedes`, `Tomedes_TEP`, `Tomedes_Trans`) for 2 projects (`codeorg` and `hour-of-code`) in 22 languages.

    Language code | Language name
    --|--
    ar | Arabic
    cs | Czech
    de | German
    el | Greek
    es-ES | Spanish
    es-MX | Spanish, Mexico
    fr | French
    hi | Hindi
    hu | Hungarian
    id | Bahasa Indonesian
    it | Italian
    ja | Japanese
    kn | Kannada
    ko | Korean
    mr | Marathi
    ms | Malay
    ta | Tamil
    tl | Tagalog
    tr | Turkish
    vi | Vietnamese
    zh-CN | Chinese Simplified
    zh-TW | Chinese Traditional