### PR TITLE
[Google Blockly] Bump to v8! (Redo of "[Google Blockly] Bump to v7!")

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -243,7 +243,7 @@
     "@dsco_/link": "^1.1.2",
     "@microsoft/immersive-reader-sdk": "^1.1.0",
     "ace-builds": "^1.4.12",
-    "blockly": "7.20211209.1",
+    "blockly": "8.0.3",
     "crypto-js": "^3.1.9-1",
     "details-element-polyfill": "https://github.com/javan/details-element-polyfill",
     "filesaver.js": "0.2.0",

--- a/apps/package.json
+++ b/apps/package.json
@@ -221,8 +221,8 @@
     "webpack-stats-plugin": "^0.2.1"
   },
   "dependencies": {
-    "@blockly/field-grid-dropdown": "^1.0.25",
-    "@blockly/plugin-scroll-options": "^1.0.4",
+    "@blockly/field-grid-dropdown": "^1.0.38",
+    "@blockly/plugin-scroll-options": "^2.0.13",
     "@code-dot-org/js-interpreter": "1.3.13",
     "@code-dot-org/remark-plugins": "^1.1.0",
     "@codemirror/closebrackets": "^0.19.0",
@@ -243,7 +243,7 @@
     "@dsco_/link": "^1.1.2",
     "@microsoft/immersive-reader-sdk": "^1.1.0",
     "ace-builds": "^1.4.12",
-    "blockly": "6.20210701.0",
+    "blockly": "7.20211209.1",
     "crypto-js": "^3.1.9-1",
     "details-element-polyfill": "https://github.com/javan/details-element-polyfill",
     "filesaver.js": "0.2.0",

--- a/apps/src/block_utils.js
+++ b/apps/src/block_utils.js
@@ -1,5 +1,7 @@
 import _ from 'lodash';
 import xml from './xml';
+import CdoFieldVariable from './blockly/addons/cdoFieldVariable';
+import {BlocklyVersion} from '@cdo/apps/constants';
 
 const ATTRIBUTES_TO_CLEAN = ['uservisible', 'deletable', 'movable'];
 const DEFAULT_COLOR = [184, 1.0, 0.74];
@@ -729,6 +731,11 @@ const STANDARD_INPUT_TYPES = {
   },
   [VARIABLE_INPUT]: {
     addInput(blockly, block, inputConfig, currentInputRow) {
+      const FieldVariableClass =
+        Blockly.version === BlocklyVersion.CDO
+          ? Blockly.FieldVariable
+          : CdoFieldVariable;
+
       // Make sure the variable name gets declared at the top of the program
       block.getVars = function() {
         return {
@@ -764,7 +771,7 @@ const STANDARD_INPUT_TYPES = {
       // Add the variable field to the block
       currentInputRow
         .appendField(inputConfig.label)
-        .appendField(new Blockly.FieldVariable(null), inputConfig.name);
+        .appendField(new FieldVariableClass(null), inputConfig.name);
     },
     generateCode(block, inputConfig) {
       return Blockly.JavaScript.translateVarName(

--- a/apps/src/blockly/addons/cdoFieldVariable.js
+++ b/apps/src/blockly/addons/cdoFieldVariable.js
@@ -51,23 +51,24 @@ export default class FieldVariable extends GoogleBlockly.FieldVariable {
       }
     }
   }
+  menuGenerator_ = function() {
+    const options = FieldVariable.dropdownCreate.call(this);
+
+    // Remove the last two options (Delete and Rename)
+    options.pop();
+    options.pop();
+
+    // Add our custom options (Rename this variable, Rename all)
+    options.push([
+      msg.renameAll({variableName: this.getText()}),
+      RENAME_ALL_ID
+    ]);
+    options.push([msg.renameThis(), RENAME_THIS_ID]);
+
+    return options;
+  };
 }
-
-FieldVariable.originalDropdownCreate = FieldVariable.dropdownCreate;
-FieldVariable.dropdownCreate = function() {
-  const options = FieldVariable.originalDropdownCreate.call(this);
-
-  // Remove the last two options (Delete and Rename)
-  options.pop();
-  options.pop();
-
-  // Add our custom options (Rename this variable, Rename all)
-  options.push([msg.renameAll({variableName: this.getText()}), RENAME_ALL_ID]);
-  options.push([msg.renameThis(), RENAME_THIS_ID]);
-
-  return options;
-};
-
+// Fix built-in block
 /**
  * Prompt the user for a variable name and perform some whitespace cleanup
  * @param {string} promptText description text for window prompt

--- a/apps/src/blockly/googleBlocklyWrapper.js
+++ b/apps/src/blockly/googleBlocklyWrapper.js
@@ -159,7 +159,14 @@ function initializeBlocklyWrapper(blocklyInstance) {
   blocklyWrapper.blockly_.FieldButton = CdoFieldButton;
   blocklyWrapper.blockly_.FieldDropdown = CdoFieldDropdown;
   blocklyWrapper.blockly_.FieldImageDropdown = CdoFieldImageDropdown;
-  blocklyWrapper.blockly_.FieldVariable = CdoFieldVariable;
+
+  // Fix built-in block
+  blocklyWrapper.blockly_.fieldRegistry.unregister('field_variable');
+  blocklyWrapper.blockly_.fieldRegistry.register(
+    'field_variable',
+    CdoFieldVariable
+  );
+
   blocklyWrapper.blockly_.FunctionEditor = FunctionEditor;
   blocklyWrapper.blockly_.Trashcan = CdoTrashcan;
 

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -3789,10 +3789,10 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
-blockly@7.20211209.1:
-  version "7.20211209.1"
-  resolved "https://registry.yarnpkg.com/blockly/-/blockly-7.20211209.1.tgz#e20a537cfbfcd764cd0b8748fbb2f3c27a250aa4"
-  integrity sha512-TzrE55MUhBuUZ3vaCmnBJsbmR5sh2LnYl36ZkK/Jd0yHqb/2ZMxXY8pHyqHu2ZUWwGVcaJM9qK7c2Yk6TfxyEA==
+blockly@8.0.3:
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/blockly/-/blockly-8.0.3.tgz#a59e5b727843115c6962a2c60759929e91d5cab0"
+  integrity sha512-6sufD+HiKjLk8BtF/mAZagnwr41TQqcj74W1m+qB4pFttXrSWiSsWRsBnJYRMxuAO7iuLcehaQhBbCs3LkoLVw==
   dependencies:
     jsdom "15.2.1"
 

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -1574,15 +1574,15 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@blockly/field-grid-dropdown@^1.0.25":
-  version "1.0.25"
-  resolved "https://registry.yarnpkg.com/@blockly/field-grid-dropdown/-/field-grid-dropdown-1.0.25.tgz#6cf6d6749e7de69a251c0e99b3269b89b561a000"
-  integrity sha512-3uGagJiJKltuS54fT/sTVWqN+j8aRUklevYPvchhg711A4gVeQzpWVVtnNk0IywKxTk61Pd/jZNZivPIq8ZFpg==
+"@blockly/field-grid-dropdown@^1.0.38":
+  version "1.0.38"
+  resolved "https://registry.yarnpkg.com/@blockly/field-grid-dropdown/-/field-grid-dropdown-1.0.38.tgz#6e10ae2a5851cf9c7b562c1fee823e3a95e13eed"
+  integrity sha512-PQiheo+yUioI2gFoREmJZ9yYU4HaAdFG0IYkx61ymHwHMplsLbtjl2CMnRZ1UVj/wvw3AhZrv9UOlB/oxuqBvw==
 
-"@blockly/plugin-scroll-options@^1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@blockly/plugin-scroll-options/-/plugin-scroll-options-1.0.4.tgz#ea85f8c3b2f0cbe8f273f89a56a306b3bb868795"
-  integrity sha512-Aex5zpSmWDvTBRGNJWwI12qYWhXG+u0bnb74LD917EdE94tsz4P2p7B/tby3NZdsE4DvNHjUG0dxCwxTbcitHg==
+"@blockly/plugin-scroll-options@^2.0.13":
+  version "2.0.13"
+  resolved "https://registry.yarnpkg.com/@blockly/plugin-scroll-options/-/plugin-scroll-options-2.0.13.tgz#b1087bb6fe445b5736c156df201cb71c6228952d"
+  integrity sha512-ZNpzxWoTMtFMcZi4Fd00pW4hmS2RR9G5NTyUD8P/GwOv+W99zPTTLw/tT+gbmFLp9YuL1uCS6hn3sKujzEOhfA==
 
 "@cdo/interpreted@link:../dashboard/config/libraries":
   version "0.0.0"
@@ -3789,10 +3789,10 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
-blockly@6.20210701.0:
-  version "6.20210701.0"
-  resolved "https://registry.yarnpkg.com/blockly/-/blockly-6.20210701.0.tgz#578dbdc59a61339a6ba29a69d0dc7bebeb8a19d1"
-  integrity sha512-cNrwFOAxXE5Pbs1FJAyLTlSRzpNW/C+0gPT2rGQDOJVVKcyF3vhFC1StgnxvQNsv//ueuksKWIXxDuSWh1VI4w==
+blockly@7.20211209.1:
+  version "7.20211209.1"
+  resolved "https://registry.yarnpkg.com/blockly/-/blockly-7.20211209.1.tgz#e20a537cfbfcd764cd0b8748fbb2f3c27a250aa4"
+  integrity sha512-TzrE55MUhBuUZ3vaCmnBJsbmR5sh2LnYl36ZkK/Jd0yHqb/2ZMxXY8pHyqHu2ZUWwGVcaJM9qK7c2Yk6TfxyEA==
   dependencies:
     jsdom "15.2.1"
 


### PR DESCRIPTION
"Redo" of: 
- code-dot-org/code-dot-org#46436

Reverts:
- code-dot-org/code-dot-org#46966

This PR is to update Blockly from v6 to v8, skipping v7.

During Thursday's DOTD shift, @breville found that our bump to v7 was causing a bunch of `Unexpected token: keyword const` from UglifyJs.
After reproducing the issue locally (by running `npm run build:dist` from `/apps`), we decide to revert the change.

After sharing the issue with the Google Blockly team, we learned that Blockly's code *should* compile down to ES5, removing all instances of `const` from the actual compiled code. However, it was discovered that there is a single instance of `const` in the manually authored code above the compiled code:
- https://unpkg.com/blockly@7.20211209.5/blockly.min.js

Fortunately, this is not the case with v8:
- https://unpkg.com/blockly@8.0.3/blockly.min.js

Sure enough, switching to v8 resolves the issues that were popping up during Thursday's build attempts. As luck would have it, we are actually ready to update to v8 today, so we can skip v7 and neatly avoid this problem. I was planning to do gradual bumps to v7 and then v8, out of an abundance of caution. There were only a few breaking changes with v8, and most didn't affect us at all. In fact, the reason Blockly Bug Bash was completed on v8, not v7! (Perhaps setting up the adhoc with v7 would have allowed us to catch this strange issue weeks ago...)

## Links

Slack threads:
- [#infra-test thread](https://codedotorg.slack.com/archives/C03CM903Y/p1656011529703479)
- [#apps-dev thread](https://codedotorg.slack.com/archives/C0T0PNR0D/p1656012835644189)

Release notes:
- [Blockly v8.0.3](https://github.com/google/blockly/releases/tag/blockly-v8.0.0)