### PR TITLE
Stop Skipping Asset Precompilation on Drone

### DIFF
--- a/docker/unit_tests.sh
+++ b/docker/unit_tests.sh
@@ -33,7 +33,6 @@ dashboard_enable_pegasus: true
 dashboard_workers: 5
 skip_seed_all: true
 optimize_webpack_assets: false
-optimize_rails_assets: false
 google_maps_api_key: boguskey
 dashboard_db_reader: \"mysql://readonly@localhost/dashboard_test\"
 " >> locals.yml

--- a/docker/unit_tests.sh
+++ b/docker/unit_tests.sh
@@ -32,7 +32,6 @@ localize_apps: true
 dashboard_enable_pegasus: true
 dashboard_workers: 5
 skip_seed_all: true
-optimize_webpack_assets: false
 google_maps_api_key: boguskey
 dashboard_db_reader: \"mysql://readonly@localhost/dashboard_test\"
 " >> locals.yml

--- a/lib/rake/build.rake
+++ b/lib/rake/build.rake
@@ -2,7 +2,6 @@ require_relative '../../deployment'
 require 'cdo/chat_client'
 require 'cdo/rake_utils'
 require 'cdo/git_utils'
-require 'benchmark'
 
 namespace :build do
   desc 'Builds apps.'
@@ -101,16 +100,10 @@ namespace :build do
         # will be unable to find them.
         raise "do not optimize rails assets without optimized webpack assets" unless CDO.optimize_webpack_assets
 
-        # temporarily measure elapsed time, for debugging purposes.
-        # TODO: remove this before merging
-        time = Benchmark.measure do
-          ChatClient.log 'Cleaning <b>dashboard</b> assets...'
-          RakeUtils.rake 'assets:clean'
-          ChatClient.log 'Precompiling <b>dashboard</b> assets...'
-          RakeUtils.rake 'assets:precompile'
-        end
-        ChatClient.log "Time spent cleaning and precompiling assets: #{time}"
-        puts "Time spent cleaning and precompiling assets: #{time}"
+        ChatClient.log 'Cleaning <b>dashboard</b> assets...'
+        RakeUtils.rake 'assets:clean'
+        ChatClient.log 'Precompiling <b>dashboard</b> assets...'
+        RakeUtils.rake 'assets:precompile'
       end
 
       ChatClient.log 'Upgrading <b>dashboard</b>.'

--- a/lib/rake/build.rake
+++ b/lib/rake/build.rake
@@ -2,6 +2,7 @@ require_relative '../../deployment'
 require 'cdo/chat_client'
 require 'cdo/rake_utils'
 require 'cdo/git_utils'
+require 'benchmark'
 
 namespace :build do
   desc 'Builds apps.'
@@ -100,10 +101,16 @@ namespace :build do
         # will be unable to find them.
         raise "do not optimize rails assets without optimized webpack assets" unless CDO.optimize_webpack_assets
 
-        ChatClient.log 'Cleaning <b>dashboard</b> assets...'
-        RakeUtils.rake 'assets:clean'
-        ChatClient.log 'Precompiling <b>dashboard</b> assets...'
-        RakeUtils.rake 'assets:precompile'
+        # temporarily measure elapsed time, for debugging purposes.
+        # TODO: remove this before merging
+        time = Benchmark.measure do
+          ChatClient.log 'Cleaning <b>dashboard</b> assets...'
+          RakeUtils.rake 'assets:clean'
+          ChatClient.log 'Precompiling <b>dashboard</b> assets...'
+          RakeUtils.rake 'assets:precompile'
+        end
+        ChatClient.log "Time spent cleaning and precompiling assets: #{time}"
+        puts "Time spent cleaning and precompiling assets: #{time}"
       end
 
       ChatClient.log 'Upgrading <b>dashboard</b>.'


### PR DESCRIPTION
For better consistency with other environments.

I added some temporary benchmarking in https://github.com/code-dot-org/code-dot-org/pull/46996/commits/84373e5c16ff8fe4cd0f36a55e8a19f139fbf00a to see how much, and this does add an average of about 3.5 minutes to the drone builds. I think that's acceptably low, but am open to feedback.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

See https://github.com/code-dot-org/code-dot-org/pull/31153, which did some work in this space and referenced unkown issues with these settings on drone. I'm not able to reproduce the issues referenced; I expect that they vanished just as mysteriously as they appeared.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
