### PR TITLE
Specify domain for dashboard routes

### DIFF
--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -11,7 +11,7 @@ Dashboard::Application.routes.draw do
     get '/style.css', constraints: {host: CDO.codeprojects_hostname}, to: redirect('/assets/weblab/footer.css')
   end
 
-  constraints host: CDO.dashboard_hostname do
+  constraints host: /.*code.org.*/ do
     # React-router will handle sub-routes on the client.
     get 'teacher_dashboard/sections/:section_id/parent_letter', to: 'teacher_dashboard#parent_letter'
     get 'teacher_dashboard/sections/:section_id/*path', to: 'teacher_dashboard#show', via: :all

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -4,1013 +4,1017 @@ Dashboard::Application.routes.draw do
   # Override Error Codes
   get "404", to: "application#render_404", via: :all
 
-  # React-router will handle sub-routes on the client.
-  get 'teacher_dashboard/sections/:section_id/parent_letter', to: 'teacher_dashboard#parent_letter'
-  get 'teacher_dashboard/sections/:section_id/*path', to: 'teacher_dashboard#show', via: :all
-  get 'teacher_dashboard/sections/:section_id', to: 'teacher_dashboard#show'
-
-  resources :survey_results, only: [:create], defaults: {format: 'json'}
-
-  resource :pairing, only: [:show, :update]
-
-  resources :user_levels, only: [:update, :destroy]
-
-  patch '/api/v1/user_scripts/:script_id', to: 'api/v1/user_scripts#update'
-
-  get '/download/:product', to: 'hoc_download#index'
-
-  get '/terms-and-privacy', to: 'home#terms_and_privacy'
-  get '/dashboardapi/terms-and-privacy', to: "home#terms_and_privacy"
-  get '/dashboardapi/hoc-courses-teacher-guides', to: "home#hoc_courses_teacher_guides"
-  get '/dashboardapi/hoc-courses-challenge', to: "home#hoc_courses_challenge"
-
-  get "/home", to: "home#home"
-
-  get "/congrats", to: "congrats#index"
-
-  resources :activity_hints, only: [:update]
-
-  resources :hint_view_requests, only: [:create]
-  resources :authored_hint_view_requests, only: [:create]
-
-  resources :puzzle_ratings, only: [:create]
-  resources :callouts
-  resources :videos do
-    collection do
-      get 'test'
-      get 'embed/:key', to: 'videos#embed', as: 'embed'
-    end
+  constraints host: CDO.codeprojects_hostname do
+    # Routes needed for the footer on weblab share links on codeprojects
+    get '/weblab/footer', to: 'projects#weblab_footer', constraints: {host: CDO.codeprojects_hostname}
+    get '/scripts/hosted.js', constraints: {host: CDO.codeprojects_hostname}, to: redirect('/weblab/footer.js')
+    get '/style.css', constraints: {host: CDO.codeprojects_hostname}, to: redirect('/assets/weblab/footer.css')
   end
 
-  get 'maker/home', to: 'maker#home'
-  get 'maker/setup', to: 'maker#setup'
-  get 'maker/discountcode', to: 'maker#discountcode'
-  post 'maker/apply', to: 'maker#apply'
-  post 'maker/schoolchoice', to: 'maker#schoolchoice'
-  post 'maker/complete', to: 'maker#complete'
-  get 'maker/application_status', to: 'maker#application_status'
-  post 'maker/override', to: 'maker#override'
-  get 'maker/google_oauth_login_code', to: 'maker#login_code'
-  get 'maker/display_google_oauth_code', to: 'maker#display_code'
-  get 'maker/google_oauth_confirm_login', to: 'maker#confirm_login'
+  constraints host: CDO.dashboard_hostname do
+    # React-router will handle sub-routes on the client.
+    get 'teacher_dashboard/sections/:section_id/parent_letter', to: 'teacher_dashboard#parent_letter'
+    get 'teacher_dashboard/sections/:section_id/*path', to: 'teacher_dashboard#show', via: :all
+    get 'teacher_dashboard/sections/:section_id', to: 'teacher_dashboard#show'
 
-  # Media proxying
-  get 'media', to: 'media_proxy#get', format: false
+    resources :survey_results, only: [:create], defaults: {format: 'json'}
 
-  # XHR proxying
-  get 'xhr', to: 'xhr_proxy#get', format: false
+    resource :pairing, only: [:show, :update]
 
-  get 'redirected_url', to: 'redirect_proxy#get', format: false
+    resources :user_levels, only: [:update, :destroy]
 
-  # We moved code docs off of curriculum builder in spring 2022.
-  # In that move, we wanted to preserve the previous /docs routes for these
-  # pages. However, there are a lot of other /docs URLs that did not move over
-  # so we're allow-listing the four IDEs that lived on curriculum builder to be
-  # served by ProgrammingEnvironmentsController and ProgrammingExpressionsController,
-  # with the rest falling back to the old proxying logic.
-  get 'docs/', to: 'programming_environments#docs_index'
-  get 'docs/:programming_environment_name', to: 'programming_environments#docs_show', constraints: {programming_environment_name: /(applab|gamelab|spritelab|weblab)/}
-  get 'docs/:programming_environment_name/:programming_expression_key', constraints: {programming_environment_name: /(applab|gamelab|spritelab|weblab)/, programming_expression_key: /#{CurriculumHelper::KEY_CHAR_RE}+/o}, to: 'programming_expressions#docs_show'
-  get 'docs/:programming_environment_name/:programming_expression_key/index.html', constraints: {programming_environment_name: /(applab|gamelab|spritelab|weblab)/, programming_expression_key: /#{CurriculumHelper::KEY_CHAR_RE}+/o}, to: 'programming_expressions#docs_show'
+    patch '/api/v1/user_scripts/:script_id', to: 'api/v1/user_scripts#update'
 
-  resources :programming_environments, only: [:index, :show], param: 'name', path: '/docs/ide/' do
-    resources :programming_expressions, param: 'programming_expression_key', constraints: {programming_expression_key: /#{CurriculumHelper::KEY_CHAR_RE}+/o}, path: '/expressions' do
-      member do
-        get :show, to: 'programming_expressions#show_by_keys'
-      end
-    end
-    resources :programming_classes, param: 'programming_class_key', constraints: {programming_class_key: /#{CurriculumHelper::KEY_CHAR_RE}+/o}, path: '/classes' do
-      member do
-        get :show, to: 'programming_classes#show_by_keys'
-      end
-    end
-  end
+    get '/download/:product', to: 'hoc_download#index'
 
-  get 'docs/*path', to: 'curriculum_proxy#get_doc'
-  get 'curriculum/*path', to: 'curriculum_proxy#get_curriculum'
+    get '/terms-and-privacy', to: 'home#terms_and_privacy'
+    get '/dashboardapi/terms-and-privacy', to: "home#terms_and_privacy"
+    get '/dashboardapi/hoc-courses-teacher-guides', to: "home#hoc_courses_teacher_guides"
+    get '/dashboardapi/hoc-courses-challenge', to: "home#hoc_courses_challenge"
 
-  # User-facing section routes
-  resources :sections, only: [:show] do
-    member do
-      post 'log_in'
-    end
-  end
-  # Section API routes (JSON only)
-  concern :section_api_routes do
-    resources :sections, only: [:index, :show, :create, :update, :destroy] do
-      resources :students, only: [:index, :update], controller: 'sections_students' do
-        collection do
-          post 'bulk_add'
-          get 'completed_levels_count'
-        end
-        member do
-          post 'remove'
-        end
-      end
-      member do
-        post 'join'
-        post 'leave'
-        post 'update_sharing_disabled'
-        get 'code_review_groups'
-        post 'code_review_groups', to: 'sections#set_code_review_groups'
-        post 'code_review_enabled', to: 'sections#set_code_review_enabled'
-      end
+    get "/home", to: "home#home"
+
+    get "/congrats", to: "congrats#index"
+
+    resources :activity_hints, only: [:update]
+
+    resources :hint_view_requests, only: [:create]
+    resources :authored_hint_view_requests, only: [:create]
+
+    resources :puzzle_ratings, only: [:create]
+    resources :callouts
+    resources :videos do
       collection do
-        get 'membership'
-        get 'valid_course_offerings'
-        get 'available_participant_types'
-        get 'require_captcha'
+        get 'test'
+        get 'embed/:key', to: 'videos#embed', as: 'embed'
       end
     end
-  end
 
-  # Used in react assessments tab
-  concern :assessments_routes do
-    resources :assessments, only: [:index] do
-      collection do
-        get 'section_responses'
-        get 'section_surveys'
-        get 'section_feedback'
-      end
-    end
-  end
+    get 'maker/home', to: 'maker#home'
+    get 'maker/setup', to: 'maker#setup'
+    get 'maker/discountcode', to: 'maker#discountcode'
+    post 'maker/apply', to: 'maker#apply'
+    post 'maker/schoolchoice', to: 'maker#schoolchoice'
+    post 'maker/complete', to: 'maker#complete'
+    get 'maker/application_status', to: 'maker#application_status'
+    post 'maker/override', to: 'maker#override'
+    get 'maker/google_oauth_login_code', to: 'maker#login_code'
+    get 'maker/display_google_oauth_code', to: 'maker#display_code'
+    get 'maker/google_oauth_confirm_login', to: 'maker#confirm_login'
 
-  post '/dashboardapi/sections/transfers', to: 'transfers#create'
-  post '/api/sections/transfers', to: 'transfers#create'
+    # Media proxying
+    get 'media', to: 'media_proxy#get', format: false
 
-  get '/sh/:id', to: redirect('/c/%{id}')
-  get '/sh/:id/:action_id', to: redirect('/c/%{id}/%{action_id}')
+    # XHR proxying
+    get 'xhr', to: 'xhr_proxy#get', format: false
 
-  get '/u/:id', to: redirect('/c/%{id}')
-  get '/u/:id/:action_id', to: redirect('/c/%{id}/%{action_id}')
+    get 'redirected_url', to: 'redirect_proxy#get', format: false
 
-  # These links should no longer be created (August 2017), though we will continue to support
-  # existing links. Instead, create /r/ links.
-  resources :level_sources, path: '/c/', only: [:show, :edit, :update] do
-    member do
-      get 'generate_image'
-      get 'original_image'
-    end
-  end
-  # These routes are being created to replace the /c/ routes (August 2017) so as to include the ID
-  # of the sharing user in the URL. Doing so allows us to block showing the level source if the user
-  # deletes themself.
-  resources :obfuscated_level_sources, path: '/r/', controller: :level_sources, param: :level_source_id_and_user_id, only: [:show, :edit, :update] do
-    member do
-      get 'generate_image'
-      get 'original_image'
-    end
-  end
+    # We moved code docs off of curriculum builder in spring 2022.
+    # In that move, we wanted to preserve the previous /docs routes for these
+    # pages. However, there are a lot of other /docs URLs that did not move over
+    # so we're allow-listing the four IDEs that lived on curriculum builder to be
+    # served by ProgrammingEnvironmentsController and ProgrammingExpressionsController,
+    # with the rest falling back to the old proxying logic.
+    get 'docs/', to: 'programming_environments#docs_index'
+    get 'docs/:programming_environment_name', to: 'programming_environments#docs_show', constraints: {programming_environment_name: /(applab|gamelab|spritelab|weblab)/}
+    get 'docs/:programming_environment_name/:programming_expression_key', constraints: {programming_environment_name: /(applab|gamelab|spritelab|weblab)/, programming_expression_key: /#{CurriculumHelper::KEY_CHAR_RE}+/o}, to: 'programming_expressions#docs_show'
+    get 'docs/:programming_environment_name/:programming_expression_key/index.html', constraints: {programming_environment_name: /(applab|gamelab|spritelab|weblab)/, programming_expression_key: /#{CurriculumHelper::KEY_CHAR_RE}+/o}, to: 'programming_expressions#docs_show'
 
-  get '/share/:id', to: redirect('/c/%{id}')
-
-  devise_scope :user do
-    get '/oauth_sign_out/:provider', to: 'sessions#oauth_sign_out', as: :oauth_sign_out
-    post '/users/begin_sign_up', to: 'registrations#begin_sign_up'
-    patch '/dashboardapi/users', to: 'registrations#update'
-    patch '/users/upgrade', to: 'registrations#upgrade'
-    patch '/users/set_age', to: 'registrations#set_age'
-    patch '/users/email', to: 'registrations#set_email'
-    patch '/users/parent_email', to: 'registrations#set_parent_email'
-    patch '/users/user_type', to: 'registrations#set_user_type'
-    get '/users/cancel', to: 'registrations#cancel'
-    post '/users/auth/:id/disconnect', to: 'authentication_options#disconnect'
-    get '/users/migrate_to_multi_auth', to: 'registrations#migrate_to_multi_auth'
-    get '/users/demigrate_from_multi_auth', to: 'registrations#demigrate_from_multi_auth'
-    get '/users/to_destroy', to: 'registrations#users_to_destroy'
-    get '/reset_session', to: 'sessions#reset'
-    get '/users/existing_account', to: 'registrations#existing_account'
-    post '/users/auth/maker_google_oauth2', to: 'omniauth_callbacks#maker_google_oauth2'
-  end
-  devise_for :users, controllers: {
-    omniauth_callbacks: 'omniauth_callbacks',
-    registrations: 'registrations',
-    confirmations: 'confirmations',
-    sessions: 'sessions',
-    passwords: 'passwords'
-  }
-  get 'discourse/sso' => 'discourse_sso#sso'
-  post '/auth/lti', to: 'lti_provider#sso'
-
-  root to: "home#index"
-  get '/home_insert', to: 'home#home_insert'
-  get '/health_check', to: 'home#health_check'
-  namespace :home do
-    HomeController.instance_methods(false).each do |action|
-      get action, action: action
-    end
-  end
-
-  resources :p, path: '/p/', only: [:index] do
-    collection do
-      ProjectsController::STANDALONE_PROJECTS.each do |key, value|
-        get '/' + key.to_s, to: 'projects#redirect_legacy', key: value[:name], as: key.to_s
-      end
-      get '/', to: redirect('/projects')
-    end
-  end
-
-  get "/gallery", to: redirect("/projects/public")
-
-  get 'projects/featured', to: 'projects#featured'
-  put '/featured_projects/:project_id/unfeature', to: 'featured_projects#unfeature'
-  put '/featured_projects/:project_id/feature', to: 'featured_projects#feature'
-
-  # Routes needed for the footer on weblab share links on codeprojects
-  get '/weblab/footer', to: 'projects#weblab_footer', constraints: {host: CDO.codeprojects_hostname}
-  get '/scripts/hosted.js', constraints: {host: CDO.codeprojects_hostname}, to: redirect('/weblab/footer.js')
-  get '/style.css', constraints: {host: CDO.codeprojects_hostname}, to: redirect('/assets/weblab/footer.css')
-
-  resources :projects, path: '/projects/', only: [:index] do
-    collection do
-      ProjectsController::STANDALONE_PROJECTS.each do |key, _|
-        get "/#{key}", to: 'projects#load', key: key.to_s, as: "#{key}_project"
-        get "/#{key}/new", to: 'projects#create_new', key: key.to_s, as: "#{key}_project_create_new"
-
-        # Weblab projects are shared on a codeprojects path. The share URL on code studio doesn't mean anything and instead
-        # should be redirected to the corresponding codeprojects path.
-        if key == 'weblab'
-          get "/#{key}/:channel_id", constraints: {host: CDO.dashboard_hostname}, to: redirect("//#{CDO.site_host('codeprojects.org')}/%{channel_id}/")
-        else
-          get "/#{key}/:channel_id", to: 'projects#show', key: key.to_s, as: "#{key}_project_share", share: true
+    resources :programming_environments, only: [:index, :show], param: 'name', path: '/docs/ide/' do
+      resources :programming_expressions, param: 'programming_expression_key', constraints: {programming_expression_key: /#{CurriculumHelper::KEY_CHAR_RE}+/o}, path: '/expressions' do
+        member do
+          get :show, to: 'programming_expressions#show_by_keys'
         end
-
-        get "/#{key}/:channel_id/edit", to: 'projects#edit', key: key.to_s, as: "#{key}_project_edit"
-        get "/#{key}/:channel_id/view", to: 'projects#show', key: key.to_s, as: "#{key}_project_view", readonly: true
-        get "/#{key}/:channel_id/embed", to: 'projects#show', key: key.to_s, as: "#{key}_project_iframe_embed", iframe_embed: true
-
-        # appending 'embed_app_and_code' to a project renders a page with just the app editor. It is distinct from appending 'embed'
-        # to a project in that appending 'embed' renders only the app, wheras 'embed_app_and_code renders the app and the workspace
-        # for building the app, in view only mode. Specifically, appending 'embed_app_and_code' to a project does the following:
-        #
-        # - set view options to remove headers/footers
-        # - set a view option 'iframeEmbedAppAndCode' to true, setting the config.level.iframeEmbedAppAndCode variable to true on the client side
-        #   This makes a number of changes to how StudioApp behaves, and some changes to how P5Lab.js behaves
-        get "/#{key}/:channel_id/embed_app_and_code", to: 'projects#show', key: key.to_s, as: "#{key}_project_iframe_embed_app_and_code", iframe_embed_app_and_code: true, readonly: true
-        get "/#{key}/:channel_id/remix", to: 'projects#remix', key: key.to_s, as: "#{key}_project_remix"
-        get "/#{key}/:channel_id/export_create_channel", to: 'projects#export_create_channel', key: key.to_s, as: "#{key}_project_export_create_channel"
-        get "/#{key}/:channel_id/export_config", to: 'projects#export_config', key: key.to_s, as: "#{key}_project_export_config"
       end
-
-      get '/:tab_name', to: 'projects#index', constraints: {tab_name: /(public|libraries)/}
-    end
-  end
-
-  post '/locale', to: 'home#set_locale', as: 'locale'
-
-  # quick links for cartoon network arabic
-  get '/flappy/lang/ar', to: 'home#set_locale', as: 'flappy/lang/ar', locale: 'ar-SA', user_return_to: '/flappy/1'
-  get '/playlab/lang/ar', to: 'home#set_locale', as: 'playlab/lang/ar', locale: 'ar-SA', user_return_to: '/s/playlab/lessons/1/levels/1'
-  get '/artist/lang/ar', to: 'home#set_locale', as: 'artist/lang/ar', locale: 'ar-SA', user_return_to: '/s/artist/lessons/1/levels/1'
-
-  # /lang/xx shortcut for all routes
-  get '/lang/:locale', to: 'home#set_locale', user_return_to: '/'
-  get '*i18npath/lang/:locale', to: 'home#set_locale'
-
-  get 'pools', to: 'pools#index', as: 'pools'
-  scope 'pools/:pool' do
-    resources :blocks, constraints: {id: /[^\/]+/}
-  end
-  resources :shared_blockly_functions, path: '/functions'
-
-  resources :libraries do
-    collection do
-      get '/get_updates', to: 'libraries#get_updates'
-    end
-  end
-
-  resources :datasets, param: 'dataset_name', constraints: {dataset_name: /[^\/]+/}, only: [:index, :show, :update, :destroy] do
-    collection do
-      get '/manifest/edit', to: 'datasets#edit_manifest'
-      post '/manifest/update', to: 'datasets#update_manifest'
-    end
-  end
-
-  resources :levels do
-    collection do
-      get 'get_filtered_levels'
-    end
-    member do
-      get 'get_rubric'
-      get 'embed_level'
-      get 'edit_blocks/:type', to: 'levels#edit_blocks', as: 'edit_blocks'
-      get 'edit_exemplar', to: 'levels#edit_exemplar', as: 'edit_exemplar'
-      get 'get_serialized_maze'
-      post 'update_properties'
-      post 'update_blocks/:type', to: 'levels#update_blocks', as: 'update_blocks'
-      post 'clone'
-      post 'update_start_code'
-      post 'update_exemplar_code'
-    end
-  end
-
-  post 'level_assets/upload', to: 'level_assets#upload'
-
-  resources :level_starter_assets, only: [:show], param: 'level_name', constraints: {level_name: /[^\/]+/} do
-    member do
-      get '/:filename', to: 'level_starter_assets#file', format: true
-      post '', to: 'level_starter_assets#upload'
-      delete '/:filename', to: 'level_starter_assets#destroy'
-    end
-  end
-
-  resources :course_offerings, only: [:edit, :update], param: 'key'
-
-  get '/course/:course_name', to: redirect('/courses/%{course_name}')
-  get '/courses/:course_name/vocab/edit', to: 'vocabularies#edit'
-  # these routes use course_course_name to match generated routes below that are nested within courses
-  get '/courses/:course_course_name/guides/edit', to: 'reference_guides#edit_all', as: :edit_all_reference_guides
-
-  resources :courses, param: 'course_name' do
-    member do
-      get 'vocab'
-      get 'resources'
-      get 'code'
-      get 'standards'
-      get 'get_rollup_resources'
+      resources :programming_classes, param: 'programming_class_key', constraints: {programming_class_key: /#{CurriculumHelper::KEY_CHAR_RE}+/o}, path: '/classes' do
+        member do
+          get :show, to: 'programming_classes#show_by_keys'
+        end
+      end
     end
 
-    resources :reference_guides, param: 'key', path: 'guides'
-  end
+    get 'docs/*path', to: 'curriculum_proxy#get_doc'
+    get 'curriculum/*path', to: 'curriculum_proxy#get_curriculum'
 
-  # CSP 20-21 lockable lessons with lesson plan redirects
-  get '/s/csp1-2020/lockable/2(*all)', to: redirect(path: '/s/csp1-2020/lessons/14%{all}')
-  get '/s/csp2-2020/lockable/1(*all)', to: redirect(path: '/s/csp2-2020/lessons/9%{all}')
-  get '/s/csp3-2020/lockable/1(*all)', to: redirect(path: '/s/csp3-2020/lessons/11%{all}')
-  get '/s/csp4-2020/lockable/1(*all)', to: redirect(path: '/s/csp4-2020/lessons/15%{all}')
-  get '/s/csp5-2020/lockable/1(*all)', to: redirect(path: '/s/csp5-2020/lessons/18%{all}')
-  get '/s/csp6-2020/lockable/1(*all)', to: redirect(path: '/s/csp6-2020/lessons/6%{all}')
-  get '/s/csp7-2020/lockable/1(*all)', to: redirect(path: '/s/csp7-2020/lessons/11%{all}')
-  get '/s/csp9-2020/lockable/1(*all)', to: redirect(path: '/s/csp9-2020/lessons/9%{all}')
-  get '/s/csp10-2020/lockable/1(*all)', to: redirect(path: '/s/csp10-2020/lessons/14%{all}')
-
-  resources :lessons, only: [:edit, :update] do
-    member do
-      get :show, to: 'lessons#show_by_id'
-      post :clone
-    end
-  end
-
-  resources :resources, only: [:create, :update] do
-    collection do
-      get :search
-    end
-  end
-
-  resources :vocabularies, only: [:create, :update] do
-    collection do
-      get :search
-    end
-  end
-
-  resources :programming_classes, only: [:new, :create, :edit, :update, :show, :destroy] do
-    collection do
-      get :get_filtered_results
-    end
-    member do
-      post :clone
-    end
-  end
-
-  resources :programming_expressions, only: [:index, :new, :create, :edit, :update, :show, :destroy] do
-    collection do
-      get :search
-      get :get_filtered_results
-    end
-    member do
-      post :clone
-    end
-  end
-
-  resources :programming_environments, only: [:index, :new, :create, :edit, :update, :show, :destroy], param: 'name' do
-    member do
-      get :get_summary_by_name
-    end
-    resources :programming_expressions, param: 'programming_expression_key', constraints: {programming_expression_key: /#{CurriculumHelper::KEY_CHAR_RE}+/o} do
+    # User-facing section routes
+    resources :sections, only: [:show] do
       member do
-        get :show, to: 'programming_expressions#show_by_keys'
+        post 'log_in'
       end
     end
-  end
-
-  resources :programming_methods, only: [:edit, :update]
-
-  resources :standards, only: [] do
-    collection do
-      get :search
-    end
-  end
-
-  # Redirects from old /stage/x/extras url to new /lessons/x/extras url
-  get '/s/:script_name/stage/:position/extras', to: redirect(path: '/s/%{script_name}/lessons/%{position}/extras')
-
-  # Redirects from old /stage/x/puzzle url to new /lessons/x/levels url
-  get '/s/:script_name/stage/:position/puzzle', to: redirect(path: '/s/%{script_name}/lessons/%{position}/levels')
-  get '/s/:script_name/stage/:position/puzzle/(*all)', to: redirect(path: '/s/%{script_name}/lessons/%{position}/levels/%{all}')
-
-  # Redirects from old /lockable/x/puzzle url to new /lockable/x/levels url
-  get '/s/:script_name/lockable/:position/puzzle', to: redirect(path: '/s/%{script_name}/lockable/%{position}/levels')
-  get '/s/:script_name/lockable/:position/puzzle/(*all)', to: redirect(path: '/s/%{script_name}/lockable/%{position}/levels/%{all}')
-
-  resources :scripts, path: '/s/' do
-    # /s/xxx/reset
-    get 'reset', to: 'script_levels#reset'
-    get 'next', to: 'script_levels#next'
-    get 'hidden_lessons', to: 'script_levels#hidden_lesson_ids'
-    post 'toggle_hidden', to: 'script_levels#toggle_hidden'
-
-    member do
-      get 'vocab'
-      get 'resources'
-      get 'code'
-      get 'standards'
-      get 'instructions'
-      get 'get_rollup_resources'
-    end
-
-    # /s/xxx/lessons/yyy
-    resources :lessons, only: [:show], param: 'position', format: false do
-      get 'student', to: 'lessons#student_lesson_plan'
-      get 'extras', to: 'script_levels#lesson_extras', format: false
-      get 'summary_for_lesson_plans', to: 'script_levels#summary_for_lesson_plans', format: false
-      get 'edit', to: 'lessons#edit_with_lesson_position'
-
-      # /s/xxx/lessons/yyy/levels/zzz
-      resources :script_levels, only: [:show], path: "/levels", format: false do
-        member do
-          # /s/xxx/lessons/yyy/levels/zzz/page/ppp
-          get 'page/:puzzle_page', to: 'script_levels#show', as: 'puzzle_page', format: false
-          # /s/xxx/lessons/yyy/levels/zzz/sublevel/sss
-          get 'sublevel/:sublevel_position', to: 'script_levels#show', as: 'sublevel', format: false
-        end
-      end
-    end
-
-    # /s/xxx/lockable/yyy/levels/zzz
-    resources :lockable_lessons, only: [], path: "/lockable", param: 'position', format: false do
-      get 'summary_for_lesson_plans', to: 'script_levels#summary_for_lesson_plans', format: false
-      resources :script_levels, only: [:show], path: "/levels", format: false do
-        member do
-          # /s/xxx/lockable/yyy/levels/zzz/page/ppp
-          get 'page/:puzzle_page', to: 'script_levels#show', as: 'puzzle_page', format: false
-        end
-      end
-    end
-
-    get 'preview-assignments', to: 'plc/enrollment_evaluations#preview_assignments', as: 'preview_assignments'
-    post 'confirm_assignments', to: 'plc/enrollment_evaluations#confirm_assignments', as: 'confirm_assignments'
-
-    get 'pull-review', to: 'peer_reviews#pull_review', as: 'pull_review'
-  end
-
-  get '/certificate_images/:filename', to: 'certificate_images#show'
-
-  get '/print_certificates/:encoded_params', to: 'print_certificates#show'
-
-  get '/certificates/:encoded_params', to: 'certificates#show'
-
-  get '/beta', to: redirect('/')
-
-  get '/hoc/reset', to: 'script_levels#reset', script_id: Script::HOC_NAME, as: 'hoc_reset'
-  get '/hoc/:chapter', to: 'script_levels#show', script_id: Script::HOC_NAME, as: 'hoc_chapter', format: false
-
-  get '/flappy/:chapter', to: 'script_levels#show', script_id: Script::FLAPPY_NAME, as: 'flappy_chapter', format: false
-  get '/jigsaw/:chapter', to: 'script_levels#show', script_id: Script::JIGSAW_NAME, as: 'jigsaw_chapter', format: false
-
-  get '/weblab/host', to: 'weblab_host#index'
-
-  get '/join(/:section_code)', to: 'followers#student_user_new', as: 'student_user_new'
-  post '/join(/:section_code)', to: 'followers#student_register', as: 'student_register'
-
-  post '/milestone/:user_id/level/:level_id', to: 'activities#milestone', as: 'milestone_level'
-  post '/milestone/:user_id/:script_level_id', to: 'activities#milestone', as: 'milestone'
-  post '/milestone/:user_id/:script_level_id/:level_id', to: 'activities#milestone', as: 'milestone_script_level'
-
-  get '/admin', to: 'admin_reports#directory', as: 'admin_directory'
-  resources :regional_partners
-  post 'regional_partners/:id/assign_program_manager', controller: 'regional_partners', action: 'assign_program_manager'
-  get 'regional_partners/:id/remove_program_manager/:program_manager_id', controller: 'regional_partners', action: 'remove_program_manager'
-  post 'regional_partners/:id/add_mapping', controller: 'regional_partners', action: 'add_mapping'
-  get 'regional_partners/:id/remove_mapping/:id', controller: 'regional_partners', action: 'remove_mapping'
-  post 'regional_partners/:id/replace_mappings',  controller: 'regional_partners', action: 'replace_mappings'
-
-  # HOC dashboards.
-  get '/admin/hoc/students_served', to: 'admin_hoc#students_served', as: 'hoc_students_served'
-
-  # NPS dashboards
-  get '/admin/nps/nps_form', to: 'admin_nps#nps_form', as: 'nps_form'
-  post '/admin/nps/nps_update', to: 'admin_nps#nps_update', as: 'nps_update'
-
-  # internal report dashboards
-  get '/admin/levels', to: 'admin_reports#level_completions', as: 'level_completions'
-  get '/admin/level_answers(.:format)', to: 'admin_reports#level_answers', as: 'level_answers'
-  get '/admin/pd_progress(/:script)', to: 'admin_reports#pd_progress', as: 'pd_progress'
-  get '/admin/debug', to: 'admin_reports#debug'
-
-  # internal search tools
-  get '/admin/find_students', to: 'admin_search#find_students', as: 'find_students'
-  get '/admin/lookup_section', to: 'admin_search#lookup_section', as: 'lookup_section'
-  post '/admin/lookup_section', to: 'admin_search#lookup_section'
-  post '/admin/undelete_section', to: 'admin_search#undelete_section', as: 'undelete_section'
-  get '/admin/pilots/', to: 'admin_search#pilots', as: 'pilots'
-  post '/admin/pilots/', to: 'admin_search#create_pilot', as: 'create_pilot'
-  get '/admin/pilots/:pilot_name', to: 'admin_search#show_pilot', as: 'show_pilot'
-  post '/admin/add_to_pilot', to: 'admin_search#add_to_pilot', as: 'add_to_pilot'
-  post '/admin/remove_from_pilot', to: 'admin_search#remove_from_pilot', as: 'remove_from_pilot'
-
-  # internal engineering dashboards
-  get '/admin/dynamic_config', to: 'dynamic_config#show', as: 'dynamic_config_state'
-  get '/admin/feature_mode', to: 'feature_mode#show', as: 'feature_mode'
-  post '/admin/feature_mode', to: 'feature_mode#update', as: 'feature_mode_update'
-
-  # internal support tools
-  get '/admin/account_repair', to: 'admin_users#account_repair_form', as: 'account_repair_form'
-  post '/admin/account_repair', to: 'admin_users#account_repair',  as: 'account_repair'
-  get '/admin/assume_identity', to: 'admin_users#assume_identity_form', as: 'assume_identity_form'
-  post '/admin/assume_identity', to: 'admin_users#assume_identity', as: 'assume_identity'
-  post '/admin/undelete_user', to: 'admin_users#undelete_user', as: 'undelete_user'
-  get '/admin/manual_pass', to: 'admin_users#manual_pass_form', as: 'manual_pass_form'
-  post '/admin/manual_pass', to: 'admin_users#manual_pass', as: 'manual_pass'
-  get '/admin/permissions', to: 'admin_users#permissions_form', as: 'permissions_form'
-  post '/admin/grant_permission', to: 'admin_users#grant_permission', as: 'grant_permission'
-  get '/admin/revoke_permission', to: 'admin_users#revoke_permission', as: 'revoke_permission'
-  post '/admin/bulk_grant_permission', to: 'admin_users#bulk_grant_permission', as: 'bulk_grant_permission'
-  get '/admin/studio_person', to: 'admin_users#studio_person_form', as: 'studio_person_form'
-  post '/admin/studio_person_merge', to: 'admin_users#studio_person_merge', as: 'studio_person_merge'
-  post '/admin/studio_person_split', to: 'admin_users#studio_person_split', as: 'studio_person_split'
-  post '/admin/studio_person_add_email_to_emails', to: 'admin_users#studio_person_add_email_to_emails', as: 'studio_person_add_email_to_emails'
-  get '/admin/user_progress', to: 'admin_users#user_progress_form', as: 'user_progress_form'
-  get '/admin/user_projects', to: 'admin_users#user_projects_form', as: 'user_projects_form'
-  put '/admin/user_project', to: 'admin_users#user_project_restore_form', as: 'user_project_restore_form'
-  get '/admin/delete_progress', to: 'admin_users#delete_progress_form', as: 'delete_progress_form'
-  post '/admin/delete_progress', to: 'admin_users#delete_progress', as: 'delete_progress'
-  get '/census/review', to: 'census_reviewers#review_reported_inaccuracies', as: 'review_reported_inaccuracies'
-  post '/census/review', to: 'census_reviewers#create'
-
-  get '/admin/styleguide', to: redirect('/styleguide/')
-
-  get '/admin/gatekeeper', to: 'dynamic_config#gatekeeper_show', as: 'gatekeeper_show'
-  post '/admin/gatekeeper/delete', to: 'dynamic_config#gatekeeper_delete', as: 'gatekeeper_delete'
-  post '/admin/gatekeeper/set', to: 'dynamic_config#gatekeeper_set', as: 'gatekeeper_set'
-
-  get '/notes/:key', to: 'notes#index'
-
-  resources :zendesk_session, only: [:index]
-
-  post '/report_abuse', to: 'report_abuse#report_abuse'
-  get '/report_abuse', to: 'report_abuse#report_abuse_form'
-
-  get '/too_young', to: 'too_young#index'
-
-  post '/sms/send', to: 'sms#send_to_phone', as: 'send_to_phone'
-  post '/sms/send_download', to: 'sms#send_download_url_to_phone', as: 'send_download_url_to_phone'
-
-  # Experiments are get requests so that a user can click on a link to join or leave an experiment
-  get '/experiments/set_course_experiment/:experiment_name', to: 'experiments#set_course_experiment'
-  get '/experiments/set_single_user_experiment/:experiment_name', to: 'experiments#set_single_user_experiment'
-  get '/experiments/disable_single_user_experiment/:experiment_name', to: 'experiments#disable_single_user_experiment'
-
-  get '/peer_reviews/dashboard', to: 'peer_reviews#dashboard'
-  resources :peer_reviews
-
-  get '/plc/user_course_enrollments/group_view', to: 'plc/user_course_enrollments#group_view'
-  get '/plc/user_course_enrollments/manager_view/:id', to: 'plc/user_course_enrollments#manager_view', as: 'plc_user_course_enrollment_manager_view'
-
-  namespace :plc do
-    root to: 'plc#index'
-    resources :user_course_enrollments
-    resources :course_units, only: [] do
-      collection do
-        get :launch
-        post :launch_plc_course
-      end
-    end
-  end
-
-  concern :api_v1_pd_routes do
-    namespace :pd do
-      resources :workshops do
-        collection do
-          get :filter
-          get :upcoming_teachercons
-        end
-        member do # See http://guides.rubyonrails.org/routing.html#adding-more-restful-actions
-          post :start
-          post :unstart
-          post :end
-          post :reopen
-          get  :summary
-          get  :potential_organizers
-        end
-        resources :enrollments, controller: 'workshop_enrollments', only: [:index, :destroy, :create]
-
-        get :attendance, action: 'index', controller: 'workshop_attendance'
-        get 'attendance/:session_id', action: 'show', controller: 'workshop_attendance'
-        put 'attendance/:session_id/user/:user_id', action: 'create', controller: 'workshop_attendance'
-        delete 'attendance/:session_id/user/:user_id', action: 'destroy', controller: 'workshop_attendance'
-        put 'attendance/:session_id/enrollment/:enrollment_id', action: 'create_by_enrollment', controller: 'workshop_attendance'
-        delete 'attendance/:session_id/enrollment/:enrollment_id', action: 'destroy_by_enrollment', controller: 'workshop_attendance'
-
-        get :workshop_survey_report, action: :workshop_survey_report, controller: 'workshop_survey_report'
-        get :local_workshop_survey_report, action: :local_workshop_survey_report, controller: 'workshop_survey_report'
-        get :generic_survey_report, action: :generic_survey_report, controller: 'workshop_survey_report'
-        get :experiment_survey_report, action: :experiment_survey_report, controller: 'workshop_survey_report'
-        get :teachercon_survey_report, action: :teachercon_survey_report, controller: 'workshop_survey_report'
-        get :workshop_organizer_survey_report, action: :workshop_organizer_survey_report, controller: 'workshop_organizer_survey_report'
-
-        get 'foorm/generic_survey_report', action: :generic_survey_report, controller: 'workshop_survey_foorm_report'
-        get 'foorm/csv_survey_report', action: :csv_survey_report, controller: 'workshop_survey_foorm_report'
-        get 'foorm/forms_for_workshop', action: :forms_for_workshop, controller: 'workshop_survey_foorm_report'
-      end
-
-      resources :workshop_summary_report, only: :index
-      resources :teacher_attendance_report, only: :index
-      resources :course_facilitators, only: :index
-      resources :workshop_organizers, only: :index
-      delete 'enrollments/:enrollment_code', action: 'cancel', controller: 'workshop_enrollments'
-      post 'enrollment/:enrollment_id/scholarship_info', action: 'update_scholarship_info', controller: 'workshop_enrollments'
-      post 'enrollments/move', action: 'move', controller: 'workshop_enrollments'
-      post 'enrollment/:id/edit', action: 'edit', controller: 'workshop_enrollments'
-      get 'legacy_survey_summaries', action: :legacy_survey_summaries, controller: 'legacy_survey_summaries'
-
-      # persistent namespace for FiT Weekend registrations, can be updated/replaced each year
-      post 'fit_weekend_registrations', to: 'fit_weekend_registrations#create'
-
-      post :pre_workshop_surveys, to: 'pre_workshop_surveys#create'
-      post :workshop_surveys, to: 'workshop_surveys#create'
-      post :teachercon_surveys, to: 'teachercon_surveys#create'
-      post :regional_partner_mini_contacts, to: 'regional_partner_mini_contacts#create'
-      post :international_opt_ins, to: 'international_opt_ins#create'
-      get :regional_partner_workshops, to: 'regional_partner_workshops#index'
-      get 'regional_partner_workshops/find', to: 'regional_partner_workshops#find'
-      get 'regional_partners/find', to: 'regional_partners#find'
-
-      post 'foorm/workshop_survey_submission', action: :create, controller: 'workshop_survey_foorm_submissions'
-
-      namespace :application do
-        post :facilitator, to: 'facilitator_applications#create'
-
-        resources :teacher, controller: 'teacher_applications', only: [:create, :update] do
+    # Section API routes (JSON only)
+    concern :section_api_routes do
+      resources :sections, only: [:index, :show, :create, :update, :destroy] do
+        resources :students, only: [:index, :update], controller: 'sections_students' do
+          collection do
+            post 'bulk_add'
+            get 'completed_levels_count'
+          end
           member do
-            post :send_principal_approval
-            post :principal_approval_not_required
+            post 'remove'
           end
         end
-        post :principal_approval, to: 'principal_approval_applications#create'
-      end
-
-      resources :applications, controller: 'applications', only: [:index, :show, :update, :destroy] do
-        collection do
-          get :quick_view
-          get :cohort_view
-          get :search
-          get :fit_cohort
-        end
-      end
-
-      namespace :foorm do
-        namespace :forms do
-          post 'form_with_library_items', action: :fill_in_library_items
-          get 'submissions_csv', action: :get_submissions_as_csv
-          get 'form_names', action: :get_form_names_and_versions
-          post :validate_form
-          get ':id', action: :get_form_data
-        end
-        namespace :library_questions do
-          post :validate_library_question
-        end
-      end
-    end
-  end
-
-  get '/dashboardapi/v1/regional_partners/find', to: 'api/v1/regional_partners#find'
-  get '/dashboardapi/v1/regional_partners/show/:partner_id', to: 'api/v1/regional_partners#show'
-  get '/dashboardapi/v1/pd/application/applications_closed', to: 'pd/professional_learning_landing#applications_closed'
-  post '/dashboardapi/v1/pd/regional_partner_mini_contacts', to: 'api/v1/pd/regional_partner_mini_contacts#create'
-  post '/dashboardapi/v1/amazon_future_engineer_submit', to: 'api/v1/amazon_future_engineer#submit'
-
-  post '/dashboardapi/v1/foorm/simple_survey_submission', action: :create, controller: 'api/v1/foorm_simple_survey_submissions'
-
-  get 'my-professional-learning', to: 'pd/professional_learning_landing#index', as: 'professional_learning_landing'
-
-  namespace :pd do
-    # React-router will handle sub-routes on the client.
-    get 'workshop_dashboard/*path', to: 'workshop_dashboard#index'
-    get 'workshop_dashboard', to: 'workshop_dashboard#index'
-
-    get 'misc_survey/thanks', to: 'misc_survey#thanks'
-    get 'misc_survey/:form_tag', to: 'misc_survey#new'
-    post 'misc_survey/submit', to: 'misc_survey#submit'
-
-    get 'workshop_survey/day/:day', to: 'workshop_daily_survey#new_general'
-    get 'workshop_daily_survey/day/:day', to: 'workshop_daily_survey#new_daily_foorm'
-    get 'workshop_pre_survey', to: 'workshop_daily_survey#new_pre_foorm'
-    get 'workshop_post_survey', to: 'workshop_daily_survey#new_post_foorm'
-    post 'workshop_survey/submit', to: 'workshop_daily_survey#submit_general'
-    get 'workshop_survey/post/:enrollment_code', to: 'workshop_daily_survey#new_post', as: 'new_workshop_survey'
-    get 'workshop_survey/facilitators/:session_id(/:facilitator_index)', to: 'workshop_daily_survey#new_facilitator'
-    post 'workshop_survey/facilitators/submit', to: 'workshop_daily_survey#submit_facilitator'
-    get 'workshop_survey/csf/post101(/:enrollment_code)', to: 'workshop_daily_survey#new_csf_post101'
-    get 'workshop_survey/csf/pre201', to: 'workshop_daily_survey#new_csf_pre201'
-    get 'workshop_survey/csf/post201(/:enrollment_code)', to: 'workshop_daily_survey#new_csf_post201'
-    get 'workshop_survey/foorm/csf/post201(/:enrollment_code)', to: 'workshop_daily_survey#new_csf_post201_foorm'
-    get 'workshop_survey/foorm/csf/pre201', to: 'workshop_daily_survey#new_csf_pre201_foorm'
-    get 'workshop_survey/thanks', to: 'workshop_daily_survey#thanks'
-
-    get 'post_course_survey/thanks', to: 'post_course_survey#thanks'
-    post 'post_course_survey/submit', to: 'post_course_survey#submit'
-    get 'post_course_survey/:course_initials', to: 'post_course_survey#new'
-
-    # Academic year workshops
-    get '/:workshop_subject/pre/(*agenda)', to: 'workshop_daily_survey#new_ayw_pre',
-        constraints: {agenda: /module\/[0-9_]+/}
-    get '/:workshop_subject/day/:day', to: 'workshop_daily_survey#new_ayw_daily',
-        constraints: {day: /\d/}
-    get '/:workshop_subject/post/(*agenda)', to: 'workshop_daily_survey#new_ayw_post',
-        constraints: {agenda: /(module\/[0-9_]+)|(in_person)/}
-
-    namespace :application do
-      get 'facilitator', to: 'facilitator_application#new'
-      get 'teacher', to: 'teacher_application#new'
-      get 'principal_approval/:application_guid', to: 'principal_approval_application#new', as: 'principal_approval'
-    end
-
-    # persistent namespace for Teachercon and FiT Weekend registrations, can be updated/replaced each year
-    get 'fit_weekend_registration/:application_guid', to: 'fit_weekend_registration#new'
-
-    delete 'fit_weekend_registration/:application_guid', to: 'fit_weekend_registration#destroy'
-
-    get 'workshops/:workshop_id/enroll', action: 'new', controller: 'workshop_enrollment'
-    post 'workshops/:workshop_id/enroll', action: 'create', controller: 'workshop_enrollment'
-    get 'workshop_enrollment/:code', action: 'show', controller: 'workshop_enrollment'
-    get 'workshop_enrollment/:code/thanks', action: 'thanks', controller: 'workshop_enrollment'
-    get 'workshop_enrollment/:code/cancel', action: 'cancel', controller: 'workshop_enrollment'
-
-    get 'pre_workshop_survey/:enrollment_code', action: 'new', controller: 'pre_workshop_survey', as: 'new_pre_workshop_survey'
-    get 'teachercon_survey/:enrollment_code', action: 'new', controller: 'teachercon_survey', as: 'new_teachercon_survey'
-
-    get 'generate_workshop_certificate/:enrollment_code', controller: 'workshop_certificate', action: 'generate_certificate'
-
-    get 'attend/:session_code', controller: 'session_attendance', action: 'attend'
-    post 'attend/:session_code', controller: 'session_attendance', action: 'select_enrollment'
-    get 'attend/:session_code/join', controller: 'workshop_enrollment', action: 'join_session'
-    post 'attend/:session_code/join', controller: 'workshop_enrollment', action: 'confirm_join_session'
-    get 'attend/:session_code/upgrade', controller: 'session_attendance', action: 'upgrade_account'
-    post 'attend/:session_code/upgrade', controller: 'session_attendance', action: 'confirm_upgrade_account'
-
-    get 'workshop_admins', controller: 'workshop_admins', action: 'directory', as: 'workshop_admins'
-    get 'workshop_user_management/facilitator_courses', controller: 'workshop_user_management', action: 'facilitator_courses_form', as: 'facilitator_courses'
-    post 'workshop_user_management/assign_course', controller: 'workshop_user_management', action: 'assign_course_to_facilitator'
-    # TODO: change remove_course to use http delete method
-    get 'workshop_user_management/remove_course', controller: 'workshop_user_management', action: 'remove_course_from_facilitator'
-
-    get 'regional_partner_contact/new', to: 'regional_partner_contact#new'
-    get 'regional_partner_mini_contact/new', to: 'regional_partner_mini_contact#new'
-
-    get 'international_workshop', to: 'international_opt_in#new'
-    get 'international_workshop/:contact_id/thanks', to: 'international_opt_in#thanks'
-
-    # React-router will handle sub-routes on the client.
-    get 'application_dashboard/*path', to: 'application_dashboard#index'
-    get 'application_dashboard', to: 'application_dashboard#index'
-  end
-
-  get '/dashboardapi/section_progress/:section_id', to: 'api#section_progress'
-  get '/dashboardapi/section_text_responses/:section_id', to: 'api#section_text_responses'
-  scope 'dashboardapi', module: 'api/v1' do
-    concerns :section_api_routes
-    concerns :assessments_routes
-  end
-
-  # Wildcard routes for API controller: select all public instance methods in the controller,
-  # and all template names in `app/views/api/*`.
-  api_methods = (ApiController.instance_methods(false) +
-    Dir.glob(File.join(Rails.application.config.paths['app/views'].first, 'api/*')).map do |file|
-      File.basename(file).to_s.gsub(/\..*$/, '')
-    end).uniq
-
-  namespace :dashboardapi, module: :api do
-    api_methods.each do |action|
-      get action, action: action
-    end
-  end
-  get '/dashboardapi/v1/pd/k5workshops', to: 'api/v1/pd/workshops#k5_public_map_index'
-  get '/api/v1/pd/workshops_user_enrolled_in', to: 'api/v1/pd/workshops#workshops_user_enrolled_in'
-
-  post '/api/lock_status', to: 'api#update_lockable_state'
-  get '/api/lock_status', to: 'api#lockable_state'
-  get '/dashboardapi/script_structure/:script', to: 'api#script_structure'
-  get '/api/script_structure/:script', to: 'api#script_structure'
-  get '/dashboardapi/script_standards/:script', to: 'api#script_standards'
-  get '/api/section_progress/:section_id', to: 'api#section_progress', as: 'section_progress'
-  get '/api/teacher_panel_progress/:section_id', to: 'api#teacher_panel_progress'
-  get '/api/teacher_panel_section', to: 'api#teacher_panel_section'
-  get '/dashboardapi/section_level_progress/:section_id', to: 'api#section_level_progress', as: 'section_level_progress'
-  get '/api/user_progress/:script', to: 'api#user_progress', as: 'user_progress'
-  get '/api/user_app_options/:script/:lesson_position/:level_position/:level', to: 'api#user_app_options', as: 'user_app_options'
-  get '/api/example_solutions/:script_level_id/:level_id', to: 'api#example_solutions'
-  put '/api/firehose_unreachable', to: 'api#firehose_unreachable'
-  namespace :api do
-    api_methods.each do |action|
-      get action, action: action
-    end
-  end
-
-  if rack_env?(:development, :test)
-    scope '/api' do
-      namespace :test, defaults: {format: 'json'} do
-        TestController.instance_methods(false).each do |action|
-          method = action.to_s.start_with?('get') ? :get : :post
-          send(method, action, action: action)
-        end
-      end
-    end
-  end
-
-  namespace :api do
-    namespace :v1 do
-      concerns :api_v1_pd_routes
-      concerns :section_api_routes
-      post 'users/:user_id/using_text_mode', to: 'users#post_using_text_mode'
-      post 'users/:user_id/display_theme', to: 'users#update_display_theme'
-      post 'users/:user_id/mute_music', to: 'users#post_mute_music'
-      get 'users/:user_id/using_text_mode', to: 'users#get_using_text_mode'
-      get 'users/:user_id/display_theme', to: 'users#get_display_theme'
-      get 'users/:user_id/mute_music', to: 'users#get_mute_music'
-      get 'users/:user_id/contact_details', to: 'users#get_contact_details'
-      get 'users/current', to: 'users#current'
-      get 'users/:user_id/school_name', to: 'users#get_school_name'
-      get 'users/:user_id/school_donor_name', to: 'users#get_school_donor_name'
-      get 'users/:user_id/tos_version', to: 'users#get_tos_version'
-
-      patch 'user_school_infos/:id/update_last_confirmation_date', to: 'user_school_infos#update_last_confirmation_date'
-
-      patch 'user_school_infos', to: 'user_school_infos#update'
-
-      post 'users/:user_id/post_ui_tip_dismissed', to: 'users#post_ui_tip_dismissed'
-
-      post 'users/:user_id/postpone_census_banner', to: 'users#postpone_census_banner'
-      post 'users/:user_id/dismiss_census_banner', to: 'users#dismiss_census_banner'
-      post 'users/:user_id/dismiss_donor_teacher_banner', to: 'users#dismiss_donor_teacher_banner'
-      post 'users/:user_id/dismiss_parent_email_banner', to: 'users#dismiss_parent_email_banner'
-
-      get 'school-districts/:state', to: 'school_districts#index', defaults: {format: 'json'}
-      get 'schools/:school_district_id/:school_type', to: 'schools#index', defaults: {format: 'json'}
-      get 'schools/:id', to: 'schools#show', defaults: {format: 'json'}
-      get 'regional_partners/:school_district_id/:course', to: 'regional_partners#for_school_district_and_course', defaults: {format: 'json'}
-      get 'regional_partners', to: 'regional_partners#index', defaults: {format: 'json'}
-      get 'regional_partners/capacity', to: 'regional_partners#capacity'
-      get 'regional_partners/enrolled', to: 'regional_partners#enrolled'
-
-      get 'projects/gallery/public/:project_type/:limit(/:published_before)', to: 'projects/public_gallery#index', defaults: {format: 'json'}
-
-      get 'projects/personal', to: 'projects/personal_projects#index', defaults: {format: 'json'}
-      resources :section_libraries, only: [:index], defaults: {format: 'json'}
-
-      # Routes used by UI test status pages
-      get 'test_logs/*prefix/since/:time', to: 'test_logs#get_logs_since', defaults: {format: 'json'}
-      get 'test_logs/*prefix/:name', to: 'test_logs#get_log_details', defaults: {format: 'json'}
-
-      # Routes used by the peer reviews admin pages
-      get 'peer_review_submissions/index', to: 'peer_review_submissions#index'
-      get 'peer_review_submissions/report_csv', to: 'peer_review_submissions#report_csv'
-
-      resources :ml_models, only: [:show, :destroy] do
-        collection do
-          get 'names'
-          post 'save'
-        end
-      end
-
-      resources :teacher_feedbacks, only: [:index, :create] do
-        collection do
-          get 'get_feedback_from_teacher'
-          get 'get_feedbacks'
-          get 'count'
-        end
         member do
-          post 'increment_visit_count'
+          post 'join'
+          post 'leave'
+          post 'update_sharing_disabled'
+          get 'code_review_groups'
+          post 'code_review_groups', to: 'sections#set_code_review_groups'
+          post 'code_review_enabled', to: 'sections#set_code_review_enabled'
+        end
+        collection do
+          get 'membership'
+          get 'valid_course_offerings'
+          get 'available_participant_types'
+          get 'require_captcha'
         end
       end
     end
-  end
 
-  resources :feedback, controller: 'teacher_feedbacks'
-
-  get '/dashboardapi/v1/users/:user_id/contact_details', to: 'api/v1/users#get_contact_details'
-  get '/dashboardapi/v1/users/:user_id/donor_teacher_banner_details', to: 'api/v1/users#get_donor_teacher_banner_details'
-  get '/dashboardapi/v1/users/:user_id/school_donor_name', to: 'api/v1/users#get_school_donor_name'
-  post '/dashboardapi/v1/users/accept_data_transfer_agreement', to: 'api/v1/users#accept_data_transfer_agreement'
-  get '/dashboardapi/v1/school-districts/:state', to: 'api/v1/school_districts#index', defaults: {format: 'json'}
-  get '/dashboardapi/v1/schools/:id/afe_high_needs', to: 'api/v1/schools#afe_high_needs', defaults: {format: 'json'}
-  get '/dashboardapi/v1/schools/:school_district_id/:school_type', to: 'api/v1/schools#index', defaults: {format: 'json'}
-  get '/dashboardapi/v1/schools/:id', to: 'api/v1/schools#show', defaults: {format: 'json'}
-
-  # Routes used by census
-  post '/dashboardapi/v1/census/:form_version', to: 'api/v1/census/census#create', defaults: {format: 'json'}
-
-  # Routes used by donor teacher banner
-  post '/dashboardapi/v1/users/:user_id/dismiss_donor_teacher_banner', to: 'api/v1/users#dismiss_donor_teacher_banner'
-
-  # Routes used by standards info dialog
-  post '/dashboardapi/v1/users/:user_id/set_standards_report_info_to_seen', to: 'api/v1/users#set_standards_report_info_to_seen'
-
-  # Routes used by teacher scores
-  post '/dashboardapi/v1/teacher_scores', to: 'api/v1/teacher_scores#score_lessons_for_section'
-  get '/dashboardapi/v1/teacher_scores/:section_id/:script_id', to: 'api/v1/teacher_scores#get_teacher_scores_for_script', defaults: {format: 'json'}
-
-  # We want to allow searchs with dots, for instance "St. Paul", so we specify
-  # the constraint on :q to match anything but a slash.
-  # @see http://guides.rubyonrails.org/routing.html#specifying-constraints
-  get '/dashboardapi/v1/districtsearch/:q/:limit', to: 'api/v1/school_districts#search', defaults: {format: 'json'}, constraints: {q: /[^\/]+/}
-  get '/dashboardapi/v1/schoolsearch/:q/:limit(/:use_new_search)', to: 'api/v1/schools#search', defaults: {format: 'json'}, constraints: {q: /[^\/]+/}
-
-  get '/dashboardapi/v1/regional-partners/:school_district_id', to: 'api/v1/regional_partners#index', defaults: {format: 'json'}
-  get '/dashboardapi/v1/projects/section/:section_id', to: 'api/v1/projects/section_projects#index', defaults: {format: 'json'}
-
-  post '/dashboardapi/v1/text_to_speech/azure', to: 'api/v1/text_to_speech#azure', defaults: {format: 'json'}
-
-  get 'foorm/preview/:name', to: 'foorm_preview#name', constraints: {name: /.*/}
-  get 'foorm/preview', to: 'foorm_preview#index'
-
-  post '/safe_browsing', to: 'safe_browsing#safe_to_open', defaults: {format: 'json'}
-
-  get '/curriculum_tracking_pixel', to: 'curriculum_tracking_pixel#index'
-
-  post '/profanity/find', to: 'profanity#find'
-
-  get '/help', to: redirect("https://support.code.org")
-
-  post '/i18n/track_string_usage', action: :track_string_usage, controller: :i18n
-
-  get '/javabuilder/access_token', to: 'javabuilder_sessions#get_access_token'
-  post '/javabuilder/access_token_with_override_sources', to: 'javabuilder_sessions#access_token_with_override_sources'
-  post '/javabuilder/access_token_with_override_validation', to: 'javabuilder_sessions#access_token_with_override_validation'
-
-  resources :sprites, only: [:index], controller: 'sprite_management' do
-    collection do
-      get 'sprite_upload'
-      get 'default_sprites_editor'
-      get 'select_start_animations'
-    end
-  end
-
-  # These really belong in the foorm namespace,
-  # but we leave them outside so that we can easily use the simple "/form" paths.
-  get '/form/:path/configuration', to: 'foorm/simple_survey_forms#configuration'
-  get '/form/:path', to: 'foorm/simple_survey_forms#show'
-
-  namespace :foorm do
-    resources :simple_survey_forms, only: [:index, :new, :create]
-
-    resources :forms, only: [:create] do
-      member do
-        put :update_questions
-        put :publish
-      end
-      get :editor, on: :collection
-    end
-
-    resources :libraries, only: [] do
-      member do
-        get :question_names
-      end
-      get :editor, on: :collection
-    end
-
-    resources :library_questions, only: [:create, :show, :update] do
-      member do
-        get :published_forms_appeared_in
+    # Used in react assessments tab
+    concern :assessments_routes do
+      resources :assessments, only: [:index] do
+        collection do
+          get 'section_responses'
+          get 'section_surveys'
+          get 'section_feedback'
+        end
       end
     end
+
+    post '/dashboardapi/sections/transfers', to: 'transfers#create'
+    post '/api/sections/transfers', to: 'transfers#create'
+
+    get '/sh/:id', to: redirect('/c/%{id}')
+    get '/sh/:id/:action_id', to: redirect('/c/%{id}/%{action_id}')
+
+    get '/u/:id', to: redirect('/c/%{id}')
+    get '/u/:id/:action_id', to: redirect('/c/%{id}/%{action_id}')
+
+    # These links should no longer be created (August 2017), though we will continue to support
+    # existing links. Instead, create /r/ links.
+    resources :level_sources, path: '/c/', only: [:show, :edit, :update] do
+      member do
+        get 'generate_image'
+        get 'original_image'
+      end
+    end
+    # These routes are being created to replace the /c/ routes (August 2017) so as to include the ID
+    # of the sharing user in the URL. Doing so allows us to block showing the level source if the user
+    # deletes themself.
+    resources :obfuscated_level_sources, path: '/r/', controller: :level_sources, param: :level_source_id_and_user_id, only: [:show, :edit, :update] do
+      member do
+        get 'generate_image'
+        get 'original_image'
+      end
+    end
+
+    get '/share/:id', to: redirect('/c/%{id}')
+
+    devise_scope :user do
+      get '/oauth_sign_out/:provider', to: 'sessions#oauth_sign_out', as: :oauth_sign_out
+      post '/users/begin_sign_up', to: 'registrations#begin_sign_up'
+      patch '/dashboardapi/users', to: 'registrations#update'
+      patch '/users/upgrade', to: 'registrations#upgrade'
+      patch '/users/set_age', to: 'registrations#set_age'
+      patch '/users/email', to: 'registrations#set_email'
+      patch '/users/parent_email', to: 'registrations#set_parent_email'
+      patch '/users/user_type', to: 'registrations#set_user_type'
+      get '/users/cancel', to: 'registrations#cancel'
+      post '/users/auth/:id/disconnect', to: 'authentication_options#disconnect'
+      get '/users/migrate_to_multi_auth', to: 'registrations#migrate_to_multi_auth'
+      get '/users/demigrate_from_multi_auth', to: 'registrations#demigrate_from_multi_auth'
+      get '/users/to_destroy', to: 'registrations#users_to_destroy'
+      get '/reset_session', to: 'sessions#reset'
+      get '/users/existing_account', to: 'registrations#existing_account'
+      post '/users/auth/maker_google_oauth2', to: 'omniauth_callbacks#maker_google_oauth2'
+    end
+    devise_for :users, controllers: {
+      omniauth_callbacks: 'omniauth_callbacks',
+      registrations: 'registrations',
+      confirmations: 'confirmations',
+      sessions: 'sessions',
+      passwords: 'passwords'
+    }
+    get 'discourse/sso' => 'discourse_sso#sso'
+    post '/auth/lti', to: 'lti_provider#sso'
+
+    root to: "home#index"
+    get '/home_insert', to: 'home#home_insert'
+    get '/health_check', to: 'home#health_check'
+    namespace :home do
+      HomeController.instance_methods(false).each do |action|
+        get action, action: action
+      end
+    end
+
+    resources :p, path: '/p/', only: [:index] do
+      collection do
+        ProjectsController::STANDALONE_PROJECTS.each do |key, value|
+          get '/' + key.to_s, to: 'projects#redirect_legacy', key: value[:name], as: key.to_s
+        end
+        get '/', to: redirect('/projects')
+      end
+    end
+
+    get "/gallery", to: redirect("/projects/public")
+
+    get 'projects/featured', to: 'projects#featured'
+    put '/featured_projects/:project_id/unfeature', to: 'featured_projects#unfeature'
+    put '/featured_projects/:project_id/feature', to: 'featured_projects#feature'
+
+    resources :projects, path: '/projects/', only: [:index] do
+      collection do
+        ProjectsController::STANDALONE_PROJECTS.each do |key, _|
+          get "/#{key}", to: 'projects#load', key: key.to_s, as: "#{key}_project"
+          get "/#{key}/new", to: 'projects#create_new', key: key.to_s, as: "#{key}_project_create_new"
+
+          # Weblab projects are shared on a codeprojects path. The share URL on code studio doesn't mean anything and instead
+          # should be redirected to the corresponding codeprojects path.
+          if key == 'weblab'
+            get "/#{key}/:channel_id", constraints: {host: CDO.dashboard_hostname}, to: redirect("//#{CDO.site_host('codeprojects.org')}/%{channel_id}/")
+          else
+            get "/#{key}/:channel_id", to: 'projects#show', key: key.to_s, as: "#{key}_project_share", share: true
+          end
+
+          get "/#{key}/:channel_id/edit", to: 'projects#edit', key: key.to_s, as: "#{key}_project_edit"
+          get "/#{key}/:channel_id/view", to: 'projects#show', key: key.to_s, as: "#{key}_project_view", readonly: true
+          get "/#{key}/:channel_id/embed", to: 'projects#show', key: key.to_s, as: "#{key}_project_iframe_embed", iframe_embed: true
+
+          # appending 'embed_app_and_code' to a project renders a page with just the app editor. It is distinct from appending 'embed'
+          # to a project in that appending 'embed' renders only the app, wheras 'embed_app_and_code renders the app and the workspace
+          # for building the app, in view only mode. Specifically, appending 'embed_app_and_code' to a project does the following:
+          #
+          # - set view options to remove headers/footers
+          # - set a view option 'iframeEmbedAppAndCode' to true, setting the config.level.iframeEmbedAppAndCode variable to true on the client side
+          #   This makes a number of changes to how StudioApp behaves, and some changes to how P5Lab.js behaves
+          get "/#{key}/:channel_id/embed_app_and_code", to: 'projects#show', key: key.to_s, as: "#{key}_project_iframe_embed_app_and_code", iframe_embed_app_and_code: true, readonly: true
+          get "/#{key}/:channel_id/remix", to: 'projects#remix', key: key.to_s, as: "#{key}_project_remix"
+          get "/#{key}/:channel_id/export_create_channel", to: 'projects#export_create_channel', key: key.to_s, as: "#{key}_project_export_create_channel"
+          get "/#{key}/:channel_id/export_config", to: 'projects#export_config', key: key.to_s, as: "#{key}_project_export_config"
+        end
+
+        get '/:tab_name', to: 'projects#index', constraints: {tab_name: /(public|libraries)/}
+      end
+    end
+
+    post '/locale', to: 'home#set_locale', as: 'locale'
+
+    # quick links for cartoon network arabic
+    get '/flappy/lang/ar', to: 'home#set_locale', as: 'flappy/lang/ar', locale: 'ar-SA', user_return_to: '/flappy/1'
+    get '/playlab/lang/ar', to: 'home#set_locale', as: 'playlab/lang/ar', locale: 'ar-SA', user_return_to: '/s/playlab/lessons/1/levels/1'
+    get '/artist/lang/ar', to: 'home#set_locale', as: 'artist/lang/ar', locale: 'ar-SA', user_return_to: '/s/artist/lessons/1/levels/1'
+
+    # /lang/xx shortcut for all routes
+    get '/lang/:locale', to: 'home#set_locale', user_return_to: '/'
+    get '*i18npath/lang/:locale', to: 'home#set_locale'
+
+    get 'pools', to: 'pools#index', as: 'pools'
+    scope 'pools/:pool' do
+      resources :blocks, constraints: {id: /[^\/]+/}
+    end
+    resources :shared_blockly_functions, path: '/functions'
+
+    resources :libraries do
+      collection do
+        get '/get_updates', to: 'libraries#get_updates'
+      end
+    end
+
+    resources :datasets, param: 'dataset_name', constraints: {dataset_name: /[^\/]+/}, only: [:index, :show, :update, :destroy] do
+      collection do
+        get '/manifest/edit', to: 'datasets#edit_manifest'
+        post '/manifest/update', to: 'datasets#update_manifest'
+      end
+    end
+
+    resources :levels do
+      collection do
+        get 'get_filtered_levels'
+      end
+      member do
+        get 'get_rubric'
+        get 'embed_level'
+        get 'edit_blocks/:type', to: 'levels#edit_blocks', as: 'edit_blocks'
+        get 'edit_exemplar', to: 'levels#edit_exemplar', as: 'edit_exemplar'
+        get 'get_serialized_maze'
+        post 'update_properties'
+        post 'update_blocks/:type', to: 'levels#update_blocks', as: 'update_blocks'
+        post 'clone'
+        post 'update_start_code'
+        post 'update_exemplar_code'
+      end
+    end
+
+    post 'level_assets/upload', to: 'level_assets#upload'
+
+    resources :level_starter_assets, only: [:show], param: 'level_name', constraints: {level_name: /[^\/]+/} do
+      member do
+        get '/:filename', to: 'level_starter_assets#file', format: true
+        post '', to: 'level_starter_assets#upload'
+        delete '/:filename', to: 'level_starter_assets#destroy'
+      end
+    end
+
+    resources :course_offerings, only: [:edit, :update], param: 'key'
+
+    get '/course/:course_name', to: redirect('/courses/%{course_name}')
+    get '/courses/:course_name/vocab/edit', to: 'vocabularies#edit'
+    # these routes use course_course_name to match generated routes below that are nested within courses
+    get '/courses/:course_course_name/guides/edit', to: 'reference_guides#edit_all', as: :edit_all_reference_guides
+
+    resources :courses, param: 'course_name' do
+      member do
+        get 'vocab'
+        get 'resources'
+        get 'code'
+        get 'standards'
+        get 'get_rollup_resources'
+      end
+
+      resources :reference_guides, param: 'key', path: 'guides'
+    end
+
+    # CSP 20-21 lockable lessons with lesson plan redirects
+    get '/s/csp1-2020/lockable/2(*all)', to: redirect(path: '/s/csp1-2020/lessons/14%{all}')
+    get '/s/csp2-2020/lockable/1(*all)', to: redirect(path: '/s/csp2-2020/lessons/9%{all}')
+    get '/s/csp3-2020/lockable/1(*all)', to: redirect(path: '/s/csp3-2020/lessons/11%{all}')
+    get '/s/csp4-2020/lockable/1(*all)', to: redirect(path: '/s/csp4-2020/lessons/15%{all}')
+    get '/s/csp5-2020/lockable/1(*all)', to: redirect(path: '/s/csp5-2020/lessons/18%{all}')
+    get '/s/csp6-2020/lockable/1(*all)', to: redirect(path: '/s/csp6-2020/lessons/6%{all}')
+    get '/s/csp7-2020/lockable/1(*all)', to: redirect(path: '/s/csp7-2020/lessons/11%{all}')
+    get '/s/csp9-2020/lockable/1(*all)', to: redirect(path: '/s/csp9-2020/lessons/9%{all}')
+    get '/s/csp10-2020/lockable/1(*all)', to: redirect(path: '/s/csp10-2020/lessons/14%{all}')
+
+    resources :lessons, only: [:edit, :update] do
+      member do
+        get :show, to: 'lessons#show_by_id'
+        post :clone
+      end
+    end
+
+    resources :resources, only: [:create, :update] do
+      collection do
+        get :search
+      end
+    end
+
+    resources :vocabularies, only: [:create, :update] do
+      collection do
+        get :search
+      end
+    end
+
+    resources :programming_classes, only: [:new, :create, :edit, :update, :show, :destroy] do
+      collection do
+        get :get_filtered_results
+      end
+      member do
+        post :clone
+      end
+    end
+
+    resources :programming_expressions, only: [:index, :new, :create, :edit, :update, :show, :destroy] do
+      collection do
+        get :search
+        get :get_filtered_results
+      end
+      member do
+        post :clone
+      end
+    end
+
+    resources :programming_environments, only: [:index, :new, :create, :edit, :update, :show, :destroy], param: 'name' do
+      member do
+        get :get_summary_by_name
+      end
+      resources :programming_expressions, param: 'programming_expression_key', constraints: {programming_expression_key: /#{CurriculumHelper::KEY_CHAR_RE}+/o} do
+        member do
+          get :show, to: 'programming_expressions#show_by_keys'
+        end
+      end
+    end
+
+    resources :programming_methods, only: [:edit, :update]
+
+    resources :standards, only: [] do
+      collection do
+        get :search
+      end
+    end
+
+    # Redirects from old /stage/x/extras url to new /lessons/x/extras url
+    get '/s/:script_name/stage/:position/extras', to: redirect(path: '/s/%{script_name}/lessons/%{position}/extras')
+
+    # Redirects from old /stage/x/puzzle url to new /lessons/x/levels url
+    get '/s/:script_name/stage/:position/puzzle', to: redirect(path: '/s/%{script_name}/lessons/%{position}/levels')
+    get '/s/:script_name/stage/:position/puzzle/(*all)', to: redirect(path: '/s/%{script_name}/lessons/%{position}/levels/%{all}')
+
+    # Redirects from old /lockable/x/puzzle url to new /lockable/x/levels url
+    get '/s/:script_name/lockable/:position/puzzle', to: redirect(path: '/s/%{script_name}/lockable/%{position}/levels')
+    get '/s/:script_name/lockable/:position/puzzle/(*all)', to: redirect(path: '/s/%{script_name}/lockable/%{position}/levels/%{all}')
+
+    resources :scripts, path: '/s/' do
+      # /s/xxx/reset
+      get 'reset', to: 'script_levels#reset'
+      get 'next', to: 'script_levels#next'
+      get 'hidden_lessons', to: 'script_levels#hidden_lesson_ids'
+      post 'toggle_hidden', to: 'script_levels#toggle_hidden'
+
+      member do
+        get 'vocab'
+        get 'resources'
+        get 'code'
+        get 'standards'
+        get 'instructions'
+        get 'get_rollup_resources'
+      end
+
+      # /s/xxx/lessons/yyy
+      resources :lessons, only: [:show], param: 'position', format: false do
+        get 'student', to: 'lessons#student_lesson_plan'
+        get 'extras', to: 'script_levels#lesson_extras', format: false
+        get 'summary_for_lesson_plans', to: 'script_levels#summary_for_lesson_plans', format: false
+        get 'edit', to: 'lessons#edit_with_lesson_position'
+
+        # /s/xxx/lessons/yyy/levels/zzz
+        resources :script_levels, only: [:show], path: "/levels", format: false do
+          member do
+            # /s/xxx/lessons/yyy/levels/zzz/page/ppp
+            get 'page/:puzzle_page', to: 'script_levels#show', as: 'puzzle_page', format: false
+            # /s/xxx/lessons/yyy/levels/zzz/sublevel/sss
+            get 'sublevel/:sublevel_position', to: 'script_levels#show', as: 'sublevel', format: false
+          end
+        end
+      end
+
+      # /s/xxx/lockable/yyy/levels/zzz
+      resources :lockable_lessons, only: [], path: "/lockable", param: 'position', format: false do
+        get 'summary_for_lesson_plans', to: 'script_levels#summary_for_lesson_plans', format: false
+        resources :script_levels, only: [:show], path: "/levels", format: false do
+          member do
+            # /s/xxx/lockable/yyy/levels/zzz/page/ppp
+            get 'page/:puzzle_page', to: 'script_levels#show', as: 'puzzle_page', format: false
+          end
+        end
+      end
+
+      get 'preview-assignments', to: 'plc/enrollment_evaluations#preview_assignments', as: 'preview_assignments'
+      post 'confirm_assignments', to: 'plc/enrollment_evaluations#confirm_assignments', as: 'confirm_assignments'
+
+      get 'pull-review', to: 'peer_reviews#pull_review', as: 'pull_review'
+    end
+
+    get '/certificate_images/:filename', to: 'certificate_images#show'
+
+    get '/print_certificates/:encoded_params', to: 'print_certificates#show'
+
+    get '/certificates/:encoded_params', to: 'certificates#show'
+
+    get '/beta', to: redirect('/')
+
+    get '/hoc/reset', to: 'script_levels#reset', script_id: Script::HOC_NAME, as: 'hoc_reset'
+    get '/hoc/:chapter', to: 'script_levels#show', script_id: Script::HOC_NAME, as: 'hoc_chapter', format: false
+
+    get '/flappy/:chapter', to: 'script_levels#show', script_id: Script::FLAPPY_NAME, as: 'flappy_chapter', format: false
+    get '/jigsaw/:chapter', to: 'script_levels#show', script_id: Script::JIGSAW_NAME, as: 'jigsaw_chapter', format: false
+
+    get '/weblab/host', to: 'weblab_host#index'
+
+    get '/join(/:section_code)', to: 'followers#student_user_new', as: 'student_user_new'
+    post '/join(/:section_code)', to: 'followers#student_register', as: 'student_register'
+
+    post '/milestone/:user_id/level/:level_id', to: 'activities#milestone', as: 'milestone_level'
+    post '/milestone/:user_id/:script_level_id', to: 'activities#milestone', as: 'milestone'
+    post '/milestone/:user_id/:script_level_id/:level_id', to: 'activities#milestone', as: 'milestone_script_level'
+
+    get '/admin', to: 'admin_reports#directory', as: 'admin_directory'
+    resources :regional_partners
+    post 'regional_partners/:id/assign_program_manager', controller: 'regional_partners', action: 'assign_program_manager'
+    get 'regional_partners/:id/remove_program_manager/:program_manager_id', controller: 'regional_partners', action: 'remove_program_manager'
+    post 'regional_partners/:id/add_mapping', controller: 'regional_partners', action: 'add_mapping'
+    get 'regional_partners/:id/remove_mapping/:id', controller: 'regional_partners', action: 'remove_mapping'
+    post 'regional_partners/:id/replace_mappings',  controller: 'regional_partners', action: 'replace_mappings'
+
+    # HOC dashboards.
+    get '/admin/hoc/students_served', to: 'admin_hoc#students_served', as: 'hoc_students_served'
+
+    # NPS dashboards
+    get '/admin/nps/nps_form', to: 'admin_nps#nps_form', as: 'nps_form'
+    post '/admin/nps/nps_update', to: 'admin_nps#nps_update', as: 'nps_update'
+
+    # internal report dashboards
+    get '/admin/levels', to: 'admin_reports#level_completions', as: 'level_completions'
+    get '/admin/level_answers(.:format)', to: 'admin_reports#level_answers', as: 'level_answers'
+    get '/admin/pd_progress(/:script)', to: 'admin_reports#pd_progress', as: 'pd_progress'
+    get '/admin/debug', to: 'admin_reports#debug'
+
+    # internal search tools
+    get '/admin/find_students', to: 'admin_search#find_students', as: 'find_students'
+    get '/admin/lookup_section', to: 'admin_search#lookup_section', as: 'lookup_section'
+    post '/admin/lookup_section', to: 'admin_search#lookup_section'
+    post '/admin/undelete_section', to: 'admin_search#undelete_section', as: 'undelete_section'
+    get '/admin/pilots/', to: 'admin_search#pilots', as: 'pilots'
+    post '/admin/pilots/', to: 'admin_search#create_pilot', as: 'create_pilot'
+    get '/admin/pilots/:pilot_name', to: 'admin_search#show_pilot', as: 'show_pilot'
+    post '/admin/add_to_pilot', to: 'admin_search#add_to_pilot', as: 'add_to_pilot'
+    post '/admin/remove_from_pilot', to: 'admin_search#remove_from_pilot', as: 'remove_from_pilot'
+
+    # internal engineering dashboards
+    get '/admin/dynamic_config', to: 'dynamic_config#show', as: 'dynamic_config_state'
+    get '/admin/feature_mode', to: 'feature_mode#show', as: 'feature_mode'
+    post '/admin/feature_mode', to: 'feature_mode#update', as: 'feature_mode_update'
+
+    # internal support tools
+    get '/admin/account_repair', to: 'admin_users#account_repair_form', as: 'account_repair_form'
+    post '/admin/account_repair', to: 'admin_users#account_repair',  as: 'account_repair'
+    get '/admin/assume_identity', to: 'admin_users#assume_identity_form', as: 'assume_identity_form'
+    post '/admin/assume_identity', to: 'admin_users#assume_identity', as: 'assume_identity'
+    post '/admin/undelete_user', to: 'admin_users#undelete_user', as: 'undelete_user'
+    get '/admin/manual_pass', to: 'admin_users#manual_pass_form', as: 'manual_pass_form'
+    post '/admin/manual_pass', to: 'admin_users#manual_pass', as: 'manual_pass'
+    get '/admin/permissions', to: 'admin_users#permissions_form', as: 'permissions_form'
+    post '/admin/grant_permission', to: 'admin_users#grant_permission', as: 'grant_permission'
+    get '/admin/revoke_permission', to: 'admin_users#revoke_permission', as: 'revoke_permission'
+    post '/admin/bulk_grant_permission', to: 'admin_users#bulk_grant_permission', as: 'bulk_grant_permission'
+    get '/admin/studio_person', to: 'admin_users#studio_person_form', as: 'studio_person_form'
+    post '/admin/studio_person_merge', to: 'admin_users#studio_person_merge', as: 'studio_person_merge'
+    post '/admin/studio_person_split', to: 'admin_users#studio_person_split', as: 'studio_person_split'
+    post '/admin/studio_person_add_email_to_emails', to: 'admin_users#studio_person_add_email_to_emails', as: 'studio_person_add_email_to_emails'
+    get '/admin/user_progress', to: 'admin_users#user_progress_form', as: 'user_progress_form'
+    get '/admin/user_projects', to: 'admin_users#user_projects_form', as: 'user_projects_form'
+    put '/admin/user_project', to: 'admin_users#user_project_restore_form', as: 'user_project_restore_form'
+    get '/admin/delete_progress', to: 'admin_users#delete_progress_form', as: 'delete_progress_form'
+    post '/admin/delete_progress', to: 'admin_users#delete_progress', as: 'delete_progress'
+    get '/census/review', to: 'census_reviewers#review_reported_inaccuracies', as: 'review_reported_inaccuracies'
+    post '/census/review', to: 'census_reviewers#create'
+
+    get '/admin/styleguide', to: redirect('/styleguide/')
+
+    get '/admin/gatekeeper', to: 'dynamic_config#gatekeeper_show', as: 'gatekeeper_show'
+    post '/admin/gatekeeper/delete', to: 'dynamic_config#gatekeeper_delete', as: 'gatekeeper_delete'
+    post '/admin/gatekeeper/set', to: 'dynamic_config#gatekeeper_set', as: 'gatekeeper_set'
+
+    get '/notes/:key', to: 'notes#index'
+
+    resources :zendesk_session, only: [:index]
+
+    post '/report_abuse', to: 'report_abuse#report_abuse'
+    get '/report_abuse', to: 'report_abuse#report_abuse_form'
+
+    get '/too_young', to: 'too_young#index'
+
+    post '/sms/send', to: 'sms#send_to_phone', as: 'send_to_phone'
+    post '/sms/send_download', to: 'sms#send_download_url_to_phone', as: 'send_download_url_to_phone'
+
+    # Experiments are get requests so that a user can click on a link to join or leave an experiment
+    get '/experiments/set_course_experiment/:experiment_name', to: 'experiments#set_course_experiment'
+    get '/experiments/set_single_user_experiment/:experiment_name', to: 'experiments#set_single_user_experiment'
+    get '/experiments/disable_single_user_experiment/:experiment_name', to: 'experiments#disable_single_user_experiment'
+
+    get '/peer_reviews/dashboard', to: 'peer_reviews#dashboard'
+    resources :peer_reviews
+
+    get '/plc/user_course_enrollments/group_view', to: 'plc/user_course_enrollments#group_view'
+    get '/plc/user_course_enrollments/manager_view/:id', to: 'plc/user_course_enrollments#manager_view', as: 'plc_user_course_enrollment_manager_view'
+
+    namespace :plc do
+      root to: 'plc#index'
+      resources :user_course_enrollments
+      resources :course_units, only: [] do
+        collection do
+          get :launch
+          post :launch_plc_course
+        end
+      end
+    end
+
+    concern :api_v1_pd_routes do
+      namespace :pd do
+        resources :workshops do
+          collection do
+            get :filter
+            get :upcoming_teachercons
+          end
+          member do # See http://guides.rubyonrails.org/routing.html#adding-more-restful-actions
+            post :start
+            post :unstart
+            post :end
+            post :reopen
+            get  :summary
+            get  :potential_organizers
+          end
+          resources :enrollments, controller: 'workshop_enrollments', only: [:index, :destroy, :create]
+
+          get :attendance, action: 'index', controller: 'workshop_attendance'
+          get 'attendance/:session_id', action: 'show', controller: 'workshop_attendance'
+          put 'attendance/:session_id/user/:user_id', action: 'create', controller: 'workshop_attendance'
+          delete 'attendance/:session_id/user/:user_id', action: 'destroy', controller: 'workshop_attendance'
+          put 'attendance/:session_id/enrollment/:enrollment_id', action: 'create_by_enrollment', controller: 'workshop_attendance'
+          delete 'attendance/:session_id/enrollment/:enrollment_id', action: 'destroy_by_enrollment', controller: 'workshop_attendance'
+
+          get :workshop_survey_report, action: :workshop_survey_report, controller: 'workshop_survey_report'
+          get :local_workshop_survey_report, action: :local_workshop_survey_report, controller: 'workshop_survey_report'
+          get :generic_survey_report, action: :generic_survey_report, controller: 'workshop_survey_report'
+          get :experiment_survey_report, action: :experiment_survey_report, controller: 'workshop_survey_report'
+          get :teachercon_survey_report, action: :teachercon_survey_report, controller: 'workshop_survey_report'
+          get :workshop_organizer_survey_report, action: :workshop_organizer_survey_report, controller: 'workshop_organizer_survey_report'
+
+          get 'foorm/generic_survey_report', action: :generic_survey_report, controller: 'workshop_survey_foorm_report'
+          get 'foorm/csv_survey_report', action: :csv_survey_report, controller: 'workshop_survey_foorm_report'
+          get 'foorm/forms_for_workshop', action: :forms_for_workshop, controller: 'workshop_survey_foorm_report'
+        end
+
+        resources :workshop_summary_report, only: :index
+        resources :teacher_attendance_report, only: :index
+        resources :course_facilitators, only: :index
+        resources :workshop_organizers, only: :index
+        delete 'enrollments/:enrollment_code', action: 'cancel', controller: 'workshop_enrollments'
+        post 'enrollment/:enrollment_id/scholarship_info', action: 'update_scholarship_info', controller: 'workshop_enrollments'
+        post 'enrollments/move', action: 'move', controller: 'workshop_enrollments'
+        post 'enrollment/:id/edit', action: 'edit', controller: 'workshop_enrollments'
+        get 'legacy_survey_summaries', action: :legacy_survey_summaries, controller: 'legacy_survey_summaries'
+
+        # persistent namespace for FiT Weekend registrations, can be updated/replaced each year
+        post 'fit_weekend_registrations', to: 'fit_weekend_registrations#create'
+
+        post :pre_workshop_surveys, to: 'pre_workshop_surveys#create'
+        post :workshop_surveys, to: 'workshop_surveys#create'
+        post :teachercon_surveys, to: 'teachercon_surveys#create'
+        post :regional_partner_mini_contacts, to: 'regional_partner_mini_contacts#create'
+        post :international_opt_ins, to: 'international_opt_ins#create'
+        get :regional_partner_workshops, to: 'regional_partner_workshops#index'
+        get 'regional_partner_workshops/find', to: 'regional_partner_workshops#find'
+        get 'regional_partners/find', to: 'regional_partners#find'
+
+        post 'foorm/workshop_survey_submission', action: :create, controller: 'workshop_survey_foorm_submissions'
+
+        namespace :application do
+          post :facilitator, to: 'facilitator_applications#create'
+
+          resources :teacher, controller: 'teacher_applications', only: [:create, :update] do
+            member do
+              post :send_principal_approval
+              post :principal_approval_not_required
+            end
+          end
+          post :principal_approval, to: 'principal_approval_applications#create'
+        end
+
+        resources :applications, controller: 'applications', only: [:index, :show, :update, :destroy] do
+          collection do
+            get :quick_view
+            get :cohort_view
+            get :search
+            get :fit_cohort
+          end
+        end
+
+        namespace :foorm do
+          namespace :forms do
+            post 'form_with_library_items', action: :fill_in_library_items
+            get 'submissions_csv', action: :get_submissions_as_csv
+            get 'form_names', action: :get_form_names_and_versions
+            post :validate_form
+            get ':id', action: :get_form_data
+          end
+          namespace :library_questions do
+            post :validate_library_question
+          end
+        end
+      end
+    end
+
+    get '/dashboardapi/v1/regional_partners/find', to: 'api/v1/regional_partners#find'
+    get '/dashboardapi/v1/regional_partners/show/:partner_id', to: 'api/v1/regional_partners#show'
+    get '/dashboardapi/v1/pd/application/applications_closed', to: 'pd/professional_learning_landing#applications_closed'
+    post '/dashboardapi/v1/pd/regional_partner_mini_contacts', to: 'api/v1/pd/regional_partner_mini_contacts#create'
+    post '/dashboardapi/v1/amazon_future_engineer_submit', to: 'api/v1/amazon_future_engineer#submit'
+
+    post '/dashboardapi/v1/foorm/simple_survey_submission', action: :create, controller: 'api/v1/foorm_simple_survey_submissions'
+
+    get 'my-professional-learning', to: 'pd/professional_learning_landing#index', as: 'professional_learning_landing'
+
+    namespace :pd do
+      # React-router will handle sub-routes on the client.
+      get 'workshop_dashboard/*path', to: 'workshop_dashboard#index'
+      get 'workshop_dashboard', to: 'workshop_dashboard#index'
+
+      get 'misc_survey/thanks', to: 'misc_survey#thanks'
+      get 'misc_survey/:form_tag', to: 'misc_survey#new'
+      post 'misc_survey/submit', to: 'misc_survey#submit'
+
+      get 'workshop_survey/day/:day', to: 'workshop_daily_survey#new_general'
+      get 'workshop_daily_survey/day/:day', to: 'workshop_daily_survey#new_daily_foorm'
+      get 'workshop_pre_survey', to: 'workshop_daily_survey#new_pre_foorm'
+      get 'workshop_post_survey', to: 'workshop_daily_survey#new_post_foorm'
+      post 'workshop_survey/submit', to: 'workshop_daily_survey#submit_general'
+      get 'workshop_survey/post/:enrollment_code', to: 'workshop_daily_survey#new_post', as: 'new_workshop_survey'
+      get 'workshop_survey/facilitators/:session_id(/:facilitator_index)', to: 'workshop_daily_survey#new_facilitator'
+      post 'workshop_survey/facilitators/submit', to: 'workshop_daily_survey#submit_facilitator'
+      get 'workshop_survey/csf/post101(/:enrollment_code)', to: 'workshop_daily_survey#new_csf_post101'
+      get 'workshop_survey/csf/pre201', to: 'workshop_daily_survey#new_csf_pre201'
+      get 'workshop_survey/csf/post201(/:enrollment_code)', to: 'workshop_daily_survey#new_csf_post201'
+      get 'workshop_survey/foorm/csf/post201(/:enrollment_code)', to: 'workshop_daily_survey#new_csf_post201_foorm'
+      get 'workshop_survey/foorm/csf/pre201', to: 'workshop_daily_survey#new_csf_pre201_foorm'
+      get 'workshop_survey/thanks', to: 'workshop_daily_survey#thanks'
+
+      get 'post_course_survey/thanks', to: 'post_course_survey#thanks'
+      post 'post_course_survey/submit', to: 'post_course_survey#submit'
+      get 'post_course_survey/:course_initials', to: 'post_course_survey#new'
+
+      # Academic year workshops
+      get '/:workshop_subject/pre/(*agenda)', to: 'workshop_daily_survey#new_ayw_pre',
+          constraints: {agenda: /module\/[0-9_]+/}
+      get '/:workshop_subject/day/:day', to: 'workshop_daily_survey#new_ayw_daily',
+          constraints: {day: /\d/}
+      get '/:workshop_subject/post/(*agenda)', to: 'workshop_daily_survey#new_ayw_post',
+          constraints: {agenda: /(module\/[0-9_]+)|(in_person)/}
+
+      namespace :application do
+        get 'facilitator', to: 'facilitator_application#new'
+        get 'teacher', to: 'teacher_application#new'
+        get 'principal_approval/:application_guid', to: 'principal_approval_application#new', as: 'principal_approval'
+      end
+
+      # persistent namespace for Teachercon and FiT Weekend registrations, can be updated/replaced each year
+      get 'fit_weekend_registration/:application_guid', to: 'fit_weekend_registration#new'
+
+      delete 'fit_weekend_registration/:application_guid', to: 'fit_weekend_registration#destroy'
+
+      get 'workshops/:workshop_id/enroll', action: 'new', controller: 'workshop_enrollment'
+      post 'workshops/:workshop_id/enroll', action: 'create', controller: 'workshop_enrollment'
+      get 'workshop_enrollment/:code', action: 'show', controller: 'workshop_enrollment'
+      get 'workshop_enrollment/:code/thanks', action: 'thanks', controller: 'workshop_enrollment'
+      get 'workshop_enrollment/:code/cancel', action: 'cancel', controller: 'workshop_enrollment'
+
+      get 'pre_workshop_survey/:enrollment_code', action: 'new', controller: 'pre_workshop_survey', as: 'new_pre_workshop_survey'
+      get 'teachercon_survey/:enrollment_code', action: 'new', controller: 'teachercon_survey', as: 'new_teachercon_survey'
+
+      get 'generate_workshop_certificate/:enrollment_code', controller: 'workshop_certificate', action: 'generate_certificate'
+
+      get 'attend/:session_code', controller: 'session_attendance', action: 'attend'
+      post 'attend/:session_code', controller: 'session_attendance', action: 'select_enrollment'
+      get 'attend/:session_code/join', controller: 'workshop_enrollment', action: 'join_session'
+      post 'attend/:session_code/join', controller: 'workshop_enrollment', action: 'confirm_join_session'
+      get 'attend/:session_code/upgrade', controller: 'session_attendance', action: 'upgrade_account'
+      post 'attend/:session_code/upgrade', controller: 'session_attendance', action: 'confirm_upgrade_account'
+
+      get 'workshop_admins', controller: 'workshop_admins', action: 'directory', as: 'workshop_admins'
+      get 'workshop_user_management/facilitator_courses', controller: 'workshop_user_management', action: 'facilitator_courses_form', as: 'facilitator_courses'
+      post 'workshop_user_management/assign_course', controller: 'workshop_user_management', action: 'assign_course_to_facilitator'
+      # TODO: change remove_course to use http delete method
+      get 'workshop_user_management/remove_course', controller: 'workshop_user_management', action: 'remove_course_from_facilitator'
+
+      get 'regional_partner_contact/new', to: 'regional_partner_contact#new'
+      get 'regional_partner_mini_contact/new', to: 'regional_partner_mini_contact#new'
+
+      get 'international_workshop', to: 'international_opt_in#new'
+      get 'international_workshop/:contact_id/thanks', to: 'international_opt_in#thanks'
+
+      # React-router will handle sub-routes on the client.
+      get 'application_dashboard/*path', to: 'application_dashboard#index'
+      get 'application_dashboard', to: 'application_dashboard#index'
+    end
+
+    get '/dashboardapi/section_progress/:section_id', to: 'api#section_progress'
+    get '/dashboardapi/section_text_responses/:section_id', to: 'api#section_text_responses'
+    scope 'dashboardapi', module: 'api/v1' do
+      concerns :section_api_routes
+      concerns :assessments_routes
+    end
+
+    # Wildcard routes for API controller: select all public instance methods in the controller,
+    # and all template names in `app/views/api/*`.
+    api_methods = (ApiController.instance_methods(false) +
+      Dir.glob(File.join(Rails.application.config.paths['app/views'].first, 'api/*')).map do |file|
+        File.basename(file).to_s.gsub(/\..*$/, '')
+      end).uniq
+
+    namespace :dashboardapi, module: :api do
+      api_methods.each do |action|
+        get action, action: action
+      end
+    end
+    get '/dashboardapi/v1/pd/k5workshops', to: 'api/v1/pd/workshops#k5_public_map_index'
+    get '/api/v1/pd/workshops_user_enrolled_in', to: 'api/v1/pd/workshops#workshops_user_enrolled_in'
+
+    post '/api/lock_status', to: 'api#update_lockable_state'
+    get '/api/lock_status', to: 'api#lockable_state'
+    get '/dashboardapi/script_structure/:script', to: 'api#script_structure'
+    get '/api/script_structure/:script', to: 'api#script_structure'
+    get '/dashboardapi/script_standards/:script', to: 'api#script_standards'
+    get '/api/section_progress/:section_id', to: 'api#section_progress', as: 'section_progress'
+    get '/api/teacher_panel_progress/:section_id', to: 'api#teacher_panel_progress'
+    get '/api/teacher_panel_section', to: 'api#teacher_panel_section'
+    get '/dashboardapi/section_level_progress/:section_id', to: 'api#section_level_progress', as: 'section_level_progress'
+    get '/api/user_progress/:script', to: 'api#user_progress', as: 'user_progress'
+    get '/api/user_app_options/:script/:lesson_position/:level_position/:level', to: 'api#user_app_options', as: 'user_app_options'
+    get '/api/example_solutions/:script_level_id/:level_id', to: 'api#example_solutions'
+    put '/api/firehose_unreachable', to: 'api#firehose_unreachable'
+    namespace :api do
+      api_methods.each do |action|
+        get action, action: action
+      end
+    end
+
+    if rack_env?(:development, :test)
+      scope '/api' do
+        namespace :test, defaults: {format: 'json'} do
+          TestController.instance_methods(false).each do |action|
+            method = action.to_s.start_with?('get') ? :get : :post
+            send(method, action, action: action)
+          end
+        end
+      end
+    end
+
+    namespace :api do
+      namespace :v1 do
+        concerns :api_v1_pd_routes
+        concerns :section_api_routes
+        post 'users/:user_id/using_text_mode', to: 'users#post_using_text_mode'
+        post 'users/:user_id/display_theme', to: 'users#update_display_theme'
+        post 'users/:user_id/mute_music', to: 'users#post_mute_music'
+        get 'users/:user_id/using_text_mode', to: 'users#get_using_text_mode'
+        get 'users/:user_id/display_theme', to: 'users#get_display_theme'
+        get 'users/:user_id/mute_music', to: 'users#get_mute_music'
+        get 'users/:user_id/contact_details', to: 'users#get_contact_details'
+        get 'users/current', to: 'users#current'
+        get 'users/:user_id/school_name', to: 'users#get_school_name'
+        get 'users/:user_id/school_donor_name', to: 'users#get_school_donor_name'
+        get 'users/:user_id/tos_version', to: 'users#get_tos_version'
+
+        patch 'user_school_infos/:id/update_last_confirmation_date', to: 'user_school_infos#update_last_confirmation_date'
+
+        patch 'user_school_infos', to: 'user_school_infos#update'
+
+        post 'users/:user_id/post_ui_tip_dismissed', to: 'users#post_ui_tip_dismissed'
+
+        post 'users/:user_id/postpone_census_banner', to: 'users#postpone_census_banner'
+        post 'users/:user_id/dismiss_census_banner', to: 'users#dismiss_census_banner'
+        post 'users/:user_id/dismiss_donor_teacher_banner', to: 'users#dismiss_donor_teacher_banner'
+        post 'users/:user_id/dismiss_parent_email_banner', to: 'users#dismiss_parent_email_banner'
+
+        get 'school-districts/:state', to: 'school_districts#index', defaults: {format: 'json'}
+        get 'schools/:school_district_id/:school_type', to: 'schools#index', defaults: {format: 'json'}
+        get 'schools/:id', to: 'schools#show', defaults: {format: 'json'}
+        get 'regional_partners/:school_district_id/:course', to: 'regional_partners#for_school_district_and_course', defaults: {format: 'json'}
+        get 'regional_partners', to: 'regional_partners#index', defaults: {format: 'json'}
+        get 'regional_partners/capacity', to: 'regional_partners#capacity'
+        get 'regional_partners/enrolled', to: 'regional_partners#enrolled'
+
+        get 'projects/gallery/public/:project_type/:limit(/:published_before)', to: 'projects/public_gallery#index', defaults: {format: 'json'}
+
+        get 'projects/personal', to: 'projects/personal_projects#index', defaults: {format: 'json'}
+        resources :section_libraries, only: [:index], defaults: {format: 'json'}
+
+        # Routes used by UI test status pages
+        get 'test_logs/*prefix/since/:time', to: 'test_logs#get_logs_since', defaults: {format: 'json'}
+        get 'test_logs/*prefix/:name', to: 'test_logs#get_log_details', defaults: {format: 'json'}
+
+        # Routes used by the peer reviews admin pages
+        get 'peer_review_submissions/index', to: 'peer_review_submissions#index'
+        get 'peer_review_submissions/report_csv', to: 'peer_review_submissions#report_csv'
+
+        resources :ml_models, only: [:show, :destroy] do
+          collection do
+            get 'names'
+            post 'save'
+          end
+        end
+
+        resources :teacher_feedbacks, only: [:index, :create] do
+          collection do
+            get 'get_feedback_from_teacher'
+            get 'get_feedbacks'
+            get 'count'
+          end
+          member do
+            post 'increment_visit_count'
+          end
+        end
+      end
+    end
+
+    resources :feedback, controller: 'teacher_feedbacks'
+
+    get '/dashboardapi/v1/users/:user_id/contact_details', to: 'api/v1/users#get_contact_details'
+    get '/dashboardapi/v1/users/:user_id/donor_teacher_banner_details', to: 'api/v1/users#get_donor_teacher_banner_details'
+    get '/dashboardapi/v1/users/:user_id/school_donor_name', to: 'api/v1/users#get_school_donor_name'
+    post '/dashboardapi/v1/users/accept_data_transfer_agreement', to: 'api/v1/users#accept_data_transfer_agreement'
+    get '/dashboardapi/v1/school-districts/:state', to: 'api/v1/school_districts#index', defaults: {format: 'json'}
+    get '/dashboardapi/v1/schools/:id/afe_high_needs', to: 'api/v1/schools#afe_high_needs', defaults: {format: 'json'}
+    get '/dashboardapi/v1/schools/:school_district_id/:school_type', to: 'api/v1/schools#index', defaults: {format: 'json'}
+    get '/dashboardapi/v1/schools/:id', to: 'api/v1/schools#show', defaults: {format: 'json'}
+
+    # Routes used by census
+    post '/dashboardapi/v1/census/:form_version', to: 'api/v1/census/census#create', defaults: {format: 'json'}
+
+    # Routes used by donor teacher banner
+    post '/dashboardapi/v1/users/:user_id/dismiss_donor_teacher_banner', to: 'api/v1/users#dismiss_donor_teacher_banner'
+
+    # Routes used by standards info dialog
+    post '/dashboardapi/v1/users/:user_id/set_standards_report_info_to_seen', to: 'api/v1/users#set_standards_report_info_to_seen'
+
+    # Routes used by teacher scores
+    post '/dashboardapi/v1/teacher_scores', to: 'api/v1/teacher_scores#score_lessons_for_section'
+    get '/dashboardapi/v1/teacher_scores/:section_id/:script_id', to: 'api/v1/teacher_scores#get_teacher_scores_for_script', defaults: {format: 'json'}
+
+    # We want to allow searchs with dots, for instance "St. Paul", so we specify
+    # the constraint on :q to match anything but a slash.
+    # @see http://guides.rubyonrails.org/routing.html#specifying-constraints
+    get '/dashboardapi/v1/districtsearch/:q/:limit', to: 'api/v1/school_districts#search', defaults: {format: 'json'}, constraints: {q: /[^\/]+/}
+    get '/dashboardapi/v1/schoolsearch/:q/:limit(/:use_new_search)', to: 'api/v1/schools#search', defaults: {format: 'json'}, constraints: {q: /[^\/]+/}
+
+    get '/dashboardapi/v1/regional-partners/:school_district_id', to: 'api/v1/regional_partners#index', defaults: {format: 'json'}
+    get '/dashboardapi/v1/projects/section/:section_id', to: 'api/v1/projects/section_projects#index', defaults: {format: 'json'}
+
+    post '/dashboardapi/v1/text_to_speech/azure', to: 'api/v1/text_to_speech#azure', defaults: {format: 'json'}
+
+    get 'foorm/preview/:name', to: 'foorm_preview#name', constraints: {name: /.*/}
+    get 'foorm/preview', to: 'foorm_preview#index'
+
+    post '/safe_browsing', to: 'safe_browsing#safe_to_open', defaults: {format: 'json'}
+
+    get '/curriculum_tracking_pixel', to: 'curriculum_tracking_pixel#index'
+
+    post '/profanity/find', to: 'profanity#find'
+
+    get '/help', to: redirect("https://support.code.org")
+
+    post '/i18n/track_string_usage', action: :track_string_usage, controller: :i18n
+
+    get '/javabuilder/access_token', to: 'javabuilder_sessions#get_access_token'
+    post '/javabuilder/access_token_with_override_sources', to: 'javabuilder_sessions#access_token_with_override_sources'
+    post '/javabuilder/access_token_with_override_validation', to: 'javabuilder_sessions#access_token_with_override_validation'
+
+    resources :sprites, only: [:index], controller: 'sprite_management' do
+      collection do
+        get 'sprite_upload'
+        get 'default_sprites_editor'
+        get 'select_start_animations'
+      end
+    end
+
+    # These really belong in the foorm namespace,
+    # but we leave them outside so that we can easily use the simple "/form" paths.
+    get '/form/:path/configuration', to: 'foorm/simple_survey_forms#configuration'
+    get '/form/:path', to: 'foorm/simple_survey_forms#show'
+
+    namespace :foorm do
+      resources :simple_survey_forms, only: [:index, :new, :create]
+
+      resources :forms, only: [:create] do
+        member do
+          put :update_questions
+          put :publish
+        end
+        get :editor, on: :collection
+      end
+
+      resources :libraries, only: [] do
+        member do
+          get :question_names
+        end
+        get :editor, on: :collection
+      end
+
+      resources :library_questions, only: [:create, :show, :update] do
+        member do
+          get :published_forms_appeared_in
+        end
+      end
+    end
+
+    resources :code_reviews, only: [:index, :create, :update] do
+      get :peers_with_open_reviews, on: :collection
+    end
+
+    resources :code_review_notes, only: [:create, :update, :destroy]
+
+    resources :code_review_comments, only: [:create, :destroy] do
+      patch :toggle_resolved, on: :member
+      get :project_comments, on: :collection
+    end
+
+    get '/backpacks/channel', to: 'backpacks#get_channel'
+
+    resources :project_commits, only: [:create]
+    get 'project_commits/get_token', to: 'project_commits#get_token'
+    get 'project_commits/:channel_id', to: 'project_commits#project_commits'
+
+    resources :reviewable_projects, only: [:create, :destroy]
+    get 'reviewable_projects/for_level', to: 'reviewable_projects#for_level'
+    get 'reviewable_projects/reviewable_status', to: 'reviewable_projects#reviewable_status'
+
+    # offline-service-worker*.js needs to be loaded the the root level of the
+    # domain('studio.code.org/').
+    # Matches on ".js" or ".map" in order to serve source-map files for the service worker javascript.
+    get '/s/express-2021/lessons/1/:file', action: :offline_service_worker, controller: :offline, constraints: {file: /offline-service-worker.*\.(js|map)/}
+    # Adds the experiment cookie in the User's browser which allows them to experience offline features
+    get '/offline/join_pilot', action: :set_offline_cookie, controller: :offline
+    get '/offline-files.json', action: :offline_files, controller: :offline
   end
-
-  resources :code_reviews, only: [:index, :create, :update] do
-    get :peers_with_open_reviews, on: :collection
-  end
-
-  resources :code_review_notes, only: [:create, :update, :destroy]
-
-  resources :code_review_comments, only: [:create, :destroy] do
-    patch :toggle_resolved, on: :member
-    get :project_comments, on: :collection
-  end
-
-  get '/backpacks/channel', to: 'backpacks#get_channel'
-
-  resources :project_commits, only: [:create]
-  get 'project_commits/get_token', to: 'project_commits#get_token'
-  get 'project_commits/:channel_id', to: 'project_commits#project_commits'
-
-  resources :reviewable_projects, only: [:create, :destroy]
-  get 'reviewable_projects/for_level', to: 'reviewable_projects#for_level'
-  get 'reviewable_projects/reviewable_status', to: 'reviewable_projects#reviewable_status'
-
-  # offline-service-worker*.js needs to be loaded the the root level of the
-  # domain('studio.code.org/').
-  # Matches on ".js" or ".map" in order to serve source-map files for the service worker javascript.
-  get '/s/express-2021/lessons/1/:file', action: :offline_service_worker, controller: :offline, constraints: {file: /offline-service-worker.*\.(js|map)/}
-  # Adds the experiment cookie in the User's browser which allows them to experience offline features
-  get '/offline/join_pilot', action: :set_offline_cookie, controller: :offline
-  get '/offline-files.json', action: :offline_files, controller: :offline
 end

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -6,9 +6,9 @@ Dashboard::Application.routes.draw do
 
   constraints host: CDO.codeprojects_hostname do
     # Routes needed for the footer on weblab share links on codeprojects
-    get '/weblab/footer', to: 'projects#weblab_footer', constraints: {host: CDO.codeprojects_hostname}
-    get '/scripts/hosted.js', constraints: {host: CDO.codeprojects_hostname}, to: redirect('/weblab/footer.js')
-    get '/style.css', constraints: {host: CDO.codeprojects_hostname}, to: redirect('/assets/weblab/footer.css')
+    get '/weblab/footer', to: 'projects#weblab_footer'
+    get '/scripts/hosted.js', to: redirect('/weblab/footer.js')
+    get '/style.css', to: redirect('/assets/weblab/footer.css')
   end
 
   constraints host: /.*code.org.*/ do

--- a/dashboard/test/controllers/api/v1/pd/workshop_enrollments_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshop_enrollments_controller_test.rb
@@ -22,39 +22,39 @@ class Api::V1::Pd::WorkshopEnrollmentsControllerTest < ::ActionController::TestC
 
   test 'routes' do
     assert_routing(
-      {method: :get, path: "/api/v1/pd/workshops/#{@workshop.id}/enrollments"},
+      {method: :get, path: "http://#{CDO.dashboard_hostname}/api/v1/pd/workshops/#{@workshop.id}/enrollments"},
       {controller: CONTROLLER_PATH, action: 'index', workshop_id: @workshop.id.to_s}
     )
 
     assert_routing(
-      {path: "/api/v1/pd/workshops/#{@workshop.id}/enrollments", method: :post},
+      {path: "http://#{CDO.dashboard_hostname}/api/v1/pd/workshops/#{@workshop.id}/enrollments", method: :post},
       {controller: CONTROLLER_PATH, action: 'create', workshop_id: @workshop.id.to_s}
     )
 
     assert_routing(
-      {method: :delete, path: "/api/v1/pd/workshops/#{@workshop.id}/enrollments/#{@enrollment.id}"},
+      {method: :delete, path: "http://#{CDO.dashboard_hostname}/api/v1/pd/workshops/#{@workshop.id}/enrollments/#{@enrollment.id}"},
       {controller: CONTROLLER_PATH, action: 'destroy', workshop_id: @workshop.id.to_s, id: @enrollment.id.to_s}
     )
 
     assert_routing(
-      {method: :delete, path: "/api/v1/pd/enrollments/#{@enrollment.code}"},
+      {method: :delete, path: "http://#{CDO.dashboard_hostname}/api/v1/pd/enrollments/#{@enrollment.code}"},
       {controller: CONTROLLER_PATH, action: 'cancel', enrollment_code: @enrollment.code.to_s}
     )
 
     assert_routing(
-      {method: :post, path: "/api/v1/pd/enrollment/#{@enrollment.id}/scholarship_info"},
+      {method: :post, path: "http://#{CDO.dashboard_hostname}/api/v1/pd/enrollment/#{@enrollment.id}/scholarship_info"},
       {controller: CONTROLLER_PATH, action: 'update_scholarship_info', enrollment_id: @enrollment.id.to_s}
     )
 
     assert_routing(
-      {method: :post, path: "/api/v1/pd/enrollments/move"},
+      {method: :post, path: "http://#{CDO.dashboard_hostname}/api/v1/pd/enrollments/move"},
       {controller: CONTROLLER_PATH, action: 'move', enrollment_ids: [@enrollment.id], destination_workshop_id: @unrelated_workshop.id},
       {},
       {enrollment_ids: [@enrollment.id], destination_workshop_id: @unrelated_workshop.id}
     )
 
     assert_routing(
-      {method: :post, path: "/api/v1/pd/enrollment/#{@enrollment.id}/edit"},
+      {method: :post, path: "http://#{CDO.dashboard_hostname}/api/v1/pd/enrollment/#{@enrollment.id}/edit"},
       {controller: CONTROLLER_PATH, action: 'edit', id: @enrollment.id.to_s}
     )
   end

--- a/dashboard/test/controllers/api_controller_test.rb
+++ b/dashboard/test/controllers/api_controller_test.rb
@@ -1629,30 +1629,30 @@ class ApiControllerTest < ActionController::TestCase
     get :user_menu
 
     assert_response :success
-    assert_select 'a[href="http://test.host/pairing"]', false
+    assert_select 'a[href="http://test-studio.code.org/pairing"]', false
   end
 
   test 'api routing' do
     # /dashboardapi urls
     assert_routing(
-      {method: "get", path: "/dashboardapi/user_menu"},
+      {method: "get", path: "http://#{CDO.dashboard_hostname}/dashboardapi/user_menu"},
       {controller: "api", action: "user_menu"}
     )
 
     assert_routing(
-      {method: "get", path: "/dashboardapi/section_progress/2"},
+      {method: "get", path: "http://#{CDO.dashboard_hostname}/dashboardapi/section_progress/2"},
       {controller: "api", action: "section_progress", section_id: '2'}
     )
 
     # /api urls
     assert_recognizes(
       {controller: "api", action: "user_menu"},
-      {method: "get", path: "/api/user_menu"}
+      {method: "get", path: "http://#{CDO.dashboard_hostname}/api/user_menu"}
     )
 
     assert_recognizes(
       {controller: "api", action: "section_progress", section_id: '2'},
-      {method: "get", path: "/api/section_progress/2"}
+      {method: "get", path: "http://#{CDO.dashboard_hostname}/api/section_progress/2"}
     )
   end
 

--- a/dashboard/test/controllers/callouts_controller_test.rb
+++ b/dashboard/test/controllers/callouts_controller_test.rb
@@ -8,6 +8,8 @@ class CalloutsControllerTest < ActionController::TestCase
 
     @user = create(:admin)
     sign_in(@user)
+
+    @request.host = CDO.dashboard_hostname
   end
 
   test "should get index" do

--- a/dashboard/test/controllers/followers_controller_test.rb
+++ b/dashboard/test/controllers/followers_controller_test.rb
@@ -22,6 +22,8 @@ class FollowersControllerTest < ActionController::TestCase
     @word_section = create(:section, login_type: Section::LOGIN_TYPE_WORD)
 
     @admin = create(:admin)
+
+    @request.host = CDO.dashboard_hostname
   end
 
   test "student in picture section should be redirected to picture login when joining section" do

--- a/dashboard/test/controllers/level_sources_controller_test.rb
+++ b/dashboard/test/controllers/level_sources_controller_test.rb
@@ -5,6 +5,7 @@ class LevelSourcesControllerTest < ActionController::TestCase
     @admin = create(:admin)
     @level_source = create(:level_source)
     @hidden_level_source = create(:level_source, hidden: true)
+    @request.host = CDO.dashboard_hostname
   end
 
   test "should get edit" do
@@ -82,19 +83,19 @@ class LevelSourcesControllerTest < ActionController::TestCase
 
   test 'routing' do
     assert_routing(
-      {path: '/c/1', method: :get},
+      {path: "http://#{CDO.dashboard_hostname}/c/1", method: :get},
       {controller: 'level_sources', action: 'show', id: '1'}
     )
     assert_routing(
-      {path: '/c/1/edit', method: :get},
+      {path: "http://#{CDO.dashboard_hostname}/c/1/edit", method: :get},
       {controller: 'level_sources', action: 'edit', id: '1'}
     )
     assert_routing(
-      {path: '/c/1/original_image', method: :get},
+      {path: "http://#{CDO.dashboard_hostname}/c/1/original_image", method: :get},
       {controller: 'level_sources', action: 'original_image', id: '1'}
     )
     assert_routing(
-      {path: '/c/1/generate_image', method: :get},
+      {path: "http://#{CDO.dashboard_hostname}/c/1/generate_image", method: :get},
       {controller: 'level_sources', action: 'generate_image', id: '1'}
     )
   end
@@ -167,14 +168,14 @@ class LevelSourcesControllerTest < ActionController::TestCase
   test 'artist levelsource has sharing meta tags' do
     level_source = create(:level_source, level: create(:artist))
 
-    LevelSourcesController.view_context_class.any_instance.stubs(:meta_image_url).returns('http://test.host/assets/sharing_drawing.png')
+    LevelSourcesController.view_context_class.any_instance.stubs(:meta_image_url).returns('http://test-studio.code.org/assets/sharing_drawing.png')
 
     get :show, params: {id: level_source.id}
 
     assert_response :success
     assert_sharing_meta_tags(
-      url: "http://test.host/c/#{level_source.id}",
-      image_url: 'http://test.host/assets/sharing_drawing.png',
+      url: "http://test-studio.code.org/c/#{level_source.id}",
+      image_url: 'http://test-studio.code.org/assets/sharing_drawing.png',
       image_width: 400,
       image_height: 400,
       small_thumbnail: true
@@ -184,15 +185,15 @@ class LevelSourcesControllerTest < ActionController::TestCase
   test 'playlab levelsource has sharing meta tags' do
     level_source = create(:level_source, level: create(:playlab))
 
-    LevelSourcesController.view_context_class.any_instance.stubs(:meta_image_url).returns('http://test.host/assets/studio_sharing_drawing.png')
+    LevelSourcesController.view_context_class.any_instance.stubs(:meta_image_url).returns('http://test-studio.code.org/assets/studio_sharing_drawing.png')
 
     get :show, params: {id: level_source.id}
 
     assert_response :success
 
     assert_sharing_meta_tags(
-      url: "http://test.host/c/#{level_source.id}",
-      image_url: 'http://test.host/assets/studio_sharing_drawing.png',
+      url: "http://test-studio.code.org/c/#{level_source.id}",
+      image_url: 'http://test-studio.code.org/assets/studio_sharing_drawing.png',
       image_width: 400,
       image_height: 400,
       apple_mobile_web_app: true

--- a/dashboard/test/controllers/levels_controller_test.rb
+++ b/dashboard/test/controllers/levels_controller_test.rb
@@ -29,6 +29,8 @@ class LevelsControllerTest < ActionController::TestCase
     }
     stub_request(:get, /https:\/\/cdo-v3-shared.firebaseio.com/).
       to_return({"status" => 200, "body" => "{}", "headers" => {}})
+
+    @request.host = CDO.dashboard_hostname
   end
 
   test "should get rubric" do
@@ -842,7 +844,7 @@ class LevelsControllerTest < ActionController::TestCase
   end
 
   test "should route new to levels" do
-    assert_routing({method: "post", path: "/levels"}, {controller: "levels", action: "create"})
+    assert_routing({method: "post", path: "http://#{CDO.dashboard_hostname}/levels"}, {controller: "levels", action: "create"})
   end
 
   test "should use level for route helper" do

--- a/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
+++ b/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
@@ -7,6 +7,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
 
   setup do
     @request.env["devise.mapping"] = Devise.mappings[:user]
+    @request.host = CDO.dashboard_hostname
     CDO.stubs(:properties_encryption_key).returns(STUB_ENCRYPTION_KEY)
   end
 
@@ -41,7 +42,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
       get :facebook
     end
 
-    assert_redirected_to 'http://test.host/users/sign_up'
+    assert_redirected_to 'http://test-studio.code.org/users/sign_up'
     partial_user = User.new_from_partial_registration(session)
     assert_empty partial_user.email
     assert_nil partial_user.age
@@ -154,7 +155,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
       get :clever
     end
 
-    assert_redirected_to 'http://test.host/users/sign_up'
+    assert_redirected_to 'http://test-studio.code.org/users/sign_up'
     partial_user = User.new_from_partial_registration(session)
     assert_empty partial_user.email
   end
@@ -297,7 +298,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
     assert_does_not_create(User) do
       get :google_oauth2
     end
-    assert_redirected_to 'http://test.host/home?open=rosterDialog'
+    assert_redirected_to 'http://test-studio.code.org/home?open=rosterDialog'
     google_ao = user.authentication_options.find_by_credential_type('google_oauth2')
     assert_equal 'my-new-token', google_ao.data_hash[:oauth_token]
     assert_equal 'my-new-refresh-token', google_ao.data_hash[:oauth_refresh_token]
@@ -359,7 +360,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
     assert_does_not_create(User) do
       get :facebook
     end
-    assert_redirected_to 'http://test.host/users/existing_account?email=duplicate%40email.com&provider=facebook'
+    assert_redirected_to 'http://test-studio.code.org/users/existing_account?email=duplicate%40email.com&provider=facebook'
     assert_nil signed_in_user_id
   end
 
@@ -374,7 +375,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
     assert_does_not_create(User) do
       get :facebook
     end
-    assert_redirected_to 'http://test.host/users/existing_account?email=duplicate%40email.com&provider=facebook'
+    assert_redirected_to 'http://test-studio.code.org/users/existing_account?email=duplicate%40email.com&provider=facebook'
     assert_nil signed_in_user_id
   end
 
@@ -389,7 +390,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
     assert_does_not_create(User) do
       get :facebook
     end
-    assert_redirected_to 'http://test.host/users/existing_account?email=duplicate%40email.com&provider=facebook'
+    assert_redirected_to 'http://test-studio.code.org/users/existing_account?email=duplicate%40email.com&provider=facebook'
     assert_nil signed_in_user_id
   end
 
@@ -486,7 +487,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
       type: AuthenticationOption::CLEVER,
       id: uid
     )
-    assert_redirected_to 'http://test.host/home'
+    assert_redirected_to 'http://test-studio.code.org/home'
     assert_equal user.id, signed_in_user_id
   end
 
@@ -513,7 +514,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
       type: AuthenticationOption::CLEVER,
       id: uid
     )
-    assert_redirected_to 'http://test.host/home'
+    assert_redirected_to 'http://test-studio.code.org/home'
     assert_equal user.id, signed_in_user_id
   end
 
@@ -739,7 +740,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
     end
 
     # Then I go to the registration page to finish signing up
-    assert_redirected_to 'http://test.host/users/sign_up'
+    assert_redirected_to 'http://test-studio.code.org/users/sign_up'
     partial_user = User.new_from_partial_registration(session)
     assert_equal AuthenticationOption::GOOGLE, partial_user.provider
     assert_equal uid, partial_user.uid
@@ -762,7 +763,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
     end
 
     # Then I go to the registration page to finish signing up
-    assert_redirected_to 'http://test.host/users/sign_up'
+    assert_redirected_to 'http://test-studio.code.org/users/sign_up'
     assert PartialRegistration.in_progress? session
     partial_user = User.new_with_session({}, session)
 
@@ -791,7 +792,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
     end
 
     # Then I go to the registration page to finish signing up
-    assert_redirected_to 'http://test.host/users/sign_up'
+    assert_redirected_to 'http://test-studio.code.org/users/sign_up'
     assert PartialRegistration.in_progress? session
     partial_user = User.new_with_session({}, session)
 
@@ -812,7 +813,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
     assert_does_not_create(User) do
       get :google_oauth2
     end
-    assert_redirected_to 'http://test.host/users/existing_account?email=test%40foo.xyz&provider=google_oauth2'
+    assert_redirected_to 'http://test-studio.code.org/users/existing_account?email=test%40foo.xyz&provider=google_oauth2'
     user.reload
     assert_not_equal 'google_oauth2', user.provider
   end
@@ -918,7 +919,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
     assert_does_not_create(User) do
       get :google_oauth2
     end
-    assert_redirected_to 'http://test.host/users/existing_account?email=test%40foo.xyz&provider=google_oauth2'
+    assert_redirected_to 'http://test-studio.code.org/users/existing_account?email=test%40foo.xyz&provider=google_oauth2'
     user.reload
     found_google = user.authentication_options.any? {|auth_option| auth_option.credential_type == AuthenticationOption::GOOGLE}
     assert_not found_google
@@ -1177,7 +1178,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
     end
 
     user.reload
-    assert_redirected_to 'http://test.host/users/edit'
+    assert_redirected_to 'http://test-studio.code.org/users/edit'
     assert_equal 3, user.authentication_options.length
   end
 
@@ -1206,7 +1207,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
       get :facebook
     end
 
-    assert_redirected_to 'http://test.host/users/edit'
+    assert_redirected_to 'http://test-studio.code.org/users/edit'
     assert_equal 'Email has already been taken', flash.alert
 
     user_a.reload
@@ -1222,7 +1223,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
     assert_does_not_create(AuthenticationOption) do
       get :facebook
     end
-    assert_redirected_to 'http://test.host/users/edit'
+    assert_redirected_to 'http://test-studio.code.org/users/edit'
     assert_equal 'Sorry, we cannot connect or disconnect accounts that are still using the old account experience. Please update to the new account experience.', flash.alert
   end
 
@@ -1236,7 +1237,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
     end
 
     user.reload
-    assert_redirected_to 'http://test.host/users/edit'
+    assert_redirected_to 'http://test-studio.code.org/users/edit'
     assert_auth_option(user, auth)
   end
 
@@ -1250,7 +1251,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
     end
 
     user.reload
-    assert_redirected_to 'http://test.host/users/edit'
+    assert_redirected_to 'http://test-studio.code.org/users/edit'
     assert_auth_option(user, auth)
   end
 
@@ -1264,7 +1265,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
     end
 
     user.reload
-    assert_redirected_to 'http://test.host/users/edit'
+    assert_redirected_to 'http://test-studio.code.org/users/edit'
     assert_auth_option(user, auth)
   end
 
@@ -1278,7 +1279,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
     end
 
     user.reload
-    assert_redirected_to 'http://test.host/users/edit'
+    assert_redirected_to 'http://test-studio.code.org/users/edit'
     assert_auth_option(user, auth)
   end
 
@@ -1292,7 +1293,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
     end
 
     user.reload
-    assert_redirected_to 'http://test.host/users/edit'
+    assert_redirected_to 'http://test-studio.code.org/users/edit'
     assert_auth_option(user, auth)
   end
 
@@ -1306,7 +1307,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
       get :google_oauth2
     end
 
-    assert_redirected_to 'http://test.host/users/edit'
+    assert_redirected_to 'http://test-studio.code.org/users/edit'
     expected_error = I18n.t('auth.unable_to_connect_provider', provider: I18n.t("auth.google_oauth2"))
     assert_equal expected_error, flash.alert
   end
@@ -1328,7 +1329,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
 
     # Then I should successfully add credential X
     user.reload
-    assert_redirected_to 'http://test.host/users/edit'
+    assert_redirected_to 'http://test-studio.code.org/users/edit'
     assert_auth_option(user, auth)
 
     # And the other user should be destroyed
@@ -1434,7 +1435,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
     assert_equal 1, user.authentication_options.count
 
     # And receive a helpful error message about the credential already being in use.
-    assert_redirected_to 'http://test.host/users/edit'
+    assert_redirected_to 'http://test-studio.code.org/users/edit'
     expected_error = I18n.t('auth.already_in_use', provider: I18n.t("auth.google_oauth2"))
     assert_equal expected_error, flash.alert
   end
@@ -1464,7 +1465,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
     assert_equal 1, user.authentication_options.count
 
     # And receive a helpful error message about the credential already being in use.
-    assert_redirected_to 'http://test.host/users/edit'
+    assert_redirected_to 'http://test-studio.code.org/users/edit'
     expected_error = I18n.t('auth.already_in_use', provider: I18n.t("auth.google_oauth2"))
     assert_equal expected_error, flash.alert
   end
@@ -1485,7 +1486,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
     assert_equal 2, user.authentication_options.count
 
     # And receive a friendly notice about already having the credential
-    assert_redirected_to 'http://test.host/users/edit'
+    assert_redirected_to 'http://test-studio.code.org/users/edit'
     expected_notice = I18n.t('auth.already_linked', provider: I18n.t("auth.google_oauth2"))
     assert_equal expected_notice, flash.notice
   end
@@ -1503,7 +1504,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
       setup_should_connect_provider(user, auth)
       get provider
 
-      assert_redirected_to 'http://test.host/users/edit'
+      assert_redirected_to 'http://test-studio.code.org/users/edit'
 
       provider_name = I18n.t(provider, scope: :auth)
       expected_notice = user.teacher? ?

--- a/dashboard/test/controllers/passwords_controller_test.rb
+++ b/dashboard/test/controllers/passwords_controller_test.rb
@@ -34,6 +34,7 @@ class PasswordsControllerTest < ActionController::TestCase
 
   test "create with valid email includes link for admin" do
     sign_in create(:admin)
+    @request.host = CDO.dashboard_hostname
 
     create :user, email: 'anemail@email.xx'
     post :create, params: {user: {email: 'anemail@email.xx'}}
@@ -41,11 +42,12 @@ class PasswordsControllerTest < ActionController::TestCase
     assert_redirected_to '/users/password/new'
 
     assert flash[:notice].include? 'Reset password link sent to user. You may also send this link directly:'
-    assert flash[:notice].include? 'http://test.host/users/password/edit?reset_password_token='
+    assert flash[:notice].include? 'http://test-studio.code.org/users/password/edit?reset_password_token='
   end
 
   test "create with multiple associated accounts includes link for admin" do
     sign_in create(:admin)
+    @request.host = CDO.dashboard_hostname
 
     user1 = create :student, email: 'student1@email.com', parent_email: 'parent@email.com'
     user2 = create :student, email: 'student2@email.com', parent_email: 'parent@email.com'
@@ -54,8 +56,8 @@ class PasswordsControllerTest < ActionController::TestCase
     assert_redirected_to '/users/password/new'
 
     assert flash[:notice].include? 'Reset password link sent to user. You may also send the link directly:'
-    assert flash[:notice].include? "#{user1.username}: <a href='http://test.host/users/password/edit?reset_password_token="
-    assert flash[:notice].include? "#{user2.username}: <a href='http://test.host/users/password/edit?reset_password_token="
+    assert flash[:notice].include? "#{user1.username}: <a href='http://test-studio.code.org/users/password/edit?reset_password_token="
+    assert flash[:notice].include? "#{user2.username}: <a href='http://test-studio.code.org/users/password/edit?reset_password_token="
   end
 
   test "create with valid email that doesn't exist says it doesn't work" do

--- a/dashboard/test/controllers/pd/workshop_enrollment_controller_test.rb
+++ b/dashboard/test/controllers/pd/workshop_enrollment_controller_test.rb
@@ -25,7 +25,7 @@ class Pd::WorkshopEnrollmentControllerTest < ::ActionController::TestCase
 
   test 'enroll get route' do
     assert_routing(
-      {path: "/pd/workshops/#{@workshop.id}/enroll", method: :get},
+      {path: "http://#{CDO.dashboard_hostname}/pd/workshops/#{@workshop.id}/enroll", method: :get},
       {controller: 'pd/workshop_enrollment', action: 'new', workshop_id: @workshop.id.to_s}
     )
   end
@@ -117,7 +117,7 @@ class Pd::WorkshopEnrollmentControllerTest < ::ActionController::TestCase
 
   test 'show route' do
     assert_routing(
-      {path: "/pd/workshop_enrollment/#{@existing_enrollment.code}", method: :get},
+      {path: "http://#{CDO.dashboard_hostname}/pd/workshop_enrollment/#{@existing_enrollment.code}", method: :get},
       {controller: 'pd/workshop_enrollment', action: 'show', code: @existing_enrollment.code}
     )
   end
@@ -134,7 +134,7 @@ class Pd::WorkshopEnrollmentControllerTest < ::ActionController::TestCase
 
   test 'cancel route' do
     assert_routing(
-      {path: "/pd/workshop_enrollment/#{@existing_enrollment.code}/cancel", method: :get},
+      {path: "http://#{CDO.dashboard_hostname}/pd/workshop_enrollment/#{@existing_enrollment.code}/cancel", method: :get},
       {controller: 'pd/workshop_enrollment', action: 'cancel', code: @existing_enrollment.code}
     )
   end

--- a/dashboard/test/controllers/programming_environments_controller_test.rb
+++ b/dashboard/test/controllers/programming_environments_controller_test.rb
@@ -134,6 +134,7 @@ class ProgrammingEnvironmentsControllerTest < ActionController::TestCase
   end
 
   test 'can create a new programming environment' do
+    @request.host = CDO.dashboard_hostname
     sign_in @levelbuilder
 
     File.expects(:write).with {|filename, _| filename.to_s.end_with? "new-ide.json"}.once

--- a/dashboard/test/controllers/redirect_proxy_controller_test.rb
+++ b/dashboard/test/controllers/redirect_proxy_controller_test.rb
@@ -34,7 +34,7 @@ class RedirectProxyControllerTest < ActionController::TestCase
   end
 
   test 'should avoid redirect if host/port match this server' do
-    local_uri = "http://test.host:80/foobar"
+    local_uri = "http://test-studio.code.org:80/foobar"
     get :get, params: {u: local_uri}
 
     assert_response :success

--- a/dashboard/test/controllers/script_levels_controller_test.rb
+++ b/dashboard/test/controllers/script_levels_controller_test.rb
@@ -697,34 +697,34 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     sl = ScriptLevel.find_by script: Script.twenty_hour_unit, chapter: 3
     assert_equal '/s/20-hour/lessons/2/levels/2', build_script_level_path(sl)
     assert_routing(
-      {method: "get", path: build_script_level_path(sl)},
+      {method: "get", path: "http://#{CDO.dashboard_hostname}#{build_script_level_path(sl)}"},
       {controller: "script_levels", action: "show", script_id: Script::TWENTY_HOUR_NAME, lesson_position: sl.lesson.to_param, id: sl.to_param}
     )
   end
 
   test "chapter based routing" do
     assert_routing(
-      {method: "get", path: '/hoc/reset'},
+      {method: "get", path: "http://#{CDO.dashboard_hostname}/hoc/reset"},
       {controller: "script_levels", action: "reset", script_id: Script::HOC_NAME}
     )
 
     hoc_level = ScriptLevel.find_by(script_id: Script.get_from_cache(Script::HOC_NAME).id, chapter: 1)
     assert_routing(
-      {method: "get", path: '/hoc/1'},
+      {method: "get", path: "http://#{CDO.dashboard_hostname}/hoc/1"},
       {controller: "script_levels", action: "show", script_id: Script::HOC_NAME, chapter: "1"}
     )
     assert_equal '/hoc/1', build_script_level_path(hoc_level)
 
     flappy_level = ScriptLevel.find_by(script_id: Script.get_from_cache(Script::FLAPPY_NAME).id, chapter: 5)
     assert_routing(
-      {method: "get", path: '/flappy/5'},
+      {method: "get", path: "http://#{CDO.dashboard_hostname}/flappy/5"},
       {controller: "script_levels", action: "show", script_id: Script::FLAPPY_NAME, chapter: "5"}
     )
     assert_equal "/flappy/5", build_script_level_path(flappy_level)
 
     jigsaw_level = ScriptLevel.find_by(script_id: Script.get_from_cache(Script::JIGSAW_NAME).id, chapter: 3)
     assert_routing(
-      {method: "get", path: '/jigsaw/3'},
+      {method: "get", path: "http://#{CDO.dashboard_hostname}/jigsaw/3"},
       {controller: "script_levels", action: "show", script_id: Script::JIGSAW_NAME, chapter: "3"}
     )
     assert_equal "/s/jigsaw/lessons/1/levels/3", build_script_level_path(jigsaw_level)
@@ -732,19 +732,19 @@ class ScriptLevelsControllerTest < ActionController::TestCase
 
   test "routing for custom scripts with lesson" do
     assert_routing(
-      {method: "get", path: "/s/laurel/lessons/1/levels/1"},
+      {method: "get", path: "http://#{CDO.dashboard_hostname}/s/laurel/lessons/1/levels/1"},
       {controller: "script_levels", action: "show", script_id: 'laurel', lesson_position: "1", id: "1"}
     )
     assert_equal "/s/laurel/lessons/1/levels/1", build_script_level_path(@custom_s1_l1)
 
     assert_routing(
-      {method: "get", path: "/s/laurel/lessons/2/levels/1"},
+      {method: "get", path: "http://#{CDO.dashboard_hostname}/s/laurel/lessons/2/levels/1"},
       {controller: "script_levels", action: "show", script_id: 'laurel', lesson_position: "2", id: "1"}
     )
     assert_equal "/s/laurel/lessons/2/levels/1", build_script_level_path(@custom_s2_l1)
 
     assert_routing(
-      {method: "get", path: "/s/laurel/lessons/2/levels/2"},
+      {method: "get", path: "http://#{CDO.dashboard_hostname}/s/laurel/lessons/2/levels/2"},
       {controller: "script_levels", action: "show", script_id: 'laurel', lesson_position: "2", id: "2"}
     )
     assert_equal "/s/laurel/lessons/2/levels/2", build_script_level_path(@custom_s2_l2)
@@ -757,7 +757,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
 
   test "next routing for custom scripts" do
     assert_routing(
-      {method: "get", path: "/s/laurel/next"},
+      {method: "get", path: "http://#{CDO.dashboard_hostname}/s/laurel/next"},
       {controller: "script_levels", action: "next", script_id: 'laurel'}
     )
     assert_equal "/s/laurel/next", script_next_path(@custom_script)
@@ -961,7 +961,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
 
   test "reset routing for custom scripts" do
     assert_routing(
-      {method: "get", path: "/s/laurel/reset"},
+      {method: "get", path: "http://#{CDO.dashboard_hostname}/s/laurel/reset"},
       {controller: "script_levels", action: "reset", script_id: 'laurel'}
     )
   end

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -424,6 +424,7 @@ class ScriptsControllerTest < ActionController::TestCase
 
   test 'create' do
     unit_name = 'test-unit-create'
+    @request.host = CDO.dashboard_hostname
     File.stubs(:write).with {|filename, _| filename.end_with? 'scripts.en.yml'}.once
     File.stubs(:write).with do |filename, contents|
       filename == "#{Rails.root}/config/scripts_json/#{unit_name}.script_json" && JSON.parse(contents)['script']['name'] == unit_name
@@ -449,6 +450,7 @@ class ScriptsControllerTest < ActionController::TestCase
 
   test 'create: sets course type if provided' do
     unit_name = 'test-pl-unit-create'
+    @request.host = CDO.dashboard_hostname
     File.stubs(:write).with {|filename, _| filename.end_with? 'scripts.en.yml'}.once
     File.stubs(:write).with do |filename, contents|
       filename == "#{Rails.root}/config/scripts_json/#{unit_name}.script_json" && JSON.parse(contents)['script']['name'] == unit_name

--- a/dashboard/test/controllers/sections_controller_test.rb
+++ b/dashboard/test/controllers/sections_controller_test.rb
@@ -30,6 +30,8 @@ class SectionsControllerTest < ActionController::TestCase
     create(:unit_group_unit, script: @script_in_course, unit_group: @unit_group, position: 1)
     @section_with_course = create(:section, user: @teacher, login_type: 'word', course_id: @unit_group.id)
     @section_with_course_user_1 = create(:follower, section: @section_with_course).student_user
+
+    @request.host = CDO.dashboard_hostname
   end
 
   test "do not show login screen for invalid section code" do

--- a/dashboard/test/controllers/sms_controller_test.rb
+++ b/dashboard/test/controllers/sms_controller_test.rb
@@ -51,7 +51,7 @@ class SmsControllerTest < ActionController::TestCase
   end
 
   test "send download url to phone succeeds when twilio succeeds" do
-    download_url = "http://test.host/foo.apk"
+    download_url = "http://test-studio.code.org/foo.apk"
     expected_twilio_options = {
       messaging_service_sid: 'fake_messaging_service_sid',
       to: 'xxxxxx',

--- a/dashboard/test/integration/curriculum_docs_test.rb
+++ b/dashboard/test/integration/curriculum_docs_test.rb
@@ -5,100 +5,100 @@ class CurriculumDocsTest < ActionDispatch::IntegrationTest
     test '/docs/applab is routed to ProgrammingEnvironmentsController' do
       assert_recognizes(
         {controller: 'programming_environments', action: 'docs_show', programming_environment_name: 'applab'},
-        {path: '/docs/applab', method: :get}
+        {path: "http://#{CDO.dashboard_hostname}/docs/applab", method: :get}
       )
     end
 
     test '/docs/gamelab is routed to ProgrammingEnvironmentsController' do
       assert_recognizes(
         {controller: 'programming_environments', action: 'docs_show', programming_environment_name: 'gamelab'},
-        {path: '/docs/gamelab', method: :get}
+        {path: "http://#{CDO.dashboard_hostname}/docs/gamelab", method: :get}
       )
     end
 
     test '/docs/spritelab is routed to ProgrammingEnvironmentsController' do
       assert_recognizes(
         {controller: 'programming_environments', action: 'docs_show', programming_environment_name: 'spritelab'},
-        {path: '/docs/spritelab', method: :get}
+        {path: "http://#{CDO.dashboard_hostname}/docs/spritelab", method: :get}
       )
     end
 
     test '/docs/weblab is routed to ProgrammingEnvironmentsController' do
       assert_recognizes(
         {controller: 'programming_environments', action: 'docs_show', programming_environment_name: 'weblab'},
-        {path: '/docs/weblab', method: :get}
+        {path: "http://#{CDO.dashboard_hostname}/docs/weblab", method: :get}
       )
     end
 
     test '/docs/concepts is routed to CurriculumProxyController' do
       assert_recognizes(
         {controller: 'curriculum_proxy', action: 'get_doc', path: 'concepts'},
-        {path: '/docs/concepts', method: :get}
+        {path: "http://#{CDO.dashboard_hostname}/docs/concepts", method: :get}
       )
 
       assert_recognizes(
         {controller: 'curriculum_proxy', action: 'get_doc', path: 'concepts/gamelab'},
-        {path: '/docs/concepts/gamelab', method: :get}
+        {path: "http://#{CDO.dashboard_hostname}/docs/concepts/gamelab", method: :get}
       )
     end
 
     test 'other /docs routes are routed to CurriculumProxyController' do
       assert_recognizes(
         {controller: 'curriculum_proxy', action: 'get_doc', path: 'csd-1718/html-tags'},
-        {path: '/docs/csd-1718/html-tags', method: :get}
+        {path: "http://#{CDO.dashboard_hostname}/docs/csd-1718/html-tags", method: :get}
       )
 
       assert_recognizes(
         {controller: 'curriculum_proxy', action: 'get_doc', path: 'csd/timed-loop/index', format: 'html'},
-        {path: '/docs/csd/timed-loop/index.html', method: :get}
+        {path: "http://#{CDO.dashboard_hostname}/docs/csd/timed-loop/index.html", method: :get}
       )
     end
 
     test '/docs/applab/<key> is routed to ProgrammingExpressionsController' do
       assert_recognizes(
         {controller: 'programming_expressions', action: 'docs_show', programming_environment_name: 'applab', programming_expression_key: 'button'},
-        {path: '/docs/applab/button', method: :get}
+        {path: "http://#{CDO.dashboard_hostname}/docs/applab/button", method: :get}
       )
 
       assert_recognizes(
         {controller: 'programming_expressions', action: 'docs_show', programming_environment_name: 'applab', programming_expression_key: 'button'},
-        {path: '/docs/applab/button/index.html', method: :get}
+        {path: "http://#{CDO.dashboard_hostname}/docs/applab/button/index.html", method: :get}
       )
     end
 
     test '/docs/gamelab/<key> is routed to ProgrammingExpressionsController' do
       assert_recognizes(
         {controller: 'programming_expressions', action: 'docs_show', programming_environment_name: 'gamelab', programming_expression_key: 'draw'},
-        {path: '/docs/gamelab/draw', method: :get}
+        {path: "http://#{CDO.dashboard_hostname}/docs/gamelab/draw", method: :get}
       )
 
       assert_recognizes(
         {controller: 'programming_expressions', action: 'docs_show', programming_environment_name: 'gamelab', programming_expression_key: 'draw'},
-        {path: '/docs/gamelab/draw/index.html', method: :get}
+        {path: "http://#{CDO.dashboard_hostname}/docs/gamelab/draw/index.html", method: :get}
       )
     end
 
     test '/docs/spritelab/<key> is routed to ProgrammingExpressionsController' do
       assert_recognizes(
         {controller: 'programming_expressions', action: 'docs_show', programming_environment_name: 'spritelab', programming_expression_key: 'gamelab_turn'},
-        {path: '/docs/spritelab/gamelab_turn', method: :get}
+        {path: "http://#{CDO.dashboard_hostname}/docs/spritelab/gamelab_turn", method: :get}
       )
 
       assert_recognizes(
         {controller: 'programming_expressions', action: 'docs_show', programming_environment_name: 'spritelab', programming_expression_key: 'gamelab_turn'},
-        {path: '/docs/spritelab/gamelab_turn/index.html', method: :get}
+        {path: "http://#{CDO.dashboard_hostname}/docs/spritelab/gamelab_turn/index.html", method: :get}
       )
     end
 
     test '/docs/weblab/<key> is routed to ProgrammingExpressionsController' do
       assert_recognizes(
         {controller: 'programming_expressions', action: 'docs_show', programming_environment_name: 'weblab', programming_expression_key: 'style'},
-        {path: '/docs/weblab/style', method: :get}
+        {path: "http://#{CDO.dashboard_hostname}/docs/weblab/style", method: :get}
       )
 
       assert_recognizes(
         {controller: 'programming_expressions', action: 'docs_show', programming_environment_name: 'weblab', programming_expression_key: 'style'},
-        {path: '/docs/weblab/style/index.html', method: :get}
+        {path: "http://#{CDO.dashboard_hostname}/docs/weblab/style/index.html", method: :get}
       )
     end
   end

--- a/dashboard/test/integration/join_test.rb
+++ b/dashboard/test/integration/join_test.rb
@@ -4,7 +4,7 @@ class JoinTest < ActionDispatch::IntegrationTest
   test '/join with code in query param renders followers#student_user_new with section_code' do
     section = create :section
 
-    join_url = "/join?utf8=%E2%9C%93&section_code=#{section.code}&commit=Go"
+    join_url = "http://#{CDO.dashboard_hostname}/join?utf8=%E2%9C%93&section_code=#{section.code}&commit=Go"
     assert_recognizes(
       {controller: 'followers', action: 'student_user_new', section_code: section.code},
       join_url,
@@ -20,7 +20,7 @@ class JoinTest < ActionDispatch::IntegrationTest
   test '/join with code in url renders followers#student_user_new with section_code' do
     section = create :section
 
-    join_url = "/join/#{section.code}"
+    join_url = "http://#{CDO.dashboard_hostname}/join/#{section.code}"
     assert_recognizes(
       {controller: 'followers', action: 'student_user_new', section_code: section.code},
       join_url
@@ -30,7 +30,7 @@ class JoinTest < ActionDispatch::IntegrationTest
   end
 
   test '/join without code renders followers#student_user_new' do
-    join_url = '/join'
+    join_url = "http://#{CDO.dashboard_hostname}/join"
     assert_recognizes(
       {controller: 'followers', action: 'student_user_new'},
       join_url

--- a/dashboard/test/integration/user_menu_test.rb
+++ b/dashboard/test/integration/user_menu_test.rb
@@ -60,7 +60,7 @@ class UserMenuTest < ActionDispatch::IntegrationTest
     get '/home'
 
     assert_response :success
-    assert_select 'a[href="http://test.host/pairing"]', false
+    assert_select 'a[href="http://test-studio.code.org/pairing"]', false
   end
 
   test 'show link to pair programming when in a section that has pairing enabled' do
@@ -94,6 +94,6 @@ class UserMenuTest < ActionDispatch::IntegrationTest
     get '/home'
 
     assert_response :success
-    assert_select 'a[href="http://test.host/pairing"]', false
+    assert_select 'a[href="http://test-studio.code.org/pairing"]', false
   end
 end


### PR DESCRIPTION
Note for reviewers: I would recommend reviewing this PR [with whitespace hidden](https://github.com/code-dot-org/code-dot-org/pull/46999/files?w=1).

In order to prepare to move codeprojects.org over to dashboard, we need to become more explicit as to which routes are served on which host. In particular, we do not want codeprojects.com to serve routes like /s/coursea-2022, which would be possible when we move codeprojects to dashboard without this change.

In this PR, I use [block based constraints](https://guides.rubyonrails.org/routing.html#request-based-constraints) based on the host. There are a small number of routes that apply to codeprojects.org and the rest are for studio.code.org. Note that because there are a handful of calls from code.org that are routed to dashboard, the host needs to match code.org or studio.code.org (as well as all the environment-specific derivations of these). 


## Testing story

existing tests -- particularly UI tests -- ensure nothing has been broken. Locally, I turned off the pegasus server and confirmed that studio routes were only available on localhost-studio.code.org and not on localhost.codeprojects.org.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
