### PR TITLE
Don't use fullwidth banner for CourseCard

### DIFF
--- a/apps/src/templates/studioHomepages/CourseCard.jsx
+++ b/apps/src/templates/studioHomepages/CourseCard.jsx
@@ -5,7 +5,7 @@ import color from '../../util/color';
 import FontAwesome from '../FontAwesome';
 import i18n from '@cdo/locale';
 import BlueHeader from '@cdo/static/small_blue_icons_fullwidth.png';
-import PurpleHeader from '@cdo/static/small_purple_icons_fullwidth.png';
+import PurpleHeader from '@cdo/static/small_purple_icons.png';
 
 /**
  * A card used on the homepage to display information about a particular course

--- a/apps/test/unit/templates/studioHomepages/CourseCardTest.js
+++ b/apps/test/unit/templates/studioHomepages/CourseCardTest.js
@@ -92,9 +92,6 @@ describe('CourseCard', () => {
       />
     );
 
-    assert.include(
-      wrapper.find('img').props().src,
-      'small_purple_icons_fullwidth'
-    );
+    assert.include(wrapper.find('img').props().src, 'small_purple_icons');
   });
 });


### PR DESCRIPTION
It looks like [a change](https://github.com/code-dot-org/code-dot-org/pull/44392/files#diff-c421f8d5f125a828825eb908e8634e7b88ac5f945c1aaf6afd16b76529cc28d1) was accidentally made to use the fullwidth images for the `CourseCard` banners, which cause the banners to look stretched. For the purple banners, we have the smaller asset already, so that's a simple update. I don't have a smaller asset for the blue banners so that will likely need to be done as a followup.

Before:
<img width="1010" alt="Screen Shot 2022-06-28 at 9 32 08 AM" src="https://user-images.githubusercontent.com/46464143/176232848-407275fa-7201-4389-8910-2a29713d74e1.png">


Now:
<img width="1004" alt="Screen Shot 2022-06-28 at 9 31 03 AM" src="https://user-images.githubusercontent.com/46464143/176232642-c090fe5a-e0da-4c20-b0f2-175dae973ccd.png">


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
