### PR TITLE
Migration to avoid duplicate rows in code reviews

### DIFF
--- a/dashboard/app/models/code_review.rb
+++ b/dashboard/app/models/code_review.rb
@@ -14,12 +14,14 @@
 #  deleted_at       :datetime
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
+#  active           :boolean
+#  open             :boolean
 #
 # Indexes
 #
 #  index_code_reviews_for_peer_lookup               (user_id,script_id,project_level_id,closed_at,deleted_at)
 #  index_code_reviews_on_project_id_and_deleted_at  (project_id,deleted_at)
-#  index_code_reviews_unique                        (user_id,project_id,closed_at,deleted_at) UNIQUE
+#  index_code_reviews_unique                        (user_id,project_id,open,active) UNIQUE
 #
 class CodeReview < ApplicationRecord
   acts_as_paranoid
@@ -31,6 +33,9 @@ class CodeReview < ApplicationRecord
 
   # Enforce that each student can only have one open code review per script and
   # level. (This is also enforced at the database level with a unique index.)
+  #
+  # See migration 20220627214005_add_active_to_code_reviews.rb for more information
+  # about this unique index and the active and open virtual columns
   validates_uniqueness_of :user_id, scope: [:project_id],
     conditions: -> {where(closed_at: nil)},
     message: 'already has an open code review for this project'

--- a/dashboard/db/migrate/20220627214005_add_active_to_code_reviews.rb
+++ b/dashboard/db/migrate/20220627214005_add_active_to_code_reviews.rb
@@ -1,0 +1,21 @@
+class AddActiveToCodeReviews < ActiveRecord::Migration[6.0]
+  def change
+    # Previously, the unique index was on the columns user_id, project_id, closed_at and deleted_at. The idea is
+    # that we should only have one open code review per user per project at any given time. The issue with the original
+    # unique index is that in SQL NULL != NULL and since an open code review is represented by closed_at=NULL and
+    # deleted_at=NULL this will be considered different than another record with the same values. So the old unique index
+    # was not properly guarding against duplicate open code reviews.
+    #
+    # The solution is to create inverse virtual columns for both nullable columns and including those in the unique
+    # index instead. The new index will include user_id, project_id, open and active. When a code review is open
+    # none of the columns in the unique index will be null so it is guaranteed to be distinct from other open code reviews.
+
+    # The active column is the inverse of deleted_at, it is null when deleted_at is populated
+    add_column :code_reviews, :active, :boolean, as: "IF(`deleted_at` IS NULL, true, NULL)"
+    # The open column is the inverse of closed_at, it is null when closed_at is populated
+    add_column :code_reviews, :open, :boolean, as: "IF(`closed_at` IS NULL, true, NULL)"
+
+    remove_index :code_reviews, name: 'index_code_reviews_unique'
+    add_index :code_reviews, [:user_id, :project_id, :open, :active], name: 'index_code_reviews_unique', unique: true
+  end
+end

--- a/dashboard/db/migrate/20220627214005_add_active_to_code_reviews.rb
+++ b/dashboard/db/migrate/20220627214005_add_active_to_code_reviews.rb
@@ -3,12 +3,12 @@ class AddActiveToCodeReviews < ActiveRecord::Migration[6.0]
     # Previously, the unique index was on the columns user_id, project_id, closed_at and deleted_at. There should
     # only be one open code review per user per project at any given time. The issue with the original
     # unique index is that in SQL NULL != NULL and since an open code review is represented by closed_at=NULL and
-    # deleted_at=NULL this will be considered different than another record with the same values. So the old unique index
+    # deleted_at=NULL this is considered different than another record with the same values. So the old unique index
     # was not properly guarding against duplicate open code review rows.
     #
     # The solution is to create inverse virtual columns for both nullable columns and include those in the unique
     # index instead. The new index will have user_id, project_id, open and active. When a code review is open
-    # none of the columns in the unique index will be null (closed_at=NULL => open=true, deleted_at=null => active=true)
+    # none of the columns in the unique index will be null (closed_at=NULL => open=true, deleted_at=null => active=true),
     # so it is guaranteed to be distinct from other open code reviews.
 
     # The active column is the inverse of deleted_at, it is null when deleted_at is populated

--- a/dashboard/db/migrate/20220627214005_add_active_to_code_reviews.rb
+++ b/dashboard/db/migrate/20220627214005_add_active_to_code_reviews.rb
@@ -1,14 +1,15 @@
 class AddActiveToCodeReviews < ActiveRecord::Migration[6.0]
   def change
-    # Previously, the unique index was on the columns user_id, project_id, closed_at and deleted_at. The idea is
-    # that we should only have one open code review per user per project at any given time. The issue with the original
+    # Previously, the unique index was on the columns user_id, project_id, closed_at and deleted_at. There should
+    # only be one open code review per user per project at any given time. The issue with the original
     # unique index is that in SQL NULL != NULL and since an open code review is represented by closed_at=NULL and
     # deleted_at=NULL this will be considered different than another record with the same values. So the old unique index
-    # was not properly guarding against duplicate open code reviews.
+    # was not properly guarding against duplicate open code review rows.
     #
-    # The solution is to create inverse virtual columns for both nullable columns and including those in the unique
-    # index instead. The new index will include user_id, project_id, open and active. When a code review is open
-    # none of the columns in the unique index will be null so it is guaranteed to be distinct from other open code reviews.
+    # The solution is to create inverse virtual columns for both nullable columns and include those in the unique
+    # index instead. The new index will have user_id, project_id, open and active. When a code review is open
+    # none of the columns in the unique index will be null (closed_at=NULL => open=true, deleted_at=null => active=true)
+    # so it is guaranteed to be distinct from other open code reviews.
 
     # The active column is the inverse of deleted_at, it is null when deleted_at is populated
     add_column :code_reviews, :active, :boolean, as: "IF(`deleted_at` IS NULL, true, NULL)"

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -320,7 +320,7 @@ ActiveRecord::Schema.define(version: 2022_06_27_214005) do
     t.index ["code_review_request_id"], name: "index_code_review_notes_on_code_review_request_id"
   end
 
-  create_table "code_review_requests", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "code_review_requests", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "script_id", null: false
     t.integer "level_id", null: false
@@ -333,7 +333,7 @@ ActiveRecord::Schema.define(version: 2022_06_27_214005) do
     t.index ["user_id", "script_id", "level_id", "closed_at", "deleted_at"], name: "index_code_review_requests_unique", unique: true
   end
 
-  create_table "code_reviews", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "code_reviews", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "project_id", null: false
     t.integer "script_id", null: false
@@ -476,7 +476,7 @@ ActiveRecord::Schema.define(version: 2022_06_27_214005) do
     t.index ["name"], name: "index_courses_on_name"
   end
 
-  create_table "data_docs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "data_docs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "key", null: false
     t.string "name"
     t.text "content"
@@ -2207,6 +2207,17 @@ ActiveRecord::Schema.define(version: 2022_06_27_214005) do
     t.index ["word", "definition"], name: "index_vocabularies_on_word_and_definition", type: :fulltext
   end
 
+  add_foreign_key "ap_school_codes", "schools"
+  add_foreign_key "census_inaccuracy_investigations", "census_overrides"
+  add_foreign_key "census_inaccuracy_investigations", "census_submissions"
+  add_foreign_key "census_inaccuracy_investigations", "users"
+  add_foreign_key "census_overrides", "schools"
+  add_foreign_key "census_submission_form_maps", "census_submissions"
+  add_foreign_key "census_summaries", "schools"
+  add_foreign_key "circuit_playground_discount_applications", "schools"
+  add_foreign_key "hint_view_requests", "users"
+  add_foreign_key "ib_school_codes", "schools"
+  add_foreign_key "level_concept_difficulties", "levels"
   add_foreign_key "other_curriculum_offerings", "schools"
   add_foreign_key "pd_application_emails", "pd_applications"
   add_foreign_key "pd_application_tags_applications", "pd_application_tags"

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_06_173510) do
+ActiveRecord::Schema.define(version: 2022_06_27_214005) do
 
   create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -320,7 +320,7 @@ ActiveRecord::Schema.define(version: 2022_06_06_173510) do
     t.index ["code_review_request_id"], name: "index_code_review_notes_on_code_review_request_id"
   end
 
-  create_table "code_review_requests", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "code_review_requests", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "script_id", null: false
     t.integer "level_id", null: false
@@ -333,7 +333,7 @@ ActiveRecord::Schema.define(version: 2022_06_06_173510) do
     t.index ["user_id", "script_id", "level_id", "closed_at", "deleted_at"], name: "index_code_review_requests_unique", unique: true
   end
 
-  create_table "code_reviews", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "code_reviews", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "project_id", null: false
     t.integer "script_id", null: false
@@ -345,8 +345,10 @@ ActiveRecord::Schema.define(version: 2022_06_06_173510) do
     t.datetime "deleted_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.virtual "active", type: :boolean, as: "if(isnull(`deleted_at`),TRUE,NULL)"
+    t.virtual "open", type: :boolean, as: "if(isnull(`closed_at`),TRUE,NULL)"
     t.index ["project_id", "deleted_at"], name: "index_code_reviews_on_project_id_and_deleted_at"
-    t.index ["user_id", "project_id", "closed_at", "deleted_at"], name: "index_code_reviews_unique", unique: true
+    t.index ["user_id", "project_id", "open", "active"], name: "index_code_reviews_unique", unique: true
     t.index ["user_id", "script_id", "project_level_id", "closed_at", "deleted_at"], name: "index_code_reviews_for_peer_lookup"
   end
 
@@ -474,7 +476,7 @@ ActiveRecord::Schema.define(version: 2022_06_06_173510) do
     t.index ["name"], name: "index_courses_on_name"
   end
 
-  create_table "data_docs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "data_docs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "key", null: false
     t.string "name"
     t.text "content"
@@ -2205,17 +2207,6 @@ ActiveRecord::Schema.define(version: 2022_06_06_173510) do
     t.index ["word", "definition"], name: "index_vocabularies_on_word_and_definition", type: :fulltext
   end
 
-  add_foreign_key "ap_school_codes", "schools"
-  add_foreign_key "census_inaccuracy_investigations", "census_overrides"
-  add_foreign_key "census_inaccuracy_investigations", "census_submissions"
-  add_foreign_key "census_inaccuracy_investigations", "users"
-  add_foreign_key "census_overrides", "schools"
-  add_foreign_key "census_submission_form_maps", "census_submissions"
-  add_foreign_key "census_summaries", "schools"
-  add_foreign_key "circuit_playground_discount_applications", "schools"
-  add_foreign_key "hint_view_requests", "users"
-  add_foreign_key "ib_school_codes", "schools"
-  add_foreign_key "level_concept_difficulties", "levels"
   add_foreign_key "other_curriculum_offerings", "schools"
   add_foreign_key "pd_application_emails", "pd_applications"
   add_foreign_key "pd_application_tags_applications", "pd_application_tags"


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Currently, we have several tables with unique indexes which aren't working properly and are resulting in duplicate rows. The `code_reviews` table is also susceptible to unwanted duplicate rows, it doesn't have any yet, but we'd like to take care of this issue now before the table gets any bigger. Here's the solution:
- add new virtual columns `open` and `active`
- replace `closed_at` and `deleted_at` in the unique index with these new columns

Before the deploy with this migration, I'll run the query `select count(*) as count_reviews from code_reviews where deleted_at is null and closed_at is null group by user_id, project_id having count_reviews > 1;` in production to ensure that there haven't been any duplicate rows added since this PR and to ensure the unique index can be created.

## Links
- jira ticket: [LP-2414](https://codedotorg.atlassian.net/browse/LP-2414)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()

-->
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

## Testing
Ran migration locally and opened, closed code reviews

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
