### PR TITLE
Deleted apps in workshops

### DIFF
--- a/dashboard/app/serializers/api/v1/pd/workshop_enrollment_serializer.rb
+++ b/dashboard/app/serializers/api/v1/pd/workshop_enrollment_serializer.rb
@@ -12,18 +12,12 @@ class Api::V1::Pd::WorkshopEnrollmentSerializer < ActiveModel::Serializer
   end
 
   def application_id
-    application_id = object.try(:application_id)
-    return unless application_id && Pd::Application::TeacherApplication.exists?(id: application_id)
-    application_id
+    object&.application&.id
   end
 
   def alternate_email
-    return unless application_id
-
     # Note: Use dig instead of [] because RuboCop doesn't like chaining ordinary method call after safe navigation operator.
-    Pd::Application::TeacherApplication.find(application_id)&.
-      sanitize_form_data_hash&.
-      dig(:alternate_email)
+    object&.application&.sanitize_form_data_hash&.dig(:alternate_email)
   end
 
   def school

--- a/dashboard/app/serializers/api/v1/pd/workshop_enrollment_serializer.rb
+++ b/dashboard/app/serializers/api/v1/pd/workshop_enrollment_serializer.rb
@@ -11,9 +11,14 @@ class Api::V1::Pd::WorkshopEnrollmentSerializer < ActiveModel::Serializer
     user ? user.id : nil
   end
 
-  def alternate_email
+  def application_id
     application_id = object.try(:application_id)
     return unless application_id && Pd::Application::TeacherApplication.exists?(id: application_id)
+    application_id
+  end
+
+  def alternate_email
+    return unless application_id
 
     # Note: Use dig instead of [] because RuboCop doesn't like chaining ordinary method call after safe navigation operator.
     Pd::Application::TeacherApplication.find(application_id)&.

--- a/dashboard/app/serializers/api/v1/pd/workshop_enrollment_serializer.rb
+++ b/dashboard/app/serializers/api/v1/pd/workshop_enrollment_serializer.rb
@@ -13,10 +13,10 @@ class Api::V1::Pd::WorkshopEnrollmentSerializer < ActiveModel::Serializer
 
   def alternate_email
     application_id = object.try(:application_id)
-    return unless application_id
+    return unless application_id && Pd::Application::TeacherApplication.exists?(id: application_id)
 
     # Note: Use dig instead of [] because RuboCop doesn't like chaining ordinary method call after safe navigation operator.
-    Pd::Application::ApplicationBase.find(application_id)&.
+    Pd::Application::TeacherApplication.find(application_id)&.
       sanitize_form_data_hash&.
       dig(:alternate_email)
   end


### PR DESCRIPTION
This fixes a problem where the enrollments panel wasn't loading at all if an enrollment had a deleted application. It is still unclear why an application gets deleted.

The problem is arising because enrollments.rb has an "application_id" field that gets set on a `before_save` callback. If the application is then deleted, that field doesn't get updated. It would probably be best to ensure that this field gets updated when an application gets deleted.

For now, I added a catch in the serializer to ensure that (a) the enrollments panel still loads, and (b) the "View Application" button doesn't get shown if the application is deleted.

In the screenshot, the second enrollment has a not-nil `application_id` but that application has been deleted.

<img width="1073" alt="image" src="https://user-images.githubusercontent.com/9142121/176493272-40171fbe-28f5-4057-80f4-bab7cde7164a.png">

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

Should we ensure that the `application_id` field gets updated when an application gets deleted?

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
