### PR TITLE
Change references from project versions to project commits

### DIFF
--- a/apps/src/javalab/Javalab.js
+++ b/apps/src/javalab/Javalab.js
@@ -303,7 +303,7 @@ Javalab.prototype.init = function(config) {
   // Used for some post requests made in Javalab, namely
   // when providing overrideSources or commiting code.
   // Code review manages a csrf token separately.
-  fetch('/project_versions/get_token', {
+  fetch('/project_commits/get_token', {
     method: 'GET'
   }).then(response => (this.csrf_token = response.headers.get('csrf-token')));
 
@@ -473,7 +473,7 @@ Javalab.prototype.afterClearPuzzle = function() {
 
 Javalab.prototype.onCommitCode = function(commitNotes, onSuccessCallback) {
   project.save(true).then(result => {
-    fetch('/project_versions', {
+    fetch('/project_commits', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/dashboard/app/controllers/project_commits_controller.rb
+++ b/dashboard/app/controllers/project_commits_controller.rb
@@ -1,17 +1,18 @@
-class ProjectVersionsController < ApplicationController
+class ProjectCommitsController < ApplicationController
   before_action :authenticate_user!
 
-  # POST /project_versions
+  # POST /project_commits
   def create
     _, project_id = storage_decrypt_channel_id(params[:storage_id])
-    project_version = ProjectVersion.new(project_id: project_id, object_version_id: params[:version_id], comment: params[:comment])
-    if project_version.save
+    project_commit = ProjectCommit.new(project_id: project_id, object_version_id: params[:version_id], comment: params[:comment])
+    if project_commit.save
       return head :ok
     else
       return head :bad_request
     end
   end
 
+  # GET /project_commits/get_token
   def get_token
     headers['csrf-token'] = form_authenticity_token
     return head :ok
@@ -23,7 +24,7 @@ class ProjectVersionsController < ApplicationController
     project_owner = User.find_by(id: user_id_for_storage_id(user_storage_id))
     return render :not_acceptable unless project_owner
     return render :forbidden unless can?(:view_project_commits, project_owner)
-    commits = ProjectVersion.where(project_id: project_id).where.not(comment: '').order(created_at: :asc)
+    commits = ProjectCommit.where(project_id: project_id).where.not(comment: '').order(created_at: :asc)
     commits = commits.map do |commit|
       {
         createdAt: commit.created_at,

--- a/dashboard/app/models/project_commit.rb
+++ b/dashboard/app/models/project_commit.rb
@@ -14,7 +14,8 @@
 #  index_project_versions_on_storage_app_id                        (storage_app_id)
 #  index_project_versions_on_storage_app_id_and_object_version_id  (storage_app_id,object_version_id) UNIQUE
 #
-class ProjectVersion < ApplicationRecord
+class ProjectCommit < ApplicationRecord
+  self.table_name = :project_versions
   # The projects table used to be named storage_apps. This column has not been renamed
   # to reflect the new table name, so an alias is used to clarify which table this ID maps to.
   alias_attribute :project_id, :storage_app_id

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -998,9 +998,9 @@ Dashboard::Application.routes.draw do
 
   get '/backpacks/channel', to: 'backpacks#get_channel'
 
-  resources :project_versions, only: [:create]
-  get 'project_versions/get_token', to: 'project_versions#get_token'
-  get 'project_commits/:channel_id', to: 'project_versions#project_commits'
+  resources :project_commits, only: [:create]
+  get 'project_commits/get_token', to: 'project_commits#get_token'
+  get 'project_commits/:channel_id', to: 'project_commits#project_commits'
 
   resources :reviewable_projects, only: [:create, :destroy]
   get 'reviewable_projects/for_level', to: 'reviewable_projects#for_level'

--- a/dashboard/test/controllers/project_commits_controller_test.rb
+++ b/dashboard/test/controllers/project_commits_controller_test.rb
@@ -1,20 +1,20 @@
 require 'test_helper'
 
-class ProjectVersionsControllerTest < ActionController::TestCase
-  test "can create project version" do
+class ProjectCommitsControllerTest < ActionController::TestCase
+  test "can create project commit" do
     student = create :student
     sign_in student
 
     @controller.expects(:storage_decrypt_channel_id).with("abcdef").returns([123, 654])
-    assert_creates(ProjectVersion) do
+    assert_creates(ProjectCommit) do
       post :create, params: {storage_id: 'abcdef', version_id: 'fghj', comment: 'This is a comment'}
     end
-    project_version = ProjectVersion.find_by(project_id: 654, object_version_id: 'fghj')
-    assert_not_nil project_version
-    assert_equal 'This is a comment', project_version.comment
+    project_commit = ProjectCommit.find_by(project_id: 654, object_version_id: 'fghj')
+    assert_not_nil project_commit
+    assert_equal 'This is a comment', project_commit.comment
   end
 
-  test "can fetch project versions of own project" do
+  test "can fetch project commits of own project" do
     student = create :student
     sign_in student
 
@@ -24,9 +24,9 @@ class ProjectVersionsControllerTest < ActionController::TestCase
     @controller.expects(:user_id_for_storage_id).with(fake_storage_id).returns(student.id)
     @controller.expects(:storage_decrypt_channel_id).with(fake_channel_id).returns([fake_storage_id, fake_project_id])
 
-    create :project_version, project_id: fake_project_id, comment: "First comment", created_at: 2.days.ago
-    create :project_version, project_id: fake_project_id, comment: "Second comment", created_at: 1.day.ago
-    create :project_version, project_id: fake_project_id, comment: "Third comment"
+    create :project_commit, project_id: fake_project_id, comment: "First comment", created_at: 2.days.ago
+    create :project_commit, project_id: fake_project_id, comment: "Second comment", created_at: 1.day.ago
+    create :project_commit, project_id: fake_project_id, comment: "Third comment"
 
     get :project_commits, params: {channel_id: fake_channel_id}
     assert_response :ok
@@ -36,7 +36,7 @@ class ProjectVersionsControllerTest < ActionController::TestCase
     assert_equal ['First comment', 'Second comment', 'Third comment'], returned_commits.map {|c| c['comment']}
   end
 
-  test "can fetch project versions and blank comments are filtered out" do
+  test "can fetch project commits and blank comments are filtered out" do
     student = create :student
     sign_in student
 
@@ -46,9 +46,9 @@ class ProjectVersionsControllerTest < ActionController::TestCase
     @controller.expects(:user_id_for_storage_id).with(fake_storage_id).returns(student.id)
     @controller.expects(:storage_decrypt_channel_id).with(fake_channel_id).returns([fake_storage_id, fake_project_id])
 
-    create :project_version, project_id: fake_project_id, comment: "First comment", created_at: 2.days.ago
-    create :project_version, project_id: fake_project_id, comment: "", created_at: 1.day.ago
-    create :project_version, project_id: fake_project_id, comment: "Third comment"
+    create :project_commit, project_id: fake_project_id, comment: "First comment", created_at: 2.days.ago
+    create :project_commit, project_id: fake_project_id, comment: "", created_at: 1.day.ago
+    create :project_commit, project_id: fake_project_id, comment: "Third comment"
 
     get :project_commits, params: {channel_id: fake_channel_id}
     assert_response :ok
@@ -58,7 +58,7 @@ class ProjectVersionsControllerTest < ActionController::TestCase
     assert_equal ['First comment', 'Third comment'], returned_commits.map {|c| c['comment']}
   end
 
-  test "can fetch project versions of students project if their teacher" do
+  test "can fetch project commits of students project if their teacher" do
     teacher = create :teacher
     section = create :section, user: teacher
     student = create(:follower, section: section).student_user
@@ -70,13 +70,13 @@ class ProjectVersionsControllerTest < ActionController::TestCase
     @controller.expects(:user_id_for_storage_id).with(fake_storage_id).returns(student.id)
     @controller.expects(:storage_decrypt_channel_id).with(fake_channel_id).returns([fake_storage_id, fake_project_id])
 
-    create :project_version, project_id: fake_project_id, comment: "Third comment"
+    create :project_commit, project_id: fake_project_id, comment: "Third comment"
 
     get :project_commits, params: {channel_id: fake_channel_id}
     assert_response :ok
   end
 
-  test "can fetch project versions of another students project if in the same code review group" do
+  test "can fetch project commits of another students project if in the same code review group" do
     section = create :section, code_review_expires_at: 1.year.from_now
     group = create :code_review_group, section: section
 
@@ -96,13 +96,13 @@ class ProjectVersionsControllerTest < ActionController::TestCase
     @controller.expects(:storage_decrypt_channel_id).with(fake_channel_id).returns([fake_storage_id, fake_project_id])
     create :reviewable_project, user_id: project_owner_student.id, project_id: fake_project_id
 
-    create :project_version, project_id: fake_project_id, comment: "Third comment"
+    create :project_commit, project_id: fake_project_id, comment: "Third comment"
 
     get :project_commits, params: {channel_id: fake_channel_id}
     assert_response :ok
   end
 
-  test "cannot fetch project versions of a user who isnt in the same code review group" do
+  test "cannot fetch project commits of a user who isnt in the same code review group" do
     section = create :section, code_review_expires_at: 1.year.from_now
     project_owner_student = create :student
     group1 = create :code_review_group, section: section
@@ -122,7 +122,7 @@ class ProjectVersionsControllerTest < ActionController::TestCase
     @controller.expects(:storage_decrypt_channel_id).with(fake_channel_id).returns([fake_storage_id, fake_project_id])
     create :reviewable_project, user_id: project_owner_student.id, project_id: fake_project_id
 
-    create :project_version, project_id: fake_project_id, comment: "Third comment"
+    create :project_commit, project_id: fake_project_id, comment: "Third comment"
 
     get :project_commits, params: {channel_id: fake_channel_id}
     assert_response :not_found

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -1620,7 +1620,7 @@ FactoryGirl.define do
     association :script
   end
 
-  factory :project_version do
+  factory :project_commit do
     sequence(:project_id)
     sequence(:object_version_id)
     comment 'a commit comment'

--- a/dashboard/test/helpers/delete_accounts_helper_test.rb
+++ b/dashboard/test/helpers/delete_accounts_helper_test.rb
@@ -1817,19 +1817,19 @@ class DeleteAccountsHelperTest < ActionView::TestCase
     student = create :student
     with_channel_for student do |project_id|
       comment_text = 'a comment'
-      ProjectVersion.create(
+      ProjectCommit.create(
         project_id: project_id,
         object_version_id: 'xyz',
         comment: comment_text
       )
-      assert_equal 1, ProjectVersion.where(project_id: project_id).count
-      assert_equal comment_text, ProjectVersion.where(project_id: project_id).first.comment
+      assert_equal 1, ProjectCommit.where(project_id: project_id).count
+      assert_equal comment_text, ProjectCommit.where(project_id: project_id).first.comment
 
       purge_user student
 
-      assert_equal 1, ProjectVersion.where(project_id: project_id).count
-      assert_nil ProjectVersion.where(project_id: project_id).first.comment
-      assert_logged "Cleared 1 ProjectVersion comments"
+      assert_equal 1, ProjectCommit.where(project_id: project_id).count
+      assert_nil ProjectCommit.where(project_id: project_id).first.comment
+      assert_logged "Cleared 1 ProjectCommit comments"
     end
   end
 
@@ -1840,28 +1840,28 @@ class DeleteAccountsHelperTest < ActionView::TestCase
     with_channel_for student_to_purge do |project_id_to_purge|
       with_channel_for other_student do |project_id_other|
         comment_text = 'a comment'
-        ProjectVersion.create(
+        ProjectCommit.create(
           project_id: project_id_to_purge,
           object_version_id: 'xyz',
           comment: comment_text
         )
-        ProjectVersion.create(
+        ProjectCommit.create(
           project_id: project_id_other,
           object_version_id: 'xyz',
           comment: comment_text
         )
 
-        assert_equal 1, ProjectVersion.where(project_id: project_id_to_purge).count
-        assert_equal comment_text, ProjectVersion.where(project_id: project_id_to_purge).first.comment
-        assert_equal 1, ProjectVersion.where(project_id: project_id_other).count
-        assert_equal comment_text, ProjectVersion.where(project_id: project_id_other).first.comment
+        assert_equal 1, ProjectCommit.where(project_id: project_id_to_purge).count
+        assert_equal comment_text, ProjectCommit.where(project_id: project_id_to_purge).first.comment
+        assert_equal 1, ProjectCommit.where(project_id: project_id_other).count
+        assert_equal comment_text, ProjectCommit.where(project_id: project_id_other).first.comment
 
         purge_user student_to_purge
 
-        assert_equal 1, ProjectVersion.where(project_id: project_id_to_purge).count
-        assert_nil ProjectVersion.where(project_id: project_id_to_purge).first.comment
-        assert_equal 1, ProjectVersion.where(project_id: project_id_other).count
-        assert_equal comment_text, ProjectVersion.where(project_id: project_id_other).first.comment
+        assert_equal 1, ProjectCommit.where(project_id: project_id_to_purge).count
+        assert_nil ProjectCommit.where(project_id: project_id_to_purge).first.comment
+        assert_equal 1, ProjectCommit.where(project_id: project_id_other).count
+        assert_equal comment_text, ProjectCommit.where(project_id: project_id_other).first.comment
       end
     end
   end

--- a/lib/cdo/delete_accounts_helper.rb
+++ b/lib/cdo/delete_accounts_helper.rb
@@ -49,9 +49,9 @@ class DeleteAccountsHelper
     # Clear any comments associated with specific versions of projects.
     # At time of writing, this feature is in use only in Javalab when a student
     # commits their code.
-    project_versions = ProjectVersion.where(project_id: project_ids)
-    project_versions.each {|version| version.update!(comment: nil)}
-    @log.puts "Cleared #{project_versions.count} ProjectVersion comments" if project_versions.count > 0
+    project_commits = ProjectCommit.where(project_id: project_ids)
+    project_commits.each {|version| version.update!(comment: nil)}
+    @log.puts "Cleared #{project_commits.count} ProjectCommit comments" if project_commits.count > 0
 
     # Clear S3 contents for user's channels
     @log.puts "Deleting S3 contents for #{channel_count} channels"


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Currently the `project_versions` table stores the data of a commit for a project, it's not currently used for anything else. When I was working on code review v2, I found the name `project_versions` confusing because not all version of the project are stored in the table, only the project versions associated with commits are stored in the table. The proposal is to change the table named `project_versions` to `project_commits` to more clearly signify the content and intent of the table.

The first step of this process in this PR is to change all references to the the term "project version" to "project commit" where that's what we mean, but not change the underlying DB name, so rename the model, controller, etc. The next step will be to do the actual name migration which is outlined in the "Follow-up work" below.

## Links
- jira ticket: [LP-2415](https://codedotorg.atlassian.net/browse/LP-2415)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()

-->

## Testing story
- [x] Create a commit locally
- [x] Load commits locally
- [x] Log in as teacher/peer and see commits for another user
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Follow-up work
The next piece of this work is the DB table rename. The plan is to follow a similar pattern as what was done for the storage_apps => projects table rename (https://github.com/code-dot-org/code-dot-org/pull/45476). I'll write a migration that renames the table and creates a temporary view with the old table name so that during the time between the when the migration is run and when the new code is deployed that data will continue to be served.
<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
