### PR TITLE
Remove expensive join from query

### DIFF
--- a/bin/oneoff/remove_authorized_teacher_permissions_from_students
+++ b/bin/oneoff/remove_authorized_teacher_permissions_from_students
@@ -1,14 +1,16 @@
 #!/usr/bin/env ruby
 
+time_started = Time.now
 require_relative '../../dashboard/config/environment'
+puts "Dashboard environment loaded in #{Time.now - time_started}"
 
 DRY_RUN = true
 
-authorized_teacher_student_permissions = UserPermission.where(permission: UserPermission::AUTHORIZED_TEACHER).left_joins(:user).where('users.user_type': 'student')
+authorized_teacher_student_permissions = UserPermission.where(permission: UserPermission::AUTHORIZED_TEACHER)
 
 removed_permissions = 0
 
-authorized_teacher_student_permissions.each do |permission|
+authorized_teacher_student_permissions.find_each do |permission|
   user = permission.user
   next unless user.student?
   permission.destroy! unless DRY_RUN


### PR DESCRIPTION
The query to find students with authorized teacher permissions timed out in production. Without cloning the production database, I haven't been able to figure out why the query runs reasonably quickly on the reporting database but not in production. My guess is that the join with the users table was a problem, though.

I removed the join and am querying the user_permissions table directly. There isn't an index on `permission` on this table unfortunately, but the table isn't that large. There are about 50000 `authorized_teacher` permissions in this table, so I'm using [find_each](https://apidock.com/rails/ActiveRecord/Batches/find_each), which batches the results behind the scenes. This script will likely be a bit slower to run with this change, but hopefully the queries won't time out. The rest of the queries in the block should be quick.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
