### PR TITLE
added warning for reserved pin ids

### DIFF
--- a/apps/src/lib/util/javascriptMode.js
+++ b/apps/src/lib/util/javascriptMode.js
@@ -48,7 +48,6 @@ export function apiValidateType(
   if (typeof opts[validatedTypeKey] === 'undefined') {
     var properType;
     var customWarning;
-    var warningMessage;
     switch (expectedType) {
       case 'color':
         // Special handling for colors, must be a string and a valid RGBColor:
@@ -113,7 +112,7 @@ export function apiValidateType(
       const outputValue =
         typeof varValue === 'function' ? 'function' : varValue;
       // Use the default warning message if a custom one has not been set
-      warningMessage =
+      var warningMessage =
         customWarning ||
         `${funcName}() ${varName} parameter value (${outputValue}) is not a ${expectedType}.`;
       outputWarning(warningMessage);

--- a/apps/src/lib/util/javascriptMode.js
+++ b/apps/src/lib/util/javascriptMode.js
@@ -47,6 +47,8 @@ export function apiValidateType(
   const validatedTypeKey = 'validated_type_' + varName;
   if (typeof opts[validatedTypeKey] === 'undefined') {
     var properType;
+    var customWarning;
+    var warningMessage;
     switch (expectedType) {
       case 'color':
         // Special handling for colors, must be a string and a valid RGBColor:
@@ -63,8 +65,13 @@ export function apiValidateType(
           typeof varValue === 'boolean';
         break;
       case 'pinid':
+        var reservedPins = ['A2', 'A3', 'A7', 1, 9, 10];
         properType =
-          typeof varValue === 'string' || typeof varValue === 'number';
+          (typeof varValue === 'string' || typeof varValue === 'number') &&
+          !reservedPins.includes(varValue);
+        if (reservedPins.includes(varValue)) {
+          customWarning = `${funcName}() ${varName} parameter value (${varValue}) is a reserved ${expectedType}. Please use a different ${expectedType}`;
+        }
         break;
       case 'number':
         properType =
@@ -105,9 +112,11 @@ export function apiValidateType(
     if (!properType) {
       const outputValue =
         typeof varValue === 'function' ? 'function' : varValue;
-      outputWarning(
-        `${funcName}() ${varName} parameter value (${outputValue}) is not a ${expectedType}.`
-      );
+      // Use the default warning message if a custom one has not been set
+      warningMessage =
+        customWarning ||
+        `${funcName}() ${varName} parameter value (${outputValue}) is not a ${expectedType}.`;
+      outputWarning(warningMessage);
     }
     opts[validatedTypeKey] = properType;
   }

--- a/apps/src/lib/util/javascriptMode.js
+++ b/apps/src/lib/util/javascriptMode.js
@@ -33,7 +33,7 @@ export function getAsyncOutputWarning(...args) {
 }
 
 /**
- * Validates a user function parameter, and outputs error to the console if invalid
+ * Validates a user function parameter, and outputs warning to the console if invalid
  * @returns {boolean} True if param passed validation.
  */
 export function apiValidateType(

--- a/apps/test/unit/lib/kits/maker/commandsTest.js
+++ b/apps/test/unit/lib/kits/maker/commandsTest.js
@@ -14,23 +14,36 @@ import {
   pinMode
 } from '@cdo/apps/lib/kits/maker/commands';
 import FakeBoard from '@cdo/apps/lib/kits/maker/boards/FakeBoard';
+import {injectErrorHandler} from '@cdo/apps/lib/util/javascriptMode';
 
 describe('maker/commands.js', () => {
-  let stubBoardController;
+  let stubBoardController, errorHandler;
 
   beforeEach(() => {
     stubBoardController = sinon.createStubInstance(FakeBoard);
     injectBoardController(stubBoardController);
+    errorHandler = {
+      outputWarning: sinon.spy()
+    };
+    injectErrorHandler(errorHandler);
   });
 
   afterEach(() => {
     injectBoardController(undefined);
+    injectErrorHandler(null);
   });
 
   describe('pinMode(pin, mode)', () => {
     it('delegates to makerBoard.pinMode with mapped mode id', () => {
       pinMode({pin: 0, mode: 'input'});
       expect(stubBoardController.pinMode).to.have.been.calledWith(0, 0);
+    });
+
+    it('display warning when reserved pin 1 is used', () => {
+      pinMode({pin: 1, mode: 'input'});
+      expect(errorHandler.outputWarning).to.have.been.calledWith(
+        'pinMode() pin parameter value (1) is a reserved pinid. Please use a different pinid'
+      );
     });
 
     it(`maps 'input' mode to 0`, () => {

--- a/apps/test/unit/lib/kits/maker/commandsTest.js
+++ b/apps/test/unit/lib/kits/maker/commandsTest.js
@@ -29,8 +29,8 @@ describe('maker/commands.js', () => {
 
   describe('pinMode(pin, mode)', () => {
     it('delegates to makerBoard.pinMode with mapped mode id', () => {
-      pinMode({pin: 1, mode: 'input'});
-      expect(stubBoardController.pinMode).to.have.been.calledWith(1, 0);
+      pinMode({pin: 0, mode: 'input'});
+      expect(stubBoardController.pinMode).to.have.been.calledWith(0, 0);
     });
 
     it(`maps 'input' mode to 0`, () => {


### PR DESCRIPTION
## Summary

- Added a warning message in Debug Console and gutter warning when a reserved data pin is used as a parameter for Circuit Playground Maker commands. 

- Although there are 8 available pins, only 5 of them are actually available for use. 
Allowed data pins: A0, A1, A4, A5, A6 (Express) and 0, 2, 3, 6, 12 (Classic)
Reserved data pins: A2, A3, A7 (Express) and 1, 9, 10 (Classic)

- The warning message appears only if user uses any of the reserved data pins. 

Before updates:

- Circuit Playground Classic: pins 0, 11 are usable pin ids and 1, 9, 10 are reserved pin ids but no warning for reserved pins

<img width="973" alt="Screen Shot 2022-06-30 at 7 25 21 PM" src="https://user-images.githubusercontent.com/107423305/176799402-52666a5a-4780-43f2-91e2-543e361f58b3.png">

- Circuit Playground Express: pins A0, A6 are usable pin Ids and pins A2, A7 are reserved ids but no warning for reserved pins
<img width="1002" alt="Screen Shot 2022-06-30 at 7 00 20 PM" src="https://user-images.githubusercontent.com/107423305/176799432-f28fbf40-245a-4a6c-9469-4163305e382d.png">


After updates:

- Circuit Playground Classic: pins 0, 11 are usable pin ids and 1, 9, 10 are reserved pin ids
<img width="1206" alt="Screen Shot 2022-06-30 at 6 47 59 PM" src="https://user-images.githubusercontent.com/107423305/176796780-332dd43b-4e7f-4819-b3e9-285d3e7c78c7.png">

- Circuit Playground Express: pins A0, A6 are usable pin Ids and pins A2, A7 are reserved ids 
<img width="1129" alt="Screen Shot 2022-06-30 at 6 48 49 PM" src="https://user-images.githubusercontent.com/107423305/176796817-c97b7ff6-2f9d-44fa-87f1-0f9a5410b663.png">

## Links

[jira ticket](https://codedotorg.atlassian.net/browse/STAR-1706)

## Follow up work
I observed that there is an error message thrown when invalid parameters are used such as "A8" or 30.

![image](https://user-images.githubusercontent.com/107423305/176799882-e5d8b3ef-f005-4b5c-878a-9932127c1009.png)

![image](https://user-images.githubusercontent.com/107423305/176799924-bd72a382-29be-4d9f-8849-db9b1fd8b597.png)


In other words, any string other than "A0" through "A7" and any number not within range of 0 and 30 will result in an error displayed. However, there is no error thrown when an invalid number parameter is used within range of 0 and 30 such as 25 which is not a valid pin id. 

![image](https://user-images.githubusercontent.com/107423305/176799996-73d28568-1e33-46dc-92ff-13adcd571530.png)

Follow up task could be to make sure an error is also thrown for data pin numbers other than the valid data pins (0, 1, 2, 3, 6, 9, 10, 12).
