### PR TITLE
Fix top instructions style issues 

### DIFF
--- a/apps/src/templates/instructions/InstructionsTab.jsx
+++ b/apps/src/templates/instructions/InstructionsTab.jsx
@@ -36,6 +36,8 @@ export default class InstructionsTab extends Component {
           : this.props.isMinecraft
           ? craftStyles.highlightedWrapper
           : styles.highlightedWrapper
+        : this.props.teacherOnly
+        ? styles.teacherText
         : {})
     };
     const combinedStyle = {
@@ -106,6 +108,7 @@ const styles = {
     color: color.white
   },
   teacherHighlightedWrapper: {
+    color: color.lightest_cyan,
     borderBottom: '2px solid ' + color.lightest_cyan
   }
 };

--- a/apps/src/templates/instructions/TopInstructionsHeader.jsx
+++ b/apps/src/templates/instructions/TopInstructionsHeader.jsx
@@ -132,6 +132,7 @@ function TopInstructionsHeader(props) {
               onClick={handleDocumentationTabClick}
               selected={tabSelected === TabType.DOCUMENTATION}
               text={i18n.documentation()}
+              teacherOnly={teacherOnly}
               isMinecraft={isMinecraft}
               isRtl={isRtl}
             />


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Small clean-up of top instructions styles when viewing teacher-only tabs.

Before:

![Screen Shot 2022-07-01 at 11 05 38 AM](https://user-images.githubusercontent.com/24235215/176947567-bffae3ac-2760-42bb-af39-24070fd6b8ad.png)

After:

![Screen Shot 2022-07-01 at 11 07 19 AM](https://user-images.githubusercontent.com/24235215/176947741-3fc1298f-14c8-4bfb-8b50-c90b28ff01d8.png)

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
