### PR TITLE
CSF Instructions: fix a loop on small devices

### DIFF
--- a/apps/src/templates/instructions/TopInstructions.jsx
+++ b/apps/src/templates/instructions/TopInstructions.jsx
@@ -74,6 +74,7 @@ class TopInstructions extends Component {
     isViewingAsInstructorInTraining: PropTypes.bool,
     height: PropTypes.number.isRequired,
     expandedHeight: PropTypes.number,
+    maxNeededHeight: PropTypes.number.isRequired,
     maxHeight: PropTypes.number.isRequired,
     longInstructions: PropTypes.string,
     dynamicInstructions: PropTypes.object,
@@ -346,7 +347,7 @@ class TopInstructions extends Component {
       shortInstructions,
       longInstructions,
       hasContainedLevels,
-      maxHeight,
+      maxNeededHeight,
       setInstructionsMaxHeightNeeded
     } = this.props;
 
@@ -361,15 +362,15 @@ class TopInstructions extends Component {
     const refForSelectedTab = this.refForSelectedTab();
 
     if (refForSelectedTab) {
-      const maxNeededHeight =
+      const maxNeededHeightMeasured =
         $(ReactDOM.findDOMNode(refForSelectedTab)).outerHeight(true) +
         HEADER_HEIGHT +
         RESIZER_HEIGHT;
 
-      if (maxHeight !== maxNeededHeight) {
-        setInstructionsMaxHeightNeeded(maxNeededHeight);
+      if (maxNeededHeight !== maxNeededHeightMeasured) {
+        setInstructionsMaxHeightNeeded(maxNeededHeightMeasured);
       }
-      return maxNeededHeight;
+      return maxNeededHeightMeasured;
     } else {
       return 0;
     }
@@ -876,6 +877,7 @@ export default connect(
     isBlockly: !!state.pageConstants.isBlockly,
     height: state.instructions.renderedHeight,
     expandedHeight: state.instructions.expandedHeight,
+    maxNeededHeight: state.instructions.maxNeededHeight,
     maxHeight: Math.min(
       state.instructions.maxAvailableHeight,
       state.instructions.maxNeededHeight


### PR DESCRIPTION
Follow up to https://github.com/code-dot-org/code-dot-org/pull/46325.

A couple UI tests failed on a landscape iPhone and it appeared to be because we landed in the affected code without much vertical space.  When `maxAvailableHeight` was less than `maxNeededHeight`, the calculated `maxHeight` would never actually reach the `maxNeededHeight`, and we'd end up in an infinite loop.  Now, we update the `maxNeededHeight` by itself in this code.