### PR TITLE
increase interval for running process_pd_workshop_ends

### DIFF
--- a/cookbooks/cdo-apps/templates/default/crontab.erb
+++ b/cookbooks/cdo-apps/templates/default/crontab.erb
@@ -87,7 +87,7 @@
     if node.chef_environment == 'production' # production daemon
       cronjob at:'30 14 * * *', do:dashboard_dir('bin','scheduled_pd_workshop_emails')
       cronjob at:'0 16 * * *', do:dashboard_dir('bin','scheduled_pd_application_emails')
-      cronjob at:'*/3 * * * *', do:dashboard_dir('bin', 'process_pd_workshop_ends')
+      cronjob at:'*/4 * * * *', do:dashboard_dir('bin', 'process_pd_workshop_ends')
       cronjob at:'*/5 * * * *', do:dashboard_dir('bin', 'fill_jotform_placeholders')
       cronjob at:'*/30 * * * *', do:dashboard_dir('bin', 'sync_jotforms')
       cronjob at:'0 6 * * *', do:deploy_dir('bin', 'cron', 'process_foorm_data')


### PR DESCRIPTION
speculative fix for https://app.honeybadger.io/projects/45435/faults/52787853 . the cronjob isn't failing every time, rather it is failing almost exactly every other time, because of the "only one running" rule, because it is being run every 3 minutes, but takes just over 3 minutes to finish running. the solution in this PR is to increase the interval to 4 minutes.

the runtime doesn't seem to have to do with the DB query or the number of workshops, since the DB query runs in a fraction of a second. my best guess is the run time is dominated by loading the rails environment.

see [slack](https://codedotorg.slack.com/archives/C02EEGWLHR8/p1656453845276499) for more context.

## Testing story

not tested. will check after this reaches prod to see if hb error rate goes down.