### PR TITLE
remove teacher_resources from server code

### DIFF
--- a/apps/src/code-studio/components/progress/UnitOverview.jsx
+++ b/apps/src/code-studio/components/progress/UnitOverview.jsx
@@ -9,7 +9,6 @@ import UnversionedScriptRedirectDialog from '@cdo/apps/code-studio/components/Un
 import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
 import ProgressTable from '@cdo/apps/templates/progress/ProgressTable';
 import ProgressLegend from '@cdo/apps/templates/progress/ProgressLegend';
-import {resourceShape} from '@cdo/apps/templates/courseOverview/resourceType';
 import {resourceShape as migratedResourceShape} from '@cdo/apps/lib/levelbuilder/shapes';
 import UnitOverviewHeader from './UnitOverviewHeader';
 import {isScriptHiddenForSection} from '@cdo/apps/code-studio/hiddenLessonRedux';
@@ -36,7 +35,6 @@ class UnitOverview extends React.Component {
     courseTitle: PropTypes.string,
     courseLink: PropTypes.string,
     excludeCsfColumnInLegend: PropTypes.bool.isRequired,
-    teacherResources: PropTypes.arrayOf(resourceShape),
     migratedTeacherResources: PropTypes.arrayOf(migratedResourceShape),
     studentResources: PropTypes.arrayOf(migratedResourceShape),
     showCourseUnitVersionWarning: PropTypes.bool,
@@ -85,7 +83,6 @@ class UnitOverview extends React.Component {
   render() {
     const {
       excludeCsfColumnInLegend,
-      teacherResources,
       migratedTeacherResources,
       studentResources,
       scriptId,
@@ -170,7 +167,6 @@ class UnitOverview extends React.Component {
             </div>
           )}
           <UnitOverviewTopRow
-            teacherResources={teacherResources}
             migratedTeacherResources={migratedTeacherResources}
             studentResources={studentResources}
             showAssignButton={showAssignButton}

--- a/apps/src/sites/studio/pages/scripts/show.js
+++ b/apps/src/sites/studio/pages/scripts/show.js
@@ -97,13 +97,6 @@ function initPage() {
 
   progress.initCourseProgress(scriptData);
 
-  const teacherResources = (scriptData.teacher_resources || []).map(
-    ([type, link]) => ({
-      type,
-      link
-    })
-  );
-
   const mountPoint = document.createElement('div');
   $('.user-stats-block').prepend(mountPoint);
 
@@ -122,7 +115,6 @@ function initPage() {
         courseTitle={scriptData.course_title}
         courseLink={scriptData.course_link}
         excludeCsfColumnInLegend={!scriptData.csf}
-        teacherResources={teacherResources}
         migratedTeacherResources={scriptData.migrated_teacher_resources}
         studentResources={scriptData.student_resources || []}
         showCourseUnitVersionWarning={

--- a/apps/src/templates/courseOverview/resourceType.js
+++ b/apps/src/templates/courseOverview/resourceType.js
@@ -1,4 +1,3 @@
-import PropTypes from 'prop-types';
 import i18n from '@cdo/locale';
 
 // We want level builders to be able to specify which of these strings is used,
@@ -29,8 +28,3 @@ export const stringForType = {
   [ResourceType.videos]: i18n.videos(),
   [ResourceType.curriculumGuide]: i18n.curriculumGuide()
 };
-
-export const resourceShape = PropTypes.shape({
-  type: PropTypes.oneOf(Object.values(ResourceType)).isRequired,
-  link: PropTypes.string.isRequired
-});

--- a/apps/test/unit/code-studio/components/progress/UnitOverviewTest.js
+++ b/apps/test/unit/code-studio/components/progress/UnitOverviewTest.js
@@ -8,7 +8,6 @@ import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
 
 const defaultProps = {
   excludeCsfColumnInLegend: true,
-  teacherResources: [],
   studentResources: [],
   isSignedIn: true,
   isVerifiedInstructor: true,

--- a/apps/test/unit/lib/levelbuilder/script-editor/UnitEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/script-editor/UnitEditorTest.jsx
@@ -71,7 +71,6 @@ describe('UnitEditor', () => {
       locales: [],
       name: 'test-unit',
       unitFamilies: [],
-      teacherResources: [],
       versionYearOptions: [],
       initialFamilyName: '',
       initialVersionYear: '',

--- a/dashboard/app/controllers/courses_controller.rb
+++ b/dashboard/app/controllers/courses_controller.rb
@@ -82,6 +82,13 @@ class CoursesController < ApplicationController
     @unit_group.update(course_params)
     CourseOffering.add_course_offering(@unit_group)
     @unit_group.reload
+
+    if @unit_group.has_migrated_unit? && @unit_group.course_version
+      @unit_group.resources = params[:resourceIds].map {|id| Resource.find(id)} if params.key?(:resourceIds)
+      @unit_group.student_resources = params[:studentResourceIds].map {|id| Resource.find(id)} if params.key?(:studentResourceIds)
+    end
+
+    @unit_group.reload
     @unit_group.write_serialization
     render json: @unit_group.summarize
   end

--- a/dashboard/app/controllers/courses_controller.rb
+++ b/dashboard/app/controllers/courses_controller.rb
@@ -82,14 +82,6 @@ class CoursesController < ApplicationController
     @unit_group.update(course_params)
     CourseOffering.add_course_offering(@unit_group)
     @unit_group.reload
-
-    @unit_group.update_teacher_resources(params[:resourceTypes], params[:resourceLinks]) unless @unit_group.has_migrated_unit?
-    if @unit_group.has_migrated_unit? && @unit_group.course_version
-      @unit_group.resources = params[:resourceIds].map {|id| Resource.find(id)} if params.key?(:resourceIds)
-      @unit_group.student_resources = params[:studentResourceIds].map {|id| Resource.find(id)} if params.key?(:studentResourceIds)
-    end
-
-    @unit_group.reload
     @unit_group.write_serialization
     render json: @unit_group.summarize
   end

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1771,15 +1771,12 @@ class Script < ApplicationRecord
       :use_legacy_lesson_plans,
       :is_maker_unit
     ]
-    not_defaulted_keys = []
 
     result = {}
     # If a non-boolean prop was missing from the input, it'll get populated in the result hash as nil.
     nonboolean_keys.each {|k| result[k] = unit_data[k]}
     # If a boolean prop was missing from the input, it'll get populated in the result hash as false.
     boolean_keys.each {|k| result[k] = !!unit_data[k]}
-    not_defaulted_keys.each {|k| result[k] = unit_data[k] if unit_data.keys.include?(k)}
-
     result
   end
 

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -287,7 +287,6 @@ class Script < ApplicationRecord
     student_detail_progress_view
     project_widget_visible
     project_widget_types
-    teacher_resources
     lesson_extras_available
     has_verified_resources
     curriculum_path
@@ -1355,8 +1354,7 @@ class Script < ApplicationRecord
   end
 
   def update_migrated_teacher_resources(resource_ids)
-    teacher_resources = (resource_ids || []).map {|id| Resource.find(id)}
-    self.resources = teacher_resources
+    self.resources = (resource_ids || []).map {|id| Resource.find(id)}
   end
 
   def update_student_resources(resource_ids)
@@ -1514,7 +1512,6 @@ class Script < ApplicationRecord
       student_detail_progress_view: student_detail_progress_view?,
       project_widget_visible: project_widget_visible?,
       project_widget_types: project_widget_types,
-      teacher_resources: teacher_resources,
       migrated_teacher_resources: resources.sort_by(&:name).map(&:summarize_for_resources_dropdown),
       student_resources: student_resources.sort_by(&:name).map(&:summarize_for_resources_dropdown),
       lesson_extras_available: lesson_extras_available,
@@ -1774,9 +1771,7 @@ class Script < ApplicationRecord
       :use_legacy_lesson_plans,
       :is_maker_unit
     ]
-    not_defaulted_keys = [
-      :teacher_resources, # teacher_resources gets updated from the unit edit UI through its own code path
-    ]
+    not_defaulted_keys = []
 
     result = {}
     # If a non-boolean prop was missing from the input, it'll get populated in the result hash as nil.

--- a/dashboard/app/models/unit_group.rb
+++ b/dashboard/app/models/unit_group.rb
@@ -70,7 +70,6 @@ class UnitGroup < ApplicationRecord
   include SerializedProperties
 
   serialized_attrs %w(
-    teacher_resources
     has_verified_resources
     has_numbered_units
     family_name
@@ -315,7 +314,6 @@ class UnitGroup < ApplicationRecord
         include_lessons = false
         unit.summarize(include_lessons, user).merge!(unit.summarize_i18n_for_display)
       end,
-      teacher_resources: teacher_resources,
       migrated_teacher_resources: resources.sort_by(&:name).map(&:summarize_for_resources_dropdown),
       student_resources: student_resources.sort_by(&:name).map(&:summarize_for_resources_dropdown),
       is_migrated: has_migrated_unit?,

--- a/dashboard/app/models/unit_group.rb
+++ b/dashboard/app/models/unit_group.rb
@@ -202,15 +202,6 @@ class UnitGroup < ApplicationRecord
     save!
   end
 
-  # @param types [Array<string>]
-  # @param links [Array<string>]
-  def update_teacher_resources(types, links)
-    return if types.nil? || links.nil? || types.length != links.length
-    # Only take those pairs in which we have both a type and a link
-    self.teacher_resources = types.zip(links).select {|type, link| type.present? && link.present?}
-    save!
-  end
-
   def write_serialization
     # Only save non-plc course, and only in LB mode
     return unless Rails.application.config.levelbuilder_mode && !plc_course

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -643,7 +643,6 @@ class ScriptTest < ActiveSupport::TestCase
     lesson_group = create(:lesson_group, key: 'key1', script: unit)
     lesson = create(:lesson, script: unit, name: 'lesson 1', lesson_group: lesson_group)
     create(:script_level, script: unit, lesson: lesson)
-    unit.teacher_resources = [['curriculum', '/link/to/curriculum']]
     create :resource, lessons: [lesson], include_in_pdf: true
     Services::CurriculumPdfs.stubs(:get_script_overview_url).returns('/overview-pdf-url')
     Services::CurriculumPdfs.stubs(:get_unit_resources_url).returns('/resources-pdf-url')
@@ -655,7 +654,6 @@ class ScriptTest < ActiveSupport::TestCase
     assert_equal 'teacher_led', summary[:instructionType]
     assert_equal 'teacher', summary[:instructorAudience]
     assert_equal 'student', summary[:participantAudience]
-    assert_equal [['curriculum', '/link/to/curriculum']], summary[:teacher_resources]
     assert_equal '/overview-pdf-url', summary[:scriptOverviewPdfUrl]
     assert_equal '/resources-pdf-url', summary[:scriptResourcesPdfUrl]
   end

--- a/dashboard/test/models/unit_group_test.rb
+++ b/dashboard/test/models/unit_group_test.rb
@@ -612,14 +612,12 @@ class UnitGroupTest < ActiveSupport::TestCase
     create(:unit_group_unit, unit_group: unit_group, position: 0, script: create(:script, name: 'unit1'))
     create(:unit_group_unit, unit_group: unit_group, position: 1, script: create(:script, name: 'unit2'))
 
-    unit_group.teacher_resources = [['curriculum', '/link/to/curriculum']]
-
     summary = unit_group.summarize(create(:teacher))
 
     assert_equal [:name, :id, :title, :assignment_family_title,
                   :family_name, :version_year, :published_state, :instruction_type, :instructor_audience, :participant_audience,
                   :pilot_experiment, :description_short, :description_student,
-                  :description_teacher, :version_title, :scripts, :teacher_resources, :migrated_teacher_resources,
+                  :description_teacher, :version_title, :scripts, :migrated_teacher_resources,
                   :student_resources, :is_migrated, :has_verified_resources, :has_numbered_units, :course_versions, :show_assign_button,
                   :announcements, :course_offering_id, :course_version_id, :course_path, :course_offering_edit_path], summary.keys
     assert_equal 'my-unit-group', summary[:name]
@@ -629,7 +627,6 @@ class UnitGroupTest < ActiveSupport::TestCase
     assert_equal 'Teacher description here', summary[:description_teacher]
     assert_equal 'Version title', summary[:version_title]
     assert_equal 2, summary[:scripts].length
-    assert_equal [['curriculum', '/link/to/curriculum']], summary[:teacher_resources]
     assert_equal false, summary[:has_verified_resources]
 
     # spot check that we have fields that show up in Script.summarize(false)

--- a/dashboard/test/models/unit_group_test.rb
+++ b/dashboard/test/models/unit_group_test.rb
@@ -1060,13 +1060,6 @@ class UnitGroupTest < ActiveSupport::TestCase
     end
   end
 
-  test "update_teacher_resources" do
-    unit_group = create :unit_group
-    unit_group.update_teacher_resources(['professionalLearning'], ['/link/to/plc'])
-
-    assert_equal [['professionalLearning', '/link/to/plc']], unit_group.teacher_resources
-  end
-
   test 'has pilot access' do
     unit_group = create :unit_group
     pilot_unit_group = create :unit_group, pilot_experiment: 'my-experiment'


### PR DESCRIPTION
also removes `teacherResources` and the legacy version of `resourceShape` from client code, which I missed in https://github.com/code-dot-org/code-dot-org/pull/46677 .

## Testing story

* Updated existing test coverage. When removing `not_defaulted_keys`,  I noticed that`boolean_keys` and `nonboolean_keys` stuff is somewhat covered by these tests:
  * https://github.com/code-dot-org/code-dot-org/blob/977a4c1ca51ac5050a2fabe31d64e6cd2dc43cf5/dashboard/test/controllers/scripts_controller_test.rb#L935
  * https://github.com/code-dot-org/code-dot-org/blob/977a4c1ca51ac5050a2fabe31d64e6cd2dc43cf5/dashboard/test/controllers/scripts_controller_test.rb#L967
* unit and ui test containers each have a passing run on drone

## Follow-up work

https://github.com/code-dot-org/code-dot-org/pull/47090