### PR TITLE
Fix viewAs param causing broken level page

### DIFF
--- a/dashboard/app/views/levels/show.html.haml
+++ b/dashboard/app/views/levels/show.html.haml
@@ -31,7 +31,7 @@
   level-body is used for some semi-strange DOM manipulation. When a teacher toggles to viewAs a student,
   in some cases we want to give them an entirely different rendering (i.e. hidden/locked lessons). We do
   this by hiding level-body and unhiding the other content.
-#level-body{style: params[:viewAs] ? 'visibility: hidden' : nil}
+#level-body{style: @script.can_be_instructor?(@current_user) && params[:viewAs] ? 'visibility: hidden' : nil}
   -# Render the hidden lesson partial, but make it hidden so that client can unhide if needed
   = render partial: 'levels/hidden_lesson', locals: {hidden: true}
 

--- a/dashboard/app/views/levels/show.html.haml
+++ b/dashboard/app/views/levels/show.html.haml
@@ -31,7 +31,7 @@
   level-body is used for some semi-strange DOM manipulation. When a teacher toggles to viewAs a student,
   in some cases we want to give them an entirely different rendering (i.e. hidden/locked lessons). We do
   this by hiding level-body and unhiding the other content.
-#level-body{style: @script.can_be_instructor?(@current_user) && params[:viewAs] ? 'visibility: hidden' : nil}
+#level-body{style: @script&.can_be_instructor?(@current_user) && params[:viewAs] ? 'visibility: hidden' : nil}
   -# Render the hidden lesson partial, but make it hidden so that client can unhide if needed
   = render partial: 'levels/hidden_lesson', locals: {hidden: true}
 


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Issue reported https://codedotorg.slack.com/archives/C02EEGWLHR8/p1657033682856729

The problem: on level pages we set visibility hidden if the `viewAs` url param is present to allow content to finish rendering before we show the page (I don't completely understand why this is necessary, but it's been long-existing). The content is set to visible as part of the teacher panel rendering logic so there is an assumption that the `viewAs` param is only present when the current user is an instructor. However there is a case (on `/educate/csc`) where a url is hard-coded with the `viewAs` parameter set to Teacher, so whether a user is an instructor or not, the param will be present, which is causing the page visibility to get set to hidden and never get unset since the teacher panel is not rendered for users who are not instructors or when no user is logged in.

This PR updates the display as hidden logic to only apply when the user is logged in and is an instructor so that the teacher panel will get rendered and when the content on the level page is hidden, it will also be un-hidden.

## Testing story
Tested as a logged-out user that the page renders with the `viewAs` param present
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
