### PR TITLE
rename migrated teacher resources

### DIFF
--- a/apps/src/code-studio/components/progress/ResourcesDropdown.jsx
+++ b/apps/src/code-studio/components/progress/ResourcesDropdown.jsx
@@ -4,11 +4,11 @@ import i18n from '@cdo/locale';
 import Button from '@cdo/apps/templates/Button';
 import DropdownButton from '@cdo/apps/templates/DropdownButton';
 import firehoseClient from '@cdo/apps/lib/util/firehose';
-import {resourceShape as migratedResourceShape} from '@cdo/apps/lib/levelbuilder/shapes';
+import {resourceShape} from '@cdo/apps/lib/levelbuilder/shapes';
 
 export default class ResourcesDropdown extends React.Component {
   static propTypes = {
-    migratedResources: PropTypes.arrayOf(migratedResourceShape).isRequired,
+    migratedResources: PropTypes.arrayOf(resourceShape).isRequired,
     studentFacing: PropTypes.bool,
 
     //For firehose

--- a/apps/src/code-studio/components/progress/ResourcesDropdown.jsx
+++ b/apps/src/code-studio/components/progress/ResourcesDropdown.jsx
@@ -8,7 +8,7 @@ import {resourceShape} from '@cdo/apps/lib/levelbuilder/shapes';
 
 export default class ResourcesDropdown extends React.Component {
   static propTypes = {
-    migratedResources: PropTypes.arrayOf(resourceShape).isRequired,
+    resources: PropTypes.arrayOf(resourceShape).isRequired,
     studentFacing: PropTypes.bool,
 
     //For firehose
@@ -81,9 +81,9 @@ export default class ResourcesDropdown extends React.Component {
   };
 
   render() {
-    const {migratedResources} = this.props;
+    const {resources} = this.props;
 
-    const dropdownResources = migratedResources.map(resource => (
+    const dropdownResources = resources.map(resource => (
       <a
         key={resource.key}
         href={resource.url}

--- a/apps/src/code-studio/components/progress/ResourcesDropdown.story.jsx
+++ b/apps/src/code-studio/components/progress/ResourcesDropdown.story.jsx
@@ -25,7 +25,7 @@ export default storybook => {
       name: 'migrated teacher resources',
       story: () => (
         <div>
-          <ResourcesDropdown migratedResources={migratedSampleResources} />
+          <ResourcesDropdown resources={migratedSampleResources} />
         </div>
       )
     },
@@ -34,7 +34,7 @@ export default storybook => {
       story: () => (
         <div>
           <ResourcesDropdown
-            migratedResources={migratedSampleResources}
+            resources={migratedSampleResources}
             studentFacing={true}
           />
         </div>

--- a/apps/src/code-studio/components/progress/UnitOverview.jsx
+++ b/apps/src/code-studio/components/progress/UnitOverview.jsx
@@ -9,7 +9,7 @@ import UnversionedScriptRedirectDialog from '@cdo/apps/code-studio/components/Un
 import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
 import ProgressTable from '@cdo/apps/templates/progress/ProgressTable';
 import ProgressLegend from '@cdo/apps/templates/progress/ProgressLegend';
-import {resourceShape as migratedResourceShape} from '@cdo/apps/lib/levelbuilder/shapes';
+import {resourceShape} from '@cdo/apps/lib/levelbuilder/shapes';
 import UnitOverviewHeader from './UnitOverviewHeader';
 import {isScriptHiddenForSection} from '@cdo/apps/code-studio/hiddenLessonRedux';
 import {
@@ -35,8 +35,8 @@ class UnitOverview extends React.Component {
     courseTitle: PropTypes.string,
     courseLink: PropTypes.string,
     excludeCsfColumnInLegend: PropTypes.bool.isRequired,
-    teacherResources: PropTypes.arrayOf(migratedResourceShape),
-    studentResources: PropTypes.arrayOf(migratedResourceShape),
+    teacherResources: PropTypes.arrayOf(resourceShape),
+    studentResources: PropTypes.arrayOf(resourceShape),
     showCourseUnitVersionWarning: PropTypes.bool,
     showScriptVersionWarning: PropTypes.bool,
     redirectScriptUrl: PropTypes.string,

--- a/apps/src/code-studio/components/progress/UnitOverview.jsx
+++ b/apps/src/code-studio/components/progress/UnitOverview.jsx
@@ -35,7 +35,7 @@ class UnitOverview extends React.Component {
     courseTitle: PropTypes.string,
     courseLink: PropTypes.string,
     excludeCsfColumnInLegend: PropTypes.bool.isRequired,
-    migratedTeacherResources: PropTypes.arrayOf(migratedResourceShape),
+    teacherResources: PropTypes.arrayOf(migratedResourceShape),
     studentResources: PropTypes.arrayOf(migratedResourceShape),
     showCourseUnitVersionWarning: PropTypes.bool,
     showScriptVersionWarning: PropTypes.bool,
@@ -83,7 +83,7 @@ class UnitOverview extends React.Component {
   render() {
     const {
       excludeCsfColumnInLegend,
-      migratedTeacherResources,
+      teacherResources,
       studentResources,
       scriptId,
       scriptName,
@@ -167,7 +167,7 @@ class UnitOverview extends React.Component {
             </div>
           )}
           <UnitOverviewTopRow
-            migratedTeacherResources={migratedTeacherResources}
+            teacherResources={teacherResources}
             studentResources={studentResources}
             showAssignButton={showAssignButton}
             assignedSectionId={assignedSectionId}

--- a/apps/src/code-studio/components/progress/UnitOverviewTopRow.jsx
+++ b/apps/src/code-studio/components/progress/UnitOverviewTopRow.jsx
@@ -151,7 +151,7 @@ class UnitOverviewTopRow extends React.Component {
             />
             {studentResources.length > 0 && (
               <ResourcesDropdown
-                migratedResources={studentResources}
+                resources={studentResources}
                 unitId={scriptId}
                 studentFacing
               />
@@ -173,7 +173,7 @@ class UnitOverviewTopRow extends React.Component {
             viewAs === ViewType.Instructor &&
             (isMigrated && teacherResources.length > 0) && (
               <ResourcesDropdown
-                migratedResources={teacherResources}
+                resources={teacherResources}
                 unitId={scriptId}
               />
             )}

--- a/apps/src/code-studio/components/progress/UnitOverviewTopRow.jsx
+++ b/apps/src/code-studio/components/progress/UnitOverviewTopRow.jsx
@@ -30,7 +30,7 @@ const NEXT_BUTTON_TEXT = {
 class UnitOverviewTopRow extends React.Component {
   static propTypes = {
     assignedSectionId: PropTypes.number,
-    migratedTeacherResources: PropTypes.arrayOf(migratedResourceShape),
+    teacherResources: PropTypes.arrayOf(migratedResourceShape),
     studentResources: PropTypes.arrayOf(migratedResourceShape).isRequired,
     showAssignButton: PropTypes.bool,
     unitCalendarLessons: PropTypes.arrayOf(unitCalendarLesson),
@@ -109,7 +109,7 @@ class UnitOverviewTopRow extends React.Component {
       unitTitle,
       viewAs,
       isRtl,
-      migratedTeacherResources,
+      teacherResources,
       studentResources,
       showAssignButton,
       assignedSectionId,
@@ -171,9 +171,9 @@ class UnitOverviewTopRow extends React.Component {
         <div style={styles.resourcesRow}>
           {!professionalLearningCourse &&
             viewAs === ViewType.Instructor &&
-            (isMigrated && migratedTeacherResources.length > 0) && (
+            (isMigrated && teacherResources.length > 0) && (
               <ResourcesDropdown
-                migratedResources={migratedTeacherResources}
+                migratedResources={teacherResources}
                 unitId={scriptId}
               />
             )}

--- a/apps/src/code-studio/components/progress/UnitOverviewTopRow.jsx
+++ b/apps/src/code-studio/components/progress/UnitOverviewTopRow.jsx
@@ -6,7 +6,7 @@ import Button from '@cdo/apps/templates/Button';
 import DropdownButton from '@cdo/apps/templates/DropdownButton';
 import ProgressDetailToggle from '@cdo/apps/templates/progress/ProgressDetailToggle';
 import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
-import {resourceShape as migratedResourceShape} from '@cdo/apps/lib/levelbuilder/shapes';
+import {resourceShape} from '@cdo/apps/lib/levelbuilder/shapes';
 import SectionAssigner from '@cdo/apps/templates/teacherDashboard/SectionAssigner';
 import Assigned from '@cdo/apps/templates/Assigned';
 import {sectionForDropdownShape} from '@cdo/apps/templates/teacherDashboard/shapes';
@@ -30,8 +30,8 @@ const NEXT_BUTTON_TEXT = {
 class UnitOverviewTopRow extends React.Component {
   static propTypes = {
     assignedSectionId: PropTypes.number,
-    teacherResources: PropTypes.arrayOf(migratedResourceShape),
-    studentResources: PropTypes.arrayOf(migratedResourceShape).isRequired,
+    teacherResources: PropTypes.arrayOf(resourceShape),
+    studentResources: PropTypes.arrayOf(resourceShape).isRequired,
     showAssignButton: PropTypes.bool,
     unitCalendarLessons: PropTypes.arrayOf(unitCalendarLesson),
     weeklyInstructionalMinutes: PropTypes.number,

--- a/apps/src/lib/levelbuilder/course-editor/CourseEditor.js
+++ b/apps/src/lib/levelbuilder/course-editor/CourseEditor.js
@@ -8,7 +8,7 @@ import TextareaWithMarkdownPreview from '@cdo/apps/lib/levelbuilder/TextareaWith
 import CollapsibleEditorSection from '@cdo/apps/lib/levelbuilder/CollapsibleEditorSection';
 import {announcementShape} from '@cdo/apps/code-studio/announcementsRedux';
 import AnnouncementsEditor from '@cdo/apps/lib/levelbuilder/announcementsEditor/AnnouncementsEditor';
-import {resourceShape as migratedResourceShape} from '@cdo/apps/lib/levelbuilder/shapes';
+import {resourceShape} from '@cdo/apps/lib/levelbuilder/shapes';
 import {connect} from 'react-redux';
 import CourseVersionPublishingEditor from '@cdo/apps/lib/levelbuilder/CourseVersionPublishingEditor';
 import $ from 'jquery';
@@ -55,8 +55,8 @@ class CourseEditor extends Component {
     courseOfferingEditorLink: PropTypes.string,
 
     // Provided by redux
-    teacherResources: PropTypes.arrayOf(migratedResourceShape),
-    studentResources: PropTypes.arrayOf(migratedResourceShape)
+    teacherResources: PropTypes.arrayOf(resourceShape),
+    studentResources: PropTypes.arrayOf(resourceShape)
   };
 
   constructor(props) {

--- a/apps/src/lib/levelbuilder/course-editor/CourseEditor.js
+++ b/apps/src/lib/levelbuilder/course-editor/CourseEditor.js
@@ -381,7 +381,7 @@ class CourseEditor extends Component {
             <h4>Teacher Resources</h4>
             <ResourcesEditor
               inputStyle={styles.input}
-              migratedResources={this.props.teacherResources}
+              resources={this.props.teacherResources}
               courseVersionId={this.props.courseVersionId}
               getRollupsUrl={`/courses/${this.props.name}/get_rollup_resources`}
             />
@@ -390,7 +390,7 @@ class CourseEditor extends Component {
             <h4>Student Resources</h4>
             <ResourcesEditor
               inputStyle={styles.input}
-              migratedResources={this.props.studentResources}
+              resources={this.props.studentResources}
               courseVersionId={this.props.courseVersionId}
               studentFacing
             />

--- a/apps/src/lib/levelbuilder/course-editor/CourseEditor.js
+++ b/apps/src/lib/levelbuilder/course-editor/CourseEditor.js
@@ -55,7 +55,7 @@ class CourseEditor extends Component {
     courseOfferingEditorLink: PropTypes.string,
 
     // Provided by redux
-    migratedTeacherResources: PropTypes.arrayOf(migratedResourceShape),
+    teacherResources: PropTypes.arrayOf(migratedResourceShape),
     studentResources: PropTypes.arrayOf(migratedResourceShape)
   };
 
@@ -115,10 +115,8 @@ class CourseEditor extends Component {
       scripts: this.state.unitsInCourse
     };
 
-    if (this.props.migratedTeacherResources) {
-      dataToSave.resourceIds = this.props.migratedTeacherResources.map(
-        r => r.id
-      );
+    if (this.props.teacherResources) {
+      dataToSave.resourceIds = this.props.teacherResources.map(r => r.id);
     }
 
     if (this.props.studentResources) {
@@ -383,7 +381,7 @@ class CourseEditor extends Component {
             <h4>Teacher Resources</h4>
             <ResourcesEditor
               inputStyle={styles.input}
-              migratedResources={this.props.migratedTeacherResources}
+              migratedResources={this.props.teacherResources}
               courseVersionId={this.props.courseVersionId}
               getRollupsUrl={`/courses/${this.props.name}/get_rollup_resources`}
             />
@@ -456,6 +454,6 @@ const styles = {
 export const UnconnectedCourseEditor = CourseEditor;
 
 export default connect(state => ({
-  migratedTeacherResources: state.resources,
+  teacherResources: state.resources,
   studentResources: state.studentResources
 }))(CourseEditor);

--- a/apps/src/lib/levelbuilder/course-editor/ResourcesEditor.js
+++ b/apps/src/lib/levelbuilder/course-editor/ResourcesEditor.js
@@ -26,7 +26,6 @@ export default class ResourcesEditor extends Component {
   render() {
     const {errorString} = this.state;
 
-    // If using migrated resources, we have to have a course version id
     if (!this.props.courseVersionId) {
       return (
         <strong>

--- a/apps/src/lib/levelbuilder/course-editor/ResourcesEditor.js
+++ b/apps/src/lib/levelbuilder/course-editor/ResourcesEditor.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import color from '@cdo/apps/util/color';
 import {resourceShape} from '@cdo/apps/lib/levelbuilder/shapes';
-import MigratedResourceEditor from '@cdo/apps/lib/levelbuilder/lesson-editor/ResourcesEditor';
+import LessonResourcesEditor from '@cdo/apps/lib/levelbuilder/lesson-editor/ResourcesEditor';
 import ResourcesDropdown from '@cdo/apps/code-studio/components/progress/ResourcesDropdown';
 
 //Editor for Teacher Resources
@@ -39,7 +39,7 @@ export default class ResourcesEditor extends Component {
 
     return (
       <div>
-        <MigratedResourceEditor
+        <LessonResourcesEditor
           courseVersionId={this.props.courseVersionId}
           resourceContext={
             this.props.studentFacing ? 'studentResource' : 'teacherResource'

--- a/apps/src/lib/levelbuilder/course-editor/ResourcesEditor.js
+++ b/apps/src/lib/levelbuilder/course-editor/ResourcesEditor.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import color from '@cdo/apps/util/color';
-import {resourceShape as migratedResourceShape} from '@cdo/apps/lib/levelbuilder/shapes';
+import {resourceShape} from '@cdo/apps/lib/levelbuilder/shapes';
 import MigratedResourceEditor from '@cdo/apps/lib/levelbuilder/lesson-editor/ResourcesEditor';
 import ResourcesDropdown from '@cdo/apps/code-studio/components/progress/ResourcesDropdown';
 
@@ -9,7 +9,7 @@ import ResourcesDropdown from '@cdo/apps/code-studio/components/progress/Resourc
 export default class ResourcesEditor extends Component {
   static propTypes = {
     inputStyle: PropTypes.object.isRequired,
-    migratedResources: PropTypes.arrayOf(migratedResourceShape).isRequired,
+    migratedResources: PropTypes.arrayOf(resourceShape).isRequired,
     studentFacing: PropTypes.bool,
     courseVersionId: PropTypes.number,
     getRollupsUrl: PropTypes.string

--- a/apps/src/lib/levelbuilder/course-editor/ResourcesEditor.js
+++ b/apps/src/lib/levelbuilder/course-editor/ResourcesEditor.js
@@ -9,7 +9,7 @@ import ResourcesDropdown from '@cdo/apps/code-studio/components/progress/Resourc
 export default class ResourcesEditor extends Component {
   static propTypes = {
     inputStyle: PropTypes.object.isRequired,
-    migratedResources: PropTypes.arrayOf(resourceShape).isRequired,
+    resources: PropTypes.arrayOf(resourceShape).isRequired,
     studentFacing: PropTypes.bool,
     courseVersionId: PropTypes.number,
     getRollupsUrl: PropTypes.string
@@ -44,14 +44,14 @@ export default class ResourcesEditor extends Component {
           resourceContext={
             this.props.studentFacing ? 'studentResource' : 'teacherResource'
           }
-          resources={this.props.migratedResources}
+          resources={this.props.resources}
           getRollupsUrl={this.props.getRollupsUrl}
         />
         <div style={styles.box}>
           <div style={styles.error}>{errorString}</div>
           <div style={{marginBottom: 5}}>Preview:</div>
           <ResourcesDropdown
-            migratedResources={this.props.migratedResources}
+            resources={this.props.resources}
             studentFacing={this.props.studentFacing}
           />
         </div>

--- a/apps/src/lib/levelbuilder/lesson-editor/resourcesEditorRedux.js
+++ b/apps/src/lib/levelbuilder/lesson-editor/resourcesEditorRedux.js
@@ -7,9 +7,6 @@ const ADD_RESOURCE = 'resourcesEditor/ADD_RESOURCE';
 const EDIT_RESOURCE = 'resourcesEditor/EDIT_RESOURCE';
 const REMOVE_RESOURCE = 'resourcesEditor/REMOVE_RESOURCE';
 
-// Contains operations that can be done for migrated resources,
-// i.e. ones backed by the Resource model on Rails
-
 export const initResources = (resourceContext, resources) => ({
   type: INIT,
   resourceContext,

--- a/apps/src/lib/levelbuilder/shapes.jsx
+++ b/apps/src/lib/levelbuilder/shapes.jsx
@@ -74,8 +74,6 @@ export const activityShape = PropTypes.shape({
   activitySections: PropTypes.arrayOf(activitySectionShape)
 });
 
-// Represents a migrated resource, backed by the
-// Resource model in Rails
 export const resourceShape = PropTypes.shape({
   id: PropTypes.number,
   key: PropTypes.string.isRequired,

--- a/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
+++ b/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
@@ -947,7 +947,7 @@ class UnitEditor extends React.Component {
               <ResourcesEditor
                 inputStyle={styles.input}
                 courseVersionId={this.props.initialCourseVersionId}
-                migratedResources={this.props.teacherResources}
+                resources={this.props.teacherResources}
                 getRollupsUrl={`/s/${this.props.name}/get_rollup_resources`}
               />
             </div>
@@ -961,7 +961,7 @@ class UnitEditor extends React.Component {
                 <ResourcesEditor
                   inputStyle={styles.input}
                   courseVersionId={this.props.initialCourseVersionId}
-                  migratedResources={this.props.studentResources}
+                  resources={this.props.studentResources}
                   studentFacing
                 />
               </div>

--- a/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
+++ b/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
@@ -97,8 +97,7 @@ class UnitEditor extends React.Component {
 
     // from redux
     lessonGroups: PropTypes.arrayOf(lessonGroupShape).isRequired,
-    migratedTeacherResources: PropTypes.arrayOf(migratedResourceShape)
-      .isRequired,
+    teacherResources: PropTypes.arrayOf(migratedResourceShape).isRequired,
     studentResources: PropTypes.arrayOf(migratedResourceShape).isRequired,
     init: PropTypes.func.isRequired
   };
@@ -350,9 +349,7 @@ class UnitEditor extends React.Component {
       title: this.state.title,
       description_audience: this.state.descriptionAudience,
       description_short: this.state.descriptionShort,
-      resourceIds: this.props.migratedTeacherResources.map(
-        resource => resource.id
-      ),
+      resourceIds: this.props.teacherResources.map(resource => resource.id),
       studentResourceIds: this.props.studentResources.map(
         resource => resource.id
       ),
@@ -950,7 +947,7 @@ class UnitEditor extends React.Component {
               <ResourcesEditor
                 inputStyle={styles.input}
                 courseVersionId={this.props.initialCourseVersionId}
-                migratedResources={this.props.migratedTeacherResources}
+                migratedResources={this.props.teacherResources}
                 getRollupsUrl={`/s/${this.props.name}/get_rollup_resources`}
               />
             </div>
@@ -1140,7 +1137,7 @@ export const UnconnectedUnitEditor = UnitEditor;
 export default connect(
   state => ({
     lessonGroups: state.lessonGroups,
-    migratedTeacherResources: state.resources,
+    teacherResources: state.resources,
     studentResources: state.studentResources
   }),
   {

--- a/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
+++ b/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
@@ -16,7 +16,7 @@ import {
   init,
   mapLessonGroupDataForEditor
 } from '@cdo/apps/lib/levelbuilder/unit-editor/unitEditorRedux';
-import {resourceShape as migratedResourceShape} from '@cdo/apps/lib/levelbuilder/shapes';
+import {resourceShape} from '@cdo/apps/lib/levelbuilder/shapes';
 import {lessonGroupShape} from './shapes';
 import SaveBar from '@cdo/apps/lib/levelbuilder/SaveBar';
 import CourseVersionPublishingEditor from '@cdo/apps/lib/levelbuilder/CourseVersionPublishingEditor';
@@ -97,8 +97,8 @@ class UnitEditor extends React.Component {
 
     // from redux
     lessonGroups: PropTypes.arrayOf(lessonGroupShape).isRequired,
-    teacherResources: PropTypes.arrayOf(migratedResourceShape).isRequired,
-    studentResources: PropTypes.arrayOf(migratedResourceShape).isRequired,
+    teacherResources: PropTypes.arrayOf(resourceShape).isRequired,
+    studentResources: PropTypes.arrayOf(resourceShape).isRequired,
     init: PropTypes.func.isRequired
   };
 

--- a/apps/src/sites/studio/pages/courses/edit.js
+++ b/apps/src/sites/studio/pages/courses/edit.js
@@ -22,7 +22,7 @@ function showCourseEditor() {
   store.dispatch(
     initResources(
       'teacherResource',
-      courseEditorData.course_summary.migrated_teacher_resources || []
+      courseEditorData.course_summary.teacher_resources || []
     ),
     initResources(
       'studentResource',

--- a/apps/src/sites/studio/pages/courses/show.js
+++ b/apps/src/sites/studio/pages/courses/show.js
@@ -98,7 +98,7 @@ function showCourseOverview() {
         descriptionStudent={courseSummary.description_student}
         descriptionTeacher={courseSummary.description_teacher}
         sectionsInfo={scriptData.sections}
-        migratedTeacherResources={courseSummary.migrated_teacher_resources}
+        teacherResources={courseSummary.migrated_teacher_resources}
         studentResources={courseSummary.student_resources}
         scripts={courseSummary.scripts}
         versions={versions}

--- a/apps/src/sites/studio/pages/courses/show.js
+++ b/apps/src/sites/studio/pages/courses/show.js
@@ -98,7 +98,7 @@ function showCourseOverview() {
         descriptionStudent={courseSummary.description_student}
         descriptionTeacher={courseSummary.description_teacher}
         sectionsInfo={scriptData.sections}
-        teacherResources={courseSummary.migrated_teacher_resources}
+        teacherResources={courseSummary.teacher_resources}
         studentResources={courseSummary.student_resources}
         scripts={courseSummary.scripts}
         versions={versions}

--- a/apps/src/sites/studio/pages/scripts/edit.js
+++ b/apps/src/sites/studio/pages/scripts/edit.js
@@ -30,10 +30,7 @@ export default function initPage(unitEditorData) {
   const store = getStore();
   store.dispatch(init(lessonGroups));
   store.dispatch(
-    initResources(
-      'teacherResource',
-      scriptData.migrated_teacher_resources || []
-    ),
+    initResources('teacherResource', scriptData.teacher_resources || []),
     initResources('studentResource', scriptData.student_resources || [])
   );
 

--- a/apps/src/sites/studio/pages/scripts/show.js
+++ b/apps/src/sites/studio/pages/scripts/show.js
@@ -115,7 +115,7 @@ function initPage() {
         courseTitle={scriptData.course_title}
         courseLink={scriptData.course_link}
         excludeCsfColumnInLegend={!scriptData.csf}
-        migratedTeacherResources={scriptData.migrated_teacher_resources}
+        teacherResources={scriptData.migrated_teacher_resources}
         studentResources={scriptData.student_resources || []}
         showCourseUnitVersionWarning={
           scriptData.show_course_unit_version_warning

--- a/apps/src/sites/studio/pages/scripts/show.js
+++ b/apps/src/sites/studio/pages/scripts/show.js
@@ -115,7 +115,7 @@ function initPage() {
         courseTitle={scriptData.course_title}
         courseLink={scriptData.course_link}
         excludeCsfColumnInLegend={!scriptData.csf}
-        teacherResources={scriptData.migrated_teacher_resources}
+        teacherResources={scriptData.teacher_resources}
         studentResources={scriptData.student_resources || []}
         showCourseUnitVersionWarning={
           scriptData.show_course_unit_version_warning

--- a/apps/src/templates/courseOverview/CourseOverview.js
+++ b/apps/src/templates/courseOverview/CourseOverview.js
@@ -48,7 +48,7 @@ class CourseOverview extends Component {
         name: PropTypes.string.isRequired
       })
     ).isRequired,
-    migratedTeacherResources: PropTypes.arrayOf(migratedResourceShape),
+    teacherResources: PropTypes.arrayOf(migratedResourceShape),
     studentResources: PropTypes.arrayOf(migratedResourceShape),
     viewAs: PropTypes.oneOf(Object.values(ViewType)).isRequired,
     scripts: PropTypes.array.isRequired,
@@ -121,7 +121,7 @@ class CourseOverview extends Component {
       descriptionTeacher,
       sectionsInfo,
       sectionsForDropdown,
-      migratedTeacherResources,
+      teacherResources,
       studentResources,
       viewAs,
       scripts,
@@ -211,7 +211,7 @@ class CourseOverview extends Component {
             courseVersionId={courseVersionId}
             id={id}
             title={title}
-            migratedTeacherResources={migratedTeacherResources}
+            teacherResources={teacherResources}
             studentResources={studentResources}
             showAssignButton={showAssignButton}
             isInstructor={viewAs === ViewType.Instructor}

--- a/apps/src/templates/courseOverview/CourseOverview.js
+++ b/apps/src/templates/courseOverview/CourseOverview.js
@@ -5,7 +5,7 @@ import {connect} from 'react-redux';
 import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
 import CourseScript from './CourseScript';
 import CourseOverviewTopRow from './CourseOverviewTopRow';
-import {resourceShape as migratedResourceShape} from '@cdo/apps/lib/levelbuilder/shapes';
+import {resourceShape} from '@cdo/apps/lib/levelbuilder/shapes';
 import styleConstants from '@cdo/apps/styleConstants';
 import VerifiedResourcesNotification from './VerifiedResourcesNotification';
 import * as utils from '../../utils';
@@ -48,8 +48,8 @@ class CourseOverview extends Component {
         name: PropTypes.string.isRequired
       })
     ).isRequired,
-    teacherResources: PropTypes.arrayOf(migratedResourceShape),
-    studentResources: PropTypes.arrayOf(migratedResourceShape),
+    teacherResources: PropTypes.arrayOf(resourceShape),
+    studentResources: PropTypes.arrayOf(resourceShape),
     viewAs: PropTypes.oneOf(Object.values(ViewType)).isRequired,
     scripts: PropTypes.array.isRequired,
     isVerifiedInstructor: PropTypes.bool.isRequired,

--- a/apps/src/templates/courseOverview/CourseOverviewTopRow.js
+++ b/apps/src/templates/courseOverview/CourseOverviewTopRow.js
@@ -32,10 +32,7 @@ export default class CourseOverviewTopRow extends Component {
     return (
       <div style={styles.main} className="course-overview-top-row">
         {isInstructor && teacherResources.length > 0 && (
-          <ResourcesDropdown
-            migratedResources={teacherResources}
-            unitGroupId={id}
-          />
+          <ResourcesDropdown resources={teacherResources} unitGroupId={id} />
         )}
         {isInstructor && (
           <SectionAssigner
@@ -49,7 +46,7 @@ export default class CourseOverviewTopRow extends Component {
         )}
         {!isInstructor && studentResources && studentResources.length > 0 && (
           <ResourcesDropdown
-            migratedResources={studentResources}
+            resources={studentResources}
             unitGroupId={id}
             studentFacing
           />

--- a/apps/src/templates/courseOverview/CourseOverviewTopRow.js
+++ b/apps/src/templates/courseOverview/CourseOverviewTopRow.js
@@ -11,7 +11,7 @@ export default class CourseOverviewTopRow extends Component {
     id: PropTypes.number.isRequired,
     courseOfferingId: PropTypes.number,
     courseVersionId: PropTypes.number,
-    migratedTeacherResources: PropTypes.arrayOf(migratedResourceShape),
+    teacherResources: PropTypes.arrayOf(migratedResourceShape),
     studentResources: PropTypes.arrayOf(migratedResourceShape),
     showAssignButton: PropTypes.bool,
     isInstructor: PropTypes.bool
@@ -22,7 +22,7 @@ export default class CourseOverviewTopRow extends Component {
       id,
       courseOfferingId,
       courseVersionId,
-      migratedTeacherResources,
+      teacherResources,
       studentResources,
       showAssignButton,
       sectionsForDropdown,
@@ -31,9 +31,9 @@ export default class CourseOverviewTopRow extends Component {
 
     return (
       <div style={styles.main} className="course-overview-top-row">
-        {isInstructor && migratedTeacherResources.length > 0 && (
+        {isInstructor && teacherResources.length > 0 && (
           <ResourcesDropdown
-            migratedResources={migratedTeacherResources}
+            migratedResources={teacherResources}
             unitGroupId={id}
           />
         )}

--- a/apps/src/templates/courseOverview/CourseOverviewTopRow.js
+++ b/apps/src/templates/courseOverview/CourseOverviewTopRow.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
-import {resourceShape as migratedResourceShape} from '@cdo/apps/lib/levelbuilder/shapes';
+import {resourceShape} from '@cdo/apps/lib/levelbuilder/shapes';
 import SectionAssigner from '@cdo/apps/templates/teacherDashboard/SectionAssigner';
 import {sectionForDropdownShape} from '@cdo/apps/templates/teacherDashboard/shapes';
 import ResourcesDropdown from '@cdo/apps/code-studio/components/progress/ResourcesDropdown';
@@ -11,8 +11,8 @@ export default class CourseOverviewTopRow extends Component {
     id: PropTypes.number.isRequired,
     courseOfferingId: PropTypes.number,
     courseVersionId: PropTypes.number,
-    teacherResources: PropTypes.arrayOf(migratedResourceShape),
-    studentResources: PropTypes.arrayOf(migratedResourceShape),
+    teacherResources: PropTypes.arrayOf(resourceShape),
+    studentResources: PropTypes.arrayOf(resourceShape),
     showAssignButton: PropTypes.bool,
     isInstructor: PropTypes.bool
   };

--- a/apps/test/unit/code-studio/components/progress/ResourcesDropdownTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/ResourcesDropdownTest.jsx
@@ -7,7 +7,7 @@ import i18n from '@cdo/locale';
 import Button from '@cdo/apps/templates/Button';
 
 describe('ResourcesDropdown', () => {
-  it('renders migrated resources for teacher', () => {
+  it('renders resources for teacher', () => {
     const wrapper = shallow(
       <ResourcesDropdown
         resources={[
@@ -39,7 +39,7 @@ describe('ResourcesDropdown', () => {
     ).to.be.true;
   });
 
-  it('renders migrated resources for student', () => {
+  it('renders resources for student', () => {
     const wrapper = shallow(
       <ResourcesDropdown
         resources={[

--- a/apps/test/unit/code-studio/components/progress/ResourcesDropdownTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/ResourcesDropdownTest.jsx
@@ -10,7 +10,7 @@ describe('ResourcesDropdown', () => {
   it('renders migrated resources for teacher', () => {
     const wrapper = shallow(
       <ResourcesDropdown
-        migratedResources={[
+        resources={[
           {
             key: 'key1',
             name: 'Curriculum',
@@ -42,7 +42,7 @@ describe('ResourcesDropdown', () => {
   it('renders migrated resources for student', () => {
     const wrapper = shallow(
       <ResourcesDropdown
-        migratedResources={[
+        resources={[
           {
             key: 'key1',
             name: 'Curriculum',

--- a/apps/test/unit/code-studio/components/progress/UnitOverviewTopRowTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/UnitOverviewTopRowTest.jsx
@@ -135,7 +135,7 @@ describe('UnitOverviewTopRow', () => {
   });
 
   describe('instructor resources', () => {
-    it('renders migrated resources for instructor on a migrated script', () => {
+    it('renders resources for instructor on a migrated script', () => {
       const wrapper = shallow(
         <UnitOverviewTopRow
           {...defaultProps}

--- a/apps/test/unit/code-studio/components/progress/UnitOverviewTopRowTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/UnitOverviewTopRowTest.jsx
@@ -160,7 +160,7 @@ describe('UnitOverviewTopRow', () => {
       expect(
         wrapper.containsMatchingElement(
           <ResourcesDropdown
-            migratedResources={[
+            resources={[
               {
                 id: 1,
                 key: 'curriculum',

--- a/apps/test/unit/code-studio/components/progress/UnitOverviewTopRowTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/UnitOverviewTopRowTest.jsx
@@ -141,7 +141,7 @@ describe('UnitOverviewTopRow', () => {
           {...defaultProps}
           viewAs={ViewType.Instructor}
           isMigrated={true}
-          migratedTeacherResources={[
+          teacherResources={[
             {
               id: 1,
               key: 'curriculum',

--- a/apps/test/unit/lib/levelbuilder/course-editor/CourseEditorTest.js
+++ b/apps/test/unit/lib/levelbuilder/course-editor/CourseEditorTest.js
@@ -78,7 +78,7 @@ describe('CourseEditor', () => {
   };
 
   describe('Teacher Resources', () => {
-    it('uses the migrated resource component for migrated resources', () => {
+    it('uses the resource component for resources', () => {
       const wrapper = shallow(
         <CourseEditor
           {...defaultProps}

--- a/apps/test/unit/lib/levelbuilder/course-editor/CourseEditorTest.js
+++ b/apps/test/unit/lib/levelbuilder/course-editor/CourseEditorTest.js
@@ -44,7 +44,7 @@ const defaultProps = {
   initialInstructionType: InstructionType.teacher_led,
   initialInstructorAudience: InstructorAudience.teacher,
   initialParticipantAudience: ParticipantAudience.student,
-  migratedTeacherResources: [],
+  teacherResources: [],
   studentResources: []
 };
 
@@ -82,7 +82,7 @@ describe('CourseEditor', () => {
       const wrapper = shallow(
         <CourseEditor
           {...defaultProps}
-          migratedTeacherResources={[
+          teacherResources={[
             {id: 1, key: 'curriculum', name: 'Curriculum', url: '/foo'}
           ]}
         />

--- a/apps/test/unit/lib/levelbuilder/course-editor/ResourcesEditorTest.js
+++ b/apps/test/unit/lib/levelbuilder/course-editor/ResourcesEditorTest.js
@@ -12,7 +12,7 @@ describe('ResourcesEditor', () => {
     };
   });
 
-  it('uses the new resource editor for migrated resources', () => {
+  it('uses the new resource editor for resources', () => {
     const wrapper = shallow(
       <ResourcesEditor
         {...defaultProps}
@@ -36,7 +36,7 @@ describe('ResourcesEditor', () => {
     expect(wrapper.find('Connect(ResourcesEditor)').length).to.equal(1);
   });
 
-  it('uses no editor for migrated resources without courseVersionId', () => {
+  it('uses no editor for resources without courseVersionId', () => {
     const wrapper = shallow(
       <ResourcesEditor
         {...defaultProps}

--- a/apps/test/unit/lib/levelbuilder/course-editor/ResourcesEditorTest.js
+++ b/apps/test/unit/lib/levelbuilder/course-editor/ResourcesEditorTest.js
@@ -16,7 +16,7 @@ describe('ResourcesEditor', () => {
     const wrapper = shallow(
       <ResourcesEditor
         {...defaultProps}
-        migratedResources={[
+        resources={[
           {
             id: 1,
             key: 'curriculum',
@@ -40,7 +40,7 @@ describe('ResourcesEditor', () => {
     const wrapper = shallow(
       <ResourcesEditor
         {...defaultProps}
-        migratedResources={[
+        resources={[
           {
             id: 1,
             key: 'curriculum',

--- a/apps/test/unit/templates/courseOverview/CourseOverviewTopRowTest.js
+++ b/apps/test/unit/templates/courseOverview/CourseOverviewTopRowTest.js
@@ -42,7 +42,7 @@ describe('CourseOverviewTopRow', () => {
     assert.equal(wrapper.find('Connect(SectionAssigner)').length, 0);
   });
 
-  it('renders migrated teacher resource dropdown', () => {
+  it('renders teacher resource dropdown', () => {
     const wrapper = shallow(<CourseOverviewTopRow {...defaultProps} />);
     assert.equal(wrapper.find('ResourcesDropdown').length, 1);
     assert.equal(wrapper.find('ResourcesDropdown').props().resources.length, 3);
@@ -72,7 +72,7 @@ describe('CourseOverviewTopRow', () => {
     );
   });
 
-  it('doesnt render migrated teacher resource dropdown for students', () => {
+  it('doesnt render teacher resource dropdown for students', () => {
     const wrapper = shallow(
       <CourseOverviewTopRow
         {...defaultProps}

--- a/apps/test/unit/templates/courseOverview/CourseOverviewTopRowTest.js
+++ b/apps/test/unit/templates/courseOverview/CourseOverviewTopRowTest.js
@@ -7,7 +7,7 @@ const defaultProps = {
   sectionsForDropdown: [],
   id: 30,
   title: 'Computer Science Principles',
-  migratedTeacherResources: [
+  teacherResources: [
     {
       key: 'key1',
       name: 'Curriculum',
@@ -79,7 +79,7 @@ describe('CourseOverviewTopRow', () => {
     const wrapper = shallow(
       <CourseOverviewTopRow
         {...defaultProps}
-        migratedTeacherResources={[
+        teacherResources={[
           {
             key: 'key1',
             name: 'Curriculum',

--- a/apps/test/unit/templates/courseOverview/CourseOverviewTopRowTest.js
+++ b/apps/test/unit/templates/courseOverview/CourseOverviewTopRowTest.js
@@ -45,32 +45,29 @@ describe('CourseOverviewTopRow', () => {
   it('renders migrated teacher resource dropdown', () => {
     const wrapper = shallow(<CourseOverviewTopRow {...defaultProps} />);
     assert.equal(wrapper.find('ResourcesDropdown').length, 1);
+    assert.equal(wrapper.find('ResourcesDropdown').props().resources.length, 3);
     assert.equal(
-      wrapper.find('ResourcesDropdown').props().migratedResources.length,
-      3
-    );
-    assert.equal(
-      wrapper.find('ResourcesDropdown').props().migratedResources[0].name,
+      wrapper.find('ResourcesDropdown').props().resources[0].name,
       'Curriculum'
     );
     assert.equal(
-      wrapper.find('ResourcesDropdown').props().migratedResources[0].url,
+      wrapper.find('ResourcesDropdown').props().resources[0].url,
       '/link/to/curriculum'
     );
     assert.equal(
-      wrapper.find('ResourcesDropdown').props().migratedResources[1].name,
+      wrapper.find('ResourcesDropdown').props().resources[1].name,
       'Professional Learning'
     );
     assert.equal(
-      wrapper.find('ResourcesDropdown').props().migratedResources[1].url,
+      wrapper.find('ResourcesDropdown').props().resources[1].url,
       '/link/to/professional/learning'
     );
     assert.equal(
-      wrapper.find('ResourcesDropdown').props().migratedResources[2].name,
+      wrapper.find('ResourcesDropdown').props().resources[2].name,
       'Teacher Forum'
     );
     assert.equal(
-      wrapper.find('ResourcesDropdown').props().migratedResources[2].url,
+      wrapper.find('ResourcesDropdown').props().resources[2].url,
       'https://forum.code.org/'
     );
   });
@@ -127,32 +124,29 @@ describe('CourseOverviewTopRow', () => {
       />
     );
     assert.equal(wrapper.find('ResourcesDropdown').length, 1);
+    assert.equal(wrapper.find('ResourcesDropdown').props().resources.length, 3);
     assert.equal(
-      wrapper.find('ResourcesDropdown').props().migratedResources.length,
-      3
-    );
-    assert.equal(
-      wrapper.find('ResourcesDropdown').props().migratedResources[0].name,
+      wrapper.find('ResourcesDropdown').props().resources[0].name,
       'Curriculum'
     );
     assert.equal(
-      wrapper.find('ResourcesDropdown').props().migratedResources[0].url,
+      wrapper.find('ResourcesDropdown').props().resources[0].url,
       '/link/to/curriculum'
     );
     assert.equal(
-      wrapper.find('ResourcesDropdown').props().migratedResources[1].name,
+      wrapper.find('ResourcesDropdown').props().resources[1].name,
       'Professional Learning'
     );
     assert.equal(
-      wrapper.find('ResourcesDropdown').props().migratedResources[1].url,
+      wrapper.find('ResourcesDropdown').props().resources[1].url,
       '/link/to/professional/learning'
     );
     assert.equal(
-      wrapper.find('ResourcesDropdown').props().migratedResources[2].name,
+      wrapper.find('ResourcesDropdown').props().resources[2].name,
       'Teacher Forum'
     );
     assert.equal(
-      wrapper.find('ResourcesDropdown').props().migratedResources[2].url,
+      wrapper.find('ResourcesDropdown').props().resources[2].url,
       'https://forum.code.org/'
     );
   });

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1332,7 +1332,7 @@ class Script < ApplicationRecord
       errors.add(:base, e.to_s)
       return false
     end
-    update_migrated_teacher_resources(general_params[:resourceIds])
+    update_teacher_resources(general_params[:resourceIds])
     update_student_resources(general_params[:studentResourceIds])
     tts_update(true) if need_to_update_tts
     begin
@@ -1353,7 +1353,7 @@ class Script < ApplicationRecord
     File.write(filepath, Services::ScriptSeed.serialize_seeding_json(self))
   end
 
-  def update_migrated_teacher_resources(resource_ids)
+  def update_teacher_resources(resource_ids)
     self.resources = (resource_ids || []).map {|id| Resource.find(id)}
   end
 

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1512,7 +1512,7 @@ class Script < ApplicationRecord
       student_detail_progress_view: student_detail_progress_view?,
       project_widget_visible: project_widget_visible?,
       project_widget_types: project_widget_types,
-      migrated_teacher_resources: resources.sort_by(&:name).map(&:summarize_for_resources_dropdown),
+      teacher_resources: resources.sort_by(&:name).map(&:summarize_for_resources_dropdown),
       student_resources: student_resources.sort_by(&:name).map(&:summarize_for_resources_dropdown),
       lesson_extras_available: lesson_extras_available,
       has_verified_resources: has_verified_resources?,

--- a/dashboard/app/models/unit_group.rb
+++ b/dashboard/app/models/unit_group.rb
@@ -314,7 +314,7 @@ class UnitGroup < ApplicationRecord
         include_lessons = false
         unit.summarize(include_lessons, user).merge!(unit.summarize_i18n_for_display)
       end,
-      migrated_teacher_resources: resources.sort_by(&:name).map(&:summarize_for_resources_dropdown),
+      teacher_resources: resources.sort_by(&:name).map(&:summarize_for_resources_dropdown),
       student_resources: student_resources.sort_by(&:name).map(&:summarize_for_resources_dropdown),
       is_migrated: has_migrated_unit?,
       has_verified_resources: has_verified_resources?,

--- a/dashboard/test/models/unit_group_test.rb
+++ b/dashboard/test/models/unit_group_test.rb
@@ -617,7 +617,7 @@ class UnitGroupTest < ActiveSupport::TestCase
     assert_equal [:name, :id, :title, :assignment_family_title,
                   :family_name, :version_year, :published_state, :instruction_type, :instructor_audience, :participant_audience,
                   :pilot_experiment, :description_short, :description_student,
-                  :description_teacher, :version_title, :scripts, :migrated_teacher_resources,
+                  :description_teacher, :version_title, :scripts, :teacher_resources,
                   :student_resources, :is_migrated, :has_verified_resources, :has_numbered_units, :course_versions, :show_assign_button,
                   :announcements, :course_offering_id, :course_version_id, :course_path, :course_offering_edit_path], summary.keys
     assert_equal 'my-unit-group', summary[:name]


### PR DESCRIPTION
Follow-up from  https://github.com/code-dot-org/code-dot-org/pull/47081. Finishes [PLAT-1680](https://codedotorg.atlassian.net/browse/PLAT-1680) -- teacher resources are now fully migrated!

now that all teacher resources are migrated, and the code for handling legacy teacher resources has been removed, there's no reason to keep the word "migrated" around.

## Testing story

Existing test coverage seems sufficient to catch any possible bugs introduced by this change.
