### PR TITLE
Update `mysql2` Gem to 0.5.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -568,7 +568,7 @@ GEM
     multipart-post (2.1.1)
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
-    mysql2 (0.5.2)
+    mysql2 (0.5.4)
     nakayoshi_fork (0.0.4)
     naturally (2.1.0)
     net-http-persistent (3.0.0)


### PR DESCRIPTION
To pick up several bugfixes in this version (including improved support for Ruby 2.7), but most notably a fix for an issue which prevents installing this gem on OSX with versions of Ruby >2.6

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

- https://github.com/brianmario/mysql2/pull/1135
- https://github.com/brianmario/mysql2/releases

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
