### PR TITLE
Java Lab: always show test button

### DIFF
--- a/apps/src/javalab/JavalabView.jsx
+++ b/apps/src/javalab/JavalabView.jsx
@@ -266,10 +266,7 @@ class JavalabView extends React.Component {
                     disableTestButton={awaitingContainedResponse || !canTest}
                     onContinue={() => onContinue(isSubmittable)}
                     renderSettings={this.renderSettings}
-                    showTestButton={
-                      isEditingStartSources ||
-                      experiments.isEnabled(experiments.JAVALAB_UNIT_TESTS)
-                    }
+                    showTestButton={true}
                     isSubmittable={isSubmittable}
                     isSubmitted={isSubmitted}
                   />

--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -35,7 +35,6 @@ experiments.BYPASS_DIALOG_POPUP = 'bypass-dialog-popup';
 experiments.SPECIAL_TOPIC = 'special-topic';
 experiments.CLEARER_SIGN_UP_USER_TYPE = 'clearerSignUpUserType';
 experiments.OPT_IN_EMAIL_REG_PARTNER = 'optInEmailRegPartner';
-experiments.JAVALAB_UNIT_TESTS = 'javalabUnitTests';
 experiments.STUDIO_CERTIFICATE = 'studioCertificate';
 
 /**


### PR DESCRIPTION
Remove the experiment flag that was hiding the test button in Java Lab and always show it.

## Links
- jira ticket: [JAVA-324](https://codedotorg.atlassian.net/browse/JAVA-324)

## Testing story
Tested locally
