### PR TITLE
Update `rmagick` Gem to 3.2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -182,7 +182,7 @@ gem 'redcarpet', '~> 3.3.4'
 gem 'geocoder'
 
 gem 'mini_magick', ">=4.9.4"
-gem 'rmagick'
+gem 'rmagick', '~> 3.2'
 
 gem 'acts_as_list'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -741,7 +741,7 @@ GEM
     retryable (2.0.4)
     rexml (3.2.5)
     rinku (2.0.4)
-    rmagick (2.16.0)
+    rmagick (3.2.0)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
       rspec-expectations (~> 3.5.0)
@@ -1040,7 +1040,7 @@ DEPENDENCIES
   rest-client (~> 2.0.1)
   retryable
   rinku
-  rmagick
+  rmagick (~> 3.2)
   rspec
   rubocop (= 1.28)
   rubocop-performance


### PR DESCRIPTION
In preparation for upgrading to Ruby 2.6, support for which was officially added to RMagick in 3.1.0

We target 3.2.0 specifically because it adds deprecation warnings in preparation for RMagick 4.0, which adds support for Ruby 2.7, to which we want to upgrade.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

https://github.com/rmagick/rmagick/blob/main/CHANGELOG.md#rmagick-320

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Relying on existing unit tests

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
