### PR TITLE
Remove development notice for code docs pages

### DIFF
--- a/apps/src/lib/levelbuilder/code-docs-editor/NewProgrammingEnvironmentForm.jsx
+++ b/apps/src/lib/levelbuilder/code-docs-editor/NewProgrammingEnvironmentForm.jsx
@@ -7,10 +7,6 @@ export default function NewProgrammingEnvironmentForm() {
     <form action="/programming_environments" method="post">
       <RailsAuthenticityToken />
       <h1>New Programming Environment</h1>
-      <h2>
-        This feature is in development. Please continue to use curriculum
-        builder to create code documentation.
-      </h2>
       <label>
         Programming Environment Slug
         <input name="name" style={styles.inputStyle} required />

--- a/apps/src/lib/levelbuilder/code-docs-editor/ProgrammingClassEditor.jsx
+++ b/apps/src/lib/levelbuilder/code-docs-editor/ProgrammingClassEditor.jsx
@@ -113,10 +113,6 @@ export default function ProgrammingClassEditor({
   return (
     <div>
       <h1>{`Editing Class "${initialProgrammingClass.key}"`}</h1>
-      <h2>
-        This feature is in development. Please continue to use curriculum
-        builder to edit code documentation.
-      </h2>
       <label>
         Display Name
         <input

--- a/apps/src/lib/levelbuilder/code-docs-editor/ProgrammingEnvironmentEditor.jsx
+++ b/apps/src/lib/levelbuilder/code-docs-editor/ProgrammingEnvironmentEditor.jsx
@@ -108,10 +108,6 @@ export default function ProgrammingEnvironmentEditor({
   return (
     <div>
       <h1>{`Editing ${name}`}</h1>
-      <h2>
-        This feature is in development. Please continue to use curriculum
-        builder to edit code documentation.
-      </h2>
       <label>
         Title
         <input

--- a/apps/src/lib/levelbuilder/code-docs-editor/ProgrammingExpressionEditor.jsx
+++ b/apps/src/lib/levelbuilder/code-docs-editor/ProgrammingExpressionEditor.jsx
@@ -112,10 +112,6 @@ export default function ProgrammingExpressionEditor({
   return (
     <div>
       <h1>{`Editing ${initialProgrammingExpression.key}`}</h1>
-      <h2>
-        This feature is in development. Please continue to use curriculum
-        builder to edit code documentation.
-      </h2>
       <label>
         Display Name
         <input

--- a/apps/src/lib/levelbuilder/code-docs-editor/ProgrammingMethodEditor.jsx
+++ b/apps/src/lib/levelbuilder/code-docs-editor/ProgrammingMethodEditor.jsx
@@ -113,10 +113,6 @@ export default function ProgrammingMethodEditor({
   return (
     <div>
       <h1>{`Editing Method "${programmingMethod.name}"`}</h1>
-      <h2>
-        This feature is in development. Please continue to use curriculum
-        builder to edit code documentation.
-      </h2>
       <label>
         Display Name
         <input


### PR DESCRIPTION
This should've been removed a couple months ago but I forgot. I'm not sure why I added it for CSA docs in the first place -- it didn't make sense for them.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
