### PR TITLE
Add `data-ot-ignore` attribute to jQuery script elements

### DIFF
--- a/pegasus/sites.v3/code.org/views/jquery.haml
+++ b/pegasus/sites.v3/code.org/views/jquery.haml
@@ -1,12 +1,14 @@
+-# If the user has the `onetrust_cookie_scripts` cookie to test, use the `data-ot-ignore` attribute.
+- data_ot_ignore_value = true if request.cookies['onetrust_cookie_scripts'].present?
 -# Load jQuery script normal/async/defer or not at all, depending on page header.
 - case @header['jquery']
 - when 'defer'
-  %script{src:'/js/jquery.min.js', defer: true, "data-ot-ignore" => true}
+  %script{src:'/js/jquery.min.js', defer: true, "data-ot-ignore" => data_ot_ignore_value}
   %script=view 'jquery_shim.js'
 - when 'async'
-  %script{src:'/js/jquery.min.js', async: true, "data-ot-ignore" => true}
+  %script{src:'/js/jquery.min.js', async: true, "data-ot-ignore" => data_ot_ignore_value}
   %script=view 'jquery_shim.js'
 - when 'none'
   %script=view 'jquery_shim.js'
 - else
-  %script{src:'/js/jquery.min.js', "data-ot-ignore" => true}
+  %script{src:'/js/jquery.min.js', "data-ot-ignore" => data_ot_ignore_value}

--- a/pegasus/sites.v3/code.org/views/jquery.haml
+++ b/pegasus/sites.v3/code.org/views/jquery.haml
@@ -1,12 +1,12 @@
 -# Load jQuery script normal/async/defer or not at all, depending on page header.
 - case @header['jquery']
 - when 'defer'
-  %script{src:'/js/jquery.min.js', defer: true}
+  %script{src:'/js/jquery.min.js', defer: true, "data-ot-ignore" => true}
   %script=view 'jquery_shim.js'
 - when 'async'
-  %script{src:'/js/jquery.min.js', async: true}
+  %script{src:'/js/jquery.min.js', async: true, "data-ot-ignore" => true}
   %script=view 'jquery_shim.js'
 - when 'none'
   %script=view 'jquery_shim.js'
 - else
-  %script{src:'/js/jquery.min.js'}
+  %script{src:'/js/jquery.min.js', "data-ot-ignore" => true}


### PR DESCRIPTION
**What:** Adding the `data-ot-ignore` attribute to our jQuery `script` elements. Specifically the ones in the haml file that https://code.org/cookies uses for testing purposes.

**Why:** The theory is that [this](https://docs.google.com/document/d/1oGTETD7-ANNT514ccbs5aQMOd2s-dfgoPvViDpv7iik/edit) issue where we receive `jQuery missing error: “Uncaught ReferenceError: $ is not defined”` _only_ in production is because the script element is being processed by the [OneTrust AutoBlock script](https://github.com/code-dot-org/code-dot-org/blob/fix-onetrust-autoblock-jquery/shared/haml/onetrust_cookie_scripts.haml#L7). This automatically blocks scripts from loading before being confirmed by the script that it is okay to run. This causes a timing issue when we make calls throughout the page to jQuery - as it hasn't been confirmed by the autoblock script and loaded yet.

The theory as to why it is only being blocked in production is that the OneTrust script we use takes advantage of previous "scans" of our site to decide what should and shouldn't be looked at on our pages. These scans can be found in our OneTrust Dashboard. We used production for our scan so in the case that we are on a different domain like localhost, it's possible that the scripts recognition isn't the same.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

[OneTrust Auto-Blocking](https://my.onetrust.com/articles/en_US/Knowledge/UUID-c5122557-2070-65cb-2612-f2752c0cc4aa)
[OneTrust website scans](https://community.cookiepro.com/s/article/UUID-621498be-7e5c-23af-3bfd-e772340b4933?language=en_US)

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

[jira cookie epic](https://codedotorg.atlassian.net/browse/FND-1746)

## Testing story

To test this I found a script that _was_ processed by the autoblock script locally and added the [`data-ot-ignore` attribute](https://my.onetrust.com/articles/en_US/Knowledge/UUID-71e7d0a8-03d8-e272-e683-72cadded2ecf) to it. On restarting my local server there was no longer the [type re-writing](https://community.cookiepro.com/s/article/UUID-730ad441-6c4d-7877-7f85-36f1e801e8ca?language=en_US#idm45572186078784) on the script element OneTrust uses to manage scripts. In an attempt to have jQuery also ignored in production, I've added these attributes to script elements in the haml file that loads jQuery on the https://code.org/cookies page.

The new element attribute is also hidden behind a conditional that requires a test cookie, so it is only used when engineers are intentionally trying to test it.

## Follow-up work
Once in production, check if using the [repro](https://docs.google.com/document/d/1oGTETD7-ANNT514ccbs5aQMOd2s-dfgoPvViDpv7iik/edit) steps still causes the error to occur.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
