### PR TITLE
Extend starter assets feature to remixed app lab project

### DIFF
--- a/dashboard/app/controllers/projects_controller.rb
+++ b/dashboard/app/controllers/projects_controller.rb
@@ -409,7 +409,7 @@ class ProjectsController < ApplicationController
   end
 
   private def uses_starter_assets?(project_type)
-    %w(javalab).include? project_type
+    %w(javalab applab).include? project_type
   end
 
   def export_create_channel

--- a/dashboard/test/integration/remix_test.rb
+++ b/dashboard/test/integration/remix_test.rb
@@ -78,8 +78,8 @@ class RemixTest < ActionDispatch::IntegrationTest
     assert_only_remixes_sources 'minecraft_hero'
   end
 
-  test 'applab only remixes Sources and Assets buckets' do
-    assert_only_remixes_sources_assets 'applab'
+  test 'applab only remixes Sources and Assets buckets and Starter assets' do 
+    assert_only_remixes_sources_assets_starter_assets 'applab'
   end
 
   test 'gamelab only remixes Sources, Assets and Animations buckets' do
@@ -122,7 +122,7 @@ class RemixTest < ActionDispatch::IntegrationTest
     assert_only_remixes_sources 'eval'
   end
 
-  test 'javalab only remixes Sources and Assets buckets, and starter assets' do
+  test 'javalab only remixes Sources and Assets buckets, and Starter assets' do
     assert_only_remixes_sources_assets_starter_assets 'javalab'
   end
 


### PR DESCRIPTION
## Summary
- Prior to update, when a levelbuilder remixed a curriculum level that contained starter assets, the starter assets were not carrier to remixed level because the level for a standalone project is an app lab project. 
- There was already a feature that copied starter assets from the original project and added them to the remixed project for java lab projects, so I extended this feature to app lab projects.

## Links

- [jira ticket](https://codedotorg.atlassian.net/browse/STAR-2321)
- [video](https://user-images.githubusercontent.com/107423305/177883787-133006bb-1633-42db-93a1-3906ad503935.mp4) before/after update

## Testing story

- Updated integration test for app lab projects to test that in addition to Sources and Assets buckets, the Starter assets are also carried over to remixed project in remix_test.rb.




