### PR TITLE
Move file error message into redux

### DIFF
--- a/apps/src/javalab/JavalabEditorDialogManager.jsx
+++ b/apps/src/javalab/JavalabEditorDialogManager.jsx
@@ -8,7 +8,11 @@ import JavalabDialog from './JavalabDialog';
 import NameFileDialog from './NameFileDialog';
 import CommitDialog from './CommitDialog';
 import {DisplayTheme} from './DisplayTheme';
-import {closeEditorDialog} from './javalabRedux';
+import {
+  clearNewFileError,
+  clearRenameFileError,
+  closeEditorDialog
+} from './javalabRedux';
 
 export const JavalabEditorDialog = makeEnum(
   'RENAME_FILE',
@@ -29,15 +33,16 @@ function JavalabEditorDialogManager({
   filenameToDelete,
   onRenameFile,
   filenameToRename,
-  renameFileError,
-  clearRenameFileError,
   onCreateFile,
-  newFileError,
-  clearNewFileError,
   commitDialogFileNames,
   onCommitCode,
   handleClearPuzzle,
   isProjectTemplateLevel,
+  // populated by Redux
+  newFileError,
+  clearNewFileError,
+  renameFileError,
+  clearRenameFileError,
   editorOpenDialogName,
   closeEditorDialog,
   displayTheme
@@ -104,16 +109,16 @@ JavalabEditorDialogManager.propTypes = {
   filenameToDelete: PropTypes.string,
   onRenameFile: PropTypes.func.isRequired,
   filenameToRename: PropTypes.string,
-  renameFileError: PropTypes.string,
-  clearRenameFileError: PropTypes.func.isRequired,
   onCreateFile: PropTypes.func.isRequired,
-  newFileError: PropTypes.string,
-  clearNewFileError: PropTypes.func.isRequired,
   commitDialogFileNames: PropTypes.arrayOf(PropTypes.string).isRequired,
   onCommitCode: PropTypes.func.isRequired,
   handleClearPuzzle: PropTypes.func.isRequired,
   isProjectTemplateLevel: PropTypes.bool.isRequired,
   // populated by Redux
+  newFileError: PropTypes.string,
+  clearNewFileError: PropTypes.func.isRequired,
+  renameFileError: PropTypes.string,
+  clearRenameFileError: PropTypes.func.isRequired,
   editorOpenDialogName: PropTypes.oneOf(Object.values(JavalabEditorDialog)),
   closeEditorDialog: PropTypes.func.isRequired,
   displayTheme: PropTypes.oneOf(Object.values(DisplayTheme))
@@ -122,7 +127,13 @@ JavalabEditorDialogManager.propTypes = {
 export default connect(
   state => ({
     editorOpenDialogName: state.javalab.editorOpenDialogName,
-    displayTheme: state.javalab.displayTheme
+    displayTheme: state.javalab.displayTheme,
+    newFileError: state.javalab.newFileError,
+    renameFileError: state.javalab.renameFileError
   }),
-  dispatch => ({closeEditorDialog: () => dispatch(closeEditorDialog())})
+  dispatch => ({
+    closeEditorDialog: () => dispatch(closeEditorDialog()),
+    clearNewFileError: () => dispatch(clearNewFileError()),
+    clearRenameFileError: () => dispatch(clearRenameFileError())
+  })
 )(JavalabEditorDialogManager);

--- a/apps/src/javalab/javalabRedux.js
+++ b/apps/src/javalab/javalabRedux.js
@@ -41,6 +41,10 @@ const SET_ORDERED_TAB_KEYS = 'javalab/SET_ORDERED_TAB_KEYS';
 const SET_ALL_EDITOR_METADATA = 'javalab/SET_EDITOR_METADATA';
 const OPEN_EDITOR_DIALOG = 'javalab/OPEN_EDITOR_DIALOG';
 const CLOSE_EDITOR_DIALOG = 'javalab/CLOSE_EDITOR_DIALOG';
+const SET_NEW_FILE_ERROR = 'javalab/SET_NEW_FILE_ERROR';
+const CLEAR_NEW_FILE_ERROR = 'javalab/CLEAR_NEW_FILE_ERROR';
+const SET_RENAME_FILE_ERROR = 'javalab/SET_RENAME_FILE_ERROR';
+const CLEAR_RENAME_FILE_ERROR = 'javalab/CLEAR_RENAME_FILE_ERROR';
 
 export const getTabKey = index => `file-${index}`;
 
@@ -98,7 +102,9 @@ export const initialState = {
   hasOpenCodeReview: false,
   isCommitSaveInProgress: false,
   hasCommitSaveError: false,
-  editorOpenDialogName: null
+  editorOpenDialogName: null,
+  newFileError: null,
+  renameFileError: null
 };
 
 // Action Creators
@@ -378,6 +384,24 @@ export const setAllEditorMetadata = (
   };
 };
 
+export const setNewFileError = error => ({
+  type: SET_NEW_FILE_ERROR,
+  error: error
+});
+
+export const clearNewFileError = () => ({
+  type: CLEAR_NEW_FILE_ERROR
+});
+
+export const setRenameFileError = error => ({
+  type: SET_RENAME_FILE_ERROR,
+  error: error
+});
+
+export const clearRenameFileError = () => ({
+  type: CLEAR_RENAME_FILE_ERROR
+});
+
 // Reducer
 export default function reducer(state = initialState, action) {
   if (action.type === APPEND_CONSOLE_LOG) {
@@ -640,5 +664,34 @@ export default function reducer(state = initialState, action) {
       editorOpenDialogName: null
     };
   }
+
+  if (action.type === SET_NEW_FILE_ERROR) {
+    return {
+      ...state,
+      newFileError: action.error
+    };
+  }
+
+  if (action.type === CLEAR_NEW_FILE_ERROR) {
+    return {
+      ...state,
+      newFileError: null
+    };
+  }
+
+  if (action.type === SET_RENAME_FILE_ERROR) {
+    return {
+      ...state,
+      renameFileError: action.error
+    };
+  }
+
+  if (action.type === CLEAR_RENAME_FILE_ERROR) {
+    return {
+      ...state,
+      renameFileError: null
+    };
+  }
+
   return state;
 }


### PR DESCRIPTION
Quick follow-up to https://github.com/code-dot-org/code-dot-org/pull/47116. This moves the `new/renameFileError` values into redux to reduce state coupling between `JavalabEditor` and `JavalabEditorDialogManager`. As with the previous PRs, this is branched off of the previous refactor PR and we plan to keep these unmerged until all the works has been completed and reviewed to avoid unnecessarily rewriting unit tests.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Tested locally.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
