### PR TITLE
Enable WebServer TCP Ports

### DIFF
--- a/aws/cloudformation/vpc.yml.erb
+++ b/aws/cloudformation/vpc.yml.erb
@@ -232,11 +232,6 @@ Resources:
           FromPort: 3306
           ToPort: 3306
           DestinationSecurityGroupId: {Ref: FrontendSecurityGroup}
-        - Description: S3 outbound access (us-east-1 Prefix List)
-          IpProtocol: tcp
-          FromPort: 443
-          ToPort: 443
-          DestinationPrefixListId: pl-63a5400a
   DBSecurityGroupEgress:
     Type: AWS::EC2::SecurityGroupEgress
     Properties:

--- a/aws/cloudformation/vpc.yml.erb
+++ b/aws/cloudformation/vpc.yml.erb
@@ -125,13 +125,25 @@ Resources:
           ToPort: 443
           CidrIp: 0.0.0.0/0
       SecurityGroupEgress:
+        # Forward HTTP requests to nginx on Web Application Server ("Front End") EC2 Instances.
         - IpProtocol: tcp
           FromPort: 80
           ToPort: 80
           CidrIp: 0.0.0.0/0
+        # Forward HTTP requests to nginx on Web Application Server ("Front End") EC2 Instances.
         - IpProtocol: tcp
           FromPort: 443
           ToPort: 443
+          CidrIp: 0.0.0.0/0
+        # Forward HTTP requests directly to Dashboard Puma on Web Application Server ("Front End") EC2 Instances.
+        - IpProtocol: tcp
+          FromPort: 9000
+          ToPort: 9000
+          CidrIp: 0.0.0.0/0
+        # Forward HTTP requests directly to Pegasus Puma on Web Application Server ("Front End") EC2 Instances.
+        - IpProtocol: tcp
+          FromPort: 9001
+          ToPort: 9001
           CidrIp: 0.0.0.0/0
   FrontendSecurityGroup:
     Type: AWS::EC2::SecurityGroup
@@ -139,13 +151,25 @@ Resources:
       GroupDescription: Inbound HTTP[S] from load balancer, SSH from Gateway.
       VpcId: {Ref: VPC}
       SecurityGroupIngress:
+        # nginx listens for incoming HTTP requests forwarded by Load Balancer
         - IpProtocol: tcp
           FromPort: 80
           ToPort: 80
           SourceSecurityGroupId: {Ref: ELBSecurityGroup}
+        # nginx listens for incoming HTTPS requests forwarded by Load Balancer
         - IpProtocol: tcp
           FromPort: 443
           ToPort: 443
+          SourceSecurityGroupId: {Ref: ELBSecurityGroup}
+        # Enable Dashboard Puma to listen on a TCP port (in addition to receiving HTTP requests via a Unix socket from nginx).
+        - IpProtocol: tcp
+          FromPort: 9000
+          ToPort: 9000
+          SourceSecurityGroupId: {Ref: ELBSecurityGroup}
+        # Enable Pegasus Puma to listen on a TCP port (in addition to receiving HTTP requests via a Unix socket from nginx).
+        - IpProtocol: tcp
+          FromPort: 9001
+          ToPort: 9001
           SourceSecurityGroupId: {Ref: ELBSecurityGroup}
         - IpProtocol: tcp
           FromPort: 22


### PR DESCRIPTION
Currently our "FrontEnd" Web Application Server EC2 Instances permit inbound HTTP requests on port 80 and 443 from load balancers. `nginx` listens on those ports, determines whether the request is for dashboard or pegasus by inspecting the requested domain name (and some headers), and then relays the HTTP request to a Puma Dashboard process or a Puma Pegasus process via Unix sockets.

As the first step towards eliminating the need for `nginx` (AWS CloudFront provides most of the functionality that we originally needed with `nginx`), update the Security Groups to permit Load Balancers to route HTTP requests directly to dedicated TCP ports for the Puma Dashboard web application service and the Puma Pegasus web application service.

In #47104 we configure Puma to listen on these TCP ports *in addition* to continuing to receive HTTP requests via Unix socket from `nginx`.

Also - disable outbound communication from database clusters to S3, as we no longer utilize `SELECT ... INTO S3`.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

```
export AWS_PROFILE=codeorg-admin
$ bundle exec rake stack:vpc:validate RAILS_ENV=productio

Pending update for stack `VPC`:
Modify ELBSecurityGroup [AWS::EC2::SecurityGroup] Properties (SecurityGroupEgress)
Modify FrontendSecurityGroup [AWS::EC2::SecurityGroup] Properties (SecurityGroupIngress)
```

## Deployment strategy

We should probably execute this during a low usage time period since it impacts all environments.
`bundle exec rake stack:vpc:start RAILS_ENV=production`

Completed 2022-07-08 11:30AM PDT
```
$ bundle exec rake stack:vpc:start RAILS_ENV=production

Pending update for stack `VPC`:
Modify ELBSecurityGroup [AWS::EC2::SecurityGroup] Properties (SecurityGroupEgress)
Modify FrontendSecurityGroup [AWS::EC2::SecurityGroup] Properties (SecurityGroupIngress)
Proceed? [y/n]
y
 Stack update requested, waiting for provisioning to complete...
2022-07-08 18:35:24 UTC- VPC [UPDATE_IN_PROGRESS]: User Initiated
..2022-07-08 18:35:31 UTC- ELBSecurityGroup [UPDATE_IN_PROGRESS]
..2022-07-08 18:35:48 UTC- ELBSecurityGroup [UPDATE_COMPLETE]
.2022-07-08 18:35:50 UTC- FrontendSecurityGroup [UPDATE_IN_PROGRESS]
...2022-07-08 18:36:07 UTC- FrontendSecurityGroup [UPDATE_COMPLETE]
2022-07-08 18:36:12 UTC- VPC [UPDATE_COMPLETE_CLEANUP_IN_PROGRESS]
2022-07-08 18:36:07 UTC- FrontendSecurityGroup [UPDATE_COMPLETE]
2022-07-08 18:36:12 UTC- VPC [UPDATE_COMPLETE_CLEANUP_IN_PROGRESS]

Stack update complete.
```

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
