### PR TITLE
Add 2022 views for csf courses

### DIFF
--- a/lib/cdo/script_constants.rb
+++ b/lib/cdo/script_constants.rb
@@ -69,6 +69,16 @@ module ScriptConstants
       EXPRESS_2021_NAME = 'express-2021'.freeze,
       PRE_READER_EXPRESS_2021_NAME = 'pre-express-2021'.freeze,
     ],
+    csf_2022: [
+      COURSEA_2022_NAME = 'coursea-2022'.freeze,
+      COURSEB_2022_NAME = 'courseb-2022'.freeze,
+      COURSEC_2022_NAME = 'coursec-2022'.freeze,
+      COURSED_2022_NAME = 'coursed-2022'.freeze,
+      COURSEE_2022_NAME = 'coursee-2022'.freeze,
+      COURSEF_2022_NAME = 'coursef-2022'.freeze,
+      EXPRESS_2022_NAME = 'express-2022'.freeze,
+      PRE_READER_EXPRESS_2022_NAME = 'pre-express-2022'.freeze,
+    ],
     csc_2021: [
       POETRY_2021_NAME = 'poetry-2021'.freeze,
       AI_ETHICS_2021_NAME = 'ai-ethics-2021'.freeze,

--- a/pegasus/sites.v3/code.org/views/csf_congrats.haml
+++ b/pegasus/sites.v3/code.org/views/csf_congrats.haml
@@ -71,7 +71,16 @@
     ScriptConstants::COURSEE_2021_NAME => "csf_next",
     ScriptConstants::COURSEF_2021_NAME => "csf_next",
     ScriptConstants::EXPRESS_2021_NAME => "csf_next",
-    ScriptConstants::PRE_READER_EXPRESS_2021_NAME => "csf_next"
+    ScriptConstants::PRE_READER_EXPRESS_2021_NAME => "csf_next",
+
+    ScriptConstants::COURSEA_2022_NAME => "csf_next",
+    ScriptConstants::COURSEB_2022_NAME => "csf_next",
+    ScriptConstants::COURSEC_2022_NAME => "csf_next",
+    ScriptConstants::COURSED_2022_NAME => "csf_next",
+    ScriptConstants::COURSEE_2022_NAME => "csf_next",
+    ScriptConstants::COURSEF_2022_NAME => "csf_next",
+    ScriptConstants::EXPRESS_2022_NAME => "csf_next",
+    ScriptConstants::PRE_READER_EXPRESS_2022_NAME => "csf_next"
   }
 
 #congrats.mobile-pad{:style=>'margin: 0 auto;'}

--- a/pegasus/test/test_congrats_routes.rb
+++ b/pegasus/test/test_congrats_routes.rb
@@ -26,14 +26,14 @@ class CongratsRoutesTest < Minitest::Test
         ScriptConstants::COURSEF_NAME,
         ScriptConstants::EXPRESS_NAME,
         ScriptConstants::PRE_READER_EXPRESS_NAME,
-        ScriptConstants::COURSEA_2018_NAME,
-        ScriptConstants::COURSEB_2018_NAME,
-        ScriptConstants::COURSEC_2018_NAME,
-        ScriptConstants::COURSED_2018_NAME,
-        ScriptConstants::COURSEE_2018_NAME,
-        ScriptConstants::COURSEF_2018_NAME,
-        ScriptConstants::EXPRESS_2018_NAME,
-        ScriptConstants::PRE_READER_EXPRESS_2018_NAME
+        ScriptConstants::COURSEA_2022_NAME,
+        ScriptConstants::COURSEB_2022_NAME,
+        ScriptConstants::COURSEC_2022_NAME,
+        ScriptConstants::COURSED_2022_NAME,
+        ScriptConstants::COURSEE_2022_NAME,
+        ScriptConstants::COURSEF_2022_NAME,
+        ScriptConstants::EXPRESS_2022_NAME,
+        ScriptConstants::PRE_READER_EXPRESS_2022_NAME
       ].each do |course|
         @pegasus.get "/congrats/#{course}"
         assert_equal 200, @pegasus.last_response.status


### PR DESCRIPTION
See https://codedotorg.slack.com/archives/C02EEGWLHR8/p1657299239663799. Put a ticket in our backlog https://codedotorg.atlassian.net/browse/PLAT-1914 for a more sustainable solution.

Currently on production:
<img width="703" alt="image" src="https://user-images.githubusercontent.com/9142121/178037200-21862806-0b98-4d44-a4db-8a3b50cd5019.png">


With fix:
<img width="865" alt="image" src="https://user-images.githubusercontent.com/9142121/178037162-d3085b21-5bb2-4d26-a001-110dc47e0e73.png">

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
