### PR TITLE
UI tests: Windows 7 -> Windows 10 for Chrome

### DIFF
--- a/dashboard/test/ui/browsers.json
+++ b/dashboard/test/ui/browsers.json
@@ -5,7 +5,7 @@
     "name": "Chrome",
     "browserName": "chrome",
     "version": "75",
-    "platform": "Windows 7",
+    "platform": "Windows 10",
     "screenResolution": "1280x1024",
     "extendedDebugging": true
   },


### PR DESCRIPTION
This updates the UI tests (both regular UI tests & the Eyes tests) for Chrome to use Windows 10, instead of Windows 7.

Windows 7 is no longer supported by Microsoft, and Sauce Labs support recommended making this upgrade after confirming there are some reported issues around inconsistent desktop sizes on Windows 7, which were making some of our Eyes tests inconsistent.  (Despite requesting a 1280x1024 desktop, we were sometimes getting a 1024x768 one instead.)
