### PR TITLE
Standardize AWS Deletion Protection

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -149,7 +149,7 @@ Resources:
       Subnets: <%= public_subnets.to_json %>
       LoadBalancerAttributes:
         - Key: deletion_protection.enabled
-          Value: true
+          Value: <%=rack_env?(:adhoc) ? 'false' : 'true'%>
         - Key: access_logs.s3.enabled
           Value: true
         - Key: access_logs.s3.bucket
@@ -515,6 +515,7 @@ Resources:
       InstanceType: !Ref ConsoleInstanceType
       IamInstanceProfile: !Ref FrontendInstanceProfile
       KeyName: <%=SSH_KEY_NAME%>
+      DisableApiTermination: <%= rack_env?(:adhoc) ? false : true %>
       Tags:
         - {Key: Name, Value: <%=environment%>-console}
       BlockDeviceMappings:

--- a/aws/cloudformation/components/database.yml.erb
+++ b/aws/cloudformation/components/database.yml.erb
@@ -18,7 +18,7 @@
         - audit
         - error
         - slowquery
-      DeletionProtection: true
+      DeletionProtection: <%= rack_env?(:adhoc) ? false : true %>
       BackupRetentionPeriod: !Ref DBBackupRetention
 <%
   # Integer range identifying each of the DB Instances to provision in the cluster.


### PR DESCRIPTION
Standardize deletion protection settings on AWS Resources so that it is enabled for most critical Resources (except for adhoc environments).

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

`bundle exec rake adhoc:full_stack:start RAILS_ENV=adhoc DAEMON_INSTANCE_TYPE=t2.2xlarge STACK_NAME=adhoc-deletion-protection`

## Deployment strategy

Monitor closely after merging to ensure no issues when these changes are applied to `staging`.

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
