### PR TITLE
Fix whitespace breaking linter

### DIFF
--- a/dashboard/test/integration/remix_test.rb
+++ b/dashboard/test/integration/remix_test.rb
@@ -78,7 +78,7 @@ class RemixTest < ActionDispatch::IntegrationTest
     assert_only_remixes_sources 'minecraft_hero'
   end
 
-  test 'applab only remixes Sources and Assets buckets and Starter assets' do 
+  test 'applab only remixes Sources and Assets buckets and Starter assets' do
     assert_only_remixes_sources_assets_starter_assets 'applab'
   end
 


### PR DESCRIPTION
Whitespace causing linter failure on test. Removing whitespace added here: https://github.com/code-dot-org/code-dot-org/pull/47134

cc: @fisher-alice 