### PR TITLE
Make Levels Generated by `stub_project_level` More Consistent

### DIFF
--- a/dashboard/test/integration/remix_test.rb
+++ b/dashboard/test/integration/remix_test.rb
@@ -202,8 +202,8 @@ class RemixTest < ActionDispatch::IntegrationTest
   end
 
   private def stub_project_level(type)
-    game = create :game, name: type, app: type
-    level = create :level, game: game
+    factory = FactoryGirl.factories.registered?(type) ? type : :level
+    level = FactoryGirl.create(factory)
     ProjectsController.any_instance.stubs(:get_from_cache).returns(level)
   end
 


### PR DESCRIPTION
Currently, our integration tests for project remix functionality use a very rudimentary approach to generating test content. In preparation for disabling the `unknown_asset_fallback` configuration in https://github.com/code-dot-org/code-dot-org/pull/46937, however, we need to make this test content more consistent with the rest of our application.

Specifically, we need to make sure that the Game associated with the Level is a valid one, and that the Level itself has a valid type. Without this change the remix test will fail with several errors like:

```
FAIL["test_playlab_k1_only_remixes_Sources_bucket", "RemixTest", 17.427581716998247]
 test_playlab_k1_only_remixes_Sources_bucket#RemixTest (17.43s)
        Wrong response: Sprockets::Rails::Helper::AssetNotFound at /projects/playlab_k1/NmtSSBOf2FQo8esRnFps9g/edit
        ===========================================================================================

        The asset "css/playlab_k1.css" is not present in the asset pipeline.

        > To access an interactive console with this error, point your browser to: /__better_errors

        app/views/levels/_apps_dependencies.html.haml, line 16
        ------------------------------------------------------

        ``` ruby
           11   - use_phaser ||= false
           12   - app_options[:locale] = js_locale
           13
           14   -# Common style dependencies
           15   %link{href: asset_path('css/common.css'), rel: 'stylesheet', type: 'text/css'}
        >  16   %link{href: asset_path("css/#{app}.css"), rel: 'stylesheet', type: 'text/css'}
           17
           18   - if use_p5
           19     %script{src: webpack_asset_path('js/p5-dependencies.js')}
           20
           21   -# Droplet style dependencies (only when editor present)
        ```
```

Note that I use the same basic approach here to achieve that consistency as we do in the ProjectsController test: https://github.com/code-dot-org/code-dot-org/blob/bda5b0a5e8d93f7dee51b28b541263e1b9c2645b/dashboard/test/controllers/projects_controller_test.rb#L22-L30

This does result in a bit of duplicated code; I don't think this is worth extracting into some kind of shared helper method, but I'm open to disagreement on that point.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Testing story

Manually executed the affected unit test to confirm that this change doesn't break any existing tests, and ran it again with unknown asset fallback disabled to confirm that it fixes the underlying issue.

## Follow-up work

Finally merge https://github.com/code-dot-org/code-dot-org/pull/46937
## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
