### PR TITLE
Lesson tips added to i18n pipeline.

### DIFF
--- a/dashboard/app/models/activity_section.rb
+++ b/dashboard/app/models/activity_section.rb
@@ -51,9 +51,26 @@ class ActivitySection < ApplicationRecord
       duration: duration,
       remarks: remarks,
       description: Services::I18n::CurriculumSyncUtils.get_localized_property(self, :description),
-      tips: tips,
+      tips: localized_tips,
       progressionName: localized_progression_name
     }
+  end
+
+  # Translates the content of tips in the adequate format.
+  # @attr [Array<Hash>] tips each Hash contains a "type" and a "markdown". get_localized_property returns the same
+  # [Array<Hash>] when the locale is the default_locale, otherwise, it returns or Array of to translated "markdown"
+  # content [Array<String or NilClass>].
+  #
+  # @return [Array <Hash>] copy of tips containing translated content
+  def localized_tips
+    return nil unless tips
+    all_localized_tips = Services::I18n::CurriculumSyncUtils.get_localized_property(self, :tips)
+    tips_clone = tips.map(&:clone)
+    tips_clone.each_with_index do |tip, index|
+      puts all_localized_tips[index].class
+      tip["markdown"] = all_localized_tips[index] unless (all_localized_tips[index] == tip) || all_localized_tips[index].nil?
+    end
+    tips_clone
   end
 
   def summarize_for_lesson_show(can_view_teacher_markdown, current_user)

--- a/dashboard/app/models/activity_section.rb
+++ b/dashboard/app/models/activity_section.rb
@@ -67,7 +67,6 @@ class ActivitySection < ApplicationRecord
     all_localized_tips = Services::I18n::CurriculumSyncUtils.get_localized_property(self, :tips)
     tips_clone = tips.map(&:clone)
     tips_clone.each_with_index do |tip, index|
-      puts all_localized_tips[index].class
       tip["markdown"] = all_localized_tips[index] unless (all_localized_tips[index] == tip) || all_localized_tips[index].nil?
     end
     tips_clone


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
**What:** Added method that gets the translation for tips property and returns an updated version of tips with "markdown" content translated when available. The method does not change the tips content when a translation is not available (i18n returns nil value) or the locale is the same as the default locale (i18n returns the same object)

**Why:** Lesson plans include Tips for Teaching or Assessment among others. This tips are translatable currently, despite of content being available for translation or already translated in [Crowdin](https://crowdin.com/translate/codeorg/178076/enus-de?filter=basic&value=0#2705985). 
<img width="993" alt="tips_current-behavior" src="https://user-images.githubusercontent.com/66776217/178583743-46bcd136-7908-4018-b843-5121d87ce8ca.png">


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
- jira ticket: [FND-2052](https://codedotorg.atlassian.net/browse/FND-2052)
<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
Testing included debuging checking the translated classes and values in order to ensure the adequate formats were returned in the new method.
Locally, the new method has been tested for the following scenarios:
- Default locale:
<img width="1227" alt="tips_default-locale" src="https://user-images.githubusercontent.com/66776217/178583729-1c263945-e343-4c52-876d-de5b5adb0d7d.png">

- Language with translation available (ES):
<img width="1227" alt="tips_locale-ES" src="https://user-images.githubusercontent.com/66776217/178585539-374ecf40-3a32-4a7a-b10c-9b3051ad3c46.png">

- Language with no translation available(PH): 
<img width="1227" alt="tips_colale-PH" src="https://user-images.githubusercontent.com/66776217/178585639-f1e0ee32-1cfc-4ee4-a915-de1ceba6c9d7.png">

- Language with some translations available (DE): 
<img width="1227" alt="tips_locale-DE-nontranslated" src="https://user-images.githubusercontent.com/66776217/178585705-74fcc087-7b31-4ef0-b6da-aeac26a73c1d.png">
<img width="1227" alt="tips_locale-DE-translated" src="https://user-images.githubusercontent.com/66776217/178585708-e0bff79b-4437-4e1c-a8bd-d1850e903463.png">

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
