### PR TITLE
INFERRED_NO_EXCLUSION_LIST should take year into account

### DIFF
--- a/dashboard/app/models/census/census_summary.rb
+++ b/dashboard/app/models/census/census_summary.rb
@@ -187,7 +187,7 @@ class Census::CensusSummary < ApplicationRecord
       # without a row is counted as a NO
       if high_school &&
          state_offerings.empty? &&
-         Census::StateCsOffering.infer_no(school.state) &&
+         Census::StateCsOffering.infer_no(school.state, school_year) &&
          Census::StateCsOffering::SUPPORTED_STATES.include?(school.state) &&
          state_years_with_data[school.state].include?(school_year)
         audit[:state_cs_offerings].push(nil)

--- a/dashboard/app/models/census/state_cs_offering.rb
+++ b/dashboard/app/models/census/state_cs_offering.rb
@@ -177,20 +177,20 @@ class Census::StateCsOffering < ApplicationRecord
 
   # By default we treat the lack of state data for high schools as an
   # indication that the school doesn't teach cs. We aren't as confident
-  # that the state data is complete for the following states so we do
-  # not want to treat the lack of data as a no for those.
+  # that the state data is complete for the following states in the associated
+  # years so we do not want to treat the lack of data as a no for those.
   INFERRED_NO_EXCLUSION_LIST = %w(
-    AK
-    CO
-    DC
-    HI
-    ME
-    MI
-    MN
+    AK:2021
+    CO:2021
+    DC:2021
+    HI:2021
+    ME:2021
+    MI:2021
+    MN:2021
   ).freeze
 
-  def self.infer_no(state_code)
-    INFERRED_NO_EXCLUSION_LIST.exclude? state_code.upcase
+  def self.infer_no(state_code, school_year)
+    INFERRED_NO_EXCLUSION_LIST.exclude?("#{state_code.upcase}:#{school_year}")
   end
 
   def self.get_state_school_id(state_code, row_hash, school_year, update)

--- a/dashboard/test/models/census/census_summary_test.rb
+++ b/dashboard/test/models/census/census_summary_test.rb
@@ -278,7 +278,7 @@ class Census::CensusSummaryTest < ActiveSupport::TestCase
     validate_summary(school, school_year, "MAYBE")
   end
 
-  test "High school lack of state data in a denylist state and non-denylist year does not override anything" do
+  test "High school lack of state data in a denylist state and non-denylist year does override previous years" do
     return if Census::StateCsOffering::INFERRED_NO_EXCLUSION_LIST.empty?
     school_year = 2020
     state = Census::StateCsOffering::INFERRED_NO_EXCLUSION_LIST.first.split(':').first

--- a/dashboard/test/models/census/census_summary_test.rb
+++ b/dashboard/test/models/census/census_summary_test.rb
@@ -262,9 +262,10 @@ class Census::CensusSummaryTest < ActiveSupport::TestCase
     validate_summary(school, school_year, "NO")
   end
 
-  test "High school lack of state data in a denylist state does not override anything" do
+  test "High school lack of state data in a denylist state and year does not override anything" do
     return if Census::StateCsOffering::INFERRED_NO_EXCLUSION_LIST.empty?
-    school_year = 2020
+    school_year = 2021
+    state = Census::StateCsOffering::INFERRED_NO_EXCLUSION_LIST.first.split(':').first
     school = create :census_school,
       :with_teaches_no_teacher_census_submission,
       :with_teaches_yes_teacher_census_submission,
@@ -272,9 +273,25 @@ class Census::CensusSummaryTest < ActiveSupport::TestCase
       :with_one_year_ago_teaches_yes,
       :with_two_years_ago_teaches_yes,
       :with_three_years_ago_teaches_yes,
-      state: Census::StateCsOffering::INFERRED_NO_EXCLUSION_LIST.first,
+      state: state,
       school_year: school_year
     validate_summary(school, school_year, "MAYBE")
+  end
+
+  test "High school lack of state data in a denylist state and non-denylist year does not override anything" do
+    return if Census::StateCsOffering::INFERRED_NO_EXCLUSION_LIST.empty?
+    school_year = 2020
+    state = Census::StateCsOffering::INFERRED_NO_EXCLUSION_LIST.first.split(':').first
+    school = create :census_school,
+      :with_teaches_no_teacher_census_submission,
+      :with_teaches_yes_teacher_census_submission,
+      :with_teaches_yes_parent_census_submission,
+      :with_one_year_ago_teaches_yes,
+      :with_two_years_ago_teaches_yes,
+      :with_three_years_ago_teaches_yes,
+      state: state,
+      school_year: school_year
+    validate_summary(school, school_year, "NO")
   end
 
   test "Inconsistent teacher surveys override other surveys" do


### PR DESCRIPTION
A month ago, in #46819, I added schools to this list I believe for the first time ever. What we wanted was to account for the fact that certain states, like Michigan, only gave us data on schools where they went from not teaching CS to teaching CS instead of a list of all schools that teach CS, like in past years. For schools that aren't in the new data sets, we want to infer `teaches_cs` from the previous year's data.

However, this caused an unintended downstream effect where previous years, when these states provided more complete data, were also affected because this list applied for a state for *all years*. The fix here is to make this list depend on the year as well as the state.

An example of this issue:

Correct case:
School X in Michigan does not teach CS and School Y does. Last year, Michigan gave us a complete list of schools that taught CS, so we know School Y taught CS and we should be able to infer School X did not teach CS last year. This year, Michigan only gave us a list of schools where `teaches_cs` changed, so School X should be noted as `HN` (historic no) and School Y should be noted as `HY` (historic yes).

Current case:
School X in Michigan does not teach CS and School Y does. Last year, Michigan gave us a complete list of schools that taught CS, so we know School Y taught CS and we should be able to infer School X did not teach CS last year. This worked *last year* but due to #46819, School X's status has become either `NULL` or `MAYBE`. That means that, this year, School Y is correctly noted as `HY` but School X is still a `NULL` or `MAYBE`.

Because we essentially lose the `N` and `HN` schools, our data is all wrong. I believe that tying the inclusion list to the year will resolve this particular issue.





## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
