### PR TITLE
Attempt to deflake UI test - code review v2

### DIFF
--- a/dashboard/test/ui/features/step_definitions/top_instructions.rb
+++ b/dashboard/test/ui/features/step_definitions/top_instructions.rb
@@ -37,6 +37,7 @@ end
 
 Given /^I write a code review comment with text "([^"]*)"$/ do |text|
   steps <<-STEPS
+     And I wait to see ".code-review-comment-input"
      And I press keys "#{text}" for element ".code-review-comment-input"
      And element ".code-review-comment-input" contains text "#{text}"
      And I press "code-review-comment-submit"


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Based on looking at a couple of drone runs that failed, it looks like we try to write the comment before the comment box has loaded. This is an attempt to de-flake.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
