### PR TITLE
remove hoc signup flow

### DIFF
--- a/dashboard/app/controllers/passwords_controller.rb
+++ b/dashboard/app/controllers/passwords_controller.rb
@@ -5,15 +5,6 @@ class PasswordsController < Devise::PasswordsController
   append_after_action :show_reset_url_if_admin, only: :create
 
   def create
-    email = request.parameters['user']['email']
-    if email_in_hoc_signups?(email)
-      # If the user has a full account as well, don't use the HOC flow
-      user = User.find_by_email_or_hashed_email(email)
-      unless user
-        redirect_to "#{new_user_registration_path}?already_hoc_registered=true"
-        return
-      end
-    end
     unless verify_recaptcha || current_user&.admin?
       flash[:alert] = I18n.t('password.reset_errors.captcha_required')
       redirect_to new_user_password_path
@@ -33,12 +24,6 @@ class PasswordsController < Devise::PasswordsController
   end
 
   private
-
-  def email_in_hoc_signups?(email)
-    hoc_year = DCDO.get("hoc_year", 2017)
-    normalized_email = email.strip.downcase
-    PEGASUS_DB[:forms].where(email: normalized_email, kind: "HocSignup#{hoc_year}").any?
-  end
 
   def show_reset_url_if_admin
     return unless current_user.try(:admin?)

--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -21,7 +21,6 @@ class RegistrationsController < Devise::RegistrationsController
       @user = User.new_with_session(user_params.permit(:user_type), session)
     else
       save_default_sign_up_user_type
-      @already_hoc_registered = params[:already_hoc_registered]
       SignUpTracking.begin_sign_up_tracking(session, split_test: true)
       super
     end

--- a/dashboard/app/controllers/sessions_controller.rb
+++ b/dashboard/app/controllers/sessions_controller.rb
@@ -11,7 +11,6 @@ class SessionsController < Devise::SessionsController
       redirect_to maker_google_oauth_confirm_login_path
       return
     end
-    @already_hoc_registered = params[:already_hoc_registered]
     @hide_sign_in_option = true
     @is_english = request.language == 'en'
     if params[:providerNotLinked]

--- a/dashboard/app/views/devise/registrations/_sign_up.html.haml
+++ b/dashboard/app/views/devise/registrations/_sign_up.html.haml
@@ -4,13 +4,10 @@
   .row
     .span8.header
       %h1= t('signup_form.title')
-      - if @already_hoc_registered
-        = t('signup_form.hoc_already_signed_up_content_post_hoc_markdown', studio_url: CDO.studio_url('/'), markdown: true).html_safe
-      - else
-        = t('signup_form.overview_markdown', markdown: true).html_safe
-        = t('auth.already_signedup')
-        &nbsp;
-        = link_to t('nav.user.signin'), new_session_path(resource_name)
+      = t('signup_form.overview_markdown', markdown: true).html_safe
+      = t('auth.already_signedup')
+      &nbsp;
+      = link_to t('nav.user.signin'), new_session_path(resource_name)
   .row
     .span7.oauth-links
       = render "devise/shared/oauth_links"

--- a/dashboard/lib/custom_devise_failure.rb
+++ b/dashboard/lib/custom_devise_failure.rb
@@ -1,34 +1,6 @@
 # Overrides the locale for Devise failures to use the same logic as our app.
 class CustomDeviseFailure < Devise::FailureApp
-  include ActionController::Helpers
-  include ActionController::Cookies
   include LocaleHelper
-
-  def hashed_email_in_hoc_signups?(hashed_email)
-    hoc_year = DCDO.get("hoc_year", 2017)
-    PEGASUS_DB[:forms].where(hashed_email: hashed_email, kind: "HocSignup#{hoc_year}").any?
-  end
-
-  def respond
-    user_param = request.parameters['user']
-    if user_param && user_param['hashed_email']
-      hashed_email = user_param['hashed_email']
-      if failed_login? && hashed_email_in_hoc_signups?(hashed_email)
-        # If the user has a full account as well, don't use the HOC flow
-        user = User.find_by(hashed_email: hashed_email)
-        unless user
-          redirect_to "#{new_user_registration_path}?already_hoc_registered=true"
-          return
-        end
-      end
-    end
-    super
-  end
-
-  def failed_login?
-    options = request.env["warden.options"]
-    options && options[:action] == "unauthenticated"
-  end
 
   protected
 


### PR DESCRIPTION
Finishes https://codedotorg.atlassian.net/browse/XTEAM-386. This removes one of many interdependencies between dashboard server and pegasus DB. See [Separating Pegasus](https://docs.google.com/document/d/1cJUhqrsKgcR7gISkxHini3L11ngcbV9-e6-U8PdlZcY/edit#) for more details.

When a user goes to our sign up page, dashboard server checks the pegasus database to see if the user's email was used to register to host a HOC event. If it was, we show slightly different text to the user (left image). This PR removes the feature, so that all users will now see the same text (right image):

![Screen Shot 2022-07-13 at 11 28 32 AM](https://user-images.githubusercontent.com/8001765/178807720-93341e57-94fd-4df2-9aab-b0fb2ec12c1e.png)

[analysis](https://docs.google.com/spreadsheets/d/10PByx8kW3hm5GpC9EmVPRdJhr_LJIdQ7Q6VrlJNxKVI/edit#gid=0) shows that less than 0.1% of users on https://studio.code.org/users/sign-up will be affected by this change.

## Testing story

I am relying on existing test coverage for this change, since I believe our sign up page has extensive test coverage. the drone UI test failure is in javalab_code_review_v2_scenarios_eyes which is likely unrelated, but I'll wait for a green drone run before merging.