### PR TITLE
Stop `safe_load`ing CloudFormation Templates

### DIFF
--- a/lib/cdo/aws/cloud_formation.rb
+++ b/lib/cdo/aws/cloud_formation.rb
@@ -174,7 +174,12 @@ module AWS
     end
 
     def parameters(template)
-      params = YAML.safe_load(template)['Parameters']
+      # These templates include complex classes like Dates that are not
+      # supported by safe_load
+      #
+      # rubocop:disable Security/YAMLLoad
+      params = YAML.load(template)['Parameters']
+      # rubocop:enable Security/YAMLLoad
       return [] unless params
       params.map do |key, properties|
         value = CDO[key.underscore] || ENV[key.underscore.upcase]


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/47175, which broke in staging with:

```
QUIET=1 bundle exec rake stack:start
rake aborted!
Psych::DisallowedClass: Tried to load unspecified class: Date
/home/ubuntu/staging/lib/cdo/aws/cloud_formation.rb:177:in `parameters'
/home/ubuntu/staging/lib/cdo/aws/cloud_formation.rb:212:in `stack_options'
/home/ubuntu/staging/lib/cdo/aws/cloud_formation.rb:223:in `change_set_options'
/home/ubuntu/staging/lib/cdo/aws/cloud_formation.rb:88:in `change_stack'
/home/ubuntu/staging/lib/cdo/aws/cloud_formation.rb:63:in `create_or_update'
/home/ubuntu/staging/lib/rake/stack.rake:26:in `block (3 levels) in <top (required)>'
/var/lib/gems/2.5.0/gems/rake-11.3.0/exe/rake:27:in `<top (required)>'
Tasks: TOP => stack:start => stack:start:default
(See full trace by running task with --trace)
rake aborted!
```

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
