### PR TITLE
Migration to drop project_versions temp view

### DIFF
--- a/dashboard/db/migrate/20220713165055_drop_project_versions_view.rb
+++ b/dashboard/db/migrate/20220713165055_drop_project_versions_view.rb
@@ -1,0 +1,13 @@
+class DropProjectVersionsView < ActiveRecord::Migration[6.0]
+  def up
+    execute <<-SQL
+      DROP VIEW project_versions;
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+      CREATE VIEW project_versions AS SELECT * from project_commits;
+    SQL
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_01_192307) do
+ActiveRecord::Schema.define(version: 2022_07_13_165055) do
 
   create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -2246,9 +2246,6 @@ ActiveRecord::Schema.define(version: 2022_07_01_192307) do
   add_foreign_key "user_geos", "users"
   add_foreign_key "user_proficiencies", "users"
 
-  create_view "project_versions", sql_definition: <<-SQL
-      select `project_commits`.`id` AS `id`,`project_commits`.`storage_app_id` AS `storage_app_id`,`project_commits`.`object_version_id` AS `object_version_id`,`project_commits`.`comment` AS `comment`,`project_commits`.`created_at` AS `created_at`,`project_commits`.`updated_at` AS `updated_at` from `project_commits`
-  SQL
   create_view "users_view", sql_definition: <<-SQL
       select `users`.`id` AS `id`,`users`.`studio_person_id` AS `studio_person_id`,if((`users`.`provider` = 'migrated'),`authentication_options`.`email`,`users`.`email`) AS `email`,`users`.`parent_email` AS `parent_email`,`users`.`encrypted_password` AS `encrypted_password`,`users`.`reset_password_token` AS `reset_password_token`,`users`.`reset_password_sent_at` AS `reset_password_sent_at`,`users`.`remember_created_at` AS `remember_created_at`,`users`.`sign_in_count` AS `sign_in_count`,`users`.`current_sign_in_at` AS `current_sign_in_at`,`users`.`last_sign_in_at` AS `last_sign_in_at`,`users`.`current_sign_in_ip` AS `current_sign_in_ip`,`users`.`last_sign_in_ip` AS `last_sign_in_ip`,`users`.`created_at` AS `created_at`,`users`.`updated_at` AS `updated_at`,`users`.`username` AS `username`,`users`.`provider` AS `provider`,`users`.`uid` AS `UID`,`users`.`admin` AS `ADMIN`,`users`.`gender` AS `gender`,`users`.`name` AS `name`,`users`.`locale` AS `locale`,`users`.`birthday` AS `birthday`,`users`.`user_type` AS `user_type`,`users`.`school` AS `school`,`users`.`full_address` AS `full_address`,`users`.`school_info_id` AS `school_info_id`,`users`.`total_lines` AS `total_lines`,`users`.`secret_picture_id` AS `secret_picture_id`,`users`.`active` AS `active`,if((`users`.`provider` = 'migrated'),`authentication_options`.`hashed_email`,`users`.`hashed_email`) AS `hashed_email`,`users`.`deleted_at` AS `deleted_at`,`users`.`purged_at` AS `purged_at`,`users`.`secret_words` AS `secret_words`,`users`.`properties` AS `properties`,`users`.`invitation_token` AS `invitation_token`,`users`.`invitation_created_at` AS `invitation_created_at`,`users`.`invitation_sent_at` AS `invitation_sent_at`,`users`.`invitation_accepted_at` AS `invitation_accepted_at`,`users`.`invitation_limit` AS `invitation_limit`,`users`.`invited_by_id` AS `invited_by_id`,`users`.`invited_by_type` AS `invited_by_type`,`users`.`invitations_count` AS `invitations_count`,`users`.`terms_of_service_version` AS `terms_of_service_version`,`users`.`urm` AS `urm`,`users`.`races` AS `races`,`users`.`primary_contact_info_id` AS `primary_contact_info_id` from (`users` left join `authentication_options` on((`users`.`primary_contact_info_id` = `authentication_options`.`id`)))
   SQL


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This is the clean-up from the `project_versions` -> `project_commits` DB table rename. This is the migration to drop the temporary view.

Older PRs for context:
- https://github.com/code-dot-org/code-dot-org/pull/47038
- https://github.com/code-dot-org/code-dot-org/pull/47085

## Links
- jira ticket: [LP-2415](https://codedotorg.atlassian.net/browse/LP-2415)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()

-->

## Testing story
Checked locally that the temporary view is dropped. Searched through the codebase to make sure that no references to project_versions table were left.

Also left commits on CSA level after dropping the view to ensure creating and fetching commits still works as expected.
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
