### PR TITLE
Revert "Enable modules in css loader"

### DIFF
--- a/apps/webpack.js
+++ b/apps/webpack.js
@@ -136,14 +136,7 @@ var baseConfig = {
         test: /\.scss$/,
         use: [
           {loader: 'style-loader'},
-          {
-            loader: 'css-loader',
-            options: {
-              modules: {
-                auto: true // enable CSS modules for all files matching \.module\.\w+$/i.test(filename)
-              }
-            }
-          },
+          {loader: 'css-loader'},
           {
             loader: 'sass-loader',
             options: {


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#47190.  

It seemed to regress the layout of the petition and the level icons table on some pages.