### PR TITLE
Route codeprojects to dashboard

### DIFF
--- a/cookbooks/cdo-nginx/templates/default/nginx.conf.erb
+++ b/cookbooks/cdo-nginx/templates/default/nginx.conf.erb
@@ -37,7 +37,7 @@ http {
     ~:dashboard$ "dashboard";
     ~:pegasus$ "pegasus";
     # Select dashboard if 'dashboard' or 'studio' appear anywhere in the host.
-    ~(dashboard|studio).*: "dashboard";
+    ~(dashboard|studio|codeprojects).*: "dashboard";
     # Default to pegasus.
     default "pegasus";
   }


### PR DESCRIPTION
(Hopefully) finishes moving codeprojects to dashboard.

This change is largely untestable until it hits production. However, it likely will only affect the codeprojects domain and not our other domains. As codeprojects is currently only used for weblab sharing and weblab usage is down right now, this is unlikely to cause a lot of disruption.

I plan to DTP this change tomorrow afternoon (Friday, July 15) after our regular DTP. I'll close staging before I do so so that we can get a revert through quickly.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
