### PR TITLE
update maker command error using pinid

### DIFF
--- a/apps/src/lib/kits/maker/commands.js
+++ b/apps/src/lib/kits/maker/commands.js
@@ -1,13 +1,39 @@
 /** @file Maker commands (invoked by Applab/Gamelab.executeCmd) */
 import {
   apiValidateType,
-  apiValidateTypeAndRange
+  apiValidateTypeAndRange,
+  outputError
 } from '../../util/javascriptMode';
 import {BOARD_EVENT_ALIASES} from './boards/circuitPlayground/PlaygroundConstants';
 import MicroBitBoard from './boards/microBit/MicroBitBoard';
 
 /** @private {CircuitPlaygroundBoard} */
 let board;
+function isValidPin(pin) {
+  const validPins = [
+    0,
+    1,
+    2,
+    3,
+    6,
+    9,
+    10,
+    12,
+    'A0',
+    'A1',
+    'A2',
+    'A3',
+    'A4',
+    'A5',
+    'A6',
+    'A7'
+  ];
+  if (!validPins.includes(pin)) {
+    outputError(`pin ${pin} is not a valid pinid - please use a valid pinid`);
+    return false;
+  }
+  return true;
+}
 
 /**
  * Change which board controller handles Maker Toolkit commands.
@@ -24,7 +50,9 @@ export function injectBoardController(boardController) {
 export function pinMode(opts) {
   apiValidateType(opts, 'pinMode', 'pin', opts.pin, 'pinid');
   apiValidateType(opts, 'pinMode', 'mode', opts.mode, 'string');
-
+  if (!isValidPin(opts.pin)) {
+    return;
+  }
   const modeStringToConstant = {
     input: 0,
     output: 1,
@@ -51,7 +79,9 @@ export function digitalWrite(opts) {
     0,
     1
   );
-
+  if (!isValidPin(opts.pin)) {
+    return;
+  }
   board.digitalWrite(opts.pin, opts.value);
 }
 
@@ -60,7 +90,9 @@ export function digitalWrite(opts) {
  */
 export function digitalRead(opts) {
   apiValidateType(opts, 'digitalRead', 'pin', opts.pin, 'pinid');
-
+  if (!isValidPin(opts.pin)) {
+    return;
+  }
   return board.digitalRead(opts.pin, opts.callback);
 }
 
@@ -79,6 +111,9 @@ export function analogWrite(opts) {
     0,
     255
   );
+  if (!isValidPin(opts.pin)) {
+    return;
+  }
 
   board.analogWrite(opts.pin, opts.value);
 }
@@ -88,6 +123,9 @@ export function analogWrite(opts) {
  */
 export function analogRead(opts) {
   apiValidateType(opts, 'analogRead', 'pin', opts.pin, 'pinid');
+  if (!isValidPin(opts.pin)) {
+    return;
+  }
 
   return board.analogRead(opts.pin, opts.callback);
 }
@@ -121,6 +159,9 @@ export function onBoardEvent(opts) {
  */
 export function createLed(opts) {
   apiValidateType(opts, 'createLed', 'pin', opts.pin, 'pinid');
+  if (!isValidPin(opts.pin)) {
+    return;
+  }
   return board.createLed(opts.pin);
 }
 
@@ -131,6 +172,9 @@ export function createLed(opts) {
  */
 export function createButton(opts) {
   apiValidateType(opts, 'createButton', 'pin', opts.pin, 'pinid');
+  if (!isValidPin(opts.pin)) {
+    return;
+  }
   return board.createButton(opts.pin);
 }
 

--- a/apps/src/lib/kits/maker/commands.js
+++ b/apps/src/lib/kits/maker/commands.js
@@ -1,40 +1,13 @@
 /** @file Maker commands (invoked by Applab/Gamelab.executeCmd) */
 import {
   apiValidateType,
-  apiValidateTypeAndRange,
-  outputError
+  apiValidateTypeAndRange
 } from '../../util/javascriptMode';
 import {BOARD_EVENT_ALIASES} from './boards/circuitPlayground/PlaygroundConstants';
 import MicroBitBoard from './boards/microBit/MicroBitBoard';
 
 /** @private {CircuitPlaygroundBoard} */
 let board;
-
-function isValidPin(pin) {
-  const validPins = [
-    0,
-    1,
-    2,
-    3,
-    6,
-    9,
-    10,
-    12,
-    'A0',
-    'A1',
-    'A2',
-    'A3',
-    'A4',
-    'A5',
-    'A6',
-    'A7'
-  ];
-  if (!validPins.includes(pin)) {
-    outputError(`pin ${pin} is not a valid pinid - please use a valid pinid`);
-    return false;
-  }
-  return true;
-}
 
 /**
  * Change which board controller handles Maker Toolkit commands.
@@ -51,7 +24,7 @@ export function injectBoardController(boardController) {
 export function pinMode(opts) {
   apiValidateType(opts, 'pinMode', 'pin', opts.pin, 'pinid');
   apiValidateType(opts, 'pinMode', 'mode', opts.mode, 'string');
-  if (!isValidPin(opts.pin)) {
+  if (!opts.validatedTypeKey) {
     return;
   }
   const modeStringToConstant = {
@@ -79,7 +52,7 @@ export function digitalWrite(opts) {
     0,
     1
   );
-  if (!isValidPin(opts.pin)) {
+  if (!opts.validatedTypeKey) {
     return;
   }
   board.digitalWrite(opts.pin, opts.value);
@@ -90,7 +63,7 @@ export function digitalWrite(opts) {
  */
 export function digitalRead(opts) {
   apiValidateType(opts, 'digitalRead', 'pin', opts.pin, 'pinid');
-  if (!isValidPin(opts.pin)) {
+  if (!opts.validatedTypeKey) {
     return;
   }
   return board.digitalRead(opts.pin, opts.callback);
@@ -111,7 +84,7 @@ export function analogWrite(opts) {
     0,
     255
   );
-  if (!isValidPin(opts.pin)) {
+  if (!opts.validatedTypeKey) {
     return;
   }
   board.analogWrite(opts.pin, opts.value);
@@ -122,7 +95,7 @@ export function analogWrite(opts) {
  */
 export function analogRead(opts) {
   apiValidateType(opts, 'analogRead', 'pin', opts.pin, 'pinid');
-  if (!isValidPin(opts.pin)) {
+  if (!opts.validatedTypeKey) {
     return;
   }
   return board.analogRead(opts.pin, opts.callback);
@@ -157,7 +130,7 @@ export function onBoardEvent(opts) {
  */
 export function createLed(opts) {
   apiValidateType(opts, 'createLed', 'pin', opts.pin, 'pinid');
-  if (!isValidPin(opts.pin)) {
+  if (!opts.validatedTypeKey) {
     return;
   }
   return board.createLed(opts.pin);
@@ -170,7 +143,7 @@ export function createLed(opts) {
  */
 export function createButton(opts) {
   apiValidateType(opts, 'createButton', 'pin', opts.pin, 'pinid');
-  if (!isValidPin(opts.pin)) {
+  if (!opts.validatedTypeKey) {
     return;
   }
   return board.createButton(opts.pin);

--- a/apps/src/lib/kits/maker/commands.js
+++ b/apps/src/lib/kits/maker/commands.js
@@ -22,7 +22,6 @@ export function injectBoardController(boardController) {
  * @param {string} opts.mode
  */
 export function pinMode(opts) {
-  apiValidateType(opts, 'pinMode', 'mode', opts.mode, 'string');
   if (!apiValidateType(opts, 'pinMode', 'pin', opts.pin, 'pinid')) {
     return;
   }

--- a/apps/src/lib/kits/maker/commands.js
+++ b/apps/src/lib/kits/maker/commands.js
@@ -22,9 +22,8 @@ export function injectBoardController(boardController) {
  * @param {string} opts.mode
  */
 export function pinMode(opts) {
-  apiValidateType(opts, 'pinMode', 'pin', opts.pin, 'pinid');
   apiValidateType(opts, 'pinMode', 'mode', opts.mode, 'string');
-  if (!opts.validatedTypeKey) {
+  if (!apiValidateType(opts, 'pinMode', 'pin', opts.pin, 'pinid')) {
     return;
   }
   const modeStringToConstant = {
@@ -42,7 +41,9 @@ export function pinMode(opts) {
  * @param {number} opts.value
  */
 export function digitalWrite(opts) {
-  apiValidateType(opts, 'digitalWrite', 'pin', opts.pin, 'pinid');
+  if (!apiValidateType(opts, 'digitalWrite', 'pin', opts.pin, 'pinid')) {
+    return;
+  }
   apiValidateTypeAndRange(
     opts,
     'digitalWrite',
@@ -52,9 +53,6 @@ export function digitalWrite(opts) {
     0,
     1
   );
-  if (!opts.validatedTypeKey) {
-    return;
-  }
   board.digitalWrite(opts.pin, opts.value);
 }
 
@@ -62,8 +60,7 @@ export function digitalWrite(opts) {
  * @param {string|number} opts.pin
  */
 export function digitalRead(opts) {
-  apiValidateType(opts, 'digitalRead', 'pin', opts.pin, 'pinid');
-  if (!opts.validatedTypeKey) {
+  if (!apiValidateType(opts, 'digitalRead', 'pin', opts.pin, 'pinid')) {
     return;
   }
   return board.digitalRead(opts.pin, opts.callback);
@@ -74,7 +71,9 @@ export function digitalRead(opts) {
  * @param {number} opts.value
  */
 export function analogWrite(opts) {
-  apiValidateType(opts, 'analogWrite', 'pin', opts.pin, 'pinid');
+  if (!apiValidateType(opts, 'analogWrite', 'pin', opts.pin, 'pinid')) {
+    return;
+  }
   apiValidateTypeAndRange(
     opts,
     'analogWrite',
@@ -84,9 +83,6 @@ export function analogWrite(opts) {
     0,
     255
   );
-  if (!opts.validatedTypeKey) {
-    return;
-  }
   board.analogWrite(opts.pin, opts.value);
 }
 
@@ -94,8 +90,7 @@ export function analogWrite(opts) {
  * @param {string|number} opts.pin
  */
 export function analogRead(opts) {
-  apiValidateType(opts, 'analogRead', 'pin', opts.pin, 'pinid');
-  if (!opts.validatedTypeKey) {
+  if (!apiValidateType(opts, 'analogRead', 'pin', opts.pin, 'pinid')) {
     return;
   }
   return board.analogRead(opts.pin, opts.callback);
@@ -129,8 +124,7 @@ export function onBoardEvent(opts) {
  * @param {number} opts.pin
  */
 export function createLed(opts) {
-  apiValidateType(opts, 'createLed', 'pin', opts.pin, 'pinid');
-  if (!opts.validatedTypeKey) {
+  if (!apiValidateType(opts, 'createLed', 'pin', opts.pin, 'pinid')) {
     return;
   }
   return board.createLed(opts.pin);
@@ -142,8 +136,7 @@ export function createLed(opts) {
  * @param {number} opts.pin
  */
 export function createButton(opts) {
-  apiValidateType(opts, 'createButton', 'pin', opts.pin, 'pinid');
-  if (!opts.validatedTypeKey) {
+  if (!apiValidateType(opts, 'createButton', 'pin', opts.pin, 'pinid')) {
     return;
   }
   return board.createButton(opts.pin);

--- a/apps/src/lib/kits/maker/commands.js
+++ b/apps/src/lib/kits/maker/commands.js
@@ -9,6 +9,7 @@ import MicroBitBoard from './boards/microBit/MicroBitBoard';
 
 /** @private {CircuitPlaygroundBoard} */
 let board;
+
 function isValidPin(pin) {
   const validPins = [
     0,
@@ -60,7 +61,6 @@ export function pinMode(opts) {
     pwm: 3,
     servo: 4
   };
-
   board.pinMode(opts.pin, modeStringToConstant[opts.mode]);
 }
 
@@ -114,7 +114,6 @@ export function analogWrite(opts) {
   if (!isValidPin(opts.pin)) {
     return;
   }
-
   board.analogWrite(opts.pin, opts.value);
 }
 
@@ -126,7 +125,6 @@ export function analogRead(opts) {
   if (!isValidPin(opts.pin)) {
     return;
   }
-
   return board.analogRead(opts.pin, opts.callback);
 }
 

--- a/apps/src/lib/util/javascriptMode.js
+++ b/apps/src/lib/util/javascriptMode.js
@@ -48,6 +48,7 @@ export function apiValidateType(
   if (typeof opts[validatedTypeKey] === 'undefined') {
     var properType;
     var customWarning;
+    var isWarning = true;
     switch (expectedType) {
       case 'color':
         // Special handling for colors, must be a string and a valid RGBColor:
@@ -65,11 +66,15 @@ export function apiValidateType(
         break;
       case 'pinid':
         var reservedPins = ['A2', 'A3', 'A7', 1, 9, 10];
-        properType =
-          (typeof varValue === 'string' || typeof varValue === 'number') &&
-          !reservedPins.includes(varValue);
+        var validPins = [0, 2, 3, 6, 12, 'A0', 'A1', 'A4', 'A5', 'A6'];
+        properType = validPins.includes(varValue);
         if (reservedPins.includes(varValue)) {
-          customWarning = `${funcName}() ${varName} parameter value (${varValue}) is a reserved ${expectedType}. Please use a different ${expectedType}`;
+          customWarning = `${funcName}() ${varName} parameter value (${varValue}) is a reserved ${expectedType}. Please use a different ${expectedType}.`;
+        } else if (!validPins.includes(varValue)) {
+          isWarning = false;
+          outputError(
+            `pin ${varValue} is not a valid pinid. Please use a valid pinid.`
+          );
         }
         break;
       case 'number':
@@ -108,7 +113,7 @@ export function apiValidateType(
     }
     properType =
       properType || (opt === OPTIONAL && typeof varValue === 'undefined');
-    if (!properType) {
+    if (!properType && isWarning) {
       const outputValue =
         typeof varValue === 'function' ? 'function' : varValue;
       // Use the default warning message if a custom one has not been set

--- a/apps/src/lib/util/javascriptMode.js
+++ b/apps/src/lib/util/javascriptMode.js
@@ -19,11 +19,13 @@ export function injectErrorHandler(handler) {
 
 /** @see JavaScriptModeErrorHandler#outputError */
 export function outputError(...args) {
+  console.log('calling outputError  ' + args);
   errorHandler.outputError(...args);
 }
 
 /** @see JavaScriptModeErrorHandler#outputWarning */
 export function outputWarning(...args) {
+  console.log('calling outputWarning  ' + args);
   errorHandler.outputWarning(...args);
 }
 
@@ -64,16 +66,34 @@ export function apiValidateType(
           typeof varValue === 'boolean';
         break;
       case 'pinid':
+        var validPins = [
+          'A0',
+          'A1',
+          'A2',
+          'A3',
+          'A4',
+          'A5',
+          'A6',
+          'A7',
+          0,
+          1,
+          2,
+          3,
+          6,
+          9,
+          10,
+          12
+        ];
         var reservedPins = ['A2', 'A3', 'A7', 1, 9, 10];
-        var validPins = [0, 2, 3, 6, 12, 'A0', 'A1', 'A4', 'A5', 'A6'];
-        properType = validPins.includes(varValue);
-        if (reservedPins.includes(varValue)) {
-          customWarning = `${funcName}() ${varName} parameter value (${varValue}) is a reserved ${expectedType}. Please use a different ${expectedType}.`;
-        } else if (!validPins.includes(varValue)) {
+        properType =
+          validPins.includes(varValue) && !reservedPins.includes(varValue);
+        if (!validPins.includes(varValue)) {
           outputError(
-            `${funcName}() ${varName} parameter value (${varValue}) is not a valid pinid. Please use a valid pinid.`
+            `${funcName}() ${varName} parameter value (${varValue}) is not a valid ${expectedType}. Please use a different ${expectedType}.`
           );
           return false;
+        } else if (reservedPins.includes(varValue)) {
+          customWarning = `${funcName}() ${varName} parameter value (${varValue}) is a reserved ${expectedType}. Please use a different ${expectedType}.`;
         }
         break;
       case 'number':

--- a/apps/src/lib/util/javascriptMode.js
+++ b/apps/src/lib/util/javascriptMode.js
@@ -48,7 +48,6 @@ export function apiValidateType(
   if (typeof opts[validatedTypeKey] === 'undefined') {
     var properType;
     var customWarning;
-    var isWarning = true;
     switch (expectedType) {
       case 'color':
         // Special handling for colors, must be a string and a valid RGBColor:
@@ -71,10 +70,10 @@ export function apiValidateType(
         if (reservedPins.includes(varValue)) {
           customWarning = `${funcName}() ${varName} parameter value (${varValue}) is a reserved ${expectedType}. Please use a different ${expectedType}.`;
         } else if (!validPins.includes(varValue)) {
-          isWarning = false;
           outputError(
-            `pin ${varValue} is not a valid pinid. Please use a valid pinid.`
+            `pin parameter value (${varValue}) is not a valid pinid. Please use a valid pinid.`
           );
+          return false;
         }
         break;
       case 'number':
@@ -113,7 +112,7 @@ export function apiValidateType(
     }
     properType =
       properType || (opt === OPTIONAL && typeof varValue === 'undefined');
-    if (!properType && isWarning) {
+    if (!properType) {
       const outputValue =
         typeof varValue === 'function' ? 'function' : varValue;
       // Use the default warning message if a custom one has not been set

--- a/apps/src/lib/util/javascriptMode.js
+++ b/apps/src/lib/util/javascriptMode.js
@@ -71,7 +71,7 @@ export function apiValidateType(
           customWarning = `${funcName}() ${varName} parameter value (${varValue}) is a reserved ${expectedType}. Please use a different ${expectedType}.`;
         } else if (!validPins.includes(varValue)) {
           outputError(
-            `pin parameter value (${varValue}) is not a valid pinid. Please use a valid pinid.`
+            `${funcName}() ${varName} parameter value (${varValue}) is not a valid pinid. Please use a valid pinid.`
           );
           return false;
         }

--- a/apps/src/lib/util/javascriptMode.js
+++ b/apps/src/lib/util/javascriptMode.js
@@ -19,13 +19,11 @@ export function injectErrorHandler(handler) {
 
 /** @see JavaScriptModeErrorHandler#outputError */
 export function outputError(...args) {
-  console.log('calling outputError  ' + args);
   errorHandler.outputError(...args);
 }
 
 /** @see JavaScriptModeErrorHandler#outputWarning */
 export function outputWarning(...args) {
-  console.log('calling outputWarning  ' + args);
   errorHandler.outputWarning(...args);
 }
 

--- a/apps/test/unit/lib/kits/maker/commandsTest.js
+++ b/apps/test/unit/lib/kits/maker/commandsTest.js
@@ -42,7 +42,7 @@ describe('maker/commands.js', () => {
     it('display warning when reserved pin 1 is used', () => {
       pinMode({pin: 1, mode: 'input'});
       expect(errorHandler.outputWarning).to.have.been.calledWith(
-        'pinMode() pin parameter value (1) is a reserved pinid. Please use a different pinid'
+        'pinMode() pin parameter value (1) is a reserved pinid. Please use a different pinid.'
       );
     });
 

--- a/apps/test/unit/lib/kits/maker/commandsTest.js
+++ b/apps/test/unit/lib/kits/maker/commandsTest.js
@@ -49,7 +49,7 @@ describe('maker/commands.js', () => {
 
     it('display error when invalid pin 13 is used', () => {
       pinMode({pin: 13, mode: 'input'});
-      expect(
+      expect(errorHandler.outputError).to.have.been.calledWith(
         'pinMode() pin parameter value (13) is not a valid pinid. Please use a different pinid.'
       );
     });

--- a/apps/test/unit/lib/kits/maker/commandsTest.js
+++ b/apps/test/unit/lib/kits/maker/commandsTest.js
@@ -46,14 +46,14 @@ describe('maker/commands.js', () => {
         'pinMode() pin parameter value (1) is a reserved pinid. Please use a different pinid.'
       );
     });
-    
+ 
     it('display error when invalid pin 13 is used', () => {
       pinMode({pin: 13, mode: 'input'});
       expect(
         'pinMode() pin parameter value (13) is not a valid pinid. Please use a different pinid.'
       );
     });
-    
+   
     it(`maps 'input' mode to 0`, () => {
       pinMode({pin: 0, mode: 'input'});
       expect(stubBoardController.pinMode).to.have.been.calledWith(0, 0);

--- a/apps/test/unit/lib/kits/maker/commandsTest.js
+++ b/apps/test/unit/lib/kits/maker/commandsTest.js
@@ -23,7 +23,8 @@ describe('maker/commands.js', () => {
     stubBoardController = sinon.createStubInstance(FakeBoard);
     injectBoardController(stubBoardController);
     errorHandler = {
-      outputWarning: sinon.spy()
+      outputWarning: sinon.spy(),
+      outputError: sinon.spy()
     };
     injectErrorHandler(errorHandler);
   });
@@ -45,7 +46,14 @@ describe('maker/commands.js', () => {
         'pinMode() pin parameter value (1) is a reserved pinid. Please use a different pinid.'
       );
     });
-
+    
+    it('display error when invalid pin 13 is used', () => {
+      pinMode({pin: 13, mode: 'input'});
+      expect(
+        'pinMode() pin parameter value (13) is not a valid pinid. Please use a different pinid.'
+      );
+    });
+    
     it(`maps 'input' mode to 0`, () => {
       pinMode({pin: 0, mode: 'input'});
       expect(stubBoardController.pinMode).to.have.been.calledWith(0, 0);

--- a/apps/test/unit/lib/kits/maker/commandsTest.js
+++ b/apps/test/unit/lib/kits/maker/commandsTest.js
@@ -47,56 +47,56 @@ describe('maker/commands.js', () => {
     });
 
     it(`maps 'input' mode to 0`, () => {
-      pinMode({pin: 42, mode: 'input'});
-      expect(stubBoardController.pinMode).to.have.been.calledWith(42, 0);
+      pinMode({pin: 0, mode: 'input'});
+      expect(stubBoardController.pinMode).to.have.been.calledWith(0, 0);
     });
 
     it(`maps 'output' mode to 1`, () => {
-      pinMode({pin: 42, mode: 'output'});
-      expect(stubBoardController.pinMode).to.have.been.calledWith(42, 1);
+      pinMode({pin: 0, mode: 'output'});
+      expect(stubBoardController.pinMode).to.have.been.calledWith(0, 1);
     });
 
     it(`maps 'analog' mode to 2`, () => {
-      pinMode({pin: 42, mode: 'analog'});
-      expect(stubBoardController.pinMode).to.have.been.calledWith(42, 2);
+      pinMode({pin: 0, mode: 'analog'});
+      expect(stubBoardController.pinMode).to.have.been.calledWith(0, 2);
     });
 
     it(`maps 'pwm' mode to 3`, () => {
-      pinMode({pin: 42, mode: 'pwm'});
-      expect(stubBoardController.pinMode).to.have.been.calledWith(42, 3);
+      pinMode({pin: 0, mode: 'pwm'});
+      expect(stubBoardController.pinMode).to.have.been.calledWith(0, 3);
     });
 
     it(`maps 'servo' mode to 4`, () => {
-      pinMode({pin: 42, mode: 'servo'});
-      expect(stubBoardController.pinMode).to.have.been.calledWith(42, 4);
+      pinMode({pin: 0, mode: 'servo'});
+      expect(stubBoardController.pinMode).to.have.been.calledWith(0, 4);
     });
   });
 
   describe('digitalWrite(pin, value)', () => {
     it('delegates to makerBoard.digitalWrite', () => {
-      digitalWrite({pin: 22, value: 1});
-      expect(stubBoardController.digitalWrite).to.have.been.calledWith(22, 1);
+      digitalWrite({pin: 0, value: 1});
+      expect(stubBoardController.digitalWrite).to.have.been.calledWith(0, 1);
     });
   });
 
   describe('digitalRead(pin)', () => {
     it('delegates to makerBoard.digitalRead', () => {
-      digitalRead({pin: 18});
-      expect(stubBoardController.digitalRead).to.have.been.calledWith(18);
+      digitalRead({pin: 0});
+      expect(stubBoardController.digitalRead).to.have.been.calledWith(0);
     });
   });
 
   describe('analogWrite(pin, value)', () => {
     it('delegates to makerBoard.analogWrite', () => {
-      analogWrite({pin: 22, value: 33});
-      expect(stubBoardController.analogWrite).to.have.been.calledWith(22, 33);
+      analogWrite({pin: 0, value: 33});
+      expect(stubBoardController.analogWrite).to.have.been.calledWith(0, 33);
     });
   });
 
   describe('analogRead(pin)', () => {
     it('delegates to makerBoard.analogRead', () => {
-      analogRead({pin: 18});
-      expect(stubBoardController.analogRead).to.have.been.calledWith(18);
+      analogRead({pin: 0});
+      expect(stubBoardController.analogRead).to.have.been.calledWith(0);
     });
   });
 
@@ -123,8 +123,8 @@ describe('maker/commands.js', () => {
 
   describe('createButton(pin)', () => {
     it('delegates to makerBoard.createButton', () => {
-      createButton({pin: 4});
-      expect(stubBoardController.createButton).to.have.been.calledWith(4);
+      createButton({pin: 2});
+      expect(stubBoardController.createButton).to.have.been.calledWith(2);
     });
   });
 

--- a/apps/test/unit/lib/kits/maker/commandsTest.js
+++ b/apps/test/unit/lib/kits/maker/commandsTest.js
@@ -24,7 +24,7 @@ describe('maker/commands.js', () => {
     injectBoardController(stubBoardController);
     errorHandler = {
       outputWarning: sinon.spy(),
-      outputError: sinon.spy()
+      outputError: sinon.stub()
     };
     injectErrorHandler(errorHandler);
   });
@@ -46,14 +46,14 @@ describe('maker/commands.js', () => {
         'pinMode() pin parameter value (1) is a reserved pinid. Please use a different pinid.'
       );
     });
- 
+
     it('display error when invalid pin 13 is used', () => {
       pinMode({pin: 13, mode: 'input'});
       expect(
         'pinMode() pin parameter value (13) is not a valid pinid. Please use a different pinid.'
       );
     });
-   
+
     it(`maps 'input' mode to 0`, () => {
       pinMode({pin: 0, mode: 'input'});
       expect(stubBoardController.pinMode).to.have.been.calledWith(0, 0);


### PR DESCRIPTION
For Maker commands in App lab that use pin id, the only valid parameters for pin IDs are: ‘A0’ through ‘A7’ (Express) and 0, 1, 2, 3, 6, 9, 10, 12 (Classic).

An error is displayed if any string other than ‘A0’ through ‘A7’ is used. However, if an integer was used within the range of [0, 30), no error was displayed although a [warning is displayed for reserved pin ids(1, 9, 10)](https://github.com/code-dot-org/code-dot-org/pull/47052)

After this update, an error message is displayed if any pin id other than the valid ids listed above is displayed. 
However, the program does continue to run.

## Links

[jira ticket](https://codedotorg.atlassian.net/browse/STAR-2342)
[Before/after update video](https://user-images.githubusercontent.com/107423305/179080015-58f8f7ff-3888-475f-b731-22819ce8fce1.mp4)

## Testing story

Because error in pin id is caught earlier, tests needed to be modified in commandsTest.js and call on maker commands with valid pin ids. 
Also, added a test for error message for invalid pinid.

