### PR TITLE
Java lab finish button tests: skip mobile tests

### DIFF
--- a/dashboard/test/ui/features/javalab/code_review_v2_finish_button.feature
+++ b/dashboard/test/ui/features/javalab/code_review_v2_finish_button.feature
@@ -1,4 +1,5 @@
 @no_circle
+@no_mobile
 Feature: Code review V2 Finish Button
   Background:
     Given I set up code review for teacher "Code Review Teacher" with 2 students in a group


### PR DESCRIPTION
These tests should not be run on mobile since java lab is not supported on mobile.