### PR TITLE
Rename "channel id" to "encrypted project id"

### DIFF
--- a/bin/grep-applab-source
+++ b/bin/grep-applab-source
@@ -71,8 +71,8 @@ applab_channels.each_slice(MAX_THREADS) do |chunk|
       if source
         commands.each do |regex, filename|
           source.scan(regex).each do |match|
-            channel = storage_encrypt_channel_id(owner_storage_id, project_id)
-            project_url = "https://#{CDO.dashboard_hostname}/projects/applab/#{channel}/view"
+            encrypted_project_id = storage_encrypt_project_id(owner_storage_id, project_id)
+            project_url = "https://#{CDO.dashboard_hostname}/projects/applab/#{encrypted_project_id}/view"
 
             File.open(filename, 'a') do |file|
               file.flock(File::LOCK_EX)

--- a/dashboard/app/controllers/api_controller.rb
+++ b/dashboard/app/controllers/api_controller.rb
@@ -502,8 +502,8 @@ class ApiController < ApplicationController
 
     if params[:get_channel_id] == "true"
       response[:channel] = viewing_other_user ?
-        get_channel_for(level, script.id, user) :
-        get_channel_for(level, script.id)
+        get_project_for(level, script.id, user) :
+        get_project_for(level, script.id)
       response[:reduceChannelUpdates] =
         !Gatekeeper.allows("updateChannelOnSave", where: {script_name: script.name}, default: true)
     end
@@ -540,8 +540,7 @@ class ApiController < ApplicationController
         if driver_level_source_id
           response[:pairingAttempt] = edit_level_source_path(driver_level_source_id)
         elsif level.project_backed?
-          # TODO: maureen rename
-          response[:pairingChannelId] = get_channel_for(level, script.id, driver)
+          response[:pairingChannelId] = get_project_for(level, script.id, driver)
         end
       end
     end

--- a/dashboard/app/controllers/api_controller.rb
+++ b/dashboard/app/controllers/api_controller.rb
@@ -539,7 +539,8 @@ class ApiController < ApplicationController
         response[:pairingDriver] = driver.name
         if driver_level_source_id
           response[:pairingAttempt] = edit_level_source_path(driver_level_source_id)
-        elsif level.channel_backed?
+        elsif level.project_backed?
+          # TODO: maureen rename
           response[:pairingChannelId] = get_channel_for(level, script.id, driver)
         end
       end

--- a/dashboard/app/controllers/code_review_comments_controller.rb
+++ b/dashboard/app/controllers/code_review_comments_controller.rb
@@ -68,7 +68,7 @@ class CodeReviewCommentsController < ApplicationController
 
   def decrypt_channel_id
     # TO DO: handle errors in decrypting, or can't find user
-    @storage_id, @project_id = storage_decrypt_channel_id(params[:channel_id])
+    @storage_id, @project_id = storage_decrypt_project_id(params[:channel_id])
     @project_owner = User.find_by(id: user_id_for_storage_id(@storage_id))
   end
 

--- a/dashboard/app/controllers/featured_projects_controller.rb
+++ b/dashboard/app/controllers/featured_projects_controller.rb
@@ -2,7 +2,7 @@ class FeaturedProjectsController < ApplicationController
   authorize_resource
 
   def feature
-    _, project_id = storage_decrypt_channel_id(params[:project_id])
+    _, project_id = storage_decrypt_project_id(params[:project_id])
     return render_404 unless project_id
     @featured_project = FeaturedProject.find_or_create_by!(project_id: project_id)
     @featured_project.update! unfeatured_at: nil, featured_at: DateTime.now
@@ -10,7 +10,7 @@ class FeaturedProjectsController < ApplicationController
   end
 
   def unfeature
-    _, project_id = storage_decrypt_channel_id(params[:project_id])
+    _, project_id = storage_decrypt_project_id(params[:project_id])
     return render_404 unless project_id
     @featured_project = FeaturedProject.find_by! project_id: project_id
     @featured_project.update! unfeatured_at: DateTime.now

--- a/dashboard/app/controllers/project_commits_controller.rb
+++ b/dashboard/app/controllers/project_commits_controller.rb
@@ -3,7 +3,7 @@ class ProjectCommitsController < ApplicationController
 
   # POST /project_commits
   def create
-    _, project_id = storage_decrypt_channel_id(params[:storage_id])
+    _, project_id = storage_decrypt_project_id(params[:storage_id])
     project_commit = ProjectCommit.new(project_id: project_id, object_version_id: params[:version_id], comment: params[:comment])
     if project_commit.save
       return head :ok
@@ -20,7 +20,7 @@ class ProjectCommitsController < ApplicationController
 
   # GET /project_commits/:channel_id
   def project_commits
-    user_storage_id, project_id = storage_decrypt_channel_id(params[:channel_id])
+    user_storage_id, project_id = storage_decrypt_project_id(params[:channel_id])
     project_owner = User.find_by(id: user_id_for_storage_id(user_storage_id))
     return render :not_acceptable unless project_owner
     return render :forbidden unless can?(:view_project_commits, project_owner)

--- a/dashboard/app/controllers/projects_controller.rb
+++ b/dashboard/app/controllers/projects_controller.rb
@@ -195,10 +195,10 @@ class ProjectsController < ApplicationController
     @featured_project_table_rows = []
     project_featured_project_combo_data.each do |project_details|
       project_details_value = JSON.parse(project_details[:value])
-      channel = storage_encrypt_channel_id(project_details[:storage_id], project_details[:id])
+      encrypted_project_id = storage_encrypt_project_id(project_details[:storage_id], project_details[:id])
       featured_project_row = {
         projectName: project_details_value['name'],
-        channel: channel,
+        channel: encrypted_project_id,
         type: project_details[:project_type],
         topic: project_details[:topic],
         publishedAt: project_details[:published_at],

--- a/dashboard/app/controllers/report_abuse_controller.rb
+++ b/dashboard/app/controllers/report_abuse_controller.rb
@@ -23,8 +23,9 @@ class ReportAbuseController < ApplicationController
   # blocked from abuse reports because they are created internally and we know
   # they are safe. This reduces spamming of the report abuse feature.
   def protected_project?
+    # TODO: maureen rename param
     return false if params[:channel_id].blank?
-    owner_storage_id, _ = storage_decrypt_channel_id(params[:channel_id])
+    owner_storage_id, _ = storage_decrypt_project_id(params[:channel_id])
     owner_user_id = user_id_for_storage_id(owner_storage_id)
     return false unless owner_user_id
     project_owner = User.find(owner_user_id)

--- a/dashboard/app/controllers/reviewable_projects_controller.rb
+++ b/dashboard/app/controllers/reviewable_projects_controller.rb
@@ -79,9 +79,10 @@ class ReviewableProjectsController < ApplicationController
     return render json: peers_ready_for_review.map {|user| {id: user.id, name: user.name}}
   end
 
+  # TODO: maureen rename
   def decrypt_channel_id
     # TO DO: handle errors in decrypting, or can't find user
-    @storage_id, @project_id = storage_decrypt_channel_id(params[:channel_id])
+    @storage_id, @project_id = storage_decrypt_project_id(params[:channel_id])
     @project_owner = User.find_by(id: user_id_for_storage_id(@storage_id))
   end
 end

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -542,12 +542,12 @@ class ScriptLevelsController < ApplicationController
       disallowed_html_tags: disallowed_html_tags
     )
 
-    readonly_view_options if @level.channel_backed? && params[:version].present?
+    readonly_view_options if @level.project_backed? && params[:version].present?
 
     # Add video generation URL for only the last level of Dance
     # If we eventually want to add video generation for other levels or level
     # types, this is the condition that should be extended.
-    replay_video_view_options(get_channel_for(@level, @script_level.script_id, current_user)) if @level.channel_backed? && @level.is_a?(Dancelab)
+    replay_video_view_options(get_channel_for(@level, @script_level.script_id, current_user)) if @level.project_backed? && @level.is_a?(Dancelab)
 
     @@fallback_responses ||= {}
     @fallback_response = @@fallback_responses[@script_level.id] ||= {

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -547,7 +547,7 @@ class ScriptLevelsController < ApplicationController
     # Add video generation URL for only the last level of Dance
     # If we eventually want to add video generation for other levels or level
     # types, this is the condition that should be extended.
-    replay_video_view_options(get_channel_for(@level, @script_level.script_id, current_user)) if @level.project_backed? && @level.is_a?(Dancelab)
+    replay_video_view_options(get_project_for(@level, @script_level.script_id, current_user)) if @level.project_backed? && @level.is_a?(Dancelab)
 
     @@fallback_responses ||= {}
     @fallback_response = @@fallback_responses[@script_level.id] ||= {

--- a/dashboard/app/controllers/xhr_proxy_controller.rb
+++ b/dashboard/app/controllers/xhr_proxy_controller.rb
@@ -126,18 +126,18 @@ class XhrProxyController < ApplicationController
   # is an unforgeable token which identifies the app lab app which is generating the request,
   # and may be used to enforce a per-app rate-limit.
   def get
-    channel_id = params[:c]
+    encrypted_project_id = params[:c]
     url = params[:u]
 
     begin
-      owner_storage_id, _ = storage_decrypt_channel_id(channel_id)
+      owner_storage_id, _ = storage_decrypt_project_id(encrypted_project_id)
     rescue ArgumentError, OpenSSL::Cipher::CipherError => e
-      render_error_response 403, "Invalid token: '#{channel_id}' for url: '#{url}' exception: #{e.message}"
+      render_error_response 403, "Invalid token: '#{encrypted_project_id}' for url: '#{url}' exception: #{e.message}"
       return
     end
 
     event_details = {
-      channel_id: channel_id,
+      channel_id: encrypted_project_id,
       owner_storage_id: owner_storage_id,
       url: url
     }

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -87,6 +87,7 @@ module LevelsHelper
   # If given a user, find the channel associated with the given level/user.
   # Otherwise, gets the storage_id associated with the (potentially signed out)
   # current user, and either finds or creates a channel for the level
+  # TODO: maureen rename
   def get_channel_for(level, script_id = nil, user = nil)
     if user
       # "answers" are in the channel so instead of doing
@@ -107,18 +108,18 @@ module LevelsHelper
       )
     end
 
-    channel_token&.channel
+    channel_token&.encrypted_project_id
   end
 
   # If given a level, script and a user, returns whether the level
-  # has been started by the user. A channel-backed level is considered started when a
-  # channel is created for the level, which happens when the user first visits the level page.
+  # has been started by the user. A project-backed level is considered started when a
+  # project is created for the level, which happens when the user first visits the level page.
   # Other levels are considered started when progress has been saved for the level (for example
   # clicking the run button saves progress).
   def level_started?(level, script, user)
     return false unless user.present?
 
-    if level.channel_backed?
+    if level.project_backed?
       return get_channel_for(level, script.id, user).present?
     else
       user.last_attempt(level, script).present?
@@ -195,7 +196,7 @@ module LevelsHelper
     #   are channel-backed.)
     # - In edit_blocks mode, the source code is saved as a level property and
     #   is not written to the channel.
-    level_requires_channel = (@level.channel_backed? &&
+    level_requires_channel = (@level.project_backed? &&
           !@level.try(:contained_levels).present? &&
           params[:action] != 'edit_blocks')
     # Javalab requires a channel if Javabuilder needs to access project-specific assets,
@@ -292,7 +293,7 @@ module LevelsHelper
 
     if @user
       pairing_check_user = @user
-    elsif @level.channel_backed?
+    elsif @level.project_backed?
       pairing_check_user = current_user
     end
 
@@ -309,7 +310,7 @@ module LevelsHelper
         level_view_options(@level.id, pairing_driver: driver.name)
         if driver_level_source_id
           level_view_options(@level.id, pairing_attempt: edit_level_source_path(driver_level_source_id))
-        elsif @level.channel_backed?
+        elsif @level.project_backed?
           level_view_options(@level.id, pairing_channel_id: get_channel_for(@level, @script&.id, driver))
         end
       end

--- a/dashboard/app/models/backpack.rb
+++ b/dashboard/app/models/backpack.rb
@@ -26,7 +26,7 @@ class Backpack < ApplicationRecord
       # Create a project for this user's backpack
       project = Projects.new(storage_id_for_user_id(user_id))
       encrypted_id = project.create({'hidden': true}, ip: ip, type: 'backpack')
-      _, project_id = storage_decrypt_channel_id(encrypted_id)
+      _, project_id = storage_decrypt_project_id(encrypted_id)
       backpack = create!(user_id: user_id, project_id: project_id)
     end
     backpack

--- a/dashboard/app/models/backpack.rb
+++ b/dashboard/app/models/backpack.rb
@@ -32,7 +32,8 @@ class Backpack < ApplicationRecord
     backpack
   end
 
+  # TODO: maureen rename to encrypted_project_id
   def channel
-    storage_encrypt_channel_id(storage_id_for_user_id(user_id), project_id)
+    storage_encrypt_project_id(storage_id_for_user_id(user_id), project_id)
   end
 end

--- a/dashboard/app/models/channel_token.rb
+++ b/dashboard/app/models/channel_token.rb
@@ -28,8 +28,9 @@ class ChannelToken < ApplicationRecord
   # to reflect the new table name, so an alias is used to clarify which table this ID maps to.
   alias_attribute :project_id, :storage_app_id
 
+  # TODO: maureen name to encrypted_project_id
   def channel
-    storage_encrypt_channel_id(storage_id, project_id)
+    storage_encrypt_project_id(storage_id, project_id)
   end
 
   # @param [Level] level The level associated with the channel token request.

--- a/dashboard/app/models/channel_token.rb
+++ b/dashboard/app/models/channel_token.rb
@@ -28,8 +28,7 @@ class ChannelToken < ApplicationRecord
   # to reflect the new table name, so an alias is used to clarify which table this ID maps to.
   alias_attribute :project_id, :storage_app_id
 
-  # TODO: maureen name to encrypted_project_id
-  def channel
+  def encrypted_project_id
     storage_encrypt_project_id(storage_id, project_id)
   end
 

--- a/dashboard/app/models/channel_token.rb
+++ b/dashboard/app/models/channel_token.rb
@@ -57,7 +57,7 @@ class ChannelToken < ApplicationRecord
         create!(level: level.host_level, storage_id: user_storage_id, script_id: script_id) do |ct|
           # Get a new channel_id.
           channel = create_channel ip, project, data: data, standalone: false
-          _, ct.project_id = storage_decrypt_channel_id(channel)
+          _, ct.project_id = storage_decrypt_project_id(channel)
         end
       end
     end

--- a/dashboard/app/models/code_review.rb
+++ b/dashboard/app/models/code_review.rb
@@ -46,7 +46,7 @@ class CodeReview < ApplicationRecord
   def self.open_for_project?(channel:)
     return false unless channel
 
-    _, project_id = storage_decrypt_channel_id(channel)
+    _, project_id = storage_decrypt_project_id(channel)
     CodeReview.exists?(project_id: project_id, closed_at: nil)
   end
 

--- a/dashboard/app/models/featured_project.rb
+++ b/dashboard/app/models/featured_project.rb
@@ -26,14 +26,15 @@ class FeaturedProject < ApplicationRecord
   end
 
   # Determines if a project is currently featured by decrypting the provided
-  # encrypted_channel_id, using the project_id to check for a
+  # encrypted_project_id, using the project_id to check for a
   # FeaturedProject with the corresponding project_id.  If there is a
   # FeaturedProject with that project_id, check if it is currently featured.
-  # @param encrypted_channel_id [string]
+  # @param encrypted_project_id [string]
   # @return [Boolean] whether the project associated with the given
-  # encrypted_channel_id is currently featured
-  def self.featured_channel_id?(encrypted_channel_id)
-    _, project_id = storage_decrypt_channel_id encrypted_channel_id
+  # encrypted_project_id is currently featured
+  # TODO: maureen rename
+  def self.featured_channel_id?(encrypted_project_id)
+    _, project_id = storage_decrypt_project_id encrypted_project_id
     find_by(project_id: project_id)&.featured?
   rescue ArgumentError
     false

--- a/dashboard/app/models/game.rb
+++ b/dashboard/app/models/game.rb
@@ -245,7 +245,7 @@ class Game < ApplicationRecord
     [APPLAB, GAMELAB, SPRITELAB].include? app
   end
 
-  def channel_backed?
+  def project_backed?
     [APPLAB, GAMELAB, WEBLAB, PIXELATION, SPRITELAB, JAVALAB, POETRY].include? app
   end
 

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -411,14 +411,14 @@ class Level < ApplicationRecord
     end
   end
 
-  # Returns whether this level is backed by a channel, whose id may
+  # Returns whether this level is backed by a project, whose id may
   # be passed to the client, typically to save and load user progress
   # on that level.
-  def channel_backed?
+  def project_backed?
     return false if try(:is_project_level)
     free_response_upload = is_a?(FreeResponse) && allow_user_uploads
     dance_party_free_play = is_a?(Dancelab) && try(:free_play?)
-    project_template_level || free_response_upload || game.channel_backed? || dance_party_free_play
+    project_template_level || free_response_upload || game.project_backed? || dance_party_free_play
   end
 
   def key

--- a/dashboard/app/models/project.rb
+++ b/dashboard/app/models/project.rb
@@ -41,8 +41,9 @@ class Project < ApplicationRecord
     Project.find(project_id)
   end
 
+  # TODO: maureen rename this to encrypted_project_id
   def channel_id
-    storage_encrypt_channel_id(storage_id, id)
+    storage_encrypt_project_id(storage_id, id)
   end
 
   # Returns the user_id of the owner of this project. Returns nil if the project

--- a/dashboard/app/models/project.rb
+++ b/dashboard/app/models/project.rb
@@ -31,11 +31,13 @@ class Project < ApplicationRecord
   # Finds a project by channel id. Like `find`, this method raises an
   # ActiveRecord::RecordNotFound error if the corresponding project cannot
   # be found.
-  def self.find_by_channel_id(channel_id)
+  # TODO: maureen rename
+  def self.find_by_channel_id(encrypted_project_id)
     begin
-      _, project_id = storage_decrypt_channel_id(channel_id)
+      _, project_id = storage_decrypt_project_id(encrypted_project_id)
     rescue
-      raise ActiveRecord::RecordNotFound.new("Invalid channel_id: #{channel_id}")
+      # TODO: maureen, ok to rename error?
+      raise ActiveRecord::RecordNotFound.new("Invalid channel_id: #{encrypted_project_id}")
     end
 
     Project.find(project_id)

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -661,8 +661,9 @@ class User < ApplicationRecord
     end
   end
 
-  def self.find_channel_owner(encrypted_channel_id)
-    owner_storage_id, _ = storage_decrypt_channel_id(encrypted_channel_id)
+  # TODO: maureen rename
+  def self.find_channel_owner(encrypted_project_id)
+    owner_storage_id, _ = storage_decrypt_project_id(encrypted_project_id)
     user_id = user_id_for_storage_id(owner_storage_id)
     User.find(user_id)
   rescue ArgumentError, OpenSSL::Cipher::CipherError, ActiveRecord::RecordNotFound

--- a/dashboard/app/views/levels/_admin.html.haml
+++ b/dashboard/app/views/levels/_admin.html.haml
@@ -104,7 +104,7 @@
       %br/
       Project info:
       %ul
-        - owner_storage_id, project_id = storage_decrypt_channel_id(params[:channel_id]) rescue [nil, nil]
+        - owner_storage_id, project_id = storage_decrypt_project_id(params[:channel_id]) rescue [nil, nil]
         - sources_link = "https://s3.console.aws.amazon.com/s3/buckets/#{CDO.sources_s3_bucket}/#{CDO.sources_s3_directory}/#{owner_storage_id}/#{project_id}/"
         - assets_link = "https://s3.console.aws.amazon.com/s3/buckets/#{CDO.assets_s3_bucket}/#{CDO.assets_s3_directory}/#{owner_storage_id}/#{project_id}/"
         - animations_link = "https://s3.console.aws.amazon.com/s3/buckets/#{CDO.animations_s3_bucket}/#{CDO.animations_s3_directory}/#{owner_storage_id}/#{project_id}/"

--- a/dashboard/db/migrate/20170923000355_populate_storage_id.rb
+++ b/dashboard/db/migrate/20170923000355_populate_storage_id.rb
@@ -11,7 +11,7 @@ class PopulateStorageId < ActiveRecord::Migration[5.0]
       ActiveRecord::Base.transaction do
         channel_tokens_batch.each do |channel_token|
           next unless channel_token.storage_id.nil?
-          storage_id, _storage_app_id = storage_decrypt_channel_id(channel_token.channel)
+          storage_id, _storage_app_id = storage_decrypt_project_id(channel_token.channel)
           channel_token.storage_id = storage_id
           save_result = channel_token.save(touch: false)
           raise "ERROR: ID #{channel_token.id}. STORAGE_ID: #{storage_id}." unless save_result

--- a/dashboard/lib/projects_list.rb
+++ b/dashboard/lib/projects_list.rb
@@ -171,9 +171,10 @@ module ProjectsList
     #   [{channel_id: 'abc123', version: 'xyz987'}]
     #   where `version` corresponds to an S3 version of the library.
     # @return [Array<String>] The channel_ids of libraries that have been updated since the given version.
+    # TODO: maureen rename all channel references in this file
     def fetch_updated_library_channels(libraries)
       project_ids = libraries.map do |library|
-        _, id = storage_decrypt_channel_id(library['channel_id'])
+        _, id = storage_decrypt_project_id(library['channel_id'])
         library['project_id'] = id
         id
       rescue

--- a/dashboard/lib/sample_data.rb
+++ b/dashboard/lib/sample_data.rb
@@ -200,7 +200,7 @@ class SampleData
             best_result: best_result
 
           # Create a backing channel for this level if it's a type that needs it
-          if script_level.levels.first.channel_backed?
+          if script_level.levels.first.project_backed?
             ChannelToken.find_or_create_channel_token(
               script_level.levels.first,
               '127.0.0.1',

--- a/dashboard/test/controllers/api/v1/projects/public_gallery_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/projects/public_gallery_controller_test.rb
@@ -98,7 +98,7 @@ class Api::V1::Projects::PublicGalleryControllerTest < ActionController::TestCas
     assert_equal 1, categories_list.length
     project_row = categories_list['applab'].first
     assert_equal 'Charlies App', project_row['name']
-    assert_equal storage_encrypt_channel_id(22, 33), project_row['channel']
+    assert_equal storage_encrypt_project_id(22, 33), project_row['channel']
     assert_equal '/v3/files-public/charlies_thumbnail.png', project_row['thumbnailUrl']
     assert_equal 'applab', project_row['type']
     assert_equal '2017-03-03T00:00:00.000-08:00', project_row['publishedAt']
@@ -133,7 +133,7 @@ class Api::V1::Projects::PublicGalleryControllerTest < ActionController::TestCas
 
     project_row = categories_list['applab'].first
     assert_equal 'Charlies App', project_row['name']
-    assert_equal storage_encrypt_channel_id(22, 33), project_row['channel']
+    assert_equal storage_encrypt_project_id(22, 33), project_row['channel']
     assert_equal '/v3/files-public/charlies_thumbnail.png', project_row['thumbnailUrl']
     assert_equal 'applab', project_row['type']
     assert_equal '2017-03-03T00:00:00.000-08:00', project_row['publishedAt']

--- a/dashboard/test/controllers/api/v1/projects/section_projects_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/projects/section_projects_controller_test.rb
@@ -79,7 +79,7 @@ class Api::V1::Projects::SectionProjectsControllerTest < ActionController::TestC
     # This verifies that the hidden project was not shown.
     assert_equal 2, projects_list.size
     project_row = projects_list.first
-    storage_id, _ = storage_decrypt_channel_id(project_row['channel'])
+    storage_id, _ = storage_decrypt_project_id(project_row['channel'])
     assert_equal STUDENT_STORAGE_ID, storage_id
     assert_equal 'Bobs App', project_row['name']
     assert_equal @student.name, project_row['studentName']
@@ -87,7 +87,7 @@ class Api::V1::Projects::SectionProjectsControllerTest < ActionController::TestC
     assert_equal '2017-01-25T17:48:12.358-08:00', project_row['updatedAt']
 
     project_row = projects_list.last
-    storage_id, _ = storage_decrypt_channel_id(project_row['channel'])
+    storage_id, _ = storage_decrypt_project_id(project_row['channel'])
     assert_equal STUDENT_STORAGE_ID, storage_id
     assert_equal 'Bobs Other App', project_row['name']
     assert_equal @student.name, project_row['studentName']

--- a/dashboard/test/controllers/api_controller_test.rb
+++ b/dashboard/test/controllers/api_controller_test.rb
@@ -997,7 +997,7 @@ class ApiControllerTest < ActionController::TestCase
     ApiController.any_instance.stubs(:get_storage_id).returns(storage_id)
 
     channel_token = create :channel_token, level: @level, script_id: @script.id, storage_id: storage_id
-    expected_channel = channel_token.channel
+    expected_channel = channel_token.encrypted_project_id
 
     get :user_app_options, params: {
       script: @script.name,

--- a/dashboard/test/controllers/backpacks_controller_test.rb
+++ b/dashboard/test/controllers/backpacks_controller_test.rb
@@ -19,7 +19,7 @@ class BackpacksControllerTest < ActionController::TestCase
     assert_not_nil Backpack.find_by_user_id(@user.id)
     body = JSON.parse(response.body)
     channel = body['channel']
-    storage_id, project_id = storage_decrypt_channel_id(channel)
+    storage_id, project_id = storage_decrypt_project_id(channel)
     assert storage_id > 0 && project_id > 0
   end
 

--- a/dashboard/test/controllers/code_review_comments_controller_test.rb
+++ b/dashboard/test/controllers/code_review_comments_controller_test.rb
@@ -292,7 +292,7 @@ class CodeReviewCommentsControllerTest < ActionController::TestCase
   def stub_projects_calls
     CodeReviewCommentsController.
       any_instance.
-      expects(:storage_decrypt_channel_id).
+      expects(:storage_decrypt_project_id).
       with(@project_owner_channel_id).
       returns([@project_owner_storage_id, @project_id])
     CodeReviewCommentsController.

--- a/dashboard/test/controllers/featured_projects_controller_test.rb
+++ b/dashboard/test/controllers/featured_projects_controller_test.rb
@@ -11,14 +11,14 @@ class FeaturedProjectsControllerTest < ActionController::TestCase
   test 'project validators can feature projects' do
     skip 'Investigate flaky test'
     sign_in @project_validator
-    @controller.expects(:storage_decrypt_channel_id).with("789").returns([123, 654])
+    @controller.expects(:storage_decrypt_project_id).with("789").returns([123, 654])
     put :feature, params: {project_id: "789"}
     assert_response :success
   end
 
   test 'project validators can unfeature projects' do
     sign_in @project_validator
-    @controller.expects(:storage_decrypt_channel_id).with("789").returns([123, 456])
+    @controller.expects(:storage_decrypt_project_id).with("789").returns([123, 456])
     put :unfeature, params: {project_id: "789"}
     assert_response :success
   end
@@ -38,7 +38,7 @@ class FeaturedProjectsControllerTest < ActionController::TestCase
   test 'featuring a never featured project creates a new feature project' do
     skip 'Investigate flaky test'
     sign_in @project_validator
-    @controller.expects(:storage_decrypt_channel_id).with("789").returns([123, 654])
+    @controller.expects(:storage_decrypt_project_id).with("789").returns([123, 654])
     assert_creates(FeaturedProject) do
       put :feature, params: {project_id: "789"}
     end
@@ -50,7 +50,7 @@ class FeaturedProjectsControllerTest < ActionController::TestCase
   test 'featuring a currently unfeatured project should update the correct featured project' do
     skip 'Investigate flaky test'
     sign_in @project_validator
-    @controller.expects(:storage_decrypt_channel_id).with("789").returns([123, 456])
+    @controller.expects(:storage_decrypt_project_id).with("789").returns([123, 456])
     @featured_project.update! unfeatured_at: DateTime.now
     refute @featured_project.reload.featured?
     put :feature, params: {project_id: "789"}
@@ -59,7 +59,7 @@ class FeaturedProjectsControllerTest < ActionController::TestCase
 
   test 'unfeaturing a featured project should unfeature the project' do
     sign_in @project_validator
-    @controller.expects(:storage_decrypt_channel_id).with("789").returns([123, 456])
+    @controller.expects(:storage_decrypt_project_id).with("789").returns([123, 456])
     @featured_project.update! featured_at: DateTime.now
     @featured_project.update! unfeatured_at: nil
     assert @featured_project.reload.featured?

--- a/dashboard/test/controllers/project_commits_controller_test.rb
+++ b/dashboard/test/controllers/project_commits_controller_test.rb
@@ -5,7 +5,7 @@ class ProjectCommitsControllerTest < ActionController::TestCase
     student = create :student
     sign_in student
 
-    @controller.expects(:storage_decrypt_channel_id).with("abcdef").returns([123, 654])
+    @controller.expects(:storage_decrypt_project_id).with("abcdef").returns([123, 654])
     assert_creates(ProjectCommit) do
       post :create, params: {storage_id: 'abcdef', version_id: 'fghj', comment: 'This is a comment'}
     end
@@ -20,15 +20,15 @@ class ProjectCommitsControllerTest < ActionController::TestCase
 
     fake_storage_id = 123
     fake_project_id = 654
-    fake_channel_id = 'abcdef'
+    fake_encrypted_project_id = 'abcdef'
     @controller.expects(:user_id_for_storage_id).with(fake_storage_id).returns(student.id)
-    @controller.expects(:storage_decrypt_channel_id).with(fake_channel_id).returns([fake_storage_id, fake_project_id])
+    @controller.expects(:storage_decrypt_project_id).with(fake_encrypted_project_id).returns([fake_storage_id, fake_project_id])
 
     create :project_commit, project_id: fake_project_id, comment: "First comment", created_at: 2.days.ago
     create :project_commit, project_id: fake_project_id, comment: "Second comment", created_at: 1.day.ago
     create :project_commit, project_id: fake_project_id, comment: "Third comment"
 
-    get :project_commits, params: {channel_id: fake_channel_id}
+    get :project_commits, params: {channel_id: fake_encrypted_project_id}
     assert_response :ok
 
     returned_commits = JSON.parse(@response.body)
@@ -42,15 +42,15 @@ class ProjectCommitsControllerTest < ActionController::TestCase
 
     fake_storage_id = 123
     fake_project_id = 654
-    fake_channel_id = 'abcdef'
+    fake_encrypted_project_id = 'abcdef'
     @controller.expects(:user_id_for_storage_id).with(fake_storage_id).returns(student.id)
-    @controller.expects(:storage_decrypt_channel_id).with(fake_channel_id).returns([fake_storage_id, fake_project_id])
+    @controller.expects(:storage_decrypt_project_id).with(fake_encrypted_project_id).returns([fake_storage_id, fake_project_id])
 
     create :project_commit, project_id: fake_project_id, comment: "First comment", created_at: 2.days.ago
     create :project_commit, project_id: fake_project_id, comment: "", created_at: 1.day.ago
     create :project_commit, project_id: fake_project_id, comment: "Third comment"
 
-    get :project_commits, params: {channel_id: fake_channel_id}
+    get :project_commits, params: {channel_id: fake_encrypted_project_id}
     assert_response :ok
 
     returned_commits = JSON.parse(@response.body)
@@ -66,13 +66,13 @@ class ProjectCommitsControllerTest < ActionController::TestCase
 
     fake_storage_id = 123
     fake_project_id = 654
-    fake_channel_id = 'abcdef'
+    fake_encrypted_project_id = 'abcdef'
     @controller.expects(:user_id_for_storage_id).with(fake_storage_id).returns(student.id)
-    @controller.expects(:storage_decrypt_channel_id).with(fake_channel_id).returns([fake_storage_id, fake_project_id])
+    @controller.expects(:storage_decrypt_project_id).with(fake_encrypted_project_id).returns([fake_storage_id, fake_project_id])
 
     create :project_commit, project_id: fake_project_id, comment: "Third comment"
 
-    get :project_commits, params: {channel_id: fake_channel_id}
+    get :project_commits, params: {channel_id: fake_encrypted_project_id}
     assert_response :ok
   end
 
@@ -91,14 +91,14 @@ class ProjectCommitsControllerTest < ActionController::TestCase
 
     fake_storage_id = 123
     fake_project_id = 654
-    fake_channel_id = 'abcdef'
+    fake_encrypted_project_id = 'abcdef'
     @controller.expects(:user_id_for_storage_id).with(fake_storage_id).returns(project_owner_student.id)
-    @controller.expects(:storage_decrypt_channel_id).with(fake_channel_id).returns([fake_storage_id, fake_project_id])
+    @controller.expects(:storage_decrypt_project_id).with(fake_encrypted_project_id).returns([fake_storage_id, fake_project_id])
     create :reviewable_project, user_id: project_owner_student.id, project_id: fake_project_id
 
     create :project_commit, project_id: fake_project_id, comment: "Third comment"
 
-    get :project_commits, params: {channel_id: fake_channel_id}
+    get :project_commits, params: {channel_id: fake_encrypted_project_id}
     assert_response :ok
   end
 
@@ -117,14 +117,14 @@ class ProjectCommitsControllerTest < ActionController::TestCase
 
     fake_storage_id = 123
     fake_project_id = 654
-    fake_channel_id = 'abcdef'
+    fake_encrypted_project_id = 'abcdef'
     @controller.expects(:user_id_for_storage_id).with(fake_storage_id).returns(project_owner_student.id)
-    @controller.expects(:storage_decrypt_channel_id).with(fake_channel_id).returns([fake_storage_id, fake_project_id])
+    @controller.expects(:storage_decrypt_project_id).with(fake_encrypted_project_id).returns([fake_storage_id, fake_project_id])
     create :reviewable_project, user_id: project_owner_student.id, project_id: fake_project_id
 
     create :project_commit, project_id: fake_project_id, comment: "Third comment"
 
-    get :project_commits, params: {channel_id: fake_channel_id}
+    get :project_commits, params: {channel_id: fake_encrypted_project_id}
     assert_response :not_found
   end
 end

--- a/dashboard/test/controllers/reviewable_projects_controller_test.rb
+++ b/dashboard/test/controllers/reviewable_projects_controller_test.rb
@@ -5,7 +5,7 @@ class ReviewableProjectsControllerTest < ActionController::TestCase
 
   setup_all do
     @project_owner = create :student
-    @project_owner_channel_id = 'encrypted_channel_id'
+    @encrypted_project_id = 'encrypted_project_id'
     @project_level_id = 12
     @project_script_id = 34
     @project_owner_storage_id = 56
@@ -40,7 +40,7 @@ class ReviewableProjectsControllerTest < ActionController::TestCase
 
     sign_in @project_owner
     post :create, params: {
-      channel_id: @project_owner_channel_id,
+      channel_id: @encrypted_project_id,
       level_id: @project_level_id,
       script_id: @project_script_id
     }
@@ -53,7 +53,7 @@ class ReviewableProjectsControllerTest < ActionController::TestCase
 
     sign_in @teacher
     post :create, params: {
-      channel_id: @project_owner_channel_id,
+      channel_id: @encrypted_project_id,
       level_id: @project_level_id,
       script_id: @project_script_id
     }
@@ -66,7 +66,7 @@ class ReviewableProjectsControllerTest < ActionController::TestCase
 
     sign_in @teacher
     post :create, params: {
-      channel_id: @project_owner_channel_id,
+      channel_id: @encrypted_project_id,
       level_id: @project_level_id,
       script_id: @project_script_id
     }
@@ -80,7 +80,7 @@ class ReviewableProjectsControllerTest < ActionController::TestCase
     sign_in @project_owner
 
     get :reviewable_status, params: {
-      channel_id: @project_owner_channel_id,
+      channel_id: @encrypted_project_id,
       level_id: @project_level_id,
       script_id: @project_script_id
     }
@@ -106,7 +106,7 @@ class ReviewableProjectsControllerTest < ActionController::TestCase
       script_id: @project_script_id
 
     get :reviewable_status, params: {
-      channel_id: @project_owner_channel_id,
+      channel_id: @encrypted_project_id,
       level_id: @project_level_id,
       script_id: @project_script_id
     }
@@ -127,7 +127,7 @@ class ReviewableProjectsControllerTest < ActionController::TestCase
     sign_in @another_student
 
     get :reviewable_status, params: {
-      channel_id: @project_owner_channel_id,
+      channel_id: @encrypted_project_id,
       level_id: @project_level_id,
       script_id: @project_script_id
     }
@@ -154,7 +154,7 @@ class ReviewableProjectsControllerTest < ActionController::TestCase
       script_id: @project_script_id
 
     get :reviewable_status, params: {
-      channel_id: @project_owner_channel_id,
+      channel_id: @encrypted_project_id,
       level_id: @project_level_id,
       script_id: @project_script_id
     }
@@ -242,8 +242,8 @@ class ReviewableProjectsControllerTest < ActionController::TestCase
   def stub_projects_calls
     ReviewableProjectsController.
       any_instance.
-      expects(:storage_decrypt_channel_id).
-      with(@project_owner_channel_id).
+      expects(:storage_decrypt_project_id).
+      with(@encrypted_project_id).
       returns([@project_owner_storage_id, @project_id])
     ReviewableProjectsController.
       any_instance.

--- a/dashboard/test/controllers/xhr_proxy_controller_test.rb
+++ b/dashboard/test/controllers/xhr_proxy_controller_test.rb
@@ -14,12 +14,12 @@ class XhrProxyControllerTest < ActionController::TestCase
     @user = create :user
     sign_in @user
     stub_storage_id_for_user_id(@user.id)
-    @channel_id = storage_encrypt_channel_id(storage_id_for_user_id(@user.id), 123)
+    @encrypted_project_id = storage_encrypt_project_id(storage_id_for_user_id(@user.id), 123)
   end
 
   test "should fetch proxied media with correct content type" do
     stub_request(:get, XHR_URI).to_return(body: XHR_DATA, headers: {content_type: XHR_CONTENT_TYPE})
-    get :get, params: {u: XHR_URI, c: @channel_id}
+    get :get, params: {u: XHR_URI, c: @encrypted_project_id}
     assert_response :success
     assert_equal XHR_CONTENT_TYPE, response.content_type
     cache_control = response['Cache-Control']
@@ -32,7 +32,7 @@ class XhrProxyControllerTest < ActionController::TestCase
 
   test "should handle query parameters" do
     stub_request(:get, XHR_URI).to_return(body: XHR_DATA, headers: {content_type: XHR_CONTENT_TYPE})
-    get :get, params: {u: XHR_URI, c: @channel_id}
+    get :get, params: {u: XHR_URI, c: @encrypted_project_id}
     assert_response :success
     assert_equal XHR_DATA, response.body
   end
@@ -41,7 +41,7 @@ class XhrProxyControllerTest < ActionController::TestCase
     CDO.stubs(:newrelic_logging).returns(true) do
       stub_request(:get, XHR_URI).to_return(body: XHR_DATA, headers: {content_type: XHR_CONTENT_TYPE})
       assert NewRelic::Agent.events.empty?, 'no custom events initially recorded'
-      get :get, params: {u: XHR_URI, c: @channel_id}
+      get :get, params: {u: XHR_URI, c: @encrypted_project_id}
       assert_response :success
       assert NewRelic::Agent.events.length == 1, 'one custom event recorded'
       assert NewRelic::Agent.events[0].first == 'XhrProxyControllerRequest', 'XhrProxyControllerRequest event recorded'
@@ -55,7 +55,7 @@ class XhrProxyControllerTest < ActionController::TestCase
     stub_request(:get, XHR_URI).to_return(
       body: XHR_DATA, headers: {content_type: XHR_CONTENT_TYPE}
     )
-    get :get, params: {u: XHR_REDIRECT_URI, c: @channel_id}
+    get :get, params: {u: XHR_REDIRECT_URI, c: @encrypted_project_id}
     assert_response :success
     assert_equal XHR_DATA, response.body
   end
@@ -63,7 +63,7 @@ class XhrProxyControllerTest < ActionController::TestCase
   test "should fail if invalid URL" do
     stub_request(:get, XHR_URI).to_return(body: XHR_DATA, headers: {content_type: XHR_CONTENT_TYPE})
     bad_uri = '/foo'
-    get :get, params: {u: bad_uri, c: @channel_id}
+    get :get, params: {u: bad_uri, c: @encrypted_project_id}
     assert_response 400
   end
 
@@ -77,26 +77,26 @@ class XhrProxyControllerTest < ActionController::TestCase
       response,
       response
     )
-    get :get, params: {u: XHR_URI, c: @channel_id}
+    get :get, params: {u: XHR_URI, c: @encrypted_project_id}
     assert_response 500
   end
 
   test "should fail on unauthorized content types" do
     stub_request(:get, XHR_URI).to_return(body: XHR_DATA, headers: {content_type: 'text/html'})
-    get :get, params: {u: XHR_URI, c: @channel_id}
+    get :get, params: {u: XHR_URI, c: @encrypted_project_id}
     assert_response 400
   end
 
   test "should succeed on text/plain content type" do
     stub_request(:get, XHR_URI).to_return(body: XHR_DATA, headers: {content_type: 'text/plain'})
-    get :get, params: {u: XHR_URI, c: @channel_id}
+    get :get, params: {u: XHR_URI, c: @encrypted_project_id}
     assert_response 200
   end
 
   test "should fail with ec2.internal hostname suffix" do
     url = 'https://ip-192.168.0.1.ec2.internal/my/secret/api'
     stub_request(:get, url).to_return(body: XHR_DATA, headers: {content_type: XHR_CONTENT_TYPE})
-    get :get, params: {u: url, c: @channel_id}
+    get :get, params: {u: url, c: @encrypted_project_id}
     assert_response 400
   end
 
@@ -104,20 +104,20 @@ class XhrProxyControllerTest < ActionController::TestCase
   test "should fail with wikipediaXorg hostname suffix" do
     url = 'https://www.wikipediaXorg/foo?a=1&b=2'
     stub_request(:get, url).to_return(body: XHR_DATA, headers: {content_type: XHR_CONTENT_TYPE})
-    get :get, params: {u: url, c: @channel_id}
+    get :get, params: {u: url, c: @encrypted_project_id}
     assert_response 400
   end
 
   test "should fail with wikipedia.org.evil hostname suffix" do
     url = 'https://www.wikipedia.org.evil/foo?a=1&b=2'
     stub_request(:get, url).to_return(body: XHR_DATA, headers: {content_type: XHR_CONTENT_TYPE})
-    get :get, params: {u: url, c: @channel_id}
+    get :get, params: {u: url, c: @encrypted_project_id}
     assert_response 400
   end
 
   test "should pass through server errors" do
     stub_request(:get, XHR_URI).to_return(body: XHR_DATA, headers: {content_type: XHR_CONTENT_TYPE}, status: 503)
-    get :get, params: {u: XHR_URI, c: @channel_id}
+    get :get, params: {u: XHR_URI, c: @encrypted_project_id}
     assert_response 503
   end
 

--- a/dashboard/test/helpers/delete_accounts_helper_test.rb
+++ b/dashboard/test/helpers/delete_accounts_helper_test.rb
@@ -1970,10 +1970,10 @@ class DeleteAccountsHelperTest < ActionView::TestCase
 
         bucket.any_instance.
           expects(:hard_delete_channel_content).
-          with(storage_encrypt_channel_id(storage_id, project_id_a))
+          with(storage_encrypt_project_id(storage_id, project_id_a))
         bucket.any_instance.
           expects(:hard_delete_channel_content).
-          with(storage_encrypt_channel_id(storage_id, project_id_b))
+          with(storage_encrypt_project_id(storage_id, project_id_b))
 
         purge_user student
       end
@@ -1991,8 +1991,8 @@ class DeleteAccountsHelperTest < ActionView::TestCase
       with_channel_for student do |project_id_b, storage_id|
         projects_table.where(id: project_id_a).update(state: 'deleted')
 
-        student_channels = [storage_encrypt_channel_id(storage_id, project_id_a),
-                            storage_encrypt_channel_id(storage_id, project_id_b)]
+        student_channels = [storage_encrypt_project_id(storage_id, project_id_a),
+                            storage_encrypt_project_id(storage_id, project_id_b)]
         FirebaseHelper.
           expects(:delete_channels).
           with(student_channels)

--- a/dashboard/test/helpers/levels_helper_test.rb
+++ b/dashboard/test/helpers/levels_helper_test.rb
@@ -334,7 +334,7 @@ class LevelsHelperTest < ActionView::TestCase
     assert_equal true, app_options['levelRequiresChannel']
   end
 
-  test 'get_channel_for sets a channel' do
+  test 'get_project_for sets an encrypted_project_id' do
     user = create :user
     sign_in user
 
@@ -342,13 +342,13 @@ class LevelsHelperTest < ActionView::TestCase
     level = create(:level, :blockly)
     create(:script_level, script: script, levels: [@level, level])
 
-    channel = get_channel_for(@level, script.id)
-    # Request it again, should get the same channel
-    assert_equal channel, get_channel_for(@level, script.id)
+    encrypted_project_id = get_project_for(@level, script.id)
+    # Request it again, should get the same encrypted_project_id
+    assert_equal encrypted_project_id, get_project_for(@level, script.id)
 
-    # Request it for a different level, should get a different channel
+    # Request it for a different level, should get a different encrypted_project_id
     level = create(:level, :blockly)
-    assert_not_equal channel, get_channel_for(level, script.id)
+    assert_not_equal encrypted_project_id, get_project_for(level, script.id)
   end
 
   test 'uses_google_blockly is false if not set' do
@@ -404,8 +404,8 @@ class LevelsHelperTest < ActionView::TestCase
     @level = create :applab
     create(:script_level, script: script, levels: [@level])
 
-    # channel does not exist
-    assert_nil get_channel_for(@level, script.id, @user)
+    # channel does not exist to fetch project
+    assert_nil get_project_for(@level, script.id, @user)
   end
 
   test 'applab levels should load channel when viewing student solution of a student with a channel' do
@@ -418,9 +418,9 @@ class LevelsHelperTest < ActionView::TestCase
     @level = create :applab
     create(:script_level, script: script, levels: [@level])
 
-    # channel exists
+    # channel exists to fetch project
     create :channel_token, level: @level, storage_id: fake_storage_id_for_user_id(@user.id)
-    assert_not_nil get_channel_for(@level, script.id, @user)
+    assert_not_nil get_project_for(@level, script.id, @user)
 
     # calling app_options should set readonly_workspace, since we're viewing for
     # different user
@@ -428,7 +428,7 @@ class LevelsHelperTest < ActionView::TestCase
     assert_equal true, view_options[:readonly_workspace]
   end
 
-  test 'readonly workspace should be set if the level is channel-backed and a code review is open for the project' do
+  test 'readonly workspace should be set if the level is project-backed and a code review is open for the project' do
     @user = create :user
     sign_in @user
     stub_storage_id_for_user_id(@user.id)
@@ -438,10 +438,10 @@ class LevelsHelperTest < ActionView::TestCase
     create(:script_level, script: script, levels: [@level])
 
     create :channel_token, level: @level, storage_id: fake_storage_id_for_user_id(@user.id)
-    @channel_id = get_channel_for(@level, script.id, @user)
-    assert_not_nil @channel_id
+    @encrypted_project_id = get_project_for(@level, script.id, @user)
+    assert_not_nil @encrypted_project_id
 
-    _,  @project_id = storage_decrypt_project_id(@channel_id)
+    _,  @project_id = storage_decrypt_project_id(@encrypted_project_id)
     create :code_review, user_id: @user.id, project_id: @project_id
 
     # calling app_options should set readonly_workspace, since a code review is open

--- a/dashboard/test/helpers/levels_helper_test.rb
+++ b/dashboard/test/helpers/levels_helper_test.rb
@@ -24,7 +24,7 @@ class LevelsHelperTest < ActionView::TestCase
 
     stubs(:current_user).returns nil
     stub_get_storage_id(nil)
-    stubs(:storage_decrypt_channel_id).returns([123, 456])
+    stubs(:storage_decrypt_project_id).returns([123, 456])
   end
 
   test "blockly_options refuses to generate options for non-blockly levels" do
@@ -441,7 +441,7 @@ class LevelsHelperTest < ActionView::TestCase
     @channel_id = get_channel_for(@level, script.id, @user)
     assert_not_nil @channel_id
 
-    _,  @project_id = storage_decrypt_channel_id(@channel_id)
+    _,  @project_id = storage_decrypt_project_id(@channel_id)
     create :code_review, user_id: @user.id, project_id: @project_id
 
     # calling app_options should set readonly_workspace, since a code review is open

--- a/dashboard/test/lib/projects_list_test.rb
+++ b/dashboard/test/lib/projects_list_test.rb
@@ -420,11 +420,11 @@ class ProjectsListTest < ActionController::TestCase
   end
 
   test 'fetch_updated_library_channels returns channel_ids of libraries that have been updated' do
-    updated_channel_id = storage_encrypt_channel_id(1, 1)
+    updated_encrypted_project_id = storage_encrypt_project_id(1, 1)
     libraries = [
-      {'channel_id' => updated_channel_id, 'version' => '1'},
-      {'channel_id' => storage_encrypt_channel_id(1, 2), 'version' => '1'},
-      {'channel_id' => storage_encrypt_channel_id(1, 3), 'version' => '1'}
+      {'channel_id' => updated_encrypted_project_id, 'version' => '1'},
+      {'channel_id' => storage_encrypt_project_id(1, 2), 'version' => '1'},
+      {'channel_id' => storage_encrypt_project_id(1, 3), 'version' => '1'}
     ]
     stub_projects = [
       {
@@ -443,8 +443,9 @@ class ProjectsListTest < ActionController::TestCase
 
     Projects.stubs(:table).returns(stub(where: stub_projects))
 
-    updated_channel_ids = ProjectsList.fetch_updated_library_channels(libraries)
-    assert_equal [updated_channel_id], updated_channel_ids
+    # TODO: maureen update ProjectsList method
+    updated_encrypted_project_ids = ProjectsList.fetch_updated_library_channels(libraries)
+    assert_equal [updated_encrypted_project_id], updated_encrypted_project_ids
   end
 
   test 'fetch_updated_library_channels returns empty array if no libraries given' do

--- a/dashboard/test/models/channel_token_test.rb
+++ b/dashboard/test/models/channel_token_test.rb
@@ -21,7 +21,7 @@ class ChannelTokenTest < ActiveSupport::TestCase
       @script.id
     )
 
-    storage_id, storage_app_id = storage_decrypt_channel_id(channel_token.channel)
+    storage_id, storage_app_id = storage_decrypt_project_id(channel_token.channel)
     assert_equal storage_id, channel_token.storage_id
     assert_equal storage_app_id, channel_token.storage_app_id
   end

--- a/dashboard/test/models/channel_token_test.rb
+++ b/dashboard/test/models/channel_token_test.rb
@@ -21,7 +21,7 @@ class ChannelTokenTest < ActiveSupport::TestCase
       @script.id
     )
 
-    storage_id, storage_app_id = storage_decrypt_project_id(channel_token.channel)
+    storage_id, storage_app_id = storage_decrypt_project_id(channel_token.encrypted_project_id)
     assert_equal storage_id, channel_token.storage_id
     assert_equal storage_app_id, channel_token.storage_app_id
   end

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -4605,16 +4605,17 @@ class UserTest < ActiveSupport::TestCase
   test 'find_channel_owner finds channel owner' do
     student = create :student
     with_channel_for student do |project_id, storage_id|
-      encrypted_channel_id = storage_encrypt_channel_id storage_id, project_id
-      result = User.find_channel_owner encrypted_channel_id
+      encrypted_project_id = storage_encrypt_project_id storage_id, project_id
+      result = User.find_channel_owner encrypted_project_id
       assert_equal student, result
     end
   end
 
   test 'find_channel_owner returns nil for channel with no owner' do
     with_anonymous_channel do |project_id, storage_id|
-      encrypted_channel_id = storage_encrypt_channel_id storage_id, project_id
-      result = User.find_channel_owner encrypted_channel_id
+      encrypted_project_id = storage_encrypt_project_id storage_id, project_id
+      # TODO: maureen update User method with channel reference
+      result = User.find_channel_owner encrypted_project_id
       assert_nil result
     end
   end

--- a/dashboard/test/test_helper.rb
+++ b/dashboard/test/test_helper.rb
@@ -627,7 +627,7 @@ class Projects
   def create(_, _)
     # project_id must be an integer > 0
     project_id = 1 + SecureRandom.random_number(100000)
-    storage_encrypt_channel_id(@storage_id, project_id)
+    storage_encrypt_project_id(@storage_id, project_id)
   end
 
   def most_recent(_)

--- a/dashboard/test/testing/projects_test_utils.rb
+++ b/dashboard/test/testing/projects_test_utils.rb
@@ -5,10 +5,11 @@ require_relative '../../../shared/middleware/helpers/storage_id'
 # To be included in any dashboard test that needs them.
 module ProjectsTestUtils
   # @param [User] owner - may be nil for anonymous channel
+  # TODO: maureen rename
   def with_channel_for(owner)
     with_storage_id_for owner do |storage_id|
-      encrypted_channel_id = Projects.new(storage_id).create({projectType: 'applab'}, ip: 123)
-      _, project_id = storage_decrypt_channel_id encrypted_channel_id
+      encrypted_project_id = Projects.new(storage_id).create({projectType: 'applab'}, ip: 123)
+      _, project_id = storage_decrypt_project_id encrypted_project_id
       yield project_id, storage_id
     ensure
       projects_table.where(id: project_id).delete if project_id

--- a/lib/cdo/delete_accounts_helper.rb
+++ b/lib/cdo/delete_accounts_helper.rb
@@ -36,9 +36,9 @@ class DeleteAccountsHelper
     @log.puts "Deleting project backed progress"
 
     project_ids = Projects.table.where(storage_id: user.user_storage_id).map(:id)
-    channel_count = project_ids.count
-    encrypted_channel_ids = project_ids.map do |project_id|
-      storage_encrypt_channel_id user.user_storage_id, project_id
+    project_count = project_ids.count
+    encrypted_project_ids = project_ids.map do |project_id|
+      storage_encrypt_project_id user.user_storage_id, project_id
     end
 
     # Clear potential PII from user's channels
@@ -54,17 +54,18 @@ class DeleteAccountsHelper
     @log.puts "Cleared #{project_commits.count} ProjectCommit comments" if project_commits.count > 0
 
     # Clear S3 contents for user's channels
-    @log.puts "Deleting S3 contents for #{channel_count} channels"
+    @log.puts "Deleting S3 contents for #{project_count} channels"
     buckets = [SourceBucket, AssetBucket, AnimationBucket, FileBucket].map(&:new)
-    buckets.product(encrypted_channel_ids).each do |bucket, encrypted_channel_id|
-      bucket.hard_delete_channel_content encrypted_channel_id
+    buckets.product(encrypted_project_ids).each do |bucket, encrypted_project_id|
+      bucket.hard_delete_channel_content encrypted_project_id
     end
 
     # Clear Firebase contents for user's channels
-    @log.puts "Deleting Firebase contents for #{channel_count} channels"
-    FirebaseHelper.delete_channels encrypted_channel_ids
+    # TODO: maureen do we want to keep logging as 'channels'?
+    @log.puts "Deleting Firebase contents for #{project_count} channels"
+    FirebaseHelper.delete_channels encrypted_project_ids
 
-    @log.puts "Deleted #{channel_count} channels" if channel_count > 0
+    @log.puts "Deleted #{project_count} channels" if project_count > 0
   end
 
   # Removes the link between the user's level-backed progress and the progress itself.

--- a/shared/middleware/channels_api.rb
+++ b/shared/middleware/channels_api.rb
@@ -193,8 +193,9 @@ class ChannelsApi < Sinatra::Base
   #
   # Marks the specified channel as published.
   #
+  # TODO: maureen what to do about these APIs
   post %r{/v3/channels/([^/]+)/publish/([^/]+)} do |channel_id, project_type|
-    not_authorized unless owns_channel?(channel_id)
+    not_authorized unless owns_project?(channel_id)
     bad_request unless ALL_PUBLISHABLE_PROJECT_TYPES.include?(project_type)
     forbidden if sharing_disabled? && !ALWAYS_PUBLISHABLE_PROJECT_TYPES.include?(project_type)
 
@@ -209,7 +210,7 @@ class ChannelsApi < Sinatra::Base
   # Marks the specified channel as no longer published.
   #
   post %r{/v3/channels/([^/]+)/unpublish} do |channel_id|
-    not_authorized unless owns_channel?(channel_id)
+    not_authorized unless owns_project?(channel_id)
     Projects.new(get_storage_id).unpublish(channel_id)
     {publishedAt: nil}.to_json
   end

--- a/shared/middleware/channels_api.rb
+++ b/shared/middleware/channels_api.rb
@@ -67,7 +67,7 @@ class ChannelsApi < Sinatra::Base
     project = Projects.new(get_storage_id)
 
     begin
-      _, remix_parent_id = storage_decrypt_channel_id(request.GET['parent']) if request.GET['parent']
+      _, remix_parent_id = storage_decrypt_project_id(request.GET['parent']) if request.GET['parent']
     rescue ArgumentError, OpenSSL::Cipher::CipherError
       bad_request
     end

--- a/shared/middleware/files_api.rb
+++ b/shared/middleware/files_api.rb
@@ -172,7 +172,7 @@ class FilesApi < Sinatra::Base
   # Deprecated in favor of the URL below
   #
   get %r{/([^/]+)/([^/]+)$}, {code_projects_domain: true} do |encrypted_project_id, filename|
-    pass unless valid_encrypted_channel_id(encrypted_project_id)
+    pass unless valid_encrypted_project_id(encrypted_project_id)
 
     get_file('files', encrypted_project_id, filename, true)
   end
@@ -185,7 +185,7 @@ class FilesApi < Sinatra::Base
   #
   get %r{/projects/([a-z]+)/([^/]+)/([^/]+)$}, {code_projects_domain: true} do |project_type, encrypted_project_id, filename|
     not_found unless project_type == 'weblab'
-    pass unless valid_encrypted_channel_id(encrypted_project_id)
+    pass unless valid_encrypted_project_id(encrypted_project_id)
 
     get_file('files', encrypted_project_id, filename, true)
   end
@@ -198,7 +198,7 @@ class FilesApi < Sinatra::Base
   # Deprecated in favor of the URL below
   #
   get %r{/([^/]+)$}, {code_projects_domain: true} do |encrypted_project_id|
-    pass unless valid_encrypted_channel_id(encrypted_project_id)
+    pass unless valid_encrypted_project_id(encrypted_project_id)
 
     redirect "#{request.path_info}/"
   end
@@ -211,7 +211,7 @@ class FilesApi < Sinatra::Base
   #
   get %r{/projects/([a-z]+)/([^/]+)$}, {code_projects_domain: true} do |project_type, encrypted_project_id|
     not_found unless project_type == 'weblab'
-    pass unless valid_encrypted_channel_id(encrypted_project_id)
+    pass unless valid_encrypted_project_id(encrypted_project_id)
 
     redirect "#{request.path_info}/"
   end
@@ -224,7 +224,7 @@ class FilesApi < Sinatra::Base
   # Deprecated in favor of the URL below
   #
   get %r{/([^/]+)/$}, {code_projects_domain: true} do |encrypted_project_id|
-    pass unless valid_encrypted_channel_id(encrypted_project_id)
+    pass unless valid_encrypted_project_id(encrypted_project_id)
 
     get_file('files', encrypted_project_id, 'index.html', true)
   end
@@ -238,7 +238,7 @@ class FilesApi < Sinatra::Base
   #
   get %r{/projects/([a-z]+)/([^/]+)/$}, {code_projects_domain: true} do |project_type, encrypted_project_id|
     not_found unless project_type == 'weblab'
-    pass unless valid_encrypted_channel_id(encrypted_project_id)
+    pass unless valid_encrypted_project_id(encrypted_project_id)
 
     get_file('files', encrypted_project_id, 'index.html', true)
   end

--- a/shared/middleware/files_api.rb
+++ b/shared/middleware/files_api.rb
@@ -43,7 +43,7 @@ class FilesApi < Sinatra::Base
   end
 
   def can_view_abusive_assets?(encrypted_project_id)
-    return true if owns_channel?(encrypted_project_id) || admin? || has_permission?('project_validator')
+    return true if owns_project?(encrypted_project_id) || admin? || has_permission?('project_validator')
 
     # teachers can see abusive assets of their students
     owner_storage_id, _ = storage_decrypt_project_id(encrypted_project_id)
@@ -68,7 +68,7 @@ class FilesApi < Sinatra::Base
   end
 
   def can_view_profane_or_pii_assets?(encrypted_project_id)
-    owns_channel?(encrypted_project_id) || admin? || has_permission?('project_validator')
+    owns_project?(encrypted_project_id) || admin? || has_permission?('project_validator')
   end
 
   def file_too_large(quota_type)
@@ -300,7 +300,7 @@ class FilesApi < Sinatra::Base
   # We should sanitize all sources created by under-13 users unless it is the
   # user themselves requesting to view the source
   def should_sanitize_for_under_13?(encrypted_project_id)
-    return false if owns_channel?(encrypted_project_id)
+    return false if owns_project?(encrypted_project_id)
 
     owner_storage_id, _ = storage_decrypt_project_id(encrypted_project_id)
     owner_id = user_id_for_storage_id(owner_storage_id)
@@ -410,7 +410,7 @@ class FilesApi < Sinatra::Base
   end
 
   def put_file(endpoint, encrypted_project_id, filename, body)
-    not_authorized unless owns_channel?(encrypted_project_id)
+    not_authorized unless owns_project?(encrypted_project_id)
     file_type = File.extname(filename)
     buckets = get_bucket_impl(endpoint).new
     if body.length >= max_file_size
@@ -520,7 +520,7 @@ class FilesApi < Sinatra::Base
   # @return [String] JSON containing details for new file
   #
   def copy_file(endpoint, encrypted_project_id, filename, source_filename)
-    not_authorized unless owns_channel?(encrypted_project_id)
+    not_authorized unless owns_project?(encrypted_project_id)
 
     buckets = get_bucket_impl(endpoint).new
     bad_request unless buckets.allowed_file_name? filename
@@ -673,7 +673,7 @@ class FilesApi < Sinatra::Base
   delete %r{/v3/(animations|assets|sources|libraries)/([^/]+)/([^/]+)$} do |endpoint, encrypted_project_id, filename|
     dont_cache
 
-    not_authorized unless owns_channel?(encrypted_project_id)
+    not_authorized unless owns_project?(encrypted_project_id)
 
     get_bucket_impl(endpoint).new.delete(encrypted_project_id, filename)
     no_content
@@ -702,7 +702,7 @@ class FilesApi < Sinatra::Base
     dont_cache
     content_type :json
 
-    not_authorized unless owns_channel?(encrypted_project_id)
+    not_authorized unless owns_project?(encrypted_project_id)
 
     SourceBucket.new.restore_previous_version(encrypted_project_id, filename, request.GET['version'], current_user_id).to_json
   end
@@ -872,7 +872,7 @@ class FilesApi < Sinatra::Base
     dont_cache
     content_type :json
 
-    not_authorized unless owns_channel?(encrypted_project_id)
+    not_authorized unless owns_project?(encrypted_project_id)
 
     # read the manifest
     bucket = FileBucket.new
@@ -896,7 +896,7 @@ class FilesApi < Sinatra::Base
 
     bad_request if filename.downcase == FileBucket::MANIFEST_FILENAME
 
-    not_authorized unless owns_channel?(encrypted_project_id)
+    not_authorized unless owns_project?(encrypted_project_id)
 
     # read the manifest
     bucket = FileBucket.new
@@ -941,7 +941,7 @@ class FilesApi < Sinatra::Base
     dont_cache
     content_type :json
 
-    not_authorized unless owns_channel?(encrypted_project_id)
+    not_authorized unless owns_project?(encrypted_project_id)
 
     # read the manifest using the version-id specified
     bucket = FileBucket.new
@@ -1075,7 +1075,7 @@ class FilesApi < Sinatra::Base
     bad_request unless METADATA_FILENAMES.include? filename
     filename = "#{METADATA_PATH}/#{filename}"
 
-    not_authorized unless owns_channel?(encrypted_project_id)
+    not_authorized unless owns_project?(encrypted_project_id)
 
     FileBucket.new.delete(encrypted_project_id, filename)
     no_content

--- a/shared/middleware/helpers/asset_bucket.rb
+++ b/shared/middleware/helpers/asset_bucket.rb
@@ -37,8 +37,8 @@ class AssetBucket < BucketHelper
     3600
   end
 
-  def copy_level_starter_assets(src_channel, dest_channel)
-    src_owner_id, src_storage_app_id = storage_decrypt_channel_id(src_channel)
+  def copy_level_starter_assets(src_encrypted_project_id, dest_encrypted_project_id)
+    src_owner_id, src_storage_app_id = storage_decrypt_project_id(src_encrypted_project_id)
 
     channel = ChannelToken.find_by(storage_id: src_owner_id, storage_app_id: src_storage_app_id)
     return unless channel
@@ -46,7 +46,7 @@ class AssetBucket < BucketHelper
     level = Level.cache_find(channel.level_id)
     return unless level
 
-    dest_owner_id, dest_storage_app_id = storage_decrypt_channel_id(dest_channel)
+    dest_owner_id, dest_storage_app_id = storage_decrypt_project_id(dest_encrypted_project_id)
 
     (level&.project_template_level&.starter_assets || level.starter_assets || []).map do |friendly_name, uuid_name|
       src = "#{@bucket}/#{LevelStarterAssetsController::S3_PREFIX}#{uuid_name}"

--- a/shared/middleware/helpers/file_bucket.rb
+++ b/shared/middleware/helpers/file_bucket.rb
@@ -52,9 +52,9 @@ class FileBucket < BucketHelper
   # Generates a direct link to the requested file on s3, with a default 5-minute
   # expiration.
   #
-  def make_temporary_public_url(encrypted_channel_id, filename, expires_in = 5.minutes)
-    owner_id, storage_app_id = storage_decrypt_channel_id(encrypted_channel_id)
-    key = s3_path owner_id, storage_app_id, filename
+  def make_temporary_public_url(encrypted_project_id, filename, expires_in = 5.minutes)
+    owner_id, project_id = storage_decrypt_project_id(encrypted_project_id)
+    key = s3_path owner_id, project_id, filename
     Aws::S3::Presigner.new(client: s3).presigned_url(
       :get_object,
       {

--- a/shared/middleware/helpers/projects.rb
+++ b/shared/middleware/helpers/projects.rb
@@ -32,7 +32,7 @@ class Projects
     }
     row[:id] = @table.insert(row)
 
-    storage_encrypt_channel_id(row[:storage_id], row[:id])
+    storage_encrypt_project_id(row[:storage_id], row[:id])
   end
 
   def delete(channel_id)
@@ -294,11 +294,11 @@ class Projects
 
   def to_a
     @table.where(storage_id: @storage_id).exclude(state: 'deleted').map do |row|
-      channel_id = storage_encrypt_channel_id(row[:storage_id], row[:id])
+      encrypted_project_id = storage_encrypt_project_id(row[:storage_id], row[:id])
       begin
         Projects.merged_row_value(
           row,
-          channel_id: channel_id,
+          channel_id: encrypted_project_id,
           is_owner: row[:storage_id] == @storage_id
         )
       rescue JSON::ParserError
@@ -316,7 +316,7 @@ class Projects
       # Malformed channel, or missing level.
     end
 
-    storage_encrypt_channel_id(row[:storage_id], row[:id]) if row
+    storage_encrypt_project_id(row[:storage_id], row[:id]) if row
   end
 
   # Returns the row value with 'id' and 'isOwner' merged from input params, and
@@ -374,7 +374,7 @@ class Projects
       next_row = Projects.table.where(id: project_id).first
       while next_row&.[](:remix_parent_id)
         next_row = Projects.table.where(id: next_row[:remix_parent_id]).first
-        ancestors.push storage_encrypt_channel_id(next_row[:storage_id], next_row[:id]) if next_row
+        ancestors.push storage_encrypt_project_id(next_row[:storage_id], next_row[:id]) if next_row
         break if ancestors.size >= depth
       end
     end

--- a/shared/middleware/helpers/projects.rb
+++ b/shared/middleware/helpers/projects.rb
@@ -35,32 +35,32 @@ class Projects
     storage_encrypt_project_id(row[:storage_id], row[:id])
   end
 
-  def delete(channel_id)
-    owner, project_id = storage_decrypt_channel_id(channel_id)
-    raise NotFound, "channel `#{channel_id}` not found in your storage" unless owner == @storage_id
+  def delete(encrypted_project_id)
+    owner, project_id = storage_decrypt_project_id(encrypted_project_id)
+    raise NotFound, "channel `#{encrypted_project_id}` not found in your storage" unless owner == @storage_id
 
     delete_count = @table.where(id: project_id).update(state: 'deleted')
-    raise NotFound, "channel `#{channel_id}` not found" if delete_count == 0
+    raise NotFound, "channel `#{encrypted_project_id}` not found" if delete_count == 0
 
     # TODO: Delete all storage associated with this channel (e.g. properties and tables and assets)
 
     true
   end
 
-  def restore(channel_id)
-    owner, project_id = storage_decrypt_channel_id(channel_id)
-    raise NotFound, "channel `#{channel_id}` not found in your storage" unless owner == @storage_id
+  def restore(encrypted_project_id)
+    owner, project_id = storage_decrypt_project_id(encrypted_project_id)
+    raise NotFound, "channel `#{encrypted_project_id}` not found in your storage" unless owner == @storage_id
 
     update_count = @table.where(id: project_id).update(state: 'active')
-    raise NotFound, "channel `#{channel_id}` not found" if update_count == 0
+    raise NotFound, "channel `#{encrypted_project_id}` not found" if update_count == 0
 
     true
   end
 
-  def get(channel_id)
-    owner, project_id = storage_decrypt_channel_id(channel_id)
+  def get(encrypted_project_id)
+    owner, project_id = storage_decrypt_project_id(encrypted_project_id)
     row = @table.where(id: project_id).exclude(state: 'deleted').first
-    raise NotFound, "channel `#{channel_id}` not found" unless row
+    raise NotFound, "channel `#{encrypted_project_id}` not found" unless row
 
     # For some apps, if it was created by a signed out user, we don't want anyone
     # else to be able to access it (for privacy reasons)
@@ -73,15 +73,15 @@ class Projects
       rescue JSON::ParserError
         nil
       end
-      raise NotFound, "channel `#{channel_id}` not shareable" if anonymous_age_restricted_apps.include? project_type
+      raise NotFound, "channel `#{encrypted_project_id}` not shareable" if anonymous_age_restricted_apps.include? project_type
     end
 
-    Projects.merged_row_value(row, channel_id: channel_id, is_owner: owner == @storage_id)
+    Projects.merged_row_value(row, channel_id: encrypted_project_id, is_owner: owner == @storage_id)
   end
 
-  def update(channel_id, value, ip_address, project_type: nil, locale: 'en')
-    owner, project_id = storage_decrypt_channel_id(channel_id)
-    raise NotFound, "channel `#{channel_id}` not found in your storage" unless owner == @storage_id
+  def update(encrypted_project_id, value, ip_address, project_type: nil, locale: 'en')
+    owner, project_id = storage_decrypt_project_id(encrypted_project_id)
+    raise NotFound, "channel `#{encrypted_project_id}` not found in your storage" unless owner == @storage_id
 
     new_name = value['name']
     project = @table.where(id: project_id).first
@@ -99,24 +99,24 @@ class Projects
     }
     row[:project_type] = project_type if project_type
     update_count = @table.where(id: project_id).exclude(state: 'deleted').update(row)
-    raise NotFound, "channel `#{channel_id}` not found" if update_count == 0
+    raise NotFound, "channel `#{encrypted_project_id}` not found" if update_count == 0
 
     # We can't include :created_at here without an extra DB query. Most consumers won't need :created_at during updates, so omit it.
-    JSON.parse(row[:value]).merge(id: channel_id, isOwner: owner == @storage_id, updatedAt: row[:updated_at])
+    JSON.parse(row[:value]).merge(id: encrypted_project_id, isOwner: owner == @storage_id, updatedAt: row[:updated_at])
   end
 
-  def publish(channel_id, type, user)
-    owner, project_id = storage_decrypt_channel_id(channel_id)
-    raise NotFound, "channel `#{channel_id}` not found in your storage" unless owner == @storage_id
+  def publish(encrypted_project_id, type, user)
+    owner, project_id = storage_decrypt_project_id(encrypted_project_id)
+    raise NotFound, "channel `#{encrypted_project_id}` not found in your storage" unless owner == @storage_id
     row = {
       project_type: type,
       published_at: DateTime.now,
     }
     update_count = @table.where(id: project_id).exclude(state: 'deleted').update(row)
-    raise NotFound, "channel `#{channel_id}` not found" if update_count == 0
+    raise NotFound, "channel `#{encrypted_project_id}` not found" if update_count == 0
 
     project = @table.where(id: project_id).first
-    Projects.get_published_project_data(project, channel_id).merge(
+    Projects.get_published_project_data(project, encrypted_project_id).merge(
       # For privacy reasons, include only the first initial of the student's name.
       studentName: user && UserHelpers.initial(user[:name]),
       studentAgeRange: user && UserHelpers.age_range_from_birthday(user[:birthday]),
@@ -161,10 +161,10 @@ class Projects
   end
 
   # extracts published project data from a project (aka projects table row).
-  def self.get_published_project_data(project, channel_id)
+  def self.get_published_project_data(project, encrypted_project_id)
     project_value = JSON.parse(project[:value])
     {
-      channel: channel_id,
+      channel: encrypted_project_id,
       name: project_value['name'],
       thumbnailUrl: Projects.make_thumbnail_url_cacheable(project_value['thumbnailUrl']),
       # Note that we are using the new :project_type field rather than extracting
@@ -179,19 +179,19 @@ class Projects
     url&.sub('/v3/files/', '/v3/files-public/')
   end
 
-  def unpublish(channel_id)
-    owner, project_id = storage_decrypt_channel_id(channel_id)
-    raise NotFound, "channel `#{channel_id}` not found in your storage" unless owner == @storage_id
+  def unpublish(encrypted_project_id)
+    owner, project_id = storage_decrypt_project_id(encrypted_project_id)
+    raise NotFound, "channel `#{encrypted_project_id}` not found in your storage" unless owner == @storage_id
     row = {
       published_at: nil,
     }
     update_count = @table.where(id: project_id).exclude(state: 'deleted').update(row)
-    raise NotFound, "channel `#{channel_id}` not found" if update_count == 0
+    raise NotFound, "channel `#{encrypted_project_id}` not found" if update_count == 0
   end
 
   # Determine if the current user can view the project
-  def get_sharing_disabled(channel_id, current_user_id)
-    owner_storage_id, project_id = storage_decrypt_channel_id(channel_id)
+  def get_sharing_disabled(encrypted_project_id, current_user_id)
+    owner_storage_id, project_id = storage_decrypt_project_id(encrypted_project_id)
     owner_user_id = user_id_for_storage_id(owner_storage_id)
 
     # Sharing of a project is not disabled for the project owner
@@ -228,43 +228,43 @@ class Projects
     return true
   end
 
-  def increment_abuse(channel_id, amount = 10)
-    _owner, project_id = storage_decrypt_channel_id(channel_id)
+  def increment_abuse(encrypted_project_id, amount = 10)
+    _owner, project_id = storage_decrypt_project_id(encrypted_project_id)
 
     row = @table.where(id: project_id).exclude(state: 'deleted').first
-    raise NotFound, "channel `#{channel_id}` not found" unless row
+    raise NotFound, "channel `#{encrypted_project_id}` not found" unless row
 
     new_score = row[:abuse_score] + (JSON.parse(row[:value])['frozen'] ? 0 : amount)
 
     update_count = @table.where(id: project_id).exclude(state: 'deleted').update({abuse_score: new_score})
-    raise NotFound, "channel `#{channel_id}` not found" if update_count == 0
+    raise NotFound, "channel `#{encrypted_project_id}` not found" if update_count == 0
 
     new_score
   end
 
-  def reset_abuse(channel_id)
-    _owner, project_id = storage_decrypt_channel_id(channel_id)
+  def reset_abuse(encrypted_project_id)
+    _owner, project_id = storage_decrypt_project_id(encrypted_project_id)
 
     row = @table.where(id: project_id).exclude(state: 'deleted').first
-    raise NotFound, "channel `#{channel_id}` not found" unless row
+    raise NotFound, "channel `#{encrypted_project_id}` not found" unless row
 
     update_count = @table.where(id: project_id).exclude(state: 'deleted').update({abuse_score: 0})
-    raise NotFound, "channel `#{channel_id}` not found" if update_count == 0
+    raise NotFound, "channel `#{encrypted_project_id}` not found" if update_count == 0
 
     0
   end
 
-  def buffer_abuse_score(channel_id)
+  def buffer_abuse_score(encrypted_project_id)
     buffered_abuse_score = -50
     # Reset to 0 first so projects that are featured,
     # unfeatured, then re-featured don't have super low
     # abuse scores.
-    reset_abuse(channel_id)
-    increment_abuse(channel_id, buffered_abuse_score)
+    reset_abuse(encrypted_project_id)
+    increment_abuse(encrypted_project_id, buffered_abuse_score)
   end
 
-  def content_moderation_disabled?(channel_id)
-    _owner, project_id = storage_decrypt_channel_id(channel_id)
+  def content_moderation_disabled?(encrypted_project_id)
+    _owner, project_id = storage_decrypt_project_id(encrypted_project_id)
 
     row = @table.where(id: project_id).exclude(state: 'deleted').first
     return false unless row
@@ -275,19 +275,19 @@ class Projects
   #
   # Disables or enables automated content moderation for this project by
   # altering the value for content_moderation_disabled.
-  # @param [String] channel_id - an encrypted channel id
+  # @param [String] encrypted_project_id - an encrypted project id
   # @param [Boolean] disable, whether the content moderation should be
   # skipped or not for this project.
   # @raise [NotFound] if the channel does not exist or already has the desired
   # value for content_moderation_disabled.
   #
-  def set_content_moderation(channel_id, disable)
-    _owner, project_id = storage_decrypt_channel_id(channel_id)
+  def set_content_moderation(encrypted_project_id, disable)
+    _owner, project_id = storage_decrypt_project_id(encrypted_project_id)
     rows_changed = @table.
       where(id: project_id).
       exclude(state: 'deleted').
       update({skip_content_moderation: disable})
-    raise NotFound, "channel `#{channel_id}` not found" unless rows_changed > 0
+    raise NotFound, "channel `#{encrypted_project_id}` not found" unless rows_changed > 0
 
     disable
   end
@@ -322,10 +322,10 @@ class Projects
   # Returns the row value with 'id' and 'isOwner' merged from input params, and
   # 'createdAt', 'updatedAt', 'publishedAt' and 'projectType' merged from the
   # corresponding database row values.
-  def self.merged_row_value(row, channel_id:, is_owner:)
+  def self.merged_row_value(row, encrypted_project_id:, is_owner:)
     JSON.parse(row[:value]).merge(
       {
-        id: channel_id,
+        id: encrypted_project_id,
         isOwner: is_owner,
         createdAt: row[:created_at],
         updatedAt: row[:updated_at],
@@ -341,13 +341,14 @@ class Projects
   # This isn't always possible - we aren't consistent about storing project
   # type information with the channel.
   #
-  # @param [String] channel_id - an encrypted channel id
+  # @param [String] encrypted_project_id - an encrypted project id
   # @return [String] The discovered project type, or 'unknown' if the type
   #   can't be determiend with given information.
   # @raise [NotFound] if the channel does not exist or is not shareable.
   #
-  def project_type_from_channel_id(channel_id)
-    project_type_from_merged_row(get(channel_id))
+  # TODO: maureen rename
+  def project_type_from_channel_id(encrypted_project_id)
+    project_type_from_merged_row(get(encrypted_project_id))
   end
 
   #
@@ -360,7 +361,7 @@ class Projects
   #   table against itself.  Worth investigating if we wanted to expose this
   #   to users.
   #
-  # @param [String] channel_id the child project channel id where we start
+  # @param [String] encrypted_project_id the child project encrypted project id where we start
   #   our search.
   # @param [Integer] depth (optional) how many ancestors to retrieve.  Default
   #   to just one - this could get expensive if a project has a very deep
@@ -368,9 +369,9 @@ class Projects
   # @return [Array<String>] list of channel IDs of ancestor projects in reverse
   #   chronological order, up to the provided limit.
   #
-  def self.remix_ancestry(channel_id, depth: 1)
+  def self.remix_ancestry(encrypted_project_id, depth: 1)
     [].tap do |ancestors|
-      _, project_id = storage_decrypt_channel_id(channel_id)
+      _, project_id = storage_decrypt_project_id(encrypted_project_id)
       next_row = Projects.table.where(id: project_id).first
       while next_row&.[](:remix_parent_id)
         next_row = Projects.table.where(id: next_row[:remix_parent_id]).first
@@ -382,8 +383,8 @@ class Projects
     []
   end
 
-  def self.get_abuse(channel_id)
-    _, project_id = storage_decrypt_channel_id(channel_id)
+  def self.get_abuse(encrypted_project_id)
+    _, project_id = storage_decrypt_project_id(encrypted_project_id)
     project_info = Projects.table.where(id: project_id).first
     project_info[:abuse_score]
   end

--- a/shared/middleware/helpers/storage_id.rb
+++ b/shared/middleware/helpers/storage_id.rb
@@ -155,8 +155,7 @@ def storage_id_from_cookie
   storage_id
 end
 
-# TODO: maureen rename
-def owns_channel?(encrypted_project_id)
+def owns_project?(encrypted_project_id)
   owner_storage_id, _ = storage_decrypt_project_id(encrypted_project_id)
   owner_storage_id == get_storage_id
 rescue ArgumentError, OpenSSL::Cipher::CipherError

--- a/shared/middleware/helpers/storage_id.rb
+++ b/shared/middleware/helpers/storage_id.rb
@@ -48,7 +48,7 @@ end
 # ArgumentError if encrypted is incorrectly formatted/padded for base64; or
 # OpenSSL::Cipher::CipherError if the base64-decoded value is not properly
 # encrypted or was encrypted using a different key (e.g. on localhost vs prod).
-def storage_decrypt_channel_id(encrypted)
+def storage_decrypt_project_id(encrypted)
   raise ArgumentError, "`encrypted` must be a string" unless encrypted.is_a? String
   # pad to a multiple of 4 characters to make a valid base64 string.
   encrypted += '=' * ((4 - (encrypted.length % 4)) % 4)
@@ -58,9 +58,10 @@ def storage_decrypt_channel_id(encrypted)
   [storage_id, project_id]
 end
 
+# TODO: maureen rename this
 def valid_encrypted_channel_id(encrypted)
   begin
-    storage_decrypt_channel_id(encrypted)
+    storage_decrypt_project_id(encrypted)
   rescue ArgumentError, OpenSSL::Cipher::CipherError
     return false
   end
@@ -154,8 +155,9 @@ def storage_id_from_cookie
   storage_id
 end
 
-def owns_channel?(encrypted_channel_id)
-  owner_storage_id, _ = storage_decrypt_channel_id(encrypted_channel_id)
+# TODO: maureen rename
+def owns_channel?(encrypted_project_id)
+  owner_storage_id, _ = storage_decrypt_project_id(encrypted_project_id)
   owner_storage_id == get_storage_id
 rescue ArgumentError, OpenSSL::Cipher::CipherError
   false

--- a/shared/middleware/helpers/storage_id.rb
+++ b/shared/middleware/helpers/storage_id.rb
@@ -83,7 +83,7 @@ def storage_encrypt_id(id)
   storage_encrypt("#{SecureRandom.random_number(65536)}:#{id}:#{SecureRandom.random_number(65536)}")
 end
 
-def storage_encrypt_channel_id(storage_id, project_id)
+def storage_encrypt_project_id(storage_id, project_id)
   storage_id = storage_id.to_i
   raise ArgumentError, "`storage_id` must be an integer > 0" unless storage_id > 0
   project_id = project_id.to_i

--- a/shared/middleware/helpers/storage_id.rb
+++ b/shared/middleware/helpers/storage_id.rb
@@ -58,8 +58,7 @@ def storage_decrypt_project_id(encrypted)
   [storage_id, project_id]
 end
 
-# TODO: maureen rename this
-def valid_encrypted_channel_id(encrypted)
+def valid_encrypted_project_id(encrypted)
   begin
     storage_decrypt_project_id(encrypted)
   rescue ArgumentError, OpenSSL::Cipher::CipherError

--- a/shared/test/middleware/helpers/test_bucket_helper.rb
+++ b/shared/test/middleware/helpers/test_bucket_helper.rb
@@ -32,7 +32,7 @@ class BucketHelperTest < Minitest::Test
     mock_table = mock
     mock_table.expects(:select).returns(mock_select).once
     DASHBOARD_DB.expects(:[]).with(:project_commits).returns(mock_table).once
-    bucket_helper.expects(:storage_decrypt_channel_id).returns([1, 2])
+    bucket_helper.expects(:storage_decrypt_project_id).returns([1, 2])
 
     version_list = bucket_helper.list_versions('base64', 'main.json', with_comments: true)
     assert_equal [{versionId: '1234', lastModified: '0', comment: 'Comment', isLatest: false}], version_list
@@ -65,7 +65,7 @@ class BucketHelperTest < Minitest::Test
     mock_table = mock
     mock_table.expects(:select).returns(mock_select).once
     DASHBOARD_DB.expects(:[]).with(:project_commits).returns(mock_table).once
-    bucket_helper.expects(:storage_decrypt_channel_id).returns([1, 2])
+    bucket_helper.expects(:storage_decrypt_project_id).returns([1, 2])
 
     version_list = bucket_helper.list_versions('base64', 'main.json', with_comments: true)
     assert_equal [{versionId: '1234', lastModified: '0', isLatest: false}], version_list

--- a/shared/test/test_channels.rb
+++ b/shared/test/test_channels.rb
@@ -444,9 +444,9 @@ class ChannelsTest < Minitest::Test
 
   def test_remix_parent
     post '/v3/channels', {abc: 123}.to_json, 'CONTENT_TYPE' => 'application/json;charset=utf-8'
-    encrypted_parent_channel_id = last_response.location.split('/').last
+    encrypted_parent_project_id = last_response.location.split('/').last
 
-    post "/v3/channels?parent=#{encrypted_parent_channel_id}", {def: 456}.to_json, 'CONTENT_TYPE' => 'application/json;charset=utf-8'
+    post "/v3/channels?parent=#{encrypted_parent_project_id}", {def: 456}.to_json, 'CONTENT_TYPE' => 'application/json;charset=utf-8'
     assert last_response.redirection?
     follow_redirect!
 
@@ -454,18 +454,18 @@ class ChannelsTest < Minitest::Test
     assert last_request.url.end_with? "/#{response['id']}"
     assert_equal 456, response['def']
 
-    _, storage_app_id = storage_decrypt_channel_id(response['id'])
-    _, parent_storage_app_id = storage_decrypt_channel_id(encrypted_parent_channel_id)
+    _, storage_app_id = storage_decrypt_project_id(response['id'])
+    _, parent_storage_app_id = storage_decrypt_project_id(encrypted_parent_project_id)
     assert_equal parent_storage_app_id, Projects.table.where(id: storage_app_id).first[:remix_parent_id]
   end
 
   def test_update_project_type
     post '/v3/channels', {abc: 123}.to_json, 'CONTENT_TYPE' => 'application/json;charset=utf-8'
-    encrypted_channel_id = last_response.location.split('/').last
-    _, storage_app_id = storage_decrypt_channel_id(encrypted_channel_id)
+    encrypted_project_id = last_response.location.split('/').last
+    _, storage_app_id = storage_decrypt_project_id(encrypted_project_id)
     assert_nil Projects.table.where(id: storage_app_id).first[:project_type]
 
-    post "/v3/channels/#{encrypted_channel_id}", {projectType: 'gamelab'}.to_json, 'CONTENT_TYPE' => 'application/json;charset=utf-8'
+    post "/v3/channels/#{encrypted_project_id}", {projectType: 'gamelab'}.to_json, 'CONTENT_TYPE' => 'application/json;charset=utf-8'
     assert last_response.successful?
     assert_equal 'gamelab', Projects.table.where(id: storage_app_id).first[:project_type]
   end


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This is an attempt to rename "channel", "channel id" and "encrypted channel id" to "encrypted project id" where that's what we mean. Channel is an overloaded term that we most commonly use when referring to the encrypted project id, but also sometimes in relation to a channel token or how we're storing project data in s3.

After starting this effort, I've determined that the term "channel" is heavily used and will require a bit more time/effort to replace than expected.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
