### PR TITLE
Add `data-ot-ignore` attribute to jQuery script elements permanently

### DIFF
--- a/pegasus/sites.v3/code.org/views/jquery.haml
+++ b/pegasus/sites.v3/code.org/views/jquery.haml
@@ -1,14 +1,16 @@
--# If the user has the `onetrust_cookie_scripts` cookie to test, use the `data-ot-ignore` attribute.
-- data_ot_ignore_value = true if request.cookies['onetrust_cookie_scripts'].present?
+-# `data-ot-ignore` attribute added to the jQuery script elements to prevent
+-# OneTrust Auto-Blocking from blocking the script.
+-# https://community.cookiepro.com/s/article/UUID-71e7d0a8-03d8-e272-e683-72cadded2ecf?language=en_US
+
 -# Load jQuery script normal/async/defer or not at all, depending on page header.
 - case @header['jquery']
 - when 'defer'
-  %script{src:'/js/jquery.min.js', defer: true, "data-ot-ignore" => data_ot_ignore_value}
+  %script{src:'/js/jquery.min.js', defer: true, "data-ot-ignore" => true}
   %script=view 'jquery_shim.js'
 - when 'async'
-  %script{src:'/js/jquery.min.js', async: true, "data-ot-ignore" => data_ot_ignore_value}
+  %script{src:'/js/jquery.min.js', async: true, "data-ot-ignore" => true}
   %script=view 'jquery_shim.js'
 - when 'none'
   %script=view 'jquery_shim.js'
 - else
-  %script{src:'/js/jquery.min.js', "data-ot-ignore" => data_ot_ignore_value}
+  %script{src:'/js/jquery.min.js', "data-ot-ignore" => true}


### PR DESCRIPTION
This change builds on the fact that [this test PR](https://github.com/code-dot-org/code-dot-org/pull/47133) fixed the jQuery issue we were encountering. The fix is being made permanent in this PR. Refer to the [previous PR](https://github.com/code-dot-org/code-dot-org/pull/47133) for more details.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->


- jira ticket: [FND-2084](https://codedotorg.atlassian.net/browse/FND-2084)


## Testing story

Locally spot tested different pages that load the `jquery.haml` view. This included several of our domains.

## Deployment strategy
Keep an eye on JS errors during the following DTP after merge.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
