### PR TITLE
Move weblab css into public/

### DIFF
--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -8,7 +8,7 @@ Dashboard::Application.routes.draw do
     # Routes needed for the footer on weblab share links on codeprojects
     get '/weblab/footer', to: 'projects#weblab_footer'
     get '/scripts/hosted.js', to: redirect('/weblab/footer.js')
-    get '/style.css', to: redirect('/assets/weblab/footer.css')
+    get '/style.css', to: redirect('/weblab/footer.css')
   end
 
   constraints host: /.*code.org.*/ do

--- a/dashboard/public/weblab/footer.css
+++ b/dashboard/public/weblab/footer.css
@@ -1,6 +1,3 @@
-@import "font";
-@import "color";
-
 body {
   padding-bottom: 28px !important;
 }
@@ -12,7 +9,7 @@ body {
   height: 28px;
   padding: 5px 20px;
   overflow: hidden;
-  background-color: $lightest_gray;
+  background-color: #e7e8ea;
   box-sizing: border-box;
   position: fixed;
   left: 0;
@@ -32,20 +29,20 @@ body {
   all: initial; /* blocking inheritance for all properties */
   font-size: 12px;
   font-weight: normal;
-  font-family: $gotham-regular;
+  font-family: "Gotham 4r", sans-serif;
   line-height: 18px;
   display: inline-block;
   opacity: 0.5;
-  color: $lighter_gray;
+  color: #c6cacd;
 }
 
 #codeprojects_pagefooter a.codeprojects_pagefooter_link {
   all: initial; /* blocking inheritance for all properties */
   font-size: 12px;
   font-weight: normal;
-  font-family: $gotham-regular;
+  font-family: "Gotham 4r", sans-serif;
   line-height: 18px;
-  color: $lighter_gray;
+  color: #c6cacd;
 }
 
 #codeprojects_pagefooter a.codeprojects_pagefooter_link:link {
@@ -53,5 +50,5 @@ body {
 }
 
 #codeprojects_pagefooter a.codeprojects_pagefooter_link:hover {
-  color: $dimgray;
+  color: #696969;
 }


### PR DESCRIPTION
`weblab/footer.scss` is available locally but not in production. The Rails documentation for assets is pretty confusing to me and, in general, we're okay with quicker solutions for this project, so I simply moved the file into the `public/` directory. Unfortunately, that meant it needed to be raw CSS instead of SCSS so that's most of the changes in this PR.

I believe this will work because other CSS files in the `public/` directory, such as https://studio.code.org/frequency/frequency.css, are available. I also didn't have any trouble with `public/weblab/footer.js` being available in production.

This change fixes styling issues currently live on codeprojects.org.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
