### PR TITLE
Add program stopped message on student-initiated close connection

### DIFF
--- a/apps/i18n/javalab/en_us.json
+++ b/apps/i18n/javalab/en_us.json
@@ -114,6 +114,7 @@
   "onlyVisibleToYou": "teacher comments are only visible to you",
   "openedDate": "opened {date}",
   "programCompleted": "Program completed.",
+  "programStopped": "Program stopped.",
   "refresh": "Refresh",
   "rename": "Rename",
   "replace": "Replace",

--- a/apps/src/javalab/JavabuilderConnection.js
+++ b/apps/src/javalab/JavabuilderConnection.js
@@ -366,6 +366,9 @@ export default class JavabuilderConnection {
   closeConnection() {
     if (this.socket) {
       this.socket.close();
+      this.onOutputMessage(
+        `${STATUS_MESSAGE_PREFIX} ${javalabMsg.programStopped()}`
+      );
     }
   }
 

--- a/apps/test/unit/javalab/JavabuilderConnectionTest.js
+++ b/apps/test/unit/javalab/JavabuilderConnectionTest.js
@@ -127,10 +127,18 @@ describe('JavabuilderConnection', () => {
       sinon.stub(window, 'WebSocket').returns({
         close: closeStub
       });
-      const javabuilderConnection = new JavabuilderConnection(null, () => {});
+      const javabuilderConnection = new JavabuilderConnection(
+        null,
+        onOutputMessage
+      );
+
       javabuilderConnection.establishWebsocketConnection('fake-token');
       javabuilderConnection.closeConnection();
+
       expect(closeStub).to.have.been.calledOnce;
+      expect(onOutputMessage).to.have.been.calledWith(
+        `${STATUS_MESSAGE_PREFIX} Program stopped.`
+      );
       window.WebSocket.restore();
     });
   });


### PR DESCRIPTION
Adds a "Program stopped." message when a student clicks the "Stop" button.

<img width="1025" alt="image" src="https://user-images.githubusercontent.com/25372625/179616691-fc1da2ae-3548-41fe-8e45-5795c0bcc596.png">

## Links

- jira ticket: [JAVA-346](https://codedotorg.atlassian.net/browse/JAVA-346)

## Testing story

Tested manually against a Javabuilder dev deploy that a) I saw this message and program execution stopped if I clicked it after a websocket connection had been established, and b) I did not see this message if I clicked stop before a websocket connection had been established. Also added a unit test condition to check for this message.

## Follow-up work

I noticed doing this work that programs are not stopped if a user clicks the "Stop" button before we have a websocket connection (program execution continues). This PR does not show this new message if a user clicks this button before a websocket connection has been established. I added [an item to what's next to handle this case](https://codedotorg.atlassian.net/browse/JAVA-635).