### PR TITLE
Restore teacher panel on cached pages

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -75,6 +75,10 @@ import {
   setInstructionsConstants,
   setFeedback
 } from './redux/instructions';
+import {
+  setUserRoleInCourse,
+  CourseRoles
+} from '@cdo/apps/templates/currentUserRedux';
 import {addCallouts} from '@cdo/apps/code-studio/callouts';
 import {queryParams} from '@cdo/apps/code-studio/utils';
 import {RESIZE_VISUALIZATION_EVENT} from './lib/ui/VisualizationResizeBar';
@@ -3364,6 +3368,10 @@ StudioApp.prototype.setPageConstants = function(config, appSpecificConstants) {
   );
 
   getStore().dispatch(setPageConstants(combined));
+
+  if (config.isInstructor) {
+    getStore().dispatch(setUserRoleInCourse(CourseRoles.Instructor));
+  }
 
   const instructionsConstants = determineInstructionsConstants(config);
   getStore().dispatch(setInstructionsConstants(instructionsConstants));

--- a/apps/src/code-studio/initApp/loadApp.js
+++ b/apps/src/code-studio/initApp/loadApp.js
@@ -366,6 +366,7 @@ async function loadAppAsync(appOptions) {
     const data = await userAppOptionsRequest;
 
     appOptions.disableSocialShare = data.disableSocialShare;
+    appOptions.isInstructor = data.isInstructor;
 
     if (data.isStarted) {
       appOptions.level.isStarted = data.isStarted;

--- a/dashboard/app/controllers/api_controller.rb
+++ b/dashboard/app/controllers/api_controller.rb
@@ -494,6 +494,7 @@ class ApiController < ApplicationController
       # need to be sent down.  See LP-2086 for a list of potential values.
 
       response[:disableSocialShare] = user.under_13?
+      response[:isInstructor] = script.can_be_instructor?(current_user)
       response.merge!(progress_app_options(script, level, user))
     else
       response[:signedIn] = false

--- a/dashboard/test/controllers/api_controller_test.rb
+++ b/dashboard/test/controllers/api_controller_test.rb
@@ -892,6 +892,7 @@ class ApiControllerTest < ActionController::TestCase
 
     body = JSON.parse(response.body)
     assert_equal true, body['signedIn']
+    assert_equal false, body['isInstructor']
     assert_equal false, body['disableSocialShare']
     assert_equal 'level source', body['lastAttempt']['source']
   end
@@ -913,6 +914,7 @@ class ApiControllerTest < ActionController::TestCase
     assert_response :success
     body = JSON.parse(response.body)
     assert_equal true, body['signedIn']
+    assert_equal true, body['isInstructor']
     assert_equal false, body['disableSocialShare']
     assert_equal 'level source', body['lastAttempt']['source']
     assert_equal true, body['isStarted']

--- a/dashboard/test/ui/features/learning_platform/cached_level_page.feature
+++ b/dashboard/test/ui/features/learning_platform/cached_level_page.feature
@@ -12,7 +12,7 @@ Feature: Cached level page
 
     # Teacher panel loads as expected on cached level page
     Given I sign in as "Teacher Monica"
-    Then I navigate to the script "dance-2019" lesson 1 level 10 for the section I saved
+    Then I navigate to the script "dance" lesson 1 level 13 for the section I saved
     And I wait until element "#teacher-panel-container" is visible
     And I wait until element "td:eq(1)" contains text "Joey"
     And I wait for 20 seconds

--- a/dashboard/test/ui/features/learning_platform/cached_level_page.feature
+++ b/dashboard/test/ui/features/learning_platform/cached_level_page.feature
@@ -1,0 +1,18 @@
+@no_mobile
+Feature: Cached level page
+
+  Scenario: View cached level page as teacher
+    # Set up a section with one student
+    Given I create a teacher named "Teacher Monica"
+    And I give user "Teacher Monica" authorized teacher permission
+    When I create a new student section and go home
+    And I save the section id from row 0 of the section table
+    Given I create a student named "Joey"
+    And I join the section
+
+    # Teacher panel loads as expected on cached level page
+    Given I sign in as "Teacher Monica"
+    Then I navigate to the script "dance-2019" lesson 1 level 10 for the section I saved
+    And I wait until element "#teacher-panel-container" is visible
+    And I wait until element "td:eq(1)" contains text "Joey"
+    And I wait for 20 seconds

--- a/dashboard/test/ui/features/step_definitions/section_management_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/section_management_steps.rb
@@ -238,6 +238,13 @@ Then /^I navigate to the script "([^"]*)" lesson (\d+) lesson extras page for th
   }
 end
 
+Then /^I navigate to the script "([^"]*)" lesson (\d+) level (\d+) for the section I saved$/ do |script_name, lesson_num, level_num|
+  expect(@section_id).to be > 0
+  steps %{
+    Then I am on "http://studio.code.org/s/#{script_name}/lessons/#{lesson_num}/levels/#{level_num}?section_id=#{@section_id}&noautoplay=true"
+  }
+end
+
 Then /^I hide unit "([^"]+)"$/ do |unit_name|
   selector = ".uitest-CourseScript:contains(#{unit_name}) .fa-eye-slash"
   @browser.execute_script("$(#{selector.inspect}).click();")


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Changes in the "teacher" => "instructor" migration made it so that the teacher panel does not show on cached pages. I've updated the `user_app_options` request made for cached pages to return if the user is an instructor and set that to redux so that the teacher panel will be rendered.

Alternative considered:
- We could have the teacher_panel.js make an ajax request to get the data it needs instead of relying on the user_app_options request, but the change I made follows the current pattern for getting user data for the cached page 

## Links
- jira ticket: [LP-2418](https://codedotorg.atlassian.net/browse/LP-2418)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()

-->

## Testing story
Added to unit tests and added UI test to ensure teacher panel renders on the cached page. Also tested locally on cached pages logged in as student and teacher.
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
