### PR TITLE
Fix `Performance/Casecmp` Violations and Reenable

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -203,11 +203,6 @@ Naming/RescuedExceptionsVariableName:
 Naming/VariableNumber:
   Enabled: false
 
-# Offense count: 20
-# This cop supports unsafe auto-correction (--auto-correct-all).
-Performance/Casecmp:
-  Enabled: false
-
 # Offense count: 42
 # Configuration parameters: MinSize.
 Performance/CollectionLiteralInLoop:

--- a/bin/content-push
+++ b/bin/content-push
@@ -73,7 +73,7 @@ def check_changes
   system("git status --untracked-files=all #{CONTENT_PATHS}")
   print "Should I commit and push all of these unstaged and untracked files in pegasus and dashboard? [Y/n] "
   input = gets.chomp
-  if input == '' || input[0].downcase == 'y'
+  if input == '' || input[0].casecmp?('y')
     puts "Cool!"
     true
   else

--- a/bin/kill-tests
+++ b/bin/kill-tests
@@ -45,7 +45,7 @@ def main
   end
 
   print "Kill tests on #{rack_env}? (Y/N): "
-  return unless gets.chomp.upcase == 'Y'
+  return unless gets.chomp.casecmp?('Y')
 
   print_and_chat "killing tests via #{$0}"
   kill_tests

--- a/bin/oneoff/behavior_migration.rb
+++ b/bin/oneoff/behavior_migration.rb
@@ -11,7 +11,7 @@ GamelabJr.all.each do |level|
   next unless level.custom_blocks
   blocks = JSON.parse level.custom_blocks
   blocks.each do |block|
-    if block['returnType'] && block['returnType'].downcase == 'function'
+    if block['returnType']&.casecmp?('function')
       block['returnType'] = 'Behavior'
     end
     next unless block['args']

--- a/bin/oneoff/diff_email_previews
+++ b/bin/oneoff/diff_email_previews
@@ -171,13 +171,13 @@ rescue => e
 end
 
 def main
-  if ARGV.count == 2 && ARGV[0].downcase == 'download'
+  if ARGV.count == 2 && ARGV[0].casecmp?('download')
     puts "Downloading emails to folder #{ARGV[1]}"
     download_workshop_emails ARGV[1]
-  elsif ARGV.count == 2 && ARGV[0].downcase == 'clean'
+  elsif ARGV.count == 2 && ARGV[0].casecmp?('clean')
     puts "Cleaning emails in folder #{ARGV[1]}"
     clean_email_content ARGV[1]
-  elsif ARGV.count == 3 && ARGV[0].downcase == 'diff'
+  elsif ARGV.count == 3 && ARGV[0].casecmp?('diff')
     puts "Comparing emails in folders #{ARGV[1]} and #{ARGV[2]}"
     compare_workshop_emails ARGV[1], ARGV[2]
   else

--- a/bin/update-contact-email
+++ b/bin/update-contact-email
@@ -22,7 +22,7 @@ def update_email(old_email, new_email)
   end
   puts "Update #{old_email} with #{new_email}? (y/N)"
 
-  unless STDIN.readline.strip.downcase == 'y'
+  unless STDIN.readline.strip.casecmp?('y')
     puts 'Canceled.'
     exit
   end

--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -276,7 +276,7 @@ class LevelsController < ApplicationController
   def update
     if level_params[:name] &&
         @level.name != level_params[:name] &&
-        @level.name.downcase == level_params[:name].downcase
+        @level.name.casecmp?(level_params[:name])
       # do not allow case-only changes in the level name because that confuses git on OSX
       @level.errors.add(:name, 'Cannot change only the capitalization of the level name (it confuses git on OSX)')
       log_save_error(@level)

--- a/dashboard/app/helpers/race_interstitial_helper.rb
+++ b/dashboard/app/helpers/race_interstitial_helper.rb
@@ -14,8 +14,7 @@ module RaceInterstitialHelper
     # Restrict to cases where we can successfully geolocate to the US
     return false if user.current_sign_in_ip.nil?
     location = Geocoder.search(user.current_sign_in_ip).first
-    return false unless location
-    return false if location.country_code.to_s.downcase != 'us'
+    return false unless location&.country_code.to_s.casecmp?('us')
 
     return true
   end

--- a/dashboard/app/models/pd/international_opt_in.rb
+++ b/dashboard/app/models/pd/international_opt_in.rb
@@ -182,7 +182,7 @@ class Pd::InternationalOptIn < ApplicationRecord
   end
 
   def email_opt_in?
-    sanitize_form_data_hash[:email_opt_in].downcase == "yes"
+    sanitize_form_data_hash[:email_opt_in].casecmp?("yes")
   end
 
   def email

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -230,7 +230,7 @@ class User < ApplicationRecord
     if teacher?
       EmailPreference.upsert!(
         email: email,
-        opt_in: email_preference_opt_in.downcase == "yes",
+        opt_in: email_preference_opt_in.casecmp?("yes"),
         ip_address: email_preference_request_ip,
         source: email_preference_source,
         form_kind: email_preference_form_kind,
@@ -243,7 +243,7 @@ class User < ApplicationRecord
     if student? && parent_email.present?
       EmailPreference.upsert!(
         email: parent_email,
-        opt_in: parent_email_preference_opt_in.downcase == "yes",
+        opt_in: parent_email_preference_opt_in.casecmp?("yes"),
         ip_address: parent_email_preference_request_ip,
         source: parent_email_preference_source,
         form_kind: nil
@@ -254,7 +254,7 @@ class User < ApplicationRecord
   # Enables/disables sharing of emails of teachers in the U.S. to Code.org regional partners based on user's choice.
   def save_email_reg_partner_preference
     user = User.find_by_email_or_hashed_email(email)
-    if teacher? && share_teacher_email_reg_partner_opt_in_radio_choice.downcase == "yes"
+    if teacher? && share_teacher_email_reg_partner_opt_in_radio_choice.casecmp?("yes")
       user.share_teacher_email_regional_partner_opt_in = DateTime.now
       user.save!
     end

--- a/lib/cdo/rack/request.rb
+++ b/lib/cdo/rack/request.rb
@@ -15,7 +15,7 @@ module Cdo
 
     def json_body
       return nil unless content_type.split(';').first == 'application/json'
-      return nil unless content_charset.downcase == 'utf-8'
+      return nil unless content_charset.casecmp?('utf-8')
       JSON.parse(body.read, symbolize_names: true)
     end
 

--- a/pegasus/Rakefile
+++ b/pegasus/Rakefile
@@ -36,9 +36,9 @@ def there_can_be_only_one(pidfile)
   at_exit {File.unlink(pidfile) if File.exist?(pidfile)}
 end
 
-there_can_be_only_one("#{File.basename(__FILE__)}.pid") unless ENV['PEGASUS_RAKE_RECURSIVE'].to_s.downcase == 'true'
+there_can_be_only_one("#{File.basename(__FILE__)}.pid") unless ENV['PEGASUS_RAKE_RECURSIVE'].to_s.casecmp?('true')
 
-if ENV['PEGASUS_RAKE_LOGGER'].to_s.downcase != 'true'
+unless ENV['PEGASUS_RAKE_LOGGER'].to_s.casecmp?('true')
   $log = Logger.new STDOUT
   $log.level = Logger::INFO
 end

--- a/shared/middleware/channels_api.rb
+++ b/shared/middleware/channels_api.rb
@@ -62,7 +62,7 @@ class ChannelsApi < Sinatra::Base
   #
   post '/v3/channels' do
     unsupported_media_type unless request.content_type.to_s.split(';').first == 'application/json'
-    unsupported_media_type unless request.content_charset.to_s.downcase == 'utf-8'
+    unsupported_media_type unless request.content_charset.to_s.casecmp?('utf-8')
 
     project = Projects.new(get_storage_id)
 
@@ -146,7 +146,7 @@ class ChannelsApi < Sinatra::Base
   #
   post %r{/v3/channels/([^/]+)$} do |id|
     unsupported_media_type unless request.content_type.to_s.split(';').first == 'application/json'
-    unsupported_media_type unless request.content_charset.to_s.downcase == 'utf-8'
+    unsupported_media_type unless request.content_charset.to_s.casecmp?('utf-8')
 
     begin
       value = JSON.parse(request.body.read)

--- a/shared/middleware/helpers/file_bucket.rb
+++ b/shared/middleware/helpers/file_bucket.rb
@@ -36,7 +36,7 @@ class FileBucket < BucketHelper
     src_manifest.each do |src_entry|
       src_filename = src_entry['filename']
       dest_manifest.each do |dest_entry|
-        if dest_entry['filename'].downcase == src_filename.downcase
+        if dest_entry['filename'].casecmp?(src_filename)
           dest_entry['filename'] = src_filename
         end
       end

--- a/shared/middleware/net_sim_api.rb
+++ b/shared/middleware/net_sim_api.rb
@@ -448,7 +448,7 @@ class NetSimApi < Sinatra::Base
   # @return [Boolean]
   def has_json_utf8_headers?(request)
     request.content_type.to_s.split(';').first == 'application/json' &&
-        request.content_charset.to_s.downcase == 'utf-8'
+        request.content_charset.to_s.casecmp?('utf-8')
   end
 
   # Perform delete operation, potentially on multiple rows at once,


### PR DESCRIPTION
Specifically, I ran `bundle exec rubocop -A --only Performance/Casecmp`, which automatically replaced all our manual case comparisons with calls to `casecmp().zero?`. Because we're on a version of Ruby > 2.4, we can instead simply call `casecmp?` in this case; I therefore then used sed to simply `%s/casecmp(\(.*\))\.zero?/casecmp?(\1)/gc`.

I also added a few new safe navigation calls and switched a few `if`s to `unless`es where appropriate.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
