### PR TITLE
Revert "Disable `unknown_asset_fallback` Configuration"

### DIFF
--- a/dashboard/config/application.rb
+++ b/dashboard/config/application.rb
@@ -26,9 +26,8 @@ module Dashboard
     # Explicitly load appropriate defaults for this version of Rails.
     # Eventually, we want to simply call:
     #config.load_defaults 6.0
-    config.action_dispatch.return_only_media_type_on_content_type = false
     config.active_record.belongs_to_required_by_default = true
-    config.assets.unknown_asset_fallback = false
+    config.action_dispatch.return_only_media_type_on_content_type = false
     config.autoloader = :zeitwerk
 
     unless CDO.chef_managed


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#46937

Once in production, user activity revealed that we have one more place in our system that's doing something odd with the asset pipeline: https://app.honeybadger.io/projects/3240/faults/86834791