### PR TITLE
generate missing pdfs during staging build

### DIFF
--- a/lib/rake/build.rake
+++ b/lib/rake/build.rake
@@ -91,6 +91,15 @@ namespace :build do
           RakeUtils.system 'git', 'commit', '-m', '"Update dsls.en.yml"', dsls_file
           RakeUtils.git_push
         end
+
+        if rack_env?(:staging)
+          # This step will only complete successfully if we succeed in
+          # generating all curriculum PDFs. We also attempt to generate PDFs
+          # during the seeding process, but that step is unreliable and will be
+          # removed soon. https://codedotorg.atlassian.net/browse/PLAT-1921
+          ChatClient.log "Generating missing pdfs..."
+          RakeUtils.rake_stream_output 'curriculum_pdfs:generate_missing_pdfs'
+        end
       end
 
       # Skip asset precompile in development.


### PR DESCRIPTION
Starts [PLAT-1921](https://codedotorg.atlassian.net/browse/PLAT-1921). This PR adds the generate_missing_pdfs step to the staging build. More details in code comments.

## Testing story

I patched this into staging and verified that the build step succeeds: https://codedotorg.slack.com/archives/C03CK8E51/p1658253851722669