### PR TITLE
Remove lesson name cruft

### DIFF
--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -216,12 +216,8 @@ class Lesson < ApplicationRecord
   def localized_name
     # The behavior to show the script title instead of the lesson name in
     # single-lesson scripts is deprecated.
-    #
-    # TODO(dave): once all scripts with exactly one lesson are migrated and no longer
-    # using legacy lesson plans, remove this condition and consolidate with
-    # localized_name_for_lesson_show.
-    if script.lessons.many? || (script.is_migrated && !script.use_legacy_lesson_plans)
-      get_localized_property(:name) || ''
+    if script.lessons.many?
+      localized_name_for_lesson_show
     else
       I18n.t "data.script.name.#{script.name}.title"
     end

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -214,16 +214,6 @@ class Lesson < ApplicationRecord
   end
 
   def localized_name
-    # The behavior to show the script title instead of the lesson name in
-    # single-lesson scripts is deprecated.
-    if script.lessons.many?
-      localized_name_for_lesson_show
-    else
-      I18n.t "data.script.name.#{script.name}.title"
-    end
-  end
-
-  def localized_name_for_lesson_show
     get_localized_property(:name) || ''
   end
 
@@ -451,7 +441,7 @@ class Lesson < ApplicationRecord
       lockable: lockable,
       key: key,
       duration: total_lesson_duration,
-      displayName: localized_name_for_lesson_show,
+      displayName: localized_name,
       overview: render_property(:overview),
       announcements: announcements,
       purpose: render_property(:purpose),

--- a/dashboard/test/controllers/lessons_controller_test.rb
+++ b/dashboard/test/controllers/lessons_controller_test.rb
@@ -289,7 +289,9 @@ class LessonsControllerTest < ActionController::TestCase
         }
       }
     }
+
     I18n.backend.store_translations 'en-US', custom_i18n
+    assert_equal @lesson_name, solo_lesson_in_script.localized_name
 
     get :show, params: {
       script_id: script.name,

--- a/dashboard/test/controllers/lessons_controller_test.rb
+++ b/dashboard/test/controllers/lessons_controller_test.rb
@@ -289,9 +289,7 @@ class LessonsControllerTest < ActionController::TestCase
         }
       }
     }
-
     I18n.backend.store_translations 'en-US', custom_i18n
-    assert_equal @lesson_name, solo_lesson_in_script.localized_name
 
     get :show, params: {
       script_id: script.name,


### PR DESCRIPTION
This PR addresses a TODO that got introduced at some point during migrated scripts, that I ran into while removing lesson names from scripts.en.yml.

The removed comment says: https://github.com/code-dot-org/code-dot-org/blob/490367946f783a6df923196d5d28561d363a7092/dashboard/app/models/lesson.rb#L220-L222 

I believe these conditions have been met, because:
1. All scripts we care about the visual appearance of have been migrated
2. Looking in my local DB, there are only two scripts with one lesson which still `use_legacy_lesson_plans`:
```
[development] dashboard > Script.all.select {|s| s.lessons.count == 1 && s.use_legacy_lesson_plans }.map(&:name)
=> ["csd-post-survey-2018", "csp-post-survey-2018"]
```

For those two scripts, there is no difference between script name and first lesson name:
```
[development] dashboard > scripts = Script.all.select {|s| s.lessons.count == 1 && s.use_legacy_lesson_plans }
[development] dashboard > puts JSON.pretty_generate scripts.map {|s| [I18n.t("data.script.name.#{s.name}.title"), s.lessons.first.get_localized_property(:name)]}
[
  [
    "CSD Student Post-Course Survey ('18-'19)",
    "CSD Student Post-Course Survey ('18-'19)"
  ],
  [
    "CSP Student Post-Course Survey ('18-'19)",
    "CSP Student Post-Course Survey ('18-'19)"
  ]
]
```

## Testing story

