### PR TITLE
Remove an Invalid `asset_path` Call

### DIFF
--- a/dashboard/app/views/teacher_dashboard/parent_letter.html.haml
+++ b/dashboard/app/views/teacher_dashboard/parent_letter.html.haml
@@ -1,7 +1,6 @@
 %head
   %title Parent Letter
 
-  %link{rel:'stylesheet', type:'text/css', href: asset_path('gotham-font.css')}
   :css
     body {
       max-width: 8.5in;


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/47286. As far as I can tell, it's the last remaining place in our codebase which references an invalid asset, and so is the last thing we need to fix to be able to enable this configuration setting.

Currently in production, this resolves to https://studio.code.org/gotham-font.css, which is a 404. We do have a relevant file in our codebase at `dashboard/vendor/assets/stylesheets/gotham-font.css`, but that file is not currently being referenced by this codepath and after some experimentation I was not able to figure out how to correctly refer to it. Therefore, I recommend that we simply remove the call rather than trying to fix forward.

## Links

Relevant Honeybadger error: https://app.honeybadger.io/projects/3240/faults/86834791

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
