### PR TITLE
Increase Chef timeout when executing Dashboard database setup

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -453,7 +453,7 @@ Resources:
 <% end -%>
     CreationPolicy:
       ResourceSignal:
-        Timeout: PT2H
+        Timeout: PT4H
     Properties:
       ImageId: <%=IMAGE_ID%>
       InstanceType: !Ref <%=frontends ? 'DaemonInstanceType' : 'InstanceType' %>

--- a/cookbooks/cdo-apps/libraries/cdo_apps.rb
+++ b/cookbooks/cdo-apps/libraries/cdo_apps.rb
@@ -22,6 +22,7 @@ module CdoApps
       live_stream true
       user user
       group user
+      timeout 7200 # The default 3600 seconds is often not sufficient when the database is configured as an RDS cluster.
       action :nothing
     end
 


### PR DESCRIPTION
Provisioning an adhoc with an RDS Aurora cluster database (`DATABASE=1`) instead of using `mysqld` on the web application server EC2 Instance has not worked reliable for a few months. This appears to be because dashboard database setup and seeding typically takes longer than an hour, but [we invoke](https://github.com/code-dot-org/code-dot-org/blob/0c1a2f327302f420d895034447fa35a1d9a77dda/cookbooks/cdo-apps/libraries/cdo_apps.rb#L18-L26) the `dashboard:setup_db` rake task with the Chef `execute` [command](https://github.com/code-dot-org/code-dot-org/blob/0c1a2f327302f420d895034447fa35a1d9a77dda/cookbooks/cdo-apps/libraries/cdo_apps.rb#L18-L26) and the default timeout is 3600 seconds. Increase to 7200 seconds (2 hours).

Excerpt from `/var/log/chef-bootstrap-debug.log` on an adhoc EC2 Instance where database was configured as a standalone RDS Aurora MySQL cluster

```
    ================================================================================ESC[0m
    ESC[31mError executing action `run` on resource 'execute[setup-dashboard]'ESC[0m
    ================================================================================ESC[0m

ESC[0m    Mixlib::ShellOut::CommandTimeoutESC[0m
    --------------------------------ESC[0m
    Command timed out after 3600s:
ESC[0m    Command exceeded allowed execution time, process terminated
ESC[0m    ---- Begin output of bundle exec rake dashboard:setup_db --trace ----
ESC[0m    STDOUT: Created database 'dashboard_adhoc'
ESC[0m    Finished seed:check_migrations (less than 1 second)
ESC[0m    Finished seed:videos (less than 1 second)
ESC[0m    Finished seed:concepts (less than 1 second)
ESC[0m    Finished seed:course_offerings_ui_tests (less than 1 second)
ESC[0m    Finished seed:games (less than 1 second)
ESC[0m    Finished seed:deprecated_blockly_levels (24 seconds)
ESC[0m    GetSecretValue: adhoc/cdo/properties_encryption_key
ESC[0m    Finished seed:custom_levels (49 minutes and 11 seconds)
ESC[0m    Error parsing config/scripts/cspu4_assess1_ddos.multi
ESC[0m    STDERR: ** Invoke dashboard:setup_db (first_time)
ESC[0m    ** Invoke db:setup_or_migrate (first_time)
ESC[0m    ** Execute db:setup_or_migrate
ESC[0m    ** Invoke environment (first_time)
ESC[0m    ** Execute environment
ESC[0m    ** Invoke db:load_config (first_time)
ESC[0m    ** Invoke environment
ESC[0m    ** Execute db:load_config
ESC[0m    ** Invoke db:create (first_time)
ESC[0m    ** Invoke db:load_config
ESC[0m    ** Execute db:create
ESC[0m    ** Invoke db:schema:load (first_time)
ESC[0m    ** Invoke db:load_config
ESC[0m    ** Invoke db:check_protected_environments (first_time)
ESC[0m    ** Invoke db:load_config
ESC[0m    ** Execute db:check_protected_environments
ESC[0m    ** Execute db:schema:load
ESC[0m    ** Invoke seed:default (first_time)
ESC[0m    ** Invoke seed:check_migrations (first_time)
ESC[0m    ** Invoke environment
ESC[0m    ** Execute seed:check_migrations
ESC[0m    ** Invoke seed:videos (first_time)
ESC[0m    ** Invoke environment
ESC[0m    ** Execute seed:videos
ESC[0m    ** Invoke seed:concepts (first_time)
ESC[0m    ** Invoke environment
ESC[0m    ** Execute seed:concepts
ESC[0m    ** Invoke seed:course_offerings_ui_tests (first_time)
ESC[0m    ** Invoke environment
ESC[0m    ** Execute seed:course_offerings_ui_tests
ESC[0m    ** Invoke seed:scripts_ui_tests (first_time)
ESC[0m    ** Invoke environment
ESC[0m    ** Invoke seed:check_migrations
ESC[0m    ** Invoke seed:games (first_time)
ESC[0m    ** Invoke environment
ESC[0m    ** Execute seed:games
ESC[0m    ** Invoke seed:deprecated_blockly_levels (first_time)
ESC[0m    ** Invoke environment
ESC[0m    ** Execute seed:deprecated_blockly_levels
ESC[0m    ** Invoke seed:custom_levels (first_time)
ESC[0m    ** Invoke environment
ESC[0m    ** Execute seed:custom_levels
ESC[0m    ** Invoke seed:dsls (first_time)
ESC[0m    ** Invoke environment
ESC[0m    ** Execute seed:dsls
ESC[0m    rake aborted!
ESC[0m    SignalException: SIGTERM
ESC[0m    /var/lib/gems/2.5.0/gems/activesupport-6.0.4.1/lib/active_support/notifications/instrumenter.rb:146:in `now_cpu'
ESC[0m    /var/lib/gems/2.5.0/gems/activesupport-6.0.4.1/lib/active_support/notifications/instrumenter.rb:86:in `finish!'
ESC[0m    /var/lib/gems/2.5.0/gems/activesupport-6.0.4.1/lib/active_support/subscriber.rb:141:in `finish'
ESC[0m    /var/lib/gems/2.5.0/gems/activesupport-6.0.4.1/lib/active_support/log_subscriber.rb:107:in `finish'
ESC[0m    /var/lib/gems/2.5.0/gems/activesupport-6.0.4.1/lib/active_support/notifications/fanout.rb:160:in `finish'
ESC[0m    /var/lib/gems/2.5.0/gems/activesupport-6.0.4.1/lib/active_support/notifications/fanout.rb:62:in `block in finish'
ESC[0m    /var/lib/gems/2.5.0/gems/activesupport-6.0.4.1/lib/active_support/notifications/fanout.rb:62:in `each'
ESC[0m    /var/lib/gems/2.5.0/gems/activesupport-6.0.4.1/lib/active_support/notifications/fanout.rb:62:in `finish'
ESC[0m    /var/lib/gems/2.5.0/gems/activesupport-6.0.4.1/lib/active_support/notifications/instrumenter.rb:45:in `finish_with_state'
ESC[0m    /var/lib/gems/2.5.0/gems/activesupport-6.0.4.1/lib/active_support/notifications/instrumenter.rb:30:in `instrument'
ESC[0m    /home/ubuntu/adhoc/dashboard/config/initializers/mysql_check_index_used.rb:30:in `execute'
ESC[0m    /var/lib/gems/2.5.0/gems/activerecord-6.0.4.1/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:210:in `execute_and_free'
ESC[0m    /var/lib/gems/2.5.0/gems/activerecord-6.0.4.1/lib/active_record/connection_adapters/mysql/database_statements.rb:46:in `exec_query'
ESC[0m    /var/lib/gems/2.5.0/gems/activerecord-6.0.4.1/lib/active_record/connection_adapters/abstract/database_statements.rb:135:in `exec_insert'
ESC[0m    /var/lib/gems/2.5.0/gems/composite_primary_keys-12.0.10/lib/composite_primary_keys/connection_adapters/abstract/database_statements.rb:6:in `insert'
ESC[0m    /var/lib/gems/2.5.0/gems/activerecord-6.0.4.1/lib/active_record/connection_adapters/abstract/query_cache.rb:22:in `insert'
ESC[0m    /var/lib/gems/2.5.0/gems/activerecord-6.0.4.1/lib/active_record/persistence.rb:375:in `_insert_record'
ESC[0m    /var/lib/gems/2.5.0/gems/composite_primary_keys-12.0.10/lib/composite_primary_keys/persistence.rb:64:in `_create_record'
ESC[0m    /var/lib/gems/2.5.0/gems/activerecord-6.0.4.1/lib/active_record/counter_cache.rb:166:in `_create_record'
ESC[0m    /var/lib/gems/2.5.0/gems/activerecord-6.0.4.1/lib/active_record/locking/optimistic.rb:79:in `_create_record'
ESC[0m    /var/lib/gems/2.5.0/gems/activerecord-6.0.4.1/lib/active_record/attribute_methods/dirty.rb:211:in `_create_record'
ESC[0m    /var/lib/gems/2.5.0/gems/activerecord-6.0.4.1/lib/active_record/callbacks.rb:331:in `block in _create_record'
ESC[0m    /var/lib/gems/2.5.0/gems/activesupport-6.0.4.1/lib/active_support/callbacks.rb:135:in `run_callbacks'
ESC[0m    /var/lib/gems/2.5.0/gems/activesupport-6.0.4.1/lib/active_support/callbacks.rb:825:in `_run_create_callbacks'
ESC[0m    /var/lib/gems/2.5.0/gems/activerecord-6.0.4.1/lib/active_record/callbacks.rb:331:in `_create_record'
ESC[0m    /var/lib/gems/2.5.0/gems/activerecord-6.0.4.1/lib/active_record/timestamp.rb:110:in `_create_record'
ESC[0m    /var/lib/gems/2.5.0/gems/activerecord-6.0.4.1/lib/active_record/persistence.rb:905:in `create_or_update'
ESC[0m    /var/lib/gems/2.5.0/gems/activerecord-6.0.4.1/lib/active_record/callbacks.rb:327:in `block in create_or_update'
ESC[0m    /var/lib/gems/2.5.0/gems/activesupport-6.0.4.1/lib/active_support/callbacks.rb:112:in `block in run_callbacks'
ESC[0m    /var/lib/gems/2.5.0/gems/activerecord-6.0.4.1/lib/active_record/autosave_association.rb:366:in `around_save_collection_association'
ESC[0m    /var/lib/gems/2.5.0/gems/activesupport-6.0.4.1/lib/active_support/callbacks.rb:121:in `block in run_callbacks'
ESC[0m    /var/lib/gems/2.5.0/gems/activesupport-6.0.4.1/lib/active_support/callbacks.rb:139:in `run_callbacks'
ESC[0m    /var/lib/gems/2.5.0/gems/activesupport-6.0.4.1/lib/active_support/callbacks.rb:825:in `_run_save_callbacks'
ESC[0m    /var/lib/gems/2.5.0/gems/activerecord-6.0.4.1/lib/active_record/callbacks.rb:327:in `create_or_update'
ESC[0m    /var/lib/gems/2.5.0/gems/activerecord-6.0.4.1/lib/active_record/timestamp.rb:128:in `create_or_update'
ESC[0m    /var/lib/gems/2.5.0/gems/activerecord-6.0.4.1/lib/active_record/persistence.rb:470:in `save'
ESC[0m    /var/lib/gems/2.5.0/gems/activerecord-6.0.4.1/lib/active_record/validations.rb:47:in `save'
ESC[0m    /var/lib/gems/2.5.0/gems/activerecord-6.0.4.1/lib/active_record/transactions.rb:314:in `block in save'
ESC[0m    /var/lib/gems/2.5.0/gems/activerecord-6.0.4.1/lib/active_record/transactions.rb:375:in `block in with_transaction_returning_status'
ESC[0m    /var/lib/gems/2.5.0/gems/activerecord-6.0.4.1/lib/active_record/connection_adapters/abstract/database_statements.rb:278:in `transaction'
ESC[0m    /var/lib/gems/2.5.0/gems/activerecord-6.0.4.1/lib/active_record/transactions.rb:212:in `transaction'
ESC[0m    /var/lib/gems/2.5.0/gems/activerecord-6.0.4.1/lib/active_record/transactions.rb:366:in `with_transaction_returning_status'
ESC[0m    /var/lib/gems/2.5.0/gems/activerecord-6.0.4.1/lib/active_record/transactions.rb:314:in `save'
ESC[0m    /var/lib/gems/2.5.0/gems/activerecord-6.0.4.1/lib/active_record/suppressor.rb:44:in `save'
ESC[0m    /var/lib/gems/2.5.0/gems/activerecord-6.0.4.1/lib/active_record/persistence.rb:38:in `create'
ESC[0m    /var/lib/gems/2.5.0/gems/activerecord-6.0.4.1/lib/active_record/relation.rb:100:in `block in create'
ESC[0m    /var/lib/gems/2.5.0/gems/activerecord-6.0.4.1/lib/active_record/relation.rb:407:in `block in scoping'
ESC[0m    /var/lib/gems/2.5.0/gems/activerecord-6.0.4.1/lib/active_record/relation.rb:787:in `_scoping'
ESC[0m    /var/lib/gems/2.5.0/gems/activerecord-6.0.4.1/lib/active_record/relation.rb:407:in `scoping'
ESC[0m    /var/lib/gems/2.5.0/gems/activerecord-6.0.4.1/lib/active_record/relation.rb:100:in `create'
ESC[0m    /var/lib/gems/2.5.0/gems/activerecord-6.0.4.1/lib/active_record/relation.rb:169:in `find_or_create_by'
ESC[0m    /var/lib/gems/2.5.0/gems/activerecord-6.0.4.1/lib/active_record/querying.rb:21:in `find_or_create_by'
ESC[0m    /home/ubuntu/adhoc/dashboard/app/models/levels/dsl_defined.rb:88:in `setup'
ESC[0m    /home/ubuntu/adhoc/dashboard/lib/tasks/seed.rake:254:in `block (4 levels) in <top (required)>'
ESC[0m    /home/ubuntu/adhoc/dashboard/lib/tasks/seed.rake:247:in `each'
ESC[0m    /home/ubuntu/adhoc/dashboard/lib/tasks/seed.rake:247:in `block (3 levels) in <top (required)>'
ESC[0m    /var/lib/gems/2.5.0/gems/activerecord-6.0.4.1/lib/active_record/connection_adapters/abstract/database_statements.rb:280:in `block in transaction'
ESC[0m    /var/lib/gems/2.5.0/gems/activerecord-6.0.4.1/lib/active_record/connection_adapters/abstract/transaction.rb:280:in `block in within_new_transaction'
ESC[0m    /var/lib/gems/2.5.0/gems/activesupport-6.0.4.1/lib/active_support/concurrency/load_interlock_aware_monitor.rb:26:in `block (2 levels) in synchronize'
ESC[0m    /var/lib/gems/2.5.0/gems/activesupport-6.0.4.1/lib/active_support/concurrency/load_interlock_aware_monitor.rb:25:in `handle_interrupt'
ESC[0m    /var/lib/gems/2.5.0/gems/activesupport-6.0.4.1/lib/active_support/concurrency/load_interlock_aware_monitor.rb:25:in `block in synchronize'
ESC[0m    /var/lib/gems/2.5.0/gems/activesupport-6.0.4.1/lib/active_support/concurrency/load_interlock_aware_monitor.rb:21:in `handle_interrupt'
ESC[0m    /var/lib/gems/2.5.0/gems/activesupport-6.0.4.1/lib/active_support/concurrency/load_interlock_aware_monitor.rb:21:in `synchronize'
ESC[0m    /var/lib/gems/2.5.0/gems/activerecord-6.0.4.1/lib/active_record/connection_adapters/abstract/transaction.rb:278:in `within_new_transaction'
ESC[0m    /var/lib/gems/2.5.0/gems/activerecord-6.0.4.1/lib/active_record/connection_adapters/abstract/database_statements.rb:280:in `transaction'
ESC[0m    /var/lib/gems/2.5.0/gems/activerecord-6.0.4.1/lib/active_record/transactions.rb:212:in `transaction'
ESC[0m    /home/ubuntu/adhoc/dashboard/lib/tasks/seed.rake:233:in `block (2 levels) in <top (required)>'
ESC[0m    /var/lib/gems/2.5.0/gems/rake-11.3.0/lib/rake/task.rb:248:in `block in execute'
ESC[0m    /var/lib/gems/2.5.0/gems/rake-11.3.0/lib/rake/task.rb:243:in `each'
ESC[0m    /var/lib/gems/2.5.0/gems/rake-11.3.0/lib/rake/task.rb:243:in `execute'
ESC[0m    /home/ubuntu/adhoc/dashboard/lib/tasks/seed.rake:15:in `block in execute'
ESC[0m    /usr/lib/ruby/2.5.0/benchmark.rb:308:in `realtime'
ESC[0m    /home/ubuntu/adhoc/dashboard/lib/tasks/seed.rake:15:in `execute'
ESC[0m    /var/lib/gems/2.5.0/gems/rake-11.3.0/lib/rake/task.rb:187:in `block in invoke_with_call_chain'
ESC[0m    /usr/lib/ruby/2.5.0/monitor.rb:235:in `mon_synchronize'
ESC[0m    /var/lib/gems/2.5.0/gems/rake-11.3.0/lib/rake/task.rb:180:in `invoke_with_call_chain'
ESC[0m    /var/lib/gems/2.5.0/gems/rake-11.3.0/lib/rake/task.rb:209:in `block in invoke_prerequisites'
ESC[0m    /var/lib/gems/2.5.0/gems/rake-11.3.0/lib/rake/task.rb:207:in `each'
ESC[0m    /var/lib/gems/2.5.0/gems/rake-11.3.0/lib/rake/task.rb:207:in `invoke_prerequisites'
ESC[0m    /var/lib/gems/2.5.0/gems/rake-11.3.0/lib/rake/task.rb:186:in `block in invoke_with_call_chain'
ESC[0m    /usr/lib/ruby/2.5.0/monitor.rb:235:in `mon_synchronize'
ESC[0m    /var/lib/gems/2.5.0/gems/rake-11.3.0/lib/rake/task.rb:180:in `invoke_with_call_chain'
ESC[0m    /var/lib/gems/2.5.0/gems/rake-11.3.0/lib/rake/task.rb:209:in `block in invoke_prerequisites'
ESC[0m    /var/lib/gems/2.5.0/gems/rake-11.3.0/lib/rake/task.rb:207:in `each'
ESC[0m    /var/lib/gems/2.5.0/gems/rake-11.3.0/lib/rake/task.rb:207:in `invoke_prerequisites'
ESC[0m    /var/lib/gems/2.5.0/gems/rake-11.3.0/lib/rake/task.rb:186:in `block in invoke_with_call_chain'
ESC[0m    /usr/lib/ruby/2.5.0/monitor.rb:235:in `mon_synchronize'
ESC[0m    /var/lib/gems/2.5.0/gems/rake-11.3.0/lib/rake/task.rb:180:in `invoke_with_call_chain'
ESC[0m    /var/lib/gems/2.5.0/gems/rake-11.3.0/lib/rake/task.rb:209:in `block in invoke_prerequisites'
ESC[0m    /var/lib/gems/2.5.0/gems/rake-11.3.0/lib/rake/task.rb:207:in `each'
ESC[0m    /var/lib/gems/2.5.0/gems/rake-11.3.0/lib/rake/task.rb:207:in `invoke_prerequisites'
ESC[0m    /var/lib/gems/2.5.0/gems/rake-11.3.0/lib/rake/task.rb:186:in `block in invoke_with_call_chain'
ESC[0m    /usr/lib/ruby/2.5.0/monitor.rb:235:in `mon_synchronize'
ESC[0m    /var/lib/gems/2.5.0/gems/rake-11.3.0/lib/rake/task.rb:180:in `invoke_with_call_chain'
ESC[0m    /var/lib/gems/2.5.0/gems/rake-11.3.0/lib/rake/task.rb:173:in `invoke'
ESC[0m    /var/lib/gems/2.5.0/gems/rake-11.3.0/lib/rake/application.rb:152:in `invoke_task'
ESC[0m    /var/lib/gems/2.5.0/gems/rake-11.3.0/lib/rake/application.rb:108:in `block (2 levels) in top_level'
ESC[0m    /var/lib/gems/2.5.0/gems/rake-11.3.0/lib/rake/application.rb:108:in `each'
ESC[0m    /var/lib/gems/2.5.0/gems/rake-11.3.0/lib/rake/application.rb:108:in `block in top_level'
ESC[0m    /var/lib/gems/2.5.0/gems/rake-11.3.0/lib/rake/application.rb:117:in `run_with_threads'
ESC[0m    /var/lib/gems/2.5.0/gems/rake-11.3.0/lib/rake/application.rb:102:in `top_level'
ESC[0m    /var/lib/gems/2.5.0/gems/rake-11.3.0/lib/rake/application.rb:80:in `block in run'
ESC[0m    /var/lib/gems/2.5.0/gems/rake-11.3.0/lib/rake/application.rb:178:in `standard_exception_handling'
ESC[0m    /var/lib/gems/2.5.0/gems/rake-11.3.0/lib/rake/application.rb:77:in `run'
ESC[0m    /var/lib/gems/2.5.0/gems/rake-11.3.0/exe/rake:27:in `<top (required)>'
ESC[0m    /usr/local/bin/rake:23:in `load'
ESC[0m    /usr/local/bin/rake:23:in `<top (required)>'
ESC[0m    /var/lib/gems/2.5.0/gems/bundler-1.16.1/lib/bundler/cli/exec.rb:75:in `load'
ESC[0m    /var/lib/gems/2.5.0/gems/bundler-1.16.1/lib/bundler/cli/exec.rb:75:in `kernel_load'
ESC[0m    /usr/local/bin/rake:23:in `load'
ESC[0m    /usr/local/bin/rake:23:in `<top (required)>'
ESC[0m    /var/lib/gems/2.5.0/gems/bundler-1.16.1/lib/bundler/cli/exec.rb:75:in `load'
ESC[0m    /var/lib/gems/2.5.0/gems/bundler-1.16.1/lib/bundler/cli/exec.rb:75:in `kernel_load'
ESC[0m    /var/lib/gems/2.5.0/gems/bundler-1.16.1/lib/bundler/cli/exec.rb:28:in `run'
ESC[0m    /var/lib/gems/2.5.0/gems/bundler-1.16.1/lib/bundler/cli.rb:424:in `exec'
ESC[0m    /var/lib/gems/2.5.0/gems/bundler-1.16.1/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
ESC[0m    /var/lib/gems/2.5.0/gems/bundler-1.16.1/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
ESC[0m    /var/lib/gems/2.5.0/gems/bundler-1.16.1/lib/bundler/vendor/thor/lib/thor.rb:387:in `dispatch'
ESC[0m    /var/lib/gems/2.5.0/gems/bundler-1.16.1/lib/bundler/cli.rb:27:in `dispatch'
ESC[0m    /var/lib/gems/2.5.0/gems/bundler-1.16.1/lib/bundler/vendor/thor/lib/thor/base.rb:466:in `start'
ESC[0m    /var/lib/gems/2.5.0/gems/bundler-1.16.1/lib/bundler/cli.rb:18:in `start'
ESC[0m    /var/lib/gems/2.5.0/gems/bundler-1.16.1/exe/bundle:30:in `block in <top (required)>'
ESC[0m    /var/lib/gems/2.5.0/gems/bundler-1.16.1/lib/bundler/friendly_errors.rb:122:in `with_friendly_errors'
ESC[0m    /var/lib/gems/2.5.0/gems/bundler-1.16.1/exe/bundle:22:in `<top (required)>'
ESC[0m    /usr/local/bin/bundle:23:in `load'
ESC[0m    /usr/local/bin/bundle:23:in `<main>'
ESC[0m    Tasks: TOP => dashboard:setup_db => seed:default => seed:scripts_ui_tests => seed:dsls
ESC[0m    ---- End output of bundle exec rake dashboard:setup_db --trace ----
ESC[0m    Ran bundle exec rake dashboard:setup_db --trace returned 1ESC[0m

ESC[0m    Resource Declaration:ESC[0m
ESC[0m    Tasks: TOP => dashboard:setup_db => seed:default => seed:scripts_ui_tests => seed:dsls
ESC[0m    ---- End output of bundle exec rake dashboard:setup_db --trace ----
ESC[0m    Ran bundle exec rake dashboard:setup_db --trace returned 1ESC[0m

ESC[0m    Resource Declaration:ESC[0m
    ---------------------ESC[0m
    # In /etc/chef/local-mode-cache/cache/cookbooks/cdo-apps/libraries/cdo_apps.rb
ESC[0m
ESC[0m     18:     execute "setup-#{app_name}" do
ESC[0m     19:       command "bundle exec rake #{app_name}:setup_db --trace"
ESC[0m     20:       cwd app_root
ESC[0m     21:       environment env.merge(node['cdo-apps']['bundle_env'])
ESC[0m     22:       live_stream true
ESC[0m     23:       user user
ESC[0m     24:       group user
ESC[0m     25:       action :nothing
ESC[0m     26:     end
ESC[0m     27:
ESC[0m
ESC[0m     25:       action :nothing
ESC[0m     26:     end
ESC[0m     27:
ESC[0m
ESC[0m    Compiled Resource:ESC[0m
    ------------------ESC[0m
    # Declared in /etc/chef/local-mode-cache/cache/cookbooks/cdo-apps/libraries/cdo_apps.rb:18:in `setup_app'
ESC[0m
ESC[0m    execute("setup-dashboard") do
ESC[0m      action [:nothing]
ESC[0m      default_guard_interpreter :execute
ESC[0m      command "bundle exec rake dashboard:setup_db --trace"
ESC[0m      backup 5
ESC[0m      declared_type :execute
ESC[0m      cookbook_name "cdo-apps"
ESC[0m      recipe_name "dashboard"
ESC[0m      domain nil
ESC[0m      user "ubuntu"
ESC[0m      environment {"LC_ALL"=>"en_US.UTF-8", "LANGUAGE"=>"en_US.UTF-8", "LANG"=>"en_US.UTF-8", "RAILS_ENV"=>"adhoc", "TZ"=>"UTC", "BUNDLE_WITHOUT"=>"development:production:staging:test:levelbuilder:i
ntegration", "BUNDLE_GEMFILE"=>"/home/ubuntu/adhoc/Gemfile", "BUNDLE_JOBS"=>"8", "BUNDLE_IGNORE_CONFIG"=>"1", "BUNDLE_APP_CONFIG"=>"/etc/chef/local-mode-cache/cache/.bundle"}
ESC[0m      cwd "/home/ubuntu/adhoc/dashboard"
ESC[0m      live_stream true
ESC[0m      group "ubuntu"
ESC[0m    end
ESC[0m
ESC[0m    System Info:ESC[0m
    ------------ESC[0m
    chef_version=15.2.20
ESC[0m    platform=ubuntu
ESC[0m    platform_version=18.04
ESC[0m    ruby=ruby 2.6.3p62 (2019-04-16 revision 67580) [x86_64-linux]
ESC[0m    program_name=/opt/chef/bin/chef-client
ESC[0m    executable=/opt/chef/bin/chef-clientESC[0m
```

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

`bundle exec rake adhoc:start RAILS_ENV=adhoc DATABASE=1`

`WebServer` provisioned successfully in about 2 hours
![9C7BA6B2-6FE0-44FC-8BE7-C3BFC5ABE999](https://user-images.githubusercontent.com/2157034/180040934-b6f34dae-3c39-4c53-9f89-e39a2c9039b8.jpeg)


## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
