### PR TITLE
Revert "Revert "Disable `unknown_asset_fallback` Configuration""

### DIFF
--- a/dashboard/config/application.rb
+++ b/dashboard/config/application.rb
@@ -26,8 +26,9 @@ module Dashboard
     # Explicitly load appropriate defaults for this version of Rails.
     # Eventually, we want to simply call:
     #config.load_defaults 6.0
-    config.active_record.belongs_to_required_by_default = true
     config.action_dispatch.return_only_media_type_on_content_type = false
+    config.active_record.belongs_to_required_by_default = true
+    config.assets.unknown_asset_fallback = false
     config.autoloader = :zeitwerk
 
     unless CDO.chef_managed


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#47286, restoring https://github.com/code-dot-org/code-dot-org/pull/46937

The first attempt revealed one place in the codebase where we were still attempting to render an asset that does not actually exist: https://app.honeybadger.io/projects/3240/faults/86834791

That attempt has since been removed: https://github.com/code-dot-org/code-dot-org/pull/47307

So we're ready to try again! Once this is in, we should finally be ready to merge https://github.com/code-dot-org/code-dot-org/pull/47192