### PR TITLE
Update `font-awesome-rails` Gem to 4.7.0.8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -210,7 +210,7 @@ gem 'twilio-ruby' # SMS API for send-to-phone feature
 # - /dashboard/public/fonts/
 # - /pegasus/sites.v3/code.org/public/fonts/
 # - /pegasus/sites.v3/hourofcode/public/fonts/
-gem 'font-awesome-rails', '~> 4.7.0.5'
+gem 'font-awesome-rails', '~> 4.7.0.8'
 
 gem 'sequel'
 gem 'user_agent_parser'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -438,8 +438,8 @@ GEM
       httpclient
       json
     firebase_token_generator (2.0.0)
-    font-awesome-rails (4.7.0.5)
-      railties (>= 3.2, < 6.1)
+    font-awesome-rails (4.7.0.8)
+      railties (>= 3.2, < 8.0)
     fspath (3.1.0)
     gemoji (2.1.0)
     geocoder (1.6.4)
@@ -958,7 +958,7 @@ DEPENDENCIES
   fakeredis
   firebase
   firebase_token_generator
-  font-awesome-rails (~> 4.7.0.5)
+  font-awesome-rails (~> 4.7.0.8)
   full-name-splitter!
   gctools!
   gemoji


### PR DESCRIPTION
Primarily to pick up support for Rails 6.1, which was added in 4.7.0.6: https://github.com/bokmann/font-awesome-rails/blob/master/CHANGELOG.md#changes

4.7.0.7 then added support for Ruby 3.0 and 4.7.0.8 added support for Rails 7.0, both of which we'd like to upgrade to in the future.

As per the commented warning in the Gemfile, I confirmed that the names of the font files have not changed. Nor for that matter have the contents:

https://github.com/bokmann/font-awesome-rails/tree/v4.7.0.5/app/assets/fonts

https://github.com/bokmann/font-awesome-rails/tree/v4.7.0.8/app/assets/fonts

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
