### PR TITLE
Add banner to section dialog about verified teachers

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -947,6 +947,8 @@
   "gdprDialogVisitPrivacyPolicy": "Visit Code.org’s Privacy Policy to learn more.",
   "gdprDialogLogout": "Log out",
   "gdprDialogYes": "Yes",
+  "getVerifiedTitle": "Get Verified!",
+  "getVerifiedInfo": "To teach {courseName}, you must be a verified teacher. To get verified, [fill out this form](verificationFormUrl). For more details, please read this [article on teacher verification](verificationInfoUrl).",
   "gender": "Gender",
   "genderMale": "Male",
   "genderFemale": "Female",

--- a/apps/src/templates/teacherDashboard/EditSectionForm.jsx
+++ b/apps/src/templates/teacherDashboard/EditSectionForm.jsx
@@ -15,7 +15,8 @@ import {
   finishEditingSection,
   cancelEditingSection,
   reloadAfterEditingSection,
-  assignedUnitLessonExtrasAvailable
+  assignedUnitLessonExtrasAvailable,
+  assignedUnitRequiresVerifiedInstructor
 } from './teacherSectionsRedux';
 import {
   isScriptHiddenForSection,
@@ -28,6 +29,7 @@ import {
 } from '@cdo/apps/util/sharedConstants';
 import firehoseClient from '@cdo/apps/lib/util/firehose';
 import {ParticipantAudience} from '../../generated/curriculum/sharedCourseConstants';
+import GetVerifiedBanner from './GetVerifiedBanner';
 
 /**
  * UI for editing section details: Name, grade, assigned course, etc.
@@ -54,6 +56,8 @@ class EditSectionForm extends Component {
     assignedUnitTextToSpeechEnabled: PropTypes.bool.isRequired,
     updateHiddenScript: PropTypes.func.isRequired,
     localeCode: PropTypes.string,
+    assignedUnitRequiresVerifiedInstructor: PropTypes.bool,
+    isVerifiedInstructor: PropTypes.bool,
     showLockSectionField: PropTypes.bool // DCDO Flag - show/hide Lock Section field
   };
 
@@ -141,11 +145,18 @@ class EditSectionForm extends Component {
       handleClose,
       assignedUnitLessonExtrasAvailable,
       assignedUnitTextToSpeechEnabled,
+      assignedUnitRequiresVerifiedInstructor,
       assignedUnitName,
       localeCode,
       isNewSection,
-      showLockSectionField // DCDO Flag - show/hide Lock Section field
+      showLockSectionField,
+      isVerifiedInstructor // DCDO Flag - show/hide Lock Section field
     } = this.props;
+    console.log(courseOfferings[section.courseOfferingId]);
+    const courseDisplayName =
+      section && section.courseOfferingId
+        ? courseOfferings[section.courseOfferingId].display_name
+        : '';
 
     /**
     OAuth and personal email login types can not be changed.
@@ -215,6 +226,11 @@ class EditSectionForm extends Component {
             disabled={isSaveInProgress}
             isNewSection={isNewSection}
           />
+          {!isVerifiedInstructor &&
+            assignedUnitRequiresVerifiedInstructor &&
+            courseDisplayName && (
+              <GetVerifiedBanner courseName={courseDisplayName} />
+            )}
           {assignedUnitLessonExtrasAvailable && (
             <LessonExtrasField
               value={section.lessonExtras}
@@ -551,6 +567,10 @@ let defaultPropsFromState = state => ({
   assignedUnitName: assignedUnitName(state),
   assignedUnitTextToSpeechEnabled: assignedUnitTextToSpeechEnabled(state),
   localeCode: state.locales.localeCode,
+  assignedUnitRequiresVerifiedInstructor: assignedUnitRequiresVerifiedInstructor(
+    state
+  ),
+  isVerifiedInstructor: state.verifiedInstructor.isVerified,
 
   // DCDO Flag - show/hide Lock Section field
   showLockSectionField: state.teacherSections.showLockSectionField

--- a/apps/src/templates/teacherDashboard/EditSectionForm.jsx
+++ b/apps/src/templates/teacherDashboard/EditSectionForm.jsx
@@ -152,7 +152,7 @@ class EditSectionForm extends Component {
       showLockSectionField,
       isVerifiedInstructor // DCDO Flag - show/hide Lock Section field
     } = this.props;
-    console.log(courseOfferings[section.courseOfferingId]);
+
     const courseDisplayName =
       section && section.courseOfferingId
         ? courseOfferings[section.courseOfferingId].display_name

--- a/apps/src/templates/teacherDashboard/EditSectionForm.jsx
+++ b/apps/src/templates/teacherDashboard/EditSectionForm.jsx
@@ -153,10 +153,9 @@ class EditSectionForm extends Component {
       isVerifiedInstructor // DCDO Flag - show/hide Lock Section field
     } = this.props;
 
-    const courseDisplayName =
-      section && section.courseOfferingId
-        ? courseOfferings[section.courseOfferingId].display_name
-        : '';
+    const courseDisplayName = section.courseOfferingId
+      ? courseOfferings[section.courseOfferingId].display_name
+      : '';
 
     /**
     OAuth and personal email login types can not be changed.

--- a/apps/src/templates/teacherDashboard/GetVerifiedBanner.jsx
+++ b/apps/src/templates/teacherDashboard/GetVerifiedBanner.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import i18n from '@cdo/locale';
+import color from '@cdo/apps/util/color';
+import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
+
+export default function GetVerifiedBanner({courseName}) {
+  return (
+    <div style={styles.verifiedBanner}>
+      <div>
+        <i className="fa fa-warning" style={styles.warningIcon} />
+      </div>
+      <div>
+        <h4 style={styles.title}>{i18n.getVerifiedTitle()}</h4>
+        <SafeMarkdown
+          markdown={i18n.getVerifiedInfo({
+            courseName: courseName,
+            verificationFormUrl:
+              'https://docs.google.com/forms/d/e/1FAIpQLSdGGAJuaDMBVIRYnimPhAL96w6fCl4UdvhwmynGONM75TWwWw/viewform',
+            verificationInfoUrl:
+              'https://support.code.org/hc/en-us/articles/115001550131-How-do-I-get-a-verified-teacher-account-for-CS-Principles-CS-Discoveries-and-CSA-'
+          })}
+        />
+      </div>
+    </div>
+  );
+}
+
+GetVerifiedBanner.propTypes = {
+  courseName: PropTypes.string
+};
+
+const styles = {
+  verifiedBanner: {
+    border: '1px solid',
+    borderColor: color.goldenrod,
+    borderRadius: 5,
+    marginRight: 20,
+    display: 'flex',
+    marginTop: 5
+  },
+  warningIcon: {
+    color: color.goldenrod,
+    fontSize: 22,
+    margin: '10px 15px'
+  },
+  title: {
+    color: color.goldenrod,
+    marginTop: 10,
+    fontWeight: 'bold'
+  }
+};

--- a/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
+++ b/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
@@ -1158,6 +1158,11 @@ export function assignedUnitTextToSpeechEnabled(state) {
   return assignment ? assignment.text_to_speech_enabled : false;
 }
 
+export function assignedUnitRequiresVerifiedInstructor(state) {
+  const assignment = assignedUnit(state);
+  return assignment ? assignment.requires_verified_instructor : false;
+}
+
 export function getVisibleSections(state) {
   const allSections = Object.values(getRoot(state).sections);
   return sortSectionsList(allSections || []).filter(section => !section.hidden);

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -904,6 +904,11 @@ class Script < ApplicationRecord
     csd? || csp? || csa?
   end
 
+  def requires_verified_instructor?
+    # as of now the only course that requires the instructor to be verified in order to run code is CSA.
+    return csa?
+  end
+
   def get_script_level_by_id(script_level_id)
     script_levels.find(id: script_level_id.to_i)
   end
@@ -1868,7 +1873,8 @@ class Script < ApplicationRecord
         path: link,
         lesson_extras_available: lesson_extras_available?,
         text_to_speech_enabled: text_to_speech_enabled?,
-        position: unit_group_units&.first&.position
+        position: unit_group_units&.first&.position,
+        requires_verified_instructor: requires_verified_instructor?
       }
     ]
   end

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -905,7 +905,8 @@ class Script < ApplicationRecord
   end
 
   def requires_verified_instructor?
-    # as of now the only course that requires the instructor to be verified in order to run code is CSA.
+    # As of now the only course that requires the instructor to be verified in order to run code is CSA.
+    # TODO: determine if this should be replaced with has_verified_resources? instead.
     return csa?
   end
 


### PR DESCRIPTION
This PR adds a new banner to the section dialog if CSA is selected and the user is not a verified teacher. 

<img width="1012" alt="Screen Shot 2022-07-20 at 12 30 53 PM" src="https://user-images.githubusercontent.com/33666587/180074286-d2bbd262-3edf-4e94-97c7-542b4b9b5def.png">


## Links
- jira ticket: [JAVA-634](https://codedotorg.atlassian.net/browse/JAVA-634)


## Testing story
Tested locally.


## Follow-up work
Per discussion in [this thread](https://codedotorg.slack.com/archives/C01EF4GJ9GE/p1658334276595709) we should consider reusing this banner for CSP and CSD, which also have some verified teacher requirements. We can potentially use the verified resources setting on the course to determine whether or not to show this banner. For now this is hard-coded to CSA due to limited time to get this in before school year start.

