### PR TITLE
Update `paranoia` gem to 2.5.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -215,7 +215,7 @@ gem 'font-awesome-rails', '~> 4.7.0.5'
 gem 'sequel'
 gem 'user_agent_parser'
 
-gem 'paranoia', '~> 2.4.2'
+gem 'paranoia', '~> 2.5.0'
 gem 'petit', github: 'code-dot-org/petit'  # For URL shortening
 
 # JSON model serializer for REST APIs.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -630,8 +630,8 @@ GEM
     parallel (1.12.1)
     parallel_tests (2.27.0)
       parallel
-    paranoia (2.4.2)
-      activerecord (>= 4.0, < 6.1)
+    paranoia (2.5.3)
+      activerecord (>= 5.1, < 7.1)
     parser (3.1.2.0)
       ast (~> 2.4.1)
     pdf-reader (2.9.2)
@@ -1014,7 +1014,7 @@ DEPENDENCIES
   os
   parallel
   parallel_tests
-  paranoia (~> 2.4.2)
+  paranoia (~> 2.5.0)
   pdf-reader
   petit!
   pg


### PR DESCRIPTION
Primarily to pick up support for Rails 6.1, which was added in 2.4.3: https://github.com/rubysherpas/paranoia/blob/core/CHANGELOG.md#243

Support for Rails 7.0 was added in 2.5.0, and was followed up with some minor bugfixes, so target `~> 2.5.0` in preparation for future work. The only breaking change that I can identify between versions 2.4 and 2.5 is removal of support for Ruby < 2.5 and Rails < 5.1, neither of which affect us.

## Testing story

Relying on existing unit tests

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
