### PR TITLE
Unsilence `update_attributes!?` Deprecation Warning

### DIFF
--- a/dashboard/config/initializers/backtrace_silencers.rb
+++ b/dashboard/config/initializers/backtrace_silencers.rb
@@ -13,7 +13,6 @@ silenced = [
   /The asset ".*" is not present in the asset pipeline.Falling back to an asset that may be in the public folder./,
   /NOT conditions will no longer behave as NOR in Rails 6.1. To continue using NOR conditions, NOT each condition individually/,
   /Rails 6.1 will return Content-Type header without modification/,
-  /update_attributes!? is deprecated and will be removed from Rails 6.1/,
   /Initialization autoloaded the constants/,
   /Class level methods will no longer inherit scoping/,
   /ActionView::Base instances should be constructed with a lookup context, assignments, and a controller/,


### PR DESCRIPTION
In preparation for updating to Rails 6.1

## Testing story

Grepped through the drone logs in this PR to confirm that there are no remaining instances of this deprecation warning in our test suite.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
