### PR TITLE
Enable CSS modules for *.module.scss files

### DIFF
--- a/apps/webpack.js
+++ b/apps/webpack.js
@@ -132,6 +132,11 @@ var baseConfig = {
         loader: 'ejs-webpack-loader'
       },
       {test: /\.css$/, loader: 'style-loader!css-loader'},
+
+      // Rules for global SCSS (*.scss) and modules (*.module.scss)
+      // are currently duplicated for Webpack 4. This can be simplified via
+      // css-loader's options.modules.auto option when we upgrade to Webpack 5:
+      // https://v4.webpack.js.org/loaders/css-loader/#auto
       {
         test: /\.scss$/,
         use: [
@@ -145,8 +150,26 @@ var baseConfig = {
               quietDeps: true
             }
           }
-        ]
+        ],
+        exclude: /\.module\.scss$/
       },
+      {
+        test: /\.scss$/,
+        use: [
+          {loader: 'style-loader'},
+          {loader: 'css-loader', options: {modules: {auto: true}}},
+          {
+            loader: 'sass-loader',
+            options: {
+              includePaths: [scssIncludePath],
+              implementation: sass,
+              quietDeps: true
+            }
+          }
+        ],
+        include: /\.module\.scss$/
+      },
+
       {test: /\.interpreted.js$/, loader: 'raw-loader'},
       {test: /\.exported_js$/, loader: 'raw-loader'},
       {


### PR DESCRIPTION
Follow-up to reimplement functionality in #47190, which was reverted in #47211.

The approach in the PR above is the preferred approach, but doesn't work for Webpack 4, which we're currently on. Setting the `options.modules` rule for css-loader at all resulted in all imports using CSS modules, which was unexpected. This approach duplicates the rules for global and module styles, including/excluding the appropriate file extension so that we can use both.

Once we've upgraded to Webpack 5, we should revert this and use the simpler/preferred approach in the original PR.

I've loaded the affected pages and confirmed that the global SCSS styles are loaded as expected. I also added a temporary `*.module.scss` file and made sure CSS modules work as expected.