### PR TITLE
Add dismissible and button text as input on announcement editor

### DIFF
--- a/apps/src/code-studio/announcementsRedux.js
+++ b/apps/src/code-studio/announcementsRedux.js
@@ -3,13 +3,23 @@ import {NotificationType} from '@cdo/apps/templates/Notification';
 
 const ADD_ANNOUNCEMENT = 'announcements/ADD_ANNOUNCEMENT';
 
-export const addAnnouncement = (notice, details, link, type, visibility) => ({
+export const addAnnouncement = (
+  notice,
+  details,
+  link,
+  type,
+  visibility,
+  dismissible,
+  buttonText
+) => ({
   type: ADD_ANNOUNCEMENT,
   notice,
   details,
   link,
   announcementType: type,
-  visibilityType: visibility
+  visibilityType: visibility,
+  dismissible,
+  buttonText
 });
 
 export const VisibilityType = {
@@ -23,7 +33,9 @@ export const announcementShape = PropTypes.shape({
   details: PropTypes.string.isRequired,
   link: PropTypes.string.isRequired,
   type: PropTypes.oneOf(Object.values(NotificationType)).isRequired,
-  visibility: PropTypes.oneOf(Object.values(VisibilityType))
+  visibility: PropTypes.oneOf(Object.values(VisibilityType)),
+  dismissible: PropTypes.bool,
+  buttonText: PropTypes.string
 });
 
 export default function announcements(state = [], action) {
@@ -33,7 +45,9 @@ export default function announcements(state = [], action) {
       details: action.details,
       link: action.link,
       type: action.announcementType,
-      visibility: action.visibilityType
+      visibility: action.visibilityType,
+      dismissible: action.dismissible,
+      buttonText: action.buttonText
     });
   }
 

--- a/apps/src/code-studio/components/progress/Announcements.jsx
+++ b/apps/src/code-studio/components/progress/Announcements.jsx
@@ -46,9 +46,17 @@ export default class Announcements extends Component {
             type={announcement.type}
             notice={announcement.notice}
             details={announcement.details}
-            buttonText={i18n.learnMore()}
+            buttonText={
+              announcement.buttonText === undefined
+                ? i18n.learnMore()
+                : announcement.buttonText
+            }
             buttonLink={announcement.link}
-            dismissible={true}
+            dismissible={
+              announcement.dismissible === undefined
+                ? true
+                : announcement.dismissible
+            }
             width={this.props.width}
             firehoseAnalyticsData={this.props.firehoseAnalyticsData}
           />

--- a/apps/src/lib/levelbuilder/announcementsEditor/Announcement.jsx
+++ b/apps/src/lib/levelbuilder/announcementsEditor/Announcement.jsx
@@ -45,6 +45,20 @@ export default class Announcement extends Component {
           />
         </label>
         <label>
+          Button Text
+          <input
+            value={
+              announcement.buttonText === undefined
+                ? ''
+                : announcement.buttonText
+            }
+            style={inputStyle}
+            onChange={event =>
+              onChange(index, 'buttonText', event.target.value)
+            }
+          />
+        </label>
+        <label>
           Type
           <div>
             <select
@@ -78,6 +92,21 @@ export default class Announcement extends Component {
             </select>
           </div>
         </label>
+        <label>
+          Dismissible
+          <input
+            type="checkbox"
+            checked={
+              announcement.dismissible === undefined
+                ? true
+                : announcement.dismissible
+            }
+            style={styles.checkbox}
+            onChange={event =>
+              onChange(index, 'dismissible', event.target.checked)
+            }
+          />
+        </label>
         <button
           className="btn btn-danger"
           type="button"
@@ -95,5 +124,8 @@ const styles = {
     border: '1px solid #ccc',
     padding: 5,
     marginBottom: 10
+  },
+  checkbox: {
+    margin: '0 0 0 7px'
   }
 };

--- a/apps/src/lib/levelbuilder/announcementsEditor/Announcement.jsx
+++ b/apps/src/lib/levelbuilder/announcementsEditor/Announcement.jsx
@@ -47,6 +47,7 @@ export default class Announcement extends Component {
         <label>
           Button Text
           <input
+            className="uitest-announcement-button-text"
             value={
               announcement.buttonText === undefined
                 ? ''
@@ -95,6 +96,7 @@ export default class Announcement extends Component {
         <label>
           Dismissible
           <input
+            className="uitest-announcement-dismissible"
             type="checkbox"
             checked={
               announcement.dismissible === undefined

--- a/apps/src/lib/levelbuilder/announcementsEditor/AnnouncementsEditor.jsx
+++ b/apps/src/lib/levelbuilder/announcementsEditor/AnnouncementsEditor.jsx
@@ -24,7 +24,9 @@ export default class AnnouncementsEditor extends Component {
         details: '',
         link: '',
         type: NotificationType.information,
-        visibility: VisibilityType.teacher
+        visibility: VisibilityType.teacher,
+        dismissible: true,
+        buttonText: ''
       })
     );
   };

--- a/apps/test/unit/code-studio/announcementsReduxTest.js
+++ b/apps/test/unit/code-studio/announcementsReduxTest.js
@@ -14,7 +14,9 @@ describe('announcementsRedux', () => {
         'Look what I have to say',
         '/very/interesting',
         NotificationType.information,
-        VisibilityType.teacher
+        VisibilityType.teacher,
+        true,
+        'Push the button'
       )
     );
 
@@ -24,7 +26,9 @@ describe('announcementsRedux', () => {
         details: 'Look what I have to say',
         link: '/very/interesting',
         type: NotificationType.information,
-        visibility: VisibilityType.teacher
+        visibility: VisibilityType.teacher,
+        dismissible: true,
+        buttonText: 'Push the button'
       }
     ];
     assert.deepEqual(state, expected);
@@ -37,7 +41,9 @@ describe('announcementsRedux', () => {
         'Look what I have to say',
         '/very/interesting',
         NotificationType.information,
-        VisibilityType.student
+        VisibilityType.student,
+        true,
+        'Push the button'
       )
     );
 
@@ -47,7 +53,9 @@ describe('announcementsRedux', () => {
         details: 'Look what I have to say',
         link: '/very/interesting',
         type: NotificationType.information,
-        visibility: VisibilityType.student
+        visibility: VisibilityType.student,
+        dismissible: true,
+        buttonText: 'Push the button'
       }
     ];
     assert.deepEqual(state, expected);
@@ -60,7 +68,9 @@ describe('announcementsRedux', () => {
         'Look what I have to say',
         '/very/interesting',
         NotificationType.information,
-        VisibilityType.teacherAndStudent
+        VisibilityType.teacherAndStudent,
+        true,
+        'Push the button'
       )
     );
 
@@ -70,7 +80,9 @@ describe('announcementsRedux', () => {
         details: 'Look what I have to say',
         link: '/very/interesting',
         type: NotificationType.information,
-        visibility: VisibilityType.teacherAndStudent
+        visibility: VisibilityType.teacherAndStudent,
+        dismissible: true,
+        buttonText: 'Push the button'
       }
     ];
     assert.deepEqual(state, expected);
@@ -84,7 +96,9 @@ describe('announcementsRedux', () => {
         'Look what I have to say',
         '/very/interesting',
         NotificationType.information,
-        VisibilityType.teacher
+        VisibilityType.teacher,
+        true,
+        'Push the button'
       )
     );
     const state = reducer(
@@ -94,7 +108,9 @@ describe('announcementsRedux', () => {
         'details2',
         '/link/2',
         NotificationType.bullhorn,
-        VisibilityType.teacher
+        VisibilityType.teacher,
+        false,
+        'Do you like this button?'
       )
     );
 
@@ -104,14 +120,18 @@ describe('announcementsRedux', () => {
         details: 'Look what I have to say',
         link: '/very/interesting',
         type: NotificationType.information,
-        visibility: VisibilityType.teacher
+        visibility: VisibilityType.teacher,
+        dismissible: true,
+        buttonText: 'Push the button'
       },
       {
         notice: 'Announce2',
         details: 'details2',
         link: '/link/2',
         type: NotificationType.bullhorn,
-        visibility: VisibilityType.teacher
+        visibility: VisibilityType.teacher,
+        dismissible: false,
+        buttonText: 'Do you like this button?'
       }
     ];
     assert.deepEqual(state, expected);
@@ -124,7 +144,9 @@ describe('announcementsRedux', () => {
         'Look what I have to say',
         '/very/interesting',
         NotificationType.information,
-        VisibilityType.teacher
+        VisibilityType.teacher,
+        true,
+        'Push the button'
       )
     );
     const state = reducer(
@@ -134,7 +156,9 @@ describe('announcementsRedux', () => {
         'details2',
         '/link/2',
         NotificationType.bullhorn,
-        VisibilityType.student
+        VisibilityType.student,
+        false,
+        'Do you like this button?'
       )
     );
 
@@ -144,14 +168,18 @@ describe('announcementsRedux', () => {
         details: 'Look what I have to say',
         link: '/very/interesting',
         type: NotificationType.information,
-        visibility: VisibilityType.teacher
+        visibility: VisibilityType.teacher,
+        dismissible: true,
+        buttonText: 'Push the button'
       },
       {
         notice: 'Announce2',
         details: 'details2',
         link: '/link/2',
         type: NotificationType.bullhorn,
-        visibility: VisibilityType.student
+        visibility: VisibilityType.student,
+        dismissible: false,
+        buttonText: 'Do you like this button?'
       }
     ];
     assert.deepEqual(state, expected);

--- a/apps/test/unit/code-studio/components/progress/AnnouncementsTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/AnnouncementsTest.jsx
@@ -8,6 +8,7 @@ import {
   fakeStudentAnnouncement,
   fakeTeacherAndStudentAnnouncement,
   fakeTeacherAnnouncement,
+  fakeTeacherAnnouncementWithDismissibleAndButtonText,
   fakeOldTeacherAnnouncement
 } from './FakeAnnouncementsTestData';
 
@@ -57,6 +58,33 @@ describe('Announcements', () => {
       />
     );
     assert.equal(wrapper.find(Notification).length, 1);
+  });
+
+  it('defaults to dismissible and no button text for teacher announcement without dismissible and button text', () => {
+    const wrapper = shallow(
+      <Announcements
+        {...defaultProps}
+        announcements={[fakeTeacherAnnouncement]}
+      />
+    );
+    assert.equal(wrapper.find(Notification).length, 1);
+    assert.equal(wrapper.find(Notification).props().dismissible, true);
+    assert.equal(wrapper.find(Notification).props().buttonText, 'Learn more');
+  });
+
+  it('displays new teacher announcement with dismissible and button text for instructor', () => {
+    const wrapper = shallow(
+      <Announcements
+        {...defaultProps}
+        announcements={[fakeTeacherAnnouncementWithDismissibleAndButtonText]}
+      />
+    );
+    assert.equal(wrapper.find(Notification).length, 1);
+    assert.equal(wrapper.find(Notification).props().dismissible, false);
+    assert.equal(
+      wrapper.find(Notification).props().buttonText,
+      'Push the button'
+    );
   });
 
   it('has only instructor announcements', () => {

--- a/apps/test/unit/code-studio/components/progress/FakeAnnouncementsTestData.jsx
+++ b/apps/test/unit/code-studio/components/progress/FakeAnnouncementsTestData.jsx
@@ -9,6 +9,16 @@ export const fakeTeacherAnnouncement = {
   visibility: VisibilityType.teacher
 };
 
+export const fakeTeacherAnnouncementWithDismissibleAndButtonText = {
+  notice: 'Notice - Teacher',
+  details: 'Teachers are the best',
+  link: '/foo/bar/teacher',
+  type: NotificationType.information,
+  visibility: VisibilityType.teacher,
+  dismissible: false,
+  buttonText: 'Push the button'
+};
+
 export const fakeStudentAnnouncement = {
   notice: 'Notice - Student',
   details: 'Students are the best',

--- a/apps/test/unit/lib/levelbuilder/announcementsEditor/AnnouncementTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/announcementsEditor/AnnouncementTest.jsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import Announcement from '@cdo/apps/lib/levelbuilder/announcementsEditor/Announcement';
+import {assert} from '../../../../util/reconfiguredChai';
+import sinon from 'sinon';
+
+const sampleAnnouncement = {
+  notice: 'This course has recently been updated!',
+  details: 'See what changed and how it may affect your classroom.',
+  link: 'https://support.code.org/hc/en-us/articles/115001931251',
+  type: 'information',
+  visibility: 'Teacher-only'
+};
+
+const sampleAnnouncementWithDismissibleAndButtonText = {
+  notice: 'This course has recently been updated!',
+  details: 'See what changed and how it may affect your classroom.',
+  link: 'https://support.code.org/hc/en-us/articles/115001931251',
+  type: 'information',
+  visibility: 'Teacher-only',
+  dismissible: false,
+  buttonText: 'Push the button'
+};
+
+describe('Announcement', () => {
+  let defaultProps, onChange, onRemove;
+  beforeEach(() => {
+    onChange = sinon.spy();
+    onRemove = sinon.spy();
+    defaultProps = {
+      announcement: sampleAnnouncement,
+      inputStyle: {},
+      index: 1,
+      onRemove,
+      onChange
+    };
+  });
+
+  it('defaults dismissible to true if not specified', () => {
+    const wrapper = shallow(
+      <Announcement {...defaultProps} announcement={sampleAnnouncement} />
+    );
+    assert.equal(
+      wrapper.find('.uitest-announcement-dismissible').props().checked,
+      true
+    );
+  });
+
+  it('uses dismissible value if provided', () => {
+    const wrapper = shallow(
+      <Announcement
+        {...defaultProps}
+        announcement={sampleAnnouncementWithDismissibleAndButtonText}
+      />
+    );
+    assert.equal(
+      wrapper.find('.uitest-announcement-dismissible').props().checked,
+      false
+    );
+  });
+
+  it('defaults button text to empty string if not specified', () => {
+    const wrapper = shallow(
+      <Announcement {...defaultProps} announcement={sampleAnnouncement} />
+    );
+    assert.equal(
+      wrapper.find('.uitest-announcement-button-text').props().value,
+      ''
+    );
+  });
+
+  it('uses buttonText value if provided', () => {
+    const wrapper = shallow(
+      <Announcement
+        {...defaultProps}
+        announcement={sampleAnnouncementWithDismissibleAndButtonText}
+      />
+    );
+    assert.equal(
+      wrapper.find('.uitest-announcement-button-text').props().value,
+      'Push the button'
+    );
+  });
+});

--- a/apps/test/unit/lib/levelbuilder/announcementsEditor/AnnouncementsEditorTests.js
+++ b/apps/test/unit/lib/levelbuilder/announcementsEditor/AnnouncementsEditorTests.js
@@ -57,7 +57,9 @@ describe('AnnouncementsEditor', () => {
         link: '',
         notice: '',
         type: 'information',
-        visibility: 'Teacher-only'
+        visibility: 'Teacher-only',
+        dismissible: true,
+        buttonText: ''
       }
     ]);
   });


### PR DESCRIPTION
CSA, CSP, and CSD are working on adding Unit Surveys to the announcements at the top of the Unit Overview page as a first step to making the links easier to find. When Jamila went to add the link she noticed that the button for the Announcements always defaults to 'Learn more' and asked if we had a way to update that text. In addition RED is worried about teachers closing out the announcement and never seeing the survey. As a result I took to of the things we can control about announcements as engineerings and gave content editors the ability to edit them as well.  

Content editors can now:
- Set button text
- Decide if an announcement should be dismissible

We will continue to default to an announcement being dismissible and the button text will use 'Learn more' if no button text is provided.

<img width="1040" alt="Screen Shot 2022-07-21 at 11 41 02 AM" src="https://user-images.githubusercontent.com/208083/180255623-6be009e5-9f0a-4f24-949c-d82fe9501be9.png">


## Links

https://codedotorg.atlassian.net/browse/PLAT-1923

## Testing story

- Tested manually
- Added new unit tests