### PR TITLE
removing extra certificate links for Korean students

### DIFF
--- a/apps/src/templates/certificates/Congrats.jsx
+++ b/apps/src/templates/certificates/Congrats.jsx
@@ -5,7 +5,6 @@ import StudentsBeyondHoc from './StudentsBeyondHoc';
 import TeachersBeyondHoc from './TeachersBeyondHoc';
 import PetitionCallToAction from '@cdo/apps/templates/certificates/petition/PetitionCallToAction';
 import styleConstants from '../../styleConstants';
-import {pegasus} from '@cdo/apps/lib/util/urlHelpers';
 import color from '../../util/color';
 import GraduateToNextLevel from '@cdo/apps/templates/certificates/GraduateToNextLevel';
 
@@ -33,20 +32,6 @@ export default function Congrats(props) {
    */
   const renderExtraCertificateLinks = (language, tutorial) => {
     let extraLinkUrl, extraLinkText;
-    // https://codedotorg.atlassian.net/browse/FND-2048
-    // In order to remove the certificate links remove or comment the following section -------------------------------
-    if (language === 'ko') {
-      if (/oceans/.test(tutorial)) {
-        extraLinkUrl = pegasus('/files/online-coding-party-2021-oceans.pdf');
-        extraLinkText =
-          '온라인 코딩 파티 인증서 받으러 가기! (과학기술정보통신부 인증)';
-      } else if (/dance/.test(tutorial)) {
-        extraLinkUrl = pegasus('/files/online-coding-party-2021-dance.pdf');
-        extraLinkText =
-          '온라인 코딩 파티 인증서 받으러 가기! (과학기술정보통신부 인증)';
-      }
-    }
-    // End of section to be removed or commented ----------------------------------------------------------------------
     if (!extraLinkUrl || !extraLinkText) {
       // There are no extra links to render.
       return;


### PR DESCRIPTION
**Why:** We added extra certificate links for Korean students when they complete the Dance Part or AI for Oceans HoC tutorials. This was a request from our Korean partner’s. After the event is done, those links need to be removed from the certificate.

**What:** Removed just the special cases for the Korean certificates and left the “renderExtraCertificateLinks” infrastructure there in case we want quickly support other HoC promotions.

## Links

- jira ticket: [FND-2048](https://codedotorg.atlassian.net/browse/FND-2048)
- PR adding the links: [fnd-2040-add-korean-hoc-pdf-links](https://github.com/code-dot-org/code-dot-org/pull/46801)

## Testing story

Completed dance party, oceans, and Minecraft tutorials.
Verified link is not present for any of the HoC activities.

**AI For Oceans**
No link present
<img width="1055" alt="Captura de Pantalla 2022-07-21 a la(s) 1 11 54 p m" src="https://user-images.githubusercontent.com/66776217/180289335-9dd83355-1f82-4b0a-97b6-703920a15c21.png">

**Dance Party**
No link present
<img width="1055" alt="Captura de Pantalla 2022-07-21 a la(s) 1 12 03 p m" src="https://user-images.githubusercontent.com/66776217/180289534-9809fac4-f5d9-461d-bdd9-d46acd020a61.png">

**Minecraft**
No link present
<img width="1055" alt="Captura de Pantalla 2022-07-21 a la(s) 1 42 26 p m" src="https://user-images.githubusercontent.com/66776217/180289665-a01b256a-2b6f-490c-9e6d-af82f47795fb.png">

