### PR TITLE
Make Level rubrics translatable

### DIFF
--- a/bin/i18n/sync-in.rb
+++ b/bin/i18n/sync-in.rb
@@ -91,6 +91,23 @@ def get_i18n_strings(level)
       end
     end
 
+    # rubric
+    if level.mini_rubric&.to_bool
+      rubric_properties = Hash.new
+      %w(
+        rubric_key_concept
+        rubric_performance_level_1
+        rubric_performance_level_2
+        rubric_performance_level_3
+        rubric_performance_level_4
+      ).each do |prop|
+        prop_value = level.try(prop)
+        rubric_properties[prop] = prop_value unless prop_value.nil?
+      end
+      i18n_strings['mini_rubric'] = Hash.new unless rubric_properties.empty?
+      i18n_strings['mini_rubric'].merge! rubric_properties
+    end
+
     # parse markdown properties for potential placeholder texts
     documents = []
     %w(

--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -161,11 +161,11 @@ class LevelsController < ApplicationController
   def get_rubric
     return head :no_content unless @level.mini_rubric&.to_bool
     render json: {
-      keyConcept: @level.rubric_key_concept,
-      performanceLevel1: @level.rubric_performance_level_1,
-      performanceLevel2: @level.rubric_performance_level_2,
-      performanceLevel3: @level.rubric_performance_level_3,
-      performanceLevel4: @level.rubric_performance_level_4
+      keyConcept: @level.localized_rubric_property('rubric_key_concept'),
+      performanceLevel1: @level.localized_rubric_property('rubric_performance_level_1'),
+      performanceLevel2: @level.localized_rubric_property('rubric_performance_level_2'),
+      performanceLevel3: @level.localized_rubric_property('rubric_performance_level_3'),
+      performanceLevel4: @level.localized_rubric_property('rubric_performance_level_4')
     }
   end
 

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -725,6 +725,19 @@ class Level < ApplicationRecord
     end
   end
 
+  def localized_rubric_property(property)
+    if should_localize?
+      I18n.t(
+        property,
+        scope: [:data, :mini_rubric, name],
+        default: properties[property],
+        smart: true
+      )
+    else
+      properties[property]
+    end
+  end
+
   # There's a bit of trickery here. We consider a level to be
   # hint_prompt_enabled for the sake of the level editing experience if any of
   # the scripts associated with the level are hint_prompt_enabled.


### PR DESCRIPTION
**What:** Add `Level` rubric properties into the sync-in and utilize the translations in the `levels_controller#get_rubric`.

**Why:** This will make Level rubrics translatable moving forward.

## Links

- jira ticket: [FND-2065](https://codedotorg.atlassian.net/browse/FND-2065)


## Testing story

Locally tested the sync-in and sync-out to generate test translations. These were then successfully used when visiting the level.

**English:**
![Screen Shot 2022-07-21 at 2 55 58 PM](https://user-images.githubusercontent.com/48133820/180491601-256b5635-9a73-49b0-9901-9d0befbe4dff.png)

**Test translation (es-ES):**
![Screen Shot 2022-07-21 at 2 56 30 PM](https://user-images.githubusercontent.com/48133820/180491610-c881be1c-961a-4466-b4db-e6054f53b67f.png)

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
