### PR TITLE
Revert "Remove files_api and channels_api from pegasus"

### DIFF
--- a/pegasus/config.ru
+++ b/pegasus/config.ru
@@ -56,6 +56,12 @@ end
 # Add Honeybadger::Rack::ErrorNotifier to Rack middleware directly.
 use Honeybadger::Rack::ErrorNotifier
 
+require 'files_api'
+use FilesApi
+
+require 'channels_api'
+use ChannelsApi
+
 require 'shared_resources'
 use SharedResources
 


### PR DESCRIPTION
(likely) broke all of pegasus 🙃  Reverts code-dot-org/code-dot-org#47308