### PR TITLE
Omitting cookieBanner.js from OneTrust protection

### DIFF
--- a/shared/haml/cookie_banner.haml
+++ b/shared/haml/cookie_banner.haml
@@ -3,9 +3,9 @@
   environment and the show_cookie_banner_on_test URL parameter is specified,
   presumably by a UI test.
 
-- if request.gdpr? || (rack_env == :test && request.params['show_cookie_banner_on_test'].present?)
+- if request.gdpr? || ((rack_env == :test || rack_env == :development) && request.params['show_cookie_banner_on_test'].present?)
   %link{rel:'stylesheet', type:'text/css', href:'/shared/css/cookie-banner.css'}
-  %script{src: webpack_asset_path("js/cookieBanner.js")}
+  %script{src: webpack_asset_path("js/cookieBanner.js"), "data-ot-ignore" => true}
 
   -# dashboard is passed as a parameter when the dashboard is rendering this banner.
   - dashboard ||= false


### PR DESCRIPTION
- Adding `data-ot-ignore` to *cookieBanner.js* because the OneTrust libraries are preventing it from loading correctly in browsers.
- Adding the *development* environment as one which can force the OneTrust UI to show.