### PR TITLE
Remove radium from asset thumbnail

### DIFF
--- a/apps/src/code-studio/components/AssetThumbnail.jsx
+++ b/apps/src/code-studio/components/AssetThumbnail.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Radium from 'radium';
 import color from '@cdo/apps/util/color';
 import {assets as assetsApi} from '@cdo/apps/clientApi';
 
@@ -114,7 +113,7 @@ class AssetThumbnail extends React.Component {
             isPlaying={this.state.isPlayingAudio}
           />
         ) : (
-          <div style={[styles.wrapper, style, styles.background]}>
+          <div style={{...styles.wrapper, ...style, ...styles.background}}>
             {type === 'image' ? (
               <ImageThumbnail src={this.srcPath} />
             ) : (
@@ -127,68 +126,61 @@ class AssetThumbnail extends React.Component {
   }
 }
 
-export default Radium(AssetThumbnail);
+export default AssetThumbnail;
 
-const AudioThumbnail = Radium(
-  class extends React.Component {
-    static propTypes = {
-      clickSoundControl: PropTypes.func,
-      isPlaying: PropTypes.bool
-    };
+const AudioThumbnail = class extends React.Component {
+  static propTypes = {
+    clickSoundControl: PropTypes.func,
+    isPlaying: PropTypes.bool
+  };
 
-    render() {
-      const playIcon = this.props.isPlaying
-        ? 'fa-pause-circle'
-        : 'fa-play-circle';
+  render() {
+    const playIcon = this.props.isPlaying
+      ? 'fa-pause-circle'
+      : 'fa-play-circle';
 
-      return (
-        <div style={[styles.wrapper, styles.audioWrapper]}>
-          <i
-            onClick={this.props.clickSoundControl}
-            className={'fa ' + playIcon + ' fa-4x'}
-            style={styles.audioIcon}
-          />
-        </div>
-      );
-    }
-  }
-);
-
-const ImageThumbnail = Radium(
-  class extends React.Component {
-    static propTypes = {
-      src: PropTypes.string
-    };
-
-    render() {
-      return (
-        <a href={this.props.src} target="_blank" rel="noopener noreferrer">
-          <img
-            src={this.props.src}
-            style={assetThumbnailStyle}
-            id="ui-image-thumbnail"
-          />
-        </a>
-      );
-    }
-  }
-);
-
-const DefaultThumbnail = Radium(
-  class extends React.Component {
-    static propTypes = {
-      type: PropTypes.oneOf(['image', 'audio', 'video', 'pdf', 'doc'])
-        .isRequired,
-      iconStyle: PropTypes.object
-    };
-
-    render() {
-      return (
+    return (
+      <div style={{...styles.wrapper, ...styles.audioWrapper}}>
         <i
-          className={defaultIcons[this.props.type] || defaultIcons.unknown}
-          style={[assetIconStyle, this.props.iconStyle]}
+          onClick={this.props.clickSoundControl}
+          className={'fa ' + playIcon + ' fa-4x'}
+          style={styles.audioIcon}
         />
-      );
-    }
+      </div>
+    );
   }
-);
+};
+
+const ImageThumbnail = class extends React.Component {
+  static propTypes = {
+    src: PropTypes.string
+  };
+
+  render() {
+    return (
+      <a href={this.props.src} target="_blank" rel="noopener noreferrer">
+        <img
+          src={this.props.src}
+          style={assetThumbnailStyle}
+          id="ui-image-thumbnail"
+        />
+      </a>
+    );
+  }
+};
+
+const DefaultThumbnail = class extends React.Component {
+  static propTypes = {
+    type: PropTypes.oneOf(['image', 'audio', 'video', 'pdf', 'doc']).isRequired,
+    iconStyle: PropTypes.object
+  };
+
+  render() {
+    return (
+      <i
+        className={defaultIcons[this.props.type] || defaultIcons.unknown}
+        style={{...assetIconStyle, ...this.props.iconStyle}}
+      />
+    );
+  }
+};


### PR DESCRIPTION
This is part of the work to stop using Radium. See https://github.com/code-dot-org/code-dot-org/pull/47367 for more discussion.

This component is similar to https://github.com/code-dot-org/code-dot-org/pull/47367 in that we are only merging styles. It differs in that the styles that are being merged are sometimes coming through as a prop.

This begs the following questions:
1) If we were to extract styles to a SCSS module, how would we want styling coming through as a prop to interact with the styles in the SCSS modules? Is there a consistent way that's handled, or would we need to refactor the components that consume the component that uses SCSS modules to avoid CSS-in-JS?
2) If we keep CSS-in-JS, but any of the styling coming through in props uses modifiers, states, or media queries, we might be toast. (I can't figure out exactly when we'd be toast, but here is the [Radium documentation](https://github.com/FormidableLabs/radium/tree/master/docs/guides) about it.)

In this case, AssetThumbnail is being used twice:
<img width="889" alt="image" src="https://user-images.githubusercontent.com/9142121/180482166-e7408a2c-c07f-4fee-a1fb-e0ce19ab4124.png">

Of these two usages:
1) It looks like AssetRow does not pass in any style props to AssetThumbnail (https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/code-studio/components/AssetRow.jsx#L177-L184).
2) ImportScreensDialog does pass in two style props, which both look safe to merge with the other styles: https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/applab/ImportScreensDialog.jsx#L41-L48.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Here's what storybook locally looks like:

<img width="423" alt="image" src="https://user-images.githubusercontent.com/9142121/180478080-45506f50-18b7-4aa9-940a-9b4ddc3f35c1.png">

And on prod Storybook: https://code-dot-org.github.io/cdo-styleguide/?selectedKind=AssetThumbnail&selectedStory=Overview&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel

ImportScreensDialog consumes this component and looks like the following locally:
<img width="212" alt="image" src="https://user-images.githubusercontent.com/9142121/180482453-d53a64db-7f9d-49a8-abf4-4790d23f0b87.png">

And on prod Storybook:
https://code-dot-org.github.io/cdo-styleguide/?selectedKind=ImportScreensDialog&selectedStory=Overview&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
