### PR TITLE
Attempt #2 to remove files_api and channels_api from pegasus, with dependencies explicitly included

### DIFF
--- a/pegasus/config.ru
+++ b/pegasus/config.ru
@@ -60,3 +60,6 @@ require 'shared_resources'
 use SharedResources
 
 run Documents
+
+require_relative '../shared/middleware/helpers/core.rb'
+require_relative '../shared/middleware/helpers/auth_helpers.rb'

--- a/pegasus/config.ru
+++ b/pegasus/config.ru
@@ -56,12 +56,6 @@ end
 # Add Honeybadger::Rack::ErrorNotifier to Rack middleware directly.
 use Honeybadger::Rack::ErrorNotifier
 
-require 'files_api'
-use FilesApi
-
-require 'channels_api'
-use ChannelsApi
-
 require 'shared_resources'
 use SharedResources
 


### PR DESCRIPTION
Attempt #1 (#47308) caused pegasus to go down on both staging and test. This was because both of these files require other files that were being depended on by pegasus. Why this doesn't show up in development or Drone is still a mystery to me.

The implicit dependencies are listed [here](https://github.com/code-dot-org/code-dot-org/blob/2bee4fcde780dbd025f9d774c4177f94d5ab8590/shared/middleware/files_api.rb#L117) and [here](https://github.com/code-dot-org/code-dot-org/blob/8e65b5286c0397d0d2a2fd495791241ebb73e07a/shared/middleware/channels_api.rb#L12). These dependencies are:
- animation_bucket.rb
- asset_bucket.rb
- auth_helpers.rb
- bucket_helper.rb
- core.rb
- file_bucket.rb
- library_bucket.rb
- profanity_privacy_helper.rb
- projects.rb
- storage_id.rb
- source_bucket.rb

We know from the [Honeybadger error](https://app.honeybadger.io/projects/34365/faults/86288857) that `auth_helpers` is needed and Dave pointed out [a spot](https://github.com/code-dot-org/code-dot-org/blob/9fe33a1c6dd059c687c1a9d7703fc36be3fcd2eb/pegasus/sites.v3/code.org/public/congrats.haml#L22) where `core` is needed, so these two files have been explicitly required.

I believe these two files are the only ones needed. All of the `_bucket` files contain classes, so I grepped pegasus for `Bucket` and didn't find anything notable. For `profanity_privacy_helper`, `projects`, and `storage_id`, I grepped for some of the functions in those files and came up with nothing, so I decided to take the risk and removed them.

I was able to get an adhoc to repro the issue found in staging and test and the issue is resolved by just including `core.rb` and `auth_helpers.rb`. It's possible I've missed something but I believe the majority of the risk is mitigated here.



## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
