### PR TITLE
Fix Violations of `Security/IoMethods` and Reenable

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -389,11 +389,6 @@ Rails/WhereEquals:
 Rails/WhereExists:
   Enabled: false
 
-# Offense count: 56
-# This cop supports unsafe auto-correction (--auto-correct-all).
-Security/IoMethods:
-  Enabled: false
-
 # Offense count: 2
 Security/MarshalLoad:
   Enabled: false

--- a/aws/ci_build
+++ b/aws/ci_build
@@ -71,7 +71,7 @@ def build
     count = [1, count].max
 
     log = `git log --pretty=format:"%h %s (%an)" -n #{count}`
-    IO.write(deploy_dir('rebuild'), log)
+    File.write(deploy_dir('rebuild'), log)
 
     git_revision = RakeUtils.git_revision
     git_revision_short = GitUtils.git_revision_short

--- a/bin/cron/analyze_hoc_activity
+++ b/bin/cron/analyze_hoc_activity
@@ -27,7 +27,7 @@ require_relative '../../lib/analyze_hoc_activity_helper'
 DEFAULT_LINES_OF_CODE = 20_886_942_901
 
 def main
-  to_date = JSON.parse(IO.read(pegasus_dir("cache/HourOfActivity_Totals_2014-12-05.json")))
+  to_date = JSON.parse(File.read(pegasus_dir("cache/HourOfActivity_Totals_2014-12-05.json")))
 
   total_started = to_date['started']
   total_finished = to_date['finished']
@@ -59,7 +59,7 @@ def main
   while day < today
     cache_path = pegasus_dir("cache/HourOfActivity_Results_#{day.strftime('%Y-%m-%d')}.json")
     if (day != today) && File.file?(cache_path)
-      day_data = JSON.parse(IO.read(cache_path))
+      day_data = JSON.parse(File.read(cache_path))
     else
       day_data = analyze_day_fast(day)
 

--- a/bin/cron/mysql-metrics
+++ b/bin/cron/mysql-metrics
@@ -12,8 +12,8 @@ require 'aws-sdk-cloudwatch'
 STATUS_CACHE = pegasus_dir('cache', 'mysql-status-cache.json')
 
 status = PEGASUS_DB.fetch('show global status').all.map {|x| [x[:Variable_name], x[:Value]]}.to_h
-old_status = File.file?(STATUS_CACHE) ? JSON.parse(IO.read(STATUS_CACHE)) : {}
-IO.write STATUS_CACHE, JSON.pretty_generate(status)
+old_status = File.file?(STATUS_CACHE) ? JSON.parse(File.read(STATUS_CACHE)) : {}
+File.write STATUS_CACHE, JSON.pretty_generate(status)
 
 const_keys = %w(
   Audit_log_current_size

--- a/cookbooks/cdo-apps/metadata.rb
+++ b/cookbooks/cdo-apps/metadata.rb
@@ -3,7 +3,7 @@ maintainer       'Code.org'
 maintainer_email 'will@code.org'
 license          'All rights reserved'
 description      'Installs/Configures cdo-apps'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+long_description File.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.2.515'
 
 depends 'apt'

--- a/cookbooks/cdo-authorized-keys/metadata.rb
+++ b/cookbooks/cdo-authorized-keys/metadata.rb
@@ -3,5 +3,5 @@ maintainer       'Code.org'
 maintainer_email 'dev@code.org'
 license          'All rights reserved'
 description      'Installs/Configures cdo-authorized-keys'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+long_description File.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.1.2'

--- a/cookbooks/cdo-awscli/metadata.rb
+++ b/cookbooks/cdo-awscli/metadata.rb
@@ -3,7 +3,7 @@ maintainer       'Code.org'
 maintainer_email 'dev@code.org'
 license          'All rights reserved'
 description      'Installs/Configures AWS command line interface'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+long_description File.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.1.16'
 
 depends 'apt'

--- a/cookbooks/cdo-cloudwatch-agent/metadata.rb
+++ b/cookbooks/cdo-cloudwatch-agent/metadata.rb
@@ -3,7 +3,7 @@ maintainer       'Code.org'
 maintainer_email 'will@code.org'
 license          'All rights reserved'
 description      'Installs/Configures cdo-cloudwatch-agent'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+long_description File.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.1.11'
 
 depends 'aws_cloudwatch'

--- a/cookbooks/cdo-github-access/metadata.rb
+++ b/cookbooks/cdo-github-access/metadata.rb
@@ -3,5 +3,5 @@ maintainer       'Code.org'
 maintainer_email 'dev@code.org'
 license          'All rights reserved'
 description      'Installs/Configures cdo-github-access'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+long_description File.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.1.10'

--- a/cookbooks/cdo-home-ubuntu/metadata.rb
+++ b/cookbooks/cdo-home-ubuntu/metadata.rb
@@ -3,5 +3,5 @@ maintainer       'Code.org'
 maintainer_email 'dev@code.org'
 license          'All rights reserved'
 description      'Installs/Configures cdo-home-ubuntu'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+long_description File.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.1.7'

--- a/cookbooks/cdo-java-7/metadata.rb
+++ b/cookbooks/cdo-java-7/metadata.rb
@@ -3,7 +3,7 @@ maintainer       'Code.org'
 maintainer_email 'dev@code.org'
 license          'All rights reserved'
 description      'Installs/Configures cdo-java-7'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+long_description File.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.1.1'
 
 depends          'build-essential'

--- a/cookbooks/cdo-jemalloc/metadata.rb
+++ b/cookbooks/cdo-jemalloc/metadata.rb
@@ -3,7 +3,7 @@ maintainer       'Code.org'
 maintainer_email 'will@code.org'
 license          'All rights reserved'
 description      'Installs/Configures cdo-jemalloc'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+long_description File.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.1.6'
 
 depends 'ark'

--- a/cookbooks/cdo-mysql/metadata.rb
+++ b/cookbooks/cdo-mysql/metadata.rb
@@ -3,7 +3,7 @@ maintainer       'Code.org'
 maintainer_email 'will@code.org'
 license          'All rights reserved'
 description      'Installs/Configures cdo-mysql'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+long_description File.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.1.48'
 
 depends 'apt'

--- a/cookbooks/cdo-nginx/metadata.rb
+++ b/cookbooks/cdo-nginx/metadata.rb
@@ -3,7 +3,7 @@ maintainer       'Code.org'
 maintainer_email 'will@code.org'
 license          'All rights reserved'
 description      'Installs/Configures cdo-nginx'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+long_description File.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.0.25'
 
 depends 'apt'

--- a/cookbooks/cdo-nginx/test/cookbooks/nginx_test/metadata.rb
+++ b/cookbooks/cdo-nginx/test/cookbooks/nginx_test/metadata.rb
@@ -3,7 +3,7 @@ maintainer       'Code.org'
 maintainer_email 'will@code.org'
 license          'All rights reserved'
 description      'Installs/Configures nginx_test'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+long_description File.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.1.1'
 
 depends 'cdo-nginx'

--- a/cookbooks/cdo-nodejs/metadata.rb
+++ b/cookbooks/cdo-nodejs/metadata.rb
@@ -3,7 +3,7 @@ maintainer       'YOUR_COMPANY_NAME'
 maintainer_email 'YOUR_EMAIL'
 license          'All rights reserved'
 description      'Installs/Configures cdo-nodejs'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+long_description File.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.2.36'
 
 depends 'nodejs'

--- a/cookbooks/cdo-postfix/metadata.rb
+++ b/cookbooks/cdo-postfix/metadata.rb
@@ -3,7 +3,7 @@ maintainer       'Code.org'
 maintainer_email 'will@code.org'
 license          'All rights reserved'
 description      'Installs/Configures cdo-postfix'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+long_description File.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.2.11'
 
 depends 'apt'

--- a/cookbooks/cdo-redis/metadata.rb
+++ b/cookbooks/cdo-redis/metadata.rb
@@ -3,7 +3,7 @@ maintainer       'Code.org'
 maintainer_email 'will@code.org'
 license          'All rights reserved'
 description      'Installs/Configures Redis'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+long_description File.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.1.5'
 
 depends          'redisio'

--- a/cookbooks/cdo-repository/metadata.rb
+++ b/cookbooks/cdo-repository/metadata.rb
@@ -3,7 +3,7 @@ maintainer       'Code.org'
 maintainer_email 'will@code.org'
 license          'All rights reserved'
 description      'Installs/Configures cdo-repository'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+long_description File.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.2.25'
 
 depends          'cdo-github-access'

--- a/cookbooks/cdo-ruby/metadata.rb
+++ b/cookbooks/cdo-ruby/metadata.rb
@@ -3,7 +3,7 @@ maintainer       'Code.org'
 maintainer_email 'will@code.org'
 license          'All rights reserved'
 description      'Installs/Upgrades Ruby'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+long_description File.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.2.19'
 
 depends 'apt'

--- a/cookbooks/cdo-secrets/metadata.rb
+++ b/cookbooks/cdo-secrets/metadata.rb
@@ -3,5 +3,5 @@ maintainer       'Code.org'
 maintainer_email 'will@code.org'
 license          'All rights reserved'
 description      'Installs/Configures cdo-secrets'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+long_description File.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.1.11'

--- a/cookbooks/cdo-syslog/metadata.rb
+++ b/cookbooks/cdo-syslog/metadata.rb
@@ -3,7 +3,7 @@ maintainer       'Code.org'
 maintainer_email 'will@code.org'
 license          'All rights reserved'
 description      'Installs/Configures syslog'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+long_description File.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.1.4'
 
 depends 'sudo-user'

--- a/cookbooks/cdo-tippecanoe/metadata.rb
+++ b/cookbooks/cdo-tippecanoe/metadata.rb
@@ -3,7 +3,7 @@ maintainer       'Code.org'
 maintainer_email 'will@code.org'
 license          'All rights reserved'
 description      'Installs/Upgrades Tippecanoe'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+long_description File.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.1.6'
 
 depends 'ark'

--- a/cookbooks/cdo-users/metadata.rb
+++ b/cookbooks/cdo-users/metadata.rb
@@ -3,7 +3,7 @@ maintainer       'Code.org'
 maintainer_email 'will@code.org'
 license          'All rights reserved'
 description      'Creates users for the accounts defined in Chef'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+long_description File.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.1.36'
 
 depends 'apt'

--- a/cookbooks/cdo-varnish/metadata.rb
+++ b/cookbooks/cdo-varnish/metadata.rb
@@ -3,7 +3,7 @@ maintainer       'Code.org'
 maintainer_email 'dev@code.org'
 license          'All rights reserved'
 description      'Installs/Configures cdo-varnish'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+long_description File.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.3.304'
 
 depends 'apt'

--- a/cookbooks/cdo-varnish/test/cookbooks/varnish_test/metadata.rb
+++ b/cookbooks/cdo-varnish/test/cookbooks/varnish_test/metadata.rb
@@ -3,7 +3,7 @@ maintainer       'Code.org'
 maintainer_email 'will@code.org'
 license          'All rights reserved'
 description      'Installs/Configures varnish_test'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+long_description File.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.1.0'
 
 depends 'cdo-varnish'

--- a/dashboard/config/initializers/trusted_proxies.rb
+++ b/dashboard/config/initializers/trusted_proxies.rb
@@ -1,6 +1,6 @@
 # Trust Cloudfront proxies so we get real remote IPs
 
-trusted_proxies = JSON.parse(IO.read(deploy_dir('lib/cdo/trusted_proxies.json')))['ranges'].map do |proxy|
+trusted_proxies = JSON.parse(File.read(deploy_dir('lib/cdo/trusted_proxies.json')))['ranges'].map do |proxy|
   IPAddr.new(proxy)
 end
 

--- a/dashboard/lib/announcements.rb
+++ b/dashboard/lib/announcements.rb
@@ -34,7 +34,7 @@ class Announcements
       end
       begin
         @@announcements_data = JSON.parse(
-          IO.read(@@json_path),
+          File.read(@@json_path),
           symbolize_names: true,
           object_class: HashWithIndifferentAccess
         )

--- a/lib/cdo/analytics/milestone_parser.rb
+++ b/lib/cdo/analytics/milestone_parser.rb
@@ -44,9 +44,9 @@ class MilestoneParser
     # Load v2 cache
     cache_file = MILESTONE_CACHE_V2
     FileUtils.cp(MILESTONE_CACHE, cache_file) unless File.file?(cache_file)
-    cache = File.file?(cache_file) ? JSON.parse(IO.read(cache_file)) : {}
+    cache = File.file?(cache_file) ? JSON.parse(File.read(cache_file)) : {}
     parser = new(cache, AWS::S3.create_client)
-    parser.count.tap {|_| IO.write MILESTONE_CACHE_V2, JSON.pretty_generate(parser.cache)}
+    parser.count.tap {|_| File.write MILESTONE_CACHE_V2, JSON.pretty_generate(parser.cache)}
   end
 
   def initialize(cache, s3_client)

--- a/lib/cdo/aws/s3_packaging.rb
+++ b/lib/cdo/aws/s3_packaging.rb
@@ -79,7 +79,7 @@ class S3Packaging
   private def target_commit_hash(location)
     filename = "#{location}/commit_hash"
     return nil unless File.exist?(filename)
-    IO.read(filename)
+    File.read(filename)
   end
 
   # Creates a zipped package of the provided assets folder
@@ -101,7 +101,7 @@ class S3Packaging
     @logger.info "Creating #{package.path}"
     Dir.chdir(@source_location + '/' + sub_path) do
       # add a commit_hash file whose contents represent the key for this package
-      IO.write('commit_hash', @commit_hash)
+      File.write('commit_hash', @commit_hash)
       RakeUtils.system "tar -cz --exclude='*.cache.json' --file #{package.path} *"
     end
     @logger.info 'Created'

--- a/lib/cdo/erb.rb
+++ b/lib/cdo/erb.rb
@@ -2,7 +2,7 @@ require 'erb'
 require 'ostruct'
 
 def erb_file_to_string(path, binding)
-  ERB.new(IO.read(path), nil, '-').
+  ERB.new(File.read(path), nil, '-').
     tap {|erb| erb.filename = path}.
     result(binding)
 end
@@ -10,6 +10,6 @@ end
 def erb_file_to_file(template_path, out_path, locals)
   bind = OpenStruct.new(locals).instance_eval {binding}
   content = erb_file_to_string(template_path, bind)
-  IO.write(out_path, content)
+  File.write(out_path, content)
   File.chmod(0o755, out_path) if File.executable?(template_path)
 end

--- a/lib/cdo/poste.rb
+++ b/lib/cdo/poste.rb
@@ -113,7 +113,7 @@ module Poste
     def initialize(path)
       @path = path
       @template_type = File.extname(path)[1..-1]
-      @header, @html, @text = parse_template(IO.read(path))
+      @header, @html, @text = parse_template(File.read(path))
     end
 
     def render(params={})

--- a/lib/cdo/rack/request.rb
+++ b/lib/cdo/rack/request.rb
@@ -5,7 +5,7 @@ require 'country_codes'
 
 module Cdo
   module RequestExtension
-    TRUSTED_PROXIES = JSON.parse(IO.read(deploy_dir('lib/cdo/trusted_proxies.json')))['ranges'].map do |proxy|
+    TRUSTED_PROXIES = JSON.parse(File.read(deploy_dir('lib/cdo/trusted_proxies.json')))['ranges'].map do |proxy|
       IPAddr.new(proxy)
     end
 

--- a/lib/pdf/collate.rb
+++ b/lib/pdf/collate.rb
@@ -31,7 +31,7 @@ module PDF
 
   # Reads collate file, outputs array of fully qualified PDF paths and URLs
   def self.parse_collate_file(collate_file)
-    options, body = YAML.parse_yaml_header(IO.read(collate_file))
+    options, body = YAML.parse_yaml_header(File.read(collate_file))
     all_paths = body.each_line.map(&:strip).
       reject {|s| s.nil? || s == ''}.
       map do |filename|

--- a/pegasus/data/csv.rb
+++ b/pegasus/data/csv.rb
@@ -129,7 +129,7 @@ class GSheetToCsv
   @@gdrive = nil
 
   def initialize(path)
-    @gsheet_path, settings_yml = IO.read(path).strip.split("\n", 2)
+    @gsheet_path, settings_yml = File.read(path).strip.split("\n", 2)
     settings = YAML.safe_load(settings_yml.to_s) || {}
     @include_columns = settings['include_columns'] || []
     @exclude_columns = settings['exclude_columns'] || []

--- a/pegasus/helpers/hourofcode_helpers.rb
+++ b/pegasus/helpers/hourofcode_helpers.rb
@@ -3,7 +3,7 @@ def hoc_dir(*dirs)
 end
 
 def hoc_load_countries
-  JSON.parse(IO.read(hoc_dir('i18n/countries.json')))
+  JSON.parse(File.read(hoc_dir('i18n/countries.json')))
 end
 HOC_COUNTRIES = hoc_load_countries
 

--- a/pegasus/helpers/page_helpers.rb
+++ b/pegasus/helpers/page_helpers.rb
@@ -66,7 +66,7 @@ def combine_css(*paths)
 
   files = paths.map {|path| Dir.glob(pegasus_dir('sites.v3', request_site, path, '*.css'))}.flatten
   css = files.sort_by(&File.method(:basename)).map do |i|
-    IO.read(i)
+    File.read(i)
   end.join("\n\n")
   css_min = Sass::Engine.new(css,
     syntax: :scss,

--- a/pegasus/router.rb
+++ b/pegasus/router.rb
@@ -59,7 +59,7 @@ class Documents < Sinatra::Base
   def self.load_config_in(dir)
     path = File.join(dir, 'config.json')
     return {} unless File.file?(path)
-    JSON.parse(IO.read(path), symbolize_names: true)
+    JSON.parse(File.read(path), symbolize_names: true)
   end
 
   def self.load_configs_in(dir)
@@ -242,9 +242,9 @@ class Documents < Sinatra::Base
   end
 
   # rubocop:disable Security/Eval
-  Dir.glob(pegasus_dir('routes/*.rb')).sort.each {|path| eval(IO.read(path), nil, path, 1)}
+  Dir.glob(pegasus_dir('routes/*.rb')).sort.each {|path| eval(File.read(path), nil, path, 1)}
   unless rack_env?(:production)
-    Dir.glob(pegasus_dir('routes/dev/*.rb')).sort.each {|path| eval(IO.read(path), nil, path, 1)}
+    Dir.glob(pegasus_dir('routes/dev/*.rb')).sort.each {|path| eval(File.read(path), nil, path, 1)}
   end
   # rubocop:enable Security/Eval
 
@@ -336,7 +336,7 @@ class Documents < Sinatra::Base
     end
 
     def parse_yaml_header(path)
-      content = IO.read path
+      content = File.read path
       match = content.match(/\A\s*^(?<yaml>---\s*\n.*?\n?)^(---\s*$\n?)/m)
       return [{}, content, 1] unless match
 
@@ -535,7 +535,7 @@ class Documents < Sinatra::Base
     end
 
     def render_template(path, locals={})
-      render_(IO.read(path), path, 0, locals)
+      render_(File.read(path), path, 0, locals)
     rescue => e
       Honeybadger.context({path: path, e: e})
       raise "Error rendering #{path}: #{e}"
@@ -560,7 +560,7 @@ class Documents < Sinatra::Base
           cache_file = cache_dir('fetch', request.site, request.path_info)
           unless File.file?(cache_file) && File.mtime(cache_file) > settings.launched_at
             FileUtils.mkdir_p File.dirname(cache_file)
-            IO.binwrite(cache_file, Net::HTTP.get(URI(result)))
+            File.binwrite(cache_file, Net::HTTP.get(URI(result)))
           end
           pass unless File.file?(cache_file)
 

--- a/pegasus/routes/form_routes.rb
+++ b/pegasus/routes/form_routes.rb
@@ -2,7 +2,7 @@ get '/forms/uploads/*' do |uri|
   cache_file = cache_dir('fetch', request.site, request.path_info)
   unless File.file?(cache_file) && File.mtime(cache_file) > settings.launched_at
     FileUtils.mkdir_p File.dirname(cache_file)
-    IO.write(cache_file, AWS::S3.download_from_bucket('cdo-form-uploads', uri))
+    File.write(cache_file, AWS::S3.download_from_bucket('cdo-form-uploads', uri))
   end
   pass unless File.file?(cache_file)
 

--- a/pegasus/src/curriculum_router.rb
+++ b/pegasus/src/curriculum_router.rb
@@ -61,7 +61,7 @@ class HttpDocument
 
   def self.from_file(path, headers={}, status=200)
     content_type = content_type_from_path(path)
-    new(IO.read(path), {'Content-Type' => content_type, 'X-Pegasus-File' => path}.merge(headers))
+    new(File.read(path), {'Content-Type' => content_type, 'X-Pegasus-File' => path}.merge(headers))
   end
 
   def charset?(charset)

--- a/pegasus/src/homepage.rb
+++ b/pegasus/src/homepage.rb
@@ -47,7 +47,7 @@ class Homepage
     end
     begin
       @@announcements_data = JSON.parse(
-        IO.read(@@json_path),
+        File.read(@@json_path),
         symbolize_names: true,
         object_class: HashWithIndifferentAccess
       )

--- a/pegasus/src/text_render.rb
+++ b/pegasus/src/text_render.rb
@@ -51,7 +51,7 @@ module TextRender
   end
 
   def self.f(engine, path, locals={})
-    r(engine, IO.read(path), locals)
+    r(engine, File.read(path), locals)
   end
 
   #

--- a/shared/middleware/shared_resources.rb
+++ b/shared/middleware/shared_resources.rb
@@ -82,7 +82,7 @@ class SharedResources < Sinatra::Base
     if File.file?(erb_path)
       content_type extname[1..-1].to_sym
       cache :static
-      return ERB.new(IO.read(erb_path)).result
+      return ERB.new(File.read(erb_path)).result
     end
 
     pass

--- a/shared/test/test_milestone_parser.rb
+++ b/shared/test/test_milestone_parser.rb
@@ -56,7 +56,7 @@ class TestMilestoneParser < Minitest::Test
         ]}
       ]
     )
-    @cache = JSON.parse(IO.read(CACHE_FILE))
+    @cache = JSON.parse(File.read(CACHE_FILE))
   end
 
   def test_parse_create_cache

--- a/shared/test/test_s3_packaging.rb
+++ b/shared/test/test_s3_packaging.rb
@@ -51,7 +51,7 @@ class S3PackagingTest < Minitest::Test
     # starts out as nil, since we don't have a commit_hash file
     assert @packager.send(:target_commit_hash, @target_location).nil?
 
-    IO.write(@target_location + '/commit_hash', 'manual-hash')
+    File.write(@target_location + '/commit_hash', 'manual-hash')
     assert_equal @packager.send(:target_commit_hash, @target_location), 'manual-hash'
     FileUtils.rm(@target_location + '/commit_hash')
   end
@@ -68,7 +68,7 @@ class S3PackagingTest < Minitest::Test
     # package contains a commit_hash
     commit_hash_file = @target_location + '/commit_hash'
     assert File.exist?(commit_hash_file)
-    assert_equal ORIGINAL_HASH, IO.read(commit_hash_file)
+    assert_equal ORIGINAL_HASH, File.read(commit_hash_file)
 
     assert File.exist?(@target_location + '/output.js')
   end

--- a/shared/test/test_sources.rb
+++ b/shared/test/test_sources.rb
@@ -722,7 +722,7 @@ class SourcesTest < FilesApiTestBase
   end
 
   def test_remove_under_13_comments
-    comment_block_sources = JSON.parse(IO.read(COMMENT_BLOCK_SOURCES))
+    comment_block_sources = JSON.parse(File.read(COMMENT_BLOCK_SOURCES))
     birthdays = [Date.parse("1900-01-01"), Date.today]
     sources = ["short_source_with_comments", "long_source_with_comments"]
     sessions = [:admin, :non_owner]


### PR DESCRIPTION
Specifically, I ran `bundle exec rubocop -A --only Security/IoMethods` to automatically replace all appropriate uses of `IO.` methods with comparable `File.` methods.

According to https://docs.rubocop.org/rubocop/cops_security.html#securityiomethods, this is preferable because:

> If argument starts with a pipe character ('|') and the receiver is the `IO` class, a subprocess is created in the same way as `Kernel#open`, and its output is returned. `Kernel#open` may allow unintentional command injection, which is the reason these `IO` methods are a security risk.  Consider to use `File.read` to disable the behavior of subprocess invocation.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
