### PR TITLE
Show error message in LessonLockDialog if updateLockStatus fails

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -857,6 +857,7 @@
   "errorParsingLibrary": "There is an error in your imported library ({libraryName}). Try deleting and re-importing this library. {errorMessage}",
   "errorQuestionMarksInNumberField": "Try replacing \"???\" with a value.",
   "errorRequiredParamsMissing": "Create a parameter for your function by clicking \"edit\" and adding the necessary parameters. Drag the new parameter blocks into your function definition.",
+  "errorSavingLockStatus": "An error has occurred. Changes may not have saved.",
   "errorUnusedFunction": "You created a function, but never used it on your workspace! Click on \"Functions\" in the toolbox and make sure you use it in your program.",
   "errorUnusedParam": "You added a parameter block, but didn't use it in the definition. Make sure to use your parameter by clicking \"edit\" and placing the parameter block inside the green block.",
   "errorDeleting": "Error deleting file.",

--- a/apps/src/code-studio/components/progress/lessonLockDialog/LessonLockDialog.jsx
+++ b/apps/src/code-studio/components/progress/lessonLockDialog/LessonLockDialog.jsx
@@ -77,6 +77,7 @@ function LessonLockDialog({
 
   const handleSave = async () => {
     setSaving(true);
+    setError(null);
     const csrfToken = $('meta[name="csrf-token"]').attr('content');
     const saveLockStateResponse = await saveLockState(
       serverLockState,

--- a/apps/src/code-studio/components/progress/lessonLockDialog/LessonLockDialog.jsx
+++ b/apps/src/code-studio/components/progress/lessonLockDialog/LessonLockDialog.jsx
@@ -33,6 +33,7 @@ function LessonLockDialog({
 
   const [clientLockState, setClientLockState] = useState([]);
   const [saving, setSaving] = useState(false);
+  const [error, setError] = useState(null);
 
   // The data returned from useGetLockState is the state that's currently saved
   // on the server associated with the given unit, lesson, and section. We also
@@ -77,10 +78,19 @@ function LessonLockDialog({
   const handleSave = async () => {
     setSaving(true);
     const csrfToken = $('meta[name="csrf-token"]').attr('content');
-    await saveLockState(serverLockState, clientLockState, csrfToken);
-    // Refresh the lock information on the script overview page and teacher panel
-    await refetchSectionLockStatus(selectedSectionId, unitId);
-    handleClose();
+    const saveLockStateResponse = await saveLockState(
+      serverLockState,
+      clientLockState,
+      csrfToken
+    );
+    if (saveLockStateResponse.ok) {
+      // Refresh the lock information on the script overview page and teacher panel
+      await refetchSectionLockStatus(selectedSectionId, unitId);
+      handleClose();
+    } else {
+      setSaving(false);
+      setError(commonMsg.errorSavingLockStatus());
+    }
   };
 
   //
@@ -221,6 +231,7 @@ function LessonLockDialog({
         {renderStudentTable()}
       </div>
       <div style={styles.buttonContainer}>
+        {error && <span style={styles.error}>{error}</span>}
         <button
           type="button"
           style={progressStyles.baseButton}
@@ -296,6 +307,10 @@ const styles = {
   },
   hidden: {
     display: 'none'
+  },
+  error: {
+    color: color.red,
+    fontStyle: 'italic'
   }
 };
 


### PR DESCRIPTION
Follow up to #47358. Right now, if the request to lock or unlock a lesson fails, we just close the dialog and assume it worked. This adds a simple error message if that request fails.

![Screen Shot 2022-07-25 at 2 13 45 PM](https://user-images.githubusercontent.com/46464143/181595658-1780a1b9-0cf0-454b-8672-3332d8d9adb6.png)


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
