### PR TITLE
Add CSD 2022 to translation pipeline

### DIFF
--- a/lib/cdo/script_constants.rb
+++ b/lib/cdo/script_constants.rb
@@ -148,6 +148,15 @@ module ScriptConstants
       CSD2_PILOT_NAME = 'csd2-pilot'.freeze,
       CSD3_PILOT_NAME = 'csd3-pilot'.freeze,
     ],
+    csd_2022: [
+      CSD1_2022_NAME = 'csd1-2022'.freeze,
+      CSD2_2022_NAME = 'csd2-2022'.freeze,
+      CSD3_2022_NAME = 'csd3-2022'.freeze,
+      CSD4_2022_NAME = 'csd4-2022'.freeze,
+      CSD5_2022_NAME = 'csd5-2022'.freeze,
+      CSD6_2022_NAME = 'csd6-2022'.freeze,
+      CSD7_2022_NAME = 'csd7-2022'.freeze,
+    ],
     csd_2021: [
       CSD1_2021_NAME = 'csd1-2021'.freeze,
       CSD2_2021_NAME = 'csd2-2021'.freeze,
@@ -412,6 +421,7 @@ module ScriptConstants
       ScriptConstants.unit_in_category?(:csd_2018, script) ||
       ScriptConstants.unit_in_category?(:csd_2019, script) ||
       ScriptConstants.unit_in_category?(:csd_2021, script) ||
+      ScriptConstants.unit_in_category?(:csd_2022, script) ||
       ScriptConstants.unit_in_category?(:twenty_hour, script) ||
       ScriptConstants.unit_in_category?(:hoc, script) ||
       JIGSAW_NAME == script ||


### PR DESCRIPTION
**What:** Add the CSD 2022 script to the translation pipeline.

**Why:** So all of our CSD 2022 units are translateable!

## Links
- jira ticket: [FND-2085](https://codedotorg.atlassian.net/browse/FND-2085)

## Testing story
Locally ran the sync-in to confirm the CSD 2022 scripts (`csd*-2022`) were included

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
