### PR TITLE
quick fix to prevent regenerating missing curriculum pdfs

### DIFF
--- a/dashboard/config/locales/scripts.en.yml
+++ b/dashboard/config/locales/scripts.en.yml
@@ -6285,7 +6285,7 @@ en:
         hello-world-draft:
           lesson_groups: {}
           name: hello-world-draft
-          title: '"Hello, World!"'
+          title: Hello, World!
           description_audience: ''
           description_short: ''
           description: ''

--- a/dashboard/config/scripts_json/hello-world-draft.script_json
+++ b/dashboard/config/scripts_json/hello-world-draft.script_json
@@ -10,7 +10,7 @@
     },
     "new_name": null,
     "family_name": "poster",
-    "serialized_at": "2021-11-22 19:57:44 UTC",
+    "serialized_at": "2022-07-28 18:41:12 UTC",
     "published_state": "beta",
     "instruction_type": "teacher_led",
     "instructor_audience": "teacher",

--- a/dashboard/lib/services/curriculum_pdfs.rb
+++ b/dashboard/lib/services/curriculum_pdfs.rb
@@ -127,7 +127,7 @@ module Services
     # Do no generate the resources pdf is there are no lesson plans since
     # resources are attached to lesson plans
     def self.should_generate_resource_pdf?(unit)
-      !unit.unit_without_lesson_plans?
+      !unit.unit_without_lesson_plans? && unit.lessons.map(&:resources).flatten.any?
     end
 
     # Actually generate PDFs for the given script, and upload the results to S3.

--- a/dashboard/lib/tasks/curriculum_pdfs.rake
+++ b/dashboard/lib/tasks/curriculum_pdfs.rake
@@ -36,6 +36,10 @@ namespace :curriculum_pdfs do
     puts "No missing PDFs found" unless any_missing_pdfs_found
   end
 
+  # In order to run this in development, you may first need to install puppeteer via:
+  #   bin/generate-pdf
+  #   yarn install
+  # on the staging machine, this is taken care of in cookbooks/cdo-apps/recipes/generate_pdf.rb
   desc 'Generate any PDFs that we would expect to have been generated automatically but for whatever reason haven\'t been.'
   task generate_missing_pdfs: :environment do
     get_pdf_enabled_scripts.each do |script|

--- a/dashboard/lib/tasks/curriculum_pdfs.rake
+++ b/dashboard/lib/tasks/curriculum_pdfs.rake
@@ -37,7 +37,7 @@ namespace :curriculum_pdfs do
   end
 
   # In order to run this in development, you may first need to install puppeteer via:
-  #   bin/generate-pdf
+  #   cd bin/generate-pdf
   #   yarn install
   # on the staging machine, this is taken care of in cookbooks/cdo-apps/recipes/generate_pdf.rb
   desc 'Generate any PDFs that we would expect to have been generated automatically but for whatever reason haven\'t been.'

--- a/dashboard/test/lib/services/curriculum_pdfs_test.rb
+++ b/dashboard/test/lib/services/curriculum_pdfs_test.rb
@@ -101,16 +101,23 @@ module Services
 
     test 'will only generate a resources PDF when unit has lesson plans' do
       CDO.stubs(:rack_env).returns(:staging)
-      unit_with_lesson_plans = create(:script, is_migrated: true, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.beta)
-      lg_with_lps = create(:lesson_group, script: unit_with_lesson_plans)
-      create(:lesson, script: unit_with_lesson_plans, lesson_group: lg_with_lps, has_lesson_plan: true)
 
       unit_without_lesson_plans = create(:script, is_migrated: true, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.beta)
-      lg_without_lps = create(:lesson_group, script: unit_with_lesson_plans)
-      create(:lesson, script: unit_without_lesson_plans, lesson_group: lg_without_lps, has_lesson_plan: false)
+      lg = create(:lesson_group, script: unit_without_lesson_plans)
+      create(:lesson, script: unit_without_lesson_plans, lesson_group: lg, has_lesson_plan: false)
 
-      assert Services::CurriculumPdfs.should_generate_resource_pdf?(unit_with_lesson_plans)
+      unit_with_lesson_plans = create(:script, is_migrated: true, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.beta)
+      lg = create(:lesson_group, script: unit_with_lesson_plans)
+      create(:lesson, script: unit_with_lesson_plans, lesson_group: lg, has_lesson_plan: true)
+
+      unit_with_lesson_resources = create(:script, is_migrated: true, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.beta)
+      lg = create(:lesson_group, script: unit_with_lesson_resources)
+      lesson = create(:lesson, script: unit_with_lesson_resources, lesson_group: lg, has_lesson_plan: true)
+      lesson.resources = [create(:resource)]
+
       refute Services::CurriculumPdfs.should_generate_resource_pdf?(unit_without_lesson_plans)
+      refute Services::CurriculumPdfs.should_generate_resource_pdf?(unit_with_lesson_plans)
+      assert Services::CurriculumPdfs.should_generate_resource_pdf?(unit_with_lesson_resources)
     end
 
     test 'All PDFs in the given directory are uploaded to S3' do


### PR DESCRIPTION
Now that we use `generate_missing_pdfs` as part of the staging build, it has been repeatedly trying to regenerate the following PDFs:
![Screen Shot 2022-07-28 at 11 46 32 AM](https://user-images.githubusercontent.com/8001765/181614527-fb4d184e-26bd-4a00-a723-c870f33145f3.png)

There are two problems:
1. we try to generate resource overview PDFs even when there are no resources in a script
2. the script overview PDF filename contains the script display name. quotes are stripped from the filename when we write it to S3, and then we cannot find it when we look for it later

This PR makes a proper fix for (1), and a quick fix for (2).

## Testing story

Ran `generate_missing_pdfs` locally with `DEBUG = true` here: https://github.com/code-dot-org/code-dot-org/blob/07544bebcca35ca027de102abb5b4353d609748b/dashboard/lib/services/curriculum_pdfs.rb#L80 and verified that the hello-world-draft PDFs are no longer repeatedly regenerated.

also made sure this command passes:
```
Dave-MBP:~/src/cdo/dashboard (pdf-gen-fixup)$ rake seed:single_script SCRIPT_NAME=hello-world-draft 
```

## Follow-up work

We should be canonicalizing the S3 filenames, so that when we upload to a filename, we can reliably check whether that file exists later: [PLAT-1925](https://codedotorg.atlassian.net/browse/PLAT-1925)