### PR TITLE
[Sprite Lab] Allow levelbuilders to override default success message

### DIFF
--- a/apps/src/p5lab/spritelab/CoreLibrary.js
+++ b/apps/src/p5lab/spritelab/CoreLibrary.js
@@ -26,6 +26,7 @@ export default class CoreLibrary {
     this.soundLog = [];
     this.criteria = [];
     this.previous = {};
+    this.successMessage = 'genericSuccess';
     this.validationFrames = {
       delay: 90,
       fail: 150,

--- a/apps/src/p5lab/spritelab/commands/validationCommands.js
+++ b/apps/src/p5lab/spritelab/commands/validationCommands.js
@@ -112,7 +112,10 @@ export const commands = {
     }
   },
 
-  // Used in levels to override default validation timing.
+  // Used in levels to override default validation settings.
+  setSuccessMessage(message) {
+    this.successMessage = message;
+  },
   setEarlyTime(frames) {
     this.validationFrames.early = frames;
   },

--- a/apps/src/p5lab/spritelab/commands/validationCommands.js
+++ b/apps/src/p5lab/spritelab/commands/validationCommands.js
@@ -187,7 +187,7 @@ export const commands = {
         if (this.currentFrame() > this.validationFrames.pass) {
           return {
             state: 'succeeded',
-            feedback: commands.reportSuccess(this.criteria)
+            feedback: commands.reportSuccess(this.criteria, this.successMessage)
           };
         }
         break;
@@ -284,7 +284,7 @@ export const commands = {
   },
 
   // Used at the end of a level. If there are no failed criteria, return the generic success feedback.
-  reportSuccess(criteria) {
+  reportSuccess(criteria, message) {
     let firstFailed = -1;
     for (const criterion in criteria) {
       if (!criteria[criterion].complete && firstFailed === -1) {
@@ -292,7 +292,7 @@ export const commands = {
       }
     }
     if (firstFailed === -1) {
-      return 'genericSuccess';
+      return message;
     }
   }
 };

--- a/dashboard/app/models/levels/gamelab_jr.rb
+++ b/dashboard/app/models/levels/gamelab_jr.rb
@@ -189,6 +189,7 @@ check();
 'if (World.frameCount == 1) {
   setFailTime(150); // Frames to wait before failing student
   setDelayTime(90); // Frames to wait after success before stopping program
+  setSuccessMessage("genericExplore"); // Translated string to show upon success.
 
   addCriteria(function() {
     return minimumSprites(1); // Check whether or not the student created a sprite.


### PR DESCRIPTION
## Context

The current criterion commands available to levelbuilders work with the assumption that levels should always display the `'genericSuccess'` string upon completion. In English:
>You've finished the level! Press Continue to go on.

(English strings are defined here: https://github.com/code-dot-org/code-dot-org/blob/staging/apps/i18n/spritelab/en_us.json)

We can easily add a helper function for levelbuilders to override this message, if desired.

### Without new command
| Validation Code | Default Student Feedback|
|-|-|
|<img width="685" alt="image" src="https://user-images.githubusercontent.com/43474485/182419234-d1bc2582-d60f-427b-9565-15127b5aac9a.png"> |<img width="649" alt="image" src="https://user-images.githubusercontent.com/43474485/182419680-41206175-7526-41c0-afda-45a9da73149f.png">|

### With new command
| Validation Code | Custom Student Feedback|
|-|-|
| <img width="692" alt="image" src="https://user-images.githubusercontent.com/43474485/182419104-08af90e3-a042-43af-8f71-624e78209f9e.png">| <img width="646" alt="image" src="https://user-images.githubusercontent.com/43474485/182419848-744870ba-5ea8-405d-b975-b84d137db919.png">|
**Strategy:**
1. Replace the hard-coded value `'genericSuccess'` with `successMessage`, a property defined on CoreLibrary.
2. Create a helper function to set the value of the new property.
3. Add an example usage to validation templates (see https://github.com/code-dot-org/code-dot-org/pull/47114)

## Links/Follow-up Work

Several proposed improvements for Sprite Lab validation are detailed in the doc below. If any follow-up items become ready for review before this merges, they will be added to this description.
* https://github.com/code-dot-org/code-dot-org/pull/47451

Google Doc: [Validation Proposals](https://docs.google.com/document/d/1XqGsLsDqwlz6agl9Iyn4S26y-dRm3WkDRsze43hRiug/edit)
