### PR TITLE
Remove radium from Applab Visualization Column

### DIFF
--- a/apps/src/applab/ApplabVisualizationColumn.jsx
+++ b/apps/src/applab/ApplabVisualizationColumn.jsx
@@ -4,7 +4,6 @@ import * as color from '../util/color';
 import {getAppWidth, APP_HEIGHT} from './constants';
 import React from 'react';
 import PropTypes from 'prop-types';
-import Radium from 'radium';
 import Visualization from './Visualization';
 import CompletionButton from '../templates/CompletionButton';
 import PlaySpaceHeader from './PlaySpaceHeader';
@@ -86,6 +85,8 @@ class ApplabVisualizationColumn extends React.Component {
       widgetMode
     } = this.props;
 
+    const maxWidth = !isResponsive && {maxWidth: nonResponsiveWidth};
+
     let visualization = [
       <Visualization key="1" />,
       isIframeEmbed && !isRunning && (
@@ -118,7 +119,7 @@ class ApplabVisualizationColumn extends React.Component {
       <div
         id="visualizationColumn"
         className={this.getClassNames()}
-        style={[!isResponsive && {maxWidth: nonResponsiveWidth}]}
+        style={maxWidth}
       >
         {!isReadOnlyWorkspace && (
           <PlaySpaceHeader
@@ -197,4 +198,4 @@ export default connect(state => ({
   playspacePhoneFrame: state.pageConstants.playspacePhoneFrame,
   pinWorkspaceToBottom: state.pageConstants.pinWorkspaceToBottom,
   widgetMode: state.pageConstants.widgetMode
-}))(Radium(ApplabVisualizationColumn));
+}))(ApplabVisualizationColumn);

--- a/apps/src/applab/ApplabVisualizationColumn.jsx
+++ b/apps/src/applab/ApplabVisualizationColumn.jsx
@@ -85,7 +85,7 @@ class ApplabVisualizationColumn extends React.Component {
       widgetMode
     } = this.props;
 
-    const maxWidth = !isResponsive && {maxWidth: nonResponsiveWidth};
+    const maxWidth = !isResponsive ? {maxWidth: nonResponsiveWidth} : {};
 
     let visualization = [
       <Visualization key="1" />,


### PR DESCRIPTION
This is part of the work to stop using Radium. See https://github.com/code-dot-org/code-dot-org/pull/47367 for more discussion.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

This component is in [storybook](https://code-dot-org.github.io/cdo-styleguide/?selectedKind=ApplabVisualizationColumn&selectedStory=Overview&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel). Locally, it looks like:
<img width="410" alt="image" src="https://user-images.githubusercontent.com/9142121/182460144-be479b1b-830b-46bf-9488-871b2e9ee47d.png">

There are animations when hovering over the buttons, as is consistent with storybook. Weirdly, in production storybook, some images are not loading ("Failed to load resource: the server responded with a status of 404 ()"), but barring the missing images, the styles look consistent.

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
