### PR TITLE
Remove radium from Animation Tab and dependencies

### DIFF
--- a/apps/src/p5lab/AnimationTab/AnimationListItem.jsx
+++ b/apps/src/p5lab/AnimationTab/AnimationListItem.jsx
@@ -189,10 +189,10 @@ class AnimationListItem extends React.Component {
       animationName = <div style={styles.nameLabel}>{name}</div>;
     }
 
-    const selectedStyle = this.props.isSelected && styles.selectedTile;
+    const selectedStyle = this.props.isSelected ? styles.selectedTile : {};
     const tileStyle = {...styles.tile, ...selectedStyle, ...this.props.style};
 
-    const arrowStyle = [this.props.isSelected && styles.rightArrow];
+    const arrowStyle = this.props.isSelected ? styles.rightArrow : {};
 
     return (
       <button style={tileStyle} onClick={this.onSelect} type="button">

--- a/apps/src/p5lab/AnimationTab/AnimationListItem.jsx
+++ b/apps/src/p5lab/AnimationTab/AnimationListItem.jsx
@@ -1,7 +1,6 @@
 /** A single list item representing an animation. */
 import PropTypes from 'prop-types';
 import React from 'react';
-import Radium from 'radium';
 import {connect} from 'react-redux';
 import color from '@cdo/apps/util/color';
 import * as shapes from '../shapes';
@@ -180,7 +179,7 @@ class AnimationListItem extends React.Component {
         <div style={styles.nameInputWrapper}>
           <input
             type="text"
-            style={[styles.nameInput, invalidNameStyle]}
+            style={{...styles.nameInput, ...invalidNameStyle}}
             value={name}
             onChange={this.onNameChange}
           />
@@ -190,11 +189,8 @@ class AnimationListItem extends React.Component {
       animationName = <div style={styles.nameLabel}>{name}</div>;
     }
 
-    const tileStyle = [
-      styles.tile,
-      this.props.isSelected && styles.selectedTile,
-      this.props.style
-    ];
+    const selectedStyle = this.props.isSelected && styles.selectedTile;
+    const tileStyle = {...styles.tile, ...selectedStyle, ...this.props.style};
 
     const arrowStyle = [this.props.isSelected && styles.rightArrow];
 
@@ -318,4 +314,4 @@ export default connect(
       }
     };
   }
-)(Radium(AnimationListItem));
+)(AnimationListItem);

--- a/apps/src/p5lab/AnimationTab/AnimationTab.jsx
+++ b/apps/src/p5lab/AnimationTab/AnimationTab.jsx
@@ -1,7 +1,6 @@
 /** @file Root of the animation editor interface mode for GameLab */
 import PropTypes from 'prop-types';
 import React from 'react';
-import Radium from 'radium';
 import {connect} from 'react-redux';
 import color from '@cdo/apps/util/color';
 import AnimationPicker, {PICKER_TYPE} from '../AnimationPicker/AnimationPicker';
@@ -53,7 +52,7 @@ class AnimationTab extends React.Component {
           </div>
           <div style={styles.editorColumn}>
             <PiskelEditor style={styles.piskelEl} />
-            <div style={[hidePiskelStyle, styles.emptyPiskelEl]}>
+            <div style={{...hidePiskelStyle, ...styles.emptyPiskelEl}}>
               <div style={styles.helpText}>
                 Add a new animation on the left to begin
               </div>
@@ -129,4 +128,4 @@ export default connect(
       dispatch(setColumnSizes(widths));
     }
   })
-)(Radium(AnimationTab));
+)(AnimationTab);

--- a/apps/src/p5lab/AnimationTab/ListItemButtons.jsx
+++ b/apps/src/p5lab/AnimationTab/ListItemButtons.jsx
@@ -3,7 +3,6 @@ import React from 'react';
 import {OverlayTrigger, Tooltip} from 'react-bootstrap';
 import color from '@cdo/apps/util/color';
 import PropTypes from 'prop-types';
-import Radium from 'radium';
 import SpeedSlider from '@cdo/apps/templates/SpeedSlider';
 import ItemLoopToggle from './ItemLoopToggle';
 import DeleteAnimationDialog from './DeleteAnimationDialog';
@@ -72,7 +71,7 @@ class ListItemButtons extends React.Component {
               <i
                 key="trash"
                 className="fa fa-trash-o"
-                style={[styles.icon, styles.trash]}
+                style={{...styles.icon, ...styles.trash}}
                 onClick={this.openDeleteDialog}
               />
             </OverlayTrigger>
@@ -132,4 +131,4 @@ const styles = {
   }
 };
 
-export default Radium(ListItemButtons);
+export default ListItemButtons;

--- a/apps/src/templates/SpeedSlider.jsx
+++ b/apps/src/templates/SpeedSlider.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import color from '../util/color';
 import PropTypes from 'prop-types';
-import Radium from 'radium';
 import dom from '../dom';
 
 const style = {
@@ -206,4 +205,4 @@ class SpeedSlider extends React.Component {
   }
 }
 
-export default Radium(SpeedSlider);
+export default SpeedSlider;


### PR DESCRIPTION
This is part of the work to stop using Radium. See https://github.com/code-dot-org/code-dot-org/pull/47367 for more discussion.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

The only component here that's in storybook is Speed Slider:
Speed Slider (compare to [storybook](https://code-dot-org.github.io/cdo-styleguide/?selectedKind=SpeedSlider&selectedStory=Default&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel ))
<img width="142" alt="image" src="https://user-images.githubusercontent.com/9142121/182450026-9a3feae7-b2f9-4440-877b-3169c070d586.png">

The others are part of AnimationList, given there is at least one sprite. For these, I looked at https://studio.code.org/projects/gamelab on my local machine, so http://localhost-studio.code.org:3000/projects/gamelab. From there, I added some sprits and it looks like
<img width="146" alt="image" src="https://user-images.githubusercontent.com/9142121/182458894-08ce4b45-641c-4a6e-b665-b479b7f191ea.png">

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
