### PR TITLE
Remove radium from Print Certificates

### DIFF
--- a/apps/src/templates/teacherDashboard/PrintCertificates.jsx
+++ b/apps/src/templates/teacherDashboard/PrintCertificates.jsx
@@ -1,11 +1,10 @@
 import React, {Component} from 'react';
-import i18n from '@cdo/locale';
-import $ from 'jquery';
-import {pegasus} from '@cdo/apps/lib/util/urlHelpers';
-import color from '../../util/color';
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
-
-const STANDARD_PADDING = 20;
+import $ from 'jquery';
+import i18n from '@cdo/locale';
+import {pegasus} from '@cdo/apps/lib/util/urlHelpers';
+import style from './print-certificates.module.scss;';
 
 class PrintCertificates extends Component {
   static propTypes = {
@@ -33,7 +32,7 @@ class PrintCertificates extends Component {
   render() {
     return (
       <form
-        style={styles.main}
+        className={style.main}
         ref={element => (this.certForm = element)}
         action={pegasus('/certificates')}
         method="POST"
@@ -46,10 +45,9 @@ class PrintCertificates extends Component {
         {this.state.names.map((name, index) => (
           <input key={index} type="hidden" name="names[]" value={name} />
         ))}
-        <div style={styles.outerStyle}>
+        <div className={style.outerStyle}>
           <div
-            className="uitest-certs-link"
-            style={styles.actionText}
+            className={classNames('uitest-certs-link', style.actionText)}
             onClick={this.onClickPrintCerts}
           >
             {i18n.printCertificates()}
@@ -59,25 +57,5 @@ class PrintCertificates extends Component {
     );
   }
 }
-
-const styles = {
-  main: {
-    margin: 0
-  },
-  outerStyle: {
-    paddingLeft: STANDARD_PADDING,
-    paddingRight: STANDARD_PADDING,
-    paddingTop: STANDARD_PADDING / 4,
-    paddingBottom: STANDARD_PADDING / 4,
-    cursor: 'pointer',
-    ':hover': {
-      backgroundColor: color.lightest_gray
-    }
-  },
-  actionText: {
-    fontSize: 13,
-    color: color.dark_charcoal
-  }
-};
 
 export default PrintCertificates;

--- a/apps/src/templates/teacherDashboard/PrintCertificates.jsx
+++ b/apps/src/templates/teacherDashboard/PrintCertificates.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import $ from 'jquery';
 import i18n from '@cdo/locale';
 import {pegasus} from '@cdo/apps/lib/util/urlHelpers';
-import style from './print-certificates.module.scss;';
+import style from './print-certificates.module.scss';
 
 class PrintCertificates extends Component {
   static propTypes = {

--- a/apps/src/templates/teacherDashboard/PrintCertificates.jsx
+++ b/apps/src/templates/teacherDashboard/PrintCertificates.jsx
@@ -4,7 +4,6 @@ import $ from 'jquery';
 import {pegasus} from '@cdo/apps/lib/util/urlHelpers';
 import color from '../../util/color';
 import PropTypes from 'prop-types';
-import Radium from 'radium'; // eslint-disable-line no-restricted-imports
 
 const STANDARD_PADDING = 20;
 
@@ -81,4 +80,4 @@ const styles = {
   }
 };
 
-export default Radium(PrintCertificates);
+export default PrintCertificates;

--- a/apps/src/templates/teacherDashboard/print-certificates.module.scss
+++ b/apps/src/templates/teacherDashboard/print-certificates.module.scss
@@ -1,0 +1,24 @@
+@import 'color.scss';
+
+$standard-padding: 42px;
+
+.main {
+  margin: 0;
+}
+
+.outerStyle {
+  padding-left: $standard-padding;
+  padding-right: $standard-padding;
+  padding-top: $standard-padding / 4;
+  padding-bottom: $standard-padding / 4;
+  cursor: pointer;
+
+  &:hover {
+    background-color: $lightest_gray;
+  }
+}
+
+.actionText {
+  font-size: 13px;
+  color: $dark_charcoal;
+}

--- a/apps/src/templates/teacherDashboard/print-certificates.module.scss
+++ b/apps/src/templates/teacherDashboard/print-certificates.module.scss
@@ -1,6 +1,6 @@
 @import 'color.scss';
 
-$standard-padding: 42px;
+$standard-padding: 20px;
 
 .main {
   margin: 0;


### PR DESCRIPTION
This is part of the work to stop using Radium. See https://github.com/code-dot-org/code-dot-org/pull/47367 for more discussion.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

From what I've explored, PrintCertificates is an option on a dropdown menu. Locally it looks like:

<img width="187" alt="image" src="https://user-images.githubusercontent.com/9142121/182677882-09b1b554-3ede-4f9f-a47c-6cce4707e03c.png">

I didn't do more investigation, as it looks like this component isn't using Radium.

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
