### PR TITLE
Remove radium from InstructionsCSF and dependencies

### DIFF
--- a/apps/src/templates/instructions/InstructionsCSF.jsx
+++ b/apps/src/templates/instructions/InstructionsCSF.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Radium from 'radium'; // eslint-disable-line no-restricted-imports
 import {connect} from 'react-redux';
 import ThreeColumns from './ThreeColumns';
 import {Z_INDEX as OVERLAY_Z_INDEX} from '../Overlay';
@@ -291,17 +290,20 @@ class InstructionsCSF extends React.Component {
   }
 
   render() {
-    const mainStyle = [
-      styles.main,
-      {
+    const mainStyle = {
+      ...styles.main,
+      ...{
         height: this.props.height - HEADER_HEIGHT
       },
-      this.props.noVisualization && styles.noViz,
-      this.props.overlayVisible && styles.withOverlay
-    ];
+      ...(this.props.noVisualization && styles.noViz),
+      ...(this.props.overlayVisible && styles.withOverlay)
+    };
 
     const threeColumnsStyles = {
-      container: [styles.body, this.props.isMinecraft && craftStyles.body],
+      container: {
+        ...styles.body,
+        ...(this.props.isMinecraft && craftStyles.body)
+      },
       left: this.props.isRtl ? styles.leftColRtl : styles.leftCol
     };
 
@@ -413,4 +415,4 @@ export default connect(
   },
   null,
   {withRef: true}
-)(Radium(InstructionsCSF));
+)(InstructionsCSF);

--- a/apps/src/templates/instructions/InstructionsCsfLeftCol.jsx
+++ b/apps/src/templates/instructions/InstructionsCsfLeftCol.jsx
@@ -2,7 +2,6 @@ import $ from 'jquery';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
-import Radium from 'radium'; // eslint-disable-line no-restricted-imports
 import classNames from 'classnames';
 import {connect} from 'react-redux';
 import PromptIcon from './PromptIcon';
@@ -85,10 +84,10 @@ class InstructionsCsfLeftCol extends React.Component {
         ref={c => {
           this.leftCol = c;
         }}
-        style={[
-          commonStyles.bubble,
-          !hasAuthoredHints && styles.noAuthoredHints
-        ]}
+        style={{
+          ...commonStyles.bubble,
+          ...(!hasAuthoredHints && styles.noAuthoredHints)
+        }}
       >
         <div
           className={classNames('prompt-icon-cell', {
@@ -118,7 +117,7 @@ const styles = {
   }
 };
 
-export const UnconnectedInstructionsCsfLeftCol = Radium(InstructionsCsfLeftCol);
+export const UnconnectedInstructionsCsfLeftCol = InstructionsCsfLeftCol;
 
 export default connect(
   function propsFromStore(state) {
@@ -133,4 +132,4 @@ export default connect(
   null,
   null,
   {withRef: true}
-)(Radium(InstructionsCsfLeftCol));
+)(InstructionsCsfLeftCol);

--- a/apps/src/templates/instructions/InstructionsCsfRightCol.jsx
+++ b/apps/src/templates/instructions/InstructionsCsfRightCol.jsx
@@ -2,7 +2,6 @@ import $ from 'jquery';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
-import Radium from 'radium'; // eslint-disable-line no-restricted-imports
 import {connect} from 'react-redux';
 import CollapserButton from './CollapserButton';
 import ScrollButtons from './ScrollButtons';
@@ -111,10 +110,10 @@ class InstructionsCsfRightCol extends React.Component {
             ref={c => {
               this.collapser = c;
             }}
-            style={[
-              styles.collapserButton,
-              this.props.isMinecraft && styles.craftStyles.collapserButton
-            ]}
+            style={{
+              ...styles.collapserButton,
+              ...(this.props.isMinecraft && styles.craftStyles.collapserButton)
+            }}
             collapsed={this.props.collapsed}
             onClick={this.props.handleClickCollapser}
             isMinecraft={this.props.isMinecraft}
@@ -123,14 +122,14 @@ class InstructionsCsfRightCol extends React.Component {
         )}
         {this.props.displayScrollButtons && (
           <ScrollButtons
-            style={[
-              styles.scrollButtons,
-              this.props.isMinecraft &&
+            style={{
+              ...styles.scrollButtons,
+              ...(this.props.isMinecraft &&
                 (this.props.isRtl
                   ? styles.craftStyles.scrollButtonsRtl
-                  : styles.craftStyles.scrollButtons),
-              displayCollapserButton && scrollButtonsBelowCollapserStyle
-            ]}
+                  : styles.craftStyles.scrollButtons)),
+              ...(displayCollapserButton && scrollButtonsBelowCollapserStyle)
+            }}
             ref={c => {
               this.scrollButtons = c;
             }}
@@ -181,9 +180,7 @@ const styles = {
   }
 };
 
-export const UnconnectedInstructionsCsfRightCol = Radium(
-  InstructionsCsfRightCol
-);
+export const UnconnectedInstructionsCsfRightCol = InstructionsCsfRightCol;
 
 export default connect(
   function propsFromStore(state) {
@@ -199,4 +196,4 @@ export default connect(
   null,
   null,
   {withRef: true}
-)(Radium(InstructionsCsfRightCol));
+)(InstructionsCsfRightCol);

--- a/apps/src/templates/instructions/ThreeColumns.jsx
+++ b/apps/src/templates/instructions/ThreeColumns.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Radium from 'radium'; // eslint-disable-line no-restricted-imports
 import {connect} from 'react-redux';
 
 /**
@@ -49,10 +48,12 @@ const ThreeColumns = props => {
   };
 
   return (
-    <div style={[defaultStyles.container, styles.container]}>
-      <div style={[defaultStyles.middle, styles.middle]}>{children[1]}</div>
-      <div style={[defaultStyles.left, styles.left]}>{children[0]}</div>
-      <div style={[defaultStyles.right, styles.right]}>{children[2]}</div>
+    <div style={{...defaultStyles.container, ...styles.container}}>
+      <div style={{...defaultStyles.middle, ...styles.middle}}>
+        {children[1]}
+      </div>
+      <div style={{...defaultStyles.left, ...styles.left}}>{children[0]}</div>
+      <div style={{...defaultStyles.right, ...styles.right}}>{children[2]}</div>
     </div>
   );
 };
@@ -77,4 +78,4 @@ export default connect(state => {
   return {
     isRtl: state.isRtl
   };
-})(Radium(ThreeColumns));
+})(ThreeColumns);


### PR DESCRIPTION
This is part of the work to stop using Radium. See https://github.com/code-dot-org/code-dot-org/pull/47367 for more discussion.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

This component is in [Storybook](https://code-dot-org.github.io/cdo-styleguide/?selectedKind=TopInstructionsCSF&selectedStory=Full-featured%20Right-to-Left%20example&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel):
<img width="505" alt="image" src="https://user-images.githubusercontent.com/9142121/182719442-74fe3ebe-fc88-4f2f-8ec9-b349c7033f5a.png">

Strangely, there is hover on the scroll arrows in production, but I can't repro locally (with or without my changes).

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
