### PR TITLE
Provision production database secrets.

### DIFF
--- a/aws/cloudformation/components/database.yml.erb
+++ b/aws/cloudformation/components/database.yml.erb
@@ -11,6 +11,19 @@
       Parameters: <%=values.compact.to_json%>
 <%end -%>
 
+<%  db_secrets = [nil, 'application-writer', 'readonly'].map do |user| -%>
+  DatabaseSecret<%=secret = user&.underscore&.camelcase%>:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Description: !Sub "Secrets for accessing database<%user ? " user #{user}" : ''%> from ${AWS::StackName} CloudFormation stack"
+      GenerateSecretString:
+        SecretStringTemplate: !Sub '{"username": "<%=user || '${DatabaseUsername}'%>"}'
+        GenerateStringKey: password
+        PasswordLength: 10
+        ExcludePunctuation: True
+      Name: !Sub "CfnStack/${AWS::StackName}/database-<%=user || 'secret'%>"
+<%  secret; end -%>
+
 # We don't provision these in production via CloudFormation ... yet!
 <% unless rack_env?(:production)%>
   AuroraCluster:
@@ -52,19 +65,6 @@
       Engine: aurora-mysql
       # We will usually do engine version updates manually, so don't specify an EngineVersion for the DBInstance.
 <%  end -%>
-
-<%  db_secrets = [nil, 'application-writer', 'readonly'].map do |user| -%>
-  DatabaseSecret<%=secret = user&.underscore&.camelcase%>:
-    Type: AWS::SecretsManager::Secret
-    Properties:
-      Description: !Sub "Secrets for accessing database<%user ? " user #{user}" : ''%> from ${AWS::StackName} CloudFormation stack"
-      GenerateSecretString:
-        SecretStringTemplate: !Sub '{"username": "<%=user || '${DatabaseUsername}'%>"}'
-        GenerateStringKey: password
-        PasswordLength: 10
-        ExcludePunctuation: True
-      Name: !Sub "CfnStack/${AWS::StackName}/database-<%=user || 'secret'%>"
-<%  secret; end -%>
 
   DBProxy:
     Type: AWS::RDS::DBProxy


### PR DESCRIPTION
Create production database secrets that we can use in a follow up Pull Request to provision RDS Proxy in production (RDS Proxy needs the production database passwords).

This does not change the production SQL passwords. Here’s how the production production web application servers obtain credentials to connect to the database, explained from the bottom of the stack, upwards:

- Credentials
  - **Dashboard (Rails)** uses the `CDO.dashboard_db_reader` and `CDO.dashboard_db_writer` configuration settings [to specify the server name, username, password, and database](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/config/database.yml) to connect to for write and read-split queries.
  - **Pegasus (Sinatra)** uses `CDO.pegasus_db_reader` and `CDO.pegasus_db_writer` configuration settings [when initializing Sequel](https://github.com/code-dot-org/code-dot-org/blob/0ba36731e9f1572f16f63747593edc43a9137a0d/lib/cdo/db.rb#L101) to specify the server name, username, password, and database to connect for write and read-split queries.
- Configuration entries in CDO. are [set by an order of precedence](https://github.com/code-dot-org/code-dot-org/blob/940703c0263ce2915c93b8e7192b96206e1a60be/config/README.md?plain=1#L16-L29): environment variables, locals.yml, globals.yml, env-specific config.yml, base config.yml. While the base config.yml has the lowest precedence, [it can set several database configuration keys](https://github.com/code-dot-org/code-dot-org/blob/0ba36731e9f1572f16f63747593edc43a9137a0d/config.yml.erb#L530-L542) from the core keys: `CDO.db_reader`,  `CDO.db_writer`, `CDO.reporting_db_reader` , `CDO. reporting_db_writer` which may have been set by a higher precedence option, such as globals.yml
- Production daemon and web application server ("FrontEnd") servers currently utilize the values populated in globals.yml to set the core `CDO.db_reader` and `CDO.db_writer` database configuration settings. globals.yml is populated from Chef Default Attributes set for the environment Production in the Chef Manage service via the [cdo-secrets cookbook](https://github.com/code-dot-org/code-dot-org/blob/staging/cookbooks/cdo-secrets/templates/default/globals.yml.erb) and `CDO.db_reporting_reader` and `CDO.db_reporting_writer` are Chef Override Attributes in the Production Environment. But the cdo-mysql cookbook overrides the Chef attributes used to populate globals.yml [if RDS Proxy is enabled](https://github.com/code-dot-org/code-dot-org/blob/435ebf68fc46350382e127dc211be093feb757c0/cookbooks/cdo-mysql/recipes/default.rb#L12-L13) or [if ProxySQL is enabled](https://github.com/code-dot-org/code-dot-org/blob/6e49521fd97dd1e7ced61f801863ad3b48a0d71e/cookbooks/cdo-mysql/recipes/proxy.rb#L122-L125). This override logic only changes the hostname in the credential, not the username/password. Currently ProxySQL is enabled in production, so the local ProxySQL service is substituted as the hostname. ProxySQL gets the database credentials from its main configuration file, which is [populated by a Chef cookbook at build time](https://github.com/code-dot-org/code-dot-org/blob/1ac197ffe084b3e5658d7b2b489cbeefde2b7e57/cookbooks/cdo-mysql/templates/default/proxysql.cnf.erb#L131-L144) from the [same Chef db_writer and db_reader attributes](https://github.com/code-dot-org/code-dot-org/blob/1ac197ffe084b3e5658d7b2b489cbeefde2b7e57/cookbooks/cdo-mysql/recipes/proxy.rb#L30-L33) that provide credentials to the web application servers.






## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

Manually update the passwords in these secrets to have the same value as the current set of Chef Manage attributes and AWS Secrets that are currently being used to to set application database credentials.

Provision RDS Proxy for the production database cluster using the secrets provisioned in this change.

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  3.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
