### PR TITLE
Remove Ruby 2.5

### DIFF
--- a/cookbooks/cdo-ruby/attributes/default.rb
+++ b/cookbooks/cdo-ruby/attributes/default.rb
@@ -1,5 +1,6 @@
 default['cdo-ruby'] = {
   version: '2.6',
+  old_version: '2.5',
   rubygems_version: '2.7.4',
   bundler_version: '1.17.3',
   rake_version: '11.3.0'


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/47406, which added Ruby 2.6

Right now, all of our servers have both Ruby 2.5 and 2.6 installed, but are still configured to use Ruby 2.5. Specifically, because we installed a second version with `apt`, `update-alternatives` now has a queue of possible Ruby versions it can use:

```bash
ubuntu@ip-10-0-0-77:~$ update-alternatives --list ruby                                                                     
/usr/bin/ruby2.5
/usr/bin/ruby2.6
```

Setting `old_version` tells our cookbooks [to uninstall the specified version with apt,](https://github.com/code-dot-org/code-dot-org/blob/ab203184497228c86e52d1ffc607d1c39f86c8d3/cookbooks/cdo-ruby/recipes/brightbox.rb#L24-L35) which will also remove the old version from `update-alternatives` and cause us to begin defaulting to Ruby 2.6

## Deployment strategy

~~Our persistent servers are not automatically updated with cookbooks changes, so we will need to manually run~~

```bash
sudo apt-get purge ruby2.5 ruby2.5-dev
sudo apt-get autoremove
```

~~On staging, test, levelbuilder, production-console, production-daemon, the AMI builder, and the I18N dev instance.~~

Update: Suresh helped me figure out that in fact our persistent servers ARE update with cookbooks changes; I thought they weren't because [my recent changes](https://github.com/code-dot-org/code-dot-org/pull/47406/files#diff-0ffd240287965223f85d69414093e25633e93efd66a92ecf56c75c2e28bc3428) didn't get applied, but what we figured out is that we override the default attributes for our persistent servers in Chef Manage:

![image](https://user-images.githubusercontent.com/244100/184033742-80d5f276-7742-4576-8c0a-f4c8f1e3c782.png)

New deployment plan: I'm going to track down anywhere else we might be overriding these attributes and stop doing so.

## Testing story

Manually tested on an adhoc to confirm that `apt` and `update-alternatives` interact in the desired way.

~~For automated testing, we should make sure to run the above commands on the test server _before_ the test run starts. Note that drone is already using Ruby 2.6~~

## Follow-up work

Once all our servers have been so updated, we can update our Gemfile to drop support for Ruby 2.5

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
