### PR TITLE
Update Docker Image to 1.5.1

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -188,6 +188,6 @@ trigger:
     - pull_request
 ---
 kind: signature
-hmac: de528e9c97dabebec345e9c88efb496e76e8763d87eb9eabef01e31d054cc48c
+hmac: 3926de192f64cce657b11bf4006061630ec73541022acadfa1107e825b570245
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -30,7 +30,7 @@ steps:
       filename: unit-tests-cache.tar
 
   - name: unit-tests
-    image: codedotorg/code-dot-org:1.5
+    image: codedotorg/code-dot-org:1.5.1
     pull: always
     volumes:
       - name: rbenv
@@ -121,7 +121,7 @@ steps:
       restore: true
 
   - name: ui-tests
-    image: codedotorg/code-dot-org:1.5
+    image: codedotorg/code-dot-org:1.5.1
     volumes:
       - name: rbenv
         path: /home/circleci/.rbenv

--- a/docker/setup-compose.yml
+++ b/docker/setup-compose.yml
@@ -13,7 +13,7 @@
 version: "3"
 services:
   site:
-    image: codedotorg/code-dot-org:1.5
+    image: codedotorg/code-dot-org:1.5.1
     user: ${FIXUID:-1000}:${FIXGID:-1000}
     volumes:
       - ../:/home/circleci/code-dot-org:delegated

--- a/docker/site-compose.yml
+++ b/docker/site-compose.yml
@@ -16,7 +16,7 @@
 version: "3"
 services:
   site:
-    image: codedotorg/code-dot-org:1.5
+    image: codedotorg/code-dot-org:1.5.1
     user: ${FIXUID:-1000}:${FIXGID:-1000}
     volumes:
       - ../:/home/circleci/code-dot-org:delegated

--- a/docker/ui-tests-compose.yml
+++ b/docker/ui-tests-compose.yml
@@ -24,7 +24,7 @@
 version: "3"
 services:
   site:
-    image: codedotorg/code-dot-org:1.5
+    image: codedotorg/code-dot-org:1.5.1
     user: ${FIXUID:-1000}:${FIXGID:-1000}
     volumes:
       - ../:/home/circleci/code-dot-org:delegated

--- a/docker/unit-tests-compose.yml
+++ b/docker/unit-tests-compose.yml
@@ -19,7 +19,7 @@
 version: "3"
 services:
   site:
-    image: codedotorg/code-dot-org:1.5
+    image: codedotorg/code-dot-org:1.5.1
     user: ${FIXUID:-1000}:${FIXGID:-1000}
     volumes:
       - ../:/home/circleci/code-dot-org:delegated


### PR DESCRIPTION
To capture the changes in https://github.com/code-dot-org/code-dot-org/pull/47512, I ran

```
docker build .
docker tag 4854fddb48dd codedotorg/code-dot-org:1.5.1
docker push codedotorg/code-dot-org:1.5.1
```

From the `docker/dockerfiles` directory, as described in https://github.com/code-dot-org/code-dot-org/tree/staging/docker#updating-the-docker-hub-image

After updating the various `.yml` files to reference this new version, I then ran `drone sign code-dot-org/code-dot-org --save` to re-sign the drone config as described in https://docs.google.com/document/d/1Qls20xfNN6T_DErOMwVQOFJsxAEAdMWFHzBDIbxyUQQ/edit#heading=h.blmise7gzfvg

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
