### PR TITLE
Refactor headerRedux

### DIFF
--- a/apps/src/code-studio/appRedux.js
+++ b/apps/src/code-studio/appRedux.js
@@ -1,5 +1,5 @@
-const SET_APP_LOAD_STARTED = 'SET_APP_LOAD_STARTED';
-const SET_APP_LOADED = 'SET_APP_LOADED';
+const SET_APP_LOAD_STARTED = 'app/SET_APP_LOAD_STARTED';
+const SET_APP_LOADED = 'app/SET_APP_LOADED';
 
 const initialState = {
   appLoadStarted: false,

--- a/apps/src/code-studio/appRedux.js
+++ b/apps/src/code-studio/appRedux.js
@@ -1,8 +1,8 @@
-const SET_APP_LOAD_STARTED = 'header/SET_APP_LOAD_STARTED';
-const SET_APP_LOADED = 'header/SET_APP_LOADED';
+const SET_APP_LOAD_STARTED = 'SET_APP_LOAD_STARTED';
+const SET_APP_LOADED = 'SET_APP_LOADED';
 
 const initialState = {
-  appLoading: false,
+  appLoadStarted: false,
   appLoaded: false
 };
 

--- a/apps/src/code-studio/appRedux.js
+++ b/apps/src/code-studio/appRedux.js
@@ -1,0 +1,31 @@
+const SET_APP_LOAD_STARTED = 'header/SET_APP_LOAD_STARTED';
+const SET_APP_LOADED = 'header/SET_APP_LOADED';
+
+const initialState = {
+  appLoading: false,
+  appLoaded: false
+};
+
+export default (state = initialState, action) => {
+  if (action.type === SET_APP_LOAD_STARTED) {
+    return {
+      ...state,
+      appLoadStarted: true
+    };
+  }
+  if (action.type === SET_APP_LOADED) {
+    return {
+      ...state,
+      appLoaded: true
+    };
+  }
+  return state;
+};
+
+export const setAppLoadStarted = () => ({
+  type: SET_APP_LOAD_STARTED
+});
+
+export const setAppLoaded = () => ({
+  type: SET_APP_LOADED
+});

--- a/apps/src/code-studio/components/header/EditableProjectName.jsx
+++ b/apps/src/code-studio/components/header/EditableProjectName.jsx
@@ -55,7 +55,7 @@ class UnconnectedDisplayProjectName extends React.Component {
   }
 }
 const DisplayProjectName = connect(state => ({
-  projectName: state.header.projectName
+  projectName: state.project.projectName
 }))(UnconnectedDisplayProjectName);
 
 class UnconnectedEditProjectName extends React.Component {

--- a/apps/src/code-studio/components/header/EditableProjectName.jsx
+++ b/apps/src/code-studio/components/header/EditableProjectName.jsx
@@ -9,7 +9,7 @@ import {
   refreshProjectName,
   setNameFailure,
   unsetNameFailure
-} from '../../headerRedux';
+} from '../../projectRedux';
 import NameFailureDialog from '../NameFailureDialog';
 import NameFailureError from '../../NameFailureError';
 
@@ -142,8 +142,8 @@ class UnconnectedEditProjectName extends React.Component {
 }
 const EditProjectName = connect(
   state => ({
-    projectName: state.header.projectName,
-    projectNameFailure: state.header.projectNameFailure
+    projectName: state.project.projectName,
+    projectNameFailure: state.project.projectNameFailure
   }),
   {
     refreshProjectName,

--- a/apps/src/code-studio/components/header/LevelBuilderSaveButton.jsx
+++ b/apps/src/code-studio/components/header/LevelBuilderSaveButton.jsx
@@ -7,7 +7,7 @@ import {
   setProjectUpdatedError,
   setProjectUpdatedSaving,
   setProjectUpdatedSaved
-} from '../../headerRedux';
+} from '../../projectRedux';
 
 // Levelbuilder-only UI for saving changes to a level.
 class LevelBuilderSaveButton extends React.Component {

--- a/apps/src/code-studio/components/header/MinimalProjectHeader.jsx
+++ b/apps/src/code-studio/components/header/MinimalProjectHeader.jsx
@@ -29,5 +29,5 @@ class MinimalProjectHeader extends React.Component {
 }
 
 export default connect(state => ({
-  projectName: state.header.projectName
+  projectName: state.project.projectName
 }))(MinimalProjectHeader);

--- a/apps/src/code-studio/components/header/ProjectRemix.jsx
+++ b/apps/src/code-studio/components/header/ProjectRemix.jsx
@@ -5,7 +5,7 @@ import React from 'react';
 import {connect} from 'react-redux';
 import i18n from '@cdo/locale';
 import * as utils from '../../../utils';
-import {refreshProjectName} from '../../headerRedux';
+import {refreshProjectName} from '../../projectRedux';
 import {styles} from './EditableProjectName';
 
 class ProjectRemix extends React.Component {

--- a/apps/src/code-studio/components/header/ProjectUpdatedAt.jsx
+++ b/apps/src/code-studio/components/header/ProjectUpdatedAt.jsx
@@ -5,7 +5,7 @@ import msg from '@cdo/locale';
 
 import TimeAgo from '@cdo/apps/templates/TimeAgo';
 
-import {projectUpdatedStatuses as statuses} from '../../headerRedux';
+import {projectUpdatedStatuses as statuses} from '../../projectRedux';
 import RetryProjectSaveDialog from './RetryProjectSaveDialog';
 
 class ProjectUpdatedAt extends React.Component {
@@ -76,6 +76,6 @@ const styles = {
 };
 
 export default connect(state => ({
-  status: state.header.projectUpdatedStatus,
-  updatedAt: state.header.projectUpdatedAt
+  status: state.project.projectUpdatedStatus,
+  updatedAt: state.project.projectUpdatedAt
 }))(ProjectUpdatedAt);

--- a/apps/src/code-studio/components/header/RetryProjectSaveDialog.jsx
+++ b/apps/src/code-studio/components/header/RetryProjectSaveDialog.jsx
@@ -6,7 +6,7 @@ import i18n from '@cdo/locale';
 import {
   projectUpdatedStatuses as statuses,
   retryProjectSave
-} from '../../headerRedux';
+} from '../../projectRedux';
 import BaseDialog from '../../../templates/BaseDialog';
 import DialogFooter from '../../../templates/teacherDashboard/DialogFooter';
 import Button from '../../../templates/Button';
@@ -69,8 +69,8 @@ const styles = {
 
 export default connect(
   state => ({
-    projectUpdatedStatus: state.header.projectUpdatedStatus,
-    isOpen: state.header.showTryAgainDialog
+    projectUpdatedStatus: state.project.projectUpdatedStatus,
+    isOpen: state.project.showTryAgainDialog
   }),
   dispatch => ({
     onTryAgain() {

--- a/apps/src/code-studio/components/header/RetryProjectSaveDialog.story.jsx
+++ b/apps/src/code-studio/components/header/RetryProjectSaveDialog.story.jsx
@@ -1,6 +1,6 @@
 import {UnconnectedRetryProjectSaveDialog as RetryProjectSaveDialog} from './RetryProjectSaveDialog';
 import React from 'react';
-import {projectUpdatedStatuses as statuses} from '../../headerRedux';
+import {projectUpdatedStatuses as statuses} from '../../projectRedux';
 import {action} from '@storybook/addon-actions';
 
 export default storybook => {

--- a/apps/src/code-studio/components/header/ScriptName.jsx
+++ b/apps/src/code-studio/components/header/ScriptName.jsx
@@ -139,5 +139,5 @@ const styles = {
 };
 
 export default connect(state => ({
-  showProjectUpdatedAt: state.header.showProjectUpdatedAt
+  showProjectUpdatedAt: state.project.showProjectUpdatedAt
 }))(ScriptName);

--- a/apps/src/code-studio/header.js
+++ b/apps/src/code-studio/header.js
@@ -5,14 +5,16 @@ import {
   showProjectHeader,
   showMinimalProjectHeader,
   showProjectBackedHeader,
-  showLevelBuilderSaveButton,
+  showLevelBuilderSaveButton
+} from './headerRedux';
+import {
   setProjectUpdatedError,
   setProjectUpdatedSaving,
   showProjectUpdatedAt,
   setProjectUpdatedAt,
   refreshProjectName,
   setShowTryAgainDialog
-} from './headerRedux';
+} from './projectRedux';
 import React from 'react';
 import ReactDOM from 'react-dom';
 

--- a/apps/src/code-studio/headerRedux.js
+++ b/apps/src/code-studio/headerRedux.js
@@ -1,26 +1,8 @@
-/* globals dashboard */
-
 const SHOW_PROJECT_HEADER = 'header/SHOW_PROJECT_HEADER';
 const SHOW_MINIMAL_PROJECT_HEADER = 'header/SHOW_MINIMAL_PROJECT_HEADER';
 const SHOW_PROJECT_BACKED_HEADER = 'header/SHOW_PROJECT_BACKED_HEADER';
-const SHOW_PROJECT_UPDATED_AT = 'header/SHOW_PROJECT_UPDATED_AT';
-const SET_PROJECT_UPDATED_STATUS = 'header/SET_PROJECT_UPDATED_STATUS';
-const SET_PROJECT_UPDATED_AT = 'header/SET_PROJECT_UPDATED_AT';
 const ENABLE_LEVEL_BUILDER_SAVE_BUTTON =
   'header/ENABLE_LEVEL_BUILDER_SAVE_BUTTON';
-const REFRESH_PROJECT_NAME = 'header/REFRESH_PROJECT_NAME';
-const SHOW_TRY_AGAIN_DIALOG = 'header/SHOW_TRY_AGAIN_DIALOG';
-const SET_NAME_FAILURE = 'header/SET_NAME_FAILURE';
-const UNSET_NAME_FAILURE = 'header/UNSET_NAME_FAILURE';
-const SET_APP_LOAD_STARTED = 'header/SET_APP_LOAD_STARTED';
-const SET_APP_LOADED = 'header/SET_APP_LOADED';
-
-export const projectUpdatedStatuses = {
-  default: 'default',
-  saving: 'saving',
-  saved: 'saved',
-  error: 'error'
-};
 
 export const possibleHeaders = {
   project: 'project',
@@ -31,16 +13,8 @@ export const possibleHeaders = {
 
 const initialState = {
   currentHeader: undefined,
-  showProjectUpdatedAt: false,
-  projectUpdatedStatus: projectUpdatedStatuses.default,
-  projectUpdatedAt: undefined,
   getLevelBuilderChanges: undefined,
-  projectName: '',
-  projectNameFailure: undefined,
-  includeExportInProjectHeader: false,
-  showTryAgainDialog: false,
-  appLoading: false,
-  appLoaded: false
+  includeExportInProjectHeader: false
 };
 
 export default (state = initialState, action) => {
@@ -77,74 +51,8 @@ export default (state = initialState, action) => {
     if (action.overrideOnSaveURL) {
       updatedState.overrideOnSaveURL = action.overrideOnSaveURL;
     }
-
     return updatedState;
   }
-
-  if (action.type === SHOW_PROJECT_UPDATED_AT) {
-    return {
-      ...state,
-      showProjectUpdatedAt: true
-    };
-  }
-
-  if (action.type === SET_PROJECT_UPDATED_AT) {
-    return {
-      ...state,
-      projectUpdatedAt: action.updatedAt,
-      projectUpdatedStatus: projectUpdatedStatuses.saved
-    };
-  }
-
-  if (action.type === SET_PROJECT_UPDATED_STATUS) {
-    return {
-      ...state,
-      projectUpdatedStatus: action.status
-    };
-  }
-
-  if (action.type === REFRESH_PROJECT_NAME) {
-    return {
-      ...state,
-      projectName: dashboard.project.getCurrentName()
-    };
-  }
-
-  if (action.type === SHOW_TRY_AGAIN_DIALOG) {
-    return {
-      ...state,
-      showTryAgainDialog: action.visible
-    };
-  }
-
-  if (action.type === UNSET_NAME_FAILURE) {
-    return {
-      ...state,
-      projectNameFailure: undefined
-    };
-  }
-
-  if (action.type === SET_NAME_FAILURE) {
-    return {
-      ...state,
-      projectNameFailure: action.projectNameFailure
-    };
-  }
-
-  if (action.type === SET_APP_LOAD_STARTED) {
-    return {
-      ...state,
-      appLoadStarted: true
-    };
-  }
-
-  if (action.type === SET_APP_LOADED) {
-    return {
-      ...state,
-      appLoaded: true
-    };
-  }
-
   return state;
 };
 
@@ -171,58 +79,4 @@ export const showLevelBuilderSaveButton = (
   getChanges,
   overrideHeaderText,
   overrideOnSaveURL
-});
-
-export const showProjectUpdatedAt = () => ({
-  type: SHOW_PROJECT_UPDATED_AT
-});
-
-export const setProjectUpdatedError = () => ({
-  type: SET_PROJECT_UPDATED_STATUS,
-  status: projectUpdatedStatuses.error
-});
-
-export const setProjectUpdatedSaving = () => ({
-  type: SET_PROJECT_UPDATED_STATUS,
-  status: projectUpdatedStatuses.saving
-});
-
-export const setProjectUpdatedSaved = () => ({
-  type: SET_PROJECT_UPDATED_STATUS,
-  status: projectUpdatedStatuses.saved
-});
-
-export const setProjectUpdatedAt = updatedAt => ({
-  type: SET_PROJECT_UPDATED_AT,
-  updatedAt
-});
-
-export const refreshProjectName = () => ({
-  type: REFRESH_PROJECT_NAME
-});
-
-export const setShowTryAgainDialog = visible => ({
-  type: SHOW_TRY_AGAIN_DIALOG,
-  visible
-});
-
-export const retryProjectSave = () => {
-  return dispatch => dashboard.project.save();
-};
-
-export const setNameFailure = projectNameFailure => ({
-  type: SET_NAME_FAILURE,
-  projectNameFailure
-});
-
-export const unsetNameFailure = () => ({
-  type: UNSET_NAME_FAILURE
-});
-
-export const setAppLoadStarted = () => ({
-  type: SET_APP_LOAD_STARTED
-});
-
-export const setAppLoaded = () => ({
-  type: SET_APP_LOADED
 });

--- a/apps/src/code-studio/initApp/loadApp.js
+++ b/apps/src/code-studio/initApp/loadApp.js
@@ -3,10 +3,7 @@ import $ from 'jquery';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import {getStore} from '../redux';
-import {
-  setAppLoadStarted,
-  setAppLoaded
-} from '@cdo/apps/code-studio/headerRedux';
+import {setAppLoadStarted, setAppLoaded} from '@cdo/apps/code-studio/appRedux';
 import {files} from '@cdo/apps/clientApi';
 var renderAbusive = require('./renderAbusive');
 import renderProjectNotFound from './renderProjectNotFound';

--- a/apps/src/code-studio/projectRedux.js
+++ b/apps/src/code-studio/projectRedux.js
@@ -1,13 +1,13 @@
-/** Redux actions and reducer for the inidividual projects */
+/** Redux actions and reducer for a inidividual project */
 /* globals dashboard */
 
-const SHOW_PROJECT_UPDATED_AT = 'header/SHOW_PROJECT_UPDATED_AT';
-const SET_PROJECT_UPDATED_STATUS = 'header/SET_PROJECT_UPDATED_STATUS';
-const SET_PROJECT_UPDATED_AT = 'header/SET_PROJECT_UPDATED_AT';
-const REFRESH_PROJECT_NAME = 'header/REFRESH_PROJECT_NAME';
-const SHOW_TRY_AGAIN_DIALOG = 'header/SHOW_TRY_AGAIN_DIALOG';
-const SET_NAME_FAILURE = 'header/SET_NAME_FAILURE';
-const UNSET_NAME_FAILURE = 'header/UNSET_NAME_FAILURE';
+const SHOW_PROJECT_UPDATED_AT = 'project/SHOW_PROJECT_UPDATED_AT';
+const SET_PROJECT_UPDATED_STATUS = 'project/SET_PROJECT_UPDATED_STATUS';
+const SET_PROJECT_UPDATED_AT = 'project/SET_PROJECT_UPDATED_AT';
+const REFRESH_PROJECT_NAME = 'project/REFRESH_PROJECT_NAME';
+const SHOW_TRY_AGAIN_DIALOG = 'project/SHOW_TRY_AGAIN_DIALOG';
+const SET_NAME_FAILURE = 'project/SET_NAME_FAILURE';
+const UNSET_NAME_FAILURE = 'project/UNSET_NAME_FAILURE';
 
 export const projectUpdatedStatuses = {
   default: 'default',

--- a/apps/src/code-studio/projectRedux.js
+++ b/apps/src/code-studio/projectRedux.js
@@ -1,0 +1,124 @@
+/* globals dashboard */
+
+const SHOW_PROJECT_UPDATED_AT = 'header/SHOW_PROJECT_UPDATED_AT';
+const SET_PROJECT_UPDATED_STATUS = 'header/SET_PROJECT_UPDATED_STATUS';
+const SET_PROJECT_UPDATED_AT = 'header/SET_PROJECT_UPDATED_AT';
+const REFRESH_PROJECT_NAME = 'header/REFRESH_PROJECT_NAME';
+const SHOW_TRY_AGAIN_DIALOG = 'header/SHOW_TRY_AGAIN_DIALOG';
+const SET_NAME_FAILURE = 'header/SET_NAME_FAILURE';
+const UNSET_NAME_FAILURE = 'header/UNSET_NAME_FAILURE';
+
+export const projectUpdatedStatuses = {
+  default: 'default',
+  saving: 'saving',
+  saved: 'saved',
+  error: 'error'
+};
+
+const initialState = {
+  showProjectUpdatedAt: false,
+  projectUpdatedStatus: projectUpdatedStatuses.default,
+  projectUpdatedAt: undefined,
+  projectName: '',
+  projectNameFailure: undefined,
+  showTryAgainDialog: false
+};
+
+export default (state = initialState, action) => {
+  if (action.type === SHOW_PROJECT_UPDATED_AT) {
+    return {
+      ...state,
+      showProjectUpdatedAt: true
+    };
+  }
+
+  if (action.type === SET_PROJECT_UPDATED_AT) {
+    return {
+      ...state,
+      projectUpdatedAt: action.updatedAt,
+      projectUpdatedStatus: projectUpdatedStatuses.saved
+    };
+  }
+
+  if (action.type === SET_PROJECT_UPDATED_STATUS) {
+    return {
+      ...state,
+      projectUpdatedStatus: action.status
+    };
+  }
+  if (action.type === REFRESH_PROJECT_NAME) {
+    return {
+      ...state,
+      projectName: dashboard.project.getCurrentName()
+    };
+  }
+
+  if (action.type === SHOW_TRY_AGAIN_DIALOG) {
+    return {
+      ...state,
+      showTryAgainDialog: action.visible
+    };
+  }
+
+  if (action.type === UNSET_NAME_FAILURE) {
+    return {
+      ...state,
+      projectNameFailure: undefined
+    };
+  }
+
+  if (action.type === SET_NAME_FAILURE) {
+    return {
+      ...state,
+      projectNameFailure: action.projectNameFailure
+    };
+  }
+
+  return state;
+};
+
+export const showProjectUpdatedAt = () => ({
+  type: SHOW_PROJECT_UPDATED_AT
+});
+
+export const setProjectUpdatedError = () => ({
+  type: SET_PROJECT_UPDATED_STATUS,
+  status: projectUpdatedStatuses.error
+});
+
+export const setProjectUpdatedSaving = () => ({
+  type: SET_PROJECT_UPDATED_STATUS,
+  status: projectUpdatedStatuses.saving
+});
+
+export const setProjectUpdatedSaved = () => ({
+  type: SET_PROJECT_UPDATED_STATUS,
+  status: projectUpdatedStatuses.saved
+});
+
+export const setProjectUpdatedAt = updatedAt => ({
+  type: SET_PROJECT_UPDATED_AT,
+  updatedAt
+});
+
+export const retryProjectSave = () => {
+  return dispatch => dashboard.project.save();
+};
+
+export const refreshProjectName = () => ({
+  type: REFRESH_PROJECT_NAME
+});
+
+export const setShowTryAgainDialog = visible => ({
+  type: SHOW_TRY_AGAIN_DIALOG,
+  visible
+});
+
+export const setNameFailure = projectNameFailure => ({
+  type: SET_NAME_FAILURE,
+  projectNameFailure
+});
+
+export const unsetNameFailure = () => ({
+  type: UNSET_NAME_FAILURE
+});

--- a/apps/src/code-studio/projectRedux.js
+++ b/apps/src/code-studio/projectRedux.js
@@ -1,3 +1,4 @@
+/** Redux actions and reducer for the inidividual projects */
 /* globals dashboard */
 
 const SHOW_PROJECT_UPDATED_AT = 'header/SHOW_PROJECT_UPDATED_AT';

--- a/apps/src/code-studio/redux.js
+++ b/apps/src/code-studio/redux.js
@@ -1,6 +1,8 @@
 /* eslint no-unused-vars: "error" */
 import {getStore, registerReducers} from '@cdo/apps/redux';
 import header from './headerRedux';
+import project from './projectRedux';
+import app from './appRedux';
 import progress from './progressRedux';
 import teacherSections from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 import lessonLock from './lessonLockRedux';
@@ -19,6 +21,8 @@ import teacherPanel from '@cdo/apps/code-studio/teacherPanelRedux';
 
 registerReducers({
   header,
+  project,
+  app,
   progress,
   teacherSections,
   teacherPanel,

--- a/apps/src/storage/dataBrowser/dataVisualizer/Snapshot.jsx
+++ b/apps/src/storage/dataBrowser/dataVisualizer/Snapshot.jsx
@@ -167,5 +167,5 @@ class Snapshot extends React.Component {
 
 export default connect(state => ({
   tableName: state.data.tableName || '',
-  projectName: state.header.projectName || ''
+  projectName: state.project.projectName || ''
 }))(Snapshot);

--- a/apps/test/unit/code-studio/components/header/EditableProjectNameTest.js
+++ b/apps/test/unit/code-studio/components/header/EditableProjectNameTest.js
@@ -7,9 +7,8 @@ import {mount} from 'enzyme';
 import {expect} from '../../../../util/reconfiguredChai';
 import {replaceOnWindow, restoreOnWindow} from '../../../../util/testUtils';
 
-import headerReducer, {
-  refreshProjectName
-} from '@cdo/apps/code-studio/headerRedux';
+import headerReducer from '@cdo/apps/code-studio/headerRedux';
+import {refreshProjectName} from '@cdo/apps/code-studio/projectRedux';
 import EditableProjectName from '@cdo/apps/code-studio/components/header/EditableProjectName';
 
 describe('EditableProjectName', () => {

--- a/apps/test/unit/code-studio/components/header/EditableProjectNameTest.js
+++ b/apps/test/unit/code-studio/components/header/EditableProjectNameTest.js
@@ -7,8 +7,9 @@ import {mount} from 'enzyme';
 import {expect} from '../../../../util/reconfiguredChai';
 import {replaceOnWindow, restoreOnWindow} from '../../../../util/testUtils';
 
-import headerReducer from '@cdo/apps/code-studio/headerRedux';
-import {refreshProjectName} from '@cdo/apps/code-studio/projectRedux';
+import projectReducer, {
+  refreshProjectName
+} from '@cdo/apps/code-studio/projectRedux';
 import EditableProjectName from '@cdo/apps/code-studio/components/header/EditableProjectName';
 
 describe('EditableProjectName', () => {
@@ -34,7 +35,7 @@ describe('EditableProjectName', () => {
   });
 
   it('provides a "rename project" interface', async () => {
-    const store = createStore(combineReducers({header: headerReducer}));
+    const store = createStore(combineReducers({project: projectReducer}));
     store.dispatch(refreshProjectName());
     const wrapper = mount(
       <Provider store={store}>

--- a/apps/test/unit/code-studio/components/header/ProjectHeaderTest.js
+++ b/apps/test/unit/code-studio/components/header/ProjectHeaderTest.js
@@ -6,6 +6,7 @@ import {mount} from 'enzyme';
 import headerReducer, {
   showProjectHeader
 } from '@cdo/apps/code-studio/headerRedux';
+import projectReducer from '@cdo/apps/code-studio/projectRedux';
 
 import {expect} from '../../../../util/reconfiguredChai';
 import {replaceOnWindow, restoreOnWindow} from '../../../../util/testUtils';
@@ -20,7 +21,9 @@ describe('ProjectHeader', () => {
     replaceOnWindow('appOptions', {
       level: {}
     });
-    store = createStore(combineReducers({header: headerReducer}));
+    store = createStore(
+      combineReducers({header: headerReducer, project: projectReducer})
+    );
     store.dispatch(showProjectHeader(false /* showExport */));
   });
 

--- a/apps/test/unit/code-studio/components/header/RetryProjectSaveDialogTest.jsx
+++ b/apps/test/unit/code-studio/components/header/RetryProjectSaveDialogTest.jsx
@@ -4,7 +4,7 @@ import {mount} from 'enzyme';
 
 import {expect} from '../../../../util/reconfiguredChai';
 
-import {projectUpdatedStatuses as statuses} from '@cdo/apps/code-studio/headerRedux';
+import {projectUpdatedStatuses as statuses} from '@cdo/apps/code-studio/projectRedux';
 
 import {UnconnectedRetryProjectSaveDialog as RetryProjectSaveDialog} from '@cdo/apps/code-studio/components/header/RetryProjectSaveDialog';
 


### PR DESCRIPTION
## Summary
- There were several actions within headerRedux.js such as SET_PROJECT_UPDATED_STATUS which can be used outside of the header. Thus, created 2 new redux files (projectRedux.js and appRedux.js) to contain actions that are useful to other components outside of the header. 
- projectRedux.js contain actions that have to do with individual projects (setting the project name, saving the project,...) Note that there already exists a projectsRedux.js which include actions for the projects gallery.
- The app.js contain 2 actions to load the app.

## Links
- [jira ticket](https://codedotorg.atlassian.net/browse/STAR-2360)

Note: This task was created while working on this jira ticket: https://codedotorg.atlassian.net/browse/STAR-2168.
