### PR TITLE
Pegasus pruning - csedweek.org directory - Dropbox sync

### DIFF
--- a/bin/cron/sync_dropbox
+++ b/bin/cron/sync_dropbox
@@ -21,7 +21,6 @@ require "open3"
 FOLDERS = {
   "advocacy.code.org" => "sites.v3/advocacy.code.org",
   "code.org" => "sites.v3/code.org",
-  "csedweek.org" => "sites.v3/csedweek.org",
   "curriculum-6-8" => "sites/virtual/curriculum-6-8",
   "curriculum-algebra" => "sites/virtual/curriculum-algebra",
   "curriculum-course1" => "sites/virtual/curriculum-course1",


### PR DESCRIPTION
Remove the cdedweek.org folder from being synced between the staging machine and Dropbox.

**Relevant info:** https://github.com/code-dot-org/code-dot-org/pull/47425#issuecomment-1199862908

**Related PR:** https://github.com/code-dot-org/code-dot-org/pull/47425