### PR TITLE
Skip flaky timestamp test

### DIFF
--- a/apps/test/unit/templates/sectionAssessments/SubmissionStatusAssessmentsTableTest.js
+++ b/apps/test/unit/templates/sectionAssessments/SubmissionStatusAssessmentsTableTest.js
@@ -249,7 +249,10 @@ describe('SubmissionStatusAssessmentsTable', () => {
     ).to.equal('2018-10-07T20:52:05.000Z');
   });
 
-  it('renders localized submission timestamps', () => {
+  // This test is flaky based on the browser version.
+  // TODO: Re-enable it once we determine the right browser version/timestamp
+  // combination.
+  xit('renders localized submission timestamps', () => {
     const basicNonEnglishWrapper = mount(
       <SubmissionStatusAssessmentsTable
         studentOverviewData={studentOverviewData}


### PR DESCRIPTION
Skip a test that is flaky depending on which browser version it is run on. See discussion [here](https://codedotorg.slack.com/archives/C0T0PNTM3/p1660070512246219)
