### PR TITLE
Remove text match rendering from _contained_levels

### DIFF
--- a/dashboard/app/views/levels/_contained_levels.html.haml
+++ b/dashboard/app/views/levels/_contained_levels.html.haml
@@ -13,8 +13,6 @@
       - level_class = contained_level.class.to_s.underscore
       - if level_class == "multi"
         = render partial: 'levels/single_multi', locals: {standalone: false, contained_mode: true, last_attempt: sublevel_last_attempt, level: contained_level, tight_layout: true}
-      - elsif level_class == "text_match"
-        = render partial: 'levels/single_text_match', locals: {standalone: false, level: contained_level }
       - elsif level_class == "free_response"
         = render partial: 'levels/free_response', locals: {in_level_group: true, last_attempt: sublevel_last_attempt, level: contained_level, left_align: true, is_contained_level: true }
 %div{style: 'clear: both;'}


### PR DESCRIPTION
We don't allow `TextMatch` levels to be contained levels, so this is dead code. We have a check [here](https://github.com/code-dot-org/code-dot-org/blob/8902e528063458446ad3dcfde552dd9d694a8730/dashboard/app/models/parent_levels_child_level.rb#L57) to ensure contained levels are only `FreeResponse` or `Multi` levels. I also double checked on production that we don't have any stray levels and we don't appear to:

```
mysql> select distinct levels.type from parent_levels_child_levels plcl left join levels on plcl.child_level_id = levels.id where plcl.kind='contained';
+--------------+
| type         |
+--------------+
| FreeResponse |
| Multi        |
+--------------+
2 rows in set (0.06 sec)
```

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
