### PR TITLE
Skip prompter eyes test

### DIFF
--- a/dashboard/test/ui/features/javalab/prompter.feature
+++ b/dashboard/test/ui/features/javalab/prompter.feature
@@ -1,4 +1,5 @@
 @eyes
+@skip
 Feature: Prompter
 
   @no_ie @no_circle


### PR DESCRIPTION
Skip prompter eyes test in Javalab -- we [deprecated part of the Theater API that this test relies on](https://github.com/code-dot-org/javabuilder/pull/343), which is causing it to fail. ~~I'll follow up today with a PR with changes to the starter code on the allthethings level used in this test to use the new API, and reenable this test at that time.~~ 

edit: learned that prompter isn't used in CSA right now, so waiting to decide whether to re-enable this test or remove it. Work being tracked [here](https://codedotorg.slack.com/archives/C0T0PNTM3/p1660233530879149?thread_ts=1660229048.492629&cid=C0T0PNTM3)