### PR TITLE
fix flex-grow value

### DIFF
--- a/apps/src/storage/dataBrowser/data-table-view.module.scss
+++ b/apps/src/storage/dataBrowser/data-table-view.module.scss
@@ -26,7 +26,7 @@ $minTableWidth: 600px;
     background-color: $lightest_gray;
     border-radius: 10px;
     border: 1px solid $light_gray;
-    flex-grow: 1px;
+    flex-grow: 1;
     font-family: monospace;
     overflow: scroll;
     padding: 10px;


### PR DESCRIPTION
Removes an erroneous "px" from a flex-grow property that was causing an eyes failure.

https://developer.mozilla.org/en-US/docs/Web/CSS/flex-grow

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
