### PR TITLE
Update Docker Image to Capture Chrome Update

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -30,7 +30,7 @@ steps:
       filename: unit-tests-cache.tar
 
   - name: unit-tests
-    image: codedotorg/code-dot-org:1.5.1
+    image: codedotorg/code-dot-org:1.5.2
     pull: always
     volumes:
       - name: rbenv
@@ -121,7 +121,7 @@ steps:
       restore: true
 
   - name: ui-tests
-    image: codedotorg/code-dot-org:1.5.1
+    image: codedotorg/code-dot-org:1.5.2
     volumes:
       - name: rbenv
         path: /home/circleci/.rbenv
@@ -188,6 +188,6 @@ trigger:
     - pull_request
 ---
 kind: signature
-hmac: 3926de192f64cce657b11bf4006061630ec73541022acadfa1107e825b570245
+hmac: b815d43d1ab9f9e4827c49881bae75eecd2e8c267fac81463d5906c256a913d1
 
 ...

--- a/docker/setup-compose.yml
+++ b/docker/setup-compose.yml
@@ -13,7 +13,7 @@
 version: "3"
 services:
   site:
-    image: codedotorg/code-dot-org:1.5.1
+    image: codedotorg/code-dot-org:1.5.2
     user: ${FIXUID:-1000}:${FIXGID:-1000}
     volumes:
       - ../:/home/circleci/code-dot-org:delegated

--- a/docker/site-compose.yml
+++ b/docker/site-compose.yml
@@ -16,7 +16,7 @@
 version: "3"
 services:
   site:
-    image: codedotorg/code-dot-org:1.5.1
+    image: codedotorg/code-dot-org:1.5.2
     user: ${FIXUID:-1000}:${FIXGID:-1000}
     volumes:
       - ../:/home/circleci/code-dot-org:delegated

--- a/docker/ui-tests-compose.yml
+++ b/docker/ui-tests-compose.yml
@@ -24,7 +24,7 @@
 version: "3"
 services:
   site:
-    image: codedotorg/code-dot-org:1.5.1
+    image: codedotorg/code-dot-org:1.5.2
     user: ${FIXUID:-1000}:${FIXGID:-1000}
     volumes:
       - ../:/home/circleci/code-dot-org:delegated

--- a/docker/unit-tests-compose.yml
+++ b/docker/unit-tests-compose.yml
@@ -19,7 +19,7 @@
 version: "3"
 services:
   site:
-    image: codedotorg/code-dot-org:1.5.1
+    image: codedotorg/code-dot-org:1.5.2
     user: ${FIXUID:-1000}:${FIXGID:-1000}
     volumes:
       - ../:/home/circleci/code-dot-org:delegated


### PR DESCRIPTION
Specifically, I just rebuilt the docker image with `docker build --no-cache .` to pick up a necessary update to the Headless Chrome client.

See the thread at https://codedotorg.slack.com/archives/C0T0PNTM3/p1660161851332389 for more details

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
