### PR TITLE
Add `seed.rake` to DTT Seed Cache Hash

### DIFF
--- a/lib/rake/test.rake
+++ b/lib/rake/test.rake
@@ -110,12 +110,21 @@ namespace :test do
         # Parallel tests don't seem to run more quickly over 16 processes.
         ENV['PARALLEL_TEST_PROCESSORS'] = '16' if RakeUtils.nproc > 16
 
-        # Hash of all seed-data content: All fixture files plus schema.rb.
+        # Hash of all seed-data and -config content
+        #
+        # Data:
+        # - All fixture files
+        # - CSV data (only videos right now, may want to add more; cdo-languages.csv particularly)
+        #
+        # Config:
+        # - schema.rb
+        # - seed.rake
         fixture_path = "#{dashboard_dir}/test/fixtures/"
         fixture_hash = Digest::MD5.hexdigest(
           Dir["#{fixture_path}/{**,*}/*.yml"].
             push(dashboard_dir('db/schema.rb')).
             push(dashboard_dir('config/videos.csv')).
+            push(dashboard_dir('lib/tasks/seed.rake')).
             select(&File.method(:file?)).
             sort.
             map(&Digest::MD5.method(:file)).


### PR DESCRIPTION
So that we re-seed after not only a data change but also a process change.

Follow up to https://github.com/code-dot-org/code-dot-org/pull/47540, which failed in the DTT because the DTT thought it didn't need to re-seed to pick up the new `import_pegasus_data` step

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
