### PR TITLE
Add localization support to loop block variables

### DIFF
--- a/dashboard/app/models/levels/blockly.rb
+++ b/dashboard/app/models/levels/blockly.rb
@@ -319,6 +319,7 @@ class Blockly < Level
             set_unless_nil(level_options, xml_block_prop, localized_function_blocks(level_options[xml_block_prop]))
             set_unless_nil(level_options, xml_block_prop, localized_placeholder_text_blocks(level_options[xml_block_prop]))
             set_unless_nil(level_options, xml_block_prop, localized_variable_blocks(level_options[xml_block_prop]))
+            set_unless_nil(level_options, xml_block_prop, localized_loop_blocks(level_options[xml_block_prop]))
           end
         end
       end
@@ -680,6 +681,27 @@ class Blockly < Level
         smart: true
       )
       parameter_name.content = localized_name if localized_name
+    end
+
+    return block_xml.serialize(save_with: XML_OPTIONS).strip
+  end
+
+  # Localizing variable names in "controls_for" block types
+  def localized_loop_blocks(blocks)
+    return nil if blocks.nil?
+
+    block_xml = Nokogiri::XML(blocks, &:noblanks)
+    tag = Blockly.field_or_title(block_xml)
+    block_xml.xpath("//block[@type=\"controls_for\"]").each do |controls_for_block|
+      controls_for_name = controls_for_block.at_xpath("./#{tag}[@name=\"VAR\"]")
+      next unless controls_for_name
+      localized_name = I18n.t(
+        controls_for_name.content,
+        scope: [:data, :variable_names],
+        default: nil,
+        smart: true
+      )
+      controls_for_name.content = localized_name if localized_name
     end
 
     return block_xml.serialize(save_with: XML_OPTIONS).strip


### PR DESCRIPTION
**What:** Added localization of variables within [`controls_for` blocks](https://github.com/code-dot-org/blockly/blob/main/blocks/loops.js#L104) to the `blockly` model.

**Why:** The `blockly` already translate variables nested in other types of blocks. After translation, the discrepancy between variable names in a single level causes the level to be incompletable. This specific update is to address a bug reported, but there are other block types that can/do contain variables that don't have translation support. A ticket will be created to investigate and address these and is listed in the "follow-up work" section.

## Links
- jira ticket: [FND-2088](https://codedotorg.atlassian.net/browse/FND-2088)

## Testing story

Locally visited the broken level before and after the localization support.

https://user-images.githubusercontent.com/48133820/184667533-3ce455c9-0004-4f0c-80f5-3182f0fbde58.mov

## Follow-up work

https://codedotorg.atlassian.net/browse/FND-2089

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
