### PR TITLE
Change link icon style from inline to inline-block

### DIFF
--- a/apps/src/templates/ProjectTemplateWorkspaceIcon.jsx
+++ b/apps/src/templates/ProjectTemplateWorkspaceIcon.jsx
@@ -39,7 +39,7 @@ export default class ProjectTemplateWorkspaceIcon extends React.Component {
 
 const styles = {
   container: {
-    display: 'inline'
+    display: 'inline-block'
   },
   tooltip: {
     maxWidth: 200,
@@ -48,6 +48,7 @@ const styles = {
   },
   projectTemplateIcon: {
     marginRight: 5,
-    marginTop: -1
+    marginTop: -1,
+    width: 22
   }
 };


### PR DESCRIPTION
- This PR addresses a bug which occurred when this [prior PR](https://github.com/code-dot-org/code-dot-org/pull/47551) was merged and then reverted due to a failed eyes test. When the user was not logged in, the link icon was displayed on the first line of the Workspace header area, but then the Workspace text was displayed on the second line instead of the first line so could not be seen unless the user scrolled down. This was most likely due to the slight change in the timing of the loading of elements after the refactoring of the headerRedux.js file.

![Link icon](https://user-images.githubusercontent.com/107423305/184655477-f345d5e9-31d0-4489-92e5-f0410cb7c251.png)
![workspace text](https://user-images.githubusercontent.com/107423305/184655489-91615223-5816-482c-be0a-f7706f5b9a7a.png)

- 'inline-block' is formatted like an 'inline' element, but you can set width and height values.
- When this styling change is made, the workspace header area is displayed with link icon and text next to one another even when headerRedux.js has been refactored.

![workspace header](https://user-images.githubusercontent.com/107423305/184655955-2eb915b2-0f4f-443e-86ad-3957e4fa6b50.png)

- After this PR is merged, then the revert of this [prior PR](https://github.com/code-dot-org/code-dot-org/pull/47551) can be reverted.