### PR TITLE
description localized in prog environment model

### DIFF
--- a/dashboard/app/models/programming_environment.rb
+++ b/dashboard/app/models/programming_environment.rb
@@ -112,7 +112,7 @@ class ProgrammingEnvironment < ApplicationRecord
   def summarize_for_show
     {
       title: title,
-      description: description,
+      description: localize_description,
       projectUrl: project_url,
       categories: categories_for_navigation
     }
@@ -126,6 +126,19 @@ class ProgrammingEnvironment < ApplicationRecord
       description: description,
       showPath: studio_documentation_path
     }
+  end
+
+  def localize_description
+    I18n.t(
+      'description',
+      scope: [
+        :data,
+        :programming_environments,
+        name,
+      ],
+      default: description,
+      smart: true
+    )
   end
 
   def categories_for_navigation


### PR DESCRIPTION
**What:** Adding Documentation programming environment description to the i18n pipeline.

**Why:** The Documentation pages is not fully translatable and will be necessary as CSD includes multiple Labs in the curriculum. Each programming environment has a short description that needs to be translated.

## Links

- jira ticket: [2064](https://codedotorg.atlassian.net/browse/FND-2064)

## Testing story

Descriptions appear translated:
<img width="1225" alt="Screen Shot 2022-08-15 at 11 30 23" src="https://user-images.githubusercontent.com/66776217/184678349-80e4eae9-2b4c-4feb-bc8c-0a90707610fd.png">



