### PR TITLE
move capture_queries require out of common_test_helper

### DIFF
--- a/pegasus/test/test_helper.rb
+++ b/pegasus/test/test_helper.rb
@@ -1,5 +1,6 @@
 # Test setup for unit tests in pegasus folder
 require_relative '../../shared/test/common_test_helper'
+require_relative '../../shared/test/capture_queries'
 
 # Set up JUnit output for Circle
 reporters = [Minitest::Reporters::SpecReporter.new]

--- a/shared/test/common_test_helper.rb
+++ b/shared/test/common_test_helper.rb
@@ -11,7 +11,6 @@ require 'vcr'
 require_relative '../../deployment'
 require 'cdo/db'
 require 'cdo/aws/s3'
-require_relative './capture_queries'
 
 raise 'Test helper must only be used in `test` environment!' unless rack_env? :test
 


### PR DESCRIPTION
Follow-up from https://github.com/code-dot-org/code-dot-org/pull/47563 . The background is that when I tried to move some which require `common_test_helper.rb` into `dashboard/test`, the dashboard tests started failing because the methods in `shared/test/capture_queries.rb` started conflicting with those defined in `dashboard/test/testing/capture_queries.rb`. because the methods in `shared/test/capture_queries.rb` are only used by pegasus (not by anyone else who requires common test helper), the solution is to move the require for `shared/test/capture_queries.rb` into pegasus.

## Testing story

This is a change which only affects unit tests, and all tests are passing


