### PR TITLE
remove mock Projects from dashboard test helper

### DIFF
--- a/dashboard/test/test_helper.rb
+++ b/dashboard/test/test_helper.rb
@@ -618,31 +618,6 @@ def with_locale(locale)
   end
 end
 
-# Mock Projects to generate random tokens
-class MockProjects
-  def initialize(storage_id)
-    @storage_id = storage_id
-  end
-
-  def create(_, _)
-    # project_id must be an integer > 0
-    project_id = 1 + SecureRandom.random_number(100000)
-    storage_encrypt_channel_id(@storage_id, project_id)
-  end
-
-  def most_recent(_)
-    create(nil, nil)
-  end
-
-  def get(_)
-    {
-      'name' => "Stubbed test project name",
-      'hidden' => false,
-      'frozen' => false
-    }
-  end
-end
-
 def stub_storage_id_for_user_id(user_id)
   storage_id = fake_storage_id_for_user_id(user_id)
   stubs(:storage_id_for_user_id).with(user_id).returns(storage_id)

--- a/dashboard/test/test_helper.rb
+++ b/dashboard/test/test_helper.rb
@@ -619,7 +619,7 @@ def with_locale(locale)
 end
 
 # Mock Projects to generate random tokens
-class Projects
+class MockProjects
   def initialize(storage_id)
     @storage_id = storage_id
   end


### PR DESCRIPTION
Follow-up from https://github.com/code-dot-org/code-dot-org/pull/47563. During that work, I noticed we have a "mock" Projects defined in dashboard/test/test_helper.rb, that isn't even being used, because the "real" Projects gets loaded after it does. here is the full sequence when we start up the test run:

1. `application.rb` requires `channels_api.rb` which loads "real" `dashboard_legacy/middleware/helpers/projects.rb`
2. `dashboard/test/test_helper.rb` loads "mock" Projects
3. `delete_accounts_helper_test.rb` loads `projects_test_utils.rb` which loads "real" `dashboard_legacy/middleware/helpers/projects.rb` a second time

This PR is a preventative measure to remove dead code that could otherwise accidentally get re-enabled, for example by modifying or deleting the `delete_accounts_helper_test.rb`, which could then cause a bunch of other tests to fail.

## Testing story

this is a test-only change, and the tests are passing on drone. 

