### PR TITLE
Drop Support for Ruby 2.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '>= 2.5', '< 2.7'
+ruby '2.6.6'
 
 # Force HTTPS for github-source gems.
 # This is a temporary workaround - remove when bundler version is >=2.0

--- a/cookbooks/cdo-ruby/attributes/default.rb
+++ b/cookbooks/cdo-ruby/attributes/default.rb
@@ -1,6 +1,5 @@
 default['cdo-ruby'] = {
   version: '2.6',
-  old_version: '2.5',
   rubygems_version: '2.7.4',
   bundler_version: '1.17.3',
   rake_version: '11.3.0'


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/47406, which added support for Ruby 2.6. Also stop attempting to delete 2.5 from all our servers, now that it has been.
## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
