### PR TITLE
Add more useful error messages when update_lockable_state returns a non-ok response

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -858,6 +858,7 @@
   "errorQuestionMarksInNumberField": "Try replacing \"???\" with a value.",
   "errorRequiredParamsMissing": "Create a parameter for your function by clicking \"edit\" and adding the necessary parameters. Drag the new parameter blocks into your function definition.",
   "errorSavingLockStatus": "An error has occurred. Changes may not have saved.",
+  "errorSavingLockStatusWithMessage": "An error has occurred: {errorMessage}",
   "errorUnusedFunction": "You created a function, but never used it on your workspace! Click on \"Functions\" in the toolbox and make sure you use it in your program.",
   "errorUnusedParam": "You added a parameter block, but didn't use it in the definition. Make sure to use your parameter by clicking \"edit\" and placing the parameter block inside the green block.",
   "errorDeleting": "Error deleting file.",

--- a/apps/src/code-studio/components/progress/lessonLockDialog/LessonLockDialog.jsx
+++ b/apps/src/code-studio/components/progress/lessonLockDialog/LessonLockDialog.jsx
@@ -89,8 +89,18 @@ function LessonLockDialog({
       await refetchSectionLockStatus(selectedSectionId, unitId);
       handleClose();
     } else {
-      setSaving(false);
-      setError(commonMsg.errorSavingLockStatus());
+      saveLockStateResponse.json().then(json => {
+        setSaving(false);
+        if (json.error) {
+          setError(
+            commonMsg.errorSavingLockStatusWithMessage({
+              errorMessage: json.error
+            })
+          );
+        } else {
+          setError(commonMsg.errorSavingLockStatus());
+        }
+      });
     }
   };
 

--- a/apps/test/unit/code-studio/components/progress/lessonLockDialog/LessonLockDialogTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/lessonLockDialog/LessonLockDialogTest.jsx
@@ -203,7 +203,7 @@ describe('LessonLockDialog with stubbed section selector', () => {
     lessonLockDataApi.saveLockState.restore();
   });
 
-  it('handleSave shows defult error if failed with no message', async () => {
+  it('handleSave shows default error if failed with no message', async () => {
     const initialLockStatus = [
       {name: 'fakeName1', lockStatus: LockStatus.Editable},
       {name: 'fakeName2', lockStatus: LockStatus.Editable}

--- a/dashboard/app/controllers/api_controller.rb
+++ b/dashboard/app/controllers/api_controller.rb
@@ -174,6 +174,7 @@ class ApiController < ApplicationController
   end
 
   def update_lockable_state
+    return render status: :bad_request, json: {error: I18n.t("lesson_lock.error.no_updates")} if params[:updates].blank?
     updates = params.require(:updates)
     updates.to_a.each do |item|
       # Convert string-boolean parameters to boolean
@@ -182,17 +183,17 @@ class ApiController < ApplicationController
       user_level_data = item[:user_level_data]
       if user_level_data[:user_id].nil? || user_level_data[:level_id].nil? || user_level_data[:script_id].nil?
         # Must provide user, level, and script ids
-        return head :bad_request
+        return render status: :bad_request, json: {error: I18n.t("lesson_lock.error.missing_params")}
       end
 
       if item[:locked] && item[:readonly_answers]
         # Can not view answers while locked
-        return head :bad_request
+        return render status: :bad_request, json: {error: I18n.t("lesson_lock.error.cannot_view_locked_answers")}
       end
 
       unless User.find(user_level_data[:user_id]).teachers.include? current_user
         # Can only update lockable state for user's students
-        return head :forbidden
+        return render status: :forbidden, json: {error: I18n.t("lesson_lock.error.forbidden")}
       end
       UserLevel.update_lockable_state(
         user_level_data[:user_id],

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -1216,3 +1216,9 @@ en:
   unit_prefix: "Unit %{n}"
   code_org_logo_alt: "Code.org Home"
   teacher_feedback: "Teacher Feedback"
+  lesson_lock:
+    error:
+      no_updates: "No updates to perform"
+      missing_params: "Must provide user, level, and unit ids"
+      cannot_view_locked_answers: "Cannot view answers while locked"
+      forbidden: "User cannot update student's lockable state"


### PR DESCRIPTION
Added some real error messages to the errors returned by `update_lockable_state` as well as adding a check for no updates as that is causing confusion.

If no updates to be made:
<img width="590" alt="Screen Shot 2022-08-16 at 9 56 29 AM" src="https://user-images.githubusercontent.com/46464143/184936448-9866b818-607c-4196-89c5-2e36a2da117a.png">

Some of the other message wrap a bit. It's not the prettiest but I decided to let it go as they're unlikely to occur and it is readable.
<img width="581" alt="Screen Shot 2022-08-16 at 9 55 21 AM" src="https://user-images.githubusercontent.com/46464143/184936581-4255dded-dd91-44ce-a539-26d81dea9e49.png">


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
