### PR TITLE
Ensure pixelation instructions are translatable

### DIFF
--- a/dashboard/app/models/levels/widget.rb
+++ b/dashboard/app/models/levels/widget.rb
@@ -38,16 +38,20 @@ class Widget < Level
     # Base options are just the level properties
     app_options = properties.camelize_keys
 
-    # Some options should be localized (right now, just long instructions)
+    # Some options should be localized
     if should_localize?
-      localized_long_instructions =
-        I18n.t(
-          name,
-          scope: [:data, :long_instructions],
-          default: nil,
-          smart: true
-        )
-      app_options["longInstructions"] = localized_long_instructions if localized_long_instructions
+      [:long_instructions, :short_instructions].each do |key|
+        localized =
+          I18n.t(
+            name,
+            scope: [:data, key],
+            default: nil,
+            smart: true
+          )
+
+        # Will set longInstructions and shortInstructions, if localized
+        app_options[key.to_s.camelize(:lower)] = localized if localized
+      end
     end
 
     return app_options

--- a/dashboard/test/models/levels/widget_test.rb
+++ b/dashboard/test/models/levels/widget_test.rb
@@ -2,7 +2,11 @@ require 'test_helper'
 
 class WidgetTest < ActiveSupport::TestCase
   setup_all do
-    @level = Widget.create!(name: 'Test Widget', long_instructions: 'These are the **markdown** instructions for the test widget.', level_num: 'custom')
+    @level = Widget.create!(
+      name: 'Test Widget',
+      long_instructions: 'These are the **markdown** instructions for the test widget.',
+      level_num: 'custom'
+    )
   end
 
   test 'widget_app_options are camelized' do
@@ -14,10 +18,14 @@ class WidgetTest < ActiveSupport::TestCase
     test_locale = :'te-ST'
     I18n.locale = test_locale
     translated_instruction = 'These are the **translated** long instructions'
+    translated_short_instruction = 'These are **translated** short instructions'
     translation_data = {
       data: {
         long_instructions: {
           @level.name => translated_instruction
+        },
+        short_instructions: {
+          @level.name => translated_short_instruction
         }
       }
     }
@@ -25,6 +33,7 @@ class WidgetTest < ActiveSupport::TestCase
 
     assert @level.should_localize?
     assert_equal translated_instruction, @level.widget_app_options['longInstructions']
+    assert_equal translated_short_instruction, @level.widget_app_options['shortInstructions']
 
     I18n.locale = I18n.default_locale
   end

--- a/dashboard/test/ui/features/foundations/i18n.feature
+++ b/dashboard/test/ui/features/foundations/i18n.feature
@@ -157,3 +157,15 @@ Scenario: Toolbox Categories in Arabic (RTL)
   Then element ".blocklyTreeRoot #\\:7" has "ar-SA" text from key "data.block_categories.Logic"
   Then element ".blocklyTreeRoot #\\:8" has "ar-SA" text from key "data.block_categories.Math"
   Then element ".blocklyTreeRoot #\\:9" has "ar-SA" text from key "data.block_categories.Text"
+
+Scenario: CSD Pixelation Widget long and short instructions in Spanish
+  Given I create a teacher named "teacher"
+  And I sign in as "teacher"
+  Given I am on "http://studio.code.org/s/csd5-2021/lessons/4/levels/1/lang/es-MX"
+  And I rotate to landscape
+  # We cannot use 'fully load' because that assumes there is a run button
+  # and the Pixelation widget has no such button. Instead, we wait until the
+  # instructions dialog appears, which appears dynamically at the 'ready' event.
+  And I wait to see ".markdown-instructions-container"
+  Then element ".markdown-instructions-container .instructions-markdown > div" has "es-MX" markdown from key "data.long_instructions.CSD U5 black white images pixelation_2021"
+  Then element "#below_viz_instructions" has "es-MX" text from key "data.short_instructions.CSD U5 black white images pixelation_2021"

--- a/dashboard/test/ui/features/foundations/i18n.feature
+++ b/dashboard/test/ui/features/foundations/i18n.feature
@@ -158,14 +158,15 @@ Scenario: Toolbox Categories in Arabic (RTL)
   Then element ".blocklyTreeRoot #\\:8" has "ar-SA" text from key "data.block_categories.Math"
   Then element ".blocklyTreeRoot #\\:9" has "ar-SA" text from key "data.block_categories.Text"
 
-Scenario: CSD Pixelation Widget long and short instructions in Spanish
-  Given I create a teacher named "teacher"
-  And I sign in as "teacher"
-  Given I am on "http://studio.code.org/s/csd5-2021/lessons/4/levels/1/lang/es-MX"
+Scenario: Pixelation Widget long and short instructions in Spanish
+  Given I am on "http://studio.code.org/s/allthethings/lessons/17/levels/2/lang/es-MX"
   And I rotate to landscape
   # We cannot use 'fully load' because that assumes there is a run button
   # and the Pixelation widget has no such button. Instead, we wait until the
-  # instructions dialog appears, which appears dynamically at the 'ready' event.
+  # instructions dialog appears, which appears dynamically at the 'ready' event,
+  # but just in case, we click on the short instructions div which also brings
+  # it up for us, since a video might pop up first, instead.
+  And I click selector "#below_viz_instructions" once I see it
   And I wait to see ".markdown-instructions-container"
-  Then element ".markdown-instructions-container .instructions-markdown > div" has "es-MX" markdown from key "data.long_instructions.CSD U5 black white images pixelation_2021"
-  Then element "#below_viz_instructions" has "es-MX" text from key "data.short_instructions.CSD U5 black white images pixelation_2021"
+  Then element ".markdown-instructions-container .instructions-markdown > div" has "es-MX" markdown from key "data.long_instructions.AllTheThings: Pixelation - Lesson 15 - Complete 3-bit color"
+  Then element "#below_viz_instructions" has "es-MX" text from key "data.short_instructions.AllTheThings: Pixelation - Lesson 15 - Complete 3-bit color"

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -664,6 +664,10 @@ Then /^element "([^"]*)" has "([^"]*)" text from key "((?:[^"\\]|\\.)*)"$/ do |s
   element_has_i18n_text(selector, language, loc_key)
 end
 
+Then /^element "([^"]*)" has "([^"]*)" markdown from key "((?:[^"\\]|\\.)*)"$/ do |selector, language, loc_key|
+  element_has_i18n_markdown(selector, language, loc_key)
+end
+
 Then /^element "([^"]*)" contains text "((?:[^"\\]|\\.)*)"$/ do |selector, expected_text|
   element_contains_text(selector, expected_text)
 end

--- a/dashboard/test/ui/features/support/browser_helpers.rb
+++ b/dashboard/test/ui/features/support/browser_helpers.rb
@@ -1,3 +1,5 @@
+require 'redcarpet'
+
 module BrowserHelpers
   def element_has_text(selector, expected_text)
     expected_text.gsub!('\"', '"')
@@ -18,6 +20,33 @@ module BrowserHelpers
     # Get localized text from server
     response = HTTParty.get(replace_hostname("http://studio.code.org/api/test/get_i18n_t?key=#{loc_key}&locale=#{language}")).parsed_response
     text.should eq response
+  end
+
+  # This function checks that the text within the given selector matches the
+  # text produced by rendering the markdown given by the localization string.
+  #
+  # This is used to test that localized markdown is being rendered in any given
+  # container element.
+  def element_has_i18n_markdown(selector, language, loc_key)
+    loc_key.gsub!('\"', '"')
+
+    # Grab html of the markdown container from the browser.
+    html = @browser.execute_script("return $(\"#{selector}\").html();")
+
+    # Get localized markdown from server.
+    response = HTTParty.get(replace_hostname("http://studio.code.org/api/test/get_i18n_t?key=#{loc_key}&locale=#{language}")).parsed_response
+
+    # Render the markdown and remove whitespace.
+    renderer = Redcarpet::Markdown.new(Redcarpet::Render::HTML.new(filter_html: true))
+    expected_html = renderer.render(response)
+
+    # Compare just the text, assuming the structure is correct as we only care
+    # that the localized strings are being used. We remove whitespace to avoid
+    # any minor issues when the Markdown produces multiple newlines.
+    text = Nokogiri::HTML(html).text.gsub(/\s/, "")
+    expected_text = Nokogiri::HTML(expected_html).text.gsub(/\s/, "")
+
+    text.should eq expected_text
   end
 
   def element_text(selector)


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

**What**: Add ability for Pixelation widget to see localized "short instructions" alongside "long instructions."

**Why**: These instructions are already translated but not being rendered, which limits international use of Pixelation lessons.

**Question**: Is this the right file for these UI/acceptance tests? The `i18n` features suite seems correct for this, but this is CSD and not the mentions projects at the header of the file.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

- jira ticket: [FND-2067](https://codedotorg.atlassian.net/jira/software/c/projects/FND/boards/62?modal=detail&selectedIssue=FND-2067)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

I could not reproduce nor see why the referenced ticket would not localize the long instructions (seen in the instructions dialog that pops up upon entering such a level.) However, the short instructions were not being localized. Here is the current level on production (note the long instructions are indeed translated):

![image](https://user-images.githubusercontent.com/31674/184943855-54e18bc5-0ea3-4ec9-9235-97e21fd0f777.png)

Manual testing was done to see the short instructions. These are dynamically updated on page load from `appOptions`, so the code was updated to ensure that field was populated. Then, we look to see that the instructions exist:

![image](https://user-images.githubusercontent.com/31674/184944364-d58f2d10-ab22-4c5c-bcfe-e2e6463ed345.png)

Automated testing was added to see both short and long instructions. The short instructions simply look and compare the localized string against what exists in the page after page load using the normal i18n text matcher in the UI features test.

For long instructions, these are localized markdown. There is no given way to compare the markdown output on a page to the localized string. I added `element_has_i18n_markdown` and the associated Cucumber string `element {selector} has {locale} markdown from key {translation key}`. This helper will render markdown, get just the text nodes, strip whitespace and compare to the stripped text from the page. It ignores the structure (the markdown renderer is, yanno, likely correct) and just compares the text, which is what really matters here. We might be able to reuse this for other instances of localized markdown.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
