### PR TITLE
Temporarily remove sandboxDocumentBody in p5lab/gamelab tests

### DIFF
--- a/apps/test/unit/p5lab/GameLabGroupTest.js
+++ b/apps/test/unit/p5lab/GameLabGroupTest.js
@@ -2,14 +2,15 @@
 import {spy} from 'sinon';
 import {expect} from '../../util/reconfiguredChai';
 import {createStatefulP5Wrapper} from '../../util/gamelab/TestableP5Wrapper';
-import {sandboxDocumentBody} from '../../util/testUtils';
 
 describe('P5GroupWrapper', function() {
   let p5Wrapper, createSprite, createGroup;
 
+  // TODO: Re-enable sandboxDocumentBody and fix state leakage caused by
+  // test/unit/p5lab/ tests.
   // Using the aggressive sandbox here because the P5 library generates
   // a default canvas when it's not attached to an existing one.
-  sandboxDocumentBody();
+  // sandboxDocumentBody();
 
   beforeEach(function() {
     p5Wrapper = createStatefulP5Wrapper();

--- a/apps/test/unit/p5lab/GameLabP5Test.js
+++ b/apps/test/unit/p5lab/GameLabP5Test.js
@@ -2,14 +2,15 @@
 import {spy} from 'sinon';
 import {assert, expect} from '../../util/reconfiguredChai';
 import createP5Wrapper from '../../util/gamelab/TestableP5Wrapper';
-import {sandboxDocumentBody} from '../../util/testUtils';
 
 describe('GameLabP5', function() {
   let p5Wrapper;
 
+  // TODO: Re-enable sandboxDocumentBody and fix state leakage caused by
+  // test/unit/p5lab/ tests.
   // Using the aggressive sandbox here because the P5 library generates
   // a default canvas when it's not attached to an existing one.
-  sandboxDocumentBody();
+  // sandboxDocumentBody();
 
   beforeEach(function() {
     p5Wrapper = createP5Wrapper();

--- a/apps/test/unit/p5lab/GameLabSpriteTest.js
+++ b/apps/test/unit/p5lab/GameLabSpriteTest.js
@@ -1,10 +1,7 @@
 /* @file Test of our p5.play Sprite wrapper object */
 /* global p5 */
 import {expect} from '../../util/reconfiguredChai';
-import {
-  forEveryBooleanPermutation,
-  sandboxDocumentBody
-} from '../../util/testUtils';
+import {forEveryBooleanPermutation} from '../../util/testUtils';
 import createP5Wrapper, {
   createStatefulP5Wrapper,
   expectAnimationsAreClones
@@ -13,9 +10,11 @@ import createP5Wrapper, {
 describe('P5SpriteWrapper', function() {
   let p5Wrapper, createSprite;
 
+  // TODO: Re-enable sandboxDocumentBody and fix state leakage caused by
+  // test/unit/p5lab/ tests.
   // Using the aggressive sandbox here because the P5 library generates
   // a default canvas when it's not attached to an existing one.
-  sandboxDocumentBody();
+  // sandboxDocumentBody();
 
   beforeEach(function() {
     p5Wrapper = createP5Wrapper();


### PR DESCRIPTION
Currently, `apps/` tests are not passing on Drone and it's blocking the team (see [this Slack thread](https://codedotorg.slack.com/archives/C0T0PNTM3/p1660161851332389) for details). This has come up in the past, and several people have nailed the issue down to tests within `apps/test/unit/p5lab/`.

As a test, I removed calls to `sandboxDocumentBody` within this directory, which has caused apps tests to pass on Drone (3 successful runs so far). However, this is not a good final solution because these tests will clutter `document.body.innerHTML`. This is just a temporary fix to unblock Drone while we investigate further.