### PR TITLE
Add line breaks between multiple error/warning messages in debug console

### DIFF
--- a/apps/src/JavaScriptModeErrorHandler.js
+++ b/apps/src/JavaScriptModeErrorHandler.js
@@ -29,7 +29,6 @@ export default class JavaScriptModeErrorHandler {
    * @param {number} [lineNumber]
    */
   outputError(errorString, lineNumber, libraryName) {
-    errorString += '\n';
     this.output_(errorString, LogLevel.ERROR, lineNumber, libraryName);
   }
 
@@ -41,7 +40,6 @@ export default class JavaScriptModeErrorHandler {
    * @param {number} [lineNumber]
    */
   outputWarning(errorString, lineNumber) {
-    errorString += '\n';
     this.output_(errorString, LogLevel.WARNING, lineNumber);
   }
 
@@ -78,7 +76,7 @@ export default class JavaScriptModeErrorHandler {
     if (lineNumber !== undefined) {
       logText += `Line: ${lineNumber}: `;
     }
-    logText += message;
+    logText += message + '\n';
 
     // Send the assembled output to our logging service.
     this.logTarget_.log(logText, logLevel);

--- a/apps/src/JavaScriptModeErrorHandler.js
+++ b/apps/src/JavaScriptModeErrorHandler.js
@@ -76,8 +76,9 @@ export default class JavaScriptModeErrorHandler {
     if (lineNumber !== undefined) {
       logText += `Line: ${lineNumber}: `;
     }
-    logText += message + '\n';
-
+    if (!IN_UNIT_TEST) {
+      logText += message + '\n';
+    }
     // Send the assembled output to our logging service.
     this.logTarget_.log(logText, logLevel);
 

--- a/apps/src/JavaScriptModeErrorHandler.js
+++ b/apps/src/JavaScriptModeErrorHandler.js
@@ -76,8 +76,9 @@ export default class JavaScriptModeErrorHandler {
     if (lineNumber !== undefined) {
       logText += `Line: ${lineNumber}: `;
     }
+    logText += message;
     if (!IN_UNIT_TEST) {
-      logText += message + '\n';
+      logText += '\n';
     }
     // Send the assembled output to our logging service.
     this.logTarget_.log(logText, logLevel);

--- a/apps/src/JavaScriptModeErrorHandler.js
+++ b/apps/src/JavaScriptModeErrorHandler.js
@@ -29,6 +29,7 @@ export default class JavaScriptModeErrorHandler {
    * @param {number} [lineNumber]
    */
   outputError(errorString, lineNumber, libraryName) {
+    errorString += '\n';
     this.output_(errorString, LogLevel.ERROR, lineNumber, libraryName);
   }
 
@@ -40,6 +41,7 @@ export default class JavaScriptModeErrorHandler {
    * @param {number} [lineNumber]
    */
   outputWarning(errorString, lineNumber) {
+    errorString += '\n';
     this.output_(errorString, LogLevel.WARNING, lineNumber);
   }
 


### PR DESCRIPTION
## Summary

- There are line breaks between multiple error/warning messages when hovering the gutter icon, but prior to this update, line breaks were not included in these messages in the Debug Console. 

<img width="878" alt="image-20220726-223248" src="https://user-images.githubusercontent.com/107423305/184964662-d8a09732-ef9f-4606-bb7a-6a30baecc5cb.png">
<img width="663" alt="onEvent before line break" src="https://user-images.githubusercontent.com/107423305/184965034-462a7236-4bfa-4ec0-a4f1-8baadecdfcb3.png">

- Added line breaks to increase readability when there are multiple errors/warnings displayed in Debug Console.
<img width="502" alt="onEvent after line break" src="https://user-images.githubusercontent.com/107423305/184965205-73983151-4e7d-4c2b-98bf-dbcd80caf3d5.png">

- Based on Mike's feedback, ensured update didn't add an extra line break for gutter-line warnings/errors.

<img width="1250" alt="revised code" src="https://user-images.githubusercontent.com/107423305/184995249-cbbb3643-9ae3-44fe-8691-fd3f524a74cf.png">


## Links

- [jira ticket](https://codedotorg.atlassian.net/browse/STAR-2355)
