### PR TITLE
Start creating CSA contact rollups

### DIFF
--- a/dashboard/app/models/contact_rollups_processed.rb
+++ b/dashboard/app/models/contact_rollups_processed.rb
@@ -240,6 +240,7 @@ class ContactRollupsProcessed < ApplicationRecord
     courses = extract_field contact_data, 'dashboard.sections', 'course_name'
     roles.add 'CSD Teacher' if courses.any? {|course| course&.start_with? 'csd'}
     roles.add 'CSP Teacher' if courses.any? {|course| course&.start_with? 'csp'}
+    roles.add 'CSA Teacher' if courses.any? {|course| course&.start_with? 'csa'}
 
     # @see Script model, csf?, csd? and csp? methods
     curricula = extract_field contact_data, 'dashboard.sections', 'curriculum_umbrella'
@@ -248,6 +249,8 @@ class ContactRollupsProcessed < ApplicationRecord
       curricula.any? {|curriculum| curriculum == 'CSD'}
     roles.add 'CSP Teacher' if !roles.include?('CSP Teacher') &&
       curricula.any? {|curriculum| curriculum == 'CSP'}
+    roles.add 'CSA Teacher' if !roles.include?('CSA Teacher') &&
+      curricula.any? {|curriculum| curriculum == 'CSA'}
 
     roles.add 'Form Submitter' if
       contact_data.key?('pegasus.forms') ||

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -1795,7 +1795,7 @@ ActiveRecord::Schema.define(version: 2022_08_03_162830) do
     t.index ["user_id"], name: "index_sections_on_user_id"
   end
 
-  create_table "seed_info", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "seed_info", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "table", null: false
     t.datetime "mtime"
     t.index ["table"], name: "index_seed_info_on_table"

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -1795,7 +1795,7 @@ ActiveRecord::Schema.define(version: 2022_08_03_162830) do
     t.index ["user_id"], name: "index_sections_on_user_id"
   end
 
-  create_table "seed_info", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "seed_info", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "table", null: false
     t.datetime "mtime"
     t.index ["table"], name: "index_seed_info_on_table"

--- a/dashboard/test/models/contact_rollups_processed_test.rb
+++ b/dashboard/test/models/contact_rollups_processed_test.rb
@@ -279,6 +279,7 @@ class ContactRollupsProcessedTest < ActiveSupport::TestCase
         'course_name' => [
           {'value' => 'csp-2020'},
           {'value' => 'csd-2019'},
+          {'value' => 'csa-2022'},
           {'value' => nil},
         ]
       }
@@ -339,7 +340,7 @@ class ContactRollupsProcessedTest < ActiveSupport::TestCase
       },
       {
         input: section_courses_input,
-        expected_output: {roles: 'CSD Teacher,CSP Teacher'}
+        expected_output: {roles: 'CSA Teacher,CSD Teacher,CSP Teacher'}
       },
       {
         input: section_curricula_input,


### PR DESCRIPTION
We recently added CSA as a primary course. This PR is the final step to start creating CSA contact roll ups for the marketing to use while emailing. Thanks @bencodeorg for the suggestion of what to update.  

## Links

[Jira](https://codedotorg.atlassian.net/browse/PLAT-1934)

## Testing story

- I added a unit test to make sure if there was progress in CSA a teacher would be marked as CSA Teacher
- I'm not sure if there is another good way to confirm this is working locally