### PR TITLE
Remove weight from EvaluationMultiDSL translations

### DIFF
--- a/dashboard/app/dsl/evaluation_multi_dsl.rb
+++ b/dashboard/app/dsl/evaluation_multi_dsl.rb
@@ -8,4 +8,11 @@ class EvaluationMultiDSL < MultiDSL
     }
     @hash[:answers] << answer
   end
+
+  # @override
+  def i18n_hash
+    final_hash = super
+    final_hash['answers']&.each {|answer| answer.delete 'weight'}
+    final_hash
+  end
 end


### PR DESCRIPTION
**What:** Removing the `weight` of every `answer` in `EvaluationMultiDSL` levels from its translation hash.

**Why:** A parent DSL class of `EvaluationMultiDSL` (`MatchDSL`) [adds the `answer` field(s) as fields to be translated](https://github.com/code-dot-org/code-dot-org/blob/remove-eval-multi-dsl-answer-weights-from-i18n/dashboard/app/dsl/match_dsl.rb#L23). The `EvaluationMultiDSL` classes answers are unique in that they have a `weight` integer associated with every answer. These weights shouldn't be translated, and our [sanitization](https://github.com/code-dot-org/code-dot-org/blob/remove-eval-multi-dsl-answer-weights-from-i18n/bin/i18n/sync-out.rb#L202) of the data before it is written during the sync-out doesn't support integers. 

We were seeing this issue in the latest i18n sync during the sync-out.

<img width="901" alt="Screen Shot 2022-08-16 at 6 02 28 PM" src="https://user-images.githubusercontent.com/48133820/185185033-7eb2e7fa-2fb2-4222-8a46-e59103c6a875.png">

Likely this issue has just now come to fruition with the [introduction of `LevelGroup` sublevels](https://github.com/code-dot-org/code-dot-org/pull/47209) to our sync.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Testing story

Called `level.class.dsl_class.parse(level.dsl_text, '')[1]` locally on a `EvaluationMulti` level locally - similarly to [how we obtain the properties to be synced in the sync-in](https://github.com/code-dot-org/code-dot-org/blob/remove-eval-multi-dsl-answer-weights-from-i18n/bin/i18n/sync-in.rb#L78). The weights were removed compared to before the change.

## Follow-up work

Run a fresh i18n sync.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
