### PR TITLE
Remove read argument from sync-out `File.read`

### DIFF
--- a/bin/i18n/redact_restore_utils.rb
+++ b/bin/i18n/redact_restore_utils.rb
@@ -66,13 +66,13 @@ class RedactRestoreUtils
     is_json = File.extname(source) == '.json'
     source_data =
       if is_json
-        JSON.parse(File.read(source, 'r'))
+        JSON.parse(File.read(source))
       else
         YAML.load_file(source)
       end
     redacted_data =
       if is_json
-        JSON.parse(File.read(redacted, 'r'))
+        JSON.parse(File.read(redacted))
       else
         YAML.load_file(redacted)
       end
@@ -111,7 +111,7 @@ class RedactRestoreUtils
 
     source_data =
       if File.extname(source) == '.json'
-        JSON.parse(File.read(source, 'r'))
+        JSON.parse(File.read(source))
       else
         YAML.load_file(source)
       end

--- a/bin/i18n/sync-out.rb
+++ b/bin/i18n/sync-out.rb
@@ -121,7 +121,7 @@ def find_malformed_links_images(locale, file_path)
   is_json = File.extname(file_path) == '.json'
   data =
     if is_json
-      JSON.parse(File.read(file_path, 'r'))
+      JSON.parse(File.read(file_path))
     else
       YAML.load_file(file_path)
     end


### PR DESCRIPTION
**What:** Remove the `r` argument being passed with `File.read` calls.

**Why:** A [previously ran automated script](https://github.com/code-dot-org/code-dot-org/commit/7ad083b2147d6327ebb5c8c23f306faee3db597e#diff-633e9390c16dd87eff76e337334407f9fd3c869d79663bfb7d103d0fac9b4200R124) replaced `File.open` with `File.read`. The latter no longer supporting the argument in the same way caused an error during the sync-out.

```
Sync out failed from the error: TypeError: no implicit conversion of String into Integer
bundler: failed to load command: ./bin/i18n/sync-all.rb (./bin/i18n/sync-all.rb)
Parallel::UndumpableException: TypeError: no implicit conversion of String into Integer
```

## Testing story

Successfully ran the sync-out locally after the fix.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
