### PR TITLE
Fix flaky application dashboard test

### DIFF
--- a/dashboard/test/ui/features/ed_programs/pd/teacher_application_dashboard.feature
+++ b/dashboard/test/ui/features/ed_programs/pd/teacher_application_dashboard.feature
@@ -14,6 +14,7 @@ Feature: Teacher Application Dashboard
     And I press keys "Withdrawn" for element "#status-filter"
     And I press the first ".Select-option" element
     Then I wait until element "span:contains('Withdrawn')" is visible
+    And I wait until element "td:contains('Unreviewed')" is not visible
     And I see no difference for "Admin Course View"
 
     # Access the Detail View by navigating to the first row's "view application" button href


### PR DESCRIPTION
As DOTD yesterday, there was a flaky application dashboard test:
<img width="856" alt="Screen Shot 2022-08-16 at 8 21 53 AM" src="https://user-images.githubusercontent.com/9142121/185206486-09bb822b-1b60-4d6c-bc52-bc41a7c41fad.png">

The filtered status was complete, but the new list hadn't loaded. I added a check to make sure we're waiting until no applications of a different status are there. Tested this locally to make sure this works:

<img width="894" alt="image" src="https://user-images.githubusercontent.com/9142121/185206670-b1b61c6a-f15f-47c1-acfb-d3cb0cd7e930.png">


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
