### PR TITLE
Only stylelint files in the apps directory

### DIFF
--- a/dashboard/app/assets/stylesheets/pairing.scss
+++ b/dashboard/app/assets/stylesheets/pairing.scss
@@ -7,6 +7,6 @@
     border: 1px solid $cyan;
     float: left;
     border-radius: 5px;
-    margin: 10px 10px 10px 0;
+    margin: 10px 10px 10px 0px;
   }
 }

--- a/dashboard/app/assets/stylesheets/pairing.scss
+++ b/dashboard/app/assets/stylesheets/pairing.scss
@@ -7,6 +7,6 @@
     border: 1px solid $cyan;
     float: left;
     border-radius: 5px;
-    margin: 10px 10px 10px 0px;
+    margin: 10px 10px 10px 0;
   }
 }

--- a/shared/css/color.scss
+++ b/shared/css/color.scss
@@ -4,6 +4,7 @@
 //   and aliases.  Variables defined in this file are exported to
 //   apps/src/color.js during the apps build process.
 
+$black: #000;
 $background_black: #121416;
 $dark_gray: #2D3139;
 $darkest_gray: #272822;

--- a/shared/css/color.scss
+++ b/shared/css/color.scss
@@ -4,7 +4,6 @@
 //   and aliases.  Variables defined in this file are exported to
 //   apps/src/color.js during the apps build process.
 
-$black: #000;
 $background_black: #121416;
 $dark_gray: #2D3139;
 $darkest_gray: #272822;

--- a/tools/hooks/lint.rb
+++ b/tools/hooks/lint.rb
@@ -26,7 +26,7 @@ def filter_eslint_shared(modified_files)
 end
 
 def filter_scss_apps(modified_files)
-  modified_files.select {|f| f.end_with?(".scss")}
+  modified_files.select {|f| f.match(/apps\//) && f.end_with?(".scss")}
 end
 
 RUBY_EXTENSIONS = ['.rake', '.rb', 'Rakefile', 'Gemfile'].freeze

--- a/tools/hooks/lint.rb
+++ b/tools/hooks/lint.rb
@@ -76,7 +76,7 @@ def run_haml(files)
   run("bundle exec haml-lint #{files.join(' ')}", REPO_DIR)
 end
 
-def run_scss(files)
+def run_scss_dashboard(files)
   run("bundle exec scss-lint #{files.join(' ')}", REPO_DIR)
 end
 
@@ -90,7 +90,7 @@ def do_linting
   modified_files = HooksUtils.get_staged_files
   todo = {
     Object.method(:run_haml) => filter_haml(modified_files),
-    Object.method(:run_scss) => filter_scss(modified_files),
+    Object.method(:run_scss_dashboard) => filter_scss(modified_files),
     Object.method(:run_eslint_apps) => filter_eslint_apps(modified_files),
     Object.method(:run_eslint_shared) => filter_eslint_shared(modified_files),
     Object.method(:run_stylelint_apps) => filter_scss_apps(modified_files),


### PR DESCRIPTION
This fixes an error Mike was seeing that modifying the `/shared/css/color.scss` file triggers a lint warning from stylelint––only scss files in the apps directory should be linted with styelint.

I'm guessing this was failing because although the command was run from the apps directory, it was still picking up "modified files" to include files that were not in the apps directory.

To check this fix, I modified the color.scss file successfully (change reverted), and also modified `/dashboard/app/assets/stylesheets/pairing.scss` –– the pairing file got a lint error, but when I disabled the ":run_scss_dashboard" function, the file passed the linting, indicating stylelint is only enabled in the apps directory.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
