### PR TITLE
Update `activerecord-import` Gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -325,7 +325,7 @@ install_if require_pg do
   gem 'pg', require: false
 end
 
-gem 'activerecord-import'
+gem 'activerecord-import', '~> 1.0.3'
 gem 'active_record_union'
 gem 'scenic'
 gem 'scenic-mysql_adapter'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -231,7 +231,7 @@ GEM
     activerecord (6.0.4.1)
       activemodel (= 6.0.4.1)
       activesupport (= 6.0.4.1)
-    activerecord-import (0.22.0)
+    activerecord-import (1.0.8)
       activerecord (>= 3.2)
     activestorage (6.0.4.1)
       actionpack (= 6.0.4.1)
@@ -911,7 +911,7 @@ DEPENDENCIES
   active_model_serializers (~> 0.10.13)
   active_record_query_trace
   active_record_union
-  activerecord-import
+  activerecord-import (~> 1.0.3)
   acts_as_list
   addressable
   annotate (~> 3.1.1)


### PR DESCRIPTION
To pick up support for Rails 6.1, which [was added in 1.0.3](https://github.com/zdennis/activerecord-import/blob/master/CHANGELOG.md#changes-in-103)

The only breaking change listed between these versions is a change to make `on_duplicate_key_update` no longer enabled by default in MySQL. We're using MySQL so this change could impact us, but as far as I've been able to find we are usually consistent about setting this value explicitly:

https://github.com/code-dot-org/code-dot-org/blob/b9e87de46fbc573c2e62b817af14e3add790799e/dashboard/lib/services/script_seed.rb#L406
https://github.com/code-dot-org/code-dot-org/blob/b9e87de46fbc573c2e62b817af14e3add790799e/dashboard/lib/services/script_seed.rb#L265
https://github.com/code-dot-org/code-dot-org/blob/b9e87de46fbc573c2e62b817af14e3add790799e/dashboard/lib/level_loader.rb#L73

But there are some situations in which we don't:

https://github.com/code-dot-org/code-dot-org/blob/b9e87de46fbc573c2e62b817af14e3add790799e/dashboard/lib/level_loader.rb#L49
https://github.com/code-dot-org/code-dot-org/blob/08acc05f979a25367d5fc9cac7b6727901551480/dashboard/lib/mega_section.rb#L127
https://github.com/code-dot-org/code-dot-org/blob/08acc05f979a25367d5fc9cac7b6727901551480/dashboard/app/models/video.rb#L55

In those situations, the old behavior would be that any entries with duplicate unique identifiers would be combined. The new behavior is that an error will be raised.

My expectation is that if there _is_ anywhere that we are relying on old behavior, that will be revealed by our continuous integration system.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

- [Changelog](https://github.com/zdennis/activerecord-import/blob/master/CHANGELOG.md#changes-in-100)

## Testing story

Relying on existing tests to verify that this does not result in any change in behavior.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
