### PR TITLE
Fix Violations of and Reenable `Rails/HttpStatus`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -301,13 +301,6 @@ Rails/DynamicFindBy:
 Rails/FilePath:
   Enabled: false
 
-# Offense count: 31
-# This cop supports safe auto-correction (--auto-correct).
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: numeric, symbolic
-Rails/HttpStatus:
-  Enabled: false
-
 # Offense count: 90
 Rails/I18nLocaleTexts:
   Enabled: false

--- a/dashboard/app/controllers/activities_controller.rb
+++ b/dashboard/app/controllers/activities_controller.rb
@@ -44,7 +44,7 @@ class ActivitiesController < ApplicationController
     #  - post_milestone is true, AND (we post on failed runs, or this was successful), or
     #  - this is the final level in the script - we always post on final level
     unless (post_milestone && (post_failed_run_milestone || solved)) || final_level
-      head 503
+      head :service_unavailable
       return
     end
 
@@ -98,7 +98,7 @@ class ActivitiesController < ApplicationController
       nonsubmitted_lockable = user_level.nil? && @script_level.end_of_lesson?
       # we have a lockable lesson, and user_level is locked. disallow milestone requests
       if nonsubmitted_lockable || user_level.try(:show_as_locked?, @script_level.lesson) || user_level.try(:readonly_answers?)
-        return head 403
+        return head :forbidden
       end
     end
 

--- a/dashboard/app/controllers/api/v1/amazon_future_engineer_controller.rb
+++ b/dashboard/app/controllers/api/v1/amazon_future_engineer_controller.rb
@@ -67,7 +67,7 @@ class Api::V1::AmazonFutureEngineerController < ApplicationController
     end
   rescue Services::AFEEnrollment::Error, Services::CSTAEnrollment::Error => e
     Honeybadger.notify e
-    render json: e.to_s, status: 400
+    render json: e.to_s, status: :bad_request
   end
 
   private

--- a/dashboard/app/controllers/api/v1/pd/foorm/forms_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/foorm/forms_controller.rb
@@ -8,7 +8,7 @@ class Api::V1::Pd::Foorm::FormsController < ApplicationController
       filled_in_form = Foorm::Form.fill_in_library_items(form_questions)
       render json: filled_in_form
     rescue => e
-      render status: 500, json: {error: e.message}
+      render status: :internal_server_error, json: {error: e.message}
     end
   end
 
@@ -72,9 +72,9 @@ class Api::V1::Pd::Foorm::FormsController < ApplicationController
     form_questions = params[:form_questions].as_json
     errors = Foorm::Form.validate_questions(form_questions)
     if errors.empty?
-      return render status: 200, json: {}
+      return render status: :ok, json: {}
     else
-      return render status: 500, json: {error: errors}
+      return render status: :internal_server_error, json: {error: errors}
     end
   end
 end

--- a/dashboard/app/controllers/api/v1/pd/foorm/library_questions_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/foorm/library_questions_controller.rb
@@ -10,9 +10,9 @@ class Api::V1::Pd::Foorm::LibraryQuestionsController < ApplicationController
     library_question.validate_question
 
     if library_question.errors.empty?
-      return render status: 200, json: {}
+      return render status: :ok, json: {}
     else
-      return render status: 500, json: {error: library_question.errors[:question].join(', ')}
+      return render status: :internal_server_error, json: {error: library_question.errors[:question].join(', ')}
     end
   end
 end

--- a/dashboard/app/controllers/api/v1/pd/workshop_enrollments_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshop_enrollments_controller.rb
@@ -37,7 +37,7 @@ class Api::V1::Pd::WorkshopEnrollmentsController < ApplicationController
     @workshop = Pd::Workshop.find_by_id params[:workshop_id]
     if @workshop.nil?
       return render json: {submission_status: RESPONSE_MESSAGES[:NOT_FOUND]},
-        status: 404
+        status: :not_found
     end
 
     enrollment_email = params[:email]
@@ -155,7 +155,7 @@ class Api::V1::Pd::WorkshopEnrollmentsController < ApplicationController
 
   def render_unsuccessful(error_message, options={})
     render json: options.merge({workshop_enrollment_status: error_message}),
-      status: 400
+      status: :bad_request
   end
 
   def workshop_closed?

--- a/dashboard/app/controllers/api/v1/pd/workshop_survey_foorm_report_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshop_survey_foorm_report_controller.rb
@@ -5,14 +5,14 @@ module Api::V1::Pd
     # GET /api/v1/pd/workshops/:id/foorm/generic_survey_report
     def generic_survey_report
       is_authorized, facilitator_id_filter = get_authorization_and_filter(current_user, params[:workshop_id])
-      return render json: {}, status: 401 unless is_authorized
+      return render json: {}, status: :unauthorized unless is_authorized
       report = Pd::Foorm::SurveyReporter.get_workshop_report(params[:workshop_id], facilitator_id_filter)
       render json: report
     end
 
     # GET /api/v1/pd/workshops/:id/foorm/csv_survey_report
     def csv_survey_report
-      return render json: {}, status: 401 unless current_user&.workshop_admin?
+      return render json: {}, status: :unauthorized unless current_user&.workshop_admin?
       form_name = params[:name]
       form_version = params[:version]
       workshop_id = params[:workshop_id]

--- a/dashboard/app/controllers/api/v1/sections_controller.rb
+++ b/dashboard/app/controllers/api/v1/sections_controller.rb
@@ -248,7 +248,7 @@ class Api::V1::SectionsController < Api::V1::JSONApiController
     render json: {result: 'success'}
   # if the group data is invalid we will get a record invalid exception
   rescue ActiveRecord::RecordInvalid
-    render json: {result: 'invalid groups'}, status: 400
+    render json: {result: 'invalid groups'}, status: :bad_request
   end
 
   # POST /api/v1/sections/<id>/code_review_enabled

--- a/dashboard/app/controllers/api/v1/user_school_infos_controller.rb
+++ b/dashboard/app/controllers/api/v1/user_school_infos_controller.rb
@@ -12,7 +12,7 @@ class Api::V1::UserSchoolInfosController < ApplicationController
   # PATCH /api/v1/users_school_infos
   def update
     unless school_info_params[:school_id].present? || school_info_params[:country].present?
-      render json: {error: "school id or country is not present"}, status: 422
+      render json: {error: "school id or country is not present"}, status: :unprocessable_entity
       return
     end
 
@@ -38,7 +38,7 @@ class Api::V1::UserSchoolInfosController < ApplicationController
           first_or_create(validation_type: SchoolInfo::VALIDATION_COMPLETE)
         end
       unless current_user.update(school_info: submitted_school_info)
-        render json: current_user.errors, status: 422
+        render json: current_user.errors, status: :unprocessable_entity
         return
       end
       current_user.user_school_infos.where(school_info: submitted_school_info).

--- a/dashboard/app/controllers/api/v1/users_controller.rb
+++ b/dashboard/app/controllers/api/v1/users_controller.rb
@@ -171,7 +171,7 @@ class Api::V1::UsersController < Api::V1::JSONApiController
     @user.next_census_display = next_date
     @user.save
 
-    render status: 200, json: {next_census_display: @user.next_census_display}
+    render status: :ok, json: {next_census_display: @user.next_census_display}
   end
 
   # POST /api/v1/users/<user_id>/dismiss_census_banner
@@ -185,7 +185,7 @@ class Api::V1::UsersController < Api::V1::JSONApiController
     @user.next_census_display = Date.new(year, 11, 15)
     @user.save
 
-    render status: 200, json: {next_census_display: @user.next_census_display}
+    render status: :ok, json: {next_census_display: @user.next_census_display}
   end
 
   # POST /api/v1/users/<user_id>/dismiss_donor_teacher_banner

--- a/dashboard/app/controllers/courses_controller.rb
+++ b/dashboard/app/controllers/courses_controller.rb
@@ -123,7 +123,7 @@ class CoursesController < ApplicationController
 
   def get_rollup_resources
     course_version = @unit_group.course_version
-    return render status: 400, json: {error: 'Course does not have course version'} unless course_version
+    return render status: :bad_request, json: {error: 'Course does not have course version'} unless course_version
     rollup_pages = []
     if @unit_group.default_units.any? {|s| s.lessons.any? {|l| !l.programming_expressions.empty?}}
       rollup_pages.append(Resource.find_or_create_by!(name: 'All Code', url: code_course_path(@unit_group), course_version_id: course_version.id))

--- a/dashboard/app/controllers/lessons_controller.rb
+++ b/dashboard/app/controllers/lessons_controller.rb
@@ -150,7 +150,7 @@ class LessonsController < ApplicationController
     new_level_suffix = params[:newLevelSuffix].presence
     ActiveRecord::Base.transaction do
       copied_lesson = @lesson.copy_to_unit(destination_script, new_level_suffix)
-      render(status: 200, json: {editLessonUrl: edit_lesson_path(id: copied_lesson.id), editScriptUrl: edit_script_path(copied_lesson.script)})
+      render(status: :ok, json: {editLessonUrl: edit_lesson_path(id: copied_lesson.id), editScriptUrl: edit_script_path(copied_lesson.script)})
     end
   rescue => err
     render(json: {error: err.message}.to_json, status: :not_acceptable)

--- a/dashboard/app/controllers/programming_classes_controller.rb
+++ b/dashboard/app/controllers/programming_classes_controller.rb
@@ -94,7 +94,7 @@ class ProgrammingClassesController < ApplicationController
     return render :not_found unless @programming_class
     begin
       @programming_class.destroy
-      render(status: 200, plain: "Destroyed #{@programming_class.name}")
+      render(status: :ok, plain: "Destroyed #{@programming_class.name}")
     rescue
       render(status: :not_acceptable, plain: @programming_class.errors.full_messages.join('. '))
     end

--- a/dashboard/app/controllers/programming_environments_controller.rb
+++ b/dashboard/app/controllers/programming_environments_controller.rb
@@ -69,7 +69,7 @@ class ProgrammingEnvironmentsController < ApplicationController
 
   def destroy
     @programming_environment.destroy!
-    render(status: 200, plain: "Destroyed #{@programming_environment.name}")
+    render(status: :ok, plain: "Destroyed #{@programming_environment.name}")
   rescue => e
     render(status: :not_acceptable, plain: e.message)
   end

--- a/dashboard/app/controllers/programming_expressions_controller.rb
+++ b/dashboard/app/controllers/programming_expressions_controller.rb
@@ -112,7 +112,7 @@ class ProgrammingExpressionsController < ApplicationController
     return render :not_found unless @programming_expression
     begin
       @programming_expression.destroy
-      render(status: 200, plain: "Destroyed #{@programming_expression.name}")
+      render(status: :ok, plain: "Destroyed #{@programming_expression.name}")
     rescue
       render(status: :not_acceptable, plain: @programming_expression.errors.full_messages.join('. '))
     end
@@ -124,7 +124,7 @@ class ProgrammingExpressionsController < ApplicationController
     return render(status: not_acceptable, plain: 'Must provide destination programming environment') unless params[:destinationProgrammingEnvironmentName]
     begin
       new_exp = @programming_expression.clone_to_programming_environment(params[:destinationProgrammingEnvironmentName], params[:destinationCategoryKey])
-      render(status: 200, json: {editUrl: edit_programming_expression_path(new_exp)})
+      render(status: :ok, json: {editUrl: edit_programming_expression_path(new_exp)})
     rescue => err
       render(json: {error: err.message}.to_json, status: :not_acceptable)
     end

--- a/dashboard/app/controllers/resources_controller.rb
+++ b/dashboard/app/controllers/resources_controller.rb
@@ -22,7 +22,7 @@ class ResourcesController < ApplicationController
     if resource_params[:course_version_id]
       course_version = CourseVersion.find_by_id(resource_params[:course_version_id])
       unless course_version
-        render status: 400, json: {error: "course version not found"}
+        render status: :bad_request, json: {error: "course version not found"}
         return
       end
       resource.course_version = course_version if course_version
@@ -31,7 +31,7 @@ class ResourcesController < ApplicationController
       resource.serialize_scripts
       render json: resource.summarize_for_lesson_edit
     else
-      render status: 400, json: {error: resource.errors.full_message.to_json}
+      render status: :bad_request, json: {error: resource.errors.full_message.to_json}
     end
   end
 

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -222,7 +222,7 @@ class ScriptsController < ApplicationController
   def get_rollup_resources
     unit = Script.get_from_cache(params[:id])
     course_version = unit.get_course_version
-    return render status: 400, json: {error: 'Script does not have course version'} unless course_version
+    return render status: :bad_request, json: {error: 'Script does not have course version'} unless course_version
     rollup_pages = []
     if unit.lessons.any? {|l| !l.programming_expressions.empty?}
       rollup_pages.append(Resource.find_or_create_by!(name: 'All Code', url: code_script_path(unit), course_version_id: course_version.id))

--- a/dashboard/app/controllers/videos_controller.rb
+++ b/dashboard/app/controllers/videos_controller.rb
@@ -20,7 +20,7 @@ class VideosController < ApplicationController
         require 'cdo/video/youtube'
         Youtube.process @video.key
       rescue Exception => e
-        render(layout: false, plain: "Error processing video: #{e}. Contact an engineer for support.", status: 500) && return
+        render(layout: false, plain: "Error processing video: #{e}. Contact an engineer for support.", status: :internal_server_error) && return
       end
     end
     video_info = @video.summarize(params.key?(:autoplay))

--- a/dashboard/app/controllers/vocabularies_controller.rb
+++ b/dashboard/app/controllers/vocabularies_controller.rb
@@ -13,7 +13,7 @@ class VocabulariesController < ApplicationController
   def create
     course_version = CourseVersion.find_by_id(vocabulary_params[:course_version_id])
     unless course_version
-      render status: 400, json: {error: "course version not found"}
+      render status: :bad_request, json: {error: "course version not found"}
       return
     end
     vocabulary = Vocabulary.new(
@@ -27,7 +27,7 @@ class VocabulariesController < ApplicationController
       vocabulary.serialize_scripts
       render json: vocabulary.summarize_for_lesson_edit
     rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid => e
-      render status: 400, json: {error: e.message.to_json}
+      render status: :bad_request, json: {error: e.message.to_json}
     end
   end
 


### PR DESCRIPTION
Which [enforces use of symbolic value to describe HTTP status](https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Rails/HttpStatus)

## Testing story

Relying on existing tests to verify that this represents no change in behavior.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
