### PR TITLE
Fix Violations of and Reenable `Style/TrailingUnderscoreVariable`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -751,12 +751,6 @@ Style/StringConcatenation:
 Style/TernaryParentheses:
   Enabled: false
 
-# Offense count: 42
-# This cop supports safe auto-correction (--auto-correct).
-# Configuration parameters: AllowNamedUnderscoreVariables.
-Style/TrailingUnderscoreVariable:
-  Enabled: false
-
 # Offense count: 13
 # This cop supports unsafe auto-correction (--auto-correct-all).
 # Configuration parameters: EnforcedStyle.

--- a/bin/cron/sync_dropbox
+++ b/bin/cron/sync_dropbox
@@ -48,7 +48,7 @@ while (Time.now - SCRIPT_START) < TOTAL_SECONDS
     # 'unison' will sync the two folders. It will return true on success and false on failure.
     # For full details, see unison's man page. Docs are also here: https://www.cis.upenn.edu/~bcpierce/unison/download/releases/stable/unison-manual.html
     command = "unison /home/ubuntu/Dropbox/Shared/#{key} /home/ubuntu/staging/pegasus/#{value} -silent -ignore \"Name .dropbox\" -auto -perms 0 -dontchmod -log -logfile /home/ubuntu/unison.log"
-    stdout, stderr, _ = Open3.capture3(command)
+    stdout, stderr, = Open3.capture3(command)
     if stdout == "" && stderr == ""
       HooksUtils.get_unstaged_files.each do |filename|
         ChatClient.log("<@#{DevelopersTopic.dotd}> INVALID FILENAME: #{filename}", color: 'red') if HooksUtils.prohibited?(filename) && Time.now.sec % 59 == 0

--- a/dashboard/app/controllers/report_abuse_controller.rb
+++ b/dashboard/app/controllers/report_abuse_controller.rb
@@ -24,7 +24,7 @@ class ReportAbuseController < ApplicationController
   # they are safe. This reduces spamming of the report abuse feature.
   def protected_project?
     return false if params[:channel_id].blank?
-    owner_storage_id, _ = storage_decrypt_channel_id(params[:channel_id])
+    owner_storage_id, = storage_decrypt_channel_id(params[:channel_id])
     owner_user_id = user_id_for_storage_id(owner_storage_id)
     return false unless owner_user_id
     project_owner = User.find(owner_user_id)

--- a/dashboard/app/controllers/xhr_proxy_controller.rb
+++ b/dashboard/app/controllers/xhr_proxy_controller.rb
@@ -130,7 +130,7 @@ class XhrProxyController < ApplicationController
     url = params[:u]
 
     begin
-      owner_storage_id, _ = storage_decrypt_channel_id(channel_id)
+      owner_storage_id, = storage_decrypt_channel_id(channel_id)
     rescue ArgumentError, OpenSSL::Cipher::CipherError => e
       render_error_response 403, "Invalid token: '#{channel_id}' for url: '#{url}' exception: #{e.message}"
       return

--- a/dashboard/app/models/census/ap_school_code.rb
+++ b/dashboard/app/models/census/ap_school_code.rb
@@ -83,7 +83,7 @@ class Census::ApSchoolCode < ApplicationRecord
     # "ap_school_codes/<start_year>-<end_year>.<file_extension>"
     _, filename = object_key.split('/')
     name, extension = filename.rpartition('.')
-    start_year, _ = name.split('-')
+    start_year, = name.split('-')
     [
       start_year.to_i,
       extension

--- a/dashboard/app/models/census/other_curriculum_offering.rb
+++ b/dashboard/app/models/census/other_curriculum_offering.rb
@@ -72,7 +72,7 @@ class Census::OtherCurriculumOffering < ApplicationRecord
     # "other_curriculum_offerings/<provider_code>/<start_year>-<end_year>.<file_extension>"
     _, provider_code, filename = object_key.split('/')
     name, extension = filename.rpartition('.')
-    start_year, _ = name.split('-')
+    start_year, = name.split('-')
     [
       provider_code,
       start_year.to_i,

--- a/dashboard/app/models/census/state_cs_offering.rb
+++ b/dashboard/app/models/census/state_cs_offering.rb
@@ -1534,7 +1534,7 @@ class Census::StateCsOffering < ApplicationRecord
     _, state_code, filename = object_key.split('/')
     name, _, extension = filename.rpartition('.')
     years, update = name.split('.')
-    start_year, _ = years.split('-').map(&:to_i)
+    start_year, = years.split('-').map(&:to_i)
     [
       state_code,
       start_year,
@@ -1573,7 +1573,7 @@ class Census::StateCsOffering < ApplicationRecord
         all_updates = find_all_updates_for_state_year(state_code, school_year, file_extension)
         # seed each update file
         all_updates.each do |object_key|
-          _, _, update, _ = deconstruct_object_key(object_key)
+          _, _, update, = deconstruct_object_key(object_key)
           AWS::S3.seed_from_file(CENSUS_BUCKET_NAME, object_key, dry_run) do |filename|
             seed_from_csv(state_code, school_year, update, filename, dry_run)
             seeded_objects << object_key

--- a/dashboard/app/models/levels/dsl_defined.rb
+++ b/dashboard/app/models/levels/dsl_defined.rb
@@ -107,7 +107,7 @@ class DSLDefined < Level
     text = set_editor_experiment(text, level_params[:editor_experiment])
     transaction do
       # Parse data, save updated level data to database
-      data, _ = dsl_class.parse(text, '')
+      data, = dsl_class.parse(text, '')
       level_params.delete(:name)
       level_params.delete(:type) if data[:properties][:type]
       data[:properties].merge! level_params

--- a/dashboard/app/models/pd/regional_partner_mini_contact.rb
+++ b/dashboard/app/models/pd/regional_partner_mini_contact.rb
@@ -77,6 +77,6 @@ class Pd::RegionalPartnerMiniContact < ApplicationRecord
     hash = sanitize_form_data_hash
     zipcode = hash[:zip]
 
-    self.regional_partner, _ = RegionalPartner.find_by_zip(zipcode)
+    self.regional_partner, = RegionalPartner.find_by_zip(zipcode)
   end
 end

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -662,7 +662,7 @@ class User < ApplicationRecord
   end
 
   def self.find_channel_owner(encrypted_channel_id)
-    owner_storage_id, _ = storage_decrypt_channel_id(encrypted_channel_id)
+    owner_storage_id, = storage_decrypt_channel_id(encrypted_channel_id)
     user_id = user_id_for_storage_id(owner_storage_id)
     User.find(user_id)
   rescue ArgumentError, OpenSSL::Cipher::CipherError, ActiveRecord::RecordNotFound
@@ -1949,7 +1949,7 @@ class User < ApplicationRecord
 
     if pairing_user_ids&.any? && user_level.level.should_allow_pairing?(script.id)
       pairing_user_ids.each do |navigator_user_id|
-        navigator_user_level, _ = User.track_level_progress(
+        navigator_user_level, = User.track_level_progress(
           user_id: navigator_user_id,
           level_id: level_id,
           script_id: script_id,

--- a/dashboard/test/controllers/api/v1/pd/workshop_survey_report_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshop_survey_report_controller_test.rb
@@ -104,7 +104,7 @@ module Api::V1::Pd
     end
 
     test 'local workshop survey report for the first of two facilitators' do
-      workshop_1, _ = build_sample_data
+      workshop_1, = build_sample_data
       sign_in(workshop_1.facilitators.first)
       get :local_workshop_survey_report, params: {workshop_id: workshop_1.id}
       assert_response :success

--- a/dashboard/test/controllers/api/v1/projects/section_projects_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/projects/section_projects_controller_test.rb
@@ -79,7 +79,7 @@ class Api::V1::Projects::SectionProjectsControllerTest < ActionController::TestC
     # This verifies that the hidden project was not shown.
     assert_equal 2, projects_list.size
     project_row = projects_list.first
-    storage_id, _ = storage_decrypt_channel_id(project_row['channel'])
+    storage_id, = storage_decrypt_channel_id(project_row['channel'])
     assert_equal STUDENT_STORAGE_ID, storage_id
     assert_equal 'Bobs App', project_row['name']
     assert_equal @student.name, project_row['studentName']
@@ -87,7 +87,7 @@ class Api::V1::Projects::SectionProjectsControllerTest < ActionController::TestC
     assert_equal '2017-01-25T17:48:12.358-08:00', project_row['updatedAt']
 
     project_row = projects_list.last
-    storage_id, _ = storage_decrypt_channel_id(project_row['channel'])
+    storage_id, = storage_decrypt_channel_id(project_row['channel'])
     assert_equal STUDENT_STORAGE_ID, storage_id
     assert_equal 'Bobs Other App', project_row['name']
     assert_equal @student.name, project_row['studentName']

--- a/dashboard/test/controllers/api_controller_test.rb
+++ b/dashboard/test/controllers/api_controller_test.rb
@@ -577,7 +577,7 @@ class ApiControllerTest < ActionController::TestCase
   end
 
   test "should update lockable state for new user_levels" do
-    script, level, _ = create_script_with_lockable_lesson
+    script, level, = create_script_with_lockable_lesson
 
     user_level_data = {user_id: @student_1.id, level_id: level.id, script_id: script.id}
     user_level_data2 = {user_id: @student_2.id, level_id: level.id, script_id: script.id}
@@ -648,7 +648,7 @@ class ApiControllerTest < ActionController::TestCase
 
   test "should update lockable state for existing levels" do
     Timecop.freeze do
-      script, level, _ = create_script_with_lockable_lesson
+      script, level, = create_script_with_lockable_lesson
 
       user_level_data = {user_id: @student_1.id, level_id: level.id, script_id: script.id}
       user_level = create :user_level, user_level_data
@@ -742,7 +742,7 @@ class ApiControllerTest < ActionController::TestCase
   end
 
   test "should fail to update lockable state if given bad data" do
-    script, level, _ = create_script_with_lockable_lesson
+    script, level, = create_script_with_lockable_lesson
 
     user_level_data = {user_id: @student_1.id, level_id: level.id, script_id: script.id}
     create :user_level, user_level_data
@@ -1377,7 +1377,7 @@ class ApiControllerTest < ActionController::TestCase
   end
 
   test "teacher_panel_progress returns progress when called with script and level" do
-    script, _, regular_level, _ = create_script_with_bonus_levels
+    script, _, regular_level, = create_script_with_bonus_levels
 
     # create progress for student_1 on regular_level
     create :user_level, user: @student_1, script: script, level: regular_level, best_result: ActivityConstants::BEST_PASS_RESULT

--- a/dashboard/test/controllers/levels_controller_test.rb
+++ b/dashboard/test/controllers/levels_controller_test.rb
@@ -702,7 +702,7 @@ class LevelsControllerTest < ActionController::TestCase
   test "should load file contents when editing a dsl defined level" do
     level_path = 'config/scripts/test_demo_level.external'
     contents = File.read(level_path)
-    data, _ = External.parse(contents, level_path)
+    data, = External.parse(contents, level_path)
     External.setup data
 
     level = Level.find_by_name 'Test Demo Level'
@@ -715,7 +715,7 @@ class LevelsControllerTest < ActionController::TestCase
   test "should load encrypted file contents when editing a dsl defined level with the wrong encryption key" do
     level_path = 'config/scripts/test_external_markdown.external'
     contents = File.read(level_path)
-    data, _ = External.parse(contents, level_path)
+    data, = External.parse(contents, level_path)
     External.setup data
     CDO.stubs(:properties_encryption_key).returns("thisisafakekeyyyyyyyyyyyyyyyyyyyyy")
     level = Level.find_by_name 'Test External Markdown'

--- a/dashboard/test/dsl/level_dsl_test.rb
+++ b/dashboard/test/dsl/level_dsl_test.rb
@@ -76,7 +76,7 @@ class LevelDslTest < ActiveSupport::TestCase
       answer 'answer 3', lesson_name: '#{lesson2.name}'
     DSL
 
-    output, _ = EvaluationMulti.parse(input_dsl, 'test')
+    output, = EvaluationMulti.parse(input_dsl, 'test')
     expected = {
       name: 'Test question',
       properties: {
@@ -170,7 +170,7 @@ class LevelDslTest < ActiveSupport::TestCase
     level.destroy
 
     # check parsed data
-    new_level_data, _ = External.parse(encrypted_dsl_text, 'text_external_3.external', 'test external 3')
+    new_level_data, = External.parse(encrypted_dsl_text, 'text_external_3.external', 'test external 3')
     assert new_level_data[:properties]['encrypted']
     assert_equal 'visible to teachers only', new_level_data[:properties][:teacher_markdown]
 

--- a/dashboard/test/models/lesson_test.rb
+++ b/dashboard/test/models/lesson_test.rb
@@ -6,7 +6,7 @@ class LessonTest < ActiveSupport::TestCase
   end
 
   test "lockable_state with swapped level without user_level" do
-    _, level1, _, lesson, _ = create_swapped_lockable_lesson
+    _, level1, _, lesson, = create_swapped_lockable_lesson
 
     lockable_state = lesson.lockable_state [@student]
 
@@ -26,7 +26,7 @@ class LessonTest < ActiveSupport::TestCase
   end
 
   test "lockable_state with swapped level with user_level for inactive level" do
-    script, _, level2, lesson, _ = create_swapped_lockable_lesson
+    script, _, level2, lesson, = create_swapped_lockable_lesson
     create :user_level, user: @student, script: script, level: level2, locked: false
 
     lockable_state = lesson.lockable_state [@student]
@@ -36,7 +36,7 @@ class LessonTest < ActiveSupport::TestCase
   end
 
   test "lockable_state with swapped level with user_level for active level" do
-    script, level1, _, lesson, _ = create_swapped_lockable_lesson
+    script, level1, _, lesson, = create_swapped_lockable_lesson
     create :user_level, user: @student, script: script, level: level1, locked: false
 
     lockable_state = lesson.lockable_state [@student]

--- a/dashboard/test/ui/features/step_definitions/account_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/account_steps.rb
@@ -84,7 +84,7 @@ rescue RSpec::Expectations::ExpectationNotMetError
   raise if (tries += 1) >= 5
   sleep 1
 
-  email, _ = generate_user(name)
+  email, = generate_user(name)
   steps %Q{
     And I type "#{email}" into "#user_email"
   }

--- a/dashboard/test/ui/runner.rb
+++ b/dashboard/test/ui/runner.rb
@@ -520,7 +520,7 @@ def parallel_config(parallel_limit)
     # This 'finish' lambda runs on the main thread after each Parallel.map work
     # item is completed.
     finish: lambda do |_, _, result|
-      feature_succeeded, _, _ = result
+      feature_succeeded, = result
       # Count failures so we can abort the whole test run if we exceed the limit
       $failed_features += 1 unless feature_succeeded
     end

--- a/dashboard_legacy/middleware/files_api.rb
+++ b/dashboard_legacy/middleware/files_api.rb
@@ -46,14 +46,14 @@ class FilesApi < Sinatra::Base
     return true if owns_channel?(encrypted_channel_id) || admin? || has_permission?('project_validator')
 
     # teachers can see abusive assets of their students
-    owner_storage_id, _ = storage_decrypt_channel_id(encrypted_channel_id)
+    owner_storage_id, = storage_decrypt_channel_id(encrypted_channel_id)
     owner_user_id = user_id_for_storage_id(owner_storage_id)
 
     teaches_student?(owner_user_id)
   end
 
   def codeprojects_can_view?(encrypted_channel_id)
-    owner_storage_id, _ = storage_decrypt_channel_id(encrypted_channel_id)
+    owner_storage_id, = storage_decrypt_channel_id(encrypted_channel_id)
 
     # Attempt to find active project in database. This will raise Projects::NotFound if
     # no active project exists, which is handled below.
@@ -103,7 +103,7 @@ class FilesApi < Sinatra::Base
   def record_event(quota_event_type, quota_type, encrypted_channel_id)
     return unless CDO.newrelic_logging
 
-    owner_storage_id, _ = storage_decrypt_channel_id(encrypted_channel_id)
+    owner_storage_id, = storage_decrypt_channel_id(encrypted_channel_id)
     owner_user_id = user_id_for_storage_id(owner_storage_id)
     event_details = {
       quota_type: quota_type,
@@ -308,7 +308,7 @@ class FilesApi < Sinatra::Base
   def should_sanitize_for_under_13?(encrypted_channel_id)
     return false if owns_channel?(encrypted_channel_id)
 
-    owner_storage_id, _ = storage_decrypt_channel_id(encrypted_channel_id)
+    owner_storage_id, = storage_decrypt_channel_id(encrypted_channel_id)
     owner_id = user_id_for_storage_id(owner_storage_id)
     under_13?(owner_id)
   end

--- a/dashboard_legacy/test/middleware/test_assets.rb
+++ b/dashboard_legacy/test/middleware/test_assets.rb
@@ -315,9 +315,9 @@ class AssetsTest < FilesApiTestBase
     sound_filename = 'woof.mp3'
     sound_body = 'stub-sound-contents'
 
-    response, _ = post_asset_file(src_api, image_filename, image_body, 'image/jpeg')
+    response, = post_asset_file(src_api, image_filename, image_body, 'image/jpeg')
     image_filename = JSON.parse(response)['filename']
-    response, _ = post_asset_file(src_api, sound_filename, sound_body, 'audio/mpeg')
+    response, = post_asset_file(src_api, sound_filename, sound_body, 'audio/mpeg')
     sound_filename = JSON.parse(response)['filename']
     src_api.patch_abuse(10)
 

--- a/lib/cdo/poste.rb
+++ b/lib/cdo/poste.rb
@@ -218,7 +218,7 @@ class Deliverer
     params = JSON.parse(delivery[:params])
     unsubscribe_url = poste_url("/u/#{CGI.escape(encrypted_id)}")
 
-    header, html, _ = load_template(message[:name]).render(
+    header, html, = load_template(message[:name]).render(
       params.merge(
         {
           recipient: OpenStruct.new(recipient),

--- a/lib/cdo/rake_utils.rb
+++ b/lib/cdo/rake_utils.rb
@@ -72,7 +72,7 @@ module RakeUtils
   end
 
   def self.system_(*args)
-    status, _ = system__(command_(*args))
+    status, = system__(command_(*args))
     status
   end
 

--- a/shared/middleware/helpers/storage_id.rb
+++ b/shared/middleware/helpers/storage_id.rb
@@ -38,7 +38,7 @@ def storage_decrypt(encrypted)
 end
 
 def storage_decrypt_id(encrypted)
-  _, id, _ = storage_decrypt(encrypted).split(':')
+  _, id, = storage_decrypt(encrypted).split(':')
   id = id.to_i
   raise ArgumentError, "`id` must be an integer > 0" unless id > 0
   return id
@@ -155,7 +155,7 @@ def storage_id_from_cookie
 end
 
 def owns_channel?(encrypted_channel_id)
-  owner_storage_id, _ = storage_decrypt_channel_id(encrypted_channel_id)
+  owner_storage_id, = storage_decrypt_channel_id(encrypted_channel_id)
   owner_storage_id == get_storage_id
 rescue ArgumentError, OpenSSL::Cipher::CipherError
   false

--- a/shared/test/test_log.rb
+++ b/shared/test/test_log.rb
@@ -10,7 +10,7 @@ class LogTest < Minitest::Test
   end
 
   def test_default_log
-    out, _ = capture_subprocess_io do
+    out, = capture_subprocess_io do
       CDO.log.info 'test'
     end
     assert_equal "test\n", out
@@ -23,7 +23,7 @@ class LogTest < Minitest::Test
       end
     end
 
-    out, _ = capture_subprocess_io do
+    out, = capture_subprocess_io do
       CDO.log.info 'test'
     end
     assert_equal 'TEST LOG: test', out


### PR DESCRIPTION
This is an odd one; this rule "[Checks for extra underscores in variable assignment.](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/TrailingUnderscoreVariable)"

Specifically, when you're assigning the results of a call that returns an iterable to multiple variables and want to ignore some variables later in the iterable, this rule discourages you from using plain underscores as placeholder variable names, and prefers that you instead simply omit the variables.

Repeating the examples from the documentation linked above:

```
# bad
a, b, _ = foo()
a, b, _, = foo()
a, _, _ = foo()
a, _, _, = foo()

# good
a, b, = foo()
a, = foo()
*a, b, _ = foo()
# => We need to know to not include 2 variables in a
a, *b, _ = foo()
# => The correction `a, *b, = foo()` is a syntax error
```

The `a, b, _` pattern is definitely a bit gross, but is certainly familiar. The recommended `a, b,` pattern is certainly odd, but it has the benefit of not actually resulting in an unwanted variable assignment. I'm open to feedback about whether we'd prefer to have this rule enabled or disabled.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
