### PR TITLE
Reset predict level button part 1

### DIFF
--- a/apps/src/code-studio/levels/codeStudioLevels.js
+++ b/apps/src/code-studio/levels/codeStudioLevels.js
@@ -170,7 +170,7 @@ export function resetContainedLevel() {
   getAuthenticityToken().then(() => {
     fetch('/delete_predict_level_progress', {
       method: 'POST',
-      credentials: 'same-origin', // include, *same-origin, omit
+      credentials: 'same-origin',
       headers: {
         'Content-Type': 'application/json',
         'X-CSRF-Token': authenticityToken

--- a/apps/src/code-studio/levels/codeStudioLevels.js
+++ b/apps/src/code-studio/levels/codeStudioLevels.js
@@ -102,7 +102,7 @@ export function getLevelIds() {
 }
 
 /**
- * Lock the answer fo the contained level
+ * Lock the answer for the contained level
  */
 export function lockContainedLevelAnswers() {
   const levelIds = getLevelIds();
@@ -143,4 +143,31 @@ export function getContainedLevelResult() {
  */
 export function hasValidContainedLevelResult() {
   return getContainedLevelResult().result.valid;
+}
+
+export function resetContainedLevel() {
+  const levelIds = getLevelIds();
+  if (levelIds.length !== 1) {
+    throw new Error(
+      `Expected exactly one contained level. Got ${levelIds.length}`
+    );
+  }
+  fetch('/delete_predict_level_progress', {
+    method: 'POST',
+    credentials: 'same-origin', // include, *same-origin, omit
+    headers: {
+      'Content-Type': 'application/json'
+      // 'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: JSON.stringify({
+      script_id: appOptions.scriptId,
+      level_id: levelIds[0]
+    })
+  }).then(response => {
+    if (response.ok) {
+      getLevel(levelIds[0]).resetAnswers();
+    } else {
+      console.log(response);
+    }
+  });
 }

--- a/apps/src/code-studio/levels/freeResponse.js
+++ b/apps/src/code-studio/levels/freeResponse.js
@@ -1,6 +1,6 @@
 import $ from 'jquery';
 import {TestResults} from '../../constants';
-import {onAnswerChanged} from './codeStudioLevels';
+import {onAnswerChanged, resetContainedLevel} from './codeStudioLevels';
 import {sourceForLevel} from '../clientState';
 
 export default class FreeResponse {
@@ -26,6 +26,11 @@ export default class FreeResponse {
       textarea.on('input', null, null, function() {
         onAnswerChanged(levelId, false);
       });
+
+      var resetButton = $('#reset-predict-progress-button');
+      if (resetButton) {
+        resetButton.click(() => resetContainedLevel());
+      }
     });
   }
 
@@ -49,6 +54,13 @@ export default class FreeResponse {
 
   lockAnswers() {
     $(`textarea#level_${this.levelId}.response`).prop('disabled', true);
+    $('#reset-predict-progress-button')?.prop('disabled', false);
+  }
+
+  resetAnswers() {
+    $(`textarea#level_${this.levelId}.response`).prop('disabled', false);
+    $(`textarea#level_${this.levelId}.response`).val('');
+    $('#reset-predict-progress-button')?.prop('disabled', true);
   }
 
   getCurrentAnswerFeedback() {

--- a/apps/src/code-studio/levels/multi.js
+++ b/apps/src/code-studio/levels/multi.js
@@ -1,6 +1,10 @@
 import $ from 'jquery';
 import React from 'react';
-import {registerGetResult, onAnswerChanged} from './codeStudioLevels';
+import {
+  registerGetResult,
+  onAnswerChanged,
+  resetContainedLevel
+} from './codeStudioLevels';
 import {sourceForLevel} from '../clientState';
 import Sounds from '../../Sounds';
 import {LegacyTooFewDialog} from '@cdo/apps/lib/ui/LegacyDialogContents';
@@ -188,11 +192,23 @@ Multi.prototype.ready = function() {
 
   if (this.standalone) {
     $('.submitButton').click($.proxy(this.submitButtonClick, this));
+  } else {
+    var resetButton = $('#reset-predict-progress-button');
+    if (resetButton) {
+      resetButton.click(() => resetContainedLevel());
+    }
   }
 };
 
 Multi.prototype.lockAnswers = function() {
   $('#' + this.id + ' .answerbutton').addClass('lock-answers');
+  $('#reset-predict-progress-button')?.prop('disabled', false);
+};
+
+Multi.prototype.resetAnswers = function() {
+  $('#' + this.id + ' .answerbutton').removeClass('lock-answers');
+  $('#reset-predict-progress-button')?.prop('disabled', true);
+  this.selectedAnswers.forEach(idx => this.unclickItem(idx));
 };
 
 Multi.prototype.getAppName = function() {

--- a/apps/test/unit/code-studio/levels/freeResponse.js
+++ b/apps/test/unit/code-studio/levels/freeResponse.js
@@ -62,4 +62,20 @@ describe('Free Response', () => {
       );
     });
   });
+
+  it('can reset answer', () => {
+    window.appOptions.scriptName = scriptName;
+    writeSourceForLevel(
+      scriptName,
+      levelId,
+      +new Date(2017, 1, 19),
+      lastAttemptString
+    );
+
+    const freeResponse = new FreeResponse(levelId);
+    expect(freeResponse.getResult().response).to.equal(lastAttemptString);
+
+    freeResponse.resetAnswers();
+    expect(freeResponse.getResult().response).to.be.empty;
+  });
 });

--- a/apps/test/unit/code-studio/levels/multi.js
+++ b/apps/test/unit/code-studio/levels/multi.js
@@ -174,6 +174,33 @@ describe('multi', () => {
 
       expect(multi.selectedAnswers).to.include(lastAttemptNum);
     });
+
+    it('selects none after attempt is reset', () => {
+      window.appOptions.scriptName = scriptName;
+      writeSourceForLevel(
+        scriptName,
+        levelId,
+        +new Date(2017, 1, 19),
+        lastAttemptString
+      );
+      const multi = new Multi(
+        levelId,
+        id,
+        app,
+        standalone,
+        numAnswers,
+        answers,
+        answersFeedback,
+        emptyLastAttemptString,
+        containedMode
+      );
+
+      expect(multi.selectedAnswers).to.include(lastAttemptNum);
+
+      multi.resetAnswers();
+
+      expect(multi.selectedAnswers.length).to.equal(0);
+    });
   });
 
   describe('getResult', () => {

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -3727,4 +3727,36 @@ html[dir=rtl] {
   }
 }
 
+#reset-predict-progress-button {
+  display: 'inline-block';
+  font-size: 12;
+  font-family: $gotham-regular;
+  border-width: '1px';
+  border-style: 'solid';
+  border-color: $border_gray;
+  border-bottom-left-radius: 3;
+  border-bottom-right-radius: 3;
+  border-top-left-radius: 3;
+  border-top-right-radius: 3;
+  text-decoration: 'none';
+  box-sizing: 'border-box';
+  overflow: 'hidden';
+  white-space: 'nowrap';
+  color: $white;
+  background-color: $red;
+  font-weight: 'bold';
+  box-shadow: 'inset 0 2px 0 0 rgba(255,255,255,0.40)';
+  &:hover {
+    box-shadow: 'none';
+    color: $red;
+    border-color: $red;
+    background-color: $white;
+    cursor: 'pointer';
+  }
+  &:disabled {
+    background-color: $lightest_red;
+    box-shadow: 'inset 0 2px 0 0 rgba(0,0,0,0.1)';
+  }
+}
+
 @import "NpsSurveyBlock";

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -3746,7 +3746,7 @@ html[dir=rtl] {
   background-color: $red;
   font-weight: 'bold';
   box-shadow: 'inset 0 2px 0 0 rgba(255,255,255,0.40)';
-  &:hover {
+  &:hover:not(:disabled) {
     box-shadow: 'none';
     color: $red;
     border-color: $red;

--- a/dashboard/app/views/levels/_contained_levels.html.haml
+++ b/dashboard/app/views/levels/_contained_levels.html.haml
@@ -16,6 +16,6 @@
       - elsif level_class == "free_response"
         = render partial: 'levels/free_response', locals: {in_level_group: true, last_attempt: sublevel_last_attempt, level: contained_level, left_align: true, is_contained_level: true }
       - if current_user && @script && @script.can_be_instructor?(current_user)
-        %button{id: 'reset-predict-progress-button'}
+        %button{id: 'reset-predict-progress-button', disabled: !sublevel_last_attempt}
           Clear Answer
 %div{style: 'clear: both;'}

--- a/dashboard/app/views/levels/_contained_levels.html.haml
+++ b/dashboard/app/views/levels/_contained_levels.html.haml
@@ -15,4 +15,7 @@
         = render partial: 'levels/single_multi', locals: {standalone: false, contained_mode: true, last_attempt: sublevel_last_attempt, level: contained_level, tight_layout: true}
       - elsif level_class == "free_response"
         = render partial: 'levels/free_response', locals: {in_level_group: true, last_attempt: sublevel_last_attempt, level: contained_level, left_align: true, is_contained_level: true }
+      - if current_user && @script && @script.can_be_instructor?(current_user)
+        %button{id: 'reset-predict-progress-button'}
+          Clear Answer
 %div{style: 'clear: both;'}

--- a/dashboard/app/views/levels/_contained_levels.html.haml
+++ b/dashboard/app/views/levels/_contained_levels.html.haml
@@ -18,6 +18,6 @@
       - if current_user && @script && @script.can_be_instructor?(current_user) && DCDO.get('reset-predict-level-feature', false)
         %button{id: 'reset-predict-progress-button', disabled: !sublevel_last_attempt}
           %i.fa.fa-trash
-            Delete Answer
+            =I18n.t('reset_predict_progress_button')
 
 %div{style: 'clear: both;'}

--- a/dashboard/app/views/levels/_contained_levels.html.haml
+++ b/dashboard/app/views/levels/_contained_levels.html.haml
@@ -17,5 +17,6 @@
         = render partial: 'levels/free_response', locals: {in_level_group: true, last_attempt: sublevel_last_attempt, level: contained_level, left_align: true, is_contained_level: true }
       - if current_user && @script && @script.can_be_instructor?(current_user)
         %button{id: 'reset-predict-progress-button', disabled: !sublevel_last_attempt}
-          Clear Answer
+          %i.fa.fa-trash
+            Delete Answer
 %div{style: 'clear: both;'}

--- a/dashboard/app/views/levels/_contained_levels.html.haml
+++ b/dashboard/app/views/levels/_contained_levels.html.haml
@@ -15,8 +15,9 @@
         = render partial: 'levels/single_multi', locals: {standalone: false, contained_mode: true, last_attempt: sublevel_last_attempt, level: contained_level, tight_layout: true}
       - elsif level_class == "free_response"
         = render partial: 'levels/free_response', locals: {in_level_group: true, last_attempt: sublevel_last_attempt, level: contained_level, left_align: true, is_contained_level: true }
-      - if current_user && @script && @script.can_be_instructor?(current_user)
+      - if current_user && @script && @script.can_be_instructor?(current_user) && DCDO.get('reset-predict-level-feature', false)
         %button{id: 'reset-predict-progress-button', disabled: !sublevel_last_attempt}
           %i.fa.fa-trash
             Delete Answer
+
 %div{style: 'clear: both;'}

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -1222,3 +1222,4 @@ en:
       missing_params: "Must provide user, level, and unit ids"
       cannot_view_locked_answers: "Cannot view answers while locked"
       forbidden: "User cannot update student's lockable state"
+  reset_predict_progress_button: "Delete Answer"


### PR DESCRIPTION
Partial implementation of resetting predict level progress for instructors! I decided to split this into its own PR as the flow of choosing an answer, running the level, then resetting the answer is working. However, there are still a few issues so this is currently behind a DCDO flag.

One problem I'm running into is that FreeResponse and Multi levels are both still in haml. In addition, the information as to whether the level has a response is not available in Redux (at least as far as I can tell), which is why there's this disabling and re-enabling buttons pattern. It would be great to move these levels into React and that data into the global state but that seemed out of scope for now.

Some issues I'll need to fix:
- The styling of the button isn't quite right
- The run button isn't disabled when the answer is cleared
- The progress bubbles aren't reset when the level is reset
- The tip is missing. This one is tough as our normal HelpTip component is a React component

https://user-images.githubusercontent.com/46464143/187707580-1134bf54-751f-4673-88a5-11a3a05cd4f9.mov



## Links

[product spec](https://docs.google.com/document/d/1-XwiQ2Xg6rgopTJOzEUE4wE0CdbrZ0_ockr1SFdhAJM/edit#)


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
