### PR TITLE
Modify endpoint for changing principal approvals requirement

### DIFF
--- a/apps/src/code-studio/pd/application_dashboard/principal_approval_buttons.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/principal_approval_buttons.jsx
@@ -83,7 +83,7 @@ export default class PrincipalApprovalButtons extends React.Component {
       method: 'POST',
       url: `/api/v1/pd/application/teacher/${
         this.props.applicationId
-      }/principal_approval_not_required`
+      }/change_principal_approval_requirement`
     }).done(data => {
       this.props.onChange(this.props.applicationId, data.principal_approval);
 

--- a/apps/src/code-studio/pd/application_dashboard/principal_approval_buttons.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/principal_approval_buttons.jsx
@@ -81,6 +81,7 @@ export default class PrincipalApprovalButtons extends React.Component {
   handleNotRequiredClick = () => {
     const notRequiredRequest = $.ajax({
       method: 'POST',
+      data: {principal_approval_not_required: true},
       url: `/api/v1/pd/application/teacher/${
         this.props.applicationId
       }/change_principal_approval_requirement`

--- a/dashboard/app/controllers/api/v1/pd/application/teacher_applications_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/application/teacher_applications_controller.rb
@@ -42,7 +42,7 @@ module Api::V1::Pd::Application
       render json: {principal_approval: @application.principal_approval_state}
     end
 
-    def principal_approval_not_required
+    def change_principal_approval_requirement
       @application.update!(principal_approval_not_required: true)
       render json: {principal_approval: @application.principal_approval_state}
     end

--- a/dashboard/app/controllers/api/v1/pd/application/teacher_applications_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/application/teacher_applications_controller.rb
@@ -43,7 +43,7 @@ module Api::V1::Pd::Application
     end
 
     def change_principal_approval_requirement
-      @application.update!(principal_approval_not_required: true)
+      @application.update!(principal_approval_not_required: params[:principal_approval_not_required].to_bool)
       render json: {principal_approval: @application.principal_approval_state}
     end
 

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -261,7 +261,7 @@ class Ability
           # regional partners cannot see or update incomplete teacher applications
           cannot [:show, :update, :destroy], Pd::Application::TeacherApplication, &:incomplete?
 
-          can [:send_principal_approval, :principal_approval_not_required], TEACHER_APPLICATION_CLASS, regional_partner_id: user.regional_partners.pluck(:id)
+          can [:send_principal_approval, :change_principal_approval_requirement], TEACHER_APPLICATION_CLASS, regional_partner_id: user.regional_partners.pluck(:id)
         end
       end
 

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -650,7 +650,7 @@ Dashboard::Application.routes.draw do
           resources :teacher, controller: 'teacher_applications', only: [:create, :update] do
             member do
               post :send_principal_approval
-              post :principal_approval_not_required
+              post :change_principal_approval_requirement
             end
           end
           post :principal_approval, to: 'principal_approval_applications#create'

--- a/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
@@ -199,12 +199,22 @@ module Api::V1::Pd::Application
       assert_response :ok
     end
 
-    test 'change_principal_approval_requirement changes principal_approval to not required' do
+    test 'change_principal_approval_requirement can set principal_approval_not_required to true' do
       sign_in @program_manager
       refute @application.principal_approval_not_required
 
-      post :change_principal_approval_requirement, params: {id: @application.id}
+      post :change_principal_approval_requirement, params: {id: @application.id, principal_approval_not_required: true}
       assert @application.reload.principal_approval_not_required
+    end
+
+    test 'change_principal_approval_requirement can set principal_approval_not_required to false' do
+      application = create TEACHER_APPLICATION_FACTORY, regional_partner: @partner
+      sign_in @program_manager
+      application.update!(principal_approval_not_required: true)
+
+      assert_equal true, application.principal_approval_not_required
+      post :change_principal_approval_requirement, params: {id: application.id, principal_approval_not_required: false}
+      refute application.reload.principal_approval_not_required
     end
 
     test 'send_principal_approval queues up an email if none exist' do

--- a/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
@@ -48,14 +48,14 @@ module Api::V1::Pd::Application
       params: -> {{id: @application.id}},
       response: :success
 
-    test_user_gets_response_for :principal_approval_not_required,
-                                name: 'program managers can set principal_approval_not_required for applications they own',
+    test_user_gets_response_for :change_principal_approval_requirement,
+                                name: 'program managers can set change_principal_approval_requirement for applications they own',
                                 user: -> {@program_manager},
                                 params: -> {{id: @application.id}},
                                 response: :success
 
-    test_user_gets_response_for :principal_approval_not_required,
-                                name: 'program managers cannot set principal_approval_not_required for applications they do not own',
+    test_user_gets_response_for :change_principal_approval_requirement,
+                                name: 'program managers cannot set change_principal_approval_requirement for applications they do not own',
                                 user: :program_manager,
                                 params: -> {{id: @application.id}},
                                 response: :forbidden
@@ -199,11 +199,11 @@ module Api::V1::Pd::Application
       assert_response :ok
     end
 
-    test 'principal_approval_not_required changes principal_approval to not required' do
+    test 'change_principal_approval_requirement changes principal_approval to not required' do
       sign_in @program_manager
       refute @application.principal_approval_not_required
 
-      post :principal_approval_not_required, params: {id: @application.id}
+      post :change_principal_approval_requirement, params: {id: @application.id}
       assert @application.reload.principal_approval_not_required
     end
 

--- a/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
@@ -48,6 +48,18 @@ module Api::V1::Pd::Application
       params: -> {{id: @application.id}},
       response: :success
 
+    test_user_gets_response_for :principal_approval_not_required,
+                                name: 'program managers can set principal_approval_not_required for applications they own',
+                                user: -> {@program_manager},
+                                params: -> {{id: @application.id}},
+                                response: :success
+
+    test_user_gets_response_for :principal_approval_not_required,
+                                name: 'program managers cannot set principal_approval_not_required for applications they do not own',
+                                user: :program_manager,
+                                params: -> {{id: @application.id}},
+                                response: :forbidden
+
     test_user_gets_response_for :send_principal_approval,
       name: 'program managers can send_principal_approval for applications they own',
       user: -> {@program_manager},
@@ -185,6 +197,14 @@ module Api::V1::Pd::Application
       assert_nil application.form_data_hash[:cs_total_course_hours]
       assert_equal original_school_info, @applicant.school_info
       assert_response :ok
+    end
+
+    test 'principal_approval_not_required changes principal_approval to not required' do
+      sign_in @program_manager
+      refute @application.principal_approval_not_required
+
+      post :principal_approval_not_required, params: {id: @application.id}
+      assert @application.reload.principal_approval_not_required
     end
 
     test 'send_principal_approval queues up an email if none exist' do

--- a/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
@@ -51,7 +51,7 @@ module Api::V1::Pd::Application
     test_user_gets_response_for :change_principal_approval_requirement,
                                 name: 'program managers can set change_principal_approval_requirement for applications they own',
                                 user: -> {@program_manager},
-                                params: -> {{id: @application.id}},
+                                params: -> {{id: @application.id, principal_approval_not_required: true}},
                                 response: :success
 
     test_user_gets_response_for :change_principal_approval_requirement,


### PR DESCRIPTION
This work gets us ready to be able to mark principal approval as required after it's been marked as unrequired. To do this, I'm modifying the endpoint to receive data.

This video shows functionality on staging/prod (note the weirdness that when you select "Not required," the whole button disappears), and compares it to local (also has the weirdness) –– I think I'll change this functionality on the frontend, but for now, just modifying the backend to allow for data. https://watch.screencastify.com/v/20v8iS2hIdw6UHGX0xMG

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
