### PR TITLE
Allow githubusercontent in App Lab

### DIFF
--- a/dashboard/app/controllers/xhr_proxy_controller.rb
+++ b/dashboard/app/controllers/xhr_proxy_controller.rb
@@ -78,6 +78,7 @@ class XhrProxyController < ApplicationController
     deckofcardsapi.com
     distanza.org
     dweet.io
+    githubusercontent.com
     googleapis.com
     grobchess.com
     hubblesite.org


### PR DESCRIPTION
Re-add access to raw data on GitHub via raw.githubusercontent.com. Believed to have been accidentally removed -- more discussion in [this Slack thread](https://codedotorg.slack.com/archives/C1B3PNDL7/p1660861780118039).

## Testing story

I was able to access raw data from GitHub in applab via startWebRequest after making this change (eg, https://raw.githubusercontent.com/code-dot-org/code-dot-org/staging/dashboard/config/ap_cs_offerings/CSA-2019-2020.csv).

## Follow-up work

How do I update docs for this? Our Zendesk page links to codecurricula, which I believe is out of date?