### PR TITLE
Make block tooltips translatable

### DIFF
--- a/apps/src/blockTooltips/DropletFunctionTooltip.html.ejs
+++ b/apps/src/blockTooltips/DropletFunctionTooltip.html.ejs
@@ -1,3 +1,4 @@
+<% var i18n = require('@cdo/locale'); %>
 <% function getPrefixedName () {
   return locals.tipPrefix ? locals.tipPrefix + locals.functionName : locals.functionName;
 } %>
@@ -25,11 +26,11 @@
 <% var linkText = "" %>
 <% if (locals.showCodeLink) { %>
   <div class="tooltip-code-link">
-    <a href="#">Show code</a>
+    <a href="#"><%= i18n.showGeneratedCode() %></a>
   </div>
 <% } %>
 <% if (locals.showExamplesLink) { %>
   <div class="tooltip-example-link">
-    <a href="#">See examples</a>
+    <a href="#"><%= i18n.examples() %></a>
   </div>
 <% } %>

--- a/apps/src/blockTooltips/DropletParameterTooltip.html.ejs
+++ b/apps/src/blockTooltips/DropletParameterTooltip.html.ejs
@@ -1,3 +1,4 @@
+<% var i18n = require('@cdo/locale'); %>
 <div class="function-name">
   <% if (signatureOverride) { -%>
     <%= signatureOverride %>
@@ -13,11 +14,11 @@
 <% if (parameters[currentParameterIndex] && parameters[currentParameterIndex].description) { %><div><%= parameters[currentParameterIndex].description %></div><% } %>
 <% if (parameters[currentParameterIndex] && parameters[currentParameterIndex].assetTooltip) { %>
   <div class="tooltip-choose-link">
-    <a href="#">Choose...</a>
+    <a href="#"><%= i18n.choosePrefix() %></a>
   </div>
 <% } %>
 <% if (showExamplesLink) { %>
   <div class="tooltip-example-link">
-    <a href="#">See examples</a>
+    <a href="#"><%= i18n.examples() %></a>
   </div>
 <% } %>

--- a/apps/test/integration/levelSolutions/applab1/ec_math.js
+++ b/apps/test/integration/levelSolutions/applab1/ec_math.js
@@ -291,7 +291,7 @@ module.exports = {
         );
 
         assert.equal(
-          /See examples/.test($('.tooltipster-content').text()),
+          /Examples/.test($('.tooltipster-content').text()),
           true,
           'tooltip has examples link'
         );

--- a/apps/test/unit/blockTooltips/DropletAutocompleteParameterTooltipManagerTest.js
+++ b/apps/test/unit/blockTooltips/DropletAutocompleteParameterTooltipManagerTest.js
@@ -1,0 +1,81 @@
+import {expect} from '../../util/reconfiguredChai';
+import sinon from 'sinon';
+import commonI18n from '@cdo/locale';
+
+import {DropletTooltipManagerStub} from './stubs';
+
+import DropletAutocompleteParameterTooltipManager from '@cdo/apps/blockTooltips/DropletAutocompleteParameterTooltipManager.js';
+
+describe('DropletAutocompleteParameterTooltipManager', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('getTooltipHTML', () => {
+    it('should render localized string for "Choose..."', () => {
+      // Stub the i18n calls.
+      sinon.stub(commonI18n, 'choosePrefix').returns('i18n-choose-prefix');
+
+      // Mock a DropletTooltipManager.
+      // We need to describe the function as having at least one parameter.
+      let dropletConfig = {
+        showExamplesLink: 'http://example.com/examples'
+      };
+      let blockInfo = {
+        parameterInfos: [
+          {
+            description: 'parameter description',
+            assetTooltip: 'assetTooltip'
+          }
+        ]
+      };
+      let manager = DropletTooltipManagerStub(dropletConfig, blockInfo);
+
+      // Create the parameter tooltip manager class.
+      let tooltip = new DropletAutocompleteParameterTooltipManager(manager);
+
+      // Render the tooltip (the first parameter).
+      let tooltipInfo = manager.getDropletTooltip('functionName');
+      let html = tooltip.getTooltipHTML(tooltipInfo, 0);
+
+      // It should contain a link with the "Choose..." localized text.
+      let el = document.createElement('div');
+      el.innerHTML = html;
+      let a = el.querySelector('.tooltip-choose-link a');
+      expect(a.textContent).to.equal('i18n-choose-prefix');
+    });
+
+    it('should render localized string for "Examples"', () => {
+      // Stub the i18n calls.
+      sinon.stub(commonI18n, 'examples').returns('i18n-examples');
+
+      // Mock a DropletTooltipManager.
+      // We need to describe the function as having at least one parameter.
+      let dropletConfig = {
+        showExamplesLink: 'http://example.com/examples'
+      };
+      let blockInfo = {
+        parameterInfos: [
+          {
+            description: 'parameter description',
+            assetTooltip: 'assetTooltip'
+          }
+        ]
+      };
+      let manager = DropletTooltipManagerStub(dropletConfig, blockInfo);
+
+      // Create the parameter tooltip manager class.
+      let tooltip = new DropletAutocompleteParameterTooltipManager(manager);
+
+      // Render the tooltip (the first parameter).
+      let tooltipInfo = manager.getDropletTooltip('functionName');
+      let html = tooltip.getTooltipHTML(tooltipInfo, 0);
+
+      // It should contain a link with the "Examples" localized text.
+      let el = document.createElement('div');
+      el.innerHTML = html;
+      let a = el.querySelector('.tooltip-example-link a');
+      expect(a.textContent).to.equal('i18n-examples');
+    });
+  });
+});

--- a/apps/test/unit/blockTooltips/DropletAutocompleteParameterTooltipManagerTest.js
+++ b/apps/test/unit/blockTooltips/DropletAutocompleteParameterTooltipManagerTest.js
@@ -12,15 +12,16 @@ describe('DropletAutocompleteParameterTooltipManager', () => {
   });
 
   describe('getTooltipHTML', () => {
-    it('should render localized string for "Choose..."', () => {
-      // Stub the i18n calls.
-      sinon.stub(commonI18n, 'choosePrefix').returns('i18n-choose-prefix');
+    var manager = null;
+    var tooltipInfo = null;
 
-      // Mock a DropletTooltipManager.
-      // We need to describe the function as having at least one parameter.
+    beforeEach(() => {
+      // Build a basic droplet config.
       let dropletConfig = {
         showExamplesLink: 'http://example.com/examples'
       };
+
+      // Create the bare essentials for a block description.
       let blockInfo = {
         parameterInfos: [
           {
@@ -29,13 +30,21 @@ describe('DropletAutocompleteParameterTooltipManager', () => {
           }
         ]
       };
-      let manager = DropletTooltipManagerStub(dropletConfig, blockInfo);
+
+      // Mock a DropletTooltipManager.
+      // We need to describe the function as having at least one parameter.
+      manager = DropletTooltipManagerStub(dropletConfig, blockInfo);
+      tooltipInfo = manager.getDropletTooltip('functionName');
+    });
+
+    it('should render localized string for "Choose..."', () => {
+      // Stub the i18n calls.
+      sinon.stub(commonI18n, 'choosePrefix').returns('i18n-choose-prefix');
 
       // Create the parameter tooltip manager class.
       let tooltip = new DropletAutocompleteParameterTooltipManager(manager);
 
       // Render the tooltip (the first parameter).
-      let tooltipInfo = manager.getDropletTooltip('functionName');
       let html = tooltip.getTooltipHTML(tooltipInfo, 0);
 
       // It should contain a link with the "Choose..." localized text.
@@ -49,26 +58,10 @@ describe('DropletAutocompleteParameterTooltipManager', () => {
       // Stub the i18n calls.
       sinon.stub(commonI18n, 'examples').returns('i18n-examples');
 
-      // Mock a DropletTooltipManager.
-      // We need to describe the function as having at least one parameter.
-      let dropletConfig = {
-        showExamplesLink: 'http://example.com/examples'
-      };
-      let blockInfo = {
-        parameterInfos: [
-          {
-            description: 'parameter description',
-            assetTooltip: 'assetTooltip'
-          }
-        ]
-      };
-      let manager = DropletTooltipManagerStub(dropletConfig, blockInfo);
-
       // Create the parameter tooltip manager class.
       let tooltip = new DropletAutocompleteParameterTooltipManager(manager);
 
       // Render the tooltip (the first parameter).
-      let tooltipInfo = manager.getDropletTooltip('functionName');
       let html = tooltip.getTooltipHTML(tooltipInfo, 0);
 
       // It should contain a link with the "Examples" localized text.

--- a/apps/test/unit/blockTooltips/DropletAutocompletePopupTooltipManagerTest.js
+++ b/apps/test/unit/blockTooltips/DropletAutocompletePopupTooltipManagerTest.js
@@ -1,0 +1,37 @@
+import {expect} from '../../util/reconfiguredChai';
+import sinon from 'sinon';
+import commonI18n from '@cdo/locale';
+
+import {DropletTooltipManagerStub} from './stubs';
+
+import DropletAutocompletePopupTooltipManager from '@cdo/apps/blockTooltips/DropletAutocompletePopupTooltipManager.js';
+
+describe('DropletAutocompletePopupTooltipManager', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('getTooltipHTML', () => {
+    it('should render localized string for "Examples"', () => {
+      // Stub the i18n calls.
+      sinon.stub(commonI18n, 'examples').returns('i18n-examples');
+
+      // Mock a DropletTooltipManager.
+      let tooltipManager = DropletTooltipManagerStub({
+        showExamplesLink: 'http://example.com/examples'
+      });
+
+      // Create the popup tooltip manager class.
+      let tooltip = new DropletAutocompletePopupTooltipManager(tooltipManager);
+
+      // Render the tooltip.
+      let html = tooltip.getTooltipHTML('functionName');
+
+      // It should contain a link with the "Examples" localized text.
+      let el = document.createElement('div');
+      el.innerHTML = html;
+      let a = el.querySelector('.tooltip-example-link a');
+      expect(a.textContent).to.equal('i18n-examples');
+    });
+  });
+});

--- a/apps/test/unit/blockTooltips/DropletBlockTooltipManagerTest.js
+++ b/apps/test/unit/blockTooltips/DropletBlockTooltipManagerTest.js
@@ -1,0 +1,63 @@
+import {expect} from '../../util/reconfiguredChai';
+import sinon from 'sinon';
+import commonI18n from '@cdo/locale';
+
+import {DropletTooltipManagerStub} from './stubs';
+
+import DropletBlockTooltipManager from '@cdo/apps/blockTooltips/DropletBlockTooltipManager.js';
+
+describe('DropletBlockTooltipManager', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('getTooltipHTML', () => {
+    it('should render localized string for "Show Code"', () => {
+      // Stub the i18n calls.
+      sinon.stub(commonI18n, 'showGeneratedCode').returns('i18n-show-code');
+
+      // Mock a DropletTooltipManager.
+      let dropletConfig = {};
+      let blockInfo = {
+        showCodeLink: 'http://example.com/code'
+      };
+      let tooltipManager = DropletTooltipManagerStub(dropletConfig, blockInfo);
+
+      // Create the block tooltip manager class.
+      let tooltip = new DropletBlockTooltipManager(tooltipManager);
+
+      // Render the tooltip.
+      let html = tooltip.getTooltipHTML();
+
+      // It should contain a link with the "Show Code" localized text.
+      let el = document.createElement('div');
+      el.innerHTML = html;
+      let a = el.querySelector('.tooltip-code-link a');
+      expect(a.textContent).to.equal('i18n-show-code');
+    });
+
+    it('should render localized string for "Examples"', () => {
+      // Stub the i18n calls.
+      sinon.stub(commonI18n, 'examples').returns('i18n-examples');
+
+      // Mock a DropletTooltipManager.
+      let dropletConfig = {};
+      let blockInfo = {
+        showExamplesLink: 'http://example.com/examples'
+      };
+      let tooltipManager = DropletTooltipManagerStub(dropletConfig, blockInfo);
+
+      // Create the block tooltip manager class.
+      let tooltip = new DropletBlockTooltipManager(tooltipManager);
+
+      // Render the tooltip.
+      let html = tooltip.getTooltipHTML();
+
+      // It should contain a link with the "Examples" localized text.
+      let el = document.createElement('div');
+      el.innerHTML = html;
+      let a = el.querySelector('.tooltip-example-link a');
+      expect(a.textContent).to.equal('i18n-examples');
+    });
+  });
+});

--- a/apps/test/unit/blockTooltips/stubs.js
+++ b/apps/test/unit/blockTooltips/stubs.js
@@ -1,0 +1,40 @@
+import sinon from 'sinon';
+
+import DropletTooltipManager from '@cdo/apps/blockTooltips/DropletTooltipManager.js';
+
+/**
+ * Stubs out an instance of DropletTooltipManager for the given block info.
+ *
+ * @param {Object} config - The droplet config.
+ * @param {Object} blockInfo - The block information.
+ */
+export function DropletTooltipManagerStub(config = {}, blockInfo = {}) {
+  let tooltipManager = sinon.createStubInstance(DropletTooltipManager);
+
+  // Establish the droplet configuration.
+  tooltipManager.dropletConfig = Object.assign(
+    {
+      showExamplesLink: undefined
+    },
+    config
+  );
+
+  // We need one to give us a code link.
+  tooltipManager.getDropletTooltip.returns(
+    Object.assign(
+      {
+        functionName: 'exampleFunction',
+        isProperty: false,
+        tipPrefix: undefined,
+        functionShortDescription: 'short description',
+        parameterInfos: [],
+        signatureOverride: undefined,
+        showExamplesLink: undefined,
+        showCodeLink: undefined
+      },
+      blockInfo
+    )
+  );
+
+  return tooltipManager;
+}


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

**What**: Localizes the strings in the tooltips that appear hovering over blocks and when autocompleting blocks in the editor.

**Why**: To consistently localize the editor.

**How**: Simply adding the `i18n` module to the `ejs` templates for the tooltips.

**Comment**:

This would change "Show Examples" to just "Examples", even in the English translation, since the "Examples" string exists localized already. I could *add* a new localized string. Should we? I suppose I could have the existing examples localization string be the default when any new one doesn't exist.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

- jira ticket: [FND-2071](https://codedotorg.atlassian.net/jira/software/c/projects/FND/boards/62?modal=detail&selectedIssue=FND-2071)

## Testing story

Manual testing by inspecting the block tooltips while in es-MX:

![code-dot-org-i18n-droplet-tooltip-0](https://user-images.githubusercontent.com/31674/185963303-06b0e336-2d6a-40df-8a00-110b65d90fac.png)

![code-dot-org-i18n-droplet-tooltip-1](https://user-images.githubusercontent.com/31674/185963323-d1c9af0e-ec08-4064-b4b1-798eb761eec4.png)

Then, automated unit tests in the JavaScript realm to call the code to render the tooltip with constructed block and droplet configurations and inspecting the resulting HTML DOM for the text of the links to match stubbed i18n strings.

I cannot test the code path that contains "Show code" manually... I have no clue how to find a block that actually has that info. It feels difficult to exist, somehow. But the automated test does craft such a block and sees the localized string.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
