### PR TITLE
show approximate number of students who have learned on code.org

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -463,7 +463,7 @@
   "coursesLearnHeroButton": "Get started",
   "coursesLearnHeroDescription": "Get started coding today. Our courses and activities are free! It’s easier - and way more fun - than you ever thought. Create an account to save your projects.",
   "coursesLearnHeroHeading": "Anyone can learn computer science",
-  "coursesLearnHeroSubHeading": "{studentsCount} million students have learned on Code.org!",
+  "coursesLearnHeroSubHeading": "Over {studentsCount} million students have learned on Code.org!",
   "courseOfferingSelfPacedPl": "Self-Paced Professional Learning",
   "courseOfferingVirtualPl": "Virtual Professional Learning",
   "courseOfferingOtherPl": "Other Professional Learning",

--- a/apps/src/sites/studio/pages/courses/index.js
+++ b/apps/src/sites/studio/pages/courses/index.js
@@ -16,7 +16,6 @@ function showCourses() {
   const coursesData = JSON.parse(script.dataset.courses);
   const isEnglish = coursesData.english;
   const isTeacher = coursesData.teacher;
-  const linesCount = coursesData.linescount;
   const studentsCount = coursesData.studentscount;
   const codeOrgUrlPrefix = coursesData.codeorgurlprefix;
   const signedOut = coursesData.signedout;
@@ -29,7 +28,6 @@ function showCourses() {
       <Courses
         isEnglish={isEnglish}
         isTeacher={isTeacher}
-        linesCount={linesCount}
         studentsCount={studentsCount}
         codeOrgUrlPrefix={codeOrgUrlPrefix}
         isSignedOut={signedOut}

--- a/apps/src/templates/studioHomepages/Courses.jsx
+++ b/apps/src/templates/studioHomepages/Courses.jsx
@@ -19,7 +19,6 @@ class Courses extends Component {
     isEnglish: PropTypes.bool.isRequired,
     isTeacher: PropTypes.bool.isRequired,
     isSignedOut: PropTypes.bool.isRequired,
-    linesCount: PropTypes.string.isRequired,
     studentsCount: PropTypes.string.isRequired,
     modernElementaryCoursesAvailable: PropTypes.bool.isRequired,
     specialAnnouncement: shapes.specialAnnouncement,

--- a/apps/test/unit/templates/studioHomepages/CoursesTest.jsx
+++ b/apps/test/unit/templates/studioHomepages/CoursesTest.jsx
@@ -10,7 +10,6 @@ const TEST_PROPS = {
   isEnglish: true,
   isTeacher: true,
   isSignedOut: true,
-  linesCount: '0',
   studentsCount: '0',
   modernElementaryCoursesAvailable: true
 };

--- a/dashboard/app/views/courses/index.html.haml
+++ b/dashboard/app/views/courses/index.html.haml
@@ -1,7 +1,4 @@
 :ruby
-  lines_count = fetch_metrics['lines_of_code']
-  lines_count = number_with_delimiter(lines_count, :delimiter => ',')
-
   # Number of students in millions, rounded down to the nearest 10M
   students_count = 70
   students_count = students_count.to_s
@@ -9,7 +6,6 @@
   courses_data = {}
   courses_data[:english] = @is_english
   courses_data[:teacher] = @is_teacher
-  courses_data[:linescount] = lines_count
   courses_data[:studentscount] = students_count
   courses_data[:codeorgurlprefix] = CDO.code_org_url
   courses_data[:signedout] = @is_signed_out

--- a/dashboard/app/views/courses/index.html.haml
+++ b/dashboard/app/views/courses/index.html.haml
@@ -1,8 +1,9 @@
 :ruby
   lines_count = fetch_metrics['lines_of_code']
   lines_count = number_with_delimiter(lines_count, :delimiter => ',')
-  students_count = fetch_user_metrics['number_students']
-  students_count /= 1000000
+
+  # Number of students in millions, rounded down to the nearest 10M
+  students_count = 70
   students_count = students_count.to_s
 
   courses_data = {}


### PR DESCRIPTION
As part of Milestone 1 of [Separating Pegasus](https://docs.google.com/document/d/1cJUhqrsKgcR7gISkxHini3L11ngcbV9-e6-U8PdlZcY/edit), we need to eliminate places where dashboard code accesses pegasus DB.

The purpose of this PR is to remove the following pegasus DB accesses from dashboard: 
* https://github.com/code-dot-org/code-dot-org/blob/a23aa45019faeec07135c241097d5c60d5169b61/dashboard/app/views/courses/index.html.haml#L2
* https://github.com/code-dot-org/code-dot-org/blob/a23aa45019faeec07135c241097d5c60d5169b61/dashboard/app/views/courses/index.html.haml#L4

See screenshots below for user-visible changes on https://studio.code.org/courses as a result of hard-coding the number of students. The marketing team has agreed to these changes (see [slack](https://codedotorg.slack.com/archives/C06E60KL4/p1660777454038799
)), and will own asking for this number to be updated whenever the number of students reaches the next multiple of 10M.

Also, there is no visible change associated with removing the fetch for `lines_of_code`, presumably because it was removed from the UI in a previous PR.

## Screenshots

### student

![Screen Shot 2022-08-22 at 11 00 17 AM](https://user-images.githubusercontent.com/8001765/185988810-f3c2a3b7-fc9e-4a65-8462-cebc2173d241.png)

### signed out

![Screen Shot 2022-08-22 at 10 59 26 AM](https://user-images.githubusercontent.com/8001765/185988787-098f6c3c-d42b-44a8-9b5c-4bf192324ce7.png)

### teacher

The teacher view for /courses is unchanged:

![Screen Shot 2022-08-17 at 3 24 54 PM](https://user-images.githubusercontent.com/8001765/185254323-19f0ccd6-59df-475f-ac15-c74fc862927a.png)

## Testing story

* [existing UI test coverage](https://github.com/code-dot-org/code-dot-org/blob/4008770ce7c309df7ddb39ff5064e104d1222545/dashboard/test/ui/features/learning_platform/course_overview.feature) verifies that the courses page still loads for teachers, students and signed-out users.

## Deployment strategy

normally we have to be careful about deploying translatable string changes, however in this case the new string text seems backward compatible enough, i.e. it seems ok that it will say "70M students learned" instead of "Over 70M..." or "73M students learned" for a short period of time. so I am just planning to merge the string change and the code change as part of the same PR, rather than creating a whole separate string and then waiting for it to be translated.

## Follow-up work

ideally this would not need to be updated manually in the future. the work to figure out how to share this kind of data between dashboard and pegasus will be tracked as part of the ongoing effort to separate pegasus from dashboard.
