### PR TITLE
Report Javalab connection errors to New Relic

### DIFF
--- a/apps/src/javalab/JavabuilderConnection.js
+++ b/apps/src/javalab/JavabuilderConnection.js
@@ -11,6 +11,7 @@ import project from '@cdo/apps/code-studio/initApp/project';
 import javalabMsg from '@cdo/javalab/locale';
 import {onTestResult} from './testResultHandler';
 import {SignInState} from '@cdo/apps/templates/currentUserRedux';
+import logToCloud from '@cdo/apps/logToCloud';
 
 // Creates and maintains a websocket connection with javabuilder while a user's code is running.
 export default class JavabuilderConnection {
@@ -339,6 +340,7 @@ export default class JavabuilderConnection {
     this.onNewlineMessage();
     this.handleExecutionFinished();
     console.error(`[error] ${error.message}`);
+    this.reportWebSocketConnectionError(error.message);
   }
 
   onTimeout() {
@@ -442,5 +444,15 @@ export default class JavabuilderConnection {
     // for further details.
     this.onMarkdownLog(unauthorizedMessage);
     this.onNewlineMessage();
+  }
+
+  reportWebSocketConnectionError(errorMessage) {
+    logToCloud.addPageAction(
+      logToCloud.PageAction.JavabuilderWebSocketConnectionError,
+      {
+        errorMessage,
+        channelId: this.channelId
+      }
+    );
   }
 }

--- a/apps/src/logToCloud.js
+++ b/apps/src/logToCloud.js
@@ -20,7 +20,8 @@ const PageAction = makeEnum(
   'MapboxMarkerLoadError',
   'LoadScriptProgressStarted',
   'LoadScriptProgressFinished',
-  'SectionProgressRenderedWithData'
+  'SectionProgressRenderedWithData',
+  'JavabuilderWebSocketConnectionError'
 );
 
 const MAX_FIELD_LENGTH = 4095;

--- a/dashboard/app/helpers/javalab_files_helper.rb
+++ b/dashboard/app/helpers/javalab_files_helper.rb
@@ -10,7 +10,11 @@ module JavalabFilesHelper
       http.request(upload_request)
     end
     return response
-  rescue StandardError
+  rescue StandardError => e
+    event_details = {
+      error_details: e.to_json
+    }
+    NewRelic::Agent.record_custom_event("JavabuilderHttpConnectionError", event_details) if CDO.newrelic_logging
     nil
   end
 


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Adds New Relic error reporting to Javalab when connection to Javabuilder fails. This will report a two separate events ("JavabuilderHttpConnectionError" or "JavabuilderWebSocketConnectionError") based on which API call failed. New Relic reporting in dashboard vs the client seems to be a little different, so the events in theory will be structured a little differently from each other. Unfortunately I haven't been able to find a way to publish any test events to new relic locally or from an adhoc (more details in the testing section), but the events should be structured as:

HTTP:
```
eventType: JavabuilderHttpConnectionError
eventDetails: {
   error_details: { ... error JSON ... }
}
```

WebSocket:
```
eventType: PageAction
eventDetails: {
   actionName: JavabuilderWebSocketConnectionError,
   channelId: < channel ID >,
   errorMessage: < error message >
}
```

Let me know if there's any other data we'd like to add to any of these. In all likelihood, if there is an outage or persistent error with Javabuilder, we should see the HTTP api fail first, so I'm not sure how much of the websocket error we'll actually get - but if there's a websocket-specific error (likely some error with the authorization payload), then we'll see a websocket error.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

There doesn't seem to be a straightforward way to test publishing New Relic metrics locally or from an adhoc. Comments in the apps/ new relic API seem to suggest that we only publish metrics in production. The testing I've done ensures that the payload is well-formed and contains the data we need.

Example http error details payload:
```
{:error_details=>"\"Failed to open TCP connection to localhost:8080 (Connection refused - connect(2) for \\\"localhost\\\" port 8080)\""}
```

Example websocket error details payload:
![Screen Shot 2022-08-22 at 1 04 26 PM](https://user-images.githubusercontent.com/85528507/185990645-c46fdb89-03a4-4dbb-9eea-032bc8b867fa.png)

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
