### PR TITLE
add string for displaying number of projects created in millions

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1632,6 +1632,7 @@
   "projectsViewProjectGallery": "View projects",
   "projects": "Projects",
   "projectsSubHeading": "{project_count} projects created",
+  "projectsSubHeadingMillions": "Over {project_count} million projects created",
   "print": "Print",
   "privacyPolicy": "Privacy Policy",
   "privacyPracticesForChildren": "See our privacy practices for children",


### PR DESCRIPTION
Similar to #47752, we want to remove this access to pegasus DB: 
* https://github.com/code-dot-org/code-dot-org/blob/a283d2b1390ba7896ea19b2b8d700185c2529f0b/dashboard/app/views/projects/index.html.haml#L6

in order to do that, the plan is to change this user-facing string:
 
![Screen Shot 2022-08-23 at 2 57 41 PM](https://user-images.githubusercontent.com/8001765/186274334-cc7bbc46-667d-495b-9c89-c9bc195f872b.png)

the new string will say "Over 200 million projects created" (see [slack](https://codedotorg.slack.com/archives/C06E60KL4/p1660777454038799) for discussion).

Unlike the previous PR, the new string is different enough that we need to introduce the new string first, then wait for it to be translated, before we can update the code to use the new string. So, all this PR does is add the new string.

## Follow-up work

Wait for 2-3 weeks (translation syncs), then update studio.code.org/projects to use the new string.
