### PR TITLE
Playlab: Fix another JS error

### DIFF
--- a/apps/src/studio/studio.js
+++ b/apps/src/studio/studio.js
@@ -5181,7 +5181,7 @@ Studio.vanishActor = function(opts) {
 
   var spriteIndex = opts.spriteIndex;
   if (spriteIndex < 0 || spriteIndex >= Studio.spriteCount) {
-    throw new RangeError('Incorrect parameter: ' + spriteIndex);
+    return;
   }
   var sprite = Studio.sprite[spriteIndex];
   var spriteShowing = sprite.visible || sprite.isFading();
@@ -5653,7 +5653,7 @@ Studio.setSprite = function(opts) {
 
   var spriteIndex = opts.spriteIndex;
   if (spriteIndex < 0 || spriteIndex >= Studio.spriteCount) {
-    throw new RangeError('Incorrect parameter: ' + spriteIndex);
+    return;
   }
   var sprite = Studio.sprite[spriteIndex];
 


### PR DESCRIPTION
The new highest error in New Relic was a brief spike generated by just a couple users, when throwing an error that we could instead just ignore.

```
Uncaught RangeError: Incorrect parameter: 12
```

<img width="324" alt="Screen Shot 2022-08-22 at 11 50 53 AM" src="https://user-images.githubusercontent.com/2205926/185996724-5b0c0370-563f-472f-8086-4d1233b94d27.png">
