### PR TITLE
Improve Resiliency of MySQL to Redshift Export

### DIFF
--- a/lib/cdo/redshift_import.rb
+++ b/lib/cdo/redshift_import.rb
@@ -21,6 +21,11 @@ class RedshiftImport
 
         CDO.log.info "Dropping existing table #{schema}.#{target_table} and renaming newly imported #{import_table}."
 
+        # In rare error cases, a previous scheduled export may have left some "_old_" tables behind and the renaming the
+        # existing table to "_old_" fails due to the naming conflict. Proactively attempt to delete the current table's
+        # backup from the previous run.
+        drop_table(schema, backup_table)
+
         # Rename existing table to back it up, if it exists.
         # Note: When a new table created in the source MySQL database is imported for the first time, there won't be an
         # existing table in Redshift to backup.  `rename_table` rescues that non-existing table error.


### PR DESCRIPTION
Recently, the daily export from MySQL to Redshift was failing because renaming the existing Redshift table to `_old_[tablename]` was not possible because there was an existing `_old_` table from a previous execution of this batch process. That `_old_` table wasn't originally dropped successfully because a Materialized View had been created that depended on a table and that Materialized View retained its dependency on the table, even when it was renamed. While the Materialized View was dropped, eliminating the dependency, all subsequent exports were failing until we manually deleted the stranded `_old_` tables.

Proactively delete any stranded `_old_` tables.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

I verified that `RedshiftImport.drop_table` does not raise an error if the table does not exist, so it is safe to call even if there isn't a stranded `_old_` table.

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
