### PR TITLE
Clean up outdated Java Lab exemplar logic

### DIFF
--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -712,10 +712,6 @@ class ScriptLevel < ApplicationRecord
           send("#{artist_type}_project_view_projects_url".to_sym, channel_id: example, host: 'studio.code.org', port: 443, protocol: :https)
         elsif level.is_a?(Studio) # playlab
           send("#{'playlab'}_project_view_projects_url".to_sym, channel_id: example, host: 'studio.code.org', port: 443, protocol: :https)
-        elsif level.is_a?(Javalab)
-          # TO DO: remove this statement after switching over to use new Javalab exemplars
-          # https://codedotorg.atlassian.net/browse/JAVA-525
-          example
         else
           send("#{level.game.app}_project_view_projects_url".to_sym, channel_id: example, host: 'studio.code.org', port: 443, protocol: :https)
         end

--- a/dashboard/test/models/script_level_test.rb
+++ b/dashboard/test/models/script_level_test.rb
@@ -141,15 +141,6 @@ class ScriptLevelTest < ActiveSupport::TestCase
       assert_equal sl.get_example_solutions(level, @authorized_teacher), ["https://studio.code.org/projects/playlab/example-1/view", "https://studio.code.org/projects/playlab/example-2/view"]
     end
 
-    # Should be removed as part of this task:
-    # https://codedotorg.atlassian.net/browse/JAVA-525
-    test 'get_example_solutions for javalab level with example (deprecated)' do
-      level = create(:javalab, :with_example_solutions)
-      sl = create(:script_level, levels: [level])
-
-      assert_equal sl.get_example_solutions(level, @authorized_teacher), ["https://studio.code.org/s/csa-examples/lessons/1/levels/1/"]
-    end
-
     test 'get_example_solutions for javalab level with exemplar' do
       level = create(:javalab, exemplar_sources: 'some code')
       script = create(:script)


### PR DESCRIPTION
We have a new method of providing exemplars so this logic is no longer used.

## Links

- jira ticket: [JAVA-525](https://codedotorg.atlassian.net/browse/JAVA-525)


## Testing story
Tested locally that exemplar links still work.
