### PR TITLE
ABANDONED: remove mini_racer and libv8 gems to eliminate mac development workaround

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -197,7 +197,6 @@ gem 'retryable' # retry code blocks when they throw exceptions
 # Used by `uglifier` to minify JS assets in the Asset Pipeline.
 gem 'execjs'
 # JavaScript runtime used by ExecJS.
-gem 'mini_racer'
 
 gem 'jwt' # single signon for zendesk
 

--- a/Gemfile
+++ b/Gemfile
@@ -195,7 +195,6 @@ gem 'naturally' # for sorting string naturally
 gem 'retryable' # retry code blocks when they throw exceptions
 
 # Used by `uglifier` to minify JS assets in the Asset Pipeline.
-gem 'execjs'
 # JavaScript runtime used by ExecJS.
 
 gem 'jwt' # single signon for zendesk

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -529,7 +529,6 @@ GEM
     kgio (2.11.3)
     launchy (2.4.3)
       addressable (~> 2.3)
-    libv8 (8.4.255.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -550,8 +549,6 @@ GEM
     mini_magick (4.9.5)
     mini_mime (1.1.1)
     mini_portile2 (2.6.1)
-    mini_racer (0.3.1)
-      libv8 (~> 8.4.255)
     minitest (5.15.0)
     minitest-around (0.5.0)
       minitest (~> 5.0)
@@ -987,7 +984,6 @@ DEPENDENCIES
   loofah (~> 2.2.1)
   memory_profiler
   mini_magick (>= 4.9.4)
-  mini_racer
   minitest (~> 5.15)
   minitest-around
   minitest-reporters (~> 1.2.0.beta3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -949,7 +949,6 @@ DEPENDENCIES
   devise (~> 4.7.0)
   devise_invitable (~> 1.6.0)
   dotiw
-  execjs
   eyes_selenium (= 3.18.4)
   factory_girl_rails
   fakeredis


### PR DESCRIPTION
## Background

the `libv8` and `mini_racer` gems are causing problems for mac developers, requiring open changes in the git client: https://github.com/code-dot-org/code-dot-org/blob/staging/SETUP.md#apple-silicon-m1-bundle-install-steps these problems now affect all mac developers, not just M1.

according to our comments, `mini_racer` is installed because it is needed by `execjs`. according to the [execjs docs](https://github.com/rails/execjs), `execjs` can use one of many engines for executing javascript and `mini_racer` is just one option. 

The [rails docs](https://guides.rubyonrails.org/v6.0.4.1/asset_pipeline.html) explain that:

> You will need an [ExecJS](https://github.com/rails/execjs#readme) supported runtime in order to use uglifier. If you are using macOS or Windows you have a JavaScript runtime installed in your operating system.

we do use `uglifier` here: https://github.com/code-dot-org/code-dot-org/blob/1d954b0870eca7c105b1c09b0567b776eea701f7/dashboard/lib/tasks/asset_sync.rake#L46-L50

Also, mini racer does appear to be the runtime used by execjs in our chef-managed environments:
```
[staging] dashboard > ExecJS.runtime
=> #<ExecJS::MiniRacerRuntime:0x0000556846640fd8>
```

So, if we remove `mini_racer`, we must be careful that letting `uglifier` use a different js engine will not break anything.

## Description

the solution is to remove the `mini_racer` gem (which also removes `libv8`).

## Testing story

* drone is passing
* adhoc started successfully: https://adhoc-mini-racer-remove-studio.cdn-code.org/
* no remaining code uses of `execjs` or `ExecJS` in our main repo (see [execjs docs](https://github.com/rails/execjs)), although it is still used indirectly by `uglifier`

## Deployment strategy

