### PR TITLE
Fix a JS error that occurs in Minecraft

### DIFF
--- a/apps/src/dom.js
+++ b/apps/src/dom.js
@@ -89,7 +89,7 @@ var addEvent = function(
         unbindEvent('click');
       }
 
-      handler.call(this, e);
+      handler?.call(this, e);
     });
   }
 


### PR DESCRIPTION
The next two highest JS errors in New Relic appear to be the same issue: `handler` is `undefined` when handling a touch-based click (i.e. `"touchstart"`) on the "Reset" button.  This doesn't root cause the issue, but should at least prevent the JS errors from firing.