### PR TITLE
remove mini_racer gem from development environment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -197,7 +197,7 @@ gem 'retryable' # retry code blocks when they throw exceptions
 # Used by `uglifier` to minify JS assets in the Asset Pipeline.
 gem 'execjs'
 # JavaScript runtime used by ExecJS.
-gem 'mini_racer'
+gem 'mini_racer', group: [:staging, :test, :production, :levelbuilder]
 
 gem 'jwt' # single signon for zendesk
 


### PR DESCRIPTION
the `libv8` and `mini_racer` gems are causing problems for mac developers, requiring open changes in the git client: https://github.com/code-dot-org/code-dot-org/blob/staging/SETUP.md#apple-silicon-m1-bundle-install-steps . During the rails 6 upgrade, many mac developers discovered that these problems now affect all mac developers, not just M1. This PR eliminates that painpoint by removing `mini_racer` from the development environment.

### Are we even using mini_racer?

Unfortunately, yes.

according to our comments, `mini_racer` is installed because it is needed by `execjs`. according to the [execjs docs](https://github.com/rails/execjs), `execjs` can use one of many engines for executing javascript and `mini_racer` is just one option. 

The [rails docs](https://guides.rubyonrails.org/v6.0.4.1/asset_pipeline.html) explain that:

> You will need an [ExecJS](https://github.com/rails/execjs#readme) supported runtime in order to use uglifier. If you are using macOS or Windows you have a JavaScript runtime installed in your operating system.

we do use `uglifier` here: https://github.com/code-dot-org/code-dot-org/blob/1d954b0870eca7c105b1c09b0567b776eea701f7/dashboard/lib/tasks/asset_sync.rake#L46-L50

Also, mini racer does appear to be the runtime used by execjs in our chef-managed environments:
```
[staging] dashboard > ExecJS.runtime
=> #<ExecJS::MiniRacerRuntime:0x0000556846640fd8>
```

### Why is mini_racer safe to remove in development?

Because developers have node installed, ExecJS falls back to using node as its runtime:
```
[development] dashboard > ExecJS.runtime
=> #<ExecJS::ExternalRuntime:0x00007fd03a144490 @name="Node.js (V8)", @command=["nodejs", "node"], @runner_path="/Users/dsb/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/execjs-2.7.0/lib/execjs/support/node_runner.js", @encoding="UTF-8", @deprecated=false, @binary="node", @popen_options={:external_encoding=>"UTF-8", :internal_encoding=>#<Encoding:UTF-8>}>
```

### Why can't we just remove mini_racer from other environments too?

* production doesn't have node installed, so ExecJS cannot fall back to using node when mini_racer is removed.

## Testing story

* looked for and could not find any other uses of execjs in our repo besides `uglifier`
* `rake assets:precompile_application_js` is passing locally, and running almost as fast (2.8 sec with node vs 2.5 sec with mini racer to evaluate `manifest.compile('application.js')`)
* drone is passing
* adhoc successfully started

## Follow-up work

If we want to eliminate cross-environment differences, future work could be done to eliminate mini_racer entirely. at a minimum, this would require an additional step, such as installing node in the production environment. I am leaving it up to the infrastructure team whether to pursue this.

