### PR TITLE
Neighborhood: ignore unknown signals

### DIFF
--- a/apps/src/javalab/neighborhood/Neighborhood.js
+++ b/apps/src/javalab/neighborhood/Neighborhood.js
@@ -157,7 +157,7 @@ export default class Neighborhood {
         break;
       }
       default:
-        console.log(signal.value);
+        // Ignore signals we don't know about.
         break;
     }
   }


### PR DESCRIPTION
We are going to add some additional signals to the neighborhood when users call methods such as `canMove`, `isOnBucket` etc. so we can track them for validation. Currently we console log when we see a signal we don't know how to animate. We should just ignore these signals instead.

## Links

- spec: [Validation needs v2](https://docs.google.com/document/d/1hWyBjW6eUh_n60S4iM8ai5ZXMS1sgz22IysLtyWAvjQ/edit#)
- jira ticket: [JAVA-667](https://codedotorg.atlassian.net/browse/JAVA-667)


## Testing story
Tested locally

