### PR TITLE
Adding some ids to behavior blocks so they work in non-english languages

### DIFF
--- a/bin/oneoff/update_behavior_blocks_ids4.rb
+++ b/bin/oneoff/update_behavior_blocks_ids4.rb
@@ -1,0 +1,101 @@
+#!/usr/bin/env ruby
+
+# This intentionally only updates level files in the
+# express-2021 scripts
+
+# Behavioral blocks with no id set have their id
+# set on the frontend as their text value. This causes
+# issues when viewing the levels in different languages.
+
+# Previous iterations of this oneoff script has a flaw
+# in `BEHAVIORAL_DEFINITION_NAMES`'s initialization
+# and should not be used/referenced. Refer to this files commit
+# history for more context.
+
+require_relative '../../dashboard/config/environment'
+
+BEHAVIORAL_DEFINITION_NAMES = [
+  'driving with arrow keys',
+  'growing',
+  'jittering',
+  'moving east',
+  'moving north',
+  'moving south',
+  'moving west',
+  'moving with arrow keys',
+  'patrolling',
+  'shrinking',
+  'spinning left',
+  'spinning right',
+  'swimming left and right',
+  'wandering',
+  'chasing',
+  'acting goofy'
+].freeze
+
+SCRIPT_NAMES = %w(
+  express-2021
+).freeze
+
+$level_names_to_be_updated = Script.where(name: SCRIPT_NAMES).map(&:levels).flatten.map(&:name).to_set
+
+def level_to_be_updated?(level_name)
+  $level_names_to_be_updated.include? level_name
+end
+
+def for_each_level_file(&block)
+  Dir.glob(Rails.root.join('config/scripts/**/*.level')).sort.map(&block)
+end
+
+def level_name_from_path(path)
+  File.basename(path, File.extname(path))
+end
+
+def update_behavior_blocks_ids
+  updated_levels = 0
+  skipped_levels = 0
+
+  for_each_level_file do |path|
+    next unless level_to_be_updated?(level_name_from_path(path))
+    raw_level_data = File.read(path)
+
+    xml = Nokogiri::XML(raw_level_data, &:noblanks)
+    if xml.nil?
+      skipped_levels += 1
+      next
+    end
+
+    # Get all behavior_definition and gamelab_behavior_get blocks that have title texts and ids that are different
+    did_skip = true
+    BEHAVIORAL_DEFINITION_NAMES.each do |name|
+      behavior_defs = xml.xpath("//block[@type='behavior_definition']//title[text()='#{name}'][not(@id = '#{name}')]")
+      behavior_gets = xml.xpath("//block[@type='gamelab_behavior_get']//title[text()='#{name}'][not(@id = '#{name}')]")
+      titles = behavior_defs + behavior_gets
+      next if titles.empty?
+
+      titles.each do |title|
+        title['id'] = name
+      end
+      did_skip = false
+    end
+
+    if did_skip
+      skipped_levels += 1
+      next
+    end
+
+    raw_level_data = xml.root.to_s
+    File.write(path, raw_level_data)
+    updated_levels += 1
+  rescue Exception => e
+    # print filename for better debugging
+    new_e = Exception.new("in level: #{path}: #{e.message}")
+    new_e.set_backtrace(e.backtrace)
+    raise new_e
+  end
+
+  puts "#{skipped_levels} level files didn't need updating"
+  puts "#{updated_levels} level files that had a behavior title updated"
+end
+
+update_behavior_blocks_ids

--- a/dashboard/config/scripts/levels/Fish Tank 2-validated_2021.level
+++ b/dashboard/config/scripts/levels/Fish Tank 2-validated_2021.level
@@ -104,7 +104,7 @@
                   <value name="BEHAVIOR">
                     <block type="gamelab_behavior_get">
                       <mutation/>
-                      <title name="VAR">spinning right</title>
+                      <title name="VAR" id="spinning right">spinning right</title>
                     </block>
                   </value>
                 </block>
@@ -116,7 +116,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">swimming left and right</title>
+          <title name="NAME" id="swimming left and right">swimming left and right</title>
           <statement name="STACK">
             <block type="controls_if">
               <mutation elseif="1"/>
@@ -486,7 +486,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">moving east</title>
+          <title name="NAME" id="moving east">moving east</title>
           <statement name="STACK">
             <block type="gamelab_moveInDirection">
               <title name="DIRECTION">"East"</title>
@@ -507,7 +507,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">moving north</title>
+          <title name="NAME" id="moving north">moving north</title>
           <statement name="STACK">
             <block type="gamelab_moveInDirection">
               <title name="DIRECTION">"North"</title>
@@ -528,7 +528,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">moving south</title>
+          <title name="NAME" id="moving south">moving south</title>
           <statement name="STACK">
             <block type="gamelab_moveInDirection">
               <title name="DIRECTION">"South"</title>
@@ -549,7 +549,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">moving west</title>
+          <title name="NAME" id="moving west">moving west</title>
           <statement name="STACK">
             <block type="gamelab_moveInDirection">
               <title name="DIRECTION">"West"</title>
@@ -570,7 +570,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">spinning right</title>
+          <title name="NAME" id="spinning right">spinning right</title>
           <statement name="STACK">
             <block type="gamelab_turn">
               <title name="DIRECTION">"right"</title>

--- a/dashboard/config/scripts/levels/Fish Tank 3-validated_2021.level
+++ b/dashboard/config/scripts/levels/Fish Tank 3-validated_2021.level
@@ -98,7 +98,7 @@
                   </value>
                   <value name="BEHAVIOR">
                     <block type="gamelab_behavior_get">
-                      <title name="VAR">spinning right</title>
+                      <title name="VAR" id="spinning right">spinning right</title>
                     </block>
                   </value>
                 </block>
@@ -127,11 +127,11 @@
         </block>
         <block type="gamelab_behavior_get">
           <mutation/>
-          <title name="VAR">spinning right</title>
+          <title name="VAR" id="spinning right">spinning right</title>
         </block>
         <block type="gamelab_behavior_get">
           <mutation/>
-          <title name="VAR">swimming left and right</title>
+          <title name="VAR" id="swimming left and right">swimming left and right</title>
         </block>
         <block type="gamelab_comment" id="comment">
           <title name="COMMENT"/>
@@ -159,7 +159,7 @@
                   <value name="BEHAVIOR">
                     <block type="gamelab_behavior_get">
                       <mutation/>
-                      <title name="VAR">swimming left and right</title>
+                      <title name="VAR" id="swimming left and right">swimming left and right</title>
                     </block>
                   </value>
                 </block>
@@ -171,7 +171,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">swimming left and right</title>
+          <title name="NAME" id="swimming left and right">swimming left and right</title>
           <statement name="STACK">
             <block type="controls_if">
               <mutation elseif="1"/>
@@ -541,7 +541,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">moving east</title>
+          <title name="NAME" id="moving east">moving east</title>
           <statement name="STACK">
             <block type="gamelab_moveInDirection">
               <title name="DIRECTION">"East"</title>
@@ -562,7 +562,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">moving north</title>
+          <title name="NAME" id="moving north">moving north</title>
           <statement name="STACK">
             <block type="gamelab_moveInDirection">
               <title name="DIRECTION">"North"</title>
@@ -583,7 +583,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">moving south</title>
+          <title name="NAME" id="moving south">moving south</title>
           <statement name="STACK">
             <block type="gamelab_moveInDirection">
               <title name="DIRECTION">"South"</title>
@@ -604,7 +604,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">moving west</title>
+          <title name="NAME" id="moving west">moving west</title>
           <statement name="STACK">
             <block type="gamelab_moveInDirection">
               <title name="DIRECTION">"West"</title>
@@ -625,7 +625,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">spinning right</title>
+          <title name="NAME" id="spinning right">spinning right</title>
           <statement name="STACK">
             <block type="gamelab_turn">
               <title name="DIRECTION">"right"</title>

--- a/dashboard/config/scripts/levels/Fish Tank 4-validated_2021.level
+++ b/dashboard/config/scripts/levels/Fish Tank 4-validated_2021.level
@@ -165,7 +165,7 @@
                       <value name="BEHAVIOR">
                         <block type="gamelab_behavior_get">
                           <mutation/>
-                          <title name="VAR">swimming left and right</title>
+                          <title name="VAR" id="swimming left and right">swimming left and right</title>
                         </block>
                       </value>
                     </block>
@@ -179,7 +179,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">swimming left and right</title>
+          <title name="NAME" id="swimming left and right">swimming left and right</title>
           <statement name="STACK">
             <block type="controls_if">
               <mutation elseif="1"/>
@@ -549,7 +549,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">moving east</title>
+          <title name="NAME" id="moving east">moving east</title>
           <statement name="STACK">
             <block type="gamelab_moveInDirection">
               <title name="DIRECTION">"East"</title>
@@ -570,7 +570,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">moving north</title>
+          <title name="NAME" id="moving north">moving north</title>
           <statement name="STACK">
             <block type="gamelab_moveInDirection">
               <title name="DIRECTION">"North"</title>
@@ -591,7 +591,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">moving south</title>
+          <title name="NAME" id="moving south">moving south</title>
           <statement name="STACK">
             <block type="gamelab_moveInDirection">
               <title name="DIRECTION">"South"</title>
@@ -612,7 +612,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">moving west</title>
+          <title name="NAME" id="moving west">moving west</title>
           <statement name="STACK">
             <block type="gamelab_moveInDirection">
               <title name="DIRECTION">"West"</title>
@@ -633,7 +633,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">spinning right</title>
+          <title name="NAME" id="spinning right">spinning right</title>
           <statement name="STACK">
             <block type="gamelab_turn">
               <title name="DIRECTION">"right"</title>

--- a/dashboard/config/scripts/levels/Fish Tank 5-validated_2021.level
+++ b/dashboard/config/scripts/levels/Fish Tank 5-validated_2021.level
@@ -197,7 +197,7 @@
                       <value name="BEHAVIOR">
                         <block type="gamelab_behavior_get">
                           <mutation/>
-                          <title name="VAR">swimming left and right</title>
+                          <title name="VAR" id="swimming left and right">swimming left and right</title>
                         </block>
                       </value>
                       <next>
@@ -221,7 +221,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">swimming left and right</title>
+          <title name="NAME" id="swimming left and right">swimming left and right</title>
           <statement name="STACK">
             <block type="controls_if">
               <mutation elseif="1"/>
@@ -591,7 +591,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">moving east</title>
+          <title name="NAME" id="moving east">moving east</title>
           <statement name="STACK">
             <block type="gamelab_moveInDirection">
               <title name="DIRECTION">"East"</title>
@@ -612,7 +612,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">moving north</title>
+          <title name="NAME" id="moving north">moving north</title>
           <statement name="STACK">
             <block type="gamelab_moveInDirection">
               <title name="DIRECTION">"North"</title>
@@ -633,7 +633,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">moving south</title>
+          <title name="NAME" id="moving south">moving south</title>
           <statement name="STACK">
             <block type="gamelab_moveInDirection">
               <title name="DIRECTION">"South"</title>
@@ -654,7 +654,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">moving west</title>
+          <title name="NAME" id="moving west">moving west</title>
           <statement name="STACK">
             <block type="gamelab_moveInDirection">
               <title name="DIRECTION">"West"</title>
@@ -675,7 +675,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">spinning right</title>
+          <title name="NAME" id="spinning right">spinning right</title>
           <statement name="STACK">
             <block type="gamelab_turn">
               <title name="DIRECTION">"right"</title>

--- a/dashboard/config/scripts/levels/Fish Tank 6-validated_2021.level
+++ b/dashboard/config/scripts/levels/Fish Tank 6-validated_2021.level
@@ -218,7 +218,7 @@
                       <value name="BEHAVIOR">
                         <block type="gamelab_behavior_get">
                           <mutation/>
-                          <title name="VAR">swimming left and right</title>
+                          <title name="VAR" id="swimming left and right">swimming left and right</title>
                         </block>
                       </value>
                       <next>
@@ -239,7 +239,7 @@
                               <value name="BEHAVIOR">
                                 <block type="gamelab_behavior_get">
                                   <mutation/>
-                                  <title name="VAR">spinning right</title>
+                                  <title name="VAR" id="spinning right">spinning right</title>
                                 </block>
                               </value>
                             </block>
@@ -257,7 +257,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">swimming left and right</title>
+          <title name="NAME" id="swimming left and right">swimming left and right</title>
           <statement name="STACK">
             <block type="controls_if">
               <mutation elseif="1"/>
@@ -627,7 +627,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">moving east</title>
+          <title name="NAME" id="moving east">moving east</title>
           <statement name="STACK">
             <block type="gamelab_moveInDirection">
               <title name="DIRECTION">"East"</title>
@@ -648,7 +648,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">moving north</title>
+          <title name="NAME" id="moving north">moving north</title>
           <statement name="STACK">
             <block type="gamelab_moveInDirection">
               <title name="DIRECTION">"North"</title>
@@ -669,7 +669,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">moving south</title>
+          <title name="NAME" id="moving south">moving south</title>
           <statement name="STACK">
             <block type="gamelab_moveInDirection">
               <title name="DIRECTION">"South"</title>
@@ -690,7 +690,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">moving west</title>
+          <title name="NAME" id="moving west">moving west</title>
           <statement name="STACK">
             <block type="gamelab_moveInDirection">
               <title name="DIRECTION">"West"</title>
@@ -711,7 +711,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">spinning right</title>
+          <title name="NAME" id="spinning right">spinning right</title>
           <statement name="STACK">
             <block type="gamelab_turn">
               <title name="DIRECTION">"right"</title>

--- a/dashboard/config/scripts/levels/Virtual Pet 2_2021.level
+++ b/dashboard/config/scripts/levels/Virtual Pet 2_2021.level
@@ -229,7 +229,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite to the right across the screen</description>
           </mutation>
-          <title name="NAME">moving east</title>
+          <title name="NAME" id="moving east">moving east</title>
           <statement name="STACK">
             <block type="gamelab_moveInDirection">
               <title name="DIRECTION">"East"</title>
@@ -251,7 +251,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>rotate a sprite to its left</description>
           </mutation>
-          <title name="NAME">spinning left</title>
+          <title name="NAME" id="spinning left">spinning left</title>
           <statement name="STACK">
             <block type="gamelab_turn">
               <title name="DIRECTION">"left"</title>
@@ -273,7 +273,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>rotate a sprite to its right</description>
           </mutation>
-          <title name="NAME">spinning right</title>
+          <title name="NAME" id="spinning right">spinning right</title>
           <statement name="STACK">
             <block type="gamelab_turn">
               <title name="DIRECTION">"right"</title>
@@ -339,7 +339,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite downwards across the screen</description>
           </mutation>
-          <title name="NAME">moving south</title>
+          <title name="NAME" id="moving south">moving south</title>
           <statement name="STACK">
             <block type="gamelab_moveInDirection">
               <title name="DIRECTION">"South"</title>
@@ -361,7 +361,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite horizontally, reversing direction if it touches the edges of the screen</description>
           </mutation>
-          <title name="NAME">swimming left and right</title>
+          <title name="NAME" id="swimming left and right">swimming left and right</title>
           <statement name="STACK">
             <block type="controls_if">
               <mutation elseif="1"/>
@@ -484,7 +484,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite upwards across the screen</description>
           </mutation>
-          <title name="NAME">moving north</title>
+          <title name="NAME" id="moving north">moving north</title>
           <statement name="STACK">
             <block type="gamelab_moveInDirection">
               <title name="DIRECTION">"North"</title>
@@ -537,7 +537,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite to the left across the screen</description>
           </mutation>
-          <title name="NAME">moving west</title>
+          <title name="NAME" id="moving west">moving west</title>
           <statement name="STACK">
             <block type="gamelab_moveInDirection">
               <title name="DIRECTION">"West"</title>

--- a/dashboard/config/scripts/levels/Virtual Pet 3_2021.level
+++ b/dashboard/config/scripts/levels/Virtual Pet 3_2021.level
@@ -425,7 +425,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite to the right across the screen</description>
           </mutation>
-          <title name="NAME">moving east</title>
+          <title name="NAME" id="moving east">moving east</title>
           <statement name="STACK">
             <block type="gamelab_moveInDirection">
               <title name="DIRECTION">"East"</title>
@@ -447,7 +447,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>rotate a sprite to its left</description>
           </mutation>
-          <title name="NAME">spinning left</title>
+          <title name="NAME" id="spinning left">spinning left</title>
           <statement name="STACK">
             <block type="gamelab_turn">
               <title name="DIRECTION">"left"</title>
@@ -469,7 +469,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>rotate a sprite to its right</description>
           </mutation>
-          <title name="NAME">spinning right</title>
+          <title name="NAME" id="spinning right">spinning right</title>
           <statement name="STACK">
             <block type="gamelab_turn">
               <title name="DIRECTION">"right"</title>
@@ -601,7 +601,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite downwards across the screen</description>
           </mutation>
-          <title name="NAME">moving south</title>
+          <title name="NAME" id="moving south">moving south</title>
           <statement name="STACK">
             <block type="gamelab_moveInDirection">
               <title name="DIRECTION">"South"</title>
@@ -645,7 +645,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite horizontally, reversing direction if it touches the edges of the screen</description>
           </mutation>
-          <title name="NAME">swimming left and right</title>
+          <title name="NAME" id="swimming left and right">swimming left and right</title>
           <statement name="STACK">
             <block type="controls_if">
               <mutation elseif="1"/>
@@ -935,7 +935,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite upwards across the screen</description>
           </mutation>
-          <title name="NAME">moving north</title>
+          <title name="NAME" id="moving north">moving north</title>
           <statement name="STACK">
             <block type="gamelab_moveInDirection">
               <title name="DIRECTION">"North"</title>
@@ -988,7 +988,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite to the left across the screen</description>
           </mutation>
-          <title name="NAME">moving west</title>
+          <title name="NAME" id="moving west">moving west</title>
           <statement name="STACK">
             <block type="gamelab_moveInDirection">
               <title name="DIRECTION">"West"</title>


### PR DESCRIPTION
We received some Zendesk tickets about levels not working which have behavior blocks in them. The levels worked fine in English but failed once the language was switched. The root cause is that the translated text in the behavior block was being used because the `id` attribute of the block was not defined. The fix is to run a oneoff script to update the blocks in the `.level` files in express-2021 to have an `id` attribute for behavior blocks. We have already run the script before for express-2022 and successfully fixed the issue.

## Links
* [JIRA](https://codedotorg.atlassian.net/browse/FND-2091)

## Testing story
* Tested the broken URLs on my localhost and confirmed the levels now work.
