### PR TITLE
Add Course E 2022 to the sync-in

### DIFF
--- a/lib/cdo/script_constants.rb
+++ b/lib/cdo/script_constants.rb
@@ -417,6 +417,7 @@ module ScriptConstants
       ScriptConstants.unit_in_category?(:csf_2019, script) ||
       ScriptConstants.unit_in_category?(:csf_2020, script) ||
       ScriptConstants.unit_in_category?(:csf_2021, script) ||
+      ScriptConstants.unit_in_category?(:csf_2022, script) ||
       ScriptConstants.unit_in_category?(:csd, script) ||
       ScriptConstants.unit_in_category?(:csd_2018, script) ||
       ScriptConstants.unit_in_category?(:csd_2019, script) ||


### PR DESCRIPTION
**What:** Add CSF 2022 to the translation pipeline.

**Why:** The original goal was to add just Course E 2022 to the pipeline, but we historically add entire categories to the sync. I confirmed with Jorge that it is okay we add all of the scripts under the CSF 2022 category.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->


- jira ticket: [FND-2086](https://codedotorg.atlassian.net/browse/FND-2086)


## Testing story

Ran the `sync-in` locally and confirmed the scripts under CSF 2022 were included.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
