### PR TITLE
Utf8 workspace alert

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1046,6 +1046,7 @@
   "introToAppLabTitle": "Intro to App Lab",
   "introToAppLabDesc": "Create your own app in JavaScript using either block based programming or text. If you've already done some programming with blocks, take your skills to the next level.",
   "introducedCode": "Introduced Code",
+  "invalidCharactersErrorMessage": "There was an error saving your project, please remove any invalid characters to resolve.",
   "invalidDataEntryTypeError": "Value must be boolean, number, string, `undefined`, or `null`. Make sure to include quotes for strings like \"this\". ",
   "invalidRecordTypeError": "You attempted to add a record to the table that included a list or object. The data table can only store booleans, numbers, strings, null, and undefined.",
   "joinASection": "Join a section",

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -86,7 +86,7 @@ import {userAlreadyReportedAbuse} from '@cdo/apps/reportAbuse';
 import {setArrowButtonDisabled} from '@cdo/apps/templates/arrowDisplayRedux';
 import {workspace_running_background, white} from '@cdo/apps/util/color';
 import WorkspaceAlert from '@cdo/apps/code-studio/components/WorkspaceAlert';
-import {displayWorkspaceAlertOff} from '../projectRedux';
+import {displayWorkspaceAlertOff} from './code-studio/projectRedux';
 
 var copyrightStrings;
 

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -86,6 +86,7 @@ import {userAlreadyReportedAbuse} from '@cdo/apps/reportAbuse';
 import {setArrowButtonDisabled} from '@cdo/apps/templates/arrowDisplayRedux';
 import {workspace_running_background, white} from '@cdo/apps/util/color';
 import WorkspaceAlert from '@cdo/apps/code-studio/components/WorkspaceAlert';
+import {displayWorkspaceAlertOff} from '../projectRedux';
 
 var copyrightStrings;
 
@@ -3112,6 +3113,8 @@ StudioApp.prototype.displayWorkspaceAlert = function(
   bottom = false,
   onClose = () => {}
 ) {
+  // close currently open workspace alert from CodeWorkspaceContainer.jsx
+  getStore().dispatch(displayWorkspaceAlertOff());
   var parent = $(bottom && this.editCode ? '#codeTextbox' : '#codeWorkspace');
   var container = $('<div/>');
   parent.append(container);

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -3113,7 +3113,7 @@ StudioApp.prototype.displayWorkspaceAlert = function(
   bottom = false,
   onClose = () => {}
 ) {
-  // close currently any open workspace alert
+  // close currently any open workspace alert from CodeWorkspace.jsx
   getStore().dispatch(displayWorkspaceAlertOff());
   var parent = $(bottom && this.editCode ? '#codeTextbox' : '#codeWorkspace');
   var container = $('<div/>');

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -3113,7 +3113,7 @@ StudioApp.prototype.displayWorkspaceAlert = function(
   bottom = false,
   onClose = () => {}
 ) {
-  // close currently open workspace alert from CodeWorkspaceContainer.jsx
+  // close currently any open workspace alert
   getStore().dispatch(displayWorkspaceAlertOff());
   var parent = $(bottom && this.editCode ? '#codeTextbox' : '#codeWorkspace');
   var container = $('<div/>');

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -86,7 +86,7 @@ import {userAlreadyReportedAbuse} from '@cdo/apps/reportAbuse';
 import {setArrowButtonDisabled} from '@cdo/apps/templates/arrowDisplayRedux';
 import {workspace_running_background, white} from '@cdo/apps/util/color';
 import WorkspaceAlert from '@cdo/apps/code-studio/components/WorkspaceAlert';
-import {displayWorkspaceAlertOff} from './code-studio/projectRedux';
+import {closeWorkspaceAlert} from './code-studio/projectRedux';
 
 var copyrightStrings;
 
@@ -3114,7 +3114,7 @@ StudioApp.prototype.displayWorkspaceAlert = function(
   onClose = () => {}
 ) {
   // close currently any open workspace alert from CodeWorkspace.jsx
-  getStore().dispatch(displayWorkspaceAlertOff());
+  getStore().dispatch(closeWorkspaceAlert());
   var parent = $(bottom && this.editCode ? '#codeTextbox' : '#codeWorkspace');
   var container = $('<div/>');
   parent.append(container);

--- a/apps/src/applab/AppLabView.jsx
+++ b/apps/src/applab/AppLabView.jsx
@@ -13,8 +13,6 @@ import DataWorkspace from '../storage/dataBrowser/DataWorkspace';
 import ProtectedDesignWorkspace from './ProtectedDesignWorkspace';
 import VisualizationResizeBar from '../lib/ui/VisualizationResizeBar';
 import ExternalRedirectDialog from '@cdo/apps/applab/ExternalRedirectDialog';
-import WorkspaceAlert from '@cdo/apps/code-studio/components/WorkspaceAlert';
-import {displayWorkspaceAlertOff} from '../code-studio/projectRedux';
 
 /**
  * Top-level React wrapper for App Lab.
@@ -37,10 +35,7 @@ class AppLabView extends React.Component {
       ApplabInterfaceMode.DATA
     ]).isRequired,
     isRtl: PropTypes.bool,
-    widgetMode: PropTypes.bool,
-    displayWorkspaceAlertOff: PropTypes.func,
-    displayWorkspaceAlert: PropTypes.bool.isRequired,
-    errorMsg: PropTypes.string.isRequired
+    widgetMode: PropTypes.bool
   };
 
   componentDidMount() {
@@ -93,16 +88,6 @@ class AppLabView extends React.Component {
             style={{display: codeWorkspaceVisible ? 'block' : 'none'}}
             autogenerateML={autogenerateML}
           />
-          {this.props.displayWorkspaceAlert && (
-            <WorkspaceAlert
-              type="error"
-              onClose={this.props.displayWorkspaceAlertOff}
-              isBlockly={false}
-              displayBottom={true}
-            >
-              <div>{this.props.errorMsg}</div>
-            </WorkspaceAlert>
-          )}
           {hasDesignMode && <ProtectedDesignWorkspace />}
           {hasDataMode && (
             <DataWorkspace handleVersionHistory={handleVersionHistory} />
@@ -113,20 +98,13 @@ class AppLabView extends React.Component {
   }
 }
 
-export default connect(
-  state => ({
-    hasDataMode: state.pageConstants.hasDataMode || false,
-    hasDesignMode: state.pageConstants.hasDesignMode || false,
-    interfaceMode: state.interfaceMode,
-    isRtl: state.isRtl,
-    widgetMode: state.pageConstants.widgetMode,
-    displayWorkspaceAlert: state.project.displayWorkspaceAlert,
-    errorMsg: state.project.errorMsg
-  }),
-  dispatch => ({
-    displayWorkspaceAlertOff: () => dispatch(displayWorkspaceAlertOff())
-  })
-)(AppLabView);
+export default connect(state => ({
+  hasDataMode: state.pageConstants.hasDataMode || false,
+  hasDesignMode: state.pageConstants.hasDesignMode || false,
+  interfaceMode: state.interfaceMode,
+  isRtl: state.isRtl,
+  widgetMode: state.pageConstants.widgetMode
+}))(AppLabView);
 
 const styles = {
   widgetInstructions: {

--- a/apps/src/applab/AppLabView.jsx
+++ b/apps/src/applab/AppLabView.jsx
@@ -13,6 +13,8 @@ import DataWorkspace from '../storage/dataBrowser/DataWorkspace';
 import ProtectedDesignWorkspace from './ProtectedDesignWorkspace';
 import VisualizationResizeBar from '../lib/ui/VisualizationResizeBar';
 import ExternalRedirectDialog from '@cdo/apps/applab/ExternalRedirectDialog';
+import WorkspaceAlert from '@cdo/apps/code-studio/components/WorkspaceAlert';
+import {displayWorkspaceAlertOff} from '../code-studio/projectRedux';
 
 /**
  * Top-level React wrapper for App Lab.
@@ -35,7 +37,10 @@ class AppLabView extends React.Component {
       ApplabInterfaceMode.DATA
     ]).isRequired,
     isRtl: PropTypes.bool,
-    widgetMode: PropTypes.bool
+    widgetMode: PropTypes.bool,
+    displayWorkspaceAlertOff: PropTypes.func,
+    displayWorkspaceAlert: PropTypes.bool.isRequired,
+    errorMsg: PropTypes.string.isRequired
   };
 
   componentDidMount() {
@@ -88,6 +93,16 @@ class AppLabView extends React.Component {
             style={{display: codeWorkspaceVisible ? 'block' : 'none'}}
             autogenerateML={autogenerateML}
           />
+          {this.props.displayWorkspaceAlert && (
+            <WorkspaceAlert
+              type="error"
+              onClose={this.props.displayWorkspaceAlertOff}
+              isBlockly={false}
+              displayBottom={true}
+            >
+              <div>{this.props.errorMsg}</div>
+            </WorkspaceAlert>
+          )}
           {hasDesignMode && <ProtectedDesignWorkspace />}
           {hasDataMode && (
             <DataWorkspace handleVersionHistory={handleVersionHistory} />
@@ -98,13 +113,20 @@ class AppLabView extends React.Component {
   }
 }
 
-export default connect(state => ({
-  hasDataMode: state.pageConstants.hasDataMode || false,
-  hasDesignMode: state.pageConstants.hasDesignMode || false,
-  interfaceMode: state.interfaceMode,
-  isRtl: state.isRtl,
-  widgetMode: state.pageConstants.widgetMode
-}))(AppLabView);
+export default connect(
+  state => ({
+    hasDataMode: state.pageConstants.hasDataMode || false,
+    hasDesignMode: state.pageConstants.hasDesignMode || false,
+    interfaceMode: state.interfaceMode,
+    isRtl: state.isRtl,
+    widgetMode: state.pageConstants.widgetMode,
+    displayWorkspaceAlert: state.project.displayWorkspaceAlert,
+    errorMsg: state.project.errorMsg
+  }),
+  dispatch => ({
+    displayWorkspaceAlertOff: () => dispatch(displayWorkspaceAlertOff())
+  })
+)(AppLabView);
 
 const styles = {
   widgetInstructions: {

--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -1154,9 +1154,6 @@ var projects = (module.exports = {
         packSources(),
         filename,
         function(err, response) {
-          // uncomment to test if workspace alert is displayed due to 422 status code
-          // err = {};
-          // err.message = 'httpStatusCode: 422';
           if (err) {
             if (err.message.includes('httpStatusCode: 401')) {
               this.showSaveError_();

--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -31,6 +31,8 @@ var channels = require('./clientApi').create('/v3/channels');
 var showProjectAdmin = require('../showProjectAdmin');
 import header from '../header';
 import {queryParams, hasQueryParam, updateQueryParam} from '../utils';
+import {getStore} from '../../redux';
+import {displayWorkspaceAlertOn} from '../projectRedux';
 
 // Name of the packed source file
 var SOURCE_FILE = 'main.json';
@@ -1152,6 +1154,9 @@ var projects = (module.exports = {
         packSources(),
         filename,
         function(err, response) {
+          // uncomment to test if workspace alert is displayed due to 422 status code
+          // err = {};
+          // err.message = 'httpStatusCode: 422';
           if (err) {
             if (err.message.includes('httpStatusCode: 401')) {
               this.showSaveError_();
@@ -1177,6 +1182,11 @@ var projects = (module.exports = {
               );
               if (saveSourcesErrorCount >= NUM_ERRORS_BEFORE_WARNING) {
                 header.showTryAgainDialog();
+              }
+              if (err.message.includes('httpStatusCode: 422')) {
+                var msg =
+                  'There was an error saving your project, please remove any invalid characters to resolve';
+                getStore().dispatch(displayWorkspaceAlertOn(msg));
               }
             }
             return;

--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -1182,7 +1182,7 @@ var projects = (module.exports = {
               }
               if (err.message.includes('httpStatusCode: 422')) {
                 var msg =
-                  'There was an error saving your project, please remove any invalid characters to resolve';
+                  'There was an error saving your project, please remove any invalid characters to resolve.';
                 getStore().dispatch(displayWorkspaceAlertOn(msg));
               }
             }

--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -32,7 +32,7 @@ var showProjectAdmin = require('../showProjectAdmin');
 import header from '../header';
 import {queryParams, hasQueryParam, updateQueryParam} from '../utils';
 import {getStore} from '../../redux';
-import {displayWorkspaceAlert} from '../projectRedux';
+import {workspaceAlertTypes, displayWorkspaceAlert} from '../projectRedux';
 
 // Name of the packed source file
 var SOURCE_FILE = 'main.json';
@@ -1181,10 +1181,12 @@ var projects = (module.exports = {
                 header.showTryAgainDialog();
               }
               if (err.message.includes('httpStatusCode: 422')) {
-                const msg =
-                  'There was an error saving your project, please remove any invalid characters to resolve.';
                 getStore().dispatch(
-                  displayWorkspaceAlert('error', msg, true) /* bottom */
+                  displayWorkspaceAlert(
+                    workspaceAlertTypes.error,
+                    msg.invalidCharactersErrorMessage(),
+                    /* bottom */ true
+                  )
                 );
               }
             }

--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -32,7 +32,7 @@ var showProjectAdmin = require('../showProjectAdmin');
 import header from '../header';
 import {queryParams, hasQueryParam, updateQueryParam} from '../utils';
 import {getStore} from '../../redux';
-import {displayWorkspaceAlertOn} from '../projectRedux';
+import {displayWorkspaceAlert} from '../projectRedux';
 
 // Name of the packed source file
 var SOURCE_FILE = 'main.json';
@@ -1181,9 +1181,11 @@ var projects = (module.exports = {
                 header.showTryAgainDialog();
               }
               if (err.message.includes('httpStatusCode: 422')) {
-                var msg =
+                const msg =
                   'There was an error saving your project, please remove any invalid characters to resolve.';
-                getStore().dispatch(displayWorkspaceAlertOn(msg));
+                getStore().dispatch(
+                  displayWorkspaceAlert('error', msg, true) /* bottom */
+                );
               }
             }
             return;

--- a/apps/src/code-studio/projectRedux.js
+++ b/apps/src/code-studio/projectRedux.js
@@ -4,6 +4,7 @@
 const SHOW_PROJECT_UPDATED_AT = 'project/SHOW_PROJECT_UPDATED_AT';
 const SET_PROJECT_UPDATED_STATUS = 'project/SET_PROJECT_UPDATED_STATUS';
 const SET_PROJECT_UPDATED_AT = 'project/SET_PROJECT_UPDATED_AT';
+const SET_WORKSPACE_ALERT = 'project/SET_WORKSPACE_ALERT';
 const REFRESH_PROJECT_NAME = 'project/REFRESH_PROJECT_NAME';
 const SHOW_TRY_AGAIN_DIALOG = 'project/SHOW_TRY_AGAIN_DIALOG';
 const SET_NAME_FAILURE = 'project/SET_NAME_FAILURE';
@@ -22,7 +23,9 @@ const initialState = {
   projectUpdatedAt: undefined,
   projectName: '',
   projectNameFailure: undefined,
-  showTryAgainDialog: false
+  showTryAgainDialog: false,
+  displayWorkspaceAlert: false,
+  errorMsg: ''
 };
 
 export default (state = initialState, action) => {
@@ -47,6 +50,15 @@ export default (state = initialState, action) => {
       projectUpdatedStatus: action.status
     };
   }
+
+  if (action.type === SET_WORKSPACE_ALERT) {
+    return {
+      ...state,
+      errorMsg: action.errorMsg,
+      displayWorkspaceAlert: action.displayWorkspaceAlert
+    };
+  }
+
   if (action.type === REFRESH_PROJECT_NAME) {
     return {
       ...state,
@@ -85,6 +97,18 @@ export const showProjectUpdatedAt = () => ({
 export const setProjectUpdatedError = () => ({
   type: SET_PROJECT_UPDATED_STATUS,
   status: projectUpdatedStatuses.error
+});
+
+export const displayWorkspaceAlertOn = errorMsg => ({
+  type: SET_WORKSPACE_ALERT,
+  displayWorkspaceAlert: true,
+  errorMsg
+});
+
+export const displayWorkspaceAlertOff = () => ({
+  type: SET_WORKSPACE_ALERT,
+  displayWorkspaceAlert: false,
+  errorMsg: ''
 });
 
 export const setProjectUpdatedSaving = () => ({

--- a/apps/src/code-studio/projectRedux.js
+++ b/apps/src/code-studio/projectRedux.js
@@ -4,7 +4,7 @@
 const SHOW_PROJECT_UPDATED_AT = 'project/SHOW_PROJECT_UPDATED_AT';
 const SET_PROJECT_UPDATED_STATUS = 'project/SET_PROJECT_UPDATED_STATUS';
 const SET_PROJECT_UPDATED_AT = 'project/SET_PROJECT_UPDATED_AT';
-const SET_WORKSPACE_ALERT = 'project/SET_WORKSPACE_ALERT';
+const SHOW_WORKSPACE_ALERT = 'project/SHOW_WORKSPACE_ALERT';
 const REFRESH_PROJECT_NAME = 'project/REFRESH_PROJECT_NAME';
 const SHOW_TRY_AGAIN_DIALOG = 'project/SHOW_TRY_AGAIN_DIALOG';
 const SET_NAME_FAILURE = 'project/SET_NAME_FAILURE';
@@ -24,8 +24,10 @@ const initialState = {
   projectName: '',
   projectNameFailure: undefined,
   showTryAgainDialog: false,
-  displayWorkspaceAlert: false,
-  errorMsg: ''
+  showWorkspaceAlert: false,
+  workspaceAlertType: undefined, // 'error' or 'warning'
+  workspaceAlertDisplayBottom: undefined,
+  workspaceAlertErrorMsg: ''
 };
 
 export default (state = initialState, action) => {
@@ -51,11 +53,13 @@ export default (state = initialState, action) => {
     };
   }
 
-  if (action.type === SET_WORKSPACE_ALERT) {
+  if (action.type === SHOW_WORKSPACE_ALERT) {
     return {
       ...state,
-      errorMsg: action.errorMsg,
-      displayWorkspaceAlert: action.displayWorkspaceAlert
+      showWorkspaceAlert: action.showWorkspaceAlert,
+      workspaceAlertType: action.workspaceAlertType,
+      workspaceAlertErrorMsg: action.workspaceAlertErrorMsg,
+      workspaceAlertDisplayBottom: action.workspaceAlertDisplayBottom
     };
   }
 
@@ -99,16 +103,24 @@ export const setProjectUpdatedError = () => ({
   status: projectUpdatedStatuses.error
 });
 
-export const displayWorkspaceAlertOn = errorMsg => ({
-  type: SET_WORKSPACE_ALERT,
-  displayWorkspaceAlert: true,
-  errorMsg
+export const displayWorkspaceAlert = (
+  workspaceAlertType,
+  workspaceAlertErrorMsg,
+  workspaceAlertDisplayBottom
+) => ({
+  type: SHOW_WORKSPACE_ALERT,
+  showWorkspaceAlert: true,
+  workspaceAlertType,
+  workspaceAlertErrorMsg,
+  workspaceAlertDisplayBottom
 });
 
-export const displayWorkspaceAlertOff = () => ({
-  type: SET_WORKSPACE_ALERT,
-  displayWorkspaceAlert: false,
-  errorMsg: ''
+export const closeWorkspaceAlert = () => ({
+  type: SHOW_WORKSPACE_ALERT,
+  showWorkspaceAlert: false,
+  workspaceAlertType: undefined,
+  workspaceAlertErrorMsg: '',
+  workspaceAlertDisplayBottom: undefined
 });
 
 export const setProjectUpdatedSaving = () => ({

--- a/apps/src/code-studio/projectRedux.js
+++ b/apps/src/code-studio/projectRedux.js
@@ -30,10 +30,7 @@ const initialState = {
   projectName: '',
   projectNameFailure: undefined,
   showTryAgainDialog: false,
-  showWorkspaceAlert: false,
-  workspaceAlertType: undefined,
-  workspaceAlertDisplayBottom: undefined,
-  workspaceAlertErrorMsg: ''
+  showWorkspaceAlert: {type: '', message: '', displayBottom: undefined}
 };
 
 export default (state = initialState, action) => {
@@ -62,10 +59,7 @@ export default (state = initialState, action) => {
   if (action.type === SHOW_WORKSPACE_ALERT) {
     return {
       ...state,
-      showWorkspaceAlert: action.showWorkspaceAlert,
-      workspaceAlertType: action.workspaceAlertType,
-      workspaceAlertErrorMsg: action.workspaceAlertErrorMsg,
-      workspaceAlertDisplayBottom: action.workspaceAlertDisplayBottom
+      workspaceAlert: action.workspaceAlert
     };
   }
 
@@ -111,22 +105,20 @@ export const setProjectUpdatedError = () => ({
 
 export const displayWorkspaceAlert = (
   workspaceAlertType,
-  workspaceAlertErrorMsg,
+  workspaceAlertMessage,
   workspaceAlertDisplayBottom
 ) => ({
   type: SHOW_WORKSPACE_ALERT,
-  showWorkspaceAlert: true,
-  workspaceAlertType,
-  workspaceAlertErrorMsg,
-  workspaceAlertDisplayBottom
+  workspaceAlert: {
+    type: workspaceAlertType,
+    message: workspaceAlertMessage,
+    displayBottom: workspaceAlertDisplayBottom
+  }
 });
 
 export const closeWorkspaceAlert = () => ({
   type: SHOW_WORKSPACE_ALERT,
-  showWorkspaceAlert: false,
-  workspaceAlertType: undefined,
-  workspaceAlertErrorMsg: '',
-  workspaceAlertDisplayBottom: undefined
+  workspaceAlert: null
 });
 
 export const setProjectUpdatedSaving = () => ({

--- a/apps/src/code-studio/projectRedux.js
+++ b/apps/src/code-studio/projectRedux.js
@@ -17,6 +17,12 @@ export const projectUpdatedStatuses = {
   error: 'error'
 };
 
+export const workspaceAlertTypes = {
+  error: 'error',
+  warning: 'warning',
+  notification: 'notification'
+};
+
 const initialState = {
   showProjectUpdatedAt: false,
   projectUpdatedStatus: projectUpdatedStatuses.default,
@@ -25,7 +31,7 @@ const initialState = {
   projectNameFailure: undefined,
   showTryAgainDialog: false,
   showWorkspaceAlert: false,
-  workspaceAlertType: undefined, // 'error' or 'warning'
+  workspaceAlertType: undefined,
   workspaceAlertDisplayBottom: undefined,
   workspaceAlertErrorMsg: ''
 };

--- a/apps/src/templates/CodeWorkspace.jsx
+++ b/apps/src/templates/CodeWorkspace.jsx
@@ -89,18 +89,7 @@ class CodeWorkspace extends React.Component {
       utils.fireResizeEvent();
     }
   };
-  renderWorkspaceAlert() {
-    return (
-      <WorkspaceAlert
-        type="error"
-        onClose={this.props.displayWorkspaceAlertOff}
-        isBlockly={false}
-        displayBottom={true}
-      >
-        <div>{this.props.errorMsg}</div>
-      </WorkspaceAlert>
-    );
-  }
+
   renderToolboxHeaders() {
     const {
       editCode,
@@ -158,6 +147,22 @@ class CodeWorkspace extends React.Component {
     this.blockCounterEl.style.display =
       usingBlocks && studioApp().enableShowBlockCount ? 'inline-block' : 'none';
   };
+
+  // The workspace alert will be displayed at the bottom of codeTextbox if editCode is
+  // assigned true (implies Droplet, not Blockly). Otherwise, it is displayed at the bottom
+  // of the CodeWorkspace
+  renderWorkspaceAlert() {
+    return (
+      <WorkspaceAlert
+        type="error"
+        onClose={this.props.displayWorkspaceAlertOff}
+        isBlockly={false}
+        displayBottom={true}
+      >
+        <div>{this.props.errorMsg}</div>
+      </WorkspaceAlert>
+    );
+  }
 
   render() {
     const props = this.props;

--- a/apps/src/templates/CodeWorkspace.jsx
+++ b/apps/src/templates/CodeWorkspace.jsx
@@ -231,7 +231,7 @@ class CodeWorkspace extends React.Component {
             ref={codeTextbox => (this.codeTextbox = codeTextbox)}
             id="codeTextbox"
             className={this.props.pinWorkspaceToBottom ? 'pin_bottom' : ''}
-            canUpdate={true}
+            canupdate={'yes'}
           >
             {this.props.displayWorkspaceAlert && this.renderWorkspaceAlert()}
           </ProtectedStatefulDiv>

--- a/apps/src/templates/CodeWorkspace.jsx
+++ b/apps/src/templates/CodeWorkspace.jsx
@@ -37,10 +37,7 @@ class CodeWorkspace extends React.Component {
     showMakerToggle: PropTypes.bool,
     autogenerateML: PropTypes.func,
     closeWorkspaceAlert: PropTypes.func,
-    showWorkspaceAlert: PropTypes.bool,
-    workspaceAlertType: PropTypes.string,
-    workspaceAlertDisplayBottom: PropTypes.bool,
-    workspaceAlertErrorMsg: PropTypes.string
+    workspaceAlert: PropTypes.object
   };
 
   shouldComponentUpdate(nextProps) {
@@ -51,16 +48,12 @@ class CodeWorkspace extends React.Component {
     Object.keys(nextProps).forEach(
       function(key) {
         // isRunning and style only affect style, and can be updated
-        // showWorkspaceAlert, workspaceAlertErrorMsg, workspaceAlertType, and
-        // workspaceAlertDisplayBottom are involved in displaying or closing workspace alert
-        // therefore these keys can be updated
+        // workspaceAlert is involved in displaying or closing workspace alert
+        // therefore this key can be updated
         if (
           key === 'isRunning' ||
           key === 'style' ||
-          key === 'showWorkspaceAlert' ||
-          key === 'workspaceAlertErrorMsg' ||
-          key === 'workspaceAlertType' ||
-          key === 'workspaceAlertDisplayBottom'
+          key === 'workspaceAlert'
         ) {
           return;
         }
@@ -161,12 +154,12 @@ class CodeWorkspace extends React.Component {
   renderWorkspaceAlert(isBlocklyType) {
     return (
       <WorkspaceAlert
-        type={this.props.workspaceAlertType}
+        type={this.props.workspaceAlert.type}
         onClose={this.props.closeWorkspaceAlert}
         isBlockly={isBlocklyType}
-        displayBottom={this.props.workspaceAlertDisplayBottom}
+        displayBottom={this.props.workspaceAlert.displayBottom}
       >
-        <div>{this.props.workspaceAlertErrorMsg}</div>
+        <div>{this.props.workspaceAlert.message}</div>
       </WorkspaceAlert>
     );
   }
@@ -245,7 +238,7 @@ class CodeWorkspace extends React.Component {
             className={this.props.pinWorkspaceToBottom ? 'pin_bottom' : ''}
             canUpdate={true}
           >
-            {this.props.showWorkspaceAlert && this.renderWorkspaceAlert(false)}
+            {this.props.workspaceAlert && this.renderWorkspaceAlert(false)}
           </ProtectedStatefulDiv>
         )}
         {this.props.displayNotStartedBanner && !inCsfExampleSolution && (
@@ -265,7 +258,7 @@ class CodeWorkspace extends React.Component {
           />
         )}
         {!props.editCode &&
-          this.props.showWorkspaceAlert &&
+          this.props.workspaceAlert &&
           this.renderWorkspaceAlert(true)}
       </span>
     );
@@ -323,10 +316,7 @@ export default connect(
     isMinecraft: !!state.pageConstants.isMinecraft,
     runModeIndicators: shouldUseRunModeIndicators(state),
     showMakerToggle: !!state.pageConstants.showMakerToggle,
-    showWorkspaceAlert: state.project.showWorkspaceAlert,
-    workspaceAlertType: state.project.workspaceAlertType,
-    workspaceAlertDisplayBottom: state.project.workspaceAlertDisplayBottom,
-    workspaceAlertErrorMsg: state.project.workspaceAlertErrorMsg
+    workspaceAlert: state.project.workspaceAlert
   }),
   dispatch => ({
     closeWorkspaceAlert: () => dispatch(closeWorkspaceAlert())

--- a/apps/src/templates/CodeWorkspace.jsx
+++ b/apps/src/templates/CodeWorkspace.jsx
@@ -17,7 +17,7 @@ import {singleton as studioApp} from '../StudioApp';
 import ProjectTemplateWorkspaceIcon from './ProjectTemplateWorkspaceIcon';
 import {queryParams} from '../code-studio/utils';
 import WorkspaceAlert from '@cdo/apps/code-studio/components/WorkspaceAlert';
-import {displayWorkspaceAlertOff} from '../code-studio/projectRedux';
+import {closeWorkspaceAlert} from '../code-studio/projectRedux';
 
 class CodeWorkspace extends React.Component {
   static propTypes = {
@@ -36,9 +36,11 @@ class CodeWorkspace extends React.Component {
     withSettingsCog: PropTypes.bool,
     showMakerToggle: PropTypes.bool,
     autogenerateML: PropTypes.func,
-    displayWorkspaceAlertOff: PropTypes.func,
-    displayWorkspaceAlert: PropTypes.bool.isRequired,
-    errorMsg: PropTypes.string.isRequired
+    closeWorkspaceAlert: PropTypes.func,
+    showWorkspaceAlert: PropTypes.bool,
+    workspaceAlertType: PropTypes.string,
+    workspaceAlertDisplayBottom: PropTypes.bool,
+    workspaceAlertErrorMsg: PropTypes.string
   };
 
   shouldComponentUpdate(nextProps) {
@@ -49,11 +51,16 @@ class CodeWorkspace extends React.Component {
     Object.keys(nextProps).forEach(
       function(key) {
         // isRunning and style only affect style, and can be updated
+        // showWorkspaceAlert, workspaceAlertErrorMsg, workspaceAlertType, and
+        // workspaceAlertDisplayBottom are involved in displaying or closing workspace alert
+        // therefore these keys can be updated
         if (
           key === 'isRunning' ||
           key === 'style' ||
-          key === 'displayWorkspaceAlert' ||
-          key === 'errorMsg'
+          key === 'showWorkspaceAlert' ||
+          key === 'workspaceAlertErrorMsg' ||
+          key === 'workspaceAlertType' ||
+          key === 'workspaceAlertDisplayBottom'
         ) {
           return;
         }
@@ -151,15 +158,15 @@ class CodeWorkspace extends React.Component {
   // The workspace alert will be displayed at the bottom of codeTextbox if editCode is
   // assigned true (implies Droplet, not Blockly). Otherwise, it is displayed at the bottom
   // of the CodeWorkspace
-  renderWorkspaceAlert() {
+  renderWorkspaceAlert(isBlocklyType) {
     return (
       <WorkspaceAlert
-        type="error"
-        onClose={this.props.displayWorkspaceAlertOff}
-        isBlockly={false}
-        displayBottom={true}
+        type={this.props.workspaceAlertType}
+        onClose={this.props.closeWorkspaceAlert}
+        isBlockly={isBlocklyType}
+        displayBottom={this.props.workspaceAlertDisplayBottom}
       >
-        <div>{this.props.errorMsg}</div>
+        <div>{this.props.workspaceAlertErrorMsg}</div>
       </WorkspaceAlert>
     );
   }
@@ -236,9 +243,9 @@ class CodeWorkspace extends React.Component {
             ref={codeTextbox => (this.codeTextbox = codeTextbox)}
             id="codeTextbox"
             className={this.props.pinWorkspaceToBottom ? 'pin_bottom' : ''}
-            canupdate={'yes'}
+            canUpdate={true}
           >
-            {this.props.displayWorkspaceAlert && this.renderWorkspaceAlert()}
+            {this.props.showWorkspaceAlert && this.renderWorkspaceAlert(false)}
           </ProtectedStatefulDiv>
         )}
         {this.props.displayNotStartedBanner && !inCsfExampleSolution && (
@@ -258,8 +265,8 @@ class CodeWorkspace extends React.Component {
           />
         )}
         {!props.editCode &&
-          this.props.displayWorkspaceAlert &&
-          this.renderWorkspaceAlert()}
+          this.props.showWorkspaceAlert &&
+          this.renderWorkspaceAlert(true)}
       </span>
     );
   }
@@ -316,10 +323,12 @@ export default connect(
     isMinecraft: !!state.pageConstants.isMinecraft,
     runModeIndicators: shouldUseRunModeIndicators(state),
     showMakerToggle: !!state.pageConstants.showMakerToggle,
-    displayWorkspaceAlert: state.project.displayWorkspaceAlert,
-    errorMsg: state.project.errorMsg
+    showWorkspaceAlert: state.project.showWorkspaceAlert,
+    workspaceAlertType: state.project.workspaceAlertType,
+    workspaceAlertDisplayBottom: state.project.workspaceAlertDisplayBottom,
+    workspaceAlertErrorMsg: state.project.workspaceAlertErrorMsg
   }),
   dispatch => ({
-    displayWorkspaceAlertOff: () => dispatch(displayWorkspaceAlertOff())
+    closeWorkspaceAlert: () => dispatch(closeWorkspaceAlert())
   })
 )(Radium(CodeWorkspace));

--- a/apps/src/templates/CodeWorkspaceContainer.jsx
+++ b/apps/src/templates/CodeWorkspaceContainer.jsx
@@ -10,6 +10,8 @@ import Radium from 'radium'; // eslint-disable-line no-restricted-imports
 import {connect} from 'react-redux';
 import * as utils from '../utils';
 import commonStyles from '../commonStyles';
+import WorkspaceAlert from '@cdo/apps/code-studio/components/WorkspaceAlert';
+import {displayWorkspaceAlertOff} from '../code-studio/projectRedux';
 
 class CodeWorkspaceContainer extends React.Component {
   static propTypes = {
@@ -19,7 +21,10 @@ class CodeWorkspaceContainer extends React.Component {
     // Provided by redux
     hidden: PropTypes.bool.isRequired,
     isRtl: PropTypes.bool.isRequired,
-    noVisualization: PropTypes.bool.isRequired
+    noVisualization: PropTypes.bool.isRequired,
+    displayWorkspaceAlertOff: PropTypes.func,
+    displayWorkspaceAlert: PropTypes.bool.isRequired,
+    errorMsg: PropTypes.string.isRequired
   };
 
   /**
@@ -51,6 +56,16 @@ class CodeWorkspaceContainer extends React.Component {
       <div style={mainStyle} className="editor-column">
         <div id="codeWorkspace" style={styles.codeWorkspace}>
           {children}
+          {this.props.displayWorkspaceAlert && (
+            <WorkspaceAlert
+              type="error"
+              onClose={this.props.displayWorkspaceAlertOff}
+              isBlockly={false}
+              displayBottom={true}
+            >
+              <div>{this.props.errorMsg}</div>
+            </WorkspaceAlert>
+          )}
         </div>
       </div>
     );
@@ -64,9 +79,13 @@ export default connect(
       state.pageConstants.hideSource &&
       !state.pageConstants.visualizationInWorkspace,
     isRtl: state.isRtl,
-    noVisualization: state.pageConstants.noVisualization
+    noVisualization: state.pageConstants.noVisualization,
+    displayWorkspaceAlert: state.project.displayWorkspaceAlert,
+    errorMsg: state.project.errorMsg
   }),
-  undefined,
+  dispatch => ({
+    displayWorkspaceAlertOff: () => dispatch(displayWorkspaceAlertOff())
+  }),
   null,
   {withRef: true}
 )(CodeWorkspaceContainer);

--- a/apps/src/templates/CodeWorkspaceContainer.jsx
+++ b/apps/src/templates/CodeWorkspaceContainer.jsx
@@ -10,8 +10,6 @@ import Radium from 'radium'; // eslint-disable-line no-restricted-imports
 import {connect} from 'react-redux';
 import * as utils from '../utils';
 import commonStyles from '../commonStyles';
-import WorkspaceAlert from '@cdo/apps/code-studio/components/WorkspaceAlert';
-import {displayWorkspaceAlertOff} from '../code-studio/projectRedux';
 
 class CodeWorkspaceContainer extends React.Component {
   static propTypes = {
@@ -21,10 +19,7 @@ class CodeWorkspaceContainer extends React.Component {
     // Provided by redux
     hidden: PropTypes.bool.isRequired,
     isRtl: PropTypes.bool.isRequired,
-    noVisualization: PropTypes.bool.isRequired,
-    displayWorkspaceAlertOff: PropTypes.func,
-    displayWorkspaceAlert: PropTypes.bool.isRequired,
-    errorMsg: PropTypes.string.isRequired
+    noVisualization: PropTypes.bool.isRequired
   };
 
   /**
@@ -56,16 +51,6 @@ class CodeWorkspaceContainer extends React.Component {
       <div style={mainStyle} className="editor-column">
         <div id="codeWorkspace" style={styles.codeWorkspace}>
           {children}
-          {this.props.displayWorkspaceAlert && (
-            <WorkspaceAlert
-              type="error"
-              onClose={this.props.displayWorkspaceAlertOff}
-              isBlockly={false}
-              displayBottom={true}
-            >
-              <div>{this.props.errorMsg}</div>
-            </WorkspaceAlert>
-          )}
         </div>
       </div>
     );
@@ -79,13 +64,9 @@ export default connect(
       state.pageConstants.hideSource &&
       !state.pageConstants.visualizationInWorkspace,
     isRtl: state.isRtl,
-    noVisualization: state.pageConstants.noVisualization,
-    displayWorkspaceAlert: state.project.displayWorkspaceAlert,
-    errorMsg: state.project.errorMsg
+    noVisualization: state.pageConstants.noVisualization
   }),
-  dispatch => ({
-    displayWorkspaceAlertOff: () => dispatch(displayWorkspaceAlertOff())
-  }),
+  undefined,
   null,
   {withRef: true}
 )(CodeWorkspaceContainer);

--- a/apps/src/templates/ProtectedStatefulDiv.jsx
+++ b/apps/src/templates/ProtectedStatefulDiv.jsx
@@ -4,7 +4,8 @@ import PropTypes from 'prop-types';
 import Radium from 'radium'; // eslint-disable-line no-restricted-imports
 
 /**
- * A div DOM element that will never update its contents and will throw an
+ * A div DOM element that will never update its contents unless the non-standard
+ * DOM attribute, canupdate, is assigned 'yes' It will throw an
  * exception if it is ever unmounted, enforcing that it must always be rendered
  * because its contents may contain state that the application is depending on.
  *
@@ -15,15 +16,15 @@ class ProtectedStatefulDiv extends React.Component {
   static propTypes = {
     contentFunction: PropTypes.func,
     children: PropTypes.node,
-    canUpdate: PropTypes.bool
+    canupdate: PropTypes.string
   };
 
   static defaultProps = {
-    canUpdate: false
+    canupdate: 'no'
   };
 
   shouldComponentUpdate() {
-    return this.props.canUpdate;
+    return this.props.canupdate ? 'yes' : 'no';
   }
 
   componentDidMount() {

--- a/apps/src/templates/ProtectedStatefulDiv.jsx
+++ b/apps/src/templates/ProtectedStatefulDiv.jsx
@@ -14,11 +14,16 @@ import Radium from 'radium'; // eslint-disable-line no-restricted-imports
 class ProtectedStatefulDiv extends React.Component {
   static propTypes = {
     contentFunction: PropTypes.func,
-    children: PropTypes.node
+    children: PropTypes.node,
+    canUpdate: PropTypes.bool
+  };
+
+  static defaultProps = {
+    canUpdate: false
   };
 
   shouldComponentUpdate() {
-    return false;
+    return this.props.canUpdate;
   }
 
   componentDidMount() {

--- a/apps/src/templates/ProtectedStatefulDiv.jsx
+++ b/apps/src/templates/ProtectedStatefulDiv.jsx
@@ -4,10 +4,10 @@ import PropTypes from 'prop-types';
 import Radium from 'radium'; // eslint-disable-line no-restricted-imports
 
 /**
- * A div DOM element that will never update its contents unless the non-standard
- * DOM attribute, canupdate, is assigned 'yes' It will throw an
- * exception if it is ever unmounted, enforcing that it must always be rendered
- * because its contents may contain state that the application is depending on.
+ * A div DOM element that will never update its contents unless canUpdate
+ * is assigned true. It will throw an exception if it is ever unmounted,
+ * enforcing that it must always be rendered because its contents may
+ * contain state that the application is depending on.
  *
  * Useful when React is wrapping external libraries or parts of our UI that are
  * not yet driven by React.

--- a/apps/src/templates/ProtectedStatefulDiv.jsx
+++ b/apps/src/templates/ProtectedStatefulDiv.jsx
@@ -16,15 +16,15 @@ class ProtectedStatefulDiv extends React.Component {
   static propTypes = {
     contentFunction: PropTypes.func,
     children: PropTypes.node,
-    canupdate: PropTypes.string
+    canUpdate: PropTypes.bool
   };
 
   static defaultProps = {
-    canupdate: 'no'
+    canUpdate: false
   };
 
   shouldComponentUpdate() {
-    return this.props.canupdate ? 'yes' : 'no';
+    return this.props.canUpdate;
   }
 
   componentDidMount() {
@@ -52,7 +52,8 @@ class ProtectedStatefulDiv extends React.Component {
         {..._.omit(this.props, [
           'contentFunction',
           'radiumConfigContext',
-          'styleKeeperContext'
+          'styleKeeperContext',
+          'canUpdate'
         ])}
         ref="root"
       />

--- a/apps/test/integration/levelTests.js
+++ b/apps/test/integration/levelTests.js
@@ -25,6 +25,7 @@ import arrowDisplay from '@cdo/apps/templates/arrowDisplayRedux';
 import FirebaseStorage from '@cdo/apps/storage/firebaseStorage';
 import LegacyDialog from '@cdo/apps/code-studio/LegacyDialog';
 import loadSource from './util/loadSource';
+import projectRedux from '@cdo/apps/code-studio/projectRedux';
 
 var wrappedEventListener = require('./util/wrappedEventListener');
 var testCollectionUtils = require('./util/testCollectionUtils');
@@ -125,6 +126,7 @@ describe('Level tests', function() {
       progress,
       currentUser,
       arrowDisplay,
+      project: projectRedux,
       ...jsDebuggerReducers
     });
 

--- a/apps/test/unit/templates/CodeWorkspaceTest.js
+++ b/apps/test/unit/templates/CodeWorkspaceTest.js
@@ -17,7 +17,9 @@ describe('CodeWorkspace', () => {
     showProjectTemplateWorkspaceIcon: false,
     isMinecraft: false,
     runModeIndicators: false,
-    showMakerToggle: false
+    showMakerToggle: false,
+    displayWorkspaceAlert: false,
+    errorMsg: ''
   };
 
   let studioApp, workspace;

--- a/apps/test/unit/templates/CodeWorkspaceTest.js
+++ b/apps/test/unit/templates/CodeWorkspaceTest.js
@@ -5,7 +5,7 @@ import {UnconnectedCodeWorkspace as CodeWorkspace} from '../../../src/templates/
 import {singleton as studioAppSingleton} from '@cdo/apps/StudioApp';
 import sinon from 'sinon';
 import ShowCodeToggle from '@cdo/apps/templates/ShowCodeToggle';
-
+import {workspaceAlertTypes} from '@cdo/apps/code-studio/projectRedux';
 describe('CodeWorkspace', () => {
   const MINIMUM_PROPS = {
     editCode: true,
@@ -21,7 +21,7 @@ describe('CodeWorkspace', () => {
     showWorkspaceAlert: true,
     workspaceAlertErrorMsg: 'This is an error msg',
     workspaceAlertDisplayBottom: true,
-    workspaceAlertType: 'error',
+    workspaceAlertType: workspaceAlertTypes.error,
     closeWorkspaceAlert: () => {}
   };
 

--- a/apps/test/unit/templates/CodeWorkspaceTest.js
+++ b/apps/test/unit/templates/CodeWorkspaceTest.js
@@ -6,6 +6,7 @@ import {singleton as studioAppSingleton} from '@cdo/apps/StudioApp';
 import sinon from 'sinon';
 import ShowCodeToggle from '@cdo/apps/templates/ShowCodeToggle';
 import {workspaceAlertTypes} from '@cdo/apps/code-studio/projectRedux';
+
 describe('CodeWorkspace', () => {
   const MINIMUM_PROPS = {
     editCode: true,
@@ -18,10 +19,11 @@ describe('CodeWorkspace', () => {
     isMinecraft: false,
     runModeIndicators: false,
     showMakerToggle: false,
-    showWorkspaceAlert: true,
-    workspaceAlertErrorMsg: 'This is an error msg',
-    workspaceAlertDisplayBottom: true,
-    workspaceAlertType: workspaceAlertTypes.error,
+    workspaceAlert: {
+      type: workspaceAlertTypes.error,
+      message: 'This is an error message',
+      displayBottom: false
+    },
     closeWorkspaceAlert: () => {}
   };
 
@@ -71,15 +73,15 @@ describe('CodeWorkspace', () => {
     expect(wrapper.find('div#notStartedBanner')).to.have.lengthOf(1);
   });
 
-  it('displays a workspace alert when showWorkspaceAlert is true', () => {
+  it('displays a workspace alert when workspaceAlert exists', () => {
     expect(workspace.find('WorkspaceAlert')).to.have.lengthOf(1);
   });
 
-  it('does not display a workspace alert when showWorkspaceAlert is false ', () => {
+  it('does not display a workspace alert when workspaceAlert is assigned null ', () => {
     const props = {
       ...MINIMUM_PROPS,
       ...{
-        showWorkspaceAlert: false
+        workspaceAlert: null
       }
     };
     const wrapper = shallow(<CodeWorkspace {...props} />);

--- a/apps/test/unit/templates/CodeWorkspaceTest.js
+++ b/apps/test/unit/templates/CodeWorkspaceTest.js
@@ -18,8 +18,11 @@ describe('CodeWorkspace', () => {
     isMinecraft: false,
     runModeIndicators: false,
     showMakerToggle: false,
-    displayWorkspaceAlert: false,
-    errorMsg: ''
+    showWorkspaceAlert: true,
+    workspaceAlertErrorMsg: 'This is an error msg',
+    workspaceAlertDisplayBottom: true,
+    workspaceAlertType: 'error',
+    closeWorkspaceAlert: () => {}
   };
 
   let studioApp, workspace;
@@ -66,5 +69,48 @@ describe('CodeWorkspace', () => {
     };
     const wrapper = shallow(<CodeWorkspace {...props} />);
     expect(wrapper.find('div#notStartedBanner')).to.have.lengthOf(1);
+  });
+
+  it('displays a workspace alert when showWorkspaceAlert is true', () => {
+    expect(workspace.find('WorkspaceAlert')).to.have.lengthOf(1);
+  });
+
+  it('does not display a workspace alert when showWorkspaceAlert is false ', () => {
+    const props = {
+      ...MINIMUM_PROPS,
+      ...{
+        showWorkspaceAlert: false
+      }
+    };
+    const wrapper = shallow(<CodeWorkspace {...props} />);
+    expect(wrapper.find('WorkspaceAlert')).to.have.lengthOf(0);
+  });
+
+  it('displays a workspace alert at bottom of codeTextbox when editCode = true (implies Droplet)', () => {
+    const props = {
+      ...MINIMUM_PROPS,
+      ...{
+        editCode: true
+      }
+    };
+    const wrapper = shallow(<CodeWorkspace {...props} />);
+    expect(wrapper.find('WorkspaceAlert')).to.have.lengthOf(1);
+    expect(wrapper.find('ProtectedStatefulDiv#codeTextbox')).to.have.lengthOf(
+      1
+    );
+  });
+
+  it('displays a workspace alert at bottom of CodeWorkspace when editCode = false (implies Blockly)', () => {
+    const props = {
+      ...MINIMUM_PROPS,
+      ...{
+        editCode: false
+      }
+    };
+    const wrapper = shallow(<CodeWorkspace {...props} />);
+    expect(wrapper.find('WorkspaceAlert')).to.have.lengthOf(1);
+    expect(wrapper.find('ProtectedStatefulDiv#codeTextbox')).to.have.lengthOf(
+      0
+    );
   });
 });

--- a/dashboard_legacy/middleware/files_api.rb
+++ b/dashboard_legacy/middleware/files_api.rb
@@ -467,7 +467,7 @@ class FilesApi < Sinatra::Base
       # HTML only exists for AppLab projects
       html_is_valid = html ? source.force_encoding("UTF-8").valid_encoding? : true
 
-      return bad_request unless source_is_valid && html_is_valid
+      return status(422) unless source_is_valid && html_is_valid
     end
 
     # Replacing a non-current version of main.json could lead to perceived data loss.

--- a/dashboard_legacy/test/middleware/test_sources.rb
+++ b/dashboard_legacy/test/middleware/test_sources.rb
@@ -782,7 +782,7 @@ class SourcesTest < FilesApiTestBase
     file_headers = {'CONTENT_TYPE' => 'application/json'}
 
     @api.put_object(filename, file_data, file_headers)
-    assert bad_request?
+    ssert_equal 422, last_response.status
 
     delete_all_source_versions(filename)
   end
@@ -805,7 +805,7 @@ class SourcesTest < FilesApiTestBase
     file_headers = {'CONTENT_TYPE' => 'application/json'}
 
     @api.put_object(filename, file_data, file_headers)
-    assert bad_request?
+    ssert_equal 422, last_response.status
 
     delete_all_source_versions(filename)
   end

--- a/dashboard_legacy/test/middleware/test_sources.rb
+++ b/dashboard_legacy/test/middleware/test_sources.rb
@@ -782,7 +782,7 @@ class SourcesTest < FilesApiTestBase
     file_headers = {'CONTENT_TYPE' => 'application/json'}
 
     @api.put_object(filename, file_data, file_headers)
-    ssert_equal 422, last_response.status
+    assert_equal 422, last_response.status
 
     delete_all_source_versions(filename)
   end
@@ -805,7 +805,7 @@ class SourcesTest < FilesApiTestBase
     file_headers = {'CONTENT_TYPE' => 'application/json'}
 
     @api.put_object(filename, file_data, file_headers)
-    ssert_equal 422, last_response.status
+    assert_equal 422, last_response.status
 
     delete_all_source_versions(filename)
   end


### PR DESCRIPTION
## Summary
Currently, projects that use invalid non-UTF8 characters in the project title are not able to be saved - refer to [PR](https://github.com/code-dot-org/code-dot-org/pull/44565).
As an improvement to the UI around the error handling, this PR displays a workspace alert with the message: 'There was an error saving your project, please remove any invalid characters to resolve.'

Note that this prior [PR](https://github.com/code-dot-org/code-dot-org/pull/47551) provided the groundwork for this UI update. The headerRedux was refactored into the projectRedux and appRedux. In particular, the projectRedux is where I added the actions - displayWorkspaceAlertOn and displayWorkspaceAlertOff.

## Links
- [jira ticket: Improve Error handling for Invalid Characters](https://codedotorg.atlassian.net/browse/STAR-2168)

## Testing story
In order to test the UI, an error was temporarily hard-coded in project.js at line 1157, using:
err = {message: 'httpStatusCode: 422'};
Here's a screencast with the hard-coded error:

https://user-images.githubusercontent.com/107423305/186920952-6f4061b7-0aa6-428b-b0d7-9680fc4a6360.mp4


