### PR TITLE
Stop buttons jumping around on code.org/yourschool

### DIFF
--- a/apps/src/templates/census2017/YourSchoolResources.jsx
+++ b/apps/src/templates/census2017/YourSchoolResources.jsx
@@ -13,6 +13,7 @@ class YourSchoolResources extends Component {
             description={i18n.yourSchoolAdminDesc()}
             buttonText={i18n.yourSchoolAdminButton()}
             link={pegasus('/educate/district')}
+            allowWrap
           />
         </div>
         <div style={styles.card}>
@@ -21,6 +22,7 @@ class YourSchoolResources extends Component {
             description={i18n.yourSchoolTeacherDesc()}
             buttonText={i18n.yourSchoolTeacherButton()}
             link={pegasus('/educate')}
+            allowWrap
           />
         </div>
         <div style={styles.card}>
@@ -29,7 +31,7 @@ class YourSchoolResources extends Component {
             description={i18n.yourSchoolParentDesc()}
             buttonText={i18n.yourSchoolParentButton()}
             link={pegasus('/help')}
-            allowWrap={true}
+            allowWrap
           />
         </div>
       </div>


### PR DESCRIPTION
Buttons were jumping to the bottom of the page on code.org/yourschool on hover. We noticed that the "parents and students" card did not have this "button jumping" problem, and it appears the `allowWrap` prop was keeping it in place. The `allowWrap` prop controls wrapping of the title as well, which seems ok for the teachers and administrators cards?

I did not really look into the root cause of the issue and why this happened after [we removed Radium from the ResourceCard component](https://github.com/code-dot-org/code-dot-org/pull/47459/files).

## Links

[Slack thread](https://codedotorg.slack.com/archives/C02EEGWLHR8/p1661525841432339)

## Testing story

Tested manually that I could repro the issue, and that it did not recur once I made these changes. I also looked at /yourschool on a small viewport, and didn't see any issues with the `allowWrap` setting.