### PR TITLE
Updated our rails setup to allow accessing developer EC2 instances by their IP addresses

### DIFF
--- a/dashboard/config/environments/development.rb
+++ b/dashboard/config/environments/development.rb
@@ -21,6 +21,11 @@ Dashboard::Application.configure do
   config.hosts << "localhost.hourofcode.com"
   config.hosts << "localhost.codeprojects.org"
 
+  # Adds the IP address of this environment if it is an EC2 instance, allowing us to test changes on
+  # devices that cannot run dashboard-server, such as cell phones or tablets.
+  ec2_ip_address = `curl -s -m 2 http://169.254.169.254/latest/meta-data/public-ipv4`
+  config.hosts << ec2_ip_address unless ec2_ip_address.empty?
+
   # Do not eager load code on boot.
   config.eager_load = false
 

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -9,7 +9,15 @@ Dashboard::Application.routes.draw do
     get '/weblab/footer', to: 'projects#weblab_footer'
   end
 
-  constraints host: /.*code.org.*/ do
+  # Includes the IP address of this environment if it is a developer EC2 instance, allowing us to
+  # test changes on devices that cannot run dashboard-server, such as cell phones or tablets.
+  if rack_env?(:development)
+    ec2_ip_address = `curl -s -m 2 http://169.254.169.254/latest/meta-data/public-ipv4`
+    hostname = ec2_ip_address.empty? ? /.*code.org.*/ : /.*code.org.*|#{ec2_ip_address.gsub('.', '\\.')}/
+  else
+    hostname = /.*code.org.*/
+  end
+  constraints host: hostname do
     # React-router will handle sub-routes on the client.
     get 'teacher_dashboard/sections/:section_id/parent_letter', to: 'teacher_dashboard#parent_letter'
     get 'teacher_dashboard/sections/:section_id/*path', to: 'teacher_dashboard#show', via: :all


### PR DESCRIPTION
When we updated from Rails 5 to Rails 6, we lost the ability to access developer EC2 instances by their IP addresses. This is an important scenario to support development against devices that are unable to run dashboard-server locally. Being able to reliably hit a rapidly updating remote development environment is especially important for development with user scenarios that involve phones, tablets, chromebooks, and low-powered laptops.

This PR achieves this ability by adding the EC2 instance's IP address as one of the accepted rails hostnames.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
