### PR TITLE
move blank certificate page to dashboard

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -701,6 +701,8 @@ describe('entry tests', () => {
       './src/sites/code.org/pages/public/educate/curriculum/courses.js',
     'code.org/public/educate/regional-partner/playbook':
       './src/sites/code.org/pages/public/educate/regional-partner/playbook.js',
+    'code.org/public/certificates/blank':
+      './src/sites/code.org/pages/public/certificates/blank.js',
     'code.org/public/student/middle-high':
       './src/sites/code.org/pages/public/student/middle-high.js',
     'code.org/public/teacher-dashboard/index':

--- a/apps/src/sites/code.org/pages/public/certificates/blank.js
+++ b/apps/src/sites/code.org/pages/public/certificates/blank.js
@@ -1,0 +1,8 @@
+import experiments from '@cdo/apps/util/experiments';
+
+const studioCertificate = experiments.isEnabled(experiments.STUDIO_CERTIFICATE);
+
+if (studioCertificate) {
+  const script = document.querySelector('script[data-studio-redirect-url]');
+  window.location = script.dataset['studioRedirectUrl'];
+}

--- a/dashboard/app/controllers/certificates_controller.rb
+++ b/dashboard/app/controllers/certificates_controller.rb
@@ -25,4 +25,16 @@ class CertificatesController < ApplicationController
       announcement: announcement
     }
   end
+
+  def blank
+    announcement = Announcements.get_announcement_for_page('/certificates')
+
+    @certificate_data = {
+      imageUrl: certificate_image_url(nil, 'hourofcode', nil),
+      printUrl: certificate_print_url(nil, 'hourofcode', nil),
+      announcement: announcement
+    }
+
+    render :show
+  end
 end

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -468,7 +468,7 @@ Dashboard::Application.routes.draw do
 
     get '/print_certificates/:encoded_params', to: 'print_certificates#show'
 
-    get '/certificates/blank', to: 'certificates#blank'
+    get '/certificates/blank'
     get '/certificates/:encoded_params', to: 'certificates#show'
 
     get '/beta', to: redirect('/')

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -468,6 +468,7 @@ Dashboard::Application.routes.draw do
 
     get '/print_certificates/:encoded_params', to: 'print_certificates#show'
 
+    get '/certificates/blank', to: 'certificates#blank'
     get '/certificates/:encoded_params', to: 'certificates#show'
 
     get '/beta', to: redirect('/')

--- a/dashboard/test/controllers/certificates_controller_test.rb
+++ b/dashboard/test/controllers/certificates_controller_test.rb
@@ -52,4 +52,11 @@ class CertificatesControllerTest < ActionController::TestCase
     assert_response :bad_request
     assert_includes response.body, 'invalid base64'
   end
+
+  test 'shows static image for blank certificate' do
+    get :blank
+    assert_response :success
+    response_data = JSON.parse(css_select('script[data-certificate]').first.attribute('data-certificate').to_s)
+    assert_equal '//test.code.org/images/hour_of_code_certificate.jpg', response_data['imageUrl']
+  end
 end

--- a/dashboard/test/ui/features/hour_of_code/hour_of_code_finish.feature
+++ b/dashboard/test/ui/features/hour_of_code/hour_of_code_finish.feature
@@ -76,6 +76,12 @@ Scenario: Course A 2017 uncustomized dashboard certificate pages
   And I wait until current URL contains "/print_certificates/"
   Then I wait to see an image "/certificate_images/"
 
+Scenario: blank certificate
+  When I am on "http://code.org/certificates/blank?enableExperiments=studioCertificate"
+  And I wait until current URL contains "http://studio.code.org/certificates/blank"
+
+  Then I wait to see an image "/images/hour_of_code_certificate.jpg"
+
 @eyes
 Scenario: congrats certificate pages
   Given I am on "http://studio.code.org/congrats?enableExperiments=studioCertificate"

--- a/pegasus/sites.v3/code.org/public/certificates/blank.haml
+++ b/pegasus/sites.v3/code.org/public/certificates/blank.haml
@@ -24,6 +24,9 @@ social:
   @header["social"]["og:image"] = "http://#{request.host_with_port}/images/hour_of_code_certificate-640.jpg"
   @header["social"]["og:url"] = "http://#{request.host_with_port}/certificates/blank"
 
+- studio_redirect_url = CDO.studio_url("/certificates/blank")
+%script{type: 'text/javascript', src: webpack_asset_path('js/code.org/public/certificates/blank.js'), 'data': {studio_redirect_url: studio_redirect_url}}
+
 #hoc-certificate
   %a{:href=>"/printcertificate"}
     %img{:src=>"/images/hour_of_code_certificate.jpg", :alt=>"Certificate for Completion of One Hour of Code"}


### PR DESCRIPTION
Finishes [PLAT-1536](https://codedotorg.atlassian.net/browse/PLAT-1536).

## Testing story

new unit test, new UI test

## Follow-up work

Actually updating the links which point to /certificates/blank will happen as part of the PR which launches the congrats pages on dashboard.
