### PR TITLE
Remove Unnecessary `lock_thread` Argument

### DIFF
--- a/dashboard/test/testing/transactional_test_case.rb
+++ b/dashboard/test/testing/transactional_test_case.rb
@@ -28,7 +28,7 @@ module ActiveSupport
           if use_transactional_test_case?
             @test_case_connections = enlist_transaction_connections
             @test_case_connections.each do |connection|
-              connection.begin_transaction joinable: false, _lazy: false, lock_thread: true
+              connection.begin_transaction joinable: false, _lazy: false
               connection.pool.lock_thread = true
             end
           end


### PR DESCRIPTION
Rails 6.1 changed this method to no longer accept a catchall options object and to instead use specific keyword arguments.

This change reveals that we have been passing a keyword argument which is not actually used, so in this PR we stop passing it.

## Links

- https://github.com/rails/rails/pull/36478

## Testing story

Relying on existing unit tests to verify that this does not represent any change in functionality

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
