### PR TITLE
Revert "Drop Support for Ruby 2.5"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '2.6.6'
+ruby '>= 2.5', '< 2.7'
 
 # Force HTTPS for github-source gems.
 # This is a temporary workaround - remove when bundler version is >=2.0

--- a/cookbooks/cdo-ruby/attributes/default.rb
+++ b/cookbooks/cdo-ruby/attributes/default.rb
@@ -1,5 +1,6 @@
 default['cdo-ruby'] = {
   version: '2.6',
+  old_version: '2.5',
   rubygems_version: '2.7.4',
   bundler_version: '1.17.3',
   rake_version: '11.3.0'


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#47643

Looks like the staging server is somehow still using 2.5; reverting this until I can figure out why.