### PR TITLE
Update `globalid` and `zeitwerk` Gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -445,7 +445,7 @@ GEM
     geocoder (1.6.4)
     get_process_mem (0.2.3)
     gherkin (5.1.0)
-    globalid (0.5.2)
+    globalid (1.0.0)
       activesupport (>= 5.0)
     google-api-client (0.52.0)
       addressable (~> 2.5, >= 2.5.1)
@@ -901,7 +901,7 @@ GEM
     xxhash (0.4.0)
     youtube-dl.rb (0.3.1.2016.08.19)
       cocaine (>= 0.5.4)
-    zeitwerk (2.4.2)
+    zeitwerk (2.6.0)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
Updating the installed version of Rails updates these gems as a side effect. This PR is simply updating them in isolation in advance of the Rails update. See https://github.com/code-dot-org/code-dot-org/pull/47377 for more.

Neither gem has had any breaking changes in the intermediary versions.

## Links

- https://github.com/rails/globalid/releases
- https://github.com/fxn/zeitwerk/blob/main/CHANGELOG.md

## Testing story

Relying on existing tests to verify that this does not represent any change in behavior.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
