### PR TITLE
Revert "Revert "Drop Support for Ruby 2.5""

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '>= 2.5', '< 2.7'
+ruby '2.6.6'
 
 # Force HTTPS for github-source gems.
 # This is a temporary workaround - remove when bundler version is >=2.0

--- a/cookbooks/cdo-ruby/attributes/default.rb
+++ b/cookbooks/cdo-ruby/attributes/default.rb
@@ -1,6 +1,5 @@
 default['cdo-ruby'] = {
   version: '2.6',
-  old_version: '2.5',
   rubygems_version: '2.7.4',
   bundler_version: '1.17.3',
   rake_version: '11.3.0'


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#47859, restoring https://github.com/code-dot-org/code-dot-org/pull/47643

This failed the first time because the staging server was still running Ruby 2.5. Specifically, there was a stray configuration setting in Chef which was overriding our default configuration; see internal discussion in https://codedotorg.slack.com/archives/C0T0PNTM3/p1661808818894529?thread_ts=1661804815.517309&cid=C0T0PNTM3 for more details. Said settings have since been updated, details of which are also in that thread.