### PR TITLE
Update `assert_raises` calls for Rails 6.1

### DIFF
--- a/dashboard/test/models/follower_test.rb
+++ b/dashboard/test/models/follower_test.rb
@@ -20,8 +20,8 @@ class FollowerTest < ActiveSupport::TestCase
   end
 
   test 'admins cannot be student followers' do
-    assert_raises do
-      assert_does_not_create(Follower) do
+    assert_does_not_create(Follower) do
+      assert_raises do
         create :follower, student_user: (create :admin)
       end
     end

--- a/dashboard/test/models/sections/section_test.rb
+++ b/dashboard/test/models/sections/section_test.rb
@@ -274,8 +274,8 @@ class SectionTest < ActiveSupport::TestCase
   end
 
   test 'add_student raises for admin students' do
-    assert_raises do
-      assert_does_not_create(Follower) do
+    assert_does_not_create(Follower) do
+      assert_raises ActiveRecord::RecordInvalid do
         @section.add_student(create(:admin))
       end
     end

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -724,8 +724,8 @@ class UserTest < ActiveSupport::TestCase
     student.admin = true
     refute student.valid?
 
-    assert_raises(ActiveRecord::RecordInvalid) do
-      assert_does_not_create(User) do
+    assert_does_not_create(User) do
+      assert_raises(ActiveRecord::RecordInvalid) do
         create :student, admin: true
       end
     end


### PR DESCRIPTION
In Rails 6.1 these tests fail with:

```
ERROR["test_add_student_raises_for_admin_students", "SectionTest", 855.3875930500017]
 test_add_student_raises_for_admin_students#SectionTest (855.39s)
Minitest::UnexpectedError:         ActiveRecord::RecordInvalid: Validation failed: Student user cannot be admin
            app/models/sections/section.rb:278:in `add_student'
            test/models/sections/section_test.rb:279:in `block (3 levels) in <class:SectionTest>'
            test/test_helper.rb:179:in `block in assert_does_not_create'
            test/test_helper.rb:178:in `assert_does_not_create'
            test/models/sections/section_test.rb:278:in `block (2 levels) in <class:SectionTest>'
            test/models/sections/section_test.rb:277:in `block in <class:SectionTest>'
            test/testing/setup_all_and_teardown_all.rb:36:in `run'
```

In all three cases, we are attempting to verify that an invalid "create" operation both raises an error and does not create an associated model, and in all three cases we are expecting the raised error to bubble up through the "does not create" check and into the "raises error" check. I'm not entirely sure why, but it appears that in Rails 6.1, the "does not create" check raises the error instead of bubbling.

The simple fix is to check for the raised error first, and check for lack of creation in the outer block.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
