### PR TITLE
Fix Violation of and Reenable `Lint/FloatComparison`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -104,10 +104,6 @@ Lint/EmptyFile:
 Lint/ErbNewArguments:
   Enabled: false
 
-# Offense count: 2
-Lint/FloatComparison:
-  Enabled: false
-
 # Offense count: 7
 Lint/MissingSuper:
   Enabled: false

--- a/dashboard/test/ui/runner.rb
+++ b/dashboard/test/ui/runner.rb
@@ -576,7 +576,7 @@ def how_many_reruns?(test_run_string)
     if !flakiness
       $lock.synchronize {puts "No flakiness data for #{test_run_string}".green}
       return 1
-    elsif flakiness == 0.0
+    elsif flakiness.abs < Float::EPSILON
       $lock.synchronize {puts "#{test_run_string} is not flaky".green}
       return 1
     else


### PR DESCRIPTION
Rubocop [recommends we avoid performing strict equality checks on floats:](https://msp-greg.github.io/rubocop/RuboCop/Cop/Lint/FloatComparison.html)

    # bad
    x == 0.1
    x != 0.1

    # good - using BigDecimal
    x.to_d == 0.1.to_d

    # good
    (x - 0.1).abs < Float::EPSILON

    # good
    tolerance = 0.0001
    (x - 0.1).abs < tolerance

    # Or some other epsilon based type of comparison:
    # https://www.embeddeduse.com/2019/08/26/qt-compare-two-floats/

It's probably fine in this case since we're just evaluating test flakiness, and we could get away with adding a `rubocop disable` directive rather than updating. But I figured it's slightly cleaner this way, even if it is a bit more difficult to parse. Open to pushback if anyone thinks otherwise!

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
