### PR TITLE
Fix Violations of and Reenable `Performance/RedundantEqualityComparisonBlock`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -227,11 +227,6 @@ Performance/InefficientHashSearch:
 Performance/MethodObjectAsBlock:
   Enabled: false
 
-# Offense count: 10
-# This cop supports unsafe auto-correction (--auto-correct-all).
-Performance/RedundantEqualityComparisonBlock:
-  Enabled: false
-
 # Offense count: 56
 # This cop supports safe auto-correction (--auto-correct).
 Performance/RegexpMatch:

--- a/bin/oneoff/fix_census_submission_school_ids
+++ b/bin/oneoff/fix_census_submission_school_ids
@@ -33,7 +33,7 @@ Census::CensusSubmission.
   puts "\tFound school ids: #{school_ids}"
   school_id = school_ids[0]
   #verify all are the same
-  if school_ids.all? {|id| id == school_id}
+  if school_ids.all?(school_id)
     attrs = {school_id: school_id}
     school_info = get_duplicate_school_info(attrs) || SchoolInfo.new(attrs)
     puts "\tSetting school_info to #{school_info.id}"

--- a/dashboard/app/helpers/pd/workshop_survey_results_helper.rb
+++ b/dashboard/app/helpers/pd/workshop_survey_results_helper.rb
@@ -60,8 +60,7 @@ module Pd::WorkshopSurveyResultsHelper
     surveys = workshops.flat_map(&:survey_responses)
 
     raise 'Currently just summarizes Local Summer and Teachercon surveys' unless
-      surveys.all? {|survey| survey.is_a? Pd::TeacherconSurvey} ||
-        surveys.all? {|survey| survey.is_a? Pd::LocalSummerWorkshopSurvey}
+      surveys.all?(Pd::TeacherconSurvey) || surveys.all?(Pd::LocalSummerWorkshopSurvey)
 
     return Hash.new if surveys.empty?
 

--- a/dashboard/app/models/contact_rollups_processed.rb
+++ b/dashboard/app/models/contact_rollups_processed.rb
@@ -244,13 +244,10 @@ class ContactRollupsProcessed < ApplicationRecord
 
     # @see Script model, csf?, csd? and csp? methods
     curricula = extract_field contact_data, 'dashboard.sections', 'curriculum_umbrella'
-    roles.add 'CSF Teacher' if curricula.any? {|curriculum| curriculum == 'CSF'}
-    roles.add 'CSD Teacher' if !roles.include?('CSD Teacher') &&
-      curricula.any? {|curriculum| curriculum == 'CSD'}
-    roles.add 'CSP Teacher' if !roles.include?('CSP Teacher') &&
-      curricula.any? {|curriculum| curriculum == 'CSP'}
-    roles.add 'CSA Teacher' if !roles.include?('CSA Teacher') &&
-      curricula.any? {|curriculum| curriculum == 'CSA'}
+    roles.add 'CSF Teacher' if curricula.any?('CSF')
+    roles.add 'CSD Teacher' if !roles.include?('CSD Teacher') && curricula.any?('CSD')
+    roles.add 'CSP Teacher' if !roles.include?('CSP Teacher') && curricula.any?('CSP')
+    roles.add 'CSA Teacher' if !roles.include?('CSA Teacher') && curricula.any?('CSA')
 
     roles.add 'Form Submitter' if
       contact_data.key?('pegasus.forms') ||

--- a/dashboard/app/models/pd/enrollment.rb
+++ b/dashboard/app/models/pd/enrollment.rb
@@ -157,7 +157,7 @@ class Pd::Enrollment < ApplicationRecord
   # @return [Enumerable<Pd::Enrollment>]
   def self.filter_for_survey_completion(enrollments, select_completed = true)
     raise 'Expected enrollments to be an Enumerable list of Pd::Enrollment objects' unless
-        enrollments.is_a?(Enumerable) && enrollments.all? {|e| e.is_a?(Pd::Enrollment)}
+        enrollments.is_a?(Enumerable) && enrollments.all?(Pd::Enrollment)
 
     # Local summer, CSP Workshop for Returning Teachers, or CSF Intro after 5/8/2020 will use Foorm for survey completion.
     # CSF Deep Dive after 9/1 also uses Foorm. CSF District workshops will always use Foorm

--- a/dashboard/test/lib/pd/survey_pipeline/mapper_test.rb
+++ b/dashboard/test/lib/pd/survey_pipeline/mapper_test.rb
@@ -56,13 +56,13 @@ module Pd::SurveyPipeline
     test 'group data using one key' do
       summary = group_and_summarize([:a])
       assert_equal 2, summary.size
-      assert summary.all? {|v| v == @data.size / 2}
+      assert summary.all?(@data.size / 2)
     end
 
     test 'group data using all keys' do
       summary = group_and_summarize([:a, :b, :c])
       assert_equal @data.size, summary.size
-      assert summary.all? {|v| v == 1}
+      assert summary.all?(1)
     end
 
     test 'map groups to matched reducers' do

--- a/lib/cdo/graphics/certificate_image.rb
+++ b/lib/cdo/graphics/certificate_image.rb
@@ -186,7 +186,7 @@ class CertificateImage
 
   def self.hoc_course?(course)
     hoc_course = ScriptConstants.unit_in_category?(:hoc, course)
-    hoc_course ||= tutorial_codes.any? {|code| code == course}
+    hoc_course ||= tutorial_codes.any?(course)
     hoc_course
   end
 


### PR DESCRIPTION
I didn't realize the `all?` and `any?` methods supported this, but rubocop [recommends using direct equality](https://docs.rubocop.org/rubocop-performance/cops_performance.html#performanceredundantequalitycomparisonblock)

    # bad
    items.all? { |item| pattern === item }
    items.all? { |item| item == other }
    items.all? { |item| item.is_a?(Klass) }
    items.all? { |item| item.kind_of?(Klass) }

    # good
    items.all?(pattern)

I automatically fixed violations with `bundle exec rubocop -A --only Performance/RedundantEqualityComparisonBlock`, then I manually applied some whitespace updates.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
