### PR TITLE
Add dark and light mode for photo prompter in Java Lab

### DIFF
--- a/apps/src/javalab/JavalabConsole.jsx
+++ b/apps/src/javalab/JavalabConsole.jsx
@@ -151,11 +151,12 @@ class JavalabConsole extends React.Component {
       return (
         <PhotoSelectionView
           promptText={photoPrompterPromptText}
-          style={
-            displayTheme === DisplayTheme.DARK
-              ? styles.darkModePhotoPrompter
-              : styles.lightModePhotoPrompter
-          }
+          style={{
+            ...styles.photoPrompter,
+            ...(displayTheme === DisplayTheme.DARK
+              ? styles.darkMode
+              : styles.lightMode)
+          }}
           onPhotoSelected={file => {
             onPhotoPrompterFileSelected(file);
             closePhotoPrompter();
@@ -331,14 +332,7 @@ const styles = {
     padding: 0,
     margin: 0
   },
-  darkModePhotoPrompter: {
-    flexGrow: 1,
-    backgroundColor: color.black,
-    color: color.white
-  },
-  lightModePhotoPrompter: {
-    flexGrow: 1,
-    backgroundColor: color.white,
-    color: color.black
+  photoPrompter: {
+    flexGrow: 1
   }
 };

--- a/apps/src/javalab/JavalabConsole.jsx
+++ b/apps/src/javalab/JavalabConsole.jsx
@@ -151,7 +151,11 @@ class JavalabConsole extends React.Component {
       return (
         <PhotoSelectionView
           promptText={photoPrompterPromptText}
-          style={styles.photoPrompter}
+          style={
+            displayTheme === DisplayTheme.DARK
+              ? styles.darkModePhotoPrompter
+              : styles.lightModePhotoPrompter
+          }
           onPhotoSelected={file => {
             onPhotoPrompterFileSelected(file);
             closePhotoPrompter();
@@ -327,7 +331,14 @@ const styles = {
     padding: 0,
     margin: 0
   },
-  photoPrompter: {
-    flexGrow: 1
+  darkModePhotoPrompter: {
+    flexGrow: 1,
+    backgroundColor: color.black,
+    color: color.white
+  },
+  lightModePhotoPrompter: {
+    flexGrow: 1,
+    backgroundColor: color.white,
+    color: color.black
   }
 };


### PR DESCRIPTION
## Summary
- In Java lab when the photo prompter is displayed in light mode, the background is black and the text/camera icon are black so that they are not visible. 

- Screencast video before update:

https://user-images.githubusercontent.com/107423305/187465958-b619b2df-0e4a-4348-8d2b-b0c4f0d10f58.mp4

- This PR updates the style for the photo prompter so that in light mode, the background is white and the text/icon are black and visible. In dark mode, the background remains black and the text/icon are white.

- Screencast video after update:

https://user-images.githubusercontent.com/107423305/187466001-6d12a2f6-33c1-4b34-a320-6da5f5cf19ea.mp4

## Links
[jira ticket](https://codedotorg.atlassian.net/browse/JAVA-636)

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
