### PR TITLE
Animation Library - Cast string to number after import

### DIFF
--- a/apps/src/p5lab/AnimationPicker/AnimationPickerListItem.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPickerListItem.jsx
@@ -44,6 +44,8 @@ export default class AnimationPickerListItem extends React.Component {
       selected ? 'fa-check' : 'fa-plus'
     } fa-2x`;
 
+    const previewSize = parseInt(style.previewSize);
+
     return (
       <div
         className={classNames(style.root, !label && style.noLabel)}
@@ -70,8 +72,8 @@ export default class AnimationPickerListItem extends React.Component {
               <AnimationPreview
                 animationProps={animationProps}
                 sourceUrl={animationProps.sourceUrl}
-                width={style.previewSize}
-                height={style.previewSize}
+                width={previewSize}
+                height={previewSize}
                 playBehavior={!playAnimations ? PlayBehavior.NEVER_PLAY : null}
                 onPreviewLoad={() => this.setState({loaded: true})}
               />


### PR DESCRIPTION
After merging https://github.com/code-dot-org/code-dot-org/pull/47478 I discovered that the `previewSize` variable was being exported as a string. This didn't actually create a visual regression but did result in a container `<div/>` missing its height and width attributes. [On Slack](https://codedotorg.slack.com/archives/C03MZ259SUU/p1661459456651399), we agreed that for now we can fix this by coaxing the string to a number with `parseInt()`.

**Before:**
<img width="127" alt="image" src="https://user-images.githubusercontent.com/43474485/187479576-272ee6e8-54c6-4f74-b84d-c552a6b4cf04.png"><img width="326" alt="image" src="https://user-images.githubusercontent.com/43474485/187479956-9cb89ffa-a413-4aa0-9960-f34fee70b6be.png">


**After:**
<img width="120" alt="image" src="https://user-images.githubusercontent.com/43474485/187478557-b2b58393-0d62-4687-a905-a22e5854577d.png"><img width="327" alt="image" src="https://user-images.githubusercontent.com/43474485/187480344-74b07df8-0aad-4222-bc24-337e2862479c.png">



## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

If these height and width properties aren't needed, we can look into removing them later.

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
