### PR TITLE
Play dance party songs on iOS audio even if muted

### DIFF
--- a/apps/src/Sound.js
+++ b/apps/src/Sound.js
@@ -429,6 +429,8 @@ Sound.prototype.preloadAudioElement = function(audioElement) {
     // Unhandled Promise Rejection: NotAllowedError:
     // The request is not allowed by the user agent or the platform in the current context, possibly because the user denied permission.
     // Pre-cache audio
+    // Adding load makes this work on the second click of "run"
+    audioElement.load();
     // audioElement.play();
     // audioElement.pause();
   }

--- a/apps/src/Sound.js
+++ b/apps/src/Sound.js
@@ -30,6 +30,8 @@ function isIE9() {
  */
 export default function Sound(config, audioContext) {
   this.config = config;
+  this.config.forceHTML5 = true;
+  this.config.allowHTML5Mobile = true;
   this.audioContext = audioContext;
   this.audioElement = null; // if HTML5 Audio
   this.reusableBuffer = null; // if Web Audio
@@ -97,6 +99,11 @@ Sound.prototype.play = function(options) {
     return;
   }
 
+  // If I do comment out preloading, I get the same error here when I drag the "make a new cat"
+  // block into the workspace.
+  // Oh, maybe its trying to play the click into place sound
+  // Unhandled Promise Rejection: NotAllowedError:
+  // The request is not allowed by the user agent or the platform in the current context, possibly because the user denied permission.
   var volume =
     typeof options.volume === 'undefined'
       ? 1
@@ -418,9 +425,12 @@ Sound.prototype.preloadAudioElement = function(audioElement) {
   }
 
   if (!isIE9()) {
+    // If you don't comment this out, loading in safari on iphone fails here.
+    // Unhandled Promise Rejection: NotAllowedError:
+    // The request is not allowed by the user agent or the platform in the current context, possibly because the user denied permission.
     // Pre-cache audio
-    audioElement.play();
-    audioElement.pause();
+    // audioElement.play();
+    // audioElement.pause();
   }
   this.audioElement = audioElement;
 

--- a/apps/src/Sound.js
+++ b/apps/src/Sound.js
@@ -1,3 +1,5 @@
+import DCDO from '@cdo/apps/dcdo';
+
 function isMobile() {
   return 'ontouchstart' in document.documentElement;
 }
@@ -394,9 +396,15 @@ Sound.prototype.preloadAudioElement = function(audioElement) {
     return;
   }
 
-  // iOS Safari does not automatically attempt to load the audio source,
-  // so we need to manually load.
-  audioElement.load();
+  if (!!DCDO.get('use-html5-audio-dance-party', true)) {
+    // iOS Safari does not automatically attempt to load the audio source,
+    // so we need to manually load.
+    audioElement.load();
+  } else {
+    // Pre-cache audio
+    audioElement.play();
+    audioElement.pause();
+  }
   this.audioElement = audioElement;
 
   // Fire onLoad as soon as enough of the sound is loaded to play it

--- a/apps/src/Sound.js
+++ b/apps/src/Sound.js
@@ -2,17 +2,6 @@ function isMobile() {
   return 'ontouchstart' in document.documentElement;
 }
 
-function isIE9() {
-  /** @type {number} */
-  var version = -1;
-
-  if (/MSIE\s([\d.]+)/.test(navigator.userAgent)) {
-    version = parseInt(RegExp.$1);
-  }
-
-  return version === 9;
-}
-
 /**
  * Initialize an individual sound
  * @param {Object} config available sound files for this audio
@@ -320,33 +309,21 @@ Sound.prototype.fadeToGainHtml5Audio_ = function(gain, durationSeconds) {
 };
 
 Sound.prototype.getPlayableFile = function() {
-  // IE9 Running on Windows Server SKU can throw an exception on window.Audio
-  try {
-    if (!window.Audio) {
-      return false;
-    }
+  if (!window.Audio) {
+    return false;
+  }
 
-    var audioTest = new window.Audio();
+  var audioTest = new window.Audio();
 
-    if (
-      this.config.hasOwnProperty('mp3') &&
-      audioTest.canPlayType('audio/mp3')
-    ) {
-      return this.config.mp3;
-    }
-    if (
-      this.config.hasOwnProperty('ogg') &&
-      audioTest.canPlayType('audio/ogg')
-    ) {
-      return this.config.ogg;
-    }
-    if (
-      this.config.hasOwnProperty('wav') &&
-      audioTest.canPlayType('audio/wav')
-    ) {
-      return this.config.wav;
-    }
-  } catch (e) {}
+  if (this.config.hasOwnProperty('mp3') && audioTest.canPlayType('audio/mp3')) {
+    return this.config.mp3;
+  }
+  if (this.config.hasOwnProperty('ogg') && audioTest.canPlayType('audio/ogg')) {
+    return this.config.ogg;
+  }
+  if (this.config.hasOwnProperty('wav') && audioTest.canPlayType('audio/wav')) {
+    return this.config.wav;
+  }
 
   return false;
 };
@@ -422,16 +399,9 @@ Sound.prototype.preloadAudioElement = function(audioElement) {
     return;
   }
 
-  if (!isIE9()) {
-    // If you don't comment this out, loading in safari on iphone fails here.
-    // Unhandled Promise Rejection: NotAllowedError:
-    // The request is not allowed by the user agent or the platform in the current context, possibly because the user denied permission.
-    // Pre-cache audio
-    // Adding load makes this work on the second click of "run"
-    audioElement.load();
-    // audioElement.play();
-    // audioElement.pause();
-  }
+  // iOS Safari does not automatically attempt to load the audio source,
+  // so we need to manually load.
+  audioElement.load();
   this.audioElement = audioElement;
 
   // Fire onLoad as soon as enough of the sound is loaded to play it

--- a/apps/src/Sound.js
+++ b/apps/src/Sound.js
@@ -86,11 +86,6 @@ Sound.prototype.play = function(options) {
     return;
   }
 
-  // If I do comment out preloading, I get the same error here when I drag the "make a new cat"
-  // block into the workspace.
-  // Oh, maybe its trying to play the click into place sound
-  // Unhandled Promise Rejection: NotAllowedError:
-  // The request is not allowed by the user agent or the platform in the current context, possibly because the user denied permission.
   var volume =
     typeof options.volume === 'undefined'
       ? 1

--- a/apps/src/Sound.js
+++ b/apps/src/Sound.js
@@ -308,7 +308,7 @@ Sound.prototype.getPlayableFile = function() {
     return false;
   }
 
-  var audioTest = new window.Audio();
+  const audioTest = new window.Audio();
 
   if (this.config.hasOwnProperty('mp3') && audioTest.canPlayType('audio/mp3')) {
     return this.config.mp3;
@@ -332,7 +332,7 @@ Sound.prototype.getPlayableBytes = function() {
       return false;
     }
 
-    let audioTest = new window.Audio();
+    const audioTest = new window.Audio();
     if (
       this.config.hasOwnProperty('bytes') &&
       audioTest.canPlayType('audio/mp3')

--- a/apps/src/Sound.js
+++ b/apps/src/Sound.js
@@ -30,8 +30,6 @@ function isIE9() {
  */
 export default function Sound(config, audioContext) {
   this.config = config;
-  this.config.forceHTML5 = true;
-  this.config.allowHTML5Mobile = true;
   this.audioContext = audioContext;
   this.audioElement = null; // if HTML5 Audio
   this.reusableBuffer = null; // if Web Audio

--- a/apps/src/dance/Dance.js
+++ b/apps/src/dance/Dance.js
@@ -383,6 +383,7 @@ Dance.prototype.afterInject_ = function() {
         );
         await nativeAPI.ensureSpritesAreLoaded(charactersReferenced);
       }
+      await nativeAPI.ensureSpritesAreLoaded();
       this.danceReadyPromiseResolve();
       // Log this so we can learn about how long it is taking for DanceParty to
       // load of all of its assets in the wild (will use the timeSinceLoad attribute)

--- a/apps/src/dance/Dance.js
+++ b/apps/src/dance/Dance.js
@@ -42,6 +42,7 @@ import {SongTitlesToArtistTwitterHandle} from '../code-studio/dancePartySongArti
 import firehoseClient from '@cdo/apps/lib/util/firehose';
 import {showArrowButtons} from '@cdo/apps/templates/arrowDisplayRedux';
 import queryString from 'query-string';
+import DCDO from '@cdo/apps/dcdo';
 
 const ButtonState = {
   UP: 0,
@@ -153,11 +154,13 @@ Dance.prototype.init = function(config) {
   // sprites once students hit the run button.
   // This is in place to support iOS, which will not play audio
   // if started asynchronously after fetching sprites.
-  const computeCharactersReferenced = () =>
-    this.computeCharactersReferenced(this.studioApp_.getCode());
-  this.studioApp_.addChangeHandler(() =>
-    this.nativeAPI?.ensureSpritesAreLoaded(computeCharactersReferenced())
-  );
+  if (!!DCDO.get('use-html5-audio-dance-party', true)) {
+    const computeCharactersReferenced = () =>
+      this.computeCharactersReferenced(this.studioApp_.getCode());
+    this.studioApp_.addChangeHandler(() =>
+      this.nativeAPI?.ensureSpritesAreLoaded(computeCharactersReferenced())
+    );
+  }
 
   this.awaitTimingMetrics();
 

--- a/apps/src/dance/Dance.js
+++ b/apps/src/dance/Dance.js
@@ -394,7 +394,6 @@ Dance.prototype.afterInject_ = function() {
         );
         await nativeAPI.ensureSpritesAreLoaded(charactersReferenced);
       }
-      // await nativeAPI.ensureSpritesAreLoaded();
       this.danceReadyPromiseResolve();
       // Log this so we can learn about how long it is taking for DanceParty to
       // load of all of its assets in the wild (will use the timeSinceLoad attribute)
@@ -590,13 +589,6 @@ Dance.prototype.execute = async function() {
 
   const charactersReferenced = this.initInterpreter();
 
-  // continue do ensure sprites are loaded on each run,
-  // even if we're loading them on blockly events?
-  // p5.dance.js complains if we call play before ensireSpritesAreLoaded has run
-  // but I think its mostly not doing anything if we've already loaded the images.
-  // Does provide some level of guarantee of assets being available,
-  // if eg, a student very quickly moved a block into the workspace and clicked run.
-  // might result in audio not working on iOS on this initial run, but seems better than nothing
   await this.nativeAPI.ensureSpritesAreLoaded(charactersReferenced);
 
   this.hooks.find(v => v.name === 'runUserSetup').func();

--- a/apps/src/dance/Dance.js
+++ b/apps/src/dance/Dance.js
@@ -148,16 +148,13 @@ Dance.prototype.init = function(config) {
 
   this.initSongsPromise = this.initSongs(config);
 
-  // Every time a change happens in the workspace,
-  // try to preload needed characters so we don't have to do it async
-  // when a student hits the run button.
-  // to do: optimize to only do for iOS?
-  // to do: move somewhere else?
+  // As students add new characters to their programs,
+  // load sprites asynchronously. Previously, we waited to load
+  // sprites once students hit the run button.
+  // This is in place to support iOS, which will not play audio
+  // if started asynchronously after fetching sprites.
   const computeCharactersReferenced = () =>
     this.computeCharactersReferenced(this.studioApp_.getCode());
-  // nativeAPI assigned elsewhere, so not guaranteed to exist?
-  // seems some event triggers this change handler even before any dragging into workspace
-  // (maybe init of workspace is an event?)
   this.studioApp_.addChangeHandler(() =>
     this.nativeAPI?.ensureSpritesAreLoaded(computeCharactersReferenced())
   );

--- a/apps/src/dance/songs.js
+++ b/apps/src/dance/songs.js
@@ -83,7 +83,9 @@ export function loadSong(songId, songData, onPreloadError) {
   const options = {
     id: url,
     mp3: url,
-    onPreloadError
+    onPreloadError,
+    forceHTML5: true,
+    allowHTML5Mobile: true
   };
   Sounds.getSingleton().register(options);
 }

--- a/apps/src/dance/songs.js
+++ b/apps/src/dance/songs.js
@@ -1,4 +1,5 @@
 import Sounds from '../Sounds';
+import DCDO from '@cdo/apps/dcdo';
 
 /**
  * Requests the song manifest in parallel with signed cloudfront cookies. These cookies
@@ -84,8 +85,8 @@ export function loadSong(songId, songData, onPreloadError) {
     id: url,
     mp3: url,
     onPreloadError,
-    forceHTML5: true,
-    allowHTML5Mobile: true
+    forceHTML5: !!DCDO.get('use-html5-audio-dance-party', true),
+    allowHTML5Mobile: !!DCDO.get('use-html5-audio-dance-party', true)
   };
   Sounds.getSingleton().register(options);
 }

--- a/apps/src/lib/util/audioApi.js
+++ b/apps/src/lib/util/audioApi.js
@@ -91,7 +91,8 @@ export const commands = {
     //            since we now allow students to upload and serve audio assets
     //            from our domain via the Assets API now.
     //
-    let forceHTML5 = false;
+    // Not sure if this was actually doing anything (ended up forcing HTML5 on each Sound construction
+    let forceHTML5 = true;
     if (window.location.protocol === 'file:') {
       // There is no way to make ajax requests from html on the filesystem.  So
       // the only way to play sounds is using HTML5. This scenario happens when

--- a/apps/src/lib/util/audioApi.js
+++ b/apps/src/lib/util/audioApi.js
@@ -91,8 +91,7 @@ export const commands = {
     //            since we now allow students to upload and serve audio assets
     //            from our domain via the Assets API now.
     //
-    // Not sure if this was actually doing anything (ended up forcing HTML5 on each Sound construction
-    let forceHTML5 = true;
+    let forceHTML5 = false;
     if (window.location.protocol === 'file:') {
       // There is no way to make ajax requests from html on the filesystem.  So
       // the only way to play sounds is using HTML5. This scenario happens when

--- a/lib/dynamic_config/dcdo.rb
+++ b/lib/dynamic_config/dcdo.rb
@@ -48,6 +48,7 @@ class DCDOBase < DynamicConfigBase
       'csa-skinny-banner': DCDO.get('csa-skinny-banner', false),
       'ceos-for-cs-banner': DCDO.get('ceos-for-cs-banner', false),
       'ceos-for-cs-banner-govs': DCDO.get('ceos-for-cs-banner-govs', false),
+      'use-html5-audio-dance-party': DCDO.get('use-html5-audio-dance-party', true)
     }
   end
 end


### PR DESCRIPTION
We've observed that music in Dance Party does not play if you have the mute switch toggled on (iPhone) or the mute button. Based on some research, it seems that [iOS silences Web Audio via the mute toggle](https://stackoverflow.com/questions/40789136/ios-ringer-switch-mutes-web-audio), but does not do the same for HTML5 audio.

Fix here has two short code changes-wise, but potentially impactful parts:
- **use HTML5 audio rather than the Web Audio API for playing Dance Party songs.** This change as written would apply to Dance Party across all devices -- open to feedback on whether that's a bad idea. My (not very experienced with audio) 2 cents from this work is that HTML5 audio is easier to understand than Web Audio for doing simple audio things (eg, playing a song), so I would prefer to use it when we don't need fancier features that Web Audio offers (eg, mixing)
- **change the way that we load Dance Party sprites for use in animations.** Previously, we waited to load sprites until the student hit the run button. iOS does not allow audio to play if it is being triggered asynchronously, which is what happens if we wait to load sprites until a student clicks the "run" button. Now, we load sprites any time a student adds a given sprite in their program, so that when they hit run, sprites have already been loaded. These requests only happen once per character (the p5 dance party package is smart and will only load each set of animations once -- some [more documentation in this PR](https://github.com/code-dot-org/code-dot-org/pull/26001)). A downside of this approach is that we would load sprites that may not end up being needed for execution (eg, if a student adds a block with a given sprite, then changes the sprite). This seemed like an ok tradeoff to me, but could be optimized further (eg, only do this on iOS).

As an aside, this PR also removes code in our Sound API (Sound.js) that explicitly supported IE9, which we no longer support according to our [technical requirements doc](https://support.code.org/hc/en-us/articles/202591743-Technical-requirements-for-Code-org).

## Links

- jira ticket: [STAR-2324](https://codedotorg.atlassian.net/browse/STAR-2324)

## Testing story

I've been testing manually on my iPhone (12 Mini / Chrome/Safari / iOS 15.6.1) and iPad (7th generation / Chrome/Safari / iOS 15.3.1), where I was able to repro this issue. I'm able to now play Dance Party songs consistently on both devices. I also tested manually on my laptop (M1 Macbook Pro / Chrome  / Monterey 12.5.1) that Dance Party audio continued to function as expected.

Had some manual testing done on [multiple devices/browsers here](https://docs.google.com/document/d/1iOT7LY-V8OAGL7zBDsRte3wRTawcFNpOXxLWj1Za7s0/edit). Also wrapped these changes in a flag, such that we could quickly turn it off if need be. I tested the flag locally and saw us switch back to Web Audio when it was flipped.