### PR TITLE
Lock PD Scholarships - Fall 2022

### DIFF
--- a/apps/src/code-studio/pd/components/scholarshipDropdown.jsx
+++ b/apps/src/code-studio/pd/components/scholarshipDropdown.jsx
@@ -4,7 +4,7 @@ import {FormGroup} from 'react-bootstrap';
 import Select from 'react-select';
 
 // update this to lock scholarships so that scholarship status can't be updated via the UI.
-const locked = false;
+const locked = true;
 
 export class ScholarshipDropdown extends React.Component {
   static propTypes = {

--- a/apps/test/unit/code-studio/pd/application_dashboard/detail_view_contentsTest.js
+++ b/apps/test/unit/code-studio/pd/application_dashboard/detail_view_contentsTest.js
@@ -389,7 +389,7 @@ describe('DetailViewContents', () => {
     });
   });
 
-  describe('Scholarship Teacher? row', () => {
+  xdescribe('Scholarship Teacher? row', () => {
     it('on teacher applications', () => {
       const detailView = mountDetailView('Teacher', {
         isWorkshopAdmin: true,
@@ -414,13 +414,13 @@ describe('DetailViewContents', () => {
         .last()
         .simulate('click');
 
-      // Dropdown is enabled
+      // Dropdown is still disabled
       // note: this is the scholarship dropdown which is always disabled when scholarships are locked.
       expect(
         getLastRow()
           .find('Select')
           .prop('disabled')
-      ).to.equal(false);
+      ).to.equal(true);
 
       // Click "Save"
       detailView

--- a/apps/test/unit/code-studio/pd/application_dashboard/detail_view_contentsTest.js
+++ b/apps/test/unit/code-studio/pd/application_dashboard/detail_view_contentsTest.js
@@ -389,7 +389,7 @@ describe('DetailViewContents', () => {
     });
   });
 
-  xdescribe('Scholarship Teacher? row', () => {
+  describe('Scholarship Teacher? row', () => {
     it('on teacher applications', () => {
       const detailView = mountDetailView('Teacher', {
         isWorkshopAdmin: true,


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#42540 where we unlocked them last year. Clare added locking last year in this PR: https://github.com/code-dot-org/code-dot-org/pull/42287

As part of the annual process of prepare for teacher application we lock scholarships. Locking scholarships allows us to reset the teacher application process.  We will follow up in the next couple weeks by archiving old applications and then considering how to update the teacher application for the future.

Deploy Note: This needs to be released tomorrow.