### PR TITLE
Javalab: default to test Javabuilder stack on localhost

### DIFF
--- a/config.yml.erb
+++ b/config.yml.erb
@@ -556,3 +556,10 @@ spotify_api_client_secret: !Secret
 
 # Credentials for the Open Weather API, used to provide weather data in App Labs
 open_weather_api_key: !Secret
+
+# Local Javabuilder configuration. Set 'use_localhost_javabuilder: true' to point to
+# your Javabuilder WebSocket server running on localhost.
+# Set 'local_javabuilder_stack_name: "your stack name"' to point to a deployed development
+# instance of Javabuilder. This will likely be 'javabuilder-adhoc-your_branch_name'
+use_localhost_javabuilder:
+local_javabuilder_stack_name:

--- a/lib/cdo.rb
+++ b/lib/cdo.rb
@@ -137,9 +137,14 @@ module Cdo
         # DNS record that redirects requests to localhost. Javabuilder, as a
         # separate service, uses a different port. Therefore, we can access the
         # the service directly.
-        # To use a developer instance of Javabuilder instead, replace this url with
-        # 'wss://<your-javabuilder-domain>.dev-code.org'
-        'ws://localhost:8080/javabuilder'
+        # On localhost, we default to using the "test" Javabuilder stack. To point
+        # to your Javabuilder WebSocket server running on localhost, set
+        # 'use_localhost_javabuilder: true' in your locals.yml. To point to a
+        # deployed development instance of Javabuilder, set
+        # 'local_javabuilder_stack_name: "your stack name"' in your locals.yml.
+        return 'ws://localhost:8080/javabuilder' if CDO.use_localhost_javabuilder
+        stack_name = CDO.local_javabuilder_stack_name || 'javabuilder-test'
+        "wss://#{stack_name}.code.org"
       else
         # TODO: change the default to javabuilder once we have switched over
         DCDO.get("javabuilder_websocket_url", 'wss://javabuilderbeta.code.org')
@@ -148,9 +153,14 @@ module Cdo
 
     def javabuilder_upload_url(path = '', scheme = '')
       if rack_env?(:development)
-        # To use a developer instance of Javabuilder instead, replace this url with
-        # 'https://<your-javabuilder-domain>-http.dev-code.org/seedsources/sources.json'
-        'http://localhost:8080/javabuilderfiles/seedsources'
+        # On localhost, we default to using the "test" Javabuilder stack. To point
+        # to your Javabuilder WebSocket server running on localhost, set
+        # 'use_localhost_javabuilder: true' in your locals.yml. To point to a
+        # deployed development instance of Javabuilder, set
+        # 'local_javabuilder_stack_name: "your stack name"' in your locals.yml.
+        return 'http://localhost:8080/javabuilderfiles/seedsources' if CDO.use_localhost_javabuilder
+        stack_name = CDO.local_javabuilder_stack_name || 'javabuilder-test'
+        "https://#{stack_name}-http.code.org/seedsources/sources.json"
       else
         # TODO: change the default to javabuilder once we have switched over
         http_url = DCDO.get("javabuilder_http_url", 'https://javabuilderbeta-http.code.org')

--- a/locals.yml.default
+++ b/locals.yml.default
@@ -124,3 +124,10 @@ use_my_apps: true
 # imm_reader_client_id:     ''
 # imm_reader_client_secret: ''
 # imm_reader_subdomain:     'cdo-immersive-reader-staging'
+
+# Local Javabuilder configuration. Set 'use_localhost_javabuilder: true' to point to
+# your Javabuilder WebSocket server running on localhost.
+# Set 'local_javabuilder_stack_name: "your stack name"' to point to a deployed development
+# instance of Javabuilder. This will likely be 'javabuilder-adhoc-your_branch_name'
+# use_localhost_javabuilder:
+# local_javabuilder_stack_name:


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Quick config change to make working with Javalab easier locally. With this, Javalab will point the `javabuilder-test` stack on localhost by default, so that developers don't need to spin up localhost Javabuilder or manually override the URL in cdo.rb. Developers can set the `use_localhost_javabuilder` flag in locals.yml to instead point to localhost Javabuilder, or set `local_javabuilder_stack_name` to point to a deployed dev instance of Javabuilder.

I'll also bump up the limits on the javabuilder-test configuration separately so we don't run into execution limits too easily (PR [here](https://github.com/code-dot-org/javabuilder/pull/359)).

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Tested locally, using all three configurations (default using test stack, using localhost javabuilder, point to dev stack).

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
