### PR TITLE
Fix Course-E level with field elements

### DIFF
--- a/dashboard/config/scripts/levels/courseE_artist_functions52022.level
+++ b/dashboard/config/scripts/levels/courseE_artist_functions52022.level
@@ -88,29 +88,29 @@
         </block>
         <block type="procedures_defnoreturn" movable="false" editable="false" y="300">
           <mutation/>
-          <field name="NAME">draw a star</field>
+          <title name="NAME">draw a star</title>
           <statement name="STACK">
             <block type="draw_colour" id="draw-color" movable="false" editable="false">
               <value name="COLOUR">
                 <block type="colour_picker">
-                  <field name="COLOUR">#ffffff</field>
+                  <title name="COLOUR">#ffffff</title>
                 </block>
               </value>
               <next>
                 <block type="controls_repeat" movable="false" editable="false">
-                  <field name="TIMES">8</field>
+                  <title name="TIMES">8</title>
                   <statement name="DO">
                     <block type="draw_move_by_constant" movable="false" editable="false">
-                      <field name="DIR">moveForward</field>
-                      <field name="VALUE">25</field>
+                      <title name="DIR">moveForward</title>
+                      <title name="VALUE">25</title>
                       <next>
                         <block type="draw_move_by_constant" movable="false" editable="false">
-                          <field name="DIR">moveBackward</field>
-                          <field name="VALUE">25</field>
+                          <title name="DIR">moveBackward</title>
+                          <title name="VALUE">25</title>
                           <next>
                             <block type="draw_turn_by_constant" movable="false" editable="false">
-                              <field name="DIR">turnRight</field>
-                              <field name="VALUE">45</field>
+                              <title name="DIR">turnRight</title>
+                              <title name="VALUE">45</title>
                             </block>
                           </next>
                         </block>


### PR DESCRIPTION
**What:** Replaced all of the `field` elements within the `procedures_defnoreturn` block with `title` elements

**Why:** The sync-in was failing because the proper element type for this type of block is `title`.

## Links

[Slack thread](https://codedotorg.slack.com/archives/CFTFD6BPV/p1661872923277679)

## Testing story

Locally reseeded the level and was able to complete the level.
Locally ran the sync-in with no issue.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
