### PR TITLE
Make neighborhood paint test more reliable

### DIFF
--- a/dashboard/test/ui/features/javalab/neighborhood.feature
+++ b/dashboard/test/ui/features/javalab/neighborhood.feature
@@ -12,7 +12,8 @@ Feature: NeighborhoodPainting
     Then I set slider speed to fast
     And I see no difference for "initial page load" using stitch mode "none"
     Then I press "runButton"
-    And I wait for 15 seconds
+    And I wait until element ".javalab-console" contains text "[JAVALAB] Starting painter."
+    And I wait for 7 seconds
     And I see no difference for "paint glomming" using stitch mode "none"
     Then I close my eyes
 


### PR DESCRIPTION
We previously had "wait 15 seconds" after pressing the run button to check the neighborhood paint output, but this was sometimes not long enough. I've updated this to first wait until we see the "starting painter" message, then wait 7 seconds for the painter to paint. On my machine it takes around 4 seconds for the painter to paint everything, so I added a buffer to that time.

## Links

- Jira: [JAVA-677](https://codedotorg.atlassian.net/browse/JAVA-677)


## Testing story
Tested locally that the test passes.

