### PR TITLE
Do not show 'not allowed' overlay when dragging shadow blocks to trash can

### DIFF
--- a/apps/src/blockly/addons/cdoTrashcan.js
+++ b/apps/src/blockly/addons/cdoTrashcan.js
@@ -188,8 +188,12 @@ export default class CdoTrashcan extends GoogleBlockly.DeleteArea {
 
       this.container.style.visibility = trashcanVisibility;
 
-      const isDeletable = blocklyEvent.blocks.every(block =>
-        block.isDeletable()
+      // Shadow blocks can/should be successfully deleted
+      // when dragged in conjunction with another deletable block;
+      // however, isDeletable() returns false for shadow blocks,
+      // so we manually override here.
+      const isDeletable = blocklyEvent.blocks.every(
+        block => block.isDeletable() || block.isShadow()
       );
       if (trashcanVisibility === 'visible' && !isDeletable) {
         this.notAllowed_.style.visibility = 'visible';


### PR DESCRIPTION
We were showing the "not allowed" overlay (think "no smoking") over the trash can when dragging ["shadow blocks"](https://developers.google.com/blockly/guides/configure/web/toolbox#shadow_blocks) to the trash on Google Blockly levels, despite them actually being deletable. This change no longer shows that overlay for shadow blocks.

**Before**

![image](https://user-images.githubusercontent.com/25372625/187797084-c35e698e-cdd7-4cec-9b4f-a7c4b3eb1fba.png)

**After**

![image](https://user-images.githubusercontent.com/25372625/187797577-0516ebcf-7434-47e4-8530-bd63217feb93.png)

## Links

- jira ticket: [STAR-2307](https://codedotorg.atlassian.net/browse/STAR-2307)

## Testing story

I tested manually on Poem Art (/s/poem-art-2021/lessons/1/levels/1), using Google Blockly. My understanding of the wrapping that we're doing for Google vs. Cdo Blockly is that this code only gets consumed by Google Blockly, is that right?

I don't know what the other uses of shadow blocks are -- are there other cases I should test? I also don't see any unit for the cdoTrashcan file.