### PR TITLE
Revert "Revert "Javalab: Run correct code in preview mode""

### DIFF
--- a/apps/src/javalab/Javalab.js
+++ b/apps/src/javalab/Javalab.js
@@ -388,7 +388,13 @@ Javalab.prototype.executeJavabuilder = function(executionType) {
   );
 
   let connectToJavabuilder;
-  if (this.isEditingExemplar || this.isViewingExemplar) {
+  // If in exemplar or preview mode, use the sources currently on the page
+  // (as opposed to the sources saved on the backend).
+  if (
+    this.isEditingExemplar ||
+    this.isViewingExemplar ||
+    getStore().getState().pageConstants.isReadOnlyWorkspace
+  ) {
     const overrideSources = getSources(getStore().getState());
     connectToJavabuilder = () =>
       this.javabuilderConnection.connectJavabuilderWithOverrideSources(

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -439,14 +439,13 @@ class Ability
       # These checks control access to Javabuilder.
       # All verified instructors and can generate a Javabuilder session token to run Java code.
       # Students who are also assigned to a CSA section with a verified instructor can run Java code.
-      # Verified instructors can access and run Java Lab exemplars.
-      # Levelbuilders can access and update Java Lab validation code.
-      can :get_access_token, :javabuilder_session do
+      # The get_access_token endpoint is used for normal execution, and the access_token_with_override_sources
+      # is used when viewing another version of a student's project (in preview or Code Review mode).
+      # It is also used for running exemplars, but only teachers can access exemplars.
+      # Levelbuilders can access and update Java Lab validation code (using the
+      # access_token_with_override_validation endpoint).
+      can [:get_access_token, :access_token_with_override_sources], :javabuilder_session do
         user.verified_instructor? || user.sections_as_student.any? {|s| s.assigned_csa? && s.teacher&.verified_instructor?}
-      end
-
-      can :access_token_with_override_sources, :javabuilder_session do
-        user.verified_instructor?
       end
 
       can :access_token_with_override_validation, :javabuilder_session do


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Redo of https://github.com/code-dot-org/code-dot-org/pull/47856. The initial change missed modifying permissions to authorize students to access the access_token_with_override_sources endpoint, which we now use for preview mode.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Tested locally. I was having issues with running UI tests on saucelabs locally, but I manually repro'd the issue using a student account in a code review section, and confirmed that code ran successfully after updating the permissions.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
