### PR TITLE
Revert "Turn course family validation back on"

### DIFF
--- a/dashboard/app/models/concerns/curriculum/course_types.rb
+++ b/dashboard/app/models/concerns/curriculum/course_types.rb
@@ -15,7 +15,8 @@ module Curriculum::CourseTypes
     validates :participant_audience, acceptance: {accept: Curriculum::SharedCourseConstants::PARTICIPANT_AUDIENCE.to_h.values, message: 'must be facilitator, teacher, or student'}
 
     validate :cannot_have_same_audiences
-    validate :must_have_same_course_type_as_family
+    # (Dani) Turning off this validation while I move over K5 self paced pl to the right audience
+    # validate :must_have_same_course_type_as_family
   end
 
   # All courses in the same family name must have the save instruction_type, instructor_audience, and participant audience

--- a/dashboard/test/lib/services/script_seed_test.rb
+++ b/dashboard/test/lib/services/script_seed_test.rb
@@ -89,7 +89,8 @@ module Services
       # this is slower for most individual Scripts, but there could be a savings when seeding multiple Scripts.
       # For now, leaving this as a potential future optimization, since it seems to be reasonably fast as is.
       # The game queries can probably be avoided with a little work, though they only apply for Blockly levels.
-      assert_queries(87) do
+      # (Dani) This will go back up by one when we turn the validation of families sharing course type back on
+      assert_queries(86) do
         ScriptSeed.seed_from_json(json)
       end
 

--- a/dashboard/test/models/concerns/curriculum/course_types_test.rb
+++ b/dashboard/test/models/concerns/curriculum/course_types_test.rb
@@ -239,32 +239,33 @@ class CourseTypesTests < ActiveSupport::TestCase
     assert_equal unit_without_family_name.get_family_courses, nil
   end
 
-  test 'should raise error if instruction type does not match rest of course family' do
-    error = assert_raises do
-      @unit_group_2.instruction_type = Curriculum::SharedCourseConstants::INSTRUCTION_TYPE.self_paced
-      @unit_group_2.save!
-    end
-
-    assert_includes error.message, 'Instruction type must be the same for all courses in a family.'
-  end
-
-  test 'should raise error if instructor audience does not match rest of course family' do
-    error = assert_raises do
-      @unit_group_2.instructor_audience = Curriculum::SharedCourseConstants::INSTRUCTOR_AUDIENCE.facilitator
-      @unit_group_2.save!
-    end
-
-    assert_includes error.message, 'Instructor audience must be the same for all courses in a family.'
-  end
-
-  test 'should raise error if participant audience does not match rest of course family' do
-    error = assert_raises do
-      @unit_group_2.participant_audience = Curriculum::SharedCourseConstants::PARTICIPANT_AUDIENCE.facilitator
-      @unit_group_2.save!
-    end
-
-    assert_includes error.message, 'Participant audience must be the same for all courses in a family.'
-  end
+  # (Dani) Commenting out while we turn the validation off to update the audience on some courses
+  # test 'should raise error if instruction type does not match rest of course family' do
+  #   error = assert_raises do
+  #     @unit_group_2.instruction_type = Curriculum::SharedCourseConstants::INSTRUCTION_TYPE.self_paced
+  #     @unit_group_2.save!
+  #   end
+  #
+  #   assert_includes error.message, 'Instruction type must be the same for all courses in a family.'
+  # end
+  #
+  # test 'should raise error if instructor audience does not match rest of course family' do
+  #   error = assert_raises do
+  #     @unit_group_2.instructor_audience = Curriculum::SharedCourseConstants::INSTRUCTOR_AUDIENCE.facilitator
+  #     @unit_group_2.save!
+  #   end
+  #
+  #   assert_includes error.message, 'Instructor audience must be the same for all courses in a family.'
+  # end
+  #
+  # test 'should raise error if participant audience does not match rest of course family' do
+  #   error = assert_raises do
+  #     @unit_group_2.participant_audience = Curriculum::SharedCourseConstants::PARTICIPANT_AUDIENCE.facilitator
+  #     @unit_group_2.save!
+  #   end
+  #
+  #   assert_includes error.message, 'Participant audience must be the same for all courses in a family.'
+  # end
 
   test 'should not raise error when changing course type values for a course that is the only one in its family' do
     solo_unit_in_family_name = create :script, name: 'solo-family-name', family_name: 'solo-family-name'


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#47845

Production deploy failed due to validation that looks related to this -- more [detail in this Slack thread](https://codedotorg.slack.com/archives/C0T0PNTM3/p1662069245405339).