### PR TITLE
remove unused methods from pegasus dashboard user

### DIFF
--- a/pegasus/helper_modules/dashboard.rb
+++ b/pegasus/helper_modules/dashboard.rb
@@ -48,20 +48,5 @@ module Dashboard
     def to_hash
       @row.to_hash
     end
-
-    # @returns [Hash] containing all the requested keys
-    def select(*keys)
-      {}.tap do |result|
-        keys.each do |key|
-          result[key] = if @row.key? key
-                          @row[key]
-                        elsif respond_to? key
-                          send(key)
-                        else
-                          nil
-                        end
-        end
-      end
-    end
   end
 end

--- a/pegasus/helper_modules/dashboard.rb
+++ b/pegasus/helper_modules/dashboard.rb
@@ -10,10 +10,6 @@ module Dashboard
     DASHBOARD_DB
   end
 
-  def self.db_reporting_reader
-    DASHBOARD_REPORTING_DB_READER
-  end
-
   def self.admin?(user_id)
     !!db[:users][id: user_id, admin: true]
   end
@@ -34,15 +30,6 @@ module Dashboard
       Dashboard::User.new(row)
     end
 
-    # Retrieves the indicated user from the database, ignoring soft-deletes.
-    # @returns [User] for given user_id, or nil if not found in database
-    def self.get_with_deleted(user_id)
-      return nil if user_id.nil?
-      row = Dashboard.db[:users].where(id: user_id).first
-      return nil unless row
-      Dashboard::User.new(row)
-    end
-
     def id
       @row[:id]
     end
@@ -55,17 +42,6 @@ module Dashboard
     # @returns [Boolean] true if user is a teacher
     def teacher?
       @row[:user_type] == 'teacher'
-    end
-
-    # @param [String|Symbol] permission
-    # @returns [Boolean] true if user has the named permission
-    def has_permission?(permission)
-      permission = permission.to_s.strip.downcase
-      case permission
-      when 'admin' then admin?
-      when 'teacher' then teacher?
-      else !!Dashboard.db[:user_permissions][user_id: id, permission: permission]
-      end
     end
 
     # @returns [Hash] dashboard DB row for this user as a hash
@@ -86,37 +62,6 @@ module Dashboard
                         end
         end
       end
-    end
-
-    # @param other_user_ids [Array[Integer]] the user IDs to check.
-    # @return [Array[Integer]] the subset of other_user_ids that are followeds
-    #   of the user encapsulated by this class.
-    def get_followed_bys(other_user_ids)
-      Dashboard.db[:sections].
-        join(:followers, section_id: :sections__id).
-        join(:users, id: :followers__student_user_id).
-        where(sections__user_id: id, sections__deleted_at: nil).
-        where(followers__student_user_id: other_user_ids, followers__deleted_at: nil).
-        where(users__deleted_at: nil).
-        select_map(:followers__student_user_id)
-    end
-
-    # @param other_user_id [Integer] the user ID to check.
-    # @return [Boolean] whether other_user_id is a followed of the user
-    #   encapsulated by this class.
-    def followed_by?(other_user_id)
-      Dashboard.db[:sections].
-        join(:followers, section_id: :sections__id).
-        join(:users, id: :followers__student_user_id).
-        where(sections__user_id: id, sections__deleted_at: nil).
-        where(followers__student_user_id: other_user_id, followers__deleted_at: nil).
-        where(users__deleted_at: nil).
-        any?
-    end
-
-    def owned_sections
-      Dashboard.db[:sections].
-        select(:id).where(user_id: id, deleted_at: nil).all
     end
   end
 end

--- a/pegasus/helpers.rb
+++ b/pegasus/helpers.rb
@@ -60,11 +60,6 @@ def form_error!(e)
   halt(400, {'Content-Type' => 'text/json'}, e.errors.to_json)
 end
 
-def have_permission?(permission)
-  return false unless dashboard_user_helper
-  dashboard_user_helper.has_permission?(permission)
-end
-
 def no_content!
   halt(204, "No content\n")
 end

--- a/pegasus/test/test_dashboard.rb
+++ b/pegasus/test/test_dashboard.rb
@@ -12,8 +12,6 @@ class DashboardTest < Minitest::Test
       @deleted_student = Dashboard::User.
         get(FakeDashboard::STUDENT_DELETED[:id])
       @teacher = Dashboard::User.get(FakeDashboard::TEACHER[:id])
-      @admin = Dashboard::User.get(FakeDashboard::ADMIN[:id])
-      @facilitator = Dashboard::User.get(FakeDashboard::FACILITATOR[:id])
     end
 
     describe 'to_hash' do
@@ -33,28 +31,6 @@ class DashboardTest < Minitest::Test
           @student.select(:name, :admin)
         )
       end
-
-      it 'can add getter methods to requested hash' do
-        assert_equal(
-          {
-            name: FakeDashboard::STUDENT[:name],
-            owned_sections: []
-          },
-          @student.select(:name, :owned_sections)
-        )
-
-        assert_equal(
-          {
-            name: FakeDashboard::TEACHER[:name],
-            owned_sections: [
-              {id: FakeDashboard::TEACHER_SECTIONS[0][:id]},
-              {id: FakeDashboard::TEACHER_SECTIONS[1][:id]},
-              {id: FakeDashboard::TEACHER_SECTIONS[5][:id]}
-            ]
-          },
-          @teacher.select(:name, :owned_sections)
-        )
-      end
     end
 
     describe 'get' do
@@ -64,116 +40,6 @@ class DashboardTest < Minitest::Test
 
       it 'does not return deleted students' do
         assert_nil @deleted_student
-      end
-    end
-
-    describe 'has_permission?' do
-      it 'admins have "admin" permission' do
-        refute @student.has_permission? 'admin'
-        refute @teacher.has_permission? 'admin'
-        assert @admin.has_permission? 'admin'
-      end
-
-      it 'accepts various forms of "admin"' do
-        assert @admin.has_permission? 'Admin'
-        assert @admin.has_permission? 'ADMIN'
-        assert @admin.has_permission? ' admin '
-        assert @admin.has_permission? :admin
-      end
-
-      it 'teachers have "teacher" permission' do
-        refute @student.has_permission? 'teacher'
-        assert @teacher.has_permission? 'teacher'
-        assert @admin.has_permission? 'teacher' # this user happens to be a teacher too
-      end
-
-      it 'accepts various forms of "teacher"' do
-        assert @teacher.has_permission? 'Teacher'
-        assert @teacher.has_permission? 'TEACHER'
-        assert @teacher.has_permission? ' teacher '
-        assert @teacher.has_permission? :teacher
-      end
-
-      it 'gets other permissions from the database' do
-        refute @student.has_permission? 'facilitator'
-        refute @teacher.has_permission? 'facilitator'
-        refute @admin.has_permission? 'facilitator'
-        assert @facilitator.has_permission? 'facilitator'
-      end
-
-      it 'accepts various forms of other permissions' do
-        assert @facilitator.has_permission? 'Facilitator'
-        assert @facilitator.has_permission? 'FACILITATOR'
-        assert @facilitator.has_permission? ' facilitator '
-        assert @facilitator.has_permission? :facilitator
-      end
-    end
-
-    describe 'followed_by?' do
-      it 'returns true when appropriate' do
-        assert @teacher.followed_by?(@student.id)
-      end
-
-      it 'returns false when appropriate' do
-        assert !@admin.followed_by?(@student.id)
-      end
-
-      it 'ignores deleted sections' do
-        teacher_deleted_section = Dashboard::User.get(FakeDashboard::TEACHER_DELETED_SECTION[:id])
-        refute teacher_deleted_section.followed_by?(FakeDashboard::STUDENT_DELETED_SECTION[:id])
-      end
-
-      it 'ignores deleted followers' do
-        teacher_deleted_follower = Dashboard::User.get(FakeDashboard::TEACHER_DELETED_FOLLOWER[:id])
-        refute teacher_deleted_follower.followed_by?(FakeDashboard::STUDENT_DELETED_FOLLOWER[:id])
-      end
-
-      it 'ignores deleted students' do
-        teacher_deleted_user = Dashboard::User.get(FakeDashboard::TEACHER_DELETED_USER[:id])
-        refute teacher_deleted_user.followed_by?(FakeDashboard::STUDENT_DELETED[:id])
-      end
-    end
-
-    describe 'get_followed_bys' do
-      it 'returns an appropriate subarray' do
-        assert_equal [@student.id],
-          @teacher.get_followed_bys([@admin.id, @student.id, @teacher.id])
-      end
-
-      it 'ignores_deleted_sections' do
-        teacher_deleted_section = Dashboard::User.get(FakeDashboard::TEACHER_DELETED_SECTION[:id])
-        assert_equal [],
-          teacher_deleted_section.get_followed_bys([FakeDashboard::STUDENT_DELETED_SECTION[:id]])
-      end
-
-      it 'ignores deleted followers' do
-        teacher_deleted_follower = Dashboard::User.get(FakeDashboard::TEACHER_DELETED_FOLLOWER[:id])
-        assert_equal [],
-          teacher_deleted_follower.get_followed_bys([FakeDashboard::STUDENT_DELETED_FOLLOWER[:id]])
-      end
-
-      it 'ignores deleted students' do
-        teacher_deleted_user = Dashboard::User.get(FakeDashboard::TEACHER_DELETED_USER[:id])
-        assert_equal [],
-          teacher_deleted_user.get_followed_bys([FakeDashboard::STUDENT_DELETED[:id]])
-      end
-    end
-
-    describe 'owned_sections' do
-      it 'returns no sections for a student' do
-        assert_equal 0, @student.owned_sections.count
-      end
-
-      it 'returns sections for a teacher' do
-        sections = @teacher.owned_sections
-        assert_equal 3, sections.size
-        assert_equal [{id: 150001}, {id: 150002}, {id: 150006}], sections
-      end
-
-      it 'does not return deleted sections' do
-        teacher_deleted_section = Dashboard::User.get(FakeDashboard::TEACHER_DELETED_SECTION[:id])
-        sections = teacher_deleted_section.owned_sections
-        assert_equal 0, sections.size
       end
     end
   end

--- a/pegasus/test/test_dashboard.rb
+++ b/pegasus/test/test_dashboard.rb
@@ -21,18 +21,6 @@ class DashboardTest < Minitest::Test
       end
     end
 
-    describe 'select' do
-      it 'returns only requested keys when arguments are given' do
-        assert_equal(
-          {
-            name: FakeDashboard::STUDENT[:name],
-            admin: FakeDashboard::STUDENT[:admin]
-          },
-          @student.select(:name, :admin)
-        )
-      end
-    end
-
     describe 'get' do
       it 'does return students' do
         assert @student


### PR DESCRIPTION
removes some unused codepaths which were accessing DASHBOARD_DB from within pegasus. these turned up while i was sizing up remaining work for the pegasus swarm: https://docs.google.com/spreadsheets/d/1-qAM-vMnc5PZXIJSiIArZGGWTQTiDbepQUXR5ZBxvB4/edit#gid=1537638748

Part of this PR depends on https://github.com/code-dot-org/code-dot-org/pull/47908, because that PR removed the last calls to `select` and `owned_sections`. 

## Testing story

existing test coverage