### PR TITLE
Make code review scenarios an eyes test

### DIFF
--- a/dashboard/test/ui/features/javalab/code_review_scenarios.feature
+++ b/dashboard/test/ui/features/javalab/code_review_scenarios.feature
@@ -1,9 +1,11 @@
 @no_mobile
-# @eyes
+@eyes
 Feature: Code review V2
 
+  # Note: this test does not cover adding comments to the review because the slate text editor
+  # does not work with automated testing.
   Scenario: Code review V2
-    # When I open my eyes to test "Javalab Code Review V2"
+   When I open my eyes to test "Javalab Code Review V2"
     Given I set up code review for teacher "Code Review Teacher" with 2 students in a group
     And I sign out using jquery
 
@@ -34,28 +36,23 @@ Feature: Code review V2
     And I am on "http://studio.code.org/s/allthethings/lessons/44/levels/2?noautoplay=true"
     And I load the review tab
     And I load the code review for peer number 1 in the list
-    # TODO: This test is flakey due to issues with writing text in slateJS editor, commenting out to unblock
-    # And I write a code review v2 comment with text "Great work!"
-    # Then I see no difference for "student code reviewing peer" using stitch mode "none"
+    Then I see no difference for "student code reviewing peer" using stitch mode "none"
     And I sign out using jquery
 
-    # Log in as the teacher and review the student
+    # Log in as the teacher and look at the student's review
     Given I sign in as "Code Review Teacher"
     And I am on "http://studio.code.org/s/allthethings/lessons/44/levels/2?noautoplay=true"
     And I load student number 1's project from the blue teacher panel
     And I load the review tab
-    # TODO: This test is flakey due to issues with writing text in slateJS editor, commenting out to unblock
-    # And I write a code review v2 comment with text "A comment from your teacher"
-    # Then I see no difference for "teacher code reviewing student" using stitch mode "none"
+    Then I see no difference for "teacher code reviewing student" using stitch mode "none"
     And I sign out using jquery
 
     # Log in as code review owner and close the code review
     Given I sign in as "student_0"
     And I am on "http://studio.code.org/s/allthethings/lessons/44/levels/2?noautoplay=true"
     And I load the review tab
-    # And I wait until element ".code-review-comment-body" is visible
-    # Then I see no difference for "student viewing own code review" using stitch mode "none"
+    Then I see no difference for "student viewing own code review" using stitch mode "none"
     And I press ".uitest-close-code-review" using jQuery
     And I wait until element ".uitest-open-code-review" is visible
-    # And I close my eyes
+    And I close my eyes
 

--- a/dashboard/test/ui/features/javalab/code_review_scenarios.feature
+++ b/dashboard/test/ui/features/javalab/code_review_scenarios.feature
@@ -5,7 +5,7 @@ Feature: Code review V2
   # Note: this test does not cover adding comments to the review because the slate text editor
   # does not work with automated testing.
   Scenario: Code review V2
-   When I open my eyes to test "Javalab Code Review V2"
+    When I open my eyes to test "Javalab Code Review V2"
     Given I set up code review for teacher "Code Review Teacher" with 2 students in a group
     And I sign out using jquery
 

--- a/dashboard/test/ui/features/step_definitions/top_instructions.rb
+++ b/dashboard/test/ui/features/step_definitions/top_instructions.rb
@@ -28,17 +28,6 @@ Given /^I load the review tab$/ do
   STEPS
 end
 
-Given /^I write a code review v2 comment with text "([^"]*)"$/ do |text|
-  steps <<-STEPS
-     And I press ".editable-text-area" using jQuery
-     And I wait for 2 seconds
-     And I press keys "#{text}" for element ".editable-text-area"
-     And element ".editable-text-area" contains text "#{text}"
-     And I press ".code-review-comment-submit" using jQuery
-     And I wait until element ".code-review-comment-body" is visible
-  STEPS
-end
-
 Given /^I load the code review for peer number (.*) in the list$/ do |number|
   steps <<-STEPS
    And I load the review tab


### PR DESCRIPTION
Make the code review scenarios test an eyes test again. After investigation by multiple engineers we couldn't figure out how to get the slate text editor to be automated, so these tests don't include the writing of comments. However, it will eyes test the basic timeline without comments.

## Links

- jira ticket: [JAVA-646](https://codedotorg.atlassian.net/browse/JAVA-646)

## Testing story
Tested on a saucelabs tunnel for Firefox, Chrome and Safari and tests passed.
