### PR TITLE
Add dashboard_legacy directory to watched files list when running dashboard-server

### DIFF
--- a/bin/dashboard-server
+++ b/bin/dashboard-server
@@ -4,7 +4,7 @@ require_relative '../deployment'
 # Any arguments to bin/dashboard-server will get passed through to the rerun command, for example -b to run in background,
 # which allows for pry debugging.
 def main
-  dirs = [deploy_dir('lib'), deploy_dir('shared/middleware')]
+  dirs = [deploy_dir('lib'), deploy_dir('shared/middleware'), deploy_dir('dashboard_legacy')]
   dirs += [pegasus_dir] if CDO.dashboard_enable_pegasus
   rerun = "rerun -p '**/*.{rb,ru,yml}' -d '#{dirs.join(',')}' -i '**/migrations/*.rb' -i 'test/**/*.rb' #{ARGV.join(' ')} --"
   pids = []


### PR DESCRIPTION
I was working on some changes to `files_api.rb` and wondering why I wasn't seeing my changes and realized that, in the past, `dashboard-server` restarted when those files were changed. Looks like `dashboard_legacy` wasn't in the list of watched files so adding it here.

Now when `dashboard-server` is run the top output is:
```
08:57:01 [rerun] Dashboard launched
08:57:01 [rerun] Rerun (39114) running Dashboard (39119)
2022-09-02 08:57:02 -0400 Using rack adapter
08:57:03 [rerun] Watching /Users/bethanyconnor/work-code/code-dot-org/lib, /Users/bethanyconnor/work-code/code-dot-org/shared/middleware, /Users/bethanyconnor/work-code/code-dot-org/dashboard_legacy, /Users/bethanyconnor/work-code/code-dot-org/pegasus for **/*.{rb,ru,yml} (ignoring **/migrations/*.rb,test/**/*.rb) with Polling adapter
```

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
