### PR TITLE
temporarily disable lint warnings in files api

### DIFF
--- a/dashboard/legacy/test/middleware/files_api_test_base.rb
+++ b/dashboard/legacy/test/middleware/files_api_test_base.rb
@@ -96,6 +96,7 @@ class FilesApiTestBase < Minitest::Test
     assert_equal expected, actual
   end
 
+  # rubocop:disable Rails/Delegate
   def successful?
     last_response.successful?
   end
@@ -107,6 +108,7 @@ class FilesApiTestBase < Minitest::Test
   def not_found?
     last_response.not_found?
   end
+  # rubocop:enable Rails/Delegate
 
   def conflict?
     last_response.status == 409


### PR DESCRIPTION
Moving some code from shared to dashboard caused some lint errors to start blocking the staging build. this PR temporarily disables those lint warnings.

## Testing story

`rubocop` now passing locally