### PR TITLE
exclude dashboard legacy from rubocop rails rules

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,6 +20,8 @@ Rails:
   Enabled: true
   Include:
     - dashboard/**/* # only run Rails cops on Rails-specific code
+  Exclude:
+    - dashboard/legacy/**/*
 
 # BEGIN CODE.ORG OVERRIDES
 


### PR DESCRIPTION


Moving some code into dashboard/legacy in https://github.com/code-dot-org/code-dot-org/pull/47931 caused some lint errors to start blocking the staging build, because rubocop Rails rules started being applied. This PR fixes that be excluding dashboard/legacy from the Rails rubocop rules. See https://github.com/code-dot-org/code-dot-org/blob/9c382db74241bea146458cf77147dea2730f424a/dashboard/legacy/README.md for why this makes sense -- this code is part of dashboard but not yet fully part of rails.

## Testing story

rubocop now passing locally
