### PR TITLE
hoc2022: keep the hourofcode.com/learn header same for pre-hoc

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/public/learn/index.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/learn/index.haml
@@ -59,7 +59,7 @@ social:
     vertical-align: top;
   }
 
-- unless ["soon-hoc", "actual-hoc", "post-hoc"].include?(hoc_mode)
+- unless ["pre-hoc", "soon-hoc", "actual-hoc", "post-hoc"].include?(hoc_mode)
   :css
     @media screen and (min-width: 992px) {
       #fullwidth {
@@ -87,7 +87,7 @@ social:
   = view :header
 
 
-  - if ["soon-hoc", "actual-hoc", "post-hoc"].include?(hoc_mode)
+  - if ["pre-hoc", "soon-hoc", "actual-hoc", "post-hoc"].include?(hoc_mode)
     .banner.container{style: "color: black; display: flex"}
       .col-sm-4.hidden-xs{style: "align-items: stretch; background-image: url(/shared/images/fit-1200/hoc-cse-left-fade.png); background-position: 100% 50%; background-size: contain; background-repeat: no-repeat"}
       .col-sm-4.col-xs-12{style: "text-align: center"}


### PR DESCRIPTION
Let's keep the existing https://hourofcode.com/learn background, rather than flipping to an old theme, for the switch to `hoc_mode` of `"pre-hoc"`.

Similar to https://github.com/code-dot-org/code-dot-org/pull/47956.
