### PR TITLE
Google Blockly: place trashcan correctly in RTL languages

### DIFF
--- a/apps/src/blockly/addons/cdoTrashcan.js
+++ b/apps/src/blockly/addons/cdoTrashcan.js
@@ -56,10 +56,18 @@ export default class CdoTrashcan extends GoogleBlockly.DeleteArea {
       {class: 'blocklyTrash'},
       this.container
     );
-    const left = Blockly.cdoUtils.getToolboxWidth() / 2 - WIDTH / 2;
+    // const left = Blockly.cdoUtils.getToolboxWidth() / 2 - WIDTH / 2;
+    // parent svg is still being rendered on the left, so not being rendered properly
+    // also doesn't seem to handle resize well
+    // but, trash can does seem like its in the middle of the flyout (not vislble though), which is good
+    // found it by searching "trash" in DOM
+    // const left = Blockly.cdoUtils.getToolboxWidth() / 2 - WIDTH / 2;
+    const offset =
+      Blockly.cdoUtils.getWidth() -
+      (Blockly.cdoUtils.getToolboxWidth() / 2 + WIDTH / 2);
     this.svgGroup_.setAttribute(
       'transform',
-      `translate(${left}, ${MARGIN_TOP})`
+      `translate(${offset}, ${MARGIN_TOP})`
     );
 
     // trashcan body

--- a/apps/src/blockly/addons/cdoTrashcan.js
+++ b/apps/src/blockly/addons/cdoTrashcan.js
@@ -56,18 +56,10 @@ export default class CdoTrashcan extends GoogleBlockly.DeleteArea {
       {class: 'blocklyTrash'},
       this.container
     );
-    // const left = Blockly.cdoUtils.getToolboxWidth() / 2 - WIDTH / 2;
-    // parent svg is still being rendered on the left, so not being rendered properly
-    // also doesn't seem to handle resize well
-    // but, trash can does seem like its in the middle of the flyout (not vislble though), which is good
-    // found it by searching "trash" in DOM
-    // const left = Blockly.cdoUtils.getToolboxWidth() / 2 - WIDTH / 2;
-    const offset =
-      Blockly.cdoUtils.getWidth() -
-      (Blockly.cdoUtils.getToolboxWidth() / 2 + WIDTH / 2);
+    const left = Blockly.cdoUtils.getToolboxWidth() / 2 - WIDTH / 2;
     this.svgGroup_.setAttribute(
       'transform',
-      `translate(${offset}, ${MARGIN_TOP})`
+      `translate(${left}, ${MARGIN_TOP})`
     );
 
     // trashcan body
@@ -215,7 +207,12 @@ export default class CdoTrashcan extends GoogleBlockly.DeleteArea {
   position(metrics) {
     this.container.style.height = `${metrics.viewMetrics.height}px`;
     this.container.style.width = `${Blockly.cdoUtils.getToolboxWidth()}px`;
-    this.container.style.left = '0px';
+    // maybe move into cdoUtils
+    // what is difference between workspace.getMetricsManager() and
+    // workspace.getMetrics() (used in cdoUtils)?
+    this.container.style.left = this.workspace.RTL
+      ? `${this.workspace.getMetricsManager().getViewMetrics().width}px`
+      : '0px';
     this.container.style.top = '0px';
     this.container.style.position = 'absolute';
     this.container.style.zIndex = '75';

--- a/apps/src/blockly/addons/cdoTrashcan.js
+++ b/apps/src/blockly/addons/cdoTrashcan.js
@@ -207,11 +207,8 @@ export default class CdoTrashcan extends GoogleBlockly.DeleteArea {
   position(metrics) {
     this.container.style.height = `${metrics.viewMetrics.height}px`;
     this.container.style.width = `${Blockly.cdoUtils.getToolboxWidth()}px`;
-    // maybe move into cdoUtils
-    // what is difference between workspace.getMetricsManager() and
-    // workspace.getMetrics() (used in cdoUtils)?
     this.container.style.left = this.workspace.RTL
-      ? `${this.workspace.getMetricsManager().getViewMetrics().width}px`
+      ? `${metrics.viewMetrics.width}px`
       : '0px';
     this.container.style.top = '0px';
     this.container.style.position = 'absolute';

--- a/apps/src/blockly/addons/cdoUtils.js
+++ b/apps/src/blockly/addons/cdoUtils.js
@@ -41,6 +41,25 @@ export function getToolboxWidth() {
   }
 }
 
+// this probably isn't quite right
+export function getWidth() {
+  return Blockly.getMainWorkspace().getMetrics().svgWidth;
+}
+
+export function getToolboxPosition() {
+  const workspace = Blockly.getMainWorkspace();
+  const metrics = workspace.getMetrics();
+  switch (getToolboxType()) {
+    case ToolboxType.CATEGORIZED:
+      return metrics.toolboxWidth;
+    case ToolboxType.UNCATEGORIZED:
+      return metrics.flyoutWidth;
+    case ToolboxType.NONE:
+      return 0;
+  }
+}
+// what version of blockly docs?
+// what is global Blockly object? -> console says BlocklyWrapper, version: Google
 export function workspaceSvgResize(workspace) {
   return Blockly.svgResize(workspace);
 }

--- a/apps/src/blockly/addons/cdoUtils.js
+++ b/apps/src/blockly/addons/cdoUtils.js
@@ -41,25 +41,6 @@ export function getToolboxWidth() {
   }
 }
 
-// this probably isn't quite right
-export function getWidth() {
-  return Blockly.getMainWorkspace().getMetrics().svgWidth;
-}
-
-export function getToolboxPosition() {
-  const workspace = Blockly.getMainWorkspace();
-  const metrics = workspace.getMetrics();
-  switch (getToolboxType()) {
-    case ToolboxType.CATEGORIZED:
-      return metrics.toolboxWidth;
-    case ToolboxType.UNCATEGORIZED:
-      return metrics.flyoutWidth;
-    case ToolboxType.NONE:
-      return 0;
-  }
-}
-// what version of blockly docs?
-// what is global Blockly object? -> console says BlocklyWrapper, version: Google
 export function workspaceSvgResize(workspace) {
   return Blockly.svgResize(workspace);
 }


### PR DESCRIPTION
Moves the container for the trashcan in Google Blockly to be positioned appropriately (ie, in place of toolbox) in right-to-left languages.

It feels like a better solution would be to render the trashcan as a child of the toolbox SVG element (rather than having to keep track of positioning it at the same location as the toolbox)? Not sure if there's a reason we don't do that already, but didn't feel comfortable making larger changes like that when I don't totally have my Blockly bearings yet :).

**Before**

![image](https://user-images.githubusercontent.com/25372625/188732461-1368e72c-d25c-40c2-9515-5f2616f24e0f.png)

**After**

![image](https://user-images.githubusercontent.com/25372625/188732318-29adca4f-518d-4f2f-9f46-afeac6538ca5.png)

## Links

- jira ticket: [STAR-2309](https://codedotorg.atlassian.net/browse/STAR-2309)

## Testing story

Tested manually on a level that has a "flyout" but no toolbox (s/poem-art-2021/lessons/1/levels/1) and one that has both a flyout and a toolbox (/s/dance-2019/lessons/1/levels/10?blocklyVersion=Google), and saw the trashcan appearing in the correct location (centered within the flyout in the poem art case, and within the toolbox in the dance party case). Confirmed that trash can continued to appear in correct location in English as well on each of these levels.