### PR TITLE
hoc2022: remove deadline sentence from sign-up form

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -435,7 +435,6 @@
   signup_email_preference_no: 'No'
   signup_email_preference_error: 'Email preference is required'
   signup_multiple_event_warning: "We will put your school name and city on the map when you register. If you're hosting multiple events, please submit a unique name or email for each one. We only count one event per name and email combination."
-  signup_registration_deadline: "Registration for the Hour of Code closes December 13."
 
   signup_name_placeholder: 'Your Name'
   signup_email_placeholder: 'you@example.com'

--- a/pegasus/sites.v3/hourofcode.com/views/signup_form.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/signup_form.haml
@@ -128,7 +128,6 @@
     #submit
       %p.footnote
         = hoc_s(:signup_multiple_event_warning)
-        %strong= hoc_s(:signup_registration_deadline)
       .form-group.submit-btn#submit-btn
         %div
           %button{type: "submit"}= hoc_s(:signup_submit_label)


### PR DESCRIPTION
This removes the deadline date sentence from the sign-up form on https://hourofcode.com.

### before

<img width="577" alt="Screen Shot 2022-09-06 at 4 18 48 PM" src="https://user-images.githubusercontent.com/2205926/188756703-9a014a2c-1346-45ff-bed9-18dc578b1cd9.png">

### after

<img width="581" alt="Screen Shot 2022-09-06 at 4 18 58 PM" src="https://user-images.githubusercontent.com/2205926/188756735-57e6a2b6-7c6f-4d72-9476-a2c1ee0b948d.png">
