### PR TITLE
adding "add New Animation..." raw string to i18n

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -18,6 +18,7 @@
   "additionalInformationHeader": "Additional Information",
   "additionalInformationText": "For more information, see {externalDocumentationUrl}.",
   "addNewSection": "Add New Section",
+  "addNewAnimation": "Add a new animation on the left to begin",
   "addParentEmailModal_confirmedParentEmail_label": "Confirm parent/guardian email address",
   "addParentEmailModal_confirmedParentEmail_mustMatch": "Email addresses must match.",
   "addParentEmailModal_parentEmail_invalid": "The email address you provided is not valid.",

--- a/apps/src/p5lab/AnimationTab/AnimationTab.jsx
+++ b/apps/src/p5lab/AnimationTab/AnimationTab.jsx
@@ -11,6 +11,7 @@ import ResizablePanes from '@cdo/apps/templates/ResizablePanes';
 import PiskelEditor from './PiskelEditor';
 import * as shapes from '../shapes';
 import {P5LabType} from '@cdo/apps/p5lab/constants';
+import i18n from '@cdo/locale';
 
 /**
  * Root of the animation editor interface mode for GameLab
@@ -53,9 +54,7 @@ class AnimationTab extends React.Component {
           <div style={styles.editorColumn}>
             <PiskelEditor style={styles.piskelEl} />
             <div style={{...hidePiskelStyle, ...styles.emptyPiskelEl}}>
-              <div style={styles.helpText}>
-                Add a new animation on the left to begin
-              </div>
+              <div style={styles.helpText}> {i18n.addNewAnimation()} </div>
             </div>
           </div>
         </ResizablePanes>

--- a/i18n/locales/source/blockly-mooc/common.json
+++ b/i18n/locales/source/blockly-mooc/common.json
@@ -18,6 +18,7 @@
   "additionalInformationHeader": "Additional Information",
   "additionalInformationText": "For more information, see {externalDocumentationUrl}.",
   "addNewSection": "Add New Section",
+  "addNewAnimation": "Add a new animation on the left to begin",
   "addParentEmailModal_confirmedParentEmail_label": "Confirm parent/guardian email address",
   "addParentEmailModal_confirmedParentEmail_mustMatch": "Email addresses must match.",
   "addParentEmailModal_parentEmail_invalid": "The email address you provided is not valid.",


### PR DESCRIPTION
**What**: Adding "Add a new animation on the left to begin" raw string from AnimationTab.jsx to the i18n pipeline.
**Why**: Game Lab uses animations, when there is no animation added to the project, a message is displayed. This message was coded as a raw string and needed to be included in the i18n sync.

## Links

- jira ticket: [FND-2078](https://codedotorg.atlassian.net/browse/FND-2078)


## Testing story

testing messages shows correctly on screen.
<img width="519" alt="Screen Shot 2022-08-31 at 21 09 06" src="https://user-images.githubusercontent.com/66776217/188865103-5eba2790-930f-4314-9e14-ec8312657e7f.png">
