### PR TITLE
Resources and Prep titles made translatable

### DIFF
--- a/apps/src/templates/courseRollupPages/RollupLessonEntrySection.jsx
+++ b/apps/src/templates/courseRollupPages/RollupLessonEntrySection.jsx
@@ -25,10 +25,14 @@ export default class RollupLessonEntrySection extends Component {
 
     return (
       <div style={styles.main}>
-        {(this.props.objectToRollUp === 'Resources' ||
-          this.props.objectToRollUp === 'Prep') && (
+        {this.props.objectToRollUp === 'Resources' && (
           <div style={styles.object}>
-            <h4>{this.props.objectToRollUp}</h4>
+            <h4>{i18n.resources()}</h4>
+          </div>
+        )}
+        {this.props.objectToRollUp === 'Prep' && (
+          <div style={styles.object}>
+            <h4>{i18n.preparation()}</h4>
           </div>
         )}
         <div style={styles.entries}>

--- a/apps/src/templates/courseRollupPages/RollupLessonEntrySection.jsx
+++ b/apps/src/templates/courseRollupPages/RollupLessonEntrySection.jsx
@@ -25,14 +25,14 @@ export default class RollupLessonEntrySection extends Component {
 
     return (
       <div style={styles.main}>
-        {this.props.objectToRollUp === 'Resources' && (
+        {(this.props.objectToRollUp === 'Resources' ||
+          this.props.objectToRollUp === 'Prep') && (
           <div style={styles.object}>
-            <h4>{i18n.resources()}</h4>
-          </div>
-        )}
-        {this.props.objectToRollUp === 'Prep' && (
-          <div style={styles.object}>
-            <h4>{i18n.preparation()}</h4>
+            <h4>
+              {this.props.objectToRollUp === 'Resources'
+                ? i18n.resources()
+                : i18n.preparation()}
+            </h4>
           </div>
         )}
         <div style={styles.entries}>


### PR DESCRIPTION
**What**: Making Resources and Prep titles translatable. The strings already existed in the common.json file, In order to render the titles, instead of rendering the this.props.objectToRollUp value, depending on the value (this.props.objectToRollUp === 'Prep' or this.props.objectToRollUp === 'Resources'), the corresponding i18n string is rendered.
**Why**: As part of the CSD translatability project, all the content and elements of the course resources needed to be translatable.

## Links

- jira ticket: [FND-2079](https://codedotorg.atlassian.net/browse/FND-2079)


## Testing story
Titles render translations:
<img width="1222" alt="Screen Shot 2022-09-07 at 16 39 39" src="https://user-images.githubusercontent.com/66776217/188909786-d6587f1e-bf99-4675-8584-0f734a9376f6.png">

