### PR TITLE
Revert "Revert "Update `activerecord-import` Gem""

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -325,7 +325,7 @@ install_if require_pg do
   gem 'pg', require: false
 end
 
-gem 'activerecord-import'
+gem 'activerecord-import', '~> 1.0.3'
 gem 'active_record_union'
 gem 'scenic'
 gem 'scenic-mysql_adapter'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -231,7 +231,7 @@ GEM
     activerecord (6.0.4.1)
       activemodel (= 6.0.4.1)
       activesupport (= 6.0.4.1)
-    activerecord-import (0.22.0)
+    activerecord-import (1.0.8)
       activerecord (>= 3.2)
     activestorage (6.0.4.1)
       actionpack (= 6.0.4.1)
@@ -911,7 +911,7 @@ DEPENDENCIES
   active_model_serializers (~> 0.10.13)
   active_record_query_trace
   active_record_union
-  activerecord-import
+  activerecord-import (~> 1.0.3)
   acts_as_list
   addressable
   annotate (~> 3.1.1)


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#47973, restoring https://github.com/code-dot-org/code-dot-org/pull/47703

This was reverted in response to a stalled staging build; specifically, the staging build which included this PR stalled out because it was attempting to regenerate dozens of PDFs because of a different PR, which means it did not successfully install this new dependency. Re-merging now that staging is back to a state in which it can install dependencies.