### PR TITLE
hoc2022: Update test hoc_mode to pre-hoc

### DIFF
--- a/config.yml.erb
+++ b/config.yml.erb
@@ -417,7 +417,7 @@ levelbuilder_mode:
 # make it easier to tell the difference
 use_local_header_color:
 
-default_hoc_mode: post-hoc  # overridden by 'hoc_mode' DCDO param, except in :test
+default_hoc_mode: pre-hoc   # overridden by 'hoc_mode' DCDO param, except in :test
 default_hoc_launch: ''      # overridden by 'hoc_launch' DCDO param, except in :test
 
 # teacher_application_mode values: 'open', 'closing-soon', 'closed'


### PR DESCRIPTION
Update the test environment's `hoc_mode` to `"pre-hoc"`.
