### PR TITLE
Fix duplicate table issue when dashboard has contact_rollups table before pegasus

### DIFF
--- a/pegasus/migrations/136_drop_contact_rollups.rb
+++ b/pegasus/migrations/136_drop_contact_rollups.rb
@@ -5,7 +5,7 @@ Sequel.migration do
     # We (as of April 2021) manage this process in Dashboard.
     # See this file (ContactRollupsV2) for more details:
     # https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/lib/contact_rollups_v2.rb
-    drop_table(:contact_rollups)
+    drop_table?(:contact_rollups)
 
     # This table was generated dynamically if you ran the contact rollups process
     # (ie, was never created by migration).


### PR DESCRIPTION
In relation to [this PR](https://github.com/code-dot-org/code-dot-org/pull/47983) about pegasus migrations on project tables failing, other developers were having issues executing `rake install` without [hitting a similar error](https://codedotorg.slack.com/archives/C0T10HG6N/p1648831590836519) from `136_drop_contact_rollups.rb`. As stated in [the PR above](https://github.com/code-dot-org/code-dot-org/pull/47983), this is "possibly because the tables are already created in dashboard by the time the pegasus migrations try to create the same tables."

The solution is to swap `drop_table` for `drop_table?` instead of commenting out the line (as in [the fix in the slack thread above](https://codedotorg.slack.com/archives/C0T10HG6N/p1648831590836519)) so that other people don't run into the same problem when migrating tables.

## Links
Related PR about fix pegasus migrations on project tables failing: [here](https://github.com/code-dot-org/code-dot-org/pull/47983)
Slack threads: [original thread](https://codedotorg.slack.com/archives/C0T10HG6N/p1648831590836519) and [similar thread](https://codedotorg.slack.com/archives/C0T10HG6N/p1662580583526679?thread_ts=1649875010.910049&cid=C0T10HG6N)

## Testing story
Just like [the related PR](https://github.com/code-dot-org/code-dot-org/pull/47983), "drone runs all pegasus migrations, passing drone run is a good indicator that setting up new environments from scratch should continue to work."

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
