### PR TITLE
Set Hour of Code Email Reply-To Field

### DIFF
--- a/pegasus/emails/hoc_signup_2022_receipt_en.md
+++ b/pegasus/emails/hoc_signup_2022_receipt_en.md
@@ -1,5 +1,6 @@
 ---
 from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
+reply-to: hadi_partovi@code.org
 subject: "You’re signed up for the Hour of Code!"
 ---
   <% hourofcode = CDO.canonical_hostname('hourofcode.com') %>

--- a/pegasus/test/fixtures/deliverer/expected/hoc_signup_2022_receipt_en/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/hoc_signup_2022_receipt_en/header.yaml
@@ -1,3 +1,4 @@
 ---
 from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
+reply-to: hadi_partovi@code.org
 subject: You’re signed up for the Hour of Code!


### PR DESCRIPTION
Google Mail (and possibly other email providers) are frequently classifying Hour of Code sign up email receipts as spam due to DKIM and DMARC failing. Account Sign Up and Password Reset emails are transmitted with much of the same code and the same AWS Simple Email Service configuration, but are typically passing DKIM and DMARC and are typically NOT being classified as spam.

After reviewing differences between the email headers between the two types of emails, speculatively set the `Reply-To` SMTP header in Hour of Code sign up email receipts.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
