### PR TITLE
Java Lab: add newline after stop message

### DIFF
--- a/apps/src/javalab/JavabuilderConnection.js
+++ b/apps/src/javalab/JavabuilderConnection.js
@@ -377,6 +377,7 @@ export default class JavabuilderConnection {
       this.onOutputMessage(
         `${STATUS_MESSAGE_PREFIX} ${javalabMsg.programStopped()}`
       );
+      this.onNewlineMessage();
     }
   }
 

--- a/apps/test/unit/javalab/JavabuilderConnectionTest.js
+++ b/apps/test/unit/javalab/JavabuilderConnectionTest.js
@@ -129,7 +129,11 @@ describe('JavabuilderConnection', () => {
       });
       const javabuilderConnection = new JavabuilderConnection(
         null,
-        onOutputMessage
+        onOutputMessage,
+        null,
+        null,
+        null,
+        sinon.stub()
       );
 
       javabuilderConnection.establishWebsocketConnection('fake-token');


### PR DESCRIPTION
I noticed our "Program Stopped" message doesn't include a new line after it so the next message shows up on the same line. This PR adds that new line

## Before
![Screen Shot 2022-09-07 at 5 32 15 PM](https://user-images.githubusercontent.com/33666587/189007996-65234235-bb0f-46fd-b3a1-714d47784bf1.png)

## After
![Screen Shot 2022-09-07 at 5 27 48 PM](https://user-images.githubusercontent.com/33666587/189008006-14375562-7540-4018-beac-61e63c05cc36.png)


## Testing story
Tested locally
