### PR TITLE
Add all the multiples of 45 minutes between 225 and 450 in calendar dropdown

### DIFF
--- a/apps/src/code-studio/components/progress/UnitCalendarDialog.jsx
+++ b/apps/src/code-studio/components/progress/UnitCalendarDialog.jsx
@@ -7,7 +7,18 @@ import UnitCalendar from './UnitCalendar';
 import {unitCalendarLesson} from '@cdo/apps/templates/progress/unitCalendarLessonShapes';
 import firehoseClient from '@cdo/apps/lib/util/firehose';
 
-const WEEKLY_INSTRUCTIONAL_MINUTES_OPTIONS = [45, 90, 135, 180, 225, 450];
+const WEEKLY_INSTRUCTIONAL_MINUTES_OPTIONS = [
+  45,
+  90,
+  135,
+  180,
+  225,
+  270,
+  315,
+  360,
+  405,
+  450
+];
 export const WEEK_WIDTH = 585;
 
 export default class UnitCalendarDialog extends Component {

--- a/apps/test/unit/code-studio/components/progress/UnitCalendarDialogTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/UnitCalendarDialogTest.jsx
@@ -39,7 +39,7 @@ describe('UnitCalendarDialog', () => {
         scriptId={123}
       />
     );
-    expect(wrapper.find('option').length).to.equal(6);
+    expect(wrapper.find('option').length).to.equal(10);
     expect(
       wrapper.containsMatchingElement(
         <option value={45} key={`minutes-45`}>
@@ -68,7 +68,7 @@ describe('UnitCalendarDialog', () => {
         scriptId={123}
       />
     );
-    expect(wrapper.find('option').length).to.equal(7);
+    expect(wrapper.find('option').length).to.equal(11);
     expect(
       wrapper.containsMatchingElement(
         <option value={20} key={`minutes-20`}>


### PR DESCRIPTION
We had a teacher write in asking for more options in the calendar dropdown. After [talking to curriculum](https://codedotorg.slack.com/archives/C02EEGWLHR8/p1661356819305209) we decided to add the multiples of 45 minutes between 225 and 450 in order to support more diverse schedules. We wanted to stay with 45 minutes increments because lessons are standardized on 45 minute length so this keeps the calendar looking nice when adapting to the different times.

<img width="832" alt="Screen Shot 2022-09-08 at 7 26 45 AM" src="https://user-images.githubusercontent.com/208083/189110960-c0e59437-b6e3-4483-869f-7d6b481cba8c.png">

## Links

- https://codedotorg.atlassian.net/browse/PLAT-1948

## Testing story

- Local testing see screenshot