### PR TITLE
Re-add project backed freeplay level to uncached levels list

### DIFF
--- a/cookbooks/cdo-varnish/libraries/http_cache.rb
+++ b/cookbooks/cdo-varnish/libraries/http_cache.rb
@@ -24,8 +24,16 @@ class HttpCache
   # A list of script levels that should not be cached, even though they are
   # in a cacheable script
   UNCACHED_UNIT_LEVEL_PATHS = [
+    '/s/dance/lessons/1/levels/13',
+    '/s/dance-2019/lessons/1/levels/10',
+    '/s/poem-art-2021/lessons/1/levels/9',
     '/s/poem-art-2021/lessons/1/levels/2', # prediction levels are not cacheable
     '/s/poem-art-2021/lessons/1/levels/5', # prediction levels are not cacheable
+    '/s/hello-world-food-2021/lessons/1/levels/11',
+    '/s/hello-world-animals-2021/lessons/1/levels/11',
+    '/s/hello-world-retro-2021/lessons/1/levels/11',
+    '/s/hello-world-emoji-2021/lessons/1/levels/11',
+    '/s/outbreak/lessons/1/levels/10'
   ]
 
   # A map from script name to script level URL pattern.


### PR DESCRIPTION
Reported by Brendan in [this thread](https://codedotorg.slack.com/archives/C1B3PNDL7/p1662151665213989). Users who are signed out (not 100% sure being signed out is necessary) and go to these levels all get the same channel id. This in turn leads to saving errors and data loss for these users.

Repro steps:
1. In two different chrome profiles or on two different computers, go to /s/dance-2019/lessons/1/levels/1 at the same time with the dev console open.
2. Note that the channel ids are the same in the network tab
3. Make changes in both windows/computers. After a couple of changes, one of them will show "Error saving project" and force reload, losing the changes that user made.

I confirmed that I could repro with these steps locally before this change and could not repro with these steps after this change.



## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
