### PR TITLE
skip file write when saving scripts

### DIFF
--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1355,6 +1355,9 @@ class Script < ApplicationRecord
   end
 
   def write_script_json
+    # make sure we only write script json in the levelbuilder environment.
+    return unless Rails.application.config.levelbuilder_mode
+
     filepath = Script.script_json_filepath(name)
     File.write(filepath, Services::ScriptSeed.serialize_seeding_json(self))
   end

--- a/dashboard/test/models/unit_group_test.rb
+++ b/dashboard/test/models/unit_group_test.rb
@@ -315,8 +315,6 @@ class UnitGroupTest < ActiveSupport::TestCase
     end
 
     test "set pilot experiment to nil for new UnitGroupUnits" do
-      File.stubs(:write).with {|filename, _| filename.to_s == "#{Rails.root}/config/scripts_json/unit1.script_json"}.once
-
       unit_group = create :unit_group
 
       unit1 = create(:script, name: 'unit1', published_state: 'pilot', pilot_experiment: 'unit-going-to-unit-group-pilot')


### PR DESCRIPTION
Follow-up from https://codedotorg.slack.com/archives/C02EEGWLHR8/p1662660019407159 . This PR makes it so that there is no easy way to accidentally generate changes to .script_json files in production, by making sure we only write .script_json files in levelbuilder_mode.

## Testing story

Updated existing unit tests to no longer expect file writes
