### PR TITLE
Remove extra / from locale paths

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -1067,12 +1067,12 @@ describe('entry tests', () => {
             // locale files appear in the manifest when minifying.
             {
               from: 'build/locales',
-              to: '[path]/[name][ext]',
+              to: '[path][name][ext]',
               toType: 'template'
             },
             minify && {
               from: 'build/locales',
-              to: '[path]/[name]wp[contenthash][ext]',
+              to: '[path][name]wp[contenthash][ext]',
               toType: 'template'
             },
             // Libraries in this directory are assumed to have .js and .min.js


### PR DESCRIPTION
After merging #47093 (the webpack 5 upgrade), many UI/Eyes tests are failing in the DTT. This is a fix forward.

All the tests I investigated had errors like this:

<img width="1281" alt="Screen Shot 2022-09-08 at 1 56 18 PM" src="https://user-images.githubusercontent.com/9812299/189227947-f8055e2c-01f8-44e8-856b-9aabdd32582a.png">

where requests for locale files were 404ing. The URL for those locale files had an extra `/`:

```
# Request that 404s
https://test-studio.code.org/assets/js/en_us//common_localewpe534efec894fc8ed2bc8.js
```

Attempting to load that URL failed, but removing the extra `/` successfully loaded the minified locale file. I updated the rule for locale files in our Gruntfile and tested locally that the URL was updated as expected using the "Using minified js locally" and "Using rails asset pipeline locally" documentation in [build.md](https://github.com/code-dot-org/code-dot-org/blob/staging/apps/docs/build.md#using-minified-js-locally).