### PR TITLE
Revert "Remove extra / from locale paths"

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -1067,12 +1067,12 @@ describe('entry tests', () => {
             // locale files appear in the manifest when minifying.
             {
               from: 'build/locales',
-              to: '[path][name][ext]',
+              to: '[path]/[name][ext]',
               toType: 'template'
             },
             minify && {
               from: 'build/locales',
-              to: '[path][name]wp[contenthash][ext]',
+              to: '[path]/[name]wp[contenthash][ext]',
               toType: 'template'
             },
             // Libraries in this directory are assumed to have .js and .min.js


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#48017.

The fixed the issue described in the original PR, but there's a similar filepath issue elsewhere, so I'm going to revert this and #47093 and ship 1 PR with the upgrade and fixes (hopefully all the fixes! 😅).