### PR TITLE
HoC.com - FAQ updates

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/public/css/faq.css
+++ b/pegasus/sites.v3/hourofcode.com/public/css/faq.css
@@ -8,6 +8,7 @@ summary {
   font-family: 'Gotham 5r', sans-serif;
   margin-bottom: 0.5em;
   display: list-item;
+  user-select: none;
   transition: all .2s ease-in-out;
 }
   summary:hover {

--- a/pegasus/sites.v3/hourofcode.com/public/css/faq.css
+++ b/pegasus/sites.v3/hourofcode.com/public/css/faq.css
@@ -1,0 +1,22 @@
+details {
+  margin: 3em 0 0 0;
+  display: revert;
+}
+
+summary {
+  font-size: 1.5em;
+  font-family: 'Gotham 5r', sans-serif;
+  margin-bottom: 0.5em;
+  display: list-item;
+  transition: all .2s ease-in-out;
+}
+  summary:hover {
+    cursor: pointer;
+    color: #16adbb;
+  }
+
+@media screen and (max-width: 600px){
+  summary {
+    font-size: 1.25em;
+  }
+}

--- a/pegasus/sites.v3/hourofcode.com/public/faq.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/faq.haml
@@ -1,0 +1,11 @@
+---
+layout: wide
+---
+
+:ruby
+  @header["title"] = hoc_s(:hoc_faq_title)
+
+%a#faqs{name:'faq'}
+.row
+  .col-xs-12
+    =view :faq

--- a/pegasus/sites.v3/hourofcode.com/public/faq.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/faq.haml
@@ -5,7 +5,6 @@ layout: wide
 :ruby
   @header["title"] = hoc_s(:hoc_faq_title)
 
-%a#faqs{name:'faq'}
 .row
   .col-xs-12
     =view :faq

--- a/pegasus/sites.v3/hourofcode.com/public/faq.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/faq.haml
@@ -2,9 +2,10 @@
 layout: wide
 ---
 
+%link{rel: "stylesheet", type: "text/css", href: "/css/faq.css"}
+
 :ruby
   @header["title"] = hoc_s(:hoc_faq_title)
 
-.row
-  .col-xs-12
-    =view :faq
+%section
+  =view :faq

--- a/pegasus/sites.v3/hourofcode.com/public/index.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/index.haml
@@ -216,13 +216,6 @@ social:
         %p=hoc_s(:stats_girls_more)
         %img{src: "/images/fit-300/stats-info3.jpg", style: "width: 100%;"}
 
-  -# FAQ
-
-  %a#faqs{name:'faq'}
-  .row
-    .col-xs-12
-      =view :faq
-
   =view :signup_button
 
   = view 'popup_window.js'

--- a/pegasus/sites.v3/hourofcode.com/views/404.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/404.haml
@@ -16,4 +16,4 @@ rightbar: blank
   %li<
     %a{href:resolve_url('/promote')}= hoc_s(:header_menu_promote)
   %li<
-    %a{href:resolve_url('/#faq')}= hoc_s(:header_menu_faq)
+    %a{href:resolve_url('/faq')}= hoc_s(:header_menu_faq)

--- a/pegasus/sites.v3/hourofcode.com/views/faq.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/faq.haml
@@ -1,7 +1,8 @@
 %h1= hoc_s(:hoc_faq_title)
 
-%h2#about= hoc_s(:hoc_faq_what_is_hoc_q)
-%div!= hoc_s(:hoc_faq_what_is_hoc_a_markdown, markdown: :inline, locals: {tutorials: resolve_url('/learn'), partners: resolve_url('/partners')})
+%details
+  %summary#about= hoc_s(:hoc_faq_what_is_hoc_q)
+  %p!= hoc_s(:hoc_faq_what_is_hoc_a_markdown, markdown: :inline, locals: {tutorials: resolve_url('/learn'), partners: resolve_url('/partners')})
 
 -# Hide signup buttons during Hour of Code
   %br/
@@ -9,55 +10,72 @@
     %button
     =hoc_s(:signup_host_an_hour)
 
-%h2= hoc_s(:hoc_faq_when_is_hoc_q)
-%div!= hoc_s(:hoc_faq_when_is_hoc_a_markdown, markdown: :inline, locals: {csedweek_url: 'https://csedweek.org', campaign_date_year: campaign_date('year'), campaign_date_full: campaign_date('full'), grace_hopper: 'http://en.wikipedia.org/wiki/Grace_Hopper'})
+%details
+  %summary= hoc_s(:hoc_faq_when_is_hoc_q)
+  %p!= hoc_s(:hoc_faq_when_is_hoc_a_markdown, markdown: :inline, locals: {csedweek_url: 'https://csedweek.org', campaign_date_year: campaign_date('year'), campaign_date_full: campaign_date('full'), grace_hopper: 'http://en.wikipedia.org/wiki/Grace_Hopper'})
 
-%h2= hoc_s(:hoc_faq_why_cs_q)
-%div!= hoc_s(:hoc_faq_why_cs_a_markdown, markdown: :inline, locals: {stats_url: resolve_url('/promote/stats')})
+%details
+  %summary= hoc_s(:hoc_faq_why_cs_q)
+  %p!= hoc_s(:hoc_faq_why_cs_a_markdown, markdown: :inline, locals: {stats_url: resolve_url('/promote/stats')})
 
-%h2= hoc_s(:hoc_faq_how_participate_q)
-%div!= hoc_s(:hoc_faq_how_participate_a_markdown, markdown: :inline, locals: {howto: resolve_url('/how-to'), campaign_date: campaign_date('start-short')})
+%details
+  %summary= hoc_s(:hoc_faq_how_participate_q)
+  %p!= hoc_s(:hoc_faq_how_participate_a_markdown, markdown: :inline, locals: {howto: resolve_url('/how-to'), campaign_date: campaign_date('start-short')})
 
-%h2= hoc_s(:hoc_faq_behind_hoc_q)
-%div!= hoc_s(:hoc_faq_behind_hoc_a_markdown, markdown: :inline, locals: {partner_url: resolve_url('/partners')})
+%details
+  %summary= hoc_s(:hoc_faq_behind_hoc_q)
+  %p!= hoc_s(:hoc_faq_behind_hoc_a_markdown, markdown: :inline, locals: {partner_url: resolve_url('/partners')})
 
-%h2= hoc_s(:hoc_faq_host_q)
-%div!= hoc_s(:hoc_faq_host_a_markdown, markdown: :inline, locals: {howto: resolve_url('/how-to'), codeorg_url: codeorg_url('/')})
+%details
+  %summary= hoc_s(:hoc_faq_host_q)
+  %p!= hoc_s(:hoc_faq_host_a_markdown, markdown: :inline, locals: {howto: resolve_url('/how-to'), codeorg_url: codeorg_url('/')})
 
-%h2= hoc_s(:hoc_faq_devices_q)
-%div!= hoc_s(:hoc_faq_devices_a_markdown, markdown: :inline, locals: {codeorg_url: codeorg_url('/'), partner_url: 'code.org', unplugged_url: codeorg_url('/curriculum/unplugged')})
+%details
+  %summary= hoc_s(:hoc_faq_devices_q)
+  %p!= hoc_s(:hoc_faq_devices_a_markdown, markdown: :inline, locals: {codeorg_url: codeorg_url('/'), partner_url: 'code.org', unplugged_url: codeorg_url('/curriculum/unplugged')})
 
-%h2= hoc_s(:hoc_faq_need_computers_q)
-%div!= hoc_s(:hoc_faq_need_computers_a_markdown, markdown: true, locals: {codeorg_url: codeorg_url('/'), pair_programming_research: 'http://www.ncwit.org/resources/pair-programming-box-power-collaborative-learning', pair_programming_video: 'https://www.youtube.com/watch?v=vgkahOzFH2Q', unplugged_url: codeorg_url('/curriculum/unplugged')})
+%details
+  %summary= hoc_s(:hoc_faq_need_computers_q)
+  %p!= hoc_s(:hoc_faq_need_computers_a_markdown, markdown: true, locals: {codeorg_url: codeorg_url('/'), pair_programming_research: 'http://www.ncwit.org/resources/pair-programming-box-power-collaborative-learning', pair_programming_video: 'https://www.youtube.com/watch?v=vgkahOzFsummaryQ', unplugged_url: codeorg_url('/curriculum/unplugged')})
 
 -if @country == 'us'
-  %h2= hoc_s(:hoc_faq_logo_q)
-  %div!= hoc_s(:hoc_faq_logo_a_markdown, markdown: :inline, locals: {logo_url: "https://support.code.org/hc/en-us/articles/202518403"})
+  %details
+    %summary= hoc_s(:hoc_faq_logo_q)
+    %p!= hoc_s(:hoc_faq_logo_a_markdown, markdown: :inline, locals: {logo_url: "https://support.code.org/hc/en-us/articles/202518403"})
 
 -if @country != 'us'
-  %h2= hoc_s(:hoc_faq_international_q).gsub(/<country>/, HOC_COUNTRIES[@country]['full_name'])
-  %div!= hoc_s(:hoc_faq_international_a_markdown, markdown: :inline, locals: {promote: resolve_url('/promote')})
+  %details
+    %summary= hoc_s(:hoc_faq_international_q).gsub(/<country>/, HOC_COUNTRIES[@country]['full_name'])
+    %p!= hoc_s(:hoc_faq_international_a_markdown, markdown: :inline, locals: {promote: resolve_url('/promote')})
 
-%h2= hoc_s(:hoc_faq_tutorial_q)
-%div!= hoc_s(:hoc_faq_tutorial_a_markdown, markdown: :inline, locals: {tutorial_guidelines: resolve_url('/tutorial-guidelines')})
+%details
+  %summary= hoc_s(:hoc_faq_tutorial_q)
+  %p!= hoc_s(:hoc_faq_tutorial_a_markdown, markdown: :inline, locals: {tutorial_guidelines: resolve_url('/tutorial-guidelines')})
 
-%h2= hoc_s(:hoc_faq_account_q)
-%div!= hoc_s(:hoc_faq_account_a_markdown, markdown: :inline, locals: {codeorg_url: codeorg_url('/'), section_instructions_url: "https://support.code.org/hc/en-us/articles/115000488132-Creating-a-classroom-section"})
+%details
+  %summary= hoc_s(:hoc_faq_account_q)
+  %p!= hoc_s(:hoc_faq_account_a_markdown, markdown: :inline, locals: {codeorg_url: codeorg_url('/'), section_instructions_url: "https://support.code.org/hc/en-us/articles/115000488132-Creating-a-classroom-section"})
 
-%h2= hoc_s(:hoc_faq_certificates_q)
-%div!= hoc_s(:hoc_faq_certificates_a_markdown, markdown: :inline, locals: {codeorg_url: codeorg_url('/')})
+%details
+  %summary= hoc_s(:hoc_faq_certificates_q)
+  %p!= hoc_s(:hoc_faq_certificates_a_markdown, markdown: :inline, locals: {codeorg_url: codeorg_url('/')})
 
-%h2= hoc_s(:hoc_faq_high_school_q)
-%div!= hoc_s(:hoc_faq_high_school_a_markdown, markdown: :inline, locals: {codeorg_url: codeorg_url('/'), partner_url: 'code.org'})
+%details
+  %summary= hoc_s(:hoc_faq_high_school_q)
+  %p!= hoc_s(:hoc_faq_high_school_a_markdown, markdown: :inline, locals: {codeorg_url: codeorg_url('/'), partner_url: 'code.org'})
 
-%h2= hoc_s(:hoc_faq_count_hoc_q)
-%div!= hoc_s(:hoc_faq_count_hoc_a_markdown, markdown: :inline, locals: {codeorg_url: codeorg_url('/')})
+%details
+  %summary= hoc_s(:hoc_faq_count_hoc_q)
+  %p!= hoc_s(:hoc_faq_count_hoc_a_markdown, markdown: :inline, locals: {codeorg_url: codeorg_url('/')})
 
-%h2= hoc_s(:hoc_faq_map_q)
-%div!= hoc_s(:hoc_faq_map_a_markdown, markdown: :inline, locals: {events_url: resolve_url('/events')})
+%details
+  %summary= hoc_s(:hoc_faq_map_q)
+  %p!= hoc_s(:hoc_faq_map_a_markdown, markdown: :inline, locals: {events_url: resolve_url('/events')})
 
-%h2= hoc_s(:hoc_faq_one_hour_q)
-%div!= hoc_s(:hoc_faq_one_hour_a_markdown, markdown: true)
+%details
+  %summary= hoc_s(:hoc_faq_one_hour_q)
+  %p!= hoc_s(:hoc_faq_one_hour_a_markdown, markdown: true)
 
-%h2= hoc_s(:hoc_faq_keep_learning_q)
-%div!= hoc_s(:hoc_faq_keep_learning_a_markdown, markdown: :inline, locals: {promote: resolve_url('/promote')})
+%details
+  %summary= hoc_s(:hoc_faq_keep_learning_q)
+  %p!= hoc_s(:hoc_faq_keep_learning_a_markdown, markdown: :inline, locals: {promote: resolve_url('/promote')})

--- a/pegasus/sites.v3/hourofcode.com/views/header.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/header.haml
@@ -18,10 +18,7 @@
           %li
             %a{href:resolve_url('/promote'), title:hoc_s(:header_menu_promote)}= hoc_s(:header_menu_promote)
           %li
-            - if request.path == "/"
-              %a{href:"#", onclick:"return adjustScroll('faqs')", title:hoc_s(:header_menu_faq)}= hoc_s(:header_menu_faq)
-            - else
-              %a{href:resolve_url('/#faq'), title:hoc_s(:header_menu_faq)}= hoc_s(:header_menu_faq)
+            %a{href:resolve_url('/faq'), title:hoc_s(:header_menu_faq)}= hoc_s(:header_menu_faq)
         %a#hoc-nav-hamburger{href: "#"}
           &#9776;
 %div{style: "clear: both;"}

--- a/pegasus/sites.v3/hourofcode.com/views/urls/faq.erb
+++ b/pegasus/sites.v3/hourofcode.com/views/urls/faq.erb
@@ -1,0 +1,1 @@
+<%= resolve_url('/faq') %>


### PR DESCRIPTION
Improve the UX of the FAQs on [hourofcode.com](https://hourofcode.com):
- Remove the FAQs from the bottom of the homepage and create a standalone FAQs page
- Make each FAQ an accordion using pure HTML/CSS for better readability and accessiblity

**Relevant info:** [Asana task](https://app.asana.com/0/1202764401306810/1202773411837007/f)

----

### Before 
Was an anchor link at the bottom of the homepage:
<img width="1314" alt="Screen Shot 2022-09-09 at 9 57 16 AM" src="https://user-images.githubusercontent.com/9256643/189402790-67c385e6-20e7-4be5-9704-5ca8a56cf50c.png">

### After
Moved to its own page w/ accordians:
<img width="1328" alt="Screen Shot 2022-09-09 at 9 55 51 AM" src="https://user-images.githubusercontent.com/9256643/189402875-88626233-fc14-4e51-913e-4dbe8ac67764.png">


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203316858646111