### PR TITLE
run dashboard tests when http_cache.rb changes

### DIFF
--- a/lib/rake/test.rake
+++ b/lib/rake/test.rake
@@ -319,6 +319,7 @@ namespace :test do
         [
           'Gemfile',
           'Gemfile.lock',
+          'cookbooks/cdo-varnish/libraries/http_cache.rb',
           'deployment.rb',
           'dashboard/**/*',
           'lib/**/*',


### PR DESCRIPTION
additional follow-up from https://github.com/code-dot-org/code-dot-org/pull/48008

## Testing story

not tested, because drone already runs dashboard tests as a result of me touching this rake file. however the drone run did at least make sure that `rake test:changed:dashboard` was not broken by this change.