### PR TITLE
Storybook migrations - ImportProjectDialog, SignInOrAgeDialog, UploadErrorDialog

### DIFF
--- a/apps/src/applab/ImportProjectDialog.story.jsx
+++ b/apps/src/applab/ImportProjectDialog.story.jsx
@@ -2,29 +2,23 @@ import React from 'react';
 import {ImportProjectDialog} from './ImportProjectDialog';
 import {action} from '@storybook/addon-actions';
 
-export default storybook => {
-  storybook.storiesOf('ImportProjectDialog', module).addStoryTable([
-    {
-      name: 'On open',
-      story: () => (
-        <ImportProjectDialog hideBackdrop onImport={action('onImport')} />
-      )
-    },
-    {
-      name: 'While fetching',
-      story: () => (
-        <ImportProjectDialog
-          hideBackdrop
-          isFetching
-          onImport={action('onImport')}
-        />
-      )
-    },
-    {
-      name: 'Error Fetching',
-      story: () => (
-        <ImportProjectDialog hideBackdrop error onImport={action('onImport')} />
-      )
-    }
-  ]);
+export default {
+  title: 'ImportProjectDialog',
+  component: ImportProjectDialog
+};
+
+const Template = args => (
+  <ImportProjectDialog hideBackdrop onImport={action('onImport')} {...args} />
+);
+
+export const OnOpen = Template.bind({});
+
+export const WhileFetching = Template.bind({});
+WhileFetching.args = {
+  isFetching: true
+};
+
+export const ErrorFetching = Template.bind({});
+ErrorFetching.args = {
+  error: true
 };

--- a/apps/src/templates/SignInOrAgeDialog.story.jsx
+++ b/apps/src/templates/SignInOrAgeDialog.story.jsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import {UnconnectedSignInOrAgeDialog as SignInOrAgeDialog} from './SignInOrAgeDialog';
 
-export default storybook => {
-  return storybook.storiesOf('SignInOrAgeDialog', module).addStoryTable([
-    {
-      name: 'SignInOrAgeDialog',
-      story: () => <SignInOrAgeDialog signedIn={false} age13Required={true} />
-    }
-  ]);
+export default {
+  title: 'SignInOrAgeDialog',
+  component: SignInOrAgeDialog
 };
+
+const Template = args => (
+  <SignInOrAgeDialog signedIn={false} age13Required={true} />
+);
+
+export const BasicExample = Template.bind({});

--- a/apps/src/weblab/dialogs/UploadErrorDialog.story.js
+++ b/apps/src/weblab/dialogs/UploadErrorDialog.story.js
@@ -2,19 +2,13 @@ import React from 'react';
 import {action} from '@storybook/addon-actions';
 import UploadErrorDialog from './UploadErrorDialog';
 
-export default storybook => {
-  storybook
-    .storiesOf('Weblab/dialogs/UploadErrorDialog', module)
-    .addStoryTable([
-      {
-        name: 'default',
-        story: () => (
-          <UploadErrorDialog
-            isOpen
-            handleClose={action('close')}
-            hideBackdrop
-          />
-        )
-      }
-    ]);
+export default {
+  title: 'UploadErrorDialog',
+  component: UploadErrorDialog
 };
+
+const Template = args => (
+  <UploadErrorDialog isOpen handleClose={action('close')} hideBackdrop />
+);
+
+export const BasicExample = Template.bind({});


### PR DESCRIPTION
Migrated to new Storybook API:
- ImportProjectDialog
- SignInOrAgeDialog
- UploadErrorDialog

Video of 3 components in Storybook:

https://user-images.githubusercontent.com/107423305/189453604-cfb87a73-fa49-4e0d-8519-63540aed6e7c.mp4


## Links
Refer to [this PR](https://github.com/code-dot-org/code-dot-org/pull/47777) for context.
[This spreadsheet](https://docs.google.com/spreadsheets/d/1z8r10AcR0v3GimV_-28dJ6QaiaQ3CJoo9yXqa7U_bKs/edit#gid=0)  keeps track of all migrations.
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
