### PR TITLE
Hiding old cookie banner if new banner is shown

### DIFF
--- a/dashboard/test/ui/features/xteam/onetrust_cookie_banner.feature
+++ b/dashboard/test/ui/features/xteam/onetrust_cookie_banner.feature
@@ -1,0 +1,20 @@
+@eyes
+Feature: OneTrust Cookie banner on various sites
+
+Scenario Outline: Show onetrust cookie banner on GDPR country but not the US
+  When I open my eyes to test "<test_name>"
+  And I am on "<url>?otgeo=gb&onetrust_cookie_scripts=production"
+  And I wait to see "#onetrust-banner-sdk"
+  Then I see no difference for "OneTrust cookie banner on UK"
+
+  Then I am on "<url>?otgeo=us&onetrust_cookie_scripts=production"
+  And I wait until element "#onetrust-banner-sdk" is not visible
+  Then I see no difference for "OneTrust cookie banner on US"
+
+  Then I close my eyes
+
+Examples:
+  | url                                                               | test_name                  |
+  | http://code.org/about                                             | code.org about             |
+  | http://hourofcode.com/uk                                          | hourofcode hompage         |
+  | http://studio.code.org/s/frozen/lessons/1/levels/1                | studio.code.org puzzle     |

--- a/shared/haml/cookie_banner.haml
+++ b/shared/haml/cookie_banner.haml
@@ -1,4 +1,11 @@
 -#
+  This is the old banner we should show GDPR countries in order to inform them
+  about our privacy policy. This file should be removed once we finish the
+  'onetrust_cookie_scripts' experiment.
+
+-# Don't show this banner if we are showing the new OneTrust GDPR cookie banner.
+- return if experiment_value('onetrust_cookie_scripts')
+-#
   Only show cookie banner when in a GDPR country, or when we are in the test
   environment and the show_cookie_banner_on_test URL parameter is specified,
   presumably by a UI test.

--- a/shared/haml/hoc_onetrust_cookie_scripts.haml
+++ b/shared/haml/hoc_onetrust_cookie_scripts.haml
@@ -1,5 +1,6 @@
+- require '../shared/middleware/helpers/experiments'
 -# OneTrust Cookies Consent Notice scripts for hourofcode.com
-- cookie_script_env = DCDO.get('onetrust_cookie_scripts', 'off')
+- cookie_script_env = experiment_value('onetrust_cookie_scripts')
 - if cookie_script_env == 'production'
   %script{:src=>"#{CDO.code_org_url}/js/jquery.min.js"}
   %script{src: 'https://cdn.cookielaw.org/consent/7c79c547-a2fc-4998-9b21-0c7a5e67e345/OtAutoBlock.js', type: 'text/javascript'}

--- a/shared/haml/onetrust_cookie_scripts.haml
+++ b/shared/haml/onetrust_cookie_scripts.haml
@@ -1,8 +1,6 @@
+- require '../shared/middleware/helpers/experiments'
 -# OneTrust Cookies Consent Notice scripts for code.org
-- cookie_script_env = DCDO.get('onetrust_cookie_scripts', 'off')
--# If the user has a cookie to override this, use it. This is for testing purposes.
-- cookie_script_env_override = request.cookies['onetrust_cookie_scripts']
-- cookie_script_env = cookie_script_env_override if cookie_script_env_override.present?
+- cookie_script_env = experiment_value('onetrust_cookie_scripts')
 - if cookie_script_env == 'production'
   %script{src: 'https://cdn.cookielaw.org/consent/27cca70a-7db3-4852-9ef0-a6660fd0977d/OtAutoBlock.js', type: 'text/javascript'}
   %script{src: 'https://cdn.cookielaw.org/scripttemplates/otSDKStub.js', type: 'text/javascript', charset: 'UTF-8', 'data-domain-script' => '27cca70a-7db3-4852-9ef0-a6660fd0977d'}

--- a/shared/middleware/helpers/experiments.rb
+++ b/shared/middleware/helpers/experiments.rb
@@ -1,0 +1,15 @@
+# Sometimes we want to hide features behind dynamic configurations
+# because they are not ready yet. To test these features, you might
+# want to use a URL parameter or browser cookie to temporarily
+# enable it for a single user. If you want to configure it for all
+# users, you can use DCDO.
+# If multiple configurations are available, this is the priority
+# (from highest to lowest):
+# 1. URL Parameter - https://code.org?my_experiment=1
+# 2. Browser Cookie - document.cookie = 'my_experiment=1';
+# 3. DCDO config - DCDO.set('my_experiment', 1)
+def experiment_value(name, default = nil)
+  return request.params[name] if request.params[name].present?
+  return request.cookies[name] if request.cookies[name].present?
+  DCDO.get(name, default)
+end


### PR DESCRIPTION
Right now, we display a banner at the bottom of the page to users in GDPR countries which tells them about our cookie / tracking policy. However, this banner is not GDPR compliant. We now have a GDPR compliant banner built by OneTrust which we want to display instead of the non-compliant banner. This PR hides the old banner whenever we have the `onetrust_cookie_scripts` experiment enabled.
* Hides the old cookie_banner.haml when the `onetrust_cookie_scripts` experiment is enabled.
* Shows the new onetrust_cookie_scripts banner when the `onetrust_cookie_scripts` experiment is enabled.
* Adds `experiments.rb` which makes it easier to hide/enable features using URL params or browser cookies (for testing purposes).

## Screenshot
Observe the One Trust cookie banner at the top of the screen:
![image](https://user-images.githubusercontent.com/1372238/189779689-57d185da-a873-4d84-bb60-888f716f8a39.png)

## Links
- [JIRA](https://codedotorg.atlassian.net/browse/FND-1969)

## Testing story
* Added UI test
* Manually tested:
  * http://localhost.hourofcode.com:3000/uk?otgeo=gb&onetrust_cookie_scripts=production
  * http://localhost-studio.code.org:3000/courses?otgeo=gb&onetrust_cookie_scripts=production
  * http://localhost.code.org:3000/cookies?otgeo=gb&onetrust_cookie_scripts=production

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy
* This will be deployed to production hidden behind a DCDO experiment flag. We will do a bug bash using browser cookies. Once it seems like there are no issues, we will enable the DCDO experiment flag.
## Follow-up work
* Schedule a bug bash
