### PR TITLE
Drop reviewable_projects table

### DIFF
--- a/dashboard/db/migrate/20220913225915_drop_reviewable_projects.rb
+++ b/dashboard/db/migrate/20220913225915_drop_reviewable_projects.rb
@@ -1,0 +1,5 @@
+class DropReviewableProjects < ActiveRecord::Migration[6.0]
+  def change
+    drop_table :reviewable_projects
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_09_06_231348) do
+ActiveRecord::Schema.define(version: 2022_09_13_225915) do
 
   create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -1558,16 +1558,6 @@ ActiveRecord::Schema.define(version: 2022_09_06_231348) do
     t.integer "course_version_id", null: false
     t.index ["course_version_id", "key"], name: "index_resources_on_course_version_id_and_key", unique: true
     t.index ["name", "url"], name: "index_resources_on_name_and_url", type: :fulltext
-  end
-
-  create_table "reviewable_projects", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
-    t.integer "storage_app_id", null: false
-    t.integer "user_id", null: false
-    t.integer "level_id"
-    t.integer "script_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["user_id", "script_id", "level_id", "storage_app_id"], name: "index_reviewable_projects_on_user_script_level_storage_app"
   end
 
   create_table "school_districts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|


### PR DESCRIPTION
This table was used for code review v1 and is no longer in use. The last row was added 6/22/22 (when we switched to v2). All remaining code was removed in [this PR](https://github.com/code-dot-org/code-dot-org/pull/47991/)
## Links

- jira ticket: [JAVA-643](https://codedotorg.atlassian.net/browse/JAVA-643)

## Testing story
Tested migration locally
