### PR TITLE
Add DataDoc show page

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -620,6 +620,7 @@ describe('entry tests', () => {
     'courses/edit': './src/sites/studio/pages/courses/edit.js',
     'courses/new': './src/sites/studio/pages/courses/new.js',
     'data_docs/new': './src/sites/studio/pages/data_docs/new.js',
+    'data_docs/show': './src/sites/studio/pages/data_docs/show.js', // TODO [meg]: move to codeStudioEntries once launched
     'datasets/show': './src/sites/studio/pages/datasets/show.js',
     'datasets/index': './src/sites/studio/pages/datasets/index.js',
     'datasets/edit_manifest':

--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -530,6 +530,7 @@ describe('entry tests', () => {
     'courses/resources': './src/sites/studio/pages/courses/resources.js',
     'courses/code': './src/sites/studio/pages/courses/code.js',
     'courses/standards': './src/sites/studio/pages/courses/standards.js',
+    'data_docs/show': './src/sites/studio/pages/data_docs/show.js',
     'lessons/show': './src/sites/studio/pages/lessons/show.js',
     'lessons/student_lesson_plan':
       './src/sites/studio/pages/lessons/student_lesson_plan.js',
@@ -620,7 +621,6 @@ describe('entry tests', () => {
     'courses/edit': './src/sites/studio/pages/courses/edit.js',
     'courses/new': './src/sites/studio/pages/courses/new.js',
     'data_docs/new': './src/sites/studio/pages/data_docs/new.js',
-    'data_docs/show': './src/sites/studio/pages/data_docs/show.js', // TODO [meg]: move to codeStudioEntries once launched
     'datasets/show': './src/sites/studio/pages/datasets/show.js',
     'datasets/index': './src/sites/studio/pages/datasets/index.js',
     'datasets/edit_manifest':

--- a/apps/src/lib/levelbuilder/TextareaWithMarkdownPreview.jsx
+++ b/apps/src/lib/levelbuilder/TextareaWithMarkdownPreview.jsx
@@ -14,6 +14,7 @@ import MarkdownEnabledTextarea, {
 export default class TextareaWithMarkdownPreview extends React.Component {
   static propTypes = {
     markdown: PropTypes.string,
+    name: PropTypes.string,
     label: PropTypes.node.isRequired,
     inputRows: PropTypes.number,
     helpTip: PropTypes.string,
@@ -34,6 +35,7 @@ export default class TextareaWithMarkdownPreview extends React.Component {
           <div style={styles.container}>
             <div style={{marginBottom: 5}}>Markdown:</div>
             <MarkdownEnabledTextarea
+              name={this.props.name}
               markdown={this.props.markdown}
               inputRows={this.props.inputRows || 5}
               handleMarkdownChange={this.props.handleMarkdownChange}

--- a/apps/src/lib/levelbuilder/data-docs-editor/NewDataDocForm.jsx
+++ b/apps/src/lib/levelbuilder/data-docs-editor/NewDataDocForm.jsx
@@ -30,6 +30,7 @@ const NewDataDocForm = () => {
         <input className="input" name="name" style={styles.input} />
       </label>
       <TextareaWithMarkdownPreview
+        name="content"
         label="Content"
         handleMarkdownChange={e => setDataDocContent(e.target.value)}
         markdown={dataDocContent || ''}

--- a/apps/src/sites/studio/pages/data_docs/show.js
+++ b/apps/src/sites/studio/pages/data_docs/show.js
@@ -4,10 +4,9 @@ import getScriptData from '@cdo/apps/util/getScriptData';
 import DataDocView from '@cdo/apps/templates/dataDocs/DataDocView';
 
 $(() => {
-  const dataDocName = getScriptData('dataDocName');
-  const dataDocContent = getScriptData('dataDocContent');
+  const {dataDocName, dataDocContent} = getScriptData('dataDoc');
   ReactDOM.render(
     <DataDocView dataDocName={dataDocName} dataDocContent={dataDocContent} />,
-    document.getElementById('show-container')
+    document.getElementById('view-data-doc')
   );
 });

--- a/apps/src/sites/studio/pages/data_docs/show.js
+++ b/apps/src/sites/studio/pages/data_docs/show.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import getScriptData from '@cdo/apps/util/getScriptData';
+import DataDocView from '@cdo/apps/templates/dataDocs/DataDocView';
+
+$(() => {
+  const dataDocName = getScriptData('dataDocName');
+  const dataDocContent = getScriptData('dataDocContent');
+  ReactDOM.render(
+    <DataDocView dataDocName={dataDocName} dataDocContent={dataDocContent} />,
+    document.getElementById('show-container')
+  );
+});

--- a/apps/src/templates/CopyrightInfo.jsx
+++ b/apps/src/templates/CopyrightInfo.jsx
@@ -5,7 +5,10 @@ import i18n from '@cdo/locale';
 const CopyrightInfo = () => (
   <div>
     <a href="https://creativecommons.org/">
-      <img src="https://curriculum.code.org/static/img/creativeCommons-by-nc-sa.png" />
+      <img
+        src="https://curriculum.code.org/static/img/creativeCommons-by-nc-sa.png"
+        alt="This curriculum is available under a Creative Commons License (CC BY-NC-SA 4.0)."
+      />
     </a>
     <SafeMarkdown
       markdown={i18n.licenseMaterials({link: 'https://code.org/contact'})}

--- a/apps/src/templates/dataDocs/DataDocView.jsx
+++ b/apps/src/templates/dataDocs/DataDocView.jsx
@@ -10,13 +10,13 @@ const DataDocView = props => {
   return (
     <>
       <h1 style={{marginBottom: 30}}>{dataDocName}</h1>
-      <div className="page-content">
+      <div id="data-doc-content">
         <EnhancedSafeMarkdown markdown={dataDocContent} />
-        <div id="bug-report-and-licensing" style={{marginTop: 50}}>
-          <hr />
-          <EnhancedSafeMarkdown markdown={i18n.documentationBug()} />
-          <CopyrightInfo />
-        </div>
+      </div>
+      <div id="bug-report-and-licensing" style={{marginTop: 50}}>
+        <hr />
+        <EnhancedSafeMarkdown markdown={i18n.documentationBug()} />
+        <CopyrightInfo />
       </div>
     </>
   );

--- a/apps/src/templates/dataDocs/DataDocView.jsx
+++ b/apps/src/templates/dataDocs/DataDocView.jsx
@@ -9,11 +9,14 @@ const DataDocView = props => {
 
   return (
     <>
-      <h1>{dataDocName}</h1>
+      <h1 style={{marginBottom: 30}}>{dataDocName}</h1>
       <div className="page-content">
         <EnhancedSafeMarkdown markdown={dataDocContent} />
-        <EnhancedSafeMarkdown markdown={i18n.documentationBug()} />
-        <CopyrightInfo />
+        <div id="bug-report-and-licensing" style={{marginTop: 50}}>
+          <hr />
+          <EnhancedSafeMarkdown markdown={i18n.documentationBug()} />
+          <CopyrightInfo />
+        </div>
       </div>
     </>
   );

--- a/apps/src/templates/dataDocs/DataDocView.jsx
+++ b/apps/src/templates/dataDocs/DataDocView.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import EnhancedSafeMarkdown from '@cdo/apps/templates/EnhancedSafeMarkdown';
+import i18n from '@cdo/locale';
+import CopyrightInfo from '@cdo/apps/templates/CopyrightInfo';
+
+const DataDocView = props => {
+  const {dataDocName, dataDocContent} = props;
+
+  return (
+    <>
+      <h1>{dataDocName}</h1>
+      <div className="page-content">
+        <EnhancedSafeMarkdown markdown={dataDocContent} />
+        <EnhancedSafeMarkdown markdown={i18n.documentationBug()} />
+        <CopyrightInfo />
+      </div>
+    </>
+  );
+};
+
+DataDocView.propTypes = {
+  dataDocName: PropTypes.string,
+  dataDocContent: PropTypes.string
+};
+
+DataDocView.defaultProps = {
+  dataDocName: 'Un-named Data Doc',
+  dataDocContent: '[No content]'
+};
+
+export default DataDocView;

--- a/apps/test/unit/templates/dataDocs/DataDocViewTest.js
+++ b/apps/test/unit/templates/dataDocs/DataDocViewTest.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import DataDocView from '@cdo/apps/templates/dataDocs/DataDocView';
+import {expect} from '../../../util/reconfiguredChai';
+
+describe('DataDocView', () => {
+  let defaultProps;
+  const docName = 'Name of Doc';
+  const docContent = 'Content of Doc';
+
+  beforeEach(() => {
+    defaultProps = {
+      dataDocName: docName,
+      dataDocContent: docContent
+    };
+  });
+
+  it('shows data doc name and content', () => {
+    const wrapper = shallow(<DataDocView {...defaultProps} />);
+    expect(wrapper.text()).to.contain(docName);
+    expect(
+      wrapper
+        .find('EnhancedSafeMarkdown')
+        .first()
+        .props().markdown
+    ).to.equal(docContent);
+  });
+});

--- a/dashboard/app/controllers/data_docs_controller.rb
+++ b/dashboard/app/controllers/data_docs_controller.rb
@@ -1,5 +1,5 @@
 class DataDocsController < ApplicationController
-  before_action :require_levelbuilder_mode_or_test_env
+  before_action :require_levelbuilder_mode_or_test_env # TODO [meg]: add except: [:show] to launch
   load_and_authorize_resource
 
   # GET /data_docs/new
@@ -16,5 +16,18 @@ class DataDocsController < ApplicationController
     else
       render :not_acceptable, json: @data_doc.errors
     end
+  end
+
+  def to_param
+    key
+  end
+
+  # GET /data_docs/:key
+  def show
+    @data_doc = DataDoc.find_by(key: params[:key])
+    return render :not_found unless @data_doc
+
+    @data_doc_name = @data_doc.name
+    @data_doc_content = @data_doc.content
   end
 end

--- a/dashboard/app/controllers/data_docs_controller.rb
+++ b/dashboard/app/controllers/data_docs_controller.rb
@@ -27,7 +27,9 @@ class DataDocsController < ApplicationController
     @data_doc = DataDoc.find_by(key: params[:key])
     return render :not_found unless @data_doc
 
-    @data_doc_name = @data_doc.name
-    @data_doc_content = @data_doc.content
+    @data_doc_data = {
+      dataDocName: @data_doc.name,
+      dataDocContent: @data_doc.content,
+    }
   end
 end

--- a/dashboard/app/controllers/data_docs_controller.rb
+++ b/dashboard/app/controllers/data_docs_controller.rb
@@ -1,5 +1,5 @@
 class DataDocsController < ApplicationController
-  before_action :require_levelbuilder_mode_or_test_env # TODO [meg]: add except: [:show] to launch
+  before_action :require_levelbuilder_mode_or_test_env, except: [:show]
   load_and_authorize_resource
 
   # GET /data_docs/new

--- a/dashboard/app/controllers/data_docs_controller.rb
+++ b/dashboard/app/controllers/data_docs_controller.rb
@@ -12,7 +12,7 @@ class DataDocsController < ApplicationController
 
     if @data_doc.save
       # TODO [meg] : Write serialization
-      render :ok, json: {} # TODO [meg] : Redirect to new data doc, e.g. redirect_to @data_doc
+      redirect_to action: :show, key: params[:key]
     else
       render :not_acceptable, json: @data_doc.errors
     end

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -68,6 +68,8 @@ class Ability
     ]
     cannot :index, Level
 
+    can :show, DataDoc
+
     # If you can see a level, you can also do these things:
     can [:embed_level, :get_rubric, :get_serialized_maze], Level do |level|
       can? :read, level

--- a/dashboard/app/views/data_docs/show.html.haml
+++ b/dashboard/app/views/data_docs/show.html.haml
@@ -1,2 +1,2 @@
-%script{src: webpack_asset_path('js/data_docs/show.js'), data: {dataDocName: @data_doc_name.to_json, dataDocContent: @data_doc_content.to_json}}
-#show-container
+%script{src: webpack_asset_path('js/data_docs/show.js'), data: {dataDoc: @data_doc_data.to_json}}
+#view-data-doc

--- a/dashboard/app/views/data_docs/show.html.haml
+++ b/dashboard/app/views/data_docs/show.html.haml
@@ -1,0 +1,2 @@
+%script{src: webpack_asset_path('js/data_docs/show.js'), data: {dataDocName: @data_doc_name.to_json, dataDocContent: @data_doc_content.to_json}}
+#show-container

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -347,7 +347,7 @@ Dashboard::Application.routes.draw do
     get '/s/csp9-2020/lockable/1(*all)', to: redirect(path: '/s/csp9-2020/lessons/9%{all}')
     get '/s/csp10-2020/lockable/1(*all)', to: redirect(path: '/s/csp10-2020/lessons/14%{all}')
 
-    resources :data_docs, only: [:new, :create], param: 'name'
+    resources :data_docs, only: [:new, :create, :show], param: :key
 
     resources :lessons, only: [:edit, :update] do
       member do

--- a/dashboard/test/controllers/data_docs_controller_test.rb
+++ b/dashboard/test/controllers/data_docs_controller_test.rb
@@ -4,11 +4,14 @@ class DataDocsControllerTest < ActionController::TestCase
   include Devise::Test::ControllerHelpers
 
   setup_all do
+    @data_doc_key = 'new_doc'.freeze
     @test_params = {
-      key: 'new_doc',
+      key: @data_doc_key,
       name: 'New Doc',
       content: 'This doc contains things.'
-    }
+    }.freeze
+
+    @data_doc = create :data_doc, key: @data_doc_key
   end
 
   # new page is levelbuilder only
@@ -22,4 +25,11 @@ class DataDocsControllerTest < ActionController::TestCase
   test_user_gets_response_for :create, params: -> {@test_params}, user: :student, response: :forbidden
   test_user_gets_response_for :create, params: -> {@test_params}, user: :teacher, response: :forbidden
   test_user_gets_response_for :create, params: -> {@test_params}, user: :levelbuilder, response: :success
+
+  # TODO [meg] : all should be able to see `show` page, once launched
+  # for now, only levelbuilder can see it
+  test_user_gets_response_for :show, params: -> {{key: @data_doc_key}}, user: nil, response: :redirect
+  test_user_gets_response_for :show, params: -> {{key: @data_doc_key}}, user: :student, response: :forbidden
+  test_user_gets_response_for :show, params: -> {{key: @data_doc_key}}, user: :teacher, response: :forbidden
+  test_user_gets_response_for :show, params: -> {{key: @data_doc_key}}, user: :levelbuilder, response: :success
 end

--- a/dashboard/test/controllers/data_docs_controller_test.rb
+++ b/dashboard/test/controllers/data_docs_controller_test.rb
@@ -28,22 +28,19 @@ class DataDocsControllerTest < ActionController::TestCase
   test_user_gets_response_for :create, params: -> {@test_params}, user: :teacher, response: :forbidden
   test_user_gets_response_for :create, params: -> {@test_params}, user: :levelbuilder, response: :success
 
-  # TODO [meg] : all should be able to see `show` page, once launched
-  # for now, only levelbuilder can see it
-  test_user_gets_response_for :show, params: -> {{key: @data_doc_key}}, user: nil, response: :redirect
-  test_user_gets_response_for :show, params: -> {{key: @data_doc_key}}, user: :student, response: :forbidden
-  test_user_gets_response_for :show, params: -> {{key: @data_doc_key}}, user: :teacher, response: :forbidden
+  test_user_gets_response_for :show, params: -> {{key: @data_doc_key}}, user: nil, response: :success
+  test_user_gets_response_for :show, params: -> {{key: @data_doc_key}}, user: :student, response: :success
+  test_user_gets_response_for :show, params: -> {{key: @data_doc_key}}, user: :teacher, response: :success
   test_user_gets_response_for :show, params: -> {{key: @data_doc_key}}, user: :levelbuilder, response: :success
 
   test 'creating a new data doc redirects to show page with key in URL' do
     sign_in @levelbuilder
-    new_key = "doc_key"
+    new_key = 'doc_key'
     get :create, params: {key: new_key}
-    assert_match %r{/data_docs/#{new_key}$}, @response.headers['Location']
+    assert_redirected_to action: 'show', key: new_key
   end
 
   test 'show page renders 404 when data doc is not found' do
-    sign_in @levelbuilder # TODO [meg] : should not need to sign in once launched
     get :show, params: {key: 'unknown_key'}
     assert_response :not_found
   end

--- a/dashboard/test/controllers/data_docs_controller_test.rb
+++ b/dashboard/test/controllers/data_docs_controller_test.rb
@@ -4,6 +4,8 @@ class DataDocsControllerTest < ActionController::TestCase
   include Devise::Test::ControllerHelpers
 
   setup_all do
+    @levelbuilder = create :levelbuilder
+
     @data_doc_key = 'new_doc'.freeze
     @test_params = {
       key: @data_doc_key,
@@ -32,4 +34,10 @@ class DataDocsControllerTest < ActionController::TestCase
   test_user_gets_response_for :show, params: -> {{key: @data_doc_key}}, user: :student, response: :forbidden
   test_user_gets_response_for :show, params: -> {{key: @data_doc_key}}, user: :teacher, response: :forbidden
   test_user_gets_response_for :show, params: -> {{key: @data_doc_key}}, user: :levelbuilder, response: :success
+
+  test 'show page renders 404 when data doc is not found' do
+    sign_in @levelbuilder
+    get :show, params: {key: 'unknown_key'}
+    assert_response :not_found
+  end
 end

--- a/dashboard/test/controllers/data_docs_controller_test.rb
+++ b/dashboard/test/controllers/data_docs_controller_test.rb
@@ -35,8 +35,15 @@ class DataDocsControllerTest < ActionController::TestCase
   test_user_gets_response_for :show, params: -> {{key: @data_doc_key}}, user: :teacher, response: :forbidden
   test_user_gets_response_for :show, params: -> {{key: @data_doc_key}}, user: :levelbuilder, response: :success
 
-  test 'show page renders 404 when data doc is not found' do
+  test 'creating a new data doc redirects to show page with key in URL' do
     sign_in @levelbuilder
+    new_key = "doc_key"
+    get :create, params: {key: new_key}
+    assert_match %r{/data_docs/#{new_key}$}, @response.headers['Location']
+  end
+
+  test 'show page renders 404 when data doc is not found' do
+    sign_in @levelbuilder # TODO [meg] : should not need to sign in once launched
     get :show, params: {key: 'unknown_key'}
     assert_response :not_found
   end


### PR DESCRIPTION
This work is part of https://codedotorg.atlassian.net/browse/PLAT-1279 –– Curriculum Writers can add new Data Docs.

This PR allows you to see the data doc after you've created it. To see functionality, go to http://localhost-studio.code.org:3000/data_docs/new. It should make you add Levelbuilder permissions to your local account before you can view the page, and after putting in info, the site redirects to the newly-created data doc.

<img width="671" alt="image" src="https://user-images.githubusercontent.com/9142121/190186503-56c8dbfc-0f08-40a2-88df-9808d8284506.png">

See functionality: https://watch.screencastify.com/v/kVoYeC6J8jnxu5iugfNK

## Links

[Spec](https://docs.google.com/document/d/1fIiODFYU1J0NCfrK-Jt27Iy3zyMoPtn3WZAq35IrU80/edit#heading=h.rq4jf5fkj2y4)
[Engineering Plan](https://docs.google.com/document/d/1GDGpuZWjhS9y96rCFqCk8uLJD9SzoZUiLCIry6WdHEI/edit#heading=h.p3guq9bi2b0s)

## Testing story

I added unit tests for these. In a separate PR, will add a UI test, ensuring a user can create and then see the data doc.

## Deployment strategy

## Follow-up work

Add UI test, and move asset out of curriculum builder (tracked here https://codedotorg.atlassian.net/browse/PLAT-1956)

Add UI test

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
