### PR TITLE
Move button and helptip to react

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -623,6 +623,8 @@
   "deleteAccountDialog_emailUs": "If you delete your account and change your mind, you can email us at support@code.org within 3 weeks to recover your account.",
   "deleteAccountDialog_verification": "To verify, type {verificationString} below:",
   "deleteAccountDialog_verificationString": "DELETE MY ACCOUNT",
+  "deleteAnswer": "Delete Answer",
+  "deleteAnswerHelpTip": "Clear your answer and reset the lesson. This is an instructor-only feature.",
   "deleteAsset": "Delete {assetType}",
   "deleteAssetConfirm": "Are you sure you want to delete this {assetType}? You cannot undo this action.",
   "deleteConfirm": "Delete?",

--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -852,6 +852,7 @@
   "enterSectionCode": "Enter section code",
   "enrollmentDescription": "Join your teacher's classroom by entering their section code below. Teachers will be able to see your course progress, projects, and reset your password in case you forget it.",
   "equalTo": "Equal to",
+  "errorResettingAnswer": "There was an error deleting your answer. You may not have permissions to delete this answer.",
   "errorEmptyFunctionBlockModal": "There need to be blocks inside your function definition. Click \"edit\" and drag blocks inside the green block.",
   "errorExceededLimitedBlocks": "You did it! Now go find the pattern in your code and take out the extra blocks. You can only use {limit} of these blocks:",
   "errorFindingClassLibraries": "Unable to load your class libraries at this time. Please check your internet connection and try again.",

--- a/apps/src/code-studio/levels/codeStudioLevels.js
+++ b/apps/src/code-studio/levels/codeStudioLevels.js
@@ -168,7 +168,7 @@ export function resetContainedLevel() {
     );
   }
   return getAuthenticityToken().then(() => {
-    fetch('/delete_predict_level_progress', {
+    return fetch('/delete_predict_level_progress', {
       method: 'POST',
       credentials: 'same-origin',
       headers: {
@@ -185,7 +185,7 @@ export function resetContainedLevel() {
         const runButton = $('#runButton');
         runButton.prop('disabled', true);
       } else {
-        throw 'Error resetting answer';
+        throw `Error resetting answer with status code ${response.status}`;
       }
     });
   });

--- a/apps/src/code-studio/levels/codeStudioLevels.js
+++ b/apps/src/code-studio/levels/codeStudioLevels.js
@@ -185,7 +185,7 @@ export function resetContainedLevel() {
         const runButton = $('#runButton');
         runButton.prop('disabled', true);
       } else {
-        console.log(response);
+        throw 'Error resetting answer';
       }
     });
   });

--- a/apps/src/code-studio/levels/codeStudioLevels.js
+++ b/apps/src/code-studio/levels/codeStudioLevels.js
@@ -167,7 +167,7 @@ export function resetContainedLevel() {
       `Expected exactly one contained level. Got ${levelIds.length}`
     );
   }
-  getAuthenticityToken().then(() => {
+  return getAuthenticityToken().then(() => {
     fetch('/delete_predict_level_progress', {
       method: 'POST',
       credentials: 'same-origin',
@@ -182,6 +182,8 @@ export function resetContainedLevel() {
     }).then(response => {
       if (response.ok) {
         getLevel(levelIds[0]).resetAnswers();
+        const runButton = $('#runButton');
+        runButton.prop('disabled', true);
       } else {
         console.log(response);
       }

--- a/apps/src/containedLevels.js
+++ b/apps/src/containedLevels.js
@@ -61,11 +61,15 @@ export function postContainedLevelAttempt({
   attempts,
   onAttempt
 }) {
-  if (!hasContainedLevels || attempts !== 1) {
+  if (!hasContainedLevels) {
+    return;
+  }
+  const isTeacher = getStore().getState().currentUser?.userType === 'teacher';
+
+  if (!isTeacher && attempts !== 1) {
     return;
   }
 
-  const isTeacher = getStore().getState().currentUser?.userType === 'teacher';
   if (isTeacher) {
     if (!!queryString.parse(window.location.search).user_id) {
       // if we have a user_id in the search params, we are a viewing student

--- a/apps/src/containedLevels.js
+++ b/apps/src/containedLevels.js
@@ -124,19 +124,19 @@ export function initializeContainedLevel() {
   if (!store.getState().instructions.hasContainedLevels) {
     return;
   }
+  let runButton = $('#runButton');
+  let stepButton = $('#stepButton');
+  const disabledRunButtonHandler = e => {
+    $(window).trigger('attemptedRunButtonClick');
+  };
   if (codeStudioLevels.hasValidContainedLevelResult()) {
     // We already have an answer, don't allow it to be changed, but allow Run
     // to be pressed so the code can be run again.
     codeStudioLevels.lockContainedLevelAnswers();
   } else {
     // No answers yet, disable Run button until there is an answer
-    let runButton = $('#runButton');
-    let stepButton = $('#stepButton');
     runButton.prop('disabled', true);
     stepButton.prop('disabled', true);
-    const disabledRunButtonHandler = e => {
-      $(window).trigger('attemptedRunButtonClick');
-    };
     $('#runButton').bind('click', disabledRunButtonHandler);
 
     callouts.addCallouts([
@@ -157,21 +157,20 @@ export function initializeContainedLevel() {
       }
     ]);
     store.dispatch(setAwaitingContainedResponse(true));
-
-    codeStudioLevels.registerAnswerChangedFn(() => {
-      // Ideally, runButton would be declaratively disabled or not based on redux
-      // store state. We might be close to a point where we can do that, but
-      // because runButton is also mutated outside of React (here and elsewhere)
-      // we need to worry about cases where the DOM gets out of sync with the
-      // React layer
-      const validResult = codeStudioLevels.hasValidContainedLevelResult();
-      runButton.prop('disabled', !validResult);
-      stepButton.prop('disabled', !validResult);
-      if (validResult) {
-        runButton.qtip('hide');
-        $('#runButton').unbind('click', disabledRunButtonHandler);
-      }
-      getStore().dispatch(setAwaitingContainedResponse(!validResult));
-    });
   }
+  codeStudioLevels.registerAnswerChangedFn(() => {
+    // Ideally, runButton would be declaratively disabled or not based on redux
+    // store state. We might be close to a point where we can do that, but
+    // because runButton is also mutated outside of React (here and elsewhere)
+    // we need to worry about cases where the DOM gets out of sync with the
+    // React layer
+    const validResult = codeStudioLevels.hasValidContainedLevelResult();
+    runButton.prop('disabled', !validResult);
+    stepButton.prop('disabled', !validResult);
+    if (validResult) {
+      runButton.qtip('hide');
+      $('#runButton').unbind('click', disabledRunButtonHandler);
+    }
+    getStore().dispatch(setAwaitingContainedResponse(!validResult));
+  });
 }

--- a/apps/src/templates/instructions/ContainedLevelResetButton.jsx
+++ b/apps/src/templates/instructions/ContainedLevelResetButton.jsx
@@ -30,7 +30,7 @@ export const UnconnectedContainedLevelResetButton = ({
           });
         }}
         color={Button.ButtonColor.red}
-        disabled={!hasLevelResults || codeIsRunning}
+        disabled={!hasLevelResults || !!codeIsRunning}
       />
       <HelpTip>{i18n.deleteAnswerHelpTip()}</HelpTip>
     </div>

--- a/apps/src/templates/instructions/ContainedLevelResetButton.jsx
+++ b/apps/src/templates/instructions/ContainedLevelResetButton.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useMemo} from 'react';
 import PropTypes from 'prop-types';
 import Button from '@cdo/apps/templates/Button';
 import HelpTip from '@cdo/apps/lib/ui/HelpTip';
@@ -16,7 +16,10 @@ export const UnconnectedContainedLevelResetButton = ({
   userRoleInCourse,
   codeIsRunning
 }) => {
-  const isEnabled = experiments.isEnabled('instructorPredictLevelReset');
+  const isEnabled = useMemo(
+    () => experiments.isEnabled('instructorPredictLevelReset'),
+    []
+  );
   if (userRoleInCourse !== CourseRoles.Instructor || !isEnabled) {
     return null;
   }

--- a/apps/src/templates/instructions/ContainedLevelResetButton.jsx
+++ b/apps/src/templates/instructions/ContainedLevelResetButton.jsx
@@ -13,7 +13,8 @@ export const UnconnectedContainedLevelResetButton = ({
   userId,
   queryUserProgress,
   hasLevelResults,
-  userRoleInCourse
+  userRoleInCourse,
+  codeIsRunning
 }) => {
   const isEnabled = experiments.isEnabled('instructorPredictLevelReset');
   if (userRoleInCourse !== CourseRoles.Instructor || !isEnabled) {
@@ -29,7 +30,7 @@ export const UnconnectedContainedLevelResetButton = ({
           });
         }}
         color={Button.ButtonColor.red}
-        disabled={!hasLevelResults}
+        disabled={!hasLevelResults || codeIsRunning}
       />
       <HelpTip>{i18n.deleteAnswerHelpTip()}</HelpTip>
     </div>
@@ -40,7 +41,8 @@ UnconnectedContainedLevelResetButton.propTypes = {
   userId: PropTypes.number,
   queryUserProgress: PropTypes.func.isRequired,
   hasLevelResults: PropTypes.bool,
-  userRoleInCourse: PropTypes.string
+  userRoleInCourse: PropTypes.string,
+  codeIsRunning: PropTypes.bool
 };
 
 export default connect(
@@ -49,7 +51,8 @@ export default connect(
       parseInt(state.progress.currentLevelId)
     ],
     userId: state.pageConstants.userId,
-    userRoleInCourse: state.currentUser.userRoleInCourse
+    userRoleInCourse: state.currentUser.userRoleInCourse,
+    codeIsRunning: state.runState.isRunning
   }),
   dispatch => ({
     queryUserProgress(userId) {

--- a/apps/src/templates/instructions/ContainedLevelResetButton.jsx
+++ b/apps/src/templates/instructions/ContainedLevelResetButton.jsx
@@ -35,7 +35,7 @@ const ContainedLevelResetButton = ({
 };
 
 ContainedLevelResetButton.propTypes = {
-  userId: PropTypes.integer,
+  userId: PropTypes.number,
   queryUserProgress: PropTypes.func.isRequired,
   hasLevelResults: PropTypes.bool,
   userRoleInCourse: PropTypes.string
@@ -43,7 +43,9 @@ ContainedLevelResetButton.propTypes = {
 
 export default connect(
   state => ({
-    hasLevelResults: Object.keys(state.progress.levelResults).length > 0,
+    hasLevelResults: !!state.progress.levelResults[
+      parseInt(state.progress.currentLevelId)
+    ],
     userId: state.pageConstants.userId,
     userRoleInCourse: state.currentUser.userRoleInCourse
   }),

--- a/apps/src/templates/instructions/ContainedLevelResetButton.jsx
+++ b/apps/src/templates/instructions/ContainedLevelResetButton.jsx
@@ -8,7 +8,7 @@ import {connect} from 'react-redux';
 import {queryUserProgress} from '@cdo/apps/code-studio/progressRedux';
 import i18n from '@cdo/locale';
 
-const ContainedLevelResetButton = ({
+export const UnconnectedContainedLevelResetButton = ({
   userId,
   queryUserProgress,
   hasLevelResults,
@@ -34,7 +34,7 @@ const ContainedLevelResetButton = ({
   );
 };
 
-ContainedLevelResetButton.propTypes = {
+UnconnectedContainedLevelResetButton.propTypes = {
   userId: PropTypes.number,
   queryUserProgress: PropTypes.func.isRequired,
   hasLevelResults: PropTypes.bool,
@@ -54,4 +54,4 @@ export default connect(
       dispatch(queryUserProgress(userId));
     }
   })
-)(ContainedLevelResetButton);
+)(UnconnectedContainedLevelResetButton);

--- a/apps/src/templates/instructions/ContainedLevelResetButton.jsx
+++ b/apps/src/templates/instructions/ContainedLevelResetButton.jsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Button from '@cdo/apps/templates/Button';
+import HelpTip from '@cdo/apps/lib/ui/HelpTip';
+import {CourseRoles} from '@cdo/apps/templates/currentUserRedux';
+import {resetContainedLevel} from '@cdo/apps/code-studio/levels/codeStudioLevels';
+import {connect} from 'react-redux';
+import {queryUserProgress} from '@cdo/apps/code-studio/progressRedux';
+import i18n from '@cdo/locale';
+
+const ContainedLevelResetButton = ({
+  userId,
+  queryUserProgress,
+  hasLevelResults,
+  userRoleInCourse
+}) => {
+  if (userRoleInCourse !== CourseRoles.Instructor) {
+    return null;
+  }
+  return (
+    <div>
+      <Button
+        text={i18n.deleteAnswer()}
+        onClick={() => {
+          resetContainedLevel().then(() => {
+            queryUserProgress(userId);
+          });
+        }}
+        color={Button.ButtonColor.red}
+        disabled={!hasLevelResults}
+      />
+      <HelpTip>{i18n.deleteAnswerHelpTip()}</HelpTip>
+    </div>
+  );
+};
+
+ContainedLevelResetButton.propTypes = {
+  userId: PropTypes.integer,
+  queryUserProgress: PropTypes.func.isRequired,
+  hasLevelResults: PropTypes.bool,
+  userRoleInCourse: PropTypes.string
+};
+
+export default connect(
+  state => ({
+    hasLevelResults: Object.keys(state.progress.levelResults).length > 0,
+    userId: state.pageConstants.userId,
+    userRoleInCourse: state.currentUser.userRoleInCourse
+  }),
+  dispatch => ({
+    queryUserProgress(userId) {
+      dispatch(queryUserProgress(userId));
+    }
+  })
+)(ContainedLevelResetButton);

--- a/apps/src/templates/instructions/ContainedLevelResetButton.jsx
+++ b/apps/src/templates/instructions/ContainedLevelResetButton.jsx
@@ -7,6 +7,7 @@ import {resetContainedLevel} from '@cdo/apps/code-studio/levels/codeStudioLevels
 import {connect} from 'react-redux';
 import {queryUserProgress} from '@cdo/apps/code-studio/progressRedux';
 import i18n from '@cdo/locale';
+import experiments from '@cdo/apps/util/experiments';
 
 export const UnconnectedContainedLevelResetButton = ({
   userId,
@@ -14,7 +15,8 @@ export const UnconnectedContainedLevelResetButton = ({
   hasLevelResults,
   userRoleInCourse
 }) => {
-  if (userRoleInCourse !== CourseRoles.Instructor) {
+  const isEnabled = experiments.isEnabled('instructorPredictLevelReset');
+  if (userRoleInCourse !== CourseRoles.Instructor || !isEnabled) {
     return null;
   }
   return (

--- a/apps/src/templates/instructions/ContainedLevelResetButton.jsx
+++ b/apps/src/templates/instructions/ContainedLevelResetButton.jsx
@@ -1,4 +1,4 @@
-import React, {useMemo} from 'react';
+import React, {useMemo, useState} from 'react';
 import PropTypes from 'prop-types';
 import Button from '@cdo/apps/templates/Button';
 import HelpTip from '@cdo/apps/lib/ui/HelpTip';
@@ -6,6 +6,7 @@ import {CourseRoles} from '@cdo/apps/templates/currentUserRedux';
 import {resetContainedLevel} from '@cdo/apps/code-studio/levels/codeStudioLevels';
 import {connect} from 'react-redux';
 import {queryUserProgress} from '@cdo/apps/code-studio/progressRedux';
+import color from '@cdo/apps/util/color';
 import i18n from '@cdo/locale';
 import experiments from '@cdo/apps/util/experiments';
 
@@ -20,6 +21,7 @@ export const UnconnectedContainedLevelResetButton = ({
     () => experiments.isEnabled('instructorPredictLevelReset'),
     []
   );
+  const [resetFailed, setResetFailed] = useState(false);
   if (userRoleInCourse !== CourseRoles.Instructor || !isEnabled) {
     return null;
   }
@@ -28,14 +30,21 @@ export const UnconnectedContainedLevelResetButton = ({
       <Button
         text={i18n.deleteAnswer()}
         onClick={() => {
-          resetContainedLevel().then(() => {
-            queryUserProgress(userId);
-          });
+          resetContainedLevel().then(
+            () => {
+              queryUserProgress(userId);
+              setResetFailed(false);
+            },
+            () => setResetFailed(true)
+          );
         }}
         color={Button.ButtonColor.red}
         disabled={!hasLevelResults || !!codeIsRunning}
       />
       <HelpTip>{i18n.deleteAnswerHelpTip()}</HelpTip>
+      {resetFailed && (
+        <span style={styles.error}>{i18n.errorResettingAnswer()}</span>
+      )}
     </div>
   );
 };
@@ -63,3 +72,10 @@ export default connect(
     }
   })
 )(UnconnectedContainedLevelResetButton);
+
+const styles = {
+  error: {
+    color: color.red,
+    fontStyle: 'italic'
+  }
+};

--- a/apps/src/templates/instructions/TopInstructions.jsx
+++ b/apps/src/templates/instructions/TopInstructions.jsx
@@ -36,6 +36,7 @@ import TopInstructionsHeader from './TopInstructionsHeader';
 import {Z_INDEX as OVERLAY_Z_INDEX} from '../Overlay';
 import Button from '../Button';
 import i18n from '@cdo/locale';
+import ContainedLevelResetButton from './ContainedLevelResetButton';
 
 const HEADER_HEIGHT = styleConstants['workspace-headers-height'];
 const RESIZER_HEIGHT = styleConstants['resize-bar-width'];
@@ -114,12 +115,14 @@ class TopInstructions extends Component {
     standalone: PropTypes.bool,
     // Use this if the caller wants to set an explicit height for the instructions rather
     // than allowing this component to manage its own height.
-    explicitHeight: PropTypes.number
+    explicitHeight: PropTypes.number,
+    inLessonPlan: PropTypes.bool
   };
 
   static defaultProps = {
     resizable: true,
-    collapsible: true
+    collapsible: true,
+    inLessonPlan: false
   };
 
   constructor(props) {
@@ -503,6 +506,7 @@ class TopInstructions extends Component {
             ref={ref => this.setInstructionsRef(ref)}
             hidden={tabSelected !== TabType.INSTRUCTIONS}
           />
+          {!this.props.inLessonPlan && <ContainedLevelResetButton />}
         </div>
       );
     } else if (isCSF && tabSelected === TabType.INSTRUCTIONS) {

--- a/apps/src/templates/lessonOverview/activities/LevelDetailsDialog.jsx
+++ b/apps/src/templates/lessonOverview/activities/LevelDetailsDialog.jsx
@@ -175,6 +175,7 @@ class LevelDetailsDialog extends Component {
           serverLevelId={parseInt(level.id)}
           serverScriptId={this.state.scriptLevel.scriptId}
           exampleSolutions={exampleSolutions}
+          inLessonPlan
         />
       );
     } else {

--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -36,6 +36,7 @@ experiments.SPECIAL_TOPIC = 'special-topic';
 experiments.CLEARER_SIGN_UP_USER_TYPE = 'clearerSignUpUserType';
 experiments.OPT_IN_EMAIL_REG_PARTNER = 'optInEmailRegPartner';
 experiments.STUDIO_CERTIFICATE = 'studioCertificate';
+experiments.INSTRUCTOR_PREDICT_LEVEL_RESET = 'instructorPredictLevelReset';
 
 /**
  * This was a gamified version of the finish dialog, built in 2018,

--- a/apps/test/unit/templates/instructions/ContainedLevelResetButtonTest.jsx
+++ b/apps/test/unit/templates/instructions/ContainedLevelResetButtonTest.jsx
@@ -20,6 +20,7 @@ describe('ContainedLevelResetButton', () => {
         queryUserProgress={queryUserProgressSpy}
         hasLevelResults
         userRoleInCourse="Participant"
+        codeIsRunning={false}
       />
     );
     expect(wrapper.isEmptyRender()).to.be.true;
@@ -32,6 +33,7 @@ describe('ContainedLevelResetButton', () => {
         queryUserProgress={queryUserProgressSpy}
         hasLevelResults={false}
         userRoleInCourse="Instructor"
+        codeIsRunning={false}
       />
     );
     const button = wrapper.find('Button');
@@ -45,6 +47,7 @@ describe('ContainedLevelResetButton', () => {
         queryUserProgress={queryUserProgressSpy}
         hasLevelResults
         userRoleInCourse="Instructor"
+        codeIsRunning={false}
       />
     );
     const button = wrapper.find('Button');
@@ -62,6 +65,7 @@ describe('ContainedLevelResetButton', () => {
         queryUserProgress={queryUserProgressSpy}
         hasLevelResults
         userRoleInCourse="Instructor"
+        codeIsRunning={false}
       />
     );
     const button = wrapper.find('Button');

--- a/apps/test/unit/templates/instructions/ContainedLevelResetButtonTest.jsx
+++ b/apps/test/unit/templates/instructions/ContainedLevelResetButtonTest.jsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import sinon from 'sinon';
+import {expect} from '../../../util/reconfiguredChai';
+import {UnconnectedContainedLevelResetButton as ContainedLevelResetButton} from '@cdo/apps/templates/instructions/ContainedLevelResetButton';
+import * as CodeStudioLevels from '@cdo/apps/code-studio/levels/codeStudioLevels';
+
+describe('ContainedLevelResetButton', () => {
+  let queryUserProgressSpy;
+  beforeEach(() => {
+    queryUserProgressSpy = sinon.spy();
+  });
+
+  it('displays nothing if user is not an instructor', () => {
+    const wrapper = shallow(
+      <ContainedLevelResetButton
+        userId={1}
+        queryUserProgress={queryUserProgressSpy}
+        hasLevelResults
+        userRoleInCourse="Participant"
+      />
+    );
+    expect(wrapper.isEmptyRender()).to.be.true;
+  });
+
+  it('display disabled button if level doesnt have results', () => {
+    const wrapper = shallow(
+      <ContainedLevelResetButton
+        userId={1}
+        queryUserProgress={queryUserProgressSpy}
+        hasLevelResults={false}
+        userRoleInCourse="Instructor"
+      />
+    );
+    const button = wrapper.find('Button');
+    expect(button.props().disabled).to.be.true;
+  });
+
+  it('display enabled button if level doesnt have results', () => {
+    const wrapper = shallow(
+      <ContainedLevelResetButton
+        userId={1}
+        queryUserProgress={queryUserProgressSpy}
+        hasLevelResults
+        userRoleInCourse="Instructor"
+      />
+    );
+    const button = wrapper.find('Button');
+    expect(button.props().disabled).to.be.false;
+  });
+
+  it('queries user progress after successfully resetting level', async () => {
+    const resetContainedLevelStub = sinon
+      .stub(CodeStudioLevels, 'resetContainedLevel')
+      .returns(Promise.resolve());
+
+    const wrapper = shallow(
+      <ContainedLevelResetButton
+        userId={1}
+        queryUserProgress={queryUserProgressSpy}
+        hasLevelResults
+        userRoleInCourse="Instructor"
+      />
+    );
+    const button = wrapper.find('Button');
+
+    button.simulate('click');
+    await setTimeout(() => {}, 50);
+
+    expect(resetContainedLevelStub).to.have.been.called.once;
+    expect(queryUserProgressSpy).to.have.been.called.once;
+  });
+});

--- a/apps/test/unit/templates/instructions/ContainedLevelResetButtonTest.jsx
+++ b/apps/test/unit/templates/instructions/ContainedLevelResetButtonTest.jsx
@@ -4,11 +4,13 @@ import sinon from 'sinon';
 import {expect} from '../../../util/reconfiguredChai';
 import {UnconnectedContainedLevelResetButton as ContainedLevelResetButton} from '@cdo/apps/templates/instructions/ContainedLevelResetButton';
 import * as CodeStudioLevels from '@cdo/apps/code-studio/levels/codeStudioLevels';
+import experiments from '@cdo/apps/util/experiments';
 
 describe('ContainedLevelResetButton', () => {
   let queryUserProgressSpy;
   beforeEach(() => {
     queryUserProgressSpy = sinon.spy();
+    experiments.setEnabled('instructorPredictLevelReset', true);
   });
 
   it('displays nothing if user is not an instructor', () => {

--- a/dashboard/app/controllers/api_controller.rb
+++ b/dashboard/app/controllers/api_controller.rb
@@ -436,7 +436,7 @@ class ApiController < ApplicationController
     if current_user
       if params[:user_id].present?
         user = User.find(params[:user_id])
-        return head :forbidden unless user.student_of?(current_user)
+        return head :forbidden unless user.student_of?(current_user) || user.id == current_user.id
       else
         user = current_user
       end

--- a/dashboard/app/views/levels/_contained_levels.html.haml
+++ b/dashboard/app/views/levels/_contained_levels.html.haml
@@ -15,9 +15,5 @@
         = render partial: 'levels/single_multi', locals: {standalone: false, contained_mode: true, last_attempt: sublevel_last_attempt, level: contained_level, tight_layout: true}
       - elsif level_class == "free_response"
         = render partial: 'levels/free_response', locals: {in_level_group: true, last_attempt: sublevel_last_attempt, level: contained_level, left_align: true, is_contained_level: true }
-      - if current_user && @script && @script.can_be_instructor?(current_user) && DCDO.get('reset-predict-level-feature', false)
-        %button{id: 'reset-predict-progress-button', disabled: !sublevel_last_attempt}
-          %i.fa.fa-trash
-            =I18n.t('reset_predict_progress_button')
 
 %div{style: 'clear: both;'}


### PR DESCRIPTION
Moves progress reset button to React, which allows us to use the `Button` and `HelpTip` components. As a result, I'm moving this feature out from a DCDO flag and using an experiment flag -- there are a lot of cases to work through on this feature so I'd like some more time to test (and maybe write a UI test). 


https://user-images.githubusercontent.com/46464143/191040173-7dece0a1-70dc-4ce0-9c58-98894b504648.mov


https://user-images.githubusercontent.com/46464143/191040185-2f0e0c5b-fe77-4d67-be0b-ab42406d3a55.mov



## Links

[spec](https://docs.google.com/document/d/1-XwiQ2Xg6rgopTJOzEUE4wE0CdbrZ0_ockr1SFdhAJM/edit#heading=h.8hgpnebrk2d9)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
