### PR TITLE
Enable Selecting micro:bit on Levelbuilder levels

### DIFF
--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -2028,7 +2028,7 @@ function setMakerAPIsStatusFromQueryParams() {
  */
 function setMakerAPIsStatusFromLevel() {
   if (appOptions.level.makerlabEnabled) {
-    currentSources.makerAPIsEnabled = CP_API;
+    currentSources.makerAPIsEnabled = appOptions.level.makerlabEnabled;
   }
 }
 

--- a/apps/src/lib/kits/maker/dropletConfig.js
+++ b/apps/src/lib/kits/maker/dropletConfig.js
@@ -21,7 +21,7 @@ export default config;
 
 const MAKER_CATEGORY = 'Maker';
 config.MAKER_CATEGORY = MAKER_CATEGORY;
-const CIRCUIT_CATEGORY = 'Circuit';
+export const CIRCUIT_CATEGORY = 'Circuit';
 const MICROBIT_CATEGORY = 'micro:bit';
 
 const emptySocketPrefix = '__.';
@@ -128,7 +128,7 @@ function sharedLedBlocks({category, blockPrefix, objectDropdown}) {
 /**
  * Generic Johnny-Five / Firmata blocks
  */
-function getMakerBlocks(boardType) {
+export function getMakerBlocks(boardType) {
   let defaultPin = '"A6"';
   if (boardType === MICROBIT_CATEGORY) {
     defaultPin = '0';

--- a/apps/src/lib/kits/maker/dropletConfig.js
+++ b/apps/src/lib/kits/maker/dropletConfig.js
@@ -21,7 +21,7 @@ export default config;
 
 const MAKER_CATEGORY = 'Maker';
 config.MAKER_CATEGORY = MAKER_CATEGORY;
-export const CIRCUIT_CATEGORY = 'Circuit';
+const CIRCUIT_CATEGORY = 'Circuit';
 const MICROBIT_CATEGORY = 'micro:bit';
 
 const emptySocketPrefix = '__.';

--- a/apps/src/sites/studio/pages/levels/editors/_applab.js
+++ b/apps/src/sites/studio/pages/levels/editors/_applab.js
@@ -4,6 +4,10 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import getScriptData from '@cdo/apps/util/getScriptData';
 import color from '@cdo/apps/util/color';
+import {configMicrobit} from '@cdo/apps/lib/kits/maker/dropletConfig';
+
+const microbitBlocks = {};
+configMicrobit.blocks.forEach(block => (microbitBlocks[block.func] = null));
 
 $(document).ready(function() {
   const makerBlocks = {
@@ -48,19 +52,21 @@ $(document).ready(function() {
     'toggleSwitch.isOpen': null,
     onBoardEvent: null
   };
+
   $('#level_makerlab_enabled').change(function() {
-    if ($(this).is(':checked')) {
-      const editor = $('#level_code_functions')
-        .siblings()
-        .filter('.CodeMirror')[0].CodeMirror;
-      const currentFunctions = JSON.parse(editor.getValue());
-      const functionsWithMaker = Object.assign(
-        {},
-        currentFunctions,
-        makerBlocks
-      );
-      editor.getDoc().setValue(JSON.stringify(functionsWithMaker, null, ' '));
+    const editor = $('#level_code_functions')
+      .siblings()
+      .filter('.CodeMirror')[0].CodeMirror;
+    const currentFunctions = JSON.parse(editor.getValue());
+    let functionsWithMaker;
+    if ($(this).val() === 'circuitPlayground') {
+      // Load the circuitPlayground and maker blocks.
+      functionsWithMaker = Object.assign({}, currentFunctions, makerBlocks);
+    } else if ($(this).val() === 'microbit') {
+      // Load the microbit and maker blocks
+      functionsWithMaker = Object.assign({}, currentFunctions, microbitBlocks);
     }
+    editor.getDoc().setValue(JSON.stringify(functionsWithMaker, null, ' '));
   });
 
   const styles = {

--- a/apps/src/sites/studio/pages/levels/editors/_applab.js
+++ b/apps/src/sites/studio/pages/levels/editors/_applab.js
@@ -11,21 +11,23 @@ import {
 } from '@cdo/apps/lib/kits/maker/dropletConfig';
 
 $(document).ready(function() {
-  // Get the set of blocks for the Maker Category, the Circuit Category, and the Micro:bit category
-
-  // The maker type given here sets the defaultPin in the example block. Since we are just using the function name,
-  // which doesn't include a pin parameter, we could any block type.
-  let makerBlocks = getMakerBlocks(null);
-  // Setting block values to null to match the expected behavior in code_functions.
-  makerBlocks = makerBlocks.forEach(block => (makerBlocks[block.func] = null));
-  const microbitBlocks = {};
-  configMicrobit.blocks.forEach(block => (microbitBlocks[block.func] = null));
-  const circuitBlocks = {};
-  configCircuitPlayground.blocks.forEach(
-    block => (circuitBlocks[block.func] = null)
-  );
-
   $('#level_makerlab_enabled').change(function() {
+    // Get the set of blocks for the Maker Category, the Circuit Category, and the Micro:bit category
+
+    // The maker type given here sets the defaultPin in the example block. Since we are just using the function name,
+    // which doesn't include a pin parameter, we could use any block type.
+    const configMaker = getMakerBlocks(null);
+    let makerBlocks = {};
+    // Setting block values to null to match the expected behavior in code_functions.
+    configMaker.forEach(block => (makerBlocks[block.func] = null));
+
+    let microbitBlocks = {};
+    configMicrobit.blocks.forEach(block => (microbitBlocks[block.func] = null));
+    let circuitBlocks = {};
+    configCircuitPlayground.blocks.forEach(
+      block => (circuitBlocks[block.func] = null)
+    );
+
     const editor = $('#level_code_functions')
       .siblings()
       .filter('.CodeMirror')[0].CodeMirror;

--- a/apps/src/sites/studio/pages/levels/editors/_applab.js
+++ b/apps/src/sites/studio/pages/levels/editors/_applab.js
@@ -4,54 +4,28 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import getScriptData from '@cdo/apps/util/getScriptData';
 import color from '@cdo/apps/util/color';
-import {configMicrobit} from '@cdo/apps/lib/kits/maker/dropletConfig';
-
-const microbitBlocks = {};
-configMicrobit.blocks.forEach(block => (microbitBlocks[block.func] = null));
+import {
+  configMicrobit,
+  configCircuitPlayground,
+  getMakerBlocks
+} from '@cdo/apps/lib/kits/maker/dropletConfig';
 
 $(document).ready(function() {
-  const makerBlocks = {
-    pinMode: null,
-    digitalWrite: null,
-    digitalRead: null,
-    analogWrite: null,
-    analogRead: null,
-    on: null,
-    off: null,
-    toggle: null,
-    blink: null,
-    pulse: null,
-    stop: null,
-    color: null,
-    intensity: null,
-    'led.on': null,
-    'led.off': null,
-    'led.blink': null,
-    'led.toggle': null,
-    'led.pulse': null,
-    'buzzer.frequency': null,
-    'buzzer.note': null,
-    'buzzer.off': null,
-    'buzzer.stop': null,
-    'buzzer.playNotes': null,
-    'buzzer.playSong': null,
-    'accelerometer.getOrientation': null,
-    'accelerometer.getAcceleration': null,
-    isPressed: null,
-    holdtime: null,
-    'soundSensor.value': null,
-    'soundSensor.getAveragedValue': null,
-    'soundSensor.setScale': null,
-    'soundSensor.threshold': null,
-    'lightSensor.value': null,
-    'lightSensor.getAveragedValue': null,
-    'lightSensor.setScale': null,
-    'lightSensor.threshold': null,
-    'tempSensor.F': null,
-    'tempSensor.C': null,
-    'toggleSwitch.isOpen': null,
-    onBoardEvent: null
-  };
+  // Get the set of blocks for the Maker Category, the Circuit Category, and the Micro:bit category
+
+  // The maker type given here sets the defaultPin in the example block. Since we are just using the function name,
+  // which doesn't include a pin parameter, we could any block type.
+  let makerBlocks = getMakerBlocks(null);
+  // Setting block values to null to match the expected behavior in code_functions.
+  makerBlocks = makerBlocks.blocks.forEach(
+    block => (makerBlocks[block.func] = null)
+  );
+  const microbitBlocks = {};
+  configMicrobit.blocks.forEach(block => (microbitBlocks[block.func] = null));
+  const circuitBlocks = {};
+  configCircuitPlayground.blocks.forEach(
+    block => (circuitBlocks[block.func] = null)
+  );
 
   $('#level_makerlab_enabled').change(function() {
     const editor = $('#level_code_functions')
@@ -61,10 +35,20 @@ $(document).ready(function() {
     let functionsWithMaker;
     if ($(this).val() === 'circuitPlayground') {
       // Load the circuitPlayground and maker blocks.
-      functionsWithMaker = Object.assign({}, currentFunctions, makerBlocks);
+      functionsWithMaker = Object.assign(
+        {},
+        currentFunctions,
+        makerBlocks,
+        circuitBlocks
+      );
     } else if ($(this).val() === 'microbit') {
       // Load the microbit and maker blocks
-      functionsWithMaker = Object.assign({}, currentFunctions, microbitBlocks);
+      functionsWithMaker = Object.assign(
+        {},
+        currentFunctions,
+        makerBlocks,
+        microbitBlocks
+      );
     }
     editor.getDoc().setValue(JSON.stringify(functionsWithMaker, null, ' '));
   });

--- a/apps/src/sites/studio/pages/levels/editors/_applab.js
+++ b/apps/src/sites/studio/pages/levels/editors/_applab.js
@@ -14,13 +14,12 @@ $(document).ready(function() {
   $('#level_makerlab_enabled').change(function() {
     // Get the set of blocks for the Maker Category, the Circuit Category, and the Micro:bit category
 
+    // Setting block values to null to match the expected behavior in code_functions.
     // The maker type given here sets the defaultPin in the example block. Since we are just using the function name,
     // which doesn't include a pin parameter, we could use any block type.
     const configMaker = getMakerBlocks(null);
     let makerBlocks = {};
-    // Setting block values to null to match the expected behavior in code_functions.
     configMaker.forEach(block => (makerBlocks[block.func] = null));
-
     let microbitBlocks = {};
     configMicrobit.blocks.forEach(block => (microbitBlocks[block.func] = null));
     let circuitBlocks = {};

--- a/apps/src/sites/studio/pages/levels/editors/_applab.js
+++ b/apps/src/sites/studio/pages/levels/editors/_applab.js
@@ -17,9 +17,7 @@ $(document).ready(function() {
   // which doesn't include a pin parameter, we could any block type.
   let makerBlocks = getMakerBlocks(null);
   // Setting block values to null to match the expected behavior in code_functions.
-  makerBlocks = makerBlocks.blocks.forEach(
-    block => (makerBlocks[block.func] = null)
-  );
+  makerBlocks = makerBlocks.forEach(block => (makerBlocks[block.func] = null));
   const microbitBlocks = {};
   configMicrobit.blocks.forEach(block => (microbitBlocks[block.func] = null));
   const circuitBlocks = {};

--- a/dashboard/app/models/levels/applab.rb
+++ b/dashboard/app/models/levels/applab.rb
@@ -77,6 +77,10 @@ class Applab < Blockly
     %w(Maker Circuit)
   end
 
+  def self.maker_apis
+    %w(circuitPlayground microbit)
+  end
+
   def self.create_from_level_builder(params, level_params)
     create!(
       level_params.merge(
@@ -125,7 +129,7 @@ class Applab < Blockly
   end
 
   def validate_maker_if_needed
-    maker_enabled = properties['makerlab_enabled'] == 'true'
+    maker_enabled = properties['makerlab_enabled'] == 'circuitPlayground' || properties['makerlab_enabled'] == 'microbit'
     starting_category = properties['palette_category_at_start']
     if Applab.maker_palette_categories.include?(starting_category) && !maker_enabled
       raise ArgumentError.new(

--- a/dashboard/app/views/levels/editors/fields/_droplet.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_droplet.html.haml
@@ -11,7 +11,7 @@
     = render partial: 'levels/editors/fields/checkboxes', locals: {f: f, field_name: :beginner_mode, description: "Beginner mode for loops"}
     .field
       = f.label :makerlab_enabled, 'Select Maker API:'
-      = f.select :makerlab_enabled, options_for_select(@level.class.maker_apis), {include_blank: true}
+      = f.select :makerlab_enabled, options_for_select(@level.class.maker_apis, @level.makerlab_enabled), {include_blank: true}
 
   .field
     = f.label :palette_category_at_start

--- a/dashboard/app/views/levels/editors/fields/_droplet.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_droplet.html.haml
@@ -6,11 +6,12 @@
   = render partial: 'levels/editors/fields/checkboxes', locals: {f: f, field_name: :lock_zero_param_functions, description: "Don't allow parameters to be added to user-defined functions with no parameters"}
 
   - if @level.is_a? Applab
-    = f.label :makerlab_enabled, 'Select Maker API:'
-    = f.select :makerlab_enabled, options_for_select(@level.class.maker_apis), {include_blank: true}
     = render partial: 'levels/editors/fields/checkboxes', locals: {f: f, field_name: :autocomplete_palette_apis_only, description: "Autocomplete palette APIs only"}
     = render partial: 'levels/editors/fields/checkboxes', locals: {f: f, field_name: :execute_palette_apis_only, description: "Execute palette APIs only"}
     = render partial: 'levels/editors/fields/checkboxes', locals: {f: f, field_name: :beginner_mode, description: "Beginner mode for loops"}
+    .field
+      = f.label :makerlab_enabled, 'Select Maker API:'
+      = f.select :makerlab_enabled, options_for_select(@level.class.maker_apis), {include_blank: true}
 
   .field
     = f.label :palette_category_at_start

--- a/dashboard/app/views/levels/editors/fields/_droplet.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_droplet.html.haml
@@ -6,7 +6,8 @@
   = render partial: 'levels/editors/fields/checkboxes', locals: {f: f, field_name: :lock_zero_param_functions, description: "Don't allow parameters to be added to user-defined functions with no parameters"}
 
   - if @level.is_a? Applab
-    = render partial: 'levels/editors/fields/checkboxes', locals: {f: f, field_name: :makerlab_enabled, description: "Enable Maker APIs"}
+    = f.label :makerlab_enabled, 'Select Maker API:'
+    = f.select :makerlab_enabled, options_for_select(@level.class.maker_apis), {include_blank: true}
     = render partial: 'levels/editors/fields/checkboxes', locals: {f: f, field_name: :autocomplete_palette_apis_only, description: "Autocomplete palette APIs only"}
     = render partial: 'levels/editors/fields/checkboxes', locals: {f: f, field_name: :execute_palette_apis_only, description: "Execute palette APIs only"}
     = render partial: 'levels/editors/fields/checkboxes', locals: {f: f, field_name: :beginner_mode, description: "Beginner mode for loops"}


### PR DESCRIPTION
Previously, curriculum writers only could select `true/false` for the maker toolkit. When we added micro:bit as a maker API options, projects then moved from a model of `makerAPIs: true/false` to `makerAPIs: circuitPlayground/microbit`, as saved in the project file. We didn't update this as a setting in levelbuilder because we weren't sure what the future of the micro:bit integration was and whether we would ever want to enable the ability to create 'micro:bit' levels. So `makerAPIs: true` defaulted to `circuitPlayground`. Per Dan's request, we now want the option to select the type of Maker API enabled.

This PR adjust the check box in levelbuilder to be a dropdown with both API options. The blocks associated with that API are then added to the `code_functions` list, which adds blocks available in the level. When these blocks are added and the appropriate MakerAPI is enabled, the corresponding Category appears in the block workspace.

This PR also removes a hardcoded object of blocks to add to the `code_functions`. To DRY this up, I added code that programmatically defines the Maker (API agnostic) blocks, the micro:bit blocks, and the Circuit Playground blocks, based on the available blocks in each category. This reduces the number of places we need to remember to update when we add, remove, or rename a block.

Before in Levelbuilder:
![Screenshot from 2022-09-14 10-56-20](https://user-images.githubusercontent.com/2959170/190227809-6c77cd23-499b-4385-a3e5-b20d2beea7ac.png)

After in Levelbuilder:
![Screenshot from 2022-09-13 11-06-35](https://user-images.githubusercontent.com/2959170/190227937-870b59f7-2e16-4a2d-9867-fd0addfec9a0.png)
