### PR TITLE
conditionally use new dashboard page for batch certificates

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -710,6 +710,8 @@ describe('entry tests', () => {
       './src/sites/code.org/pages/public/educate/regional-partner/playbook.js',
     'code.org/public/certificates/blank':
       './src/sites/code.org/pages/public/certificates/blank.js',
+    'code.org/public/certificates':
+      './src/sites/code.org/pages/public/certificates.js',
     'code.org/public/student/middle-high':
       './src/sites/code.org/pages/public/student/middle-high.js',
     'code.org/public/teacher-dashboard/index':

--- a/apps/src/sites/code.org/pages/public/certificates.js
+++ b/apps/src/sites/code.org/pages/public/certificates.js
@@ -1,0 +1,8 @@
+import experiments from '@cdo/apps/util/experiments';
+
+const studioCertificate = experiments.isEnabled(experiments.STUDIO_CERTIFICATE);
+
+if (studioCertificate) {
+  const script = document.querySelector('script[data-studio-redirect-url]');
+  window.location = script.dataset['studioRedirectUrl'];
+}

--- a/apps/src/sites/studio/pages/certificates/batch.js
+++ b/apps/src/sites/studio/pages/certificates/batch.js
@@ -5,9 +5,13 @@ import CertificateBatch from '@cdo/apps/templates/certificates/CertificateBatch'
 
 $(document).ready(function() {
   const certificateData = getScriptData('certificate');
-  const {courseName, imageUrl} = certificateData;
+  const {courseName, studentNames, imageUrl} = certificateData;
   ReactDOM.render(
-    <CertificateBatch courseName={courseName} imageUrl={imageUrl} />,
+    <CertificateBatch
+      courseName={courseName}
+      initialStudentNames={studentNames}
+      imageUrl={imageUrl}
+    />,
     document.getElementById('certificate-batch')
   );
 });

--- a/apps/src/templates/certificates/CertificateBatch.jsx
+++ b/apps/src/templates/certificates/CertificateBatch.jsx
@@ -11,7 +11,7 @@ export default function CertificateBatch({
   initialStudentNames,
   imageUrl
 }) {
-  const [studentNames, setStudentNames] = useState(initialStudentNames);
+  const [studentNames, setStudentNames] = useState(initialStudentNames || []);
 
   const onChange = e => {
     setStudentNames(e.target.value && e.target.value.split('\n'));

--- a/apps/src/templates/certificates/CertificateBatch.jsx
+++ b/apps/src/templates/certificates/CertificateBatch.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useState} from 'react';
 import PropTypes from 'prop-types';
 import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
 import i18n from '@cdo/locale';
@@ -6,7 +6,17 @@ import styleConstants from '../../styleConstants';
 import color from '@cdo/apps/util/color';
 import RailsAuthenticityToken from '@cdo/apps/lib/util/RailsAuthenticityToken';
 
-export default function CertificateBatch({courseName, imageUrl}) {
+export default function CertificateBatch({
+  courseName,
+  initialStudentNames,
+  imageUrl
+}) {
+  const [studentNames, setStudentNames] = useState(initialStudentNames);
+
+  const onChange = e => {
+    setStudentNames(e.target.value && e.target.value.split('\n'));
+  };
+
   return (
     <div style={styles.wrapper}>
       <h1>{i18n.printBatchCertificates()}</h1>
@@ -31,6 +41,8 @@ export default function CertificateBatch({courseName, imageUrl}) {
           name="studentNames"
           rows="10"
           style={styles.textarea}
+          value={studentNames.join('\n')}
+          onChange={onChange}
         />
         <SafeMarkdown markdown={i18n.landscapeRecommendedCertificates()} />
         <button type="submit" style={styles.submit} id="submit-button">
@@ -74,5 +86,6 @@ const styles = {
 
 CertificateBatch.propTypes = {
   courseName: PropTypes.string,
+  initialStudentNames: PropTypes.arrayOf(PropTypes.string).isRequired,
   imageUrl: PropTypes.string.isRequired
 };

--- a/apps/src/templates/teacherDashboard/PrintCertificates.jsx
+++ b/apps/src/templates/teacherDashboard/PrintCertificates.jsx
@@ -29,12 +29,16 @@ class PrintCertificates extends Component {
     this.certForm.submit();
   };
 
+  certificateUrl = () => {
+    pegasus('/certificates');
+  };
+
   render() {
     return (
       <form
         className={style.main}
         ref={element => (this.certForm = element)}
-        action={pegasus('/certificates')}
+        action={this.certificateUrl()}
         method="POST"
       >
         <input

--- a/apps/src/templates/teacherDashboard/PrintCertificates.jsx
+++ b/apps/src/templates/teacherDashboard/PrintCertificates.jsx
@@ -5,6 +5,8 @@ import $ from 'jquery';
 import i18n from '@cdo/locale';
 import {pegasus} from '@cdo/apps/lib/util/urlHelpers';
 import style from './print-certificates.module.scss';
+import experiments from '@cdo/apps/util/experiments';
+import RailsAuthenticityToken from '@cdo/apps/lib/util/RailsAuthenticityToken';
 
 class PrintCertificates extends Component {
   static propTypes = {
@@ -30,7 +32,11 @@ class PrintCertificates extends Component {
   };
 
   certificateUrl = () => {
-    pegasus('/certificates');
+    if (experiments.isEnabled(experiments.STUDIO_CERTIFICATE)) {
+      return '/certificates/batch';
+    } else {
+      return pegasus('/certificates');
+    }
   };
 
   render() {
@@ -41,6 +47,7 @@ class PrintCertificates extends Component {
         action={this.certificateUrl()}
         method="POST"
       >
+        <RailsAuthenticityToken />
         <input
           type="hidden"
           name="script"

--- a/apps/test/unit/templates/teacherDashboard/PrintCertificatesTest.js
+++ b/apps/test/unit/templates/teacherDashboard/PrintCertificatesTest.js
@@ -22,9 +22,9 @@ describe('PrintCertificates', () => {
   });
 
   it('has a hidden input for the assigned script', () => {
-    assert(wrapper.childAt(0).is('input'));
-    assert.equal(wrapper.childAt(0).props().type, 'hidden');
-    assert.equal(wrapper.childAt(0).props().defaultValue, 'playlab');
+    assert(wrapper.childAt(1).is('input'));
+    assert.equal(wrapper.childAt(1).props().type, 'hidden');
+    assert.equal(wrapper.childAt(1).props().defaultValue, 'playlab');
   });
 
   it('has trigger to open /certificates', () => {

--- a/dashboard/app/controllers/certificates_controller.rb
+++ b/dashboard/app/controllers/certificates_controller.rb
@@ -41,6 +41,7 @@ class CertificatesController < ApplicationController
   end
 
   # GET /certificates/batch
+  # POST /certificates/batch
   def batch
     unless current_user.teacher?
       return redirect_to root_path, alert: 'You must be signed in as a teacher to bulk print certificates.'
@@ -52,8 +53,11 @@ class CertificatesController < ApplicationController
       return render status: :bad_request, json: {message: 'invalid base64'}
     end
 
+    student_names = request.method == 'POST' ? params[:names] : []
+
     @certificate_data = {
       courseName: course_name,
+      studentNames: student_names,
       imageUrl: certificate_image_url(nil, course_name, nil),
     }
   end

--- a/dashboard/app/controllers/print_certificates_controller.rb
+++ b/dashboard/app/controllers/print_certificates_controller.rb
@@ -25,7 +25,7 @@ class PrintCertificatesController < ApplicationController
   def batch
     view_options(no_header: true, no_footer: true, white_background: true, full_width: true)
 
-    student_names = params[:studentNames]&.split("\n")&.map(&:strip)&.shift(30)
+    student_names = params[:studentNames]&.strip&.split("\n")&.map(&:strip)&.shift(30)
     course_name = params[:courseName].presence || ScriptConstants::HOC_NAME
     image_urls = student_names.map do |student_name|
       certificate_image_url(student_name, course_name, nil)

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -475,6 +475,7 @@ Dashboard::Application.routes.draw do
 
     get '/certificates/blank'
     get '/certificates/batch'
+    post '/certificates/batch'
     get '/certificates/:encoded_params', to: 'certificates#show'
 
     get '/beta', to: redirect('/')

--- a/dashboard/test/controllers/print_certificates_controller_test.rb
+++ b/dashboard/test/controllers/print_certificates_controller_test.rb
@@ -30,12 +30,20 @@ class PrintCertificatesControllerTest < ActionController::TestCase
   end
 
   test 'batch shows multiple certificate images' do
-    student_names = ['Alice', 'Bob', 'Charlie'].join("\n")
+    student_names = "Alice\nBob\nCharlie"
     post :batch, params: {studentNames: student_names}
     assert_response :success
     response_data = JSON.parse(css_select('script[data-certificate]').first.attribute('data-certificate').to_s)
     assert_equal 3, response_data['imageUrls'].length
     assert_includes response_data['imageUrls'].first, '/certificate_images/', 'certificate images must be customized'
+  end
+
+  test 'batch omits blank certificates' do
+    student_names = "Alice\nBob\nCharlie\n\n"
+    post :batch, params: {studentNames: student_names}
+    assert_response :success
+    response_data = JSON.parse(css_select('script[data-certificate]').first.attribute('data-certificate').to_s)
+    assert_equal 3, response_data['imageUrls'].length
   end
 
   test 'batch shows at most 30 certificate images' do

--- a/dashboard/test/ui/features/learning_platform/section_action_dropdown.feature
+++ b/dashboard/test/ui/features/learning_platform/section_action_dropdown.feature
@@ -31,16 +31,19 @@ Feature: Using the SectionActionDropdown
     And I press the first ".print-login-link" element to load a new page
     And I wait until current URL contains "/login_info"
 
-  # * Add a section and then opens the edit dialog.
-  #     * If the save button can be pressed, we are in the right dialog.
-  #     * If the save button cannot be pressed, we do not have focus in the right dialog.
-  Scenario: Editing Section Information from SectionActionDropdown
-    Given I am a teacher
-    And I create a new student section and go home
+  Scenario: Printing Certificates from SectionActionDropdown
+    Given I create a teacher-associated student named "Sally"
+    And I sign in as "Teacher_Sally"
+    And I am on "http://studio.code.org/home?enableExperiments=studioCertificate"
     And I open the section action dropdown
-    And I press the first ".edit-section-details-link" element
-    And I press the first ".uitest-saveButton" element
-    And I wait for the dialog to close
+    And I press the first ".uitest-certs-link" element to load a new page
+    And I wait until current URL contains "/certificates/batch"
+    Then element ".batch-certificate-form textarea" has value "Sally"
+
+    When I press "submit-button" to load a new page
+    And I wait until I am on "http://studio.code.org/print_certificates/batch"
+    And I wait until element ".hide-print" is visible
+    Then evaluate JavaScript expression "$('img').length === 1"
 
   # * Checks that section can be hidden and shown
   #   * The menu of a new section should have a 'Hide Section' option -> select it to hide the section

--- a/dashboard/test/ui/features/learning_platform/section_action_dropdown.feature
+++ b/dashboard/test/ui/features/learning_platform/section_action_dropdown.feature
@@ -31,7 +31,16 @@ Feature: Using the SectionActionDropdown
     And I press the first ".print-login-link" element to load a new page
     And I wait until current URL contains "/login_info"
 
-  Scenario: Printing Certificates from SectionActionDropdown
+  Scenario: Printing Certificates from SectionActionDropdown without experiment
+    Given I create a teacher-associated student named "Sally"
+    And I sign in as "Teacher_Sally"
+    And I am on "http://studio.code.org/home"
+    And I open the section action dropdown
+    And I press the first ".uitest-certs-link" element to load a new page
+    And I wait until I am on "http://code.org/certificates"
+    Then element "textarea" has value "Sally"
+
+  Scenario: Printing Certificates from SectionActionDropdown with experiment
     Given I create a teacher-associated student named "Sally"
     And I sign in as "Teacher_Sally"
     And I am on "http://studio.code.org/home?enableExperiments=studioCertificate"

--- a/pegasus/sites.v3/code.org/public/certificates.haml
+++ b/pegasus/sites.v3/code.org/public/certificates.haml
@@ -10,6 +10,9 @@ theme: responsive
 -script_name = script == "20-hour" ? "K-8 Intro to Computer Science Course" : "Hour of Code"
 -small_certificate_image_url = "/images/fit-240/#{CertificateImage.certificate_template_for(script)}"
 
+- studio_redirect_url = CDO.studio_url("/certificates/batch")
+%script{src: webpack_asset_path('js/code.org/public/certificates.js'), 'data': {studio_redirect_url: studio_redirect_url}}
+
 %h1=I18n.t :print_batch_certificates
 %div.clear
   %div{:style=>"float: left; margin: 0 40px 0 0;"}<


### PR DESCRIPTION
Continues [PLAT-1533](https://codedotorg.atlassian.net/browse/PLAT-1533). Follows https://github.com/code-dot-org/code-dot-org/pull/48000, see that PR for context.

1. redirects from code.org/certificates to studio.code.org/certificates/batch, if experiment is enabled
2. clicking Print Certificates on teacher homepage now goes to /certificates/batch, if experiment is enabled
3. strip trailing newlines to avoid blank certificates

### screenshots

from new UI test:

https://user-images.githubusercontent.com/8001765/190451072-bc2ac886-adf4-471e-a183-86f703cf35ab.mp4



## Testing story

* manually verified (1)
* (2) is covered by new UI tests

## Deployment strategy

safe to deploy because behavior is unchanged for end users, who will not have the experiment enabled

## Follow-up work

pass the course name from teacher homepage to /certificates/batch, and customize the certificate there appropriately