### PR TITLE
Support sass on all pegasus sites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,7 +63,7 @@ npm-debug.log
 /log
 /pegasus/config/newrelic.yml
 /pegasus/.sass-cache
-/pegasus/sites.v3/code.org/public/css/generated
+/pegasus/sites.v3/*/public/css/generated
 /rebuild
 /rebuild-apps
 /rebuild-shared

--- a/dashboard/config/environments/development.rb
+++ b/dashboard/config/environments/development.rb
@@ -20,6 +20,7 @@ Dashboard::Application.configure do
   config.hosts << "localhost.code.org"
   config.hosts << "localhost.hourofcode.com"
   config.hosts << "localhost.codeprojects.org"
+  config.hosts << "localhost-advocacy.code.org"
 
   # Do not eager load code on boot.
   config.eager_load = false

--- a/pegasus/router.rb
+++ b/pegasus/router.rb
@@ -112,10 +112,12 @@ class Documents < Sinatra::Base
       ['.fetch']
     # Note: shared_resources.rb has additional configuration for Sass::Plugin
     Sass::Plugin.options[:cache_location] = pegasus_dir('cache', '.sass-cache')
-    Sass::Plugin.add_template_location(
-      sites_v3_dir('code.org', 'public', 'css'),
-      sites_v3_dir('code.org', 'public', 'css', 'generated')
-    )
+    ['code.org', 'hourofcode.com', 'advocacy.code.org'].each do |site|
+      Sass::Plugin.add_template_location(
+        sites_v3_dir(site, 'public', 'css'),
+        sites_v3_dir(site, 'public', 'css', 'generated')
+      )
+    end
     set :mustermann_opts, check_anchors: false, ignore_unknown_options: true
 
     # Haml/Temple engine doesn't recognize the `path` option


### PR DESCRIPTION
Adds sass support to hourofcode.com (primary goal) and advocacy.code.org (why not). A sass file called `ben.scss` would be available at `/css/generated/ben.css`, which is the same pattern as we use in code.org currently.

As an aside, now serves advocacy.code.org at localhost.advocacy.code.org:3000 in development, which [it appears we registered to lookup localhost at some point](https://www.nslookup.io/domains/localhost-advocacy.code.org/dns-records/), but isn't configured to work currently.

## Links

- https://github.com/code-dot-org/code-dot-org/pull/46896
- jira ticket: [STAR-2372](https://codedotorg.atlassian.net/browse/STAR-2372)

## Testing story

I added a scss file to the css directories in `pegasus/sites.v3/hourofcode.com` and `pegasus/sites.v3/advocacy.code.org`, and used them to style some text on the homepage of each site. I also looked at the compiled css files at URLs like localhost.hourofcode.com:3000/css/generated/ben.css.