### PR TITLE
Add option to delete files from the backpack

### DIFF
--- a/apps/i18n/javalab/en_us.json
+++ b/apps/i18n/javalab/en_us.json
@@ -75,6 +75,8 @@
   "feedbackBeginning": "This is the beginning of feedback for your project.",
   "feedbackBeginningPeer": "This is the beginning of feedback for {peerName}'s project.",
   "illegalMethodAccess": "You tried to access a method that is blocked by our security policy.\n{cause}",
+  "fileDeleteConfirm": "Are you sure you want to delete the following files from your backpack? This action can't be undone.",
+  "fileDeleteError": "We encountered an error deleting one or more of your files. Please try again. Files unable to be deleted:",
   "fileImportError": "One or more file names are reserved by Java Lab and cannot be imported into this project. Files unable to be imported:",
   "fileImportServerError": "We encountered an error importing one or more of your files. Please try again. Files unable to be imported:",
   "fileImportWarning": "You have one or more duplicate file names between this project and your selected backpack files. Duplicate file names are:",

--- a/apps/src/code-studio/components/backpack/BackpackClientApi.js
+++ b/apps/src/code-studio/components/backpack/BackpackClientApi.js
@@ -234,31 +234,9 @@ export default class BackpackClientApi {
     );
   }
 
-  // Mark the given file as done uploading/attempting to upload.
-  // Check if all files are done uploading. If they are, call either onSuccess
+  // Mark the given file as done updating/attempting to update.
+  // Check if all files are done updating. If they are, call either onSuccess
   // or onError depending on if we saw any errors.
-  onUploadComplete(filename, onError, onSuccess, error) {
-    this.onRequestComplete(
-      filename,
-      this.fileUploadsInProgress,
-      this.fileUploadsFailed,
-      onError,
-      onSuccess,
-      error
-    );
-  }
-
-  onDeleteComplete(filename, onError, onSuccess, error) {
-    this.onRequestComplete(
-      filename,
-      this.fileDeletesInProgress,
-      this.fileDeletesFailed,
-      onError,
-      onSuccess,
-      error
-    );
-  }
-
   onRequestComplete(
     filename,
     filesInRequest,

--- a/apps/src/code-studio/components/backpack/BackpackClientApi.js
+++ b/apps/src/code-studio/components/backpack/BackpackClientApi.js
@@ -104,7 +104,7 @@ export default class BackpackClientApi {
       return;
     }
     if (filenames.length === 0) {
-      // nothing to delete
+      // nothing to update
       onSuccess();
       return;
     }

--- a/apps/src/javalab/Backpack.jsx
+++ b/apps/src/javalab/Backpack.jsx
@@ -110,15 +110,18 @@ class Backpack extends Component {
     });
     const {backpackFilenames, selectedFiles} = this.state;
     // remove correctly deleted files from backpackFilenames and selectedFiles
-    const filesDeleted = expectedFilesDeleted.filter(
-      filename => !failedFileList.includes(filename)
+    const filesDeleted = this.removeFromFileList(
+      expectedFilesDeleted,
+      failedFileList
     );
     if (filesDeleted.length > 0) {
-      const newBackpackFilenames = backpackFilenames.filter(
-        filename => !filesDeleted.includes(filename)
+      const newBackpackFilenames = this.removeFromFileList(
+        backpackFilenames,
+        filesDeleted
       );
-      const newSelectedFiles = selectedFiles.filter(
-        filename => !filesDeleted.includes(filename)
+      const newSelectedFiles = this.removeFromFileList(
+        selectedFiles,
+        filesDeleted
       );
       this.setState({
         backpackFilenames: newBackpackFilenames,
@@ -269,6 +272,10 @@ class Backpack extends Component {
         )}
       </div>
     );
+  };
+
+  removeFromFileList = (fileList, filesToRemove) => {
+    return fileList.filter(filename => !filesToRemove.includes(filename));
   };
 
   render() {

--- a/apps/src/javalab/Backpack.jsx
+++ b/apps/src/javalab/Backpack.jsx
@@ -358,6 +358,8 @@ class Backpack extends Component {
                           displayTheme === DisplayTheme.DARK &&
                             moduleStyles.fileListItemDark
                         )}
+                        /* key must be based on filename so that in case of partial delete failure
+                        we can find any successfully deleted files and remove them from the dropdown */
                         key={`backpack-file-${filename}`}
                       >
                         <input

--- a/apps/src/javalab/Backpack.jsx
+++ b/apps/src/javalab/Backpack.jsx
@@ -44,7 +44,8 @@ class Backpack extends Component {
     selectedFiles: [],
     openDialog: null,
     fileImportMessage: '',
-    fileDeleteMessage: ''
+    fileDeleteMessage: '',
+    isDeleting: false
   };
 
   expandDropdown = () => {
@@ -90,9 +91,10 @@ class Backpack extends Component {
 
   handleDelete = () => {
     const {selectedFiles} = this.state;
+    this.setState({isDeleting: true});
     this.props.backpackApi.deleteFiles(
       selectedFiles,
-      (_, failedFileList) => this.onDeleteFailed(failedFileList),
+      (_, failedFileList) => this.onDeleteFailed(failedFileList, selectedFiles),
       this.collapseDropdown
     );
   };
@@ -103,7 +105,8 @@ class Backpack extends Component {
       fileDeleteMessage: this.getFileListMessage(
         javalabMsg.fileDeleteError(),
         failedFileList
-      )
+      ),
+      isDeleting: false
     });
     const {backpackFilenames, selectedFiles} = this.state;
     // remove correctly deleted files from backpackFilenames and selectedFiles
@@ -200,7 +203,8 @@ class Backpack extends Component {
     this.setState({
       dropdownOpen: false,
       fileImportMessage: '',
-      openDialog: null
+      openDialog: null,
+      isDeleting: false
     });
   };
 
@@ -249,24 +253,6 @@ class Backpack extends Component {
     }
   };
 
-  // getFileImportMessage = (isWarning, overwriteFileList, message) => {
-  //   return (
-  //     <div>
-  //       <p>{message}</p>
-  //       <ul className={moduleStyles.importMessageList}>
-  //         {overwriteFileList.map(filename => {
-  //           return <li key={filename}>{filename}</li>;
-  //         })}
-  //       </ul>
-  //       {isWarning && (
-  //         <p className={moduleStyles.importWarningConfirm}>
-  //           {javalabMsg.fileImportWarningConfirm()}
-  //         </p>
-  //       )}
-  //     </div>
-  //   );
-  // };
-
   getFileListMessage = (message, fileList, confirmationMessage) => {
     return (
       <div>
@@ -299,7 +285,8 @@ class Backpack extends Component {
       selectedFiles,
       openDialog,
       fileImportMessage,
-      fileDeleteMessage
+      fileDeleteMessage,
+      isDeleting
     } = this.state;
 
     const showFiles =
@@ -357,23 +344,23 @@ class Backpack extends Component {
                   {/* In the case of a very long filename, this div adds styling
                   that maintains highlighting even when scrolled to the right */}
                   <div className={moduleStyles.listContainer}>
-                    {backpackFilenames.map((filename, index) => (
+                    {backpackFilenames.map(filename => (
                       <div
                         className={classNames(
                           moduleStyles.fileListItem,
                           displayTheme === DisplayTheme.DARK &&
                             moduleStyles.fileListItemDark
                         )}
-                        key={`backpack-file-${index}`}
+                        key={`backpack-file-${filename}`}
                       >
                         <input
                           type="checkbox"
-                          id={`backpack-file-${index}`}
+                          id={`backpack-file-${filename}`}
                           name={filename}
                           onChange={this.handleFileCheckboxChange}
                         />
                         <label
-                          htmlFor={`backpack-file-${index}`}
+                          htmlFor={`backpack-file-${filename}`}
                           className={moduleStyles.fileListLabel}
                         >
                           {filename}
@@ -449,6 +436,8 @@ class Backpack extends Component {
           displayTheme={displayTheme}
           confirmButtonText={javalabMsg.delete()}
           closeButtonText={javalabMsg.cancel()}
+          showSpinner={isDeleting}
+          disableButtons={isDeleting}
         />
         <JavalabDialog
           className="ignore-react-onclickoutside"

--- a/apps/src/javalab/JavalabDialog.jsx
+++ b/apps/src/javalab/JavalabDialog.jsx
@@ -63,8 +63,7 @@ export default class JavalabDialog extends Component {
                   ...styles.button,
                   ...(displayTheme === DisplayTheme.DARK
                     ? styles.darkButton
-                    : styles.lightCancel),
-                  ...(disableButtons ? styles.disabledButton : {})
+                    : styles.lightCancel)
                 }}
                 onClick={handleClose}
                 disabled={disableButtons}
@@ -79,8 +78,7 @@ export default class JavalabDialog extends Component {
                   ...styles.button,
                   ...(displayTheme === DisplayTheme.DARK
                     ? styles.darkButton
-                    : styles.lightConfirm),
-                  ...(disableButtons ? styles.disabledButton : {})
+                    : styles.lightConfirm)
                 }}
                 onClick={handleConfirm}
                 disabled={disableButtons}

--- a/apps/src/javalab/JavalabDialog.jsx
+++ b/apps/src/javalab/JavalabDialog.jsx
@@ -3,6 +3,7 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import color from '@cdo/apps/util/color';
 import {DisplayTheme} from './DisplayTheme';
+import classNames from 'classnames';
 
 export default class JavalabDialog extends Component {
   static propTypes = {
@@ -14,7 +15,9 @@ export default class JavalabDialog extends Component {
     // message could be a string or html
     message: PropTypes.any,
     confirmButtonText: PropTypes.string,
-    closeButtonText: PropTypes.string
+    closeButtonText: PropTypes.string,
+    showSpinner: PropTypes.bool,
+    disableButtons: PropTypes.bool
   };
 
   render() {
@@ -26,7 +29,9 @@ export default class JavalabDialog extends Component {
       displayTheme,
       message,
       confirmButtonText,
-      closeButtonText
+      closeButtonText,
+      showSpinner,
+      disableButtons
     } = this.props;
     return (
       <BaseDialog
@@ -45,6 +50,12 @@ export default class JavalabDialog extends Component {
         >
           <div style={styles.message}>{message}</div>
           <div style={styles.buttons}>
+            {showSpinner && (
+              <i
+                className={classNames('fa', 'fa-spin', 'fa-spinner')}
+                style={styles.spinner}
+              />
+            )}
             {closeButtonText && (
               <button
                 type="button"
@@ -52,9 +63,11 @@ export default class JavalabDialog extends Component {
                   ...styles.button,
                   ...(displayTheme === DisplayTheme.DARK
                     ? styles.darkButton
-                    : styles.lightCancel)
+                    : styles.lightCancel),
+                  ...(disableButtons ? styles.disabledButton : {})
                 }}
                 onClick={handleClose}
+                disabled={disableButtons}
               >
                 {closeButtonText}
               </button>
@@ -66,9 +79,11 @@ export default class JavalabDialog extends Component {
                   ...styles.button,
                   ...(displayTheme === DisplayTheme.DARK
                     ? styles.darkButton
-                    : styles.lightConfirm)
+                    : styles.lightConfirm),
+                  ...(disableButtons ? styles.disabledButton : {})
                 }}
                 onClick={handleConfirm}
+                disabled={disableButtons}
               >
                 {confirmButtonText}
               </button>
@@ -93,7 +108,8 @@ const styles = {
   },
   buttons: {
     display: 'flex',
-    justifyContent: 'flex-end'
+    justifyContent: 'flex-end',
+    paddingBottom: '10px'
   },
   button: {
     textAlign: 'center',
@@ -116,5 +132,10 @@ const styles = {
     whiteSpace: 'normal',
     lineHeight: '18px',
     padding: 12
+  },
+  spinner: {
+    textAlign: 'center',
+    fontSize: 16,
+    padding: '10px'
   }
 };

--- a/apps/src/javalab/JavalabDialog.jsx
+++ b/apps/src/javalab/JavalabDialog.jsx
@@ -3,7 +3,6 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import color from '@cdo/apps/util/color';
 import {DisplayTheme} from './DisplayTheme';
-import classNames from 'classnames';
 
 export default class JavalabDialog extends Component {
   static propTypes = {
@@ -51,10 +50,7 @@ export default class JavalabDialog extends Component {
           <div style={styles.message}>{message}</div>
           <div style={styles.buttons}>
             {showSpinner && (
-              <i
-                className={classNames('fa', 'fa-spin', 'fa-spinner')}
-                style={styles.spinner}
-              />
+              <i className="fa fa-spin fa-spinner" style={styles.spinner} />
             )}
             {closeButtonText && (
               <button

--- a/apps/src/javalab/backpack.module.scss
+++ b/apps/src/javalab/backpack.module.scss
@@ -93,3 +93,30 @@
   margin-top: 10px;
   margin-bottom: 0;
 }
+
+%backpack-button {
+  color: $white;
+  font-size: 14px;
+  padding: 5px 10px;
+  width: fit-content;
+}
+
+.buttonRow {
+  display: flex;
+  justify-content: flex-end;
+  padding: 0 10px 5px 10px;
+}
+
+.button {
+  &Orange {
+    @extend %backpack-button;
+    background-color: $orange;
+    border-color: $orange;
+  }
+
+  &Red {
+    @extend %backpack-button;
+    background-color: $red;
+    border-color: $red;
+  }
+}

--- a/apps/test/unit/javalab/BackpackTest.js
+++ b/apps/test/unit/javalab/BackpackTest.js
@@ -132,4 +132,92 @@ describe('Java Lab Backpack Test', () => {
     );
     expect(wrapper.isEmptyRender()).to.be.true;
   });
+
+  it('delete shows warning before deleting files', () => {
+    const otherProps = {
+      sources: {file1: {isVisible: true}, file2: {isVisible: true}}
+    };
+    const wrapper = shallow(<Backpack {...{...defaultProps, ...otherProps}} />);
+    wrapper.instance().setState({
+      dropdownOpen: true,
+      backpackFilenames: ['file1', 'file2', 'file3'],
+      selectedFiles: ['file1', 'file3']
+    });
+
+    wrapper.instance().confirmAndDeleteFiles();
+
+    const state = wrapper.instance().state;
+    expect(state.openDialog).to.equal('DELETE_CONFIRM');
+  });
+
+  it('dropdown and modal are closed if delete succeeds', () => {
+    const otherProps = {
+      sources: {file1: {isVisible: true}, file2: {isVisible: true}}
+    };
+    const wrapper = shallow(<Backpack {...{...defaultProps, ...otherProps}} />);
+    wrapper.instance().setState({
+      dropdownOpen: true,
+      backpackFilenames: ['file1', 'file2', 'file3'],
+      selectedFiles: ['file1', 'file3']
+    });
+    // set up delete files to call success callback
+    backpackApiStub.deleteFiles.callsArg(2);
+
+    // open modal
+    wrapper.instance().confirmAndDeleteFiles();
+    // click delete
+    wrapper.instance().handleDelete();
+
+    const state = wrapper.instance().state;
+    expect(state.openDialog).to.equal(null);
+  });
+
+  it('Delete error modal is shown if delete fails', () => {
+    const otherProps = {
+      sources: {file1: {isVisible: true}, file2: {isVisible: true}}
+    };
+    const wrapper = shallow(<Backpack {...{...defaultProps, ...otherProps}} />);
+    wrapper.instance().setState({
+      dropdownOpen: true,
+      backpackFilenames: ['file1', 'file2', 'file3'],
+      selectedFiles: ['file1', 'file3']
+    });
+    // set up delete files to call failure callback
+    backpackApiStub.deleteFiles.callsArgWith(1, null, ['file1', 'file3']);
+
+    // open modal
+    wrapper.instance().confirmAndDeleteFiles();
+    // click delete
+    wrapper.instance().handleDelete();
+
+    const state = wrapper.instance().state;
+    expect(state.openDialog).to.equal('DELETE_ERROR');
+  });
+
+  it('Deleted files are removed from dropdown on partial delete success', () => {
+    const otherProps = {
+      sources: {file1: {isVisible: true}, file2: {isVisible: true}}
+    };
+    const wrapper = shallow(<Backpack {...{...defaultProps, ...otherProps}} />);
+    wrapper.instance().setState({
+      dropdownOpen: true,
+      backpackFilenames: ['file1', 'file2', 'file3'],
+      selectedFiles: ['file1', 'file3']
+    });
+    // set up delete files to call failure callback where only file 1 failed to delete
+    backpackApiStub.deleteFiles.callsArgWith(1, null, ['file1']);
+
+    // open modal
+    wrapper.instance().confirmAndDeleteFiles();
+    // click delete
+    wrapper.instance().handleDelete();
+
+    const state = wrapper.instance().state;
+    const selectedFiles = state.selectedFiles;
+    // selected files should only contain the file that failed to delete (file1).
+    expect(selectedFiles.length).to.equal(1);
+    expect(selectedFiles[0]).to.equal('file1');
+    // backpackFilenames should have length 2 (file3 should be gone)
+    expect(state.backpackFilenames.length).to.equal(2);
+  });
 });


### PR DESCRIPTION
Add a delete button to the backpack dropdown menu, which will delete all selected files from the backpack. The user has to confirm delete with a pop-up modal. While the delete is in progress the modal will show a spinner and the buttons will not be clickable.

If the delete succeeds, the modal and dropdown will close automatically. If it fails the user will see an error message with which files failed to delete, and the dropdown will remain open. Any files that were successfully deleted will be gone from the dropdown.

## Screenshots
### New button (light mode)
<img width="185" alt="Screen Shot 2022-09-14 at 4 34 17 PM" src="https://user-images.githubusercontent.com/33666587/190281483-5d38774e-7497-4523-b6e4-fd7c9b42220d.png">

### New button (dark mode)
<img width="190" alt="Screen Shot 2022-09-14 at 2 50 26 PM" src="https://user-images.githubusercontent.com/33666587/190281611-9e26b804-810d-4f6b-8a05-a0af10bd0935.png">

### Confirmation modal (light mode)
<img width="543" alt="Screen Shot 2022-09-14 at 4 31 58 PM" src="https://user-images.githubusercontent.com/33666587/190281537-a5647dbf-a361-4344-8beb-fe8da08c471a.png">


### Confirmation modal (dark mode, delete in progress)
<img width="543" alt="Screen Shot 2022-09-14 at 2 50 46 PM" src="https://user-images.githubusercontent.com/33666587/190281579-515bf8cb-39ec-4f59-99af-24d8c53f74ba.png">


### Error modal (dark mode)
<img width="543" alt="Screen Shot 2022-09-14 at 2 50 58 PM" src="https://user-images.githubusercontent.com/33666587/190281557-04f79343-94f7-4642-b095-5a17eec649a1.png">


## Links

- [spec](https://docs.google.com/document/d/1TNIZwpGWLpB3P5IY7nJ8uHbvgNbzsxaeRSqtGzuSmEw/edit#bookmark=id.oborh38yy0vz)
- jira ticket: [JAVA-658](https://codedotorg.atlassian.net/browse/JAVA-658)

## Testing story
Tested locally and with unit tests


