### PR TITLE
HoC.com - Update UI on activity tiles (post-revert-version)

### DIFF
--- a/apps/src/tutorialExplorer/tutorial.jsx
+++ b/apps/src/tutorialExplorer/tutorial.jsx
@@ -58,17 +58,15 @@ export default class Tutorial extends React.Component {
 const styles = {
   tutorialOuter: {
     float: 'left',
-    paddingTop: 5,
-    paddingBottom: 5,
-    paddingLeft: 7,
-    paddingRight: 7,
+    padding: '7px 7px',
     cursor: 'pointer'
   },
   tutorialImageContainer: {
     position: 'relative',
     width: '100%',
     height: 0,
-    paddingTop: '75%'
+    paddingTop: '75%',
+    borderRadius: '8px 8px 0 0'
   },
   tutorialImageBackground: {
     position: 'absolute',
@@ -77,25 +75,35 @@ const styles = {
     left: 0,
     bottom: 0,
     backgroundColor: '#f1f1f1',
-    border: 'solid 1px #cecece'
+    border: '1px solid rgb(162, 162, 162)',
+    borderRadius: '8px 8px 0 0'
   },
   tutorialImage: {
     position: 'absolute',
     top: 0,
     left: 0,
-    width: '100%'
+    width: '100%',
+    borderRadius: '8px 8px 0 0',
+    border: '1px solid rgb(162, 162, 162)'
   },
   tutorialName: {
     fontFamily: '"Gotham 5r", sans-serif',
     fontSize: 15,
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
-    overflow: 'hidden'
+    overflow: 'hidden',
+    borderLeft: '1px solid rgb(162, 162, 162)',
+    borderRight: '1px solid rgb(162, 162, 162)',
+    padding: '8px 10px 0'
   },
   tutorialSub: {
     fontFamily: '"Gotham 4r", sans-serif',
     fontSize: 12,
     lineHeight: '16px',
-    height: 40
+    height: 55,
+    border: '1px solid rgb(162, 162, 162)',
+    borderTop: 0,
+    padding: '0px 10px 8px',
+    borderRadius: '0 0 8px 8px'
   }
 };

--- a/apps/src/tutorialExplorer/tutorial.jsx
+++ b/apps/src/tutorialExplorer/tutorial.jsx
@@ -100,10 +100,13 @@ const styles = {
     fontFamily: '"Gotham 4r", sans-serif',
     fontSize: 12,
     lineHeight: '16px',
-    height: 55,
+    height: 28,
     border: '1px solid rgb(162, 162, 162)',
     borderTop: 0,
     padding: '0px 10px 8px',
-    borderRadius: '0 0 8px 8px'
+    borderRadius: '0 0 8px 8px',
+    overflow: 'hidden',
+    whiteSpace: 'nowrap',
+    textOverflow: 'ellipsis'
   }
 };


### PR DESCRIPTION
Make the activity tiles look like more cohesive units on https://hourofcode.com/us/learn and https://code.org/learn
- Add a border 
- Round corners
- Update spacing

**Relevant info:** [Asana task](https://app.asana.com/0/0/1202772354330427/f) • [Slack convo](https://codedotorg.slack.com/archives/C5V9YCXTR/p1663200952797679) re: discussion around truncating the details line

----

### Before
<img width="966" alt="Before" src="https://user-images.githubusercontent.com/9256643/190027506-18b858c8-681b-4b4a-9545-019e46090c3f.png">

### After
<img width="967" alt="Screen Shot 2022-09-14 at 4 43 23 PM" src="https://user-images.githubusercontent.com/9256643/190503588-09fa6ed6-dc97-41c5-acf8-500b011d6b92.png">
