### PR TITLE
Refactor progress table style constants into SCSS module

### DIFF
--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableContentView.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableContentView.jsx
@@ -12,7 +12,8 @@ import {
   lessonIsAllAssessment,
   lessonHasLevels
 } from '@cdo/apps/templates/progress/progressHelpers';
-import progressTableStyles from './progressTableStyles.scss';
+import styleConstants from './progress-table-constants.module.scss';
+import './progressTableStyles.scss';
 import ProgressTableLessonNumber from './ProgressTableLessonNumber';
 
 // Extra header column to account for scrollbar in progress tables
@@ -119,7 +120,7 @@ export default class ProgressTableContentView extends React.Component {
     if (columnWidths) {
       width = columnWidths[index];
     } else if (!lessonHasLevels(scriptData.lessons[index])) {
-      width = parseInt(progressTableStyles.MIN_COLUMN_WIDTH);
+      width = parseInt(styleConstants.MIN_COLUMN_WIDTH);
     }
     return width ? {style: {minWidth: width, maxWidth: width}} : {};
   }
@@ -184,7 +185,7 @@ export default class ProgressTableContentView extends React.Component {
           style={{
             overflowX: 'scroll',
             overflowY: 'auto',
-            maxHeight: parseInt(progressTableStyles.MAX_BODY_HEIGHT)
+            maxHeight: parseInt(styleConstants.MAX_BODY_HEIGHT)
           }}
           ref={r => {
             this.body = r && r.getRef();

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableStudentList.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableStudentList.jsx
@@ -8,7 +8,8 @@ import {
   studentTableRowType
 } from '../sectionProgressConstants';
 import ProgressTableStudentName from './ProgressTableStudentName';
-import progressTableStyles from './progressTableStyles.scss';
+import styleConstants from './progress-table-constants.module.scss';
+import './progressTableStyles.scss';
 import {scriptUrlForStudent} from '@cdo/apps/templates/teacherDashboard/urlHelpers';
 import i18n from '@cdo/locale';
 
@@ -104,7 +105,7 @@ export default class ProgressTableStudentList extends React.Component {
           style={{
             overflowX: 'scroll',
             overflowY: 'hidden',
-            maxHeight: parseInt(progressTableStyles.MAX_BODY_HEIGHT)
+            maxHeight: parseInt(styleConstants.MAX_BODY_HEIGHT)
           }}
           ref={r => {
             this.body = r && r.getRef();

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableView.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableView.jsx
@@ -34,7 +34,8 @@ import {studentShape} from '@cdo/apps/templates/teacherDashboard/teacherSections
  * Since our progress tables are built out of standard HTML table elements,
  * we can leverage CSS classes for laying out and styling those elements.
  */
-import progressTableStyles from './progressTableStyles.scss';
+import progressTableStyleConstants from './progress-table-constants.module.scss';
+import './progressTableStyles.scss';
 
 function idForExpansionIndex(studentId, index) {
   return `${studentId}.${index}`;
@@ -142,7 +143,7 @@ class ProgressTableView extends React.Component {
    * Override the default initial number of rows to render
    */
   setRowsToRender() {
-    const initialRows = parseInt(progressTableStyles.MAX_ROWS);
+    const initialRows = parseInt(progressTableStyleConstants.MAX_ROWS);
 
     // amountOfRowsToRender is a reactabular internal
     this.studentList?.bodyComponent.setState({
@@ -205,7 +206,10 @@ class ProgressTableView extends React.Component {
    * account for the horizontal space used by the vertical scrollbar.
    */
   needsContentHeaderGutter() {
-    return this.props.students.length > parseInt(progressTableStyles.MAX_ROWS);
+    return (
+      this.props.students.length >
+      parseInt(progressTableStyleConstants.MAX_ROWS)
+    );
   }
 
   onToggleRow(studentId) {
@@ -297,7 +301,7 @@ class ProgressTableView extends React.Component {
   summaryContentViewProps() {
     return {
       columnWidths: new Array(this.props.scriptData.lessons.length).fill(
-        parseInt(progressTableStyles.MIN_COLUMN_WIDTH)
+        parseInt(progressTableStyleConstants.MIN_COLUMN_WIDTH)
       ),
       lessonCellFormatters: this.summaryCellFormatters,
       includeHeaderArrows: false
@@ -375,7 +379,7 @@ const styles = {
   },
   contentView: {
     display: 'inline-block',
-    width: parseInt(progressTableStyles.CONTENT_VIEW_WIDTH)
+    width: parseInt(progressTableStyleConstants.CONTENT_VIEW_WIDTH)
   }
 };
 

--- a/apps/src/templates/sectionProgress/progressTables/progress-table-constants.module.scss
+++ b/apps/src/templates/sectionProgress/progressTables/progress-table-constants.module.scss
@@ -1,0 +1,19 @@
+@use "sass:math";
+@import "style-constants";
+
+$scrollbar-height: 15px;
+$row-height: 42px;
+$expanded-row-height: 30px;
+$max-rows: 14;
+$max-height: $max-rows * $row-height + $scrollbar-height;
+$student-list-width: 170px;
+$content-view-width: $content-width - $student-list-width;
+
+:export {
+  MAX_BODY_HEIGHT: math.div($max-height, 1px);
+  STUDENT_LIST_WIDTH: math.div($student-list-width, 1px);
+  CONTENT_VIEW_WIDTH: math.div($content-view-width, 1px);
+  ROW_HEIGHT: math.div($row-height, 1px);
+  MAX_ROWS: $max-rows;
+  MIN_COLUMN_WIDTH: 40;
+}

--- a/apps/src/templates/sectionProgress/progressTables/progressTableStyles.scss
+++ b/apps/src/templates/sectionProgress/progressTables/progressTableStyles.scss
@@ -1,14 +1,6 @@
-@use "sass:math";
+@use "./progress-table-constants.module.scss" as constants;
 @import "color.scss";
 @import "style-constants";
-
-$scrollbar-height: 15px;
-$row-height: 42px;
-$expanded-row-height: 30px;
-$max-rows: 14;
-$max-height: $max-rows * $row-height + $scrollbar-height;
-$student-list-width: 170px;
-$content-view-width: $content-width - $student-list-width;
 
 .progress-table {
   table {
@@ -22,7 +14,7 @@ $content-view-width: $content-width - $student-list-width;
     color: $charcoal;
     border-width: 0 1px 2px 0;
     border-color: $border-gray;
-    height: $row-height;
+    height: constants.$row-height;
   }
   th,
   td {
@@ -39,12 +31,12 @@ $content-view-width: $content-width - $student-list-width;
   }
   .primary-row {
     td {
-      height: $row-height;
+      height: constants.$row-height;
     }
   }
   .expanded-row {
     td {
-      height: $expanded-row-height;
+      height: constants.$expanded-row-height;
       border-width: 0 1px 1px 0;
       border-style: solid;
       border-color: $border-gray;
@@ -65,7 +57,7 @@ $content-view-width: $content-width - $student-list-width;
     table,
     th,
     td {
-      width: $student-list-width;
+      width: constants.$student-list-width;
     }
     tbody {
       tr,
@@ -75,7 +67,7 @@ $content-view-width: $content-width - $student-list-width;
       }
     }
     .content {
-      height: $row-height;
+      height: constants.$row-height;
       box-sizing: border-box;
       padding: 10px;
       font-size: 14px;
@@ -105,7 +97,7 @@ $content-view-width: $content-width - $student-list-width;
   .content-view {
     thead,
     tbody {
-      max-width: $content-view-width;
+      max-width: constants.$content-view-width;
       td {
         text-align: center;
       }
@@ -136,14 +128,4 @@ $content-view-width: $content-width - $student-list-width;
       }
     }
   }
-}
-
-/* stylelint-disable */
-:export {
-  MAX_BODY_HEIGHT: math.div($max-height, 1px);
-  STUDENT_LIST_WIDTH: math.div($student-list-width, 1px);
-  CONTENT_VIEW_WIDTH: math.div($content-view-width, 1px);
-  ROW_HEIGHT: math.div($row-height, 1px);
-  MAX_ROWS: $max-rows;
-  MIN_COLUMN_WIDTH: 40;
 }

--- a/apps/test/unit/templates/sectionProgress/progressTables/ProgressTableContentViewTest.jsx
+++ b/apps/test/unit/templates/sectionProgress/progressTables/ProgressTableContentViewTest.jsx
@@ -3,7 +3,7 @@ import {expect} from '../../../../util/reconfiguredChai';
 import {mount} from 'enzyme';
 import ProgressTableContentView from '@cdo/apps/templates/sectionProgress/progressTables/ProgressTableContentView';
 import ProgressTableLessonNumber from '@cdo/apps/templates/sectionProgress/progressTables/ProgressTableLessonNumber';
-import progressTableStyles from '@cdo/apps/templates/sectionProgress/progressTables/progressTableStyles.scss';
+import progressTableStyleConstants from '@cdo/apps/templates/sectionProgress/progressTables/progress-table-constants.module.scss';
 import * as Virtualized from 'reactabular-virtualized';
 import {
   fakeLevel,
@@ -137,10 +137,10 @@ describe('ProgressTableContentView', () => {
     expect(headers.at(0).props().style?.minWidth).to.be.undefined;
     expect(headers.at(0).props().style?.maxWidth).to.be.undefined;
     expect(headers.at(3).props().style.minWidth).to.equal(
-      parseInt(progressTableStyles.MIN_COLUMN_WIDTH)
+      parseInt(progressTableStyleConstants.MIN_COLUMN_WIDTH)
     );
     expect(headers.at(3).props().style.maxWidth).to.equal(
-      parseInt(progressTableStyles.MIN_COLUMN_WIDTH)
+      parseInt(progressTableStyleConstants.MIN_COLUMN_WIDTH)
     );
   });
 });

--- a/apps/webpack.js
+++ b/apps/webpack.js
@@ -161,28 +161,6 @@ var baseConfig = {
       },
       {test: /\.css$/, use: [{loader: 'style-loader'}, {loader: 'css-loader'}]},
 
-      // Rules for global SCSS (*.scss) and modules (*.module.scss)
-      // are currently duplicated for Webpack 4. This can be simplified via
-      // css-loader's options.modules.auto option when we upgrade to Webpack 5:
-      // https://v4.webpack.js.org/loaders/css-loader/#auto
-      {
-        test: /\.scss$/,
-        use: [
-          {loader: 'style-loader'},
-          {loader: 'css-loader', options: {modules: true}},
-          {
-            loader: 'sass-loader',
-            options: {
-              implementation: sass,
-              sassOptions: {
-                includePaths: [scssIncludePath],
-                outputStyle: 'compressed'
-              }
-            }
-          }
-        ],
-        exclude: /\.module\.scss$/
-      },
       {
         test: /\.scss$/,
         use: [
@@ -198,8 +176,7 @@ var baseConfig = {
               }
             }
           }
-        ],
-        include: /\.module\.scss$/
+        ]
       },
 
       {test: /\.interpreted.js$/, type: 'asset/source'},


### PR DESCRIPTION
This branch will be merged into the Webpack upgrade #48105.

Prior to this fix, SCSS modules were broken with the upgrade to Webpack 5. Our Webpack configuration for modules was no longer working as expected because we had an SCSS file that was trying to behave as both global SCSS and as a module in different contexts; see #48103 for more details. 

I've refactored that file into two separate files -- some global SCSS and constants stored in a module file. I initially tried to refactor everything into a module file, but there are some classes that can't be modularized because they are owned by external libraries (I've left a comment in the appropriate place to explain more).