### PR TITLE
Prevent granting user permissions to students

### DIFF
--- a/dashboard/app/models/concerns/user_permission_grantee.rb
+++ b/dashboard/app/models/concerns/user_permission_grantee.rb
@@ -26,6 +26,7 @@ module UserPermissionGrantee
   end
 
   def permission=(permission)
+    throw 'User must be a teacher' unless user_type == 'teacher'
     @permissions = nil
     permissions << permissions.find_or_create_by(user_id: id, permission: permission)
   end

--- a/dashboard/test/models/concerns/user_permission_grantee_test.rb
+++ b/dashboard/test/models/concerns/user_permission_grantee_test.rb
@@ -222,4 +222,11 @@ class UserPermissionGranteeTest < ActiveSupport::TestCase
     TeacherMailer.expects(:verified_teacher_email).never
     create :admin
   end
+
+  test 'cannot grant permission to student user' do
+    student = create :student
+    assert_raises do
+      student.permission = UserPermission::AUTHORIZED_TEACHER
+    end
+  end
 end

--- a/dashboard/test/models/user_permission_test.rb
+++ b/dashboard/test/models/user_permission_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class UserPermissionTest < ActiveSupport::TestCase
   test 'Log granting of levelbuilder permission to slack' do
-    levelbuilder = create :user
+    levelbuilder = create :teacher
     UserPermission.stubs(:should_log?).returns(true)
     ChatClient.
       expects(:message).
@@ -19,7 +19,7 @@ class UserPermissionTest < ActiveSupport::TestCase
   end
 
   test 'Does not log granting of authorized teacher permission to slack' do
-    authorized_teacher = create :user
+    authorized_teacher = create :teacher
     UserPermission.stubs(:should_log?).returns(true)
     ChatClient.expects(:message).never
 


### PR DESCRIPTION
Adds another layer of protection against granting user permissions to students, alongside the verification on the admin form. People could still create the model directly (`UserPermission.create(user_id: student.id, permission: 'verified_teacher')`) but they won't be able to use the grantee (`student.permissions = 'verified_teacher'`).

