### PR TITLE
Java Lab: fix support file bug

### DIFF
--- a/apps/src/javalab/JavalabFileHelper.js
+++ b/apps/src/javalab/JavalabFileHelper.js
@@ -21,9 +21,12 @@ export const fileMetadataForEditor = (sources, isEditingStartSources) => {
   let fileMetadata = {};
   let orderedTabKeys = [];
 
-  Object.keys(sources).forEach((file, index) => {
+  Object.keys(sources).forEach(file => {
     if (sources[file].isVisible || isEditingStartSources) {
-      let tabKey = getTabKey(index);
+      // tabIndex should be the length of orderedTabKeys, not the index
+      // from the list, because we skip hidden files in the tabs.
+      const tabIndex = orderedTabKeys.length;
+      let tabKey = getTabKey(tabIndex);
       fileMetadata[tabKey] = file;
       orderedTabKeys.push(tabKey);
     }


### PR DESCRIPTION
We had a bug where if you added a file (in the screenshot, named `TestClass.java`) to a level with at least one hidden file you would see the following:
![Screen Shot 2022-09-15 at 11 16 54 AM](https://user-images.githubusercontent.com/33666587/190480736-5da72af6-c587-49ab-bc4a-2612af880ac6.png)
The contents of `TestClass.java` would be whatever the contents of the last file in the editor was. If you reloaded the page, everything would look correct again (only one, empty `TestClass.java`).

The cause of this bug was we used the index in the file list for the tab key for each file, which meant if a hidden file was in the list at index 2 our tab keys would be `file-0-tab, file-1-tab, file-3-tab...`. However, we set the `lastTabIndex` to be the length of the list instead of the last index. This PR changes the tab indexes to equal with the index that tab is in the list not including support files.

Now when you add a new file to a level with a support file you see:
![Screen Shot 2022-09-15 at 11 17 18 AM](https://user-images.githubusercontent.com/33666587/190481272-8a2da6ec-2b54-43f2-9a46-bd0a37d159ab.png)


## Links
- jira ticket: [JAVA-652](https://codedotorg.atlassian.net/browse/JAVA-652)

## Testing story
tested locally
