### PR TITLE
Google Blockly: always center trashcan in toolbox

### DIFF
--- a/apps/src/blockly/addons/cdoTrashcan.js
+++ b/apps/src/blockly/addons/cdoTrashcan.js
@@ -30,8 +30,8 @@ export default class CdoTrashcan extends GoogleBlockly.DeleteArea {
     const svg = this.workspace.getParentSvg();
     this.container = Blockly.utils.dom.createSvgElement(Blockly.utils.Svg.SVG);
     this.container.style.visibility = 'hidden';
-    this.position(this.workspace.getMetricsManager().getUiMetrics());
     this.createTrashcanSvg();
+    this.position(this.workspace.getMetricsManager().getUiMetrics());
 
     svg.parentNode.insertBefore(this.container, svg);
 
@@ -55,11 +55,6 @@ export default class CdoTrashcan extends GoogleBlockly.DeleteArea {
       Blockly.utils.Svg.G,
       {class: 'blocklyTrash'},
       this.container
-    );
-    const left = Blockly.cdoUtils.getToolboxWidth() / 2 - WIDTH / 2;
-    this.svgGroup_.setAttribute(
-      'transform',
-      `translate(${left}, ${MARGIN_TOP})`
     );
 
     // trashcan body
@@ -205,18 +200,28 @@ export default class CdoTrashcan extends GoogleBlockly.DeleteArea {
 
   /**
    * IPositionable method
-   * Positions the element. Called when the window is resized.
+   * Positions the container and the trashcan itself. Called when the window is resized and on initialization.
    * @param {!Blockly.MetricsManager.UiMetrics} metrics The workspace metrics.
    */
   position(metrics) {
+    const toolboxWidth = Blockly.cdoUtils.getToolboxWidth();
+
+    // Position container
     this.container.style.height = `${metrics.viewMetrics.height}px`;
-    this.container.style.width = `${Blockly.cdoUtils.getToolboxWidth()}px`;
+    this.container.style.width = `${toolboxWidth}px`;
     this.container.style.left = this.workspace.RTL
       ? `${metrics.viewMetrics.width}px`
       : '0px';
     this.container.style.top = '0px';
     this.container.style.position = 'absolute';
     this.container.style.zIndex = '75';
+
+    // Position trashcan within container
+    const left = toolboxWidth / 2 - WIDTH / 2;
+    this?.svgGroup_.setAttribute(
+      'transform',
+      `translate(${left}, ${MARGIN_TOP})`
+    );
   }
 
   /**


### PR DESCRIPTION
While a full refactor of where we render the trashcan may not be in the cards, I did notice a quick fix for misplacement of the trashcan if your resize the window (and force the toolbox to change size). Previously, we only positioned the trashcan icon once (on creation). Now, we reposition the trashcan every time that we reposition its container, resulting in it staying centered.

Maybe more importantly, moves trashcan placement logic into the `position` function (which previously only positioned the trashcan container), which seems like a more natural place for it code-wise.

**Before**

<img width="564" alt="image" src="https://user-images.githubusercontent.com/25372625/190518028-94da34c5-e647-438d-912a-3041a205b513.png">


**After**

<img width="585" alt="image" src="https://user-images.githubusercontent.com/25372625/190518205-c1d0eb85-1e68-48e5-bf1c-6c314b10e01d.png">

## Testing story

Tested manually on a level with a toolbox (/s/dance-2019/lessons/1/levels/10?blocklyVersion=Google) and without one (ie, only flyout -- /s/poem-art-2021/lessons/1/levels/1) in both LTR and RTL.