### PR TITLE
Change code references from code_review_notes to code_review_comments

### DIFF
--- a/apps/src/templates/instructions/codeReviewV2/CodeReviewDataApi.js
+++ b/apps/src/templates/instructions/codeReviewV2/CodeReviewDataApi.js
@@ -99,7 +99,7 @@ export default class CodeReviewDataApi {
             });
           } else {
             $.ajax({
-              url: `/code_review_notes`,
+              url: `/code_review_comments`,
               type: 'POST',
               headers: {'X-CSRF-Token': this.token},
               data: {
@@ -118,7 +118,7 @@ export default class CodeReviewDataApi {
   toggleResolveComment(commentId, isResolved) {
     return new Promise((resolve, reject) => {
       $.ajax({
-        url: `/code_review_notes/${commentId}`,
+        url: `/code_review_comments/${commentId}`,
         type: 'PATCH',
         headers: {'X-CSRF-Token': this.token},
         data: {isResolved}
@@ -130,7 +130,7 @@ export default class CodeReviewDataApi {
 
   deleteCodeReviewComment(commentId) {
     return $.ajax({
-      url: `/code_review_notes/${commentId}`,
+      url: `/code_review_comments/${commentId}`,
       type: 'DELETE',
       headers: {'X-CSRF-Token': this.token}
     });

--- a/apps/test/unit/templates/instructions/codeReviewV2/CodeReviewDataApiTest.js
+++ b/apps/test/unit/templates/instructions/codeReviewV2/CodeReviewDataApiTest.js
@@ -259,7 +259,7 @@ describe('CodeReviewDataApi', () => {
       utils.findProfanity.restore();
     });
 
-    it('calls code_review_note endpoint if profanity is not found', async () => {
+    it('calls code_review_comments endpoint if profanity is not found', async () => {
       sinon.stub(utils, 'findProfanity').returns({
         done: successCallback => successCallback(null)
       });
@@ -267,7 +267,7 @@ describe('CodeReviewDataApi', () => {
       await dataApi.submitNewCodeReviewComment(fakeComment, fakeReviewId);
 
       expect(ajaxStub).to.have.been.calledWith({
-        url: `/code_review_notes`,
+        url: `/code_review_comments`,
         type: 'POST',
         headers: {'X-CSRF-Token': undefined},
         data: {
@@ -303,10 +303,10 @@ describe('CodeReviewDataApi', () => {
       ajaxStub.restore();
     });
 
-    it('calls code_review_notes PATCH endpoint with the isResolved value to set', async () => {
+    it('calls code_review_comments PATCH endpoint with the isResolved value to set', async () => {
       await dataApi.toggleResolveComment(11, true);
       expect(ajaxStub).to.have.been.calledWith({
-        url: `/code_review_notes/11`,
+        url: `/code_review_comments/11`,
         type: 'PATCH',
         headers: {'X-CSRF-Token': undefined},
         data: {

--- a/dashboard/app/controllers/code_review_comments_controller.rb
+++ b/dashboard/app/controllers/code_review_comments_controller.rb
@@ -1,13 +1,13 @@
-class CodeReviewNotesController < ApplicationController
+class CodeReviewCommentsController < ApplicationController
   before_action :authenticate_user!
 
-  load_and_authorize_resource :code_review_note, only: [:update, :destroy]
+  load_and_authorize_resource :code_review_comment, only: [:update, :destroy]
 
-  # POST /code_review_notes
+  # POST /code_review_comments
   def create
     params.require([:comment, :codeReviewId])
 
-    @code_review_note = CodeReviewNote.new(
+    @code_review_comment = CodeReviewComment.new(
       {
         comment: params[:comment],
         code_review_request_id: params[:codeReviewId],
@@ -18,26 +18,26 @@ class CodeReviewNotesController < ApplicationController
 
     # We wait to authorize until this point because we need to know
     # who owns the project that the comment is associated with.
-    authorize! :create, @code_review_note
-    @code_review_note.save!
-    render json: @code_review_note.summarize
+    authorize! :create, @code_review_comment
+    @code_review_comment.save!
+    render json: @code_review_comment.summarize
   end
 
-  # PATCH /code_review_notes/:id
+  # PATCH /code_review_comments/:id
   # Currently, updating is_resolved the note is the only allowed update.
   def update
     params.require(:id)
 
     if params[:isResolved]
-      @code_review_note.update!(is_resolved: params[:isResolved])
+      @code_review_comment.update!(is_resolved: params[:isResolved])
     end
 
-    render json: @code_review_note.summarize
+    render json: @code_review_comment.summarize
   end
 
-  # DELETE /code_review_notes/:id
+  # DELETE /code_review_comments/:id
   def destroy
-    if @code_review_note.delete
+    if @code_review_comment.delete
       return head :ok
     else
       return head :bad_request

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -131,20 +131,20 @@ class Ability
         in_shared_section_with_code_review && user.in_code_review_group_with?(other_user)
       end
 
-      can :create, CodeReviewNote do |code_review_note|
-        code_review_note.code_review.open? && can?(:code_review, code_review_note.code_review.owner)
+      can :create, CodeReviewComment do |code_review_comment|
+        code_review_comment.code_review.open? && can?(:code_review, code_review_comment.code_review.owner)
       end
 
-      can :update, CodeReviewNote do |code_review_note|
-        code_review_note.code_review.user_id == user.id
+      can :update, CodeReviewComment do |code_review_comment|
+        code_review_comment.code_review.user_id == user.id
       end
 
-      can :destroy, CodeReviewNote do |code_review_note|
+      can :destroy, CodeReviewComment do |code_review_comment|
         # Teachers can delete comments on their student's projects,
         # their own comments anywhere, and comments on their projects.
-        code_review_note.code_review.owner&.student_of?(user) ||
-          (user.teacher? && user.id == code_review_note.commenter_id) ||
-          (user.teacher? && user.id == code_review_note.code_review.user_id)
+        code_review_comment.code_review.owner&.student_of?(user) ||
+          (user.teacher? && user.id == code_review_comment.commenter_id) ||
+          (user.teacher? && user.id == code_review_comment.code_review.user_id)
       end
 
       can :create, Pd::RegionalPartnerProgramRegistration, user_id: user.id

--- a/dashboard/app/models/code_review.rb
+++ b/dashboard/app/models/code_review.rb
@@ -29,7 +29,7 @@ class CodeReview < ApplicationRecord
   belongs_to :owner, class_name: 'User', foreign_key: :user_id, optional: true
   # TODO: Once all the renaming has settled, the following association should be:
   # has_many :comments, class_name: 'CodeReviewComment', dependent:  :destroy
-  has_many :comments, class_name: 'CodeReviewNote', foreign_key: 'code_review_request_id', dependent:  :destroy, inverse_of: 'code_review'
+  has_many :comments, class_name: 'CodeReviewComment', foreign_key: 'code_review_request_id', dependent:  :destroy, inverse_of: 'code_review'
 
   # Enforce that each student can only have one open code review per script and
   # level. (This is also enforced at the database level with a unique index.)

--- a/dashboard/app/models/code_review_comment.rb
+++ b/dashboard/app/models/code_review_comment.rb
@@ -15,9 +15,9 @@
 #
 #  index_code_review_notes_on_code_review_request_id  (code_review_request_id)
 #
-class CodeReviewNote < ApplicationRecord
-  # TODO: This model will be renamed to CodeReviewComment once the old models are
-  # removed.
+class CodeReviewComment < ApplicationRecord
+  # TODO: rename the table to code_review_notes
+  self.table_name = :code_review_notes
 
   belongs_to :commenter, class_name: 'User', optional: true
   # TODO: When the column is renamed, update this association

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -994,7 +994,7 @@ Dashboard::Application.routes.draw do
       get :peers_with_open_reviews, on: :collection
     end
 
-    resources :code_review_notes, only: [:create, :update, :destroy]
+    resources :code_review_comments, only: [:create, :update, :destroy]
 
     get '/backpacks/channel', to: 'backpacks#get_channel'
 

--- a/dashboard/test/controllers/admin_users_controller_test.rb
+++ b/dashboard/test/controllers/admin_users_controller_test.rb
@@ -386,11 +386,11 @@ class AdminUsersControllerTest < ActionController::TestCase
     sign_in @admin
 
     review1 = create :code_review, user_id: @project_owner.id, script_id: @script.id, level_id: @level1.id, project_id: @project.id
-    create :code_review_note, code_review_request_id: review1.id
+    create :code_review_comment, code_review_request_id: review1.id
 
     post :delete_progress, params: {user_id: @project_owner.id, script_id: @script.id, reason: 'Testing'}
     assert_equal 0, CodeReview.where(user_id: @project_owner.id, script_id: @script.id).count
-    assert_equal 0, CodeReviewNote.where(code_review_request_id: review1.id).count
+    assert_equal 0, CodeReviewComment.where(code_review_request_id: review1.id).count
   end
 
   generate_admin_only_tests_for :user_projects_form

--- a/dashboard/test/controllers/code_review_comments_controller_test.rb
+++ b/dashboard/test/controllers/code_review_comments_controller_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class CodeReviewNotesControllerTest < ActionController::TestCase
+class CodeReviewCommentsControllerTest < ActionController::TestCase
   self.use_transactional_test_case = false
 
   setup_all do
@@ -44,7 +44,7 @@ class CodeReviewNotesControllerTest < ActionController::TestCase
     assert_not_nil response_json['createdAt']
   end
 
-  test 'cannot create a code review note for a closed code review' do
+  test 'cannot create a code review comment for a closed code review' do
     student_2_closed_code_review = create :code_review, user_id: @student_2.id, project_id: @student_2_project.id, closed_at: DateTime.now
 
     sign_in @student_1
@@ -57,7 +57,7 @@ class CodeReviewNotesControllerTest < ActionController::TestCase
     assert_response :forbidden
   end
 
-  test 'cannot create a code review note for someone outside the code review group' do
+  test 'cannot create a code review comment for someone outside the code review group' do
     code_review_outside_group = create :code_review, user_id: @student_3.id, project_id: @student_3_project.id
 
     sign_in @student_2
@@ -71,12 +71,12 @@ class CodeReviewNotesControllerTest < ActionController::TestCase
   end
 
   test 'update resolved for code review comment' do
-    review_note = create :code_review_note, code_review: @code_review, commenter: @student_2
+    review_comment = create :code_review_comment, code_review: @code_review, commenter: @student_2
 
     sign_in @student_1
 
     patch :update, params: {
-      id: review_note.id,
+      id: review_comment.id,
       isResolved: true
     }
 
@@ -87,24 +87,24 @@ class CodeReviewNotesControllerTest < ActionController::TestCase
   end
 
   test 'delete code review comment' do
-    review_note = create :code_review_note, code_review: @code_review, commenter: @student_2
+    review_comment = create :code_review_comment, code_review: @code_review, commenter: @student_2
 
     sign_in @teacher
 
     delete :destroy, params: {
-      id: review_note.id
+      id: review_comment.id
     }
 
     assert_response :success
   end
 
   test 'students cannot delete code review comment' do
-    review_note = create :code_review_note, code_review: @code_review, commenter: @student_2
+    review_comment = create :code_review_comment, code_review: @code_review, commenter: @student_2
 
     sign_in @student_1
 
     delete :destroy, params: {
-      id: review_note.id
+      id: review_comment.id
     }
 
     assert_response :forbidden

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -1592,7 +1592,7 @@ FactoryGirl.define do
     storage_id 1
   end
 
-  factory :code_review_note do
+  factory :code_review_comment do
     association :commenter, factory: :student
     association :code_review
 

--- a/dashboard/test/helpers/delete_accounts_helper_test.rb
+++ b/dashboard/test/helpers/delete_accounts_helper_test.rb
@@ -886,13 +886,13 @@ class DeleteAccountsHelperTest < ActionView::TestCase
 
   #
   # Table: dashboard.code_review_requests
-  # Table: dashboard.code_review_notes
+  # Table: dashboard.code_review_comments
   #
   test "deletes comment text and soft deletes comments for purged user" do
     student = create :student
     review = create :code_review, user_id: student.id
     student_2 = create :student
-    comment = create :code_review_note, commenter: student_2, code_review: review
+    comment = create :code_review_comment, commenter: student_2, code_review: review
     assert_nil review.deleted_at
     assert_nil comment.deleted_at
     refute_nil comment.comment
@@ -910,7 +910,7 @@ class DeleteAccountsHelperTest < ActionView::TestCase
 
   test "anonymizes and deletes code review comments written by user" do
     student = create :student
-    comment = create :code_review_note, commenter: student
+    comment = create :code_review_comment, commenter: student
     refute_nil comment.commenter
     refute_nil comment.comment
     assert_nil comment.deleted_at

--- a/lib/cdo/delete_accounts_helper.rb
+++ b/lib/cdo/delete_accounts_helper.rb
@@ -273,7 +273,7 @@ class DeleteAccountsHelper
 
   def clean_and_destroy_code_reviews(user_id)
     # anonymize notes the user wrote
-    comments_written = CodeReviewNote.where(commenter_id: user_id)
+    comments_written = CodeReviewComment.where(commenter_id: user_id)
     comments_written_count = comments_written.count
     comments_written.each do |comment|
       comment.comment = nil
@@ -281,7 +281,7 @@ class DeleteAccountsHelper
       comment.save!
     end
     comments_written.destroy_all
-    @log.puts "Cleared and deleted #{comments_written_count} CodeReviewNote" if comments_written_count > 0
+    @log.puts "Cleared and deleted #{comments_written_count} CodeReviewComment" if comments_written_count > 0
     # Clear comments and soft delete any code reviews for the user.
     code_reviews = CodeReview.where(user_id: user_id)
     code_reviews_count = code_reviews.count


### PR DESCRIPTION
Change code references from `code_review_notes` table to`code_review_comments`. `code_review_comments` makes more sense, but was previously the name of a v1 table. Now that table has been [dropped](https://github.com/code-dot-org/code-dot-org/pull/48016) we can use the name for v2.

This PR changes all the code references from `code_review_notes` to `code_review_comments`. There will be a follow up once this is deployed to change the table name itself.


## Links

- jira ticket: [JAVA-642](https://codedotorg.atlassian.net/browse/JAVA-642)


## Testing story
Tested that creating, deleting and getting comments still worked, and that all unit tests pass.


## Follow-up work
Rename the table in the database.


