### PR TITLE
Java Lab documentation: increase border width around methods

### DIFF
--- a/apps/src/templates/codeDocs/MethodWithOverloads.jsx
+++ b/apps/src/templates/codeDocs/MethodWithOverloads.jsx
@@ -156,7 +156,7 @@ const styles = {
   container: {
     borderStyle: 'solid',
     borderColor: color.lighter_gray,
-    borderWidth: 1,
+    borderWidth: 3,
     borderRadius: 5,
     padding: 5,
     marginBottom: 10,


### PR DESCRIPTION
We got a request to increase the border width around methods to make it clearer.

## Before
<img width="754" alt="Screen Shot 2022-09-16 at 10 42 33 AM" src="https://user-images.githubusercontent.com/33666587/190703008-1d0cd04e-7a96-4558-9825-885f0ddeb81a.png">


## After
<img width="754" alt="Screen Shot 2022-09-16 at 10 40 10 AM" src="https://user-images.githubusercontent.com/33666587/190703020-d75cfb07-ec81-48d6-84e3-856fce79d6b8.png">


## Links

- jira ticket: [JAVA-684](https://codedotorg.atlassian.net/browse/JAVA-684)


## Testing story
Tested locally
