### PR TITLE
Send exit surveys for academic year workshops

### DIFF
--- a/dashboard/app/mailers/pd/workshop_mailer.rb
+++ b/dashboard/app/mailers/pd/workshop_mailer.rb
@@ -244,12 +244,6 @@ class Pd::WorkshopMailer < ActionMailer::Base
     # Don't send if there's no associated survey
     return unless @survey_url
 
-    # Don't send for Academic Year Workshops.
-    # 2020-2021 AYW post-workshop survey configuration
-    # is too complicated to automate quickly, so we'll
-    # solicit survey responses by other means.
-    return if Pd::Workshop::ACADEMIC_YEAR_WORKSHOP_SUBJECTS.include? @workshop.subject
-
     content_type = 'text/html'
     if @workshop.course == Pd::Workshop::COURSE_CSF
       attachments['certificate.jpg'] = generate_csf_certificate

--- a/dashboard/test/mailers/pd/workshop_mailer_test.rb
+++ b/dashboard/test/mailers/pd/workshop_mailer_test.rb
@@ -67,12 +67,12 @@ class WorkshopMailerTest < ActionMailer::TestCase
     end
   end
 
-  test 'exit survey emails are skipped for academic year workshops' do
+  test 'exit survey emails are not skipped for academic year workshops' do
     workshop = create :csp_academic_year_workshop, :ended
     enrollment = create :pd_enrollment, workshop: workshop
     Pd::Enrollment.any_instance.expects(:exit_survey_url).returns('a url')
 
-    assert_emails 0 do
+    assert_emails 1 do
       Pd::WorkshopMailer.exit_survey(enrollment).deliver_now
     end
   end


### PR DESCRIPTION
We want to start sending exit surveys for academic year workshops again.

https://codedotorg.slack.com/archives/C02EEGWLHR8/p1663351618771119?thread_ts=1663345065.698709&cid=C02EEGWLHR8