### PR TITLE
show course display name on non-HOC congrats certificates

### DIFF
--- a/dashboard/app/controllers/certificate_images_controller.rb
+++ b/dashboard/app/controllers/certificate_images_controller.rb
@@ -27,8 +27,10 @@ class CertificateImagesController < ApplicationController
       return render status: :bad_request, json: {message: "invalid course name: #{data['course']}"}
     end
 
+    course_version = CurriculumHelper.find_matching_course_version(data['course'])
+    course_title = course_version&.localized_title
     begin
-      image = CertificateImage.create_course_certificate_image(data['name'], data['course'], data['donor'])
+      image = CertificateImage.create_course_certificate_image(data['name'], data['course'], data['donor'], course_title)
       image.format = format
       content_type = "image/#{format}"
       send_data image.to_blob, type: content_type

--- a/dashboard/test/controllers/certificate_images_controller_test.rb
+++ b/dashboard/test/controllers/certificate_images_controller_test.rb
@@ -31,19 +31,39 @@ class CertificateImagesControllerTest < ActionController::TestCase
     assert_includes response.body, 'invalid donor name'
   end
 
-  test 'can show csf course name' do
+  test 'can show course1 course name' do
     data = {name: 'student', course: 'course1'}
     filename = Base64.urlsafe_encode64(data.to_json)
     get :show, format: 'jpg', params: {filename: filename}
     assert_response :success
   end
 
+  test 'can show coursea course name' do
+    coursea = create :script, name: "coursea-2021", is_course: true
+    create :course_version, content_root: coursea
+
+    # stub the image, so that we can verify the params passed to create_course_certificate_image
+    stub_path = dashboard_dir('app/assets/images/hour-of-code-logo.png')
+    stub_image = Magick::Image.read(stub_path).first
+
+    data = {name: 'student', course: 'coursea-2021'}
+    filename = Base64.urlsafe_encode64(data.to_json)
+    CertificateImage.expects(:create_course_certificate_image).with('student', 'coursea-2021', nil, "Course A (2021)").returns(stub_image).once
+    get :show, format: 'jpg', params: {filename: filename}
+    assert_response :success
+  end
+
   test 'can show csp course name' do
-    csp = create :unit_group, name: "csp-1999"
+    csp = create :unit_group, name: "csp-2021"
     create :course_version, content_root: csp
 
-    data = {name: 'student', course: 'csp-1999'}
+    # stub the image, so that we can verify the params passed to create_course_certificate_image
+    stub_path = dashboard_dir('app/assets/images/hour-of-code-logo.png')
+    stub_image = Magick::Image.read(stub_path).first
+
+    data = {name: 'student', course: 'csp-2021'}
     filename = Base64.urlsafe_encode64(data.to_json)
+    CertificateImage.expects(:create_course_certificate_image).with('student', 'csp-2021', nil, "Computer Science Principles ('21-'22)").returns(stub_image).once
     get :show, format: 'jpg', params: {filename: filename}
     assert_response :success
   end


### PR DESCRIPTION
Finishes [PLAT-1888](https://codedotorg.atlassian.net/browse/PLAT-1888). Depends on https://github.com/code-dot-org/code-dot-org/pull/48126 . 

All user-facing changes are hidden behind an experiment flag -- although studio.code.org/congrats is live, it is only used today for HOC courses. CSF courses are only visible there if you have the experiment enabled.

### screenshots (before / after)

![Screen Shot 2022-09-16 at 12 51 20 PM](https://user-images.githubusercontent.com/8001765/190720913-74f9f717-c11a-4b74-988f-a31f59a409ac.png)

![Screen Shot 2022-09-16 at 12 53 24 PM](https://user-images.githubusercontent.com/8001765/190720943-45753cde-f01d-4bdd-84a0-487161590744.png)



## Testing story

* new unit tests validate course display name is getting passed to the image rendering library
* manual verification shown in screenshots
* existing eyes tests, whose baseline images will need to be updated: https://github.com/code-dot-org/code-dot-org/blob/a5842e95ab72db2cade2ca05adee50ecf8103e8f/dashboard/test/ui/features/hour_of_code/hour_of_code_finish.feature#L113-L122

