### PR TITLE
Upgrade `sync-down` to use v2 Crowdin API

### DIFF
--- a/bin/i18n/codeorg-testing_crowdin.yml
+++ b/bin/i18n/codeorg-testing_crowdin.yml
@@ -7,7 +7,7 @@
 
 # API Credentials must be loaded from a separate identity file. See
 # https://support.crowdin.com/configuration-file/#split-project-configuration-and-api-credentials
-"api_token" : ""
+"api_key" : ""
 
 #
 # Files configuration

--- a/bin/i18n/codeorg-testing_crowdin.yml
+++ b/bin/i18n/codeorg-testing_crowdin.yml
@@ -7,7 +7,7 @@
 
 # API Credentials must be loaded from a separate identity file. See
 # https://support.crowdin.com/configuration-file/#split-project-configuration-and-api-credentials
-"api_key" : ""
+"api_token" : ""
 
 #
 # Files configuration

--- a/bin/i18n/i18n_script_utils.rb
+++ b/bin/i18n/i18n_script_utils.rb
@@ -11,28 +11,24 @@ I18N_SOURCE_DIR = "i18n/locales/source"
 CROWDIN_PROJECTS = {
   "codeorg": {
     config_file: File.join(File.dirname(__FILE__), "codeorg_crowdin.yml"),
-    identity_file: File.join(File.dirname(__FILE__), "codeorg_credentials.yml"),
     identity_file_v2: File.join(File.dirname(__FILE__), "crowdin_credentials.yml"),
     etags_json: File.join(File.dirname(__FILE__), "crowdin", "codeorg_etags.json"),
     files_to_sync_out_json: File.join(File.dirname(__FILE__), "crowdin", "codeorg_files_to_sync_out.json")
   },
   "codeorg-markdown": {
     config_file: File.join(File.dirname(__FILE__), "codeorg_markdown_crowdin.yml"),
-    identity_file: File.join(File.dirname(__FILE__), "codeorg_markdown_credentials.yml"),
     identity_file_v2: File.join(File.dirname(__FILE__), "crowdin_credentials.yml"),
     etags_json: File.join(File.dirname(__FILE__), "crowdin", "codeorg-markdown_etags.json"),
     files_to_sync_out_json: File.join(File.dirname(__FILE__), "crowdin", "codeorg-markdown_files_to_sync_out.json")
   },
   "hour-of-code": {
     config_file: File.join(File.dirname(__FILE__), "hourofcode_crowdin.yml"),
-    identity_file: File.join(File.dirname(__FILE__), "hourofcode_credentials.yml"),
     identity_file_v2: File.join(File.dirname(__FILE__), "crowdin_credentials.yml"),
     etags_json: File.join(File.dirname(__FILE__), "crowdin", "hour-of-code_etags.json"),
     files_to_sync_out_json: File.join(File.dirname(__FILE__), "crowdin", "hour-of-code_files_to_sync_out.json")
   },
   "codeorg-restricted": {
     config_file: File.join(File.dirname(__FILE__), "codeorg_restricted_crowdin.yml"),
-    identity_file: File.join(File.dirname(__FILE__), "codeorg_restricted_credentials.yml"),
     identity_file_v2: File.join(File.dirname(__FILE__), "crowdin_credentials.yml"),
     etags_json: File.join(File.dirname(__FILE__), "crowdin", "codeorg-restricted_etags.json"),
     files_to_sync_out_json: File.join(File.dirname(__FILE__), "crowdin", "codeorg-restricted_files_to_sync_out.json")
@@ -42,7 +38,6 @@ CROWDIN_PROJECTS = {
 CROWDIN_TEST_PROJECTS = {
   "codeorg-testing": {
     config_file: File.join(File.dirname(__FILE__), "codeorg-testing_crowdin.yml"),
-    identity_file: File.join(File.dirname(__FILE__), "codeorg-testing_credentials.yml"),
     identity_file_v2: File.join(File.dirname(__FILE__), "crowdin_credentials.yml"),
     etags_json: File.join(File.dirname(__FILE__), "crowdin", "codeorg-testing_etags.json"),
     files_to_sync_out_json: File.join(File.dirname(__FILE__), "crowdin", "codeorg-testing_files_to_sync_out.json")

--- a/bin/i18n/i18n_script_utils.rb
+++ b/bin/i18n/i18n_script_utils.rb
@@ -11,25 +11,25 @@ I18N_SOURCE_DIR = "i18n/locales/source"
 CROWDIN_PROJECTS = {
   "codeorg": {
     config_file: File.join(File.dirname(__FILE__), "codeorg_crowdin.yml"),
-    identity_file_v2: File.join(File.dirname(__FILE__), "crowdin_credentials.yml"),
+    identity_file: File.join(File.dirname(__FILE__), "crowdin_credentials.yml"),
     etags_json: File.join(File.dirname(__FILE__), "crowdin", "codeorg_etags.json"),
     files_to_sync_out_json: File.join(File.dirname(__FILE__), "crowdin", "codeorg_files_to_sync_out.json")
   },
   "codeorg-markdown": {
     config_file: File.join(File.dirname(__FILE__), "codeorg_markdown_crowdin.yml"),
-    identity_file_v2: File.join(File.dirname(__FILE__), "crowdin_credentials.yml"),
+    identity_file: File.join(File.dirname(__FILE__), "crowdin_credentials.yml"),
     etags_json: File.join(File.dirname(__FILE__), "crowdin", "codeorg-markdown_etags.json"),
     files_to_sync_out_json: File.join(File.dirname(__FILE__), "crowdin", "codeorg-markdown_files_to_sync_out.json")
   },
   "hour-of-code": {
     config_file: File.join(File.dirname(__FILE__), "hourofcode_crowdin.yml"),
-    identity_file_v2: File.join(File.dirname(__FILE__), "crowdin_credentials.yml"),
+    identity_file: File.join(File.dirname(__FILE__), "crowdin_credentials.yml"),
     etags_json: File.join(File.dirname(__FILE__), "crowdin", "hour-of-code_etags.json"),
     files_to_sync_out_json: File.join(File.dirname(__FILE__), "crowdin", "hour-of-code_files_to_sync_out.json")
   },
   "codeorg-restricted": {
     config_file: File.join(File.dirname(__FILE__), "codeorg_restricted_crowdin.yml"),
-    identity_file_v2: File.join(File.dirname(__FILE__), "crowdin_credentials.yml"),
+    identity_file: File.join(File.dirname(__FILE__), "crowdin_credentials.yml"),
     etags_json: File.join(File.dirname(__FILE__), "crowdin", "codeorg-restricted_etags.json"),
     files_to_sync_out_json: File.join(File.dirname(__FILE__), "crowdin", "codeorg-restricted_files_to_sync_out.json")
   }
@@ -38,7 +38,7 @@ CROWDIN_PROJECTS = {
 CROWDIN_TEST_PROJECTS = {
   "codeorg-testing": {
     config_file: File.join(File.dirname(__FILE__), "codeorg-testing_crowdin.yml"),
-    identity_file_v2: File.join(File.dirname(__FILE__), "crowdin_credentials.yml"),
+    identity_file: File.join(File.dirname(__FILE__), "crowdin_credentials.yml"),
     etags_json: File.join(File.dirname(__FILE__), "crowdin", "codeorg-testing_etags.json"),
     files_to_sync_out_json: File.join(File.dirname(__FILE__), "crowdin", "codeorg-testing_files_to_sync_out.json")
   }

--- a/bin/i18n/sync-down.rb
+++ b/bin/i18n/sync-down.rb
@@ -24,7 +24,7 @@ def sync_down
 
     CROWDIN_PROJECTS.each do |name, options|
       puts "Downloading translations from #{name} project"
-      api_token = YAML.load_file(options[:identity_file_v2])["api_token"]
+      api_token = YAML.load_file(options[:identity_file])["api_token"]
       project_identifier = YAML.load_file(options[:config_file])["project_identifier"]
       project = Crowdin::Project.new(project_identifier, api_token)
       options = {

--- a/bin/i18n/sync-down.rb
+++ b/bin/i18n/sync-down.rb
@@ -24,10 +24,9 @@ def sync_down
 
     CROWDIN_PROJECTS.each do |name, options|
       puts "Downloading translations from #{name} project"
-      api_key = YAML.load_file(options[:identity_file])["api_key"]
       api_token = YAML.load_file(options[:identity_file_v2])["api_token"]
       project_identifier = YAML.load_file(options[:config_file])["project_identifier"]
-      project = Crowdin::Project.new(project_identifier, api_key, api_token)
+      project = Crowdin::Project.new(project_identifier, api_token)
       options = {
         etags_json: options[:etags_json],
         files_to_sync_out_json: options[:files_to_sync_out_json],

--- a/bin/i18n/sync-down.rb
+++ b/bin/i18n/sync-down.rb
@@ -25,8 +25,9 @@ def sync_down
     CROWDIN_PROJECTS.each do |name, options|
       puts "Downloading translations from #{name} project"
       api_key = YAML.load_file(options[:identity_file])["api_key"]
+      api_token = YAML.load_file(options[:identity_file_v2])["api_token"]
       project_identifier = YAML.load_file(options[:config_file])["project_identifier"]
-      project = Crowdin::Project.new(project_identifier, api_key)
+      project = Crowdin::Project.new(project_identifier, api_key, api_token)
       options = {
         etags_json: options[:etags_json],
         files_to_sync_out_json: options[:files_to_sync_out_json],

--- a/bin/i18n/sync-up.rb
+++ b/bin/i18n/sync-up.rb
@@ -13,7 +13,7 @@ def sync_up
     puts "Sync up starting"
     CROWDIN_PROJECTS.each do |name, options|
       puts "Uploading source strings to #{name} project"
-      command = "crowdin upload sources --config #{options[:config_file]} --identity #{options[:identity_file_v2]}"
+      command = "crowdin upload sources --config #{options[:config_file]} --identity #{options[:identity_file]}"
       Open3.popen2(command) do |_stdin, stdout, status_thread|
         while line = stdout.gets
           # skip lines detailing individual file upload, unless that file

--- a/lib/cdo/crowdin/client_extentions.rb
+++ b/lib/cdo/crowdin/client_extentions.rb
@@ -11,14 +11,16 @@ module Crowdin
       'codeorg' => 26074,
       'hour-of-code' => 55536,
       'codeorg-markdown' => 314545,
-      'codeorg-restricted' => 464582
+      'codeorg-restricted' => 464582,
+      'codeorg-testing' => 346087
     }
 
     CDO_PROJECT_SOURCE_LANGUAGES = {
       'codeorg' => 'enus',
       'hour-of-code' => 'en',
       'codeorg-markdown' => 'en',
-      'codeorg-restricted' => 'en'
+      'codeorg-restricted' => 'en',
+      'codeorg-testing' => 'en'
     }
 
     # Maximum number of items to retrieve from Crowdin in an API call

--- a/lib/cdo/crowdin/legacy_utils.rb
+++ b/lib/cdo/crowdin/legacy_utils.rb
@@ -48,7 +48,7 @@ module Crowdin
       languages = @project.languages
       num_languages = languages.length
       languages.each_with_index do |language, i|
-        language_code = language["code"]
+        language_code = language["id"]
         @logger.debug("#{language['name']} (#{language_code}): #{i}/#{num_languages}")
         @logger.info("~#{(i * 100 / num_languages).round(-1)}% complete (#{i}/#{num_languages})") if i > 0 && i % (num_languages / 5) == 0
 
@@ -56,11 +56,19 @@ module Crowdin
         files = @project.list_files
 
         changed_files = Parallel.map(files, in_threads: MAX_THREADS) do |file|
-          etag = etags[language_code].fetch(file, nil)
-          response = @project.export_file(file, language_code, etag: etag, only_head: true)
+          file_id = file['id']
+          filepath = file['path']
+          etag = etags[language_code].fetch(filepath, nil)
+          response = @project.export_file(file_id, language_code, etag: etag)
           case response.code
           when 200
-            [file, response.headers["etag"]]
+            [
+              filepath,
+              {
+                etag: response["data"]["etag"],
+                download_url: response["data"]["url"]
+              }
+            ]
           when 304
             nil
           else
@@ -91,7 +99,7 @@ module Crowdin
       files_to_sync_out = JSON.parse(File.read(@files_to_sync_out_json))
 
       @project.languages.each do |language|
-        code = language["code"]
+        code = language["id"]
         name = language["name"]
         files = files_to_download.fetch(code, nil)
         next unless files.present?
@@ -102,7 +110,7 @@ module Crowdin
 
         @logger.debug("#{name} (#{code}): #{filenames.length} files have changes")
         downloaded_files = Parallel.map(filenames, in_threads: MAX_THREADS) do |file|
-          response = @project.export_file(file, code)
+          response = HTTParty.get(files[file]["download_url"])
           dest = File.join(locale_dir, file)
           FileUtils.mkdir_p(File.dirname(dest))
           # Make sure to specify the encoding; we expect to get quite a lot
@@ -110,7 +118,8 @@ module Crowdin
           File.open(dest, "w:#{response.body.encoding}") do |destfile|
             destfile.write(response.body)
           end
-          [file, response.headers["etag"]]
+
+          [file, {etag: files[file]["etag"]}]
         end.to_h
 
         # Save incremental progress so we don't have to re-download everything
@@ -127,7 +136,7 @@ module Crowdin
         File.write @files_to_download_json, JSON.pretty_generate(files_to_download)
 
         etags[code] ||= {}
-        etags[code].merge! downloaded_files
+        etags[code].merge! downloaded_files.each {|file, data| downloaded_files[file] = data[:etag]}
         File.write @etags_json, JSON.pretty_generate(etags)
       end
     end

--- a/lib/cdo/crowdin/legacy_utils.rb
+++ b/lib/cdo/crowdin/legacy_utils.rb
@@ -1,5 +1,6 @@
 require 'json'
 require 'parallel'
+require 'httparty'
 
 module Crowdin
   # Crowdin's API is limited to 20 simultaneous requests. Limit our

--- a/lib/cdo/crowdin/legacy_utils.rb
+++ b/lib/cdo/crowdin/legacy_utils.rb
@@ -65,8 +65,8 @@ module Crowdin
             [
               filepath,
               {
-                etag: response["data"]["etag"],
-                download_url: response["data"]["url"]
+                download_url: response["data"]["url"],
+                etag: response["data"]["etag"]
               }
             ]
           when 304
@@ -119,7 +119,7 @@ module Crowdin
             destfile.write(response.body)
           end
 
-          [file, {etag: files[file]["etag"]}]
+          [file, files[file]["etag"]]
         end.to_h
 
         # Save incremental progress so we don't have to re-download everything
@@ -136,7 +136,7 @@ module Crowdin
         File.write @files_to_download_json, JSON.pretty_generate(files_to_download)
 
         etags[code] ||= {}
-        etags[code].merge! downloaded_files.each {|file, data| downloaded_files[file] = data[:etag]}
+        etags[code].merge! downloaded_files
         File.write @etags_json, JSON.pretty_generate(etags)
       end
     end

--- a/lib/cdo/crowdin/project.rb
+++ b/lib/cdo/crowdin/project.rb
@@ -29,6 +29,16 @@ module Crowdin
       )
     end
 
+    # @param file_id [String] name of file (within crowdin) to be downloaded
+    # @param language [String] crowdin language code
+    # @param etag [String, nil] the last file version tag returned by crowdin
+    #  for this file. If no changes have occurred since the provided etag was
+    #  generated, crowdin will return a 304 (Not Modified) status instead of
+    #  downloading the file. See the Build Project File Translation Crowdin
+    #  documentation for details
+    # @param attempts [Number, nil] how many times we should retry the download
+    #  if it fails
+    # @see https://developer.crowdin.com/api/v2/#operation/api.projects.translations.builds.files.post
     def export_file(file_id, language, etag: nil, attempts: 3)
       options = {
         body: {

--- a/lib/cdo/crowdin/project.rb
+++ b/lib/cdo/crowdin/project.rb
@@ -1,4 +1,5 @@
 require 'httparty'
+require_relative 'client_extentions.rb'
 
 module Crowdin
   # This class represents a single project hosted on Crowdin, and provides
@@ -12,38 +13,28 @@ module Crowdin
     # @param api_key [String]
     # @see https://crowdin.com/project/codeorg/integrations/api for an example of
     #  how to retrieve these values for the "code.org" project
-    def initialize(project_identifier, api_key)
+    def initialize(project_identifier, api_key, api_token)
       @id = project_identifier
-      self.class.base_uri("https://api.crowdin.com/api/project/#{project_identifier}")
-      self.class.default_params({"account-key" => api_key, "login" => "code-org"})
-    end
-
-    # @see https://support.crowdin.com/api/api-integration-setup/#titles-project-details
-    def project_info
-      # cache the result; we end up calling this method quite a lot since it's
-      # the source of both our lists of files and of languages, and it also
-      # shouldn't ever change mid-sync.
-      @info ||= self.class.post("/info")
-    end
-
-    # @param file [String] name of file (within crowdin) to be downloaded
-    # @param language [String] crowdin language code
-    # @param etag [String, nil] the last file version tag returned by crowdin
-    #  for this file. If no changes have occurred since the provided etag was
-    #  generated, crowdin will return a 304 (Not Modified) status instead of
-    #  downloading the file. See the export-file Crowdin documentation for
-    #  details
-    # @param attempts [Number, nil] how many times we should retry the download
-    #  if it fails
-    # @param only_head [Boolean, nil] whether to make a HEAD request rather
-    #  than a full GET request. Defaults to false.
-    # @see https://support.crowdin.com/api/api-integration-setup/#titles-export-file
-    def export_file(file, language, etag: nil, attempts: 3, only_head: false)
-      options = {
-        query: {
-          file: file,
-          language: language
+      @crowdin_client = Crowdin::Client.new do |config|
+        config.api_token = api_token
+        config.project_id = Crowdin::Client::CDO_PROJECT_IDS[@id]
+      end
+      # For more specific requests outside of the crowdin gem
+      self.class.base_uri("https://api.crowdin.com/api/v2")
+      self.class.headers(
+        {
+          "Authorization" => "Bearer #{api_token}",
+          "Content-Type" => "application/json"
         }
+      )
+    end
+
+    def export_file(file_id, language, etag: nil, attempts: 3)
+      options = {
+        body: {
+          targetLanguageId: language
+        }.to_json,
+        follow_redirects: true
       }
 
       unless etag.nil?
@@ -52,7 +43,7 @@ module Crowdin
         }
       end
 
-      only_head ? self.class.head("/export-file", options) : self.class.get("/export-file", options)
+      self.class.post("/projects/#{@crowdin_client.config.project_id}/translations/builds/files/#{file_id}", options)
     rescue Net::ReadTimeout, Net::OpenTimeout => error
       # Handle a timeout by simply retrying. We default to three attempts before
       # giving up; if this doesn't work out, other things we could consider:
@@ -62,54 +53,46 @@ module Crowdin
       #   - increasing the timeout, either globally or for this specific call
       STDERR.puts "Crowdin.export_file(#{file}) timed out: #{error}"
       raise if attempts <= 1
-      export_file(file, language, etag: etag, attempts: attempts - 1, only_head: only_head)
+      export_file(file, language, etag: etag, attempts: attempts - 1)
     end
 
     # Retrieve all languages currently enabled in the crowdin project. Each
     # language is a hash containing the language name and code, as well as
     # other internal crowdin values.
-    # @example [{"name"=>"Norwegian", "code"=>"no", "can_translate"=>"1", "can_approve"=>"1"}, ...]
+    # @example [{"name"=>"Norwegian", "code"=>"no", ...]
     # @return [Array<Hash>]
     def languages
-      project_info["info"]["languages"]["item"]
+      # cache the result; we end up calling this method quite a lot since it's
+      # the source of both our lists of files and of languages, and it also
+      # shouldn't ever change mid-sync.
+      query = {
+        limit: Crowdin::Client::MAX_ITEMS_COUNT,
+        offset: 0
+      }
+
+      @languages ||= @crowdin_client.request_loop(query) do
+        @crowdin_client.list_languages(query)
+      end
     end
 
     # Retrieve all files currently uploaded to the crowdin project.
-    # @example ["/dashboard/base.yml", "/dashboard/data.yml", ...]
-    # @return [Array<String>]
+    # @example [{"id"=>169076, "path"=>"/pegasus/mobile.yml"}, {"id"=>169080, "path"=>"/blockly-core/core.json"}, ...]
+    # @return [Array<Hash>]
     def list_files
-      files = project_info["info"]["files"]["item"]
-      results = []
-      each_file(files) do |file, path|
-        results << File.join(path, file["name"])
+      query = {
+        limit: Crowdin::Client::MAX_ITEMS_COUNT,
+        offset: 0
+      }
+
+      results = @crowdin_client.request_loop(query) do
+        @crowdin_client.list_files(query)
       end
-      results
-    end
 
-    private
-
-    # Iterate through files as returned by crowdin. Crowdin returns files in a
-    # nested format, where each file is a "node", and directories are nodes
-    # that can contain other nodes. This helper simply knows how to traverse
-    # that simulated directory structure, and will yield each file in turn
-    # along with its directory.
-    # @param files [Array<Hash>]
-    # @param path [String, nil]
-    # @yield [name, path] the name of a file and the full path to the directory
-    #   in which it can be found.
-    def each_file(files, path="")
-      files = [files] unless files.is_a? Array
-      files.each do |file|
-        case file["node_type"]
-        when "directory"
-          subfiles = file["files"]["item"]
-          subpath = File.join(path, file["name"])
-          each_file(subfiles, subpath) {|f, p| yield f, p}
-        when "file"
-          yield file, path
-        else
-          raise "Cannot process file of type #{file['node_type']}"
-        end
+      results.map! do |file|
+        {
+          "id" => file["data"]["id"],
+          "path" => file["data"]["path"]
+        }
       end
     end
   end

--- a/lib/cdo/crowdin/project.rb
+++ b/lib/cdo/crowdin/project.rb
@@ -10,11 +10,10 @@ module Crowdin
     attr_reader :id
 
     # @param project_identifier [String]
-    # @param api_key [String]
     # @param api_token [String]
     # @see https://crowdin.com/project/codeorg/integrations/api for an example of
     #  how to retrieve these values for the "code.org" project
-    def initialize(project_identifier, api_key, api_token)
+    def initialize(project_identifier, api_token)
       @id = project_identifier
       @crowdin_client = Crowdin::Client.new do |config|
         config.api_token = api_token

--- a/lib/cdo/crowdin/project.rb
+++ b/lib/cdo/crowdin/project.rb
@@ -43,8 +43,7 @@ module Crowdin
       options = {
         body: {
           targetLanguageId: language
-        }.to_json,
-        follow_redirects: true
+        }.to_json
       }
 
       unless etag.nil?

--- a/lib/test/cdo/crowdin/test_legacy_utils.rb
+++ b/lib/test/cdo/crowdin/test_legacy_utils.rb
@@ -1,6 +1,8 @@
 require_relative '../../test_helper'
 require_relative '../../../cdo/crowdin/legacy_utils'
 require 'tempfile'
+require 'HTTParty'
+require 'webmock/minitest'
 
 class MockCrowdinProject < Minitest::Mock
   LATEST_ETAG_VALUE = "0123"
@@ -10,29 +12,45 @@ class MockCrowdinProject < Minitest::Mock
   end
 
   def languages
-    [{"name" => "Test Language", "code" => "i1-8n"}]
+    [{"name" => "Test Language", "id" => "i1-8n"}]
   end
 
   def list_files
-    ["/foo.bar", "/baz.bat"]
+    [
+      {"id" => 1, "path" => "/foo.bar"},
+      {"id" => 1, "path" => "/baz.bat"}
+    ]
   end
 
   def export_file(file, language, etag: nil, attempts: 3, only_head: false)
-    mock_response = Minitest::Mock.new
+    mock_response = OpenStruct.new
     if etag.nil? || (etag != LATEST_ETAG_VALUE)
-      def mock_response.body; "test"; end
-      def mock_response.headers; {"etag" => LATEST_ETAG_VALUE}; end
-      def mock_response.code; 200; end
+      mock_response.code = 200
+      mock_response["data"] = {
+        "url" => CrowdinLegacyUtilsTest::DOWNLOAD_URL,
+        "etag" => LATEST_ETAG_VALUE
+      }
     else
-      def mock_response.code; 304; end
+      mock_response.code = 304
     end
+
     mock_response
   end
 end
 
 class CrowdinLegacyUtilsTest < Minitest::Test
+  DOWNLOAD_URL = "http://foo.com/"
+
   def setup
     @mock_project = MockCrowdinProject.new
+
+    stub_request(
+      :get,
+      DOWNLOAD_URL
+    ).to_return(
+      status: 200,
+      body: "Test body"
+    )
 
     @options = {
       etags_json: Tempfile.new('etags.json'),
@@ -46,6 +64,18 @@ class CrowdinLegacyUtilsTest < Minitest::Test
       "i1-8n" => {
         "/foo.bar" => MockCrowdinProject::LATEST_ETAG_VALUE,
         "/baz.bat" => MockCrowdinProject::LATEST_ETAG_VALUE,
+      }
+    }
+    @latest_files_to_download = {
+      "i1-8n" => {
+        "/foo.bar" => {
+          "download_url" => DOWNLOAD_URL,
+          "etag" => MockCrowdinProject::LATEST_ETAG_VALUE
+        },
+        "/baz.bat" => {
+          "download_url" => DOWNLOAD_URL,
+          "etag" => MockCrowdinProject::LATEST_ETAG_VALUE
+        }
       }
     }
   end
@@ -71,7 +101,7 @@ class CrowdinLegacyUtilsTest < Minitest::Test
     @utils.fetch_changes
 
     assert_equal({}, JSON.parse(File.read(@options[:etags_json])))
-    assert_equal @latest_crowdin_etags, JSON.parse(File.read(@options[:files_to_download_json]))
+    assert_equal @latest_files_to_download, JSON.parse(File.read(@options[:files_to_download_json]))
   end
 
   def test_fetching_is_idempotent
@@ -84,7 +114,7 @@ class CrowdinLegacyUtilsTest < Minitest::Test
     @utils.fetch_changes
 
     assert_equal({}, JSON.parse(File.read(@options[:etags_json])))
-    assert_equal @latest_crowdin_etags, JSON.parse(File.read(@options[:files_to_download_json]))
+    assert_equal @latest_files_to_download, JSON.parse(File.read(@options[:files_to_download_json]))
   end
 
   def test_fetching_respects_unchanged_files
@@ -103,7 +133,10 @@ class CrowdinLegacyUtilsTest < Minitest::Test
     assert_equal local_etags, JSON.parse(File.read(@options[:etags_json]))
     expected_files_to_download = {
       "i1-8n" => {
-        "/baz.bat" => MockCrowdinProject::LATEST_ETAG_VALUE,
+        "/baz.bat" => {
+          "download_url" => DOWNLOAD_URL,
+          "etag" => MockCrowdinProject::LATEST_ETAG_VALUE
+        }
       }
     }
     assert_equal expected_files_to_download, JSON.parse(File.read(@options[:files_to_download_json]))
@@ -128,7 +161,7 @@ class CrowdinLegacyUtilsTest < Minitest::Test
     # If +download_changed_files+ successfully downloads files from Crowdin,
     # it should update the local state tracked by the 3 files: etags_json,
     # files_to_sync_out_json, and files_to_download_json.
-    File.write @options[:files_to_download_json], JSON.pretty_generate(@latest_crowdin_etags)
+    File.write @options[:files_to_download_json], JSON.pretty_generate(@latest_files_to_download)
     File.write @options[:files_to_sync_out_json], JSON.pretty_generate({})
     File.write @options[:etags_json], JSON.pretty_generate({})
 
@@ -149,7 +182,10 @@ class CrowdinLegacyUtilsTest < Minitest::Test
     # already exists in etags_json and files_to_sync_out.
     files_to_download = {
       "i1-8n" => {
-        "/baz.bat" => MockCrowdinProject::LATEST_ETAG_VALUE
+        "/baz.bat" => {
+          "download_url" => DOWNLOAD_URL,
+          "etag" => MockCrowdinProject::LATEST_ETAG_VALUE
+        }
       }
     }
     files_to_sync_out = {
@@ -170,9 +206,13 @@ class CrowdinLegacyUtilsTest < Minitest::Test
 
     @utils.download_changed_files
 
+    # Deep dup
+    expected_downloaded_files = JSON.parse(files_to_download.to_json)
+    expected_downloaded_files["i1-8n"]["/baz.bat"] = expected_downloaded_files["i1-8n"]["/baz.bat"]["etag"]
+
     assert_equal({}, JSON.parse(File.read(@options[:files_to_download_json])))
-    assert_equal files_to_sync_out.deep_merge(files_to_download), JSON.parse(File.read(@options[:files_to_sync_out_json]))
-    assert_equal local_etags.deep_merge(files_to_download), JSON.parse(File.read(@options[:etags_json]))
+    assert_equal files_to_sync_out.deep_merge(expected_downloaded_files), JSON.parse(File.read(@options[:files_to_sync_out_json]))
+    assert_equal local_etags.deep_merge(expected_downloaded_files), JSON.parse(File.read(@options[:etags_json]))
     expected_local_files = ["#{@options[:locales_dir]}/Test Language/baz.bat"]
     assert_equal expected_local_files, Dir.glob(@options[:locales_dir] + "/**/*.*")
   end

--- a/lib/test/cdo/crowdin/test_legacy_utils.rb
+++ b/lib/test/cdo/crowdin/test_legacy_utils.rb
@@ -1,7 +1,6 @@
 require_relative '../../test_helper'
 require_relative '../../../cdo/crowdin/legacy_utils'
 require 'tempfile'
-require 'HTTParty'
 require 'webmock/minitest'
 
 class MockCrowdinProject < Minitest::Mock


### PR DESCRIPTION
**What:** Utilize the v2 Crowdin API during the `sync-down`. The `files_to_download_json` which is maintained to bridge the fetching of what files have changed, to actually downloading them, now contains a download URL. The Crowdin API no longer directly hosts the translated files and returns a URL to an S3 bucket to pull from.

It is also worth noting that this download URL can only be used once and returns `AccessDenied` if visited two or more times.

**Why:** The v1 API is deprecated and also has caused issues due to the reduced number of concurrent requests the v1 API supports.

## Links

https://developer.crowdin.com/api/v2/#operation/api.projects.translations.builds.files.post

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Locally ran the sync against the Test Crowdin project.
Updated the unit tests

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->


## Follow-up work

Take a close look as a team at the following sync after this is merged.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
