### PR TITLE
Fix Add Level dialog pagination bug

### DIFF
--- a/apps/src/lib/levelbuilder/lesson-editor/AddLevelDialogTop.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/AddLevelDialogTop.jsx
@@ -27,7 +27,7 @@ function AddLevelDialogTop(props) {
   useEffect(() => {
     handleSearch();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [currentPage]);
 
   const setCurrentPageAndSearch = value => {
     setCurrentPage(value);


### PR DESCRIPTION
When using the Add Level dialog when making an activity or lesson, the page numbers were not lining up with the results shown from the given search. They would be behind by one click in a sense, so if a user started on page 1 and clicked 2, then 3, then 2, then 1 again, the results they would see would correspond to pages 1, 1, 2, 3, 2, respectively (more clearly demonstrated in [this slack thread with a demo](https://codedotorg.slack.com/archives/C02EEGWLHR8/p1644874797438499?thread_ts=1644874779.355639&cid=C02EEGWLHR8).

The issue was in the `setCurrentPageAndSearch` method which was called when the user clicked a page number. It first calls the `setCurrentPage()` which asynchronously updates `currentPage` to the new page number selected (but it waits for a rerender since it is a state hook). Then it calls `handleSearch()` which queries the necessary chunk of levels based on the user's search parameters (including page number selection). However, since `setCurrentPage()` is waiting for a rerender, `handleSearch()` only has the previous value of `currentPage` so the rerender has the correct page number but the search results of the previous page number selected.

Adding this one line change will ensure that every time `currentPage` changes, `handleSearch()` will run and show the correct search results for that page.

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/browse/PLAT-1604?atlOrigin=eyJpIjoiMTRmOGQ0MjJkMGY4NDAwYjk0ZjIwZDk3MGJjM2JkNDYiLCJwIjoiaiJ9)

## Testing story
Locally tested and passed drone tests.

Previous behavior demo: [here](https://codedotorg.slack.com/archives/C02EEGWLHR8/p1644874797438499?thread_ts=1644874779.355639&cid=C02EEGWLHR8)
New behavior demo: [here](https://user-images.githubusercontent.com/56283563/190831677-74c2b7ec-aa24-44db-a17c-d7769d3a029a.mp4)

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
