### PR TITLE
Update create-release script to account for squash merge commits

### DIFF
--- a/bin/create-release
+++ b/bin/create-release
@@ -21,9 +21,9 @@ def git_generate_changelog
   # command will error out unless the latest commit is a merge
   return nil if status.exitstatus != 0
 
-  # Finds PRs that were either merged or squash-merged
-  merge_commit_pattern = /Merge pull request #(?<pr>\d*) from code-dot-org\/(?<branch>\S*) (?<description>.*)/
-  squash_merge_pattern = /(?<description>.*) \(#(?<pr>\d*)\)/
+  # Finds PRs that were either merged or squash-merged. As of 10/19/22, PR numbers should have at least 5 digits
+  merge_commit_pattern = /Merge pull request #(?<pr>\d\d\d\d\d+) from code-dot-org\/(?<branch>\S*) (?<description>.*)/
+  squash_merge_pattern = /(?<description>.*) \(#(?<pr>\d\d\d\d\d+)\)/
 
   matches = changes.split("\n").map do |change|
     # first, extract the relevant data from the commit message

--- a/bin/create-release
+++ b/bin/create-release
@@ -16,22 +16,24 @@ require 'tzinfo'
 REPO = 'code-dot-org/code-dot-org'.freeze
 
 def git_generate_changelog
-  changes, _err, status = Open3.capture3("git log --merges --oneline production^1..production^2 --format=\"%s %b\"")
+  changes, _err, status = Open3.capture3("git log --oneline production^1..production^2 --format=\"%s %b\"")
 
   # command will error out unless the latest commit is a merge
   return nil if status.exitstatus != 0
 
-  re = /Merge pull request #(?<pr>\d*) from code-dot-org\/(?<branch>\S*) (?<description>.*)/
+  # Finds PRs that were either merged or squash-merged
+  merge_commit_pattern = /Merge pull request #(?<pr>\d*) from code-dot-org\/(?<branch>\S*) (?<description>.*)/
+  squash_merge_pattern = /(?<description>.*) \(#(?<pr>\d*)\)/
 
   matches = changes.split("\n").map do |change|
     # first, extract the relevant data from the commit message
-    re.match(change)
+    merge_commit_pattern.match(change) || squash_merge_pattern.match(change)
   end
 
   relevant_matches = matches.select do |match|
     # ignore merges from staging and test, which represent standard
     # deploy operations
-    !match.nil? && !['staging', 'test'].include?(match['branch'])
+    !match.nil? && (!match.names.include?('branch') || !['staging', 'test'].include?(match['branch']))
   end
 
   items = relevant_matches.map do |match|


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Updates the `create-release` script to include squash merge commits when creating a new release changelog. The method of identifying squash merges here is looking for `(#\d+)` e.g. `(#12345)` which isn't necessarily _super_ robust, but I thought it best to at least get this added for now. Part of the challenge is that squash merge commits are just commits, so they'd need to be identified based on commit message. However, if we're good about using the default commit message when squash merging, then this should pick up the changes correctly.

## Links

Slack discussion: https://codedotorg.slack.com/archives/C0T0PNTM3/p1662668103782079?thread_ts=1662572922.185429&cid=C0T0PNTM3

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Tested this out with the last 5 DTPs (generating output only). Results below:

### DTP: https://github.com/code-dot-org/code-dot-org/pull/48146

Expected: 8 changes (2 squash merge commits / 6 merges)

Generated output:

Changelog:
- [More clear error message for a remixed neighborhood level](https://github.com/code-dot-org/code-dot-org/pull/48119)
- [DTS (Levelbuilder > Staging) [robo-dts]](https://github.com/code-dot-org/code-dot-org/pull/48132)
- [Adding Warning to Hidden Assessments form LockDialog](https://github.com/code-dot-org/code-dot-org/pull/48078)
- [fix tab index](https://github.com/code-dot-org/code-dot-org/pull/48122)
- [conditionally use new dashboard page for batch certificates](https://github.com/code-dot-org/code-dot-org/pull/48101)
- [Remove "order posters" Link from HoC Welcome Email](https://github.com/code-dot-org/code-dot-org/pull/48040)
- [Fix duplicate table issue when dashboard has contact_rollups table before pegasus](https://github.com/code-dot-org/code-dot-org/pull/47993)
- [PR 48115](https://github.com/code-dot-org/code-dot-org/pull/48115)

### DTP: https://github.com/code-dot-org/code-dot-org/pull/48124

Expected: 16 changes (6 squash merge commits / 10 merges)

Generated output:

Changelog:
- [HoC.com - FAQ updates](https://github.com/code-dot-org/code-dot-org/pull/48031)
- [Support sass on all pegasus sites](https://github.com/code-dot-org/code-dot-org/pull/48102)
- [Storybook Refactor - MazeThumbnail](https://github.com/code-dot-org/code-dot-org/pull/48099)
- [Handle FatalErrors in Java Lab](https://github.com/code-dot-org/code-dot-org/pull/48061)
- [Migrated ResourceLink story, deleted ProjectsGallery story](https://github.com/code-dot-org/code-dot-org/pull/48100)
- [Javalab: add resize text options in the settings menu](https://github.com/code-dot-org/code-dot-org/pull/48077)
- [DTS (Levelbuilder > Staging) [robo-dts]](https://github.com/code-dot-org/code-dot-org/pull/48114)
- [Upgrade FatalErrorDialog story](https://github.com/code-dot-org/code-dot-org/pull/48045)
- [drop reviewable projects table](https://github.com/code-dot-org/code-dot-org/pull/48079)
- [Revert "HoC.com - Update UI on activity tiles"](https://github.com/code-dot-org/code-dot-org/pull/48108)
- [HoC.com - Update UI on activity tiles](https://github.com/code-dot-org/code-dot-org/pull/48080)
- [Revert "Revert "Revert "Upgrade to webpack 5"""](https://github.com/code-dot-org/code-dot-org/pull/48103)
- [Add DataDoc show page](https://github.com/code-dot-org/code-dot-org/pull/48084)
- [Revert "Revert "Upgrade to webpack 5""](https://github.com/code-dot-org/code-dot-org/pull/48021)
- [Fix invalid font: Gotham 3r -> Gotham 4r](https://github.com/code-dot-org/code-dot-org/pull/48046)
- [PR 48083](https://github.com/code-dot-org/code-dot-org/pull/48083)

### DTP: https://github.com/code-dot-org/code-dot-org/pull/48094

Expected: 9 changes (3 squash merge commits / 6 merges)

Generated output:

Changelog:
- [Regional Partner Playbook page updates](https://github.com/code-dot-org/code-dot-org/pull/48060)
- [Removing OneTrust UI test because it was failing eyes tests](https://github.com/code-dot-org/code-dot-org/pull/48089)
- [Storybook Refactor - AssetThumbnail and RetryProjectSaveDialog](https://github.com/code-dot-org/code-dot-org/pull/48071)
- [A few storybook migrations](https://github.com/code-dot-org/code-dot-org/pull/48037)
- [DTS (Levelbuilder > Staging) [robo-dts]](https://github.com/code-dot-org/code-dot-org/pull/48082)
- [add page to dashboard for batch printing of certificates](https://github.com/code-dot-org/code-dot-org/pull/48000)
- [Hiding old cookie banner if new banner is shown](https://github.com/code-dot-org/code-dot-org/pull/48044)
- [Add new DataDoc frontend](https://github.com/code-dot-org/code-dot-org/pull/48055)
- [PR 48064](https://github.com/code-dot-org/code-dot-org/pull/48064)


### DTP: https://github.com/code-dot-org/code-dot-org/pull/48074

Expected: 10 changes (4 squash merge commits / 6 merges)

Generated output:

Changelog:
- [Keep code review submit button disabled until there is text](https://github.com/code-dot-org/code-dot-org/pull/48069)
- [[Storybook] Migrate ResetSuccessDialog.story.js to CSF](https://github.com/code-dot-org/code-dot-org/pull/48056)
- [Skip pd tests](https://github.com/code-dot-org/code-dot-org/pull/48065)
- [DTS (Levelbuilder > Staging) [robo-dts]](https://github.com/code-dot-org/code-dot-org/pull/48063)
- [Hide Print Certificate Button on PL Courses](https://github.com/code-dot-org/code-dot-org/pull/48006)
- [Storybook Refactor - ConfirmEnableMakerDialog and ValidationStep](https://github.com/code-dot-org/code-dot-org/pull/48043)
- [Storybook migrations - ImportProjectDialog, SignInOrAgeDialog, UploadErrorDialog](https://github.com/code-dot-org/code-dot-org/pull/48039)
- [[Storybook] Migrate DisallowedHtmlWarningDialog to CSF](https://github.com/code-dot-org/code-dot-org/pull/48036)
- [Test validate_key_format method](https://github.com/code-dot-org/code-dot-org/pull/48032)
- [Change application current year constant](https://github.com/code-dot-org/code-dot-org/pull/48052)

### DTP: https://github.com/code-dot-org/code-dot-org/pull/48059

Expected: 9 changes (2 squash merge commits / 7 merges

Generated output:

Changelog:
- [DTT (Staging > Test) [robo-dtt]](https://github.com/code-dot-org/code-dot-org/pull/48053)
- [Drop code_review_comments table](https://github.com/code-dot-org/code-dot-org/pull/48016)
- [Add new modules to CS Connections landing page](https://github.com/code-dot-org/code-dot-org/pull/48023)
- [WebSerial on Chromebooks](https://github.com/code-dot-org/code-dot-org/pull/47863)
- [Delete discountcode page and components](https://github.com/code-dot-org/code-dot-org/pull/48042)
- [DTS (Levelbuilder > Staging) [mike]](https://github.com/code-dot-org/code-dot-org/pull/48051)
- [PR 48050](https://github.com/code-dot-org/code-dot-org/pull/48050)
- [Fix Violations of and Reenable `Rails/Blank`](https://github.com/code-dot-org/code-dot-org/pull/48015)
- [PR 48028](https://github.com/code-dot-org/code-dot-org/pull/48028)


<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
