### PR TITLE
explicitly check that experiment is set in hoc finish eyes tests

### DIFF
--- a/apps/src/templates/certificates/Certificate.jsx
+++ b/apps/src/templates/certificates/Certificate.jsx
@@ -137,6 +137,10 @@ function Certificate(props) {
 
   const print = getPrintPath(certificate);
 
+  const wrapperClassName = props.showStudioCertificate
+    ? 'show-studio-certificate'
+    : undefined;
+
   return (
     <div style={styles.container}>
       <h1 style={headingStyle}>{i18n.congratsCertificateHeading()}</h1>
@@ -146,7 +150,11 @@ function Certificate(props) {
           linkText={i18n.backToActivity()}
         />
       )}
-      <div id="uitest-certificate" style={certificateStyle}>
+      <div
+        id="uitest-certificate"
+        className={wrapperClassName}
+        style={certificateStyle}
+      >
         <BackToFrontConfetti active={personalized} style={styles.confetti} />
         <a href={certificateShareLink}>
           <img src={imgSrc} />

--- a/dashboard/test/ui/features/hour_of_code/hour_of_code_finish.feature
+++ b/dashboard/test/ui/features/hour_of_code/hour_of_code_finish.feature
@@ -86,11 +86,13 @@ Scenario: blank certificate
 Scenario: congrats certificate pages
   Given I am on "http://studio.code.org/congrats?enableExperiments=studioCertificate"
   And I wait until element "#uitest-certificate" is visible
+  And element "#uitest-certificate.show-studio-certificate" is visible
   And I open my eyes to test "congrats certificate pages"
 
   When I am on "http://code.org/api/hour/finish/flappy"
   And I wait until current URL contains "/congrats"
   And I wait to see element with ID "uitest-certificate"
+  And element "#uitest-certificate.show-studio-certificate" is visible
   And I wait for image "#uitest-certificate img" to load
   And I see no difference for "uncustomized flappy certificate"
 
@@ -102,6 +104,7 @@ Scenario: congrats certificate pages
   When I am on "http://code.org/api/hour/finish/oceans"
   And I wait until current URL contains "/congrats"
   And I wait to see element with ID "uitest-certificate"
+  And element "#uitest-certificate.show-studio-certificate" is visible
   And I wait for image "#uitest-certificate img" to load
   And I see no difference for "uncustomized oceans certificate"
 
@@ -113,6 +116,7 @@ Scenario: congrats certificate pages
   When I am on "http://code.org/congrats/coursea-2017?enableExperiments=studioCertificate"
   And I wait until current URL contains "http://studio.code.org/congrats"
   And I wait to see element with ID "uitest-certificate"
+  And element "#uitest-certificate.show-studio-certificate" is visible
   And I wait for image "#uitest-certificate img" to load
   And I see no difference for "uncustomized Course A 2017 certificate"
 
@@ -124,6 +128,7 @@ Scenario: congrats certificate pages
   When I am on "http://code.org/congrats/accelerated?enableExperiments=studioCertificate"
   And I wait until current URL contains "http://studio.code.org/congrats"
   And I wait to see element with ID "uitest-certificate"
+  And element "#uitest-certificate.show-studio-certificate" is visible
   And I wait for image "#uitest-certificate img" to load
   And I see no difference for "uncustomized 20-hour certificate"
 


### PR DESCRIPTION
sometimes this eyes tests has flaky failures with a broken image icon. I was able to reproduce this problem when I try to use the page with the experiment set on code.org but not on studio.code.org. This PR adds some explicit checks to ensure that the experiment is set when we think it is. this PR is unlikely to actually eliminate any flakiness, but should help to narrow down the problem the next time it fails.

## Testing story

the affected eyes test is passing locally