### PR TITLE
Advocacy: serve State of CS 2022 PDFs via our site

### DIFF
--- a/pegasus/router.rb
+++ b/pegasus/router.rb
@@ -562,7 +562,7 @@ class Documents < Sinatra::Base
           cache_file = cache_dir('fetch', request.site, request.path_info)
           unless File.file?(cache_file) && File.mtime(cache_file) > settings.launched_at
             FileUtils.mkdir_p File.dirname(cache_file)
-            File.binwrite(cache_file, Net::HTTP.get(URI(result)))
+            File.binwrite(cache_file, Net::HTTP.get(URI(result.chomp)))
           end
           pass unless File.file?(cache_file)
 

--- a/pegasus/sites.v3/advocacy.code.org/public/2022_state_of_cs.pdf.fetch
+++ b/pegasus/sites.v3/advocacy.code.org/public/2022_state_of_cs.pdf.fetch
@@ -1,1 +1,1 @@
-https://cdo-advocacy.s3.amazonaws.com/stateofcs/2022/2022_state_of_cs.pdf
+https://advocacy.code.org/assets/advocacy/stateofcs/2022/2022_state_of_cs.pdf

--- a/pegasus/sites.v3/advocacy.code.org/public/2022_state_of_cs.pdf.fetch
+++ b/pegasus/sites.v3/advocacy.code.org/public/2022_state_of_cs.pdf.fetch
@@ -1,0 +1,1 @@
+https://cdo-advocacy.s3.amazonaws.com/stateofcs/2022/2022_state_of_cs.pdf

--- a/pegasus/sites.v3/advocacy.code.org/public/state-handouts/splat.fetch.haml
+++ b/pegasus/sites.v3/advocacy.code.org/public/state-handouts/splat.fetch.haml
@@ -10,4 +10,4 @@
   # Render a 404 if this isn't one of the states.
   not_found! unless STATE_ABBR_WITH_DC_HASH.values.map{|s| s.delete(' ')}.include?(base_filename)
 
-= "https://cdo-advocacy.s3.amazonaws.com/stateofcs/2022/" + filename
+= "https://advocacy.code.org/assets/advocacy/stateofcs/2022/" + filename

--- a/pegasus/sites.v3/advocacy.code.org/public/state-handouts/splat.fetch.haml
+++ b/pegasus/sites.v3/advocacy.code.org/public/state-handouts/splat.fetch.haml
@@ -1,2 +1,13 @@
-- filename = File.basename(URI.parse(request.url).path)
+:ruby
+  require 'state_abbr'
+
+  # Get a filename like "NewJersey.pdf".
+  filename = File.basename(URI.parse(request.url).path)
+
+  # Get the base filename without extension like "NewJersey".
+  base_filename = File.basename(filename,File.extname(filename))
+
+  # Render a 404 if this isn't one of the states.
+  not_found! unless STATE_ABBR_WITH_DC_HASH.values.map{|s| s.delete(' ')}.include?(base_filename)
+
 = "https://cdo-advocacy.s3.amazonaws.com/stateofcs/2022/" + filename

--- a/pegasus/sites.v3/advocacy.code.org/public/state-handouts/splat.fetch.haml
+++ b/pegasus/sites.v3/advocacy.code.org/public/state-handouts/splat.fetch.haml
@@ -1,0 +1,2 @@
+- filename = File.basename(URI.parse(request.url).path)
+= "https://cdo-advocacy.s3.amazonaws.com/stateofcs/2022/" + filename

--- a/pegasus/sites.v3/advocacy.code.org/public/stateofcs.haml
+++ b/pegasus/sites.v3/advocacy.code.org/public/stateofcs.haml
@@ -45,7 +45,7 @@ layout: none
 
     %br
     %select.small-state-dropdown{style: "padding: 6px 12px; border-radius: 4px;"}
-      %option Pick a State Handout
+      %option{selected: true, disabled: true} Pick a State Handout
       -STATE_ABBR_WITH_DC_HASH.each do |_, state|
         %option{value: state.delete(' ')}= state
       :javascript

--- a/pegasus/sites.v3/advocacy.code.org/public/stateofcs.haml
+++ b/pegasus/sites.v3/advocacy.code.org/public/stateofcs.haml
@@ -67,7 +67,7 @@ layout: none
   function statePicker() {
     $(".small-state-dropdown").on('change', function() {
       var value = $(this).val();
-      location.href = "https://cdo-advocacy.s3.amazonaws.com/stateofcs/2022/" + documents[value] +".pdf";
+      location.href = "/state-handouts/" + documents[value] +".pdf";
     });
   }
 
@@ -94,7 +94,7 @@ layout: none
     This annual report on K-12 computer science in the United States provides an update on national and state-level computer science education policy, including policy trends, maps, state summaries, and implementation data.
     %br
 
-    %a{href: "https://cdo-advocacy.s3.amazonaws.com/stateofcs/2022/2022_state_of_cs.pdf", target: "_blank", style: "text-decoration: none"}
+    %a{href: "/2022_state_of_cs.pdf", target: "_blank", style: "text-decoration: none"}
       %button{style: "background-color: #ffa400; color: white; border-color: #ffa400; margin-top: 20px; margin-bottom: 20px"} Download Report
 
     %br

--- a/pegasus/sites.v3/advocacy.code.org/public/stateofcs.haml
+++ b/pegasus/sites.v3/advocacy.code.org/public/stateofcs.haml
@@ -10,64 +10,10 @@ layout: none
 =inline_css 'advocacy-stateofcsreport.css'
 
 :javascript
-  var documents = {
-    AK: "Alaska",
-    AL: "Alabama",
-    AR: "Arkansas",
-    AZ: "Arizona",
-    CA: "California",
-    CO: "Colorado",
-    CT: "Connecticut",
-    DC: "DistrictofColumbia",
-    DE: "Delaware",
-    FL: "Florida",
-    GA: "Georgia",
-    HI: "Hawaii",
-    IA: "Iowa",
-    ID: "Idaho",
-    IL: "Illinois",
-    IN: "Indiana",
-    KS: "Kansas",
-    KY: "Kentucky",
-    LA: "Louisiana",
-    MA: "Massachusetts",
-    MD: "Maryland",
-    ME: "Maine",
-    MI: "Michigan",
-    MN: "Minnesota",
-    MO: "Missouri",
-    MS: "Mississippi",
-    MT: "Montana",
-    NC: "NorthCarolina",
-    ND: "NorthDakota",
-    NE: "Nebraska",
-    NH: "NewHampshire",
-    NJ: "NewJersey",
-    NM: "NewMexico",
-    NV: "Nevada",
-    NY: "NewYork",
-    OH: "Ohio",
-    OK: "Oklahoma",
-    OR: "Oregon",
-    PA: "Pennsylvania",
-    RI: "RhodeIsland",
-    SC: "SouthCarolina",
-    SD: "SouthDakota",
-    TN: "Tennessee",
-    TX: "Texas",
-    UT: "Utah",
-    VA: "Virginia",
-    VT: "Vermont",
-    WA: "Washington",
-    WI: "Wisconsin",
-    WV: "WestVirginia",
-    WY: "Wyoming"
-  };
-
   function statePicker() {
     $(".small-state-dropdown").on('change', function() {
       var value = $(this).val();
-      location.href = "/state-handouts/" + documents[value] +".pdf";
+      location.href = "/state-handouts/" + value +".pdf";
     });
   }
 
@@ -100,10 +46,10 @@ layout: none
     %br
     %select.small-state-dropdown{style: "padding: 6px 12px; border-radius: 4px;"}
       %option Pick a State Handout
-      -STATE_ABBR_WITH_DC_HASH.each do |abbr, state|
-        %option{value: abbr}= state
-        :javascript
-          statePicker()
+      -STATE_ABBR_WITH_DC_HASH.each do |_, state|
+        %option{value: state.delete(' ')}= state
+      :javascript
+        statePicker()
 
   .col-50
     %img{style: "width: 75%; margin-left: 20%; margin-top: 35px", src: "images/advocacy1-subject.png"}

--- a/pegasus/test/test_pegasus_documents.rb
+++ b/pegasus/test/test_pegasus_documents.rb
@@ -76,7 +76,7 @@ class PegasusTest < Minitest::Test
   def test_render_pegasus_documents
     all_documents = app.helpers.all_documents.reject do |page|
       # 'Splat' documents not yet handled.
-      page[:uri].end_with?('/splat') ||
+      page[:uri].end_with?('/splat', '/splat.fetch') ||
       # Private routes not yet handled.
       page[:uri].start_with?('/private')
     end


### PR DESCRIPTION
In https://github.com/code-dot-org/code-dot-org/pull/48129 we started serving the main State of Computer Science PDF and also the state handout PDFs, for 2022, via S3.  This would result in users seeing non-code.org URLs in their browser.

This PR makes use of existing functionality so that Pegasus will retrieve the PDFs from S3, cache them locally, and then serve them from that local cache, so that users see them coming from `code.org` URLs.  The PDF files are stored in S3 in the `cdo-dist` bucket's `production/assets/advocacy/stateofcs/2022` directory; Pegasus internally retrieves those contents via https://advocacy.code.org/assets/advocacy/stateofcs/2022.

The report itself was straightforward, and while it's a 70 MB file to cache, the user sees it at https://advocacy.code.org/2022_state_of_cs.pdf.

The state handouts could have been done similarly with a bunch of individual `.fetch` files, but it turns out it's possible to have a `splat.fetch.haml` file!  The `splat` part intercepts all requests under https://advocacy.code.org/state-reports, the `.haml` part lets us generate the matching URL on S3, and the `.fetch` part triggers the retrieval, caching, and serving functionality so that the PDF is actually served off of Pegasus.  This means the user sees a state handout at a URL like https://advocacy.code.org/state-handouts/Washington.pdf.  

This change also simplifies the code dealing with state handouts; in particular there is no longer a duplicated list of states.

The state handout part is only possible because of the excellent work done by @Hamms back in https://github.com/code-dot-org/code-dot-org/pull/28746.
