### PR TITLE
Switch back to mainline NewRelic Agent gem and to latest version.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -170,12 +170,7 @@ gem 'highline', '~> 1.6.21'
 
 gem 'honeybadger', '>= 4.5.6' # error monitoring
 
-gem 'newrelic_rpm', group: [:staging, :development, :production], # perf/error/etc monitoring
-  # Ref:
-  # https://github.com/newrelic/newrelic-ruby-agent/pull/359
-  # https://github.com/newrelic/newrelic-ruby-agent/pull/372
-  # https://github.com/newrelic/newrelic-ruby-agent/issues/340
-  github: 'code-dot-org/newrelic-ruby-agent', ref: 'PR-359_prevent_reconnect_attempts_during_shutdowns'
+gem 'newrelic_rpm', group: [:staging, :development, :production] # perf/error/etc monitoring
 
 gem 'redcarpet', '~> 3.3.4'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,13 +6,6 @@ GIT
       omniauth-oauth2 (>= 1.1, <= 1.5)
 
 GIT
-  remote: https://github.com/code-dot-org/newrelic-ruby-agent.git
-  revision: 5a46cdf3f3f144018bca2edce6b008d464da18fa
-  ref: PR-359_prevent_reconnect_attempts_during_shutdowns
-  specs:
-    newrelic_rpm (6.12.0)
-
-GIT
   remote: https://github.com/code-dot-org/petit.git
   revision: bbe411d61d3f78fff59d9fa79d21c14b1c635750
   specs:
@@ -578,6 +571,7 @@ GEM
     net-ssh (5.2.0)
     net_http_ssl_fix (0.0.10)
     netrc (0.11.0)
+    newrelic_rpm (8.10.1)
     nio4r (2.5.8)
     nokogiri (1.12.4)
       mini_portile2 (~> 2.6.1)
@@ -998,7 +992,7 @@ DEPENDENCIES
   net-http-persistent
   net-scp
   net-ssh
-  newrelic_rpm!
+  newrelic_rpm
   nokogiri (>= 1.10.0)
   octokit
   oj


### PR DESCRIPTION
We were using a fork of the NewRelic 6.1 gem due to an [issue](https://github.com/newrelic/newrelic-ruby-agent/issues/340) we opened. That issue has been resolved and the Pull Request we submitted upstream has been accepted/merged. Return back to the mainline gem and also update to the latest version (8.x), particularly because we noticed that NewRelic is no longer capturing metrics about our usage of ActiveRecord (possibly due to our recent Rails 6 upgrade).

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
