### PR TITLE
Advocacy: improve State of CS 2022 thumbnail

### DIFF
--- a/pegasus/sites.v3/advocacy.code.org/views/forum_banner.haml
+++ b/pegasus/sites.v3/advocacy.code.org/views/forum_banner.haml
@@ -3,7 +3,7 @@
 .announcement
   .left.col-80
     .announcement-thumbnail
-      %img{src: "/images/fit-100/socs-cover-2022.png", alt: "screenshot of the front page cover of the State of CS 2022 report"}
+      %img{style: "width: 100px", src: "/images/fit-400/socs-cover-2022.png", alt: "screenshot of the front page cover of the State of CS 2022 report"}
     .title
       2022 State of Computer Science Education
     .details


### PR DESCRIPTION
The thumbnail image at https://advocacy.code.org now makes use of a retina display.

Follow-up to https://github.com/code-dot-org/code-dot-org/pull/48129.

<img width="997" alt="Screen Shot 2022-09-19 at 8 17 58 AM" src="https://user-images.githubusercontent.com/2205926/191053130-f34a2b9e-83ce-4dc7-a4f1-131e0c01bcd8.png">
