### PR TITLE
store studentNames state as string rather than array

### DIFF
--- a/apps/src/templates/certificates/CertificateBatch.jsx
+++ b/apps/src/templates/certificates/CertificateBatch.jsx
@@ -12,10 +12,12 @@ export default function CertificateBatch({
   initialStudentNames,
   imageUrl
 }) {
-  const [studentNames, setStudentNames] = useState(initialStudentNames || []);
+  const [studentNames, setStudentNames] = useState(
+    initialStudentNames?.join('\n') || ''
+  );
 
   const onChange = e => {
-    setStudentNames(e.target.value && e.target.value.split('\n'));
+    setStudentNames(e.target.value);
   };
 
   return (
@@ -42,7 +44,7 @@ export default function CertificateBatch({
           name="studentNames"
           rows="10"
           style={styles.textarea}
-          value={studentNames.join('\n')}
+          value={studentNames}
           onChange={onChange}
         />
         <SafeMarkdown markdown={i18n.landscapeRecommendedCertificates()} />


### PR DESCRIPTION
Follow-up from https://github.com/code-dot-org/code-dot-org/pull/48126. Fixes the following bug:

https://user-images.githubusercontent.com/8001765/191117316-2790a40d-d65b-442b-88d6-ef8249f0a668.mov

## Testing story

I didn't write a test for this exact scenario, but the new implementation reduces the amount of complexity and makes me feel like the existing test cases now cover all of the possibilities pretty well:
* hoc_batch_certificates.feature covers entering 1-3 student names and then printing
* section_action_dropdown.feature covers navigating from teacher homepage to /certificates/batch, with initialStudentNames set

I did also manually verify that typing in a student name and then deleting it does not crash the page.
