### PR TITLE
Remove references to javabuilderbeta

### DIFF
--- a/lib/cdo.rb
+++ b/lib/cdo.rb
@@ -146,8 +146,7 @@ module Cdo
         stack_name = CDO.local_javabuilder_stack_name || 'javabuilder-test'
         "wss://#{stack_name}.code.org"
       else
-        # TODO: change the default to javabuilder once we have switched over
-        DCDO.get("javabuilder_websocket_url", 'wss://javabuilderbeta.code.org')
+        DCDO.get("javabuilder_websocket_url", 'wss://javabuilder.code.org')
       end
     end
 
@@ -162,8 +161,7 @@ module Cdo
         stack_name = CDO.local_javabuilder_stack_name || 'javabuilder-test'
         "https://#{stack_name}-http.code.org/seedsources/sources.json"
       else
-        # TODO: change the default to javabuilder once we have switched over
-        http_url = DCDO.get("javabuilder_http_url", 'https://javabuilderbeta-http.code.org')
+        http_url = DCDO.get("javabuilder_http_url", 'https://javabuilder-http.code.org')
         http_url + "/seedsources/sources.json"
       end
     end

--- a/pegasus/sites.v3/code.org/public/educate/websocket.html
+++ b/pegasus/sites.v3/code.org/public/educate/websocket.html
@@ -46,7 +46,7 @@
 </div>
 <script>
   function connect() {
-    let socket = new WebSocket("wss://javabuilderbeta.code.org?Authorization=connectivityTest");
+    let socket = new WebSocket("wss://javabuilder.code.org?Authorization=connectivityTest");
     document.querySelector("#loading").style.display = "block";
     document.querySelector("#success").style.display = "none";
     document.querySelector("#fail").style.display = "none";


### PR DESCRIPTION
Now that we are no longer on javabuilderbeta, remove all remaining references to it. The only ones remaining were the default value for the DCDO variables, and the url for the websocket connectivity test.

