### PR TITLE
Checks that lock states are different before saving

### DIFF
--- a/apps/src/code-studio/components/progress/lessonLockDialog/LessonLockDialog.jsx
+++ b/apps/src/code-studio/components/progress/lessonLockDialog/LessonLockDialog.jsx
@@ -17,6 +17,7 @@ import {
 } from '@cdo/apps/code-studio/components/progress/lessonLockDialog/LessonLockDataApi';
 import StudentRow from '@cdo/apps/code-studio/components/progress/lessonLockDialog/StudentRow';
 import SkeletonRows from '@cdo/apps/code-studio/components/progress/lessonLockDialog/SkeletonRows';
+import _ from 'lodash';
 
 function LessonLockDialog({
   unitId,
@@ -81,7 +82,7 @@ function LessonLockDialog({
   the dialog without sending to api post method.
   */
   const handleSave = async () => {
-    if (serverLockState === clientLockState) {
+    if (_.isEqual(serverLockState, clientLockState)) {
       handleClose();
     } else {
       sendSave();

--- a/apps/src/code-studio/components/progress/lessonLockDialog/LessonLockDialog.jsx
+++ b/apps/src/code-studio/components/progress/lessonLockDialog/LessonLockDialog.jsx
@@ -76,7 +76,19 @@ function LessonLockDialog({
     );
   };
 
+  /*
+  Checks that the user is trying to save new information, otherwise closes
+  the dialog without sending to api post method.
+  */
   const handleSave = async () => {
+    if (serverLockState === clientLockState) {
+      handleClose();
+    } else {
+      sendSave();
+    }
+  };
+
+  const sendSave = async () => {
     setSaving(true);
     setError(null);
     const csrfToken = $('meta[name="csrf-token"]').attr('content');


### PR DESCRIPTION
Update: When a user tries to save a lock status from the lesson lock dialog without making any changes, the dialog behaves as if it were saving, updating the button to "saving" and then closing the dialog. Before, when a user tried to save without changes, they got an error message complaining that there was nothing to save.

This is the simplest change I could come up with, though there are two other solutions that requires updating the LessonLockApi. I'd love feedback on the correct approach. 

Here are the solutions I see:
1. (What is currently in this PR): Add a quick method to check if the states are the same, close the dialog if they are without  actually calling the save method
2. Remove [line 76 from LessonLockDataApi](https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/code-studio/components/progress/lessonLockDialog/LessonLockDataApi.js#L76) that filters out requests where the previous and new states match: 
 .filter((item, index) => !_.isEqual(item, previousLockState[index]))
 This would mean that we no longer check to see if the state is different. I think this is a worse solution, as it would increase our POST calls to include every time a user hits save without updates to save. It would also require updating all calls to this method to exclude the previous check.
3. Both- check that they are different in the dialog component before sending, and remove the (resulting) redundant check in the api file. I think this is also a worse solution, as it relies on any future components to do the double check and removes the api failsafe. 

Any thoughts?

## Links


- spec: []()
- jira ticket: []https://codedotorg.atlassian.net/browse/LP-2430

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  4.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
