### PR TITLE
Cloudformation template for Greenhouse DNS Records

### DIFF
--- a/aws/cloudformation/standalone/greenhouse_dns.yml
+++ b/aws/cloudformation/standalone/greenhouse_dns.yml
@@ -1,0 +1,46 @@
+# Greenhouse DNS Configuration
+# See: https://support.greenhouse.io/hc/en-us/articles/201111684-Email-domain-verification
+
+Resources:
+
+  GreenhouseHostedZone:
+    Type: "AWS::Route53::HostedZone"
+    Properties:
+      Name: 'gh-mail.code.org'
+
+  NameServerRecord:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      HostedZoneId : Z8VLZEXAMPLE
+      Name: gh-mail.code.org
+      ResourceRecords: !GetAtt GreenhouseHostedZone.NameServers
+      TTL: 3600
+      Type: NS
+
+  GreenhouseRecords:
+    Type: AWS::Route53::RecordSetGroup
+    Properties:
+      Comment: Creating records for mail server
+      HostedZoneId: Z1PA6795UKMFR9
+      RecordSets:
+      - Name: email.gh-mail.code.org.
+        ResourceRecords: 
+        - 'mailgun.org'
+        TTL: 3600
+        Type: CNAME
+      - Name: gh-mail.code.org.
+        ResourceRecords:
+          - "10 mxa.mailgun.org"
+          - "10 mxb.mailgun.org"
+        TTL: 3600
+        Type: MX
+      - Name: "gh-mail.code.org."
+        ResourceRecords: 
+        - '"v=spf1 include:mg-spf.greenhouse.io ~all"'
+        TTL: 3600
+        Type: TXT
+      - Name: "k1._domainkey.gh-mail.code.org."
+        ResourceRecords: 
+        - '"k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA3DJFLhRJaJAscD2fyydX5ujqvXcvNo7fK62/SgIp1VzGP/PHOD5vy1EJ44erYq+6s2lRjcFEpZzRFwlWkyEumTYiWQumcH8AVTtjWQiRDSDZf4+JLgwNwnuBrH/QSP9wHh5sF3Elf9yrOl9Q5pkwhbZNW0BFxAllLy5rlNiDuy6zvDICmbzykoXWOBwAzWNg5fXcjraD4I8DknH2rFDENyg6ai8uSAujafeRfpU8tQQxohDolKMW+n6idbsLWJwB9sdlIbrgW1rPjCzFCKea327+7bK5x/E9qBVo6ARB0ype8M+XY8CK6CSDHxVnpmciRbOUy2jLXT+MdpmKbEI2AwIDAQAB"'
+        TTL: 3600
+        Type: TXT

--- a/aws/cloudformation/standalone/greenhouse_dns.yml
+++ b/aws/cloudformation/standalone/greenhouse_dns.yml
@@ -1,10 +1,6 @@
 # Greenhouse DNS Configuration
 # See: https://support.greenhouse.io/hc/en-us/articles/201111684-Email-domain-verification
 
-# TODO:
-# - Fix HostedZoneId or switch to HostedZoneName
-# - cfn-lint and validate, or otherwise test
-
 Resources:
 
   GreenhouseHostedZone:
@@ -15,7 +11,7 @@ Resources:
   NameServerRecord:
     Type: AWS::Route53::RecordSet
     Properties:
-      HostedZoneId : TODO
+      HostedZoneName : code.org.
       Name: gh-mail.code.org
       ResourceRecords: !GetAtt GreenhouseHostedZone.NameServers
       TTL: 3600
@@ -25,26 +21,28 @@ Resources:
     Type: AWS::Route53::RecordSetGroup
     Properties:
       Comment: Creating records for mail server
-      HostedZoneId: TODO
+      HostedZoneName: gh-mail.code.org.
       RecordSets:
+      - Name: gh-mail.code.org.
+        ResourceRecords:
+          - '10 mxa.mailgun.org'
+          - '10 mxb.mailgun.org'
+        TTL: 3600
+        Type: MX
+      - Name: gh-mail.code.org.
+        ResourceRecords: 
+        - '"v=spf1 include:mg-spf.greenhouse.io ~all"'
+        TTL: 3600
+        Type: TXT
       - Name: email.gh-mail.code.org.
         ResourceRecords: 
         - 'mailgun.org'
         TTL: 3600
         Type: CNAME
-      - Name: gh-mail.code.org.
-        ResourceRecords:
-          - "10 mxa.mailgun.org"
-          - "10 mxb.mailgun.org"
-        TTL: 3600
-        Type: MX
-      - Name: "gh-mail.code.org."
+      - Name: k1._domainkey.gh-mail.code.org.
         ResourceRecords: 
-        - '"v=spf1 include:mg-spf.greenhouse.io ~all"'
-        TTL: 3600
-        Type: TXT
-      - Name: "k1._domainkey.gh-mail.code.org."
-        ResourceRecords: 
-        - '"k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA3DJFLhRJaJAscD2fyydX5ujqvXcvNo7fK62/SgIp1VzGP/PHOD5vy1EJ44erYq+6s2lRjcFEpZzRFwlWkyEumTYiWQumcH8AVTtjWQiRDSDZf4+JLgwNwnuBrH/QSP9wHh5sF3Elf9yrOl9Q5pkwhbZNW0BFxAllLy5rlNiDuy6zvDICmbzykoXWOBwAzWNg5fXcjraD4I8DknH2rFDENyg6ai8uSAujafeRfpU8tQQxohDolKMW+n6idbsLWJwB9sdlIbrgW1rPjCzFCKea327+7bK5x/E9qBVo6ARB0ype8M+XY8CK6CSDHxVnpmciRbOUy2jLXT+MdpmKbEI2AwIDAQAB"'
+        # Values over 255 characters must be broken up
+        - '"k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA3DJFLhRJaJAscD2fyydX5ujqvXcvNo7fK62/SgIp1VzGP/PHOD5vy1EJ44erYq+6s2lRjcFEpZzRFwlWkyEumTYiWQumcH8AVTtjWQiRDSDZf4+JLgwNwnuBrH/QSP9wHh5sF3Elf9yrOl9Q5pkwhbZNW0BFxAllLy5rlNiDuy6zvDICmbzykoXWOBwAzWNg5fXcjraD4I"'
+        - '"8DknH2rFDENyg6ai8uSAujafeRfpU8tQQxohDolKMW+n6idbsLWJwB9sdlIbrgW1rPjCzFCKea327+7bK5x/E9qBVo6ARB0ype8M+XY8CK6CSDHxVnpmciRbOUy2jLXT+MdpmKbEI2AwIDAQAB"'
         TTL: 3600
         Type: TXT

--- a/aws/cloudformation/standalone/greenhouse_dns.yml
+++ b/aws/cloudformation/standalone/greenhouse_dns.yml
@@ -6,10 +6,11 @@ Resources:
   GreenhouseHostedZone:
     Type: "AWS::Route53::HostedZone"
     Properties:
-      Name: 'gh-mail.code.org'
+      Name: gh-mail.code.org.
 
   NameServerRecord:
     Type: AWS::Route53::RecordSet
+    DependsOn: GreenhouseHostedZone
     Properties:
       HostedZoneName : code.org.
       Name: gh-mail.code.org
@@ -19,9 +20,10 @@ Resources:
 
   GreenhouseRecords:
     Type: AWS::Route53::RecordSetGroup
+    DependsOn: GreenhouseHostedZone
     Properties:
       Comment: Creating records for mail server
-      HostedZoneName: gh-mail.code.org.
+      HostedZoneId: !Ref GreenhouseHostedZone
       RecordSets:
       - Name: gh-mail.code.org.
         ResourceRecords:

--- a/aws/cloudformation/standalone/greenhouse_dns.yml
+++ b/aws/cloudformation/standalone/greenhouse_dns.yml
@@ -1,6 +1,10 @@
 # Greenhouse DNS Configuration
 # See: https://support.greenhouse.io/hc/en-us/articles/201111684-Email-domain-verification
 
+# TODO:
+# - Fix HostedZoneId or switch to HostedZoneName
+# - cfn-lint and validate, or otherwise test
+
 Resources:
 
   GreenhouseHostedZone:
@@ -11,7 +15,7 @@ Resources:
   NameServerRecord:
     Type: AWS::Route53::RecordSet
     Properties:
-      HostedZoneId : Z8VLZEXAMPLE
+      HostedZoneId : TODO
       Name: gh-mail.code.org
       ResourceRecords: !GetAtt GreenhouseHostedZone.NameServers
       TTL: 3600
@@ -21,7 +25,7 @@ Resources:
     Type: AWS::Route53::RecordSetGroup
     Properties:
       Comment: Creating records for mail server
-      HostedZoneId: Z1PA6795UKMFR9
+      HostedZoneId: TODO
       RecordSets:
       - Name: email.gh-mail.code.org.
         ResourceRecords: 


### PR DESCRIPTION
Add a standalone template for greenhouse dns records, to be deployed manually.

This also creates a folder for templates like these, that are not deployed by CICD and not part of the main application suite.

## Links

- docs: https://support.greenhouse.io/hc/en-us/articles/360022003791-Add-DNS-records-to-verify-email-domain
- jira: [INF-686](https://codedotorg.atlassian.net/browse/INF-686)

## Testing story

Ran `aws cloudformation validate-template` and `cfn-lint` to spot errors.

## Deployment strategy

Safe to deploy and troubleshoot any issues. No changes to production resources. Once approved, deploy this stack, if successful, merge to staging. If unsuccessful, troubleshoot and update this branch before merging.

## Follow-up work

Test Greenhouse mail integration.

## PR Checklist:

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
