### PR TITLE
Disallow double clicks on open/close code review

### DIFF
--- a/apps/src/templates/instructions/CommitsAndReviewTab.jsx
+++ b/apps/src/templates/instructions/CommitsAndReviewTab.jsx
@@ -41,6 +41,7 @@ const CommitsAndReviewTab = props => {
   const [timelineData, setTimelineData] = useState([]);
   const [timelineLoadingError, setTimelineLoadingError] = useState(null);
   const [openReviewError, setOpenReviewError] = useState(null);
+  const [openingCodeReview, setOpeningCodeReview] = useState(false);
 
   const dataApi = useMemo(
     () =>
@@ -152,17 +153,19 @@ const CommitsAndReviewTab = props => {
 
   const handleOpenReview = async () => {
     try {
+      setOpeningCodeReview(true);
       await project.save(true);
       const currentVersion = project.getCurrentSourceVersionId();
       const newReview = await dataApi.openNewCodeReview(currentVersion);
+      setHasOpenCodeReview(true);
       setOpenReviewData(newReview);
       setIsReadOnlyWorkspace(true);
-      setHasOpenCodeReview(true);
       setOpenReviewError(false);
     } catch (err) {
       console.log(err);
       setOpenReviewError(true);
     }
+    setOpeningCodeReview(false);
   };
 
   // channelId is not available on projects where the student has not edited the starter code.
@@ -232,7 +235,7 @@ const CommitsAndReviewTab = props => {
                 onClick={handleOpenReview}
                 text={javalabMsg.startReview()}
                 color={Button.ButtonColor.blue}
-                disabled={!codeReviewEnabled}
+                disabled={!codeReviewEnabled || openingCodeReview}
               />
               {openReviewError && <CodeReviewError />}
             </div>

--- a/apps/src/templates/instructions/codeReviewV2/CodeReviewTimelineReview.jsx
+++ b/apps/src/templates/instructions/codeReviewV2/CodeReviewTimelineReview.jsx
@@ -25,15 +25,22 @@ const CodeReviewTimelineReview = ({
 }) => {
   const {id, createdAt, isOpen, version, ownerId, ownerName, comments} = review;
   const [displayCloseError, setDisplayCloseError] = useState(false);
+  const [isClosing, setIsClosing] = useState(false);
   const formattedDate = moment(createdAt).format('M/D/YYYY [at] h:mm A');
 
   const isViewingOldVersion = !!queryParams('version');
 
   const handleCloseCodeReview = () => {
+    setIsClosing(true);
     closeReview(
-      () => setDisplayCloseError(false), // on success
-      () => setDisplayCloseError(true) // on failure
+      () => handleCloseComplete(false), // on success
+      () => handleCloseComplete(true) // on failure
     );
+  };
+
+  const handleCloseComplete = requestFailed => {
+    setDisplayCloseError(requestFailed);
+    setIsClosing(false);
   };
 
   const viewingAsOwner = ownerId === currentUserId;
@@ -71,6 +78,7 @@ const CodeReviewTimelineReview = ({
                 onClick={handleCloseCodeReview}
                 text={javalabMsg.closeReview()}
                 color={Button.ButtonColor.blue}
+                disabled={isClosing}
               />
               {displayCloseError && <CodeReviewError />}
             </div>


### PR DESCRIPTION
We got some [honeybadger errors](https://app.honeybadger.io/projects/3240/faults/86088433/01GDDX5S60G8JTDSA88G5QX9N2?q=occurred.after%3A%2224+hours+ago%22) around code review that I can reproduce by double-clicking on the "start review" button. This pr disabled the "start review" button while the review is in the opening state (the button disappears once the review is open). We don't get an error if you double close the review, but we are sending two patch requests unnecessarily if you double-click that button. So I did the same thing for the "close review" button.

## Links

- [honeybadger error](https://app.honeybadger.io/projects/3240/faults/86088433/01GDDX5S60G8JTDSA88G5QX9N2?q=occurred.after%3A%2224+hours+ago%22)

## Testing story
Tested locally. Double clicking the buttons now only sends one request.
