### PR TITLE
Localizes frameworks/standards in their own place.

### DIFF
--- a/bin/i18n/sync-out.rb
+++ b/bin/i18n/sync-out.rb
@@ -449,6 +449,56 @@ def distribute_translations(upload_manifests)
       sanitize_data_and_write(loc_data, destination)
     end
 
+    ### Standards
+    Dir.glob("i18n/locales/#{locale}/standards/*.json") do |loc_file|
+      # For every framework, we place the frameworks and categories in their
+      # respective places.
+      relative_path = loc_file.delete_prefix(locale_dir)
+      next unless file_changed?(locale, relative_path)
+
+      # These JSON files contain the framework name, a set of categories, and a
+      # set of standards.
+      loc_data = JSON.parse(File.read(loc_file))
+      framework = File.basename(loc_file, '.json')
+
+      # Frameworks
+      destination = "dashboard/config/locales/frameworks.#{locale}.json"
+      framework_data = File.exist?(destination) ?
+        parse_file(destination).dig(locale, "data", "frameworks") || {} :
+        {}
+      framework_data[framework] = {
+        "name" => loc_data["name"]
+      }
+      framework_data = wrap_with_locale(framework_data, locale, "frameworks")
+      sanitize_data_and_write(framework_data, destination)
+
+      # Standard Categories
+      destination = "dashboard/config/locales/standard_categories.#{locale}.json"
+      category_data = File.exist?(destination) ?
+        parse_file(destination).dig(locale, "data", "standard_categories") || {} :
+        {}
+      (loc_data["categories"] || {}).keys.each do |category|
+        category_data[category] = {
+          "description" => loc_data["categories"][category]["description"]
+        }
+      end
+      category_data = wrap_with_locale(category_data, locale, "standard_categories")
+      sanitize_data_and_write(category_data, destination)
+
+      # Standards
+      destination = "dashboard/config/locales/standards.#{locale}.json"
+      standard_data = File.exist?(destination) ?
+        parse_file(destination).dig(locale, "data", "standards") || {} :
+        {}
+      (loc_data["standards"] || {}).keys.each do |standard|
+        standard_data[standard] = {
+          "description" => loc_data["standards"][standard]["description"]
+        }
+      end
+      standard_data = wrap_with_locale(standard_data, locale, "standards")
+      sanitize_data_and_write(standard_data, destination)
+    end
+
     ### Pegasus
     loc_file = "#{locale_dir}/pegasus/mobile.yml"
     destination = "pegasus/cache/i18n/#{locale}.yml"

--- a/dashboard/lib/services/i18n/curriculum_sync_utils/serializers.rb
+++ b/dashboard/lib/services/i18n/curriculum_sync_utils/serializers.rb
@@ -124,28 +124,6 @@ module Services::I18n::CurriculumSyncUtils
       attribute :description
     end
 
-    class FrameworkCrowdinSerializer < CrowdinSerializer
-      attributes :name
-
-      delegate :crowdin_key, to: :object
-    end
-
-    class StandardCategoryCrowdinSerializer < CrowdinSerializer
-      attributes :description
-
-      delegate :crowdin_key, to: :object
-    end
-
-    class StandardCrowdinSerializer < CrowdinSerializer
-      attributes :description
-
-      belongs_to :framework, serializer: FrameworkCrowdinSerializer, optional: true
-      belongs_to :parent_category, serializer: StandardCategoryCrowdinSerializer, optional: true
-      belongs_to :category, serializer: StandardCategoryCrowdinSerializer, optional: true
-
-      delegate :crowdin_key, to: :object
-    end
-
     class ReferenceGuideCrowdinSerializer < CrowdinSerializer
       attributes :display_name, :content
 
@@ -169,8 +147,6 @@ module Services::I18n::CurriculumSyncUtils
       has_many :objectives, serializer: ObjectiveCrowdinSerializer
       has_many :resources, serializer: ResourceCrowdinSerializer
       has_many :vocabularies, serializer: VocabularyCrowdinSerializer
-      has_many :standards, serializer: StandardCrowdinSerializer
-      has_many :opportunity_standards, serializer: StandardCrowdinSerializer
 
       # override
       def crowdin_key


### PR DESCRIPTION
**What**: Localizing the standards area of courses.

**Why**: To increase the accessibility through localization.

**How**:  Helps localize frameworks/standards/etc. Since they appear alongside lessons, they were ingested with their singular keys (framework, category, etc) and need to be named after the pluralism of their model name (frameworks, standard_categories, etc). Before, singular versions were ingested and created `framework.es-mx.json` etc, which were then ingested by the `I18n` module but not used.

To stop this problem, and make localization of this data more clear and coherent, this change to the sync will move frameworks, standard categories, and standards localization to their own files based on the framework name. So, all localization for CSTA happens within `csta.json`, etc. So localizing a framework just happens on its own and gets used by all such lessons that relate to it.

**Consideration**: If we move framework descriptions to their own sections, we would then want to hide the keys when they appear alongside courses in crowdin. Is it more difficult to translate these framework descriptions if they are by themselves? Should we lean toward just improving the keys when they are found in lessons?

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

- jira ticket: [FND-2066](https://codedotorg.atlassian.net/jira/software/c/projects/FND/boards/62?modal=detail&selectedIssue=FND-2066)

## Testing story

I manually tested that, after localization was placed in the appropriate place (`frameworks` instead of `framework`) that the standards page shows a localized view. For instance at http://localhost-studio.code.org:3000/s/flappy/standards?lang=es-MX

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Follow-up work

After this change, the files `framework.{locale}.json`, and all `category.{locale}.json` files within `dashboard/config/locales` should be deleted. They are not even being used right now. In their place will be the `frameworks.{locale}.json` and `standard_categories.{locale}.json` files which match the expected convention.

This probably should happen on the next sync.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
