### PR TITLE
HoC 2022 i18n string typo fix

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -416,7 +416,7 @@
   hoc_homepage_join_the_movement_description: 'Hour of Code is available year-round, but every year in December your class can join millions of students around the world celebrating Computer Science Education Week with the Hour of Code. Registration for the annual celebration starts each year in October.'
   hoc_homepage_what_is_hoc_subhead: 'One-hour tutorials in over 45 languages. No experience needed. Hour of Code activities are available for free year-round.'
   hoc_homepage_what_is_hoc_description: 'The Hour of Code is a one-hour introduction to computer science, using fun tutorials to show that anybody can learn the basics. This grassroots campaign is supported by over 400 partners and 200,000 educators worldwide.'
-  hoc_homepage_what_is_hoc_cta_how_to_guide: "[Read our How-to guide]({%howto_guide_url}) to plan an event for your class."
+  hoc_homepage_what_is_hoc_cta_how_to_guide: "[Read our How-to guide](%{howto_guide_url}) to plan an event for your class."
   hoc_homepage_highlights_heading: 'Hour of Code highlights'
   hoc_homepage_organized_by: 'The Hour of Code is organized by [Code.org](%{codeorg_url}).'
 


### PR DESCRIPTION
Fix the broken markdown link on the `hoc_homepage_what_is_hoc_cta_how_to_guide` string

**Related PRs:** https://github.com/code-dot-org/code-dot-org/pull/48198