### PR TITLE
Serialize data docs and add data doc import

### DIFF
--- a/bin/curriculum/import_data_docs.rb
+++ b/bin/curriculum/import_data_docs.rb
@@ -68,7 +68,7 @@ def main(options)
 
   until data_doc_path_stack.empty?
     current_path = data_doc_path_stack.pop
-    url = "#{cb_url_prefix}/documentation/export/#{current_path}.json?format=json"
+    url = "http://www.codecurricula.com/documentation/export/#{current_path}.json?format=json"
     guide_json = fetch(url)
     guide = JSON.parse(guide_json)
 

--- a/bin/curriculum/import_data_docs.rb
+++ b/bin/curriculum/import_data_docs.rb
@@ -1,0 +1,139 @@
+#!/usr/bin/env ruby
+
+require 'set'
+require 'json'
+require 'optparse'
+require 'uri'
+require 'net/http'
+require_relative '../../deployment'
+
+raise unless [:development, :adhoc, :levelbuilder].include? rack_env
+
+$verbose = false
+def log(str)
+  puts str if $verbose
+end
+
+$quiet = false
+def warn(str)
+  puts str unless $quiet && !$verbose
+end
+
+# Wait until after initial error checking before loading the rails environment.
+def require_rails_env
+  log "loading rails environment..."
+  start_time = Time.now
+  require_relative '../../dashboard/config/environment'
+  log "rails environment loaded in #{(Time.now - start_time).to_i} seconds."
+end
+
+def parse_options
+  OpenStruct.new.tap do |options|
+    options.local = false
+    options.dry_run = false
+
+    opt_parser = OptionParser.new do |opts|
+      opts.banner = <<~BANNER
+        Usage: #{$0} [options]
+      BANNER
+
+      opts.separator ""
+
+      opts.on('-l', '--local', 'Use local curriculum builder running on localhost:8000.') do
+        options.local = true
+      end
+
+      opts.on('-n', '--dry-run', 'Perform basic validation without importing any data.') do
+        options.dry_run = true
+      end
+
+      opts.on('-q', '--quiet', 'Silence warnings.') do
+        $quiet = true
+      end
+
+      opts.on('-v', '--verbose', 'Use verbose debug logging.') do
+        $verbose = true
+      end
+
+      opts.on_tail("-h", "--help", "Show this message") do
+        puts opts
+        exit
+      end
+    end
+
+    opt_parser.parse!(ARGV)
+  end
+end
+
+def main(options)
+  cb_url_prefix = options.local ? 'http://localhost:8000' : 'http://www.codecurricula.com'
+
+  # recursively find all the data docs!
+  data_doc_slug_stack = ['concepts/data-library']
+  data_doc_key_set = Set[]
+  data_doc_count = 0
+
+  until data_doc_slug_stack.empty?
+    current_slug = data_doc_slug_stack.pop
+
+    # only import Data Docs
+    # next unless current_slug.start_with?('concepts/data-library')
+
+    url = "#{cb_url_prefix}/documentation/export/#{current_slug}.json?format=json"
+    guide_json = fetch(url)
+
+    guide = JSON.parse(guide_json)
+
+    # find a unique key based on the end of the slug
+    # if there are duplicates, append -N where N is a number that makes it unique
+    key_base = guide['slug'].rpartition('/').last
+
+    unique_key = key_base
+    iteration = 2
+    while data_doc_key_set.include?(unique_key)
+      unique_key = "#{key_base}-#{iteration}"
+      iteration += 1
+    end
+
+    # don't reuse that key
+    data_doc_key_set.add(unique_key)
+
+    # store the children with their parent key because we only want its children
+    data_doc_slug_stack.concat(guide['children'])
+
+    # skip serializing the 'concepts/data-library' map
+    next if guide['slug'] == 'concepts/data-library'
+
+    next if options.dry_run
+
+    data_doc = DataDoc.find_or_initialize_by(
+      {
+        key: unique_key,
+      }
+    )
+
+    data_doc.name = guide['title']
+    data_doc.content = guide['content']
+
+    data_doc.save!
+    data_doc.write_serialization
+
+    data_doc_count += 1
+  end
+
+  puts "imported #{data_doc_count} data docs"
+end
+
+def fetch(url)
+  uri = URI(url)
+  response = Net::HTTP.get_response(uri)
+  raise "HTTP status #{response.code} fetching #{uri}" unless response.is_a? Net::HTTPSuccess
+  body = response.body
+  log "fetched #{body.length} bytes of unit json from #{uri}"
+  body
+end
+
+options = parse_options
+
+require_rails_env
+main(options)

--- a/dashboard/app/controllers/data_docs_controller.rb
+++ b/dashboard/app/controllers/data_docs_controller.rb
@@ -11,7 +11,7 @@ class DataDocsController < ApplicationController
     @data_doc = DataDoc.new(key: params[:key], name: params[:name], content: params[:content])
 
     if @data_doc.save
-      # TODO [meg] : Write serialization
+      @data_doc.write_serialization
       redirect_to action: :show, key: params[:key]
     else
       render :not_acceptable, json: @data_doc.errors

--- a/dashboard/app/models/data_doc.rb
+++ b/dashboard/app/models/data_doc.rb
@@ -19,4 +19,29 @@ class DataDoc < ApplicationRecord
 
   validates_uniqueness_of :key, case_sensitive: false
   validate :validate_key_format
+
+  def file_path
+    Rails.root.join("config/data_docs/#{key.parameterize(preserve_case: false)}.json")
+  end
+
+  def serialize
+    {
+      key: key,
+      name: name,
+      content: content
+    }
+  end
+
+  # writes data doc to a seed file in the config directory
+  def write_serialization
+    return unless Rails.application.config.levelbuilder_mode
+    directory_name = File.dirname(file_path)
+    Dir.mkdir(directory_name) unless File.exist?(directory_name)
+    File.write(file_path, JSON.pretty_generate(serialize))
+  end
+
+  def remove_serialization
+    return unless Rails.application.config.levelbuilder_mode
+    File.delete(file_path) if File.exist?(file_path)
+  end
 end

--- a/dashboard/app/models/data_doc.rb
+++ b/dashboard/app/models/data_doc.rb
@@ -21,7 +21,7 @@ class DataDoc < ApplicationRecord
   validate :validate_key_format
 
   def file_path
-    Rails.root.join("config/data_docs/#{key.parameterize(preserve_case: false)}.json")
+    Rails.root.join("config/data_docs/#{key}.json")
   end
 
   def serialize

--- a/dashboard/test/controllers/data_docs_controller_test.rb
+++ b/dashboard/test/controllers/data_docs_controller_test.rb
@@ -33,9 +33,12 @@ class DataDocsControllerTest < ActionController::TestCase
   test_user_gets_response_for :show, params: -> {{key: @data_doc_key}}, user: :teacher, response: :success
   test_user_gets_response_for :show, params: -> {{key: @data_doc_key}}, user: :levelbuilder, response: :success
 
-  test 'creating a new data doc redirects to show page with key in URL' do
+  test 'creating a new data doc writes serialization and redirects to show page with key in URL' do
     sign_in @levelbuilder
     new_key = 'doc_key'
+
+    DataDoc.any_instance.expects(:write_serialization).once
+
     get :create, params: {key: new_key}
     assert_redirected_to action: 'show', key: new_key
   end

--- a/dashboard/test/models/data_doc_test.rb
+++ b/dashboard/test/models/data_doc_test.rb
@@ -13,4 +13,18 @@ class DataDocTest < ActiveSupport::TestCase
       DataDoc.create!(key: 'myblock', name: 'invalid block')
     end
   end
+
+  test "serialize returns an object with the correct fields" do
+    key = 'dataDocKey'
+    name = 'Data Doc Name'
+    content = 'Data Doc Content'
+    data_doc = DataDoc.create!(key: key, name: name, content: content)
+
+    serialized_doc = data_doc.serialize
+
+    assert serialized_doc.is_a? Object
+    assert_equal serialized_doc[:key], key
+    assert_equal serialized_doc[:name], name
+    assert_equal serialized_doc[:content], content
+  end
 end


### PR DESCRIPTION
This gets the data doc import ready by (a) adding the import, (b) writing the serialization, and then (c) testing locally both the import and the serialization. We'll need to work with the Curriculum Team before actually running the import on levelbuilder.

There are 103 data docs currently on Curriculum Builder. Once I ran the script locally, I saw 103 data docs created:

<img width="916" alt="Screen Shot 2022-09-22 at 1 08 22 PM" src="https://user-images.githubusercontent.com/9142121/191829363-3832a69c-47bb-463b-945d-22504a5c558f.png">

There were also 103 json files written:

<img width="1003" alt="Screen Shot 2022-09-22 at 12 58 08 PM" src="https://user-images.githubusercontent.com/9142121/191829189-10a4806d-9eac-4901-b072-1fd609567e3d.png">

Here's a sample of their content:

<img width="941" alt="Screen Shot 2022-09-22 at 12 59 04 PM" src="https://user-images.githubusercontent.com/9142121/191829319-ba32f270-d4f7-4ad5-8d15-9bd74f367074.png">



## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

I added some unit tests, but I think the model tests can get stronger once the seeding logic is added. I didn't do that here.

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
