### PR TITLE
Add create variable button

### DIFF
--- a/apps/src/music/MusicView.jsx
+++ b/apps/src/music/MusicView.jsx
@@ -249,6 +249,11 @@ class MusicView extends React.Component {
           },
           contents: [
             {
+              kind: 'button',
+              text: 'Create variable...',
+              callbackKey: 'createVariableHandler'
+            },
+            {
               kind: 'block',
               type: 'variable_get'
             },
@@ -352,7 +357,7 @@ class MusicView extends React.Component {
             },
             {
               type: 'field_variable',
-              name: 'measure',
+              name: 'var',
               variable: 'measure'
             }
           ],
@@ -579,15 +584,20 @@ class MusicView extends React.Component {
         'Music.play_sound("' +
         ctx.getFieldValue('sound') +
         '", ' +
-        'measure' +
-        //ctx.getFieldValue('measure') +
+        Blockly.JavaScript.nameDB_.getName(
+          ctx.getFieldValue('var'),
+          Blockly.Names.NameType.VARIABLE
+        ) +
         ');\n'
       );
     };
 
     Blockly.JavaScript.variable_get = function(ctx) {
-      return Blockly.JavaScript.valueToCode(ctx, 'measure');
-      //return ctx.getFieldValue('var');
+      const code = Blockly.JavaScript.nameDB_.getName(
+        ctx.getFieldValue('var'),
+        Blockly.Names.NameType.VARIABLE
+      );
+      return [code, Blockly.JavaScript.ORDER_ATOMIC];
     };
 
     Blockly.JavaScript.variable_set = function(ctx) {
@@ -667,6 +677,14 @@ class MusicView extends React.Component {
     Blockly.Xml.domToBlockSpace(Blockly.mainBlockSpace, xml);
 
     Blockly.addChangeListener(Blockly.mainBlockSpace, this.onBlockSpaceChange);
+
+    this.workspace.registerButtonCallback('createVariableHandler', button => {
+      Blockly.Variables.createVariableButtonHandler(
+        button.getTargetWorkspace(),
+        null,
+        null
+      );
+    });
   };
 
   onBlockSpaceChange = () => {


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Adds a create variable button to the toolbox, and updates the play with variable block to use whatever variable was passed to it
![Screen Shot 2022-09-22 at 10 43 15 AM](https://user-images.githubusercontent.com/85528507/191830364-68349ef7-b54d-403d-b4ae-d41300f99e44.png)

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
