### PR TITLE
RestyleJava Lab tabs so tab heights remain constant

### DIFF
--- a/apps/src/javalab/javalab-editor.module.scss
+++ b/apps/src/javalab/javalab-editor.module.scss
@@ -32,6 +32,7 @@
   margin-bottom: 0;
   display: flex;
   align-items: center;
+  white-space: nowrap;
 }
 
 .fileTypeIcon {


### PR DESCRIPTION
This PR updates the style of Java Lab tabs so that when the file tabs reach or extend beyond the end of the editor window, the heights of the tabs remain constant. 

Before the update, the heights of the file tabs would increase when the file tabs reached the end of the editor window because the dropdown caret moved to the next line.

![image](https://user-images.githubusercontent.com/107423305/191854428-11cf722c-ac98-4822-b122-5db9e91c6f18.png)

I added `white-space: nowrap` so that the up/down caret will not be displayed on the next line. Thanks to @cat5inthecradle for the suggestion!

After the update:

<img width="978" alt="Screen Shot 2022-09-22 at 4 33 32 PM" src="https://user-images.githubusercontent.com/107423305/191855177-e583ca14-4554-4d23-b97e-ce8205d8dc89.png">


## Links

[jira ticket](https://codedotorg.atlassian.net/browse/JAVA-685)
[Slack thread discussion](https://codedotorg.slack.com/archives/C01EF4GJ9GE/p1663256543324329)

## Testing story

Tested update locally.

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Follow-up work

If there are several files within a Java Lab project so that the file tabs extend to the end of the editor window, the tab menu may get cut off - [jira ticket](https://codedotorg.atlassian.net/browse/JAVA-688)

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
