### PR TITLE
Music prototype: hide groups

### DIFF
--- a/apps/src/music/MusicView.jsx
+++ b/apps/src/music/MusicView.jsx
@@ -79,7 +79,7 @@ class MusicView extends React.Component {
       // ideally our music player will use the above data structure as the source
       // of truth, but since the current implementation has already told WebAudio
       // about all known sounds to play, let's tee up this one here.
-      const fullSoundId = this.getCurrentSamplePack().path + '/' + id;
+      const fullSoundId = this.getCurrentGroup().path + '/' + id;
       PlaySound(fullSoundId, '', nextMeasureStartTime);
     }
   };
@@ -129,8 +129,8 @@ class MusicView extends React.Component {
       windowHeight,
       appWidth: this.codeAppRef.offsetWidth,
       appHeight: this.codeAppRef.offsetHeight,
-      currentPanel: 'samplepacks',
-      samplePanel: 'main',
+      currentPanel: 'groups',
+      groupPanel: 'all',
       isPlaying: false,
       startPlayingAudioTime: null,
       currentAudioTime: null,
@@ -155,7 +155,7 @@ class MusicView extends React.Component {
         .map(group => {
           return group.folders?.map(folder => {
             return folder.sounds.map(sound => {
-              return group.path + '/' + folder.name + '/' + sound.src;
+              return group.path + '/' + folder.path + '/' + sound.src;
             });
           });
         })
@@ -307,14 +307,14 @@ class MusicView extends React.Component {
       this.getInput('sound').appendField(
         new Blockly.FieldDropdown(function() {
           var options = [['anything', 'anything']];
-          if (self.state.samplePanel && self.state.samplePanel !== 'main') {
-            const folders = self.getCurrentSamplePackSounds();
+          if (self.state.groupPanel && self.state.groupPanel !== 'main') {
+            const folders = self.getCurrentGroupSounds();
             options = folders
               .map(folder => {
                 return folder.sounds.map(sound => {
                   return [
-                    folder.name + '/' + sound.id,
-                    folder.name + '/' + sound.id
+                    folder.name + '/' + sound.name,
+                    folder.path + '/' + sound.src
                   ];
                 });
               })
@@ -743,8 +743,8 @@ class MusicView extends React.Component {
     this.resizeBlockly();
   };
 
-  setSamplePanel = panel => {
-    this.setState({samplePanel: panel});
+  setGroupPanel = panel => {
+    this.setState({groupPanel: panel});
   };
 
   playTrigger = () => {
@@ -785,7 +785,7 @@ class MusicView extends React.Component {
     for (const songEvent of songData.events) {
       if (songEvent.type === 'play') {
         PlaySound(
-          this.getCurrentSamplePack().path + '/' + songEvent.id,
+          this.getCurrentGroup().path + '/' + songEvent.id,
           'mainaudio',
           currentAudioTime + this.convertMeasureToSeconds(songEvent.when)
         );
@@ -806,7 +806,7 @@ class MusicView extends React.Component {
   previewSound = id => {
     StopSound('mainaudio');
 
-    PlaySound(this.getCurrentSamplePack().path + '/' + id, 'mainaudio', 0);
+    PlaySound(this.getCurrentGroup().path + '/' + id, 'mainaudio', 0);
   };
 
   getVerticalOffsetForEventId = id => {
@@ -831,19 +831,19 @@ class MusicView extends React.Component {
     );
   };
 
-  getCurrentSamplePack = () => {
-    const currentSamplePack =
-      this.state.samplePanel !== 'main' &&
+  getCurrentGroup = () => {
+    const currentGroup =
+      this.state.groupPanel !== 'main' &&
       this.state.library &&
       this.state.library.groups.find(
-        group => group.id === this.state.samplePanel
+        group => group.id === this.state.groupPanel
       );
 
-    return currentSamplePack;
+    return currentGroup;
   };
 
-  getCurrentSamplePackSounds = () => {
-    return this.getCurrentSamplePack()?.folders;
+  getCurrentGroupSounds = () => {
+    return this.getCurrentGroup()?.folders;
   };
 
   getWaveformImage = id => {
@@ -897,8 +897,6 @@ class MusicView extends React.Component {
     const mobileWidth = 601;
     const isDesktop = this.state.windowWidth >= mobileWidth;
 
-    const showSamplePacks =
-      isDesktop || this.state.currentPanel === 'samplepacks';
     const showCode = isDesktop || this.state.currentPanel === 'code';
     const showTimeline = isDesktop || this.state.currentPanel === 'timeline';
 
@@ -910,8 +908,7 @@ class MusicView extends React.Component {
         this.convertMeasureToSeconds(1)
       : null;
 
-    const currentSamplePack = this.getCurrentSamplePack();
-    const currentSamplePackSounds = this.getCurrentSamplePackSounds();
+    const currentGroup = this.getCurrentGroup();
 
     return (
       <div
@@ -927,6 +924,18 @@ class MusicView extends React.Component {
           overflow: 'hidden'
         }}
       >
+        <div
+          id="blocklyArea"
+          style={{
+            float: 'left',
+            width: '100%',
+            marginTop: 10,
+            height: showCode ? 'calc(100% - 110px)' : 0
+          }}
+        >
+          <div id="blocklyDiv" style={{position: 'absolute'}} />
+        </div>
+
         {showTimeline && (
           <div
             style={{
@@ -937,11 +946,11 @@ class MusicView extends React.Component {
               padding: 10,
               boxSizing: 'border-box',
               backgroundImage:
-                currentSamplePack &&
+                currentGroup &&
                 `url("${baseUrl +
-                  currentSamplePack.path +
+                  currentGroup.path +
                   '/' +
-                  currentSamplePack.themeImageSrc}")`,
+                  currentGroup.themeImageSrc}")`,
               backgroundSize: '100% 200%'
             }}
           >
@@ -1038,124 +1047,6 @@ class MusicView extends React.Component {
             </div>
           </div>
         )}
-        {showSamplePacks && (
-          <div
-            style={{
-              backgroundColor: '#222',
-              float: 'left',
-              width: isDesktop ? 'calc(40% - 10px)' : '100%',
-              height: 'calc(100% - 110px)',
-              borderRadius: 4,
-              marginTop: 10,
-              boxSizing: 'border-box',
-              marginRight: isDesktop ? 10 : 0
-            }}
-          >
-            {!currentSamplePack && (
-              <div style={{padding: 10}}>
-                <div>Sample packs</div>
-                <br />
-
-                {this.state.library &&
-                  this.state.library.groups.map((group, index) => {
-                    return (
-                      <div
-                        key={index}
-                        style={{cursor: 'pointer', paddingBottom: 10}}
-                        onClick={() => this.setSamplePanel(group.id)}
-                      >
-                        <img
-                          src={baseUrl + group.path + '/' + group.imageSrc}
-                          style={{width: 60, paddingRight: 20}}
-                        />
-                        {group.name}
-                      </div>
-                    );
-                  })}
-              </div>
-            )}
-            {currentSamplePack && (
-              <div style={{height: '100%'}}>
-                <div
-                  style={{cursor: 'pointer', height: 20, padding: 10}}
-                  onClick={() => this.setSamplePanel('main')}
-                >
-                  &lt; Back
-                </div>
-                <div
-                  style={{
-                    padding: 10,
-                    backgroundImage: `url("${baseUrl +
-                      currentSamplePack.path +
-                      '/' +
-                      currentSamplePack.themeImageSrc}")`,
-                    backgroundSize: '100% 110%',
-                    backgroundPositionY: '100%',
-                    height: 'calc(100% - 40px)',
-                    boxSizing: 'border-box',
-                    overflow: 'scroll'
-                  }}
-                >
-                  <br />
-                  <div>"{currentSamplePack.name}" sample pack</div>
-                  <br />
-                  <div>
-                    <img
-                      src={
-                        baseUrl +
-                        currentSamplePack.path +
-                        '/' +
-                        currentSamplePack.imageSrc
-                      }
-                      style={{width: '70%'}}
-                    />
-                  </div>
-
-                  {currentSamplePackSounds.map((folder, folderIndex) => {
-                    return (
-                      <div key={folderIndex}>
-                        <details>
-                          <summary>{folder.name}</summary>
-                          {folder.sounds.map((sound, soundIndex) => {
-                            return (
-                              <div key={soundIndex}>
-                                <img
-                                  src={this.getWaveformImage(sound.id)}
-                                  style={{
-                                    width: 90,
-                                    paddingRight: 20,
-                                    cursor: 'pointer'
-                                  }}
-                                  onClick={() =>
-                                    this.previewSound(
-                                      folder.name + '/' + sound.id
-                                    )
-                                  }
-                                />
-                                {sound.id}
-                              </div>
-                            );
-                          })}
-                        </details>
-                      </div>
-                    );
-                  })}
-                </div>
-              </div>
-            )}
-          </div>
-        )}
-        <div
-          id="blocklyArea"
-          style={{
-            float: 'left',
-            width: isDesktop ? '60%' : '100%',
-            marginTop: 10,
-            height: showCode ? 'calc(100% - 110px)' : 0
-          }}
-        >
-          <div id="blocklyDiv" style={{position: 'absolute'}} />
-        </div>
         <div
           style={{
             position: 'fixed',
@@ -1175,13 +1066,12 @@ class MusicView extends React.Component {
             style={{
               textAlign: 'center',
               cursor: 'pointer',
-              color:
-                isDesktop || currentPanel === 'samplepacks' ? 'white' : '#777'
+              color: isDesktop || currentPanel === 'groups' ? 'white' : '#777'
             }}
-            onClick={() => this.choosePanel('samplepacks')}
+            onClick={() => this.choosePanel('groups')}
           >
             <FontAwesome icon="book" style={{fontSize: 25}} />
-            <div style={{fontSize: 8}}>Sample packs</div>
+            <div style={{fontSize: 8}}>Groups</div>
           </div>
           <div
             style={{

--- a/apps/static/music/music-library.json
+++ b/apps/static/music/music-library.json
@@ -1,142 +1,79 @@
 {
   "groups": [
     {
-      "id": "pop",
-      "name": "Upbeat Pop",
-      "imageSrc": "samplepack3.png",
-      "themeImageSrc": "highlight3.png",
-      "path": "pop",
+      "id": "all",
+      "name": "All",
+      "imageSrc": "all.png",
+      "themeImageSrc": "all-theme.png",
+      "path": "all",
       "folders": [
         {
-          "name": "all",
+          "name": "Pop",
+          "path": "pop",
+          "imageSrc": "thumbnail.png",
           "sounds": [
-            {
-              "id": "drums-alt1",
-              "src": "drums-alt1",
-              "length": 1
-            },
-            {
-              "id": "drums-alt2",
-              "src": "drums-alt2",
-              "length": 1
-            },
-            {
-              "id": "drums1",
-              "src": "drums1",
-              "length": 2
-            },
-            {
-              "id": "synth1",
-              "src": "synth1",
-              "length": 4
-            },
-            {
-              "id": "synth2",
-              "src": "synth2",
-              "length": 2
-            },
-            {
-              "id": "bass1",
-              "src": "bass1",
-              "length": 4
-            },
-            {
-              "id": "guitar1",
-              "src": "guitar1",
-              "length": 2
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "country",
-      "name": "Country",
-      "imageSrc": "samplepack1.png",
-      "themeImageSrc": "highlight1.png",
-      "path": "country",
-      "folders": [
-        {
-          "name": "low",
-          "sounds": [
-            {
-              "id": "bass",
-              "src": "bass",
-              "length": 2
-            },
-            {
-              "id": "drum",
-              "src": "drum",
-              "length": 2
-            }
+            { "name": "Cafe Beat", "src": "cafe_beat", "length": 2},
+            { "name": "Acoustic Bass", "src": "acoustic_bass" , "length": 2},
+            { "name": "Bold Beat", "src": "bold_beat", "length": 2},
+            { "name": "Strings", "src": "strings", "length": 2},
+            { "name": "Clap", "src": "clap", "length": 2},
+            { "name": "Hey!", "src": "hey", "length": 2},
+            { "name": "Rhythm Guitar", "src": "rhythm_guitar", "length": 2},
+            { "name": "Picked Guitar", "src": "picked_guitar", "length": 2},
+            { "name": "Shake Beat", "src": "shake_beat", "length": 2},
+            { "name": "Sugar Beat", "src": "sugar_beat", "length": 2},
+            { "name": "Boom Bass", "src": "boom_bass", "length": 2},
+            { "name": "Acoustic Bass 2", "src": "acoustic_alternate_bass", "length": 2},
+            { "name": "Bold Beat 2", "src": "bold_alternate_beat", "length": 2},
+            { "name": "Sugar Beat 2", "src": "sugar_alternate_beat", "length": 2}
           ]
         },
         {
-          "name": "hi",
+          "name": "Dance",
+          "path": "dance",
+          "imageSrc": "thumbnail.png",
           "sounds": [
-            {
-              "id": "lead",
-              "src": "lead",
-              "length": 2
-            }
+            { "name": "Disco Beat", "src": "disco_beat", "length": 2},
+            { "name": "Funky Bass", "src": "funky_bass", "length": 2},
+            { "name": "Groovy Beat", "src": "groovy_beat", "length": 2},
+            { "name": "Lucky Guitar", "src": "lucky_guitar", "length": 2},
+            { "name": "Swish", "src": "swish", "length": 2},
+            { "name": "Groovy Beat 2", "src": "groovy_alternate_beat", "length": 2}
           ]
-        }
-      ]
-    },
-    {
-      "id": "dance",
-      "name": "Dance",
-      "imageSrc": "samplepack2.png",
-      "themeImageSrc": "highlight2.png",
-      "path": "dance",
-      "folders": [
+        },
         {
-          "name": "all",
+          "name": "Rock",
+          "path": "rock",
+          "imageSrc": "thumbnail.png",
           "sounds": [
-            {
-              "id": "bass",
-              "src": "bass",
-              "length": 2
-            },
-            {
-              "id": "drum",
-              "src": "drum",
-              "length": 2
-            },
-            {
-              "id": "lead",
-              "src": "lead",
-              "length": 2
-            }
+            { "name": "Amped Bass", "src": "amped_bass", "length": 2},
+            { "name": "Arena Beat", "src": "arena_beat", "length": 2},
+            { "name": "Riff Guitar", "src": "riff_guitar", "length": 2},
+            { "name": "Gutter Beat", "src": "gutter_beat", "length": 2},
+            { "name": "Power Guitar", "src": "power_guitar", "length": 2},
+            { "name": "Punk Beat", "src": "punk_beat", "length": 2},
+            { "name": "Shredded Guitar", "src": "shredded_guitar", "length": 2},
+            { "name": "Crash", "src": "crash", "length": 1},
+            { "name": "Feedback", "src": "feedback", "length": 1},
+            { "name": "Amped Bass 2", "src": "amped_alternate_bass", "length": 2},
+            { "name": "Punk Beat 2", "src": "punk_alternate_beat", "length": 2},
+            { "name": "Arena Beat 2", "src": "arena_alternate_beat", "length": 2}
           ]
-        }
-      ]
-    },
-    {
-      "id": "hip",
-      "name": "Hip Hop",
-      "imageSrc": "samplepack3.png",
-      "themeImageSrc": "highlight3.png",
-      "path": "hip",
-      "folders": [
+        },
         {
-          "name": "all",
+          "name": "Hip Hop",
+          "path": "hiphop",
+          "imageSrc": "thumbnail.png",
           "sounds": [
-            {
-              "id": "bass",
-              "src": "bass",
-              "length": 2
-            },
-            {
-              "id": "drum",
-              "src": "drum",
-              "length": 2
-            },
-            {
-              "id": "lead",
-              "src": "lead",
-              "length": 2
-            }
+            { "name": "Vinyl Beat", "src": "vinyl_beat", "length": 2},
+            { "name": "Brass", "src": "brass", "length": 2},
+            { "name": "Horns", "src": "horns", "length": 2},
+            { "name": "Piano Chords", "src": "piano_chords", "length": 2},
+            { "name": "Relaxed Beat", "src": "relaxed_beat", "length": 2},
+            { "name": "Sub Beat", "src": "sub_beat", "length": 2},
+            { "name": "Hats Beat", "src": "hats_beat", "length": 2},
+            { "name": "Swoosh", "src": "swoosh", "length": 2},
+            { "name": "Relaxed Beat 2", "src": "relaxed_alternate_beat", "length": 2}
           ]
         }
       ]


### PR DESCRIPTION
This updates the manifest, the arrangement of files on S3 (not in repo), and the code to make some changes:

- we default to group "all" but hide this in the UI.
- we hide the groups (formerly sample packs) panel.
- we make the blockly area full width.
- we move the timeline to the bottom.
- we distinguish friendly names from IDs/filenames of sounds.

The folder & song filenames can now be in snake case, while the friendly names of both can be more flexible.

<img width="1512" alt="Screen Shot 2022-09-22 at 3 16 58 PM" src="https://user-images.githubusercontent.com/2205926/191861095-32528da8-79d2-4dc1-8b15-323891525fa7.png">
