### PR TITLE
Refactor Sprite lab constants

### DIFF
--- a/apps/src/p5lab/spritelab/CoreLibrary.js
+++ b/apps/src/p5lab/spritelab/CoreLibrary.js
@@ -3,7 +3,7 @@ import * as drawUtils from '@cdo/apps/p5lab/drawUtils';
 import commands from './commands/index';
 import {getStore} from '@cdo/apps/redux';
 import {APP_HEIGHT, APP_WIDTH} from '../constants';
-import {MAX_NUM_SPRITES, SPRITE_WARNING_THRESHOLD} from './constants';
+import {MAX_NUM_SPRITES, SPRITE_WARNING_BUFFER} from './constants';
 import {
   workspaceAlertTypes,
   displayWorkspaceAlert
@@ -374,18 +374,18 @@ export default class CoreLibrary {
   }
 
   reachedSpriteWarningThreshold() {
-    return this.getNumberOfSprites() === SPRITE_WARNING_THRESHOLD;
+    return (
+      this.getNumberOfSprites() === MAX_NUM_SPRITES - SPRITE_WARNING_BUFFER
+    );
   }
 
   // This function is called within the addSprite function BEFORE a new sprite is created
-  // If the total number of sprites is equal to SPRITE_WARNING_THRESHOLD, a workspace
-  // alert warning is displayed to let user know they have reached the sprite limit
-  // Note that SPRITE_WARNING_THRESHOLD = MAX_NUM_SPRITES - 1
+  // If the total number of sprites is equal to (MAX_NUM_SPRITES - SPRITE_WARNING_BUFFER),
+  // a workspace alert warning is displayed to let user know they have reached the sprite limit
   dispatchSpriteLimitWarning() {
     getStore().dispatch(
       displayWorkspaceAlert(
         workspaceAlertTypes.warning,
-        /* display warning when user exceeds SPRITE_WARNING_THRESHOLD */
         msg.spriteLimitReached({limit: MAX_NUM_SPRITES}),
         /* bottom */ true
       )

--- a/apps/src/p5lab/spritelab/constants.js
+++ b/apps/src/p5lab/spritelab/constants.js
@@ -101,8 +101,8 @@ export const exampleSprites = {
 // Big numbers in some blocks can cause performance issues. Combined with live-preview,
 // this results in hanging the tab and students unable to edit their blocks. We
 // guard against this by capping number of sprites.
-// The user will receive a workspace alert at SPRITE_WARNING_THRESHOLD number of sprites.
-// The actual cap is MAX_NUM_SPRITES
+// The sprite cap is MAX_NUM_SPRITES, and a workspace alert will be dispatched
+// at (MAX_NUM_SPRITES - SPRITE_WARNING_BUFFER) number of sprites.
 export const MAX_NUM_SPRITES = 1000;
-export const SPRITE_WARNING_THRESHOLD = MAX_NUM_SPRITES - 1;
+export const SPRITE_WARNING_BUFFER = 1;
 export const MAX_NUM_TEXTS = 1000;

--- a/apps/test/unit/p5lab/spritelab/CoreLibraryTest.js
+++ b/apps/test/unit/p5lab/spritelab/CoreLibraryTest.js
@@ -6,7 +6,7 @@ import CoreLibrary from '@cdo/apps/p5lab/spritelab/CoreLibrary';
 import {commands as spriteCommands} from '@cdo/apps/p5lab/spritelab/commands/spriteCommands';
 import {
   MAX_NUM_SPRITES,
-  SPRITE_WARNING_THRESHOLD
+  SPRITE_WARNING_BUFFER
 } from '@cdo/apps/p5lab/spritelab/constants';
 import msg from '@cdo/locale';
 import {
@@ -201,51 +201,47 @@ describe('SpriteLab Core Library', () => {
       redux.getStore.restore();
     });
 
-    // if the total number of sprites created is equal to or less than SPRITE_WARNING_THRESHOLD
-    // then a display workspace alert should not have been called
-    it(`If ${SPRITE_WARNING_THRESHOLD} sprites or less are created, a workspace alert is NOT dispatched`, () => {
-      for (let i = 0; i < SPRITE_WARNING_THRESHOLD; i++) {
+    // If the total number of sprites created is equal to or less than
+    // MAX_NUM_SPRITES - SPRITE_WARNING_BUFFER, then a display workspace alert
+    // should not have been dispatched
+    it(`If ${MAX_NUM_SPRITES -
+      SPRITE_WARNING_BUFFER} sprites or less are created, a workspace alert is NOT dispatched`, () => {
+      for (let i = 0; i < MAX_NUM_SPRITES - SPRITE_WARNING_BUFFER; i++) {
         coreLibrary.addSprite();
       }
       expect(stubbedDispatch).to.not.have.been.calledWith(
         displayWorkspaceAlert(
           workspaceAlertTypes.warning,
-          /* display warning when total number of sprites is equal to SPRITE_WARNING_THRESHOLD */
           msg.spriteLimitReached({limit: MAX_NUM_SPRITES}),
           /* bottom */ true
         )
       );
     });
-    // Once the total number of sprite is equal to SPRITE_WARNING_THRESHOLD, if
-    // an additional addSprite call will result in displayWorkspaceAlert being dispatched
-    // Note that SPRITE_WARNING_THRESHOLD = MAX_NUM_SPRITES - 1
-    it(`When ${SPRITE_WARNING_THRESHOLD} sprites is reached, an additional addSprite call will dispatch a workspace alert`, () => {
-      for (let i = 0; i < SPRITE_WARNING_THRESHOLD + 1; i++) {
+    // Once the total number of sprites created is equal to MAX_NUM_SPRITES, a
+    // displayWorkspaceAlert has been dispatched
+    it(`When ${MAX_NUM_SPRITES} sprites is reached, a workspace alert was dispatched`, () => {
+      for (let i = 0; i < MAX_NUM_SPRITES; i++) {
         coreLibrary.addSprite();
       }
       expect(stubbedDispatch).to.have.been.calledOnceWith(
         displayWorkspaceAlert(
           workspaceAlertTypes.warning,
-          /* display warning when total number of sprites is equal to SPRITE_WARNING_THRESHOLD */
           msg.spriteLimitReached({limit: MAX_NUM_SPRITES}),
           /* bottom */ true
         )
       );
     });
 
-    // When total number of sprite is equal to SPRITE_WARNING_THRESHOLD, if multiple
-    // addSprite calls are made, the dispatch of displayWorkspaceAlert will occur
-    // only once due to the early return from the reachedSpriteMax function
-    // when total number of sprites is >= MAX_NUM_SPRITES.
-    // Note that SPRITE_WARNING_THRESHOLD = MAX_NUM_SPRITES - 1
-    it(`Even when 100 more than ${SPRITE_WARNING_THRESHOLD} sprites is reached, workspace alert is dispatched only once`, () => {
-      for (let i = 0; i < SPRITE_WARNING_THRESHOLD + 100; i++) {
+    // When total number of sprites is >= MAX_NUM_SPRITES, the dispatch of
+    // displayWorkspaceAlert will occur only once due to the early return from
+    // the reachedSpriteMax function
+    it(`Even when 100 more than ${MAX_NUM_SPRITES} sprites is reached, workspace alert is dispatched only once`, () => {
+      for (let i = 0; i < MAX_NUM_SPRITES + 100; i++) {
         coreLibrary.addSprite();
       }
       expect(stubbedDispatch).to.have.been.calledOnceWith(
         displayWorkspaceAlert(
           workspaceAlertTypes.warning,
-          /* display warning when total number of sprites is equal to SPRITE_WARNING_THRESHOLD */
           msg.spriteLimitReached({limit: MAX_NUM_SPRITES}),
           /* bottom */ true
         )


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR refactors a Sprite Lab constant that is used when a workspace alert warning is displayed to the user if they reached the max number of sprites possible. Note that the number of sprites to create in Sprite Lab was capped to help performance. More details about this prior work [here](https://github.com/code-dot-org/code-dot-org/pull/47953).

To aid in future maintenance and readability, the constant SPRITE_WARNING_THRESHOLD was revised to SPRITE_WARNING_BUFFER, this buffer being the difference from MAX_NUM_SPRITES at which the workspace alert warning is dispatched. At this point, SPRITE_WARNING_BUFFER is assigned 1 but may be adjusted.


## Links

[jira ticket](https://codedotorg.atlassian.net/browse/STAR-2418)


## Testing story

Unit tests in CoreLibraryTest.js were updated using refactored constant.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
