### PR TITLE
Split up contained_levels.feature

### DIFF
--- a/dashboard/test/ui/features/learning_platform/level_types/free_response_contained_levels.feature
+++ b/dashboard/test/ui/features/learning_platform/level_types/free_response_contained_levels.feature
@@ -1,5 +1,5 @@
 @eyes
-Feature: Contained Levels
+Feature: Free Response Contained Levels
 
   Background:
     Given I create an authorized teacher-associated student named "Lillian"
@@ -27,45 +27,6 @@ Scenario: Applab with free response contained level
   And I press "continue-button"
   # Make sure continue takes us to next level
   And I wait until current URL contains "/lessons/18/levels/16"
-  Then I close my eyes
-
-Scenario: GameLab with a submittable contained level
-  When I open my eyes to test "gamelab submittable contained level"
-  Given I am on "http://studio.code.org/s/allthethings/lessons/41/levels/7"
-  And I rotate to landscape
-  And I wait for the page to fully load
-  Then I see no difference for "initial load" using stitch mode "none"
-  Then I press "unchecked_0"
-  And I see no difference for "answer entered" using stitch mode "none"
-  Then I press "runButton"
-  And I see no difference for "level run" using stitch mode "none"
-  And I press "submitButton"
-  And I press "confirm-button"
-  And I wait until current URL contains "/lessons/41/levels/8"
-  Then I close my eyes
-
-Scenario: Gamelab with multiple choice contained level
-  When I open my eyes to test "gamelab multiple choice contained level"
-  Given I am on "http://studio.code.org/s/allthethings/lessons/41/levels/2"
-  And I rotate to landscape
-  And I wait for the page to fully load
-  Then I see no difference for "initial load" using stitch mode "none"
-  Then I press "unchecked_0"
-  And I see no difference for "answer entered" using stitch mode "none"
-  Then I press "runButton"
-  And I see no difference for "level run" using stitch mode "none"
-  # At this point, we should have submitted our result to the server, do
-  # a reload and make sure we have the submission
-  Then I am on "http://studio.code.org/s/allthethings/lessons/41/levels/2"
-  And I rotate to landscape
-  And I wait for the page to fully load
-  And I see no difference for "reloaded with contained level answered" using stitch mode "none"
-  Then I press "runButton"
-  And I press "finishButton"
-  And I see no difference for "finished level with contained level" using stitch mode "none"
-  And I press "continue-button"
-  # Make sure continue takes us to next level
-  And I wait until current URL contains "/lessons/41/levels/3"
   Then I close my eyes
 
 Scenario: Javalab with free response contained level
@@ -124,25 +85,6 @@ Scenario: Authorized Teacher on App Lab with free response contained level
   And I wait to see ".editor-column"
   And element ".editor-column" contains text "For Teachers Only"
   And I see no difference for "free response answer for teacher"
-  Then I press "runButton"
-  And I see no difference for "level run"
-  Then I close my eyes
-
-Scenario: Unauthorized Teacher on Maze with multiple choice contained level
-  When I open my eyes to test "maze multi contained level"
-  Given I create a teacher-associated student named "Sally"
-  And I sign in as "Teacher_Sally" and go home
-  Then I am on "http://studio.code.org/s/coursee-2019/lessons/4/levels/2"
-  And I rotate to landscape
-  And I wait for the page to fully load
-  Then I see no difference for "initial load"
-  Then I press "unchecked_0"
-  And I see no difference for "answer entered"
-  # Check that answer shows in teacher only tab
-  Then I press the first ".uitest-teacherOnlyTab" element
-  And I wait to see ".editor-column"
-  And element ".editor-column" contains text "Answer"
-  And I see no difference for "multiple choice answer for teacher"
   Then I press "runButton"
   And I see no difference for "level run"
   Then I close my eyes

--- a/dashboard/test/ui/features/learning_platform/level_types/multiple_choice_contained_levels.feature
+++ b/dashboard/test/ui/features/learning_platform/level_types/multiple_choice_contained_levels.feature
@@ -1,0 +1,64 @@
+@eyes
+Feature: Multiple Choice Contained Levels
+
+  Background:
+    Given I create an authorized teacher-associated student named "Lillian"
+    Then I sign in as "Lillian"
+
+Scenario: GameLab with a submittable contained level
+  When I open my eyes to test "gamelab submittable contained level"
+  Given I am on "http://studio.code.org/s/allthethings/lessons/41/levels/7"
+  And I rotate to landscape
+  And I wait for the page to fully load
+  Then I see no difference for "initial load" using stitch mode "none"
+  Then I press "unchecked_0"
+  And I see no difference for "answer entered" using stitch mode "none"
+  Then I press "runButton"
+  And I see no difference for "level run" using stitch mode "none"
+  And I press "submitButton"
+  And I press "confirm-button"
+  And I wait until current URL contains "/lessons/41/levels/8"
+  Then I close my eyes
+
+Scenario: Gamelab with multiple choice contained level
+  When I open my eyes to test "gamelab multiple choice contained level"
+  Given I am on "http://studio.code.org/s/allthethings/lessons/41/levels/2"
+  And I rotate to landscape
+  And I wait for the page to fully load
+  Then I see no difference for "initial load" using stitch mode "none"
+  Then I press "unchecked_0"
+  And I see no difference for "answer entered" using stitch mode "none"
+  Then I press "runButton"
+  And I see no difference for "level run" using stitch mode "none"
+  # At this point, we should have submitted our result to the server, do
+  # a reload and make sure we have the submission
+  Then I am on "http://studio.code.org/s/allthethings/lessons/41/levels/2"
+  And I rotate to landscape
+  And I wait for the page to fully load
+  And I see no difference for "reloaded with contained level answered" using stitch mode "none"
+  Then I press "runButton"
+  And I press "finishButton"
+  And I see no difference for "finished level with contained level" using stitch mode "none"
+  And I press "continue-button"
+  # Make sure continue takes us to next level
+  And I wait until current URL contains "/lessons/41/levels/3"
+  Then I close my eyes
+
+Scenario: Unauthorized Teacher on Maze with multiple choice contained level
+  When I open my eyes to test "maze multi contained level"
+  Given I create a teacher-associated student named "Sally"
+  And I sign in as "Teacher_Sally" and go home
+  Then I am on "http://studio.code.org/s/coursee-2019/lessons/4/levels/2"
+  And I rotate to landscape
+  And I wait for the page to fully load
+  Then I see no difference for "initial load"
+  Then I press "unchecked_0"
+  And I see no difference for "answer entered"
+  # Check that answer shows in teacher only tab
+  Then I press the first ".uitest-teacherOnlyTab" element
+  And I wait to see ".editor-column"
+  And element ".editor-column" contains text "Answer"
+  And I see no difference for "multiple choice answer for teacher"
+  Then I press "runButton"
+  And I see no difference for "level run"
+  Then I close my eyes


### PR DESCRIPTION
This test is one of our slowest, if not our slowest, UI test at around 16 minutes long, and is often the bottleneck for our eyes test completing (the eyes tests run normally equals the time this test takes, give or take a few seconds). I want to add new tests to this file to test resetting progress so I'm splitting this up before I do that.

I did not change any of the steps of these tests, just copied them into new files.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
