### PR TITLE
Expo: remove download link to phone and secrets

### DIFF
--- a/apps/src/code-studio/components/SendToPhone.jsx
+++ b/apps/src/code-studio/components/SendToPhone.jsx
@@ -42,7 +42,6 @@ export default class SendToPhone extends React.Component {
   static propTypes = {
     isLegacyShare: PropTypes.bool.isRequired,
     channelId: PropTypes.string,
-    downloadUrl: PropTypes.string,
     appType: PropTypes.string.isRequired,
     styles: PropTypes.shape({
       label: PropTypes.object,
@@ -74,7 +73,7 @@ export default class SendToPhone extends React.Component {
   }
 
   handleSubmit = () => {
-    const {appType, channelId, isLegacyShare, downloadUrl} = this.props;
+    const {appType, channelId, isLegacyShare} = this.props;
     // Do nothing if we aren't in a state where we can send.
     if (this.state.sendState !== SendState.canSubmit) {
       return;
@@ -89,15 +88,11 @@ export default class SendToPhone extends React.Component {
     };
     if (isLegacyShare) {
       params.level_source = +location.pathname.split('/')[2];
-    } else if (downloadUrl) {
-      params.url = downloadUrl;
     } else {
       params.channel_id = channelId;
     }
 
-    const apiUrl = downloadUrl ? '/sms/send_download' : '/sms/send';
-
-    $.post(apiUrl, $.param(params))
+    $.post('/sms/send', $.param(params))
       .done(
         function() {
           this.setState({sendState: SendState.sent});

--- a/apps/src/constants.js
+++ b/apps/src/constants.js
@@ -181,14 +181,9 @@ export const ALPHABET =
 export const CIPHER =
   'Iq61F8kiaUHPGcsY7DgX4yAu3LwtWhnCmeR5pVrJoKfQZMx0BSdlOjEv2TbN9z';
 
-export const EXPO_SESSION_SECRET =
-  '{"id":"fakefake-67ec-4314-a438-60589b9c0fa2","version":1,"expires_at":2000000000000}';
-
 export const BASE_DIALOG_WIDTH = 700;
 
 export const TOOLBOX_EDIT_MODE = 'toolbox_blocks';
-
-export const PROFANITY_FOUND = 'profanity_found';
 
 export const NOTIFICATION_ALERT_TYPE = 'notification';
 

--- a/config.yml.erb
+++ b/config.yml.erb
@@ -329,7 +329,6 @@ allowed_iframe_ancestors: http://*.disney.com http://*.diznee.net cuantrix.mx <%
 skip_locales:
 secret_pictures_csv:
 no_https_store:
-expo_session_secret: !Secret
 firebase_debug:
 pd_teacher_application_list_secret_key:
 

--- a/dashboard/app/controllers/sms_controller.rb
+++ b/dashboard/app/controllers/sms_controller.rb
@@ -1,6 +1,6 @@
 require 'twilio-ruby'
 class SmsController < ApplicationController
-  protect_from_forgery except: [:send_to_phone, :send_download_url_to_phone] # the page that posts here is cached
+  protect_from_forgery except: [:send_to_phone] # the page that posts here is cached
 
   # set up a client to talk to the Twilio REST API
   def send_to_phone
@@ -17,11 +17,6 @@ class SmsController < ApplicationController
     else
       head :not_acceptable
     end
-  end
-
-  def send_download_url_to_phone
-    body = "Install this app created in Code Studio on your Android device: #{params[:url]} (reply STOP to stop receiving this)"
-    send_sms(body, params[:phone])
   end
 
   private

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -667,11 +667,6 @@ module LevelsHelper
       end
     end
 
-    # Expo-specific options (only needed for Applab and Gamelab)
-    if (@level.is_a? Gamelab) || (@level.is_a? Applab)
-      app_options[:expoSession] = CDO.expo_session_secret.to_json unless CDO.expo_session_secret.blank?
-    end
-
     # User/session-dependent options
     app_options[:disableSocialShare] = true if current_user&.under_13? || app_options[:embed]
     app_options[:legacyShareStyle] = true if @legacy_share_style

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -568,7 +568,6 @@ Dashboard::Application.routes.draw do
     get '/too_young', to: 'too_young#index'
 
     post '/sms/send', to: 'sms#send_to_phone', as: 'send_to_phone'
-    post '/sms/send_download', to: 'sms#send_download_url_to_phone', as: 'send_download_url_to_phone'
 
     # Experiments are get requests so that a user can click on a link to join or leave an experiment
     get '/experiments/set_course_experiment/:experiment_name', to: 'experiments#set_course_experiment'

--- a/dashboard/test/controllers/sms_controller_test.rb
+++ b/dashboard/test/controllers/sms_controller_test.rb
@@ -50,26 +50,6 @@ class SmsControllerTest < ActionController::TestCase
     assert_response :ok
   end
 
-  test "send download url to phone succeeds when twilio succeeds" do
-    download_url = "http://test-studio.code.org/foo.apk"
-    expected_twilio_options = {
-      messaging_service_sid: 'fake_messaging_service_sid',
-      to: 'xxxxxx',
-      body: "Install this app created in Code Studio on your Android device: #{download_url} (reply STOP to stop receiving this)"
-    }
-
-    twilio_messages_mock = stub(:messages)
-    twilio_messages_mock.expects(:create).with(expected_twilio_options).returns(true)
-    Twilio::REST::Client.any_instance.stubs(:messages).returns(twilio_messages_mock)
-
-    post :send_download_url_to_phone, params: {
-      url: download_url,
-      phone: 'xxxxxx'
-    }
-
-    assert_response :ok
-  end
-
   test "send to phone fails instead of raising an exception when the phone number is invalid" do
     twilio_messages_mock = stub(:messages)
     twilio_messages_mock.expects(:create).raises(Twilio::REST::RestError.new("The 'To' number +12141870331 is not a valid phone number.", OpenStruct.new(body: {})))


### PR DESCRIPTION
- Removes sending an app download link via SMS. Used previously for our now deprecated export to native app feature (aka Expo).
- Removes references to an Expo secret we no longer use.

## Links

## Links

- Part 1 of Expo removal: https://github.com/code-dot-org/code-dot-org/pull/48186
- Part 2 of Expo removal: https://github.com/code-dot-org/code-dot-org/pull/48209
- Part 3 of Expo removal: https://github.com/code-dot-org/code-dot-org/pull/48224
- Part 4 of Expo removal: https://github.com/code-dot-org/code-dot-org/pull/48227

## Testing story

Tested manually that send project link to SMS feature continued to function as expected.

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

- Delete the secret from AWS secrets manager.
- Last thing for Expo deprecation (I think) is to remove a couple of apps dependencies (snack-sdk, snack-build). I'm waiting on that change and coordinating with Maddie on her Webpack upgrade PR, such that we don't have massive merge conflicts in yarn.lock.