### PR TITLE
removing total lines of code updates from back end, not including table storage

### DIFF
--- a/apps/src/code-studio/clientState.js
+++ b/apps/src/code-studio/clientState.js
@@ -20,13 +20,6 @@ clientState.queryParams = require('./utils').queryParams;
 clientState.EXPIRY_DAYS = 365;
 
 /**
- * Maximum number of lines of code that can be stored in the cookie
- * @type {number}
- * @private
- */
-var MAX_LINES_TO_SAVE = 1000;
-
-/**
  * Values larger than this result are server-dependent and shouldn't be cached
  * in client storage.
  */
@@ -97,18 +90,6 @@ clientState.writeSourceForLevel = function(
 };
 
 /**
- * Tracks the lines of code written after the user clicks run if their
- * solution is successful.
- * @param {boolean} result - Whether the user's solution is successful
- * @param {number} lines - Number of lines of code user wrote in this solution
- */
-clientState.trackLines = function(result, lines) {
-  if (result && isFinite(lines)) {
-    addLines(lines);
-  }
-};
-
-/**
  * Merges the given testResult for the given level into the progress
  * data stored in session storage.
  * @param {string} scriptName
@@ -157,33 +138,6 @@ function levelProgressByScript() {
     // Recover from malformed data.
     return {};
   }
-}
-
-/**
- * Returns the number of lines completed from the cookie.
- *
- * TODO: The user's total line count is no longer shown anywhere in the UI.
- * Remove this as part of LP-2291 to clean up the code that stores and
- * maintains the total line count.
- *
- * @returns {number}
- */
-clientState.lines = function() {
-  var linesStr = sessionStorage.getItem('lines');
-  return isFinite(linesStr) ? Number(linesStr) : 0;
-};
-
-/**
- * Adds the given number of completed lines.
- * @param {number} addedLines
- */
-function addLines(addedLines) {
-  var newLines = Math.min(
-    clientState.lines() + Math.max(addedLines, 0),
-    MAX_LINES_TO_SAVE
-  );
-
-  trySetSessionStorage('lines', String(newLines));
 }
 
 /**

--- a/apps/src/code-studio/reporting.js
+++ b/apps/src/code-studio/reporting.js
@@ -357,7 +357,6 @@ reporting.sendReport = function(report) {
  * @param report
  */
 function saveReportLocally(report) {
-  clientState.trackLines(report.result, report.lines);
   clientState.trackProgress(
     appOptions.scriptName,
     appOptions.serverLevelId,

--- a/apps/test/unit/code-studio/clientStateTest.js
+++ b/apps/test/unit/code-studio/clientStateTest.js
@@ -34,73 +34,6 @@ describe('clientState#sourceForLevel', function() {
   });
 });
 
-describe('clientState#trackLines', function() {
-  beforeEach(function() {
-    state.reset();
-  });
-
-  it('records line counts when level is completed', function() {
-    state.lines().should.equal(0);
-
-    //User has passed a level
-    state.trackLines(true, 5);
-    state.lines().should.equal(5);
-
-    //User has passed another level
-    state.trackLines(true, 10);
-    state.lines().should.equal(15);
-  });
-
-  it('does not record line counts when level is failed', function() {
-    state.lines().should.equal(0);
-
-    //User has failed a level
-    state.trackLines(false, 5);
-    state.lines().should.equal(0);
-  });
-
-  it('truncates line count at a certain level', function() {
-    state.trackLines(true, 999);
-    state.lines().should.equal(999);
-
-    state.trackLines(true, 5);
-    state.lines().should.equal(1000);
-
-    state.trackLines(true, 1);
-    state.lines().should.equal(1000);
-  });
-
-  it('does not allow negative line counts', function() {
-    state.trackLines(true, 10);
-    state.lines().should.equal(10);
-
-    state.trackLines(true, -10);
-    state.lines().should.equal(10);
-  });
-
-  it('Does not record line counts when level progress does not have a line count', function() {
-    sessionStorage.setItem('lines', 50);
-    state.lines().should.equal(50);
-    state.trackLines(true, undefined);
-    state.lines().should.equal(50);
-    state.trackLines(true, Infinity);
-    state.lines().should.equal(50);
-    state.trackLines(true, NaN);
-    state.lines().should.equal(50);
-    state.trackLines(true, '');
-    state.lines().should.equal(50);
-    state.trackLines(true, 50);
-    state.lines().should.equal(100);
-  });
-
-  it('Handled malformed line counts in session storage', function() {
-    sessionStorage.setItem('lines', NaN);
-    state.lines().should.equal(0);
-    state.trackLines(true, 50);
-    state.lines().should.equal(50);
-  });
-});
-
 describe('clientState#queryParams', function() {
   it('parses query params', function() {
     window.history.replaceState('', '', '?foo=1&bar=2');
@@ -198,16 +131,13 @@ describe('clientState#reset', function() {
   it('Resetting client state actually resets everything', function() {
     state.recordCalloutSeen('someCallout');
     state.recordVideoSeen('someVideo');
-    state.trackLines(true, 5);
 
     state.hasSeenCallout('someCallout').should.equal(true);
     state.hasSeenVideo('someVideo').should.equal(true);
-    state.lines().should.equal(5);
 
     state.reset();
 
     state.hasSeenCallout('someCallout').should.equal(false);
     state.hasSeenVideo('someVideo').should.equal(false);
-    state.lines().should.equal(0);
   });
 });

--- a/dashboard/app/controllers/activities_controller.rb
+++ b/dashboard/app/controllers/activities_controller.rb
@@ -213,16 +213,6 @@ class ActivitiesController < ApplicationController
         )
       end
     end
-
-    passed = ActivityConstants.passing?(test_result)
-    if lines > 0 && passed
-      # TODO: The user's total line count is no longer shown anywhere in the UI.
-      # Remove this as part of LP-2291 to clean up the code that stores and
-      # maintains the total line count.
-      current_user.total_lines += lines
-      # bypass validations/transactions/etc
-      User.where(id: current_user.id).update_all(total_lines: current_user.total_lines)
-    end
   end
 
   def track_progress_in_session

--- a/dashboard/test/controllers/activities_controller_test.rb
+++ b/dashboard/test/controllers/activities_controller_test.rb
@@ -57,7 +57,6 @@ class ActivitiesControllerTest < ActionController::TestCase
     @milestone_params = {
       user_id: @user,
       script_level_id: @script_level.id,
-      lines: 20,
       attempt: '1',
       result: 'true',
       testResult: '100',
@@ -107,9 +106,7 @@ class ActivitiesControllerTest < ActionController::TestCase
     @controller.expects :log_milestone
 
     assert_creates(LevelSource, Activity, UserLevel, UserScript) do
-      assert_difference('@user.reload.total_lines', 20) do # update total lines
-        post :milestone, params: @milestone_params
-      end
+      post :milestone, params: @milestone_params
     end
     assert_response :success
 
@@ -227,9 +224,7 @@ class ActivitiesControllerTest < ActionController::TestCase
 
     assert_creates(LevelSource, Activity) do
       assert_does_not_create(UserLevel, UserScript) do
-        assert_difference('@user.reload.total_lines', 20) do # update total lines
-          post :milestone, params: @milestone_params
-        end
+        post :milestone, params: @milestone_params
       end
     end
 
@@ -244,9 +239,7 @@ class ActivitiesControllerTest < ActionController::TestCase
 
     assert_creates(Activity, UserLevel, UserScript) do
       assert_does_not_create(LevelSource) do
-        assert_difference('@user.reload.total_lines', 20) do # update total lines
-          post :milestone, params: @milestone_params.merge(program: "<hey>" * 10000)
-        end
+        post :milestone, params: @milestone_params.merge(program: "<hey>" * 10000)
       end
     end
 
@@ -271,9 +264,7 @@ class ActivitiesControllerTest < ActionController::TestCase
     @controller.expects :log_milestone
 
     assert_creates(Activity, UserLevel, UserScript, LevelSource) do
-      assert_difference('@user.reload.total_lines', 20) do # update total lines
-        post :milestone, params: @milestone_params.merge(program: "<hey>#{panda_panda}</hey>")
-      end
+      post :milestone, params: @milestone_params.merge(program: "<hey>#{panda_panda}</hey>")
     end
 
     assert_response :success
@@ -286,48 +277,6 @@ class ActivitiesControllerTest < ActionController::TestCase
     @controller.send(:milestone_logger).expects(:info).with do |log_string|
       log_string !~ regexp
     end
-  end
-
-  test "logged in milestone does not allow negative lines of code" do
-    expect_controller_logs_milestone_regexp(/-20/)
-
-    assert_creates(LevelSource, Activity, UserLevel, UserScript) do
-      assert_no_difference('@user.reload.total_lines') do # update total lines
-        post :milestone, params: @milestone_params.merge(lines: -20)
-      end
-    end
-
-    # pretend it succeeded
-    assert_response :success
-
-    expected_response = build_expected_response(
-      level_source: "http://test.host/c/#{assigns(:level_source).id}"
-    )
-    assert_equal_expected_keys expected_response, JSON.parse(@response.body)
-
-    # activity does not have unreasonable lines of code either
-    assert_equal 0, Activity.last.lines
-  end
-
-  test "logged in milestone does not allow unreasonably high lines of code" do
-    expect_controller_logs_milestone_regexp(/9999999/)
-
-    assert_creates(LevelSource, Activity, UserLevel, UserScript) do
-      assert_difference('@user.reload.total_lines', 1000) do # update total lines
-        post :milestone, params: @milestone_params.merge(lines: 9_999_999)
-      end
-    end
-
-    # pretend it succeeded
-    assert_response :success
-
-    expected_response = build_expected_response(
-      level_source: "http://test.host/c/#{assigns(:level_source).id}"
-    )
-    assert_equal_expected_keys expected_response, JSON.parse(@response.body)
-
-    # activity does not have unreasonable lines of code either
-    assert_equal 1000, Activity.last.lines
   end
 
   test "logged in milestone with messed up email" do
@@ -343,10 +292,8 @@ class ActivitiesControllerTest < ActionController::TestCase
     @controller.expects :log_milestone
 
     assert_creates(LevelSource, Activity, UserLevel) do
-      assert_no_difference('@user.reload.total_lines') do # don't update total lines
-        post :milestone,
-          params: @milestone_params.merge(result: 'false', testResult: 10)
-      end
+      post :milestone,
+        params: @milestone_params.merge(result: 'false', testResult: 10)
     end
 
     assert_response :success
@@ -358,14 +305,12 @@ class ActivitiesControllerTest < ActionController::TestCase
     @controller.expects :log_milestone
 
     assert_creates(LevelSource, Activity, UserLevel) do
-      assert_no_difference('@user.reload.total_lines') do # don't update total lines
-        post :milestone,
-          params: @milestone_params.merge(
-            result: 'false',
-            testResult: 10,
-            image: Base64.encode64(@good_image)
-          )
-      end
+      post :milestone,
+        params: @milestone_params.merge(
+          result: 'false',
+          testResult: 10,
+          image: Base64.encode64(@good_image)
+        )
     end
 
     # assert_equal @good_image.size, LevelSourceImage.last.image.size
@@ -386,10 +331,8 @@ class ActivitiesControllerTest < ActionController::TestCase
     expected_created_classes = [LevelSource, UserLevel, LevelSourceImage]
 
     assert_creates(*expected_created_classes) do
-      assert_difference('@user.reload.total_lines', 20) do # update total lines
-        post :milestone,
-          params: @milestone_params.merge(image: Base64.encode64(@good_image))
-      end
+      post :milestone,
+        params: @milestone_params.merge(image: Base64.encode64(@good_image))
     end
     assert_equal original_activity_count + 1, Activity.count
     assert_equal original_user_level_count + 1, UserLevel.count
@@ -424,13 +367,11 @@ class ActivitiesControllerTest < ActionController::TestCase
 
     assert_creates(Activity, UserLevel) do
       assert_does_not_create(LevelSource) do
-        assert_difference('@user.reload.total_lines', 20) do # update total lines
-          post :milestone,
-            params: @milestone_params.merge(
-              program: program,
-              image: Base64.encode64(@good_image)
-            )
-        end
+        post :milestone,
+          params: @milestone_params.merge(
+            program: program,
+            image: Base64.encode64(@good_image)
+          )
       end
     end
 
@@ -458,13 +399,11 @@ class ActivitiesControllerTest < ActionController::TestCase
 
     assert_creates(Activity, UserLevel) do
       assert_does_not_create(LevelSource) do
-        assert_difference('@user.reload.total_lines', 20) do # update total lines
-          post :milestone,
-            params: @milestone_params.merge(
-              program: program,
-              image: Base64.encode64(@good_image)
-            )
-        end
+        post :milestone,
+          params: @milestone_params.merge(
+            program: program,
+            image: Base64.encode64(@good_image)
+          )
       end
     end
 
@@ -490,13 +429,11 @@ class ActivitiesControllerTest < ActionController::TestCase
 
     assert_creates(Activity, UserLevel) do
       assert_does_not_create(LevelSource) do
-        assert_difference('@user.reload.total_lines', 20) do # update total lines
-          post :milestone,
-            params: @milestone_params.merge(
-              program: program,
-              image: Base64.encode64(@blank_image)
-            )
-        end
+        post :milestone,
+          params: @milestone_params.merge(
+            program: program,
+            image: Base64.encode64(@blank_image)
+          )
       end
     end
 
@@ -524,13 +461,11 @@ class ActivitiesControllerTest < ActionController::TestCase
 
     assert_creates(Activity, UserLevel) do
       assert_does_not_create(LevelSource) do
-        assert_difference('@user.reload.total_lines', 20) do # update total lines
-          post :milestone,
-            params: @milestone_params.merge(
-              program: program,
-              image: Base64.encode64(@another_good_image)
-            )
-        end
+        post :milestone,
+          params: @milestone_params.merge(
+            program: program,
+            image: Base64.encode64(@another_good_image)
+          )
       end
     end
 
@@ -568,9 +503,7 @@ class ActivitiesControllerTest < ActionController::TestCase
 
     assert_creates(LevelSource, Activity) do
       assert_does_not_create(UserLevel) do
-        assert_difference('@user.reload.total_lines', 20) do # update total lines
-          post :milestone, params: @milestone_params
-        end
+        post :milestone, params: @milestone_params
       end
     end
 


### PR DESCRIPTION
This PR continues the goal of removing total lines of code, without disrupting the messages at the end of levels that state "You just wrote [x] lines of code!". 

This PR does not go through the trouble of removing total_lines from the User table, which may be another follow up task. For now, I'm hoping to remove writes to this table so that we are no longer updating the metric. 

All total lines of code displays have already been removed from the front end, so this is just the back-end work to match (relevant PR linked below).

## Links

A follow up from this pr: https://github.com/code-dot-org/code-dot-org/pull/46934


- spec: []()
- jira ticket: []https://codedotorg.atlassian.net/browse/LP-2291


## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
