### PR TITLE
Add Data docs index page

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -133,7 +133,7 @@
     "html2canvas": "^0.5.0-beta4",
     "http-server": "^0.9.0",
     "immutable": "3.8.1",
-    "isolate-react": "^2.0.0",
+    "isolate-react": "^2.3.0",
     "istanbul-instrumenter-loader": "^3.0.1",
     "jquery": "1.12.1",
     "jquery-ui": "^1.12.1",

--- a/apps/src/sites/studio/pages/data_docs/index.js
+++ b/apps/src/sites/studio/pages/data_docs/index.js
@@ -1,18 +1,12 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import getScriptData from '@cdo/apps/util/getScriptData';
-import {TextLink} from '@dsco_/link';
+import DataDocIndex from '@cdo/apps/templates/dataDocs/DataDocIndex';
 
 $(() => {
   const dataDocs = getScriptData('dataDocs');
   ReactDOM.render(
-    dataDocs.map(({key, name}) =>
-      React.createElement(TextLink, {
-        href: `/data_docs/${key}`,
-        text: name,
-        key: key
-      })
-    ),
+    <DataDocIndex dataDocs={dataDocs} />,
     document.getElementById('see-data-docs')
   );
 });

--- a/apps/src/templates/dataDocs/DataDocIndex.jsx
+++ b/apps/src/templates/dataDocs/DataDocIndex.jsx
@@ -1,16 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {TextLink} from '@dsco_/link';
+import {Link} from '@dsco_/link';
 
 const DataDocIndex = ({dataDocs}) => (
   <>
     <h1 style={{marginBottom: 30}}>Data Docs</h1>
     <ul>
       {dataDocs.map(
-        ({key, name}) =>
-          name && (
+        ({key, name, content}) =>
+          name &&
+          content && (
             <li key={key}>
-              <TextLink href={`/data_docs/${key}`} text={name} />
+              <Link href={`/data_docs/${key}`}>{name}</Link>
             </li>
           )
       )}

--- a/apps/src/templates/dataDocs/DataDocIndex.jsx
+++ b/apps/src/templates/dataDocs/DataDocIndex.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {TextLink} from '@dsco_/link';
+
+const DataDocIndex = ({dataDocs}) => (
+  <>
+    <h1 style={{marginBottom: 30}}>Data Docs</h1>
+    <ul>
+      {dataDocs.map(
+        ({key, name}) =>
+          name && (
+            <li key={key}>
+              <TextLink href={`/data_docs/${key}`} text={name} />
+            </li>
+          )
+      )}
+    </ul>
+  </>
+);
+
+DataDocIndex.propTypes = {
+  dataDocs: PropTypes.arrayOf(
+    PropTypes.shape({
+      key: PropTypes.string,
+      name: PropTypes.string,
+      content: PropTypes.string
+    })
+  )
+};
+
+export default DataDocIndex;

--- a/apps/test/unit/templates/dataDocs/DataDocIndexTest.js
+++ b/apps/test/unit/templates/dataDocs/DataDocIndexTest.js
@@ -7,11 +7,13 @@ describe('DataDocIndex', () => {
   let defaultProps;
   const dataDoc1 = {
     key: 'key1',
-    name: 'First Name'
+    name: 'First Name',
+    content: 'First Content'
   };
   const dataDoc2 = {
     key: 'key2',
-    name: 'Second Name'
+    name: 'Second Name',
+    content: 'Second Content'
   };
   const allDocs = [dataDoc1, dataDoc2];
 
@@ -28,5 +30,29 @@ describe('DataDocIndex', () => {
       expect(links[index]).to.contain(doc.name);
       expect(links[index]).to.contain(`/data_docs/${doc.key}`);
     });
+  });
+
+  it('does not show Doc without a name', () => {
+    const docNoName = {
+      key: 'noName',
+      content: 'Content'
+    };
+    const wrapper = isolateComponentTree(
+      <DataDocIndex dataDocs={[docNoName]} />
+    );
+    const links = wrapper.findAll('a').map(link => link.toString());
+    expect(links).to.have.length(0);
+  });
+
+  it('does not show Doc without content', () => {
+    const docNoName = {
+      key: 'noContent',
+      name: 'Name'
+    };
+    const wrapper = isolateComponentTree(
+      <DataDocIndex dataDocs={[docNoName]} />
+    );
+    const links = wrapper.findAll('a').map(link => link.toString());
+    expect(links).to.have.length(0);
   });
 });

--- a/apps/test/unit/templates/dataDocs/DataDocIndexTest.js
+++ b/apps/test/unit/templates/dataDocs/DataDocIndexTest.js
@@ -4,7 +4,6 @@ import DataDocIndex from '@cdo/apps/templates/dataDocs/DataDocIndex';
 import {expect} from '../../../util/reconfiguredChai';
 
 describe('DataDocIndex', () => {
-  let defaultProps;
   const dataDoc1 = {
     key: 'key1',
     name: 'First Name',
@@ -17,15 +16,13 @@ describe('DataDocIndex', () => {
   };
   const allDocs = [dataDoc1, dataDoc2];
 
-  beforeEach(() => {
-    defaultProps = {
-      dataDocs: allDocs
-    };
-  });
+  const getLinksOnIndexPage = dataDocs => {
+    const wrapper = isolateComponentTree(<DataDocIndex dataDocs={dataDocs} />);
+    return wrapper.findAll('a').map(link => link.toString());
+  };
 
   it('shows names of Data Docs and links to their pages', () => {
-    const wrapper = isolateComponentTree(<DataDocIndex {...defaultProps} />);
-    const links = wrapper.findAll('a').map(link => link.toString());
+    const links = getLinksOnIndexPage(allDocs);
     allDocs.forEach((doc, index) => {
       expect(links[index]).to.contain(doc.name);
       expect(links[index]).to.contain(`/data_docs/${doc.key}`);
@@ -37,22 +34,16 @@ describe('DataDocIndex', () => {
       key: 'noName',
       content: 'Content'
     };
-    const wrapper = isolateComponentTree(
-      <DataDocIndex dataDocs={[docNoName]} />
-    );
-    const links = wrapper.findAll('a').map(link => link.toString());
+    const links = getLinksOnIndexPage([docNoName]);
     expect(links).to.have.length(0);
   });
 
   it('does not show Doc without content', () => {
-    const docNoName = {
+    const docNoContent = {
       key: 'noContent',
       name: 'Name'
     };
-    const wrapper = isolateComponentTree(
-      <DataDocIndex dataDocs={[docNoName]} />
-    );
-    const links = wrapper.findAll('a').map(link => link.toString());
+    const links = getLinksOnIndexPage([docNoContent]);
     expect(links).to.have.length(0);
   });
 });

--- a/apps/test/unit/templates/dataDocs/DataDocIndexTest.js
+++ b/apps/test/unit/templates/dataDocs/DataDocIndexTest.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import {isolateComponentTree} from 'isolate-react';
+import DataDocIndex from '@cdo/apps/templates/dataDocs/DataDocIndex';
+import {expect} from '../../../util/reconfiguredChai';
+
+describe('DataDocIndex', () => {
+  let defaultProps;
+  const dataDoc1 = {
+    key: 'key1',
+    name: 'First Name'
+  };
+  const dataDoc2 = {
+    key: 'key2',
+    name: 'Second Name'
+  };
+  const allDocs = [dataDoc1, dataDoc2];
+
+  beforeEach(() => {
+    defaultProps = {
+      dataDocs: allDocs
+    };
+  });
+
+  it('shows names of Data Docs and links to their pages', () => {
+    const wrapper = isolateComponentTree(<DataDocIndex {...defaultProps} />);
+    const links = wrapper.findAll('a').map(link => link.toString());
+    allDocs.forEach((doc, index) => {
+      expect(links[index]).to.contain(doc.name);
+      expect(links[index]).to.contain(`/data_docs/${doc.key}`);
+    });
+  });
+});

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -2886,6 +2886,15 @@
     "@types/prop-types" "*"
     csstype "^2.2.0"
 
+"@types/react@^18.0.9":
+  version "18.0.21"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.21.tgz#b8209e9626bb00a34c76f55482697edd2b43cc67"
+  integrity sha512-7QUCOxvFgnD5Jk8ZKlUAhVcRj7GuJRjnjjiY/IUBWKgOlnvDvTMLD4RTF7NPyVmbRhNrbomZiOepg7M/2Kj1mA==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
 "@types/scheduler@*":
   version "0.16.2"
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
@@ -10321,10 +10330,12 @@ isobject@^4.0.0:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-4.0.0.tgz#3f1c9155e73b192022a80819bacd0343711697b0"
   integrity sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==
 
-isolate-react@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/isolate-react/-/isolate-react-2.0.0.tgz#4c88cb773baff929c15908f4a9af60c04a2b6826"
-  integrity sha512-quxb6hTC5FyEzoMrh0nwAzmmPwmkUZCgHHPMeIfi1FyhEHxEaJif1coYOKZq2F8sHl0fB7uoT4rpuKdX5poM3g==
+isolate-react@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/isolate-react/-/isolate-react-2.3.0.tgz#f4fc7ff7fbdbd9b884264926692a29aff02f10e4"
+  integrity sha512-xvNPPRQpRfvEGf3BXggQ97TO8Hjh5iVS56b7NWaPIDFwtshZwOh1JkQq3X+7drL6z1BLtNJzkrZAZ9tyn5VKYQ==
+  dependencies:
+    "@types/react" "^18.0.9"
 
 isomorphic-fetch@^2.1.1:
   version "2.2.1"


### PR DESCRIPTION
Builds on https://github.com/code-dot-org/code-dot-org/pull/48281 by finishing the student/teacher-facing Data Docs index page:

<img width="899" alt="Screen Shot 2022-09-26 at 2 02 35 PM" src="https://user-images.githubusercontent.com/9142121/192391745-38cd77e3-1089-4cab-b618-02446ce01461.png">


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--

- spec: []()
- jira ticket: []()
-->

## Testing story

I'm not sure I love these unit tests –– they rely heavily on the implementation

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
