### PR TITLE
Fix Violations of and Reenable Performance/RegexpMatch

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -219,11 +219,6 @@ Performance/InefficientHashSearch:
 Performance/MethodObjectAsBlock:
   Enabled: false
 
-# Offense count: 56
-# This cop supports safe auto-correction (--auto-correct).
-Performance/RegexpMatch:
-  Enabled: false
-
 # Offense count: 29
 # This cop supports safe auto-correction (--auto-correct).
 Performance/StringInclude:

--- a/bin/content-push
+++ b/bin/content-push
@@ -42,7 +42,7 @@ end
 
 def disallow_state_pdf
   `git status --porcelain --untracked-files=all #{CONTENT_PATHS}`.split("\n").each do |line|
-    next unless %r{pegasus/sites.v3/code.org/public/advocacy/state-facts/..\.pdf$} =~ line
+    next unless %r{pegasus/sites.v3/code.org/public/advocacy/state-facts/..\.pdf$}.match?(line)
     STDERR.puts "\nAborting because state pdf generation appears to be in progress:\n\n    #{line}\n\n"
     STDERR.puts "Please wait 10 minutes and then try again.\n\n"
     `git reset HEAD`

--- a/bin/cron/detect_restricted_videos
+++ b/bin/cron/detect_restricted_videos
@@ -54,7 +54,7 @@ CSV.foreach(dashboard_dir('config/videos.csv'), headers: true) do |row|
 
   # Skip checking this video if it doesn't match a provided filter
   if options[:filter]
-    next unless Regexp.new(options[:filter]) =~ video_key
+    next unless Regexp.new(options[:filter])&.match?(video_key)
   end
 
   # Check both Strict and Moderate restricted mode for each video

--- a/bin/cron/process_forms
+++ b/bin/cron/process_forms
@@ -33,7 +33,7 @@ def send_receipts(kind, form)
   begin
     recipient = Poste2.create_recipient(form[:email], name: form[:name], ip_address: form[:updated_ip])
   rescue ArgumentError => e
-    raise e unless e.message =~ /Invalid email address/
+    raise e unless /Invalid email address/.match?(e.message)
     ChatClient.log "Unable to send receipt for form #{form[:id]} because #{e.message}."
     return 0
   end

--- a/bin/i18n/sync-in.rb
+++ b/bin/i18n/sync-in.rb
@@ -252,7 +252,7 @@ def get_placeholder_texts(document, block_type, title_names)
 
       # Skip empty or untranslatable string.
       # A translatable string must have at least 3 consecutive alphabetic characters.
-      next unless title&.content =~ /[a-zA-Z]{3,}/
+      next unless /[a-zA-Z]{3,}/.match?(title&.content)
 
       # Use only alphanumeric characters in lower cases as string key
       text_key = Digest::MD5.hexdigest title.content

--- a/bin/oneoff/census/ap-data/upload-ap-offering-data.rb
+++ b/bin/oneoff/census/ap-data/upload-ap-offering-data.rb
@@ -32,7 +32,7 @@ end.parse!
 missing_args = [:filename, :course, :school_year].select {|arg| options[arg].nil?}
 raise OptionParser::MissingArgument.new(missing_args.join(', ')) unless missing_args.empty?
 raise OptionParser::InvalidOption.new("Course must be one of #{ap_courses.join(' or ')}") unless ap_courses.include? options[:course]
-raise OptionParser::InvalidOption.new("School year must be four digits") unless options[:school_year] =~ /^\d{4}$/
+raise OptionParser::InvalidOption.new("School year must be four digits") unless /^\d{4}$/.match?(options[:school_year])
 
 bucket_name = Census::ApCsOffering::CENSUS_BUCKET_NAME
 object_key = Census::ApCsOffering.construct_object_key(options[:course], options[:school_year].to_i)

--- a/bin/oneoff/census/ib-data/upload-ib-offering-data.rb
+++ b/bin/oneoff/census/ib-data/upload-ib-offering-data.rb
@@ -25,7 +25,7 @@ end.parse!
 
 missing_args = [:filename, :school_year].select {|arg| options[arg].nil?}
 raise OptionParser::MissingArgument.new(missing_args.join(', ')) unless missing_args.empty?
-raise OptionParser::InvalidOption.new("School year must be four digits") unless options[:school_year] =~ /^\d{4}$/
+raise OptionParser::InvalidOption.new("School year must be four digits") unless /^\d{4}$/.match?(options[:school_year])
 
 bucket_name = Census::IbCsOffering::CENSUS_BUCKET_NAME
 object_key = Census::IbCsOffering.construct_object_key(options[:school_year].to_i)

--- a/bin/oneoff/census/state-data/reseed-state-data.rb
+++ b/bin/oneoff/census/state-data/reseed-state-data.rb
@@ -26,7 +26,7 @@ end.parse!
 missing_args = [:state, :school_year].select {|arg| options[arg].nil?}
 raise OptionParser::MissingArgument.new(missing_args.join(', ')) unless missing_args.empty?
 raise OptionParser::InvalidOption.new("State code must be a two-character US state code") unless us_state_abbr?(options[:state], true)
-raise OptionParser::InvalidOption.new("School year must be four digits") unless options[:school_year] =~ /^\d{4}$/
+raise OptionParser::InvalidOption.new("School year must be four digits") unless /^\d{4}$/.match?(options[:school_year])
 
 state_code = options[:state].upcase
 school_year = options[:school_year].to_i

--- a/bin/oneoff/census/state-data/upload-state-data.rb
+++ b/bin/oneoff/census/state-data/upload-state-data.rb
@@ -30,7 +30,7 @@ end.parse!
 missing_args = [:filename, :state, :school_year].select {|arg| options[arg].nil?}
 raise OptionParser::MissingArgument.new(missing_args.join(', ')) unless missing_args.empty?
 raise OptionParser::InvalidOption.new("State code must be a two-character US state code") unless us_state_abbr?(options[:state], true)
-raise OptionParser::InvalidOption.new("School year must be four digits") unless options[:school_year] =~ /^\d{4}$/
+raise OptionParser::InvalidOption.new("School year must be four digits") unless /^\d{4}$/.match?(options[:school_year])
 
 bucket_name = Census::StateCsOffering::CENSUS_BUCKET_NAME
 object_key = Census::StateCsOffering.construct_object_key(options[:state].upcase, options[:school_year].to_i)

--- a/bin/oneoff/rename-projecturl-to-level
+++ b/bin/oneoff/rename-projecturl-to-level
@@ -9,7 +9,7 @@ STORAGE_APPS = PEGASUS_DB[:storage_apps]
 def main
   STORAGE_APPS.where {updated_at > '2015-06-23'}.each do |row|
     val = row[:value]
-    if /"projectUrl":/ =~ val
+    if /"projectUrl":/.match?(val)
       STORAGE_APPS.where(id: row[:id]).update(value: val.sub('"projectUrl":', '"level":'))
     end
   end

--- a/cookbooks/cdo-users/recipes/default.rb
+++ b/cookbooks/cdo-users/recipes/default.rb
@@ -113,7 +113,7 @@ node['cdo-users'].each_pair do |user_name, user_data|
       # SSH requires that hostnames consist of zero or more non-whitespace
       # characters, with optional wildcards:
       # http://man.openbsd.org/OpenBSD-current/man5/ssh_config.5#PATTERNS
-      next unless name.value =~ /^\S*$/
+      next unless /^\S*$/.match?(name.value)
 
       hosts[name.value] = instance.private_dns_name
     end

--- a/dashboard/app/controllers/admin_users_controller.rb
+++ b/dashboard/app/controllers/admin_users_controller.rb
@@ -204,7 +204,7 @@ class AdminUsersController < ApplicationController
     search_term = params[:search_term]
     permission = params[:permission]
     if search_term.present?
-      if search_term =~ /^\d+$/
+      if /^\d+$/.match?(search_term)
         @user = restricted_users.find_by(id: search_term)
       else
         users = restricted_users.where(hashed_email: User.hash_email(search_term)).or(restricted_users.where(username: search_term))

--- a/dashboard/app/controllers/pd/workshop_user_management_controller.rb
+++ b/dashboard/app/controllers/pd/workshop_user_management_controller.rb
@@ -17,7 +17,7 @@ class Pd::WorkshopUserManagementController < ApplicationController
   # get /pd/workshop_user_management/facilitator_courses
   def facilitator_courses_form
     search_term = params[:search_term]
-    if search_term =~ /^\d+$/
+    if /^\d+$/.match?(search_term)
       @user = restricted_users.find_by(id: search_term)
     elsif search_term
       @user = restricted_users.find_by(hashed_email: restricted_users.hash_email(search_term))

--- a/dashboard/app/controllers/regional_partners_controller.rb
+++ b/dashboard/app/controllers/regional_partners_controller.rb
@@ -16,7 +16,7 @@ class RegionalPartnersController < ApplicationController
   # GET /regional_partners
   def index
     search_term = params[:search_term]
-    if search_term =~ /^\d+$/
+    if /^\d+$/.match?(search_term)
       @regional_partners = RegionalPartner.where(id: search_term)
     elsif search_term
       @regional_partners = RegionalPartner.where("name LIKE :partial_name", {partial_name: "%#{search_term}%"})

--- a/dashboard/app/controllers/sms_controller.rb
+++ b/dashboard/app/controllers/sms_controller.rb
@@ -40,10 +40,10 @@ class SmsController < ApplicationController
     )
     head :ok
   rescue Twilio::REST::RestError => e
-    if e.message =~ /The message From\/To pair violates a blacklist rule./
+    if /The message From\/To pair violates a blacklist rule./.match?(e.message)
       # recipient unsubscribed from twilio, pretend it succeeded
       head :ok
-    elsif e.message =~ /The \'To\' number .* is not a valid phone number\./
+    elsif /The \'To\' number .* is not a valid phone number\./.match?(e.message)
       head :bad_request
     else
       raise

--- a/dashboard/app/models/concerns/serialized_properties.rb
+++ b/dashboard/app/models/concerns/serialized_properties.rb
@@ -88,7 +88,7 @@ module SerializedProperties
     def init_internals
       sti_hierarchy.map {|x| serialized_properties[x.to_s] || []}.flatten.each do |property|
         property = property.to_s
-        if property =~ ENCRYPTED_PROPERTY_REGEX
+        if ENCRYPTED_PROPERTY_REGEX.match?(property)
           define_methods_for_encrypted_property property
         else
           define_methods_for_property property

--- a/dashboard/app/models/plc/user_course_enrollment.rb
+++ b/dashboard/app/models/plc/user_course_enrollment.rb
@@ -41,7 +41,7 @@ class Plc::UserCourseEnrollment < ApplicationRecord
     other_failure_errors = []
 
     user_keys.each do |user_key|
-      user = user_key =~ /^\d+$/ ? User.find(user_key) : User.find_by_email_or_hashed_email(user_key)
+      user = /^\d+$/.match?(user_key) ? User.find(user_key) : User.find_by_email_or_hashed_email(user_key)
 
       email = user.try(:email)
 

--- a/dashboard/config/initializers/backtrace_silencers.rb
+++ b/dashboard/config/initializers/backtrace_silencers.rb
@@ -14,7 +14,7 @@ silenced = [
 silenced_expr = Regexp.new(silenced.join('|'))
 
 ActiveSupport::Deprecation.behavior = lambda do |message, callstack, deprecation_horizon, gem_name|
-  unless message =~ silenced_expr
+  unless message&.match?(silenced_expr)
     ActiveSupport::Deprecation::DEFAULT_BEHAVIORS[:stderr].call(message, callstack, deprecation_horizon, gem_name)
   end
 end

--- a/dashboard/lib/mega_section.rb
+++ b/dashboard/lib/mega_section.rb
@@ -65,7 +65,7 @@ class MegaSection
       user.sections.each do |section|
         # Hard-delete all students in each section.
         section.students.each do |student_user|
-          raise "Not a sample student - #{student_user.name}" unless student_user.name =~ SAMPLE_STUDENT_NAME_REGEX
+          raise "Not a sample student - #{student_user.name}" unless SAMPLE_STUDENT_NAME_REGEX.match?(student_user.name)
           environment_check!
           UserGeo.where(user_id: student_user.id).destroy_all
           student_user.really_destroy!

--- a/dashboard/lib/sample_data.rb
+++ b/dashboard/lib/sample_data.rb
@@ -85,7 +85,7 @@ class SampleData
       user.sections.each do |section|
         # Hard-delete all students in each section.
         section.students.each do |student_user|
-          raise "Not a sample student - #{student_user.name}" unless student_user.name =~ SAMPLE_STUDENT_NAME_REGEX
+          raise "Not a sample student - #{student_user.name}" unless SAMPLE_STUDENT_NAME_REGEX.match?(student_user.name)
           environment_check!
           UserGeo.where(user_id: student_user.id).destroy_all
           student_user.really_destroy!

--- a/dashboard/lib/services/afe_enrollment.rb
+++ b/dashboard/lib/services/afe_enrollment.rb
@@ -63,7 +63,7 @@ class Services::AFEEnrollment
     )
 
     raise Error.new("AFE submission failed with HTTP #{response.code}") unless response.code == '200'
-    raise Error.new("AFE submission failed with a validation error") if response.body =~ /Cannot find error page/
+    raise Error.new("AFE submission failed with a validation error") if /Cannot find error page/.match?(response.body)
     submission_body
   end
 

--- a/dashboard/lib/single_sign_on.rb
+++ b/dashboard/lib/single_sign_on.rb
@@ -35,7 +35,7 @@ class SingleSignOn
     parsed = Rack::Utils.parse_query(payload)
     if sso.sign(parsed["sso"]) != parsed["sig"]
       diags = "\n\nsso: #{parsed['sso']}\n\nsig: #{parsed['sig']}\n\nexpected sig: #{sso.sign(parsed['sso'])}"
-      if parsed["sso"] =~ /[^a-zA-Z0-9=\r\n\/+]/m
+      if /[^a-zA-Z0-9=\r\n\/+]/m.match?(parsed["sso"])
         raise "The SSO field should be Base64 encoded, using only A-Z, a-z, 0-9, +, /, and = characters. Your input contains characters we don't understand as Base64, see http://en.wikipedia.org/wiki/Base64 #{diags}"
       else
         raise "Bad signature for payload #{diags}"

--- a/dashboard/scripts/smoke
+++ b/dashboard/scripts/smoke
@@ -33,7 +33,7 @@ end
 #
 
 @host = ARGV.shift || "localhost:3000"
-@host = "http://#{@host}" if @host !~ /^http:\/\//
+@host = "http://#{@host}" unless /^http:\/\//.match?(@host)
 @host = @host.gsub(/\/$/, "")
 
 thread_count = [ARGV.shift.to_i, 1].max
@@ -73,7 +73,7 @@ def run_tests(options = {})
         raise "Redirect error. Expecting #{test[:redirect]}, got #{location_uri.path}- #{" - #{test[:failure_message]}" if test[:failure_message]}" if location_uri.path != test[:redirect]
       end
     rescue Exception => e
-      exit 1 if e.inspect =~ /Interrupt/
+      exit 1 if /Interrupt/.match?(e.inspect)
       if options[:quiet]
         puts "#{url} ... #{e}"
       else

--- a/dashboard/test/ui/runner.rb
+++ b/dashboard/test/ui/runner.rb
@@ -242,11 +242,11 @@ def parse_options
       options.pegasus_db_access = true
       options.dashboard_db_access = true
     elsif rack_env?(:development)
-      options.pegasus_db_access = true if options.pegasus_domain =~ /(localhost|ngrok)/
-      options.dashboard_db_access = true if options.dashboard_domain =~ /(localhost|ngrok)/
+      options.pegasus_db_access = true if /(localhost|ngrok)/.match?(options.pegasus_domain)
+      options.dashboard_db_access = true if /(localhost|ngrok)/.match?(options.dashboard_domain)
     elsif rack_env?(:test)
-      options.pegasus_db_access = true if options.pegasus_domain =~ /test/
-      options.dashboard_db_access = true if options.dashboard_domain =~ /test/
+      options.pegasus_db_access = true if /test/.match?(options.pegasus_domain)
+      options.dashboard_db_access = true if /test/.match?(options.dashboard_domain)
     end
 
     if options.config

--- a/lib/cdo/contact_rollups/v2/pardot.rb
+++ b/lib/cdo/contact_rollups/v2/pardot.rb
@@ -262,7 +262,7 @@ class PardotV2
   rescue StandardError => e
     # If the input pardot_id does not exist, Pardot will response with
     # HTTP code 400 and error code 3 "Invalid prospect ID" in the body.
-    return false if e.message =~ /Pardot request failed with HTTP 400/
+    return false if /Pardot request failed with HTTP 400/.match?(e.message)
     raise e
   end
 
@@ -275,7 +275,7 @@ class PardotV2
   rescue StandardError => e
     # If the input email does not exist, Pardot will response with
     # HTTP code 400, and error code 4 "Invalid prospect email address" in the body.
-    return [] if e.message =~ /Pardot request failed with HTTP 400/
+    return [] if /Pardot request failed with HTTP 400/.match?(e.message)
     raise e
   end
 

--- a/lib/cdo/eyes_utils.rb
+++ b/lib/cdo/eyes_utils.rb
@@ -17,7 +17,7 @@ module EyesUtils
 
   def self.ensure_merge_util
     java_version_output = `java -version 2>&1`
-    raise "Applitools merge util requires Java 1.8 #{Emoji.find_by_alias('sweat_smile').raw}" unless java_version_output =~ /version "1\.8/
+    raise "Applitools merge util requires Java 1.8 #{Emoji.find_by_alias('sweat_smile').raw}" unless /version "1\.8/.match?(java_version_output)
     unless File.exist? MERGE_UTIL_PATH
       Kernel.system("wget #{REMOTE_JAR_SOURCE} -O #{MERGE_UTIL_PATH}")
     end

--- a/lib/cdo/geocoder.rb
+++ b/lib/cdo/geocoder.rb
@@ -75,7 +75,7 @@ module Geocoder
 
       def mapbox_context(name)
         context.map do |c|
-          c if c['id'] =~ Regexp.new(name)
+          c if c['id']&.match?(Regexp.new(name))
         end&.compact&.first
       end
     end

--- a/lib/cdo/github.rb
+++ b/lib/cdo/github.rb
@@ -246,7 +246,7 @@ module GitHub
   def self.open_url(url)
     raise "GitHub.open_url called on non-dev environment" unless rack_env?(:development)
     # Based on http://stackoverflow.com/a/14053693/5000129
-    if RbConfig::CONFIG['host_os'] =~ /linux|bsd/
+    if /linux|bsd/.match?(RbConfig::CONFIG['host_os'])
       system "sensible-browser \"#{url}\""
     else
       system "open \"#{url}\""

--- a/lib/cdo/infra_test_topic.rb
+++ b/lib/cdo/infra_test_topic.rb
@@ -21,7 +21,7 @@ module InfraTestTopic
   #   topic (if one exists) or nil.
   def self.green_commit
     current_topic = Slack.get_topic('infra-test')
-    return nil unless current_topic =~ /:greenbeer:/
+    return nil unless /:greenbeer:/.match?(current_topic)
     current_topic[0..7]
   end
 

--- a/lib/cdo/parse_email_address_string.rb
+++ b/lib/cdo/parse_email_address_string.rb
@@ -16,7 +16,7 @@ def parse_email_address_string(string)
   # The regular expression itself matches commas unless they are surrounded
   # by a pair of double-quotes, and is adapted from
   # https://stackoverflow.com/a/18893443.
-  if /,(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)/ =~ string
+  if /,(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)/.match?(string)
     Honeybadger.notify(
       error_message: "Comma outside of surrounding double-quotes detected in address string: #{string}"
     )

--- a/lib/cdo/pegasus/string.rb
+++ b/lib/cdo/pegasus/string.rb
@@ -15,7 +15,7 @@ class String
   # Converts a string to a boolean
   unless method_defined?(:to_bool) # May be provided by Rails
     def to_bool
-      return true if self =~ (/^(true|t|yes|y|1)$/i)
+      return true if self&.match?((/^(true|t|yes|y|1)$/i))
       return false if empty? || self =~ (/^(false|f|no|n|0)$/i)
       raise ArgumentError.new("'#{self}' is not convertable to true/false.")
     end

--- a/lib/cdo/poste.rb
+++ b/lib/cdo/poste.rb
@@ -320,7 +320,7 @@ class Deliverer
     name = address[:name].to_s.strip
     return email if name.empty?
 
-    name = "\"#{name.tr('"', '\"').tr("'", "\'")}\"" if name =~ /[;,\"\'\(\)]/
+    name = "\"#{name.tr('"', '\"').tr("'", "\'")}\"" if /[;,\"\'\(\)]/.match?(name)
     "#{name} <#{email}>".strip
   end
 

--- a/lib/cdo/profanity_filter.rb
+++ b/lib/cdo/profanity_filter.rb
@@ -49,7 +49,7 @@ class ProfanityFilter
     LANGUAGE_SPECIFIC_ALLOWLIST.each do |word, languages|
       next if languages.include? language_code
       r = Regexp.new "\\b#{word}\\b", Regexp::IGNORECASE
-      return [word.to_s] if r =~ updated_text
+      return [word.to_s] if r&.match?(updated_text)
     end
     WebPurify.find_potential_profanities(updated_text, ['en', language_code])
   end

--- a/lib/cdo/rack/locale.rb
+++ b/lib/cdo/rack/locale.rb
@@ -30,7 +30,7 @@ module Rack
       return if accept_langs.nil?
 
       languages_and_qvalues = accept_langs.split(",").map do |l|
-        l += ';q=1.0' unless l =~ /;q=\d+(?:\.\d+)?$/
+        l += ';q=1.0' unless /;q=\d+(?:\.\d+)?$/.match?(l)
         l.split(';q=')
       end
 

--- a/lib/cdo/rack/optimize.rb
+++ b/lib/cdo/rack/optimize.rb
@@ -63,7 +63,7 @@ module Rack
       return false unless Gatekeeper.allows('optimize', default: true)
 
       # Skip no-transform or uncacheable responses.
-      return false if headers['Cache-Control'].to_s =~ /\b(no-transform|private|no-store|max-age=0)\b/
+      return false if /\b(no-transform|private|no-store|max-age=0)\b/.match?(headers['Cache-Control'].to_s)
 
       true
     end

--- a/lib/cdo/slack.rb
+++ b/lib/cdo/slack.rb
@@ -202,7 +202,7 @@ class Slack
   private_class_method def self.slackify(message)
     message_copy = message.dup
     message_copy.strip!
-    message_copy = "```#{message_copy[7..-1]}```" if message_copy =~ /^\/quote /
+    message_copy = "```#{message_copy[7..-1]}```" if /^\/quote /.match?(message_copy)
     message_copy.
       gsub(/<\/?i>/, '_').
       gsub(/<\/?b>/, '*').

--- a/lib/cdo/video/youtube.rb
+++ b/lib/cdo/video/youtube.rb
@@ -19,7 +19,7 @@ class Youtube
   # When downloading from YouTube, an HTTP head request will first check the absence of the file.
   # If `force`==true, the head request will be skipped.
   def self.process(id, filename=nil, force=false)
-    raise 'Invalid YouTube ID' unless id =~ /^#{Video::YOUTUBE_ID_REGEX}$/o
+    raise 'Invalid YouTube ID' unless /^#{Video::YOUTUBE_ID_REGEX}$/o.match?(id)
     if filename.nil? && !force
       thumbnail_url = "https:#{CDO.videos_url}/youtube/#{id}.jpg"
       response = HTTParty.head(thumbnail_url).response

--- a/pegasus/forms/class_submission.rb
+++ b/pegasus/forms/class_submission.rb
@@ -7,7 +7,7 @@ class ClassSubmission < Form
     # Class fields
     result[:class_description_s] = required stripped data[:class_description_s]
     result[:class_format_s] = required downcased stripped data[:class_format_s]
-    result[:class_format_other_s] = required stripped data[:class_format_other_s] if result[:class_format_s] =~ /_other$/
+    result[:class_format_other_s] = required stripped data[:class_format_other_s] if /_other$/.match?(result[:class_format_s])
     result[:class_languages_ss] = required stripped data[:class_languages_ss]
     if result[:class_languages_ss].class != FieldError && result[:class_languages_ss].include?('Other')
       result[:class_languages_other_ss] = required stripped csv_multivalue data[:class_languages_other_ss]
@@ -15,7 +15,7 @@ class ClassSubmission < Form
 
     # School fields
     result[:school_name_s] = required stripped data[:school_name_s]
-    result[:school_address_s] = result[:class_format_s] =~ /^online_/ ? nil_if_empty(stripped(data[:school_address_s])) : required(stripped(data[:school_address_s]))
+    result[:school_address_s] = /^online_/.match?(result[:class_format_s]) ? nil_if_empty(stripped(data[:school_address_s])) : required(stripped(data[:school_address_s]))
     result[:school_website_s] = required stripped data[:school_website_s]
     result[:school_level_ss] = required downcased stripped data[:school_level_ss]
     result[:school_gender_s] = required enum(data[:school_gender_s].to_s.strip.downcase, ['both', 'girls', 'boys'])
@@ -160,7 +160,7 @@ class ClassSubmission < Form
 
     ['in_school', 'out_of_school', 'online'].each do |prefix|
       class_format = data['class_format_s']
-      if class_format =~ /^#{prefix}_/
+      if /^#{prefix}_/.match?(class_format)
         new_data['class_format_category_s'] = prefix
         new_data['class_format_subcategory_s'] = class_format.sub(/^#{prefix}_/, '')
       end

--- a/pegasus/forms/petition.rb
+++ b/pegasus/forms/petition.rb
@@ -57,7 +57,7 @@ class Petition < Form
   def self.get_location(zip_code_or_country)
     # Note that, empirically, we see non-US zip codes so we check for
     # numerality and length.
-    unless /^\d{5}$/ =~ zip_code_or_country
+    unless /^\d{5}$/.match?(zip_code_or_country)
       return {country_s: zip_code_or_country}
     end
 

--- a/pegasus/rake/i18n.rake
+++ b/pegasus/rake/i18n.rake
@@ -9,7 +9,7 @@ require 'cdo/google/drive'
 def format_enus_yml_with_quotes(line)
   match_data = /^ +[a-zA-Z0-9_ ]+?: *(.+)$/.match(line)
   if match_data # formats the values
-    unless /^(".*"|'.*'|\|.*)$/ =~ match_data[1]
+    unless /^(".*"|'.*'|\|.*)$/.match?(match_data[1])
       line.gsub!(/"/, '\\"')
       line.gsub!(/^([ a-zA-Z0-9_]+?): *(.*)$/, '\1: "\2"')
     end

--- a/pegasus/routes/hourofcode_routes.rb
+++ b/pegasus/routes/hourofcode_routes.rb
@@ -1,5 +1,5 @@
 get '/' do
-  pass unless request.user_agent =~ /^facebookexternalhit\/1\.1/
+  pass unless /^facebookexternalhit\/1\.1/.match?(request.user_agent)
   dont_cache
   env['PATH_INFO'] = '/us'
   pass

--- a/pegasus/src/curriculum_router.rb
+++ b/pegasus/src/curriculum_router.rb
@@ -238,7 +238,7 @@ module Pegasus
     end
 
     after do
-      response.headers.keys.each {|i| response.headers.delete(i) if i =~ /^X-Pegasus-/;}
+      response.headers.keys.each {|i| response.headers.delete(i) if /^X-Pegasus-/.match?(i);}
 
       status = response.status.to_s.to_i
       message = "#{status} returned for #{request.site}#{request.path_info}"

--- a/tools/scripts/autorun_generateSoundMetadata.rb
+++ b/tools/scripts/autorun_generateSoundMetadata.rb
@@ -42,7 +42,7 @@ class NewSoundAliasesMetadataBuilder
     Dir[folder_path + "/*.mp3"].each do |f|
       filename = File.basename(f, File.extname(f))
 
-      if filename =~ CORRUPTED_FILENAME_REGEX
+      if CORRUPTED_FILENAME_REGEX.match?(filename)
         fixed_name = fix_corrupted_filename(filename)
         File.rename(f, folder_path + "/" + fixed_name + File.extname(f))
         f.gsub!(f.split('/')[-1], "#{fixed_name}.mp3")
@@ -89,12 +89,12 @@ class NewSoundAliasesMetadataBuilder
       Dir[folder_path + "/mp3_files/*"].each do |file_path|
         regex = /^#{name}$/
 
-        if file_path.split('/')[-1].downcase =~ CORRUPTED_FILENAME_REGEX
+        if CORRUPTED_FILENAME_REGEX.match?(file_path.split('/')[-1].downcase)
           raise "#{file_path.split('/')[-1].downcase} is corrupted with space/multiple underscores"
         end
 
         next unless file_path.split('/')[-1].downcase.match(regex)
-        raise "Aliase is corrupted with space/multiple commas/spaces/uppercase/dots: #{aliases}" if aliases =~ /(,{2,}|\s|[A-Z]|[.])/
+        raise "Aliase is corrupted with space/multiple commas/spaces/uppercase/dots: #{aliases}" if /(,{2,}|\s|[A-Z]|[.])/.match?(aliases)
         aliases << ",category_#{file_path.split('/')[-3].downcase},noResale"
         puts `./generateSoundMetadata.rb --aliases "#{aliases}" "#{file_path}"`
       end


### PR DESCRIPTION
[This rule](https://docs.rubocop.org/rubocop-performance/cops_performance.html#performanceregexpmatch) encourages the use of the new-in-Ruby-2.4 `match?` methods, since they're more efficient than other comparisons.

Applied automatically with `bundle exec rubocop --auto-correct --only Performance/RegexpMatch`

## Links

- https://github.com/fastruby/fast-ruby#regexp-vs-stringmatch-vs-string-vs-stringmatch-code-

## Testing story

Relying on existing unit tests.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
