### PR TITLE
Truncate code review tables in test

### DIFF
--- a/shared/test/common_test_helper.rb
+++ b/shared/test/common_test_helper.rb
@@ -39,7 +39,7 @@ VCR.configure do |c|
 end
 
 # Truncate database tables to ensure repeatable tests.
-DASHBOARD_TEST_TABLES = %w(channel_tokens user_project_storage_ids projects project_commits).freeze
+DASHBOARD_TEST_TABLES = %w(channel_tokens user_project_storage_ids projects project_commits code_review_comments code_reviews).freeze
 DASHBOARD_TEST_TABLES.each do |table|
   DASHBOARD_DB[table.to_sym].truncate
 end.freeze


### PR DESCRIPTION
We need to do this to prevent potential eyes test failures/flakiness. We did this for [v1 of code review](https://github.com/code-dot-org/code-dot-org/pull/46469), redoing for v2 now that the tables have been renamed.

## Links

- jira ticket: [SL-271](https://codedotorg.atlassian.net/browse/SL-271)
