### PR TITLE
Refactor `sync-down` to consolidate change fetching and downloading

### DIFF
--- a/bin/i18n/sync-down.rb
+++ b/bin/i18n/sync-down.rb
@@ -16,21 +16,13 @@ def with_elapsed
   return Time.at(after - before).utc.strftime('%H:%M:%S')
 end
 
-# dj = Crowdin::Project.new('codeorg', '923a2787d4381052eefa42f769a16192')
-# dj = Crowdin::Project.new('codeorg', '57cc0e4a80c4db5e983106a1fa0ea63e2bb9fc1198fa39c3cd41348c268304fc900e3512b1eaf0b1')
-
-# pj = Crowdin::Client.new do |config|
-#   config.api_token = '57cc0e4a80c4db5e983106a1fa0ea63e2bb9fc1198fa39c3cd41348c268304fc900e3512b1eaf0b1'
-#   config.project_id = '26074'
-# end
-
 def sync_down
   I18nScriptUtils.with_synchronous_stdout do
     puts "Sync down starting"
     logger = Logger.new(STDOUT)
     logger.level = Logger::INFO
 
-    CROWDIN_TEST_PROJECTS.each do |name, options|
+    CROWDIN_PROJECTS.each do |name, options|
       puts "Downloading translations from #{name} project"
       api_token = YAML.load_file(options[:identity_file])["api_token"]
       project_identifier = YAML.load_file(options[:config_file])["project_identifier"]
@@ -53,9 +45,6 @@ def sync_down
 
       utils = Crowdin::LegacyUtils.new(project, options)
 
-      # puts "Fetching list of changed files"
-      # elapsed = with_elapsed {utils.fetch_changes}
-      # puts "Changes fetched in #{elapsed}"
       puts "Downloading changed files"
       elapsed = with_elapsed {utils.download_changed_files}
       puts "Files downloaded in #{elapsed}"

--- a/bin/i18n/sync-down.rb
+++ b/bin/i18n/sync-down.rb
@@ -16,13 +16,21 @@ def with_elapsed
   return Time.at(after - before).utc.strftime('%H:%M:%S')
 end
 
+# dj = Crowdin::Project.new('codeorg', '923a2787d4381052eefa42f769a16192')
+# dj = Crowdin::Project.new('codeorg', '57cc0e4a80c4db5e983106a1fa0ea63e2bb9fc1198fa39c3cd41348c268304fc900e3512b1eaf0b1')
+
+# pj = Crowdin::Client.new do |config|
+#   config.api_token = '57cc0e4a80c4db5e983106a1fa0ea63e2bb9fc1198fa39c3cd41348c268304fc900e3512b1eaf0b1'
+#   config.project_id = '26074'
+# end
+
 def sync_down
   I18nScriptUtils.with_synchronous_stdout do
     puts "Sync down starting"
     logger = Logger.new(STDOUT)
     logger.level = Logger::INFO
 
-    CROWDIN_PROJECTS.each do |name, options|
+    CROWDIN_TEST_PROJECTS.each do |name, options|
       puts "Downloading translations from #{name} project"
       api_token = YAML.load_file(options[:identity_file])["api_token"]
       project_identifier = YAML.load_file(options[:config_file])["project_identifier"]
@@ -45,9 +53,9 @@ def sync_down
 
       utils = Crowdin::LegacyUtils.new(project, options)
 
-      puts "Fetching list of changed files"
-      elapsed = with_elapsed {utils.fetch_changes}
-      puts "Changes fetched in #{elapsed}"
+      # puts "Fetching list of changed files"
+      # elapsed = with_elapsed {utils.fetch_changes}
+      # puts "Changes fetched in #{elapsed}"
       puts "Downloading changed files"
       elapsed = with_elapsed {utils.download_changed_files}
       puts "Files downloaded in #{elapsed}"

--- a/lib/cdo/crowdin/client_extentions.rb
+++ b/lib/cdo/crowdin/client_extentions.rb
@@ -157,6 +157,12 @@ module Crowdin
     end
   end
 
+  class CrowdinInternalServerError < StandardError
+  end
+
+  class CrowdinServiceUnavailableError < StandardError
+  end
+
   class Client
     include ClientExtensions
   end

--- a/lib/cdo/crowdin/client_extentions.rb
+++ b/lib/cdo/crowdin/client_extentions.rb
@@ -158,9 +158,15 @@ module Crowdin
   end
 
   class CrowdinInternalServerError < StandardError
+    def initialize(msg="Internal Server Error")
+      super
+    end
   end
 
   class CrowdinServiceUnavailableError < StandardError
+    def initialize(msg="Service Unavailable")
+      super
+    end
   end
 
   class Client

--- a/lib/cdo/crowdin/client_extentions.rb
+++ b/lib/cdo/crowdin/client_extentions.rb
@@ -157,6 +157,12 @@ module Crowdin
     end
   end
 
+  class CrowdinRateLimitError < StandardError
+    def initialize(msg="Rate Limit Error")
+      super
+    end
+  end
+
   class CrowdinInternalServerError < StandardError
     def initialize(msg="Internal Server Error")
       super

--- a/lib/cdo/crowdin/legacy_utils.rb
+++ b/lib/cdo/crowdin/legacy_utils.rb
@@ -108,7 +108,7 @@ module Crowdin
       File.open(dest, "w:#{response.body.encoding}") do |destfile|
         destfile.write(response.body)
       end
-    rescue Net::ReadTimeout, Net::OpenTimeout, AWSSlowDownError => error
+    rescue Net::ReadTimeout, Net::OpenTimeout, AWSBadGatewayError, AWSSlowDownError => error
       # Only attempting retries on network errors. Surfacing errors during write.
       STDERR.puts "download_file(#{dest}) timed out: #{error}"
       raise if attempts <= 1

--- a/lib/cdo/crowdin/legacy_utils.rb
+++ b/lib/cdo/crowdin/legacy_utils.rb
@@ -109,7 +109,7 @@ module Crowdin
       end
     rescue Net::ReadTimeout, Net::OpenTimeout, AWSError => error
       # Only attempting retries on request errors. Surfacing errors during write.
-      STDERR.puts "download_file(#{dest}) timed out: #{error}"
+      STDERR.puts "download_file(#{dest})#{response.present? ? " error code: #{response.code}" : ""} error: #{error}"
       raise if attempts <= 1
       download_file(download_url, dest, attempts: attempts - 1)
     end

--- a/lib/cdo/crowdin/legacy_utils.rb
+++ b/lib/cdo/crowdin/legacy_utils.rb
@@ -4,9 +4,9 @@ require 'httparty'
 
 module Crowdin
   # Crowdin's API is limited to 20 simultaneous requests. Limit our
-  # implementation to half that, just for safety.
+  # implementation just for safety.
   # @see https://support.crowdin.com/api/api-integration-setup/#rate-limits
-  MAX_THREADS = 10
+  MAX_THREADS = 8
 
   class LegacyUtils
     attr_reader :project
@@ -40,106 +40,75 @@ module Crowdin
       @logger = options.fetch(:logger, Logger.new(STDOUT))
     end
 
-    # Fetch from Crowdin a list of files changed since the last download. Uses
-    # etags sourced from the @etags_json file to define what we mean by "since
-    # the last download," and writes the results out to @files_to_download_json.
-    def fetch_changes
-      etags = File.exist?(@etags_json) ? JSON.parse(File.read(@etags_json)) : {}
-      files_to_download = {}
-      languages = @project.languages
-      num_languages = languages.length
-      languages.each_with_index do |language, i|
-        language_code = language["id"]
-        @logger.debug("#{language['name']} (#{language_code}): #{i}/#{num_languages}")
-        @logger.info("~#{(i * 100 / num_languages).round(-1)}% complete (#{i}/#{num_languages})") if i > 0 && i % (num_languages / 5) == 0
-
-        etags[language_code] ||= {}
-        files = @project.list_files
-
-        changed_files = Parallel.map(files, in_threads: MAX_THREADS) do |file|
-          file_id = file['id']
-          filepath = file['path']
-          etag = etags[language_code].fetch(filepath, nil)
-          response = @project.export_file(file_id, language_code, etag: etag)
-          case response.code
-          when 200
-            [
-              filepath,
-              {
-                download_url: response["data"]["url"],
-                etag: response["data"]["etag"]
-              }
-            ]
-          when 304
-            nil
-          else
-            raise "cannot handle response code #{response.code}"
-          end
-        end.compact
-
-        next if changed_files.empty?
-        files_to_download[language_code] ||= {}
-        files_to_download[language_code].merge! changed_files.to_h
-      end
-
-      File.write @files_to_download_json, JSON.pretty_generate(files_to_download)
-    end
-
-    # Downloads all files referenced in @files_to_download_json to @locales_dir
-    # Merge the list of successfully downloaded files to @files_to_sync_out_json
-    # to signal the sync-out step to process them.
+    # Fetch from Crowdin a list of all of the project's files. Uses
+    # etags sourced from the @etags_json file to define what we mean by "changed",
+    # and updates the etags by writing the results out to @etags_json.
     def download_changed_files
-      raise "File not found #{@files_to_download_json}; please run fetch_changes first" unless File.exist?(@files_to_download_json)
-      files_to_download = JSON.parse File.read(@files_to_download_json)
-      @logger.info("#{files_to_download.keys.length} languages have changes")
-
       etags = File.exist?(@etags_json) ? JSON.parse(File.read(@etags_json)) : {}
       # Initialize @files_to_sync_out file if it doesn't exist yet.
       # It could already exist if multiple sync-down's occurred since the last sync-out.
       File.write @files_to_sync_out_json, JSON.pretty_generate({}) unless File.exist?(@files_to_sync_out_json)
       files_to_sync_out = JSON.parse(File.read(@files_to_sync_out_json))
 
-      @project.languages.each do |language|
-        code = language["id"]
-        name = language["name"]
-        files = files_to_download.fetch(code, nil)
-        next unless files.present?
-        filenames = files.keys
+      files = @project.list_files
+      languages = @project.languages
+      num_languages = languages.length
 
+      languages.each_with_index do |language, i|
+        language_code = language["id"]
+        @logger.debug("#{language['name']} (#{language_code}): #{i}/#{num_languages}")
+        @logger.info("~#{(i * 100 / num_languages).round(-1)}% complete (#{i}/#{num_languages})") if i > 0 && i % (num_languages / 5) == 0
+
+        etags[language_code] ||= {}
         # construct download directory; locale_subdir is optional, so compact
         locale_dir = File.join([@locales_dir, language["name"], @locale_subdir].compact)
 
-        @logger.debug("#{name} (#{code}): #{filenames.length} files have changes")
-        downloaded_files = Parallel.map(filenames, in_threads: MAX_THREADS) do |file|
-          response = HTTParty.get(files[file]["download_url"])
-          dest = File.join(locale_dir, file)
-          FileUtils.mkdir_p(File.dirname(dest))
-          # Make sure to specify the encoding; we expect to get quite a lot
-          # of non-ASCII characters in this data
-          File.open(dest, "w:#{response.body.encoding}") do |destfile|
-            destfile.write(response.body)
-          end
+        downloaded_files = Parallel.map(files, in_threads: MAX_THREADS) do |file|
+          file_id = file['id']
+          file_path = file['path']
+          etag = etags[language_code].fetch(file_path, nil)
+          response = @project.export_file(file_id, language_code, etag: etag)
+          case response.code
+          when 200
+            dest = File.join(locale_dir, file_path)
+            download_file(response["data"]["url"], dest)
 
-          [file, files[file]["etag"]]
-        end.to_h
+            [file_path, response["data"]["etag"]]
+          when 304
+            nil
+          else
+            raise "cannot handle response code #{response.code}"
+          end
+        end.compact.to_h
 
         # Save incremental progress so we don't have to re-download everything
         # if the current run fails for any reason.
         # The order of saving progress is important for recovery purpose.
-        # Since @files_to_sync_out_json depends on @files_to_download_json,
-        # which in turn depends on @etags_json, @etags_json should be updated last.
-        files_to_sync_out[code] ||= {}
-        files_to_sync_out[code].merge! downloaded_files
+        # Since @files_to_sync_out_json depends on @etags_json, @etags_json
+        # should be updated last.
+        files_to_sync_out[language_code] ||= {}
+        files_to_sync_out[language_code].merge! downloaded_files
         File.write @files_to_sync_out_json, JSON.pretty_generate(files_to_sync_out)
 
-        files_to_download[code].delete_if {|file, _etag| downloaded_files.key? file}
-        files_to_download.delete code if files_to_download[code].empty?
-        File.write @files_to_download_json, JSON.pretty_generate(files_to_download)
-
-        etags[code] ||= {}
-        etags[code].merge! downloaded_files
+        etags[language_code] ||= {}
+        etags[language_code].merge! downloaded_files
         File.write @etags_json, JSON.pretty_generate(etags)
       end
+    end
+
+    def download_file(download_url, dest, attempts: 3)
+      response = HTTParty.get(download_url)
+      FileUtils.mkdir_p(File.dirname(dest))
+      # Make sure to specify the encoding; we expect to get quite a lot
+      # of non-ASCII characters in this data
+      File.open(dest, "w:#{response.body.encoding}") do |destfile|
+        destfile.write(response.body)
+      end
+    rescue HTTParty::Error => error
+      # Only attempting retries on network errors. Surfacing errors during write.
+      STDERR.puts "download_file(#{dest}) timed out: #{error}"
+      raise if attempts <= 1
+      download_file(download_url, dest, attempts - 1)
     end
   end
 end

--- a/lib/cdo/crowdin/legacy_utils.rb
+++ b/lib/cdo/crowdin/legacy_utils.rb
@@ -108,7 +108,7 @@ module Crowdin
         destfile.write(response.body)
       end
     rescue Net::ReadTimeout, Net::OpenTimeout, AWSError => error
-      # Only attempting retries on network errors. Surfacing errors during write.
+      # Only attempting retries on request errors. Surfacing errors during write.
       STDERR.puts "download_file(#{dest}) timed out: #{error}"
       raise if attempts <= 1
       download_file(download_url, dest, attempts: attempts - 1)

--- a/lib/cdo/crowdin/legacy_utils.rb
+++ b/lib/cdo/crowdin/legacy_utils.rb
@@ -81,6 +81,7 @@ module Crowdin
           end
         end.compact.to_h
 
+        next if downloaded_files.empty?
         # Save incremental progress so we don't have to re-download everything
         # if the current run fails for any reason.
         # The order of saving progress is important for recovery purpose.
@@ -104,7 +105,7 @@ module Crowdin
       File.open(dest, "w:#{response.body.encoding}") do |destfile|
         destfile.write(response.body)
       end
-    rescue HTTParty::Error => error
+    rescue Net::ReadTimeout, Net::OpenTimeout => error
       # Only attempting retries on network errors. Surfacing errors during write.
       STDERR.puts "download_file(#{dest}) timed out: #{error}"
       raise if attempts <= 1

--- a/lib/cdo/crowdin/project.rb
+++ b/lib/cdo/crowdin/project.rb
@@ -52,17 +52,24 @@ module Crowdin
         }
       end
 
-      self.class.post("/projects/#{@crowdin_client.config.project_id}/translations/builds/files/#{file_id}", options)
-    rescue Net::ReadTimeout, Net::OpenTimeout => error
+      response = self.class.post(
+        "/projects/#{@crowdin_client.config.project_id}/translations/builds/files/#{file_id}",
+        options
+      )
+      raise CrowdinInternalServerError.new "Internal Server Error" if response.code == 500
+      raise CrowdinServiceUnavailableError.new "Service Unavailable" if response.code == 503
+
+      response
+    rescue Net::ReadTimeout, Net::OpenTimeout, CrowdinInternalServerError, CrowdinServiceUnavailableError => error
       # Handle a timeout by simply retrying. We default to three attempts before
       # giving up; if this doesn't work out, other things we could consider:
       #
       #   - increasing the default number of attempts
       #   - increasing the number of attempts for certain high-failure-rate calls
       #   - increasing the timeout, either globally or for this specific call
-      STDERR.puts "Crowdin.export_file(#{file}) timed out: #{error}"
+      STDERR.puts "Crowdin.export_file(#{file_id}) timed out: #{error}"
       raise if attempts <= 1
-      export_file(file, language, etag: etag, attempts: attempts - 1)
+      export_file(file_id, language, etag: etag, attempts: attempts - 1)
     end
 
     # Retrieve all languages currently enabled in the crowdin project. Each
@@ -79,15 +86,8 @@ module Crowdin
     end
 
     def list_languages
-      query = {
-        limit: Crowdin::Client::MAX_ITEMS_COUNT,
-        offset: 0
-      }
-
-      result = @crowdin_client.request_loop(query) do
-        @crowdin_client.list_languages(query)
-      end
-      result.map {|lang| lang["data"]}
+      result = @crowdin_client.get_project(Crowdin::Client::CDO_PROJECT_IDS[@id])
+      result['data']['targetLanguages']
     end
 
     # Retrieve all files currently uploaded to the crowdin project.

--- a/lib/cdo/crowdin/project.rb
+++ b/lib/cdo/crowdin/project.rb
@@ -67,7 +67,7 @@ module Crowdin
       #   - increasing the default number of attempts
       #   - increasing the number of attempts for certain high-failure-rate calls
       #   - increasing the timeout, either globally or for this specific call
-      STDERR.puts "Crowdin.export_file(#{file_id}) timed out: #{error}"
+      STDERR.puts "Crowdin.export_file(#{file_id}) error: #{error}"
       raise if attempts <= 1
       export_file(file_id, language, etag: etag, attempts: attempts - 1)
     end

--- a/lib/cdo/crowdin/project.rb
+++ b/lib/cdo/crowdin/project.rb
@@ -56,8 +56,8 @@ module Crowdin
         "/projects/#{@crowdin_client.config.project_id}/translations/builds/files/#{file_id}",
         options
       )
-      raise CrowdinInternalServerError.new "Internal Server Error" if response.code == 500
-      raise CrowdinServiceUnavailableError.new "Service Unavailable" if response.code == 503
+      raise CrowdinInternalServerError if response.code == 500
+      raise CrowdinServiceUnavailableError if response.code == 503
 
       response
     rescue Net::ReadTimeout, Net::OpenTimeout, CrowdinInternalServerError, CrowdinServiceUnavailableError => error

--- a/lib/test/cdo/crowdin/test_legacy_utils.rb
+++ b/lib/test/cdo/crowdin/test_legacy_utils.rb
@@ -17,7 +17,7 @@ class MockCrowdinProject < Minitest::Mock
   def list_files
     [
       {"id" => 1, "path" => "/foo.bar"},
-      {"id" => 1, "path" => "/baz.bat"}
+      {"id" => 2, "path" => "/baz.bat"}
     ]
   end
 
@@ -79,94 +79,40 @@ class CrowdinLegacyUtilsTest < Minitest::Test
     }
   end
 
-  def test_fetching_with_no_changes
-    # When the etag values on local are the same as the ones in Crowdin,
-    # +fetch_changes+ should not modify any local file.
-    File.write @options[:etags_json], JSON.pretty_generate(@latest_crowdin_etags)
-    File.write @options[:files_to_download_json], JSON.pretty_generate({})
+  def test_downloading_is_idempotent
+    # +download_changed_files+ should return the same results (files_to_sync_out_json)
+    # if it runs multiple times.
+    File.write @options[:etags_json], JSON.pretty_generate({})
+    File.write @options[:files_to_sync_out_json], JSON.pretty_generate({})
 
-    @utils.fetch_changes
+    @utils.download_changed_files
+    @utils.download_changed_files
 
     assert_equal @latest_crowdin_etags, JSON.parse(File.read(@options[:etags_json]))
-    assert_equal({}, JSON.parse(File.read(@options[:files_to_download_json])))
-  end
-
-  def test_fetching_with_empty_local_etags
-    # If the local etags_json file is empty, +fetch_changes+
-    # should return all the current files in Crowdin.
-    File.write @options[:etags_json], JSON.pretty_generate({})
-    File.write @options[:files_to_download_json], JSON.pretty_generate({})
-
-    @utils.fetch_changes
-
-    assert_equal({}, JSON.parse(File.read(@options[:etags_json])))
-    assert_equal @latest_files_to_download, JSON.parse(File.read(@options[:files_to_download_json]))
-  end
-
-  def test_fetching_is_idempotent
-    # +fetch_changes+ should return the same results (files_to_download_json)
-    # if it runs multiple times. And it should not modify its input (etags_json).
-    File.write @options[:etags_json], JSON.pretty_generate({})
-    File.write @options[:files_to_download_json], JSON.pretty_generate({})
-
-    @utils.fetch_changes
-    @utils.fetch_changes
-
-    assert_equal({}, JSON.parse(File.read(@options[:etags_json])))
-    assert_equal @latest_files_to_download, JSON.parse(File.read(@options[:files_to_download_json]))
-  end
-
-  def test_fetching_respects_unchanged_files
-    # +fetch_changes+ should return only the files that have newer versions in Crowdin.
-    local_etags = {
-      "i1-8n" => {
-        "/foo.bar" => MockCrowdinProject::LATEST_ETAG_VALUE,
-        "/baz.bat" => "not_the_latest_etag"
-      }
-    }
-    File.write @options[:etags_json], JSON.pretty_generate(local_etags)
-    File.write @options[:files_to_download_json], JSON.pretty_generate({})
-
-    @utils.fetch_changes
-
-    assert_equal local_etags, JSON.parse(File.read(@options[:etags_json]))
-    expected_files_to_download = {
-      "i1-8n" => {
-        "/baz.bat" => {
-          "download_url" => DOWNLOAD_URL,
-          "etag" => MockCrowdinProject::LATEST_ETAG_VALUE
-        }
-      }
-    }
-    assert_equal expected_files_to_download, JSON.parse(File.read(@options[:files_to_download_json]))
+    assert_equal @latest_crowdin_etags, JSON.parse(File.read(@options[:files_to_sync_out_json]))
   end
 
   def test_downloading_with_no_changes
     # If files_to_download_json is empty, +download_changed_files+
     # should not modify any local file.
-    File.write @options[:files_to_download_json], JSON.pretty_generate({})
     File.write @options[:files_to_sync_out_json], JSON.pretty_generate({})
-    File.write @options[:etags_json], JSON.pretty_generate({})
+    File.write @options[:etags_json], JSON.pretty_generate(@latest_crowdin_etags)
 
     @utils.download_changed_files
 
-    assert_equal({}, JSON.parse(File.read(@options[:files_to_download_json])))
     assert_equal({}, JSON.parse(File.read(@options[:files_to_sync_out_json])))
-    assert_equal({}, JSON.parse(File.read(@options[:etags_json])))
+    assert_equal(@latest_crowdin_etags, JSON.parse(File.read(@options[:etags_json])))
     assert_equal [], Dir.glob(@options[:locales_dir] + "/**/*.*")
   end
 
   def test_downloading_updates_local_state
     # If +download_changed_files+ successfully downloads files from Crowdin,
-    # it should update the local state tracked by the 3 files: etags_json,
-    # files_to_sync_out_json, and files_to_download_json.
-    File.write @options[:files_to_download_json], JSON.pretty_generate(@latest_files_to_download)
+    # it should update the local state tracked by etags_json and files_to_sync_out_json.
     File.write @options[:files_to_sync_out_json], JSON.pretty_generate({})
     File.write @options[:etags_json], JSON.pretty_generate({})
 
     @utils.download_changed_files
 
-    assert_equal({}, JSON.parse(File.read(@options[:files_to_download_json])))
     assert_equal @latest_crowdin_etags, JSON.parse(File.read(@options[:files_to_sync_out_json]))
     assert_equal @latest_crowdin_etags, JSON.parse(File.read(@options[:etags_json]))
     expected_local_files = [
@@ -199,7 +145,6 @@ class CrowdinLegacyUtilsTest < Minitest::Test
       }
     }
 
-    File.write @options[:files_to_download_json], JSON.pretty_generate(files_to_download)
     File.write @options[:files_to_sync_out_json], JSON.pretty_generate(files_to_sync_out)
     File.write @options[:etags_json], JSON.pretty_generate(local_etags)
 
@@ -209,7 +154,6 @@ class CrowdinLegacyUtilsTest < Minitest::Test
     expected_downloaded_files = JSON.parse(files_to_download.to_json)
     expected_downloaded_files["i1-8n"]["/baz.bat"] = expected_downloaded_files["i1-8n"]["/baz.bat"]["etag"]
 
-    assert_equal({}, JSON.parse(File.read(@options[:files_to_download_json])))
     assert_equal files_to_sync_out.deep_merge(expected_downloaded_files), JSON.parse(File.read(@options[:files_to_sync_out_json]))
     assert_equal local_etags.deep_merge(expected_downloaded_files), JSON.parse(File.read(@options[:etags_json]))
     expected_local_files = ["#{@options[:locales_dir]}/Test Language/baz.bat"]


### PR DESCRIPTION
**What:** Consolidate our two parts of the `sync-down` process, `fetch_changes` and `download_changed_files`, into one call that downloads the changed file immediately after we learn whether it has changed or not. This removes the need for the `files_to_download_json` file that bridged that gap between the two calls. Explicit error handling is also introduced for the two network calls.

**Why:** The original attempt to use the [v2 Crowdin API](https://github.com/code-dot-org/code-dot-org/pull/48148) was to not alter our existing logic and simply replace calls to the old API with the new v2 API. This introduced a flaw in our logic because the v2 API only allows for the external download URL on S3 to be used within the next 120 seconds after being ["built"](https://developer.crowdin.com/api/v2/#operation/api.projects.translations.builds.files.post). The original process would take 1+ hours to fetch all the files that _should_ be downloaded, and _then_ download them which was well beyond the 120 seconds.

The response status codes are also explicitly check after calls for errors. Without this the error message in the body of the response would be written to the translation file(s).

The `MAX_THREADS` were reduced to 8 so we don't hit the Crowdin rate limit. At 10 we were still receiving `429` responses.

## Links

[First v2 Crowdin API PR](https://github.com/code-dot-org/code-dot-org/pull/48148)

## Testing story

- Ran the sync-down and sync-out multiple times locally
- Updated the unit tests
- Locally tested updating a translation in the Crowdin Test Project and then syncing
- Locally tested request error handling

## Follow-up work

Take a close look at the following sync after this is merged.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
