### PR TITLE
Quick Fix - Link to external Greenhouse job board on careers page

### DIFF
--- a/pegasus/sites.v3/code.org/public/about/careers.md.erb
+++ b/pegasus/sites.v3/code.org/public/about/careers.md.erb
@@ -4,6 +4,7 @@ nav: about_nav
 video_player: true
 theme: responsive
 ---
+
 <link rel="stylesheet" type="text/css" rel= "stylesheet" href="/css/careers.css" />
 
 <div class="careers__banner careers__teal">
@@ -84,8 +85,9 @@ theme: responsive
 
 Code.org is based in Seattle, but many of our team members are remote; remote candidates are welcome and encouraged to apply!
 
-<div id="grnhse_app"></div>
-<script src="https://boards.greenhouse.io/embed/job_board/js?for=codeorg"></script>
+<a href="https://boards.greenhouse.io/codeorg" target="_blank"><button>View open positions</button></a>
+<!--<div id="grnhse_app"></div>
+<script src="https://boards.greenhouse.io/embed/job_board/js?for=codeorg"></script>-->
 
 <h2 class="careers-header">Get Involved</h2>
 

--- a/pegasus/sites.v3/code.org/public/about/careers.md.erb
+++ b/pegasus/sites.v3/code.org/public/about/careers.md.erb
@@ -85,7 +85,7 @@ theme: responsive
 
 Code.org is based in Seattle, but many of our team members are remote; remote candidates are welcome and encouraged to apply!
 
-<a href="https://boards.greenhouse.io/codeorg" target="_blank"><button>View open positions</button></a>
+<a href="https://boards.greenhouse.io/codeorg"><button>View open positions</button></a>
 
 <h2 class="careers-header">Get Involved</h2>
 

--- a/pegasus/sites.v3/code.org/public/about/careers.md.erb
+++ b/pegasus/sites.v3/code.org/public/about/careers.md.erb
@@ -86,8 +86,6 @@ theme: responsive
 Code.org is based in Seattle, but many of our team members are remote; remote candidates are welcome and encouraged to apply!
 
 <a href="https://boards.greenhouse.io/codeorg" target="_blank"><button>View open positions</button></a>
-<!--<div id="grnhse_app"></div>
-<script src="https://boards.greenhouse.io/embed/job_board/js?for=codeorg"></script>-->
 
 <h2 class="careers-header">Get Involved</h2>
 


### PR DESCRIPTION
This is a quick fix to replace the embedded Greenhouse job board w/ a button that links to our external job board on https://code.org/about/careers.

There was an implementation error with the embedded version that will need more engineering time to implement before we launch with Greenhouse tomorrow.

**Related PR:** https://github.com/code-dot-org/code-dot-org/pull/48073

<img width="826" alt="Screen Shot 2022-09-27 at 1 44 58 PM" src="https://user-images.githubusercontent.com/9256643/192631642-0af1cc18-ca94-482a-a187-11372ee981ff.png">
