### PR TITLE
Revert "Remove `cdo-varnish` Logic from `cdo-nginx`"

### DIFF
--- a/cookbooks/cdo-nginx/.kitchen.yml
+++ b/cookbooks/cdo-nginx/.kitchen.yml
@@ -27,4 +27,5 @@ suites:
       - recipe[nginx_test]
   - name: https
     run_list:
+      - recipe[cdo-varnish]
       - recipe[nginx_test]

--- a/cookbooks/cdo-nginx/Berksfile
+++ b/cookbooks/cdo-nginx/Berksfile
@@ -12,4 +12,5 @@ cookbook 'nginx_test', path: './test/cookbooks/nginx_test'
 # (forked to our own project purely to ensure stability).
 cookbook 'ssl_certificate', github: 'code-dot-org/ssl_certificate-cookbook', branch: 'add_provider-issue_45'
 
+cookbook 'cdo-varnish', path: '../cdo-varnish'
 cookbook 'sudo-user', path: '../sudo-user'

--- a/cookbooks/cdo-nginx/templates/default/nginx.conf.erb
+++ b/cookbooks/cdo-nginx/templates/default/nginx.conf.erb
@@ -26,6 +26,7 @@ http {
   client_max_body_size 4G;
   keepalive_timeout 30;
 
+<% unless node['cdo-varnish']['enabled'] -%>
   # Copy Accept-Language header to X-Varnish-Accept-Language.
   # TODO: Update application code to read Accept-Language instead of X-Varnish-Accept-Language.
   proxy_set_header X-Varnish-Accept-Language $http_accept_language;
@@ -58,6 +59,15 @@ http {
       proxy_set_header Host $upstream_host;
     }
   }
+<%   redirects = node['cdo-varnish']['redirects'].group_by(&:last).transform_values {|v| v.to_h.keys}
+     redirects.each do |site, domains| -%>
+  server {
+    listen 80;
+    server_name <%=domains.join(' ')%>;
+    return 301 https://<%=site%>$request_uri;
+  }
+<%   end -%>
+<% end -%>
 
   server {
     listen <%= node['cdo-apps']['dashboard']['port'] %> default deferred;
@@ -67,7 +77,6 @@ http {
       proxy_set_header Host $http_host;
     }
   }
-
   server {
     listen <%= node['cdo-apps']['pegasus']['port'] %> default deferred;
     server_name pegasus_proxy;
@@ -76,13 +85,17 @@ http {
       proxy_set_header Host $http_host;
     }
   }
-
   server {
     server_name ssl_proxy;
     listen 443 ssl;
     <%= render 'nginx.erb', cookbook: 'ssl_certificate' %>
     location / {
+<% if node['cdo-varnish']['enabled'] -%>
+      # Pass the request on to Varnish.
+      proxy_pass  http://127.0.0.1;
+<% else -%>
       proxy_pass http://unix:<%= @run_dir %>/$upstream.sock;
+<% end -%>
       proxy_set_header Host $http_host;
       proxy_set_header X-Forwarded-Proto https;
     }


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#47982; we actually are still using these redirects. See https://app.honeybadger.io/projects/34365/faults/88725672 and https://codedotorg.slack.com/archives/C0T0PNTM3/p1664311140819099 for more