### PR TITLE
Fix Violations of and Reenable `Rails/Present`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -306,12 +306,6 @@ Rails/Pick:
 Rails/Pluck:
   Enabled: false
 
-# Offense count: 33
-# This cop supports safe auto-correction (--auto-correct).
-# Configuration parameters: NotNilAndNotEmpty, NotBlank, UnlessBlank.
-Rails/Present:
-  Enabled: false
-
 # Offense count: 85
 # This cop supports unsafe auto-correction (--auto-correct-all).
 # Configuration parameters: Include.

--- a/dashboard/app/controllers/foorm/simple_survey_forms_controller.rb
+++ b/dashboard/app/controllers/foorm/simple_survey_forms_controller.rb
@@ -176,7 +176,7 @@ module Foorm
         key = "survey_data_key_#{id}".to_sym
         value = "survey_data_value_#{id}".to_sym
 
-        survey_data[params[key]] = params[value] unless params[key].blank?
+        survey_data[params[key]] = params[value] if params[key].present?
       end
 
       survey_data

--- a/dashboard/app/controllers/omniauth_callbacks_controller.rb
+++ b/dashboard/app/controllers/omniauth_callbacks_controller.rb
@@ -134,7 +134,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     end
     email = auth_hash.info.email || ""
     hashed_email = nil
-    hashed_email = User.hash_email(email) unless email.blank?
+    hashed_email = User.hash_email(email) if email.present?
     auth_option = AuthenticationOption.new(
       user: current_user,
       email: email,

--- a/dashboard/app/controllers/report_abuse_controller.rb
+++ b/dashboard/app/controllers/report_abuse_controller.rb
@@ -64,7 +64,7 @@ class ReportAbuseController < ApplicationController
         raise ZendeskError.new(response.code, response.body) unless response.success?
       end
 
-      unless params[:channel_id].blank?
+      if params[:channel_id].present?
         channels_path = "/v3/channels/#{params[:channel_id]}/abuse"
         assets_path = "/v3/assets/#{params[:channel_id]}/"
         files_path = "/v3/files/#{params[:channel_id]}/"

--- a/dashboard/app/controllers/sms_controller.rb
+++ b/dashboard/app/controllers/sms_controller.rb
@@ -4,7 +4,7 @@ class SmsController < ApplicationController
 
   # set up a client to talk to the Twilio REST API
   def send_to_phone
-    if params[:level_source] && !params[:level_source].empty? && params[:phone] && (level_source = LevelSource.find(params[:level_source]))
+    if params[:level_source].present? && params[:phone] && (level_source = LevelSource.find(params[:level_source]))
       send_sms_link(level_source_url(level_source), params[:phone])
     elsif params[:channel_id] && params[:phone] && ProjectsController::STANDALONE_PROJECTS.include?(params[:type])
       url =

--- a/dashboard/app/models/concerns/text_to_speech.rb
+++ b/dashboard/app/models/concerns/text_to_speech.rb
@@ -129,7 +129,7 @@ module TextToSpeech
   # @return [String] URL where the TTS audio file can be downloaded from. `nil` is returned if any of
   # the params are blank or if TTS is not supported for the given locale.
   def tts_url(text, locale = I18n.locale)
-    return nil unless TextToSpeech.locale_supported?(locale) && !text.blank?
+    return nil unless TextToSpeech.locale_supported?(locale) && text.present?
     "https://tts.code.org/#{tts_path(text)}"
   end
 

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -841,7 +841,7 @@ class Lesson < ApplicationRecord
             Services::MarkdownPreprocessor.sub_vocab_definitions!(copied_activity_section.description, update_vocab_definition_on_clone)
           end
 
-          unless copied_activity_section.tips.blank?
+          if copied_activity_section.tips.present?
             copied_activity_section.tips.each do |tip|
               next unless tip && tip['markdown']
               Services::MarkdownPreprocessor.sub_resource_links!(tip['markdown'], update_resource_link_on_clone)
@@ -863,7 +863,7 @@ class Lesson < ApplicationRecord
             "levels" => [copied_level]
           }
         end
-        copied_activity_section.update_script_levels(sl_data) unless sl_data.blank?
+        copied_activity_section.update_script_levels(sl_data) if sl_data.present?
         copied_activity_section
       end
       copied_lesson_activity

--- a/dashboard/app/models/levels/blockly.rb
+++ b/dashboard/app/models/levels/blockly.rb
@@ -162,7 +162,7 @@ class Blockly < Level
   end
 
   def self.count_xml_blocks(xml_string)
-    unless xml_string.blank?
+    if xml_string.present?
       xml = Nokogiri::XML(xml_string, &:noblanks)
       # The structure of the XML will be
       # <document>

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -199,7 +199,7 @@ class Level < ApplicationRecord
 
   def available_callouts(script_level)
     if custom?
-      unless callout_json.blank?
+      if callout_json.present?
         return JSON.parse(callout_json).map do |callout_definition|
           i18n_key = "data.callouts.#{name}.#{callout_definition['localization_key']}"
           callout_text = (should_localize? &&
@@ -758,7 +758,7 @@ class Level < ApplicationRecord
       ],
       ownerOptions: [
         ['Any owner', ''],
-        *Level.joins(:user).distinct.pluck('users.name, users.id').select {|a| !a[0].blank? && !a[1].blank?}.sort_by {|a| a[0]}
+        *Level.joins(:user).distinct.pluck('users.name, users.id').select {|a| a[0].present? && a[1].present?}.sort_by {|a| a[0]}
       ]
     }
   end

--- a/dashboard/app/models/pd/application/facilitator_application_base.rb
+++ b/dashboard/app/models/pd/application/facilitator_application_base.rb
@@ -324,7 +324,7 @@ module Pd::Application
           if !hash[:regional_partner_id]
             required << :csd_csp_no_partner_summer_workshop
           else
-            if hash[:summer_workshops] && !hash[:summer_workshops].empty?
+            if hash[:summer_workshops].present?
               required.concat [
                 :csd_csp_partner_with_summer_workshop,
                 :csd_csp_which_summer_workshop
@@ -332,7 +332,7 @@ module Pd::Application
             else
               required << :csd_csp_partner_but_no_summer_workshop
             end
-            if hash[:fit_workshops] && !hash[:fit_workshops].empty?
+            if hash[:fit_workshops].present?
               required << :csd_csp_which_fit_weekend
             end
           end

--- a/dashboard/app/models/programming_class.rb
+++ b/dashboard/app/models/programming_class.rb
@@ -159,7 +159,7 @@ class ProgrammingClass < ApplicationRecord
     # ones without overload_of set
     methods = []
     programming_methods.each do |m|
-      next unless m.overload_of.blank?
+      next if m.overload_of.present?
       methods += [m.summarize_for_show]
     end
     methods

--- a/dashboard/app/models/programming_method.rb
+++ b/dashboard/app/models/programming_method.rb
@@ -112,7 +112,7 @@ class ProgrammingMethod < ApplicationRecord
     end
     overload = ProgrammingMethod.find_by(programming_class_id: programming_class_id, key: overload_of)
     if overload
-      errors.add(:overload_of, "Overloaded method cannot have overload_of be non-blank") unless overload.overload_of.blank?
+      errors.add(:overload_of, "Overloaded method cannot have overload_of be non-blank") if overload.overload_of.present?
     else
       errors.add(:overload_of, "Overload method must exist")
     end

--- a/dashboard/app/models/school_info.rb
+++ b/dashboard/app/models/school_info.rb
@@ -263,16 +263,16 @@ class SchoolInfo < ApplicationRecord
   # needs to be, but correlates to the list of valid configurations given
   # in https://github.com/code-dot-org/code-dot-org/pull/8624.
   def validate_school_district_without_country
-    return if school_type == SCHOOL_TYPE_CHARTER && !zip.blank?
-    return if school_type == SCHOOL_TYPE_PRIVATE && !zip.blank?
+    return if school_type == SCHOOL_TYPE_CHARTER && zip.present?
+    return if school_type == SCHOOL_TYPE_PRIVATE && zip.present?
     if school_type == SCHOOL_TYPE_PUBLIC
       return if state == SCHOOL_STATE_OTHER
-      return if !state.blank? && !school_district_id.blank?
-      return if !state.blank? && school_district_id.blank? && !school_district_other.blank?
+      return if state.present? && school_district_id.present?
+      return if state.present? && school_district_id.blank? && school_district_other.present?
     elsif school_type == SCHOOL_TYPE_OTHER
       return if state == SCHOOL_STATE_OTHER
-      return if !state.blank? && !school_district_id.blank?
-      return if !state.blank? && school_district_id.blank? && !school_district_other.blank?
+      return if state.present? && school_district_id.present?
+      return if state.present? && school_district_id.blank? && school_district_other.present?
     end
 
     errors.add(:school_district, "is required")
@@ -320,6 +320,6 @@ class SchoolInfo < ApplicationRecord
     ].include?(school_type)
 
     # Given we got past above cases, school name is sufficient
-    !school_name.blank?
+    school_name.present?
   end
 end

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -220,7 +220,7 @@ class Script < ApplicationRecord
   #
   # This returns true if a course uses the PLC course models.
   def old_professional_learning_course?
-    !professional_learning_course.blank?
+    professional_learning_course.present?
   end
 
   def generate_plc_objects
@@ -1973,7 +1973,7 @@ class Script < ApplicationRecord
   end
 
   def pilot?
-    !get_pilot_experiment.blank?
+    get_pilot_experiment.present?
   end
 
   def has_pilot_access?(user = nil)

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -701,7 +701,7 @@ class User < ApplicationRecord
 
   def email_and_hashed_email_must_be_unique
     # skip the db lookup if we are already invalid
-    return unless errors.blank?
+    return if errors.present?
 
     if ((email.present? && (other_user = User.find_by_email_or_hashed_email(email))) ||
         (hashed_email.present? && (other_user = User.find_by_hashed_email(hashed_email)))) &&

--- a/dashboard/db/migrate/20160824002113_create_school_infos.rb
+++ b/dashboard/db/migrate/20160824002113_create_school_infos.rb
@@ -23,7 +23,7 @@ class CreateSchoolInfos < ActiveRecord::Migration[4.2]
         # Set district_other to true for all entries that should have had a school_district_id but didn't.
         if (attributes[:school_type] == SchoolInfo::SCHOOL_TYPE_PUBLIC ||
             attributes[:school_type] == SchoolInfo::SCHOOL_TYPE_CHARTER) &&
-           (!attributes.blank? && attributes[:state] != SchoolInfo::SCHOOL_STATE_OTHER) &&
+           (attributes.present? && attributes[:state] != SchoolInfo::SCHOOL_STATE_OTHER) &&
            attributes[:school_district_id].blank?
           attributes[:school_district_other] = true
         end

--- a/dashboard/test/ui/runner.rb
+++ b/dashboard/test/ui/runner.rb
@@ -806,7 +806,7 @@ def run_feature(browser, feature, options)
   unless parsed_output.nil?
     scenario_count = parsed_output[:scenarios].to_i
     scenario_info = parsed_output[:info]
-    scenario_info = ", #{scenario_info}" unless scenario_info.blank?
+    scenario_info = ", #{scenario_info}" if scenario_info.present?
   end
 
   rerun_info = " with #{reruns} reruns" if reruns > 0


### PR DESCRIPTION
Quoting from [the documentation](https://docs.rubocop.org/rubocop-rails/cops_rails.html#railspresent), this rule:

> Checks for code that can be written with simpler conditionals using `Object#present?` defined by Active Support.

In general, this updates instances of expressions like `unless foo.blank?` to `if foo.present?`.

Changes were applied automatically with `bundle exec rubocop --auto-correct --only Rails/Present`

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

- https://docs.rubocop.org/rubocop-rails/cops_rails.html#railspresent

## Testing story

Relying on existing tests to verify that this does not represent any change in functionality.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
