### PR TITLE
Fixing styling of list items in OneTrust dialog on hourofcode.com

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/public/css/common.css
+++ b/pegasus/sites.v3/hourofcode.com/public/css/common.css
@@ -574,3 +574,13 @@
   font-weight: 900;
   margin-bottom: 25px;
 }
+
+/* Styling for items in the OneTrust cookie banner */
+
+/*
+   We have some default styling which adds bullet points on <li> items, but we
+   don't want to see those in the OneTrust dialog.
+ */
+#onetrust-consent-sdk ul li:before {
+  content: none;
+}


### PR DESCRIPTION
_Bug_ - There are small bullet points between some `<li>`s  in the OneTrust popup.
_Cause_ - There is an overly aggressive and old `ul li:before` in the hourofcode.com CSS which adds "• " before all `<li>`s.
_Fix_ - Revert the styling for all `<li>`s in the `#onetrust-consent-sdk` `<div>`

## Links
* [JIRA](https://codedotorg.atlassian.net/browse/FND-2101)

## Screenshots
### Before
Note the small circles between the cookie types on the left.
![Screen Shot 2022-09-27 at 3 12 11 PM](https://user-images.githubusercontent.com/1372238/192647140-7da37280-acb1-4fad-8ccd-fac52b37d2a8.png)

### After
![Screen Shot 2022-09-27 at 3 11 49 PM](https://user-images.githubusercontent.com/1372238/192647159-37495ff3-eb60-4d69-98e7-60b324fbc6d5.png)


## Testing story
Manually test on http://localhost.hourofcode.com:3000/us?otgeo=gb&onetrust_cookie_scripts=production 

