### PR TITLE
Fix Violations of and Reenable `Performance/InefficientHashSearch`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -210,11 +210,6 @@ Performance/CollectionLiteralInLoop:
 Performance/Detect:
   Enabled: false
 
-# Offense count: 9
-# This cop supports unsafe auto-correction (--auto-correct-all).
-Performance/InefficientHashSearch:
-  Enabled: false
-
 # Offense count: 20
 Performance/MethodObjectAsBlock:
   Enabled: false

--- a/dashboard/app/models/sections/section.rb
+++ b/dashboard/app/models/sections/section.rb
@@ -152,7 +152,7 @@ class Section < ApplicationRecord
   end
 
   def self.valid_participant_type?(type)
-    Curriculum::SharedCourseConstants::PARTICIPANT_AUDIENCE.to_h.values.include? type
+    Curriculum::SharedCourseConstants::PARTICIPANT_AUDIENCE.to_h.value?(type)
   end
 
   def self.valid_grade?(grade)

--- a/dashboard/lib/projects_list.rb
+++ b/dashboard/lib/projects_list.rb
@@ -110,7 +110,7 @@ module ProjectsList
         raise ArgumentError, 'Cannot specify published_before when requesting all project types' if published_before
         return include_featured(limit: limit)
       end
-      raise ArgumentError, "invalid project type: #{project_group}" unless PUBLISHED_PROJECT_TYPE_GROUPS.keys.include?(project_group.to_sym)
+      raise ArgumentError, "invalid project type: #{project_group}" unless PUBLISHED_PROJECT_TYPE_GROUPS.key?(project_group.to_sym)
       fetch_published_project_types([project_group.to_sym], limit: limit, published_before: published_before)
     end
 

--- a/dashboard/test/controllers/api/v1/pd/application/principal_approval_applications_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/application/principal_approval_applications_controller_test.rb
@@ -111,7 +111,7 @@ module Api::V1::Pd::Application
         principal_wont_replace_existing_course: "I don't know (Please Explain): this is the other for replace course",
       }
       actual_principal_fields = teacher_application.reload.sanitize_form_data_hash.select do |k, _|
-        expected_principal_fields.keys.include? k
+        expected_principal_fields.key?(k)
       end
 
       assert_equal expected_principal_fields, actual_principal_fields

--- a/dashboard/test/models/course_offering_test.rb
+++ b/dashboard/test/models/course_offering_test.rb
@@ -349,7 +349,7 @@ class CourseOfferingTest < ActiveSupport::TestCase
     ].sort
 
     assignable_course_offerings = CourseOffering.assignable_course_offerings_info(@levelbuilder)
-    expected_course_offering_info.each {|co| assert assignable_course_offerings.keys.include?(co)}
+    expected_course_offering_info.each {|co| assert assignable_course_offerings.key?(co)}
   end
 
   test 'in assignable course offerings summary display names of course offerings include star if they are not launched' do
@@ -376,7 +376,7 @@ class CourseOfferingTest < ActiveSupport::TestCase
     ].sort
 
     assignable_course_offerings = CourseOffering.assignable_course_offerings_info(@pilot_teacher)
-    expected_course_offering_info.each {|co| assert assignable_course_offerings.keys.include?(co)}
+    expected_course_offering_info.each {|co| assert assignable_course_offerings.key?(co)}
   end
 
   test 'get assignable course offerings for partner should return offerings where partner can be instructor and partners courses' do
@@ -387,7 +387,7 @@ class CourseOfferingTest < ActiveSupport::TestCase
     ].sort
 
     assignable_course_offerings = CourseOffering.assignable_course_offerings_info(@partner)
-    expected_course_offering_info.each {|co| assert assignable_course_offerings.keys.include?(co)}
+    expected_course_offering_info.each {|co| assert assignable_course_offerings.key?(co)}
   end
 
   test 'get assignable course offerings for pl pilot instructor should return offerings where pl pilot instructor can be instructor' do
@@ -399,7 +399,7 @@ class CourseOfferingTest < ActiveSupport::TestCase
     ].sort
 
     assignable_course_offerings = CourseOffering.assignable_course_offerings_info(@pilot_instructor)
-    expected_course_offering_info.each {|co| assert assignable_course_offerings.keys.include?(co)}
+    expected_course_offering_info.each {|co| assert assignable_course_offerings.key?(co)}
   end
 
   test 'get assignable course offerings for teacher should return offerings where teacher can be instructor' do
@@ -409,7 +409,7 @@ class CourseOfferingTest < ActiveSupport::TestCase
     ].sort
 
     assignable_course_offerings = CourseOffering.assignable_course_offerings_info(@teacher)
-    expected_course_offering_info.each {|co| assert assignable_course_offerings.keys.include?(co)}
+    expected_course_offering_info.each {|co| assert assignable_course_offerings.key?(co)}
   end
 
   test 'get assignable course offerings for facilitator should return all offerings, versions, amd units where facilitator can be instructor' do
@@ -421,7 +421,7 @@ class CourseOfferingTest < ActiveSupport::TestCase
 
     assignable_course_offerings = CourseOffering.assignable_course_offerings_info(@facilitator)
 
-    expected_course_offering_info.each {|co| assert assignable_course_offerings.keys.include?(co)}
+    expected_course_offering_info.each {|co| assert assignable_course_offerings.key?(co)}
 
     unit_group_course_versions = assignable_course_offerings[@unit_group.course_version.course_offering.id][:course_versions]
     assert_equal unit_group_course_versions.keys, [@unit_group.course_version.id]


### PR DESCRIPTION
Replaces checks like `{}.keys.include?` and `{}.values.include?` with the more-efficient equivalents `{}.key?` and `{}.value?`

Fix applied automatically with `bundle exec rubocop --auto-correct-all --only Performance/InefficientHashSearch`. Note that I used `--auto-correct-all` rather than `--auto-correct` because rubocop can't be sure that all instances are actually hashes and not some other object which defines a `keys` method. I manually inspected each change, and I'm confident that is not the case here.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

- https://www.rubydoc.info/gems/rubocop/0.58.0/RuboCop/Cop/Performance/InefficientHashSearch
- https://docs.rubocop.org/rubocop-performance/cops_performance.html#performanceinefficienthashsearch

## Testing story

Relying on existing tests to verify that this does not represent any change in functionality.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
