### PR TITLE
canonicalize curriculum pdf paths

### DIFF
--- a/dashboard/lib/services/curriculum_pdfs.rb
+++ b/dashboard/lib/services/curriculum_pdfs.rb
@@ -127,7 +127,7 @@ module Services
           any_pdf_generated = false
 
           get_pdfless_lessons(script).each do |lesson|
-            puts "Generating missing PDFs for #{lesson.key} (from #{script.name})"
+            puts "Generating missing Lesson PDFs for #{lesson.key} (from #{script.name})"
             generate_lesson_pdf(lesson, dir)
             generate_lesson_pdf(lesson, dir, true)
             any_pdf_generated = true

--- a/dashboard/lib/services/curriculum_pdfs.rb
+++ b/dashboard/lib/services/curriculum_pdfs.rb
@@ -106,13 +106,6 @@ module Services
       end
     end
 
-    # safe characters are those listed at:
-    # https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html
-    S3_UNSAFE_CHARACTER_REGEX = %r{[^-0-9a-zA-Z!_.*'()]}
-    def self.canonicalize_s3_filename(filename)
-      filename.gsub(S3_UNSAFE_CHARACTER_REGEX, '-')
-    end
-
     def self.get_pdf_enabled_scripts
       Script.all.select do |script|
         next false if [PUBLISHED_STATE.pilot, PUBLISHED_STATE.in_development].include?(script.get_published_state)

--- a/dashboard/lib/services/curriculum_pdfs.rb
+++ b/dashboard/lib/services/curriculum_pdfs.rb
@@ -106,6 +106,13 @@ module Services
       end
     end
 
+    # safe characters are those listed at:
+    # https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html
+    S3_UNSAFE_CHARACTER_REGEX = %r{[^-0-9a-zA-Z!_.*'()]}
+    def self.canonicalize_s3_filename(filename)
+      filename.gsub(S3_UNSAFE_CHARACTER_REGEX, '-')
+    end
+
     def self.get_pdf_enabled_scripts
       Script.all.select do |script|
         next false if [PUBLISHED_STATE.pilot, PUBLISHED_STATE.in_development].include?(script.get_published_state)

--- a/dashboard/lib/services/curriculum_pdfs/lesson_plans.rb
+++ b/dashboard/lib/services/curriculum_pdfs/lesson_plans.rb
@@ -21,6 +21,7 @@ module Services
           return nil unless lesson&.script&.seeded_from
           version_number = Time.parse(lesson.script.seeded_from).to_s(:number)
           filename = ActiveStorage::Filename.new(lesson.key + ".pdf").sanitized
+          filename = canonicalize_s3_filename(filename)
           filename = CGI.escape(filename) if as_url
           subdir = student_facing ? "student-lesson-plans" : "teacher-lesson-plans"
           return Pathname.new(File.join(lesson.script.name, version_number, subdir, filename))

--- a/dashboard/lib/services/curriculum_pdfs/lesson_plans.rb
+++ b/dashboard/lib/services/curriculum_pdfs/lesson_plans.rb
@@ -20,8 +20,7 @@ module Services
         def get_lesson_plan_pathname(lesson, student_facing = false, as_url = false)
           return nil unless lesson&.script&.seeded_from
           version_number = Time.parse(lesson.script.seeded_from).to_s(:number)
-          filename = ActiveStorage::Filename.new(lesson.key + ".pdf").sanitized
-          filename = canonicalize_s3_filename(filename)
+          filename = ActiveStorage::Filename.new(lesson.key.parameterize(preserve_case: true) + ".pdf").to_s
           filename = CGI.escape(filename) if as_url
           subdir = student_facing ? "student-lesson-plans" : "teacher-lesson-plans"
           return Pathname.new(File.join(lesson.script.name, version_number, subdir, filename))

--- a/dashboard/lib/services/curriculum_pdfs/lesson_plans.rb
+++ b/dashboard/lib/services/curriculum_pdfs/lesson_plans.rb
@@ -17,11 +17,10 @@ module Services
         # <Pathname:csp1-2021/20210216001309/teacher-lesson-plans/Welcome to CSP.pdf>
         # and this for student lesson plans
         # <Pathname:csp1-2021/20210216001309/student-lesson-plans/Welcome to CSP.pdf>
-        def get_lesson_plan_pathname(lesson, student_facing = false, as_url = false)
+        def get_lesson_plan_pathname(lesson, student_facing = false)
           return nil unless lesson&.script&.seeded_from
           version_number = Time.parse(lesson.script.seeded_from).to_s(:number)
           filename = ActiveStorage::Filename.new(lesson.key.parameterize(preserve_case: true) + ".pdf").to_s
-          filename = CGI.escape(filename) if as_url
           subdir = student_facing ? "student-lesson-plans" : "teacher-lesson-plans"
           return Pathname.new(File.join(lesson.script.name, version_number, subdir, filename))
         end
@@ -30,7 +29,7 @@ module Services
         #
         # Expect this to look something like this: "https://lesson-plans.code.org/csp1-2021/20210909014219/teacher-lesson-plans/Welcome+to+CSP.pdf"
         def get_lesson_plan_url(lesson, student_facing=false)
-          pathname = get_lesson_plan_pathname(lesson, student_facing, true)
+          pathname = get_lesson_plan_pathname(lesson, student_facing)
           return nil if pathname.blank?
 
           File.join(get_base_url, pathname)

--- a/dashboard/lib/services/curriculum_pdfs/lesson_plans.rb
+++ b/dashboard/lib/services/curriculum_pdfs/lesson_plans.rb
@@ -20,7 +20,8 @@ module Services
         def get_lesson_plan_pathname(lesson, student_facing = false)
           return nil unless lesson&.script&.seeded_from
           version_number = Time.parse(lesson.script.seeded_from).to_s(:number)
-          filename = ActiveStorage::Filename.new(lesson.localized_name.parameterize(preserve_case: true) + ".pdf").to_s
+          suffix = student_facing ? '-Student' : ''
+          filename = ActiveStorage::Filename.new(lesson.localized_name.parameterize(preserve_case: true) + suffix + ".pdf").to_s
           subdir = student_facing ? "student-lesson-plans" : "teacher-lesson-plans"
           return Pathname.new(File.join(lesson.script.name, version_number, subdir, filename))
         end

--- a/dashboard/lib/services/curriculum_pdfs/lesson_plans.rb
+++ b/dashboard/lib/services/curriculum_pdfs/lesson_plans.rb
@@ -20,7 +20,7 @@ module Services
         def get_lesson_plan_pathname(lesson, student_facing = false)
           return nil unless lesson&.script&.seeded_from
           version_number = Time.parse(lesson.script.seeded_from).to_s(:number)
-          filename = ActiveStorage::Filename.new(lesson.key.parameterize(preserve_case: true) + ".pdf").to_s
+          filename = ActiveStorage::Filename.new(lesson.localized_name.parameterize(preserve_case: true) + ".pdf").to_s
           subdir = student_facing ? "student-lesson-plans" : "teacher-lesson-plans"
           return Pathname.new(File.join(lesson.script.name, version_number, subdir, filename))
         end

--- a/dashboard/lib/services/curriculum_pdfs/resources.rb
+++ b/dashboard/lib/services/curriculum_pdfs/resources.rb
@@ -17,9 +17,8 @@ module Services
         # version of the script in the environment.
         #
         # For example: <Pathname:csp1-2021/20210909014219/Digital+Information+('21-'22)+-+Resources.pdf>
-        def get_script_resources_pathname(script, as_url = false)
+        def get_script_resources_pathname(script)
           filename = ActiveStorage::Filename.new(script.localized_title.parameterize(preserve_case: true) + "-Resources.pdf").to_s
-          filename = CGI.escape(filename) if as_url
           script_overview_pathname = get_script_overview_pathname(script)
           return nil unless script_overview_pathname
           subdirectory = File.dirname(script_overview_pathname)
@@ -32,7 +31,7 @@ module Services
         # For example: https://lesson-plans.code.org/csp1-2021/20210909014219/Digital+Information+%28%2721-%2722%29+-+Resources.pdf
         def get_unit_resources_url(script)
           return nil unless Services::CurriculumPdfs.should_generate_resource_pdf?(script)
-          pathname = get_script_resources_pathname(script, true)
+          pathname = get_script_resources_pathname(script)
           return nil if pathname.blank?
           File.join(get_base_url, pathname)
         end

--- a/dashboard/lib/services/curriculum_pdfs/resources.rb
+++ b/dashboard/lib/services/curriculum_pdfs/resources.rb
@@ -19,6 +19,7 @@ module Services
         # For example: <Pathname:csp1-2021/20210909014219/Digital+Information+('21-'22)+-+Resources.pdf>
         def get_script_resources_pathname(script, as_url = false)
           filename = ActiveStorage::Filename.new(script.localized_title + " - Resources.pdf").sanitized
+          filename = canonicalize_s3_filename(filename)
           filename = CGI.escape(filename) if as_url
           script_overview_pathname = get_script_overview_pathname(script)
           return nil unless script_overview_pathname
@@ -121,6 +122,7 @@ module Services
           )
 
           filename = ActiveStorage::Filename.new("lesson.#{lesson.key}.title.pdf").sanitized
+          filename = canonicalize_s3_filename(filename)
           path = File.join(directory, filename)
 
           PDF.generate_from_html(page_content, path)
@@ -153,6 +155,7 @@ module Services
         # based on the key of that Resource) to the given directory.
         def fetch_resource_pdf(resource, directory="/tmp/")
           filename = ActiveStorage::Filename.new("resource.#{resource.key}.pdf").sanitized
+          filename = canonicalize_s3_filename(filename)
           path = File.join(directory, filename)
           return path if File.exist?(path)
           return fetch_url_to_path(resource.url, path)

--- a/dashboard/lib/services/curriculum_pdfs/resources.rb
+++ b/dashboard/lib/services/curriculum_pdfs/resources.rb
@@ -119,7 +119,7 @@ module Services
             type: :haml
           )
 
-          filename = ActiveStorage::Filename.new("lesson.#{lesson.key.parameterize(preserve_case: true)}.title.pdf").to_s
+          filename = ActiveStorage::Filename.new("lesson.#{lesson.key.parameterize}.title.pdf").to_s
           path = File.join(directory, filename)
 
           PDF.generate_from_html(page_content, path)
@@ -151,7 +151,7 @@ module Services
         # Given a Resource object, persist a PDF of that Resource (with a name
         # based on the key of that Resource) to the given directory.
         def fetch_resource_pdf(resource, directory="/tmp/")
-          filename = ActiveStorage::Filename.new("resource.#{resource.key.parameterize(preserve_case: true)}.pdf").to_s
+          filename = ActiveStorage::Filename.new("resource.#{resource.key.parameterize}.pdf").to_s
           path = File.join(directory, filename)
           return path if File.exist?(path)
           return fetch_url_to_path(resource.url, path)

--- a/dashboard/lib/services/curriculum_pdfs/resources.rb
+++ b/dashboard/lib/services/curriculum_pdfs/resources.rb
@@ -18,8 +18,7 @@ module Services
         #
         # For example: <Pathname:csp1-2021/20210909014219/Digital+Information+('21-'22)+-+Resources.pdf>
         def get_script_resources_pathname(script, as_url = false)
-          filename = ActiveStorage::Filename.new(script.localized_title + " - Resources.pdf").sanitized
-          filename = canonicalize_s3_filename(filename)
+          filename = ActiveStorage::Filename.new(script.localized_title.parameterize(preserve_case: true) + "-Resources.pdf").to_s
           filename = CGI.escape(filename) if as_url
           script_overview_pathname = get_script_overview_pathname(script)
           return nil unless script_overview_pathname
@@ -121,8 +120,7 @@ module Services
             type: :haml
           )
 
-          filename = ActiveStorage::Filename.new("lesson.#{lesson.key}.title.pdf").sanitized
-          filename = canonicalize_s3_filename(filename)
+          filename = ActiveStorage::Filename.new("lesson.#{lesson.key.parameterize(preserve_case: true)}.title.pdf").to_s
           path = File.join(directory, filename)
 
           PDF.generate_from_html(page_content, path)
@@ -154,8 +152,7 @@ module Services
         # Given a Resource object, persist a PDF of that Resource (with a name
         # based on the key of that Resource) to the given directory.
         def fetch_resource_pdf(resource, directory="/tmp/")
-          filename = ActiveStorage::Filename.new("resource.#{resource.key}.pdf").sanitized
-          filename = canonicalize_s3_filename(filename)
+          filename = ActiveStorage::Filename.new("resource.#{resource.key.parameterize(preserve_case: true)}.pdf").to_s
           path = File.join(directory, filename)
           return path if File.exist?(path)
           return fetch_url_to_path(resource.url, path)

--- a/dashboard/lib/services/curriculum_pdfs/script_overview.rb
+++ b/dashboard/lib/services/curriculum_pdfs/script_overview.rb
@@ -18,8 +18,7 @@ module Services
         def get_script_overview_pathname(script, as_url = false)
           return nil unless script&.seeded_from
           version_number = Time.parse(script.seeded_from).to_s(:number)
-          filename = ActiveStorage::Filename.new(script.localized_title + ".pdf").sanitized
-          filename = canonicalize_s3_filename(filename)
+          filename = ActiveStorage::Filename.new(script.localized_title.parameterize(preserve_case: true) + ".pdf").to_s
           filename = CGI.escape(filename) if as_url
           return Pathname.new(File.join(script.name, version_number, filename))
         end
@@ -52,8 +51,7 @@ module Services
           pdfs = []
 
           # Include a PDF of the /s/script.name page itself
-          script_filename = ActiveStorage::Filename.new("script.#{script.name}.pdf").sanitized
-          script_filename = canonicalize_s3_filename(script_filename)
+          script_filename = ActiveStorage::Filename.new("script.#{script.name.parameterize(preserve_case: true)}.pdf").to_s
           script_path = File.join(pdfs_dir, script_filename)
           # Make sure to specify
           # 1. 'no_redirect' so we're guaranteed to get the actual script we want

--- a/dashboard/lib/services/curriculum_pdfs/script_overview.rb
+++ b/dashboard/lib/services/curriculum_pdfs/script_overview.rb
@@ -15,11 +15,10 @@ module Services
         # version
         #
         # For example: <Pathname:csp1-2021/20210909014219/Digital+Information+%28%2721-%2722%29.pdf>
-        def get_script_overview_pathname(script, as_url = false)
+        def get_script_overview_pathname(script)
           return nil unless script&.seeded_from
           version_number = Time.parse(script.seeded_from).to_s(:number)
           filename = ActiveStorage::Filename.new(script.localized_title.parameterize(preserve_case: true) + ".pdf").to_s
-          filename = CGI.escape(filename) if as_url
           return Pathname.new(File.join(script.name, version_number, filename))
         end
 
@@ -29,7 +28,7 @@ module Services
         # For example: https://lesson-plans.code.org/csp1-2021/20210909014219/Digital+Information+%28%2721-%2722%29.pdf
         def get_script_overview_url(script)
           return nil unless Services::CurriculumPdfs.should_generate_overview_pdf?(script)
-          pathname = get_script_overview_pathname(script, true)
+          pathname = get_script_overview_pathname(script)
           return nil if pathname.blank?
           File.join(get_base_url, pathname)
         end

--- a/dashboard/lib/services/curriculum_pdfs/script_overview.rb
+++ b/dashboard/lib/services/curriculum_pdfs/script_overview.rb
@@ -50,7 +50,7 @@ module Services
           pdfs = []
 
           # Include a PDF of the /s/script.name page itself
-          script_filename = ActiveStorage::Filename.new("script.#{script.name.parameterize(preserve_case: true)}.pdf").to_s
+          script_filename = ActiveStorage::Filename.new("script.#{script.name.parameterize}.pdf").to_s
           script_path = File.join(pdfs_dir, script_filename)
           # Make sure to specify
           # 1. 'no_redirect' so we're guaranteed to get the actual script we want

--- a/dashboard/lib/services/curriculum_pdfs/script_overview.rb
+++ b/dashboard/lib/services/curriculum_pdfs/script_overview.rb
@@ -19,6 +19,7 @@ module Services
           return nil unless script&.seeded_from
           version_number = Time.parse(script.seeded_from).to_s(:number)
           filename = ActiveStorage::Filename.new(script.localized_title + ".pdf").sanitized
+          filename = canonicalize_s3_filename(filename)
           filename = CGI.escape(filename) if as_url
           return Pathname.new(File.join(script.name, version_number, filename))
         end
@@ -52,6 +53,7 @@ module Services
 
           # Include a PDF of the /s/script.name page itself
           script_filename = ActiveStorage::Filename.new("script.#{script.name}.pdf").sanitized
+          script_filename = canonicalize_s3_filename(script_filename)
           script_path = File.join(pdfs_dir, script_filename)
           # Make sure to specify
           # 1. 'no_redirect' so we're guaranteed to get the actual script we want

--- a/dashboard/test/lib/services/curriculum_pdfs/lesson_plans_test.rb
+++ b/dashboard/test/lib/services/curriculum_pdfs/lesson_plans_test.rb
@@ -20,19 +20,19 @@ class Services::CurriculumPdfs::LessonPlansTest < ActiveSupport::TestCase
 
   test 'urls are escaped' do
     script = create(:script, name: "test-escapes-script", seeded_from: Time.at(0))
-    lesson = create(:lesson, script: script, key: "Some!key_with?special/characters")
-    assert_equal Pathname.new("test-escapes-script/19700101000000/teacher-lesson-plans/Some%21key_with%3Fspecial-characters.pdf"),
+    lesson = create(:lesson, script: script, name: "Some!name_with?special/characters")
+    assert_equal Pathname.new("test-escapes-script/19700101000000/teacher-lesson-plans/Some-name_with-special-characters.pdf"),
       Services::CurriculumPdfs.get_lesson_plan_pathname(lesson, false)
-    assert_equal "https://lesson-plans.code.org/test-escapes-script/19700101000000/teacher-lesson-plans/Some%21key_with%3Fspecial-characters.pdf",
+    assert_equal "https://lesson-plans.code.org/test-escapes-script/19700101000000/teacher-lesson-plans/Some-name_with-special-characters.pdf",
       Services::CurriculumPdfs.get_lesson_plan_url(lesson, false)
   end
 
   test 'pathnames are differentiated by audience' do
     script = create(:script, name: "test-pathnames-script", seeded_from: Time.at(0))
-    lesson = create(:lesson, script: script, key: "test-pathnames-lesson")
+    lesson = create(:lesson, script: script, name: "test-pathnames-lesson")
     assert_equal Pathname.new("test-pathnames-script/19700101000000/teacher-lesson-plans/test-pathnames-lesson.pdf"),
       Services::CurriculumPdfs.get_lesson_plan_pathname(lesson)
-    assert_equal Pathname.new("test-pathnames-script/19700101000000/student-lesson-plans/test-pathnames-lesson.pdf"),
+    assert_equal Pathname.new("test-pathnames-script/19700101000000/student-lesson-plans/test-pathnames-lesson-Student.pdf"),
       Services::CurriculumPdfs.get_lesson_plan_pathname(lesson, true)
   end
 

--- a/dashboard/test/lib/services/curriculum_pdfs/lesson_plans_test.rb
+++ b/dashboard/test/lib/services/curriculum_pdfs/lesson_plans_test.rb
@@ -22,7 +22,7 @@ class Services::CurriculumPdfs::LessonPlansTest < ActiveSupport::TestCase
     script = create(:script, name: "test-escapes-script", seeded_from: Time.at(0))
     lesson = create(:lesson, script: script, key: "Some!key_with?special/characters")
     assert_equal Pathname.new("test-escapes-script/19700101000000/teacher-lesson-plans/Some%21key_with%3Fspecial-characters.pdf"),
-      Services::CurriculumPdfs.get_lesson_plan_pathname(lesson, false, true)
+      Services::CurriculumPdfs.get_lesson_plan_pathname(lesson, false)
     assert_equal "https://lesson-plans.code.org/test-escapes-script/19700101000000/teacher-lesson-plans/Some%21key_with%3Fspecial-characters.pdf",
       Services::CurriculumPdfs.get_lesson_plan_url(lesson, false)
   end

--- a/dashboard/test/lib/services/curriculum_pdfs_test.rb
+++ b/dashboard/test/lib/services/curriculum_pdfs_test.rb
@@ -110,5 +110,11 @@ module Services
         Services::CurriculumPdfs.upload_generated_pdfs_to_s3(tmpdir)
       end
     end
+
+    test 'canonicalize_s3_filename only allows safe characters' do
+      assert_equal 'keep*safe_chars()', Services::CurriculumPdfs.canonicalize_s3_filename('keep*safe_chars()')
+      assert_equal '-replace-problem-chars-', Services::CurriculumPdfs.canonicalize_s3_filename('"replace&problem?chars"')
+      assert_equal 'preserve-dashes', Services::CurriculumPdfs.canonicalize_s3_filename('preserve-dashes')
+    end
   end
 end

--- a/dashboard/test/lib/services/curriculum_pdfs_test.rb
+++ b/dashboard/test/lib/services/curriculum_pdfs_test.rb
@@ -110,11 +110,5 @@ module Services
         Services::CurriculumPdfs.upload_generated_pdfs_to_s3(tmpdir)
       end
     end
-
-    test 'canonicalize_s3_filename only allows safe characters' do
-      assert_equal 'keep*safe_chars()', Services::CurriculumPdfs.canonicalize_s3_filename('keep*safe_chars()')
-      assert_equal '-replace-problem-chars-', Services::CurriculumPdfs.canonicalize_s3_filename('"replace&problem?chars"')
-      assert_equal 'preserve-dashes', Services::CurriculumPdfs.canonicalize_s3_filename('preserve-dashes')
-    end
   end
 end

--- a/dashboard/test/models/lesson_test.rb
+++ b/dashboard/test/models/lesson_test.rb
@@ -742,30 +742,30 @@ class LessonTest < ActiveSupport::TestCase
   test 'lesson_plan_pdf_url supports new lesson plan PDFs' do
     old_lesson = create :lesson
     assert_equal(
-      old_lesson.lesson_plan_pdf_url,
-      "//test.code.org/curriculum/#{old_lesson.script.name}/1/Teacher.pdf"
+      "//test.code.org/curriculum/#{old_lesson.script.name}/1/Teacher.pdf",
+      old_lesson.lesson_plan_pdf_url
     )
 
     script = create :script, is_migrated: true
-    new_lesson = create :lesson, script: script, key: 'Some Verbose Lesson Name', has_lesson_plan: true
+    new_lesson = create :lesson, script: script, name: 'Some Verbose Lesson Name', has_lesson_plan: true
     assert_nil(new_lesson.lesson_plan_pdf_url)
 
     script.seeded_from = Time.now.to_s
     assert_equal(
-      new_lesson.lesson_plan_pdf_url,
-      "https://lesson-plans.code.org/#{script.name}/#{Time.parse(script.seeded_from).to_s(:number)}/teacher-lesson-plans/Some+Verbose+Lesson+Name.pdf"
+      "https://lesson-plans.code.org/#{script.name}/#{Time.parse(script.seeded_from).to_s(:number)}/teacher-lesson-plans/Some-Verbose-Lesson-Name.pdf",
+      new_lesson.lesson_plan_pdf_url
     )
   end
 
   test 'student_lesson_plan_pdf_url gets url for migrated script with student lesson plans' do
     script = create :script, is_migrated: true, include_student_lesson_plans: true
-    new_lesson = create :lesson, script: script, key: 'Some Verbose Lesson Name', has_lesson_plan: true
+    new_lesson = create :lesson, script: script, name: 'Some Verbose Lesson Name', has_lesson_plan: true
     assert_nil(new_lesson.student_lesson_plan_pdf_url)
 
     script.seeded_from = Time.now.to_s
     assert_equal(
-      new_lesson.student_lesson_plan_pdf_url,
-      "https://lesson-plans.code.org/#{script.name}/#{Time.parse(script.seeded_from).to_s(:number)}/student-lesson-plans/Some+Verbose+Lesson+Name.pdf"
+      "https://lesson-plans.code.org/#{script.name}/#{Time.parse(script.seeded_from).to_s(:number)}/student-lesson-plans/Some-Verbose-Lesson-Name-Student.pdf",
+      new_lesson.student_lesson_plan_pdf_url
     )
   end
 


### PR DESCRIPTION
Finishes [PLAT-1925](https://codedotorg.atlassian.net/browse/PLAT-1925). Here's what it does:

1. Rather than specifically eliminating the characters that are problematic for S3 as described in Jira, this PR uses the even more restrictive [parameterize](https://apidock.com/rails/ActiveSupport/Inflector/parameterize) method to replace any special characters with `-`, trimming and removing duplicates (only alphanumeric, `-` and `_` are allowed). 
2. because these characters are all url safe, we also get to remove the calls to `sanitized`, `CGI.escape`, as well as the `as_url` method param.
3. to improve the UX a bit, we now use the user-visible lesson name as the source for the PDF filename, rather than the lesson key (which can sometimes just be `lesson-1`).

## Screenshots

The user-visible change is that now PDF filenames are different, generally being more readable. this one is found under Printing Options at https://studio.code.org/s/hello-world-draft:
![Screen Shot 2022-09-29 at 11 35 11 AM](https://user-images.githubusercontent.com/8001765/193115074-9dd944fd-9e42-455c-8276-9f56de128ce7.png)

The PDF name is also changed to use the user-visible lesson name rather than the key. Here is an example of this improvement on https://studio.code.org/s/aiml-2021/lessons/1/ : 

![Screen Shot 2022-09-29 at 11 38 56 AM](https://user-images.githubusercontent.com/8001765/193115580-6bfcdf52-762f-4305-a375-1c6bc60bad59.png)

## Testing story

* the tests modified in this PR show the test coverage on lesson plan URLs
* other existing tests in ... provide coverage for other PDF types
* manual verification as follows:

after adding a lesson resource to hello-world-draft and then generating PDFs, the following files get generated in S3:
```
ubuntu@adhoc-launch-congrats:~/adhoc$ aws s3 ls --recursive s3://cdo-lesson-plans-dev/hello-world-draft
2022-09-29 19:10:31     983325 hello-world-draft/20220728184112/Hello-World-Resources.pdf
2022-09-29 19:10:31      82929 hello-world-draft/20220728184112/Hello-World.pdf
2022-09-29 19:10:32      95294 hello-world-draft/20220728184112/student-lesson-plans/Hello-world-Student.pdf
2022-09-29 19:10:32      55596 hello-world-draft/20220728184112/teacher-lesson-plans/Hello-world.pdf
```

then I verified that I could find and view all of these PDFs via the UI.

## Deployment strategy

I had to exclude some PDFs in order for generation to work locally. So, my plan is to merge this to staging one afternoon after the DTP is complete, and consider reverting if there are any unanticipated errors.

