### PR TITLE
Temporarily load SVG from JSX while fixing assets for SCSS

### DIFF
--- a/apps/src/templates/CsaSkinnyBanner.jsx
+++ b/apps/src/templates/CsaSkinnyBanner.jsx
@@ -15,13 +15,19 @@ export default function CsaSkinnyBanner() {
   const text =
     'Creative projects and real world connections in our equity-driven curriculum';
 
+  // TODO (madelynkasula 09/29/2022): Remove JS styles below and address TODO in
+  // csaSkinnyBanner.scss once asset loading has been fixed for webpack 5.
+  const asideStyle = {
+    background: `url("${IMAGE_BASE_URL}csa-skinny-banner-bg.svg") center no-repeat`
+  };
+
   if (!!DCDO.get('csa-skinny-banner', false)) {
     return (
       <a
         href={pegasus('/educate/csa')}
         title="Learn more about Code.org's AP® CSA curriculum"
       >
-        <aside>
+        <aside style={asideStyle}>
           <div className="text-wrapper">
             <h1>{headerText}</h1>
             <p>{text}</p>

--- a/apps/src/templates/csaSkinnyBanner.scss
+++ b/apps/src/templates/csaSkinnyBanner.scss
@@ -17,7 +17,10 @@ aside {
   overflow: auto;
   margin: 4em auto 5em;
   padding: 0 2.5em;
-  background: url("@cdo/static/csa-skinny-banner-bg.svg") center no-repeat;
+  // TODO (madelynkasula 09/29/2022): Fix the asset path below and remove
+  // JS styles from <CsaSkinnyBanner> once asset loading has been fixed for
+  // webpack 5.
+  // background: url("@cdo/static/csa-skinny-banner-bg.svg") center no-repeat;
   display: flex;
   justify-content: space-between;
   align-items: center;


### PR DESCRIPTION
When we upgraded to webpack 5, I changed the way we were loading a background image in `csaSkinnyBanner.scss`, which broke it. I'm currently working on a long-term fix for asset loading in SCSS modules, so I'm implementing a workaround here in the meantime.

**Before:**
<img width="1126" alt="Screen Shot 2022-09-29 at 7 56 56 AM" src="https://user-images.githubusercontent.com/9812299/193104659-b6ec4ccf-266a-4a02-aff0-67b3078ffa6f.png">

**After:**
<img width="1265" alt="Screen Shot 2022-09-29 at 10 43 57 AM" src="https://user-images.githubusercontent.com/9812299/193104686-b7d54279-e075-4bd0-82fc-cb55933c1666.png">
