### PR TITLE
Downgrade grunt-concurrent to last working version

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -117,7 +117,7 @@
     "glob": "5.0.14",
     "grunt": "^1.4.1",
     "grunt-cli": "1.4.3",
-    "grunt-concurrent": "3.0.0",
+    "grunt-concurrent": "1.0.1",
     "grunt-contrib-clean": "^2.0.0",
     "grunt-contrib-copy": "^1.0.0",
     "grunt-contrib-uglify": "5.0.1",

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -3859,10 +3859,15 @@ async@0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/async/-/async-0.9.0.tgz#ac3613b1da9bed1b47510bb4651b8931e47146c7"
 
+async@^0.9.0:
+  version "0.9.2"
+  resolved "https://registry.yarnpkg.com/async/-/async-0.9.2.tgz#aea74d5e61c1f899613bf64bda66d4c78f2fd17d"
+  integrity sha512-l6ToIJIotphWahxxHyzK9bnLR6kM4jJIIgLShZeqLY7iboHoGkdgFl7W2/Ivi4SkMJYGKqW8vSuk0uKUj6qsSw==
+
 async@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
-  integrity sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=
+  integrity sha512-nSVgobk4rv61R9PUSDtYt7mPVB2olxNR5RWJcAsH676/ef11bUZwvu7+RGYrYauVdDPcO519v68wRhXQtxsV9w==
 
 async@^2.4.1, async@^2.6.2:
   version "2.6.3"
@@ -3885,7 +3890,7 @@ async@^2.6.4:
   dependencies:
     lodash "^4.17.14"
 
-async@^3.1.0, async@~3.2.0:
+async@~3.2.0:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/async/-/async-3.2.4.tgz#2d22e00f8cddeb5fde5dd33522b56d1cf569a81c"
   integrity sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==
@@ -8569,15 +8574,13 @@ grunt-cli@1.4.3, grunt-cli@~1.4.3:
     nopt "~4.0.1"
     v8flags "~3.2.0"
 
-grunt-concurrent@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/grunt-concurrent/-/grunt-concurrent-3.0.0.tgz#643e72b1110ca70d1dbcc52fc540c429456097cb"
-  integrity sha512-AgXtjUJESHEGeGX8neL3nmXBTHSj1QC48ABQ3ng2/vjuSBpDD8gKcVHSlXP71pFkIR8TQHf+eomOx6OSYSgfrA==
+grunt-concurrent@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/grunt-concurrent/-/grunt-concurrent-1.0.1.tgz#d6e2fb1c3ce0d9d074cbfcd78537e4e407bf2fb1"
+  integrity sha512-1eXGKuiyuZnWbKbTophjM4X6zaVsqqNX4giBnLx+ag7mbMXYiUGydgOclssCWHjQcLQFSERdwyWKNMWW9bmbqQ==
   dependencies:
-    arrify "^2.0.1"
-    async "^3.1.0"
-    indent-string "^4.0.0"
-    pad-stream "^2.0.0"
+    async "^0.9.0"
+    pad-stdio "^1.0.0"
 
 grunt-contrib-clean@^2.0.0:
   version "2.0.0"
@@ -11240,6 +11243,11 @@ lower-case@^2.0.2:
   dependencies:
     tslib "^2.0.3"
 
+lpad@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/lpad/-/lpad-1.0.0.tgz#a231dd2c129a4eebc7335b324c147ede3abfb6da"
+  integrity sha512-g5YIAkT1BD0SVx88e2oJkGXrg90r7RqA/zLwH6KfwF6qOw77NSBUpYfE7HIlr5tKyhz8Kmm9A8nRNesCGjFICw==
+
 lru-cache@2.2.x:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-2.2.4.tgz#6c658619becf14031d0d0b594b16042ce4dc063d"
@@ -12962,14 +12970,12 @@ pa11y@^5.0.3:
     puppeteer "^1.13.0"
     semver "^5.6.0"
 
-pad-stream@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/pad-stream/-/pad-stream-2.0.0.tgz#3bebf34cda49597212a669f2fe417d646a7cba56"
-  integrity sha512-3QeQw19K48BQzUGZ9dEf/slX5Jbfy5ZeBTma2XICketO7kFNK7omF00riVcecOKN+DSiJZcK2em1eYKaVOeXKg==
+pad-stdio@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/pad-stdio/-/pad-stdio-1.0.0.tgz#79b282ae258e587f695dbd0381914362c0c98fcb"
+  integrity sha512-QC78pJjwMWU4YSBW7wU0Kx2Idz6b9jWD3vjPs3zIJLEriR+yZyWrUz0DgNzk/ql/yGM/JWR3D7XD+15896Ozmg==
   dependencies:
-    pumpify "^1.3.3"
-    split2 "^2.1.1"
-    through2 "^2.0.0"
+    lpad "^1.0.0"
 
 pako@~1.0.2:
   version "1.0.11"
@@ -16126,13 +16132,6 @@ split-string@^3.0.1, split-string@^3.0.2:
   dependencies:
     extend-shallow "^3.0.0"
 
-split2@^2.1.1:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/split2/-/split2-2.2.0.tgz#186b2575bcf83e85b7d18465756238ee4ee42493"
-  integrity sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==
-  dependencies:
-    through2 "^2.0.2"
-
 sprintf-js@^1.0.3, sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
@@ -16950,7 +16949,7 @@ text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
 
-through2@^2.0.0, through2@^2.0.2:
+through2@^2.0.0:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.5.tgz#01c1e39eb31d07cb7d03a96a70823260b23132cd"
   dependencies:


### PR DESCRIPTION
Follow-up to #48105.

Upgrading `grunt-concurrent` broke the output for the webpack build that displays % building message. This plugin isn't actively developed anymore ([the latest version, 3.0.0, was published 3 years ago](https://www.npmjs.com/package/grunt-concurrent/v/3.0.0)). I tried downgrading to 2.x.x, but it had the same issue. I did some digging to find whether there was a configuration change or something that's causing this, but couldn't find anything, so I'm downgrading to the last known working version.

Now, when you run `yarn start`, which runs 2 concurrent watch tasks:

https://github.com/code-dot-org/code-dot-org/blob/bed387492a394138fa5692ac1219e6d01c26a493/apps/Gruntfile.js#L1228-L1239

...you see the expected output as the concurrent tasks are building:

https://user-images.githubusercontent.com/9812299/193157075-f4a89dc5-9ce8-4468-b788-67f17918a69c.mov

