### PR TITLE
Maker Chromebook UI Update

### DIFF
--- a/apps/i18n/applab/en_us.json
+++ b/apps/i18n/applab/en_us.json
@@ -354,6 +354,8 @@
   "makerSetupBrowserSupported": "Using a supported browser",
   "makerSetupCheck": "Setup Check",
   "makerSetupCheckInternetConnection": "Please make sure you are connected to the internet, and [https://downloads.code.org](https://downloads.code.org/index.html) is reachable from your network.",
+  "makerSetupChromebook": "Maker Toolkit works on Chromebooks without any installations or extensions. You should be able to plug in your board and get started right away!",
+  "makerSetupChromebookHistoricalNote": "Previously, we required the installation of the Code.org Serial Connector to use the Maker Toolkit with Chromebooks. This is no longer needed. If you have the Code.org Serial Connector installed, you may uninstall it if you wish. We will be removing it from the Chrome Web Store at the end of November. This will not affect your experience with the Maker Toolkit and requires no action from you.",
   "makerSetupChromebookPage": "Open this page ([{makerSetupPage}]({makerSetupPage})) on your Chromebook.",
   "makerSetupDownloadAndInstall": "Download and install the Code.org Maker App using the download button above.",
   "makerSetupDownloadProblem": "There was a problem getting your download link.",

--- a/apps/i18n/applab/en_us.json
+++ b/apps/i18n/applab/en_us.json
@@ -386,6 +386,7 @@
   "manageAssets": "Click to view or update your images and sounds.",
   "nextLevel": "Congratulations! You have completed this puzzle.",
   "no": "No",
+  "note": "Note",
   "numBlocksNeeded": "This puzzle can be solved with %1 blocks.",
   "redetect": "re-detect",
   "reinfFeedbackMsg": "Are you finished? With App Lab, you're in control - it's up to you to check your work and decide when you're done.",

--- a/apps/src/lib/kits/maker/ui/SetupGuide.jsx
+++ b/apps/src/lib/kits/maker/ui/SetupGuide.jsx
@@ -341,10 +341,19 @@ const SetupInstructions = () => (
 const MAKER_SETUP_PAGE_URL = document.location.origin + '/maker/setup';
 
 class ChromebookInstructions extends React.Component {
-  render() {
+  webSerialSetupInstructions() {
     return (
       <div>
-        <h2>{applabI18n.makerSetupMakerAppForChromebook()}</h2>
+        {applabI18n.makerSetupChromebook()}
+        <h4> Note </h4>
+        {applabI18n.makerSetupChromebookHistoricalNote()}
+      </div>
+    );
+  }
+
+  chromeAppSetupInstructions() {
+    return (
+      <div>
         <SafeMarkdown
           markdown={applabI18n.makerSetupSerialConnector({
             webstoreURL: CHROME_APP_WEBSTORE_URL
@@ -362,6 +371,21 @@ class ChromebookInstructions extends React.Component {
           <li>{applabI18n.makerSetupFollowInstructions()}</li>
           <li>{applabI18n.makerSetupPlugInBoard()}</li>
         </ol>
+      </div>
+    );
+  }
+
+  render() {
+    let setupInstructions;
+    if (experiments.isEnabled('webserial')) {
+      setupInstructions = this.webSerialSetupInstructions();
+    } else {
+      setupInstructions = this.chromeAppSetupInstructions();
+    }
+    return (
+      <div>
+        <h2>{applabI18n.makerSetupMakerAppForChromebook()}</h2>
+        {setupInstructions}
       </div>
     );
   }

--- a/apps/src/lib/kits/maker/ui/SetupGuide.jsx
+++ b/apps/src/lib/kits/maker/ui/SetupGuide.jsx
@@ -21,7 +21,10 @@ import isRtl from '@cdo/apps/code-studio/isRtlRedux';
 import responsive from '@cdo/apps/code-studio/responsiveRedux';
 import {Provider} from 'react-redux';
 import experiments from '@cdo/apps/util/experiments';
-import {WEB_SERIAL_FILTERS} from '@cdo/apps/lib/kits/maker/util/boardUtils';
+import {
+  WEB_SERIAL_FILTERS,
+  isWebSerialPortAvailable
+} from '@cdo/apps/lib/kits/maker/util/boardUtils';
 
 const DOWNLOAD_PREFIX = 'https://downloads.code.org/maker/';
 const WINDOWS = 'windows';
@@ -53,7 +56,8 @@ export default class SetupGuide extends React.Component {
     const {webSerialPort} = this.state;
 
     // Experiment 'webserial' uses the WebSerial protocol and requires no downloads.
-    let isWebSerial = experiments.isEnabled('webserial');
+    let isWebSerial =
+      experiments.isEnabled('webserial') && isWebSerialPortAvailable();
 
     // WebSerial requires user input for user to select port.
     // Add a button for user interaction before initiated Setup Checklist

--- a/apps/src/lib/kits/maker/ui/SetupGuide.jsx
+++ b/apps/src/lib/kits/maker/ui/SetupGuide.jsx
@@ -345,7 +345,7 @@ class ChromebookInstructions extends React.Component {
     return (
       <div>
         {applabI18n.makerSetupChromebook()}
-        <h4> Note </h4>
+        <h4>{applabI18n.note()}</h4>
         {applabI18n.makerSetupChromebookHistoricalNote()}
       </div>
     );
@@ -376,16 +376,12 @@ class ChromebookInstructions extends React.Component {
   }
 
   render() {
-    let setupInstructions;
-    if (experiments.isEnabled('webserial')) {
-      setupInstructions = this.webSerialSetupInstructions();
-    } else {
-      setupInstructions = this.chromeAppSetupInstructions();
-    }
     return (
       <div>
         <h2>{applabI18n.makerSetupMakerAppForChromebook()}</h2>
-        {setupInstructions}
+        {experiments.isEnabled('webserial')
+          ? this.webSerialSetupInstructions()
+          : this.chromeAppSetupInstructions()}
       </div>
     );
   }

--- a/apps/src/lib/kits/maker/util/boardUtils.js
+++ b/apps/src/lib/kits/maker/util/boardUtils.js
@@ -52,6 +52,13 @@ export function isWebSerialPort(port) {
   return port instanceof WebSerialPortWrapper;
 }
 
+/**
+ * Determines whether WebSerial port is available in the current browser
+ */
+export function isWebSerialPortAvailable() {
+  return 'serial' in navigator;
+}
+
 /** @const {number} serial port transfer rate */
 export const SERIAL_BAUD = 57600;
 


### PR DESCRIPTION
This PR applies changes text changes to /maker/setup. I decided to apply this behind the 'webserial' flag so that we can merge this now and not wait for the webserial flag removal.

Previously, users would see the OS-specific setup in the following cases:
* On Chromebook when SerialApp not installed
* On Mac/PC in any browser

With WebSerial, this OS-specific setup page is only seen in this case:
* On Mac/PC in non-Chromium browser (i.e. Firefox)

This is because webserial 'just works' - so we rarely need to see this page.

I have open questions for Moneppo on this ticket: https://codedotorg.atlassian.net/browse/SL-243?atlOrigin=eyJpIjoiY2VjMjEwMWIwZTZkNDZmNmEyMDgwMDNkMGFmMjQ3YjIiLCJwIjoiaiJ9 about whether we might want to apply some of the text-change to the checklist-board-connection state.

Screenshot, Firefox with enableExperiment:
![Screenshot from 2022-09-30 09-33-54](https://user-images.githubusercontent.com/2959170/193320778-d8890bc9-11b5-479d-8541-cbb1f8938c53.png)

Screenshot, Firefox with disableExperiment:
![Screenshot from 2022-09-30 09-34-19](https://user-images.githubusercontent.com/2959170/193320796-e41bdfc2-cabe-4c60-b825-751c0eb85058.png)
