### PR TITLE
Update `devise_invitable` to >= 2.0.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -141,7 +141,7 @@ gem 'gemoji'
 # Authentication and permissions.
 gem 'cancancan', '~> 3.0.0'
 gem 'devise', '~> 4.7.0'
-gem 'devise_invitable', '~> 1.6.0'
+gem 'devise_invitable', '~> 2.0.2'
 
 # Ref: https://github.com/instructure/ims-lti/pull/90
 gem 'ims-lti', github: 'wjordan/ims-lti', ref: 'oauth_051'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -391,9 +391,9 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
-    devise_invitable (1.6.0)
-      actionmailer (>= 3.2.6)
-      devise (>= 3.2.0)
+    devise_invitable (2.0.6)
+      actionmailer (>= 5.0)
+      devise (>= 4.6)
     diff-lcs (1.3)
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
@@ -950,7 +950,7 @@ DEPENDENCIES
   dalli-elasticache
   datapackage
   devise (~> 4.7.0)
-  devise_invitable (~> 1.6.0)
+  devise_invitable (~> 2.0.2)
   dotiw
   execjs
   eyes_selenium (= 3.18.4)


### PR DESCRIPTION
To pick up a fix for a Ruby 2.7 deprecation warning.

The only breaking changes between versions 1 and 2 of this library were removal of support for old dependencies, none of which impact us:

> Drop Devise < 4.6 support
> Drop Rails 4.2 support
> Drop Ruby 2.1 support

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

- https://github.com/scambra/devise_invitable/blob/master/CHANGELOG.md

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
