### PR TITLE
Revert "Update Rubygems to 3.1.6"

### DIFF
--- a/cookbooks/cdo-apps/spec/default_spec.rb
+++ b/cookbooks/cdo-apps/spec/default_spec.rb
@@ -7,7 +7,7 @@ describe 'cdo-apps::default' do
   end
 
   let :chef_run do
-    stub_command("which gem && gem --version | grep -q '3.1.6'").and_return(true)
+    stub_command("which gem && gem --version | grep -q '2.7.4'").and_return(true)
     stub_command('bundle check').and_return(true)
     ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '14.04') do |node|
       node.automatic['memory']['total'] = "#{(8 * 1024 * 1024)}kB"

--- a/cookbooks/cdo-ruby/attributes/default.rb
+++ b/cookbooks/cdo-ruby/attributes/default.rb
@@ -1,6 +1,6 @@
 default['cdo-ruby'] = {
   version: '2.6',
-  rubygems_version: '3.1.6',
+  rubygems_version: '2.7.4',
   bundler_version: '1.17.3',
   rake_version: '11.3.0'
 }

--- a/cookbooks/cdo-ruby/test/integration/default/serverspec/ruby_spec.rb
+++ b/cookbooks/cdo-ruby/test/integration/default/serverspec/ruby_spec.rb
@@ -2,5 +2,5 @@ require_relative '../../../kitchen/data/helper_spec'
 
 file_exist '/usr/bin/ruby2.6'
 cmd 'ruby -v', 'ruby 2.6'
-cmd 'gem -v', '3.1.6'
+cmd 'gem -v', '2.7.4'
 cmd 'bundler -v', '1.17.3'


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#48294

This started generating deprecation warnings in our cronjobs (see https://app.honeybadger.io/projects/45435/faults/88796148 and others like it).