### PR TITLE
Update `raindrops` to 0.20.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -710,7 +710,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.20.3, < 2.0)
     rainbow (3.0.0)
-    raindrops (0.19.0)
+    raindrops (0.20.0)
     rake (11.3.0)
     rambling-trie (2.2.1)
     rb-fsevent (0.10.2)


### PR DESCRIPTION
To pick up a fix for a Ruby 2.7 deprecation warning:

    /var/lib/gems/2.7.0/gems/raindrops-0.19.0/lib/raindrops/linux.rb:60: warning: Using the last argument as keyword parameters is deprecated

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- https://yhbt.net/raindrops.git/tree/lib/raindrops/linux.rb?h=v0.19.0#n60
- https://yhbt.net/raindrops.git/tree/lib/raindrops/linux.rb?h=v0.20.0#n59

<!--
- spec: []()
- jira ticket: []()
-->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
