### PR TITLE
Storybook migrations - MakerLanding, ScrollButtons

### DIFF
--- a/apps/src/lib/kits/maker/boards/circuitPlayground/Button.js
+++ b/apps/src/lib/kits/maker/boards/circuitPlayground/Button.js
@@ -1,5 +1,5 @@
 /** @file Wrapper around Johnny-Five Button component */
-import five from '@code-dot-org/johnny-five-deprecated';
+import five from '@code-dot-org/johnny-five';
 import '../../../../../utils'; // For Function.prototype.inherits
 import {EXTERNAL_PINS} from './PlaygroundConstants';
 

--- a/apps/src/lib/kits/maker/boards/circuitPlayground/CircuitPlaygroundBoard.js
+++ b/apps/src/lib/kits/maker/boards/circuitPlayground/CircuitPlaygroundBoard.js
@@ -1,7 +1,7 @@
 /** @file Board controller for Adafruit Circuit Playground */
 import _ from 'lodash';
 import {EventEmitter} from 'events'; // provided by webpack's node-libs-browser
-import five from '@code-dot-org/johnny-five-deprecated';
+import five from '@code-dot-org/johnny-five';
 import Playground from 'playground-io';
 import experiments from '@cdo/apps/util/experiments';
 import Firmata from 'firmata';

--- a/apps/src/lib/kits/maker/boards/circuitPlayground/Led.js
+++ b/apps/src/lib/kits/maker/boards/circuitPlayground/Led.js
@@ -1,5 +1,5 @@
 /** @file Extended Johnny-Five Led component with Code.org-specific behavior */
-import five from '@code-dot-org/johnny-five-deprecated';
+import five from '@code-dot-org/johnny-five';
 
 export default class Led extends five.Led {
   on() {

--- a/apps/src/lib/kits/maker/boards/circuitPlayground/NeoPixel.js
+++ b/apps/src/lib/kits/maker/boards/circuitPlayground/NeoPixel.js
@@ -1,5 +1,5 @@
 /** @file Wrapper around Johnny-Five NeoPixel component */
-import five from '@code-dot-org/johnny-five-deprecated';
+import five from '@code-dot-org/johnny-five';
 
 export default class NeoPixel extends five.Led.RGB {
   on() {

--- a/apps/src/lib/kits/maker/boards/circuitPlayground/Piezo.js
+++ b/apps/src/lib/kits/maker/boards/circuitPlayground/Piezo.js
@@ -1,5 +1,5 @@
 /** @file Wrapper around Johnny-Five Piezo component to modify play() */
-import five from '@code-dot-org/johnny-five-deprecated';
+import five from '@code-dot-org/johnny-five';
 import '../../../../../utils'; // For Function.prototype.inherits
 
 /**

--- a/apps/src/lib/kits/maker/boards/circuitPlayground/PlaygroundComponents.js
+++ b/apps/src/lib/kits/maker/boards/circuitPlayground/PlaygroundComponents.js
@@ -11,7 +11,7 @@ import {
 } from './PlaygroundConstants';
 import LookbackLogger from '../../LookbackLogger';
 import _ from 'lodash';
-import five from '@code-dot-org/johnny-five-deprecated';
+import five from '@code-dot-org/johnny-five';
 import PlaygroundIO from 'playground-io';
 import PlaygroundButton from './Button';
 import PlaygroundThermometer from './Thermometer';

--- a/apps/src/lib/kits/maker/boards/circuitPlayground/Switch.js
+++ b/apps/src/lib/kits/maker/boards/circuitPlayground/Switch.js
@@ -4,7 +4,7 @@
  */
 import _ from 'lodash';
 import {EventEmitter} from 'events'; // provided by webpack's node-libs-browser
-import five from '@code-dot-org/johnny-five-deprecated';
+import five from '@code-dot-org/johnny-five';
 
 /** @const {number} Pin for the toggle switch on a Circuit Playground. */
 const SWITCH_PIN = 21;

--- a/apps/src/templates/MakerLanding.story.jsx
+++ b/apps/src/templates/MakerLanding.story.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import MakerLanding from './MakerLanding';
+import {Provider} from 'react-redux';
+import {reduxStore} from '@cdo/storybook/decorators';
 
 const topCourse = {
   assignableName: 'CSD Unit 6 - Physical Computing',
@@ -9,15 +11,18 @@ const topCourse = {
     'http://localhost-studio.code.org:3000/s/csd6/lessons/1/levels/1'
 };
 
-export default storybook => {
-  return storybook
-    .storiesOf('MakerToolkit/MakerLanding', module)
-    .withReduxStore()
-    .addStoryTable([
-      {
-        name: 'MakerLanding',
-        description: 'Landing page for Maker Toolkit',
-        story: () => <MakerLanding topCourse={topCourse} />
-      }
-    ]);
+export default {
+  title: 'MakerLanding',
+  component: MakerLanding
+};
+
+const Template = args => (
+  <Provider store={reduxStore()}>
+    <MakerLanding {...args} />
+  </Provider>
+);
+
+export const MakerExample = Template.bind({});
+MakerExample.args = {
+  topCourse: topCourse
 };

--- a/apps/src/templates/instructions/ScrollButtons.story.jsx
+++ b/apps/src/templates/instructions/ScrollButtons.story.jsx
@@ -1,47 +1,57 @@
 import React from 'react';
-
 import ScrollButtons from './ScrollButtons';
 
-export default storybook => {
-  return storybook.storiesOf('ScrollButtons', module).addStoryTable([
-    {
-      name: 'Scroll Buttons',
-      story: () => {
-        let container;
-        return (
-          <div style={{minWidth: 200}}>
-            <div
-              style={{
-                float: 'left',
-                overflowY: 'hidden',
-                height: 200,
-                width: '80%'
-              }}
-              ref={c => {
-                container = c;
-              }}
-            >
-              <div
-                style={{
-                  height: 1000,
-                  background: 'linear-gradient(red, yellow)'
-                }}
-              />
-            </div>
-            <div style={{float: 'left', width: '10%'}}>
-              <ScrollButtons
-                style={{
-                  position: 'relative'
-                }}
-                getScrollTarget={() => container}
-                height={200}
-                isMinecraft={false}
-                visible
-              />
-            </div>
-          </div>
-        );
-      }
-    }
-  ]);
+export default {
+  title: 'ScrollButtons',
+  component: ScrollButtons
+};
+
+const Template = args => {
+  let container;
+  return (
+    <div style={{minWidth: 200}}>
+      <div
+        style={{
+          float: 'left',
+          overflowY: 'hidden',
+          height: 200,
+          width: '80%'
+        }}
+        ref={c => {
+          container = c;
+        }}
+      >
+        <div
+          style={{
+            height: 500,
+            background: 'linear-gradient(red, yellow)'
+          }}
+        />
+      </div>
+      <div style={{float: 'left', width: '10%'}}>
+        <ScrollButtons
+          style={{
+            position: 'relative'
+          }}
+          getScrollTarget={() => container}
+          height
+          isMinecraft
+          visible
+          {...args}
+        />
+      </div>
+    </div>
+  );
+};
+
+export const BasicExample = Template.bind({});
+BasicExample.args = {
+  height: 200,
+  isMinecraft: false
+};
+
+export const MinecraftExample = Template.bind({});
+MinecraftExample.args = {
+  height: 200,
+  isMinecraft: true
 };

--- a/apps/test/unit/lib/kits/maker/boards/circuitPlayground/ButtonTest.js
+++ b/apps/test/unit/lib/kits/maker/boards/circuitPlayground/ButtonTest.js
@@ -1,7 +1,7 @@
 /** @file Tests for our johnny-five Button wrapper */
 import _ from 'lodash';
 import {expect} from '../../../../../../util/reconfiguredChai';
-import five from '@code-dot-org/johnny-five-deprecated';
+import five from '@code-dot-org/johnny-five';
 import {makeStubBoard} from '../makeStubBoard';
 import PlaygroundButton from '@cdo/apps/lib/kits/maker/boards/circuitPlayground/Button';
 import {EXTERNAL_PINS} from '@cdo/apps/lib/kits/maker/boards/circuitPlayground/PlaygroundConstants';

--- a/apps/test/unit/lib/kits/maker/boards/circuitPlayground/CircuitPlaygroundBoardTest.js
+++ b/apps/test/unit/lib/kits/maker/boards/circuitPlayground/CircuitPlaygroundBoardTest.js
@@ -3,7 +3,7 @@ import sinon from 'sinon';
 import {expect} from '../../../../../../util/reconfiguredChai';
 import {EventEmitter} from 'events'; // see node-libs-browser
 import Playground from 'playground-io';
-import five from '@code-dot-org/johnny-five-deprecated';
+import five from '@code-dot-org/johnny-five';
 import CircuitPlaygroundBoard from '@cdo/apps/lib/kits/maker/boards/circuitPlayground/CircuitPlaygroundBoard';
 import {
   SONG_CHARGE,

--- a/apps/test/unit/lib/kits/maker/boards/circuitPlayground/LedTest.js
+++ b/apps/test/unit/lib/kits/maker/boards/circuitPlayground/LedTest.js
@@ -1,7 +1,7 @@
 /** @file Tests for our johnny-five Led wrapper */
 import {expect} from '../../../../../../util/reconfiguredChai';
 import sinon from 'sinon';
-import five from '@code-dot-org/johnny-five-deprecated';
+import five from '@code-dot-org/johnny-five';
 import {makeStubBoard} from '../makeStubBoard';
 import Led from '@cdo/apps/lib/kits/maker/boards/circuitPlayground/Led';
 

--- a/apps/test/unit/lib/kits/maker/boards/circuitPlayground/NeoPixelTest.js
+++ b/apps/test/unit/lib/kits/maker/boards/circuitPlayground/NeoPixelTest.js
@@ -1,7 +1,7 @@
 /** @file Tests for our johnny-five Led.RGB wrapper */
 import {expect} from '../../../../../../util/reconfiguredChai';
 import sinon from 'sinon';
-import five from '@code-dot-org/johnny-five-deprecated';
+import five from '@code-dot-org/johnny-five';
 import NeoPixel from '@cdo/apps/lib/kits/maker/boards/circuitPlayground/NeoPixel';
 
 describe('NeoPixel', function() {

--- a/apps/test/unit/lib/kits/maker/boards/circuitPlayground/PiezoTest.js
+++ b/apps/test/unit/lib/kits/maker/boards/circuitPlayground/PiezoTest.js
@@ -1,7 +1,7 @@
 /** @file Tests for our johnny-five Piezo wrapper */
 import {expect} from '../../../../../../util/reconfiguredChai';
 import sinon from 'sinon';
-import five from '@code-dot-org/johnny-five-deprecated';
+import five from '@code-dot-org/johnny-five';
 import Piezo from '@cdo/apps/lib/kits/maker/boards/circuitPlayground/Piezo';
 
 describe('Piezo', function() {

--- a/apps/test/unit/lib/kits/maker/boards/circuitPlayground/PlaygroundComponentsTest.js
+++ b/apps/test/unit/lib/kits/maker/boards/circuitPlayground/PlaygroundComponentsTest.js
@@ -1,5 +1,5 @@
 /** @file Playground Component setup tests */
-import five from '@code-dot-org/johnny-five-deprecated';
+import five from '@code-dot-org/johnny-five';
 import Playground from 'playground-io';
 import {EventEmitter} from 'events'; // provided by webpack's node-libs-browser
 import {expect} from '../../../../../../util/reconfiguredChai';

--- a/apps/test/unit/lib/kits/maker/boards/makeStubBoard.js
+++ b/apps/test/unit/lib/kits/maker/boards/makeStubBoard.js
@@ -1,4 +1,4 @@
-import five from '@code-dot-org/johnny-five-deprecated';
+import five from '@code-dot-org/johnny-five';
 import Playground from 'playground-io';
 
 export function makeStubBoard() {


### PR DESCRIPTION
Migrated to new Storybook API:
- MakerLanding
- ScrollButtons

I added another story in ScrollButtons.story
Video of 2 components in Storybook:


## Links
Refer to [this PR](https://github.com/code-dot-org/code-dot-org/pull/47777) for context.
[This spreadsheet](https://docs.google.com/spreadsheets/d/1z8r10AcR0v3GimV_-28dJ6QaiaQ3CJoo9yXqa7U_bKs/edit#gid=0)  keeps track of all migrations.
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
