### PR TITLE
Migrate MakerLanding and ScrollButtons storybooks

### DIFF
--- a/apps/src/templates/MakerLanding.story.jsx
+++ b/apps/src/templates/MakerLanding.story.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import MakerLanding from './MakerLanding';
+import {Provider} from 'react-redux';
+import {reduxStore} from '@cdo/storybook/decorators';
 
 const topCourse = {
   assignableName: 'CSD Unit 6 - Physical Computing',
@@ -9,15 +11,18 @@ const topCourse = {
     'http://localhost-studio.code.org:3000/s/csd6/lessons/1/levels/1'
 };
 
-export default storybook => {
-  return storybook
-    .storiesOf('MakerToolkit/MakerLanding', module)
-    .withReduxStore()
-    .addStoryTable([
-      {
-        name: 'MakerLanding',
-        description: 'Landing page for Maker Toolkit',
-        story: () => <MakerLanding topCourse={topCourse} />
-      }
-    ]);
+export default {
+  title: 'MakerLanding',
+  component: MakerLanding
+};
+
+const Template = args => (
+  <Provider store={reduxStore()}>
+    <MakerLanding {...args} />
+  </Provider>
+);
+
+export const MakerExample = Template.bind({});
+MakerExample.args = {
+  topCourse: topCourse
 };

--- a/apps/src/templates/instructions/ScrollButtons.story.jsx
+++ b/apps/src/templates/instructions/ScrollButtons.story.jsx
@@ -1,47 +1,57 @@
 import React from 'react';
-
 import ScrollButtons from './ScrollButtons';
 
-export default storybook => {
-  return storybook.storiesOf('ScrollButtons', module).addStoryTable([
-    {
-      name: 'Scroll Buttons',
-      story: () => {
-        let container;
-        return (
-          <div style={{minWidth: 200}}>
-            <div
-              style={{
-                float: 'left',
-                overflowY: 'hidden',
-                height: 200,
-                width: '80%'
-              }}
-              ref={c => {
-                container = c;
-              }}
-            >
-              <div
-                style={{
-                  height: 1000,
-                  background: 'linear-gradient(red, yellow)'
-                }}
-              />
-            </div>
-            <div style={{float: 'left', width: '10%'}}>
-              <ScrollButtons
-                style={{
-                  position: 'relative'
-                }}
-                getScrollTarget={() => container}
-                height={200}
-                isMinecraft={false}
-                visible
-              />
-            </div>
-          </div>
-        );
-      }
-    }
-  ]);
+export default {
+  title: 'ScrollButtons',
+  component: ScrollButtons
+};
+
+const Template = args => {
+  let container;
+  return (
+    <div style={{minWidth: 200}}>
+      <div
+        style={{
+          float: 'left',
+          overflowY: 'hidden',
+          height: 200,
+          width: '80%'
+        }}
+        ref={c => {
+          container = c;
+        }}
+      >
+        <div
+          style={{
+            height: 500,
+            background: 'linear-gradient(red, yellow)'
+          }}
+        />
+      </div>
+      <div style={{float: 'left', width: '10%'}}>
+        <ScrollButtons
+          style={{
+            position: 'relative'
+          }}
+          getScrollTarget={() => container}
+          height
+          isMinecraft
+          visible
+          {...args}
+        />
+      </div>
+    </div>
+  );
+};
+
+export const BasicExample = Template.bind({});
+BasicExample.args = {
+  height: 200,
+  isMinecraft: false
+};
+
+export const MinecraftExample = Template.bind({});
+MinecraftExample.args = {
+  height: 200,
+  isMinecraft: true
 };


### PR DESCRIPTION
Migrated to new Storybook API:
- MakerLanding
- ScrollButtons

I added another story in ScrollButtons.story.jsx to show ScrollButtons when isMinecraft is assigned true which results in square instead of arrow buttons.
I was also debating about whether to keep MakerLanding, but with possible upcoming work for Maker unit with MicroBit, we may need another landing page for a MicroBit version of the CSD curriculum so decided to keep.

Video of 2 components in Storybook:

https://user-images.githubusercontent.com/107423305/193369274-661984bf-ce0c-4ac0-aa0f-fab994a1e83e.mp4


## Links
Refer to [this PR](https://github.com/code-dot-org/code-dot-org/pull/47777) for context.
[This spreadsheet](https://docs.google.com/spreadsheets/d/1z8r10AcR0v3GimV_-28dJ6QaiaQ3CJoo9yXqa7U_bKs/edit#gid=0)  keeps track of all migrations.
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
