### PR TITLE
Updating student-learning zendesk alert

### DIFF
--- a/bin/cron/zendesk_slack_report
+++ b/bin/cron/zendesk_slack_report
@@ -31,7 +31,6 @@ STATUSES_TO_REPORT = %w(new open)
 # Slack room -> Zendesk group mappings to report on
 MONITORING_GROUPS = {
   # 'slack-room-name' => ['Zendesk group name', 'Zendesk group name', ...]
-  'ap-csa-dev' => ['CSA Engineering'],
   'ap-csa-pilot' => ['CSA Curric.'],
   'csf' => ['CSF'],
   'cspalooza' => ['CSP'],
@@ -48,7 +47,7 @@ MONITORING_GROUPS = {
   'product' => ['Product'],
   'programsnpartners_theluau' => ['PNP'],
   'regional_managers' => ['Outreach'],
-  'star-labs' => ['*Labs']
+  'student-learning' => ['*Labs', 'CSA Engineering']
 }
 
 # Zendesk group -> Zendesk filter id mappings for helpful links (optional)


### PR DESCRIPTION
CSA and Star Labs are combining 🎉 

This updates the Zendesk alert so only one channel is notified with Zendesk alerts.