### PR TITLE
Music prototype: triggers get keyboard shortcuts

### DIFF
--- a/apps/src/music/MusicView.jsx
+++ b/apps/src/music/MusicView.jsx
@@ -382,6 +382,11 @@ class MusicView extends React.Component {
     if (event.key === 't') {
       this.setState({timelineAtTop: !this.state.timelineAtTop});
     }
+    Triggers.map(trigger => {
+      if (event.key === trigger.keyboardKey) {
+        this.playTrigger(trigger.id);
+      }
+    });
   };
 
   render() {

--- a/apps/src/music/constants.js
+++ b/apps/src/music/constants.js
@@ -2,16 +2,19 @@ export const Triggers = [
   {
     id: 'trigger1',
     dropdownLabel: 'Trigger 1',
-    buttonLabel: '1'
+    buttonLabel: '1',
+    keyboardKey: '1'
   },
   {
     id: 'trigger2',
     dropdownLabel: 'Trigger 2',
-    buttonLabel: '2'
+    buttonLabel: '2',
+    keyboardKey: '2'
   },
   {
     id: 'trigger3',
     dropdownLabel: 'Trigger 3',
-    buttonLabel: '3'
+    buttonLabel: '3',
+    keyboardKey: '3'
   }
 ];


### PR DESCRIPTION
For now, pressing `1`, `2`, or `3` on the keyboard will trigger the corresponding event.