### PR TITLE
Fix node dependencies for updated johnny-five

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -108,6 +108,7 @@
     "eslint-plugin-prettier": "^3.3.1",
     "eslint-plugin-react": "^7.11.0",
     "eslint-plugin-react-hooks": "^4.3.0",
+    "events": "^3.3.0",
     "fast-memoize": "2.0.2",
     "file-loader": "^6.2.0",
     "firebase": "^2.4.2",

--- a/apps/webpack.js
+++ b/apps/webpack.js
@@ -49,6 +49,7 @@ const nodePolyfillConfig = {
   plugins: [
     new webpack.ProvidePlugin({
       Buffer: ['buffer', 'Buffer'],
+      events: 'events',
       stream: 'stream-browserify',
       path: 'path-browserify',
       process: 'process/browser',
@@ -57,8 +58,11 @@ const nodePolyfillConfig = {
   ],
   resolve: {
     fallback: {
-      stream: require.resolve('stream-browserify'),
+      buffer: require.resolve('buffer/'),
+      events: require.resolve('events/'),
       path: require.resolve('path-browserify'),
+      'process/browser': require.resolve('process/browser'),
+      stream: require.resolve('stream-browserify'),
       timers: require.resolve('timers-browserify'),
       crypto: false
     }

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -7264,7 +7264,7 @@ eventlistener@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/eventlistener/-/eventlistener-0.0.1.tgz#ed2baabb852227af2bcf889152c72c63ca532eb8"
 
-events@^3.0.0, events@^3.3.0:
+events@^3.0.0, events@^3.2.0, events@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
   integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -7264,7 +7264,7 @@ eventlistener@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/eventlistener/-/eventlistener-0.0.1.tgz#ed2baabb852227af2bcf889152c72c63ca532eb8"
 
-events@^3.0.0, events@^3.2.0:
+events@^3.0.0, events@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
   integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==


### PR DESCRIPTION
With the [recent update](https://github.com/code-dot-org/johnny-five/pull/12) of @code-dot-org/johnny-five to the latest release of its mainline repo and the recent webpack update of code-dot-org, node dependencies had to be fixed. Prior to webpack 5, polyfills were included for node.js core modules by default. Because this is no longer the case for >4 webpack, this PR provides fallbacks for 'events', 'buffer', and 'process/browser'. 

## Links

- [jira ticket:](https://codedotorg.atlassian.net/browse/SL-281) - includes error messages when attempted build before this update 


## Testing story
Ran dashboard-server locally to check both johnny-five and johnny-five-deprecated.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
