### PR TITLE
HoC.com - quick form fix

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/public/css/front-page.scss
+++ b/pegasus/sites.v3/hourofcode.com/public/css/front-page.scss
@@ -558,3 +558,7 @@ a.category-link {
 .required-asterisk {
   color: #008b9a;
 }
+
+#join-us-header {
+  display: none;
+}

--- a/pegasus/sites.v3/hourofcode.com/public/css/front-page.scss
+++ b/pegasus/sites.v3/hourofcode.com/public/css/front-page.scss
@@ -559,6 +559,7 @@ a.category-link {
   color: #008b9a;
 }
 
+/* Hiding this text snippet visually so the JS on the school census form will work */
 #join-us-header {
   display: none;
 }

--- a/pegasus/sites.v3/hourofcode.com/views/home_signup.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/home_signup.haml
@@ -2,6 +2,7 @@
 -# We are hiding announcements in 2020
 - showAnnouncements = false
 %a#hocsignupform{name: 'signup'}
+#join-us-header=hoc_s(:front_join_us_button)
 -if ["actual-hoc", "post-hoc", false].include?(hoc_mode)
   #signup-closed
     !=hoc_s(:signup_registration_not_required_markdown, markdown: :inline, locals: {hoc_activities_url: resolve_url('/learn'), howto_guide_url: resolve_url('/how-to')})


### PR DESCRIPTION
Fix an issue that was causing an error on the `Event Type > School` on the hourofcode.com signup form by adding back this line: `#join-us-header=hoc_s(:front_join_us_button)`

Related to this PR on `line 6`: https://github.com/code-dot-org/code-dot-org/pull/48187/files?diff=split&w=1#diff-ddb745c2eceb1dae26602c13d8587861d644ac70fc0074831fec3a9b8c5308cd)