### PR TITLE
only shut down adhocs on friday nights

### DIFF
--- a/cookbooks/cdo-apps/templates/default/crontab.erb
+++ b/cookbooks/cdo-apps/templates/default/crontab.erb
@@ -100,7 +100,7 @@
       cronjob at:'30 */2 * * *', do:deploy_dir('bin', 'cron', 'summer_workshops_to_gdrive')
       cronjob at:'0 12 * * *', do:deploy_dir('bin', 'cron', 'csf_workshop_attendance_to_gdrive')
       cronjob at:'0 13 * * *', do:deploy_dir('bin', 'cron', 'eir_teachers_to_gdrive')
-      cronjob at:'0 7 * * *', do:deploy_dir('bin', 'cron', 'stop_inactive_adhoc_instances')
+      cronjob at:'0 7 * * 6', do:deploy_dir('bin', 'cron', 'stop_inactive_adhoc_instances')
       cronjob at:'0 10 * * *', do:deploy_dir('bin', 'cron', 'redshift_rollups')
       cronjob at:'1 7 * * 6', do:deploy_dir('bin', 'cron', 'cleanup_workshop_attendance_codes')
       cronjob at:'31 16 * * 1-5', do:deploy_dir('bin', 'cron', 'zendesk_slack_report')


### PR DESCRIPTION
per discussion in [slack](https://codedotorg.slack.com/archives/C03CK49G9/p1664564513426389?thread_ts=1664554158.592019&cid=C03CK49G9), we are moving to only shutting down adhocs on friday nights as part of a plan to (1) make it easier to use cdn-based adhocs, which do not work after they are turned off at night, and (2) to make the entire adhoc experience a bit more user friendly for all adhoc users.