### PR TITLE
Music prototype: shrink blockly text

### DIFF
--- a/apps/src/music/MusicView.jsx
+++ b/apps/src/music/MusicView.jsx
@@ -167,6 +167,10 @@ class MusicView extends React.Component {
       base: CdoTheme,
       componentStyles: {
         toolboxBackgroundColour: '#222'
+      },
+      fontStyle: {
+        family: '"Gotham 4r", sans-serif',
+        size: 11
       }
     });
 

--- a/apps/src/music/blockly/toolbox.js
+++ b/apps/src/music/blockly/toolbox.js
@@ -9,7 +9,8 @@ export const baseToolbox = {
       name: 'Play',
       cssConfig: {
         container: moduleStyles.toolboxCategoryContainer,
-        row: moduleStyles.blocklyTreeRow
+        row: moduleStyles.blocklyTreeRow,
+        label: moduleStyles.blocklyTreeLabel
       },
       contents: [
         {
@@ -47,7 +48,8 @@ export const baseToolbox = {
       name: 'Samples',
       cssConfig: {
         container: moduleStyles.toolboxCategoryContainer,
-        row: moduleStyles.blocklyTreeRow
+        row: moduleStyles.blocklyTreeRow,
+        label: moduleStyles.blocklyTreeLabel
       },
       contents: []
     },
@@ -56,7 +58,8 @@ export const baseToolbox = {
       name: 'Events',
       cssConfig: {
         container: moduleStyles.toolboxCategoryContainer,
-        row: moduleStyles.blocklyTreeRow
+        row: moduleStyles.blocklyTreeRow,
+        label: moduleStyles.blocklyTreeLabel
       },
       contents: [
         {
@@ -70,7 +73,8 @@ export const baseToolbox = {
       name: 'Control',
       cssConfig: {
         container: moduleStyles.toolboxCategoryContainer,
-        row: moduleStyles.blocklyTreeRow
+        row: moduleStyles.blocklyTreeRow,
+        label: moduleStyles.blocklyTreeLabel
       },
       contents: [
         {
@@ -114,7 +118,8 @@ export const baseToolbox = {
       name: 'Math',
       cssConfig: {
         container: moduleStyles.toolboxCategoryContainer,
-        row: moduleStyles.blocklyTreeRow
+        row: moduleStyles.blocklyTreeRow,
+        label: moduleStyles.blocklyTreeLabel
       },
       contents: [
         {
@@ -186,7 +191,8 @@ export const baseToolbox = {
       name: 'Variables',
       cssConfig: {
         container: moduleStyles.toolboxCategoryContainer,
-        row: moduleStyles.blocklyTreeRow
+        row: moduleStyles.blocklyTreeRow,
+        label: moduleStyles.blocklyTreeLabel
       },
       contents: [
         {
@@ -228,7 +234,8 @@ export const createMusicToolbox = library => {
       name: folder.name,
       cssConfig: {
         container: moduleStyles.toolboxCategoryContainer,
-        row: moduleStyles.blocklyTreeRow
+        row: moduleStyles.blocklyTreeRow,
+        label: moduleStyles.blocklyTreeLabel
       },
       contents: []
     };

--- a/apps/src/music/music.module.scss
+++ b/apps/src/music/music.module.scss
@@ -8,3 +8,7 @@
 .blocklyTreeRow {
   cursor: pointer;
 }
+
+.blocklyTreeLabel {
+  font-size: 15px;
+}


### PR DESCRIPTION
Just exploring an idea to slightly shrink the blockly text.

### before

<img width="1512" alt="Screen Shot 2022-10-04 at 6 07 05 PM" src="https://user-images.githubusercontent.com/2205926/193958340-27bf7abb-d81c-432b-b46c-a35c39184185.png">

### after

<img width="1512" alt="Screen Shot 2022-10-04 at 6 08 28 PM" src="https://user-images.githubusercontent.com/2205926/193958354-3e623bef-a4fd-4e60-905f-fa0671d1dd34.png">
