### PR TITLE
Default to dropdown sample blocks, with keyboard shortcuts for other modes

### DIFF
--- a/apps/src/music/MusicView.jsx
+++ b/apps/src/music/MusicView.jsx
@@ -109,7 +109,7 @@ class MusicView extends React.Component {
 
     this.loadLibrary().then(library => {
       this.setState({library});
-      this.workspace.updateToolbox(createMusicToolbox(library));
+      this.workspace.updateToolbox(createMusicToolbox(library, 'dropdown'));
       this.player.initialize(library);
     });
   }
@@ -370,6 +370,24 @@ class MusicView extends React.Component {
         this.playTrigger(trigger.id);
       }
     });
+    if (event.key === 'd') {
+      this.workspace.updateToolbox(
+        createMusicToolbox(this.state.library, 'dropdown')
+      );
+    }
+    if (event.key === 'v') {
+      this.workspace.updateToolbox(
+        createMusicToolbox(this.state.library, 'valueSample')
+      );
+    }
+    if (event.key === 'p') {
+      this.workspace.updateToolbox(
+        createMusicToolbox(this.state.library, 'playSample')
+      );
+    }
+    if (event.code === 'Space') {
+      this.setPlaying(!this.state.isPlaying);
+    }
   };
 
   render() {
@@ -460,13 +478,14 @@ class MusicView extends React.Component {
               overflow: 'scroll'
             }}
           >
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-            eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
-            ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
-            aliquip ex ea commodo consequat. Duis aute irure dolor in
-            reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
-            pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
-            culpa qui officia deserunt mollit anim id est laborum.
+            <p>Music Lab Prototype Keyboard Shortcuts:</p>
+            <p>i: show/hide instructions</p>
+            <p>t: move timeline to bottom/top</p>
+            <p>d: sample block mode = play block + dropdown </p>
+            <p>v: sample block mode = values </p>
+            <p>p: sample block mode = play block + values</p>
+            <p>space: play/stop song</p>
+            <p>[1, 2, 3]: trigger buttons</p>
           </div>
         )}
         <div

--- a/apps/src/music/blockly/toolbox.js
+++ b/apps/src/music/blockly/toolbox.js
@@ -217,8 +217,14 @@ export const baseToolbox = {
   ]
 };
 
-export const createMusicToolbox = library => {
+export const createMusicToolbox = (library, mode) => {
   const toolbox = {...baseToolbox};
+
+  if (!library) {
+    return toolbox;
+  }
+
+  toolbox.contents[1].contents = [];
 
   // Currently only supports 1 group
   const group = library.groups[0];
@@ -234,34 +240,62 @@ export const createMusicToolbox = library => {
     };
 
     for (let sound of folder.sounds) {
-      // Dropdown Play block:
-      /*
-       category.contents.push({
-        kind: 'block',
-        type: BlockTypes.PLAY_SOUND,
-        fields: {
-          sound: folder.path + '/' + sound.src
-        },
-        inputs: {
-          measure: {
-            shadow: {
-              type: 'math_number',
-              fields: {
-                NUM: 1
+      switch (mode) {
+        case 'dropdown': {
+          category.contents.push({
+            kind: 'block',
+            type: BlockTypes.PLAY_SOUND,
+            fields: {
+              sound: folder.path + '/' + sound.src
+            },
+            inputs: {
+              measure: {
+                shadow: {
+                  type: 'math_number',
+                  fields: {
+                    NUM: 1
+                  }
+                }
               }
             }
-          }
+          });
+          break;
         }
-      });
-      */
-
-      category.contents.push({
-        kind: 'block',
-        type: BlockTypes.SAMPLE,
-        fields: {
-          sample: sound.name
+        case 'valueSample': {
+          category.contents.push({
+            kind: 'block',
+            type: BlockTypes.SAMPLE,
+            fields: {
+              sample: sound.name
+            }
+          });
+          break;
         }
-      });
+        case 'playSample': {
+          category.contents.push({
+            kind: 'block',
+            type: BlockTypes.PLAY_SAMPLE,
+            inputs: {
+              sample: {
+                block: {
+                  type: BlockTypes.SAMPLE,
+                  fields: {
+                    sample: sound.name
+                  }
+                }
+              },
+              measure: {
+                shadow: {
+                  type: 'math_number',
+                  fields: {
+                    NUM: 1
+                  }
+                }
+              }
+            }
+          });
+        }
+      }
     }
 
     // Add to samples category


### PR DESCRIPTION
Switch back to using the dropdown sample blocks by default. I added keyboard shortcuts to switch to different sample modes (d = dropdown, v = value blocks, p = play blocks with value input), and updated the instructions panel to document all the keyboard shortcuts.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
