### PR TITLE
Fixing date and links on the Cookie Notice Page

### DIFF
--- a/shared/partials/cookie_notice.partial
+++ b/shared/partials/cookie_notice.partial
@@ -1,7 +1,7 @@
 <a id="top"></a>
 <h1>Code.org Cookie Notice</h1>
 
-<strong>Date Last Updated:</strong> 02/22/2022
+<strong>Date Last Updated:</strong> 10/03/2022
 <p class="cookies-intro">When you visit our website it may ask your browser to store a small piece of data (text file) called a cookie on your device to remember specific information, such as your language preference or login status.  We may use both session cookies and persistent cookies. A session cookie disappears automatically after the User closes their browser. A persistent cookie remains after the browser is closed and may be used by the browser on subsequent visits to the Services.  Cookies set by us and called first-party cookies. We also use third-party cookies, which are cookies from a domain other than the domain of the website you are visiting.  We use cookies and related technologies as follows:</p>
 
 <h2>Strictly Necessary Cookies</h2>
@@ -37,7 +37,7 @@
     <li><a href="https://support.apple.com/en-gb/safari">Apple Safari</a></li>
 </ul>
 <p>To find information relating to other browsers, visit the browser developer's website.</p>
-<p>To find out more about cookies, including how to see what cookies have been set, visit <a href="www.aboutcookies.org">www.aboutcookies.org</a> or <a href="www.allaboutcookies.org">www.allaboutcookies.org</a>.</p>
+<p>To find out more about cookies, including how to see what cookies have been set, visit <a href="https://www.aboutcookies.org">www.aboutcookies.org</a> or <a href="https://www.allaboutcookies.org">www.allaboutcookies.org</a>.</p>
 <p>To opt out of being tracked by Google Analytics across all websites, visit <a href="http://tools.google.com/dlpage/gaoptout">http://tools.google.com/dlpage/gaoptout</a>.</p>
 
 <h2>Questions?</h2>


### PR DESCRIPTION
* Correcting the date on https://code.org/cookies to be Oct 3, 2022 when we first launched the new cookie policy.
* Correct the URLs to aboutcookies.org and allaboutcookies.org

## Testing story
* Manually tested on http://localhost.code.org:3000/cookies
 
![image](https://user-images.githubusercontent.com/1372238/194159245-dda4765c-6c3d-4313-baf9-fd954c7f7f54.png)

![image](https://user-images.githubusercontent.com/1372238/194159376-4b556616-ef06-4531-bf81-e9d716b9fadd.png)