### PR TITLE
Disable aquatic.feature and dialogs.feature to unblock builds

### DIFF
--- a/dashboard/test/ui/features/star_labs/craft/aquatic.feature
+++ b/dashboard/test/ui/features/star_labs/craft/aquatic.feature
@@ -1,3 +1,6 @@
+# Temporarily skip this test to unblock Drone builds. See ticket for details:
+# https://codedotorg.atlassian.net/browse/SL-288
+@skip
 Feature: Minecraft aquatic
 
   Background:

--- a/dashboard/test/ui/features/star_labs/craft/dialogs.feature
+++ b/dashboard/test/ui/features/star_labs/craft/dialogs.feature
@@ -1,4 +1,7 @@
 #  @eyes
+# Temporarily skip this test to unblock Drone builds. See ticket for details:
+# https://codedotorg.atlassian.net/browse/SL-289
+@skip
 @chrome
 Feature: Minecraft dialog levels
 


### PR DESCRIPTION
These tests are blocking Drone builds and are rising in flakiness in the DTT. We are temporarily disabling the tests because they are failing at various steps, so we need time to investigate and unblock others. More details in the linked Jira tickets:
- `aquatic.feature` ticket: https://codedotorg.atlassian.net/browse/SL-288
- `dialogs.feature` ticket: https://codedotorg.atlassian.net/browse/SL-289

We upgraded our test harness to test on Chrome 105 (previously was 75) yesterday, so these failures are likely related to that.