### PR TITLE
Music prototype: fix drag error

### DIFF
--- a/apps/src/music/MusicView.jsx
+++ b/apps/src/music/MusicView.jsx
@@ -223,8 +223,16 @@ class MusicView extends React.Component {
     });
   };
 
-  onBlockSpaceChange = () => {
-    //console.log('onBlockSpaceChange');
+  onBlockSpaceChange = e => {
+    // A drag event can leave the blocks in a temporarily unusable state,
+    // e.g. when a disabled variable is dragged into a slot, it can still
+    // be disabled.
+    // A subsequent non-drag event should arrive and the blocks will be
+    // usable then.
+    // It's possible that other events should similarly be ignored here.
+    if (e.type === Blockly.blockly_.Events.BLOCK_DRAG) {
+      return;
+    }
 
     this.executeSong();
 


### PR DESCRIPTION
We were seeing an error when a variable block was first dragged onto the workspace by itself, causing it to be detected as an orphaned block and disabled, and then dragged onto another enabled block's slot.  We were notified of the drag event, and were attempting to re-execute the program, but the variable block was still disabled and its contents not emitted, and so the execution raised an unhandled exception.  This exception prevented any further processing of events.  If this exception had not occurred, [`disableOrphans`](https://github.com/google/blockly/blob/55cf92a2d0845e8f9c2bdb0c78958c2d532a907e/core/events/utils.ts#L531) would have run, the variable block would have been reenabled, and subsequent events would have arrived, at which point we could have successfully executed the program with the newly-placed variable block.

The solution here is to not execute the program upon receiving a drag event.  It is possible that we should do similar for other [events](https://developers.google.com/blockly/guides/configure/web/events).  We might even want to behave more like the above-linked `disableOrphans`, which only processes "move" and "create" events. 

It also seems that the relevant [documentation](https://developers.google.com/blockly/guides/configure/web/code-generators#realtime_generation) could increase awareness of this potential issue.
