### PR TITLE
Localize pre/post survey teacher markdown.

### DIFF
--- a/dashboard/app/models/levels/dsl_defined.rb
+++ b/dashboard/app/models/levels/dsl_defined.rb
@@ -43,6 +43,12 @@ class DSLDefined < Level
     "Enter the level definition here.\n"
   end
 
+  def localized_teacher_markdown
+    # Overrides the normal behavior since for DSLDefined levels, the teacher
+    # markdown is part of the dsl.
+    localized_property('teacher_markdown')
+  end
+
   def localized_property(property)
     # We have to manually check for default here rather than just passing
     # self.send(property) directly  because some properties used here (like

--- a/dashboard/app/views/levels/_external.html.haml
+++ b/dashboard/app/views/levels/_external.html.haml
@@ -22,7 +22,7 @@
         %a.btn.btn-large.btn-primary.next-lesson.submitButton.pull-right= t('continue')
 
   = render partial: 'levels/content', locals: {app: 'external', data: level.properties, content_class: level.properties['options'].try(:[], 'css'), postcontent: postcontent, source_level: level}
-  = render partial: 'levels/teacher_markdown', locals: {data: level.properties}
+  = render partial: 'levels/teacher_markdown', locals: {data: {'teacher_markdown' => level.localized_teacher_markdown}}
 
 - if in_level_group
   -# This partial will take care of milestone posts in the contexts of levelgroups,


### PR DESCRIPTION
**What**: Localization of pre/post survey levels.

**Why**: To promote our localization epic and increase accessibility.

**How**: The pre/post surveys were coincidentally localized (mostly) when a change to the sync added Level sublevels. Specifically this commit: 67fd7c7284237c5c3f586caa8ba84c2eb1b2657b

Add override for teacher_markdown localization to use localized_property for DSLDefined levels.

Ensures `teacher_markdown` renderer sees the localized `teacher_markdown` instead of just using the key found in the Level properties. The surveys use `external` levels to render the teacher-only text blobs within survey pages. Yet, there are other sections of the codebase that also use `teacher_markdown` views with the un-localized properties data.

Apparently, teacher_markdown *can* be found in its own localization context. However, surveys still localize teacher_markdown in the normal place for all other level properties. Without this fallback, surveys will not localize the teacher_markdown sections preceding some of them, such as in the CSD pre and post surveys.

The original behavior still exists for teacher_markdown for video content that might appear with a script/unit/level/etc. This will not break this old behavior nor add any complication since it only overrides for DSL-based Level models which do not localize teacher_markdown to their own file via the sync-in.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
-->

- jira ticket: [FND-2068](https://codedotorg.atlassian.net/jira/software/c/projects/FND/boards/62?modal=detail&selectedIssue=FND-2068)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

Manual testing with crowdin codeorg-testing sync and seeing the result.

![image](https://user-images.githubusercontent.com/31674/194374138-17e02aca-d774-411a-97b1-840f197cb844.png)

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
