### PR TITLE
Fix Violations of and Reenable `Rails/DurationArithmetic`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -246,11 +246,6 @@ Rails/Date:
 Rails/DeprecatedActiveModelErrorsMethods:
   Enabled: false
 
-# Offense count: 11
-# This cop supports safe auto-correction (--auto-correct).
-Rails/DurationArithmetic:
-  Enabled: false
-
 # Offense count: 478
 # This cop supports unsafe auto-correction (--auto-correct-all).
 # Configuration parameters: Whitelist, AllowedMethods, AllowedReceivers.

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -270,7 +270,7 @@ class Pd::Workshop < ApplicationRecord
   # Filters those those workshops that have not yet ended, but whose
   # final session was scheduled to end more than two days ago
   def self.should_have_ended
-    in_state(STATE_IN_PROGRESS).scheduled_end_on_or_before(Time.zone.now - 2.days)
+    in_state(STATE_IN_PROGRESS).scheduled_end_on_or_before(2.days.ago)
   end
 
   # Find the workshop that is closest in time to today

--- a/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
@@ -1167,7 +1167,7 @@ class Api::V1::Pd::WorkshopsControllerTest < ::ActionController::TestCase
   private
 
   def tomorrow_at(hour, minute = nil)
-    tomorrow = Time.zone.now + 1.day
+    tomorrow = 1.day.from_now
     Time.zone.local(tomorrow.year, tomorrow.month, tomorrow.mday, hour, minute)
   end
 

--- a/dashboard/test/models/pd/application/teacher_application_test.rb
+++ b/dashboard/test/models/pd/application/teacher_application_test.rb
@@ -428,7 +428,7 @@ module Pd::Application
       application.update!(status: 'pending')
       assert_status_log(
         [
-          {status: 'unreviewed', at: Time.zone.now - 2.seconds},
+          {status: 'unreviewed', at: 2.seconds.ago},
           {status: 'pending', at: Time.zone.now}
         ],
         application

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -219,7 +219,7 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
 
   test 'sessions must start and end on the same day' do
     workshop = create :workshop, num_sessions: 0
-    session = build :pd_session, start: Time.zone.now, end: Time.zone.now + 1.day
+    session = build :pd_session, start: Time.zone.now, end: 1.day.from_now
     workshop.sessions << session
 
     refute workshop.valid?
@@ -229,7 +229,7 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
 
   test 'sessions must start before they end' do
     workshop = create :workshop, num_sessions: 0
-    session = build :pd_session, start: Time.zone.now, end: Time.zone.now - 2.hours
+    session = build :pd_session, start: Time.zone.now, end: 2.hours.ago
     workshop.sessions << session
 
     refute workshop.valid?
@@ -277,18 +277,18 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
   test 'should have ended' do
     workshop_recently_started = create :workshop, num_sessions: 0
     workshop_recently_started.started_at = Time.now
-    workshop_recently_started.sessions << (build :pd_session, start: Time.zone.now - 13.hours, end: Time.zone.now - 12.hours)
+    workshop_recently_started.sessions << (build :pd_session, start: 13.hours.ago, end: 12.hours.ago)
     workshop_recently_started.save!
 
     workshop_should_have_ended = create :workshop, num_sessions: 0
     workshop_should_have_ended.started_at = Time.now
-    workshop_should_have_ended.sessions << (build :pd_session, start: Time.zone.now - 51.hours, end: Time.zone.now - 50.hours)
+    workshop_should_have_ended.sessions << (build :pd_session, start: 51.hours.ago, end: 50.hours.ago)
     workshop_should_have_ended.save!
 
     workshop_already_ended = create :workshop, num_sessions: 0
     workshop_already_ended.started_at = Time.now
     workshop_already_ended.ended_at = Time.now - 1.hour
-    workshop_already_ended.sessions << (build :pd_session, start: Time.zone.now - 51.hours, end: Time.zone.now - 50.hours)
+    workshop_already_ended.sessions << (build :pd_session, start: 51.hours.ago, end: 50.hours.ago)
     workshop_already_ended.save!
 
     assert_equal [workshop_should_have_ended.id], Pd::Workshop.should_have_ended.pluck(:id)


### PR DESCRIPTION
Rather than adding and subtracting with current time, [the Rails styleguide] recommends using the provided Duration methods.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

- [rubocop docs]
- [the Rails styleguide]

[rubocop docs]: https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsdurationarithmetic
[the Rails styleguide]: https://rails.rubystyle.guide/#duration-arithmetic

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
