### PR TITLE
Circuit Playground: stop raising exception for full queue

### DIFF
--- a/apps/src/lib/kits/maker/boards/circuitPlayground/CircuitPlaygroundBoard.js
+++ b/apps/src/lib/kits/maker/boards/circuitPlayground/CircuitPlaygroundBoard.js
@@ -430,9 +430,8 @@ export default class CircuitPlaygroundBoard extends EventEmitter {
           return;
         }
         if (port.queue.length > 512) {
-          throw new Error(
-            'Send queue is full! More than 512 pending messages.'
-          );
+          // Send queue is full.  More than 512 pending messages.
+          return;
         }
 
         const toSend = port.queue.shift();


### PR DESCRIPTION
Our top error on New Relic is currently this exception, thrown when our Circuit Playground send queue is full.

I don't know the full implications of this change, so would like the team to weight in on whether there is a better approach.

But it's important to take this kind of load off of New Relic:

<img width="495" alt="Screen Shot 2022-10-06 at 5 17 07 PM" src="https://user-images.githubusercontent.com/2205926/194440811-e9d802c2-182c-4303-ac7a-649a10a92f0b.png">
