### PR TITLE
Fix Violations of and Reenable `Rails/IndexWith`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -260,11 +260,6 @@ Rails/FilePath:
 Rails/I18nLocaleTexts:
   Enabled: false
 
-# Offense count: 11
-# This cop supports safe auto-correction (--auto-correct).
-Rails/IndexWith:
-  Enabled: false
-
 # Offense count: 19
 # This cop supports unsafe auto-correction (--auto-correct-all).
 Rails/NegateInclude:

--- a/dashboard/app/models/level_concept_difficulty.rb
+++ b/dashboard/app/models/level_concept_difficulty.rb
@@ -42,7 +42,7 @@ class LevelConceptDifficulty < ApplicationRecord
     return super if new_record?
 
     # Otherwise, make sure we write `nil` over unpassed attributes
-    defaults = CONCEPTS.index_with {|concept| nil}
+    defaults = CONCEPTS.index_with(nil)
     super(defaults.merge(attrs))
   end
 

--- a/dashboard/app/models/level_concept_difficulty.rb
+++ b/dashboard/app/models/level_concept_difficulty.rb
@@ -42,7 +42,7 @@ class LevelConceptDifficulty < ApplicationRecord
     return super if new_record?
 
     # Otherwise, make sure we write `nil` over unpassed attributes
-    defaults = Hash[CONCEPTS.map {|concept| [concept, nil]}]
+    defaults = CONCEPTS.index_with {|concept| nil}
     super(defaults.merge(attrs))
   end
 

--- a/dashboard/app/models/pd/international_opt_in.rb
+++ b/dashboard/app/models/pd/international_opt_in.rb
@@ -178,7 +178,7 @@ class Pd::InternationalOptIn < ApplicationRecord
       chileanSchoolId
     )
 
-    Hash[keys.collect {|v| [v, I18n.t("pd.form_labels.#{v.underscore}")]}]
+    keys.index_with {|v| I18n.t("pd.form_labels.#{v.underscore}")}
   end
 
   def email_opt_in?

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -697,11 +697,10 @@ class Pd::Workshop < ApplicationRecord
     end
 
     # Get number of sessions attended by teacher
-    attendance_count_by_teacher = Hash[
-      teachers_attending.uniq.map do |teacher|
-        [teacher, teachers_attending.count(teacher)]
+    attendance_count_by_teacher =
+      teachers_attending.uniq.index_with do |teacher|
+        teachers_attending.count(teacher)
       end
-    ]
 
     # Return only teachers who attended all sessions
     attendance_count_by_teacher.select {|_, attendances| attendances == sessions.count}.keys

--- a/dashboard/app/models/school_stats_by_year.rb
+++ b/dashboard/app/models/school_stats_by_year.rb
@@ -60,7 +60,7 @@ class SchoolStatsByYear < ApplicationRecord
     ActiveRecord::Base.transaction do
       CSV.read(filename, options).each do |row|
         parsed = yield row
-        loaded = find_by(primary_keys.map(&:to_sym).map {|k| [k, parsed[k]]}.to_h)
+        loaded = find_by(primary_keys.map(&:to_sym).index_with {|k| parsed[k]})
         if loaded.nil?
           begin
             SchoolStatsByYear.new(parsed).save!

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1617,7 +1617,7 @@ class Script < ApplicationRecord
   def section_hidden_unit_info(user)
     return {} unless user && can_be_instructor?(user)
     hidden_section_ids = SectionHiddenScript.where(script_id: id, section: user.sections).pluck(:section_id)
-    hidden_section_ids.map {|section_id| [section_id, [id]]}.to_h
+    hidden_section_ids.index_with {|section_id| [id]}
   end
 
   # Similar to summarize, but returns an even more narrow set of fields, restricted
@@ -1647,9 +1647,9 @@ class Script < ApplicationRecord
   def summarize_i18n_for_copy(new_name, new_course_version)
     resource_markdown_replacement_proc = proc {|r| "[r #{Services::GloballyUniqueIdentifiers.build_resource_key(r.copy_to_course_version(new_course_version))}]"}
     vocab_markdown_replacement_proc = proc {|v| "[v #{Services::GloballyUniqueIdentifiers.build_vocab_key(v.copy_to_course_version(new_course_version))}]"}
-    data = %w(title description student_description description_short description_audience).map do |key|
-      [key, I18n.t("data.script.name.#{name}.#{key}", default: '')]
-    end.to_h
+    data = %w(title description student_description description_short description_audience).index_with do |key|
+      I18n.t("data.script.name.#{name}.#{key}", default: '')
+    end
     Services::MarkdownPreprocessor.sub_resource_links!(data['description'], resource_markdown_replacement_proc) if data['description']
     Services::MarkdownPreprocessor.sub_vocab_definitions!(data['description'], vocab_markdown_replacement_proc) if data['description']
     Services::MarkdownPreprocessor.sub_resource_links!(data['student_description'], resource_markdown_replacement_proc) if data['student_description']

--- a/dashboard/app/models/user_script.rb
+++ b/dashboard/app/models/user_script.rb
@@ -53,8 +53,8 @@ class UserScript < ApplicationRecord
       joins(:script).
       where(user: for_user, scripts: {name: script_names}).
       pluck(:name)
-    script_names.map do |name|
-      [name, filtered_progress.include?(name)]
-    end.to_h
+    script_names.index_with do |name|
+      filtered_progress.include?(name)
+    end
   end
 end

--- a/dashboard/test/controllers/concerns/pd/workshop_filters_test.rb
+++ b/dashboard/test/controllers/concerns/pd/workshop_filters_test.rb
@@ -280,7 +280,7 @@ class Pd::WorkshopFiltersTest < ActionController::TestCase
       :order_by,
     ]
 
-    params expected_keys.map {|k| [k, 'some value']}.to_h
+    params expected_keys.index_with {|k| 'some value'}
     assert_equal expected_keys.map(&:to_s), @controller.filter_params.keys
   end
 

--- a/dashboard/test/controllers/concerns/pd/workshop_filters_test.rb
+++ b/dashboard/test/controllers/concerns/pd/workshop_filters_test.rb
@@ -280,7 +280,7 @@ class Pd::WorkshopFiltersTest < ActionController::TestCase
       :order_by,
     ]
 
-    params expected_keys.index_with {|k| 'some value'}
+    params expected_keys.index_with('some value')
     assert_equal expected_keys.map(&:to_s), @controller.filter_params.keys
   end
 

--- a/dashboard/test/models/pd/application/facilitator1920_application_test.rb
+++ b/dashboard/test/models/pd/application/facilitator1920_application_test.rb
@@ -358,7 +358,7 @@ module Pd::Application
     test 'meets_criteria says yes if everything is set to YES, no if anything is NO, and INCOMPLETE if anything is unset' do
       %w(csf csd csp).each do |course|
         application = create :pd_facilitator1920_application, course: course
-        score_hash = SCOREABLE_QUESTIONS["criteria_score_questions_#{course}".to_sym].map {|key| [key, YES]}.to_h
+        score_hash = SCOREABLE_QUESTIONS["criteria_score_questions_#{course}".to_sym].index_with {|key| YES}
 
         application.update(
           response_scores: {meets_minimum_criteria_scores: score_hash}.to_json

--- a/dashboard/test/models/pd/application/facilitator1920_application_test.rb
+++ b/dashboard/test/models/pd/application/facilitator1920_application_test.rb
@@ -358,7 +358,7 @@ module Pd::Application
     test 'meets_criteria says yes if everything is set to YES, no if anything is NO, and INCOMPLETE if anything is unset' do
       %w(csf csd csp).each do |course|
         application = create :pd_facilitator1920_application, course: course
-        score_hash = SCOREABLE_QUESTIONS["criteria_score_questions_#{course}".to_sym].index_with {|key| YES}
+        score_hash = SCOREABLE_QUESTIONS["criteria_score_questions_#{course}".to_sym].index_with(YES)
 
         application.update(
           response_scores: {meets_minimum_criteria_scores: score_hash}.to_json

--- a/dashboard/test/models/pd/application/teacher_application_test.rb
+++ b/dashboard/test/models/pd/application/teacher_application_test.rb
@@ -80,13 +80,13 @@ module Pd::Application
     test 'meets criteria says an application meets criteria when all YES_NO fields are marked yes' do
       teacher_application = build :pd_teacher_application, course: 'csd',
                                   response_scores: {
-                                    meets_minimum_criteria_scores: SCOREABLE_QUESTIONS[:criteria_score_questions_csd].index_with {|x| 'Yes'}
+                                    meets_minimum_criteria_scores: SCOREABLE_QUESTIONS[:criteria_score_questions_csd].index_with('Yes')
                                   }.to_json
       assert_equal 'Yes', teacher_application.meets_criteria
 
       teacher_application = build :pd_teacher_application, course: 'csp',
                                   response_scores: {
-                                    meets_minimum_criteria_scores: SCOREABLE_QUESTIONS[:criteria_score_questions_csp].index_with {|x| 'Yes'}
+                                    meets_minimum_criteria_scores: SCOREABLE_QUESTIONS[:criteria_score_questions_csp].index_with('Yes')
                                   }.to_json
       assert_equal 'Yes', teacher_application.meets_criteria
     end

--- a/dashboard/test/models/pd/application/teacher_application_test.rb
+++ b/dashboard/test/models/pd/application/teacher_application_test.rb
@@ -80,13 +80,13 @@ module Pd::Application
     test 'meets criteria says an application meets criteria when all YES_NO fields are marked yes' do
       teacher_application = build :pd_teacher_application, course: 'csd',
                                   response_scores: {
-                                    meets_minimum_criteria_scores: SCOREABLE_QUESTIONS[:criteria_score_questions_csd].map {|x| [x, 'Yes']}.to_h
+                                    meets_minimum_criteria_scores: SCOREABLE_QUESTIONS[:criteria_score_questions_csd].index_with {|x| 'Yes'}
                                   }.to_json
       assert_equal 'Yes', teacher_application.meets_criteria
 
       teacher_application = build :pd_teacher_application, course: 'csp',
                                   response_scores: {
-                                    meets_minimum_criteria_scores: SCOREABLE_QUESTIONS[:criteria_score_questions_csp].map {|x| [x, 'Yes']}.to_h
+                                    meets_minimum_criteria_scores: SCOREABLE_QUESTIONS[:criteria_score_questions_csp].index_with {|x| 'Yes'}
                                   }.to_json
       assert_equal 'Yes', teacher_application.meets_criteria
     end


### PR DESCRIPTION
Quoting from the documentation (linked below):

> This cop looks for uses of `each_with_object({}) { … }`, `map { … }.to_h`, and `Hash[map { … }]` that are transforming an enumerable into a hash where the keys are the original elements. Rails provides the `index_with` method for this purpose.

Fixes applied automatically with `bundle exec rubocop --auto-correct --only Rails/IndexWith`. I then manually fixed up a few of the automatically-added `index_with` calls that could be simplified even futher.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

- https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsindexwith
- https://www.rubydoc.info/gems/rubocop-rails/2.5.2/RuboCop/Cop/Rails/IndexWith

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
