### PR TITLE
Javalab: Contained levels can't be edited in start mode

### DIFF
--- a/apps/src/code-studio/initApp/loadApp.js
+++ b/apps/src/code-studio/initApp/loadApp.js
@@ -44,7 +44,7 @@ export function setupApp(appOptions) {
       // Lock the contained levels if this is a teacher viewing student work:
       lockContainedLevelAnswers();
     }
-    if (!appOptions.level.edit_blocks) {
+    if (!(appOptions.level.edit_blocks || appOptions.level.editBlocks)) {
       // Always mark the workspace as readonly when we have contained levels,
       // unless editing:
       appOptions.readonlyWorkspace = true;


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Root cause here was that non-blockly levels like Javalab only have a camel-case `"editBlocks"` key in their app options (as opposed to the snake-case `"edit_blocks"` present in blockly levels), so the flag wasn't being set properly. I think there's a bigger discussion here about camel case vs snake case when referring to data in app options (which we can have in #student-learning), but I felt that this was the most straightforward fix for now.

## Links

https://codedotorg.atlassian.net/browse/SL-273

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Tested on multiple Javalab contained levels in start mode, and confirmed starter code could be edited and saved.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
