### PR TITLE
External links added for Korean

### DIFF
--- a/apps/src/templates/certificates/Congrats.jsx
+++ b/apps/src/templates/certificates/Congrats.jsx
@@ -5,6 +5,7 @@ import StudentsBeyondHoc from './StudentsBeyondHoc';
 import TeachersBeyondHoc from './TeachersBeyondHoc';
 import PetitionCallToAction from '@cdo/apps/templates/certificates/petition/PetitionCallToAction';
 import styleConstants from '../../styleConstants';
+import {pegasus} from '@cdo/apps/lib/util/urlHelpers';
 import color from '../../util/color';
 import GraduateToNextLevel from '@cdo/apps/templates/certificates/GraduateToNextLevel';
 
@@ -32,6 +33,19 @@ export default function Congrats(props) {
    */
   const renderExtraCertificateLinks = (language, tutorial) => {
     let extraLinkUrl, extraLinkText;
+    // In order to remove the certificate links remove or comment the following section -------------------------------
+    if (language === 'ko') {
+      if (/oceans/.test(tutorial)) {
+        extraLinkUrl = pegasus('/files/online-coding-party-2021-oceans.pdf');
+        extraLinkText =
+          '온라인 코딩 파티 인증서 받으러 가기! (과학기술정보통신부 인증)';
+      } else if (/dance/.test(tutorial)) {
+        extraLinkUrl = pegasus('/files/online-coding-party-2021-dance.pdf');
+        extraLinkText =
+          '온라인 코딩 파티 인증서 받으러 가기! (과학기술정보통신부 인증)';
+      }
+    }
+    // End of section to be removed or commented ----------------------------------------------------------------------
     if (!extraLinkUrl || !extraLinkText) {
       // There are no extra links to render.
       return;


### PR DESCRIPTION
**What:** Extra Certificate Links added for Dance Party and AI for Oceans, as per request of our South Korean partners.


## Links

- jira ticket: [FND-2106](https://codedotorg.atlassian.net/browse/FND-2106)


## Testing story

Testes that links for Korean language only appear in Dance Party and AI for oceans.
Link appears in AI for oceans:
![Screen Shot 2022-10-10 at 00 21 54](https://user-images.githubusercontent.com/66776217/194803434-8cd76ce9-8e80-4bb6-9238-c6eba389fdfc.png)

Link appears in dance party:
![Screen Shot 2022-10-10 at 00 21 46](https://user-images.githubusercontent.com/66776217/194803440-b5d55143-e6bc-4253-bb90-0ca8ca8585fc.png)

Link does not appear for Minecraft:
![Screen Shot 2022-10-10 at 00 22 04](https://user-images.githubusercontent.com/66776217/194803446-a3815240-c4d9-4beb-9b02-952ec4c04da4.png)


Tested that links did not appear for other languages:
![Screen Shot 2022-10-09 at 19 34 44](https://user-images.githubusercontent.com/66776217/194801577-9983656d-73af-42b6-a6c4-e9c604318cbf.png)

###Testing links: 
- http://localhost-studio.code.org:3000/s/dance-2019/lessons/1/levels/1?lang=ko-KR
- http://localhost-studio.code.org:3000/s/oceans/lessons/1/levels/2?lang=ko-KR
- http://localhost-studio.code.org:3000/s/aquatic/lessons/1/levels/1?lang=ko-KR
## Follow-up work

Removing certificate links on November 21st
- jira ticket: [FND-2107](https://codedotorg.atlassian.net/browse/FND-2107)
<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->