### PR TITLE
Revert "Revert "Launch reset predict level""

### DIFF
--- a/apps/src/code-studio/levels/codeStudioLevels.js
+++ b/apps/src/code-studio/levels/codeStudioLevels.js
@@ -176,7 +176,7 @@ export function resetContainedLevel() {
         'X-CSRF-Token': authenticityToken
       },
       body: JSON.stringify({
-        script_id: appOptions.scriptId,
+        script_id: appOptions.serverScriptId,
         level_id: levelIds[0]
       })
     }).then(response => {

--- a/apps/src/templates/instructions/ContainedLevelResetButton.jsx
+++ b/apps/src/templates/instructions/ContainedLevelResetButton.jsx
@@ -1,4 +1,4 @@
-import React, {useMemo, useState} from 'react';
+import React, {useState} from 'react';
 import PropTypes from 'prop-types';
 import Button from '@cdo/apps/templates/Button';
 import HelpTip from '@cdo/apps/lib/ui/HelpTip';
@@ -9,7 +9,6 @@ import {queryUserProgress} from '@cdo/apps/code-studio/progressRedux';
 import firehoseClient from '@cdo/apps/lib/util/firehose';
 import color from '@cdo/apps/util/color';
 import i18n from '@cdo/locale';
-import experiments from '@cdo/apps/util/experiments';
 
 export const UnconnectedContainedLevelResetButton = ({
   userId,
@@ -20,10 +19,6 @@ export const UnconnectedContainedLevelResetButton = ({
   serverScriptId,
   serverLevelId
 }) => {
-  const isEnabled = useMemo(
-    () => experiments.isEnabled('instructorPredictLevelReset'),
-    []
-  );
   const [resetFailed, setResetFailed] = useState(false);
 
   const logButtonClick = () => {
@@ -35,7 +30,7 @@ export const UnconnectedContainedLevelResetButton = ({
     });
   };
 
-  if (userRoleInCourse !== CourseRoles.Instructor || !isEnabled) {
+  if (userRoleInCourse !== CourseRoles.Instructor) {
     return null;
   }
   return (

--- a/apps/src/templates/instructions/TopInstructions.jsx
+++ b/apps/src/templates/instructions/TopInstructions.jsx
@@ -506,7 +506,9 @@ class TopInstructions extends Component {
             ref={ref => this.setInstructionsRef(ref)}
             hidden={tabSelected !== TabType.INSTRUCTIONS}
           />
-          {!this.props.inLessonPlan && <ContainedLevelResetButton />}
+          {!this.props.inLessonPlan && tabSelected === TabType.INSTRUCTIONS && (
+            <ContainedLevelResetButton />
+          )}
         </div>
       );
     } else if (isCSF && tabSelected === TabType.INSTRUCTIONS) {

--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -36,7 +36,6 @@ experiments.SPECIAL_TOPIC = 'special-topic';
 experiments.CLEARER_SIGN_UP_USER_TYPE = 'clearerSignUpUserType';
 experiments.OPT_IN_EMAIL_REG_PARTNER = 'optInEmailRegPartner';
 experiments.STUDIO_CERTIFICATE = 'studioCertificate';
-experiments.INSTRUCTOR_PREDICT_LEVEL_RESET = 'instructorPredictLevelReset';
 
 /**
  * This was a gamified version of the finish dialog, built in 2018,

--- a/apps/test/unit/templates/instructions/TopInstructionsTest.jsx
+++ b/apps/test/unit/templates/instructions/TopInstructionsTest.jsx
@@ -51,6 +51,34 @@ describe('TopInstructions', () => {
     expect(wrapper.find('ContainedLevelAnswer')).to.have.lengthOf(1);
   });
 
+  it('shows ContainedLevelResetButton on instructions tab', () => {
+    const wrapper = shallow(
+      <TopInstructions
+        {...DEFAULT_PROPS}
+        hasContainedLevels={true}
+        isViewingAsInstructorInTraining={true}
+        initialSelectedTab={TabType.INSTRUCTIONS}
+      />
+    );
+    expect(
+      wrapper.find('Connect(UnconnectedContainedLevelResetButton)')
+    ).to.have.lengthOf(1);
+  });
+
+  it('does not shows ContainedLevelResetButton on teacher only tab', () => {
+    const wrapper = shallow(
+      <TopInstructions
+        {...DEFAULT_PROPS}
+        hasContainedLevels={true}
+        isViewingAsInstructorInTraining={true}
+        initialSelectedTab={TabType.TEACHER_ONLY}
+      />
+    );
+    expect(
+      wrapper.find('Connect(UnconnectedContainedLevelResetButton)')
+    ).to.have.lengthOf(0);
+  });
+
   it('shows teacher only markdown in teacher only tab if instructor in training level', () => {
     const wrapper = shallow(
       <TopInstructions


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#48488, restoring https://github.com/code-dot-org/code-dot-org/pull/48368. The [button started appearing](https://codedotorg.slack.com/archives/C0T0PNTM3/p1665089026217329?thread_ts=1665080608.547289&cid=C0T0PNTM) on the "Teacher Only" tab, which was not expected. This PR fixes that issue and relauches resetting predict levels.