### PR TITLE
make new certificate pages work with non-ASCII characters

### DIFF
--- a/apps/src/templates/certificates/Certificate.jsx
+++ b/apps/src/templates/certificates/Certificate.jsx
@@ -68,11 +68,11 @@ function Certificate(props) {
   const getEncodedParams = () => {
     const donor = studentName ? props.randomDonorName : null;
     const data = {
-      name: reEncodeNonLatin1(studentName),
+      name: studentName,
       course: props.tutorial,
       donor
     };
-    return btoa(JSON.stringify(data));
+    return btoa(reEncodeNonLatin1(JSON.stringify(data)));
   };
 
   const getCertificateImagePath = certificate => {

--- a/apps/src/templates/certificates/Certificate.jsx
+++ b/apps/src/templates/certificates/Certificate.jsx
@@ -11,6 +11,23 @@ import SocialShare from './SocialShare';
 import LargeChevronLink from './LargeChevronLink';
 import {ResponsiveSize} from '@cdo/apps/code-studio/responsiveRedux';
 
+/**
+ * Without this, we get an error on the server "invalid byte sequence in UTF-8".
+ *
+ * Workaround via
+ * https://github.com/exupero/saveSvgAsPng/commit/fd9453f576d202dd36e08105cd18d5aed9174d22
+ *
+ * @param {string} data
+ * @returns {string}
+ */
+function reEncodeNonLatin1(data) {
+  var encodedData = encodeURIComponent(data);
+  encodedData = encodedData.replace(/%([0-9A-F]{2})/g, function(match, p1) {
+    return String.fromCharCode('0x' + p1);
+  });
+  return decodeURIComponent(encodedData);
+}
+
 function Certificate(props) {
   const [personalized, setPersonalized] = useState(false);
   const [studentName, setStudentName] = useState();
@@ -51,7 +68,7 @@ function Certificate(props) {
   const getEncodedParams = () => {
     const donor = studentName ? props.randomDonorName : null;
     const data = {
-      name: studentName,
+      name: reEncodeNonLatin1(studentName),
       course: props.tutorial,
       donor
     };

--- a/dashboard/test/ui/features/hour_of_code/hour_of_code_finish.feature
+++ b/dashboard/test/ui/features/hour_of_code/hour_of_code_finish.feature
@@ -13,7 +13,7 @@ Scenario: Completing Minecraft HoC should go to certificate page and generate a 
   And my query params match "\?i\=.*\&s\=bWM\="
   And I wait to see element with ID "congrats-container"
   And I wait to see element with ID "uitest-certificate"
-  And I type "Robo Coder" into "#name"
+  And I type "Robo Códer" into "#name"
   And I press "button:contains(Submit)" using jQuery
   And I wait to see element with ID "uitest-thanks"
 
@@ -27,7 +27,7 @@ Scenario: Flappy customized dashboard certificate pages
   Then the href of selector ".social-print-link" contains "/print_certificates/"
   Then I wait to see an image "/images/hour_of_code_certificate.jpg"
 
-  When I type "Robo Coder" into "#name"
+  When I type "Robo Códer" into "#name"
   And I press "button:contains(Submit)" using jQuery
   And I wait to see element with ID "uitest-thanks"
   Then I wait to see an image "/certificate_images/"
@@ -96,7 +96,7 @@ Scenario: congrats certificate pages
   And I wait for image "#uitest-certificate img" to load
   And I see no difference for "uncustomized flappy certificate"
 
-  When I type "Robo Coder" into "#name"
+  When I type "Robo Códer" into "#name"
   And I press "button:contains(Submit)" using jQuery
   And I wait to see element with ID "uitest-thanks"
   And I see no difference for "customized flappy certificate"
@@ -108,7 +108,7 @@ Scenario: congrats certificate pages
   And I wait for image "#uitest-certificate img" to load
   And I see no difference for "uncustomized oceans certificate"
 
-  When I type "Robo Coder" into "#name"
+  When I type "Robo Códer" into "#name"
   And I press "button:contains(Submit)" using jQuery
   And I wait to see element with ID "uitest-thanks"
   And I see no difference for "customized oceans certificate"
@@ -120,7 +120,7 @@ Scenario: congrats certificate pages
   And I wait for image "#uitest-certificate img" to load
   And I see no difference for "uncustomized Course A 2017 certificate"
 
-  When I type "Robo Coder" into "#name"
+  When I type "Robo Códer" into "#name"
   And I press "button:contains(Submit)" using jQuery
   And I wait to see element with ID "uitest-thanks"
   And I see no difference for "customized Course A 2017 certificate"
@@ -132,7 +132,7 @@ Scenario: congrats certificate pages
   And I wait for image "#uitest-certificate img" to load
   And I see no difference for "uncustomized 20-hour certificate"
 
-  When I type "Robo Coder" into "#name"
+  When I type "Robo Códer" into "#name"
   And I press "button:contains(Submit)" using jQuery
   And I wait to see element with ID "uitest-thanks"
   And I see no difference for "customized 20-hour certificate"


### PR DESCRIPTION
Finishes https://codedotorg.atlassian.net/browse/PLAT-2016, which blocks congrats page launch.  See [slack](https://codedotorg.slack.com/archives/CFTFD6BPV/p1665307196834429) for context. launching congrats pages broke the ability of users with non-ASCII characters in their names to customize certificates. the launch PRs were then reverted while this fix was investigated.

I spent some time trying to get to the bottom of this and had trouble figuring out what the best solution would be or why the existing solution works, but came up empty handed. So, I did a simple copy of the solution that was already in place on the existing pegasus version of this page, which seems fair given that we are going for feature parity with the existing pegasus versions of these pages.

one thing I did determine is that the problem is specific to base64 encoding. so, codepaths which do not base64-encode the student name are not affected, such as the batch certificate page.

## Screenshots

### before
the issue as reported by the user over the weekend:

https://user-images.githubusercontent.com/8001765/194964338-d8a92ab7-8312-4853-a4a9-072dcb5eb9b9.mov

### after

https://user-images.githubusercontent.com/8001765/194964528-867ab1e2-ad14-4d36-a66a-346e722a51c9.mov

## Testing story

* updated UI tests to cover the case shown in the screenshots
* manually verified teacher homepage --> batch certificate --> batch print flow works and was not affected by this issue

## Follow-up work

relaunch congrats pages, possibly in the same DTP as this PR
