### PR TITLE
Fix special events without a city

### DIFF
--- a/apps/src/sites/hourofcode.com/pages/views/hoc_events_map.js
+++ b/apps/src/sites/hourofcode.com/pages/views/hoc_events_map.js
@@ -3,7 +3,7 @@
 $(document).ready(function() {
   // We keep some style elements as a Mapbox style for simplicity.
   const stylePath = 'mapbox://styles/codeorg/cjz36duae88ds1cp7ll7smx6s';
-  var map = new mapboxgl.Map({
+  const map = new mapboxgl.Map({
     container: 'mapbox-map',
     style: stylePath,
     zoom: 1,
@@ -11,7 +11,7 @@ $(document).ready(function() {
     center: [-98, 39]
   });
 
-  var popup = null;
+  let popup = null;
 
   map.dragRotate.disable();
   map.scrollZoom.disable();
@@ -21,7 +21,7 @@ $(document).ready(function() {
   // copies of the point are visible, the popup appears
   // over the point clicked on.
   function getPopupCoordinates(clickLngLat, featureCoordinates) {
-    var normalizedCoordinates = featureCoordinates;
+    const normalizedCoordinates = featureCoordinates;
     while (Math.abs(clickLngLat.lng - normalizedCoordinates[0]) > 180) {
       normalizedCoordinates[0] +=
         clickLngLat.lng > normalizedCoordinates[0] ? 360 : -360;
@@ -72,7 +72,7 @@ $(document).ready(function() {
       'bottom-right'
     );
 
-    var legend = document.createElement('div');
+    const legend = document.createElement('div');
     legend.id = 'inmaplegend';
     legend.className = 'inmap-mapbox-legend';
     legend.index = 1;
@@ -100,15 +100,15 @@ $(document).ready(function() {
     });
 
     map.on('click', 'hoc-events', function(e) {
-      var coordinates = e.features[0].geometry.coordinates.slice();
-      var organizationName = e.features[0].properties.organization_name;
-      var city = e.features[0].properties.city;
+      const coordinates = e.features[0].geometry.coordinates.slice();
+      const organizationName = e.features[0].properties.organization_name;
+      const city = e.features[0].properties.city;
 
       if (popup) {
         popup.remove();
       }
-      const popupText =
-        organizationName + (city.length > 0 ? ' (' + city + ')' : '');
+      const citySuffix = city && city.length > 0 ? ' (' + city + ')' : '';
+      const popupText = organizationName + citySuffix;
       popup = new mapboxgl.Popup({closeButton: false})
         .setLngLat(getPopupCoordinates(e.lngLat, coordinates))
         .setText(popupText)
@@ -116,19 +116,17 @@ $(document).ready(function() {
     });
 
     map.on('click', 'hoc-special-events', function(e) {
-      var coordinates = e.features[0].geometry.coordinates.slice();
-      var organizationName = e.features[0].properties.organization_name;
-      var city = e.features[0].properties.city;
-      var event_description = e.features[0].properties.description;
+      const coordinates = e.features[0].geometry.coordinates.slice();
+      const organizationName = e.features[0].properties.organization_name;
+      const city = e.features[0].properties.city;
+      const event_description = e.features[0].properties.description;
 
       if (popup) {
         popup.remove();
       }
+      const citySuffix = city && city.length > 0 ? ' (' + city + ')' : '';
       const popupText =
-        organizationName +
-        (city.length > 0 ? ' (' + city + ')' : '') +
-        '<br>' +
-        event_description;
+        organizationName + citySuffix + '<br>' + event_description;
       popup = new mapboxgl.Popup({closeButton: false})
         .setLngLat(getPopupCoordinates(e.lngLat, coordinates))
         .setHTML(popupText)

--- a/apps/src/sites/hourofcode.com/pages/views/hoc_events_map.js
+++ b/apps/src/sites/hourofcode.com/pages/views/hoc_events_map.js
@@ -29,6 +29,27 @@ $(document).ready(function() {
     return normalizedCoordinates;
   }
 
+  function setPopup(e, isSpecialEvent) {
+    const coordinates = e.features[0].geometry.coordinates.slice();
+    const organizationName = e.features[0].properties.organization_name;
+    const city = e.features[0].properties.city;
+
+    if (popup) {
+      popup.remove();
+    }
+    const citySuffix = city && city.length > 0 ? ' (' + city + ')' : '';
+    let popupText = organizationName + citySuffix;
+    if (isSpecialEvent) {
+      const eventDescription = e.features[0].properties.description;
+      popupText += '<br>' + eventDescription;
+    }
+
+    popup = new mapboxgl.Popup({closeButton: false})
+      .setLngLat(getPopupCoordinates(e.lngLat, coordinates))
+      .setHTML(popupText)
+      .addTo(map);
+  }
+
   map.on('load', function() {
     map.addSource('hoctiles', {
       type: 'vector',
@@ -99,39 +120,8 @@ $(document).ready(function() {
       enableMouseControls();
     });
 
-    map.on('click', 'hoc-events', function(e) {
-      const coordinates = e.features[0].geometry.coordinates.slice();
-      const organizationName = e.features[0].properties.organization_name;
-      const city = e.features[0].properties.city;
-
-      if (popup) {
-        popup.remove();
-      }
-      const citySuffix = city && city.length > 0 ? ' (' + city + ')' : '';
-      const popupText = organizationName + citySuffix;
-      popup = new mapboxgl.Popup({closeButton: false})
-        .setLngLat(getPopupCoordinates(e.lngLat, coordinates))
-        .setText(popupText)
-        .addTo(map);
-    });
-
-    map.on('click', 'hoc-special-events', function(e) {
-      const coordinates = e.features[0].geometry.coordinates.slice();
-      const organizationName = e.features[0].properties.organization_name;
-      const city = e.features[0].properties.city;
-      const event_description = e.features[0].properties.description;
-
-      if (popup) {
-        popup.remove();
-      }
-      const citySuffix = city && city.length > 0 ? ' (' + city + ')' : '';
-      const popupText =
-        organizationName + citySuffix + '<br>' + event_description;
-      popup = new mapboxgl.Popup({closeButton: false})
-        .setLngLat(getPopupCoordinates(e.lngLat, coordinates))
-        .setHTML(popupText)
-        .addTo(map);
-    });
+    map.on('click', 'hoc-events', e => setPopup(e, false));
+    map.on('click', 'hoc-special-events', e => setPopup(e, true));
 
     map.on('mouseenter', 'hoc-events', function() {
       map.getCanvas().style.cursor = 'pointer';

--- a/bin/cron/update_hoc_map
+++ b/bin/cron/update_hoc_map
@@ -30,6 +30,11 @@ def main
   DB_READONLY[:forms].where(kind: CURRENT_HOC_SIGNUP).paged_each(rows_per_fetch: 10_000) do |form|
     data = JSON.parse(form[:data])
     processed_data = JSON.parse(form[:processed_data]) rescue {}
+    # ***
+    # If these rules are changed and we wish to display a broader set of events,
+    # update our JS code (hoc_events_map.js) that visualizes these events
+    # to handle missing data.
+    # ***
     # In order to be placed on the map, all events require an organization name,
     # processed location, and city. With the exception that approved special events
     # don't need a city so we can show events like the Cocos Keeling Islands.


### PR DESCRIPTION
Special events without a city are allowed on the Ruby side, but weren't handled in our JS code. Fixes our JS code to handle missing events. Also ES6-ified our HOC events JS code, and deduped some very similar popup logic.

For context, we have 18 events affected by this issue so far this year. 21 were affected last year.

## Links

- [slack discussion with zendesk ticket](https://codedotorg.slack.com/archives/C5V9YCXTR/p1665408900801979)

## Testing story

I tested this locally (kind of convenient that the map that gets displayed in development uses production data 😆 ), and saw the popup appearing for an affected event in Turkey.