### PR TITLE
Music prototype: adjust sound events management

### DIFF
--- a/apps/src/music/MusicView.jsx
+++ b/apps/src/music/MusicView.jsx
@@ -234,8 +234,22 @@ class MusicView extends React.Component {
       return;
     }
 
+    // Stop all when_run sounds that are still to play, because if they
+    // are still valid after the when_run code is re-executed, they
+    // will be scheduled again.
+    this.stopAllSoundsStillToPlay();
+
+    // Also clear all when_run sounds from the events list, because it
+    // will be recreated in its entirely when the when_run code is
+    // re-executed.
+    this.player.clearWhenRunEvents();
+
     this.executeSong();
 
+    console.log('onBlockSpaceChange', Blockly.getWorkspaceCode());
+
+    // This is a way to tell React to re-render the scene, notably
+    // the timeline.
     this.setState({updateNumber: this.state.updateNumber + 1});
   };
 
@@ -301,7 +315,7 @@ class MusicView extends React.Component {
   };
 
   playTrigger = id => {
-    console.log('Playhead position: ' + this.player.getPlayheadPosition());
+    //console.log('Playhead position: ' + this.player.getPlayheadPosition());
     this.inputContext.onTrigger(id);
     this.callUserGeneratedCode(hooks.triggeredAtButton);
   };
@@ -325,30 +339,38 @@ class MusicView extends React.Component {
       hooks[hook.name] = hook.func;
     });
 
-    this.player.clearQueue();
-
     this.callUserGeneratedCode(hooks.whenRunButton);
   };
 
   playSong = () => {
     this.player.stopSong();
+
+    // Clear the events list of when_run sounds, because it will be
+    // populated next.
+    this.player.clearWhenRunEvents();
+
     this.executeSong();
+
     this.player.playSong();
 
     this.setState({isPlaying: true});
 
-    console.log(Blockly.getWorkspaceCode());
+    console.log('playSong', Blockly.getWorkspaceCode());
   };
 
   stopSong = () => {
     this.player.stopSong();
     this.inputContext.clearTriggers();
 
+    // Clear the events list, and hence the visual timeline, of any
+    // user-triggered sounds.
+    this.player.clearTriggeredEvents();
+
     this.setState({isPlaying: false});
   };
 
-  previewSound = id => {
-    this.player.playSoundImmediately(id);
+  stopAllSoundsStillToPlay = () => {
+    this.player.stopAllSoundsStillToPlay();
   };
 
   getCurrentGroup = () => {

--- a/apps/src/music/blockly/blocks/samples.js
+++ b/apps/src/music/blockly/blocks/samples.js
@@ -1,5 +1,17 @@
 import {BlockTypes} from '../blockTypes';
 
+// Examine chain of parents to see if one is 'when_run'.
+const isBlockInsideWhenRun = ctx => {
+  let block = ctx;
+  while ((block = block.getParent())) {
+    if (block.type === 'when_run') {
+      return true;
+    }
+  }
+
+  return false;
+};
+
 export const playSound = {
   definition: {
     type: BlockTypes.PLAY_SOUND,
@@ -39,6 +51,8 @@ export const playSound = {
       'measure',
       Blockly.JavaScript.ORDER_ASSIGNMENT
     ) +
+    ', ' +
+    (isBlockInsideWhenRun(ctx) ? 'true' : 'false') +
     ');\n'
 };
 
@@ -85,6 +99,8 @@ export const playSample = {
       'measure',
       Blockly.JavaScript.ORDER_ASSIGNMENT
     ) +
+    ', ' +
+    (isBlockInsideWhenRun(ctx) ? 'true' : 'false') +
     ');\n'
 };
 

--- a/apps/src/music/player/sound.js
+++ b/apps/src/music/player/sound.js
@@ -45,8 +45,7 @@ export function PlaySound(name, groupTag, when = 0, loop = false) {
   for (var i = 0; i < soundList.length; i++) {
     if (soundList[i] === name) {
       // Always provide a groupTag.  If one wasn't provided, just use the sound name as the group name.
-      PlaySoundByIndex(i, groupTag || name, when, loop);
-      break;
+      return PlaySoundByIndex(i, groupTag || name, when, loop);
     }
   }
 }
@@ -81,7 +80,7 @@ function PlaySoundByIndex(audioBufferIndex, groupTag, when, loop) {
   );
 
   tagGroup.sources.push({source: source, id: audioIdUpto});
-  audioIdUpto++;
+  return audioIdUpto++;
 }
 
 function RemoveStoppedBuffer(groupTag, soundSourceId) {
@@ -106,6 +105,14 @@ export function StopSound(groupTag) {
 
   for (var b = 0; b < sources.length; b++) {
     var source = sources[b].source;
+    audioSystem.StopSoundBySource(source);
+  }
+}
+
+export function StopSoundByUniqueId(groupTag, uniqueId) {
+  var sources = tagGroups[groupTag].sources;
+  const source = sources.find(source => source.id === uniqueId)?.source;
+  if (source) {
     audioSystem.StopSoundBySource(source);
   }
 }

--- a/apps/src/music/player/soundSub.js
+++ b/apps/src/music/player/soundSub.js
@@ -101,9 +101,12 @@ WebAudio.prototype.PlaySoundByBuffer = function(
 };
 
 WebAudio.prototype.StopSoundBySource = function(source) {
-  if (source.context.state === 'running') {
-    source.stop();
-  }
+  // todo: investigate whether this condition is needed/useful
+  // across browsers.
+
+  //if (source.context.state === 'running') {
+  source.stop();
+  //}
 };
 
 export default WebAudio;


### PR DESCRIPTION
Until now, there was an interesting issue with sound event management: if you had some code which generated many sounds in the future, and then adjusted the code in any way while the song was playing, once you arrived at those future sounds, they would be quite loud.  This was because the code was re-executing as it was changed, and it would schedule additional Web Audio plays of the same sounds in the future.

First, some background on the model used for sound events thus far.  It is tempting to maintain a central list of events, and to generate Web Audio plays just before it's time for them to play, which is indeed the idea in the popular article [A tale of two clocks](https://web.dev/audio-scheduling/), in which a regular timer is used to generate Web Audio plays shortly before they are needed.  We might end up using a similar model in the future.

But right now, I took a slightly different approach, which is to maintain a central list of events, but to also schedule Web Audio plays as soon as I know they are in the future, even if they aren't yet near.  This allows us to use the same code for events we know are in the distant future, as well as for events that should begin immediately, such as user-triggered code that wants to play instantly.

This does mean that we are maintaining a couple sets of information at the same time: the sound events list, which is used to render the visual timeline; and the implicit set of Web Audio plays that have their own play times, though these should always match the visual timeline unless we have a bug.

Making things work properly took some new plumbing.  First, the audio system now returns a unique ID for each scheduled play, which we can use to cancel that play.  (We need to make sure it's possible to stop a Web Audio play that has not yet started, across all browsers and devices.). Second, when user code does generate a play, we track whether the code was under the `when_run` block or is otherwise presumed to be a user-triggered play.

Then, our higher level code can do a few new things.  While the song is playing, the code can be edited and the visual timeline and scheduled audio can change.  But when the code is re-executed, we clear the `when_run`-generated sound events and cancel the corresponding Web Audio plays that are yet to begin (though any that are in progress should continue playing), and then the re-execution will regenerate these as appropriate.  User-triggered sounds should be untouched, whether they have played already or not.  And when the song is stopped, we leave the `when_run`-generated sounds intact on the visual timeline, though user-triggered sound events are cleared.