### PR TITLE
Music prototype: instructions

### DIFF
--- a/apps/src/music/Instructions.jsx
+++ b/apps/src/music/Instructions.jsx
@@ -1,0 +1,95 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+export default class Instructions extends React.Component {
+  static propTypes = {
+    instructions: PropTypes.object,
+    baseUrl: PropTypes.string.isRequired
+  };
+
+  state = {
+    currentPanel: 0
+  };
+
+  changePanel = nextPanel => {
+    if (
+      nextPanel &&
+      this.state.currentPanel + 1 <
+        this.props.instructions?.groups[0].panels.length
+    ) {
+      this.setState({currentPanel: this.state.currentPanel + 1});
+    } else if (!nextPanel && this.state.currentPanel > 0) {
+      this.setState({currentPanel: this.state.currentPanel - 1});
+    }
+  };
+
+  render() {
+    const {instructions, baseUrl} = this.props;
+
+    return (
+      <div
+        id="instructions"
+        style={{
+          backgroundColor: '#222',
+          width: '100%',
+          height: '100%',
+          borderRadius: 4,
+          backgroundSize: '100% 200%',
+          padding: 10,
+          boxSizing: 'border-box',
+          position: 'relative'
+        }}
+      >
+        {instructions?.groups[0].panels.map((panel, index) => {
+          return (
+            <div
+              key={index}
+              style={{
+                position: 'absolute',
+                top: 10,
+                opacity: index === this.state.currentPanel ? 1 : 0
+              }}
+            >
+              {panel.imageSrc && (
+                <div style={{float: 'left'}}>
+                  <img
+                    src={
+                      baseUrl +
+                      instructions.groups[0].path +
+                      '/' +
+                      panel.imageSrc
+                    }
+                    style={{height: 70, marginRight: 10}}
+                  />
+                </div>
+              )}
+              <div style={{float: 'left'}}>{panel.text}</div>
+            </div>
+          );
+        })}
+        <div
+          style={{
+            bottom: 4,
+            right: 4,
+            position: 'absolute'
+          }}
+        >
+          <button
+            type="button"
+            onClick={() => this.changePanel(false)}
+            style={{fontSize: 13, padding: '4px 8px'}}
+          >
+            Previous
+          </button>
+          <button
+            type="button"
+            onClick={() => this.changePanel(true)}
+            style={{fontSize: 13, padding: '4px 8px'}}
+          >
+            Next
+          </button>
+        </div>
+      </div>
+    );
+  }
+}

--- a/apps/src/music/MusicView.jsx
+++ b/apps/src/music/MusicView.jsx
@@ -7,6 +7,7 @@ import CustomMarshalingInterpreter from '../lib/tools/jsinterpreter/CustomMarsha
 import {parseElement as parseXmlElement} from '../xml';
 import queryString from 'query-string';
 import {baseToolbox, createMusicToolbox} from './blockly/toolbox';
+import Instructions from './Instructions';
 import Controls from './Controls';
 import Timeline from './Timeline';
 import {MUSIC_BLOCKS} from './blockly/musicBlocks';
@@ -69,6 +70,7 @@ class MusicView extends React.Component {
       appWidth: this.codeAppRef.offsetWidth,
       appHeight: this.codeAppRef.offsetHeight,
       library: null,
+      instructions: null,
       currentPanel: 'groups',
       groupPanel: 'all',
       isPlaying: false,
@@ -76,7 +78,7 @@ class MusicView extends React.Component {
       currentAudioElapsedTime: 0,
       updateNumber: 0,
       timelineAtTop: !!getRandomIntInclusive(0, 1),
-      showInstructions: false
+      showInstructions: true
     };
   }
 
@@ -112,6 +114,10 @@ class MusicView extends React.Component {
       this.workspace.updateToolbox(createMusicToolbox(library, 'dropdown'));
       this.player.initialize(library);
     });
+
+    this.loadInstructions().then(instructions => {
+      this.setState({instructions});
+    });
   }
 
   componentDidUpdate() {
@@ -131,6 +137,13 @@ class MusicView extends React.Component {
     const libraryFilename = parameters['library']
       ? `music-library-${parameters['library']}.json`
       : 'music-library.json';
+    const response = await fetch(baseUrl + libraryFilename);
+    const library = await response.json();
+    return library;
+  };
+
+  loadInstructions = async () => {
+    const libraryFilename = 'music-instructions.json';
     const response = await fetch(baseUrl + libraryFilename);
     const library = await response.json();
     return library;
@@ -486,14 +499,10 @@ class MusicView extends React.Component {
               overflow: 'scroll'
             }}
           >
-            <p>Music Lab Prototype Keyboard Shortcuts:</p>
-            <p>i: show/hide instructions</p>
-            <p>t: move timeline to bottom/top</p>
-            <p>d: sample block mode = play block + dropdown </p>
-            <p>v: sample block mode = values </p>
-            <p>p: sample block mode = play block + values</p>
-            <p>space: play/stop song</p>
-            <p>[1, 2, 3]: trigger buttons</p>
+            <Instructions
+              instructions={this.state.instructions}
+              baseUrl={baseUrl}
+            />
           </div>
         )}
         <div

--- a/apps/static/music/music-instructions.json
+++ b/apps/static/music/music-instructions.json
@@ -1,0 +1,24 @@
+{
+  "groups": [
+    {
+      "path": "initial-instructions",
+      "panels": [
+        {
+          "text": "These are the first instructions.",
+          "imageSrc": "instructions0.png"
+        },
+        {
+          "text": "These are the second instructions.",
+          "imageSrc": "instructions1.png"
+        },
+        {
+          "text": "These are the third instructions.",
+          "imageSrc": "instructions2.png"
+        },
+        {
+          "text": "These are the fourth instructions."
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Support for simple multi-panel instructions, self-contained and temporary until we integrate with our regular instructions system.  The instructions are driven by a JSON file loaded from S3, a sample of which is included, and can optionally contain one image per panel.

<img width="1512" alt="Screen Shot 2022-10-10 at 11 08 29 PM" src="https://user-images.githubusercontent.com/2205926/195009881-103197fb-852a-4fe3-a776-49efb032339a.png">
