### PR TITLE
Fix `whitelist/allow_authorized` Deprecation Warning

### DIFF
--- a/dashboard/config/initializers/mini_profiler.rb
+++ b/dashboard/config/initializers/mini_profiler.rb
@@ -19,6 +19,6 @@ Rack::MiniProfiler.config.storage = Rack::MiniProfiler::FileStore
 
 # Only allow when it's explicitly allowed based on the rules in ApplicationController.check_profiler,
 # across all environments for consistency.
-# By default, this would be :allow_all for dev and test, :whitelist for other environments.
-# The whitelist mode means we must explicitly call authorize_request on a given request.
-Rack::MiniProfiler.config.authorization_mode = :whitelist
+# By default, this would be :allow_all for dev and test, :allow_authorized for other environments.
+# The "allow authorized" mode means we must explicitly call authorize_request on a given request.
+Rack::MiniProfiler.config.authorization_mode = :allow_authorized


### PR DESCRIPTION
As of Ruby 2.7, we started seeing the deprecation warning:

> [DEPRECATION] `:whitelist` authorization mode is deprecated. Please use `:allow_authorized` instead.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
