### PR TITLE
stop slack alerts on zendesk-plctools issues

### DIFF
--- a/bin/cron/zendesk_slack_report
+++ b/bin/cron/zendesk_slack_report
@@ -68,7 +68,6 @@ GROUP_FILTERS = {
 
 # Slack room -> username of a code.org email
 MONITORING_USERS = {
-  'ed-programs-tools' => ['zendesk-plctools'],
   'outreach_honky-tonk' => ['zendesk-outreach'],
   'pl-team-only' => ['zendesk-pl']
 }


### PR DESCRIPTION
Follow-up from https://github.com/code-dot-org/code-dot-org/pull/48466 . Slack alerts seem to be working in `#acquisition-products`, but are still also showing up in `#ed-programs-tools`. So, it seems like (1) we might or might not have had redundant alerting previously, but (2) we want to simply remove the unwanted alerting to get into a good state.

## Testing story

Not tested. Launch and iterate