### PR TITLE
Removing learn at home banner from Student Homepage and Course pages

### DIFF
--- a/apps/src/sites/studio/pages/home/_homepage.js
+++ b/apps/src/sites/studio/pages/home/_homepage.js
@@ -87,7 +87,6 @@ function showHomepage() {
             sections={homepageData.sections}
             canViewAdvancedTools={homepageData.canViewAdvancedTools}
             studentId={homepageData.studentId}
-            isEnglish={isEnglish}
             showVerifiedTeacherWarning={
               homepageData.showStudentAsVerifiedTeacherWarning
             }

--- a/apps/src/templates/studioHomepages/Courses.jsx
+++ b/apps/src/templates/studioHomepages/Courses.jsx
@@ -7,7 +7,6 @@ import {CourseBlocksIntl} from './CourseBlocks';
 import CoursesTeacherEnglish from './CoursesTeacherEnglish';
 import CoursesStudentEnglish from './CoursesStudentEnglish';
 import ProtectedStatefulDiv from '../ProtectedStatefulDiv';
-import SpecialAnnouncement from './SpecialAnnouncement';
 import {SpecialAnnouncementActionBlock} from './TwoColumnActionBlock';
 import Button from '@cdo/apps/templates/Button';
 import i18n from '@cdo/locale';
@@ -119,7 +118,6 @@ class Courses extends Component {
             {/* English, student.  (Also the default to be shown when signed out.) */}
             {isEnglish && !isTeacher && (
               <div className={'announcements'}>
-                <SpecialAnnouncement isTeacher={isTeacher} />
                 <CoursesStudentEnglish />
               </div>
             )}

--- a/apps/src/templates/studioHomepages/StudentHomepage.jsx
+++ b/apps/src/templates/studioHomepages/StudentHomepage.jsx
@@ -20,7 +20,6 @@ export default class StudentHomepage extends Component {
     sections: shapes.sections,
     canViewAdvancedTools: PropTypes.bool,
     studentId: PropTypes.number.isRequired,
-    isEnglish: PropTypes.bool.isRequired,
     showVerifiedTeacherWarning: PropTypes.bool
   };
 

--- a/apps/src/templates/studioHomepages/StudentHomepage.jsx
+++ b/apps/src/templates/studioHomepages/StudentHomepage.jsx
@@ -2,7 +2,6 @@ import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import ReactDOM from 'react-dom';
 import HeaderBanner from '../HeaderBanner';
-import SpecialAnnouncement from './SpecialAnnouncement';
 import RecentCourses from './RecentCourses';
 import JoinSectionArea from '@cdo/apps/templates/studioHomepages/JoinSectionArea';
 import ProjectWidgetWithData from '@cdo/apps/templates/projects/ProjectWidgetWithData';
@@ -38,7 +37,6 @@ export default class StudentHomepage extends Component {
       sections,
       topCourse,
       hasFeedback,
-      isEnglish,
       showVerifiedTeacherWarning
     } = this.props;
     const {canViewAdvancedTools, studentId} = this.props;
@@ -54,7 +52,6 @@ export default class StudentHomepage extends Component {
         />
         <div className={'container main'}>
           <ProtectedStatefulDiv ref="flashes" />
-          {isEnglish && <SpecialAnnouncement isTeacher={false} />}
           {showVerifiedTeacherWarning && (
             <Notification
               type={NotificationType.failure}

--- a/apps/test/unit/templates/studioHomepages/CoursesTest.jsx
+++ b/apps/test/unit/templates/studioHomepages/CoursesTest.jsx
@@ -38,7 +38,6 @@ describe('Courses', () => {
       it('as student', () => {
         const wrapper = mountCourses({isEnglish, isTeacher: false});
         assertComponentsInOrder(wrapper, [
-          'SpecialAnnouncement',
           'CourseBlocksStudentGradeBands',
           'CourseBlocksHoc',
           'LocalClassActionBlock'

--- a/apps/test/unit/templates/studioHomepages/StudentHomepageTest.js
+++ b/apps/test/unit/templates/studioHomepages/StudentHomepageTest.js
@@ -14,7 +14,6 @@ describe('StudentHomepage', () => {
     sections: joinedSections,
     codeOrgUrlPrefix: 'http://localhost:3000',
     studentId: 123,
-    isEnglish: true,
     showVerifiedTeacherWarning: false
   };
 
@@ -55,20 +54,6 @@ describe('StudentHomepage', () => {
     assert.deepEqual(joinSectionArea.props(), {
       initialJoinedStudentSections: joinedSections
     });
-  });
-
-  it('shows the special announcement for English', () => {
-    const wrapper = shallow(
-      <StudentHomepage {...TEST_PROPS} isEnglish={true} />
-    );
-    assert(wrapper.find('SpecialAnnouncement').exists());
-  });
-
-  it('does not show the special announcement for non-English', () => {
-    const wrapper = shallow(
-      <StudentHomepage {...TEST_PROPS} isEnglish={false} />
-    );
-    assert.isFalse(wrapper.find('SpecialAnnouncement').exists());
   });
 
   it('displays a notification for verified teacher permissions if showVerifiedTeacherWarning is true', () => {


### PR DESCRIPTION
This banner was added in March 2020 to encourage students to learn from home. Now, most students are back in person and the banner still takes up a large part of these landing pages. (Old pr here: https://github.com/code-dot-org/code-dot-org/pull/33675)

Approach: Instead of reworking the logic for the special announcement component altogether, I simply removed the Announcements from the course and student homepages. The announcement component is still in use for teachers, so this is the simplest approach, also allowing for a student banner to be shown in the case we have other important messaging later.

Before:

<img width="1095" alt="Screen Shot 2022-10-11 at 12 21 05 PM" src="https://user-images.githubusercontent.com/37230822/195182236-1deb1bb7-94af-470d-ad66-01bb650c575c.png">


<img width="1433" alt="Screen Shot 2022-10-11 at 10 41 06 AM" src="https://user-images.githubusercontent.com/37230822/195182255-ff5e1c7c-ef07-42c6-bd40-cd0344249a8a.png">

After:
<img width="1435" alt="Screen Shot 2022-10-11 at 12 25 58 PM" src="https://user-images.githubusercontent.com/37230822/195182313-fa783547-ed12-47f2-926d-9de99be4507f.png">
<img width="1390" alt="Screen Shot 2022-10-11 at 12 25 44 PM" src="https://user-images.githubusercontent.com/37230822/195182347-9930d893-c188-4631-95ee-d457db24135b.png">



## Links


- spec: []()
- jira ticket: []https://codedotorg.atlassian.net/browse/LP-3050


## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
