### PR TITLE
Restore "cleanup dead js code from congrats page launch"

### DIFF
--- a/apps/src/sites/studio/pages/congrats/index.js
+++ b/apps/src/sites/studio/pages/congrats/index.js
@@ -36,7 +36,6 @@ $(document).ready(function() {
   } catch (e) {}
 
   const mcShareLink = tryGetLocalStorage('craftHeroShareLink', '');
-  const showStudioCertificate = true;
   ReactDOM.render(
     <Provider store={store}>
       <Congrats
@@ -49,7 +48,6 @@ $(document).ready(function() {
         randomDonorTwitter={randomDonorTwitter}
         randomDonorName={randomDonorName}
         hideDancePartyFollowUp={hideDancePartyFollowUp}
-        showStudioCertificate={showStudioCertificate}
         initialCertificateImageUrl={certificateImageUrl}
         isHocTutorial={isHocTutorial}
         nextCourseScriptName={nextCourseScriptName}

--- a/apps/src/templates/certificates/Certificate.jsx
+++ b/apps/src/templates/certificates/Certificate.jsx
@@ -1,4 +1,3 @@
-/* global dashboard */
 import React, {useRef, useState} from 'react';
 import {connect} from 'react-redux';
 import $ from 'jquery';
@@ -32,12 +31,6 @@ function Certificate(props) {
   const [personalized, setPersonalized] = useState(false);
   const [studentName, setStudentName] = useState();
   const nameInputRef = useRef(null);
-
-  const isMinecraft = () =>
-    /mc|minecraft|hero|aquatic|mee|mee_empathy|mee_timecraft/.test(
-      props.tutorial
-    );
-  const isAIOceans = () => /oceans/.test(props.tutorial);
 
   const personalizeCertificate = session => {
     if (isHocTutorial) {
@@ -75,44 +68,17 @@ function Certificate(props) {
     return btoa(reEncodeNonLatin1(JSON.stringify(data)));
   };
 
-  const getCertificateImagePath = certificate => {
-    if (!props.showStudioCertificate) {
-      return `${
-        dashboard.CODE_ORG_URL
-      }/api/hour/certificate/${certificate}.jpg`;
-    }
-
+  const getCertificateImagePath = () => {
     const filename = getEncodedParams();
     return `/certificate_images/${filename}.jpg`;
   };
 
-  const getPrintPath = certificate => {
-    if (!props.showStudioCertificate) {
-      let print = `${dashboard.CODE_ORG_URL}/printcertificate/${certificate}`;
-      if (isMinecraft() && !personalized) {
-        // Correct the minecraft print url for non-personalized certificates.
-        print = `${dashboard.CODE_ORG_URL}/printcertificate?s=${
-          props.tutorial
-        }`;
-      }
-      if (isAIOceans() && !personalized) {
-        // Correct the minecraft print url for non-personalized certificates.
-        print = `${dashboard.CODE_ORG_URL}/printcertificate?s=${
-          props.tutorial
-        }`;
-      }
-      return print;
-    }
-
+  const getPrintPath = () => {
     const encoded = getEncodedParams();
     return `/print_certificates/${encoded}`;
   };
 
-  const getCertificateSharePath = certificate => {
-    if (!props.showStudioCertificate) {
-      return `https:${dashboard.CODE_ORG_URL}/certificates/${certificate}`;
-    }
-
+  const getCertificateSharePath = () => {
     const encoded = getEncodedParams();
     return `/certificates/${encoded}`;
   };
@@ -129,11 +95,11 @@ function Certificate(props) {
   } = props;
 
   const certificate = certificateId || 'blank';
-  const personalizedCertificate = getCertificateImagePath(certificate);
+  const personalizedCertificate = getCertificateImagePath();
   const imgSrc = personalized
     ? personalizedCertificate
     : initialCertificateImageUrl;
-  const certificateShareLink = getCertificateSharePath(certificate);
+  const certificateShareLink = getCertificateSharePath();
   const desktop =
     responsiveSize === ResponsiveSize.lg ||
     responsiveSize === ResponsiveSize.md;
@@ -152,11 +118,7 @@ function Certificate(props) {
       : i18n.justDidHourOfCode()
   });
 
-  const print = getPrintPath(certificate);
-
-  const wrapperClassName = props.showStudioCertificate
-    ? 'show-studio-certificate'
-    : undefined;
+  const print = getPrintPath();
 
   return (
     <div style={styles.container}>
@@ -167,11 +129,7 @@ function Certificate(props) {
           linkText={i18n.backToActivity()}
         />
       )}
-      <div
-        id="uitest-certificate"
-        className={wrapperClassName}
-        style={certificateStyle}
-      >
+      <div id="uitest-certificate" style={certificateStyle}>
         <BackToFrontConfetti active={personalized} style={styles.confetti} />
         <a href={certificateShareLink}>
           <img src={imgSrc} />
@@ -224,7 +182,6 @@ Certificate.propTypes = {
   responsiveSize: PropTypes.oneOf(['lg', 'md', 'sm', 'xs']).isRequired,
   under13: PropTypes.bool,
   children: PropTypes.node,
-  showStudioCertificate: PropTypes.bool,
   initialCertificateImageUrl: PropTypes.string.isRequired,
   isHocTutorial: PropTypes.bool
 };

--- a/apps/src/templates/certificates/Congrats.jsx
+++ b/apps/src/templates/certificates/Congrats.jsx
@@ -69,7 +69,6 @@ export default function Congrats(props) {
     randomDonorTwitter,
     randomDonorName,
     hideDancePartyFollowUp,
-    showStudioCertificate,
     initialCertificateImageUrl,
     isHocTutorial,
     nextCourseScriptName,
@@ -88,7 +87,6 @@ export default function Congrats(props) {
         randomDonorTwitter={randomDonorTwitter}
         randomDonorName={randomDonorName}
         under13={under13}
-        showStudioCertificate={showStudioCertificate}
         initialCertificateImageUrl={initialCertificateImageUrl}
         isHocTutorial={isHocTutorial}
       >
@@ -129,7 +127,6 @@ Congrats.propTypes = {
   randomDonorTwitter: PropTypes.string,
   randomDonorName: PropTypes.string,
   hideDancePartyFollowUp: PropTypes.bool,
-  showStudioCertificate: PropTypes.bool,
   initialCertificateImageUrl: PropTypes.string.isRequired,
   isHocTutorial: PropTypes.bool,
   nextCourseScriptName: PropTypes.string,

--- a/apps/src/templates/teacherDashboard/PrintCertificates.jsx
+++ b/apps/src/templates/teacherDashboard/PrintCertificates.jsx
@@ -9,8 +9,6 @@ import RailsAuthenticityToken from '@cdo/apps/lib/util/RailsAuthenticityToken';
 class PrintCertificates extends Component {
   static propTypes = {
     sectionId: PropTypes.number.isRequired,
-    // TODO(dave): remove assignmentName prop after launching studioCertificate experiment
-    assignmentName: PropTypes.string,
     courseVersionName: PropTypes.string
   };
 
@@ -44,11 +42,6 @@ class PrintCertificates extends Component {
         method="POST"
       >
         <RailsAuthenticityToken />
-        <input
-          type="hidden"
-          name="script"
-          defaultValue={this.props.assignmentName}
-        />
         {courseVersionName && (
           <input type="hidden" name="course" value={btoa(courseVersionName)} />
         )}

--- a/apps/src/templates/teacherDashboard/SectionActionDropdown.jsx
+++ b/apps/src/templates/teacherDashboard/SectionActionDropdown.jsx
@@ -130,7 +130,6 @@ class SectionActionDropdown extends Component {
             )}
           <PrintCertificates
             sectionId={sectionData.id}
-            assignmentName={sectionData.assignmentNames[0]}
             courseVersionName={sectionData.courseVersionName}
           />
           {sectionData.loginType === OAuthSectionTypes.clever && (

--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -35,7 +35,6 @@ experiments.BYPASS_DIALOG_POPUP = 'bypass-dialog-popup';
 experiments.SPECIAL_TOPIC = 'special-topic';
 experiments.CLEARER_SIGN_UP_USER_TYPE = 'clearerSignUpUserType';
 experiments.OPT_IN_EMAIL_REG_PARTNER = 'optInEmailRegPartner';
-experiments.INSTRUCTOR_PREDICT_LEVEL_RESET = 'instructorPredictLevelReset';
 
 /**
  * This was a gamified version of the finish dialog, built in 2018,

--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -35,7 +35,7 @@ experiments.BYPASS_DIALOG_POPUP = 'bypass-dialog-popup';
 experiments.SPECIAL_TOPIC = 'special-topic';
 experiments.CLEARER_SIGN_UP_USER_TYPE = 'clearerSignUpUserType';
 experiments.OPT_IN_EMAIL_REG_PARTNER = 'optInEmailRegPartner';
-experiments.STUDIO_CERTIFICATE = 'studioCertificate';
+experiments.INSTRUCTOR_PREDICT_LEVEL_RESET = 'instructorPredictLevelReset';
 
 /**
  * This was a gamified version of the finish dialog, built in 2018,

--- a/apps/test/unit/templates/certificates/CertificateTest.js
+++ b/apps/test/unit/templates/certificates/CertificateTest.js
@@ -49,56 +49,7 @@ describe('Certificate', () => {
       server.restore();
     });
 
-    it('renders using pegasus without experiment', () => {
-      const data = {
-        certificate_sent: true,
-        name: 'Student'
-      };
-      server.respondWith('POST', `/v2/certificate`, [
-        200,
-        {'Content-Type': 'application/json'},
-        JSON.stringify(data)
-      ]);
-
-      const initialCertificateImageUrl =
-        'https://code.org/images/placeholder-hoc-image.jpg';
-      const wrapper = wrapperWithParams({
-        tutorial: 'dance',
-        certificateId: 'sessionId',
-        initialCertificateImageUrl
-      });
-      let image = wrapper.find('#uitest-certificate img');
-      expect(image.prop('src')).to.equal(initialCertificateImageUrl);
-
-      const printLink = wrapper.find('.social-print-link');
-      expect(printLink.prop('href')).to.equal(
-        '//code.org/printcertificate/sessionId'
-      );
-
-      // the share link is used in the image thumbnail as well as the facebook
-      // and twitter links. just test its value in the thumbnail, because it is
-      // harder to extract from the facebook and twitter links.
-      const thumbnailLink = wrapper.find('#uitest-certificate a');
-      expect(thumbnailLink.prop('href')).to.equal(
-        'https://code.org/certificates/sessionId'
-      );
-
-      const input = wrapper.find('input#name');
-      input.simulate('change', {target: {value: 'Student'}});
-      const submitButton = wrapper
-        .find('button')
-        .filterWhere(button => button.text() === 'Submit');
-      submitButton.simulate('click');
-      server.respond();
-
-      wrapper.update();
-      image = wrapper.find('#uitest-certificate img');
-      expect(image.prop('src')).to.equal(
-        '//code.org/api/hour/certificate/sessionId.jpg'
-      );
-    });
-
-    it('renders using code studio with experiment', () => {
+    it('renders code studio image urls', () => {
       const data = {
         certificate_sent: true,
         name: 'Student'
@@ -115,7 +66,6 @@ describe('Certificate', () => {
         tutorial: 'dance',
         certificateId: 'sessionId',
         initialCertificateImageUrl,
-        showStudioCertificate: true,
         isHocTutorial: true
       });
       let image = wrapper.find('#uitest-certificate img');

--- a/apps/test/unit/templates/teacherDashboard/PrintCertificatesTest.js
+++ b/apps/test/unit/templates/teacherDashboard/PrintCertificatesTest.js
@@ -11,7 +11,7 @@ describe('PrintCertificates', () => {
   const wrapper = shallow(
     <PrintCertificates
       sectionId={sectionId}
-      assignmentName="playlab"
+      courseVersionName="playlab"
       curriedPegasusUrl={path => `${path}`}
     />
   );
@@ -21,10 +21,10 @@ describe('PrintCertificates', () => {
     assert(wrapper.props().action, pegasus('/certificates'));
   });
 
-  it('has a hidden input for the assigned script', () => {
+  it('has a hidden input for the course name', () => {
     assert(wrapper.childAt(1).is('input'));
     assert.equal(wrapper.childAt(1).props().type, 'hidden');
-    assert.equal(wrapper.childAt(1).props().defaultValue, 'playlab');
+    assert.equal(atob(wrapper.childAt(1).props().value), 'playlab');
   });
 
   it('has trigger to open /certificates', () => {

--- a/apps/test/unit/templates/teacherDashboard/SectionActionDropdownTest.js
+++ b/apps/test/unit/templates/teacherDashboard/SectionActionDropdownTest.js
@@ -9,49 +9,45 @@ const sections = [
   {
     id: 1,
     name: 'NoStudents',
+    courseVersionName: 'cv',
     loginType: 'word',
     studentCount: 0,
     code: 'ABCD',
     grade: '10',
     providerManaged: false,
-    assignmentNames: ['a'],
-    assignmentPaths: ['b'],
     hidden: false
   },
   {
     id: 2,
     name: 'ThirdParty',
+    courseVersionName: 'cv',
     loginType: 'google_classroom',
     studentCount: 0,
     code: 'EFGH',
     grade: '11',
     providerManaged: true,
-    assignmentNames: ['a'],
-    assignmentPaths: ['b'],
     hidden: false
   },
   {
     id: 3,
     name: 'HasStudents',
+    courseVersionName: 'cv',
     loginType: 'picture',
     studentCount: 4,
     code: 'IJKL',
     grade: '9',
     providerManaged: false,
-    assignmentNames: ['a'],
-    assignmentPaths: ['b'],
     hidden: false
   },
   {
     id: 4,
     name: 'Hidden',
+    courseVersionName: 'cv',
     loginType: 'email',
     studentCount: 2,
     code: 'MNOP',
     grade: '6',
     providerManaged: false,
-    assignmentNames: ['a'],
-    assignmentPaths: ['b'],
     hidden: true
   }
 ];
@@ -103,7 +99,7 @@ describe('SectionActionDropdown', () => {
     expect(wrapper).to.not.contain('Print Login Cards');
     expect(wrapper).to.contain('Edit Section Details');
     expect(
-      wrapper.find(<PrintCertificates sectionId={2} assignmentName="a" />)
+      wrapper.find(<PrintCertificates sectionId={2} courseVersionName="cv" />)
         .length,
       1
     );
@@ -118,7 +114,7 @@ describe('SectionActionDropdown', () => {
     expect(wrapper).to.contain('Print Login Cards');
     expect(wrapper).to.contain('Edit Section Details');
     expect(
-      wrapper.find(<PrintCertificates sectionId={1} assignmentName="a" />)
+      wrapper.find(<PrintCertificates sectionId={1} courseVersionName="cv" />)
         .length,
       1
     );

--- a/dashboard/test/ui/features/hour_of_code/hour_of_code_finish.feature
+++ b/dashboard/test/ui/features/hour_of_code/hour_of_code_finish.feature
@@ -102,13 +102,13 @@ Scenario: sharecertificate page redirects to blank certificate page
 Scenario: congrats certificate pages
   Given I am on "http://studio.code.org/congrats"
   And I wait until element "#uitest-certificate" is visible
-  And element "#uitest-certificate.show-studio-certificate" is visible
+  And element "#uitest-certificate" is visible
   And I open my eyes to test "congrats certificate pages"
 
   When I am on "http://code.org/api/hour/finish/flappy"
   And I wait until current URL contains "/congrats"
   And I wait to see element with ID "uitest-certificate"
-  And element "#uitest-certificate.show-studio-certificate" is visible
+  And element "#uitest-certificate" is visible
   And I wait for image "#uitest-certificate img" to load
   And I see no difference for "uncustomized flappy certificate"
 
@@ -120,7 +120,7 @@ Scenario: congrats certificate pages
   When I am on "http://code.org/api/hour/finish/oceans"
   And I wait until current URL contains "/congrats"
   And I wait to see element with ID "uitest-certificate"
-  And element "#uitest-certificate.show-studio-certificate" is visible
+  And element "#uitest-certificate" is visible
   And I wait for image "#uitest-certificate img" to load
   And I see no difference for "uncustomized oceans certificate"
 
@@ -132,7 +132,7 @@ Scenario: congrats certificate pages
   When I am on "http://code.org/congrats/coursea-2017"
   And I wait until current URL contains "http://studio.code.org/congrats"
   And I wait to see element with ID "uitest-certificate"
-  And element "#uitest-certificate.show-studio-certificate" is visible
+  And element "#uitest-certificate" is visible
   And I wait for image "#uitest-certificate img" to load
   And I see no difference for "uncustomized Course A 2017 certificate"
 
@@ -144,7 +144,7 @@ Scenario: congrats certificate pages
   When I am on "http://code.org/congrats/accelerated"
   And I wait until current URL contains "http://studio.code.org/congrats"
   And I wait to see element with ID "uitest-certificate"
-  And element "#uitest-certificate.show-studio-certificate" is visible
+  And element "#uitest-certificate" is visible
   And I wait for image "#uitest-certificate img" to load
   And I see no difference for "uncustomized 20-hour certificate"
 


### PR DESCRIPTION
* Reverts #48511  , restoring #48203 . Depends on #48544 , which re-launched congrats pages on dashboard. see that PR for more details on the revert and the fix. This PR just redoes the js cleanup work that followed the launch.

## Testing story

existing test coverage

## Deployment strategy

* safe to ship in the same DTP as #48544 , since the first attempt at that PR already had a chance to bake in prod for long enough for any other showstopping issues to pop up.

## Follow-up work
* #48211 
* also see [work plan](https://docs.google.com/document/d/1wTObDFZdWS6RzpM3R6wEm04ToY2fM1B5Kb2rUHCNq28/edit#)