### PR TITLE
Fix `Lint/UnusedBlockArgument` Violation

### DIFF
--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1617,7 +1617,7 @@ class Script < ApplicationRecord
   def section_hidden_unit_info(user)
     return {} unless user && can_be_instructor?(user)
     hidden_section_ids = SectionHiddenScript.where(script_id: id, section: user.sections).pluck(:section_id)
-    hidden_section_ids.index_with {|section_id| [id]}
+    hidden_section_ids.index_with([id])
   end
 
   # Similar to summarize, but returns an even more narrow set of fields, restricted


### PR DESCRIPTION
Introduced by https://github.com/code-dot-org/code-dot-org/pull/48498; I attempted to manually fix up all `index_with` clauses that had lingering unnecessary arguments, but clearly I missed one.

## Testing Story

Ran the unit test associated with this model:

```
[~/code-dot-org/dashboard (fix-Lint/UnusedBlockArgument)]$ TZ=UTC RAILS_ENV=test RACK_ENV=test bundle exec r
uby -Itest test/models/script_test.rb
Ignoring db/schema_cache.yml because it has expired. The current schema version is 20220713165055, but the one in the cache is 20221003141047.
Ignoring db/schema_cache.yml because it has expired. The current schema version is 20220713165055, but the one in the cache is 20221003141047.
Finished seed:check_migrations (less than 1 second)
Finished seed:videos (less than 1 second)
Finished seed:games (less than 1 second)
Finished seed:concepts (less than 1 second)
Finished seed:secret_words (less than 1 second)
Finished seed:secret_pictures (less than 1 second)
Finished seed:school_districts (less than 1 second)
Finished seed:schools (less than 1 second)
Finished seed:standards (20 seconds)
Finished seed:foorms (1 second)
Finished seed:import_pegasus_data (2 seconds)
Finished seed:test (less than 1 second)
Started with run options --seed 6815

/home/elijah/code-dot-org/dashboard/app/models/script.rb:1485: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/home/elijah/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/i18n-1.8.10/lib/i18n.rb:196: warning: The called method `t' is defined here
  141/141: [=======================] 100% Time: 00:01:03, Time: 00:01:03

Finished in 63.16089s
141 tests, 458 assertions, 0 failures, 0 errors, 0 skips
```

## Deployment Strategy

Planning to merge this PR ahead of drone to unblock the staging build, will rely on CI tests later down the pipeline to verify this change.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
