### PR TITLE
Revert Cookbook-specific Bundle Version Change

### DIFF
--- a/cookbooks/Gemfile.lock
+++ b/cookbooks/Gemfile.lock
@@ -369,4 +369,4 @@ RUBY VERSION
    ruby 2.7.5p203
 
 BUNDLED WITH
-   2.3.22
+   1.17.3


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/48402, which updated us to a newer version of `bundler`; unfortunately, it also tried to change the version of bundler we use in the embedded ruby provided by chef, which we don't want to do.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
