### PR TITLE
Update the Regional Partner Edit Page

### DIFF
--- a/dashboard/app/views/regional_partners/_form.html.haml
+++ b/dashboard/app/views/regional_partners/_form.html.haml
@@ -8,6 +8,17 @@
   .field
     = f.label :name
     = f.text_field :name
+  %h2 Regional Manager Information
+  .field
+    = f.label :contact_name
+    = f.text_field :contact_name
+  .field
+    = f.label :contact_email
+    = f.text_field :contact_email
+  .field
+    = f.label :phone_number
+    = f.text_field :phone_number
+  %h2 Teacher Application Settings
   .field
     = f.label nil, "Apps Open Date for Teachers (YYYY-MM-DD)"
     = f.text_field :apps_open_date_teacher
@@ -15,14 +26,14 @@
     = f.label nil, "Apps Close Date for Teachers (YYYY-MM-DD)"
     = f.text_field :apps_close_date_teacher
   .field
-    = f.label nil, "Applications Principal Approval"
+    = f.label nil, "Applications Administrator/School Leader Approval"
     .applications_principal_approval
       %label
         = f.radio_button :applications_principal_approval, RegionalPartner::ALL_REQUIRE_APPROVAL, checked: @regional_partner.applications_principal_approval == RegionalPartner::ALL_REQUIRE_APPROVAL
-        = 'All apps require principal approval'
+        = 'All apps require administrator/school leader approval'
       %label
         = f.radio_button :applications_principal_approval, RegionalPartner::SELECTIVE_APPROVAL, checked: @regional_partner.applications_principal_approval == RegionalPartner::SELECTIVE_APPROVAL
-        = 'Selectively require some apps to have principal approval'
+        = 'Selectively require some apps to have administrator/school leader approval'
   .field
     = f.label nil, "Applications Decision Emails"
     .applications_decision_emails
@@ -44,13 +55,4 @@
   .field
     = f.label :additional_program_information
     = f.text_area :additional_program_information, {style: 'width: 1000px; height: 200px'}
-  .field
-    = f.label :contact_name
-    = f.text_field :contact_name
-  .field
-    = f.label :contact_email
-    = f.text_field :contact_email
-  .field
-    = f.label :phone_number
-    = f.text_field :phone_number
   %button.btn.btn-primary{type: 'submit', style: 'margin: 0'} Save

--- a/dashboard/app/views/regional_partners/_form.html.haml
+++ b/dashboard/app/views/regional_partners/_form.html.haml
@@ -9,12 +9,6 @@
     = f.label :name
     = f.text_field :name
   .field
-    = f.label :group
-    = f.text_field :group
-  .field
-    = f.label :urban
-    = f.check_box :urban
-  .field
     = f.label nil, "Apps Open Date for Teachers (YYYY-MM-DD)"
     = f.text_field :apps_open_date_teacher
   .field

--- a/dashboard/app/views/regional_partners/_form.html.haml
+++ b/dashboard/app/views/regional_partners/_form.html.haml
@@ -20,13 +20,13 @@
     = f.text_field :phone_number
   %h2 Teacher Application Settings
   .field
-    = f.label nil, "Apps Open Date for Teachers (YYYY-MM-DD)"
+    = f.label nil, "Apps Open Date (YYYY-MM-DD)"
     = f.text_field :apps_open_date_teacher
   .field
-    = f.label nil, "Apps Close Date for Teachers (YYYY-MM-DD)"
+    = f.label nil, "Apps Close Date (YYYY-MM-DD)"
     = f.text_field :apps_close_date_teacher
   .field
-    = f.label nil, "Applications Administrator/School Leader Approval"
+    = f.label nil, "Applications Administrator/School Leader Approval", {style: 'margin-top: 20px'}
     .applications_principal_approval
       %label
         = f.radio_button :applications_principal_approval, RegionalPartner::ALL_REQUIRE_APPROVAL, checked: @regional_partner.applications_principal_approval == RegionalPartner::ALL_REQUIRE_APPROVAL
@@ -35,7 +35,7 @@
         = f.radio_button :applications_principal_approval, RegionalPartner::SELECTIVE_APPROVAL, checked: @regional_partner.applications_principal_approval == RegionalPartner::SELECTIVE_APPROVAL
         = 'Selectively require some apps to have administrator/school leader approval'
   .field
-    = f.label nil, "Applications Decision Emails"
+    = f.label nil, "Applications Decision Emails", {style: 'margin-top: 20px'}
     .applications_decision_emails
       %label
         = f.radio_button :applications_decision_emails, RegionalPartner::SENT_BY_PARTNER, checked: @regional_partner.applications_decision_emails == RegionalPartner::SENT_BY_PARTNER
@@ -44,7 +44,7 @@
         = f.radio_button :applications_decision_emails, RegionalPartner::SENT_BY_SYSTEM, checked: @regional_partner.applications_decision_emails == RegionalPartner::SENT_BY_SYSTEM
         = 'System sends decision emails'
   .field
-    = f.label :link_to_partner_application
+    = f.label :link_to_partner_application, {style: 'margin-top: 20px'}
     = f.text_field :link_to_partner_application, {style: 'width: 500px'}
   .field
     = f.label nil, "PL Programs Offered"

--- a/dashboard/app/views/regional_partners/_form.html.haml
+++ b/dashboard/app/views/regional_partners/_form.html.haml
@@ -40,10 +40,10 @@
     = f.select :pl_programs_offered, Pd::SharedWorkshopConstants::OFFERED_PROGRAMS, {}, {multiple: true}
   .field
     = f.label nil, "Program information"
-    = f.text_area :cost_scholarship_information, {style: 'width: 500px'}
+    = f.text_area :cost_scholarship_information, {style: 'width: 1000px; height: 200px'}
   .field
     = f.label :additional_program_information
-    = f.text_area :additional_program_information, {style: 'width: 500px'}
+    = f.text_area :additional_program_information, {style: 'width: 1000px; height: 200px'}
   .field
     = f.label :contact_name
     = f.text_field :contact_name

--- a/dashboard/app/views/regional_partners/index.html.haml
+++ b/dashboard/app/views/regional_partners/index.html.haml
@@ -33,7 +33,8 @@
       %th ID
       %th Name
       %th Contact
-      %th
+      %th Edit
+      %th Show
     %tbody
       - @regional_partners.each do |regional_partner|
         %tr
@@ -42,3 +43,4 @@
           %td= regional_partner.contact_email_with_backup
           - if can? :update, regional_partner
             %td= link_to t('crud.edit'), edit_regional_partner_path(regional_partner)
+            %td= link_to t('crud.show'), @regional_partner

--- a/dashboard/app/views/regional_partners/index.html.haml
+++ b/dashboard/app/views/regional_partners/index.html.haml
@@ -32,8 +32,6 @@
     %thead
       %th ID
       %th Name
-      %th Group
-      %th Urban
       %th Contact
       %th
     %tbody
@@ -41,8 +39,6 @@
         %tr
           %td= link_to regional_partner.id, regional_partner
           %td= regional_partner.name
-          %td= regional_partner.group
-          %td= regional_partner.urban ? 'Yes' : 'No'
           %td= regional_partner.contact_email_with_backup
           - if can? :update, regional_partner
             %td= link_to t('crud.edit'), edit_regional_partner_path(regional_partner)

--- a/dashboard/app/views/regional_partners/show.html.haml
+++ b/dashboard/app/views/regional_partners/show.html.haml
@@ -15,12 +15,6 @@
   %strong Name:
   = @regional_partner.name
 %p
-  %strong Group:
-  = @regional_partner.group
-%p
-  %strong Urban:
-  = @regional_partner.urban? ? 'Yes' : 'No'
-%p
   %strong Apps open date for teachers:
   = @regional_partner.apps_open_date_teacher
 %p

--- a/dashboard/app/views/regional_partners/show.html.haml
+++ b/dashboard/app/views/regional_partners/show.html.haml
@@ -51,10 +51,15 @@
   = @regional_partner.pl_programs_offered
 %p
   %strong Program information:
-  = @regional_partner.cost_scholarship_information
+.field{style: 'border: 1px solid black; padding: 5px' }
+  :markdown
+    #{@regional_partner.cost_scholarship_information}
+
 %p
   %strong Additional Partner information:
-  = @regional_partner.additional_program_information
+.field{style: 'border: 1px solid black; padding: 5px' }
+  :markdown
+    #{@regional_partner.additional_program_information}
 
 %br
 %h2 Regions

--- a/dashboard/app/views/regional_partners/show.html.haml
+++ b/dashboard/app/views/regional_partners/show.html.haml
@@ -15,24 +15,6 @@
   %strong Name:
   = @regional_partner.name
 %p
-  %strong Apps open date for teachers:
-  = @regional_partner.apps_open_date_teacher
-%p
-  %strong Apps close date for teachers:
-  = @regional_partner.apps_close_date_teacher
-%p
-  %strong Program information:
-  = @regional_partner.cost_scholarship_information
-%p
-  %strong Additional Partner information:
-  = @regional_partner.additional_program_information
-%p
-  %strong Link to Partner's Application:
-  = @regional_partner.link_to_partner_application
-%p
-  %strong PL Programs Offered:
-  = @regional_partner.pl_programs_offered
-%p
   %strong Contact Email:
   = @regional_partner.contact_email
 %p
@@ -51,6 +33,27 @@
   = link_to 'Edit', edit_regional_partner_path(@regional_partner)
 \|
 = link_to 'Back', regional_partners_path
+
+%h2 Teacher Application Settings
+%p
+  %strong Apps open date for teachers:
+  = @regional_partner.apps_open_date_teacher
+%p
+  %strong Apps close date for teachers:
+  = @regional_partner.apps_close_date_teacher
+%p
+  %strong Link to Partner's Application:
+  = @regional_partner.link_to_partner_application
+%p
+  %strong PL Programs Offered:
+  = @regional_partner.pl_programs_offered
+%p
+  %strong Program information:
+  = @regional_partner.cost_scholarship_information
+%p
+  %strong Additional Partner information:
+  = @regional_partner.additional_program_information
+
 %br
 %h2 Regions
 %p

--- a/dashboard/app/views/regional_partners/show.html.haml
+++ b/dashboard/app/views/regional_partners/show.html.haml
@@ -8,7 +8,13 @@
   - if flash[:upload_error]
     = content_tag(:div, flash[:upload_error], {class: 'alert alert-danger'}, false)
     - flash[:upload_error] = nil
-%p
+
+- if can? :update, @regional_partner
+  = link_to 'Edit', edit_regional_partner_path(@regional_partner)
+\|
+= link_to 'Back', regional_partners_path
+
+%p{style: 'margin-top: 20px' }
   %strong ID:
   = @regional_partner.id
 %p
@@ -29,10 +35,6 @@
 %p
   %strong Updated At:
   = @regional_partner.updated_at.strftime('%F')
-- if can? :update, @regional_partner
-  = link_to 'Edit', edit_regional_partner_path(@regional_partner)
-\|
-= link_to 'Back', regional_partners_path
 
 %h2 Teacher Application Settings
 %p


### PR DESCRIPTION
Each year regional partners have to update their settings for the Teacher Applications. Outreach managers help them do this work through a series of admin pages. There have been some pain points with these pages in the past which make the process harder for the team. Addresses many of those pain points including:

* Removing group and urban from these pages
* Making the page easier to navigate with headers and organization
* Making edit boxes bigger to fit the usually text amount 
* Showing the program information with the markdown styling applied as a preview to help with editing 

### Regional Partner Admin Edit Page

#### Before
![Screen Shot 2022-10-12 at 11 52 55 AM](https://user-images.githubusercontent.com/208083/195390337-03dbfdb3-1d59-400f-9422-a2864029b339.png)

#### After
<img width="558" alt="Screen Shot 2022-10-11 at 10 10 56 PM" src="https://user-images.githubusercontent.com/208083/195232788-61457cca-1892-4c8b-a620-cdc291fd3940.png">

### Regional Partner Admin Show Page

#### Before
![Screen Shot 2022-10-12 at 11 52 07 AM](https://user-images.githubusercontent.com/208083/195390154-97136e86-20bb-4e78-9a3f-54b367f8ee24.png)

#### After
<img width="535" alt="Screen Shot 2022-10-11 at 11 32 38 PM" src="https://user-images.githubusercontent.com/208083/195243744-1c8bb880-ff6a-4dda-8fa3-74a971a3c0fa.png">

### Regional Partner Admin Index Page

#### Before

![Screen Shot 2022-10-12 at 11 52 35 AM](https://user-images.githubusercontent.com/208083/195390256-050ced6f-782a-46f9-9645-7d2ce857ccf5.png)

#### After
<img width="526" alt="Screen Shot 2022-10-12 at 9 46 24 AM" src="https://user-images.githubusercontent.com/208083/195359824-88efeeba-beb6-4c29-92d4-9cf0175bee43.png">



## Links

https://codedotorg.atlassian.net/browse/PLAT-2028

## Testing story

Local testing