### PR TITLE
Fixes weblab report abuse link

### DIFF
--- a/apps/src/reportAbuse.js
+++ b/apps/src/reportAbuse.js
@@ -19,6 +19,8 @@ export const getChannelIdFromUrl = function(abuseUrl) {
   let match;
   if (abuseUrl.indexOf('codeprojects') >= 0 && abuseUrl.indexOf('weblab') < 0) {
     match = /.*codeprojects.*[^\/]+\/([^\/]+)/.exec(abuseUrl);
+  } else if (abuseUrl.indexOf('channelId=') >= 0) {
+    match = /\?channelId=(.*)/.exec(abuseUrl);
   } else {
     match = /.*\/projects\/[^\/]+\/([^\/]+)/.exec(abuseUrl);
   }

--- a/apps/src/sites/studio/pages/report_abuse/report_abuse_form.js
+++ b/apps/src/sites/studio/pages/report_abuse/report_abuse_form.js
@@ -6,7 +6,16 @@ import ReportAbuseForm from '@cdo/apps/code-studio/components/ReportAbuseForm';
 
 $(document).ready(function() {
   const props = getScriptData('abuse');
-  props.abuseUrl = props.weblabUrl || document.referrer;
+  const weblabUrl = window.location.href;
+  /*
+    If the channelId is in the url, we have appended it there from the weblab
+    codeprojects footer. Leave appended url as-is, and let getChannelIdFromUrl
+    in reportAbuse.js parse out the channel id. Otherwise, we can retrieve the
+    project url directly from document.referrer.
+  */
+  props.abuseUrl = weblabUrl.includes('channelId')
+    ? weblabUrl
+    : document.referrer;
   ReactDOM.render(
     <ReportAbuseForm {...props} />,
     document.getElementById('report-abuse-form')

--- a/apps/src/sites/studio/pages/report_abuse/report_abuse_form.js
+++ b/apps/src/sites/studio/pages/report_abuse/report_abuse_form.js
@@ -6,7 +6,7 @@ import ReportAbuseForm from '@cdo/apps/code-studio/components/ReportAbuseForm';
 
 $(document).ready(function() {
   const props = getScriptData('abuse');
-  props.abuseUrl = document.referrer;
+  props.abuseUrl = props.weblabUrl || document.referrer;
   ReactDOM.render(
     <ReportAbuseForm {...props} />,
     document.getElementById('report-abuse-form')

--- a/apps/test/unit/code-studio/components/ReportAbuseFormTest.js
+++ b/apps/test/unit/code-studio/components/ReportAbuseFormTest.js
@@ -43,4 +43,19 @@ describe('ReportAbuseForm', () => {
       '123abc'
     );
   });
+
+  it('getChannelIdFromUrl returns the channel id for weblab projects', () => {
+    assert.equal(
+      getChannelIdFromUrl(
+        'https://studio.code.org/report_abuse?channelId=123abc'
+      ),
+      '123abc'
+    );
+    assert.equal(
+      getChannelIdFromUrl(
+        'http://localhost-studio.code.org:3000/report_abuse?channelId=123abc'
+      ),
+      '123abc'
+    );
+  });
 });

--- a/dashboard/app/controllers/projects_controller.rb
+++ b/dashboard/app/controllers/projects_controller.rb
@@ -268,8 +268,7 @@ class ProjectsController < ApplicationController
   end
 
   def weblab_footer
-    channel_id = params[:channel_id]
-    render partial: 'projects/weblab_footer', locals: {channel_id: channel_id}
+    render partial: 'projects/weblab_footer'
   end
 
   private def initial_data

--- a/dashboard/app/controllers/projects_controller.rb
+++ b/dashboard/app/controllers/projects_controller.rb
@@ -268,6 +268,7 @@ class ProjectsController < ApplicationController
   end
 
   def weblab_footer
+    channel_id = params[:channel_id]
     render partial: 'projects/weblab_footer', locals: {channel_id: channel_id}
   end
 

--- a/dashboard/app/controllers/projects_controller.rb
+++ b/dashboard/app/controllers/projects_controller.rb
@@ -268,7 +268,7 @@ class ProjectsController < ApplicationController
   end
 
   def weblab_footer
-    render partial: 'projects/weblab_footer'
+    render partial: 'projects/weblab_footer', locals: {channel_id: channel_id}
   end
 
   private def initial_data

--- a/dashboard/app/controllers/report_abuse_controller.rb
+++ b/dashboard/app/controllers/report_abuse_controller.rb
@@ -103,6 +103,7 @@ class ReportAbuseController < ApplicationController
   end
 
   def report_abuse_form
+    puts params[:weblabUrl]
     @react_props = {
       name: current_user&.name,
       email: current_user&.email,

--- a/dashboard/app/controllers/report_abuse_controller.rb
+++ b/dashboard/app/controllers/report_abuse_controller.rb
@@ -103,7 +103,6 @@ class ReportAbuseController < ApplicationController
   end
 
   def report_abuse_form
-    puts params[:weblabUrl]
     @react_props = {
       name: current_user&.name,
       email: current_user&.email,

--- a/dashboard/app/views/projects/_weblab_footer.html.haml
+++ b/dashboard/app/views/projects/_weblab_footer.html.haml
@@ -1,5 +1,3 @@
-- channel_id ||= ""
-
 %footer#codeprojects_pagefooter
   .codeprojects_pagefooter_content
     %a.codeprojects_pagefooter_link{:href=>CDO.studio_url()}= I18n.t('footer.built_on_code_studio')

--- a/dashboard/app/views/projects/_weblab_footer.html.haml
+++ b/dashboard/app/views/projects/_weblab_footer.html.haml
@@ -1,8 +1,10 @@
+- channel_id ||= ""
+
 %footer#codeprojects_pagefooter
   .codeprojects_pagefooter_content
     %a.codeprojects_pagefooter_link{:href=>CDO.studio_url()}= I18n.t('footer.built_on_code_studio')
     .codeprojects_pagefooter_dim &nbsp; | &nbsp;
-    %a.codeprojects_pagefooter_link{:href=>CDO.studio_url("report_abuse?weblabUrl=#{request.url}"), :target=>"blank"}= I18n.t('footer.report_abuse')
+    %a.codeprojects_pagefooter_link{:href=>CDO.studio_url("report_abuse?channelId=#{channel_id}"), :target=>"blank"}= I18n.t('footer.report_abuse')
     .codeprojects_pagefooter_dim &nbsp; | &nbsp;
     %a.codeprojects_pagefooter_link{:href=>CDO.studio_url("projects/weblab"), :id=>"pagefooter_view_code"}= I18n.t('footer.view_code')
     .codeprojects_pagefooter_dim &nbsp; | &nbsp;

--- a/dashboard/app/views/projects/_weblab_footer.html.haml
+++ b/dashboard/app/views/projects/_weblab_footer.html.haml
@@ -2,7 +2,7 @@
   .codeprojects_pagefooter_content
     %a.codeprojects_pagefooter_link{:href=>CDO.studio_url()}= I18n.t('footer.built_on_code_studio')
     .codeprojects_pagefooter_dim &nbsp; | &nbsp;
-    %a.codeprojects_pagefooter_link{:href=>CDO.studio_url("report_abuse"), :target=>"blank"}= I18n.t('footer.report_abuse')
+    %a.codeprojects_pagefooter_link{:href=>CDO.studio_url("report_abuse?weblabUrl=#{request.url}"), :target=>"blank"}= I18n.t('footer.report_abuse')
     .codeprojects_pagefooter_dim &nbsp; | &nbsp;
     %a.codeprojects_pagefooter_link{:href=>CDO.studio_url("projects/weblab"), :id=>"pagefooter_view_code"}= I18n.t('footer.view_code')
     .codeprojects_pagefooter_dim &nbsp; | &nbsp;

--- a/dashboard/app/views/projects/_weblab_footer.html.haml
+++ b/dashboard/app/views/projects/_weblab_footer.html.haml
@@ -4,7 +4,7 @@
   .codeprojects_pagefooter_content
     %a.codeprojects_pagefooter_link{:href=>CDO.studio_url()}= I18n.t('footer.built_on_code_studio')
     .codeprojects_pagefooter_dim &nbsp; | &nbsp;
-    %a.codeprojects_pagefooter_link{:href=>CDO.studio_url("report_abuse?channelId=#{channel_id}"), :target=>"blank"}= I18n.t('footer.report_abuse')
+    %a.codeprojects_pagefooter_link{:href=>CDO.studio_url("report_abuse"), :id=>"pagefooter_report_abuse", :target=>"blank"}= I18n.t('footer.report_abuse')
     .codeprojects_pagefooter_dim &nbsp; | &nbsp;
     %a.codeprojects_pagefooter_link{:href=>CDO.studio_url("projects/weblab"), :id=>"pagefooter_view_code"}= I18n.t('footer.view_code')
     .codeprojects_pagefooter_dim &nbsp; | &nbsp;

--- a/dashboard/public/weblab/footer.js
+++ b/dashboard/public/weblab/footer.js
@@ -29,11 +29,11 @@ var applyFooter = function() {
     document.body.appendChild(footerContents.childNodes[0]);
   }
   if (window.encrypted_channel_id) {
-    var link = document.getElementById("pagefooter_view_code");
-    link.onclick = function() {
-      window.location.href =
-        link.href + "/" + window.encrypted_channel_id + "/view";
-      return false;
-    };
+    var viewCodeLink = document.getElementById("pagefooter_view_code");
+    viewCodeLink.href =
+      viewCodeLink.href + "/" + window.encrypted_channel_id + "/view";
+    var abuseLink = document.getElementById("pagefooter_report_abuse");
+    abuseLink.href =
+      abuseLink.href + "?channelId=" + window.encrypted_channel_id;
   }
 };


### PR DESCRIPTION
The solution to this is not particularly beautiful, but it matches existing patterns and has been tested to ensure the abuse score is automatically updated for weblab projects (and reporting for other labs are unchanged). 

The base issue: cross-origin sharing is no longer allowed, but weblab projects are hosted on codeprojects and abuse reporting is hosted on studio. The way we autofill the report abuse form is through checking document.referrer, which works for all project types except weblab. 

This solution appends the channelId through a custom href created in footer.js (which was already happening in the View Code link, a solution I updated slightly away from a click event to match). 

From there, if the abuse form sees the channelId added to its url, it will use this new custom url as the abuseUrl. Otherwise, it grabs the document.referrer. I built out the getChannelIdFromUrl function to work with this new url (looking for 'channelId='), but left the other two cases so this function can still be utilized for parsing codeprojects urls if necessary.

There is a comment explaining this new logic in the code to hopefully avoid confusion.

## Links

- spec: []()
- jira ticket: []https://codedotorg.atlassian.net/jira/software/c/projects/LP/boards/21?modal=detail&selectedIssue=LP-2446


## Testing story

I tested this locally, making sure the url is piped through with the channel id, and making sure that actually reporting it will increment the abuse score on a weblab project.

I also tested that report abuse still works correctly with other project types and tested that the abuse score is updated by reporting a local gamelab project.

I also tested the new regex logic in ReportAbuseFormTest to make sure the channelId is retrieved properly from the new custom urls created.

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
