### PR TITLE
Update `ffi` sub-dependency to 1.15.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -434,7 +434,7 @@ GEM
       http-cookie (~> 1.0.0)
     faraday_middleware (0.14.0)
       faraday (>= 0.7.4, < 1.0)
-    ffi (1.10.0)
+    ffi (1.15.5)
     firebase (0.2.6)
       httpclient
       json


### PR DESCRIPTION
To pick up support for Ruby 2.7, which was added in 1.11.3. Specifically, I ran `bundle update ffi` to update the lockfile. We don't directly depend on this library, so there's nothing in the Gemfile itself to update.

We want to apply this update to address a deprecation warning which we started seeing in Ruby 2.7:

```
/home/elijah/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/rb-inotify-0.10.1/lib/rb-inotify/watcher.rb:66: warning: rb_safe_level will be removed in Ruby 3.0
```

Misleadingly, this is not actually an issue with the `rb-inotify` gem itself: see https://github.com/guard/rb-inotify/issues/99#issuecomment-599033572 for more context.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

- https://github.com/ffi/ffi/blob/master/CHANGELOG.md#1113--2019-11-25

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
