### PR TITLE
Add Reference guides to translation pipeline

### DIFF
--- a/dashboard/app/models/reference_guide.rb
+++ b/dashboard/app/models/reference_guide.rb
@@ -32,6 +32,13 @@ class ReferenceGuide < ApplicationRecord
     ReferenceGuide.where(course_version_id: course_version_id, parent_reference_guide_key: key)
   end
 
+  # A simple helper function to encapsulate creating a unique key, since this
+  # model does not have a unique identifier field of its own.
+  def get_localized_property(property_name)
+    key = Services::GloballyUniqueIdentifiers.build_reference_guide_key(self)
+    Services::I18n::CurriculumSyncUtils.get_localized_property(self, property_name, key)
+  end
+
   def serialize
     {
       key: key,
@@ -126,8 +133,8 @@ class ReferenceGuide < ApplicationRecord
     {
       key: key,
       parent_reference_guide_key: parent_reference_guide_key,
-      display_name: display_name,
-      content: content
+      display_name: get_localized_property(:display_name),
+      content: get_localized_property(:content)
     }
   end
 

--- a/dashboard/lib/services/globally_unique_identifiers.rb
+++ b/dashboard/lib/services/globally_unique_identifiers.rb
@@ -91,5 +91,11 @@ module Services
       return if lesson&.script.blank?
       [lesson.script.name, lesson.key].join('/')
     end
+
+    # Returns a key which can be used by to globally and uniquely identify the
+    # given Reference Guide object
+    def self.build_reference_guide_key(reference_guide)
+      [reference_guide.course_offering_version, reference_guide.key].join('/')
+    end
   end
 end

--- a/dashboard/lib/services/i18n/curriculum_sync_utils/sync_out.rb
+++ b/dashboard/lib/services/i18n/curriculum_sync_utils/sync_out.rb
@@ -79,6 +79,27 @@ module Services
             result[:lessons] = rekeyed_lessons.compact.to_h
           end
 
+          # Same case as lessons for reference_guides
+          if result.key?(:reference_guides)
+            rekeyed_reference_guides = result[:reference_guides].map do |reference_guide_url, reference_guide_data|
+              route_params = Rails.application.routes.recognize_path(reference_guide_url)
+              # :course_course_name param is generated with ReferenceGuide.course_offering_version.
+              # Reversing that to look up the object.
+              split_course_name = route_params[:course_course_name].split("-")
+              course_version_key = split_course_name.pop
+              course_offering_key = split_course_name.join("-")
+              reference_guide = CourseOffering.find_by_key(course_offering_key).
+                course_versions.find_by_key(course_version_key).
+                reference_guides.find_by_key(route_params[:key])
+              if reference_guide.nil?
+                STDERR.puts "Could not find reference_guide for url #{reference_guide_url.inspect}"
+                next
+              end
+              [Services::GloballyUniqueIdentifiers.build_reference_guide_key(reference_guide), reference_guide_data]
+            end
+            result[:reference_guides] = rekeyed_reference_guides.compact.to_h
+          end
+
           # We also provide URLs to the translators for Resources only; because
           # the sync has a side effect of applying Markdown formatting to
           # everything it encounters, we want to make sure to un-Markdownify


### PR DESCRIPTION
**What:** Add `ReferenceGuide` model to the serializers within CurriculumSyncUtils.

Being that there is large markdown strings that are being uploaded to Crowdin with this update, I've followed an existing pattern we have to use the URL of the page as the Crowdin Key. This allows the translator to see the content in context. This also required the creation of a `GloballyUniqueIdentifier` method for `ReferenceGuides` specifically.

**Why:** To add ReferenceGuide attributes to the translation pipeline

## Links

- jira ticket: [FND-2103](https://codedotorg.atlassian.net/browse/FND-2103)

## Testing story

Ran sync locally against the Crowdin Test project. Visiting the respective Reference Guide on my local server showed the translated strings.
<img width="1147" alt="Screen Shot 2022-10-12 at 2 09 07 PM" src="https://user-images.githubusercontent.com/48133820/195721622-b9e34d84-2214-4054-a476-fcdde606fd9a.png">


<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
