### PR TITLE
Add `.irb_history` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ dashboard/brakeman_security_report.htm
 .tmputils
 .rakeTasks
 .idea/
+.irb_history
 jsconfig.json
 /bin/i18n/*_credentials.yml
 /bin/i18n/crowdin/*files_to_sync_out.json


### PR DESCRIPTION
Since Ruby 2.7, the ruby console persists history. Although quite helpful for local development, we don't want to persist this history to git.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

- https://docs.ruby-lang.org/en/master/IRB/Context.html#method-i-save_history-3D

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
