### PR TITLE
eliminate unqualified use of CourseVersion.all

### DIFF
--- a/dashboard/app/models/course_version.rb
+++ b/dashboard/app/models/course_version.rb
@@ -185,7 +185,7 @@ class CourseVersion < ApplicationRecord
   end
 
   def self.unit_group_course_versions_with_units(unit_ids)
-    CourseVersion.all.select {|cv| cv.included_in_units?(unit_ids) && cv.content_root_type == 'UnitGroup'}
+    CourseVersion.where(content_root_type: 'UnitGroup').all.select {|cv| cv.included_in_units?(unit_ids)}
   end
 
   def self.unit_group_course_versions_with_units_info(unit_ids)


### PR DESCRIPTION
This PR addresses the problems with https://github.com/code-dot-org/code-dot-org/pull/48426 which led to it being reverted. see [slack](https://codedotorg.slack.com/archives/C0T0PNTM3/p1665682266060239) for details.

In preparation for the Script -> Unit model rename, https://github.com/code-dot-org/code-dot-org/pull/48425 tried to set up a situation where we could have CourseVersion objects of types `Script` and `Unit` coexist, with only one of them being visible to the application code at a time. Unfortunately I missed an instance of `CourseVersion.all` which invalidated this assumption. This PR fixes that glitch by adding a where clause on `content_root_type`.

## Testing story

drone is not fully reliable for catching problems in this area because it sometimes starts with a clean copy of the database, whereas the failures in the DTT happened in a database with existing CourseVersion objects of type `Script`. Therefore, I did some manual verification locally on the pages which broke during the DTT. I did the following steps sequentially, verifying that teacher dashboard "show" page is loading properly after each:
- [x] apply this PR
- [x] apply #48604, run `rake seed:scripts`, then unapply the same PR, to simulate the situation on prod where that PR has just finished seeding but code update has not yet happened
- [x] re-apply #48604

This codepath also has unit test coverage via the tests for the `courses_for_unit_selector` method in course_version_test.rb, which are passing locally.

## Deployment strategy

* Merge this PR
* wait for a DTP
* ship https://github.com/code-dot-org/code-dot-org/pull/48604 without any additional changes

it is important to wait for a DTP in between, so that production application code using the codepath in this PR is safely updated before #48604 ships and seeds.
