### PR TITLE
Fix Violation of and Reenable `Lint/SelfAssignment`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -141,10 +141,6 @@ Lint/ScriptPermission:
   Enabled: false
 
 # Offense count: 1
-Lint/SelfAssignment:
-  Enabled: false
-
-# Offense count: 1
 Lint/StructNewOverride:
   Enabled: false
 

--- a/dashboard/app/controllers/foorm/forms_controller.rb
+++ b/dashboard/app/controllers/foorm/forms_controller.rb
@@ -57,8 +57,6 @@ module Foorm
         # If questions does contain a published state and a published state was provided as a param, verify they match.
       elsif !published_params.nil? && published != published_params
         return render(status: :bad_request, plain: "Published state in questions did not match provided published parameter.")
-      else
-        published = published
       end
 
       form_questions = JSON.pretty_generate(questions_json)


### PR DESCRIPTION
This rule simply checks for redundant self assignments.

I took a quick glance at [the git history of our one violation](https://github.com/code-dot-org/code-dot-org/commit/fead1862276d72034176cb1c0e0b96f4d4467429#diff-e6a275257d3098ecd983a2580807046da9521bcd91992bdaac5939de4609bf7fR45), and it looks like it ended up this way as a bit of an evolutionary accident. Please let me know if I'm mistaken and there's some intentional functionality happening here!

## Links

- https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/SelfAssignment

## Testing story

Relying on existing tests to verify that this does not represent any change in functionality.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
