### PR TITLE
configure curriculum.code.org to redirect to studio.code.org/courses

### DIFF
--- a/aws/s3/cdo-curriculum/redirection_rules.rb
+++ b/aws/s3/cdo-curriculum/redirection_rules.rb
@@ -14,6 +14,15 @@ BUCKET_NAME = "cdo-curriculum"
 routing_rules = [
   {
     condition: {
+      key_prefix_equals: "index.html"
+    },
+    redirect: {
+      host_name: CODE_STUDIO_HOST_NAME,
+      replace_key_prefix_with: "courses/"
+    }
+  },
+  {
+    condition: {
       key_prefix_equals: "csp/"
     },
     redirect: {


### PR DESCRIPTION
Finishes [ACQ-126](https://codedotorg.atlassian.net/browse/ACQ-126)

## Testing story


https://user-images.githubusercontent.com/8001765/195718745-1138c669-6036-45b2-be67-064f18e208df.mov



## Deployment strategy

The change has already been deployed via the instructions at the top of the file.