### PR TITLE
Update broken "more details" link for weblab project ideas

### DIFF
--- a/pegasus/sites.v3/code.org/public/project-ideas.md.partial
+++ b/pegasus/sites.v3/code.org/public/project-ideas.md.partial
@@ -23,8 +23,8 @@ theme: responsive
 [Sprite Lab](https://code.org/educate/spritelab) can be used by anyone but is
 targeted at elementary school students. Programming in a brand new environment
 can be challenging, but you can do it! For more information about full course
-offerings, check out [CS Fundamentals](https://code.org/educate/curriculum/
-elementary-school) to find the right course for your age and skill level.
+offerings, check out [CS Fundamentals](https://code.org/educate/curriculum/elementary-school)
+to find the right course for your age and skill level.
 
 ## [**Sprite Lab**](https://code.org/educate/spritelab)
 <div class="col-33" style="padding-right: 20px;">

--- a/pegasus/sites.v3/code.org/public/project-ideas.md.partial
+++ b/pegasus/sites.v3/code.org/public/project-ideas.md.partial
@@ -134,7 +134,7 @@ Principles](https://code.org/educate/csp) for high school.
         <br>
         <br>
         <p>
-          <a href="https://docs.google.com/document/d 1t9MluD6MXBpXC6vO2iJZth2XngFNt1cNcfDnSnAzMA/edit">
+          <a href="https://docs.google.com/document/d/1t9MluD6MXBpXC6v-O2iJZth2XngFNt1cNcfDnSnAzMA/edit#">
             More Details
           </a>
         </p>


### PR DESCRIPTION
The existing link is close, but there is a space instead of a '/', and a missing '-' char. Currently brings you to this page:

<img width="741" alt="Screen Shot 2022-10-13 at 4 23 00 PM" src="https://user-images.githubusercontent.com/37230822/195728473-dd32fd4c-4f1f-4885-b8b0-9fef6331b48e.png">

## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/jira/software/c/projects/LP/boards/21?modal=detail&selectedIssue=LP-3051

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
