### PR TITLE
Advocacy: speculative fix for missing map

### DIFF
--- a/pegasus/sites.v3/code.org/views/interactive_map.haml
+++ b/pegasus/sites.v3/code.org/views/interactive_map.haml
@@ -60,7 +60,7 @@
 :javascript
   var webServiceLocation = '/promote/state/';
 
-  $(document).ready(function() {
+  $(window).on("load", function() {
     if (#{use_url}) {
       // Check if the URL specifies a specific state. If so, load the state
       if (window.location.pathname.replace("/promote", "") !== "") {


### PR DESCRIPTION
We don't have a localhost repro, but we are seeing production often (though not always) failing to load the interactive map at https://advocacy.code.org.

In the failure case, we are seeing the browser hit [this line](https://github.com/code-dot-org/code-dot-org/blob/cc8f0fcd8d7c3dfca0b600fb7644faa92d269379/pegasus/sites.v3/code.org/views/interactive_map.haml#L102) before [this line](https://github.com/code-dot-org/code-dot-org/blob/cc8f0fcd8d7c3dfca0b600fb7644faa92d269379/pegasus/sites.v3/code.org/public/js/extended_us_map.js#L723), while the order is reversed in the success case.  The `extended_us_map.js` script file does show as being loaded by the browser when hitting the first line in the failure case, but it has not yet been executed.

This fix is speculative, but based on the idea that being DOM-ready didn't mean we've necessarily executed the code in the script file.  The hope is that waiting for the window load will mean that the content of the script file has actually been executed.