### PR TITLE
Remove in-progress note from create and edit data doc page

### DIFF
--- a/apps/src/lib/levelbuilder/data-docs-editor/DataDocFormEditor.jsx
+++ b/apps/src/lib/levelbuilder/data-docs-editor/DataDocFormEditor.jsx
@@ -42,10 +42,6 @@ const DataDocFormEditor = props => {
     <div>
       <RailsAuthenticityToken />
       <h1>Edit Data Doc</h1>
-      <h2>
-        This feature is in progress. It is not ready for use on Levelbuilder
-        yet.
-      </h2>
       <label style={styles.label}>
         Slug
         <input

--- a/apps/src/lib/levelbuilder/data-docs-editor/NewDataDocForm.jsx
+++ b/apps/src/lib/levelbuilder/data-docs-editor/NewDataDocForm.jsx
@@ -10,10 +10,6 @@ const NewDataDocForm = () => {
     <form action="/data_docs" method="post">
       <RailsAuthenticityToken />
       <h1>New Data Doc</h1>
-      <h2>
-        This feature is in progress. It is not ready for use on Levelbuilder
-        yet.
-      </h2>
       <label style={styles.label}>
         Slug
         <input className="input" name="key" required style={styles.input} />


### PR DESCRIPTION
Removes the in-progress note from data doc pages.

<img width="622" alt="Screen Shot 2022-10-14 at 8 18 54 AM" src="https://user-images.githubusercontent.com/9142121/195845251-f6048313-fb31-4056-a24d-55add12cd813.png">
<img width="657" alt="Screen Shot 2022-10-14 at 8 18 22 AM" src="https://user-images.githubusercontent.com/9142121/195845254-67f734ca-5311-4e93-99d6-44105fdbea05.png">


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
