### PR TITLE
Music prototype: misc changes

### DIFF
--- a/apps/src/blockly/googleBlocklyWrapper.js
+++ b/apps/src/blockly/googleBlocklyWrapper.js
@@ -365,7 +365,7 @@ function initializeBlocklyWrapper(blocklyInstance) {
   blocklyWrapper.WorkspaceSvg.prototype.resize = function() {
     googleBlocklyBlocklyResize.call(this);
     if (cdoUtils.getToolboxType() === ToolboxType.UNCATEGORIZED) {
-      // this.flyout_?.resize();
+      this.flyout_?.resize();
     }
   };
 
@@ -426,7 +426,7 @@ function initializeBlocklyWrapper(blocklyInstance) {
           'xmlns:html': 'http://www.w3.org/1999/xhtml',
           'xmlns:xlink': 'http://www.w3.org/1999/xlink',
           version: '1.1',
-          class: 'zelos-renderer modern-theme readOnlyBlockSpace'
+          class: 'geras-renderer modern-theme readOnlyBlockSpace'
         },
         null
       );

--- a/apps/src/music/Instructions.jsx
+++ b/apps/src/music/Instructions.jsx
@@ -49,7 +49,9 @@ export default class Instructions extends React.Component {
           backgroundSize: '100% 200%',
           padding: 10,
           boxSizing: 'border-box',
-          position: 'relative'
+          position: 'relative',
+          fontSize: 14,
+          lineHeight: 1.5
         }}
       >
         {instructions?.groups[0].panels.map((panel, index) => {

--- a/apps/src/music/MusicView.jsx
+++ b/apps/src/music/MusicView.jsx
@@ -493,7 +493,8 @@ export default class MusicView extends React.Component {
           borderRadius: 4,
           padding: 0,
           boxSizing: 'border-box',
-          overflow: 'hidden'
+          overflow: 'hidden',
+          userSelect: 'none'
         }}
       >
         {this.state.showInstructions && (


### PR DESCRIPTION
A few misc changes for the music prototype:

- remove some unnecessary changes in the Google Blockly wrapper
- disable user selection across the UI, making it feel more sturdy
- slightly increase instruction text size

<img width="1512" alt="Screen Shot 2022-10-14 at 9 54 00 AM" src="https://user-images.githubusercontent.com/2205926/195900754-34262ccd-2c7d-4991-9f31-aaeb5ecf29ad.png">
