### PR TITLE
Fix Database Configuration to Secrets

### DIFF
--- a/aws/cloudformation/components/database.yml.erb
+++ b/aws/cloudformation/components/database.yml.erb
@@ -107,7 +107,7 @@
       Description: 'Publish Database Cluster Writer Endpoint to application configuration setting CDO.db_writer_endpoint'
       Name: '<%=environment%>/cdo/db_writer_endpoint'
       # Publish a placeholder string for production. We set the value of the Secret manually in production.
-      SecretString: <%=rack_env?(:production) ? "'PLACEHOLDER'" : '!GetAtt AuroraCluster.Endpoint.Address'%>
+      SecretString: <%=rack_env?(:production) ? 'PLACEHOLDER' : '!GetAtt AuroraCluster.Endpoint.Address'%>
   DBProxyReportingEndpointConfig:
     Type: AWS::SecretsManager::Secret
     Properties:

--- a/aws/cloudformation/components/database.yml.erb
+++ b/aws/cloudformation/components/database.yml.erb
@@ -106,8 +106,8 @@
     Properties:
       Description: 'Publish Database Cluster Writer Endpoint to application configuration setting CDO.db_writer_endpoint'
       Name: '<%=environment%>/cdo/db_writer_endpoint'
-      # Publish an empty string for production. We set the value of the Secret manually in production.
-      SecretString: <%=rack_env?(:production) ? "''" : '!GetAtt AuroraCluster.Endpoint.Address'%>
+      # Publish a placeholder string for production. We set the value of the Secret manually in production.
+      SecretString: <%=rack_env?(:production) ? "'PLACEHOLDER'" : '!GetAtt AuroraCluster.Endpoint.Address'%>
   DBProxyReportingEndpointConfig:
     Type: AWS::SecretsManager::Secret
     Properties:


### PR DESCRIPTION
Fix #48601 which failed to deploy in production because an AWS Secret cannot have an empty string as its value (or at least the `Secret` CloudFormation Resource requires the length of the `SecretString` Property to be >= 1):

```
[stack update] DBWriterEndpointConfig [CREATE_FAILED]: Property validation failure: [Length of value for property {/SecretString} is less than minimum allowed length {1}]
```

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
