### PR TITLE
Music prototype: only show vertical scrollbar for instructions

### DIFF
--- a/apps/src/music/Instructions.jsx
+++ b/apps/src/music/Instructions.jsx
@@ -88,7 +88,7 @@ export default class Instructions extends React.Component {
                   float: 'left',
                   width: 'calc(100% - 290px)',
                   height: 70,
-                  overflow: 'scroll'
+                  overflowY: 'scroll'
                 }}
               >
                 {panel.text}


### PR DESCRIPTION
No need to show a horizontal scrollbar.
