### PR TITLE
Music prototype: shrink blockly text

### DIFF
--- a/apps/src/music/blockly/themes.js
+++ b/apps/src/music/blockly/themes.js
@@ -15,6 +15,10 @@ export const musicLabDarkTheme = GoogleBlockly.Theme.defineTheme(
     base: CdoTheme,
     blockStyles,
     categoryStyles,
-    componentStyles
+    componentStyles,
+    fontStyle: {
+      family: '"Gotham 4r", sans-serif',
+      size: 10.5
+    }
   }
 );

--- a/apps/src/music/blockly/toolbox.module.scss
+++ b/apps/src/music/blockly/toolbox.module.scss
@@ -24,7 +24,7 @@
 
 .toolboxLabel {
   font-family: $gotham-regular;
-  font-size: 16px;
+  font-size: 14px;
   padding: 0 5px;
   vertical-align: middle;
 }


### PR DESCRIPTION
A second (and now simpler) attempt at reducing the blockly text to `14px`.

<img width="1023" alt="Screen Shot 2022-10-14 at 11 50 45 PM" src="https://user-images.githubusercontent.com/2205926/195973803-b3397430-7b9e-4c7a-aed8-05115da3994c.png">
