### PR TITLE
Enable the i18n dropdown for AppLab, GameLab, and WebLab levels.

### DIFF
--- a/dashboard/app/models/game.rb
+++ b/dashboard/app/models/game.rb
@@ -234,7 +234,7 @@ class Game < ApplicationRecord
   end
 
   def has_i18n?
-    !([NETSIM, APPLAB, GAMELAB, WEBLAB].include? app)
+    !([NETSIM].include? app)
   end
 
   def use_firebase?


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

**What**: Adds the language dropdown in footer for AppLab/GameLab/WebLab levels.

**Why**: Localization support has been added to these levels, so these should turn back on.

**Considerations**: The WebLab footer looks terrible! But it always has, so what can you do.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

- jira ticket: [FND-2104](https://codedotorg.atlassian.net/jira/software/c/projects/FND/boards/62?modal=detail&selectedIssue=FND-2104)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

Manually created each type of project and used the dropdown to change language.

AppLab:

![image](https://user-images.githubusercontent.com/31674/196281581-2607e6ab-5b50-46a9-b088-787728c3509d.png)

WebLab:

![image](https://user-images.githubusercontent.com/31674/196281653-21f3b2b8-0e20-4a0e-831b-c35b3626b532.png)

GameLab:

![image](https://user-images.githubusercontent.com/31674/196281749-1f214fa4-66dd-4000-8efc-84dad349531b.png)

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
