### PR TITLE
generate and use fallback pdfs for script overview and resources

### DIFF
--- a/dashboard/lib/services/curriculum_pdfs/resources.rb
+++ b/dashboard/lib/services/curriculum_pdfs/resources.rb
@@ -17,9 +17,9 @@ module Services
         # version of the script in the environment.
         #
         # For example: <Pathname:csp1-2021/20210909014219/Digital+Information+('21-'22)+-+Resources.pdf>
-        def get_script_resources_pathname(script)
+        def get_script_resources_pathname(script, versioned: true)
           filename = ActiveStorage::Filename.new(script.localized_title.parameterize(preserve_case: true) + "-Resources.pdf").to_s
-          script_overview_pathname = get_script_overview_pathname(script)
+          script_overview_pathname = get_script_overview_pathname(script, versioned: versioned)
           return nil unless script_overview_pathname
           subdirectory = File.dirname(script_overview_pathname)
           return Pathname.new(File.join(subdirectory, filename))
@@ -31,7 +31,8 @@ module Services
         # For example: https://lesson-plans.code.org/csp1-2021/20210909014219/Digital+Information+%28%2721-%2722%29+-+Resources.pdf
         def get_unit_resources_url(script)
           return nil unless Services::CurriculumPdfs.should_generate_resource_pdf?(script)
-          pathname = get_script_resources_pathname(script)
+          versioned = script_resources_pdf_exists_for?(script)
+          pathname = get_script_resources_pathname(script, versioned: versioned)
           return nil if pathname.blank?
           File.join(get_base_url, pathname)
         end
@@ -59,6 +60,7 @@ module Services
 
           # Merge all gathered PDFs
           destination = File.join(directory, get_script_resources_pathname(script))
+          fallback_destination = File.join(directory, get_script_resources_pathname(script, versioned: false))
           FileUtils.mkdir_p(File.dirname(destination))
 
           # We've been having an intermittent issue where this step will fail
@@ -92,6 +94,9 @@ module Services
             raise e
           end
           FileUtils.remove_entry_secure(pdfs_dir)
+
+          FileUtils.mkdir_p(File.dirname(fallback_destination))
+          FileUtils.cp(destination, fallback_destination)
 
           return destination
         end

--- a/dashboard/lib/services/curriculum_pdfs/script_overview.rb
+++ b/dashboard/lib/services/curriculum_pdfs/script_overview.rb
@@ -15,9 +15,9 @@ module Services
         # version
         #
         # For example: <Pathname:csp1-2021/20210909014219/Digital+Information+%28%2721-%2722%29.pdf>
-        def get_script_overview_pathname(script)
+        def get_script_overview_pathname(script, versioned: true)
           return nil unless script&.seeded_from
-          version_number = Time.parse(script.seeded_from).to_s(:number)
+          version_number = versioned ? Time.parse(script.seeded_from).to_s(:number) : 'fallback'
           filename = ActiveStorage::Filename.new(script.localized_title.parameterize(preserve_case: true) + ".pdf").to_s
           return Pathname.new(File.join(script.name, version_number, filename))
         end
@@ -28,7 +28,8 @@ module Services
         # For example: https://lesson-plans.code.org/csp1-2021/20210909014219/Digital+Information+%28%2721-%2722%29.pdf
         def get_script_overview_url(script)
           return nil unless Services::CurriculumPdfs.should_generate_overview_pdf?(script)
-          pathname = get_script_overview_pathname(script)
+          versioned = script_overview_pdf_exists_for?(script)
+          pathname = get_script_overview_pathname(script, versioned: versioned)
           return nil if pathname.blank?
           File.join(get_base_url, pathname)
         end
@@ -83,10 +84,15 @@ module Services
 
           # Merge all included PDFs
           pathname = get_script_overview_pathname(script)
+          fallback_pathname = get_script_overview_pathname(script, versioned: false)
           destination = File.join(directory, pathname)
+          fallback_destination = File.join(directory, fallback_pathname)
           FileUtils.mkdir_p(File.dirname(destination))
           PDF.merge_local_pdfs(destination, *pdfs)
           FileUtils.remove_entry_secure(pdfs_dir)
+
+          FileUtils.mkdir_p(File.dirname(fallback_destination))
+          FileUtils.cp(destination, fallback_destination)
 
           return destination
         end

--- a/dashboard/test/lib/services/curriculum_pdfs/resources_test.rb
+++ b/dashboard/test/lib/services/curriculum_pdfs/resources_test.rb
@@ -31,6 +31,7 @@ class Services::CurriculumPdfs::ResourcesTest < ActiveSupport::TestCase
   test 'script resources PDF includes resources from all lessons' do
     script = create(:script, seeded_from: Time.now)
     lesson_group = create(:lesson_group, script: script)
+    FileUtils.stubs(:cp)
 
     Dir.mktmpdir('script resources pdf test') do |tmpdir|
       PDF.expects(:merge_local_pdfs).with {|_output, *input| input.empty?}
@@ -63,6 +64,7 @@ class Services::CurriculumPdfs::ResourcesTest < ActiveSupport::TestCase
     lesson.resources << verified_teacher_resource
     lesson_group.lessons << lesson
     script.reload
+    FileUtils.stubs(:cp)
 
     Dir.mktmpdir('script resources pdf test') do |tmpdir|
       PDF.expects(:merge_local_pdfs).with {|_output, *input| input.empty?}

--- a/dashboard/test/lib/services/curriculum_pdfs/script_overview_test.rb
+++ b/dashboard/test/lib/services/curriculum_pdfs/script_overview_test.rb
@@ -41,6 +41,7 @@ class Services::CurriculumPdfs::ScriptOverviewTest < ActiveSupport::TestCase
       PDF.expects(:generate_from_url).with do |url, _outpath|
         url == Rails.application.routes.url_helpers.script_url(script) + "?no_redirect=true&viewAs=Instructor"
       end
+      FileUtils.stubs(:cp)
       Services::CurriculumPdfs.generate_script_overview_pdf(script, tmpdir)
     end
   end


### PR DESCRIPTION
Finishes [ACQ-46](https://codedotorg.atlassian.net/browse/ACQ-46). Copies the approach from https://github.com/code-dot-org/code-dot-org/pull/48476, which did the same for lesson plans.

## Testing story

* updated existing unit tests
* followed the same manual verification steps in the testing section at https://github.com/code-dot-org/code-dot-org/pull/48476

in step 4, here are the newly generated files:
```
ubuntu@staging:~$ aws s3 ls --recursive s3://cdo-lesson-plans-dev/hello-world-draft
2022-10-17 20:58:36      33665 hello-world-draft/20220728184112/Hello-World-Resources.pdf
2022-10-17 20:58:36      83210 hello-world-draft/20220728184112/Hello-World.pdf
2022-10-17 20:58:37      95815 hello-world-draft/20220728184112/student-lesson-plans/Hello-world-Student.pdf
2022-10-17 20:58:37      55829 hello-world-draft/20220728184112/teacher-lesson-plans/Hello-world.pdf
2022-10-17 20:58:37      33665 hello-world-draft/fallback/Hello-World-Resources.pdf
2022-10-17 20:58:38      83210 hello-world-draft/fallback/Hello-World.pdf
2022-10-17 20:58:38      95815 hello-world-draft/fallback/student-lesson-plans/Hello-world-Student.pdf
2022-10-17 20:58:38      55829 hello-world-draft/fallback/teacher-lesson-plans/Hello-world.pdf
```

in step 8, confirmed that fallback URLs were served to the user at these urls:
* https://cdo-lesson-plans-dev.s3.amazonaws.com/hello-world-draft/fallback/Hello-World.pdf
* https://cdo-lesson-plans-dev.s3.amazonaws.com/hello-world-draft/fallback/Hello-World-Resources.pdf
