### PR TITLE
Release WebSerial Path for Chromium Browsers

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1261,6 +1261,7 @@
   "mac": "Mac",
   "makeMyOwn": "Make my own",
   "makeNewSounds": "Make new sounds",
+  "makerConnectExplanation": "If you're having issues connecting to a Circuit Playground board, click the button below to run some connectivity checks.",
   "makerNewProjectButton": "Create a project",
   "makerNewProjectDesc": "Create a new App Lab app with Maker Toolkit enabled",
   "makerNewProjectTitle": "Create a new app",

--- a/apps/src/lib/kits/maker/ui/SetupChecklist.jsx
+++ b/apps/src/lib/kits/maker/ui/SetupChecklist.jsx
@@ -17,7 +17,7 @@ import {
 } from '../util/browserChecks';
 import ValidationStep, {Status} from '../../../ui/ValidationStep';
 import experiments from '@cdo/apps/util/experiments';
-import {BOARD_TYPE} from '../util/boardUtils';
+import {BOARD_TYPE, shouldUseWebSerial} from '../util/boardUtils';
 import {CHROME_APP_WEBSTORE_URL} from '../util/makerConstants';
 import WebSerialPortWrapper from '@cdo/apps/lib/kits/maker/WebSerialPortWrapper';
 
@@ -89,9 +89,9 @@ export default class SetupChecklist extends Component {
       // Is Chrome App Installed?
       .then(
         () =>
-          // Only necessary for ChromeOS when the webserial flag is not-enabled
+          // Only necessary for ChromeOS when not using webserial
           (isChromeOS() || isChrome()) &&
-          !experiments.isEnabled('webserial') &&
+          !shouldUseWebSerial() &&
           this.detectStep(STATUS_APP_INSTALLED, () =>
             setupChecker.detectChromeAppInstalled()
           )
@@ -209,8 +209,7 @@ export default class SetupChecklist extends Component {
         />
       );
     } else if (isChromeOS() || isChrome()) {
-      if (experiments.isEnabled('webserial')) {
-        // Chromebooks use WebSerial for connection
+      if (shouldUseWebSerial()) {
         return (
           <ValidationStep
             stepName={applabI18n.makerSetupBrowserSupported()}

--- a/apps/src/lib/kits/maker/ui/SetupChecklist.jsx
+++ b/apps/src/lib/kits/maker/ui/SetupChecklist.jsx
@@ -50,7 +50,8 @@ export default class SetupChecklist extends Component {
 
   static propTypes = {
     webSerialPort: PropTypes.object,
-    stepDelay: PropTypes.number
+    stepDelay: PropTypes.number,
+    displaySupport: PropTypes.bool
   };
 
   fail(selector) {
@@ -364,11 +365,13 @@ export default class SetupChecklist extends Component {
             </ValidationStep>
           )}
         </div>
-        <div>
-          <h2>{i18n.support()}</h2>
-          <SafeMarkdown markdown={i18n.debugMakerToolkit()} />
-          {this.contactSupport()}
-        </div>
+        {this.props.displaySupport && (
+          <div>
+            <h2>{i18n.support()}</h2>
+            <SafeMarkdown markdown={i18n.debugMakerToolkit()} />
+            {this.contactSupport()}
+          </div>
+        )}
       </div>
     );
   }

--- a/apps/src/lib/kits/maker/ui/SetupGuide.jsx
+++ b/apps/src/lib/kits/maker/ui/SetupGuide.jsx
@@ -24,7 +24,6 @@ import {
   WEB_SERIAL_FILTERS,
   shouldUseWebSerial
 } from '@cdo/apps/lib/kits/maker/util/boardUtils';
-import PropTypes from 'prop-types';
 
 const DOWNLOAD_PREFIX = 'https://downloads.code.org/maker/';
 const WINDOWS = 'windows';
@@ -62,38 +61,45 @@ export default class SetupGuide extends React.Component {
     if (shouldUseWebSerial()) {
       if (!webSerialPort) {
         webSerialRender = (
-          <input
-            style={{margin: 15, marginBottom: 25}}
-            className="btn"
-            type="button"
-            value={'Connect to Board'}
-            onClick={() => {
-              navigator.serial
-                .requestPort({filters: WEB_SERIAL_FILTERS})
-                .then(port => {
-                  this.setState({webSerialPort: port});
-                });
-            }}
-          />
+          <div>
+            <input
+              style={{margin: 15, marginBottom: 25}}
+              className="btn"
+              type="button"
+              value={'Connect to Board'}
+              onClick={() => {
+                navigator.serial
+                  .requestPort({filters: WEB_SERIAL_FILTERS})
+                  .then(port => {
+                    this.setState({webSerialPort: port});
+                  });
+              }}
+            />
+            <SafeMarkdown markdown={i18n.contactGeneralSupport()} />
+          </div>
         );
       } else {
-        webSerialRender = <SetupChecklist webSerialPort={webSerialPort} />;
+        webSerialRender = (
+          <SetupChecklist
+            webSerialPort={webSerialPort}
+            displaySupport={false}
+          />
+        );
       }
     }
 
-    webSerialRender = (
-      <div>
-        <p>{i18n.makerConnectExplanation()}</p>
-        {webSerialRender}
-      </div>
-    );
-
     if (isCodeOrgBrowser()) {
-      return <SetupChecklist webSerialPort={webSerialPort} />;
+      return (
+        <SetupChecklist webSerialPort={webSerialPort} displaySupport={true} />
+      );
     }
     return (
       <Provider store={store}>
-        <Downloads webSerialChildren={webSerialRender} />
+        <div>
+          <Downloads />
+          <p>{i18n.makerConnectExplanation()}</p>
+          {webSerialRender}
+        </div>
       </Provider>
     );
   }
@@ -104,10 +110,6 @@ class Downloads extends React.Component {
     super(props);
     this.state = {platform: Downloads.platformFromHash()};
   }
-
-  static propTypes = {
-    webSerialChildren: PropTypes.object
-  };
 
   componentDidMount() {
     window.addEventListener('hashchange', this.onHashChange);
@@ -164,8 +166,6 @@ class Downloads extends React.Component {
         {CHROMEBOOK === platform && <ChromebookInstructions />}
         <h2>{i18n.support()}</h2>
         <SafeMarkdown markdown={i18n.debugMakerToolkit()} />
-        {this.props.webSerialChildren}
-        <SafeMarkdown markdown={i18n.contactGeneralSupport()} />
       </div>
     );
   }

--- a/apps/src/lib/kits/maker/ui/SetupGuide.jsx
+++ b/apps/src/lib/kits/maker/ui/SetupGuide.jsx
@@ -9,7 +9,8 @@ import {
   isCodeOrgBrowser,
   isOSX,
   isWindows,
-  isLinux
+  isLinux,
+  isChromeOS
 } from '../util/browserChecks';
 import Button from '../../../../templates/Button';
 import ToggleGroup from '../../../../templates/ToggleGroup';
@@ -88,7 +89,8 @@ export default class SetupGuide extends React.Component {
       }
     }
 
-    if (isCodeOrgBrowser()) {
+    // For Chromebooks and Maker App, skip the download instructions
+    if (isCodeOrgBrowser() || (isChromeOS() && shouldUseWebSerial())) {
       return (
         <SetupChecklist webSerialPort={webSerialPort} displaySupport={true} />
       );

--- a/apps/src/lib/kits/maker/util/boardUtils.js
+++ b/apps/src/lib/kits/maker/util/boardUtils.js
@@ -8,7 +8,6 @@ import {
 import WebSerialPortWrapper from '@cdo/apps/lib/kits/maker/WebSerialPortWrapper';
 import DCDO from '@cdo/apps/dcdo';
 import {isChromeOS} from '../util/browserChecks';
-import experiments from '@cdo/apps/util/experiments';
 
 export const BOARD_TYPE = {
   CLASSIC: 'classic',
@@ -57,16 +56,15 @@ export function isWebSerialPort(port) {
 
 /**
  * Determines whether WebSerial port is available in the current browser.
- * WebSerial should be available in ChromeOS (depending on DCDO flag) and, when
- * the webserial experiment is set, in Chromium browsers.
+ * WebSerial should be available in ChromeOS (depending on DCDO flag) and
+ * in Chromium browsers.
  */
 export function shouldUseWebSerial() {
-  let experimentEnabledInChromium =
-    experiments.isEnabled('webserial') && 'serial' in navigator;
+  let webSerialAvailableInBrowser = 'serial' in navigator;
   let usingChromeOSAndDCDO =
     isChromeOS() && !!DCDO.get('webserial-on-chromeos', true);
 
-  return usingChromeOSAndDCDO || experimentEnabledInChromium;
+  return usingChromeOSAndDCDO || webSerialAvailableInBrowser;
 }
 
 /** @const {number} serial port transfer rate */

--- a/apps/src/lib/kits/maker/util/boardUtils.js
+++ b/apps/src/lib/kits/maker/util/boardUtils.js
@@ -60,8 +60,8 @@ export function isWebSerialPort(port) {
  * in Chromium browsers.
  */
 export function shouldUseWebSerial() {
-  let webSerialAvailableInBrowser = 'serial' in navigator;
-  let usingChromeOSAndDCDO =
+  const webSerialAvailableInBrowser = 'serial' in navigator;
+  const usingChromeOSAndDCDO =
     isChromeOS() && !!DCDO.get('webserial-on-chromeos', true);
 
   return usingChromeOSAndDCDO || webSerialAvailableInBrowser;


### PR DESCRIPTION
Here we go!

This releases WebSerial on Chromium browsers. This allows students and teachers to use the Maker Toolkit directly from their (Chrome or Edge) browser. This does not allow users to use WebSerial non-Chromium browsers, like Firefox. Users are still able to use the Maker App.

Per discussion on Slack: https://codedotorg.slack.com/archives/C0T0EGE8L/p1666035655461009, we're adding the connect button to the end of the download instructions in Chrome to support both paths. Firefox, Maker App, and ChromeOS are unaffected by this change.

Maker App - /maker/setup
![Screenshot from 2022-10-17 17-22-14](https://user-images.githubusercontent.com/2959170/196507563-96b6db3d-5609-4de1-b793-80bdfaee27ad.png)

Firefox - /maker/setup
![Screenshot from 2022-10-17 17-19-24](https://user-images.githubusercontent.com/2959170/196507801-47a0d280-4d60-4009-88c4-67f7fa14b6ab.png)

Chrome - /maker/setup
![Screenshot from 2022-10-17 17-04-41](https://user-images.githubusercontent.com/2959170/196508175-292c6cbb-e5bb-4db4-8303-e728ba0f3565.png)


Chrome - /maker/setup
![Screenshot from 2022-10-17 17-11-13](https://user-images.githubusercontent.com/2959170/196508071-60a18fe6-4e9a-491f-90bd-72ccde674fc6.png)

