### PR TITLE
fix certificate links in k5-onlinepd levels

### DIFF
--- a/dashboard/config/scripts/csp5_virtual_ending.external
+++ b/dashboard/config/scripts/csp5_virtual_ending.external
@@ -16,5 +16,5 @@ You have learned some foundational concepts of computer programming, and how to 
 
 ![](https://images.code.org/20e9431f430073a88b9fad0927f41ff2-image-1587503492264.jpg)
 
-## [Print your certificate!](https://code.org/certificates?course=Event-Driven%20Programming%20in%20App%20Lab)
+## [Print your certificate!](https://studio.code.org/certificates/batch?course=Y3NwNS12aXJ0dWFs)
 MARKDOWN

--- a/dashboard/config/scripts/opd_k5_connect_copy_2021.external
+++ b/dashboard/config/scripts/opd_k5_connect_copy_2021.external
@@ -1,18 +1,18 @@
 name 'OPD-K5 Connect_copy_2021'
 skip_dialog true
 markdown <<MARKDOWN
-# Part III:  Next Steps 
+# Part III:  Next Steps
 
 
 ## Take the post-survey
 
-Regardless of how much of this course you completed, we want to hear your feedback. Please submit this short survey to help us improve the course going forward! 
+Regardless of how much of this course you completed, we want to hear your feedback. Please submit this short survey to help us improve the course going forward!
 
 <a class="btn btn-large btn-primary submitButton" href="https://form.jotform.com/211795510260147?user_id=<user_id/>" target="blank" rel="noopener noreferrer"> Take the post-survey</a>
 
 ## Print a certificate
 Congratulations on completing this professional development online course. Provided you have completed all levels in this training, you can download and print a certificate of accomplishment now by completing the following steps:
-- <a href="https://code.org/certificates?course=Teaching%20Computer%20Science%20Fundamentals" target="blank" rel="noopener noreferrer">Click here to create your certificate.</a>
+- <a href="https://studio.code.org/certificates/batch?course=azUtb25saW5lcGQtMjAyMQ==" target="blank" rel="noopener noreferrer">Click here to create your certificate.</a>
 - Enter your name into the input field/box.
 - Click Print Certificates.
 - Right click on the image of the certificate and choose "Save Image As..." to download to your computer.
@@ -21,12 +21,12 @@ Congratulations on completing this professional development online course. Provi
 
 Check out <a href="http://code.org/professional-development-workshops" target="blank" rel="noopener noreferrer">our professional learning map</a> to see the Computer Science Fundamentals workshops that are being offered in your area.
 
-* **CS Fundamentals Intro Workshop** proactively prepares you to successfully 
+* **CS Fundamentals Intro Workshop** proactively prepares you to successfully
 
 	* implement CS Fundamentals courses, regardless of prior computer science experience.
 	* establish an equitable CS Fundamentals classroom.
 
-* **CS Fundamentals Deep Dive Workshop** provides a deeper understanding of 
+* **CS Fundamentals Deep Dive Workshop** provides a deeper understanding of
 
 	* the curriculum and how it supports inclusive learning environments.
 	* computer science teaching practices that support teaching CS Fundamentals courses equitably.
@@ -42,5 +42,5 @@ Check out <a href="http://code.org/professional-development-workshops" target="b
 
 ##### **Remember... you can return to this online course anytime to review your learning, access links or resources, or just refresh your memory!**
 
-## Thank you for your participation! 
+## Thank you for your participation!
 MARKDOWN

--- a/dashboard/config/scripts/opd_k5_connect_copy_2022.external
+++ b/dashboard/config/scripts/opd_k5_connect_copy_2022.external
@@ -1,18 +1,18 @@
 name 'OPD-K5 Connect_copy_2022'
 skip_dialog true
 markdown <<MARKDOWN
-# Part III:  Next Steps 
+# Part III:  Next Steps
 
 
 ## Take the post-survey
 
-Regardless of how much of this course you completed, we want to hear your feedback. Please submit this short survey to help us improve the course going forward! 
+Regardless of how much of this course you completed, we want to hear your feedback. Please submit this short survey to help us improve the course going forward!
 
 <a class="btn btn-large btn-primary submitButton" href="https://form.jotform.com/211795510260147?user_id=<user_id/>" target="blank" rel="noopener noreferrer"> Take the post-survey</a>
 
 ## Print a certificate
 Congratulations on completing this professional development online course. Provided you have completed all levels in this training, you can download and print a certificate of accomplishment now by completing the following steps:
-- <a href="https://code.org/certificates?course=Teaching%20Computer%20Science%20Fundamentals" target="blank" rel="noopener noreferrer">Click here to create your certificate.</a>
+- <a href="https://studio.code.org/certificates/batch?course=azUtb25saW5lcGQtMjAyMg==" target="blank" rel="noopener noreferrer">Click here to create your certificate.</a>
 - Enter your name into the input field/box.
 - Click Print Certificates.
 - Right click on the image of the certificate and choose "Save Image As..." to download to your computer.
@@ -21,12 +21,12 @@ Congratulations on completing this professional development online course. Provi
 
 Check out <a href="http://code.org/professional-development-workshops" target="blank" rel="noopener noreferrer">our professional learning map</a> to see the Computer Science Fundamentals workshops that are being offered in your area.
 
-* **CS Fundamentals Intro Workshop** proactively prepares you to successfully 
+* **CS Fundamentals Intro Workshop** proactively prepares you to successfully
 
 	* implement CS Fundamentals courses, regardless of prior computer science experience.
 	* establish an equitable CS Fundamentals classroom.
 
-* **CS Fundamentals Deep Dive Workshop** provides a deeper understanding of 
+* **CS Fundamentals Deep Dive Workshop** provides a deeper understanding of
 
 	* the curriculum and how it supports inclusive learning environments.
 	* computer science teaching practices that support teaching CS Fundamentals courses equitably.
@@ -42,5 +42,5 @@ Check out <a href="http://code.org/professional-development-workshops" target="b
 
 ##### **Remember... you can return to this online course anytime to review your learning, access links or resources, or just refresh your memory!**
 
-## Thank you for your participation! 
+## Thank you for your participation!
 MARKDOWN


### PR DESCRIPTION
See [slack](https://codedotorg.slack.com/archives/C045UAX4WKH/p1666044395995249). As part of the congrats page move, the certificate links in k5-onlinepd-2021 and k5-onlinepd-2022 regressed, showing "The Hour of Code" rather than "Teaching Computer Science Fundamentals" on the certificate. This is because the url format changed from requiring the course display name ("Teaching Computer Science Fundamentals") to the script name as it appears in the url (`k5-onlinepd-2021`), which is then base64-encoded.

This PR fixes the links. The opaque part of the urls were generated as follows:
```
[development] dashboard > Base64.urlsafe_encode64 'k5-onlinepd-2022'
=> "azUtb25saW5lcGQtMjAyMg=="
[development] dashboard > Base64.urlsafe_encode64 'k5-onlinepd-2021'
=> "azUtb25saW5lcGQtMjAyMQ=="
[development] dashboard > Base64.urlsafe_encode64 'csp5-virtual'
=> "Y3NwNS12aXJ0dWFs"
```

## Screenshots 

### before / after

after going to https://studio.code.org/s/k5-onlinepd-2022/lessons/16/levels/5 and clicking the certificate link:

![Screen Shot 2022-10-17 at 3 46 36 PM](https://user-images.githubusercontent.com/8001765/196298447-0413b386-3781-4129-8c8f-b597cffd1bf1.png)

### new certificate close-ups

![Screen Shot 2022-10-17 at 3 49 39 PM](https://user-images.githubusercontent.com/8001765/196298482-d37a69d8-522d-41dc-9574-084c638887a0.png)

![Screen Shot 2022-10-17 at 4 03 19 PM](https://user-images.githubusercontent.com/8001765/196299511-3c3465e3-bcf7-4315-98fe-b7a6b88afe83.png)

![Screen Shot 2022-10-17 at 4 01 50 PM](https://user-images.githubusercontent.com/8001765/196299520-3b742f8e-a7bb-4cc9-8b5c-e10019d270d1.png)


## Testing story

* manually verified on each modified level locally:
  * https://studio.code.org/s/k5-onlinepd-2022/lessons/16/levels/5
  * https://studio.code.org/s/k5-onlinepd-2021/lessons/17/levels/5
  * https://studio.code.org/s/csp5-virtual/lessons/11/levels/2
* searched the codebase for any other instances of code.org/certificates?course=... and did not find any that were user-visible (there was 1 other occurrence in an unused level)

## Follow-up work

when k5-onlinepd-2022 is cloned, the certificate link will be outdated and hard to update. According to the slack convo, we are trying to move away from providing these links, so I'm suggesting we wait to see if this is a problem before trying to come up with a fix.