### PR TITLE
Update Akiera to Dave on RP contact form

### DIFF
--- a/dashboard/app/mailers/pd/regional_partner_mini_contact_mailer.rb
+++ b/dashboard/app/mailers/pd/regional_partner_mini_contact_mailer.rb
@@ -1,6 +1,6 @@
 class Pd::RegionalPartnerMiniContactMailer < ActionMailer::Base
   NO_REPLY = 'Code.org <noreply@code.org>'
-  default from: 'Akiera Gilbert <partner@code.org>'
+  default from: 'Dave Frye <partner@code.org>'
   default bcc: MailerConstants::PLC_EMAIL_LOG
 
   def matched(form, rp_pm)

--- a/dashboard/app/views/pd/regional_partner_mini_contact_mailer/matched.html.haml
+++ b/dashboard/app/views/pd/regional_partner_mini_contact_mailer/matched.html.haml
@@ -28,9 +28,9 @@
   %br
   &nbsp;
   %br
-  Akiera Gilbert
+  Dave Frye
   %br
-  Regional Partner Network Manager
+  Director of Programs
   %br
   partner@code.org
   %br


### PR DESCRIPTION
Request came in through slack https://codedotorg.slack.com/archives/C04540KNGDQ/p1666117086973739 to update the RP contact form to come from Dave Frye instead of Akiera. Did a quick search for Akiera's name and updated the 2 places it showed up.

