### PR TITLE
Update TerserWebpackPlugin configuration

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -926,7 +926,10 @@ describe('entry tests', () => {
             // Excludes these from minification to avoid breaking functionality,
             // but still adds .min to the output filename suffix.
             exclude: [/\/blockly.js$/, /\/brambleHost.js$/],
-            sourceMap: envConstants.DEBUG_MINIFIED
+            parallel: true,
+            terserOptions: {
+              sourceMap: envConstants.DEBUG_MINIFIED
+            }
           })
         ],
 

--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -922,9 +922,11 @@ describe('entry tests', () => {
       optimization: {
         minimizer: [
           new TerserPlugin({
+            minify: TerserPlugin.uglifyJsMinify,
             // Excludes these from minification to avoid breaking functionality,
             // but still adds .min to the output filename suffix.
-            exclude: [/\/blockly.js$/, /\/brambleHost.js$/]
+            exclude: [/\/blockly.js$/, /\/brambleHost.js$/],
+            sourceMap: envConstants.DEBUG_MINIFIED
           })
         ],
 

--- a/apps/package.json
+++ b/apps/package.json
@@ -220,6 +220,7 @@
     "stylelint": "^14.10.0",
     "stylelint-config-standard": "^27.0.0",
     "stylelint-config-standard-scss": "^5.0.0",
+    "terser-webpack-plugin": "^5.3.6",
     "uglifyjs-webpack-plugin": "^2.2.0",
     "unminified-webpack-plugin": "^3.0.0",
     "url-loader": "^4.1.1",

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -16855,7 +16855,7 @@ terser-webpack-plugin@^4.2.3:
     terser "^5.3.4"
     webpack-sources "^1.4.3"
 
-terser-webpack-plugin@^5.0.3:
+terser-webpack-plugin@^5.0.3, terser-webpack-plugin@^5.3.6:
   version "5.3.6"
   resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.3.6.tgz#5590aec31aa3c6f771ce1b1acca60639eab3195c"
   integrity sha512-kfLFk+PoLUQIbLmB1+PZDMRSZS99Mp+/MHqDNmMA6tOItzRt+Npe3E+fsMs5mfcM0wCtrrdU387UnV+vnSffXQ==


### PR DESCRIPTION
When we upgraded from webpack 4 to 5, we changed the minimizer from UglifyJsPlugin to TerserPlugin. Last week, a CloudWatch alarm was triggered because the disk usage on our test environment had been steadily increasing after the webpack upgrade ([Slack thread](https://codedotorg.slack.com/archives/C03CK49G9/p1665786591961429)). The culprit was that `node_modules/.cache/terser-webpack-plugin` was taking up ~36G of disk space.

I believe this was happening because the terser-webpack-plugin package was missing from our package.json devDependencies. We were only successful in using the plugin because it was used by another dependency. After adding the package and building for production (`yarn build:dist`), a `node_modules/.cache/terser-webpack-plugin` directory was no longer created.

I also fixed some of the TerserPlugin options to be more like our previous UglifyJsPlugin options, which were:

https://github.com/code-dot-org/code-dot-org/blob/a909990ddfb01b7f9d5425b6769d439f24eac8d1/apps/Gruntfile.js#L878-L888

### Follow-Up Work
- Remove unused uglifyjs-webpack-plugin dependency