### PR TITLE
Music prototype: update media URL

### DIFF
--- a/apps/src/music/MusicView.jsx
+++ b/apps/src/music/MusicView.jsx
@@ -29,7 +29,7 @@ function getRandomIntInclusive(min, max) {
   return Math.floor(Math.random() * (max - min + 1) + min);
 }
 
-const baseUrl = 'https://cdo-dev-music-prototype.s3.amazonaws.com/';
+const baseUrl = 'https://curriculum.code.org/media/musiclab/';
 
 var hooks = {};
 


### PR DESCRIPTION
This one seems like a good candidate.  It maps to `s3://cdo-curriculum/media/musiclab/`.