### PR TITLE
Fix theater assets not available for teacher/reviewer

### DIFF
--- a/apps/src/javalab/JavabuilderConnection.js
+++ b/apps/src/javalab/JavabuilderConnection.js
@@ -80,6 +80,7 @@ export default class JavabuilderConnection {
   connectJavabuilderWithOverrideSources(overrideSources) {
     let requestData = this.getDefaultRequestData();
     requestData.overrideSources = overrideSources;
+    // we include the channel id so that assets are available
     requestData.channelId = this.channelId;
 
     // When we have override sources, we do not need to check if the project has been edited,

--- a/apps/src/javalab/JavabuilderConnection.js
+++ b/apps/src/javalab/JavabuilderConnection.js
@@ -80,6 +80,7 @@ export default class JavabuilderConnection {
   connectJavabuilderWithOverrideSources(overrideSources) {
     let requestData = this.getDefaultRequestData();
     requestData.overrideSources = overrideSources;
+    requestData.channelId = this.channelId;
 
     // When we have override sources, we do not need to check if the project has been edited,
     // as the override sources are what we want to run.

--- a/dashboard/app/controllers/javabuilder_sessions_controller.rb
+++ b/dashboard/app/controllers/javabuilder_sessions_controller.rb
@@ -32,6 +32,7 @@ class JavabuilderSessionsController < ApplicationController
       return render status: :bad_request, json: {}
     end
     override_sources = params[:overrideSources]
+    # channel id is not required but can be included in order to retrieve assets
     channel_id = params[:channelId]
 
     session_id = SecureRandom.uuid

--- a/dashboard/app/controllers/javabuilder_sessions_controller.rb
+++ b/dashboard/app/controllers/javabuilder_sessions_controller.rb
@@ -32,12 +32,13 @@ class JavabuilderSessionsController < ApplicationController
       return render status: :bad_request, json: {}
     end
     override_sources = params[:overrideSources]
+    channel_id = params[:channelId]
 
     session_id = SecureRandom.uuid
     encoded_payload = get_encoded_payload({sid: session_id})
 
     level_id = params[:levelId].to_i
-    project_files = JavalabFilesHelper.get_project_files_with_override_sources(override_sources, level_id)
+    project_files = JavalabFilesHelper.get_project_files_with_override_sources(override_sources, level_id, channel_id)
     upload_project_files_and_render(session_id, project_files, encoded_payload)
   end
 

--- a/dashboard/app/helpers/javalab_files_helper.rb
+++ b/dashboard/app/helpers/javalab_files_helper.rb
@@ -136,6 +136,5 @@ module JavalabFilesHelper
     asset_list.each do |asset|
       all_level_files["assetUrls"][asset[:filename]] = generate_asset_url(asset[:filename], channel_id)
     end
-    puts all_level_files
   end
 end

--- a/dashboard/app/helpers/javalab_files_helper.rb
+++ b/dashboard/app/helpers/javalab_files_helper.rb
@@ -36,11 +36,7 @@ module JavalabFilesHelper
     all_files["sources"]["main.json"] = source_data[:body].string
 
     # get level assets
-    asset_bucket = AssetBucket.new
-    asset_list = asset_bucket.list(channel_id)
-    asset_list.each do |asset|
-      all_files["assetUrls"][asset[:filename]] = generate_asset_url(asset[:filename], channel_id)
-    end
+    get_assets_for_channel(channel_id, all_files)
 
     all_files
   end
@@ -55,9 +51,10 @@ module JavalabFilesHelper
   #   "validation": <all validation code for a project, in json format>
   # }
   # If the level doesn't have validation and/or a maze, those fields will not be present.
-  def self.get_project_files_with_override_sources(sources, level_id)
+  def self.get_project_files_with_override_sources(sources, level_id, channel_id)
     all_files = get_level_files(level_id)
     all_files["sources"]["main.json"] = {source: sources}.to_json
+    get_assets_for_channel(channel_id, all_files) if channel_id
     all_files
   end
 
@@ -131,5 +128,14 @@ module JavalabFilesHelper
     rack_env?(:development) ?
       "http://" + CDO.dashboard_hostname + ":3000" :
       "https://" + CDO.dashboard_hostname
+  end
+
+  def self.get_assets_for_channel(channel_id, all_level_files)
+    asset_bucket = AssetBucket.new
+    asset_list = asset_bucket.list(channel_id)
+    asset_list.each do |asset|
+      all_level_files["assetUrls"][asset[:filename]] = generate_asset_url(asset[:filename], channel_id)
+    end
+    puts all_level_files
   end
 end


### PR DESCRIPTION
When we switched to sending assets as urls we missed the `overrideSources` scenario, which is used when a teacher is looking at student code or a student is peer-reviewing another student. In this scenario we did not pass the channel id of the original project, so any assets that the student uploaded were not available to javabuilder. This fix includes the original channel id in the request so we can send the appropriate urls to javabuilder.

## Links

- jira ticket: [SL-313](https://codedotorg.atlassian.net/browse/SL-313)
- [slack discussion](https://codedotorg.slack.com/archives/C03DBDN67B7/p1666101508728619)

## Testing story
Tested locally against javabuilder-test and localhost javabuilder. I was able to reproduce the error on both systems and see it resolved with the fix. I wanted to test against an adhoc to fully test against javabuilder-test (as javabuilder-test against localhost cannot get localhost assets, and returns a default image instead), but adhocs are currently broken. However, I am confident this will fix the issue because before the fix javabuilder-test returned a file not found exception, and after it returned the default image. Local javabuilder successfully got the original image.

