### PR TITLE
Display error from Bramble on EFILESYSTEMERROR

### DIFF
--- a/apps/i18n/weblab/en_us.json
+++ b/apps/i18n/weblab/en_us.json
@@ -6,7 +6,7 @@
   "disallowedHtml": "The file \"{filename}\" contains HTML elements that are not allowed: `{disallowedTags}`. They will be removed when this dialog is closed.",
   "errorSavingProject": "Something didn't work while auto-saving your project. Check your internet connection and try manually saving. If this problem persists, try reloading the page to start over.",
   "fatalError": "Fatal Error: {message}. If you're in Private Browsing mode, data can't be written.",
-  "loadFailure": "We're sorry, Web Lab failed to load for some reason.",
+  "loadFailure": "We're sorry, Web Lab failed to load for some reason. Error: {message}",
   "refreshPreview": "Refresh and Save",
   "reloading": "Reloading...",
   "reset": "Reset Web Lab",

--- a/apps/src/weblab/WebLab.js
+++ b/apps/src/weblab/WebLab.js
@@ -590,7 +590,7 @@ WebLab.prototype.openFatalErrorDialog = function(
 
   let errorMessage = weblabI18n.fatalError({message});
   if (type === FatalErrorType.LoadFailure) {
-    errorMessage = weblabI18n.loadFailure();
+    errorMessage = weblabI18n.loadFailure({message});
   } else if (type === FatalErrorType.ResetFailure) {
     errorMessage = weblabI18n.resetFailure({message});
   }


### PR DESCRIPTION
Multiple classrooms are running into the same error in Weblab, which Bramble hands to us as `EFILESYSTEMERROR`. Up to this point, we would display a generic dialog when we hit this error, but many teachers are hitting this and they aren't able to see the JS console (it's disabled on their school computers), so we're going to display the message that Bramble hands us as well:

<img width="721" alt="Screen Shot 2022-10-19 at 1 30 35 PM" src="https://user-images.githubusercontent.com/9812299/196797950-48b71077-a0a0-44af-a883-948393b18b77.png">

In my fake example above, Bramble hands us an error of type EFILESYSTEMERROR with the message "cannot access."