### PR TITLE
Decorative Images with Blank Alt Text

### DIFF
--- a/pegasus/sites.v3/code.org/public/help.md
+++ b/pegasus/sites.v3/code.org/public/help.md
@@ -92,7 +92,7 @@ Volunteer to teach the Hour of Code or be a guest speaker in a local classroom. 
 ### Volunteer weekly with these great organizations
 [col-33]
 
-<img src="/images/fit-300/teals/quincy.jpg" style="border-radius: 5px; margin-left: 0px;">
+<img src="/images/fit-300/teals/quincy.jpg" style="border-radius: 5px; margin-left: 0px;" alt="">
 
 [/col-33]
 

--- a/pegasus/sites.v3/code.org/views/stats_advocate_locally.haml
+++ b/pegasus/sites.v3/code.org/views/stats_advocate_locally.haml
@@ -1,7 +1,7 @@
 %link{:href=>"/css/advocate-locally.css", :rel=>"stylesheet"}
 
 .join-coalition-wrapper
-  %img.left-side-image{src:"/images/fill-484x289/promote/promote-advocacy-students.jpg"}
+  %img.left-side-image{src:"/images/fill-484x289/promote/promote-advocacy-students.jpg", alt:""}
   .right
     %p.title
       Advocate for State and Federal Policy


### PR DESCRIPTION
Adding blank alt text on two images because they are decorative images and do not convey information.

![Screenshot from 2022-10-19 13-35-37](https://user-images.githubusercontent.com/2959170/196798645-1d2bf126-773c-4677-b6dc-f2f5f5c0c109.png)
![Screenshot from 2022-10-19 13-35-19](https://user-images.githubusercontent.com/2959170/196798650-9b5493de-5cae-4d25-93e4-6aad77fb59b4.png)
