### PR TITLE
Customize hoc congrats certificate

### DIFF
--- a/apps/src/sites/studio/pages/congrats/index.js
+++ b/apps/src/sites/studio/pages/congrats/index.js
@@ -32,7 +32,8 @@ $(document).ready(function() {
   try {
     const params = queryString.parse(window.location.search);
     certificateId = params['i'] && params['i'].replace(/[^a-z0-9_]/g, '');
-    tutorial = atob(params['s']).replace(/[^A-Za-z0-9_\- ]/g, '');
+    const s = params['s'];
+    tutorial = s ? atob(s).replace(/[^A-Za-z0-9_\- ]/g, '') : 'hourofcode';
   } catch (e) {}
 
   const mcShareLink = tryGetLocalStorage('craftHeroShareLink', '');

--- a/apps/src/templates/certificates/Certificate.jsx
+++ b/apps/src/templates/certificates/Certificate.jsx
@@ -33,7 +33,7 @@ function Certificate(props) {
   const nameInputRef = useRef(null);
 
   const personalizeCertificate = session => {
-    if (isHocTutorial) {
+    if (isHocTutorial && session) {
       personalizeHocCertificate(session);
     } else {
       setStudentName(nameInputRef.current.value);
@@ -94,7 +94,6 @@ function Certificate(props) {
     isHocTutorial
   } = props;
 
-  const certificate = certificateId || 'blank';
   const personalizedCertificate = getCertificateImagePath();
   const imgSrc = personalized
     ? personalizedCertificate
@@ -149,7 +148,7 @@ function Certificate(props) {
             <button
               type="button"
               style={styles.submit}
-              onClick={personalizeCertificate.bind(this, certificate)}
+              onClick={personalizeCertificate.bind(this, certificateId)}
             >
               {i18n.submit()}
             </button>

--- a/dashboard/test/ui/features/hour_of_code/hour_of_code_finish.feature
+++ b/dashboard/test/ui/features/hour_of_code/hour_of_code_finish.feature
@@ -92,6 +92,25 @@ Scenario: Course A 2017 uncustomized dashboard certificate pages
   And I wait until current URL contains "/print_certificates/"
   Then I wait to see an image "/certificate_images/"
 
+Scenario: customized dashboard certificate pages with no course name
+  Given I am on "http://studio.code.org/congrats"
+  And I wait to see element with ID "uitest-certificate"
+  Then the href of selector ".social-print-link" contains "/print_certificates/"
+  Then I wait to see an image "/images/hour_of_code_certificate.jpg"
+
+  When I type "Robo Códer" into "#name"
+  And I press "button:contains(Submit)" using jQuery
+  And I wait to see element with ID "uitest-thanks"
+  Then I wait to see an image "/certificate_images/"
+
+  When I press the first "#uitest-certificate img" element to load a new page
+  And I wait until current URL contains "/certificates/"
+  Then I wait to see an image "/certificate_images/"
+
+  When I press the first "#certificate-share img" element to load a new page
+  And I wait until current URL contains "/print_certificates/"
+  Then I wait to see an image "/certificate_images/"
+
 @eyes
 Scenario: congrats certificate pages
   Given I am on "http://studio.code.org/congrats"


### PR DESCRIPTION
follow-on to https://github.com/code-dot-org/code-dot-org/pull/48712 . Makes it possible for students to add their name to a generic "Hour of Code" certificate on https://studio.code.org/congrats . This fixes user flow for links like https://code.org/api/hour/finish/kodable_hero, which take you to https://studio.code.org/congrats . This issue was a regression as part of moving congrats pages to dashboard -- we didn't realize anyone was using https://studio.code.org/congrats without a course name encoded into the `s` param.

## Screenshots

### before
![Screen Shot 2022-10-19 at 2 42 40 PM](https://user-images.githubusercontent.com/8001765/196810391-1806b038-4820-4fb9-9bfd-eb44a939053b.png)

### after
saucelabs video from new ui test:

https://user-images.githubusercontent.com/8001765/196810460-bc39ad3a-7a35-4f80-a647-696384d47aff.mp4

## Testing story

new ui test