### PR TITLE
Add alt-text on logo home

### DIFF
--- a/dashboard/app/views/layouts/_logo.html.haml
+++ b/dashboard/app/views/layouts/_logo.html.haml
@@ -1,6 +1,6 @@
 %div{id: 'main-logo'}
   %div{id: 'logo-container'}
     - if current_user
-      = link_to(image_tag('logo.svg'), '/home', {id: "logo-img"})
+      = link_to(image_tag('logo.svg'), '/home', {id: "logo-img", alt: I18n.t(:code_org_logo_alt)})
     - else
-      = link_to(image_tag('logo.svg'), CDO.code_org_url, {id: "logo-img"})
+      = link_to(image_tag('logo.svg'), CDO.code_org_url, {id: "logo-img", alt: I18n.t(:code_org_logo_alt)})

--- a/pegasus/sites.v3/code.org/views/header.haml
+++ b/pegasus/sites.v3/code.org/views/header.haml
@@ -41,10 +41,10 @@
           #logo-wrapper
             - if current_user
               %a.linktag#logo-signedin{:href=>CDO.studio_url("/home")}
-                %img#logo{:src=>'/images/logo.svg'}
+                %img#logo{:src=>'/images/logo.svg', alt: I18n.t(:code_org_logo_alt)}
             - else
               %a.linktag#logo-signedout{:href=>CDO.code_org_url}
-                %img#logo{:src=>'/images/logo.svg'}
+                %img#logo{:src=>'/images/logo.svg', alt: I18n.t(:code_org_logo_alt)}
           #headerlinks.desktop-feature
             - Hamburger.get_header_contents(header_contents_options).each do |entry|
               %a.headerlink.linktag{id: entry[:id], href: entry[:url]}= entry[:title]

--- a/pegasus/sites.v3/code.org/views/mobile_header_responsive.haml
+++ b/pegasus/sites.v3/code.org/views/mobile_header_responsive.haml
@@ -10,7 +10,7 @@
     .container_responsive
       #left
         %a{:href=>'/'}
-          %img#logo{:src=>'/images/logo.svg'}
+          %img#logo{:src=>'/images/logo.svg', alt: I18n.t(:code_org_logo_alt)}
 
       - if request.language == "en"
         = view :hamburger, user_type: user_type, level: nil, script_level: nil, language: request.language, show_gallery: false, loc_prefix: "header_"

--- a/pegasus/sites/all/views/mobile_header_responsive.haml
+++ b/pegasus/sites/all/views/mobile_header_responsive.haml
@@ -4,4 +4,4 @@
   .content
     #left
       %a{:href=>"/"}
-        %img#logo{:src=>'/images/logo.svg'}
+        %img#logo{:src=>'/images/logo.svg', alt: I18n.t(:code_org_logo_alt)}

--- a/pegasus/sites/code.org/views/page_header.haml
+++ b/pegasus/sites/code.org/views/page_header.haml
@@ -3,7 +3,7 @@
     .content{style: "padding-left: 10px"}
       #left
         %a{:href=>"/"}
-          %img#logo{:src=>'/images/logo.svg', style: "height: 42px; padding-left: 16px; padding-top: 4px; box-sizing: content-box"}
+          %img#logo{:src=>'/images/logo.svg', alt: I18n.t(:code_org_logo_alt), style: "height: 42px; padding-left: 16px; padding-top: 4px; box-sizing: content-box"}
     #clear{:style=>'clear:both'}
 
 :javascript


### PR DESCRIPTION
In places where we use the Code.org logo as a "Home" button, this adds alt-text to the logos. We were doing this in [some places already](https://github.com/code-dot-org/code-dot-org/blob/dbb2897d2c7bf0ce6ada6ecb0c1bc111368fa641/dashboard/app/views/layouts/_header.html.haml#L75), so we just extend that policy here.

In particular, this impacts the code.org homepage. Currently, my screen-reader reads the logo as "To get missing image descriptions open the context menu link" or "visited link" (depending on if I've clicked on the logo yet). Now the logo is read as "Code.org Home link" or "Code.org Home visited link".