### PR TITLE
Adding empty alt text to Professional Learning page

### DIFF
--- a/pegasus/sites.v3/code.org/public/educate/professional-learning.md.erb
+++ b/pegasus/sites.v3/code.org/public/educate/professional-learning.md.erb
@@ -16,7 +16,7 @@ video_player: true
 
 <div class="col-50">
 	<a href="/professional-development-workshops">
-		<img src="/images/k5-pl.jpg" width="95%"/>
+		<img src="/images/k5-pl.jpg" width="95%" alt=""/>
 	</a>
 	<a href="/professional-development-workshops" style='text-decoration:none'>
 		<button>I teach elementary school</button>
@@ -26,7 +26,7 @@ video_player: true
 
 <div class="col-50">
 	<a href="/educate/professional-learning/middle-high">
-		<img src="/images/mid-high-pl.jpg" width="95%"/>
+		<img src="/images/mid-high-pl.jpg" width="95%" alt=""/>
 	</a>
 	<a href="/educate/professional-learning/middle-high" style='text-decoration:none'>
 		<button>I teach middle or high school</button>


### PR DESCRIPTION
There are two decorative images on this page, and neither has alt text. This PR adds it!

<img width="1186" alt="Screen Shot 2022-10-19 at 2 56 09 PM" src="https://user-images.githubusercontent.com/37230822/196812432-46d55b95-cfda-4d6e-9238-b3300c5d52f6.png">


## Links


- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/LP-3059


## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
