### PR TITLE
Fix Violations of and Reenable `Style/SingleArgumentDig`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -641,11 +641,6 @@ Style/RescueModifier:
 Style/RescueStandardError:
   Enabled: false
 
-# Offense count: 17
-# This cop supports unsafe auto-correction (--auto-correct-all).
-Style/SingleArgumentDig:
-  Enabled: false
-
 # Offense count: 38
 # This cop supports unsafe auto-correction (--auto-correct-all).
 Style/SlicingWithRange:

--- a/dashboard/app/models/pd/enrollment.rb
+++ b/dashboard/app/models/pd/enrollment.rb
@@ -309,7 +309,7 @@ class Pd::Enrollment < ApplicationRecord
   # workshop id
   # @return [Integer, nil] application id or nil if cannot find any application
   def set_application_id
-    course_match = ->(application) {Pd::Application::ApplicationBase::COURSE_NAME_MAP.dig(application.try(:course)&.to_sym) == workshop.try(:course)}
+    course_match = ->(application) {Pd::Application::ApplicationBase::COURSE_NAME_MAP[application.try(:course)&.to_sym] == workshop.try(:course)}
     pd_match = ->(application) {application.try(:pd_workshop_id) == pd_workshop_id}
 
     application_id = nil

--- a/dashboard/lib/pd/survey_pipeline/helper.rb
+++ b/dashboard/lib/pd/survey_pipeline/helper.rb
@@ -156,9 +156,9 @@ module Pd::SurveyPipeline::Helper
 
     # Rules to map groups of survey answers to reducers
     is_single_select_answer =
-      lambda {|hash| [ANSWER_SINGLE_SELECT, ANSWER_SCALE].include? hash.dig(:answer_type)}
+      lambda {|hash| [ANSWER_SINGLE_SELECT, ANSWER_SCALE].include? hash[:answer_type]}
     not_single_select_answer =
-      lambda {|hash| ![ANSWER_SINGLE_SELECT, ANSWER_SCALE].include?(hash.dig(:answer_type))}
+      lambda {|hash| ![ANSWER_SINGLE_SELECT, ANSWER_SCALE].include?(hash[:answer_type])}
 
     map_config = [
       {condition: is_single_select_answer, field: :answer, reducers: [Pd::SurveyPipeline::Reducer::Histogram]},

--- a/dashboard/test/controllers/pd/application/teacher_application_controller_test.rb
+++ b/dashboard/test/controllers/pd/application/teacher_application_controller_test.rb
@@ -42,9 +42,9 @@ module Pd::Application
       assert_template :new
 
       @script_data = assigns(:script_data)
-      assert_equal application.id, JSON.parse(@script_data.dig(:props)).dig('applicationId')
-      assert_equal application.form_data, JSON.parse(@script_data.dig(:props)).dig('savedFormData')
-      assert_equal application.status, JSON.parse(@script_data.dig(:props)).dig('savedStatus')
+      assert_equal application.id, JSON.parse(@script_data[:props])['applicationId']
+      assert_equal application.form_data, JSON.parse(@script_data[:props])['savedFormData']
+      assert_equal application.status, JSON.parse(@script_data[:props])['savedStatus']
     end
 
     test 'teachers with a reopened application have an application id and saved form data' do
@@ -57,8 +57,8 @@ module Pd::Application
       assert_template :new
 
       @script_data = assigns(:script_data)
-      assert_equal application.id, JSON.parse(@script_data.dig(:props)).dig('applicationId')
-      assert_equal application.form_data, JSON.parse(@script_data.dig(:props)).dig('savedFormData')
+      assert_equal application.id, JSON.parse(@script_data[:props])['applicationId']
+      assert_equal application.form_data, JSON.parse(@script_data[:props])['savedFormData']
     end
 
     test 'teachers without an application have no id nor form data' do
@@ -68,8 +68,8 @@ module Pd::Application
       assert_template :new
 
       @script_data = assigns(:script_data)
-      assert_nil JSON.parse(@script_data.dig(:props)).dig('applicationId')
-      assert_nil JSON.parse(@script_data.dig(:props)).dig('savedFormData')
+      assert_nil JSON.parse(@script_data[:props])['applicationId']
+      assert_nil JSON.parse(@script_data[:props])['savedFormData']
     end
   end
 end


### PR DESCRIPTION
This is a simple one; quoting from [the documentation](https://www.rubydoc.info/gems/rubocop/1.13.0/RuboCop/Cop/Style/SingleArgumentDig):

> Sometimes using dig method ends up with just a single argument. In such cases, dig should be replaced with [].

Fix was applied automatically with `bundle exec rubocop --auto-correct-all --only Style/SingleArgumentDig`

- https://docs.rubocop.org/rubocop/cops_style.html#stylesingleargumentdig
- https://www.rubydoc.info/gems/rubocop/1.13.0/RuboCop/Cop/Style/SingleArgumentDig

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
