### PR TITLE
Make empty string default for altText prop

### DIFF
--- a/apps/src/templates/VerticalImageResourceCard.jsx
+++ b/apps/src/templates/VerticalImageResourceCard.jsx
@@ -14,6 +14,7 @@ import Button from './Button';
 
 class VerticalImageResourceCard extends Component {
   static propTypes = {
+    altText: PropTypes.string,
     title: PropTypes.string.isRequired,
     description: PropTypes.string.isRequired,
     buttonText: PropTypes.string.isRequired,
@@ -26,6 +27,7 @@ class VerticalImageResourceCard extends Component {
 
   render() {
     const {
+      altText,
       title,
       description,
       link,
@@ -84,7 +86,7 @@ class VerticalImageResourceCard extends Component {
       <div style={cardStyle}>
         <div style={imageStyle}>
           <a href={link}>
-            <img src={imgSrc} alt={title} />
+            <img src={imgSrc} alt={altText} />
           </a>
         </div>
         <div>
@@ -113,6 +115,10 @@ class VerticalImageResourceCard extends Component {
     );
   }
 }
+
+VerticalImageResourceCard.defaultProps = {
+  altText: ''
+};
 
 const styles = {
   card: {

--- a/apps/src/templates/studioHomepages/CourseCard.jsx
+++ b/apps/src/templates/studioHomepages/CourseCard.jsx
@@ -13,6 +13,7 @@ import PurpleHeader from '@cdo/static/small_purple_icons.png';
  */
 class CourseCard extends Component {
   static propTypes = {
+    altText: PropTypes.string,
     title: PropTypes.string.isRequired,
     description: PropTypes.string.isRequired,
     link: PropTypes.string.isRequired,
@@ -22,6 +23,7 @@ class CourseCard extends Component {
 
   render() {
     const {
+      altText,
       title,
       description,
       link,
@@ -35,7 +37,7 @@ class CourseCard extends Component {
         <img
           src={isProfessionalLearningCourse ? BlueHeader : PurpleHeader}
           style={styles.image}
-          alt=""
+          alt={altText}
         />
         <div style={isRtl ? styles.titleRtl : styles.title}>{title}</div>
         <div style={styles.description}>
@@ -52,6 +54,10 @@ class CourseCard extends Component {
     );
   }
 }
+
+CourseCard.defaultProps = {
+  altText: ''
+};
 
 const styles = {
   card: {

--- a/apps/src/templates/studioHomepages/ImageResourceCard.jsx
+++ b/apps/src/templates/studioHomepages/ImageResourceCard.jsx
@@ -6,6 +6,7 @@ import color from '../../util/color';
 
 class ImageResourceCard extends Component {
   static propTypes = {
+    altText: PropTypes.string,
     title: PropTypes.string.isRequired,
     callout: PropTypes.string,
     description: PropTypes.string.isRequired,
@@ -20,7 +21,15 @@ class ImageResourceCard extends Component {
   }
 
   render() {
-    const {title, callout, description, buttonText, link, isRtl} = this.props;
+    const {
+      altText,
+      title,
+      callout,
+      description,
+      buttonText,
+      link,
+      isRtl
+    } = this.props;
 
     return (
       <div style={{...styles.card, ...(isRtl && styles.rtl)}}>
@@ -44,11 +53,15 @@ class ImageResourceCard extends Component {
             style={styles.button}
           />
         </div>
-        <img style={styles.image} src={this.getImage()} />
+        <img style={styles.image} src={this.getImage()} alt={altText} />
       </div>
     );
   }
 }
+
+ImageResourceCard.defaultProps = {
+  altText: ''
+};
 
 const styles = {
   card: {


### PR DESCRIPTION
After listening to just how bad our images sound when there is no alt text provided ...

https://user-images.githubusercontent.com/9142121/197048380-c3d6ad65-25e7-4c7c-b3c9-b88e54b3e76b.mov

I've made the empty string the default alt text for the components I could find that have images. Are there others you know of? Now the default sounds like this:

https://user-images.githubusercontent.com/9142121/197048676-d572504e-cd7b-4937-9ca8-aa5554851b8c.mov


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
