### PR TITLE
Advocacy: speculative fix for missing map (fourth attempt)

### DIFF
--- a/pegasus/sites.v3/code.org/public/js/extended_us_map.js
+++ b/pegasus/sites.v3/code.org/public/js/extended_us_map.js
@@ -798,11 +798,23 @@ $(document).ready(function () {
   initExtendedMap();
 });
 
+// NOTE: This is not a good pattern to replicate, but is a workaround
+// for an issue with loading Raphael before attempting to render the map.
+// A better implementation would move this code to /apps/src.
+
+let initAttemptsRemaining = 10;
+
 function initExtendedMap() {
-  if (Raphael) {
+  if (initAttemptsRemaining === 0) {
+    return;
+  }
+
+  initAttemptsRemaining --;
+
+  if (typeof Raphael !== 'undefined') {
     renderMap();
   } else {
-    setTimeout(initExtendedMap, 100);
+    setTimeout(initExtendedMap, 1000);
   }
 };
 

--- a/pegasus/sites.v3/code.org/public/js/extended_us_map.js
+++ b/pegasus/sites.v3/code.org/public/js/extended_us_map.js
@@ -795,18 +795,18 @@ document.addEventListener("DOMContentLoaded", function() {
 });
 
 $(document).ready(function () {
-  init();
+  initExtendedMap();
 });
 
-function init() {
+function initExtendedMap() {
   if (Raphael) {
-    initMap();
+    renderMap();
   } else {
-    setTimeout(init, 100);
+    setTimeout(initExtendedMap, 100);
   }
 };
 
-function initMap() {
+function renderMap() {
   setupMapDrawing(jQuery, document, window, Raphael);
 
   if (useUrl) {

--- a/pegasus/sites.v3/code.org/public/js/extended_us_map.js
+++ b/pegasus/sites.v3/code.org/public/js/extended_us_map.js
@@ -789,7 +789,24 @@ function setupMapDrawing($, document, window, Raphael, undefined) {
 
 var webServiceLocation = "/promote/state/";
 
+// Just adding this handler to assist with debugging on production.
+document.addEventListener("DOMContentLoaded", function() {
+  console.log("DOMContentLoaded");
+});
+
 $(document).ready(function () {
+  init();
+});
+
+function init() {
+  if (Raphael) {
+    initMap();
+  } else {
+    setTimeout(init, 100);
+  }
+};
+
+function initMap() {
   setupMapDrawing(jQuery, document, window, Raphael);
 
   if (useUrl) {
@@ -877,7 +894,7 @@ $(document).ready(function () {
       $("#" + state.toUpperCase()).click();
     }
   }
-});
+}
 
 // When the user uses the "back" button, load previous data into infobox and URL bar
 window.onpopstate = function (event) {


### PR DESCRIPTION
The interactive map continues to sometimes fail to render at https://advocacy.code.org on production.  With just a few reloads on Chrome we see it both load and fail.  This doesn't seem to reproduce in non-production environments.

This is a fourth attempt at fixing the missing map, with the prior attempt in https://github.com/code-dot-org/code-dot-org/pull/48708.

### Failure case

In the failure case, the following happens:

In `extended_us_map.js`, we get a `$(document).ready`.  (The `document.readyState` is `"interactive"`.)

But `window.Raphael` is not yet set. That occurs shortly afterwards.  What is confusing to me is that the callstack [when it's set](https://github.com/DmitryBaranovskiy/raphael/blame/2b0c5a21127dc8a9f25ffb0fe68d883f51435061/raphael.core.js#L4707) does not appear to be deferred in any way, but is simply a few calls deep from the top-level function call in the file.  For that reason, I'd have expected it to complete this code before executing any of the code in `extended_us_map.js`, since it's [loaded](https://github.com/code-dot-org/code-dot-org/blob/4895030bdc15c4f62d0c66542303c762e93fbbef/pegasus/sites.v3/code.org/views/interactive_map.haml#L64-L65) in the next `<script>` tag to the Raphael one.

As a result, we get an `Uncaught ReferenceError: Raphael is not defined`.

(Intriguingly, Raphael does have [some code](https://github.com/DmitryBaranovskiy/raphael/blame/2b0c5a21127dc8a9f25ffb0fe68d883f51435061/raphael.core.js#L4702) that defers some further work until the `document.readyState` is `"complete"`, setting a timeout if it's `"loading"` or `"interactive"`, but that doesn't seem to delay the simple operation of setting `window.Raphael`).


### Success case

In the success case, the following happens:

Raphael gets to set `window.Raphael`.  (The `document.readyState` is `"interactive"` at that point.)  

In `extended_us_map.js`, we get a `$(document).ready`.  We can use `window.Raphael` successfully.


## A simple fix

To get things working, this fix uses a technique inspired by Raphael's own handling of `document.readyState`, with a series of timer-based retries.  If we get a `$(document).ready` in `extended_us_map.js`, but Raphael is not yet available, we just set a timer to check again a while later, and keep doing this until `window.Raphael` is ready and we can continue.  It's not the most satisfying fix, but hopefully will get the map back in all page loads.

## Gathering extra information

Separately, the fix adds a bit of console logging to see whether a more finessed solution might be possible.  It seems that `<script>`-based code should have completed executing when we get a `DOMContentLoaded` event, so we might be able to depend on that event rather than using timer-based retries.  So, we now register a handler for this event.  It doesn't output much right now, but it's enough that we can add Chrome [logpoints](https://developer.chrome.com/blog/new-in-devtools-73/#logpoints) to understand when this event can be successfully registered, when it fires, and what the state of `window.Raphael` is at that point.

`DOMContentLoaded` seems straightforward, but the lengthy discussions on some of these posts imply some nuance and inconsistency around when it's too late to register for it, when it fires related to `document.readyState` changes, and I'm still not sure whether it will solve our `window.Raphael` problem anyway.

- https://stackoverflow.com/questions/1206937/javascript-domready
- https://stackoverflow.com/questions/9237044/async-loaded-scripts-with-domcontentloaded-or-load-event-handlers-not-being-call
- https://stackoverflow.com/questions/13346746/document-readystate-on-domcontentloaded
