### PR TITLE
Update `json` Gem to 2.6.2

### DIFF
--- a/cookbooks/Gemfile.lock
+++ b/cookbooks/Gemfile.lock
@@ -140,7 +140,7 @@ GEM
       train (~> 0.32)
     ipaddress (0.8.3)
     jmespath (1.3.1)
-    json (2.1.0)
+    json (2.6.2)
     kitchen-docker (2.6.0)
       test-kitchen (>= 1.0.0)
     kitchen-dokken (2.6.6)


### PR DESCRIPTION
Specifically, the `json` gem used by our cookbooks, and to pick up support for Ruby 2.7, which was added in 2.3.0

Addresses the deprecation warning `/home/elijah/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/json-2.1.0/lib/json/common.rb:156: warning: Using the last argument as keyword parameters is deprecated`

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

https://github.com/flori/json/blob/master/CHANGES.md#2019-12-11-230

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
