### PR TITLE
Translating TeacherDashboard.jsx into a functional component

### DIFF
--- a/apps/src/templates/teacherDashboard/TeacherDashboard.jsx
+++ b/apps/src/templates/teacherDashboard/TeacherDashboard.jsx
@@ -1,4 +1,4 @@
-import React, {useEffect} from 'react';
+import React, {useEffect, useRef} from 'react';
 import PropTypes from 'prop-types';
 import {Route, Switch} from 'react-router-dom';
 import TeacherDashboardNavigation, {
@@ -28,8 +28,8 @@ function TeacherDashboard({
   location
 }) {
   const usePrevious = value => {
-    const ref = React.useRef();
-    React.useEffect(() => {
+    const ref = useRef();
+    useEffect(() => {
       ref.current = value;
     });
 
@@ -168,5 +168,4 @@ const styles = {
   }
 };
 
-export const UnconnectedTeacherDashboard = TeacherDashboard;
 export default TeacherDashboard;

--- a/apps/src/templates/teacherDashboard/TeacherDashboard.jsx
+++ b/apps/src/templates/teacherDashboard/TeacherDashboard.jsx
@@ -1,4 +1,4 @@
-import React, {Component} from 'react';
+import React, {useEffect} from 'react';
 import PropTypes from 'prop-types';
 import {Route, Switch} from 'react-router-dom';
 import TeacherDashboardNavigation, {
@@ -19,142 +19,146 @@ import StandardsReport from '../sectionProgress/standards/StandardsReport';
 import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
 import i18n from '@cdo/locale';
 
-class TeacherDashboard extends Component {
-  static propTypes = {
-    studioUrlPrefix: PropTypes.string.isRequired,
-    sectionId: PropTypes.number.isRequired,
-    sectionName: PropTypes.string.isRequired,
-    studentCount: PropTypes.number.isRequired,
-    coursesWithProgress: PropTypes.array.isRequired,
+function TeacherDashboard({
+  studioUrlPrefix,
+  sectionId,
+  sectionName,
+  studentCount,
+  coursesWithProgress,
+  location
+}) {
+  const usePrevious = value => {
+    const ref = React.useRef();
+    React.useEffect(() => {
+      ref.current = value;
+    });
 
-    // Provided by React router in parent.
-    location: PropTypes.object.isRequired
+    return ref.current;
   };
 
-  componentDidUpdate(prevProps, prevState, snapshot) {
-    const previousTab = _.last(_.split(prevProps.location.pathname, '/'));
-    const newTab = _.last(_.split(this.props.location.pathname, '/'));
+  const useLocationChange = action => {
+    const prevLocation = usePrevious(location);
+    useEffect(() => {
+      if (prevLocation) {
+        action(location, prevLocation);
+      }
+    }, [prevLocation]);
+  };
 
+  useLocationChange((location, prevLocation) => {
+    const previousTab = _.last(_.split(prevLocation.pathname, '/'));
+    const newTab = _.last(_.split(location.pathname, '/'));
     // Log if we switched tabs in the teacher dashboard
-    if (prevProps.location !== this.props.location) {
-      firehoseClient.putRecord(
-        {
-          study: 'teacher_dashboard_actions',
-          study_group: previousTab,
-          event: 'click_new_tab',
-          data_json: JSON.stringify({
-            section_id: this.props.sectionId,
-            new_tab: newTab
-          })
-        },
-        {includeUserId: true}
-      );
-    }
+    firehoseClient.putRecord(
+      {
+        study: 'teacher_dashboard_actions',
+        study_group: previousTab,
+        event: 'click_new_tab',
+        data_json: JSON.stringify({
+          section_id: sectionId,
+          new_tab: newTab
+        })
+      },
+      {includeUserId: true}
+    );
+  });
+
+  // Select a default tab if current path doesn't match one of the paths in our TeacherDashboardPath type.
+  const emptyOrInvalidPath = !Object.values(TeacherDashboardPath).includes(
+    location.pathname
+  );
+  if (emptyOrInvalidPath && studentCount === 0) {
+    // Default to the Manage Students tab if section has 0 students.
+    location.pathname = TeacherDashboardPath.manageStudents;
+  } else if (emptyOrInvalidPath) {
+    // Default to the Progress tab if section otherwise.
+    location.pathname = TeacherDashboardPath.progress;
   }
 
-  render() {
-    const {
-      location,
-      studioUrlPrefix,
-      sectionId,
-      sectionName,
-      studentCount,
-      coursesWithProgress
-    } = this.props;
+  // Include header components unless we are on the /login_info or /standards_report page.
+  const includeHeader =
+    location.pathname !== TeacherDashboardPath.loginInfo &&
+    location.pathname !== TeacherDashboardPath.standardsReport;
 
-    // Select a default tab if current path doesn't match one of the paths in our TeacherDashboardPath type.
-    const emptyOrInvalidPath = !Object.values(TeacherDashboardPath).includes(
-      location.pathname
-    );
-    if (emptyOrInvalidPath && studentCount === 0) {
-      // Default to the Manage Students tab if section has 0 students.
-      location.pathname = TeacherDashboardPath.manageStudents;
-    } else if (emptyOrInvalidPath) {
-      // Default to the Progress tab if section otherwise.
-      location.pathname = TeacherDashboardPath.progress;
-    }
-
-    // Include header components unless we are on the /login_info or /standards_report page.
-    const includeHeader =
-      location.pathname !== TeacherDashboardPath.loginInfo &&
-      location.pathname !== TeacherDashboardPath.standardsReport;
-
-    return (
-      <div>
-        {includeHeader && (
-          <div>
-            {/* TeacherDashboardNavigation must be outside of
+  return (
+    <div>
+      {includeHeader && (
+        <div>
+          {/* TeacherDashboardNavigation must be outside of
             TeacherDashboardHeader. Routing components do not work with
             components using Connect/Redux. Library we could use to fix issue:
             https://github.com/supasate/connected-react-router */}
-            <TeacherDashboardHeader />
-            <TeacherDashboardNavigation />
-          </div>
+          <TeacherDashboardHeader />
+          <TeacherDashboardNavigation />
+        </div>
+      )}
+      <Switch>
+        <Route
+          path={TeacherDashboardPath.manageStudents}
+          component={props => (
+            <ManageStudents studioUrlPrefix={studioUrlPrefix} />
+          )}
+        />
+        <Route
+          path={TeacherDashboardPath.loginInfo}
+          component={props => (
+            <SectionLoginInfo studioUrlPrefix={studioUrlPrefix} />
+          )}
+        />
+        <Route
+          path={TeacherDashboardPath.standardsReport}
+          component={props => <StandardsReport />}
+        />
+        {/* Break out of Switch if we have 0 students. Display EmptySection component instead. */}
+        {studentCount === 0 && (
+          <Route component={props => <EmptySection sectionId={sectionId} />} />
         )}
-        <Switch>
-          <Route
-            path={TeacherDashboardPath.manageStudents}
-            component={props => (
-              <ManageStudents studioUrlPrefix={studioUrlPrefix} />
-            )}
-          />
-          <Route
-            path={TeacherDashboardPath.loginInfo}
-            component={props => (
-              <SectionLoginInfo studioUrlPrefix={studioUrlPrefix} />
-            )}
-          />
-          <Route
-            path={TeacherDashboardPath.standardsReport}
-            component={props => <StandardsReport />}
-          />
-          {/* Break out of Switch if we have 0 students. Display EmptySection component instead. */}
-          {studentCount === 0 && (
-            <Route
-              component={props => <EmptySection sectionId={sectionId} />}
-            />
+        <Route
+          path={TeacherDashboardPath.projects}
+          component={props => (
+            <SectionProjectsListWithData studioUrlPrefix={studioUrlPrefix} />
           )}
+        />
+        <Route
+          path={TeacherDashboardPath.stats}
+          component={props => <StatsTableWithData />}
+        />
+        {coursesWithProgress.length === 0 && (
           <Route
-            path={TeacherDashboardPath.projects}
-            component={props => (
-              <SectionProjectsListWithData studioUrlPrefix={studioUrlPrefix} />
+            component={() => (
+              <div style={styles.text}>
+                <SafeMarkdown markdown={i18n.noProgressSection()} />
+              </div>
             )}
           />
-          <Route
-            path={TeacherDashboardPath.stats}
-            component={props => <StatsTableWithData />}
-          />
-          {coursesWithProgress.length === 0 && (
-            <Route
-              component={() => (
-                <div style={styles.text}>
-                  <SafeMarkdown markdown={i18n.noProgressSection()} />
-                </div>
-              )}
-            />
-          )}
-          <Route
-            path={TeacherDashboardPath.progress}
-            component={props => <SectionProgress />}
-          />
-          <Route
-            path={TeacherDashboardPath.textResponses}
-            component={props => <TextResponses />}
-          />
-          <Route
-            path={TeacherDashboardPath.assessments}
-            component={props => (
-              <SectionAssessments sectionName={sectionName} />
-            )}
-          />
-        </Switch>
-      </div>
-    );
-  }
+        )}
+        <Route
+          path={TeacherDashboardPath.progress}
+          component={props => <SectionProgress />}
+        />
+        <Route
+          path={TeacherDashboardPath.textResponses}
+          component={props => <TextResponses />}
+        />
+        <Route
+          path={TeacherDashboardPath.assessments}
+          component={props => <SectionAssessments sectionName={sectionName} />}
+        />
+      </Switch>
+    </div>
+  );
 }
 
-export const UnconnectedTeacherDashboard = TeacherDashboard;
-export default TeacherDashboard;
+TeacherDashboard.propTypes = {
+  studioUrlPrefix: PropTypes.string.isRequired,
+  sectionId: PropTypes.number.isRequired,
+  sectionName: PropTypes.string.isRequired,
+  studentCount: PropTypes.number.isRequired,
+  coursesWithProgress: PropTypes.array.isRequired,
+
+  // Provided by React router in parent.
+  location: PropTypes.object.isRequired
+};
 
 const styles = {
   text: {
@@ -163,3 +167,6 @@ const styles = {
     paddingTop: 10
   }
 };
+
+export const UnconnectedTeacherDashboard = TeacherDashboard;
+export default TeacherDashboard;

--- a/apps/test/unit/templates/teacherDashboard/TeacherDashboardTest.js
+++ b/apps/test/unit/templates/teacherDashboard/TeacherDashboardTest.js
@@ -38,41 +38,37 @@ describe('TeacherDashboard', () => {
 
   it('defaults to progress tab if no tab provided in route', () => {
     const location = {pathname: '/'};
-    const wrapper = shallow(
-      <TeacherDashboard {...DEFAULT_PROPS} location={location} />
-    );
-    expect(wrapper.instance().location.pathname).to.equal('/progress');
+    shallow(<TeacherDashboard {...DEFAULT_PROPS} location={location} />);
+    expect(location.pathname).to.equal('/progress');
   });
 
   it('defaults to progress tab if incorrect tab provided in route', () => {
     const location = {pathname: '/some_fake_path'};
-    const wrapper = shallow(
-      <TeacherDashboard {...DEFAULT_PROPS} location={location} />
-    );
-    expect(wrapper.instance().location.pathname).to.equal('/progress');
+    shallow(<TeacherDashboard {...DEFAULT_PROPS} location={location} />);
+    expect(location.pathname).to.equal('/progress');
   });
 
   it('defaults to manage students tab if no tab provided in route and section has 0 students', () => {
     const location = {pathname: '/'};
-    const wrapper = shallow(
+    shallow(
       <TeacherDashboard
         {...DEFAULT_PROPS}
         location={location}
         studentCount={0}
       />
     );
-    expect(wrapper.instance().location.pathname).to.equal('/manage_students');
+    expect(location.pathname).to.equal('/manage_students');
   });
 
   it('defaults to manage students tab if incorrect tab provided in route and section has 0 students', () => {
     const location = {pathname: '/some_fake_path'};
-    const wrapper = shallow(
+    shallow(
       <TeacherDashboard
         {...DEFAULT_PROPS}
         location={location}
         studentCount={0}
       />
     );
-    expect(wrapper.instance().location.pathname).to.equal('/manage_students');
+    expect(location.pathname).to.equal('/manage_students');
   });
 });

--- a/apps/test/unit/templates/teacherDashboard/TeacherDashboardTest.js
+++ b/apps/test/unit/templates/teacherDashboard/TeacherDashboardTest.js
@@ -71,4 +71,10 @@ describe('TeacherDashboard', () => {
     );
     expect(location.pathname).to.equal('/manage_students');
   });
+
+  it('does not override given path if there are students and path is legitimate', () => {
+    const location = {pathname: '/assessments'};
+    shallow(<TeacherDashboard {...DEFAULT_PROPS} location={location} />);
+    expect(location.pathname).to.equal('/assessments');
+  });
 });

--- a/apps/test/unit/templates/teacherDashboard/TeacherDashboardTest.js
+++ b/apps/test/unit/templates/teacherDashboard/TeacherDashboardTest.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import {shallow} from 'enzyme';
 import {expect} from '../../../util/reconfiguredChai';
-import {UnconnectedTeacherDashboard as TeacherDashboard} from '@cdo/apps/templates/teacherDashboard/TeacherDashboard';
+import TeacherDashboard from '@cdo/apps/templates/teacherDashboard/TeacherDashboard';
 import {fakeCoursesWithProgress} from '@cdo/apps/templates/teacherDashboard/teacherDashboardTestHelpers';
 
 const DEFAULT_PROPS = {

--- a/apps/test/unit/templates/teacherDashboard/TeacherDashboardTest.js
+++ b/apps/test/unit/templates/teacherDashboard/TeacherDashboardTest.js
@@ -41,7 +41,7 @@ describe('TeacherDashboard', () => {
     const wrapper = shallow(
       <TeacherDashboard {...DEFAULT_PROPS} location={location} />
     );
-    expect(wrapper.instance().props.location.pathname).to.equal('/progress');
+    expect(wrapper.instance().location.pathname).to.equal('/progress');
   });
 
   it('defaults to progress tab if incorrect tab provided in route', () => {
@@ -49,7 +49,7 @@ describe('TeacherDashboard', () => {
     const wrapper = shallow(
       <TeacherDashboard {...DEFAULT_PROPS} location={location} />
     );
-    expect(wrapper.instance().props.location.pathname).to.equal('/progress');
+    expect(wrapper.instance().location.pathname).to.equal('/progress');
   });
 
   it('defaults to manage students tab if no tab provided in route and section has 0 students', () => {
@@ -61,9 +61,7 @@ describe('TeacherDashboard', () => {
         studentCount={0}
       />
     );
-    expect(wrapper.instance().props.location.pathname).to.equal(
-      '/manage_students'
-    );
+    expect(wrapper.instance().location.pathname).to.equal('/manage_students');
   });
 
   it('defaults to manage students tab if incorrect tab provided in route and section has 0 students', () => {
@@ -75,8 +73,6 @@ describe('TeacherDashboard', () => {
         studentCount={0}
       />
     );
-    expect(wrapper.instance().props.location.pathname).to.equal(
-      '/manage_students'
-    );
+    expect(wrapper.instance().location.pathname).to.equal('/manage_students');
   });
 });


### PR DESCRIPTION
This PR translates the TeacherDashboard into a functional component! There shouldn't be any changes of the actual functionality of the page.

The trickiest part was handing the firehose logging, which requires access to the react router tab changes (prev and current, which are built into ComponentDidUpdate, but not the functional replacement useEffect()). I created a useEffect hook plus a couple helper functions for this. This is my first time using this kind of elaborate useEffect pattern, so some extra eyes here would be great!

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/LP-2447

## Testing story

I updated the TeacherDashboardTest file to check the location props sent in directly instead of trying to access an instance of the wrapper. 

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
