### PR TITLE
Display Version Year on Levels Page

### DIFF
--- a/apps/src/code-studio/components/SmallFooter.jsx
+++ b/apps/src/code-studio/components/SmallFooter.jsx
@@ -47,7 +47,7 @@ export default class SmallFooter extends React.Component {
     rowHeight: PropTypes.number,
     fullWidth: PropTypes.bool,
     channel: PropTypes.string,
-    scriptYear: PropTypes.string
+    unitYear: PropTypes.string
   };
 
   state = {
@@ -185,9 +185,9 @@ export default class SmallFooter extends React.Component {
       ...(this.props.fullWidth && styles.baseFullWidth)
     };
 
-    // Possible edge cases include scriptYear with value 'unversioned'.
+    // Possible edge cases include unitYear with value 'unversioned'.
     // Filter for year ('20XX') all-numeral format.
-    const yearIsNumeric = /^[0-9]+$/.test(this.props.scriptYear);
+    const yearIsNumeric = /^[0-9]+$/.test(this.props.unitYear);
 
     return (
       <div className={this.props.className} style={styles.smallFooter}>
@@ -199,9 +199,9 @@ export default class SmallFooter extends React.Component {
         >
           {this.renderI18nDropdown()}
           {this.renderCopyright()}
-          {!!this.props.scriptYear && yearIsNumeric && (
+          {!!this.props.unitYear && yearIsNumeric && (
             <p>
-              {i18n.version()}: {this.props.scriptYear}
+              {i18n.version()}: {this.props.unitYear}
             </p>
           )}
           {this.renderMoreMenuButton()}

--- a/apps/src/code-studio/components/SmallFooter.jsx
+++ b/apps/src/code-studio/components/SmallFooter.jsx
@@ -185,6 +185,10 @@ export default class SmallFooter extends React.Component {
       ...(this.props.fullWidth && styles.baseFullWidth)
     };
 
+    // Possible edge cases include scriptYear with value 'unversioned'.
+    // Filter for year ('20XX') all-numeral format.
+    const yearIsNumeric = /^[0-9]+$/.test(this.props.scriptYear);
+
     return (
       <div className={this.props.className} style={styles.smallFooter}>
         <div
@@ -195,7 +199,7 @@ export default class SmallFooter extends React.Component {
         >
           {this.renderI18nDropdown()}
           {this.renderCopyright()}
-          {!!this.props.scriptYear && (
+          {!!this.props.scriptYear && yearIsNumeric && (
             <p>
               {i18n.version()}: {this.props.scriptYear}
             </p>

--- a/apps/src/code-studio/components/SmallFooter.jsx
+++ b/apps/src/code-studio/components/SmallFooter.jsx
@@ -6,6 +6,7 @@ import React from 'react';
 import debounce from 'lodash/debounce';
 import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
 import {userAlreadyReportedAbuse} from '@cdo/apps/reportAbuse';
+import i18n from '@cdo/locale';
 
 const MenuState = {
   MINIMIZING: 'MINIMIZING',
@@ -45,7 +46,8 @@ export default class SmallFooter extends React.Component {
     fontSize: PropTypes.number,
     rowHeight: PropTypes.number,
     fullWidth: PropTypes.bool,
-    channel: PropTypes.string
+    channel: PropTypes.string,
+    scriptYear: PropTypes.string
   };
 
   state = {
@@ -193,6 +195,11 @@ export default class SmallFooter extends React.Component {
         >
           {this.renderI18nDropdown()}
           {this.renderCopyright()}
+          {!!this.props.scriptYear && (
+            <p>
+              {i18n.version()}: {this.props.scriptYear}
+            </p>
+          )}
           {this.renderMoreMenuButton()}
         </div>
         <div id="copyright-flyout" style={styles.copyright}>

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -260,7 +260,7 @@ module LevelsHelper
     end
 
     if @script
-      view_options(script_name: @script.name)
+      view_options(script_name: @script.name, script_year: @script.get_course_version.key)
     end
 
     unless params[:share]

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -260,7 +260,7 @@ module LevelsHelper
     end
 
     if @script
-      view_options(script_name: @script.name, script_year: @script.get_course_version&.key)
+      view_options(script_name: @script.name, unit_year: @script.get_course_version&.key)
     end
 
     unless params[:share]

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -260,7 +260,7 @@ module LevelsHelper
     end
 
     if @script
-      view_options(script_name: @script.name, script_year: @script.get_course_version.key)
+      view_options(script_name: @script.name, script_year: @script.get_course_version&.key)
     end
 
     unless params[:share]

--- a/dashboard/app/helpers/view_options_helper.rb
+++ b/dashboard/app/helpers/view_options_helper.rb
@@ -27,6 +27,7 @@ module ViewOptionsHelper
     :game_display_name,
     :app_name,
     :script_name,
+    :script_year,
     :lesson_position,
     :level_position,
     :public_caching,

--- a/dashboard/app/helpers/view_options_helper.rb
+++ b/dashboard/app/helpers/view_options_helper.rb
@@ -27,7 +27,7 @@ module ViewOptionsHelper
     :game_display_name,
     :app_name,
     :script_name,
-    :script_year,
+    :unit_year,
     :lesson_position,
     :level_position,
     :public_caching,

--- a/dashboard/app/views/layouts/_small_footer.html.haml
+++ b/dashboard/app/views/layouts/_small_footer.html.haml
@@ -13,7 +13,7 @@
     phoneFooter: false,
     fullWidth: full_width,
     channel: channel,
-    scriptYear: view_options[:script_year]
+    unitYear: view_options[:unit_year]
   }
 
 #page-small-footer

--- a/dashboard/app/views/layouts/_small_footer.html.haml
+++ b/dashboard/app/views/layouts/_small_footer.html.haml
@@ -12,7 +12,8 @@
     # false because we're not rendering into a phone wireframe here
     phoneFooter: false,
     fullWidth: full_width,
-    channel: channel
+    channel: channel,
+    scriptYear: view_options[:script_year]
   }
 
 #page-small-footer


### PR DESCRIPTION
Adds "Version: <unit year>" on levels in the small footer. Screenshots below - overlapping is due to how I compressed the page to be able to show both the url and the footer and is not an artifact of this change.

![Screenshot from 2022-10-20 14-39-09](https://user-images.githubusercontent.com/2959170/197066648-c2e25499-e5d3-46a2-bfb3-28d28aa7b136.png)

Express Course. Highlights that the text wraps when compressed.
![Screenshot from 2022-10-20 14-39-53](https://user-images.githubusercontent.com/2959170/197066644-2ca1b0b2-fe66-4498-bc58-02cbf8d9981c.png)

![Screenshot from 2022-10-20 14-38-42](https://user-images.githubusercontent.com/2959170/197066649-a278fd19-c067-4c78-8f46-21f13fbbf556.png)
