### PR TITLE
Add `ml-playground` dataset metadata JSON files to the translation pipeline

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -61,7 +61,7 @@
     "@code-dot-org/js-numbers": "0.1.0-cdo.0",
     "@code-dot-org/maze": "2.16.0",
     "@code-dot-org/ml-activities": "0.0.26",
-    "@code-dot-org/ml-playground": "0.0.39",
+    "@code-dot-org/ml-playground": "0.0.40",
     "@code-dot-org/p5.play": "^1.3.20-cdo",
     "@code-dot-org/piskel": "0.13.0-cdo.9",
     "@code-dot-org/redactable-markdown": "0.4.0",

--- a/apps/package.json
+++ b/apps/package.json
@@ -61,7 +61,7 @@
     "@code-dot-org/js-numbers": "0.1.0-cdo.0",
     "@code-dot-org/maze": "2.16.0",
     "@code-dot-org/ml-activities": "0.0.26",
-    "@code-dot-org/ml-playground": "0.0.40",
+    "@code-dot-org/ml-playground": "0.0.41",
     "@code-dot-org/p5.play": "^1.3.20-cdo",
     "@code-dot-org/piskel": "0.13.0-cdo.9",
     "@code-dot-org/redactable-markdown": "0.4.0",

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -1408,10 +1408,10 @@
     messageformat "^1.1.0"
     react-typist "^2.0.5"
 
-"@code-dot-org/ml-playground@0.0.39":
-  version "0.0.39"
-  resolved "https://registry.yarnpkg.com/@code-dot-org/ml-playground/-/ml-playground-0.0.39.tgz#78de40425f562be700ef98e2e2b8ff75e34f6a05"
-  integrity sha512-A3Lh6z4zk7j00W787CBe+zSbyTdZ5y1JH3V9WOxtHef3173LXGFKmr7wB4jWeomHhktg7pmDpp86EelJuFbK9g==
+"@code-dot-org/ml-playground@0.0.40":
+  version "0.0.40"
+  resolved "https://registry.yarnpkg.com/@code-dot-org/ml-playground/-/ml-playground-0.0.40.tgz#77e312f58ae116a0ae74bb529870ae39f4d4838d"
+  integrity sha512-H99KHwdMR3ygzttACqxDwsTjGQnsRK2uBUiKu0nepZjt17eGZryVsN63qYmU/hQwROD+nyJHa5JurMTTs8xa9A==
   dependencies:
     "@fortawesome/fontawesome-svg-core" "^1.2.25"
     "@fortawesome/free-solid-svg-icons" "^5.11.2"
@@ -1419,6 +1419,7 @@
     chart.js "^2.9.4"
     react-chartjs-2 "^2.11.1"
     reselect "^4.0.0"
+    yarn "^1.22.10"
 
 "@code-dot-org/p5.play@^1.3.20-cdo":
   version "1.3.20-cdo"
@@ -18682,6 +18683,11 @@ yargs@~3.10.0:
     cliui "^2.1.0"
     decamelize "^1.0.0"
     window-size "0.1.0"
+
+yarn@^1.22.10:
+  version "1.22.19"
+  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.22.19.tgz#4ba7fc5c6e704fce2066ecbfb0b0d8976fe62447"
+  integrity sha512-/0V5q0WbslqnwP91tirOvldvYISzaqhClxzyUKXYxs07yUILIs5jx/k6CFe8bvKSkds5w+eiOqta39Wk3WxdcQ==
 
 yauzl@^2.10.0:
   version "2.10.0"

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -1408,10 +1408,10 @@
     messageformat "^1.1.0"
     react-typist "^2.0.5"
 
-"@code-dot-org/ml-playground@0.0.40":
-  version "0.0.40"
-  resolved "https://registry.yarnpkg.com/@code-dot-org/ml-playground/-/ml-playground-0.0.40.tgz#77e312f58ae116a0ae74bb529870ae39f4d4838d"
-  integrity sha512-H99KHwdMR3ygzttACqxDwsTjGQnsRK2uBUiKu0nepZjt17eGZryVsN63qYmU/hQwROD+nyJHa5JurMTTs8xa9A==
+"@code-dot-org/ml-playground@0.0.41":
+  version "0.0.41"
+  resolved "https://registry.yarnpkg.com/@code-dot-org/ml-playground/-/ml-playground-0.0.41.tgz#6fb1322ca30df85934bac35b76fd6d0611f9ca73"
+  integrity sha512-Yfn5VepU+0m0Phop4nBiP4dQpicI5/tjAgQ3RQOrTvCGePoRaBNd7cCL48ClTQYspP3+22FM4V9pUXTKMHaVAw==
   dependencies:
     "@fortawesome/fontawesome-svg-core" "^1.2.25"
     "@fortawesome/free-solid-svg-icons" "^5.11.2"
@@ -1419,7 +1419,6 @@
     chart.js "^2.9.4"
     react-chartjs-2 "^2.11.1"
     reselect "^4.0.0"
-    yarn "^1.22.10"
 
 "@code-dot-org/p5.play@^1.3.20-cdo":
   version "1.3.20-cdo"
@@ -18683,11 +18682,6 @@ yargs@~3.10.0:
     cliui "^2.1.0"
     decamelize "^1.0.0"
     window-size "0.1.0"
-
-yarn@^1.22.10:
-  version "1.22.19"
-  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.22.19.tgz#4ba7fc5c6e704fce2066ecbfb0b0d8976fe62447"
-  integrity sha512-/0V5q0WbslqnwP91tirOvldvYISzaqhClxzyUKXYxs07yUILIs5jx/k6CFe8bvKSkds5w+eiOqta39Wk3WxdcQ==
 
 yauzl@^2.10.0:
   version "2.10.0"

--- a/bin/i18n-codeorg/in.sh
+++ b/bin/i18n-codeorg/in.sh
@@ -59,7 +59,7 @@ cp_in apps/node_modules/@code-dot-org/ml-activities/i18n/oceans.json i18n/locale
 ### AI Lab datasets
 
 orig_dir=apps/node_modules/@code-dot-org/ml-playground/public/datasets
-loc_dir=i18n/locales/source/external-sources/ml-playgound/datasets
+loc_dir=i18n/locales/source/external-sources/ml-playground/datasets
 mkdir -p $loc_dir
 
 # Copy JSON files.

--- a/bin/i18n-codeorg/in.sh
+++ b/bin/i18n-codeorg/in.sh
@@ -56,6 +56,18 @@ done
 ### Oceans tutorial
 cp_in apps/node_modules/@code-dot-org/ml-activities/i18n/oceans.json i18n/locales/source/blockly-mooc/fish.json
 
+### AI Lab datasets
+
+orig_dir=apps/node_modules/@code-dot-org/ml-playground/public/datasets
+loc_dir=i18n/locales/source/external-sources/ml-playgound/datasets
+mkdir -p $loc_dir
+
+# Copy JSON files.
+for file in $(find $orig_dir -name '*.json'); do
+  relname=${file#$orig_dir}
+  cp_in $file $loc_dir$relname
+done
+
 ### Pegasus
 
 orig_dir=pegasus/cache/i18n

--- a/bin/i18n/sync-in.rb
+++ b/bin/i18n/sync-in.rb
@@ -124,10 +124,10 @@ def localize_external_sources
 
     # Currently only including fields for translation.
     # Use field id as unique identifier.
-    final_dataset = Hash.new
-    final_dataset["fields"] = Hash.new
-    dataset_fields = original_dataset["fields"]
-    dataset_fields.each {|field| final_dataset["fields"][field["id"]] = field}
+    fields_as_hash = original_dataset["fields"].map {|field| [field["id"], field]}.to_h
+    final_dataset = {
+      "fields" => fields_as_hash
+    }
 
     File.open(dataset_file, "w") do |f|
       f.write(JSON.pretty_generate(final_dataset))

--- a/bin/i18n/sync-in.rb
+++ b/bin/i18n/sync-in.rb
@@ -28,6 +28,7 @@ def sync_in
   localize_docs
   puts "Copying source files"
   I18nScriptUtils.run_bash_script "bin/i18n-codeorg/in.sh"
+  localize_external_sources
   redact_level_content
   redact_block_content
   redact_script_and_course_content
@@ -106,6 +107,31 @@ def localize_docs
   FileUtils.mkdir_p(File.dirname(docs_content_file))
   File.open(docs_content_file, "w") do |file|
     file.write(JSON.pretty_generate(programming_env_docs))
+  end
+end
+
+# These files are synced in using the `bin/i18n-codeorg/in.sh` script.
+def localize_external_sources
+  puts "Preparing external sources"
+  external_sources_dir = File.join(I18N_SOURCE_DIR, "external-sources")
+
+  # ml-playground files
+  # These are overwritten in this format so the properties that use
+  # arrays have unique identifiers for translation.
+  dataset_files = File.join(external_sources_dir, 'ml-playground', 'datasets', '*')
+  Dir.glob(dataset_files).each do |dataset_file|
+    original_dataset = JSON.parse(File.read(dataset_file))
+
+    # Currently only including fields for translation.
+    # Use field id as unique identifier.
+    final_dataset = Hash.new
+    final_dataset["fields"] = Hash.new
+    dataset_fields = original_dataset["fields"]
+    dataset_fields.each {|field| final_dataset["fields"][field["id"]] = field}
+
+    File.open(dataset_file, "w") do |f|
+      f.write(JSON.pretty_generate(final_dataset))
+    end
   end
 end
 

--- a/bin/i18n/sync-out.rb
+++ b/bin/i18n/sync-out.rb
@@ -390,6 +390,23 @@ def distribute_translations(upload_manifests)
       sanitize_file_and_write(loc_file, destination)
     end
 
+    ### Merge ml-playground datasets into apps' ailab JSON
+    Dir.glob("#{locale_dir}/external-sources/ml-playground/datasets/*.json") do |loc_file|
+      ailab_path = "apps/i18n/ailab/#{js_locale}.json"
+      name = File.basename(loc_file, '.json')
+      relative_path = loc_file.delete_prefix(locale_dir)
+      next unless file_changed?(locale, relative_path)
+
+      external_translations = JSON.parse(File.read(loc_file))
+      next if external_translations.empty?
+
+      # Merge new translations
+      existing_translations = JSON.parse(File.read(ailab_path))
+      existing_translations['datasets'] = existing_translations['datasets'] || Hash.new
+      existing_translations['datasets'][name] = external_translations
+      sanitize_data_and_write(existing_translations, ailab_path)
+    end
+
     ### Animation library
     spritelab_animation_translation_path = "/animations/spritelab_animation_library.json"
     if file_changed?(locale, spritelab_animation_translation_path)


### PR DESCRIPTION
**What:** Pull the dataset metadata JSON files from the `ml-playground` node module into our i18n source directory. Then, restructure the file so the `fields` have a unique identifier during the sync. This also creates a new `external-sources` source subdirectory. The `ml-playground` version was bumped to `0.0.41` to pick up [these updates](https://github.com/code-dot-org/ml-playground/pull/294).

**How:** After our i18n shell script [pulls in the dataset files](https://github.com/code-dot-org/code-dot-org/pull/48767/files#diff-4d25ecd2b4993515de3eddddcfc627a6f492ae0cfade490aa3b607491f6cf680R65), the sync-in pulls all of the `field` objects out of the original. The file is replaced with them stored as a hash with the `field`'s `id`  as they key. This is so adding, removing, etc. fields can be accurately updated during translation - versus if they were stored in an array.

Our goal is to have these translations passed into the Ailab UI component. So during the sync-out we attach these translated strings to the existing `ailab.json` that is currently passed in.

**Why:** This will allow us pass these translations to the Ailab component to [eventually](https://codedotorg.atlassian.net/browse/FND-2110) be consumed.

**Note:** Only the `fields` and its children are being translated from the dataset files. If(when) we want to add other strings from this file it would make sense for it to be an addition [here](https://github.com/code-dot-org/code-dot-org/pull/48767/files#diff-705d3439a97ecb724df168c450a44b5d98c659c127f1c31666c17dda231469c2R125).

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [FND-2110](https://codedotorg.atlassian.net/browse/FND-2110)
- [technical analysis doc](https://docs.google.com/document/d/1e8Neskfa020V3yMRsjr5e5lXABXCeIU_yUcvo0GOj4s/edit#)
## Testing story

Ran the sync-in locally and confirmed the newly created files (also had [these changes](https://github.com/code-dot-org/ml-playground/pull/293) in my local environment as expected)

Locally tested attaching the ailab locale object to the `window` to see if the new translations are accessable.
<img width="1286" alt="Screen Shot 2022-10-26 at 5 15 44 PM" src="https://user-images.githubusercontent.com/48133820/198340781-548c1246-5a27-4320-8f43-8c7dcdf4e0b5.png">


<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Follow-up work

https://codedotorg.atlassian.net/browse/FND-2096

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
