### PR TITLE
Add API driven job board on /about/careers

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -783,6 +783,7 @@ describe('entry tests', () => {
       './src/sites/code.org/pages/views/amazon_future_engineer.js',
     'code.org/views/amazon_future_engineer_eligibility':
       './src/sites/code.org/pages/views/amazon_future_engineer_eligibility.js',
+    'code.org/views/job_board': './src/sites/code.org/pages/views/job_board.js',
 
     // hourofcode.com
     'hourofcode.com/public/index':

--- a/apps/src/sites/code.org/pages/views/JobBoardComponent.jsx
+++ b/apps/src/sites/code.org/pages/views/JobBoardComponent.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+// rename this file
+export default function JobBoard({jobsByDepartment}) {
+  const renderDepartment = department => {
+    return (
+      <div>
+        <h3>{department.name}</h3>
+        {department.jobs.map(renderJob)}
+      </div>
+    );
+  };
+
+  const renderJob = job => {
+    return (
+      <div>
+        <a href={job.applicationUrl} target="_blank" rel="noopener noreferrer">
+          {job.jobTitle}
+        </a>
+        <p>{job.location}</p>
+      </div>
+    );
+  };
+
+  if (Object.keys(jobsByDepartment).length === 0) {
+    return <div>No jobs are available at this time. Check back soon!</div>;
+  }
+  return <div>{Object.values(jobsByDepartment).map(renderDepartment)}</div>;
+}
+
+JobBoard.propTypes = {
+  jobsByDepartment: PropTypes.object.isRequired
+};

--- a/apps/src/sites/code.org/pages/views/job_board.js
+++ b/apps/src/sites/code.org/pages/views/job_board.js
@@ -1,0 +1,48 @@
+import $ from 'jquery';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import JobBoard from './JobBoardComponent';
+
+$(document).ready(showJobBoard);
+
+function showJobBoard() {
+  const jobBoardElement = $('#job-board-container');
+  const jobsByDepartment = {};
+
+  $.ajax({
+    type: 'GET',
+    url: 'https://boards-api.greenhouse.io/v1/boards/codeorg/jobs?content=true'
+  })
+    .done(result => {
+      result.jobs.forEach(job => {
+        const departmentName = job.departments[0].name;
+        if (!departmentName) {
+          return;
+        }
+
+        if (departmentName in jobsByDepartment) {
+          const jobDetails = getJobDetails(job);
+          jobsByDepartment[departmentName].jobs.push(jobDetails);
+        } else {
+          jobsByDepartment[departmentName] = {
+            name: departmentName,
+            jobs: [getJobDetails(job)]
+          };
+        }
+      });
+    })
+    .complete(() => {
+      ReactDOM.render(
+        <JobBoard jobsByDepartment={jobsByDepartment} />,
+        jobBoardElement[0]
+      );
+    });
+}
+
+const getJobDetails = job => {
+  return {
+    jobTitle: job.title,
+    location: job.location.name,
+    applicationUrl: job.absolute_url
+  };
+};

--- a/apps/src/sites/code.org/pages/views/job_board.js
+++ b/apps/src/sites/code.org/pages/views/job_board.js
@@ -26,7 +26,8 @@ function showJobBoard() {
       //   ]
       // }
       result.jobs.forEach(job => {
-        const departmentName = job.departments[0].name;
+        // Jobs should always have a department, but optional chaining just in case.
+        const departmentName = job?.departments[0]?.name;
         if (!departmentName) {
           return;
         }

--- a/apps/src/sites/code.org/pages/views/job_board.js
+++ b/apps/src/sites/code.org/pages/views/job_board.js
@@ -1,7 +1,7 @@
 import $ from 'jquery';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import JobBoard from './JobBoardComponent';
+import JobBoard from '@cdo/apps/templates/jobBoard/JobBoard';
 
 $(document).ready(showJobBoard);
 
@@ -14,6 +14,17 @@ function showJobBoard() {
     url: 'https://boards-api.greenhouse.io/v1/boards/codeorg/jobs?content=true'
   })
     .done(result => {
+      // Reshape into an object with jobs by department. Shape:
+      // {
+      //   departmentName: "Engineering",
+      //   jobs: [
+      //           {
+      //             jobTitle: "Software Engineer"
+      //             location: "Seattle",
+      //             applicationUrl: "https://boards.greenhouse.io/codeorg/jobs/4098667005"
+      //           },...
+      //   ]
+      // }
       result.jobs.forEach(job => {
         const departmentName = job.departments[0].name;
         if (!departmentName) {

--- a/apps/src/templates/jobBoard/JobBoard.jsx
+++ b/apps/src/templates/jobBoard/JobBoard.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-// rename this file
 export default function JobBoard({jobsByDepartment}) {
   const renderDepartment = department => {
     return (
@@ -24,7 +23,11 @@ export default function JobBoard({jobsByDepartment}) {
   };
 
   if (Object.keys(jobsByDepartment).length === 0) {
-    return <div>No jobs are available at this time. Check back soon!</div>;
+    return (
+      <div>
+        We currently do not have any openings. Please check back another time!
+      </div>
+    );
   }
   return <div>{Object.values(jobsByDepartment).map(renderDepartment)}</div>;
 }

--- a/pegasus/sites.v3/code.org/public/about/careers.md.erb
+++ b/pegasus/sites.v3/code.org/public/about/careers.md.erb
@@ -85,7 +85,7 @@ theme: responsive
 
 Code.org is based in Seattle, but many of our team members are remote; remote candidates are welcome and encouraged to apply!
 
-<a href="https://boards.greenhouse.io/codeorg"><button>View open positions</button></a>
+<%= view :job_board %>
 
 <h2 class="careers-header">Get Involved</h2>
 

--- a/pegasus/sites.v3/code.org/views/job_board.haml
+++ b/pegasus/sites.v3/code.org/views/job_board.haml
@@ -1,0 +1,2 @@
+#job-board-container
+%script{src: webpack_asset_path('js/code.org/views/job_board.js')}


### PR DESCRIPTION
Get job listings from our hiring site (Greenhouse), and display them directly in our /about/careers page.

![image](https://user-images.githubusercontent.com/25372625/197081073-d034f635-7c94-4129-b0d8-e45df64eda54.png)

## Links

- jira ticket: [SL-280](https://codedotorg.atlassian.net/browse/SL-280)

## Testing story

Tested manually with actual data from Greenhouse. Also tested that the component loads if no jobs are available.