### PR TITLE
Update `newrelic-ruby-agent` Gem to 6.14

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -177,12 +177,7 @@ gem 'highline', '~> 1.6.21'
 
 gem 'honeybadger', '>= 4.5.6' # error monitoring
 
-gem 'newrelic_rpm', group: [:staging, :development, :production], # perf/error/etc monitoring
-  # Ref:
-  # https://github.com/newrelic/newrelic-ruby-agent/pull/359
-  # https://github.com/newrelic/newrelic-ruby-agent/pull/372
-  # https://github.com/newrelic/newrelic-ruby-agent/issues/340
-  github: 'code-dot-org/newrelic-ruby-agent', ref: 'PR-359_prevent_reconnect_attempts_during_shutdowns'
+gem 'newrelic_rpm', '~> 6.14.0', group: [:staging, :development, :production] # perf/error/etc monitoring
 
 gem 'redcarpet', '~> 3.3.4'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,13 +6,6 @@ GIT
       omniauth-oauth2 (>= 1.1, <= 1.5)
 
 GIT
-  remote: https://github.com/code-dot-org/newrelic-ruby-agent.git
-  revision: 5a46cdf3f3f144018bca2edce6b008d464da18fa
-  ref: PR-359_prevent_reconnect_attempts_during_shutdowns
-  specs:
-    newrelic_rpm (6.12.0)
-
-GIT
   remote: https://github.com/code-dot-org/petit.git
   revision: bbe411d61d3f78fff59d9fa79d21c14b1c635750
   specs:
@@ -578,6 +571,7 @@ GEM
     net-ssh (5.2.0)
     net_http_ssl_fix (0.0.10)
     netrc (0.11.0)
+    newrelic_rpm (6.14.0)
     nio4r (2.5.8)
     nokogiri (1.12.4)
       mini_portile2 (~> 2.6.1)
@@ -1000,7 +994,7 @@ DEPENDENCIES
   net-http-persistent
   net-scp
   net-ssh
-  newrelic_rpm!
+  newrelic_rpm (~> 6.14.0)
   nokogiri (>= 1.10.0)
   octokit
   oj


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/48161; we're not quite ready to update to 8.x versions, but we do want to pick up fixes for the reconnection issue which originally prompted us to create a custom branch (which were added in 6.13) and for some misc Ruby 2.7 issue which were added in 6.14

## Links

- https://github.com/newrelic/newrelic-ruby-agent/blob/dev/CHANGELOG.md

## Testing story

I'm not sure that we have a great way to test this, since the gem is only installed on staging and production and we've had some issues with this gem in particular exhibiting different behavior on staging vs production. Open to suggestions!

## Deployment strategy

I definitely plan to keep a close eye on staging and production when this hits, and will be prepared with a revert in case we see issues with pegasus again.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
