### PR TITLE
Stop Installing `newrelic-ruby-agent` Gem in Staging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -177,7 +177,7 @@ gem 'highline', '~> 1.6.21'
 
 gem 'honeybadger', '>= 4.5.6' # error monitoring
 
-gem 'newrelic_rpm', group: [:staging, :development, :production], # perf/error/etc monitoring
+gem 'newrelic_rpm', group: [:development, :production], # perf/error/etc monitoring
   # Ref:
   # https://github.com/newrelic/newrelic-ruby-agent/pull/359
   # https://github.com/newrelic/newrelic-ruby-agent/pull/372


### PR DESCRIPTION
We don't actually need it there, and it's causing issues. See thread at https://codedotorg.slack.com/archives/C03CK49G9/p1666301732802119 for more context

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
