### PR TITLE
Fix MySQL Client Launcher Scripts on Development Environments

### DIFF
--- a/config/development.yml.erb
+++ b/config/development.yml.erb
@@ -3,6 +3,18 @@
 
 dashboard_enable_pegasus: true
 
+db_cluster_id: localhost
+db_proxy_reporting_endpoint: localhost
+db_writer_endpoint: localhost
+
+db_admin_user: root
+db_admin_password: ''
+db_writer_user: root
+db_writer_password: ''
+db_reader_user: root
+db_reader_password: ''
+db_writer: 'mysql://root@localhost/'
+
 firebase_name: cdo-v3-dev
 # provide a unique path for firebase channels data for development, to avoid conflicts in channel ids.
 firebase_secret: !Secret
@@ -31,7 +43,6 @@ pusher_application_secret: fake_application_secret
 poste_secret: not a real secret
 dashboard_devise_pepper: not a pepper!
 dashboard_secret_key_base: not a secret
-db_writer: 'mysql://root@localhost/'
 
 custom_error_response: false
 


### PR DESCRIPTION
Fix for #48510
The Ruby scripts that launch the MySQL client stopped working on local development environments.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
