### PR TITLE
Refactor pd apps tests

### DIFF
--- a/dashboard/app/models/pd/application/teacher_application.rb
+++ b/dashboard/app/models/pd/application/teacher_application.rb
@@ -131,7 +131,7 @@ module Pd::Application
     # @override
     def set_type_and_year
       self.application_type = TEACHER_APPLICATION
-      self.application_year = ActiveApplicationModels::APPLICATION_CURRENT_YEAR unless application_year
+      self.application_year = Pd::Application::ActiveApplicationModels::APPLICATION_CURRENT_YEAR unless application_year
     end
 
     def set_course_from_program

--- a/dashboard/test/ui/features/acquisition_products/pd/application_detail_view.feature
+++ b/dashboard/test/ui/features/acquisition_products/pd/application_detail_view.feature
@@ -4,8 +4,7 @@
 Feature: Teacher Application Detail View
 
   Scenario: Regional Partner can set Principal Approval as Not Required and Required
-    Given there is a CSP application affiliated with a temporary regional partner
-    And I am a program manager with the temporary regional partner
+    Given I am a program manager with a regional partner and teacher application
     And I am on "http://studio.code.org/pd/application_dashboard/summary"
     Then I wait until element "table#summary-csp-teachers" is visible
 
@@ -22,5 +21,3 @@ Feature: Teacher Application Detail View
     Then I scroll the "#change-principal-approval-requirement" element into view
     Then I click selector "button:contains('Make required')"
     And I wait until element "button:contains('Make not required')" is visible
-
-    And I delete the temp regional partner, program manager, and csp teacher

--- a/dashboard/test/ui/features/acquisition_products/pd/application_detail_view.feature
+++ b/dashboard/test/ui/features/acquisition_products/pd/application_detail_view.feature
@@ -1,19 +1,16 @@
-@skip
-@dashboard_db_access
 @no_mobile
+@dashboard_db_access
+
 Feature: Teacher Application Detail View
 
   Scenario: Regional Partner can set Principal Approval as Not Required and Required
-    Given I am a workshop administrator with some applications of each type and status
+    Given there is a CSP application affiliated with a temporary regional partner
+    And I am a program manager with the temporary regional partner
     And I am on "http://studio.code.org/pd/application_dashboard/summary"
     Then I wait until element "table#summary-csp-teachers" is visible
 
     Then I click selector "table#summary-csp-teachers ~ .btn:contains(View all applications)"
     Then I wait until element "#status-filter" is visible
-    And I press keys "Pending" for element "#status-filter"
-    And I press the first ".Select-option" element
-    Then I wait until element "span:contains('Pending')" is visible
-    And I wait until element "td:contains('Unreviewed')" is not visible
     Then I click selector "button:contains('Make not required')"
     And I wait until element "button:contains('Make required')" is visible
 
@@ -25,3 +22,5 @@ Feature: Teacher Application Detail View
     Then I scroll the "#change-principal-approval-requirement" element into view
     Then I click selector "button:contains('Make required')"
     And I wait until element "button:contains('Make not required')" is visible
+
+    And I delete the temp regional partner, program manager, and csp teacher

--- a/dashboard/test/ui/features/acquisition_products/pd/application_detail_view.feature
+++ b/dashboard/test/ui/features/acquisition_products/pd/application_detail_view.feature
@@ -1,10 +1,10 @@
 @no_mobile
-@dashboard_db_access
 
 Feature: Teacher Application Detail View
 
   Scenario: Regional Partner can set Principal Approval as Not Required and Required
-    Given I am a program manager with a regional partner and teacher application
+    Given I am a program manager
+    And I have a regional partner with a teacher application
     And I am on "http://studio.code.org/pd/application_dashboard/summary"
     Then I wait until element "table#summary-csp-teachers" is visible
 
@@ -21,3 +21,5 @@ Feature: Teacher Application Detail View
     Then I scroll the "#change-principal-approval-requirement" element into view
     Then I click selector "button:contains('Make required')"
     And I wait until element "button:contains('Make not required')" is visible
+
+    And I delete the program manager, regional partner, teacher, and application

--- a/dashboard/test/ui/features/acquisition_products/pd/teacher_application_dashboard.feature
+++ b/dashboard/test/ui/features/acquisition_products/pd/teacher_application_dashboard.feature
@@ -1,5 +1,3 @@
-@skip
-@dashboard_db_access
 @eyes
 Feature: Teacher Application Dashboard
 

--- a/dashboard/test/ui/features/step_definitions/pd.rb
+++ b/dashboard/test/ui/features/step_definitions/pd.rb
@@ -44,6 +44,52 @@ Given /^I am a program manager named "([^"]*)" for regional partner "([^"]*)"$/ 
   }
 end
 
+And(/^I am a program manager with the temporary regional partner$/) do
+  require_rails_env
+
+  regional_partner = RegionalPartner.find_by(name: @rp_name)
+
+  pm_name = "pm#{Time.now.to_i}#{rand(1_000_000)}"
+  email, password = generate_user(pm_name)
+
+  FactoryGirl.create(:program_manager, name: pm_name, email: email, password: password, regional_partner: regional_partner)
+
+  steps %Q{
+    And I sign in as "#{pm_name}"
+  }
+end
+
+Given(/^there is a CSP application affiliated with temporary regional partner$/) do
+  require_rails_env
+
+  @rp_name = "regional-partner-#{Time.now.to_i}-#{rand(1_000_000)}"
+  regional_partner = RegionalPartner.create!(name: @rp_name)
+
+  teacher_name = "teacher#{Time.now.to_i}#{rand(1_000_000)}"
+  teacher_email = "teacher-#{Time.now.to_i}-#{rand(1_000_000)}"
+  password = teacher_name + "password"
+  attributes = {
+    name: teacher_name,
+    email: teacher_email,
+    password: password,
+    user_type: "teacher",
+    age: "21+"
+  }
+  teacher = User.create!(attributes)
+
+  form_data_hash = FactoryGirl.build(:pd_teacher_application_hash_common, 'csp'.to_sym, first_name: teacher_name, last_name: 'teacher')
+  FactoryGirl.create(
+    :pd_teacher_application,
+    form_data_hash: form_data_hash,
+    user: teacher,
+    status: 'unreviewed',
+    regional_partner_id: regional_partner.id
+  )
+end
+
+And(/^I delete the temp regional partner, program manager, and csp teacher$/) do
+end
+
 Given /^there is a facilitator named "([^"]+)" for course "([^"]+)"$/ do |name, course|
   require_rails_env
 

--- a/dashboard/test/ui/features/step_definitions/pd.rb
+++ b/dashboard/test/ui/features/step_definitions/pd.rb
@@ -44,29 +44,14 @@ Given /^I am a program manager named "([^"]*)" for regional partner "([^"]*)"$/ 
   }
 end
 
-And(/^I am a program manager with the temporary regional partner$/) do
-  require_rails_env
-
-  regional_partner = RegionalPartner.find_by(name: @rp_name)
-
-  pm_name = "pm#{Time.now.to_i}#{rand(1_000_000)}"
-  email, password = generate_user(pm_name)
-
-  FactoryGirl.create(:program_manager, name: pm_name, email: email, password: password, regional_partner: regional_partner)
-
-  steps %Q{
-    And I sign in as "#{pm_name}"
-  }
-end
-
-Given(/^there is a CSP application affiliated with temporary regional partner$/) do
+Given(/^I am a program manager with a regional partner and teacher application$/) do
   require_rails_env
 
   @rp_name = "regional-partner-#{Time.now.to_i}-#{rand(1_000_000)}"
   regional_partner = RegionalPartner.create!(name: @rp_name)
 
   teacher_name = "teacher#{Time.now.to_i}#{rand(1_000_000)}"
-  teacher_email = "teacher-#{Time.now.to_i}-#{rand(1_000_000)}"
+  teacher_email = "teacher-#{Time.now.to_i}-#{rand(1_000_000)}@test.xx"
   password = teacher_name + "password"
   attributes = {
     name: teacher_name,
@@ -85,9 +70,15 @@ Given(/^there is a CSP application affiliated with temporary regional partner$/)
     status: 'unreviewed',
     regional_partner_id: regional_partner.id
   )
-end
 
-And(/^I delete the temp regional partner, program manager, and csp teacher$/) do
+  pm_name = "pm#{Time.now.to_i}#{rand(1_000_000)}"
+  email, password = generate_user(pm_name)
+
+  FactoryGirl.create(:program_manager, name: pm_name, email: email, password: password, regional_partner: regional_partner)
+
+  steps %Q{
+    And I sign in as "#{pm_name}"
+  }
 end
 
 Given /^there is a facilitator named "([^"]+)" for course "([^"]+)"$/ do |name, course|

--- a/dashboard/test/ui/features/step_definitions/pd.rb
+++ b/dashboard/test/ui/features/step_definitions/pd.rb
@@ -162,7 +162,10 @@ And(/^I create some fake applications of each type and status$/) do
       teacher = User.find_or_create_teacher(
         {name: "#{course} #{status}", email: teacher_email}, nil, nil
       )
-      next if Pd::Application::TeacherApplication.find_by(user_id: teacher.id)
+      next if Pd::Application::TeacherApplication.find_by(
+        application_year: Pd::Application::ActiveApplicationModels::APPLICATION_CURRENT_YEAR,
+        user_id: teacher.id
+      )
       form_data_hash = FactoryGirl.build(:pd_teacher_application_hash_common, course.to_sym, first_name: course, last_name: status)
       if status == 'incomplete'
         FactoryGirl.create(

--- a/dashboard/test/ui/features/step_definitions/pd.rb
+++ b/dashboard/test/ui/features/step_definitions/pd.rb
@@ -1,5 +1,4 @@
 Given(/^I am a workshop administrator with some applications of each type and status$/) do
-  require_rails_env
   random_name = "TestWorkshopAdmin" + SecureRandom.hex(10)
   steps %Q{
     And I create a teacher named "#{random_name}"
@@ -181,40 +180,7 @@ And(/^I make the teacher named "([^"]*)" a workshop admin$/) do |name|
 end
 
 And(/^I create some fake applications of each type and status$/) do
-  require_rails_env
-  time_start = Time.now
-
-  %w(csd csp).each do |course|
-    (Pd::Application::TeacherApplication.statuses).each do |status|
-      teacher_email = "#{course}_#{status}@code.org"
-      teacher = User.find_or_create_teacher(
-        {name: "#{course} #{status}", email: teacher_email}, nil, nil
-      )
-      next if Pd::Application::TeacherApplication.find_by(
-        application_year: Pd::Application::ActiveApplicationModels::APPLICATION_CURRENT_YEAR,
-        user_id: teacher.id
-      )
-      form_data_hash = FactoryGirl.build(:pd_teacher_application_hash_common, course.to_sym, first_name: course, last_name: status)
-      if status == 'incomplete'
-        FactoryGirl.create(
-          :pd_teacher_application,
-          form_data_hash: form_data_hash,
-          user: teacher,
-          status: 'incomplete'
-        )
-      else
-        application = FactoryGirl.create(
-          :pd_teacher_application,
-          form_data_hash: form_data_hash,
-          user: teacher,
-          status: 'unreviewed'
-        )
-        application.update!(status: status)
-      end
-    end
-  end
-  time_end = Time.now
-  puts "Creating applications took #{time_end - time_start} seconds"
+  browser_request(url: '/api/test/create_applications', method: 'POST')
 end
 
 And(/^I am viewing a workshop with fake survey results$/) do


### PR DESCRIPTION
This (finally!) refactors pd apps tests to (a) only query current-year applications, and (b) avoid loading the rails environment for the tests to run.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
