### PR TITLE
preserve url params when redirecting congrats page to dashboard

### DIFF
--- a/dashboard/test/ui/features/hour_of_code/hour_of_code_finish.feature
+++ b/dashboard/test/ui/features/hour_of_code/hour_of_code_finish.feature
@@ -56,6 +56,16 @@ Scenario: Pegasus share page preserves certificate when redirecting
   And I wait to see an image "/certificate_images/"
   And I see custom certificate image with name "Robo Coder" and course "mc"
 
+Scenario: non-mee 3rd party tutorial redirects to congrats page with params
+  Given I am on "http://code.org/api/hour/finish/kodable"
+  And I wait until current URL contains "http://studio.code.org/congrats"
+  Then my query params match "\?i\=.*\&s\=a29kYWJsZQ=="
+
+  When I wait to see element with ID "uitest-certificate"
+  And I type "Robo Coder" into "#name"
+  And I press "button:contains(Submit)" using jQuery
+  Then I wait to see element with ID "uitest-thanks"
+
 Scenario: Oceans uncustomized dashboard certificate pages
   Given I am on "http://studio.code.org/congrats"
   And I wait until element "#uitest-certificate" is visible

--- a/pegasus/sites.v3/code.org/public/congrats.haml
+++ b/pegasus/sites.v3/code.org/public/congrats.haml
@@ -1,2 +1,3 @@
 :ruby
-  redirect CDO.studio_url('/congrats', CDO.default_scheme)
+  suffix = request.query_string.present? ? "?#{request.query_string}" : ''
+  redirect CDO.studio_url("/congrats#{suffix}", CDO.default_scheme)

--- a/pegasus/sites.v3/code.org/public/congrats.haml
+++ b/pegasus/sites.v3/code.org/public/congrats.haml
@@ -1,0 +1,2 @@
+:ruby
+  redirect CDO.studio_url('/congrats', CDO.default_scheme)

--- a/pegasus/sites.v3/code.org/public/congrats.moved
+++ b/pegasus/sites.v3/code.org/public/congrats.moved
@@ -1,1 +1,0 @@
-https://studio.code.org/congrats

--- a/pegasus/test/test_hoc_routes.rb
+++ b/pegasus/test/test_hoc_routes.rb
@@ -81,6 +81,13 @@ class HocRoutesTest < Minitest::Test
       assert_equal expected_url, @pegasus.last_response['Location']
     end
 
+    it 'preserves url params when redirecting congrats page' do
+      @pegasus.get CDO.code_org_url('/congrats?i=foo&s=bar')
+      assert_equal 302, @pegasus.last_response.status
+      expected_url = CDO.studio_url('/congrats?i=foo&s=bar', CDO.default_scheme)
+      assert_equal expected_url, @pegasus.last_response['Location']
+    end
+
     it 'starts and ends given tutorial, tracking company and tutorial' do
       DB.transaction(rollback: :always) do
         with_test_company 'testcompany'

--- a/pegasus/test/test_hoc_routes.rb
+++ b/pegasus/test/test_hoc_routes.rb
@@ -76,9 +76,9 @@ class HocRoutesTest < Minitest::Test
 
     it 'redirects vanilla congrats page to code studio' do
       @pegasus.get CDO.code_org_url('/congrats')
-      assert_equal 301, @pegasus.last_response.status
-      expected_url = 'https://studio.code.org/congrats'
-      assert_equal expected_url, @pegasus.last_response['Location'].strip
+      assert_equal 302, @pegasus.last_response.status
+      expected_url = CDO.studio_url('/congrats', CDO.default_scheme)
+      assert_equal expected_url, @pegasus.last_response['Location']
     end
 
     it 'starts and ends given tutorial, tracking company and tutorial' do

--- a/pegasus/test/test_pegasus_documents.rb
+++ b/pegasus/test/test_pegasus_documents.rb
@@ -30,6 +30,7 @@ class PegasusTest < Minitest::Test
   STATUS_EXCEPTIONS = {
     302 => %w[
       code.org/amazon-future-engineer
+      code.org/congrats
       code.org/educate
       code.org/review-hociyskvuwa
       code.org/teach
@@ -37,9 +38,6 @@ class PegasusTest < Minitest::Test
     ],
     301 => %w[
       csedweek.org/resource_kit
-    ],
-    401 => %w[
-      code.org/create-company-profile
     ]
   }
 


### PR DESCRIPTION
Finishes [ACQ-195](https://codedotorg.atlassian.net/browse/ACQ-195), fixing a regression caused in https://github.com/code-dot-org/code-dot-org/pull/48211. 

the scenario that broke is when a 3rd party tutorial which is not part of Minecraft Education Edition ("mee") is completed. in this scenario, we display a customizable certificate, but fail to log the hoc activity to the database.

#### original flow
* code.org/api/hour/finish/kodable --> 302 redirect to
* code.org/congrats?i=...&s=... --> 200
* that page requests `/v2/certificate` via ajax, which logs a completion event into the pegasus `hoc_activity` table.

#### current flow (broken in https://github.com/code-dot-org/code-dot-org/pull/48211)
* code.org/api/hour/finish/kodable --> 302 redirect to
* code.org/congrats?i=...&s=... --> 301 redirect to
* studio.code.org/congrats
* that page renders a customizable hoc certificate, but fails to log to the `hoc_activity` table.

#### new flow (fixed in this PR)
* localhost.code.org:3000/api/hour/finish/kodable --> 302 redirect to
* localhost.code.org:3000/congrats?i=...&s=... --> 302 redirect to
* localhost-studio.code.org:3000/congrats?i=...&s=... --> 200
* renders customizable certificate _and_ logs to `hoc_activity` table via `/v2/certificate`

note that the "mee" tutorials were not broken in this way because of this line: https://github.com/code-dot-org/code-dot-org/blob/b0e886bfc170a2c35ac60d2a0601686d803b7e0b/pegasus/helpers/hoc_helpers.rb#L124-L125

## Screenshots

after navigating to https://code.org/api/hour/finish/kodable, the destination url now includes params, and the request to /v2/certificates is made.

### before ("current flow")

https://user-images.githubusercontent.com/8001765/197292808-a65d90a8-3e11-40ac-8081-2a7913de404d.mov

### after ("new flow")

https://user-images.githubusercontent.com/8001765/197292901-adcce259-cfa7-409a-b2ff-4f1937a67bae.mov

## Testing story

* new unit test for congrats page redirect with non-mee 3rd party tutorial
* new UI test verifies correct url params are working end to end
* manually verified /v2/certificates network request is restored (see screenshots)

