### PR TITLE
Modify SpriteLabs buttons to remove hover action when disabled

### DIFF
--- a/apps/style/spritelab/style.scss
+++ b/apps/style/spritelab/style.scss
@@ -1,9 +1,8 @@
 @import "../gamelab/style.scss";
 
-button.arrow:disabled {
-  pointer-events: none;
-}
-
-button#pauseButton:disabled {
-  pointer-events: none;
+button {
+  &.arrow:disabled,
+  &#pauseButton:disabled {
+    pointer-events: none;
+  }
 }

--- a/apps/style/spritelab/style.scss
+++ b/apps/style/spritelab/style.scss
@@ -1,1 +1,9 @@
 @import "../gamelab/style.scss";
+
+button.arrow:disabled {
+  pointer-events: none;
+}
+
+button#pauseButton:disabled {
+  pointer-events: none;
+}


### PR DESCRIPTION
Currently in Sprite Labs, when the arrow buttons or pause button are disabled, they still look clickable because the cursor changes to the "pointer" on hover.

Setting the `pointer-events` are set to `none` for arrow and pause buttons with the disabled attribute fixes this issue.

See video below:

https://user-images.githubusercontent.com/26844240/197296176-50095589-280c-4d8f-bda7-ebe6e7889f54.mov

## Links

Jira ticket: [SL-283](https://codedotorg.atlassian.net/browse/SL-283)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

Tested manually.

https://user-images.githubusercontent.com/26844240/197296943-64ec0357-55f5-428f-82ac-48a779b91d80.mov

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
