### PR TITLE
Add mangling rule for terser to conform to Safari 10.

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -926,7 +926,14 @@ describe('entry tests', () => {
           new TerserPlugin({
             // Excludes these from minification to avoid breaking functionality,
             // but still adds .min to the output filename suffix.
-            exclude: [/\/blockly.js$/, /\/brambleHost.js$/]
+            exclude: [/\/blockly.js$/, /\/brambleHost.js$/],
+            terserOptions: {
+              // Handle Safari 10.x issues: [See FND-2108 / FND-2109]
+              // Can remove when we can safely drop support for older iPad/iOS.
+              mangle: {
+                safari10: true
+              }
+            }
           })
         ],
 


### PR DESCRIPTION
**What**: Fix JavaScript loading on older iPads running Safari 10.

**How**: Uses `safari10` mangling rule for `terser` via TerserPlugin via Gruntfile.

Safari 10 is a little broken with regard to some simple syntax that it does not like. Namely, shadowed parameters and inner block let variables. We can remove this once Safari 10 is less used, but we were getting several tickets (a couple each week) regarding this issue.

The safari bug: https://bugs.webkit.org/show_bug.cgi?id=171041

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

- jira investigation ticket: [FND-2108](https://codedotorg.atlassian.net/browse/FND-2108)
- jira ticket: [FND-2109](https://codedotorg.atlassian.net/browse/FND-2109)

## Testing story

Complicated manual process.

I have a virtual machine running OS X 10.14 with XCode 10.3 and a simulator running iOS 10.3.1 with, thus, Safari 10. I then opened Safari to my local development server with the optimized assets option (`optimize_webpack_assets`) set to true. This means my dev server is loading the optimized assets. Then created a course section with secret words and added myself as a student and then went to the section's login screen to see the secret words input after clicking my name.

**Before**: (production page)

![image](https://user-images.githubusercontent.com/31674/197306175-4fbf3f2c-297f-49c8-ac92-e6c1ec105494.png)

**After**: (my own section in development)

![image](https://user-images.githubusercontent.com/31674/197306095-54660da1-69b6-47e5-bf89-ebc8dbd9d99b.png)

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

<!--
## Deployment strategy
-->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
