### PR TITLE
remove references to pegasus tutorials table from congrats pages

### DIFF
--- a/dashboard/app/controllers/certificate_images_controller.rb
+++ b/dashboard/app/controllers/certificate_images_controller.rb
@@ -23,14 +23,12 @@ class CertificateImagesController < ApplicationController
       return render status: :bad_request, json: {message: 'invalid donor name'}
     end
 
-    unless valid_course_name?(data['course'])
-      return render status: :bad_request, json: {message: "invalid course name: #{data['course']}"}
-    end
+    course_name = valid_course_name?(data['course']) ? data['course'] : 'hourofcode'
 
-    course_version = CurriculumHelper.find_matching_course_version(data['course'])
+    course_version = CurriculumHelper.find_matching_course_version(course_name)
     course_title = course_version&.localized_title
     begin
-      image = CertificateImage.create_course_certificate_image(data['name'], data['course'], data['donor'], course_title)
+      image = CertificateImage.create_course_certificate_image(data['name'], course_name, data['donor'], course_title)
       image.format = format
       content_type = "image/#{format}"
       send_data image.to_blob, type: content_type

--- a/dashboard/app/controllers/certificate_images_controller.rb
+++ b/dashboard/app/controllers/certificate_images_controller.rb
@@ -23,7 +23,9 @@ class CertificateImagesController < ApplicationController
       return render status: :bad_request, json: {message: 'invalid donor name'}
     end
 
-    course_name = valid_course_name?(data['course']) ? data['course'] : 'hourofcode'
+    # if we do not recognize the course name, assume it is a 3rd party hour of
+    # code tutorial.
+    course_name = recognized_course_name?(data['course']) ? data['course'] : 'hourofcode'
 
     course_version = CurriculumHelper.find_matching_course_version(course_name)
     course_title = course_version&.localized_title
@@ -39,7 +41,7 @@ class CertificateImagesController < ApplicationController
 
   private
 
-  def valid_course_name?(name)
+  def recognized_course_name?(name)
     name.nil? ||
       name == ScriptConstants::ACCELERATED_NAME ||
       CertificateImage.prefilled_title_course?(name) ||

--- a/dashboard/lib/certificate_image.rb
+++ b/dashboard/lib/certificate_image.rb
@@ -182,9 +182,7 @@ class CertificateImage
   end
 
   def self.hoc_course?(course)
-    hoc_course = ScriptConstants.unit_in_category?(:hoc, course)
-    hoc_course ||= tutorial_codes.any?(course)
-    hoc_course
+    ScriptConstants.unit_in_category?(:hoc, course)
   end
 
   def self.prefilled_title_course?(course)
@@ -219,9 +217,5 @@ class CertificateImage
     else
       'blank_certificate.png'
     end
-  end
-
-  def self.tutorial_codes
-    @@tutorial_codes ||= PEGASUS_DB[:tutorials].all.map {|t| t[:code]}
   end
 end

--- a/dashboard/lib/certificate_image.rb
+++ b/dashboard/lib/certificate_image.rb
@@ -184,7 +184,8 @@ class CertificateImage
   # assume any unrecognized course name is a hoc course
   def self.hoc_course?(course)
     return true if ScriptConstants.unit_in_category?(:hoc, course)
-    return false if CurriculumHelper.find_matching_course_version(name)
+    return false if [ScriptConstants::ACCELERATED_NAME, ScriptConstants::TWENTY_HOUR_NAME].include?(course)
+    return false if CurriculumHelper.find_matching_course_version(course)
     true
   end
 

--- a/dashboard/lib/certificate_image.rb
+++ b/dashboard/lib/certificate_image.rb
@@ -181,8 +181,11 @@ class CertificateImage
     image
   end
 
+  # assume any unrecognized course name is a hoc course
   def self.hoc_course?(course)
-    ScriptConstants.unit_in_category?(:hoc, course)
+    return true if ScriptConstants.unit_in_category?(:hoc, course)
+    return false if CurriculumHelper.find_matching_course_version(name)
+    true
   end
 
   def self.prefilled_title_course?(course)

--- a/dashboard/lib/certificate_image.rb
+++ b/dashboard/lib/certificate_image.rb
@@ -181,10 +181,14 @@ class CertificateImage
     image
   end
 
+  def self.accelerated_course?(course)
+    [ScriptConstants::ACCELERATED_NAME, ScriptConstants::TWENTY_HOUR_NAME].include?(course)
+  end
+
   # assume any unrecognized course name is a hoc course
   def self.hoc_course?(course)
     return true if ScriptConstants.unit_in_category?(:hoc, course)
-    return false if [ScriptConstants::ACCELERATED_NAME, ScriptConstants::TWENTY_HOUR_NAME].include?(course)
+    return false if accelerated_course?(course)
     return false if CurriculumHelper.find_matching_course_version(course)
     true
   end
@@ -212,12 +216,12 @@ class CertificateImage
       'MC_Hour_Of_Code_Certificate_mee_estate.png'
     elsif course == ScriptConstants::OCEANS_NAME
       'oceans_hoc_certificate.png'
-    elsif hoc_course?(course)
-      'hour_of_code_certificate.jpg'
-    elsif ScriptConstants.unit_in_category?(:twenty_hour, course) || course == ScriptConstants::ACCELERATED_NAME
+    elsif accelerated_course?(course)
       # The 20-hour course is referred to as "accelerated" throughout the
       # congrats and certificate pages (see csf_finish_url).
       '20hours_certificate.jpg'
+    elsif hoc_course?(course)
+      'hour_of_code_certificate.jpg'
     else
       'blank_certificate.png'
     end

--- a/dashboard/lib/certificate_image.rb
+++ b/dashboard/lib/certificate_image.rb
@@ -157,8 +157,6 @@ class CertificateImage
       vertical_offset = course == '20-hour' ? -125 : -120
       image = create_certificate_image2(path, name, y: vertical_offset)
     else # all other courses use a certificate image where the course name is also blank
-      course_title ||= fallback_course_title_for(course)
-
       image = Magick::Image.read(path).first
       apply_text(image, name, 75, 'Helvetica bold', 'rgb(118,101,160)', 0, -135, CERT_NAME_AREA_WIDTH, CERT_NAME_AREA_HEIGHT)
       # The area in pixels which will display the course title.
@@ -191,25 +189,6 @@ class CertificateImage
 
   def self.prefilled_title_course?(course)
     certificate_template_for(course) != 'blank_certificate.png'
-  end
-
-  # Specify a fallback certificate title for a given non-HoC course ID. As of HoC
-  # 2015 this fallback mapping is only ever hit on bulk /certificates pages.
-  def self.fallback_course_title_for(course)
-    case course
-    when ScriptConstants::ARTIST_NAME
-      'Artist'
-    when ScriptConstants::COURSE1_NAME
-      'Course 1'
-    when ScriptConstants::COURSE2_NAME
-      'Course 2'
-    when ScriptConstants::COURSE3_NAME
-      'Course 3'
-    when ScriptConstants::COURSE4_NAME
-      'Course 4'
-    else
-      course
-    end
   end
 
   def self.certificate_template_for(course)

--- a/dashboard/test/controllers/certificate_images_controller_test.rb
+++ b/dashboard/test/controllers/certificate_images_controller_test.rb
@@ -82,11 +82,11 @@ class CertificateImagesControllerTest < ActionController::TestCase
     assert_response :success
   end
 
-  test 'bad request given bogus course name' do
+  test 'can show bogus course name' do
     data = {name: 'student', course: 'bogus'}
     filename = Base64.urlsafe_encode64(data.to_json)
     get :show, format: 'jpg', params: {filename: filename}
-    assert_response :bad_request
+    assert_response :success
   end
 
   test 'returns bad request given invalid format' do

--- a/dashboard/test/lib/certificate_image_test.rb
+++ b/dashboard/test/lib/certificate_image_test.rb
@@ -34,13 +34,6 @@ class CertificateImageTest < ActiveSupport::TestCase
     assert_equal 'blank_certificate.png', CertificateImage.certificate_template_for('course4')
   end
 
-  def test_course_fallback_titles
-    assert_equal 'Course 1', CertificateImage.fallback_course_title_for('course1')
-    assert_equal 'Course 2', CertificateImage.fallback_course_title_for('course2')
-    assert_equal 'Course 3', CertificateImage.fallback_course_title_for('course3')
-    assert_equal 'Course 4', CertificateImage.fallback_course_title_for('course4')
-  end
-
   def test_image_generation
     mc_certificate_image = CertificateImage.create_course_certificate_image('Robot Tester', 'mc')
     assert_image mc_certificate_image, 1754, 1235, 'PNG'

--- a/dashboard/test/lib/certificate_image_test.rb
+++ b/dashboard/test/lib/certificate_image_test.rb
@@ -104,6 +104,25 @@ class CertificateImageTest < ActiveSupport::TestCase
     assert_equal '\\\\', CertificateImage.escape_image_magick_string('\\')
   end
 
+  def test_hoc_course
+    coursea = create :script, name: "coursea-2021", is_course: true
+    create :course_version, content_root: coursea
+
+    csp = create :unit_group, name: 'csp-2021'
+    create :course_version, content_root: csp
+
+    assert CertificateImage.hoc_course?('flappy')
+    assert CertificateImage.hoc_course?('oceans')
+    assert CertificateImage.hoc_course?('mc')
+    assert CertificateImage.hoc_course?('mee')
+    assert CertificateImage.hoc_course?('kodable')
+
+    # course1 is created by dashboard test fixtures
+    refute CertificateImage.hoc_course?('course1')
+    refute CertificateImage.hoc_course?('coursea-2021')
+    refute CertificateImage.hoc_course?('csp-2021')
+  end
+
   private
 
   def assert_image(image, width, height, format)


### PR DESCRIPTION
The purpose of this PR is to remove this unwanted DB access: 
* https://github.com/code-dot-org/code-dot-org/blob/29b38fb5004581dd0f5e5b003bb2dec5cb1078eb/dashboard/lib/certificate_image.rb#L186-L188
* https://github.com/code-dot-org/code-dot-org/blob/03b5c541c2a9cf11bdcf10853ebf9c25b8a1974f/dashboard/lib/certificate_image.rb#L245-L246

It also happens to fix a congrats page issue on staging and test (see follow-up comments).

In order to remove the DB access, I had to change around the logic for how we decide whether a course is a HOC course. to summarize, we now assume that any course we don't recognize in dashboard code (certificate_image.rb) or dashboard DB (unit or unit group) is a HOC course, rather than using the pegasus tutorials table as an allowlist. This seems justifiable because the consequence of a user getting to a congrats page for a bogus course name is very low (no different than someone filling out a certificate on vanilla https://studio.code.org/congrats).

old vs new logic can be seen in the diff in certificate_image.rb: https://github.com/code-dot-org/code-dot-org/pull/48797/files#diff-2915d409201a798a03acae10ddca416c22ac2139b8e05de28c21b8a135b0f314L186 

While I was in here, I also did the following cleanup: c73de3c49a40e6db591b8cd30bb93901a1a0c8d2 remove unused fallback_course_title_for helper. this seemed safe because `course_title` is always provided for courses with fallback titles (list of courses is visible in the diff).

## Testing story

* new unit tests confirm that there are no regressions in what gets classified as a HOC course
* green drone run, may need to click "show all checks" below for some reason