### PR TITLE
Advocacy: speculative fix for missing map (fifth attempt)

### DIFF
--- a/pegasus/sites.v3/code.org/public/js/extended_us_map.js
+++ b/pegasus/sites.v3/code.org/public/js/extended_us_map.js
@@ -794,15 +794,15 @@ document.addEventListener("DOMContentLoaded", function() {
   console.log("DOMContentLoaded");
 });
 
-$(document).ready(function () {
-  initExtendedMap();
-});
-
 // NOTE: This is not a good pattern to replicate, but is a workaround
 // for an issue with loading Raphael before attempting to render the map.
 // A better implementation would move this code to /apps/src.
 
 let initAttemptsRemaining = 10;
+
+$(document).ready(function () {
+  initExtendedMap();
+});
 
 function initExtendedMap() {
   if (initAttemptsRemaining === 0) {


### PR DESCRIPTION
The interactive map continues to sometimes fail to render at https://advocacy.code.org/ on production.

This is a fourth attempt at fixing the missing map, with the prior attempt in https://github.com/code-dot-org/code-dot-org/pull/48758.

The latest twist was this error:

```
ReferenceError: Cannot access 'initAttemptsRemaining' before initialization
    at initExtendedMap
```

With the last change, it appears that on production, `$(document.ready)` runs `initExtendedMap` instantly (the DOM must be ready by the time the script executes) and we skip the declaration of `initAttemptsRemaining`.
