### PR TITLE
Add http_cache to list of files that might affect shared tests

### DIFF
--- a/lib/rake/test.rake
+++ b/lib/rake/test.rake
@@ -369,7 +369,17 @@ namespace :test do
 
     desc 'Runs shared tests if shared might have changed from staging.'
     task :shared do
-      run_tests_if_changed('shared', ['Gemfile', 'Gemfile.lock', 'deployment.rb', 'shared/**/*', 'lib/**/*']) do
+      run_tests_if_changed(
+        'shared',
+        [
+          'Gemfile',
+          'Gemfile.lock',
+          'cookbooks/cdo-varnish/libraries/http_cache.rb',
+          'deployment.rb',
+          'shared/**/*',
+          'lib/**/*',
+        ]
+      ) do
         TestRunUtils.run_shared_tests
       end
     end


### PR DESCRIPTION
When reviewing #48784, I remembered an [old thread](https://codedotorg.slack.com/archives/C03CK49G9/p1634846250002800) from last year where a change to `http_cache.rb` broke a test in `shared/`. We should've added this file to the list of files that could affect shared tests then but adding now as we're updating `http_cache.rb` in advance of HoC.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
