### PR TITLE
Mike/move get field to cdo utils

### DIFF
--- a/apps/src/blockly/addons/cdoUtils.js
+++ b/apps/src/blockly/addons/cdoUtils.js
@@ -1,4 +1,4 @@
-import {ToolboxType} from '../constants';
+import {ToolboxType, CLAMPED_NUMBER_REGEX} from '../constants';
 
 export function setHSV(block, h, s, v) {
   block.setColour(Blockly.utils.colour.hsvToHex(h, s, v * 255));
@@ -67,17 +67,14 @@ export function getBlockLimit(blockType) {
   return 0;
 }
 
+/**
+ * Returns a new Field object,
+ * conditional on the type of block we're trying to create.
+ * @param {string} type
+ * @returns {?Blockly.Field}
+ */
 export function getField(type) {
   let field;
-  // Used for custom field type ClampedNumber(,)
-  // Captures two optional arguments from the type string
-  // Allows:
-  //   ClampedNumber(x,y)
-  //   ClampedNumber( x , y )
-  //   ClampedNumber(,y)
-  //   ClampedNumber(x,)
-  //   ClampedNumber(,)
-  const CLAMPED_NUMBER_REGEX = /^ClampedNumber\(\s*([\d.]*)\s*,\s*([\d.]*)\s*\)$/;
   if (type === 'Number') {
     field = new Blockly.FieldNumber();
   } else if (type.includes('ClampedNumber')) {

--- a/apps/src/blockly/addons/cdoUtils.js
+++ b/apps/src/blockly/addons/cdoUtils.js
@@ -66,3 +66,29 @@ export function blockLimitExceeded() {
 export function getBlockLimit(blockType) {
   return 0;
 }
+
+export function getField(type) {
+  let field;
+  // Used for custom field type ClampedNumber(,)
+  // Captures two optional arguments from the type string
+  // Allows:
+  //   ClampedNumber(x,y)
+  //   ClampedNumber( x , y )
+  //   ClampedNumber(,y)
+  //   ClampedNumber(x,)
+  //   ClampedNumber(,)
+  const CLAMPED_NUMBER_REGEX = /^ClampedNumber\(\s*([\d.]*)\s*,\s*([\d.]*)\s*\)$/;
+  if (type === 'Number') {
+    field = new Blockly.FieldNumber();
+  } else if (type.includes('ClampedNumber')) {
+    const clampedNumberMatch = type.match(CLAMPED_NUMBER_REGEX);
+    if (clampedNumberMatch) {
+      const min = parseFloat(clampedNumberMatch[1]);
+      const max = parseFloat(clampedNumberMatch[2]);
+      field = new Blockly.FieldNumber(0, min, max);
+    }
+  } else {
+    field = new Blockly.FieldTextInput();
+  }
+  return field;
+}

--- a/apps/src/blockly/cdoBlocklyWrapper.js
+++ b/apps/src/blockly/cdoBlocklyWrapper.js
@@ -1,4 +1,5 @@
 import {BlocklyVersion} from '@cdo/apps/constants';
+import {CLAMPED_NUMBER_REGEX} from './constants';
 
 const INFINITE_LOOP_TRAP =
   '  executionInfo.checkTimeout(); if (executionInfo.isTerminated()){return;}\n';
@@ -70,20 +71,10 @@ function strip(code) {
 /**
  * Given a type string for a field input, returns an appropriate change handler function
  * for that type, which customizes the input field and provides validation on blur.
- * @param {Blockly} blockly
  * @param {string} type
  * @returns {?function}
  */
 function getFieldInputChangeHandler(type) {
-  // Used for custom field type ClampedNumber(,)
-  // Captures two optional arguments from the type string
-  // Allows:
-  //   ClampedNumber(x,y)
-  //   ClampedNumber( x , y )
-  //   ClampedNumber(,y)
-  //   ClampedNumber(x,)
-  //   ClampedNumber(,)
-  const CLAMPED_NUMBER_REGEX = /^ClampedNumber\(\s*([\d.]*)\s*,\s*([\d.]*)\s*\)$/;
   const clampedNumberMatch = type.match(CLAMPED_NUMBER_REGEX);
   if (clampedNumberMatch) {
     const min = parseFloat(clampedNumberMatch[1]);
@@ -95,6 +86,7 @@ function getFieldInputChangeHandler(type) {
     return undefined;
   }
 }
+
 function initializeBlocklyWrapper(blocklyInstance) {
   const blocklyWrapper = new BlocklyWrapper(blocklyInstance);
 

--- a/apps/src/blockly/cdoBlocklyWrapper.js
+++ b/apps/src/blockly/cdoBlocklyWrapper.js
@@ -67,6 +67,34 @@ function strip(code) {
   );
 }
 
+/**
+ * Given a type string for a field input, returns an appropriate change handler function
+ * for that type, which customizes the input field and provides validation on blur.
+ * @param {Blockly} blockly
+ * @param {string} type
+ * @returns {?function}
+ */
+function getFieldInputChangeHandler(type) {
+  // Used for custom field type ClampedNumber(,)
+  // Captures two optional arguments from the type string
+  // Allows:
+  //   ClampedNumber(x,y)
+  //   ClampedNumber( x , y )
+  //   ClampedNumber(,y)
+  //   ClampedNumber(x,)
+  //   ClampedNumber(,)
+  const CLAMPED_NUMBER_REGEX = /^ClampedNumber\(\s*([\d.]*)\s*,\s*([\d.]*)\s*\)$/;
+  const clampedNumberMatch = type.match(CLAMPED_NUMBER_REGEX);
+  if (clampedNumberMatch) {
+    const min = parseFloat(clampedNumberMatch[1]);
+    const max = parseFloat(clampedNumberMatch[2]);
+    return Blockly.FieldTextInput.clampedNumberValidator(min, max);
+  } else if ('Number' === type) {
+    return Blockly.FieldTextInput.numberValidator;
+  } else {
+    return undefined;
+  }
+}
 function initializeBlocklyWrapper(blocklyInstance) {
   const blocklyWrapper = new BlocklyWrapper(blocklyInstance);
 
@@ -248,6 +276,9 @@ function initializeBlocklyWrapper(blocklyInstance) {
     },
     bindBrowserEvent: function(element, name, thisObject, func, useCapture) {
       return Blockly.bindEvent_(element, name, thisObject, func, useCapture);
+    },
+    getField: function(type) {
+      return new Blockly.FieldTextInput('', getFieldInputChangeHandler(type));
     }
   };
   return blocklyWrapper;

--- a/apps/src/blockly/constants.js
+++ b/apps/src/blockly/constants.js
@@ -1,3 +1,13 @@
 import {makeEnum} from '@cdo/apps/utils';
 
 export const ToolboxType = makeEnum('CATEGORIZED', 'UNCATEGORIZED', 'NONE');
+
+// Used for custom field type ClampedNumber(,)
+// Captures two optional arguments from the type string
+// Allows:
+//   ClampedNumber(x,y)
+//   ClampedNumber( x , y )
+//   ClampedNumber(,y)
+//   ClampedNumber(x,)
+//   ClampedNumber(,)
+export const CLAMPED_NUMBER_REGEX = /^ClampedNumber\(\s*([\d.]*)\s*,\s*([\d.]*)\s*\)$/;


### PR DESCRIPTION
A convention we've been using for functions like these is to move the definitions for each version into cdoUtils so that files like block_utils don't need awareness of Blockly version to operate. Let me know what you think!

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
