### PR TITLE
HoC 2022 - Update Hello World activity body string

### DIFF
--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -695,7 +695,7 @@ en:
       title: 'Dance Party'
     hello-world:
       title: 'Hello World'
-      body: 'Choose from four fun themes to code interactive characters in a world you create.'
+      body: 'Choose from six fun themes (including space and soccer!) to code interactive characters in a world you create.'
     poem-art:
       title: 'Poem Art'
       body: 'Express yourself! Use code to create animated poems.'


### PR DESCRIPTION
Update the Hello World activity `body` string on [/dashboard/config/locales/en.yml](https://github.com/code-dot-org/code-dot-org/blob/aaea70038819dfd4ae00a3136976fefd23f9a40c/dashboard/config/locales/en.yml) for localization.
- Shown on this page: https://code.org/hourofcode/overview
- Updates number of progressions from four to six and includes a space and soccer callout

**Before:**
<img width="244" alt="Before" src="https://user-images.githubusercontent.com/9256643/197578918-9465b1a9-1f04-4eb9-9a73-00782e4c5617.png">

**After:**
<img width="240" alt="After" src="https://user-images.githubusercontent.com/9256643/197578930-23e9134d-f5d4-41fb-b5fc-404a3b0cde0d.png">