### PR TITLE
preload studio congrats page in kodable ui test

### DIFF
--- a/dashboard/test/ui/features/hour_of_code/hour_of_code_finish.feature
+++ b/dashboard/test/ui/features/hour_of_code/hour_of_code_finish.feature
@@ -57,7 +57,10 @@ Scenario: Pegasus share page preserves certificate when redirecting
   And I see custom certificate image with name "Robo Coder" and course "mc"
 
 Scenario: non-mee 3rd party tutorial redirects to congrats page with params
-  Given I am on "http://code.org/api/hour/finish/kodable"
+  Given I am on "http://studio.code.org/congrats"
+  And I wait until element "#uitest-certificate" is visible
+
+  When I am on "http://code.org/api/hour/finish/kodable"
   And I wait until current URL contains "http://studio.code.org/congrats"
   Then my query params match "\?i\=.*\&s\=a29kYWJsZQ=="
 


### PR DESCRIPTION
see [slack](https://codedotorg.slack.com/archives/C0T0PNTM3/p1666642815628329?thread_ts=1666634281.477539&cid=C0T0PNTM3). this scenario is failing in safari. this is a speculative fix, to make it look more like the other test cases which are passing. I'm doing this rather than disabling the test in safari, because I am not able to repro the safari failure locally. if this doesn't work, we can disable the test in safari.

## Testing story

UI test is passing locally

## Deployment strategy

ship it and see if test starts passing in safari
