### PR TITLE
Revert "Revert "Add terser-webpack-plugin as devDependency""

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -924,12 +924,15 @@ describe('entry tests', () => {
       ],
       mode: minify ? 'production' : 'development',
       optimization: {
+        minimize: minify,
         minimizer: [
           new TerserPlugin({
+            parallel: 4,
             // Excludes these from minification to avoid breaking functionality,
             // but still adds .min to the output filename suffix.
             exclude: [/\/blockly.js$/, /\/brambleHost.js$/],
             terserOptions: {
+              sourceMap: envConstants.DEBUG_MINIFIED,
               // Handle Safari 10.x issues: [See FND-2108 / FND-2109]
               // Can remove when we can safely drop support for older iPad/iOS.
               mangle: {

--- a/apps/package.json
+++ b/apps/package.json
@@ -220,6 +220,7 @@
     "stylelint": "^14.10.0",
     "stylelint-config-standard": "^27.0.0",
     "stylelint-config-standard-scss": "^5.0.0",
+    "terser-webpack-plugin": "^5.3.6",
     "uglifyjs-webpack-plugin": "^2.2.0",
     "unminified-webpack-plugin": "^3.0.0",
     "url-loader": "^4.1.1",

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -17164,7 +17164,7 @@ terser-webpack-plugin@^4.2.3:
     terser "^5.3.4"
     webpack-sources "^1.4.3"
 
-terser-webpack-plugin@^5.0.3:
+terser-webpack-plugin@^5.0.3, terser-webpack-plugin@^5.3.6:
   version "5.3.6"
   resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.3.6.tgz#5590aec31aa3c6f771ce1b1acca60639eab3195c"
   integrity sha512-kfLFk+PoLUQIbLmB1+PZDMRSZS99Mp+/MHqDNmMA6tOItzRt+Npe3E+fsMs5mfcM0wCtrrdU387UnV+vnSffXQ==


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#48727.

### Background

CloudWatch alerts were triggered due to critically low disk space on the test and staging servers. The infra team narrowed it down to `node_modules/.cache/terser-webpack-plugin` taking up an enormous amount of disk space after the webpack 5 upgrade. This directory was growing after every apps production build, which is why it took some time for the alerts to be triggered. ([original Slack thread](https://codedotorg.slack.com/archives/C03CK49G9/p1665786591961429), [follow-up Slack thread](https://codedotorg.slack.com/archives/C03CK49G9/p1666728008297979))

### What this change does

Similar to #48706 but with different configuration updates. The original PR worked locally but caused an OOM error on the test machine during `yarn build:dist`. I then introduced #48724, which just added `terser-webpack-plugin` with no configuration change, which had the same OOM issue.

I ran the production build on the test machine with the changes in this branch and it completed successfully. I also confirmed that the original problem (the build creating an ever-growing `node_modules/.cache/terser-webpack-plugin` directory) should no longer happen by doing the following:
1. Deleting `node_modules/.cache/terser-webpack-plugin` (just manually with `rm -rf`)
2. Running the production build (`yarn build:dist`)
3. Confirming that `node_modules/.cache/terser-webpack-plugin` was not created