### PR TITLE
Fix settings options being cut off in JavaLab while in starter mode (levelbuilder) 

### DIFF
--- a/apps/src/javalab/ControlButtons.jsx
+++ b/apps/src/javalab/ControlButtons.jsx
@@ -66,14 +66,16 @@ export default function ControlButtons({
       </div>
       <div className={style.rightButtons}>
         <JavalabSettings />
-        <JavalabButton
-          text={finishButtonText}
-          onClick={isSubmittable ? null : onContinue}
-          className={style.buttonBlue}
-          isDisabled={disableFinishButton}
-          id={finishButtonId}
-          tooltipText={finishButtonTooltipText}
-        />
+        {!isEditingStartSources && (
+          <JavalabButton
+            text={finishButtonText}
+            onClick={isSubmittable ? null : onContinue}
+            className={style.buttonBlue}
+            isDisabled={disableFinishButton}
+            id={finishButtonId}
+            tooltipText={finishButtonTooltipText}
+          />
+        )}
       </div>
     </div>
   );

--- a/apps/src/javalab/ControlButtons.jsx
+++ b/apps/src/javalab/ControlButtons.jsx
@@ -66,16 +66,14 @@ export default function ControlButtons({
       </div>
       <div className={style.rightButtons}>
         <JavalabSettings />
-        {!isEditingStartSources && (
-          <JavalabButton
-            text={finishButtonText}
-            onClick={isSubmittable ? null : onContinue}
-            className={style.buttonBlue}
-            isDisabled={disableFinishButton}
-            id={finishButtonId}
-            tooltipText={finishButtonTooltipText}
-          />
-        )}
+        <JavalabButton
+          text={finishButtonText}
+          onClick={isSubmittable ? null : onContinue}
+          className={style.buttonBlue}
+          isDisabled={disableFinishButton}
+          id={finishButtonId}
+          tooltipText={finishButtonTooltipText}
+        />
       </div>
     </div>
   );

--- a/apps/src/javalab/javalab-settings.module.scss
+++ b/apps/src/javalab/javalab-settings.module.scss
@@ -16,7 +16,7 @@
 .settingsDropdown {
   @extend %dropdown;
   bottom: 40px;
-  margin-left: 5px;
+  margin-left: -47px;
 }
 
 .item {


### PR DESCRIPTION
If a curriculum writer is editing starter sources in LevelBuilder in JavaLab, the settings menu is cut off because there is no Finish button displayed. The only time this happens is in start mode on LevelBuilder.

~~After consulting with Jamila who reported this issue, I removed a condition so that the Finish button is displayed in start mode. When I asked in [this Slack thread](https://codedotorg.slack.com/archives/C01EF4GJ9GE/p1665168509948309) about her preference, she said she didn't have a preference. The alternative I was considering was having the dropdown menu open to the left which would have been a much more involved update.~~

Updated per [Slack discussion](https://codedotorg.slack.com/archives/C01EF4GJ9GE/p1665168509948309). Turns out that opening menu to the left was not much more involved! I was able to display the settings dropdown opening to the left by changing the margin-left property from 5px to -47px settingsDropdown in the javalab-settings.module.scss file. 

However, I am unsure if the settings menu should open to the left if there is a Finish button or if it should still open to the right. I'm open to suggestions! Update: Checked with Mike O, and he said it was fine to have Settings menu open to left in all cases. [Slack thread discusssion](https://codedotorg.slack.com/archives/C01EF4GJ9GE/p1666821047062899?thread_ts=1665168509.948309&cid=C01EF4GJ9GE)

https://user-images.githubusercontent.com/107423305/198109364-ab8ea145-5a81-43d5-b972-0808683d906f.mp4

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

[jra ticket](https://codedotorg.atlassian.net/browse/SL-298)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
I tested this update locally.

Screencast video before update: 

https://user-images.githubusercontent.com/107423305/197890900-352900b1-a746-404d-9ef0-183ff04acfb4.mp4


Screencast video after update (keeping Finish button in start mode): THIS IS NO LONGER BEING IMPLEMENTED but wanted to keep documented.

https://user-images.githubusercontent.com/107423305/197890926-5be48821-e88e-4cef-9354-033f6515455e.mp4



<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

1. If a Javalab level only has a console (no instructions, no theater,…) then the settings menu is displayed on top of the Settings button. We should fix this - [jira ticket](https://codedotorg.atlassian.net/browse/SL-348)

2. Also, as mentioned in this [Slack discussion](https://codedotorg.slack.com/archives/C01EF4GJ9GE/p1665168509948309), folks agreed that there shouldn't be a Finish button in standalone Javalab projects using [studio.code.org/projects/javalab/new](http://studio.code.org/projects/javalab/new).
Just a note that I discussed this with Kaitie O'Bryan, and she shared that there is not a place in the CSA curriculum where students are working on standalone Javalab projects. 
But there are certainly teachers and students who discover this URL! [jira ticket](https://codedotorg.atlassian.net/browse/SL-349)

Also wanted to add a note about [this jira ticket](https://codedotorg.atlassian.net/browse/SL-132) because this PR addresses issue by having dropdown open to the left, we could possibly use this approach for the issue of Javalab tab file names being cut off if in rightmost position.

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
