### PR TITLE
WebSerial - ChromeOS - Only Browsers After v 90

### DIFF
--- a/apps/src/lib/kits/maker/ui/SetupGuide.jsx
+++ b/apps/src/lib/kits/maker/ui/SetupGuide.jsx
@@ -82,9 +82,9 @@ export default class SetupGuide extends React.Component {
       return this.webSerialButtonRender();
     }
 
-    // In the Maker App and in Chromebooks when a webSerial connection has been selected,
-    // skip the download instructions and display y checklist
-    if (isCodeOrgBrowser() || (isChromeOS() && shouldUseWebSerial())) {
+    // In the Maker App and in Chromebooks when a webSerial connection has been selected
+    // or when web serial is no enabled, skip the download instructions and display checklist
+    if (isCodeOrgBrowser() || isChromeOS()) {
       return this.webSerialSetupChecklist(webSerialPort, true);
     }
 

--- a/apps/src/lib/kits/maker/util/boardUtils.js
+++ b/apps/src/lib/kits/maker/util/boardUtils.js
@@ -7,7 +7,7 @@ import {
 } from '../portScanning';
 import WebSerialPortWrapper from '@cdo/apps/lib/kits/maker/WebSerialPortWrapper';
 import DCDO from '@cdo/apps/dcdo';
-import {isChromeOS} from '../util/browserChecks';
+import {isChromeOS, getChromeVersion} from '../util/browserChecks';
 
 export const BOARD_TYPE = {
   CLASSIC: 'classic',
@@ -56,13 +56,15 @@ export function isWebSerialPort(port) {
 
 /**
  * Determines whether WebSerial port is available in the current browser.
- * WebSerial should be available in ChromeOS (depending on DCDO flag) and
- * in Chromium browsers.
+ * WebSerial should be available in ChromeOS (depending on DCDO flag and
+ * in a version after WebSerial was released) and in Chromium browsers.
  */
 export function shouldUseWebSerial() {
   const webSerialAvailableInBrowser = 'serial' in navigator;
   const usingChromeOSAndDCDO =
-    isChromeOS() && !!DCDO.get('webserial-on-chromeos', true);
+    isChromeOS() &&
+    !!DCDO.get('webserial-on-chromeos', true) &&
+    getChromeVersion() >= 90;
 
   return usingChromeOSAndDCDO || webSerialAvailableInBrowser;
 }

--- a/apps/src/lib/kits/maker/util/browserChecks.js
+++ b/apps/src/lib/kits/maker/util/browserChecks.js
@@ -14,7 +14,7 @@ export function isCodeOrgBrowser() {
   return !!window.MakerBridge;
 }
 
-function getChromeVersion() {
+export function getChromeVersion() {
   const raw = navigator.userAgent.match(/Chrom(e|ium)\/([0-9]+)\./);
   return raw ? parseInt(raw[2], 10) : false;
 }


### PR DESCRIPTION
We currently support Chrome as old as v87, but WebSerial was not made publicly available until v90. Adding an additional logic step here to direct ChromeOS users on older browsers to the ChromeSerialPath.
