### PR TITLE
Music: fix triggered sounds sometimes not playing

### DIFF
--- a/apps/src/music/player/MusicPlayer.js
+++ b/apps/src/music/player/MusicPlayer.js
@@ -210,7 +210,19 @@ export default class MusicPlayer {
         this.startPlayingAudioTime +
         this.convertMeasureToSeconds(soundEvent.when);
 
-      if (eventStart >= GetCurrentAudioTime()) {
+      const currentAudioTime = GetCurrentAudioTime();
+
+      // Triggered sounds might have a target play time that is very slightly in
+      // the past, specificially when they use the currentTime passed (slightly
+      // earlier) into the event handler code as the target play time.
+      // To compensate for this delay, if the target play time is within a tenth of
+      // a second of the current play time, then play it.
+      // Note that we still don't play sounds older than that, because they might
+      // have been scheduled for some time ago, and Web Audio will play a
+      // sound immediately if its target time is in the past.
+      const delayCompensation = soundEvent.insideWhenRun ? 0 : 0.1;
+
+      if (eventStart >= currentAudioTime - delayCompensation) {
         soundEvent.uniqueId = PlaySound(
           this.groupPrefix + '/' + soundEvent.id,
           GROUP_TAG,


### PR DESCRIPTION
<img width="462" alt="Screenshot 2022-10-26 at 10 21 37 PM" src="https://user-images.githubusercontent.com/2205926/198198650-bb8c12af-8468-41dd-bc5d-79a2ea51846e.png">

Sometimes, a triggered sound played at `currentTime` wouldn't be played.  This was because the current audio time had progressed slightly beyond the event time by the time we got to the code that sets up the play.

The fix:

Triggered sounds might have a target play time that is very slightly in the past, specificially when they use the `currentTime` passed (slightly earlier) into the event handler code as the target play time.

To compensate for this delay, if the target play time is within a tenth of a second of the current play time, then play it.

Note that we still don't play sounds older than that, because they might have been scheduled for some time ago, and Web Audio will play a sound immediately if its target time is in the past.
