### PR TITLE
Localize remaining block variables

### DIFF
--- a/dashboard/test/models/blockly_test.rb
+++ b/dashboard/test/models/blockly_test.rb
@@ -1042,4 +1042,208 @@ class BlocklyTest < ActiveSupport::TestCase
 
     assert_equal expected_localized_block_xml, localized_block_xml
   end
+
+  test 'localizes math_change blocks' do
+    test_locale = 'te-ST'
+    level_name = 'test localize math change blocks'
+    original_variable_str = 'counter'
+    localized_variable_str = 'contador'
+    level = create(
+      :level,
+      :blockly,
+      name: level_name,
+    )
+
+    # Add translation mapping to the I18n backend
+    custom_i18n = {
+      'data' => {
+        'variable_names' => {
+          original_variable_str => localized_variable_str
+        }
+      }
+    }
+    I18n.locale = test_locale
+    I18n.backend.store_translations test_locale, custom_i18n
+
+    # Create a simple blockly level XML structure containing the
+    # original string, then localize the XML structure.
+    # A snippet of: https://studio.code.org/s/coursef-2021/lessons/12/levels/5
+    block_xml = <<~XML
+      <block type="maze_move">
+        <title name="DIR">moveForward</title>
+        <next>
+          <block type="controls_repeat_ext">
+            <value name="TIMES">
+              <block type="variables_get">
+                <title name="VAR">counter</title>
+              </block>
+            </value>
+            <statement name="DO">
+              <block type="maze_honey"/>
+            </statement>
+            <next>
+              <block type="maze_turn">
+                <title name="DIR">turnLeft</title>
+                <next>
+                  <block type="math_change">
+                    <title name="VAR">counter</title>
+                    <value name="DELTA">
+                      <block type="math_number">
+                        <title name="NUM">1</title>
+                      </block>
+                    </value>
+                  </block>
+                </next>
+              </block>
+            </next>
+          </block>
+        </next>
+      </block>
+    XML
+
+    # Localized output to be tested
+    localized_block_xml = level.localized_remaining_variable_blocks(block_xml)
+
+    # Expected output
+    parsed_xml = Nokogiri::XML(localized_block_xml, &:noblanks)
+    assert_equal parsed_xml.at_xpath('//block[@type="math_change"]/*[@name="VAR"]').content, localized_variable_str
+  end
+
+  test 'localizes gamelab_textVariableJoin blocks' do
+    test_locale = 'te-ST'
+    level_name = 'test localize gamelab_textVariableJoin blocks'
+    original_variable_str = 'name'
+    localized_variable_str = 'nombre'
+    level = create(
+      :level,
+      :blockly,
+      name: level_name,
+    )
+
+    # Add translation mapping to the I18n backend
+    custom_i18n = {
+      'data' => {
+        'variable_names' => {
+          original_variable_str => localized_variable_str
+        }
+      }
+    }
+    I18n.locale = test_locale
+    I18n.backend.store_translations test_locale, custom_i18n
+
+    # Create a simple blockly level XML structure containing the
+    # original string, then localize the XML structure.
+    # A snippet of: https://studio.code.org/s/coursef-2022/lessons/7/levels/1
+    block_xml = <<~XML
+      <block type="gamelab_whenPromptAnswered">
+        <value name="VAR">
+          <block type="variables_get">
+            <title name="VAR">name</title>
+          </block>
+        </value>
+        <next>
+          <block type="gamelab_printText">
+            <value name="TEXT">
+              <block type="gamelab_textJoin">
+                <title name="TEXT1">Hello </title>
+                <value name="TEXT2">
+                  <block type="gamelab_textVariableJoin">
+                    <title name="VAR">name</title>
+                    <value name="TEXT2">
+                      <block type="text">
+                        <title name="TEXT">!</title>
+                      </block>
+                    </value>
+                  </block>
+                </value>
+              </block>
+            </value>
+          </block>
+        </next>
+      </block>
+    XML
+
+    # Localized output to be tested
+    localized_block_xml = level.localized_remaining_variable_blocks(block_xml)
+
+    # Expected output
+    parsed_xml = Nokogiri::XML(localized_block_xml, &:noblanks)
+    assert_equal parsed_xml.at_xpath('//block[@type="gamelab_textVariableJoin"]/*[@name="VAR"]').content, localized_variable_str
+  end
+
+  test 'localizes studio_ask blocks' do
+    test_locale = 'te-ST'
+    level_name = 'test localize studio_ask blocks'
+    original_variable_str = 'name'
+    localized_variable_str = 'nombre'
+    level = create(
+      :level,
+      :blockly,
+      name: level_name,
+    )
+
+    # Add translation mapping to the I18n backend
+    custom_i18n = {
+      'data' => {
+        'variable_names' => {
+          original_variable_str => localized_variable_str
+        }
+      }
+    }
+    I18n.locale = test_locale
+    I18n.backend.store_translations test_locale, custom_i18n
+
+    # Create a simple blockly level XML structure containing the
+    # original string, then localize the XML structure.
+    # A snippet of: https://studio.code.org/s/coursef-2017/lessons/17/levels/5
+    block_xml = <<~XML
+      <block type="when_run" deletable="false">
+        <next>
+          <block type="studio_ask" can_disconnect_from_parent="false">
+            <title name="TEXT">What be yer name?</title>
+            <title name="VAR">name</title>
+            <next>
+              <block type="studio_saySpriteParams" inline="true" can_disconnect_from_parent="false">
+                <title name="SPRITE">1</title>
+                <value name="TEXT">
+                  <block type="variables_get" editable="false" can_disconnect_from_parent="false">
+                    <title name="VAR">name</title>
+                  </block>
+                </value>
+                <next>
+                  <block type="studio_saySpriteParams" inline="true">
+                    <title name="SPRITE">0</title>
+                    <value name="TEXT">
+                      <block type="text_join_simple" inline="false" inputcount="3">
+                        <value name="ADD0">
+                          <block type="text">
+                            <title name="TEXT">It be a pleasure, </title>
+                          </block>
+                        </value>
+                        <value name="ADD2">
+                          <block type="text">
+                            <title name="TEXT">.</title>
+                          </block>
+                        </value>
+                      </block>
+                    </value>
+                  </block>
+                </next>
+              </block>
+            </next>
+          </block>
+        </next>
+      </block>
+      <block type="variables_get">
+        <title name="VAR">name</title>
+      </block>
+    XML
+
+    # Localized output to be tested
+    localized_block_xml = level.localized_remaining_variable_blocks(block_xml)
+
+    # Expected output
+    parsed_xml = Nokogiri::XML(localized_block_xml, &:noblanks)
+    assert_equal parsed_xml.at_xpath('//block[@type="studio_ask"]/*[@name="VAR"]').content, localized_variable_str
+  end
 end


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

**What**: Localizes some other blocks that otherwise covered by previous work.

**How**: Added a function based mostly on existing work that will iterate through extra blocks and then localize any immediate `<title name="VAR">` child tag within them. Any future blocks or those somehow not covered by this could be added to the list within this function. The related investigation ticket, however, did not find any such blocks.

The blocks affected are `studio_ask` (assigning a variable the contents of user input), `math_change` (math operator assignment), and `gamelab_textVariableJoin` (prevalent in Course F levels to join variables to strings). Real world levels are linked in the ticket with screenshots. The real world levels are also used to create unit tests.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

- jira ticket: [FND-2113](https://codedotorg.atlassian.net/browse/FND-2113)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

Took the affected levels and created test cases using them and their start_blocks XML as a basis. There is one for each of `studio_ask`, `math_change` and `gamelab_textVariableJoin`.

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
