### PR TITLE
Music: fix for infinite loop when loop field cleared

### DIFF
--- a/apps/src/music/blockly/blocks/control.js
+++ b/apps/src/music/blockly/blocks/control.js
@@ -109,12 +109,18 @@ export const forLoop = {
         'TO',
         Blockly.JavaScript.ORDER_ASSIGNMENT
       ) || '0';
+
+    // + is used to convert this value to a number.
+    // Useful if the field is blank, because '0' will
+    // be returned, and in that case we need the fallback
+    // to '1' to occur.
     const increment =
-      Blockly.JavaScript.valueToCode(
+      +Blockly.JavaScript.valueToCode(
         ctx,
         'BY',
         Blockly.JavaScript.ORDER_ASSIGNMENT
       ) || '1';
+
     let branch = Blockly.JavaScript.statementToCode(ctx, 'DO');
     branch = Blockly.JavaScript.addLoopTrap(branch, ctx);
     let code;


### PR DESCRIPTION
<img width="428" alt="Screenshot 2022-10-26 at 10 56 11 PM" src="https://user-images.githubusercontent.com/2205926/198203686-add842a3-e440-491a-a1d5-c0b5568a9f38.png">

When the "by" field was cleared, an infinite loop would occur, due to the generated code including something like this:
```
for (i = 1; i <= 3; i += 0)
```

The issue is subtle, but it turns out that `Blockly.JavaScript.valueToCode` was returning `'0'`, and while `'0' == false` might be `true`, `'0' || '1'` will return `'0'`.

The simple fix here is to use the [unary plus operator ](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Unary_plus)to convert the `'0'` to `0`.  Then we will fall back to `'1'` when the field is blank.