### PR TITLE
Don't skip verify_authenticity_token on level_starter_assets#destroy

### DIFF
--- a/dashboard/app/controllers/level_starter_assets_controller.rb
+++ b/dashboard/app/controllers/level_starter_assets_controller.rb
@@ -2,7 +2,6 @@ class LevelStarterAssetsController < ApplicationController
   authorize_resource class: false, except: [:show, :file]
   before_action :require_levelbuilder_mode, except: [:show, :file]
   before_action :set_level
-  skip_before_action :verify_authenticity_token, only: [:destroy]
 
   S3_BUCKET = 'cdo-v3-assets'.freeze
   S3_PREFIX = 'starter_assets/'.freeze


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

The delete functionality seems to still work locally without this line. Strangely, I don't see a token being passed in the HTTP request at all, so I'm not sure why this works?

![image](https://user-images.githubusercontent.com/1382374/198356948-efbe7014-4800-408e-b5fa-9176c252df08.png)


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- -->
- jira ticket: [TEACH-17](https://codedotorg.atlassian.net/browse/TEACH-17)


## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

Visit a block level editor (with levelbuilder perms/levelbuilder mode enabled), click the Toolbox gear and "Manage Assets", add/remove an asset.
