### PR TITLE
Add CSP and CSA eyes test coverage for PD Teacher Application

### DIFF
--- a/dashboard/test/ui/features/acquisition_products/pd/teacher_application.feature
+++ b/dashboard/test/ui/features/acquisition_products/pd/teacher_application.feature
@@ -249,7 +249,7 @@ Scenario: Teacher starts a new csp application and submits it
 
   # Section 2
   Then I wait until element "h3" contains text "Section 2: Choose Your Program"
-  And I press the second "input[name='program']" using jQuery
+  And I press the first "input[name='program'][value='Computer Science Principles (appropriate for 9th - 12th grade, and can be implemented as an AP or introductory course)']" element
   And I press the first "input[name='cspWhichGrades']" element
   And I press the first "input[name='cspHowOffer']" element
   And I press the first "input[name='enoughCourseHours']" element

--- a/dashboard/test/ui/features/acquisition_products/pd/teacher_application.feature
+++ b/dashboard/test/ui/features/acquisition_products/pd/teacher_application.feature
@@ -190,8 +190,7 @@ Scenario: Teacher starts a new csp application and submits it
 
   # Section 4
   Then I wait until element "h3" contains text "Section 4: Additional Demographic Information and Submission"
-  And I complete Section 3 of the teacher PD application
-  And I press the first "input#agree" element
+  And I complete Section 4 of the teacher PD application
 
   And I press the first "button[type='submit']" element
 

--- a/dashboard/test/ui/features/acquisition_products/pd/teacher_application.feature
+++ b/dashboard/test/ui/features/acquisition_products/pd/teacher_application.feature
@@ -3,7 +3,7 @@
 
 Feature: Teacher Application
 
-Scenario: Teacher starts a new application and submits it
+Scenario: Teacher starts a new csd application and submits it with principal approval
   Given I create a teacher named "Severus"
     And I am on "http://studio.code.org/pd/application/teacher"
     And I wait until element "h1" contains text "Professional Learning Program Teacher Application"
@@ -203,4 +203,161 @@ Scenario: Teacher saves, re-opens, and submits an application
   Then I wait until element "h1" contains text "Thank you for submitting your application!"
   Then I see no difference for "Confirmation after submitting previously saved application"
   Then I close my eyes
-  
+
+Scenario: Teacher starts a new csp application and submits it
+  Given I create a teacher named "Severus"
+    And I am on "http://studio.code.org/pd/application/teacher"
+    And I wait until element "h1" contains text "Professional Learning Program Teacher Application"
+    And I open my eyes to test "Teacher Application"
+
+  # Section 1
+  When I wait until element "h3" contains text "Section 1: About You and Your School"
+    And I press the first "input[name='country']" element
+    And I press the first "input[name='completingOnBehalfOfSomeoneElse'][value='No']" element
+    And I press keys "Severus" for element "input#firstName"
+    And I press keys "Snape" for element "input#lastName"
+    And I press keys "5558675309" for element "input#phone"
+    And I press keys "1501 4th Ave" for element "input#streetAddress"
+    And I press keys "Seattle" for element "input#city"
+    And I select the "Washington" option in dropdown "state"
+    And I press keys "98101" for element "input#zipCode"
+    And I press the first "input[name='previousYearlongCdoPd']" element
+    And I press the first "input[name='currentRole']" element
+    And I press keys "nonexistent" for element "#school input"
+
+  # School: select other and enter manual data
+  Then I wait until element ".VirtualizedSelectOption:contains('Other school not listed below')" is visible
+    And I press ".VirtualizedSelectOption:contains('Other school not listed below')" using jQuery
+    Then I wait until element "input#schoolName" is visible
+    And I press keys "Code.org" for element "input#schoolName"
+    And I press keys "Code.org District" for element "input#schoolDistrictName"
+    And I press keys "1501 4th Ave" for element "input#schoolAddress"
+    And I press keys "Seattle" for element "input#schoolCity"
+    And I select the "Washington" option in dropdown "schoolState"
+    And I press keys "98101" for element "input#schoolZipCode"
+    And I press the first "input[name='schoolType'][value='Other']" element
+  Then I press keys "Headmaster" for element "input#principalRole"
+  And I press keys "Albus" for element "input#principalFirstName"
+  And I press keys "Dumbledore" for element "input#principalLastName"
+  And I press keys "socks@hogwarts.edu" for element "input#principalEmail"
+  And I press keys "socks@hogwarts.edu" for element "input#principalConfirmEmail"
+  And I press keys "5555882300" for element "input#principalPhoneNumber"
+
+  Then I see no difference for "Section 1: About You and Your School"
+  And I press the first "button#next" element
+
+
+  # Section 2
+  Then I wait until element "h3" contains text "Section 2: Choose Your Program"
+  And I press "input[name='program']:second" using jQuery
+  And I press the first "input[name='cspWhichGrades']" element
+  And I press the first "input[name='cspHowOffer']" element
+  And I press the first "input[name='enoughCourseHours']" element
+  And I press the first "input[name='replaceExisting']" element
+
+  Then I see no difference for "Section 2: Choose Your Program"
+  And I press the first "button#next" element
+
+
+  # Section 3
+  Then I wait until element "h3" contains text "Section 3: Professional Learning Program Requirements"
+  Then I wait until element "input[name='committed']" is visible
+  And I press "input[name='committed']:first" using jQuery
+  And I press the first "input#understandFee" element
+  And I click selector "input[name='payFee']" if I see it
+  Then I see no difference for "Section 3: Professional Learning Program Requirements"
+  And I press the first "button#next" element
+
+
+  # Section 4
+  Then I wait until element "h3" contains text "Section 4: Additional Demographic Information and Submission"
+  And I press "input[name='genderIdentity']:first" using jQuery
+  And I press the first "input[name='race']" element
+  And I press the first "input[name='howHeard']" element
+  And I press the first "input#agree" element
+  Then I see no difference for "Section 4: Additional Demographic Information and Submission"
+  And I press the first "button[type='submit']" element
+
+  # Confirmation page
+  Then I wait until element "h1" contains text "Thank you for submitting your application!"
+  Then I see no difference for "Confirmation"
+
+Scenario: Teacher starts a new csa application and submits it
+  Given I create a teacher named "Severus"
+    And I am on "http://studio.code.org/pd/application/teacher"
+    And I wait until element "h1" contains text "Professional Learning Program Teacher Application"
+    And I open my eyes to test "Teacher Application"
+
+  # Section 1
+  When I wait until element "h3" contains text "Section 1: About You and Your School"
+    And I press the first "input[name='country']" element
+    And I press the first "input[name='completingOnBehalfOfSomeoneElse'][value='No']" element
+    And I press keys "Severus" for element "input#firstName"
+    And I press keys "Snape" for element "input#lastName"
+    And I press keys "5558675309" for element "input#phone"
+    And I press keys "1501 4th Ave" for element "input#streetAddress"
+    And I press keys "Seattle" for element "input#city"
+    And I select the "Washington" option in dropdown "state"
+    And I press keys "98101" for element "input#zipCode"
+    And I press the first "input[name='previousYearlongCdoPd']" element
+    And I press the first "input[name='currentRole']" element
+    And I press keys "nonexistent" for element "#school input"
+
+  # School: select other and enter manual data
+  Then I wait until element ".VirtualizedSelectOption:contains('Other school not listed below')" is visible
+    And I press ".VirtualizedSelectOption:contains('Other school not listed below')" using jQuery
+    Then I wait until element "input#schoolName" is visible
+    And I press keys "Code.org" for element "input#schoolName"
+    And I press keys "Code.org District" for element "input#schoolDistrictName"
+    And I press keys "1501 4th Ave" for element "input#schoolAddress"
+    And I press keys "Seattle" for element "input#schoolCity"
+    And I select the "Washington" option in dropdown "schoolState"
+    And I press keys "98101" for element "input#schoolZipCode"
+    And I press the first "input[name='schoolType'][value='Other']" element
+  Then I press keys "Headmaster" for element "input#principalRole"
+  And I press keys "Albus" for element "input#principalFirstName"
+  And I press keys "Dumbledore" for element "input#principalLastName"
+  And I press keys "socks@hogwarts.edu" for element "input#principalEmail"
+  And I press keys "socks@hogwarts.edu" for element "input#principalConfirmEmail"
+  And I press keys "5555882300" for element "input#principalPhoneNumber"
+
+  Then I see no difference for "Section 1: About You and Your School"
+  And I press the first "button#next" element
+
+
+  # Section 2
+  Then I wait until element "h3" contains text "Section 2: Choose Your Program"
+  And I press "input[name='program']:last" using jQuery
+  And I press the first "input[name='csaAlreadyKnow']" element
+  And I press the first "input[name='csaPhoneScreen']" element
+  And I press the first "input[name='csaWhichGrades']" element
+  And I press the first "input[name='csaHowOffer']" element
+  And I press the first "input[name='enoughCourseHours']" element
+  And I press the first "input[name='replaceExisting']" element
+
+  Then I see no difference for "Section 2: Choose Your Program"
+  And I press the first "button#next" element
+
+
+  # Section 3
+  Then I wait until element "h3" contains text "Section 3: Professional Learning Program Requirements"
+  Then I wait until element "input[name='committed']" is visible
+  And I press "input[name='committed']:first" using jQuery
+  And I press the first "input#understandFee" element
+  And I click selector "input[name='payFee']" if I see it
+  Then I see no difference for "Section 3: Professional Learning Program Requirements"
+  And I press the first "button#next" element
+
+
+  # Section 4
+  Then I wait until element "h3" contains text "Section 4: Additional Demographic Information and Submission"
+  And I press "input[name='genderIdentity']:first" using jQuery
+  And I press the first "input[name='race']" element
+  And I press the first "input[name='howHeard']" element
+  And I press the first "input#agree" element
+  Then I see no difference for "Section 4: Additional Demographic Information and Submission"
+  And I press the first "button[type='submit']" element
+
+  # Confirmation page
+  Then I wait until element "h1" contains text "Thank you for submitting your application!"
+  Then I see no difference for "Confirmation"

--- a/dashboard/test/ui/features/acquisition_products/pd/teacher_application.feature
+++ b/dashboard/test/ui/features/acquisition_products/pd/teacher_application.feature
@@ -1,46 +1,14 @@
 @dashboard_db_access
-@eyes
 
 Feature: Teacher Application
 
+@eyes
 Scenario: Teacher starts a new csd application and submits it with principal approval
   Given I create a teacher named "Severus"
     And I am on "http://studio.code.org/pd/application/teacher"
     And I wait until element "h1" contains text "Professional Learning Program Teacher Application"
     And I open my eyes to test "Teacher Application"
-
-  # Section 1
-  When I wait until element "h3" contains text "Section 1: About You and Your School"
-    And I press the first "input[name='country']" element
-    And I press the first "input[name='completingOnBehalfOfSomeoneElse'][value='No']" element
-    And I press keys "Severus" for element "input#firstName"
-    And I press keys "Snape" for element "input#lastName"
-    And I press keys "5558675309" for element "input#phone"
-    And I press keys "1501 4th Ave" for element "input#streetAddress"
-    And I press keys "Seattle" for element "input#city"
-    And I select the "Washington" option in dropdown "state"
-    And I press keys "98101" for element "input#zipCode"
-    And I press the first "input[name='previousYearlongCdoPd']" element
-    And I press the first "input[name='currentRole']" element
-    And I press keys "nonexistent" for element "#school input"
-
-  # School: select other and enter manual data
-  Then I wait until element ".VirtualizedSelectOption:contains('Other school not listed below')" is visible
-    And I press ".VirtualizedSelectOption:contains('Other school not listed below')" using jQuery
-    Then I wait until element "input#schoolName" is visible
-    And I press keys "Code.org" for element "input#schoolName"
-    And I press keys "Code.org District" for element "input#schoolDistrictName"
-    And I press keys "1501 4th Ave" for element "input#schoolAddress"
-    And I press keys "Seattle" for element "input#schoolCity"
-    And I select the "Washington" option in dropdown "schoolState"
-    And I press keys "98101" for element "input#schoolZipCode"
-    And I press the first "input[name='schoolType'][value='Other']" element
-  Then I press keys "Headmaster" for element "input#principalRole"
-  And I press keys "Albus" for element "input#principalFirstName"
-  And I press keys "Dumbledore" for element "input#principalLastName"
-  And I press keys "socks@hogwarts.edu" for element "input#principalEmail"
-  And I press keys "socks@hogwarts.edu" for element "input#principalConfirmEmail"
-  And I press keys "5555882300" for element "input#principalPhoneNumber"
+    And I complete Section 1 of the teacher PD application
 
   Then I see no difference for "Section 1: About You and Your School"
   And I press the first "button#next" element
@@ -59,20 +27,16 @@ Scenario: Teacher starts a new csd application and submits it with principal app
 
   # Section 3
   Then I wait until element "h3" contains text "Section 3: Professional Learning Program Requirements"
-  Then I wait until element "input[name='committed']" is visible
-  And I press "input[name='committed']:first" using jQuery
-  And I press the first "input#understandFee" element
-  And I click selector "input[name='payFee']" if I see it
+  And I complete Section 3 of the teacher PD application
+
   Then I see no difference for "Section 3: Professional Learning Program Requirements"
   And I press the first "button#next" element
 
 
   # Section 4
   Then I wait until element "h3" contains text "Section 4: Additional Demographic Information and Submission"
-  And I press "input[name='genderIdentity']:first" using jQuery
-  And I press the first "input[name='race']" element
-  And I press the first "input[name='howHeard']" element
-  And I press the first "input#agree" element
+  And I complete Section 4 of the teacher PD application
+
   Then I see no difference for "Section 4: Additional Demographic Information and Submission"
   And I press the first "button[type='submit']" element
 
@@ -124,6 +88,7 @@ Scenario: Teacher starts a new csd application and submits it with principal app
   Then I see no difference for "Principal approval confirmation form"
   Then I close my eyes
 
+@eyes
 Scenario: Teacher saves, re-opens, and submits an application
   Given I create a teacher named "Severus"
   And I am on "http://studio.code.org/pd/application/teacher"
@@ -185,18 +150,12 @@ Scenario: Teacher saves, re-opens, and submits an application
 
   # Section 3
   Then I wait until element "h3" contains text "Section 3: Professional Learning Program Requirements"
-  Then I wait until element "input[name='committed']" is visible
-  And I press "input[name='committed']:first" using jQuery
-  And I press the first "input#understandFee" element
-  And I click selector "input[name='payFee']" if I see it
+  And I complete Section 3 of the teacher PD application
   And I press the first "button#next" element
 
   # Section 4
   Then I wait until element "h3" contains text "Section 4: Additional Demographic Information and Submission"
-  And I press "input[name='genderIdentity']:first" using jQuery
-  And I press the first "input[name='race']" element
-  And I press the first "input[name='howHeard']" element
-  And I press the first "input#agree" element
+  And I complete Section 4 of the teacher PD application
   And I press the first "button[type='submit']" element
 
   # Confirmation page
@@ -208,43 +167,8 @@ Scenario: Teacher starts a new csp application and submits it
   Given I create a teacher named "Severus"
     And I am on "http://studio.code.org/pd/application/teacher"
     And I wait until element "h1" contains text "Professional Learning Program Teacher Application"
-    And I open my eyes to test "Teacher Application"
-
-  # Section 1
-  When I wait until element "h3" contains text "Section 1: About You and Your School"
-    And I press the first "input[name='country']" element
-    And I press the first "input[name='completingOnBehalfOfSomeoneElse'][value='No']" element
-    And I press keys "Severus" for element "input#firstName"
-    And I press keys "Snape" for element "input#lastName"
-    And I press keys "5558675309" for element "input#phone"
-    And I press keys "1501 4th Ave" for element "input#streetAddress"
-    And I press keys "Seattle" for element "input#city"
-    And I select the "Washington" option in dropdown "state"
-    And I press keys "98101" for element "input#zipCode"
-    And I press the first "input[name='previousYearlongCdoPd']" element
-    And I press the first "input[name='currentRole']" element
-    And I press keys "nonexistent" for element "#school input"
-
-  # School: select other and enter manual data
-  Then I wait until element ".VirtualizedSelectOption:contains('Other school not listed below')" is visible
-    And I press ".VirtualizedSelectOption:contains('Other school not listed below')" using jQuery
-    Then I wait until element "input#schoolName" is visible
-    And I press keys "Code.org" for element "input#schoolName"
-    And I press keys "Code.org District" for element "input#schoolDistrictName"
-    And I press keys "1501 4th Ave" for element "input#schoolAddress"
-    And I press keys "Seattle" for element "input#schoolCity"
-    And I select the "Washington" option in dropdown "schoolState"
-    And I press keys "98101" for element "input#schoolZipCode"
-    And I press the first "input[name='schoolType'][value='Other']" element
-  Then I press keys "Headmaster" for element "input#principalRole"
-  And I press keys "Albus" for element "input#principalFirstName"
-  And I press keys "Dumbledore" for element "input#principalLastName"
-  And I press keys "socks@hogwarts.edu" for element "input#principalEmail"
-  And I press keys "socks@hogwarts.edu" for element "input#principalConfirmEmail"
-  And I press keys "5555882300" for element "input#principalPhoneNumber"
-
-  Then I see no difference for "Section 1: About You and Your School"
-  And I press the first "button#next" element
+    And I complete Section 1 of the teacher PD application
+    And I press the first "button#next" element
 
 
   # Section 2
@@ -255,75 +179,31 @@ Scenario: Teacher starts a new csp application and submits it
   And I press the first "input[name='enoughCourseHours']" element
   And I press the first "input[name='replaceExisting']" element
 
-  Then I see no difference for "Section 2: Choose Your Program"
   And I press the first "button#next" element
 
 
   # Section 3
   Then I wait until element "h3" contains text "Section 3: Professional Learning Program Requirements"
-  Then I wait until element "input[name='committed']" is visible
-  And I press "input[name='committed']:first" using jQuery
-  And I press the first "input#understandFee" element
-  And I click selector "input[name='payFee']" if I see it
-  Then I see no difference for "Section 3: Professional Learning Program Requirements"
+  And I complete Section 3 of the teacher PD application
   And I press the first "button#next" element
 
 
   # Section 4
   Then I wait until element "h3" contains text "Section 4: Additional Demographic Information and Submission"
-  And I press "input[name='genderIdentity']:first" using jQuery
-  And I press the first "input[name='race']" element
-  And I press the first "input[name='howHeard']" element
+  And I complete Section 3 of the teacher PD application
   And I press the first "input#agree" element
-  Then I see no difference for "Section 4: Additional Demographic Information and Submission"
+
   And I press the first "button[type='submit']" element
 
   # Confirmation page
   Then I wait until element "h1" contains text "Thank you for submitting your application!"
-  Then I see no difference for "Confirmation"
 
 Scenario: Teacher starts a new csa application and submits it
   Given I create a teacher named "Severus"
     And I am on "http://studio.code.org/pd/application/teacher"
     And I wait until element "h1" contains text "Professional Learning Program Teacher Application"
-    And I open my eyes to test "Teacher Application"
-
-  # Section 1
-  When I wait until element "h3" contains text "Section 1: About You and Your School"
-    And I press the first "input[name='country']" element
-    And I press the first "input[name='completingOnBehalfOfSomeoneElse'][value='No']" element
-    And I press keys "Severus" for element "input#firstName"
-    And I press keys "Snape" for element "input#lastName"
-    And I press keys "5558675309" for element "input#phone"
-    And I press keys "1501 4th Ave" for element "input#streetAddress"
-    And I press keys "Seattle" for element "input#city"
-    And I select the "Washington" option in dropdown "state"
-    And I press keys "98101" for element "input#zipCode"
-    And I press the first "input[name='previousYearlongCdoPd']" element
-    And I press the first "input[name='currentRole']" element
-    And I press keys "nonexistent" for element "#school input"
-
-  # School: select other and enter manual data
-  Then I wait until element ".VirtualizedSelectOption:contains('Other school not listed below')" is visible
-    And I press ".VirtualizedSelectOption:contains('Other school not listed below')" using jQuery
-    Then I wait until element "input#schoolName" is visible
-    And I press keys "Code.org" for element "input#schoolName"
-    And I press keys "Code.org District" for element "input#schoolDistrictName"
-    And I press keys "1501 4th Ave" for element "input#schoolAddress"
-    And I press keys "Seattle" for element "input#schoolCity"
-    And I select the "Washington" option in dropdown "schoolState"
-    And I press keys "98101" for element "input#schoolZipCode"
-    And I press the first "input[name='schoolType'][value='Other']" element
-  Then I press keys "Headmaster" for element "input#principalRole"
-  And I press keys "Albus" for element "input#principalFirstName"
-  And I press keys "Dumbledore" for element "input#principalLastName"
-  And I press keys "socks@hogwarts.edu" for element "input#principalEmail"
-  And I press keys "socks@hogwarts.edu" for element "input#principalConfirmEmail"
-  And I press keys "5555882300" for element "input#principalPhoneNumber"
-
-  Then I see no difference for "Section 1: About You and Your School"
-  And I press the first "button#next" element
-
+    And I complete Section 1 of the teacher PD application
+    And I press the first "button#next" element
 
   # Section 2
   Then I wait until element "h3" contains text "Section 2: Choose Your Program"
@@ -335,29 +215,19 @@ Scenario: Teacher starts a new csa application and submits it
   And I press the first "input[name='enoughCourseHours']" element
   And I press the first "input[name='replaceExisting']" element
 
-  Then I see no difference for "Section 2: Choose Your Program"
   And I press the first "button#next" element
 
 
   # Section 3
   Then I wait until element "h3" contains text "Section 3: Professional Learning Program Requirements"
-  Then I wait until element "input[name='committed']" is visible
-  And I press "input[name='committed']:first" using jQuery
-  And I press the first "input#understandFee" element
-  And I click selector "input[name='payFee']" if I see it
-  Then I see no difference for "Section 3: Professional Learning Program Requirements"
+  And I complete Section 3 of the teacher PD application
   And I press the first "button#next" element
 
 
   # Section 4
   Then I wait until element "h3" contains text "Section 4: Additional Demographic Information and Submission"
-  And I press "input[name='genderIdentity']:first" using jQuery
-  And I press the first "input[name='race']" element
-  And I press the first "input[name='howHeard']" element
-  And I press the first "input#agree" element
-  Then I see no difference for "Section 4: Additional Demographic Information and Submission"
+  And I complete Section 4 of the teacher PD application
   And I press the first "button[type='submit']" element
 
   # Confirmation page
   Then I wait until element "h1" contains text "Thank you for submitting your application!"
-  Then I see no difference for "Confirmation"

--- a/dashboard/test/ui/features/acquisition_products/pd/teacher_application.feature
+++ b/dashboard/test/ui/features/acquisition_products/pd/teacher_application.feature
@@ -5,14 +5,12 @@ Feature: Teacher Application
 @eyes
 Scenario: Teacher starts a new csd application and submits it with principal approval
   Given I create a teacher named "Severus"
-    And I am on "http://studio.code.org/pd/application/teacher"
-    And I wait until element "h1" contains text "Professional Learning Program Teacher Application"
-    And I open my eyes to test "Teacher Application"
-    And I complete Section 1 of the teacher PD application
-
+  And I am on "http://studio.code.org/pd/application/teacher"
+  And I wait until element "h1" contains text "Professional Learning Program Teacher Application"
+  And I open my eyes to test "Teacher Application"
+  And I complete Section 1 of the teacher PD application
   Then I see no difference for "Section 1: About You and Your School"
   And I press the first "button#next" element
-
 
   # Section 2
   Then I wait until element "h3" contains text "Section 2: Choose Your Program"
@@ -20,30 +18,22 @@ Scenario: Teacher starts a new csd application and submits it with principal app
   And I press the first "input[name='csdWhichGrades']" element
   And I press the first "input[name='enoughCourseHours']" element
   And I press the first "input[name='replaceExisting']" element
-
   Then I see no difference for "Section 2: Choose Your Program"
   And I press the first "button#next" element
 
-
   # Section 3
-  Then I wait until element "h3" contains text "Section 3: Professional Learning Program Requirements"
   And I complete Section 3 of the teacher PD application
-
   Then I see no difference for "Section 3: Professional Learning Program Requirements"
   And I press the first "button#next" element
 
-
   # Section 4
-  Then I wait until element "h3" contains text "Section 4: Additional Demographic Information and Submission"
   And I complete Section 4 of the teacher PD application
-
   Then I see no difference for "Section 4: Additional Demographic Information and Submission"
   And I press the first "button[type='submit']" element
 
   # Confirmation page
   Then I wait until element "h1" contains text "Thank you for submitting your application!"
   Then I see no difference for "Confirmation"
-
 
   # Principal approval
   Then I sign out
@@ -53,14 +43,14 @@ Scenario: Teacher starts a new csd application and submits it with principal app
 
   And I press keys "nonexistent" for element "#nces_school"
   Then I wait until element ".VirtualizedSelectOption:contains('Other school not listed below')" is visible
-    And I press ".VirtualizedSelectOption:contains('Other school not listed below')" using jQuery
-    Then I wait until element "input#schoolName" is visible
-    And I press keys "Code.org" for element "input#schoolName"
-    And I press keys "1501 4th Ave" for element "input#schoolAddress"
-    And I press keys "Seattle" for element "input#schoolCity"
-    And I select the "Washington" option in dropdown "schoolState"
-    # zip code is autofilled from the teacher app data (in order to fetch the regional partner)
-    And I press the first "input[name='schoolType'][value='Other']" element
+  And I press ".VirtualizedSelectOption:contains('Other school not listed below')" using jQuery
+  Then I wait until element "input#schoolName" is visible
+  And I press keys "Code.org" for element "input#schoolName"
+  And I press keys "1501 4th Ave" for element "input#schoolAddress"
+  And I press keys "Seattle" for element "input#schoolCity"
+  And I select the "Washington" option in dropdown "schoolState"
+  # zip code is autofilled from the teacher app data (in order to fetch the regional partner)
+  And I press the first "input[name='schoolType'][value='Other']" element
 
   Then I press keys "1000" for element "#totalStudentEnrollment"
   Then I press keys "10" for element "#freeLunchPercent"
@@ -111,33 +101,7 @@ Scenario: Teacher saves, re-opens, and submits an application
   And I see no difference for "Viewing previously-saved teacher application"
 
   # Finish application to submit it
-  And I press keys "Snape" for element "input#lastName"
-  And I press keys "5558675309" for element "input#phone"
-  And I press keys "1501 4th Ave" for element "input#streetAddress"
-  And I press keys "Seattle" for element "input#city"
-  And I select the "Washington" option in dropdown "state"
-  And I press keys "98101" for element "input#zipCode"
-  And I press the first "input[name='previousYearlongCdoPd']" element
-  And I press the first "input[name='currentRole']" element
-  And I press keys "nonexistent" for element "#school input"
-
-  # School: select other and enter manual data
-  Then I wait until element ".VirtualizedSelectOption:contains('Other school not listed below')" is visible
-  And I press ".VirtualizedSelectOption:contains('Other school not listed below')" using jQuery
-  Then I wait until element "input#schoolName" is visible
-  And I press keys "Code.org" for element "input#schoolName"
-  And I press keys "Code.org District" for element "input#schoolDistrictName"
-  And I press keys "1501 4th Ave" for element "input#schoolAddress"
-  And I press keys "Seattle" for element "input#schoolCity"
-  And I select the "Washington" option in dropdown "schoolState"
-  And I press keys "98101" for element "input#schoolZipCode"
-  And I press the first "input[name='schoolType'][value='Other']" element
-  Then I press keys "Headmaster" for element "input#principalRole"
-  And I press keys "Albus" for element "input#principalFirstName"
-  And I press keys "Dumbledore" for element "input#principalLastName"
-  And I press keys "socks@hogwarts.edu" for element "input#principalEmail"
-  And I press keys "socks@hogwarts.edu" for element "input#principalConfirmEmail"
-  And I press keys "5555882300" for element "input#principalPhoneNumber"
+  And I complete Section 1 of the teacher PD application
   And I press the first "button#next" element
 
   # Section 2
@@ -149,12 +113,10 @@ Scenario: Teacher saves, re-opens, and submits an application
   And I press the first "button#next" element
 
   # Section 3
-  Then I wait until element "h3" contains text "Section 3: Professional Learning Program Requirements"
   And I complete Section 3 of the teacher PD application
   And I press the first "button#next" element
 
   # Section 4
-  Then I wait until element "h3" contains text "Section 4: Additional Demographic Information and Submission"
   And I complete Section 4 of the teacher PD application
   And I press the first "button[type='submit']" element
 
@@ -165,11 +127,10 @@ Scenario: Teacher saves, re-opens, and submits an application
 
 Scenario: Teacher starts a new csp application and submits it
   Given I create a teacher named "Severus"
-    And I am on "http://studio.code.org/pd/application/teacher"
-    And I wait until element "h1" contains text "Professional Learning Program Teacher Application"
-    And I complete Section 1 of the teacher PD application
-    And I press the first "button#next" element
-
+  And I am on "http://studio.code.org/pd/application/teacher"
+  And I wait until element "h1" contains text "Professional Learning Program Teacher Application"
+  And I complete Section 1 of the teacher PD application
+  And I press the first "button#next" element
 
   # Section 2
   Then I wait until element "h3" contains text "Section 2: Choose Your Program"
@@ -178,20 +139,14 @@ Scenario: Teacher starts a new csp application and submits it
   And I press the first "input[name='cspHowOffer']" element
   And I press the first "input[name='enoughCourseHours']" element
   And I press the first "input[name='replaceExisting']" element
-
   And I press the first "button#next" element
 
-
   # Section 3
-  Then I wait until element "h3" contains text "Section 3: Professional Learning Program Requirements"
   And I complete Section 3 of the teacher PD application
   And I press the first "button#next" element
 
-
   # Section 4
-  Then I wait until element "h3" contains text "Section 4: Additional Demographic Information and Submission"
   And I complete Section 4 of the teacher PD application
-
   And I press the first "button[type='submit']" element
 
   # Confirmation page
@@ -199,10 +154,10 @@ Scenario: Teacher starts a new csp application and submits it
 
 Scenario: Teacher starts a new csa application and submits it
   Given I create a teacher named "Severus"
-    And I am on "http://studio.code.org/pd/application/teacher"
-    And I wait until element "h1" contains text "Professional Learning Program Teacher Application"
-    And I complete Section 1 of the teacher PD application
-    And I press the first "button#next" element
+  And I am on "http://studio.code.org/pd/application/teacher"
+  And I wait until element "h1" contains text "Professional Learning Program Teacher Application"
+  And I complete Section 1 of the teacher PD application
+  And I press the first "button#next" element
 
   # Section 2
   Then I wait until element "h3" contains text "Section 2: Choose Your Program"
@@ -213,18 +168,13 @@ Scenario: Teacher starts a new csa application and submits it
   And I press the first "input[name='csaHowOffer']" element
   And I press the first "input[name='enoughCourseHours']" element
   And I press the first "input[name='replaceExisting']" element
-
   And I press the first "button#next" element
 
-
   # Section 3
-  Then I wait until element "h3" contains text "Section 3: Professional Learning Program Requirements"
   And I complete Section 3 of the teacher PD application
   And I press the first "button#next" element
 
-
   # Section 4
-  Then I wait until element "h3" contains text "Section 4: Additional Demographic Information and Submission"
   And I complete Section 4 of the teacher PD application
   And I press the first "button[type='submit']" element
 

--- a/dashboard/test/ui/features/acquisition_products/pd/teacher_application.feature
+++ b/dashboard/test/ui/features/acquisition_products/pd/teacher_application.feature
@@ -249,7 +249,7 @@ Scenario: Teacher starts a new csp application and submits it
 
   # Section 2
   Then I wait until element "h3" contains text "Section 2: Choose Your Program"
-  And I press "input[name='program']:second" using jQuery
+  And I press the second "input[name='program']" using jQuery
   And I press the first "input[name='cspWhichGrades']" element
   And I press the first "input[name='cspHowOffer']" element
   And I press the first "input[name='enoughCourseHours']" element

--- a/dashboard/test/ui/features/step_definitions/pd.rb
+++ b/dashboard/test/ui/features/step_definitions/pd.rb
@@ -154,29 +154,31 @@ end
 
 And(/^I complete Section 1 of the teacher PD application$/) do
   steps %Q{
-    When I wait until element "h3" contains text "Section 1: About You and Your School"
-      And I press the first "input[name='country']" element
-      And I press the first "input[name='completingOnBehalfOfSomeoneElse'][value='No']" element
-      And I press keys "Severus" for element "input#firstName"
-      And I press keys "Snape" for element "input#lastName"
-      And I press keys "5558675309" for element "input#phone"
-      And I press keys "1501 4th Ave" for element "input#streetAddress"
-      And I press keys "Seattle" for element "input#city"
-      And I select the "Washington" option in dropdown "state"
-      And I press keys "98101" for element "input#zipCode"
-      And I press the first "input[name='previousYearlongCdoPd']" element
-      And I press the first "input[name='currentRole']" element
-      And I press keys "nonexistent" for element "#school input"
+    Then I wait until element "h3" contains text "Section 1: About You and Your School"
+    And I press the first "input[name='country']" element
+    And I press the first "input[name='completingOnBehalfOfSomeoneElse'][value='No']" element
+    And I press keys "Severus" for element "input#firstName"
+    And I press keys "Snape" for element "input#lastName"
+    And I press keys "5558675309" for element "input#phone"
+    And I press keys "1501 4th Ave" for element "input#streetAddress"
+    And I press keys "Seattle" for element "input#city"
+    And I select the "Washington" option in dropdown "state"
+    And I press keys "98101" for element "input#zipCode"
+    And I press the first "input[name='previousYearlongCdoPd']" element
+    And I press the first "input[name='currentRole']" element
+    And I press keys "nonexistent" for element "#school input"
+
     Then I wait until element ".VirtualizedSelectOption:contains('Other school not listed below')" is visible
-      And I press ".VirtualizedSelectOption:contains('Other school not listed below')" using jQuery
-      Then I wait until element "input#schoolName" is visible
-      And I press keys "Code.org" for element "input#schoolName"
-      And I press keys "Code.org District" for element "input#schoolDistrictName"
-      And I press keys "1501 4th Ave" for element "input#schoolAddress"
-      And I press keys "Seattle" for element "input#schoolCity"
-      And I select the "Washington" option in dropdown "schoolState"
-      And I press keys "98101" for element "input#schoolZipCode"
-      And I press the first "input[name='schoolType'][value='Other']" element
+    And I press ".VirtualizedSelectOption:contains('Other school not listed below')" using jQuery
+    Then I wait until element "input#schoolName" is visible
+    And I press keys "Code.org" for element "input#schoolName"
+    And I press keys "Code.org District" for element "input#schoolDistrictName"
+    And I press keys "1501 4th Ave" for element "input#schoolAddress"
+    And I press keys "Seattle" for element "input#schoolCity"
+    And I select the "Washington" option in dropdown "schoolState"
+    And I press keys "98101" for element "input#schoolZipCode"
+    And I press the first "input[name='schoolType'][value='Other']" element
+
     Then I press keys "Headmaster" for element "input#principalRole"
     And I press keys "Albus" for element "input#principalFirstName"
     And I press keys "Dumbledore" for element "input#principalLastName"
@@ -188,6 +190,7 @@ end
 
 And(/^I complete Section 3 of the teacher PD application$/) do
   steps %Q{
+    Then I wait until element "h3" contains text "Section 3: Professional Learning Program Requirements"
     Then I wait until element "input[name='committed']" is visible
     And I press "input[name='committed']:first" using jQuery
     And I press the first "input#understandFee" element
@@ -197,6 +200,7 @@ end
 
 And(/^I complete Section 4 of the teacher PD application$/) do
   steps %Q{
+    Then I wait until element "h3" contains text "Section 4: Additional Demographic Information and Submission"
     And I press "input[name='genderIdentity']:first" using jQuery
     And I press the first "input[name='race']" element
     And I press the first "input[name='howHeard']" element

--- a/dashboard/test/ui/features/step_definitions/pd.rb
+++ b/dashboard/test/ui/features/step_definitions/pd.rb
@@ -152,6 +152,58 @@ And(/^I make the teacher named "([^"]*)" a workshop admin$/) do |name|
   user.permission = UserPermission::WORKSHOP_ADMIN
 end
 
+And(/^I complete Section 1 of the teacher PD application$/) do
+  steps %Q{
+    When I wait until element "h3" contains text "Section 1: About You and Your School"
+      And I press the first "input[name='country']" element
+      And I press the first "input[name='completingOnBehalfOfSomeoneElse'][value='No']" element
+      And I press keys "Severus" for element "input#firstName"
+      And I press keys "Snape" for element "input#lastName"
+      And I press keys "5558675309" for element "input#phone"
+      And I press keys "1501 4th Ave" for element "input#streetAddress"
+      And I press keys "Seattle" for element "input#city"
+      And I select the "Washington" option in dropdown "state"
+      And I press keys "98101" for element "input#zipCode"
+      And I press the first "input[name='previousYearlongCdoPd']" element
+      And I press the first "input[name='currentRole']" element
+      And I press keys "nonexistent" for element "#school input"
+    Then I wait until element ".VirtualizedSelectOption:contains('Other school not listed below')" is visible
+      And I press ".VirtualizedSelectOption:contains('Other school not listed below')" using jQuery
+      Then I wait until element "input#schoolName" is visible
+      And I press keys "Code.org" for element "input#schoolName"
+      And I press keys "Code.org District" for element "input#schoolDistrictName"
+      And I press keys "1501 4th Ave" for element "input#schoolAddress"
+      And I press keys "Seattle" for element "input#schoolCity"
+      And I select the "Washington" option in dropdown "schoolState"
+      And I press keys "98101" for element "input#schoolZipCode"
+      And I press the first "input[name='schoolType'][value='Other']" element
+    Then I press keys "Headmaster" for element "input#principalRole"
+    And I press keys "Albus" for element "input#principalFirstName"
+    And I press keys "Dumbledore" for element "input#principalLastName"
+    And I press keys "socks@hogwarts.edu" for element "input#principalEmail"
+    And I press keys "socks@hogwarts.edu" for element "input#principalConfirmEmail"
+    And I press keys "5555882300" for element "input#principalPhoneNumber"
+  }
+end
+
+And(/^I complete Section 3 of the teacher PD application$/) do
+  steps %Q{
+    Then I wait until element "input[name='committed']" is visible
+    And I press "input[name='committed']:first" using jQuery
+    And I press the first "input#understandFee" element
+    And I click selector "input[name='payFee']" if I see it
+  }
+end
+
+And(/^I complete Section 4 of the teacher PD application$/) do
+  steps %Q{
+    And I press "input[name='genderIdentity']:first" using jQuery
+    And I press the first "input[name='race']" element
+    And I press the first "input[name='howHeard']" element
+    And I press the first "input#agree" element
+  }
+end
+
 And(/^I create some fake applications of each type and status$/) do
   require_rails_env
   time_start = Time.now


### PR DESCRIPTION
This UI test file currently has 2 test scenarios:
- Teacher starting and finishing an application for the CSD Professional Learning Program (plus having the associated Administrator/School Leader Approval Application completed)
- Teacher starting then reopening a CSD application and being able to complete it

This PR adds 2 more scenarios to cover the other types of programs teachers can apply for (CSP and CSA) since there are some questions in the application specific to CSP and/or CSA. The 2 scenarios are:
- Teacher finishing an application for the CSP Professional Learning Program (with CSP-specific fields: `cspWhichGrades` and `cspHowOffer`)
- Teacher finishing an application for the CSA Professional Learning Program (with CSA-specific fields: `csaAlreadyKnow`, `csaPhoneScreen`, `csaWhichGrades`, and `csaHowOffer`

Neither of the new scenarios includes the Administrator/School Leader Approval Application part of it since that application doesn't have any questions that would be different if CSP or CSA was selected instead of CSD.

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/browse/ACQ-201?atlOrigin=eyJpIjoiYzJmNmMwZDY3MTc4NDUzNzk5M2ZiNWM1NDkzNWMxMWMiLCJwIjoiaiJ9)

## Testing story
Passing drone build with the modification of a ui test.

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
