### PR TITLE
Fix Violations of and Reenable `Lint/ErbNewArguments`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -95,11 +95,6 @@ Lint/EmptyClass:
 Lint/EmptyFile:
   Enabled: false
 
-# Offense count: 4
-# This cop supports safe auto-correction (--auto-correct).
-Lint/ErbNewArguments:
-  Enabled: false
-
 # Offense count: 7
 Lint/MissingSuper:
   Enabled: false

--- a/lib/cdo/cloud_formation/stack_template.rb
+++ b/lib/cdo/cloud_formation/stack_template.rb
@@ -68,7 +68,7 @@ module Cdo::CloudFormation
         binding.local_variable_set(key, value)
       end
       Dir.chdir(File.dirname(filename)) do
-        ERB.new(str, nil, '-').tap {|erb| erb.filename = filename}.result(binding)
+        ERB.new(str, trim_mode: '-').tap {|erb| erb.filename = filename}.result(binding)
       end
     end
 

--- a/lib/cdo/erb.rb
+++ b/lib/cdo/erb.rb
@@ -2,7 +2,7 @@ require 'erb'
 require 'ostruct'
 
 def erb_file_to_string(path, binding)
-  ERB.new(File.read(path), nil, '-').
+  ERB.new(File.read(path), trim_mode: '-').
     tap {|erb| erb.filename = path}.
     result(binding)
 end


### PR DESCRIPTION
Fix applied automatically (and safely) with `bundle exec rubocop --auto-correct --only Lint/ErbNewArguments`

Another simple one; quoting from [the documentation](https://www.rubydoc.info/github/bbatsov/RuboCop/RuboCop/Cop/Lint/ErbNewArguments):

> This cop emulates the following Ruby warnings in Ruby 2.6.
> ```
> % cat example.rb
> ERB.new('hi', nil, '-', '@output_buffer')
> % ruby -rerb example.rb
> example.rb:1: warning: Passing safe_level with the 2nd argument of ERB.new is
> deprecated. Do not use it, and specify other arguments as keyword arguments.
> example.rb:1: warning: Passing trim_mode with the 3rd argument of ERB.new is
> deprecated. Use keyword argument like ERB.new(str, trim_mode:...) instead.
> example.rb:1: warning: Passing eoutvar with the 4th argument of ERB.new is
> deprecated. Use keyword argument like ERB.new(str, eoutvar: ...) instead.
> ```

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
