### PR TITLE
Remove `cdo-varnish` Logic from `cdo-nginx` (again)

### DIFF
--- a/cookbooks/cdo-nginx/.kitchen.yml
+++ b/cookbooks/cdo-nginx/.kitchen.yml
@@ -27,5 +27,4 @@ suites:
       - recipe[nginx_test]
   - name: https
     run_list:
-      - recipe[cdo-varnish]
       - recipe[nginx_test]

--- a/cookbooks/cdo-nginx/Berksfile
+++ b/cookbooks/cdo-nginx/Berksfile
@@ -12,5 +12,4 @@ cookbook 'nginx_test', path: './test/cookbooks/nginx_test'
 # (forked to our own project purely to ensure stability).
 cookbook 'ssl_certificate', github: 'code-dot-org/ssl_certificate-cookbook', branch: 'add_provider-issue_45'
 
-cookbook 'cdo-varnish', path: '../cdo-varnish'
 cookbook 'sudo-user', path: '../sudo-user'

--- a/cookbooks/cdo-nginx/templates/default/nginx.conf.erb
+++ b/cookbooks/cdo-nginx/templates/default/nginx.conf.erb
@@ -26,7 +26,6 @@ http {
   client_max_body_size 4G;
   keepalive_timeout 30;
 
-<% unless node['cdo-varnish']['enabled'] -%>
   # Copy Accept-Language header to X-Varnish-Accept-Language.
   # TODO: Update application code to read Accept-Language instead of X-Varnish-Accept-Language.
   proxy_set_header X-Varnish-Accept-Language $http_accept_language;
@@ -59,15 +58,6 @@ http {
       proxy_set_header Host $upstream_host;
     }
   }
-<%   redirects = node['cdo-varnish']['redirects'].group_by(&:last).transform_values {|v| v.to_h.keys}
-     redirects.each do |site, domains| -%>
-  server {
-    listen 80;
-    server_name <%=domains.join(' ')%>;
-    return 301 https://<%=site%>$request_uri;
-  }
-<%   end -%>
-<% end -%>
 
   server {
     listen <%= node['cdo-apps']['dashboard']['port'] %> default deferred;
@@ -90,12 +80,7 @@ http {
     listen 443 ssl;
     <%= render 'nginx.erb', cookbook: 'ssl_certificate' %>
     location / {
-<% if node['cdo-varnish']['enabled'] -%>
-      # Pass the request on to Varnish.
-      proxy_pass  http://127.0.0.1;
-<% else -%>
       proxy_pass http://unix:<%= @run_dir %>/$upstream.sock;
-<% end -%>
       proxy_set_header Host $http_host;
       proxy_set_header X-Forwarded-Proto https;
     }


### PR DESCRIPTION
Reapply https://github.com/code-dot-org/code-dot-org/pull/47982 (reverted by https://github.com/code-dot-org/code-dot-org/pull/48328) now that we're handling these redirects at the cloudfront level. Alternative to https://github.com/code-dot-org/code-dot-org/pull/48703

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
