### PR TITLE
Add Override for and Standardize `Style/AccessorGrouping`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,20 +25,11 @@ Rails:
 
 # BEGIN CODE.ORG OVERRIDES
 
-Layout/ParameterAlignment:
-  EnforcedStyle: with_fixed_indentation
-
 Layout/DotPosition:
   EnforcedStyle: trailing
 
-Style/EmptyElse:
-  EnforcedStyle: empty
-
 Layout/EmptyLineBetweenDefs:
   AllowAdjacentOneLineDefs: true
-
-Style/EmptyMethod:
-  EnforcedStyle: expanded
 
 Layout/FirstParameterIndentation:
   EnforcedStyle: consistent
@@ -46,11 +37,8 @@ Layout/FirstParameterIndentation:
 Layout/MultilineMethodCallBraceLayout:
   EnforcedStyle: new_line
 
-Style/NumericLiterals:
-  MinDigits: 7
-
-Style/Semicolon:
-  AllowAsExpressionSeparator: true
+Layout/ParameterAlignment:
+  EnforcedStyle: with_fixed_indentation
 
 Layout/SpaceInsideBlockBraces:
   EnforcedStyle: no_space
@@ -58,6 +46,21 @@ Layout/SpaceInsideBlockBraces:
 
 Layout/SpaceInsideHashLiteralBraces:
   EnforcedStyle: no_space
+
+Style/AccessorGrouping:
+  EnforcedStyle: separated
+
+Style/EmptyElse:
+  EnforcedStyle: empty
+
+Style/EmptyMethod:
+  EnforcedStyle: expanded
+
+Style/NumericLiterals:
+  MinDigits: 7
+
+Style/Semicolon:
+  AllowAsExpressionSeparator: true
 
 Style/WordArray:
   MinSize: 5

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -337,13 +337,6 @@ Security/MarshalLoad:
 Style/AccessModifierDeclarations:
   Enabled: false
 
-# Offense count: 35
-# This cop supports safe auto-correction (--auto-correct).
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: separated, grouped
-Style/AccessorGrouping:
-  Enabled: false
-
 # Offense count: 20
 # This cop supports safe auto-correction (--auto-correct).
 # Configuration parameters: AllowOnConstant.

--- a/dashboard/lib/client_state.rb
+++ b/dashboard/lib/client_state.rb
@@ -4,7 +4,8 @@
 # without loss of progress, this implementation also includes code to migrate
 # state from unencrypted cookies back into the session cookie.)
 class ClientState
-  attr_reader :session, :cookies
+  attr_reader :session
+  attr_reader :cookies
 
   def initialize(session, cookies)
     @session = session

--- a/dashboard/lib/expired_deleted_account_purger.rb
+++ b/dashboard/lib/expired_deleted_account_purger.rb
@@ -25,8 +25,12 @@ require 'cdo/chat_client'
 class ExpiredDeletedAccountPurger
   class SafetyConstraintViolation < RuntimeError; end
 
-  attr_reader :dry_run, :deleted_after, :deleted_before, :max_teachers_to_purge,
-    :max_accounts_to_purge, :log
+  attr_reader :dry_run
+  attr_reader :deleted_after
+  attr_reader :deleted_before
+  attr_reader :max_teachers_to_purge
+  attr_reader :max_accounts_to_purge
+  attr_reader :log
   alias :dry_run? :dry_run
 
   def initialize(options = {})

--- a/dashboard/lib/pd/jot_form/question.rb
+++ b/dashboard/lib/pd/jot_form/question.rb
@@ -6,14 +6,12 @@ module Pd
     class Question
       include Constants
 
-      attr_accessor(
-        :id,   # question id
-        :type, # See Translation::QUESTION_CLASSES for a complete list of supported types
-        :name, # "unique" (not actually enforced by JotForm) name per form
-        :text, # label
-        :order, # 1-based order the question appears in the form
-        :hidden,
-      )
+      attr_accessor :id # question id
+      attr_accessor :type # See Translation::QUESTION_CLASSES for a complete list of supported types
+      attr_accessor :name # "unique" (not actually enforced by JotForm) name per form
+      attr_accessor :text # label
+      attr_accessor :order # 1-based order the question appears in the form
+      attr_accessor :hidden
 
       alias_method :hidden?, :hidden
 

--- a/dashboard/lib/pd/jot_form/select_question.rb
+++ b/dashboard/lib/pd/jot_form/select_question.rb
@@ -13,11 +13,9 @@ module Pd
       # Other question keys are numbered.
       OTHER_ANSWER_KEY = 'other'.freeze
 
-      attr_accessor(
-        :allow_other,
-        :other_text,
-        :preserve_text # kept for backward compatibility
-      )
+      attr_accessor :allow_other
+      attr_accessor :other_text
+      attr_accessor :preserve_text # kept for backward compatibility
 
       def self.from_jotform_question(jotform_question)
         super.tap do |select_question|

--- a/dashboard/lib/pd/payment/teacher_summary.rb
+++ b/dashboard/lib/pd/payment/teacher_summary.rb
@@ -20,11 +20,14 @@ module Pd::Payment
 
     attr_reader :workshop_summary
 
-    attr_reader :teacher, :enrollment
+    attr_reader :teacher
+    attr_reader :enrollment
 
-    attr_reader :raw_days, :raw_hours
+    attr_reader :raw_days
+    attr_reader :raw_hours
 
-    attr_reader :days, :hours
+    attr_reader :days
+    attr_reader :hours
 
     # @return [TeacherPayment] payment information for this teacher in this workshop
     attr_accessor :payment

--- a/dashboard/lib/pd/payment/workshop_summary.rb
+++ b/dashboard/lib/pd/payment/workshop_summary.rb
@@ -27,7 +27,11 @@ module Pd::Payment
       @teacher_summaries = []
     end
 
-    attr_reader :workshop, :pay_period, :num_days, :num_hours, :min_attendance_days
+    attr_reader :workshop
+    attr_reader :pay_period
+    attr_reader :num_days
+    attr_reader :num_hours
+    attr_reader :min_attendance_days
 
     # @return [Class] calculator class that was used to calculate this payment.
     attr_reader :calculator_class

--- a/dashboard/lib/pd/survey_pipeline/generic_mapper.rb
+++ b/dashboard/lib/pd/survey_pipeline/generic_mapper.rb
@@ -2,7 +2,8 @@ require_relative 'reducer'
 
 module Pd::SurveyPipeline
   class GenericMapper < SurveyPipelineWorker
-    attr_reader :group_config, :map_config
+    attr_reader :group_config
+    attr_reader :map_config
 
     REQUIRED_INPUT_KEYS = [:question_answer_joined]
     OUTPUT_KEYS = [:summaries, :errors]

--- a/dashboard/lib/purged_account_log.rb
+++ b/dashboard/lib/purged_account_log.rb
@@ -6,8 +6,12 @@ class PurgedAccountLog
     REQUESTED_BY_USER = 'requested by user',
   ]
 
-  attr_reader :user_id, :hashed_email
-  attr_accessor :pardot_ids, :poste_contact_ids, :purged_at, :confirmed_at
+  attr_reader :user_id
+  attr_reader :hashed_email
+  attr_accessor :pardot_ids
+  attr_accessor :poste_contact_ids
+  attr_accessor :purged_at
+  attr_accessor :confirmed_at
 
   def initialize(user, reason:)
     # enum indicating delete source

--- a/dashboard/lib/single_sign_on.rb
+++ b/dashboard/lib/single_sign_on.rb
@@ -18,7 +18,8 @@ class SingleSignOn
   BOOLS = [:avatar_force_update, :admin, :moderator].freeze
 
   attr_accessor(*ACCESSORS)
-  attr_accessor :sso_secret, :sso_url
+  attr_accessor :sso_secret
+  attr_accessor :sso_url
 
   def self.sso_secret
     raise "sso_secret not implemented on class, be sure to set it on instance"

--- a/dashboard/test/controllers/level_starter_assets_controller_test.rb
+++ b/dashboard/test/controllers/level_starter_assets_controller_test.rb
@@ -269,7 +269,9 @@ end
 # Mock Aws::S3::ObjectSummary class since we can't request the objects from S3 in tests:
 # https://docs.aws.amazon.com/sdkforruby/api/Aws/S3/ObjectSummary.html
 class MockS3ObjectSummary
-  attr_reader :key, :size, :last_modified
+  attr_reader :key
+  attr_reader :size
+  attr_reader :last_modified
 
   def initialize(key, size, last_modified)
     @key = key

--- a/lib/cdo/analytics/milestone_parser.rb
+++ b/lib/cdo/analytics/milestone_parser.rb
@@ -32,7 +32,9 @@ class MilestoneParser
   # Number of bytes to compare to test for rotated log
   COMPARE_BYTE_LENGTH = 1024
 
-  attr_accessor :cache, :s3_client, :s3_resource
+  attr_accessor :cache
+  attr_accessor :s3_client
+  attr_accessor :s3_resource
 
   cattr_accessor :log_debug
 

--- a/lib/cdo/data/csv_to_sql_table.rb
+++ b/lib/cdo/data/csv_to_sql_table.rb
@@ -3,7 +3,8 @@ require 'cdo/chat_client'
 require 'cdo/google/drive'
 
 class CsvToSqlTable
-  attr_reader :db, :table
+  attr_reader :db
+  attr_reader :table
 
   def initialize(path, db, table_prefix = '')
     @db = db

--- a/lib/cdo/log_collector.rb
+++ b/lib/cdo/log_collector.rb
@@ -7,7 +7,10 @@
 #   such as HoneyBadger and Slack.
 #
 class LogCollector
-  attr_reader :exceptions, :logs, :metrics, :task_name
+  attr_reader :exceptions
+  attr_reader :logs
+  attr_reader :metrics
+  attr_reader :task_name
 
   # @param task_name [String] friendly name of the task to collect logs for
   # @param print_log_immediately [Boolean] print a log as soon as it is added to the log collector

--- a/lib/cdo/server_tools.rb
+++ b/lib/cdo/server_tools.rb
@@ -83,7 +83,9 @@ class ServerTools
 
   # A struct for bundling together the name, hostname, and instance_id for a server.
   class ServerIdentifier
-    attr_accessor :name, :hostname, :instance_id
+    attr_accessor :name
+    attr_accessor :hostname
+    attr_accessor :instance_id
 
     def initialize(name:, hostname:, instance_id:)
       @name = name

--- a/lib/forms/pegasus_form_errors.rb
+++ b/lib/forms/pegasus_form_errors.rb
@@ -22,7 +22,8 @@ class FormError < ArgumentError
 end
 
 class FieldError
-  attr_accessor :value, :message
+  attr_accessor :value
+  attr_accessor :message
 
   def initialize(value, message)
     @value = value

--- a/pegasus/src/curriculum_router.rb
+++ b/pegasus/src/curriculum_router.rb
@@ -47,7 +47,9 @@ end
 # HttpDocument normalizes a document-in-transition through our system.
 #
 class HttpDocument
-  attr_accessor :status, :headers, :body
+  attr_accessor :status
+  attr_accessor :headers
+  attr_accessor :body
 
   def initialize(body, headers={}, status=200)
     @body = body


### PR DESCRIPTION
Specifically, start enforcing the "separated" style. Fix was applied automatically (and safely) with `bundle exec rubocop --auto-correct --only Style/AccessorGrouping`. A possible alternative to https://github.com/code-dot-org/code-dot-org/pull/48499 and https://github.com/code-dot-org/code-dot-org/pull/48904

I also alphabetized our existing overrides while I was in there, to match the organizational style of the other rubocop config files.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
