### PR TITLE
Disable `Style/AccessorGrouping` Rubocp Rule

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -67,19 +67,28 @@ Style/WordArray:
 # BEGIN BLACKLIST: Below are rules we don't plan to enable in the forseeable
 # future. Rules we plan to fix (but are currently failing) belong in
 # .rubocop_todo.yml.
-Metrics/BlockLength:
+Layout/ClosingParenthesisIndentation:
   Enabled: false
 
-Metrics/AbcSize:
-  Enabled: false
-
-Metrics/BlockNesting:
+Layout/ExtraSpacing:
   Enabled: false
 
 Layout/LineLength:
   Enabled: false
 
+Metrics/AbcSize:
+  Enabled: false
+
+Metrics/BlockLength:
+  Enabled: false
+
+Metrics/BlockNesting:
+  Enabled: false
+
 Metrics/ModuleLength:
+  Enabled: false
+
+Style/AccessorGrouping:
   Enabled: false
 
 Style/AsciiComments:
@@ -88,10 +97,7 @@ Style/AsciiComments:
 Style/BarePercentLiterals:
   Enabled: false
 
-Layout/ClosingParenthesisIndentation:
-  Enabled: false
-
-Layout/ExtraSpacing:
+Style/ClassAndModuleChildren:
   Enabled: false
 
 Style/IdenticalConditionalBranches:
@@ -112,13 +118,9 @@ Style/RedundantReturn:
 Style/StringLiterals:
   Enabled: false
 
-Style/TrivialAccessors:
-  AllowDSLWriters: true
-
 Style/SymbolArray:
   Enabled: false
 
-Style/ClassAndModuleChildren:
-  Enabled: false
-
+Style/TrivialAccessors:
+  AllowDSLWriters: true
 # END BLACKLIST

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -337,13 +337,6 @@ Security/MarshalLoad:
 Style/AccessModifierDeclarations:
   Enabled: false
 
-# Offense count: 35
-# This cop supports safe auto-correction (--auto-correct).
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: separated, grouped
-Style/AccessorGrouping:
-  Enabled: false
-
 # Offense count: 20
 # This cop supports safe auto-correction (--auto-correct).
 # Configuration parameters: AllowOnConstant.


### PR DESCRIPTION
We want to support a variety of accessor organization styles. A possible alternative to https://github.com/code-dot-org/code-dot-org/pull/48903 and https://github.com/code-dot-org/code-dot-org/pull/48499

Also alphabetize our existing disabled rules, to match the organizational style of our other rubocop config files.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
