### PR TITLE
remove begin_ tracking pixel from encryption levels

### DIFF
--- a/dashboard/config/scripts/levels/CodeBreak E03 Practice Beg2.level
+++ b/dashboard/config/scripts/levels/CodeBreak E03 Practice Beg2.level
@@ -6,7 +6,7 @@
   "user_id": 42,
   "properties": {
     "short_instructions": "Instructions",
-    "long_instructions": "# Crack a Caesar cipher!\r\n\r\nThis tool lets you play with text and do Caesar ciphers. You can use this to either encrypt a message or decrypt it.\r\n\r\n# Do this\r\n- Load a **Sample message** from the message dropdown. This will load a message that has been encrypted with a Caesar cipher.\r\n\r\n![](https://images.code.org/347139486c8c729bf3c6e72ce67da878-image-1476286380409.gif)\r\n\r\n- Using the buttons in the Caesar substitution tab, you can shift the alphabet forwards or backwards to try to unscramble the message.\r\n\r\n![](https://images.code.org/ef9ebc16d2f1442dc46fba9bd48b5d43-image-1476285966821.gif)\r\n\r\nSee how long it takes you to crack the cipher! Is this a good method of encrypting secret data?\r\n\r\n<img src=\"http://code.org/api/hour/begin_encryption.png\">\r\n\r\n",
+    "long_instructions": "# Crack a Caesar cipher!\r\n\r\nThis tool lets you play with text and do Caesar ciphers. You can use this to either encrypt a message or decrypt it.\r\n\r\n# Do this\r\n- Load a **Sample message** from the message dropdown. This will load a message that has been encrypted with a Caesar cipher.\r\n\r\n![](https://images.code.org/347139486c8c729bf3c6e72ce67da878-image-1476286380409.gif)\r\n\r\n- Using the buttons in the Caesar substitution tab, you can shift the alphabet forwards or backwards to try to unscramble the message.\r\n\r\n![](https://images.code.org/ef9ebc16d2f1442dc46fba9bd48b5d43-image-1476285966821.gif)\r\n\r\nSee how long it takes you to crack the cipher! Is this a good method of encrypting secret data?",
     "skip_dialog": true,
     "href": "frequency/frequency.html",
     "cipher": "caesar",

--- a/dashboard/config/scripts/levels/Crack a Caesar Cipher.level
+++ b/dashboard/config/scripts/levels/Crack a Caesar Cipher.level
@@ -6,7 +6,7 @@
   "user_id": 42,
   "properties": {
     "short_instructions": "Instructions",
-    "long_instructions": "# Crack a Caesar cipher!\r\n\r\nThis tool lets you play with text and do Caesar ciphers. You can use this to either encrypt a message or decrypt it.\r\n\r\n# Do this\r\n- Load a **Sample message** from the message dropdown. This will load a message that has been encrypted with a Caesar cipher.\r\n\r\n![](https://images.code.org/347139486c8c729bf3c6e72ce67da878-image-1476286380409.gif)\r\n\r\n- Using the buttons in the Caesar substitution tab, you can shift the alphabet forwards or backwards to try to unscramble the message.\r\n\r\n![](https://images.code.org/ef9ebc16d2f1442dc46fba9bd48b5d43-image-1476285966821.gif)\r\n\r\nSee how long it takes you to crack the cipher! Is this a good method of encrypting secret data?\r\n\r\n<img src=\"http://code.org/api/hour/begin_encryption.png\">\r\n\r\n",
+    "long_instructions": "# Crack a Caesar cipher!\r\n\r\nThis tool lets you play with text and do Caesar ciphers. You can use this to either encrypt a message or decrypt it.\r\n\r\n# Do this\r\n- Load a **Sample message** from the message dropdown. This will load a message that has been encrypted with a Caesar cipher.\r\n\r\n![](https://images.code.org/347139486c8c729bf3c6e72ce67da878-image-1476286380409.gif)\r\n\r\n- Using the buttons in the Caesar substitution tab, you can shift the alphabet forwards or backwards to try to unscramble the message.\r\n\r\n![](https://images.code.org/ef9ebc16d2f1442dc46fba9bd48b5d43-image-1476285966821.gif)\r\n\r\nSee how long it takes you to crack the cipher! Is this a good method of encrypting secret data?",
     "skip_dialog": true,
     "href": "frequency/frequency.html",
     "cipher": "caesar",

--- a/dashboard/config/scripts/levels/Crack a Caesar Cipher2022.level
+++ b/dashboard/config/scripts/levels/Crack a Caesar Cipher2022.level
@@ -6,7 +6,7 @@
   "user_id": 42,
   "properties": {
     "short_instructions": "Instructions",
-    "long_instructions": "# Crack a Caesar cipher!\r\n\r\nThis tool lets you play with text and do Caesar ciphers. You can use this to either encrypt a message or decrypt it.\r\n\r\n# Do this\r\n- Load a **Sample message** from the message dropdown. This will load a message that has been encrypted with a Caesar cipher.\r\n\r\n![](https://images.code.org/347139486c8c729bf3c6e72ce67da878-image-1476286380409.gif)\r\n\r\n- Using the buttons in the Caesar substitution tab, you can shift the alphabet forwards or backwards to try to unscramble the message.\r\n\r\n![](https://images.code.org/ef9ebc16d2f1442dc46fba9bd48b5d43-image-1476285966821.gif)\r\n\r\nSee how long it takes you to crack the cipher! Is this a good method of encrypting secret data?\r\n\r\n<img src=\"http://code.org/api/hour/begin_encryption.png\">\r\n\r\n",
+    "long_instructions": "# Crack a Caesar cipher!\r\n\r\nThis tool lets you play with text and do Caesar ciphers. You can use this to either encrypt a message or decrypt it.\r\n\r\n# Do this\r\n- Load a **Sample message** from the message dropdown. This will load a message that has been encrypted with a Caesar cipher.\r\n\r\n![](https://images.code.org/347139486c8c729bf3c6e72ce67da878-image-1476286380409.gif)\r\n\r\n- Using the buttons in the Caesar substitution tab, you can shift the alphabet forwards or backwards to try to unscramble the message.\r\n\r\n![](https://images.code.org/ef9ebc16d2f1442dc46fba9bd48b5d43-image-1476285966821.gif)\r\n\r\nSee how long it takes you to crack the cipher! Is this a good method of encrypting secret data?",
     "skip_dialog": true,
     "href": "frequency/frequency.html",
     "cipher": "caesar",

--- a/dashboard/config/scripts/levels/Crack a Caesar Cipher_2018.level
+++ b/dashboard/config/scripts/levels/Crack a Caesar Cipher_2018.level
@@ -6,7 +6,7 @@
   "user_id": 42,
   "properties": {
     "short_instructions": "Instructions",
-    "long_instructions": "# Crack a Caesar cipher!\r\n\r\nThis tool lets you play with text and do Caesar ciphers. You can use this to either encrypt a message or decrypt it.\r\n\r\n# Do this\r\n- Load a **Sample message** from the message dropdown. This will load a message that has been encrypted with a Caesar cipher.\r\n\r\n![](https://images.code.org/347139486c8c729bf3c6e72ce67da878-image-1476286380409.gif)\r\n\r\n- Using the buttons in the Caesar substitution tab, you can shift the alphabet forwards or backwards to try to unscramble the message.\r\n\r\n![](https://images.code.org/ef9ebc16d2f1442dc46fba9bd48b5d43-image-1476285966821.gif)\r\n\r\nSee how long it takes you to crack the cipher! Is this a good method of encrypting secret data?\r\n\r\n<img src=\"http://code.org/api/hour/begin_encryption.png\">\r\n\r\n",
+    "long_instructions": "# Crack a Caesar cipher!\r\n\r\nThis tool lets you play with text and do Caesar ciphers. You can use this to either encrypt a message or decrypt it.\r\n\r\n# Do this\r\n- Load a **Sample message** from the message dropdown. This will load a message that has been encrypted with a Caesar cipher.\r\n\r\n![](https://images.code.org/347139486c8c729bf3c6e72ce67da878-image-1476286380409.gif)\r\n\r\n- Using the buttons in the Caesar substitution tab, you can shift the alphabet forwards or backwards to try to unscramble the message.\r\n\r\n![](https://images.code.org/ef9ebc16d2f1442dc46fba9bd48b5d43-image-1476285966821.gif)\r\n\r\nSee how long it takes you to crack the cipher! Is this a good method of encrypting secret data?",
     "skip_dialog": true,
     "href": "frequency/frequency.html",
     "cipher": "caesar",

--- a/dashboard/config/scripts/levels/Crack a Caesar Cipher_2019.level
+++ b/dashboard/config/scripts/levels/Crack a Caesar Cipher_2019.level
@@ -6,7 +6,7 @@
   "user_id": 42,
   "properties": {
     "short_instructions": "Instructions",
-    "long_instructions": "# Crack a Caesar cipher!\r\n\r\nThis tool lets you play with text and do Caesar ciphers. You can use this to either encrypt a message or decrypt it.\r\n\r\n# Do this\r\n- Load a **Sample message** from the message dropdown. This will load a message that has been encrypted with a Caesar cipher.\r\n\r\n![](https://images.code.org/347139486c8c729bf3c6e72ce67da878-image-1476286380409.gif)\r\n\r\n- Using the buttons in the Caesar substitution tab, you can shift the alphabet forwards or backwards to try to unscramble the message.\r\n\r\n![](https://images.code.org/ef9ebc16d2f1442dc46fba9bd48b5d43-image-1476285966821.gif)\r\n\r\nSee how long it takes you to crack the cipher! Is this a good method of encrypting secret data?\r\n\r\n<img src=\"http://code.org/api/hour/begin_encryption.png\">\r\n\r\n",
+    "long_instructions": "# Crack a Caesar cipher!\r\n\r\nThis tool lets you play with text and do Caesar ciphers. You can use this to either encrypt a message or decrypt it.\r\n\r\n# Do this\r\n- Load a **Sample message** from the message dropdown. This will load a message that has been encrypted with a Caesar cipher.\r\n\r\n![](https://images.code.org/347139486c8c729bf3c6e72ce67da878-image-1476286380409.gif)\r\n\r\n- Using the buttons in the Caesar substitution tab, you can shift the alphabet forwards or backwards to try to unscramble the message.\r\n\r\n![](https://images.code.org/ef9ebc16d2f1442dc46fba9bd48b5d43-image-1476285966821.gif)\r\n\r\nSee how long it takes you to crack the cipher! Is this a good method of encrypting secret data?",
     "skip_dialog": true,
     "href": "frequency/frequency.html",
     "cipher": "caesar",

--- a/dashboard/config/scripts/levels/Crack a Caesar Cipher_2020.level
+++ b/dashboard/config/scripts/levels/Crack a Caesar Cipher_2020.level
@@ -6,7 +6,7 @@
   "user_id": 42,
   "properties": {
     "short_instructions": "Instructions",
-    "long_instructions": "# Crack a Caesar cipher!\r\n\r\nThis tool lets you play with text and do Caesar ciphers. You can use this to either encrypt a message or decrypt it.\r\n\r\n# Do this\r\n- Load a **Sample message** from the message dropdown. This will load a message that has been encrypted with a Caesar cipher.\r\n\r\n![](https://images.code.org/347139486c8c729bf3c6e72ce67da878-image-1476286380409.gif)\r\n\r\n- Using the buttons in the Caesar substitution tab, you can shift the alphabet forwards or backwards to try to unscramble the message.\r\n\r\n![](https://images.code.org/ef9ebc16d2f1442dc46fba9bd48b5d43-image-1476285966821.gif)\r\n\r\nSee how long it takes you to crack the cipher! Is this a good method of encrypting secret data?\r\n\r\n<img src=\"http://code.org/api/hour/begin_encryption.png\">\r\n\r\n",
+    "long_instructions": "# Crack a Caesar cipher!\r\n\r\nThis tool lets you play with text and do Caesar ciphers. You can use this to either encrypt a message or decrypt it.\r\n\r\n# Do this\r\n- Load a **Sample message** from the message dropdown. This will load a message that has been encrypted with a Caesar cipher.\r\n\r\n![](https://images.code.org/347139486c8c729bf3c6e72ce67da878-image-1476286380409.gif)\r\n\r\n- Using the buttons in the Caesar substitution tab, you can shift the alphabet forwards or backwards to try to unscramble the message.\r\n\r\n![](https://images.code.org/ef9ebc16d2f1442dc46fba9bd48b5d43-image-1476285966821.gif)\r\n\r\nSee how long it takes you to crack the cipher! Is this a good method of encrypting secret data?",
     "skip_dialog": true,
     "href": "frequency/frequency.html",
     "cipher": "caesar",

--- a/dashboard/config/scripts/levels/Crack a Caesar Cipher_2021.level
+++ b/dashboard/config/scripts/levels/Crack a Caesar Cipher_2021.level
@@ -6,7 +6,7 @@
   "user_id": 42,
   "properties": {
     "short_instructions": "Instructions",
-    "long_instructions": "# Crack a Caesar cipher!\r\n\r\nThis tool lets you play with text and do Caesar ciphers. You can use this to either encrypt a message or decrypt it.\r\n\r\n# Do this\r\n- Load a **Sample message** from the message dropdown. This will load a message that has been encrypted with a Caesar cipher.\r\n\r\n![](https://images.code.org/347139486c8c729bf3c6e72ce67da878-image-1476286380409.gif)\r\n\r\n- Using the buttons in the Caesar substitution tab, you can shift the alphabet forwards or backwards to try to unscramble the message.\r\n\r\n![](https://images.code.org/ef9ebc16d2f1442dc46fba9bd48b5d43-image-1476285966821.gif)\r\n\r\nSee how long it takes you to crack the cipher! Is this a good method of encrypting secret data?\r\n\r\n<img src=\"http://code.org/api/hour/begin_encryption.png\">\r\n\r\n",
+    "long_instructions": "# Crack a Caesar cipher!\r\n\r\nThis tool lets you play with text and do Caesar ciphers. You can use this to either encrypt a message or decrypt it.\r\n\r\n# Do this\r\n- Load a **Sample message** from the message dropdown. This will load a message that has been encrypted with a Caesar cipher.\r\n\r\n![](https://images.code.org/347139486c8c729bf3c6e72ce67da878-image-1476286380409.gif)\r\n\r\n- Using the buttons in the Caesar substitution tab, you can shift the alphabet forwards or backwards to try to unscramble the message.\r\n\r\n![](https://images.code.org/ef9ebc16d2f1442dc46fba9bd48b5d43-image-1476285966821.gif)\r\n\r\nSee how long it takes you to crack the cipher! Is this a good method of encrypting secret data?",
     "skip_dialog": true,
     "href": "frequency/frequency.html",
     "cipher": "caesar",

--- a/dashboard/config/scripts/levels/Crack a Caesar Cipher_2023.level
+++ b/dashboard/config/scripts/levels/Crack a Caesar Cipher_2023.level
@@ -6,7 +6,7 @@
   "user_id": 42,
   "properties": {
     "short_instructions": "Instructions",
-    "long_instructions": "# Crack a Caesar cipher!\r\n\r\nThis tool lets you play with text and do Caesar ciphers. You can use this to either encrypt a message or decrypt it.\r\n\r\n# Do this\r\n- Load a **Sample message** from the message dropdown. This will load a message that has been encrypted with a Caesar cipher.\r\n\r\n![](https://images.code.org/347139486c8c729bf3c6e72ce67da878-image-1476286380409.gif)\r\n\r\n- Using the buttons in the Caesar substitution tab, you can shift the alphabet forwards or backwards to try to unscramble the message.\r\n\r\n![](https://images.code.org/ef9ebc16d2f1442dc46fba9bd48b5d43-image-1476285966821.gif)\r\n\r\nSee how long it takes you to crack the cipher! Is this a good method of encrypting secret data?\r\n\r\n<img src=\"http://code.org/api/hour/begin_encryption.png\">\r\n\r\n",
+    "long_instructions": "# Crack a Caesar cipher!\r\n\r\nThis tool lets you play with text and do Caesar ciphers. You can use this to either encrypt a message or decrypt it.\r\n\r\n# Do this\r\n- Load a **Sample message** from the message dropdown. This will load a message that has been encrypted with a Caesar cipher.\r\n\r\n![](https://images.code.org/347139486c8c729bf3c6e72ce67da878-image-1476286380409.gif)\r\n\r\n- Using the buttons in the Caesar substitution tab, you can shift the alphabet forwards or backwards to try to unscramble the message.\r\n\r\n![](https://images.code.org/ef9ebc16d2f1442dc46fba9bd48b5d43-image-1476285966821.gif)\r\n\r\nSee how long it takes you to crack the cipher! Is this a good method of encrypting secret data?",
     "skip_dialog": true,
     "href": "frequency/frequency.html",
     "cipher": "caesar",


### PR DESCRIPTION
See [slack](https://codedotorg.slack.com/archives/CFGAVL2CA/p1666973961853059) for background. A broken image was showing up on the first level of the `hoc-encryption` script:
![image (8)](https://user-images.githubusercontent.com/8001765/198705464-b878d6b0-8765-4cb5-a6da-8b3c06382f09.png)

The broken url is `http://code.org/api/hour/begin_encryption.png`, which points here: 
* https://github.com/code-dot-org/code-dot-org/blob/c5b3acf3e62b94893d4bd191dafa12d6df168ea0/pegasus/routes/hoc_routes.rb#L45-L48

the request fails because there is no tutorial in the `cdo_tutorials` table (derived from the cdo-tutorials gsheet) named `encryption`, rather it is named `hoc-encryption` to match the name of the script.

we use urls like this as tracking pixels to count how many users attempt each HOC activity. in this case it was an easy choice to remove it because we already have a different mechanism to automatically add these tracking pixels to the first level of each HOC script, which you can see here:
<img width="739" alt="Screen Shot 2022-10-28 at 11 15 10 AM" src="https://user-images.githubusercontent.com/8001765/198708114-de2e0d38-ebe5-45f5-90a5-02254ff6a723.png">

So, since this image was redundant anyway, I just went and removed it from this level's instructions. while I was in there, I removed it from a bunch of other levels that were created by copying this level, which didn't need it either (because they weren't even in HOC scripts).

## Testing story

Confirmed the broken image url no longer appears:
<img width="833" alt="Screen Shot 2022-10-28 at 11 33 35 AM" src="https://user-images.githubusercontent.com/8001765/198707945-ff50f45e-2565-449e-83fb-5a2154a620d2.png">
