### PR TITLE
Update Dance Party to new 2022 songs

### DIFF
--- a/apps/src/code-studio/dancePartySongArtistTags.js
+++ b/apps/src/code-studio/dancePartySongArtistTags.js
@@ -90,5 +90,13 @@ export const SongTitlesToArtistTwitterHandle = {
   levitating_dualipa: 'DUALIPA',
   stay_thekidlaroi: 'TheKidLaroi',
   watermelonsugar_harrystyles: 'Harry_Styles',
-  higherpower_coldplay: 'Coldplay'
+  higherpower_coldplay: 'Coldplay',
+  // 2022 Songs
+  '2beloved_lizzo': 'Lizzo',
+  asitwas_harrystyles: 'Harry_Styles',
+  breakmysoul_beyonce: 'Beyonce',
+  sunflower_postmaloneftswaelee: 'PostMalone',
+  sunroof_nickyoureanddazy: 'Nicky_Youre',
+  taconesrojos_sebastianyatra: 'SebastianYatra',
+  wedonttalkaboutbruno_encanto: 'EncantoMovie'
 };

--- a/apps/src/dance/songs.js
+++ b/apps/src/dance/songs.js
@@ -13,7 +13,7 @@ import Sounds from '../Sounds';
 export async function getSongManifest(useRestrictedSongs, manifestFilename) {
   if (!manifestFilename || manifestFilename.length === 0) {
     manifestFilename = useRestrictedSongs
-      ? 'songManifest2021_v3.json'
+      ? 'songManifest2022.json'
       : 'testManifest.json';
   }
 


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Updates the manifest version to songManifest2022.json so the new 2022 songs will appear in the Dance Party song selection dropdown. Note: I'm going ahead and prepping this change now, but will merge only when we get the go-ahead from product/curriculum.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
