### PR TITLE
renaming SetupGuide to SetupInstructions

### DIFF
--- a/apps/src/lib/kits/maker/ui/SetupInstructions.jsx
+++ b/apps/src/lib/kits/maker/ui/SetupInstructions.jsx
@@ -37,7 +37,7 @@ const style = {
   }
 };
 
-export default class SetupGuide extends React.Component {
+export default class SetupInstructions extends React.Component {
   constructor(props) {
     super(props);
     this.state = {webSerialPort: null};
@@ -253,7 +253,7 @@ class MacDownloads extends React.Component {
           />
         )}
         {error && <FetchingLatestVersionError />}
-        <SetupInstructions />
+        <Instructions />
       </div>
     );
   }
@@ -297,7 +297,7 @@ class LinuxDownloads extends React.Component {
         )}
         {error && <FetchingLatestVersionError />}
         <div>
-          <SetupInstructions />
+          <Instructions />
           <h4>{applabI18n.makerSetupLinuxAlternative()}</h4>
           <ul>
             {debFile && (
@@ -346,7 +346,7 @@ const FetchingLatestVersionError = () => (
   </div>
 );
 
-const SetupInstructions = () => (
+const Instructions = () => (
   <div>
     <h4>{i18n.instructionsWithColon()}</h4>
     <ol>

--- a/apps/src/sites/studio/pages/maker/setup.js
+++ b/apps/src/sites/studio/pages/maker/setup.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import SetupGuide from '@cdo/apps/lib/kits/maker/ui/SetupGuide';
+import SetupInstructions from '@cdo/apps/lib/kits/maker/ui/SetupInstructions';
 
 $(function() {
   ReactDOM.render(
-    <SetupGuide />,
+    <SetupInstructions />,
     document.getElementById('setup-status-mount')
   );
   $('.maker-setup a').attr('target', '_blank');


### PR DESCRIPTION
**What:** 
Renaming SetupGuide.jsx to SetupInstructions.jsx and fixing dependencies.

**Why:** 
As part of CSD translatability, we need to add Circuit Playground and Micro:bit descriptions into a React component. 
In order to keep modularity and to avoid adding complex logic to the existing component, descriptions will exist in a different React component. Ultimately, all components must be rendered keeping the existing structure, this prevents unnecessary UI changes that will affect the User Experience and will require to update tests. For that purpose, the projected final setup guide will be hosting descriptions, instructions and Support through modular components that are easier to maintain.

**How:** 
- SetupGuide.jsx refactored as SetupInstructions.jsx
- SetupGuide component renamed as SetupInstructions
- SetupInstructions constant rename as Instructions
- setup.js imports now SetupInstructions from SetupInstructions.jsx

## Links

- jira ticket: [FND-2075](https://codedotorg.atlassian.net/browse/FND-2075)

## Testing story
Checked that the page renders SetupInstructions component with and without webserial experiment.

![setup_instructions](https://user-images.githubusercontent.com/66776217/198708003-cfb5c4e6-4580-443e-b273-eb307b2dd3d0.png)

![setup_instructions_webserial](https://user-images.githubusercontent.com/66776217/198708015-abc7ba14-e7ec-4884-857d-8af10f9891af.png)

## Follow-up work
- Additional PR: [fnd-2075-i18n-maker-toolkit-setup](https://github.com/code-dot-org/code-dot-org/pull/48344), to migrate raw strings into React component.
- Adding existing untranslated strings to the i18n pipeline (some button texts is in form of raw strings).

## PR Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
