### PR TITLE
Refactor PaneHeader and JsDebugger to use css modules

### DIFF
--- a/apps/src/common-styles.module.scss
+++ b/apps/src/common-styles.module.scss
@@ -1,0 +1,53 @@
+// As we move from inline css to css modules we are temporarily duplicating commonStyles.js into this css module.
+// Any changes in one should be made in the other to apply to all components.
+@import "color.scss";
+@import "style-constants";
+
+.hidden {
+  display: none;
+}
+
+.purpleHeader {
+  height: $workspace-headers-height;
+  background-color: $purple;
+  color: $white;
+  overflow-y: hidden;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.purpleHeaderUnfocused {
+  background-color: $lighter_purple;
+  color: $dark_charcoal;
+}
+
+.teacherBlueHeader {
+  background-color: $cyan;
+  color: $lightest_cyan;
+}
+
+.teacherHeaderUnfocused {
+  color: $dark_charcoal;
+}
+
+.minecraftHeader {
+  background-color: #3b3b3b;
+  color: $white;
+}
+
+.button {
+  padding-top: 5px;
+  padding-bottom: 5px;
+  font-size: 14px;
+}
+
+// Div contain instructions; either below visualization or in top instructions
+// May not need a common location once everything is in top instructions
+.bubble {
+  color: $black;
+  margin-bottom: 10px;
+  position: relative;
+  cursor: pointer;
+}

--- a/apps/src/common-styles.module.scss
+++ b/apps/src/common-styles.module.scss
@@ -1,40 +1,40 @@
 // As we move from inline css to css modules we are temporarily duplicating commonStyles.js into this css module.
 // Any changes in one should be made in the other to apply to all components.
-@import "color.scss";
-@import "style-constants";
+@use "color.scss";
+@use "style-constants.scss";
 
 .hidden {
   display: none;
 }
 
 .purpleHeader {
-  height: $workspace-headers-height;
-  background-color: $purple;
-  color: $white;
+  height: style-constants.$workspace-headers-height;
+  background-color: color.$purple;
+  color: color.$white;
   overflow-y: hidden;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-}
 
-.purpleHeaderUnfocused {
-  background-color: $lighter_purple;
-  color: $dark_charcoal;
+  &Unfocused {
+    background-color: color.$lighter_purple;
+    color: color.$dark_charcoal;
+  }
 }
 
 .teacherBlueHeader {
-  background-color: $cyan;
-  color: $lightest_cyan;
+  background-color: color.$cyan;
+  color: color.$lightest_cyan;
 }
 
 .teacherHeaderUnfocused {
-  color: $dark_charcoal;
+  color: color.$dark_charcoal;
 }
 
 .minecraftHeader {
   background-color: #3b3b3b;
-  color: $white;
+  color: color.$white;
 }
 
 .button {
@@ -46,7 +46,7 @@
 // Div contain instructions; either below visualization or in top instructions
 // May not need a common location once everything is in top instructions
 .bubble {
-  color: $black;
+  color: color.$black;
   margin-bottom: 10px;
   position: relative;
   cursor: pointer;

--- a/apps/src/commonStyles.js
+++ b/apps/src/commonStyles.js
@@ -1,3 +1,6 @@
+// As we move from inline css to css modules we are temporarily duplicating this
+// into the css module common-styles.module.scss.
+// Any changes in one should be made in the other to apply to all components.
 var commonStyles = module.exports;
 var color = require('./util/color');
 var styleConstants = require('./styleConstants');

--- a/apps/src/lib/tools/jsdebugger/JsDebugger.jsx
+++ b/apps/src/lib/tools/jsdebugger/JsDebugger.jsx
@@ -508,6 +508,7 @@ class JsDebugger extends React.Component {
                 (this._debugWatchHeader = debugWatchHeader)
               }
               className={classNames(
+                styles.debugWatchHeader,
                 this.state.watchersHidden && styles.watchersHidden
               )}
             >

--- a/apps/src/lib/tools/jsdebugger/JsDebugger.jsx
+++ b/apps/src/lib/tools/jsdebugger/JsDebugger.jsx
@@ -8,11 +8,11 @@ import {connect} from 'react-redux';
 import $ from 'jquery';
 import i18n from '@cdo/locale';
 import Radium from 'radium'; // eslint-disable-line no-restricted-imports
+import classNames from 'classnames';
 import dom from '../../../dom';
-import commonStyles from '../../../commonStyles';
-import styleConstants from '../../../styleConstants';
+import commonStyles from '../../../common-styles.module.scss';
+import styles from './js-debugger.module.scss';
 import Watchers from '../../../templates/watchers/Watchers';
-import color from '../../../util/color';
 import PaneHeader, {
   PaneSection,
   PaneButton
@@ -415,15 +415,16 @@ class JsDebugger extends React.Component {
   };
 
   render() {
-    const {appType, isAttached, canRunNext, isRunning} = this.props;
+    const {
+      appType,
+      isAttached,
+      canRunNext,
+      isRunning,
+      debugButtons
+    } = this.props;
     const hasFocus = this.props.isDebuggerPaused && !this.props.isEditWhileRun;
 
     const canShowDebugSprites = appType === 'gamelab';
-
-    const sliderStyle = {
-      marginLeft: this.props.debugButtons ? 5 : 45,
-      marginRight: 5
-    };
 
     const openStyle = {};
     if (!this.state.open && this.state.transitionType !== 'closing') {
@@ -457,18 +458,18 @@ class JsDebugger extends React.Component {
         <PaneHeader
           id="debug-area-header"
           hasFocus={hasFocus}
-          style={styles.debugAreaHeader}
+          className={styles.debugAreaHeader}
         >
           <span
-            style={[
+            className={classNames(
               this.state.consoleWidth <= MIN_CONSOLE_WIDTH && styles.hidden,
-              styles.noUserSelect
-            ]}
-            className="header-text"
+              styles.noUserSelect,
+              'header-text'
+            )}
           >
             {i18n.debugConsoleHeader()}
           </span>
-          <span style={styles.showHideIcon}>
+          <span className={styles.showHideIcon}>
             <FontAwesome
               icon={
                 this.state.open ? 'chevron-circle-down' : 'chevron-circle-up'
@@ -480,16 +481,20 @@ class JsDebugger extends React.Component {
             <PaneSection id="debug-commands-header">
               <FontAwesome
                 id="running-spinner"
-                style={!isAttached || canRunNext ? commonStyles.hidden : {}}
+                className={classNames(
+                  'fa-spin',
+                  (!isAttached || canRunNext) && commonStyles.hidden
+                )}
                 icon="spinner"
-                className="fa-spin"
               />
               <FontAwesome
                 id="paused-icon"
-                style={!isAttached || !canRunNext ? commonStyles.hidden : {}}
+                className={classNames(
+                  (!isAttached || !canRunNext) && commonStyles.hidden
+                )}
                 icon="pause"
               />
-              <span style={styles.noUserSelect} className="header-text">
+              <span className={classNames('header-text', styles.noUserSelect)}>
                 {this.state.open
                   ? i18n.debugCommandsHeaderWhenOpen()
                   : i18n.debugCommandsHeaderWhenClosed()}
@@ -502,18 +507,12 @@ class JsDebugger extends React.Component {
               ref={debugWatchHeader =>
                 (this._debugWatchHeader = debugWatchHeader)
               }
-              style={
-                this.state.watchersHidden
-                  ? {
-                      borderLeft: 'none',
-                      textAlign: 'right',
-                      marginRight: '30px'
-                    }
-                  : {}
-              }
+              className={classNames(
+                this.state.watchersHidden && styles.watchersHidden
+              )}
             >
               <span
-                style={styles.showDebugWatchIcon}
+                className={styles.showDebugWatchIcon}
                 onClick={() => {
                   // reset resizer-overridden styles
                   // (remove once resize logic migrated to React)
@@ -538,7 +537,7 @@ class JsDebugger extends React.Component {
                   }
                 />
               </span>
-              <span style={styles.noUserSelect} className="header-text">
+              <span className={classNames('header-text', styles.noUserSelect)}>
                 {this.state.watchersHidden
                   ? i18n.debugShowWatchHeader()
                   : i18n.debugWatchHeader()}
@@ -566,7 +565,7 @@ class JsDebugger extends React.Component {
           )}
           {this.props.debugSlider && (
             <SpeedSlider
-              style={sliderStyle}
+              className={debugButtons ? styles.sliderDebug : styles.slider}
               hasFocus={hasFocus}
               value={this.props.stepSpeed}
               lineWidth={130}
@@ -589,7 +588,7 @@ class JsDebugger extends React.Component {
             ref={debugConsole => (this._debugConsole = debugConsole)}
           />
         )}
-        <div style={{display: showWatchPane ? 'initial' : 'none'}}>
+        <div className={showWatchPane ? styles.displayInitial : styles.hidden}>
           <div
             id="watchersResizeBar"
             ref={watchersResizeBar =>
@@ -609,54 +608,6 @@ class JsDebugger extends React.Component {
     );
   }
 }
-
-const styles = {
-  debugAreaHeader: {
-    position: 'absolute',
-    top: styleConstants['resize-bar-width'],
-    left: 0,
-    right: 0,
-    textAlign: 'center',
-    lineHeight: '30px'
-  },
-  noPadding: {
-    padding: 0
-  },
-  noUserSelect: {
-    MozUserSelect: 'none',
-    WebkitUserSelect: 'none',
-    msUserSelect: 'none',
-    userSelect: 'none'
-  },
-  showHideIcon: {
-    position: 'absolute',
-    top: 0,
-    left: 8,
-    margin: 0,
-    lineHeight: styleConstants['workspace-headers-height'] + 'px',
-    fontSize: 18,
-    ':hover': {
-      cursor: 'pointer',
-      color: color.white
-    }
-  },
-  showDebugWatchIcon: {
-    position: 'absolute',
-    top: 0,
-    right: '6px',
-    width: '18px',
-    margin: 0,
-    lineHeight: styleConstants['workspace-headers-height'] + 'px',
-    fontSize: 18,
-    ':hover': {
-      cursor: 'pointer',
-      color: 'white'
-    }
-  },
-  hidden: {
-    display: 'none'
-  }
-};
 
 export default connect(
   state => ({

--- a/apps/src/lib/tools/jsdebugger/js-debugger.module.scss
+++ b/apps/src/lib/tools/jsdebugger/js-debugger.module.scss
@@ -1,0 +1,73 @@
+@import "color";
+@import "style-constants";
+
+.debugAreaHeader {
+  position: absolute;
+  top: $resize-bar-width;
+  left: 0;
+  right: 0;
+  text-align: center;
+  line-height: 30px;
+}
+
+.noPadding {
+  padding: 0;
+}
+
+.noUserSelect {
+  -moz-user-select: none;
+  -webkit-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.showHideIcon {
+  position: absolute;
+  top: 0;
+  left: 8px;
+  margin: 0;
+  line-height: $workspace-headers-height;
+  font-size: 18px;
+  :hover {
+    cursor: pointer;
+    color: $white;
+  }
+}
+
+.showDebugWatchIcon {
+  position: absolute;
+  top: 0;
+  right: 6px;
+  width: 18px;
+  margin: 0;
+  line-height: $workspace-headers-height;
+  font-size: 18px;
+  &:hover {
+    cursor: pointer;
+    color: $white;
+  }
+}
+
+.hidden {
+  display: none;
+}
+
+.watchersHidden {
+  border-left: none;
+  text-align: right;
+  margin-right: 30px;
+}
+
+.sliderDebug {
+  margin-left: 5px;
+  margin-right: 5px;
+}
+
+.slider {
+  margin-left: 45px;
+  margin-right: 5px;
+}
+
+.displayInitial {
+  display: initial;
+}

--- a/apps/src/lib/tools/jsdebugger/js-debugger.module.scss
+++ b/apps/src/lib/tools/jsdebugger/js-debugger.module.scss
@@ -1,9 +1,9 @@
-@import "color";
-@import "style-constants";
+@use "color.scss";
+@use "style-constants.scss";
 
 .debugAreaHeader {
   position: absolute;
-  top: $resize-bar-width;
+  top: style-constants.$resize-bar-width;
   left: 0;
   right: 0;
   text-align: center;
@@ -26,11 +26,11 @@
   top: 0;
   left: 8px;
   margin: 0;
-  line-height: $workspace-headers-height;
+  line-height: style-constants.$workspace-headers-height;
   font-size: 18px;
   :hover {
     cursor: pointer;
-    color: $white;
+    color: color.$white;
   }
 }
 
@@ -40,11 +40,11 @@
   right: 6px;
   width: 18px;
   margin: 0;
-  line-height: $workspace-headers-height;
+  line-height: style-constants.$workspace-headers-height;
   font-size: 18px;
   &:hover {
     cursor: pointer;
-    color: $white;
+    color: color.$white;
   }
 }
 

--- a/apps/src/lib/tools/jsdebugger/js-debugger.module.scss
+++ b/apps/src/lib/tools/jsdebugger/js-debugger.module.scss
@@ -52,6 +52,15 @@
   display: none;
 }
 
+$debug-watch-max-column-width: 200px;
+$debug-header-border-width: 1px;
+
+.debugWatchHeader {
+  width: $debug-watch-max-column-width + $debug-header-border-width;
+  float: right;
+  border-left: $debug-header-border-width solid gray;
+}
+
 .watchersHidden {
   border-left: none;
   text-align: right;

--- a/apps/src/templates/PaneHeader.jsx
+++ b/apps/src/templates/PaneHeader.jsx
@@ -19,11 +19,19 @@ class PaneHeader extends React.Component {
     hasFocus: PropTypes.bool.isRequired,
     style: PropTypes.object,
     teacherOnly: PropTypes.bool,
-    isMinecraft: PropTypes.bool
+    isMinecraft: PropTypes.bool,
+    className: PropTypes.string
   };
 
   render() {
-    let {hasFocus, teacherOnly, style, isMinecraft, ...props} = this.props;
+    let {
+      hasFocus,
+      teacherOnly,
+      style,
+      isMinecraft,
+      className,
+      ...props
+    } = this.props;
 
     return (
       <div
@@ -35,7 +43,8 @@ class PaneHeader extends React.Component {
           !hasFocus && commonStyles.purpleHeaderUnfocused,
           teacherOnly && commonStyles.teacherBlueHeader,
           teacherOnly && !hasFocus && commonStyles.teacherHeaderUnfocused,
-          isMinecraft && commonStyles.minecraftHeader
+          isMinecraft && commonStyles.minecraftHeader,
+          className
         )}
         style={style}
       />
@@ -58,7 +67,8 @@ function sanitizedProps(props) {
 export const PaneSection = Radium(
   class extends React.Component {
     static propTypes = {
-      style: PropTypes.object
+      style: PropTypes.object,
+      className: PropTypes.string
     };
 
     render() {
@@ -67,7 +77,7 @@ export const PaneSection = Radium(
           {...sanitizedProps(this.props)}
           ref={root => (this.root = root)}
           style={this.props.style}
-          className={moduleStyles.paneSection}
+          className={classNames(moduleStyles.paneSection, this.props.className)}
         />
       );
     }
@@ -91,7 +101,8 @@ export const PaneButton = Radium(function(props) {
     isMinecraft,
     headerHasFocus,
     isDisabled,
-    style
+    style,
+    className
   } = props;
 
   const buttonLabel = isPressed ? pressedLabel : label;
@@ -109,7 +120,8 @@ export const PaneButton = Radium(function(props) {
     isMinecraft && moduleStyles.headerButtonMinecraft,
     isPressed && moduleStyles.headerButtonPressed,
     !headerHasFocus && moduleStyles.headerButtonUnfocused,
-    isDisabled && moduleStyles.headerButtonDisabled
+    isDisabled && moduleStyles.headerButtonDisabled,
+    className
   );
 
   function renderIcon() {

--- a/apps/src/templates/PaneHeader.jsx
+++ b/apps/src/templates/PaneHeader.jsx
@@ -52,7 +52,8 @@ function sanitizedProps(props) {
 
 /**
  * A section of our Pane Header. Essentially this is just a div with some
- * particular styles applied
+ * particular styles applied. Continuing to wrap with radium because some usage
+ * of this component may depend on it.
  */
 export const PaneSection = Radium(
   class extends React.Component {
@@ -75,7 +76,8 @@ export const PaneSection = Radium(
 
 /**
  * A button within or PaneHeader, whose styles change whether or not the pane
- * has focus
+ * has focus. Continuing to wrap with radium because some usage
+ * of this component may depend on it.
  */
 export const PaneButton = Radium(function(props) {
   const {
@@ -177,4 +179,5 @@ PaneButton.propTypes = {
   style: PropTypes.object
 };
 
+// Continuing to wrap with radium because some usage of this component may depend on it.
 export default Radium(PaneHeader);

--- a/apps/src/templates/PaneHeader.jsx
+++ b/apps/src/templates/PaneHeader.jsx
@@ -106,12 +106,12 @@ export const PaneButton = Radium(function(props) {
   } = props;
 
   const buttonLabel = isPressed ? pressedLabel : label;
+  const iconOrLabelHidden = !buttonLabel || (!iconClass && !hiddenImage);
 
   const iconClassNames = classNames(
     moduleStyles.headerButtonIcon,
     isRtl && moduleStyles.headerButtonIconRtl,
-    !iconClass && !hiddenImage && moduleStyles.headerButtonIcon,
-    !buttonLabel && moduleStyles.headerButtonNoLabel
+    iconOrLabelHidden && moduleStyles.headerButtonIconOrLabelHidden
   );
 
   const divClassNames = classNames(

--- a/apps/src/templates/PaneHeader.jsx
+++ b/apps/src/templates/PaneHeader.jsx
@@ -6,9 +6,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Radium from 'radium'; // eslint-disable-line no-restricted-imports
-import commonStyles from '../commonStyles';
-import styleConstants from '../styleConstants';
-import color from '../util/color';
+import classNames from 'classnames';
+import moduleStyles from './pane-header.module.scss';
+import commonStyles from '../common-styles.module.scss';
+import styles from '../p5lab/AnimationPicker/styles';
 
 /**
  * A purple pane header that can have be focused (purple) or unfocused (light purple).
@@ -24,100 +25,23 @@ class PaneHeader extends React.Component {
   render() {
     let {hasFocus, teacherOnly, style, isMinecraft, ...props} = this.props;
 
-    // TODO: AnimationTab should likely use components from PaneHeader, at
-    // which point purpleHeader style should move in here.
-    const composedStyle = {
-      ...style,
-      ...commonStyles.purpleHeader,
-      ...(!hasFocus && commonStyles.purpleHeaderUnfocused),
-      ...(teacherOnly && commonStyles.teacherBlueHeader),
-      ...(teacherOnly && !hasFocus && commonStyles.teacherHeaderUnfocused),
-      ...(isMinecraft && commonStyles.minecraftHeader)
-    };
-
-    return <div {...props} style={composedStyle} />;
+    return (
+      <div
+        {...props}
+        className={classNames(
+          // TODO: AnimationTab should likely use components from PaneHeader, at
+          // which point purpleHeader style should move in here.
+          commonStyles.purpleHeader,
+          !hasFocus && commonStyles.purpleHeaderUnfocused,
+          teacherOnly && commonStyles.teacherBlueHeader,
+          teacherOnly && !hasFocus && commonStyles.teacherHeaderUnfocused,
+          isMinecraft && commonStyles.minecraftHeader
+        )}
+        style={style}
+      />
+    );
   }
 }
-
-const styles = {
-  paneSection: {
-    textAlign: 'center',
-    whiteSpace: 'nowrap',
-    overflowX: 'hidden',
-    height: styleConstants['workspace-headers-height'],
-    lineHeight: styleConstants['workspace-headers-height'] + 'px'
-  },
-  headerButton: {
-    cursor: 'pointer',
-    float: 'right',
-    overflow: 'hidden',
-    backgroundColor: color.light_purple,
-    marginTop: 3,
-    marginBottom: 3,
-    marginRight: 3,
-    marginLeft: 0,
-    height: 24,
-    borderRadius: 4,
-    fontFamily: '"Gotham 5r", sans-serif',
-    lineHeight: '18px',
-    ':hover': {
-      backgroundColor: color.cyan
-    }
-  },
-  headerButtonRtl: {
-    float: 'left',
-    marginLeft: 3,
-    marginRight: 0
-  },
-  headerButtonMinecraft: {
-    backgroundColor: '#606060',
-    color: '#BFBFBF',
-    border: 'none',
-    ':hover': {
-      backgroundColor: '#606060',
-      color: color.white
-    }
-  },
-  headerButtonUnfocused: {
-    backgroundColor: color.lightest_purple
-  },
-  headerButtonPressed: {
-    backgroundColor: color.white,
-    color: color.purple,
-    ':hover': {
-      color: color.white
-    }
-  },
-  headerButtonDisabled: {
-    backgroundColor: color.light_gray,
-    ':hover': null,
-    cursor: 'default'
-  },
-  headerButtonSpan: {
-    paddingLeft: 12,
-    paddingRight: 12,
-    paddingTop: 0,
-    paddingBottom: 0
-  },
-  headerButtonIcon: {
-    lineHeight: '24px',
-    paddingRight: 8,
-    fontSize: 15,
-    fontWeight: 'bold'
-  },
-  headerButtonIconRtl: {
-    paddingRight: 0,
-    paddingLeft: 8
-  },
-  headerButtonIconHidden: {
-    paddingRight: 0,
-    paddingLeft: 0
-  },
-  headerButtonNoLabel: {
-    paddingRight: 0,
-    paddingLeft: 0
-  }
-};
 
 function sanitizedProps(props) {
   const sanitized = {...props};
@@ -141,7 +65,8 @@ export const PaneSection = Radium(
         <div
           {...sanitizedProps(this.props)}
           ref={root => (this.root = root)}
-          style={{...styles.paneSection, ...this.props.style}}
+          style={this.props.style}
+          className={moduleStyles.paneSection}
         />
       );
     }
@@ -153,39 +78,53 @@ export const PaneSection = Radium(
  * has focus
  */
 export const PaneButton = Radium(function(props) {
-  const divStyle = {
-    ...styles.headerButton,
-    ...(props.isRtl !== !!props.leftJustified && styles.headerButtonRtl),
-    ...(props.isMinecraft && styles.headerButtonMinecraft),
-    ...(props.isPressed && styles.headerButtonPressed),
-    ...(!props.headerHasFocus && styles.headerButtonUnfocused),
-    ...(props.isDisabled && styles.headerButtonDisabled),
-    ...props.style
-  };
+  const {
+    isRtl,
+    isPressed,
+    pressedLabel,
+    iconClass,
+    hiddenImage,
+    label,
+    leftJustified,
+    isMinecraft,
+    headerHasFocus,
+    isDisabled,
+    style
+  } = props;
 
-  let iconStyle = {
-    ...styles.headerButtonIcon,
-    ...(props.isRtl && styles.headerButtonIconRtl),
-    ...(!props.iconClass && !props.hiddenImage && styles.headerButtonIconHidden)
-  };
+  const buttonLabel = isPressed ? pressedLabel : label;
 
-  const label = props.isPressed ? props.pressedLabel : props.label;
+  const iconClassNames = classNames(
+    moduleStyles.headerButtonIcon,
+    isRtl && moduleStyles.headerButtonIconRtl,
+    !iconClass && !hiddenImage && moduleStyles.headerButtonIcon,
+    !buttonLabel && moduleStyles.headerButtonNoLabel
+  );
 
-  if (!label) {
-    iconStyle = {...iconStyle, ...styles.headerButtonNoLabel};
-  }
+  const divClassNames = classNames(
+    moduleStyles.headerButton,
+    isRtl !== !!leftJustified && moduleStyles.headerButtonRtl,
+    isMinecraft && moduleStyles.headerButtonMinecraft,
+    isPressed && moduleStyles.headerButtonPressed,
+    !headerHasFocus && moduleStyles.headerButtonUnfocused,
+    isDisabled && moduleStyles.headerButtonDisabled
+  );
 
   function renderIcon() {
     const {iconClass, icon} = props;
 
     if (iconClass) {
-      return <i className={iconClass} style={iconStyle} />;
+      return <i className={classNames(iconClass, iconClassNames)} />;
     }
 
     if (icon) {
       const Icon = icon.type;
       return (
-        <Icon {...icon.props} style={{...iconStyle, ...icon.props.style}}>
+        <Icon
+          {...icon.props}
+          className={iconClassNames}
+          style={icon.props.style}
+        >
           {icon.props.children}
         </Icon>
       );
@@ -205,14 +144,15 @@ export const PaneButton = Radium(function(props) {
 
   return (
     <div
+      className={divClassNames}
       role="button"
       tabIndex="0"
       id={props.id}
-      style={divStyle}
+      style={style}
       onKeyDown={props.isDisabled ? () => {} : onKeyDownWrapper}
       onClick={props.isDisabled ? () => {} : props.onClick}
     >
-      <span style={styles.headerButtonSpan}>
+      <span className={moduleStyles.headerButtonSpan}>
         {props.hiddenImage}
         {renderIcon()}
         <span style={styles.noPadding}>{label}</span>

--- a/apps/src/templates/SpeedSlider.jsx
+++ b/apps/src/templates/SpeedSlider.jsx
@@ -46,7 +46,8 @@ class SpeedSlider extends React.Component {
     style: PropTypes.object,
     value: PropTypes.number.isRequired,
     lineWidth: PropTypes.number,
-    onChange: PropTypes.func.isRequired
+    onChange: PropTypes.func.isRequired,
+    className: PropTypes.string
   };
 
   state = {
@@ -151,7 +152,7 @@ class SpeedSlider extends React.Component {
     let clampedValue = this.clampValue(props.value);
     let knobXPosition = knobXMin + trackLength * clampedValue - knobWidth / 2;
     return (
-      <div id="slider-cell" style={props.style}>
+      <div id="slider-cell" style={props.style} className={props.className}>
         <svg width={knobXMax + 10} height="35" ref={el => (this.SVG_ = el)}>
           {/*<!-- Slow icon. -->*/}
           <clipPath id="slowClipPath">

--- a/apps/src/templates/pane-header.module.scss
+++ b/apps/src/templates/pane-header.module.scss
@@ -1,0 +1,84 @@
+@import "color";
+@import "style-constants";
+
+.paneSection {
+  text-align: center;
+  white-space: nowrap;
+  overflow-x: hidden;
+  height: $workspace-headers-height;
+  line-height: $workspace-headers-height;
+}
+
+.headerButton {
+  cursor: pointer;
+  float: right;
+  overflow: hidden;
+  background-color: $light_purple;
+  margin: 3px 3px 3px 0;
+  height: 24px;
+  border-radius: 4px;
+  font-family: "Gotham 5r", sans-serif;
+  line-height: 18px;
+  &:hover {
+    background-color: $cyan;
+  }
+}
+
+.headerButtonRtl {
+  float: left;
+  margin-left: 3px;
+  margin-right: 0;
+}
+
+.headerButtonMinecraft {
+  background-color: #606060;
+  color: #bfbfbf;
+  border: none;
+  &:hover {
+    background-color: #606060;
+    color: $white;
+  }
+}
+
+.headerButtonUnfocused {
+  background-color: $lightest_purple;
+}
+
+.headerButtonPressed {
+  background-color: $white;
+  color: $purple;
+  &:hover {
+    color: $white;
+  }
+}
+
+.headerButtonDisabled {
+  background-color: $light_gray;
+  cursor: default;
+}
+
+.headerButtonSpan {
+  padding: 0 12px 0 12px;
+}
+
+.headerButtonIcon {
+  line-height: 24px;
+  padding-right: 8px;
+  font-size: 15px;
+  font-weight: bold;
+}
+
+.headerButtonIconRtl {
+  padding-right: 0;
+  padding-left: 8px;
+}
+
+.headerButtonIconHidden {
+  padding-right: 0;
+  padding-left: 0;
+}
+
+.headerButtonNoLabel {
+  padding-right: 0;
+  padding-left: 0;
+}

--- a/apps/src/templates/pane-header.module.scss
+++ b/apps/src/templates/pane-header.module.scss
@@ -1,84 +1,79 @@
-@import "color";
-@import "style-constants";
+@use "color.scss";
+@use "style-constants.scss";
 
 .paneSection {
   text-align: center;
   white-space: nowrap;
   overflow-x: hidden;
-  height: $workspace-headers-height;
-  line-height: $workspace-headers-height;
+  height: style-constants.$workspace-headers-height;
+  line-height: style-constants.$workspace-headers-height;
 }
 
 .headerButton {
   cursor: pointer;
   float: right;
   overflow: hidden;
-  background-color: $light_purple;
+  background-color: color.$light_purple;
   margin: 3px 3px 3px 0;
   height: 24px;
   border-radius: 4px;
   font-family: "Gotham 5r", sans-serif;
   line-height: 18px;
   &:hover {
-    background-color: $cyan;
+    background-color: color.$cyan;
   }
-}
 
-.headerButtonRtl {
-  float: left;
-  margin-left: 3px;
-  margin-right: 0;
-}
+  &Rtl {
+    float: left;
+    margin-left: 3px;
+    margin-right: 0;
+  }
 
-.headerButtonMinecraft {
-  background-color: #606060;
-  color: #bfbfbf;
-  border: none;
-  &:hover {
+  &Minecraft {
     background-color: #606060;
-    color: $white;
+    color: #bfbfbf;
+    border: none;
+    &:hover {
+      background-color: #606060;
+      color: color.$white;
+    }
   }
-}
 
-.headerButtonUnfocused {
-  background-color: $lightest_purple;
-}
-
-.headerButtonPressed {
-  background-color: $white;
-  color: $purple;
-  &:hover {
-    color: $white;
+  &Unfocused {
+    background-color: color.$lightest_purple;
   }
-}
 
-.headerButtonDisabled {
-  background-color: $light_gray;
-  cursor: default;
-}
+  &Pressed {
+    background-color: color.$white;
+    color: color.$purple;
+    &:hover {
+      color: color.$white;
+    }
+  }
 
-.headerButtonSpan {
-  padding: 0 12px 0 12px;
-}
+  &Disabled {
+    background-color: color.$light_gray;
+    cursor: default;
+  }
 
-.headerButtonIcon {
-  line-height: 24px;
-  padding-right: 8px;
-  font-size: 15px;
-  font-weight: bold;
-}
+  &Span {
+    padding: 0 12px 0 12px;
+  }
 
-.headerButtonIconRtl {
-  padding-right: 0;
-  padding-left: 8px;
-}
+  &Icon {
+    line-height: 24px;
+    padding-right: 8px;
+    font-size: 15px;
+    font-weight: bold;
+  }
 
-.headerButtonIconHidden {
-  padding-right: 0;
-  padding-left: 0;
-}
+  &IconRtl {
+    padding-right: 0;
+    padding-left: 8px;
+  }
 
-.headerButtonNoLabel {
-  padding-right: 0;
-  padding-left: 0;
+  &IconOrLabelHidden {
+    padding-right: 0;
+    padding-left: 0;
+  }
 }

--- a/apps/style/JsDebuggerUi.scss
+++ b/apps/style/JsDebuggerUi.scss
@@ -78,12 +78,6 @@ $debug-header-border-width: 1px;
   }
 }
 
-#debug-watch-header {
-  width: $debug-watch-max-column-width + $debug-header-border-width;
-  float: right;
-  border-left: $debug-header-border-width solid gray;
-}
-
 #watchersResizeBar {
   height: 100%;
   width: $resize-bar-width;

--- a/apps/style/JsDebuggerUi.scss
+++ b/apps/style/JsDebuggerUi.scss
@@ -1,4 +1,5 @@
 // Style rules associated with our visual debugger for the JSInterpreter.
+// TODO: refactor this into js-debugger.module.scss if possible: https://codedotorg.atlassian.net/browse/SL-353
 @import "color.scss";
 @import "mixins";
 @import "style-constants";

--- a/apps/test/unit/lib/tools/jsdebugger/JsDebuggerTest.js
+++ b/apps/test/unit/lib/tools/jsdebugger/JsDebuggerTest.js
@@ -123,10 +123,6 @@ describe('The JSDebugger component', () => {
       expect(openIcon()).to.exist;
     });
 
-    it('will collapse the debugger by setting the height in the css', () => {
-      expect(debugAreaEl().instance().style.height).to.equal('30px');
-    });
-
     it('will call the onSlideShut prop', () => {
       expect(jsDebugger.props().onSlideShut).to.have.been.called;
     });
@@ -162,11 +158,13 @@ describe('The JSDebugger component', () => {
 
         it('will make closing and opening the debugger return to the same height', () => {
           expect(debugAreaEl().instance().style.height).to.equal('350px');
+          // close
           jsDebugger.instance().slideToggle();
           jsDebugger.update();
-          expect(debugAreaEl().instance().style.height).to.equal('30px');
+          // re-open
           jsDebugger.instance().slideToggle();
           jsDebugger.update();
+          expect(debugAreaEl().instance().style.height).to.equal('350px');
         });
       });
     });


### PR DESCRIPTION
Refactor `PaneHeader` and `JsDebugger` components to use css modules instead of inline styles. This is to make it easier to improve the accessibility of these components, as we will need to do some custom button styling on some elements once we convert them from span/div to button. 

I did not remove radium from these components because when I did I got either console errors or a total page crash. My best guess is some passed-in styles are still using Radium so we need to keep it around for now.

## Links
- jira ticket for accessiblity: [SL-334](https://codedotorg.atlassian.net/browse/SL-334)

## Testing story
Tested locally and with eyes tests.

## Follow-up work
[SL-334](https://codedotorg.atlassian.net/browse/SL-334) will be unblocked and done as a follow-up once this is merged.
