### PR TITLE
drop pegasus tutorials table

### DIFF
--- a/pegasus/migrations/140_drop_tutorials.rb
+++ b/pegasus/migrations/140_drop_tutorials.rb
@@ -1,0 +1,6 @@
+Sequel.migration do
+  up do
+    # The tutorials table has been replaced by cdo_tutorials.
+    drop_table?(:tutorials)
+  end
+end


### PR DESCRIPTION
This is a cleanup step that is possible now that the last reference to `PEGASUS_DB[:tutorials]` was removed in https://github.com/code-dot-org/code-dot-org/pull/48797 . The table now used is `cdo_tutorials`, which pulls its data from the cdo-tutorials gsheet. References to `Tutorials.new(:tutorials)` point to the `cdo_tutorials` table following the logic here: 
* https://github.com/code-dot-org/code-dot-org/blob/2710502c86aba0c7526699bc82595bdda1a42467/pegasus/src/database.rb#L20-L21

For more background, see [slack](https://codedotorg.slack.com/archives/C04540KNGDQ/p1666651340884779).

## Testing story

* exhaustive code search for anything pointing toward the `tutorials` table didn't turn up anything
* `test_pegasus_documents.rb` ensures that every pegasus page can still render