### PR TITLE
Use cdo_tutorials instead of tutorials in analyze_hoc_activiy

### DIFF
--- a/pegasus/helpers/analyze_hoc_activity_helper.rb
+++ b/pegasus/helpers/analyze_hoc_activity_helper.rb
@@ -89,9 +89,9 @@ def analyze_day_fast(date)
   # Code.org hosted tutorials below.
   codedotorg_tutorials = []
   PEGASUS_DB_READER.fetch(
-    "SELECT code FROM tutorials WHERE orgname = 'Code.org'"
+    "SELECT code_s FROM cdo_tutorials WHERE orgname_s = 'Code.org'"
   ).each do |row|
-    codedotorg_tutorials.push(row[:code])
+    codedotorg_tutorials.push(row[:code_s])
   end
 
   codedotorg_tutorial_count = 0


### PR DESCRIPTION
Fix for https://app.honeybadger.io/projects/45435/faults/89684840 in test. The `tutorials` table was dropped in https://github.com/code-dot-org/code-dot-org/pull/48925.



## Testing story

Ran recent migrations then ran `./bin/cron/analyze_hoc_activity` locally and it succeeded.






## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
