### PR TITLE
[Sprite Lab] Commands for validating "StoryLab" block pool levels.

### DIFF
--- a/apps/src/p5lab/spritelab/commands/storyLabCommands.js
+++ b/apps/src/p5lab/spritelab/commands/storyLabCommands.js
@@ -20,5 +20,17 @@ export const commands = {
 
   setSubheading(subheading) {
     this.storyLabText.subheading = subheading;
+  },
+
+  getHeading(heading) {
+    return this.storyLabText.heading;
+  },
+
+  getSubheading(subheading) {
+    return this.storyLabText.subheading;
+  },
+
+  getStoryLabText() {
+    return this.storyLabText;
   }
 };

--- a/apps/src/p5lab/spritelab/commands/storyLabCommands.js
+++ b/apps/src/p5lab/spritelab/commands/storyLabCommands.js
@@ -22,11 +22,11 @@ export const commands = {
     this.storyLabText.subheading = subheading;
   },
 
-  getHeading(heading) {
+  getHeading() {
     return this.storyLabText.heading;
   },
 
-  getSubheading(subheading) {
+  getSubheading() {
     return this.storyLabText.subheading;
   },
 


### PR DESCRIPTION
Request from CSC Curriculum Team to unblock development:
<img width="779" alt="image" src="https://user-images.githubusercontent.com/43474485/199052818-976ec5e0-522a-4850-b639-72eaba90ae27.png">

This adds three commands for the purposes of validating Sprite Lab levels that use the experimental "StoryLab" block pool. These commands have been added to the `storyLabCommands.js` file as they do not work with core Spite Lab.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
