### PR TITLE
Revert "Update `json` Gem to 2.6.2"

### DIFF
--- a/cookbooks/Gemfile.lock
+++ b/cookbooks/Gemfile.lock
@@ -140,7 +140,7 @@ GEM
       train (~> 0.32)
     ipaddress (0.8.3)
     jmespath (1.3.1)
-    json (2.6.2)
+    json (2.1.0)
     kitchen-docker (2.6.0)
       test-kitchen (>= 1.0.0)
     kitchen-dokken (2.6.6)


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#48760

This might've broken test: https://cdo-build-logs.s3.amazonaws.com/test/20221031T212304%2B0000?versionId=QxmmdZaoVUTRt9QaaQNIsMwi5AWcv12J&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAW5P5EEELHRHQUAWD%2F20221031%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20221031T212317Z&X-Amz-Expires=259200&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEJX%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEaCXVzLWVhc3QtMSJIMEYCIQCn3oqMTnVpMc6S28FuPJ25R1%2BueA99bZ8jzs3MmwoALwIhAIXW46KP3JAbKmjcDiMgBtEAwJ8spjcPhfo%2Fu2QnXB50Ks0ECH4QABoMNDc1NjYxNjA3MTkwIgzKyxDahDmoX9R%2Ft9wqqgRhbEpbTWXGPGQ2pxPRJnwFckpRJDicllwOA0r2Te2U2mwknljaA4zylRvMNSXfBk6JpiNbZilGEbkqIAWhN0zU%2B8f2miCcjZxDdyStpa1Tga9hfXkTUrDLd9ESmZqBszZdMkImCUSvooRvIQPykgxDvMSDEh3niVKohgRgm5w5%2Blv5KZX7GUCveKHh5f0gUQWObMtzrulgtoQlN%2FBB8nMyQVvVuXUjcET3gkziIeJlxf2sCSJpNw0pUMULWfXt07Nestjq2MnTuuc3VIVT7%2B7dGwIcsuclYdXUVycITF6mOuZmrZMXcK8DmiYYKRd4NIFsnVoBiKEbtz8rSaCwTnAFC%2FvcfVbODvPWk5GUKIsTrPjKF03tbwXS65D0zNVBW4AePV7lLWvbsAXC0TbuNrrn%2BLz8bviOy1LspiUZMQriptp9JpAn6D%2BC%2F3UUrpQnmFV8uAmo9yAGE3SOiCkL0AYVZPWz3hFtCGSZLG5Dts4qzIYA1YcagJUjYRqMbnPWq1lXUG2WTD2x8bQ%2BJ6UWEU7l3HOxa1grdUoe3CtJDV43Fgkr7gt0qxNyYU0zv1N857Gv8sv1kxpMyosAj1EtNa0LHEhcu8t43rTd%2FT3G52SZoS1xQPbhwgcAQJ6xeHxYTPcAhEJsHXaxhNXaOgJJWzxG%2FcdZwnNcJOer7YIjKEE4nzGfBoOoy6tWtAyY%2BdoQkzpu0i2XsM3wRk7gHeOPXGHes47ZakJaMOUDNTCo3oCbBjqoAc7GLNh6UuscuYHV40Nhio9ShNuKsmKZleGOFSqOu2lAB3EsKPwlgjcJ%2FXjjZFgOdPSPVjTnNeVQOpNfp7nRGlm5yvXl%2FTeeSPrST1sH3bezsrAXGdN6weNTVFRKeoVL8X%2FGeTLUgPAnrXufgr7Yd7UFY%2FKx4iXFHUXnanJHC1aWvQZ81FSNv8C1dHb1nc3gzLo48FMxjNSq6p%2FD%2FmHjri1Rawaxenw4lQ%3D%3D&X-Amz-SignedHeaders=host&X-Amz-Signature=300330317f68090d635965d21d6dfacc1df6d71b1541fc44e675838e22aea09c