### PR TITLE
Remove johnny-five-deprecated, update firmata/serialport

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -36,7 +36,8 @@
     "storybook:test": "grunt storybookTest"
   },
   "resolutions": {
-    "uglifyjs-webpack-plugin/uglify-js": "3.5.1"
+    "uglifyjs-webpack-plugin/uglify-js": "3.5.1",
+    "firmata": "^2.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.18.10",
@@ -55,7 +56,6 @@
     "@code-dot-org/blockly": "4.0.5",
     "@code-dot-org/craft": "0.2.2",
     "@code-dot-org/dance-party": "1.0.5",
-    "@code-dot-org/johnny-five-deprecated": "0.11.1-cdo.2",
     "@code-dot-org/js-interpreter-tyrant": "0.2.2",
     "@code-dot-org/js-numbers": "0.1.0-cdo.0",
     "@code-dot-org/maze": "2.16.0",
@@ -113,7 +113,7 @@
     "firebase": "^2.4.2",
     "firebase-bolt": "^0.8.0",
     "firebase-mock": "^1.0.5",
-    "firmata": "0.16.0",
+    "firmata": "^2.2.0",
     "glob": "5.0.14",
     "grunt": "^1.4.1",
     "grunt-cli": "1.4.3",

--- a/apps/webpack.js
+++ b/apps/webpack.js
@@ -377,8 +377,7 @@ var karmaConfig = _.extend({}, baseConfig, {
         'kits',
         'maker',
         'StubChromeSerialPort.js'
-      ),
-      serialport: false
+      )
     })
   }),
   externals: {
@@ -389,12 +388,7 @@ var karmaConfig = _.extend({}, baseConfig, {
     cheerio: 'window',
     'react/addons': true,
     'react/lib/ExecutionEnvironment': true,
-    'react/lib/ReactContext': true,
-
-    // The below are necessary for serialport import to not choke during webpack-ing.
-    fs: '{}',
-    child_process: true,
-    bindings: true
+    'react/lib/ReactContext': true
   },
   plugins: [
     new webpack.ProvidePlugin({

--- a/apps/webpack.js
+++ b/apps/webpack.js
@@ -20,6 +20,7 @@ var toTranspileWithinNodeModules = [
   path.resolve(__dirname, 'node_modules', '@code-dot-org', 'dance-party'),
   path.resolve(__dirname, 'node_modules', '@code-dot-org', 'johnny-five'),
   path.resolve(__dirname, 'node_modules', '@code-dot-org', 'remark-plugins'),
+  path.resolve(__dirname, 'node_modules', 'firmata'),
   // parse5 ships in ES6: https://github.com/inikulin/parse5/issues/263#issuecomment-410745073
   path.resolve(__dirname, 'node_modules', 'parse5'),
   path.resolve(__dirname, 'node_modules', 'vmsg'),
@@ -149,7 +150,8 @@ var baseConfig = {
       '@cdo/apps': path.resolve(__dirname, 'src'),
       '@cdo/static': path.resolve(__dirname, 'static'),
       repl: path.resolve(__dirname, 'src/noop'),
-      '@cdo/storybook': path.resolve(__dirname, '.storybook')
+      '@cdo/storybook': path.resolve(__dirname, '.storybook'),
+      serialport: false
     }
   },
   module: {
@@ -306,8 +308,8 @@ function storybookConfig(sbConfig) {
           envConstants.NODE_ENV || 'development'
         ),
         PISKEL_DEVELOPMENT_MODE: JSON.stringify(false)
-      }),
-      new webpack.IgnorePlugin({resourceRegExp: /^serialport$/})
+      })
+      //new webpack.IgnorePlugin({resourceRegExp: /^serialport$/})
     ]
   };
 }
@@ -464,7 +466,7 @@ function create(options) {
         PISKEL_DEVELOPMENT_MODE: JSON.stringify(piskelDevMode),
         DEBUG_MINIFIED: envConstants.DEBUG_MINIFIED || 0
       }),
-      new webpack.IgnorePlugin({resourceRegExp: /^serialport$/}),
+      //new webpack.IgnorePlugin({resourceRegExp: /^serialport$/}),
       ...plugins
     ],
     watch: watch,

--- a/apps/webpack.js
+++ b/apps/webpack.js
@@ -309,7 +309,6 @@ function storybookConfig(sbConfig) {
         ),
         PISKEL_DEVELOPMENT_MODE: JSON.stringify(false)
       })
-      //new webpack.IgnorePlugin({resourceRegExp: /^serialport$/})
     ]
   };
 }
@@ -466,7 +465,6 @@ function create(options) {
         PISKEL_DEVELOPMENT_MODE: JSON.stringify(piskelDevMode),
         DEBUG_MINIFIED: envConstants.DEBUG_MINIFIED || 0
       }),
-      //new webpack.IgnorePlugin({resourceRegExp: /^serialport$/}),
       ...plugins
     ],
     watch: watch,

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -1334,24 +1334,6 @@
   resolved "https://registry.yarnpkg.com/@code-dot-org/dance-party/-/dance-party-1.0.5.tgz#0872991761e8f4458c73ba3b7f288b2e747af240"
   integrity sha512-Wr4zQgSpBh/Pus0+91Cshl93efew051PfVM4BBzcf0hqNGMVGj8Pztgvtqew07AnMrjxBVDITSlLzCfhHmyBQw==
 
-"@code-dot-org/johnny-five-deprecated@0.11.1-cdo.2":
-  version "0.11.1-cdo.2"
-  resolved "https://registry.yarnpkg.com/@code-dot-org/johnny-five-deprecated/-/johnny-five-deprecated-0.11.1-cdo.2.tgz#929196662ce707c708ebba8ecb6ac1bdda4cbbef"
-  integrity sha512-Zeq37rNClJtIl+emUP4mL4XdLuHJj+0JFLbQQvVlBwAIEW2ydAqRbutEPmEEgQnnbdcevhIuzWZgooofWY0Fmg==
-  dependencies:
-    chalk latest
-    color-convert "~1.2.2"
-    ease-component latest
-    es6-shim latest
-    lodash.clonedeep "^4.3.0"
-    lodash.debounce "^4.0.3"
-    nanotimer "0.3.10"
-    temporal latest
-  optionalDependencies:
-    browser-serialport latest
-    firmata latest
-    serialport "^4.0.0"
-
 "@code-dot-org/johnny-five@2.1.0-cdo.1":
   version "2.1.0-cdo.1"
   resolved "https://registry.yarnpkg.com/@code-dot-org/johnny-five/-/johnny-five-2.1.0-cdo.1.tgz#6042ea1ca0dcea42d45a620df39846946d321887"
@@ -4453,7 +4435,7 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
 
-bindings@1.2.1, bindings@1.2.x:
+bindings@1.2.x:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.2.1.tgz#14ad6113812d2d37d72e67b4cacb4bb726505f11"
 
@@ -5099,7 +5081,7 @@ chai@^1.9.1:
     assertion-error "1.0.0"
     deep-eql "0.1.3"
 
-chalk@1.1.3, chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3, chalk@latest:
+chalk@1.1.3, chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   dependencies:
@@ -6212,12 +6194,6 @@ debug@3.1.0, debug@^3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@^2.1.1:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.3.0.tgz#3912dc55d7167fc3af17d2b85c13f93deaedaa43"
-  dependencies:
-    ms "0.7.2"
-
 debug@^3.0.0, debug@^3.2.7:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
@@ -6703,10 +6679,6 @@ duplexify@^3.4.2, duplexify@^3.6.0:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
     stream-shift "^1.0.0"
-
-ease-component@latest:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/ease-component/-/ease-component-1.0.0.tgz#b375726db0b5b04595b77440396fec7daa5d77c9"
 
 ecc-jsbn@~0.1.1:
   version "0.1.1"
@@ -8005,15 +7977,7 @@ firmata-io@^2.3.0:
   resolved "https://registry.yarnpkg.com/firmata-io/-/firmata-io-2.3.0.tgz#6811563e75af4e876a789285b30d6d8a803c45c8"
   integrity sha512-OQ1Q0TInQ23ogI61kVwf3WJUD+viPbDI6uLN99yGLe6GioN3EbRSDSZVn1gEXyQLNjD2ZFVKnTbpiQ2t3VoecA==
 
-firmata@0.16.0, firmata@>=0.11.3, firmata@latest:
-  version "0.16.0"
-  resolved "https://registry.yarnpkg.com/firmata/-/firmata-0.16.0.tgz#6f2a759b1a98de234ced010fa3d4d9534d62b2e7"
-  dependencies:
-    browser-serialport latest
-    es6-shim latest
-    serialport "^4.0.0"
-
-firmata@^2.2.0:
+firmata@>=0.11.3, firmata@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/firmata/-/firmata-2.3.0.tgz#9e3ea3c00db73c1c670502389b43e2377b244640"
   integrity sha512-6zl27bHtIlRFM2n5GnU7YeTM5qhRTHQDJ0Zgs8/O/KrbLz3BXIsJFs5Ek2QD6gMG3wgPPQGNaegbTZcj+mo84A==
@@ -11111,12 +11075,6 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-lie@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lie/-/lie-3.1.0.tgz#65e0139eaef9ae791a1f5c8c53692c8d3b4718f4"
-  dependencies:
-    immediate "~3.0.5"
-
 lie@~3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/lie/-/lie-3.3.0.tgz#dcf82dee545f46074daf200c7c1c5a08e0f40f6a"
@@ -12237,7 +12195,7 @@ mux.js@5.2.1:
   resolved "https://registry.yarnpkg.com/mux.js/-/mux.js-5.2.1.tgz#6698761fc88da5acecea0758ac25f11d3a08bee8"
   integrity sha512-1t2payD3Y8izfZRq7tfUQlhL2fKzjeLr9v1/2qNCTkEQnd9Abtn1JgzsBgGZubEXh6lM5L8B0iLGoWQiukjtbQ==
 
-nan@2.4.x, nan@^2.3.0, nan@^2.3.5:
+nan@2.4.x, nan@^2.3.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.4.0.tgz#fb3c59d45fe4effe215f0b890f8adf6eb32d2232"
 
@@ -12477,7 +12435,7 @@ node-pre-gyp@^0.10.0:
     semver "^5.3.0"
     tar "^4"
 
-node-pre-gyp@^0.6.26, node-pre-gyp@^0.6.29:
+node-pre-gyp@^0.6.29:
   version "0.6.31"
   resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.6.31.tgz#d8a00ddaa301a940615dbcc8caad4024d58f6017"
   dependencies:
@@ -12714,13 +12672,13 @@ object-is@^1.1.2:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
 
-object-keys@^1.0.10, object-keys@^1.0.8:
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
-
 object-keys@^1.0.11, object-keys@^1.0.12:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.0.tgz#11bd22348dd2e096a045ab06f6c85bcc340fa032"
+
+object-keys@^1.0.8:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
 
 object-keys@^1.1.1:
   version "1.1.1"
@@ -12732,14 +12690,6 @@ object-visit@^1.0.0:
   resolved "https://registry.yarnpkg.com/object-visit/-/object-visit-1.0.1.tgz#f79c4493af0c5377b59fe39d395e41042dd045bb"
   dependencies:
     isobject "^3.0.0"
-
-object.assign@^4.0.3:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.0.4.tgz#b1c9cc044ef1b9fe63606fc141abbb32e14730cc"
-  dependencies:
-    define-properties "^1.1.2"
-    function-bind "^1.1.0"
-    object-keys "^1.0.10"
 
 object.assign@^4.1.0:
   version "4.1.0"
@@ -15914,18 +15864,6 @@ serialize-javascript@^6.0.0:
   integrity sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==
   dependencies:
     randombytes "^2.1.0"
-
-serialport@^4.0.0:
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/serialport/-/serialport-4.0.5.tgz#68908a6fb85a4728fe52e5de438cc4ba0b3bba9b"
-  dependencies:
-    bindings "1.2.1"
-    commander "^2.9.0"
-    debug "^2.1.1"
-    lie "^3.1.0"
-    nan "^2.3.5"
-    node-pre-gyp "^0.6.26"
-    object.assign "^4.0.3"
 
 serialport@^8.0.5:
   version "8.0.8"


### PR DESCRIPTION
This PR removes `johnny-five-deprecated` from `package.json` and updates the versions of `firmata` and `serialport`. Now that we updated [johnny-five](https://github.com/code-dot-org/code-dot-org/pull/48807), we are removing the `johnny-five-deprecated` dependency. However, other updates were needed. Just wanted to include a shout out here to @bencodeorg for his help throughout this debugging process!

- I updated the `firmata` version from 0.16.0 to ^2.2.0 according to `johnny-five`'s `package.json`. Both `firmata` and `serialport` are optionalDependencies for `johnny-five`.

I noted the following:
- [@code-dot-org/playground-io](https://github.com/code-dot-org/playground-io) lists as a dependency `firmata` at >=0.11.3.
- `firmata` has `serialport` as a dependency - `firmata` 0.16.0 uses `serialport` ^4.0.X  and `firmata` 2.2.0 uses `serialport` ^8.0.X.
Running the command `yarn why serialport` confirmed this: 

<img width="732" alt="Screen Shot 2022-11-01 at 11 20 56 AM" src="https://user-images.githubusercontent.com/107423305/199340638-5d38207a-78fa-41b8-96d9-5b7ae68d641f.png">

Prior to this PR, there were 2 versions of `firmata` that were being installed and therefore 2 versions of `serialport` were in turn being installed.

I used a `resolutions` field in `package.json` in order to install just one version of `firmata` so that only the later version of `serialport` was installed. This not only allows us to have one version of these packages but also eliminates error and warning messages when building due to the outdated version of `serialport` we were using. (Thanks Ben!)

Once I updated these packages, ran the dashboard server locally and opened an App Lab project, I got the following error:
![Screen Shot 2022-10-31 at 11 15 22 AM](https://user-images.githubusercontent.com/107423305/199342102-c02728bf-cdb2-4a27-b869-653d33520f9a.png)

Looking at this line in `com.js`:

![Screen Shot 2022-10-31 at 11 15 51 AM](https://user-images.githubusercontent.com/107423305/199342168-e7441470-3a0c-4917-a1cd-a123d7ac7e0b.png)

There is a problem with `serialport`. In `webpack.js`, there are `IgnorePlugin` commands for `serialport` I tried to remove, and got errors about not resolving `serialport`. Ben suggested using `resolve.alias` instead of using `IgnorePlugin`. Documentation about using an alias in this [webpack article](https://webpack.js.org/configuration/resolve/).
The use of `resolve.alias` for `serialport` removed the `Uncaught Missing serialport dependency` error.

Next in App Lab, I enabled Maker Toolkit, and received the following error:
<img width="1159" alt="Screen Shot 2022-11-01 at 12 43 35 PM" src="https://user-images.githubusercontent.com/107423305/199346160-714c6af9-441a-4b88-914c-ec30a4e10b43.png">
I recognized this error from my work with updating johnny-five. I had to add firmata to the list of packages that ship in ES6 and need to get transpiled. 

After this change, I was able to connect the Circuit Playground successfully and run Maker commands.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links
[jira ticket - Update package.json to remove johnny-five-deprecated](https://codedotorg.atlassian.net/browse/SL-231)
[jira ticket - Quiet "Can't resolve 'serialport'" error](https://codedotorg.atlassian.net/browse/SL-274)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
Unit tests cover component initialization so I locally tested the Circuit Playground manually after a clean local build (rm -rf node_modules && yarn && yarn run clean && yarn run build).  
I was able to connect to the Circuit Playground successfully on the setup page. Then I tested each component in app lab.
Screenshots of local tests are available below.

Component | CP Express Test result | CP Classic Test result | Notes
--- | --- | --- | ---
Connects on maker/setup | ✅  | ✅ 
Neopixels / color LEDs | :white_check_mark: | ✅ 
Red LED | :white_check_mark: |  ✅  
Toggle switch | :white_check_mark: | ✅  | When testing for [this PR](https://github.com/code-dot-org/code-dot-org/pull/14641), Brad described a bug that already existed on prod with this [program](https://studio.code.org/projects/applab/I7RzYE8KSMpc7JcZPr4nkA/view)  - that the toggle events fire on buttonR down/up. This is no longer a bug on CP Express nor the CP Classic.
Buttons (L/R) | ✅  |  ✅ 
Piezo / buzzer | ✅  |  ✅ 
Sound sensor | ✅  |  ✅ 
Light sensor | ✅  |  ✅ 
Thermometer | ✅  |  ✅ 
Accelerometer | ✅  |  ✅ 

![Screen Shot 2022-11-02 at 11 19 42 AM](https://user-images.githubusercontent.com/107423305/199544461-d721425d-44ae-4163-be11-e26abd076a4d.png)

![Screen Shot 2022-11-02 at 11 18 43 AM](https://user-images.githubusercontent.com/107423305/199544471-830f65d2-cc37-4ed1-b8f8-5f492a29b601.png)

![Screen Shot 2022-11-02 at 11 20 36 AM](https://user-images.githubusercontent.com/107423305/199544476-36933326-f679-4db6-8eec-198e0a8d72ec.png)

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work
`@code-dot-org/playground-io` lists `firmata` at >=0.11.3. I think we should update to ^2.2.0 to better depict the version it is using. Brad loosened this firmata dependency in [this PR](https://github.com/code-dot-org/playground-io/pull/2) to prevent two copies of firmata from getting installed when using `@code-dot-org/johnny-five` and `@code-dot-org/playground-io` together. 
<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
