### PR TITLE
Migrate old csd-1718 links to csd-2022 format

### DIFF
--- a/dashboard/config/scripts/levels/CSD U2 Image Tag Add Image_2022.level
+++ b/dashboard/config/scripts/levels/CSD U2 Image Tag Add Image_2022.level
@@ -10,11 +10,11 @@
     "parent_level_id": 18899,
     "name_suffix": "_2022",
     "reference_links": [
-      "/docs/csd-1718/html_tags/index.html",
-      "/docs/csd-1718/headers/index.html",
-      "/docs/csd-1718/lists/index.html"
+      "/courses/csd-2022/guides/html-tags",
+      "/courses/csd-2022/guides/headings-and-paragraphs",
+      "/courses/csd-2022/guides/lists"
     ],
-    "map_reference": "/docs/csd-1718/images-in-html/index.html",
+    "map_reference": "/courses/csd-2022/guides/images-in-html",
     "encrypted": "false",
     "mini_rubric": "false",
     "display_name": "Add new image",

--- a/dashboard/config/scripts/levels/CSD U2 Image Tag Add Image_2023.level
+++ b/dashboard/config/scripts/levels/CSD U2 Image Tag Add Image_2023.level
@@ -14,11 +14,11 @@
     "parent_level_id": 18899,
     "name_suffix": "_2023",
     "reference_links": [
-      "/docs/csd-1718/html_tags/index.html",
-      "/docs/csd-1718/headers/index.html",
-      "/docs/csd-1718/lists/index.html"
+      "/courses/csd-2022/guides/html-tags",
+      "/courses/csd-2022/guides/headings-and-paragraphs",
+      "/courses/csd-2022/guides/lists"
     ],
-    "map_reference": "/docs/csd-1718/images-in-html/index.html",
+    "map_reference": "/courses/csd-2022/guides/images-in-html",
     "encrypted": "false",
     "mini_rubric": "false",
     "display_name": "Add new image",

--- a/dashboard/config/scripts/levels/CSD U3 Draw Loop Plugged update your scene_2022.level
+++ b/dashboard/config/scripts/levels/CSD U3 Draw Loop Plugged update your scene_2022.level
@@ -73,13 +73,13 @@
     "parent_level_id": 20718,
     "name_suffix": "_2022",
     "reference_links": [
-      "/docs/csd-1718/draw_loop/index.html",
-      "/docs/csd-1718/sprites/index.html",
-      "/docs/csd-1718/animation_tab/index.html",
-      "/docs/csd-1718/variables_intro_csd/index.html",
-      "/docs/csd-1718/random_numbers_csd/index.html"
+      "/courses/csd-2022/guides/the-draw-loop",
+      "/courses/csd-2022/guides/sprites",
+      "/courses/csd-2022/guides/animation-tab",
+      "/courses/csd-2022/guides/variables",
+      "/courses/csd-2022/guides/random-numbers"
     ],
-    "map_reference": "/docs/csd-1718/sprite_properties/index.html",
+    "map_reference": "/courses/csd-2022/guides/sprite-properties",
     "video_key": "csd_gamelab_drawloop",
     "show_type_hints": "false",
     "encrypted": "false",

--- a/dashboard/config/scripts/levels/CSD U3 Draw Loop Plugged update your scene_2023.level
+++ b/dashboard/config/scripts/levels/CSD U3 Draw Loop Plugged update your scene_2023.level
@@ -77,13 +77,13 @@
     "parent_level_id": 20718,
     "name_suffix": "_2023",
     "reference_links": [
-      "/docs/csd-1718/draw_loop/index.html",
-      "/docs/csd-1718/sprites/index.html",
-      "/docs/csd-1718/animation_tab/index.html",
-      "/docs/csd-1718/variables_intro_csd/index.html",
-      "/docs/csd-1718/random_numbers_csd/index.html"
+      "/courses/csd-2022/guides/the-draw-loop",
+      "/courses/csd-2022/guides/sprites",
+      "/courses/csd-2022/guides/animation-tab",
+      "/courses/csd-2022/guides/variables",
+      "/courses/csd-2022/guides/random-numbers"
     ],
-    "map_reference": "/docs/csd-1718/sprite_properties/index.html",
+    "map_reference": "/courses/csd-2022/guides/sprite-properties",
     "video_key": "csd_gamelab_drawloop",
     "show_type_hints": "false",
     "encrypted": "false",

--- a/dashboard/config/scripts/levels/CSD U3 Sprites Free Play 2_2023.level
+++ b/dashboard/config/scripts/levels/CSD U3 Sprites Free Play 2_2023.level
@@ -62,14 +62,14 @@
     "parent_level_id": 19232,
     "name_suffix": "_2023",
     "reference_links": [
-      "/docs/csd-1718/sprites/index.html",
-      "/docs/csd-1718/drawing_shapes_map/index.html",
-      "/docs/csd-1718/shape_size_map/index.html",
-      "/docs/csd-1718/random_numbers_csd/index.html",
-      "/docs/csd-1718/variables_intro_csd/index.html",
-      "/docs/csd-1718/naming_variables/index.html"
+      "/courses/csd-2022/guides/sprites",
+      "/courses/csd-2022/guides/drawing-shapes",
+      "/courses/csd-2022/guides/shapes-and-parameters",
+      "/courses/csd-2022/guides/random-numbers",
+      "/courses/csd-2022/guides/variables",
+      "/courses/csd-2022/guides/naming-variables"
     ],
-    "map_reference": "/docs/csd-1718/animation_tab/index.html",
+    "map_reference": "/courses/csd-2022/guides/animation-tab",
     "video_key": "csd_gamelab_animation_tab",
     "disable_procedure_autopopulate": "false",
     "top_level_procedure_autopopulate": "false",

--- a/dashboard/config/scripts/levels/CSD U3 Sprites Free Play 2_test2023.level
+++ b/dashboard/config/scripts/levels/CSD U3 Sprites Free Play 2_test2023.level
@@ -66,14 +66,14 @@
     "parent_level_id": 19232,
     "name_suffix": "_test2023",
     "reference_links": [
-      "/docs/csd-1718/sprites/index.html",
-      "/docs/csd-1718/drawing_shapes_map/index.html",
-      "/docs/csd-1718/shape_size_map/index.html",
-      "/docs/csd-1718/random_numbers_csd/index.html",
-      "/docs/csd-1718/variables_intro_csd/index.html",
-      "/docs/csd-1718/naming_variables/index.html"
+      "/courses/csd-2022/guides/sprites",
+      "/courses/csd-2022/guides/drawing-shapes",
+      "/courses/csd-2022/guides/shapes-and-parameters",
+      "/courses/csd-2022/guides/random-numbers",
+      "/courses/csd-2022/guides/variables",
+      "/courses/csd-2022/guides/naming-variables"
     ],
-    "map_reference": "/docs/csd-1718/animation_tab/index.html",
+    "map_reference": "/courses/csd-2022/guides/animation-tab",
     "video_key": "csd_gamelab_animation_tab",
     "disable_procedure_autopopulate": "false",
     "top_level_procedure_autopopulate": "false",

--- a/dashboard/config/scripts/levels/CSD U3 Sprites add own animation_2023.level
+++ b/dashboard/config/scripts/levels/CSD U3 Sprites add own animation_2023.level
@@ -61,14 +61,14 @@
     "parent_level_id": 19231,
     "name_suffix": "_2023",
     "reference_links": [
-      "/docs/csd-1718/sprites/index.html",
-      "/docs/csd-1718/drawing_shapes_map/index.html",
-      "/docs/csd-1718/shape_size_map/index.html",
-      "/docs/csd-1718/random_numbers_csd/index.html",
-      "/docs/csd-1718/variables_intro_csd/index.html",
-      "/docs/csd-1718/naming_variables/index.html"
+      "/courses/csd-2022/guides/sprites",
+      "/courses/csd-2022/guides/drawing-shapes",
+      "/courses/csd-2022/guides/shapes-and-parameters",
+      "/courses/csd-2022/guides/random-numbers",
+      "/courses/csd-2022/guides/variables",
+      "/courses/csd-2022/guides/naming-variables"
     ],
-    "map_reference": "/docs/csd-1718/animation_tab/index.html",
+    "map_reference": "/courses/csd-2022/guides/animation-tab",
     "video_key": "csd_gamelab_animation_tab",
     "disable_procedure_autopopulate": "false",
     "top_level_procedure_autopopulate": "false",

--- a/dashboard/config/scripts/levels/CSD U3 Sprites add own animation_test2023.level
+++ b/dashboard/config/scripts/levels/CSD U3 Sprites add own animation_test2023.level
@@ -65,14 +65,14 @@
     "parent_level_id": 19231,
     "name_suffix": "_test2023",
     "reference_links": [
-      "/docs/csd-1718/sprites/index.html",
-      "/docs/csd-1718/drawing_shapes_map/index.html",
-      "/docs/csd-1718/shape_size_map/index.html",
-      "/docs/csd-1718/random_numbers_csd/index.html",
-      "/docs/csd-1718/variables_intro_csd/index.html",
-      "/docs/csd-1718/naming_variables/index.html"
+      "/courses/csd-2022/guides/sprites",
+      "/courses/csd-2022/guides/drawing-shapes",
+      "/courses/csd-2022/guides/shapes-and-parameters",
+      "/courses/csd-2022/guides/random-numbers",
+      "/courses/csd-2022/guides/variables",
+      "/courses/csd-2022/guides/naming-variables"
     ],
-    "map_reference": "/docs/csd-1718/animation_tab/index.html",
+    "map_reference": "/courses/csd-2022/guides/animation-tab",
     "video_key": "csd_gamelab_animation_tab",
     "disable_procedure_autopopulate": "false",
     "top_level_procedure_autopopulate": "false",

--- a/dashboard/config/scripts/levels/CSD U3 Sprites anitab 2_2022.level
+++ b/dashboard/config/scripts/levels/CSD U3 Sprites anitab 2_2022.level
@@ -64,14 +64,14 @@
     "parent_level_id": 18487,
     "name_suffix": "_2022",
     "reference_links": [
-      "/docs/csd-1718/sprites/index.html",
-      "/docs/csd-1718/drawing_shapes_map/index.html",
-      "/docs/csd-1718/shape_size_map/index.html",
-      "/docs/csd-1718/random_numbers_csd/index.html",
-      "/docs/csd-1718/variables_intro_csd/index.html",
-      "/docs/csd-1718/naming_variables/index.html"
+      "/courses/csd-2022/guides/sprites",
+      "/courses/csd-2022/guides/drawing-shapes",
+      "/courses/csd-2022/guides/shapes-and-parameters",
+      "/courses/csd-2022/guides/random-numbers",
+      "/courses/csd-2022/guides/variables",
+      "/courses/csd-2022/guides/naming-variables"
     ],
-    "map_reference": "/docs/csd-1718/animation_tab/index.html",
+    "map_reference": "/courses/csd-2022/guides/animation-tab",
     "video_key": "csd_gamelab_animation_tab",
     "disable_procedure_autopopulate": "false",
     "top_level_procedure_autopopulate": "false",

--- a/dashboard/config/scripts/levels/CSD U3 Sprites anitab 2_2023.level
+++ b/dashboard/config/scripts/levels/CSD U3 Sprites anitab 2_2023.level
@@ -68,14 +68,14 @@
     "parent_level_id": 18487,
     "name_suffix": "_2023",
     "reference_links": [
-      "/docs/csd-1718/sprites/index.html",
-      "/docs/csd-1718/drawing_shapes_map/index.html",
-      "/docs/csd-1718/shape_size_map/index.html",
-      "/docs/csd-1718/random_numbers_csd/index.html",
-      "/docs/csd-1718/variables_intro_csd/index.html",
-      "/docs/csd-1718/naming_variables/index.html"
+      "/courses/csd-2022/guides/sprites",
+      "/courses/csd-2022/guides/drawing-shapes",
+      "/courses/csd-2022/guides/shapes-and-parameters",
+      "/courses/csd-2022/guides/random-numbers",
+      "/courses/csd-2022/guides/variables",
+      "/courses/csd-2022/guides/naming-variables"
     ],
-    "map_reference": "/docs/csd-1718/animation_tab/index.html",
+    "map_reference": "/courses/csd-2022/guides/animation-tab",
     "video_key": "csd_gamelab_animation_tab",
     "disable_procedure_autopopulate": "false",
     "top_level_procedure_autopopulate": "false",

--- a/dashboard/config/scripts/levels/CSD U3 Sprites anitab 2_test2023.level
+++ b/dashboard/config/scripts/levels/CSD U3 Sprites anitab 2_test2023.level
@@ -68,14 +68,14 @@
     "parent_level_id": 18487,
     "name_suffix": "_test2023",
     "reference_links": [
-      "/docs/csd-1718/sprites/index.html",
-      "/docs/csd-1718/drawing_shapes_map/index.html",
-      "/docs/csd-1718/shape_size_map/index.html",
-      "/docs/csd-1718/random_numbers_csd/index.html",
-      "/docs/csd-1718/variables_intro_csd/index.html",
-      "/docs/csd-1718/naming_variables/index.html"
+      "/courses/csd-2022/guides/sprites",
+      "/courses/csd-2022/guides/drawing-shapes",
+      "/courses/csd-2022/guides/shapes-and-parameters",
+      "/courses/csd-2022/guides/random-numbers",
+      "/courses/csd-2022/guides/variables",
+      "/courses/csd-2022/guides/naming-variables"
     ],
-    "map_reference": "/docs/csd-1718/animation_tab/index.html",
+    "map_reference": "/courses/csd-2022/guides/animation-tab",
     "video_key": "csd_gamelab_animation_tab",
     "disable_procedure_autopopulate": "false",
     "top_level_procedure_autopopulate": "false",

--- a/dashboard/config/scripts/levels/CSD U3 Sprites combine_2022.level
+++ b/dashboard/config/scripts/levels/CSD U3 Sprites combine_2022.level
@@ -62,14 +62,14 @@
     "parent_level_id": 19232,
     "name_suffix": "_2022",
     "reference_links": [
-      "/docs/csd-1718/sprites/index.html",
-      "/docs/csd-1718/drawing_shapes_map/index.html",
-      "/docs/csd-1718/shape_size_map/index.html",
-      "/docs/csd-1718/random_numbers_csd/index.html",
-      "/docs/csd-1718/variables_intro_csd/index.html",
-      "/docs/csd-1718/naming_variables/index.html"
+      "/courses/csd-2022/guides/sprites",
+      "/courses/csd-2022/guides/drawing-shapes",
+      "/courses/csd-2022/guides/shapes-and-parameters",
+      "/courses/csd-2022/guides/random-numbers",
+      "/courses/csd-2022/guides/variables",
+      "/courses/csd-2022/guides/naming-variables"
     ],
-    "map_reference": "/docs/csd-1718/animation_tab/index.html",
+    "map_reference": "/courses/csd-2022/guides/animation-tab",
     "video_key": "csd_gamelab_animation_tab",
     "disable_procedure_autopopulate": "false",
     "top_level_procedure_autopopulate": "false",

--- a/dashboard/config/scripts/levels/CSD U3 Sprites combine_2023.level
+++ b/dashboard/config/scripts/levels/CSD U3 Sprites combine_2023.level
@@ -62,14 +62,14 @@
     "parent_level_id": 19232,
     "name_suffix": "_2023",
     "reference_links": [
-      "/docs/csd-1718/sprites/index.html",
-      "/docs/csd-1718/drawing_shapes_map/index.html",
-      "/docs/csd-1718/shape_size_map/index.html",
-      "/docs/csd-1718/random_numbers_csd/index.html",
-      "/docs/csd-1718/variables_intro_csd/index.html",
-      "/docs/csd-1718/naming_variables/index.html"
+      "/courses/csd-2022/guides/sprites",
+      "/courses/csd-2022/guides/drawing-shapes",
+      "/courses/csd-2022/guides/shapes-and-parameters",
+      "/courses/csd-2022/guides/random-numbers",
+      "/courses/csd-2022/guides/variables",
+      "/courses/csd-2022/guides/naming-variables"
     ],
-    "map_reference": "/docs/csd-1718/animation_tab/index.html",
+    "map_reference": "/courses/csd-2022/guides/animation-tab",
     "video_key": "csd_gamelab_animation_tab",
     "disable_procedure_autopopulate": "false",
     "top_level_procedure_autopopulate": "false",

--- a/dashboard/config/scripts/levels/CSD U3 Sprites combine_test2023.level
+++ b/dashboard/config/scripts/levels/CSD U3 Sprites combine_test2023.level
@@ -66,14 +66,14 @@
     "parent_level_id": 19232,
     "name_suffix": "_test2023",
     "reference_links": [
-      "/docs/csd-1718/sprites/index.html",
-      "/docs/csd-1718/drawing_shapes_map/index.html",
-      "/docs/csd-1718/shape_size_map/index.html",
-      "/docs/csd-1718/random_numbers_csd/index.html",
-      "/docs/csd-1718/variables_intro_csd/index.html",
-      "/docs/csd-1718/naming_variables/index.html"
+      "/courses/csd-2022/guides/sprites",
+      "/courses/csd-2022/guides/drawing-shapes",
+      "/courses/csd-2022/guides/shapes-and-parameters",
+      "/courses/csd-2022/guides/random-numbers",
+      "/courses/csd-2022/guides/variables",
+      "/courses/csd-2022/guides/naming-variables"
     ],
-    "map_reference": "/docs/csd-1718/animation_tab/index.html",
+    "map_reference": "/courses/csd-2022/guides/animation-tab",
     "video_key": "csd_gamelab_animation_tab",
     "disable_procedure_autopopulate": "false",
     "top_level_procedure_autopopulate": "false",

--- a/dashboard/config/scripts/levels/CSD U3 Sprites draw animation_2022.level
+++ b/dashboard/config/scripts/levels/CSD U3 Sprites draw animation_2022.level
@@ -61,14 +61,14 @@
     "parent_level_id": 19231,
     "name_suffix": "_2022",
     "reference_links": [
-      "/docs/csd-1718/sprites/index.html",
-      "/docs/csd-1718/drawing_shapes_map/index.html",
-      "/docs/csd-1718/shape_size_map/index.html",
-      "/docs/csd-1718/random_numbers_csd/index.html",
-      "/docs/csd-1718/variables_intro_csd/index.html",
-      "/docs/csd-1718/naming_variables/index.html"
+      "/courses/csd-2022/guides/sprites",
+      "/courses/csd-2022/guides/drawing-shapes",
+      "/courses/csd-2022/guides/shapes-and-parameters",
+      "/courses/csd-2022/guides/random-numbers",
+      "/courses/csd-2022/guides/variables",
+      "/courses/csd-2022/guides/naming-variables"
     ],
-    "map_reference": "/docs/csd-1718/animation_tab/index.html",
+    "map_reference": "/courses/csd-2022/guides/animation-tab",
     "video_key": "csd_gamelab_animation_tab",
     "disable_procedure_autopopulate": "false",
     "top_level_procedure_autopopulate": "false",

--- a/dashboard/config/scripts/levels/CSD U3 Sprites draw animation_2023.level
+++ b/dashboard/config/scripts/levels/CSD U3 Sprites draw animation_2023.level
@@ -65,14 +65,14 @@
     "parent_level_id": 19231,
     "name_suffix": "_2023",
     "reference_links": [
-      "/docs/csd-1718/sprites/index.html",
-      "/docs/csd-1718/drawing_shapes_map/index.html",
-      "/docs/csd-1718/shape_size_map/index.html",
-      "/docs/csd-1718/random_numbers_csd/index.html",
-      "/docs/csd-1718/variables_intro_csd/index.html",
-      "/docs/csd-1718/naming_variables/index.html"
+      "/courses/csd-2022/guides/sprites",
+      "/courses/csd-2022/guides/drawing-shapes",
+      "/courses/csd-2022/guides/shapes-and-parameters",
+      "/courses/csd-2022/guides/random-numbers",
+      "/courses/csd-2022/guides/variables",
+      "/courses/csd-2022/guides/naming-variables"
     ],
-    "map_reference": "/docs/csd-1718/animation_tab/index.html",
+    "map_reference": "/courses/csd-2022/guides/animation-tab",
     "video_key": "csd_gamelab_animation_tab",
     "disable_procedure_autopopulate": "false",
     "top_level_procedure_autopopulate": "false",

--- a/dashboard/config/scripts/levels/CSD U3 Sprites draw animation_test2023.level
+++ b/dashboard/config/scripts/levels/CSD U3 Sprites draw animation_test2023.level
@@ -65,14 +65,14 @@
     "parent_level_id": 19231,
     "name_suffix": "_test2023",
     "reference_links": [
-      "/docs/csd-1718/sprites/index.html",
-      "/docs/csd-1718/drawing_shapes_map/index.html",
-      "/docs/csd-1718/shape_size_map/index.html",
-      "/docs/csd-1718/random_numbers_csd/index.html",
-      "/docs/csd-1718/variables_intro_csd/index.html",
-      "/docs/csd-1718/naming_variables/index.html"
+      "/courses/csd-2022/guides/sprites",
+      "/courses/csd-2022/guides/drawing-shapes",
+      "/courses/csd-2022/guides/shapes-and-parameters",
+      "/courses/csd-2022/guides/random-numbers",
+      "/courses/csd-2022/guides/variables",
+      "/courses/csd-2022/guides/naming-variables"
     ],
-    "map_reference": "/docs/csd-1718/animation_tab/index.html",
+    "map_reference": "/courses/csd-2022/guides/animation-tab",
     "video_key": "csd_gamelab_animation_tab",
     "disable_procedure_autopopulate": "false",
     "top_level_procedure_autopopulate": "false",

--- a/dashboard/config/scripts/levels/CSD U3 Variables Predict Where X_2022.level
+++ b/dashboard/config/scripts/levels/CSD U3 Variables Predict Where X_2022.level
@@ -46,11 +46,11 @@
     "parent_level_id": 20661,
     "name_suffix": "_2022",
     "reference_links": [
-      "/docs/csd-1718/drawing_shapes_map/index.html",
-      "/docs/csd-1718/shape_size_map/index.html",
-      "/docs/csd-1718/random_numbers_csd/index.html"
+      "/courses/csd-2022/guides/drawing-shapes",
+      "/courses/csd-2022/guides/shapes-and-parameters",
+      "/courses/csd-2022/guides/random-numbers"
     ],
-    "map_reference": "/docs/csd-1718/variables_intro_csd/index.html",
+    "map_reference": "/courses/csd-2022/guides/variables",
     "video_key": "csd_gamelab_variables_1",
     "disable_procedure_autopopulate": "false",
     "top_level_procedure_autopopulate": "false",

--- a/dashboard/config/scripts/levels/CSD web text explore_2022.level
+++ b/dashboard/config/scripts/levels/CSD web text explore_2022.level
@@ -47,11 +47,11 @@
     "parent_level_id": 23035,
     "name_suffix": "_2022",
     "reference_links": [
-      "/docs/csd-1718/drawing_shapes_map/index.html",
-      "/docs/csd-1718/shape_size_map/index.html",
-      "/docs/csd-1718/random_numbers_csd/index.html"
+      "/courses/csd-2022/guides/drawing-shapes",
+      "/courses/csd-2022/guides/shapes-and-parameters",
+      "/courses/csd-2022/guides/random-numbers"
     ],
-    "map_reference": "/docs/csd-1718/variables_intro_csd/index.html",
+    "map_reference": "/courses/csd-2022/guides/variables",
     "video_key": "csd_gamelab_variables_1",
     "disable_procedure_autopopulate": "false",
     "top_level_procedure_autopopulate": "false",

--- a/dashboard/config/scripts/levels/CSD web text explore_2023.level
+++ b/dashboard/config/scripts/levels/CSD web text explore_2023.level
@@ -51,11 +51,11 @@
     "parent_level_id": 23035,
     "name_suffix": "_2023",
     "reference_links": [
-      "/docs/csd-1718/drawing_shapes_map/index.html",
-      "/docs/csd-1718/shape_size_map/index.html",
-      "/docs/csd-1718/random_numbers_csd/index.html"
+      "/courses/csd-2022/guides/drawing-shapes",
+      "/courses/csd-2022/guides/shapes-and-parameters",
+      "/courses/csd-2022/guides/random-numbers"
     ],
-    "map_reference": "/docs/csd-1718/variables_intro_csd/index.html",
+    "map_reference": "/courses/csd-2022/guides/variables",
     "video_key": "csd_gamelab_variables_1",
     "disable_procedure_autopopulate": "false",
     "top_level_procedure_autopopulate": "false",

--- a/dashboard/config/scripts/levels/VPL - CSD U3 Variables Predict Where X_2022.level
+++ b/dashboard/config/scripts/levels/VPL - CSD U3 Variables Predict Where X_2022.level
@@ -50,11 +50,11 @@
     "parent_level_id": 20661,
     "name_suffix": "_2022",
     "reference_links": [
-      "/docs/csd-1718/drawing_shapes_map/index.html",
-      "/docs/csd-1718/shape_size_map/index.html",
-      "/docs/csd-1718/random_numbers_csd/index.html"
+      "/courses/csd-2022/guides/drawing-shapes",
+      "/courses/csd-2022/guides/shapes-and-parameters",
+      "/courses/csd-2022/guides/random-numbers"
     ],
-    "map_reference": "/docs/csd-1718/variables_intro_csd/index.html",
+    "map_reference": "/courses/csd-2022/guides/variables",
     "video_key": "csd_gamelab_variables_1",
     "disable_procedure_autopopulate": "false",
     "top_level_procedure_autopopulate": "false",


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Dan asked for us to automatically migrate these broken links for both 2022 and 2023 versions of the curriculum. The 2023 course isn't up yet, so all the `*2023.level` files still use `csd-2022` links.

I tried completely automating this, but ran into some pages that had different URL slugs than they used to, so I had to manually find and fix those. The commands below will reproduce the changes in this PR.

```sh
# From inside the repo:
cd dashboard/config/scripts/levels
sed -ri 's,/docs/csd-[0-9]+/(.*)/(index.html)?,/courses/csd-2022/guides/\1,' *202[23].level
fixit() { sed -i "s,$1,$2," *202[23].level ; }
fixit '/courses/csd-2022/guides/animation_tab' '/courses/csd-2022/guides/animation-tab'
fixit '/courses/csd-2022/guides/draw_loop' '/courses/csd-2022/guides/the-draw-loop'
fixit '/courses/csd-2022/guides/drawing_shapes_map' '/courses/csd-2022/guides/drawing-shapes'
fixit '/courses/csd-2022/guides/headers' '/courses/csd-2022/guides/headings-and-paragraphs'
fixit '/courses/csd-2022/guides/html_tags' '/courses/csd-2022/guides/html-tags'
fixit '/courses/csd-2022/guides/naming_variables' '/courses/csd-2022/guides/naming-variables'
fixit '/courses/csd-2022/guides/random_numbers_csd' '/courses/csd-2022/guides/random-numbers'
fixit '/courses/csd-2022/guides/shape_size_map' '/courses/csd-2022/guides/shapes-and-parameters'
fixit '/courses/csd-2022/guides/sprite_properties' '/courses/csd-2022/guides/sprite-properties'
fixit '/courses/csd-2022/guides/variables_intro_csd' '/courses/csd-2022/guides/variables'
```

The pages that were migrated correctly by the first `sed` line, without any manual slug changes, were:

* /courses/csd-2022/guides/images-in-html
* /courses/csd-2022/guides/lists
* /courses/csd-2022/guides/sprites

So in total, here's the before/after:

| old link | new link |
| ----- | ----- |
| https://studio.code.org/docs/csd-1718/images-in-html/index.html | https://studio.code.org/courses/csd-2022/guides/images-in-html |
| https://studio.code.org/docs/csd-1718/lists/index.html | https://studio.code.org/courses/csd-2022/guides/lists |
| https://studio.code.org/docs/csd-1718/sprites/index.html | https://studio.code.org/courses/csd-2022/guides/sprites |
| https://studio.code.org/docs/csd-1718/animation_tab/index.html | https://studio.code.org/courses/csd-2022/guides/animation-tab |
| https://studio.code.org/docs/csd-1718/draw_loop/index.html | https://studio.code.org/courses/csd-2022/guides/the-draw-loop |
| https://studio.code.org/docs/csd-1718/drawing_shapes_map/index.html | https://studio.code.org/courses/csd-2022/guides/drawing-shapes |
| https://studio.code.org/docs/csd-1718/headers/index.html | https://studio.code.org/courses/csd-2022/guides/headings-and-paragraphs |
| https://studio.code.org/docs/csd-1718/html_tags/index.html | https://studio.code.org/courses/csd-2022/guides/html-tags |
| https://studio.code.org/docs/csd-1718/naming_variables/index.html | https://studio.code.org/courses/csd-2022/guides/naming-variables |
| https://studio.code.org/docs/csd-1718/random_numbers_csd/index.html | https://studio.code.org/courses/csd-2022/guides/random-numbers |
| https://studio.code.org/docs/csd-1718/shape_size_map/index.html | https://studio.code.org/courses/csd-2022/guides/shapes-and-parameters |
| https://studio.code.org/docs/csd-1718/sprite_properties/index.html | https://studio.code.org/courses/csd-2022/guides/sprite-properties |
| https://studio.code.org/docs/csd-1718/variables_intro_csd/index.html | https://studio.code.org/courses/csd-2022/guides/variables |

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->


- jira ticket: [TEACH-3](https://codedotorg.atlassian.net/browse/TEACH-3)


## Testing story

Test that all new links are valid:

```sh
# From inside the repo, with this branch pulled down:
pages=$(git diff 1a1bb462be09081725f6b8718fbc80b0632ddaf8 d520326de7cc9384a45e091f41d37fc906850f2a| grep ^+|grep -o '/courses/csd-2022[^"]*'|sort -u)
for page in $pages; do wget -q "https://studio.code.org$page" -O- >/dev/null || echo "$page"; done
```

It will print out any pages that 404, or have no output if all the links worked.

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

Try to merge at a good time so it doesn't conflict with the levelbuilder scoop?

## Follow-up work

Hopefully none, though if anyone has additional context on the course migration process or other links that might get missed, let me know.

