### PR TITLE
Refactor PaneHeader and JsDebugger to use css modules (again)

### DIFF
--- a/apps/src/common-styles.module.scss
+++ b/apps/src/common-styles.module.scss
@@ -1,0 +1,53 @@
+// As we move from inline css to css modules we are temporarily duplicating commonStyles.js into this css module.
+// Any changes in one should be made in the other to apply to all components.
+@use "color.scss";
+@use "style-constants.scss";
+
+.hidden {
+  display: none;
+}
+
+.purpleHeader {
+  height: style-constants.$workspace-headers-height;
+  background-color: color.$purple;
+  color: color.$white;
+  overflow-y: hidden;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+
+  &Unfocused {
+    background-color: color.$lighter_purple;
+    color: color.$dark_charcoal;
+  }
+}
+
+.teacherBlueHeader {
+  background-color: color.$cyan;
+  color: color.$lightest_cyan;
+}
+
+.teacherHeaderUnfocused {
+  color: color.$dark_charcoal;
+}
+
+.minecraftHeader {
+  background-color: #3b3b3b;
+  color: color.$white;
+}
+
+.button {
+  padding-top: 5px;
+  padding-bottom: 5px;
+  font-size: 14px;
+}
+
+// Div contain instructions; either below visualization or in top instructions
+// May not need a common location once everything is in top instructions
+.bubble {
+  color: color.$black;
+  margin-bottom: 10px;
+  position: relative;
+  cursor: pointer;
+}

--- a/apps/src/commonStyles.js
+++ b/apps/src/commonStyles.js
@@ -1,3 +1,6 @@
+// As we move from inline css to css modules we are temporarily duplicating this
+// into the css module common-styles.module.scss.
+// Any changes in one should be made in the other to apply to all components.
 var commonStyles = module.exports;
 var color = require('./util/color');
 var styleConstants = require('./styleConstants');

--- a/apps/src/lib/tools/jsdebugger/JsDebugger.jsx
+++ b/apps/src/lib/tools/jsdebugger/JsDebugger.jsx
@@ -8,11 +8,11 @@ import {connect} from 'react-redux';
 import $ from 'jquery';
 import i18n from '@cdo/locale';
 import Radium from 'radium'; // eslint-disable-line no-restricted-imports
+import classNames from 'classnames';
 import dom from '../../../dom';
-import commonStyles from '../../../commonStyles';
-import styleConstants from '../../../styleConstants';
+import commonStyles from '../../../common-styles.module.scss';
+import styles from './js-debugger.module.scss';
 import Watchers from '../../../templates/watchers/Watchers';
-import color from '../../../util/color';
 import PaneHeader, {
   PaneSection,
   PaneButton
@@ -415,15 +415,16 @@ class JsDebugger extends React.Component {
   };
 
   render() {
-    const {appType, isAttached, canRunNext, isRunning} = this.props;
+    const {
+      appType,
+      isAttached,
+      canRunNext,
+      isRunning,
+      debugButtons
+    } = this.props;
     const hasFocus = this.props.isDebuggerPaused && !this.props.isEditWhileRun;
 
     const canShowDebugSprites = appType === 'gamelab';
-
-    const sliderStyle = {
-      marginLeft: this.props.debugButtons ? 5 : 45,
-      marginRight: 5
-    };
 
     const openStyle = {};
     if (!this.state.open && this.state.transitionType !== 'closing') {
@@ -457,18 +458,18 @@ class JsDebugger extends React.Component {
         <PaneHeader
           id="debug-area-header"
           hasFocus={hasFocus}
-          style={styles.debugAreaHeader}
+          className={styles.debugAreaHeader}
         >
           <span
-            style={[
+            className={classNames(
               this.state.consoleWidth <= MIN_CONSOLE_WIDTH && styles.hidden,
-              styles.noUserSelect
-            ]}
-            className="header-text"
+              styles.noUserSelect,
+              'header-text'
+            )}
           >
             {i18n.debugConsoleHeader()}
           </span>
-          <span style={styles.showHideIcon}>
+          <span className={styles.showHideIcon}>
             <FontAwesome
               icon={
                 this.state.open ? 'chevron-circle-down' : 'chevron-circle-up'
@@ -480,16 +481,20 @@ class JsDebugger extends React.Component {
             <PaneSection id="debug-commands-header">
               <FontAwesome
                 id="running-spinner"
-                style={!isAttached || canRunNext ? commonStyles.hidden : {}}
+                className={classNames(
+                  'fa-spin',
+                  (!isAttached || canRunNext) && commonStyles.hidden
+                )}
                 icon="spinner"
-                className="fa-spin"
               />
               <FontAwesome
                 id="paused-icon"
-                style={!isAttached || !canRunNext ? commonStyles.hidden : {}}
+                className={classNames(
+                  (!isAttached || !canRunNext) && commonStyles.hidden
+                )}
                 icon="pause"
               />
-              <span style={styles.noUserSelect} className="header-text">
+              <span className={classNames('header-text', styles.noUserSelect)}>
                 {this.state.open
                   ? i18n.debugCommandsHeaderWhenOpen()
                   : i18n.debugCommandsHeaderWhenClosed()}
@@ -502,18 +507,13 @@ class JsDebugger extends React.Component {
               ref={debugWatchHeader =>
                 (this._debugWatchHeader = debugWatchHeader)
               }
-              style={
-                this.state.watchersHidden
-                  ? {
-                      borderLeft: 'none',
-                      textAlign: 'right',
-                      marginRight: '30px'
-                    }
-                  : {}
-              }
+              className={classNames(
+                styles.debugWatchHeader,
+                this.state.watchersHidden && styles.watchersHidden
+              )}
             >
               <span
-                style={styles.showDebugWatchIcon}
+                className={styles.showDebugWatchIcon}
                 onClick={() => {
                   // reset resizer-overridden styles
                   // (remove once resize logic migrated to React)
@@ -538,7 +538,7 @@ class JsDebugger extends React.Component {
                   }
                 />
               </span>
-              <span style={styles.noUserSelect} className="header-text">
+              <span className={classNames('header-text', styles.noUserSelect)}>
                 {this.state.watchersHidden
                   ? i18n.debugShowWatchHeader()
                   : i18n.debugWatchHeader()}
@@ -566,7 +566,7 @@ class JsDebugger extends React.Component {
           )}
           {this.props.debugSlider && (
             <SpeedSlider
-              style={sliderStyle}
+              className={debugButtons ? styles.sliderDebug : styles.slider}
               hasFocus={hasFocus}
               value={this.props.stepSpeed}
               lineWidth={130}
@@ -589,7 +589,7 @@ class JsDebugger extends React.Component {
             ref={debugConsole => (this._debugConsole = debugConsole)}
           />
         )}
-        <div style={{display: showWatchPane ? 'initial' : 'none'}}>
+        <div className={showWatchPane ? styles.displayInitial : styles.hidden}>
           <div
             id="watchersResizeBar"
             ref={watchersResizeBar =>
@@ -609,54 +609,6 @@ class JsDebugger extends React.Component {
     );
   }
 }
-
-const styles = {
-  debugAreaHeader: {
-    position: 'absolute',
-    top: styleConstants['resize-bar-width'],
-    left: 0,
-    right: 0,
-    textAlign: 'center',
-    lineHeight: '30px'
-  },
-  noPadding: {
-    padding: 0
-  },
-  noUserSelect: {
-    MozUserSelect: 'none',
-    WebkitUserSelect: 'none',
-    msUserSelect: 'none',
-    userSelect: 'none'
-  },
-  showHideIcon: {
-    position: 'absolute',
-    top: 0,
-    left: 8,
-    margin: 0,
-    lineHeight: styleConstants['workspace-headers-height'] + 'px',
-    fontSize: 18,
-    ':hover': {
-      cursor: 'pointer',
-      color: color.white
-    }
-  },
-  showDebugWatchIcon: {
-    position: 'absolute',
-    top: 0,
-    right: '6px',
-    width: '18px',
-    margin: 0,
-    lineHeight: styleConstants['workspace-headers-height'] + 'px',
-    fontSize: 18,
-    ':hover': {
-      cursor: 'pointer',
-      color: 'white'
-    }
-  },
-  hidden: {
-    display: 'none'
-  }
-};
 
 export default connect(
   state => ({

--- a/apps/src/lib/tools/jsdebugger/js-debugger.module.scss
+++ b/apps/src/lib/tools/jsdebugger/js-debugger.module.scss
@@ -1,0 +1,82 @@
+@use "color.scss";
+@use "style-constants.scss";
+
+.debugAreaHeader {
+  position: absolute;
+  top: style-constants.$resize-bar-width;
+  left: 0;
+  right: 0;
+  text-align: center;
+  line-height: 30px;
+}
+
+.noPadding {
+  padding: 0;
+}
+
+.noUserSelect {
+  -moz-user-select: none;
+  -webkit-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.showHideIcon {
+  position: absolute;
+  top: 0;
+  left: 8px;
+  margin: 0;
+  line-height: style-constants.$workspace-headers-height;
+  font-size: 18px;
+  :hover {
+    cursor: pointer;
+    color: color.$white;
+  }
+}
+
+.showDebugWatchIcon {
+  position: absolute;
+  top: 0;
+  right: 6px;
+  width: 18px;
+  margin: 0;
+  line-height: style-constants.$workspace-headers-height;
+  font-size: 18px;
+  &:hover {
+    cursor: pointer;
+    color: color.$white;
+  }
+}
+
+.hidden {
+  display: none;
+}
+
+$debug-watch-max-column-width: 200px;
+$debug-header-border-width: 1px;
+
+.debugWatchHeader {
+  width: $debug-watch-max-column-width + $debug-header-border-width;
+  float: right;
+  border-left: $debug-header-border-width solid gray;
+}
+
+.watchersHidden {
+  border-left: none;
+  text-align: right;
+  margin-right: 30px;
+}
+
+.sliderDebug {
+  margin-left: 5px;
+  margin-right: 5px;
+}
+
+.slider {
+  margin-left: 45px;
+  margin-right: 5px;
+}
+
+.displayInitial {
+  display: initial;
+}

--- a/apps/src/templates/CollapserIcon.jsx
+++ b/apps/src/templates/CollapserIcon.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 
 const styles = {
   icon: {
@@ -14,7 +15,8 @@ function CollapserIcon({
   onClick,
   collapsedIconClass,
   expandedIconClass,
-  style
+  style,
+  className
 }) {
   const iconClass = isCollapsed ? collapsedIconClass : expandedIconClass;
 
@@ -23,7 +25,7 @@ function CollapserIcon({
       id={id}
       onClick={onClick}
       role="button"
-      className={iconClass + ' fa'}
+      className={classNames(iconClass + ' fa', className)}
       style={{...style, ...styles.icon}}
     />
   );
@@ -35,7 +37,8 @@ CollapserIcon.propTypes = {
   isCollapsed: PropTypes.bool.isRequired,
   collapsedIconClass: PropTypes.string,
   expandedIconClass: PropTypes.string,
-  style: PropTypes.object
+  style: PropTypes.object,
+  className: PropTypes.string
 };
 
 CollapserIcon.defaultProps = {

--- a/apps/src/templates/PaneHeader.jsx
+++ b/apps/src/templates/PaneHeader.jsx
@@ -6,9 +6,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Radium from 'radium'; // eslint-disable-line no-restricted-imports
-import commonStyles from '../commonStyles';
-import styleConstants from '../styleConstants';
-import color from '../util/color';
+import classNames from 'classnames';
+import moduleStyles from './pane-header.module.scss';
+import commonStyles from '../common-styles.module.scss';
+import styles from '../p5lab/AnimationPicker/styles';
 
 /**
  * A purple pane header that can have be focused (purple) or unfocused (light purple).
@@ -18,106 +19,38 @@ class PaneHeader extends React.Component {
     hasFocus: PropTypes.bool.isRequired,
     style: PropTypes.object,
     teacherOnly: PropTypes.bool,
-    isMinecraft: PropTypes.bool
+    isMinecraft: PropTypes.bool,
+    className: PropTypes.string
   };
 
   render() {
-    let {hasFocus, teacherOnly, style, isMinecraft, ...props} = this.props;
+    let {
+      hasFocus,
+      teacherOnly,
+      style,
+      isMinecraft,
+      className,
+      ...props
+    } = this.props;
 
-    // TODO: AnimationTab should likely use components from PaneHeader, at
-    // which point purpleHeader style should move in here.
-    const composedStyle = {
-      ...style,
-      ...commonStyles.purpleHeader,
-      ...(!hasFocus && commonStyles.purpleHeaderUnfocused),
-      ...(teacherOnly && commonStyles.teacherBlueHeader),
-      ...(teacherOnly && !hasFocus && commonStyles.teacherHeaderUnfocused),
-      ...(isMinecraft && commonStyles.minecraftHeader)
-    };
-
-    return <div {...props} style={composedStyle} />;
+    return (
+      <div
+        {...props}
+        className={classNames(
+          // TODO: AnimationTab should likely use components from PaneHeader, at
+          // which point purpleHeader style should move in here.
+          commonStyles.purpleHeader,
+          !hasFocus && commonStyles.purpleHeaderUnfocused,
+          teacherOnly && commonStyles.teacherBlueHeader,
+          teacherOnly && !hasFocus && commonStyles.teacherHeaderUnfocused,
+          isMinecraft && commonStyles.minecraftHeader,
+          className
+        )}
+        style={style}
+      />
+    );
   }
 }
-
-const styles = {
-  paneSection: {
-    textAlign: 'center',
-    whiteSpace: 'nowrap',
-    overflowX: 'hidden',
-    height: styleConstants['workspace-headers-height'],
-    lineHeight: styleConstants['workspace-headers-height'] + 'px'
-  },
-  headerButton: {
-    cursor: 'pointer',
-    float: 'right',
-    overflow: 'hidden',
-    backgroundColor: color.light_purple,
-    marginTop: 3,
-    marginBottom: 3,
-    marginRight: 3,
-    marginLeft: 0,
-    height: 24,
-    borderRadius: 4,
-    fontFamily: '"Gotham 5r", sans-serif',
-    lineHeight: '18px',
-    ':hover': {
-      backgroundColor: color.cyan
-    }
-  },
-  headerButtonRtl: {
-    float: 'left',
-    marginLeft: 3,
-    marginRight: 0
-  },
-  headerButtonMinecraft: {
-    backgroundColor: '#606060',
-    color: '#BFBFBF',
-    border: 'none',
-    ':hover': {
-      backgroundColor: '#606060',
-      color: color.white
-    }
-  },
-  headerButtonUnfocused: {
-    backgroundColor: color.lightest_purple
-  },
-  headerButtonPressed: {
-    backgroundColor: color.white,
-    color: color.purple,
-    ':hover': {
-      color: color.white
-    }
-  },
-  headerButtonDisabled: {
-    backgroundColor: color.light_gray,
-    ':hover': null,
-    cursor: 'default'
-  },
-  headerButtonSpan: {
-    paddingLeft: 12,
-    paddingRight: 12,
-    paddingTop: 0,
-    paddingBottom: 0
-  },
-  headerButtonIcon: {
-    lineHeight: '24px',
-    paddingRight: 8,
-    fontSize: 15,
-    fontWeight: 'bold'
-  },
-  headerButtonIconRtl: {
-    paddingRight: 0,
-    paddingLeft: 8
-  },
-  headerButtonIconHidden: {
-    paddingRight: 0,
-    paddingLeft: 0
-  },
-  headerButtonNoLabel: {
-    paddingRight: 0,
-    paddingLeft: 0
-  }
-};
 
 function sanitizedProps(props) {
   const sanitized = {...props};
@@ -128,12 +61,14 @@ function sanitizedProps(props) {
 
 /**
  * A section of our Pane Header. Essentially this is just a div with some
- * particular styles applied
+ * particular styles applied. Continuing to wrap with radium because some usage
+ * of this component may depend on it.
  */
 export const PaneSection = Radium(
   class extends React.Component {
     static propTypes = {
-      style: PropTypes.object
+      style: PropTypes.object,
+      className: PropTypes.string
     };
 
     render() {
@@ -141,7 +76,8 @@ export const PaneSection = Radium(
         <div
           {...sanitizedProps(this.props)}
           ref={root => (this.root = root)}
-          style={{...styles.paneSection, ...this.props.style}}
+          style={this.props.style}
+          className={classNames(moduleStyles.paneSection, this.props.className)}
         />
       );
     }
@@ -150,42 +86,59 @@ export const PaneSection = Radium(
 
 /**
  * A button within or PaneHeader, whose styles change whether or not the pane
- * has focus
+ * has focus. Continuing to wrap with radium because some usage
+ * of this component may depend on it.
  */
 export const PaneButton = Radium(function(props) {
-  const divStyle = {
-    ...styles.headerButton,
-    ...(props.isRtl !== !!props.leftJustified && styles.headerButtonRtl),
-    ...(props.isMinecraft && styles.headerButtonMinecraft),
-    ...(props.isPressed && styles.headerButtonPressed),
-    ...(!props.headerHasFocus && styles.headerButtonUnfocused),
-    ...(props.isDisabled && styles.headerButtonDisabled),
-    ...props.style
-  };
+  const {
+    isRtl,
+    isPressed,
+    pressedLabel,
+    iconClass,
+    hiddenImage,
+    label,
+    leftJustified,
+    isMinecraft,
+    headerHasFocus,
+    isDisabled,
+    style,
+    className
+  } = props;
 
-  let iconStyle = {
-    ...styles.headerButtonIcon,
-    ...(props.isRtl && styles.headerButtonIconRtl),
-    ...(!props.iconClass && !props.hiddenImage && styles.headerButtonIconHidden)
-  };
+  const buttonLabel = isPressed ? pressedLabel : label;
+  const iconOrLabelHidden = !buttonLabel || (!iconClass && !hiddenImage);
 
-  const label = props.isPressed ? props.pressedLabel : props.label;
+  const iconClassNames = classNames(
+    moduleStyles.headerButtonIcon,
+    isRtl && moduleStyles.headerButtonIconRtl,
+    iconOrLabelHidden && moduleStyles.headerButtonIconOrLabelHidden
+  );
 
-  if (!label) {
-    iconStyle = {...iconStyle, ...styles.headerButtonNoLabel};
-  }
+  const divClassNames = classNames(
+    moduleStyles.headerButton,
+    isRtl !== !!leftJustified && moduleStyles.headerButtonRtl,
+    isMinecraft && moduleStyles.headerButtonMinecraft,
+    isPressed && moduleStyles.headerButtonPressed,
+    !headerHasFocus && moduleStyles.headerButtonUnfocused,
+    isDisabled && moduleStyles.headerButtonDisabled,
+    className
+  );
 
   function renderIcon() {
     const {iconClass, icon} = props;
 
     if (iconClass) {
-      return <i className={iconClass} style={iconStyle} />;
+      return <i className={classNames(iconClass, iconClassNames)} />;
     }
 
     if (icon) {
       const Icon = icon.type;
       return (
-        <Icon {...icon.props} style={{...iconStyle, ...icon.props.style}}>
+        <Icon
+          {...icon.props}
+          className={iconClassNames}
+          style={icon.props.style}
+        >
           {icon.props.children}
         </Icon>
       );
@@ -205,14 +158,15 @@ export const PaneButton = Radium(function(props) {
 
   return (
     <div
+      className={divClassNames}
       role="button"
       tabIndex="0"
       id={props.id}
-      style={divStyle}
+      style={style}
       onKeyDown={props.isDisabled ? () => {} : onKeyDownWrapper}
       onClick={props.isDisabled ? () => {} : props.onClick}
     >
-      <span style={styles.headerButtonSpan}>
+      <span className={moduleStyles.headerButtonSpan}>
         {props.hiddenImage}
         {renderIcon()}
         <span style={styles.noPadding}>{label}</span>
@@ -237,4 +191,5 @@ PaneButton.propTypes = {
   style: PropTypes.object
 };
 
+// Continuing to wrap with radium because some usage of this component may depend on it.
 export default Radium(PaneHeader);

--- a/apps/src/templates/PaneHeader.story.jsx
+++ b/apps/src/templates/PaneHeader.story.jsx
@@ -5,8 +5,7 @@ const styles = {
   header: {
     borderLeft: 'thick solid white',
     paddingLeft: 30,
-    paddingRight: 30,
-    color: 'white'
+    paddingRight: 30
   },
   flex: {
     display: 'flex',
@@ -14,112 +13,102 @@ const styles = {
   }
 };
 
-export default storybook => {
-  storybook.storiesOf('PaneHeaders with PaneSections', module).addStoryTable([
-    {
-      name: 'PaneHeader - has focus',
-      story: () => (
-        <PaneHeader hasFocus={true}>
-          <div style={styles.flex}>
-            <PaneSection style={styles.header}>
-              <span>Section1</span>
-            </PaneSection>
-            <PaneSection style={styles.header}>
-              <span>Section2</span>
-            </PaneSection>
-            <PaneButton
-              headerHasFocus={false}
-              iconClass="fa fa-arrow-down"
-              label="Button"
-              isRtl={false}
-            />
-          </div>
-        </PaneHeader>
-      )
-    },
-    {
-      name: 'PaneHeader - does not have focus',
-      story: () => (
-        <PaneHeader hasFocus={false}>
-          <div style={styles.flex}>
-            <PaneSection style={styles.header}>
-              <span>Section1</span>
-            </PaneSection>
-            <PaneSection style={styles.header}>
-              <span>Section2</span>
-            </PaneSection>
-            <PaneButton
-              headerHasFocus={false}
-              iconClass="fa fa-arrow-down"
-              label="Button"
-              isRtl={false}
-            />
-          </div>
-        </PaneHeader>
-      )
-    },
-    {
-      name: 'PaneHeader - teacher only',
-      story: () => (
-        <PaneHeader hasFocus={true} teacherOnly={true}>
-          <div style={styles.flex}>
-            <PaneSection style={styles.header}>
-              <span>Section1</span>
-            </PaneSection>
-            <PaneSection style={styles.header}>
-              <span>Section2</span>
-            </PaneSection>
-            <PaneButton
-              headerHasFocus={false}
-              iconClass="fa fa-arrow-down"
-              label="Button"
-              isRtl={false}
-            />
-          </div>
-        </PaneHeader>
-      )
-    },
-    {
-      name: 'PaneHeader - teacher only, does not have focus',
-      story: () => (
-        <PaneHeader hasFocus={false} teacherOnly={true}>
-          <div style={styles.flex}>
-            <PaneSection style={styles.header}>
-              <span>Section1</span>
-            </PaneSection>
-            <PaneSection style={styles.header}>
-              <span>Section2</span>
-            </PaneSection>
-            <PaneButton
-              headerHasFocus={false}
-              iconClass="fa fa-arrow-down"
-              label="Button"
-              isRtl={false}
-            />
-          </div>
-        </PaneHeader>
-      )
-    },
-    {
-      name: 'PaneHeader - with RTL and LTR buttons',
-      story: () => (
-        <PaneHeader hasFocus={false} teacherOnly={true}>
-          <div style={styles.flex}>
-            <PaneButton
-              headerHasFocus={false}
-              iconClass="fa fa-arrow-down"
-              label="ButtonRTL"
-              isRtl={true}
-            />
-            <PaneButton
-              headerHasFocus={false}
-              iconClass="fa fa-arrow-down"
-              label="ButtonLTR"
-              isRtl={false}
-            />
-          </div>
-        </PaneHeader>
-      )
-    }
-  ]);
+export default {
+  title: 'PaneHeader with PaneSections',
+  component: PaneHeader
 };
+
+export const hasFocus = () => (
+  <PaneHeader hasFocus={true}>
+    <div style={styles.flex}>
+      <PaneSection style={styles.header}>
+        <span>Section1</span>
+      </PaneSection>
+      <PaneSection style={styles.header}>
+        <span>Section2</span>
+      </PaneSection>
+      <PaneButton
+        headerHasFocus={true}
+        iconClass="fa fa-arrow-down"
+        label="Button"
+        isRtl={false}
+      />
+    </div>
+  </PaneHeader>
+);
+
+export const doesNotHaveFocus = () => (
+  <PaneHeader hasFocus={false}>
+    <div style={styles.flex}>
+      <PaneSection style={styles.header}>
+        <span>Section1</span>
+      </PaneSection>
+      <PaneSection style={styles.header}>
+        <span>Section2</span>
+      </PaneSection>
+      <PaneButton
+        headerHasFocus={false}
+        iconClass="fa fa-arrow-down"
+        label="Button"
+        isRtl={false}
+      />
+    </div>
+  </PaneHeader>
+);
+
+export const teacherOnlyWithFocus = () => (
+  <PaneHeader hasFocus={true} teacherOnly={true}>
+    <div style={styles.flex}>
+      <PaneSection style={styles.header}>
+        <span>Section1</span>
+      </PaneSection>
+      <PaneSection style={styles.header}>
+        <span>Section2</span>
+      </PaneSection>
+      <PaneButton
+        headerHasFocus={true}
+        iconClass="fa fa-arrow-down"
+        label="Button"
+        isRtl={false}
+      />
+    </div>
+  </PaneHeader>
+);
+
+export const teacherOnlyWithoutFocus = () => (
+  <PaneHeader hasFocus={false} teacherOnly={true}>
+    <div style={styles.flex}>
+      <PaneSection style={styles.header}>
+        <span>Section1</span>
+      </PaneSection>
+      <PaneSection style={styles.header}>
+        <span>Section2</span>
+      </PaneSection>
+      <PaneButton
+        headerHasFocus={false}
+        iconClass="fa fa-arrow-down"
+        label="Button"
+        isRtl={false}
+      />
+    </div>
+  </PaneHeader>
+);
+
+export const withRTLAndLTRButtons = () => (
+  <PaneHeader hasFocus={false} teacherOnly={true}>
+    <div style={styles.flex}>
+      <PaneButton
+        headerHasFocus={false}
+        iconClass="fa fa-arrow-down"
+        label="ButtonRTL"
+        isRtl={true}
+      />
+      <PaneButton
+        headerHasFocus={false}
+        iconClass="fa fa-arrow-down"
+        label="ButtonLTR"
+        isRtl={false}
+      />
+    </div>
+  </PaneHeader>
+);

--- a/apps/src/templates/SpeedSlider.jsx
+++ b/apps/src/templates/SpeedSlider.jsx
@@ -46,7 +46,8 @@ class SpeedSlider extends React.Component {
     style: PropTypes.object,
     value: PropTypes.number.isRequired,
     lineWidth: PropTypes.number,
-    onChange: PropTypes.func.isRequired
+    onChange: PropTypes.func.isRequired,
+    className: PropTypes.string
   };
 
   state = {
@@ -151,7 +152,7 @@ class SpeedSlider extends React.Component {
     let clampedValue = this.clampValue(props.value);
     let knobXPosition = knobXMin + trackLength * clampedValue - knobWidth / 2;
     return (
-      <div id="slider-cell" style={props.style}>
+      <div id="slider-cell" style={props.style} className={props.className}>
         <svg width={knobXMax + 10} height="35" ref={el => (this.SVG_ = el)}>
           {/*<!-- Slow icon. -->*/}
           <clipPath id="slowClipPath">

--- a/apps/src/templates/pane-header.module.scss
+++ b/apps/src/templates/pane-header.module.scss
@@ -1,0 +1,79 @@
+@use "color.scss";
+@use "style-constants.scss";
+
+.paneSection {
+  text-align: center;
+  white-space: nowrap;
+  overflow-x: hidden;
+  height: style-constants.$workspace-headers-height;
+  line-height: style-constants.$workspace-headers-height;
+}
+
+.headerButton {
+  cursor: pointer;
+  float: right;
+  overflow: hidden;
+  background-color: color.$light_purple;
+  margin: 3px 3px 3px 0;
+  height: 24px;
+  border-radius: 4px;
+  font-family: "Gotham 5r", sans-serif;
+  line-height: 18px;
+  &:hover {
+    background-color: color.$cyan;
+  }
+
+  &Rtl {
+    float: left;
+    margin-left: 3px;
+    margin-right: 0;
+  }
+
+  &Minecraft {
+    background-color: #606060;
+    color: #bfbfbf;
+    border: none;
+    &:hover {
+      background-color: #606060;
+      color: color.$white;
+    }
+  }
+
+  &Unfocused {
+    background-color: color.$lightest_purple;
+  }
+
+  &Pressed {
+    background-color: color.$white;
+    color: color.$purple;
+    &:hover {
+      color: color.$white;
+    }
+  }
+
+  &Disabled {
+    background-color: color.$light_gray;
+    cursor: default;
+  }
+
+  &Span {
+    padding: 0 12px 0 12px;
+  }
+
+  &Icon {
+    line-height: 24px;
+    padding-right: 8px;
+    font-size: 15px;
+    font-weight: bold;
+  }
+
+  &IconRtl {
+    padding-right: 0;
+    padding-left: 8px;
+  }
+
+  &IconOrLabelHidden {
+    padding-right: 0;
+    padding-left: 0;
+  }
+}

--- a/apps/style/JsDebuggerUi.scss
+++ b/apps/style/JsDebuggerUi.scss
@@ -1,4 +1,5 @@
 // Style rules associated with our visual debugger for the JSInterpreter.
+// TODO: refactor this into js-debugger.module.scss if possible: https://codedotorg.atlassian.net/browse/SL-353
 @import "color.scss";
 @import "mixins";
 @import "style-constants";
@@ -76,12 +77,6 @@ $debug-header-border-width: 1px;
   .fa {
     margin: 0 0.25em;
   }
-}
-
-#debug-watch-header {
-  width: $debug-watch-max-column-width + $debug-header-border-width;
-  float: right;
-  border-left: $debug-header-border-width solid gray;
 }
 
 #watchersResizeBar {

--- a/apps/style/common.scss
+++ b/apps/style/common.scss
@@ -1026,13 +1026,6 @@ $workspace-header-button-margin: ($workspace-headers-height - $workspace-header-
   user-select: none;
 }
 
-.readonly {
-  #headers,
-  #design-headers {
-    background-color: $charcoal;
-  }
-}
-
 #headers,
 .purple-header {
   #show-toolbox-icon,

--- a/apps/test/unit/lib/tools/jsdebugger/JsDebuggerTest.js
+++ b/apps/test/unit/lib/tools/jsdebugger/JsDebuggerTest.js
@@ -123,10 +123,6 @@ describe('The JSDebugger component', () => {
       expect(openIcon()).to.exist;
     });
 
-    it('will collapse the debugger by setting the height in the css', () => {
-      expect(debugAreaEl().instance().style.height).to.equal('30px');
-    });
-
     it('will call the onSlideShut prop', () => {
       expect(jsDebugger.props().onSlideShut).to.have.been.called;
     });
@@ -162,11 +158,13 @@ describe('The JSDebugger component', () => {
 
         it('will make closing and opening the debugger return to the same height', () => {
           expect(debugAreaEl().instance().style.height).to.equal('350px');
+          // close
           jsDebugger.instance().slideToggle();
           jsDebugger.update();
-          expect(debugAreaEl().instance().style.height).to.equal('30px');
+          // re-open
           jsDebugger.instance().slideToggle();
           jsDebugger.update();
+          expect(debugAreaEl().instance().style.height).to.equal('350px');
         });
       });
     });


### PR DESCRIPTION
Redo of #48922. The first attempt had two unexpected eyes diffs: a button in Java Lab visualizations was shifted up, and view only headers were gray. The button shift was because `CollapserIcon` was not expecting a `className` to be passed in, which I've fixed. The gray header was due to an old, defunct [css rule](https://github.com/code-dot-org/code-dot-org/blob/a730ff4101b907090f1b932397e22c54a48a4c15/apps/style/common.scss#L1029). We discussed this in [slack](https://codedotorg.slack.com/archives/C03DBDN67B7/p1667346571446759) and decided to continue with our existing purple header for readonly, so I deleted this old rule.

All the previously failing eyes tests now pass, so I am hopeful this will pass eyes tests now. However I think there is a slight risk with this change because this component is used in many places and with many anti-patterns when it comes to how we style it (mixing css by ids, class names, and inline styles). I manually tested multiple places where this header exists to try to verify we weren't changing anything, and I rewrote the `PaneHeader` storybook story to try to ensure there weren't any unexpected differences. I didn't rewrite the `JsDebugger` storybook story because it was not straightforward to port over and I ran out of time.


## Testing story
Manually tested, tested with some eyes tests, and tested in Storybook.
