### PR TITLE
Updates teacher resource cards on Teacher Dashboard to descriptive (accessible) buttons

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -917,6 +917,7 @@
   "explainRestrictedSectionWordAndPicture": "If set to ‘yes,’ students will not be able to join this section using the section code. You can still add students to the section manually on the Manage Students tab.",
   "explainRestrictedSectionLearnMore": "Learn More",
   "exploreDataset": "Visualize {datasetName}",
+  "exploreProfessionalLearning": "Explore Professional Learning",
   "export": "Export",
   "exportForWeb": "Export for web",
   "extrasStageNChallenges": "Lesson {lessonNumber} Challenges",

--- a/apps/src/templates/studioHomepages/TeacherResources.jsx
+++ b/apps/src/templates/studioHomepages/TeacherResources.jsx
@@ -23,7 +23,7 @@ export default class TeacherResources extends Component {
             title={i18n.professionalLearning()}
             description={i18n.professionalLearningDescription()}
             image="professionallearning.png"
-            buttonText={i18n.learnMore()}
+            buttonText={i18n.exploreProfessionalLearning()}
             link="/my-professional-learning"
           />
           <ImageResourceCard
@@ -31,7 +31,7 @@ export default class TeacherResources extends Component {
             callout={i18n.newExclame()}
             description={i18n.csJourneysDescription()}
             image="csjourneys.png"
-            buttonText={i18n.learnMore()}
+            buttonText={i18n.learnMoreCsJourneys()}
             link={pegasus('/csjourneys')}
           />
           <ImageResourceCard


### PR DESCRIPTION
This PR updates the text on the teacher resource cards so the buttons are not labeled "Learn More" without more descriptive text.

Before:
<img width="983" alt="Screen Shot 2022-11-02 at 3 45 58 PM" src="https://user-images.githubusercontent.com/37230822/199616898-c7b61bc1-9839-470d-b5be-943184c524fe.png">

After:
<img width="1059" alt="Screen Shot 2022-11-02 at 3 48 45 PM" src="https://user-images.githubusercontent.com/37230822/199616948-d6bde744-dc46-4084-b743-ddf6d3d3ab31.png">


## Links


- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/TEACH-64

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
