### PR TITLE
Kaitie/table changes

### DIFF
--- a/apps/src/templates/EnhancedSafeMarkdown.jsx
+++ b/apps/src/templates/EnhancedSafeMarkdown.jsx
@@ -64,7 +64,8 @@ export default class EnhancedSafeMarkdown extends React.Component {
   static propTypes = {
     markdown: PropTypes.string.isRequired,
     openExternalLinksInNewTab: PropTypes.bool,
-    expandableImages: PropTypes.bool
+    expandableImages: PropTypes.bool,
+    className: PropTypes.string
   };
 
   render() {
@@ -81,6 +82,7 @@ export default class EnhancedSafeMarkdown extends React.Component {
       <SafeMarkdown
         markdown={this.props.markdown}
         openExternalLinksInNewTab={this.props.openExternalLinksInNewTab}
+        className={this.props.className}
       />
     );
 

--- a/apps/src/templates/SafeMarkdown.jsx
+++ b/apps/src/templates/SafeMarkdown.jsx
@@ -17,6 +17,7 @@ import rehypeReact from 'rehype-react';
 import defaultSanitizationSchema from 'hast-util-sanitize/lib/github.json';
 
 import externalLinks from './plugins/externalLinks';
+import '../../style/curriculum/documentation_tables.scss';
 
 /**
  * Basic component for rendering a markdown string as HTML, with sanitization.
@@ -54,9 +55,14 @@ class SafeMarkdown extends React.Component {
       rendered.type === 'div' &&
       !Object.keys(markdownProps).length
     ) {
-      return rendered;
+      return <div className="docs-table">{rendered}</div>;
     } else {
-      return <div {...markdownProps}>{rendered}</div>;
+      console.log('this has more than one child');
+      return (
+        <div className="docs-table" {...markdownProps}>
+          {rendered}
+        </div>
+      );
     }
   }
 }

--- a/apps/src/templates/SafeMarkdown.jsx
+++ b/apps/src/templates/SafeMarkdown.jsx
@@ -55,14 +55,9 @@ class SafeMarkdown extends React.Component {
       rendered.type === 'div' &&
       !Object.keys(markdownProps).length
     ) {
-      return <div className="docs-table">{rendered}</div>;
+      return rendered;
     } else {
-      console.log('this has more than one child');
-      return (
-        <div className="docs-table" {...markdownProps}>
-          {rendered}
-        </div>
-      );
+      return <div {...markdownProps}>{rendered}</div>;
     }
   }
 }

--- a/apps/src/templates/SafeMarkdown.jsx
+++ b/apps/src/templates/SafeMarkdown.jsx
@@ -17,7 +17,6 @@ import rehypeReact from 'rehype-react';
 import defaultSanitizationSchema from 'hast-util-sanitize/lib/github.json';
 
 import externalLinks from './plugins/externalLinks';
-import '../../style/curriculum/documentation_tables.scss';
 
 /**
  * Basic component for rendering a markdown string as HTML, with sanitization.

--- a/apps/src/templates/codeDocs/ProgrammingExpressionOverview.jsx
+++ b/apps/src/templates/codeDocs/ProgrammingExpressionOverview.jsx
@@ -108,7 +108,7 @@ export default function ProgrammingExpressionOverview({
           <EnhancedSafeMarkdown
             markdown={programmingExpression.content.trim()}
             expandableImages
-            className="docs-table"
+            className="docs-pages"
           />
         </div>
       )}
@@ -130,7 +130,7 @@ export default function ProgrammingExpressionOverview({
           <EnhancedSafeMarkdown
             markdown={`\`${programmingExpression.syntax}\``}
             expandableImages
-            className="docs-table"
+            className="docs-pages"
           />
         </div>
       )}
@@ -155,7 +155,7 @@ export default function ProgrammingExpressionOverview({
           <EnhancedSafeMarkdown
             markdown={programmingExpression.tips.trim()}
             expandableImages
-            className="docs-table"
+            className="docs-pages"
           />
         </div>
       )}
@@ -166,7 +166,7 @@ export default function ProgrammingExpressionOverview({
             markdown={i18n.additionalInformationText({
               externalDocumentationUrl: programmingExpression.externalDocumentation.trim()
             })}
-            className="docs-table"
+            className="docs-pages"
           />
         </div>
       )}

--- a/apps/src/templates/codeDocs/ProgrammingExpressionOverview.jsx
+++ b/apps/src/templates/codeDocs/ProgrammingExpressionOverview.jsx
@@ -108,6 +108,7 @@ export default function ProgrammingExpressionOverview({
           <EnhancedSafeMarkdown
             markdown={programmingExpression.content.trim()}
             expandableImages
+            className="docs-table"
           />
         </div>
       )}
@@ -129,6 +130,7 @@ export default function ProgrammingExpressionOverview({
           <EnhancedSafeMarkdown
             markdown={`\`${programmingExpression.syntax}\``}
             expandableImages
+            className="docs-table"
           />
         </div>
       )}
@@ -153,6 +155,7 @@ export default function ProgrammingExpressionOverview({
           <EnhancedSafeMarkdown
             markdown={programmingExpression.tips.trim()}
             expandableImages
+            className="docs-table"
           />
         </div>
       )}
@@ -163,6 +166,7 @@ export default function ProgrammingExpressionOverview({
             markdown={i18n.additionalInformationText({
               externalDocumentationUrl: programmingExpression.externalDocumentation.trim()
             })}
+            className="docs-table"
           />
         </div>
       )}

--- a/apps/src/templates/codeDocs/ProgrammingExpressionOverview.jsx
+++ b/apps/src/templates/codeDocs/ProgrammingExpressionOverview.jsx
@@ -11,6 +11,7 @@ import {
   shrinkBlockSpaceContainer
 } from '@cdo/apps/templates/instructions/utils';
 import {parseElement} from '@cdo/apps/xml';
+import '../../../style/curriculum/documentation_tables.scss';
 
 const VIDEO_WIDTH = 560;
 const VIDEO_HEIGHT = 315;

--- a/apps/src/templates/referenceGuides/ReferenceGuide.jsx
+++ b/apps/src/templates/referenceGuides/ReferenceGuide.jsx
@@ -13,11 +13,11 @@ export default function ReferenceGuide({referenceGuide}) {
     <div>
       <EnhancedSafeMarkdown
         markdown={referenceGuide.content}
-        className="docs-table"
+        className="docs-pages"
       />
       <EnhancedSafeMarkdown
         markdown={i18n.documentationBug()}
-        className="docs-table"
+        className="docs-pages"
       />
       <CopyrightInfo />
     </div>

--- a/apps/src/templates/referenceGuides/ReferenceGuide.jsx
+++ b/apps/src/templates/referenceGuides/ReferenceGuide.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import EnhancedSafeMarkdown from '@cdo/apps/templates/EnhancedSafeMarkdown';
 import i18n from '@cdo/locale';
 import CopyrightInfo from '@cdo/apps/templates/CopyrightInfo';
+import '../../../style/curriculum/documentation_tables.scss';
 
 const referenceGuideShape = PropTypes.shape({
   content: PropTypes.string

--- a/apps/src/templates/referenceGuides/ReferenceGuide.jsx
+++ b/apps/src/templates/referenceGuides/ReferenceGuide.jsx
@@ -11,8 +11,14 @@ const referenceGuideShape = PropTypes.shape({
 export default function ReferenceGuide({referenceGuide}) {
   return (
     <div>
-      <EnhancedSafeMarkdown markdown={referenceGuide.content} />
-      <EnhancedSafeMarkdown markdown={i18n.documentationBug()} />
+      <EnhancedSafeMarkdown
+        markdown={referenceGuide.content}
+        className="docs-table"
+      />
+      <EnhancedSafeMarkdown
+        markdown={i18n.documentationBug()}
+        className="docs-table"
+      />
       <CopyrightInfo />
     </div>
   );

--- a/apps/style/curriculum/documentation_tables.scss
+++ b/apps/style/curriculum/documentation_tables.scss
@@ -2,7 +2,7 @@
 @import "font";
 @import "markdown";
 
-.docs-table {
+.docs-pages {
   th {
     background-color: $charcoal;
     color: $white;

--- a/apps/style/curriculum/documentation_tables.scss
+++ b/apps/style/curriculum/documentation_tables.scss
@@ -1,0 +1,21 @@
+@import "color.scss";
+@import "font";
+@import "markdown";
+
+.docs-table {
+  th {
+    background-color: $charcoal;
+    color: $white;
+    border: 1px solid $white;
+    text-align: left;
+    font-size: 120%;
+    font-family: $gotham-bold;
+    font-weight: normal;
+    padding: 5px;
+  }
+
+  td {
+    padding: 5px;
+    border: 1px solid $charcoal;
+  }
+}

--- a/apps/test/unit/templates/EnhancedSafeMarkdownTest.js
+++ b/apps/test/unit/templates/EnhancedSafeMarkdownTest.js
@@ -16,6 +16,15 @@ describe('EnhancedSafeMarkdown', () => {
     expect(wrapper.equals(<SafeMarkdown markdown="test" />)).to.equal(true);
   });
 
+  it('renders SafeMarkdown by default with class name', () => {
+    const wrapper = shallow(
+      <EnhancedSafeMarkdown markdown="test" className="class test" />
+    );
+    expect(
+      wrapper.equals(<SafeMarkdown markdown="test" className="class test" />)
+    ).to.equal(true);
+  });
+
   it('wraps output in enhancements as specified', () => {
     const wrapper = shallow(
       <EnhancedSafeMarkdown markdown="test" expandableImages />

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -115,6 +115,11 @@ th {
   padding: 5px;
 }
 
+td {
+  padding: 5px;
+  border: 1px solid $charcoal;
+}
+
 strong {
   font-family: $gotham-extra-bold;
   font-weight: normal;

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -115,11 +115,6 @@ th {
   padding: 5px;
 }
 
-td {
-  padding: 5px;
-  border: 1px solid $charcoal;
-}
-
 strong {
   font-family: $gotham-extra-bold;
   font-weight: normal;


### PR DESCRIPTION
Changed the styling on tables on reference pages and guide pages.

([Example 1](https://levelbuilder-studio.code.org/courses/csp-2022/guides/when-to-make-a-function), [Example 2](https://levelbuilder-studio.code.org/docs/ide/applab/expressions/onEvent), [Example 3](https://levelbuilder-studio.code.org/courses/csp-2022/guides/tableDataStorage) ).

**New styling**
<img width="748" alt="image" src="https://user-images.githubusercontent.com/24883357/199825423-011e5893-d2b5-401e-8940-057afa13cfb9.png">

**Old styling**
<img width="604" alt="image" src="https://user-images.githubusercontent.com/24883357/199825516-2b2f79b8-5650-4495-bd69-ceb63097f2f6.png">



## Links

[Jira Ticket](https://codedotorg.atlassian.net/browse/TEACH-45)

## Testing story

- I did a visual check of the pages Ken had mentioned in the Slack Thread. 
- I also visually checked that it rendered in the "Markdown preview" on the level builder editor page.
- Ran tests on: ProgrammingExpressionOverview, EnhancedSafeMarkdown, SafeMarkdown - these PASSED 
- **COULD NOT find a test file for ReferenceGuide.jsx** - I would love feedback on how to approach testing this.


