### PR TITLE
Tutorial explorer: show accessibility details

### DIFF
--- a/apps/src/tutorialExplorer/shapes.jsx
+++ b/apps/src/tutorialExplorer/shapes.jsx
@@ -11,7 +11,8 @@ const shapes = {
     tags_activity_type: PropTypes.string,
     tags_international_languages: PropTypes.string,
     tags_grade: PropTypes.string,
-    tags_programming_language: PropTypes.string
+    tags_programming_language: PropTypes.string,
+    tags_accessibility: PropTypes.string
   })
 };
 

--- a/apps/src/tutorialExplorer/util.jsx
+++ b/apps/src/tutorialExplorer/util.jsx
@@ -76,7 +76,13 @@ export function getTagString(prefix, tagString) {
     student_experience_comfortable: i18n.filterStudentExperienceComfortable(),
 
     'activity_type_online-tutorial': i18n.filterActivityTypeOnlineTutorial(),
-    'activity_type_lesson-plan': i18n.filterActivityTypeLessonPlan()
+    'activity_type_lesson-plan': i18n.filterActivityTypeLessonPlan(),
+
+    accessibility_screenreader: i18n.filterAccessibilityScreenReader(),
+    accessibility_tts: i18n.filterAccessibilityTTS(),
+    accessibility_keyboard: i18n.filterAccessibilityKeyboard(),
+    accessibility_captions: i18n.filterAccessibilityCaptions(),
+    accessibility_highcontrast: i18n.filterAccessibilityHighContrast()
   };
 
   return tagString


### PR DESCRIPTION
Show the accessibility tag values as readable text in the tutorial details pop-up.

Follow-up to https://github.com/code-dot-org/code-dot-org/pull/48306.


### before

<img width="921" alt="Screenshot 2022-11-04 at 11 55 23 AM" src="https://user-images.githubusercontent.com/2205926/200053727-74909675-8ca5-441b-8e11-88fce610018b.png">

### after

<img width="922" alt="Screenshot 2022-11-04 at 11 55 02 AM" src="https://user-images.githubusercontent.com/2205926/200053750-08866f25-f169-4f1c-ad20-051775025f04.png">

