### PR TITLE
Remove regional partner playbook eyes test

### DIFF
--- a/dashboard/test/ui/features/initial_page_views3.feature
+++ b/dashboard/test/ui/features/initial_page_views3.feature
@@ -32,7 +32,6 @@ Feature: Looking at a few things with Applitools Eyes - Part 3
       | url                                               | test_name                  |
       | http://studio.code.org/                           | logged out studio homepage |
       | http://studio.code.org/s/allthethings             | logged out script progress |
-      | http://code.org/educate/regional-partner/playbook | regional partner playbook  |
 
   @no_circle
   Scenario Outline: Temporarily eyes disabled simple page view without instructions dialog


### PR DESCRIPTION
It looks like we used to have a more complicated page at https://code.org/educate/regional-partner/playbook -- now it's an embedded google doc (thanks for the simplification Kelby!) Removing our eyes test on this page, which is currently fully covered in an ignore region.

## Links

- Playbook simplification PR: https://github.com/code-dot-org/code-dot-org/pull/48060
- Current eyes test (fully ignored): https://eyes.applitools.com/app/test-results/00000251734802209680/00000251734801896315/steps/1?accountId=mG4DoRfv0ntEgI3XIYBulrKxlZqrHtGwbP3V103ojvLFU110&mode=step-editor
- Regression that inspired this eyes test: https://github.com/code-dot-org/code-dot-org/pull/33670
- Original eyes test added here: https://github.com/code-dot-org/code-dot-org/pull/33706