### PR TITLE
adding start_html to the sync, as well as its redaction/restoration p…

### DIFF
--- a/bin/i18n/sync-in.rb
+++ b/bin/i18n/sync-in.rb
@@ -160,6 +160,7 @@ def get_i18n_strings(level)
       teacher_markdown
       placeholder
       title
+      start_html
     ).each do |prop|
       i18n_strings[prop] = level.try(prop)
     end
@@ -537,6 +538,7 @@ def select_redactable(i18n_strings)
     long_instructions
     short_instructions
     teacher_markdown
+    start_html
   )
 
   redactable = i18n_strings.select do |key, _|
@@ -571,7 +573,7 @@ def redact_level_file(source_path)
     file.write(JSON.pretty_generate(redactable_data))
   end
 
-  redacted_data = RedactRestoreUtils.redact_data(redactable_data, ['blockly'])
+  redacted_data = RedactRestoreUtils.redact_data(redactable_data, ['blockly', 'startHtml'])
 
   File.open(source_path, 'w') do |source_file|
     source_file.write(JSON.pretty_generate(source_data.deep_merge(redacted_data)))

--- a/bin/i18n/sync-out.rb
+++ b/bin/i18n/sync-out.rb
@@ -165,7 +165,7 @@ def restore_redacted_files
       elsif original_path.starts_with? "i18n/locales/original/course_content"
         # Course content should be merged with existing content, so existing
         # data doesn't get lost
-        restored_data = RedactRestoreUtils.restore_file(original_path, translated_path, ['blockly'])
+        restored_data = RedactRestoreUtils.restore_file(original_path, translated_path, ['blockly', 'startHtml'])
         translated_data = JSON.parse(File.read(translated_path))
         File.open(translated_path, "w") do |file|
           file.write(JSON.pretty_generate(translated_data.deep_merge(restored_data)))


### PR DESCRIPTION
…lugin

This PR adds the `start_html` attribute in levels to the sync in, as well as its associated plugin for redaction and restoration.

Plugin PR: https://github.com/code-dot-org/remark-plugins/pull/46

Note that this PR does NOT support the redaction of `<div>` tags, due to the decision not to parse those tags by remarkJS. This solution will be pursued in a different task.

Jira: https://codedotorg.atlassian.net/browse/FND-2094?atlOrigin=eyJpIjoiOTVjOGI4OWQyMWY5NGFiMGFiNmU5MWZmYzFhOGFiYzgiLCJwIjoiaiJ9

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Manually ran a local sync with the updated plugin package linked via npm to verify that `start_html` was added to the sync and redacted.

```
"start_html": "<divtest id=\"designModeViz\" class=\"appModern clip-content\" tabindex=\"1\" data-radium=\"true\" style=\"width: 320px; height: 450px;\"><divtest class=\"screen\" tabindex=\"1\" id=\"home_screen\" style=\"display: block; height: 450px; width: 320px; left: 0px; top: 0px; position: absolute; z-index: 0; background-color: rgb(255, 255, 255);\" data-theme=\"classic\"><label style=\"margin: 0px; padding: 2px; line-height: 1; font-size: 14px; overflow: hidden; overflow-wrap: break-word; color: rgb(51, 51, 51); max-width: 320px; width: 320px; height: 70px; position: absolute; left: 0px; top: 0px; background-color: rgba(0, 0, 0, 0); text-rendering: optimizespeed; border-style: solid; border-width: 0px; border-color: rgb(0, 0, 0); border-radius: 0px; font-family: Arial, Helvetica, sans-serif;\" id=\"title\">title</label><label style=\"margin: 0px; padding: 2px; line-height: 1; font-size: 14px; overflow: hidden; overflow-wrap: break-word; color: rgb(51, 51, 51); max-width: 320px; width: 319px; height: 47px; position: absolute; left: 1.66533e-16px; top: 20px; background-color: rgba(0, 0, 0, 0); text-rendering: optimizespeed; border-style: solid; border-width: 0px; border-color: rgb(0, 0, 0); border-radius: 0px; font-family: Arial, Helvetica, sans-serif;\" id=\"description\">You've always wondered what your cat is saying when it meows in the middle of the night. Now you can finally know!</label><img data-canonical-image-url=\"icon://fa-exchange\" id=\"logo\" style=\"height: 100px; width: 100px; position: absolute; left: 105px; top: 65px; margin: 0px; border-style: solid; border-width: 0px; border-color: rgb(0, 0, 0); border-radius: 0px;\" data-image-type=\"icon\"><button id=\"translate_button\" style=\"padding: 0px; margin: 0px; height: 30px; width: 80px; font-size: 14px; color: rgb(255, 255, 255); background-color: rgb(26, 188, 156); position: absolute; left: 4.44089e-16px; top: 350px; border-style: solid; border-width: 0px; border-color: rgb(0, 0, 0); border-radius: 0px; font-family: Arial, Helvetica, sans-serif;\">Button</button></divtest></divtest>"
```
was redacted to:
```
"start_html": "[][0][][1][][2]title[][3][][4]You've always wondered what your cat is saying when it meows in the middle of the night. Now you can finally know![][5][][6][][7]Button[][8][][9][][10]"
```

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
