### PR TITLE
including *labs.json to i18n pipeline

### DIFF
--- a/bin/i18n/codeorg-testing_crowdin.yml
+++ b/bin/i18n/codeorg-testing_crowdin.yml
@@ -47,12 +47,9 @@ files: [
   "translation" : "/%language%/**/%original_file_name%",
   "ignore" : [
     "/source/hourofcode/**",
-    "/source/blockly-mooc/applab.json",
     "/source/blockly-mooc/calc.json",
     "/source/blockly-mooc/eval.json",
-    "/source/blockly-mooc/gamelab.json",
-    "/source/blockly-mooc/netsim.json",
-    "/source/blockly-mooc/weblab.json"
+    "/source/blockly-mooc/netsim.json"
   ],
   "update_option" : "update_as_unapproved"
  }

--- a/bin/i18n/codeorg_crowdin.yml
+++ b/bin/i18n/codeorg_crowdin.yml
@@ -47,12 +47,9 @@ files: [
   "translation" : "/%language%/**/%original_file_name%",
   "ignore" : [
     "/source/hourofcode/**",
-    "/source/blockly-mooc/applab.json",
     "/source/blockly-mooc/calc.json",
     "/source/blockly-mooc/eval.json",
-    "/source/blockly-mooc/gamelab.json",
-    "/source/blockly-mooc/netsim.json",
-    "/source/blockly-mooc/weblab.json"
+    "/source/blockly-mooc/netsim.json"
   ],
   "update_option" : "update_as_unapproved"
  }

--- a/bin/i18n/sync-in.rb
+++ b/bin/i18n/sync-in.rb
@@ -32,6 +32,7 @@ def sync_in
   redact_level_content
   redact_block_content
   redact_script_and_course_content
+  redact_all_labs_content
   localize_markdown_content
   puts "Sync in completed successfully"
 rescue => e
@@ -583,6 +584,19 @@ def redact_level_content
 
   Dir.glob(File.join(I18N_SOURCE_DIR, "course_content/**/*.json")).each do |source_path|
     redact_level_file(source_path)
+  end
+end
+
+def redact_all_labs_content
+  puts "Redacting all *labs content"
+
+  Dir.glob(File.join(I18N_SOURCE_DIR, "blockly-mooc", "*lab.json")).each do |source_path|
+    puts source_path
+    backup_path = source_path.sub("source", "original")
+    puts backup_path
+    FileUtils.mkdir_p(File.dirname(backup_path))
+    FileUtils.cp(source_path, backup_path)
+    RedactRestoreUtils.redact(source_path, source_path, ['link'])
   end
 end
 

--- a/bin/i18n/sync-in.rb
+++ b/bin/i18n/sync-in.rb
@@ -587,6 +587,7 @@ def redact_level_content
   end
 end
 
+# These files are synced in using the `bin/i18n-codeorg/in.sh` script.
 def redact_labs_content
   puts "Redacting *labs content"
 

--- a/bin/i18n/sync-in.rb
+++ b/bin/i18n/sync-in.rb
@@ -32,7 +32,7 @@ def sync_in
   redact_level_content
   redact_block_content
   redact_script_and_course_content
-  redact_all_labs_content
+  redact_labs_content
   localize_markdown_content
   puts "Sync in completed successfully"
 rescue => e
@@ -587,10 +587,15 @@ def redact_level_content
   end
 end
 
-def redact_all_labs_content
+def redact_labs_content
   puts "Redacting *labs content"
 
-  Dir.glob(File.join(I18N_SOURCE_DIR, "blockly-mooc", "*lab.json")).each do |source_path|
+  # Only CSD labs are redacted, since other labs were already part of the i18n pipeline and redaction would edit
+  # strings existing in crowdin already
+  redactable_labs = %w(applab gamelab weblab)
+
+  redactable_labs.each do |lab_name|
+    source_path = File.join(I18N_SOURCE_DIR, "blockly-mooc", lab_name + ".json")
     backup_path = source_path.sub("source", "original")
     FileUtils.mkdir_p(File.dirname(backup_path))
     FileUtils.cp(source_path, backup_path)

--- a/bin/i18n/sync-in.rb
+++ b/bin/i18n/sync-in.rb
@@ -588,12 +588,10 @@ def redact_level_content
 end
 
 def redact_all_labs_content
-  puts "Redacting all *labs content"
+  puts "Redacting *labs content"
 
   Dir.glob(File.join(I18N_SOURCE_DIR, "blockly-mooc", "*lab.json")).each do |source_path|
-    puts source_path
     backup_path = source_path.sub("source", "original")
-    puts backup_path
     FileUtils.mkdir_p(File.dirname(backup_path))
     FileUtils.cp(source_path, backup_path)
     RedactRestoreUtils.redact(source_path, source_path, ['link'])

--- a/bin/i18n/sync-out.rb
+++ b/bin/i18n/sync-out.rb
@@ -181,6 +181,8 @@ def restore_redacted_files
           plugins << 'vocabularyDefinition'
         elsif original_path.starts_with? "i18n/locales/original/curriculum_content"
           plugins.push(*Services::I18n::CurriculumSyncUtils::REDACT_RESTORE_PLUGINS)
+        elsif File.fnmatch('i18n/locales/original/blockly-mooc/*lab.json', original_path)
+          plugins << 'link'
         end
         RedactRestoreUtils.restore(original_path, translated_path, translated_path, plugins)
       end
@@ -527,7 +529,7 @@ end
 
 # For untranslated apps, copy English file for all locales
 def copy_untranslated_apps
-  untranslated_apps = %w(applab calc eval gamelab netsim weblab)
+  untranslated_apps = %w(calc eval netsim)
 
   PegasusLanguages.get_locale.each do |prop|
     next unless prop[:locale_s] != 'en-US'

--- a/bin/i18n/sync-out.rb
+++ b/bin/i18n/sync-out.rb
@@ -181,7 +181,7 @@ def restore_redacted_files
           plugins << 'vocabularyDefinition'
         elsif original_path.starts_with? "i18n/locales/original/curriculum_content"
           plugins.push(*Services::I18n::CurriculumSyncUtils::REDACT_RESTORE_PLUGINS)
-        elsif File.fnmatch('i18n/locales/original/blockly-mooc/*lab.json', original_path)
+        elsif %w(applab gamelab weblab).include?(File.basename(original_path, '.json'))
           plugins << 'link'
         end
         RedactRestoreUtils.restore(original_path, translated_path, translated_path, plugins)


### PR DESCRIPTION
**What:** Adding applab, weblab y gamelab to the translation pipeline.

**Why:** In the current state of the sync, the pipeline excludes applab, weblab y gamelab. Those strings need to be translatable as a pat of the CSD Translatability Epic.

**How:** 
- Removing applab, gamelab and weblab from ignore section in `codeorg_crowding.yml` and `codeorg-testing_crowding.yml`.
- Adding link redaction for `*lab.json` files in the sync-in.
- Adding link restoration for `*lab.json` files in the sync-out.
- Removing applab, gamelab and weblab from `copy_untranslated_apps` in the sync-out.

## Links
- jira ticket: [FND-2117](https://codedotorg.atlassian.net/browse/FND-2117)
- Epic: [CSD Translatability](https://codedotorg.atlassian.net/browse/FND-1652)

## Testing story

I ran sync locally in the testing projects.
I also introduced some translations to ensure the sync was successful and working as intended.
![Screen Shot 2022-11-03 at 23 29 46](https://user-images.githubusercontent.com/66776217/199889866-e20cfd77-c88e-409d-940a-c27a522ce3ac.png)



## Deployment strategy
In the next i18n sync, it will be necessary to confirm all*lab strings are in fact:
1. Added to Crowdin
2. Redact/Restored properly
3. Distributed in the correct locale.


## PR Checklist:


- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
