### PR TITLE
Add reference_guides redirect for current course version

### DIFF
--- a/dashboard/app/controllers/reference_guides_controller.rb
+++ b/dashboard/app/controllers/reference_guides_controller.rb
@@ -1,5 +1,6 @@
 class ReferenceGuidesController < ApplicationController
   include CurriculumHelper
+  before_action :redirect_unit_group, only: [:show, :index]
   before_action :find_reference_guide, only: [:show, :update, :edit, :destroy]
   before_action :find_reference_guides, only: [:show, :edit, :edit_all]
   before_action :require_levelbuilder_mode_or_test_env, except: [:show, :index]
@@ -80,6 +81,16 @@ class ReferenceGuidesController < ApplicationController
       where(course_version_id: course_version_id, parent_reference_guide_key: parent_key).
       order('position').
       last&.position || 0) + 1
+  end
+
+  def redirect_unit_group
+    course_name = params[:course_course_name]
+
+    # When the url of a course family is requested, redirect to a specific course version.
+    if UnitGroup.family_names.include?(course_name)
+      unit_group = UnitGroup.latest_stable_version(course_name)
+      redirect_to action: params[:action], course_course_name: unit_group.name, key: params[:key] if unit_group
+    end
   end
 
   def find_reference_guide

--- a/dashboard/app/views/helpful_links/index.html.haml
+++ b/dashboard/app/views/helpful_links/index.html.haml
@@ -2,9 +2,9 @@
 
 %h2 Reference Guides
 %ul
-  %li= link_to 'CSD', '/courses/csd-2022/guides/'
-  %li= link_to 'CSP', '/courses/csp-2022/guides/'
-  %li= link_to 'CSA', '/courses/csa-2022/guides/'
+  %li= link_to 'CSD', '/courses/csd/guides/'
+  %li= link_to 'CSP', '/courses/csp/guides/'
+  %li= link_to 'CSA', '/courses/csa/guides/'
 
 %h2 Miscellaneous
 %ul

--- a/dashboard/test/controllers/reference_guides_controller_test.rb
+++ b/dashboard/test/controllers/reference_guides_controller_test.rb
@@ -7,8 +7,8 @@ class ReferenceGuidesControllerTest < ActionController::TestCase
     File.stubs(:write)
     Rails.application.config.stubs(:levelbuilder_mode).returns true
     @levelbuilder = create :levelbuilder
-    @unit_group = create :unit_group, family_name: 'bogus-course', version_year: '2022', name: 'bogus-course-2022'
-    CourseOffering.add_course_offering(@unit_group)
+    @unit_group = create :unit_group, family_name: 'bogus-course', version_year: '2022', name: 'bogus-course-2022', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable
+    @offering = CourseOffering.add_course_offering(@unit_group)
     # category
     @reference_guide = create :reference_guide, course_version: @unit_group.course_version
     # subcategory
@@ -146,6 +146,27 @@ class ReferenceGuidesControllerTest < ActionController::TestCase
     end
 
     assert ReferenceGuide.find_by_course_version_id_and_key(@unit_group.course_version.id, key).position > old_last_position
+  end
+
+  test 'redirect to index of latest version in course family' do
+    sign_in @levelbuilder
+
+    get :index, params: {
+      course_course_name: @reference_guide.course_version.course_offering.key
+    }
+    assert_response :redirect
+    assert_redirected_to "/courses/#{@reference_guide_subcategory.course_offering_version}/guides"
+  end
+
+  test 'redirect to latest version in course family' do
+    sign_in @levelbuilder
+
+    get :show, params: {
+      course_course_name: @reference_guide.course_version.course_offering.key,
+      key: @reference_guide.key,
+    }
+    assert_response :redirect
+    assert_redirected_to "/courses/#{@reference_guide_subcategory.course_offering_version}/guides/#{@reference_guide.key}"
   end
 
   test_user_gets_response_for :show, params: -> {{course_course_name: @reference_guide.course_offering_version, key: 'unknown_ref_guide'}}, user: :student, response: :not_found

--- a/dashboard/test/controllers/reference_guides_controller_test.rb
+++ b/dashboard/test/controllers/reference_guides_controller_test.rb
@@ -8,7 +8,7 @@ class ReferenceGuidesControllerTest < ActionController::TestCase
     Rails.application.config.stubs(:levelbuilder_mode).returns true
     @levelbuilder = create :levelbuilder
     @unit_group = create :unit_group, family_name: 'bogus-course', version_year: '2022', name: 'bogus-course-2022', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable
-    @offering = CourseOffering.add_course_offering(@unit_group)
+    CourseOffering.add_course_offering(@unit_group)
     # category
     @reference_guide = create :reference_guide, course_version: @unit_group.course_version
     # subcategory


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Followup from #48824. Adds latest-course redirects for reference guides pages, like `/courses/csd/guides/variables` -> `/courses/csd-2022/guides/variables`.

Also updated the "helpful links" to use these new URLs, since that was mentioned in the ticket.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [TEACH-50](https://codedotorg.atlassian.net/browse/TEACH-50)

## Testing story

Manual testing locally, and updated unit tests.

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

