### PR TITLE
Simplify copying starter assets on remix

### DIFF
--- a/dashboard/legacy/middleware/helpers/asset_bucket.rb
+++ b/dashboard/legacy/middleware/helpers/asset_bucket.rb
@@ -43,12 +43,14 @@ class AssetBucket < BucketHelper
     channel = ChannelToken.find_by(storage_id: src_owner_id, storage_app_id: src_storage_app_id)
     return unless channel
 
+    # For a template-backed level, the level associated with the channel
+    # is the template level
     level = Level.cache_find(channel.level_id)
-    return unless level
+    return unless level&.starter_assets
 
     dest_owner_id, dest_storage_app_id = storage_decrypt_channel_id(dest_channel)
 
-    (level&.project_template_level&.starter_assets || level.starter_assets || []).map do |friendly_name, uuid_name|
+    level.starter_assets.map do |friendly_name, uuid_name|
       src = "#{@bucket}/#{LevelStarterAssetsController::S3_PREFIX}#{uuid_name}"
       dest = s3_path dest_owner_id, dest_storage_app_id, friendly_name
       s3.copy_object(bucket: @bucket, key: dest, copy_source: URI.encode(src), metadata_directive: 'REPLACE')

--- a/dashboard/legacy/middleware/helpers/asset_bucket.rb
+++ b/dashboard/legacy/middleware/helpers/asset_bucket.rb
@@ -44,12 +44,15 @@ class AssetBucket < BucketHelper
     return unless channel
 
     # For a template-backed level, the level associated with the channel
-    # is the template level
+    # is the template level, not the "derived" level.
     level = Level.cache_find(channel.level_id)
     return unless level&.starter_assets
 
     dest_owner_id, dest_storage_app_id = storage_decrypt_channel_id(dest_channel)
 
+    # As noted above, when copying from a template-backed level,
+    # the level associated with the channel is the template level (rather than the "derived" level).
+    # Therefore, we always copy the level's starter assets (rather than having to look up a template level's assets).
     level.starter_assets.map do |friendly_name, uuid_name|
       src = "#{@bucket}/#{LevelStarterAssetsController::S3_PREFIX}#{uuid_name}"
       dest = s3_path dest_owner_id, dest_storage_app_id, friendly_name


### PR DESCRIPTION
When copying starter assets on remix, the level associated with the channel (ie, project) being copied is the template level, not the "derived" level. Simplifying our asset copying logic to reflect this. I got confused by this, so updating so hopefully the next person won't go through the same thing :)

## Links

Discovered as part of the investigation described in this Slack thread: https://codedotorg.slack.com/archives/C03DBDN67B7/p1666101508728619

## Testing story

Tested manually that Javalab levels where assets are defined on the level and on the template continued to work when remixed.
- on Javalab level: /s/allthethings/lessons/44/levels/4
- on Javalab template: /s/csa5-2022/lessons/13/levels/1
- on Applab level: /s/csd6-2022/lessons/14/levels/10 (images are broken when you share in Applab, but that's a result of [this bug](https://codedotorg.atlassian.net/browse/SL-278?jql=text%20~%20%22remix%20asset%22) -- assets are appearing in manage assets modal)
- on Applab template: /s/csd6-2022/lessons/14/levels/6