### PR TITLE
Skip javalab finish button tests on phone

### DIFF
--- a/dashboard/test/ui/features/javalab/finish_button.feature
+++ b/dashboard/test/ui/features/javalab/finish_button.feature
@@ -1,4 +1,5 @@
-@no_circle
+# Item to track renabling this: https://codedotorg.atlassian.net/browse/SL-375
+@no_circle @no_phone
 Feature: Finish Button
 
 Background:


### PR DESCRIPTION
Blocking upgrade from iOS 11 -> 15 for iPhone on Saucelabs, task to look into re-enabling (or leaving permanently disabled) here:

https://codedotorg.atlassian.net/browse/SL-375