### PR TITLE
Fix applitools OS version

### DIFF
--- a/dashboard/test/ui/features/step_definitions/eyes_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/eyes_steps.rb
@@ -71,8 +71,5 @@ def ensure_eyes_available
   return if @eyes
   @eyes = Applitools::Selenium::Eyes.new
   @eyes.api_key = CDO.applitools_eyes_api_key
-  # Force eyes to use a consistent host OS identifier for now
-  # BrowserStack was reporting Windows 6.0 and 6.1, causing different baselines
-  @eyes.host_os = ENV['APPLITOOLS_HOST_OS']
   @eyes.log_handler = Logger.new('../../log/eyes.log')
 end

--- a/dashboard/test/ui/runner.rb
+++ b/dashboard/test/ui/runner.rb
@@ -728,10 +728,6 @@ def run_feature(browser, feature, options)
   run_environment['SKIP_I18N_INIT'] = 'true'
   run_environment['SKIP_DASHBOARD_ENABLE_PEGASUS'] = 'true'
 
-  # Force Applitools eyes to use a consistent host OS identifier for now
-  # BrowserStack was reporting Windows 6.0 and 6.1, causing different baselines
-  run_environment['APPLITOOLS_HOST_OS'] = browser['name'] ? "#{browser['platformName']} #{browser['platformVersion']}" : 'Windows 6x'
-
   max_reruns = how_many_reruns?(test_run_string)
 
   html_log = html_output_filename(test_run_string, options)

--- a/dashboard/test/ui/runner.rb
+++ b/dashboard/test/ui/runner.rb
@@ -730,7 +730,7 @@ def run_feature(browser, feature, options)
 
   # Force Applitools eyes to use a consistent host OS identifier for now
   # BrowserStack was reporting Windows 6.0 and 6.1, causing different baselines
-  run_environment['APPLITOOLS_HOST_OS'] = browser['mobile'] ? 'iOS 11.3' : 'Windows 6x'
+  run_environment['APPLITOOLS_HOST_OS'] = browser['name'] ? "#{browser['platformName']} #{browser['platformVersion']}" : 'Windows 6x'
 
   max_reruns = how_many_reruns?(test_run_string)
 


### PR DESCRIPTION
~~Not exactly sure why we do this, but we explicitly set the iOS version for Applitools. Noticed that it showing 11.3 even after updating iOS version in Saucelabs per [this PR](https://github.com/code-dot-org/code-dot-org/pull/48481). Updating now that iPhone uses 15.4.~~

Currently, we manually set the OS shown in Applitools, which is incorrect (we're on Windows 10, not 6):

![image](https://user-images.githubusercontent.com/25372625/201170766-9118614b-d63a-49c8-8985-e71afc5065e9.png)

Looks like this override was here for "Browserstack", which looks like a competitor to Saucelabs that we no longer use. Removing this config.

## Testing story

Ran a [iPhone](https://eyes.applitools.com/app/test-results/00000251734365327849/?accountId=mG4DoRfv0ntEgI3XIYBulrKxlZqrHtGwbP3V103ojvLFU110) and [Chrome](https://eyes.applitools.com/app/test-results/00000251734364844735/?accountId=mG4DoRfv0ntEgI3XIYBulrKxlZqrHtGwbP3V103ojvLFU110) eyes test and saw the correct OS versions displayed in Applitools.