### PR TITLE
Update URL for Bramble S3 object to remove "indianred" suggestion in WebLab

### DIFF
--- a/dashboard/app/controllers/weblab_host_controller.rb
+++ b/dashboard/app/controllers/weblab_host_controller.rb
@@ -1,7 +1,7 @@
 class WeblabHostController < ApplicationController
   layout false
 
-  BRAMBLE_URL = 'https://downloads.computinginthecore.org/bramble_0.1.30'
+  BRAMBLE_URL = 'https://downloads.computinginthecore.org/bramble_0.1.31'
   BRAMBLE_LOCALHOST_URL = 'http://127.0.0.1:8000/src'
 
   def index


### PR DESCRIPTION
The following change, when merged, will remove "indianred" from the list of color suggestions in WebLab. The change involves updating the Bramble version to 0.1.31 by pointing the BRAMBLE_URL at the new bucket. The code hints in Bramble were modified to remove "indianred" from the list of colors it is aware of (specified with a constant).

## Links

Jira ticket: [https://codedotorg.atlassian.net/browse/SL-285](https://codedotorg.atlassian.net/browse/SL-285)

## Testing story

Automated tests are not included in the CDO PR because the responsibility for generating/rendering the indianred suggestion lies with Bramble. Manual tests show that the suggestion has been removed as expected (see screenshots below).

**Before Bramble update**

Indianred is a suggestion for both "indi" and "red",
<img width="1254" alt="Screen Shot 2022-11-07 at 4 31 31 PM" src="https://user-images.githubusercontent.com/26844240/200637179-8487a7d2-ec6a-4263-9cf1-e403101e62fa.png">
<img width="1244" alt="Screen Shot 2022-11-07 at 4 31 41 PM" src="https://user-images.githubusercontent.com/26844240/200637344-cdee335b-e25f-42fb-86c8-69acb31487c1.png">

And indianred is a valid selection (note: this will still be true).
<img width="1240" alt="Screen Shot 2022-11-07 at 4 31 50 PM" src="https://user-images.githubusercontent.com/26844240/200637413-fb741715-3404-402d-bcd0-7d67ba562c10.png">

**After Bramble update**

Indianred is no longer suggested,
<img width="1252" alt="Screen Shot 2022-11-07 at 4 30 45 PM" src="https://user-images.githubusercontent.com/26844240/200637591-b6af5c62-3986-44f1-94c9-b0e0ed7f45f1.png">
<img width="1243" alt="Screen Shot 2022-11-07 at 4 32 11 PM" src="https://user-images.githubusercontent.com/26844240/200637541-2cca0321-5d8c-4fda-8ba7-7f7a92ae0733.png">

But indianred is still a valid selection.
<img width="1243" alt="Screen Shot 2022-11-07 at 4 31 06 PM" src="https://user-images.githubusercontent.com/26844240/200637714-df3e3167-1ff8-4a58-ba97-3d28d099a0e7.png">


## Follow-up work

Further work could be done to improve unit testing in Bramble; however, the Student Learning team is currently brainstorming ways to replace Bramble in WebLab, so no ticket has been filed at this time. 

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
