### PR TITLE
[Google Blockly] Remove padding in blocks rendered to read only workspaces in Dance

### DIFF
--- a/apps/src/block_utils.js
+++ b/apps/src/block_utils.js
@@ -346,7 +346,7 @@ exports.mathBlockXml = function(type, inputs, titles) {
 };
 
 /**
- * Generate xml for a functional defintion
+ * Generate xml for a functional definition
  * @param {string} name The name of the function
  * @param {string} outputType Function's output type
  * @param {Object<string, string>[]} argList Name and type for each arg

--- a/apps/src/blockly/addons/cdoXml.js
+++ b/apps/src/blockly/addons/cdoXml.js
@@ -98,7 +98,7 @@ export default function initializeBlocklyXml(blocklyWrapper) {
         // Position RTLs with coordinates from the left.
         block.x = viewWidth - block.x;
       }
-      // Adjust for Svg Frames for function defintion blocks
+      // Adjust for Svg Frames for function definition blocks
       if (!blockSpace.RTL) {
         block.x += frameSvgMargin;
       } else {

--- a/apps/src/blockly/addons/cdoXml.js
+++ b/apps/src/blockly/addons/cdoXml.js
@@ -67,17 +67,22 @@ export default function initializeBlocklyXml(blocklyWrapper) {
     const blockWidth = blocks[0]
       ? blocks[0].blockly_block.getHeightWidth().width
       : 0;
-    const padding = 16;
+    // Add padding if we are in a workspace.
+    const padding = viewWidth ? 16 : 0;
     const verticalSpaceBetweenBlocks = 10;
 
+    // The cursor is used to position blocks that don't have explicit x/y coordinates
     let cursor = {
-      x: blockSpace.RTL
-        ? viewWidth
-          ? viewWidth - padding
-          : blockWidth + padding
-        : padding,
+      x: padding,
       y: padding
     };
+    if (blockSpace.RTL && viewWidth) {
+      // Position the cursor from the right of the workspace.
+      cursor.x = viewWidth - padding;
+    } else if (blockSpace.RTL && !viewWidth) {
+      // Position the cursor from the right of the block.
+      cursor.x = blockWidth - padding;
+    }
 
     const positionBlock = function(block) {
       const heightWidth = block.blockly_block.getHeightWidth();
@@ -86,14 +91,19 @@ export default function initializeBlocklyXml(blocklyWrapper) {
       const frameSvgTop = hasFrameSvg ? 35 : 0;
       const frameSvgMargin = hasFrameSvg ? 16 : 0;
 
+      // If the block doesn't already have coordinates, use the cursor.
       if (isNaN(block.x)) {
         block.x = cursor.x;
-      } else {
-        block.x = blockSpace.RTL ? viewWidth - block.x : block.x;
+      } else if (blockSpace.RTL) {
+        // Position RTLs with coordinates from the left.
+        block.x = viewWidth - block.x;
       }
-      blockSpace.RTL
-        ? (block.x -= frameSvgMargin)
-        : (block.x += frameSvgMargin);
+      // Adjust for Svg Frames for function defintion blocks
+      if (!blockSpace.RTL) {
+        block.x += frameSvgMargin;
+      } else {
+        block.x -= frameSvgMargin;
+      }
 
       if (isNaN(block.y)) {
         block.y = cursor.y + frameSvgTop;

--- a/apps/src/blockly/googleBlocklyWrapper.js
+++ b/apps/src/blockly/googleBlocklyWrapper.js
@@ -518,13 +518,13 @@ function initializeBlocklyWrapper(blocklyInstance) {
     trashcan.init();
 
     if (options.useModalFunctionEditor) {
-      // Customize auto-populated Functions toolbox category
+      // Customize auto-populated Functions toolbox category.
       workspace.registerToolboxCategoryCallback(
         'PROCEDURE',
         functionsFlyoutCategory
       );
     }
-    // Customize function defintion blocks
+    // Customize function definition blocks.
     Blockly.blockly_.Blocks['procedures_defnoreturn'].init =
       FUNCTION_BLOCK.init;
     return workspace;

--- a/apps/src/lib/util/audioApi.js
+++ b/apps/src/lib/util/audioApi.js
@@ -1,5 +1,5 @@
 /* globals appOptions */
-/** @file Droplet-friendly command defintions for audio commands. */
+/** @file Droplet-friendly command definitions for audio commands. */
 import * as assetPrefix from '@cdo/apps/assetManagement/assetPrefix';
 import {apiValidateType, OPTIONAL, outputWarning} from './javascriptMode';
 import i18n from '@cdo/locale';

--- a/apps/src/lib/util/timeoutApi.js
+++ b/apps/src/lib/util/timeoutApi.js
@@ -1,5 +1,5 @@
 /**
- * @file Droplet-friendly command defintions for timeout and
+ * @file Droplet-friendly command definitions for timeout and
  * interval commands (shared between App Lab and Game Lab).
  */
 import * as apiTimeoutList from './timeoutList';

--- a/apps/test/integration/levelTests.js
+++ b/apps/test/integration/levelTests.js
@@ -49,7 +49,7 @@ var example = {
   levelFile: 'levels',
   // id of the level within the levels file
   levelId: '5_5',
-  // a complete level defintion, can be used instead of levelFile/levelId
+  // a complete level definition, can be used instead of levelFile/levelId
   levelDefinition: {},
   // a set of tests
   tests: [

--- a/tools/scripts/convertScssToJs.js
+++ b/tools/scripts/convertScssToJs.js
@@ -14,7 +14,7 @@ var cachedVariables = {};
 
 // In color.scss some variable definitions reference previous
 // variable definitions.  Since we're reading them in order,
-// we can recursively resolve these referential defintions
+// we can recursively resolve these referential definitions
 // until we land on an actual variable.
 function resolveVariable(value) {
   while (/^\$/.test(value)) {


### PR DESCRIPTION
Blocks in instructions cut off on https://studio.code.org/s/dance-2019/lessons/1/levels/1?blocklyVersion=Google
During a Dance Party bug bash, it was discovered that in-line blocks in instructions were being cut off. This was due to a 16px `padding` value, typically used to for positioning blocks within the main workspace.
![image](https://user-images.githubusercontent.com/43474485/200667966-c35652cc-ea7e-49be-bde6-200410bbe017.png)

![image](https://user-images.githubusercontent.com/43474485/200666853-0047d3ae-261e-4d94-ba4d-f5236223401e.png)
![image](https://user-images.githubusercontent.com/43474485/200669398-7ee40084-de8e-4034-9ca7-b31dbef5dfac.png)


This space was last touched here: 
- https://github.com/code-dot-org/code-dot-org/pull/48137

The changes here allow `padding` to be 0 if there's no `mainBlockSpace`. This ensures that the block fits inside the SVGs as expected if they're in a read only blockspace. I also refactored some nasty nested ternary logic to be hopefully more readable and added some comments. (Every time I've had to touch this file I've started by getting really confused about what it was even doing!)

I checked for this to fix the reported in issue in several Dance levels using the Google Blockly flag and also looked for regressions. Cases I considered include:
* Blocks rendered in-line within text in instructions/hint
* Blocks on their own line within text in instructions/hint
* Standard blocks on the workspace.
* Blocks with SVG frames (ie. function definitions) on the workspace.
* All of the cases as they appear in RTL mode

## Screenshots

### LTR

http://localhost-studio.code.org:3000/s/dance-2019/lessons/1/levels/1?blocklyVersion=Google
<img width="984" alt="image" src="https://user-images.githubusercontent.com/43474485/200668083-719e5e87-cc9f-42b8-802b-3a45b94c6bf1.png">
http://localhost-studio.code.org:3000/s/dance-2019/lessons/1/levels/4?blocklyVersion=Google
<img width="987" alt="image" src="https://user-images.githubusercontent.com/43474485/200669024-f146afd4-0941-43df-a705-c685fd7e9d83.png">
http://localhost-studio.code.org:3000/flappy/1
<img width="989" alt="image" src="https://user-images.githubusercontent.com/43474485/200668218-56e9ec01-8e4a-4f44-ad91-e5b85a47f7c8.png">
http://localhost-studio.code.org:3000/s/poem-art-2021/lessons/1/levels/1
<img width="992" alt="image" src="https://user-images.githubusercontent.com/43474485/200668268-62e37443-57de-413c-993d-676059239074.png">
<img width="623" alt="image" src="https://user-images.githubusercontent.com/43474485/200668329-e16260a8-53df-4cee-a6c9-4daf79048e2c.png">

### RTL

http://localhost-studio.code.org:3000/s/dance-2019/lessons/1/levels/1?blocklyVersion=Google&lang=ar-SA
<img width="988" alt="image" src="https://user-images.githubusercontent.com/43474485/200668627-1e43921e-9ece-4c6e-b10a-0d5db187a2b4.png">
http://localhost-studio.code.org:3000/s/dance-2019/lessons/1/levels/4?blocklyVersion=Google&lang=ar-SA
<img width="989" alt="image" src="https://user-images.githubusercontent.com/43474485/200668573-798060e1-a546-49f0-b3ca-245679f26a9a.png">
http://localhost-studio.code.org:3000/flappy/1?lang=ar-SA
<img width="988" alt="image" src="https://user-images.githubusercontent.com/43474485/200668694-102ab426-6a5b-49fd-b290-71851bd089a8.png">
http://localhost-studio.code.org:3000/s/poem-art-2021/lessons/1/levels/1?lang=ar-SA
<img width="986" alt="image" src="https://user-images.githubusercontent.com/43474485/200668742-21903f72-b7ff-418c-b87f-60484df4a5a2.png">
<img width="725" alt="image" src="https://user-images.githubusercontent.com/43474485/200668807-cdcd8726-f86b-402a-ae56-950f0a5c1cb1.png">



## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
