### PR TITLE
Add "After school program" to HoC.com dropdown

### DIFF
--- a/apps/src/sites/hourofcode.com/pages/public/index.js
+++ b/apps/src/sites/hourofcode.com/pages/public/index.js
@@ -46,7 +46,6 @@ function schoolDropdownOnChange(field, event) {
 }
 
 $(document).ready(function() {
-  console.log('im getting here!');
   const hocEventLocationElement = document.getElementById(
     'hoc-event-location-selector'
   );

--- a/apps/src/sites/hourofcode.com/pages/public/index.js
+++ b/apps/src/sites/hourofcode.com/pages/public/index.js
@@ -126,8 +126,7 @@ $(document).ready(function() {
       $('#continue-btn').hide();
       $('#submit-btn').show();
     } else if (
-      $('#hoc-event-type').val() === 'out_of_school' ||
-      $('#hoc-event-type').val() === 'after_school'
+      ['out_of_school', 'after_school'].includes($('#hoc-event-type').val())
     ) {
       // out of school, either US or non-US
       $('#school-autocomplete').hide();
@@ -244,10 +243,7 @@ function validateFields() {
     $('#event-type-error').hide();
   }
 
-  if (
-    $('#hoc-event-type').val() === 'out_of_school' ||
-    $('#hoc-event-type').val() === 'after_school'
-  ) {
+  if (['out_of_school', 'after_school'].includes($('#hoc-event-type').val())) {
     if ($('#organization-name').val() === '') {
       $('#organization-name-error').show();
       return false;

--- a/apps/src/sites/hourofcode.com/pages/public/index.js
+++ b/apps/src/sites/hourofcode.com/pages/public/index.js
@@ -128,7 +128,8 @@ $(document).ready(function() {
     } else if (
       ['out_of_school', 'after_school'].includes($('#hoc-event-type').val())
     ) {
-      // out of school, either US or non-US
+      // out of school (Organization/Company) and after school (After School Program),
+      // either US or non-US, require the same fields
       $('#school-autocomplete').hide();
       $('#organization-name-field').show();
       $('#hoc-event-location-field').show();

--- a/apps/src/sites/hourofcode.com/pages/public/index.js
+++ b/apps/src/sites/hourofcode.com/pages/public/index.js
@@ -46,6 +46,7 @@ function schoolDropdownOnChange(field, event) {
 }
 
 $(document).ready(function() {
+  console.log('im getting here!');
   const hocEventLocationElement = document.getElementById(
     'hoc-event-location-selector'
   );
@@ -125,7 +126,10 @@ $(document).ready(function() {
       $('#hoc-entire-school').show();
       $('#continue-btn').hide();
       $('#submit-btn').show();
-    } else if ($('#hoc-event-type').val() === 'out_of_school') {
+    } else if (
+      $('#hoc-event-type').val() === 'out_of_school' ||
+      $('#hoc-event-type').val() === 'after_school'
+    ) {
       // out of school, either US or non-US
       $('#school-autocomplete').hide();
       $('#organization-name-field').show();
@@ -241,7 +245,10 @@ function validateFields() {
     $('#event-type-error').hide();
   }
 
-  if ($('#hoc-event-type').val() === 'out_of_school') {
+  if (
+    $('#hoc-event-type').val() === 'out_of_school' ||
+    $('#hoc-event-type').val() === 'after_school'
+  ) {
     if ($('#organization-name').val() === '') {
       $('#organization-name-error').show();
       return false;

--- a/pegasus/forms/hoc_signup_2022.rb
+++ b/pegasus/forms/hoc_signup_2022.rb
@@ -4,6 +4,39 @@ require pegasus_dir 'forms/hoc_signup_2020'
 # Most of the logic hasn't changed since the 2017 form, but the 2020 form added
 # support for "at_home" as an event type.
 class HocSignup2022 < HocSignup2020
+  def self.normalize(data)
+    Honeybadger.context({data: data})
+    result = {}
+    result[:email_s] = required email_address data[:email_s]
+    result[:name_s] = required stripped data[:name_s]
+    result[:organization_name_s] = stripped data[:organization_name_s]
+    result[:event_type_s] = required enum(data[:event_type_s].to_s.strip.downcase, ['in_school', 'after_school', 'out_of_school', 'at_home'])
+    result[:entire_school_flag_b] = stripped data[:entire_school_flag_b]
+    result[:send_posters_flag_b] = stripped data[:send_posters_flag_b]
+    result[:send_posters_address_s] = stripped data[:send_posters_address_s]
+    result[:special_event_flag_b] = stripped data[:special_event_flag_b]
+    result[:special_event_details_s] = stripped data[:special_event_details_s]
+    result[:match_volunteer_flag_b] = stripped data[:match_volunteer_flag_b]
+    result[:hoc_country_s] = required enum(data[:hoc_country_s].to_s.strip.downcase, HOC_COUNTRIES.keys)
+    result[:hoc_company_s] = nil_if_empty data[:hoc_company_s]
+
+    # If the user's school is not found via the school dropdown
+    # we still need to require location for US in school events to match
+    # to NCES id for census data.
+    result[:event_location_s] =
+      if result[:event_type_s] == 'in_school' && result[:hoc_country_s] == 'US'
+        required stripped data[:event_location_s]
+      else
+        stripped data[:event_location_s]
+      end
+
+    result[:nces_school_s] = data[:nces_school_s]
+    result[:school_name_s] = data[:school_name_s]
+    result[:hoc_event_country_s] = data[:hoc_event_country_s]
+    result[:email_preference_opt_in_s] = required enum(data[:email_preference_opt_in_s].to_s.strip.downcase, ['yes', 'no'])
+    result
+  end
+
   def self.receipt(data)
     country = data["hoc_event_country_s"].downcase unless data["hoc_event_country_s"].nil_or_empty?
     if %w(ar bo cl co cr cu do ec gq gt hn mx ni pa pe pr py sv uy ve).include? country

--- a/pegasus/forms/hoc_signup_2022.rb
+++ b/pegasus/forms/hoc_signup_2022.rb
@@ -1,8 +1,8 @@
 require pegasus_dir 'forms/hoc_signup_2020'
 
 # HOC Sign up form for 2022.
-# Most of the logic hasn't changed since the 2017 form, but the 2020 form added
-# support for "at_home" as an event type.
+# Most of the logic hasn't changed since the 2020 form, but the 2022 form added support for "after_school" as an event type,
+# requiring we override the normalize() function to include it in the event_type_s validation (see below).
 class HocSignup2022 < HocSignup2020
   def self.normalize(data)
     Honeybadger.context({data: data})

--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -465,6 +465,7 @@
   signup_send_posters_address_placeholder: 'This address will not be shared on our map'
 
   signup_event_type_in_school: 'School'
+  signup_event_type_after_school: 'After school program'
   signup_event_type_out_of_school: 'Organization/Company'
   signup_event_type_at_home: 'Home'
 

--- a/pegasus/sites.v3/hourofcode.com/views/signup_form.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/signup_form.haml
@@ -50,7 +50,7 @@
         %div
           %select#hoc-event-type.form-control{name: "event_type_s", type: "select"}
             %option{value: nil, selected: true}
-            -%w(in_school out_of_school at_home).each do |event_type|
+            -%w(in_school after_school out_of_school at_home).each do |event_type|
               %option{value: event_type}= hoc_s('signup_event_type_' + event_type)
         #event-type-error.error-message{style: "display:none;"}
           = hoc_s(:signup_event_type_error)


### PR DESCRIPTION
The following PR adds "After school program” as an option to the “Event type” dropdown on www.hourofcode.com, and (I think) ensures the string gets into the translation pipeline.

TODO:
- [x] Verify work in this PR is sufficient for translation (thanks @wilkie!)
- [x] Determine if other testing steps are needed (thanks most of Student Learning and half of Infra!)

## Links

Jira ticket: [https://codedotorg.atlassian.net/browse/SL-357](https://codedotorg.atlassian.net/browse/SL-357)

## Testing story

Tested on http://localhost.hourofcode.com:3000/ by setting `DCDO.hoc_year` to 2022 and confirming that a new submission appeared in `pegasus_development.forms` with the appropriate `event_type_s`. 

<img width="643" alt="Screen Shot 2022-11-08 at 4 14 56 PM" src="https://user-images.githubusercontent.com/26844240/200705130-be20903d-7199-4426-8c44-27a771d55fb4.png">

It appears the language will fall back to English until translations are added.

<img width="647" alt="Screen Shot 2022-11-08 at 3 47 04 PM" src="https://user-images.githubusercontent.com/26844240/200705168-1e801506-e80a-4d7f-b90d-a78815ab4b9e.png">

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
