### PR TITLE
Fix delete action in Google Blockly labs

### DIFF
--- a/apps/src/blockly/googleBlocklyWrapper.js
+++ b/apps/src/blockly/googleBlocklyWrapper.js
@@ -273,8 +273,8 @@ function initializeBlocklyWrapper(blocklyInstance) {
   };
 
   const googleBlocklyDispose = blocklyWrapper.BlockSvg.prototype.dispose;
-  blocklyWrapper.BlockSvg.prototype.dispose = function() {
-    googleBlocklyDispose.call(this);
+  blocklyWrapper.BlockSvg.prototype.dispose = function(healStack, animate) {
+    googleBlocklyDispose.call(this, healStack, animate);
     this.removeUnusedBlockFrame();
   };
 

--- a/apps/src/blockly/googleBlocklyWrapper.js
+++ b/apps/src/blockly/googleBlocklyWrapper.js
@@ -272,7 +272,11 @@ function initializeBlocklyWrapper(blocklyInstance) {
     this.removeUnusedBlockFrame();
   };
 
+  // overridden dispose function definition at https://github.com/google/blockly/blob/develop/core/block_svg.ts#L863
   const googleBlocklyDispose = blocklyWrapper.BlockSvg.prototype.dispose;
+  // if param healStack is true, then tries to heal any gap by connecting the next
+  // statement with the previous statement
+  // if param animate is true, shows a disposal animation and sound
   blocklyWrapper.BlockSvg.prototype.dispose = function(healStack, animate) {
     googleBlocklyDispose.call(this, healStack, animate);
     this.removeUnusedBlockFrame();


### PR DESCRIPTION
Currently in our Google Blockly labs (like Poetry) if a user deletes a block, the next blocks are also removed. This is undesirable behavior and is different from what happens in CDO Blockly labs and in the Google Blockly playground. In the latter labs, if a user deletes a block, only the block and its child blocks (but not its next blocks) are removed.
In order to change this behavior, the `healStack` and `animate` parameters were added as expected arguments in the override of the dispose function. 

This was also impacting the cut action when using the [Google cross tab copy/cut/paste plugin](https://github.com/code-dot-org/code-dot-org/pull/48997) in that when a user 'cuts' a block, the next blocks were also deleted even though the next blocks were NOT included in the paste action.

Once this PR is merged, it will fix the behavior for the cut/paste actions with the plugin.

Screencast video before update:

https://user-images.githubusercontent.com/107423305/200917804-07b144e7-389f-4073-8efd-2a67971eea95.mp4


Screencast video after update:

https://user-images.githubusercontent.com/107423305/200917857-3d77e8f7-ada2-4be5-a209-b03625161e4a.mp4


<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links
[jira ticket - Fix delete action in Google Blockly labs](https://codedotorg.atlassian.net/browse/SL-388)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
I tested locally on one of our Google Blockly labs. We are planning to add integration tests for functions that override Google Blockly functions, but we would like to merge this bug fix before Dance party migrates from CDO Blockly to Google Blockly. 

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
