### PR TITLE
Handle localized view markdown templates in pegasus and the sync.

### DIFF
--- a/bin/i18n/codeorg-testing_markdown_crowdin.yml
+++ b/bin/i18n/codeorg-testing_markdown_crowdin.yml
@@ -1,0 +1,12 @@
+"project_identifier" : "codeorg-markdown-testing"
+"project_id" : "547997"
+"base_path" : ""
+
+# API Credentials must be loaded from a separate identity file. See
+# https://support.crowdin.com/configuration-file/#split-project-configuration-and-api-credentials
+"api_key" : ""
+
+files: [{
+  "source": "/i18n/locales/source/markdown/**/*.md",
+  "translation": "/pegasus/sites.v3/code.org/i18n/**/%file_name%.%locale%.md.partial",
+  }]

--- a/bin/i18n/i18n_script_utils.rb
+++ b/bin/i18n/i18n_script_utils.rb
@@ -41,6 +41,12 @@ CROWDIN_TEST_PROJECTS = {
     identity_file: File.join(File.dirname(__FILE__), "crowdin_credentials.yml"),
     etags_json: File.join(File.dirname(__FILE__), "crowdin", "codeorg-testing_etags.json"),
     files_to_sync_out_json: File.join(File.dirname(__FILE__), "crowdin", "codeorg-testing_files_to_sync_out.json")
+  },
+  "codeorg-markdown-testing": {
+    config_file: File.join(File.dirname(__FILE__), "codeorg-testing_markdown_crowdin.yml"),
+    identity_file: File.join(File.dirname(__FILE__), "crowdin_credentials.yml"),
+    etags_json: File.join(File.dirname(__FILE__), "crowdin", "codeorg-testing_markdown_etags.json"),
+    files_to_sync_out_json: File.join(File.dirname(__FILE__), "crowdin", "codeorg-testing_markdown_files_to_sync_out.json")
   }
 }
 

--- a/bin/i18n/sync-down.rb
+++ b/bin/i18n/sync-down.rb
@@ -37,7 +37,7 @@ def sync_down
       # download strings not in the regular codeorg project to
       # a specific subdirectory within the locale directory
       case name.to_s
-      when "codeorg-markdown"
+      when "codeorg-markdown-testing", "codeorg-markdown"
         options[:locale_subdir] = "codeorg-markdown"
       when "hour-of-code"
         options[:locale_subdir] = "hourofcode"

--- a/bin/i18n/sync-in.rb
+++ b/bin/i18n/sync-in.rb
@@ -647,12 +647,19 @@ def localize_markdown_content
     hourofcode/unplugged-conditionals-with-cards.md.partial
     international/about.md.partial
     poetry.md.partial
+    ../views/hoc2022_create_activities.md.partial
+    ../views/hoc2022_play_activities.md.partial
+    ../views/hoc2022_explore_activities.md.partial
   ]
   markdown_files_to_localize.each do |path|
     original_path = File.join('pegasus/sites.v3/code.org/public', path)
     original_path_exists = File.exist?(original_path)
     puts "#{original_path} does not exist" unless original_path_exists
     next unless original_path_exists
+    # This reforms the `../` relative paths so they appear as though they are
+    # within the `public` path. This is a legacy solution to keep things clean
+    # when viewed by the translators in crowdin.
+    path = path[3...] if path.start_with? "../"
     # Remove the .partial if it exists
     source_path = File.join(I18N_SOURCE_DIR, 'markdown/public', File.dirname(path), File.basename(path, '.partial'))
     FileUtils.mkdir_p(File.dirname(source_path))

--- a/bin/i18n/sync-out.rb
+++ b/bin/i18n/sync-out.rb
@@ -445,6 +445,9 @@ def distribute_translations(upload_manifests)
       next unless file_changed?(locale, relative_path)
 
       destination_dir = "pegasus/sites.v3/code.org/i18n/public"
+      # The `views` path is actually outside of the `public` path, so when we
+      # see such files, we make sure we restore the `/..` to the destination.
+      destination_dir << "/.." if relative_path.start_with? "/views"
       relative_dir = File.dirname(relative_path)
       name = File.basename(loc_file, ".*")
       destination = File.join(destination_dir, relative_dir, "#{name}.#{locale}.md.partial")

--- a/lib/cdo/crowdin/client_extentions.rb
+++ b/lib/cdo/crowdin/client_extentions.rb
@@ -12,7 +12,8 @@ module Crowdin
       'hour-of-code' => 55536,
       'codeorg-markdown' => 314545,
       'codeorg-restricted' => 464582,
-      'codeorg-testing' => 346087
+      'codeorg-testing' => 346087,
+      'codeorg-markdown-testing' => 547997
     }
 
     CDO_PROJECT_SOURCE_LANGUAGES = {

--- a/lib/cdo/crowdin/legacy_utils.rb
+++ b/lib/cdo/crowdin/legacy_utils.rb
@@ -57,7 +57,7 @@ module Crowdin
       languages.each_with_index do |language, i|
         language_code = language["id"]
         @logger.debug("#{language['name']} (#{language_code}): #{i}/#{num_languages}")
-        @logger.info("~#{(i * 100 / num_languages).round(-1)}% complete (#{i}/#{num_languages})") if i > 0 && i % (num_languages / 5) == 0
+        @logger.info("~#{(i * 100 / num_languages).round(-1)}% complete (#{i}/#{num_languages})") if i > 0 && i % [num_languages / 5, 1].max == 0
 
         etags[language_code] ||= {}
         # construct download directory; locale_subdir is optional, so compact

--- a/pegasus/router.rb
+++ b/pegasus/router.rb
@@ -447,7 +447,12 @@ class Documents < Sinatra::Base
     def resolve_template(subdir, extnames, uri, is_document = false)
       dirs = is_document ? @dirs - [@config[:base_no_documents]] : @dirs
       dirs.each do |dir|
-        found = MultipleExtnameFileUtils.find_with_extnames(content_dir(dir, subdir), uri, extnames)
+        # Negotiate for a locale specific partial
+        found = []
+        ["#{uri}.#{request.locale}", uri].each do |search_uri|
+          found = MultipleExtnameFileUtils.find_with_extnames(content_dir(dir, subdir), search_uri, extnames)
+          break unless found.empty?
+        end
         return found.first unless found.empty?
       end
 


### PR DESCRIPTION
**What**: Return locale specific view template, if exists, in pegasus.

**How**: Add "views" markdown (by just referring to it as a relative path via `../` and then removing that `../` to make it seem like it was inside `public` all along... ugh)

**Why**: https://code.org/hourofcode2022 is not being translated (the cards describing different labs)

We want to make sure that the 'views' markdown exists as a sub-directory so that it won't interfere with the existing `public` markdown from the pegasus directory while we translate the views paths. It is messy.

This allows localized view templates to exist and be used on certain pages.

This does add a markdown testing crowdin repository.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

Did a test sync using the newly created markdown-testing project. Then manually set the keys and saw them rendered.

Here it is rendering with my silly strings:

![image](https://user-images.githubusercontent.com/31674/201172643-0d710980-195c-4ef1-a087-3cc17b77c95a.png)

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

Translations would need to be done and a sync up.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
