### PR TITLE
[Google Blockly] No modal input on mobile for FieldTextInput

### DIFF
--- a/apps/src/blockly/addons/cdoFieldAngle.js
+++ b/apps/src/blockly/addons/cdoFieldAngle.js
@@ -1,0 +1,6 @@
+import GoogleBlockly from 'blockly/core';
+import {noMobileShowEditorOverride} from './cdoFieldTextInput';
+
+export default class CdoFieldAngle extends GoogleBlockly.FieldNumber {
+  showEditor_ = noMobileShowEditorOverride;
+}

--- a/apps/src/blockly/addons/cdoFieldAngle.js
+++ b/apps/src/blockly/addons/cdoFieldAngle.js
@@ -1,6 +1,6 @@
 import GoogleBlockly from 'blockly/core';
 import {noMobileShowEditorOverride} from './cdoFieldTextInput';
 
-export default class CdoFieldAngle extends GoogleBlockly.FieldNumber {
+export default class CdoFieldAngle extends GoogleBlockly.FieldAngle {
   showEditor_ = noMobileShowEditorOverride;
 }

--- a/apps/src/blockly/addons/cdoFieldButton.js
+++ b/apps/src/blockly/addons/cdoFieldButton.js
@@ -3,7 +3,7 @@ import GoogleBlockly from 'blockly/core';
 const CORNER_RADIUS = 3;
 const INNER_HEIGHT = 16;
 
-export default class FieldButton extends GoogleBlockly.Field {
+export default class CdoFieldButton extends GoogleBlockly.Field {
   constructor(title, opt_buttonHandler, opt_color, opt_changeHandler) {
     super('');
 

--- a/apps/src/blockly/addons/cdoFieldDropdown.js
+++ b/apps/src/blockly/addons/cdoFieldDropdown.js
@@ -2,7 +2,7 @@ import GoogleBlockly from 'blockly/core';
 
 const EMPTY_OPTION = '???';
 
-export default class FieldDropdown extends GoogleBlockly.FieldDropdown {
+export default class CdoFieldDropdown extends GoogleBlockly.FieldDropdown {
   static ARROW_CHAR = '\u25BC';
 
   /** Turn changeHandler into validator

--- a/apps/src/blockly/addons/cdoFieldMultilineInput.js
+++ b/apps/src/blockly/addons/cdoFieldMultilineInput.js
@@ -1,0 +1,6 @@
+import GoogleBlockly from 'blockly/core';
+import {noMobileShowEditorOverride} from './cdoFieldTextInput';
+
+export default class CdoFieldMultilineInput extends GoogleBlockly.FieldNumber {
+  showEditor_ = noMobileShowEditorOverride;
+}

--- a/apps/src/blockly/addons/cdoFieldMultilineInput.js
+++ b/apps/src/blockly/addons/cdoFieldMultilineInput.js
@@ -1,6 +1,6 @@
 import GoogleBlockly from 'blockly/core';
 import {noMobileShowEditorOverride} from './cdoFieldTextInput';
 
-export default class CdoFieldMultilineInput extends GoogleBlockly.FieldNumber {
+export default class CdoFieldMultilineInput extends GoogleBlockly.FieldMultilineInput {
   showEditor_ = noMobileShowEditorOverride;
 }

--- a/apps/src/blockly/addons/cdoFieldNumber.js
+++ b/apps/src/blockly/addons/cdoFieldNumber.js
@@ -1,11 +1,8 @@
 import GoogleBlockly from 'blockly/core';
+import {noMobileShowEditorOverride} from './cdoFieldTextInput';
 
 // override should probably be in cdoFieldTextInput, then subclass from that here
 // how do we make sure all FieldTextInput subclasses to have this customization though?
 export default class CdoFieldNumber extends GoogleBlockly.FieldNumber {
-  showEditor_(opt_event, opt_quietInput) {
-    this.workspace_ = this.sourceBlock_.workspace;
-    const quietInput = opt_quietInput || false;
-    this.showInlineEditor_(quietInput);
-  }
+  showEditor_ = noMobileShowEditorOverride;
 }

--- a/apps/src/blockly/addons/cdoFieldNumber.js
+++ b/apps/src/blockly/addons/cdoFieldNumber.js
@@ -1,8 +1,6 @@
 import GoogleBlockly from 'blockly/core';
 import {noMobileShowEditorOverride} from './cdoFieldTextInput';
 
-// override should probably be in cdoFieldTextInput, then subclass from that here
-// how do we make sure all FieldTextInput subclasses to have this customization though?
 export default class CdoFieldNumber extends GoogleBlockly.FieldNumber {
   showEditor_ = noMobileShowEditorOverride;
 }

--- a/apps/src/blockly/addons/cdoFieldNumber.js
+++ b/apps/src/blockly/addons/cdoFieldNumber.js
@@ -1,0 +1,11 @@
+import GoogleBlockly from 'blockly/core';
+
+// override should probably be in cdoFieldTextInput, then subclass from that here
+// how do we make sure all FieldTextInput subclasses to have this customization though?
+export default class CdoFieldNumber extends GoogleBlockly.FieldNumber {
+  showEditor_(opt_event, opt_quietInput) {
+    this.workspace_ = this.sourceBlock_.workspace;
+    const quietInput = opt_quietInput || false;
+    this.showInlineEditor_(quietInput);
+  }
+}

--- a/apps/src/blockly/addons/cdoFieldTextInput.js
+++ b/apps/src/blockly/addons/cdoFieldTextInput.js
@@ -1,0 +1,9 @@
+// import GoogleBlockly from 'blockly/core';
+//
+// export default class CdoFieldTextInput extends GoogleBlockly.FieldTextInput {
+//   showEditor_(opt_event, opt_quietInput) {
+//     this.workspace_ = this.sourceBlock_.workspace;
+//     const quietInput = opt_quietInput || false;
+//     this.showInlineEditor_(quietInput);
+//   }
+// }

--- a/apps/src/blockly/addons/cdoFieldTextInput.js
+++ b/apps/src/blockly/addons/cdoFieldTextInput.js
@@ -1,9 +1,14 @@
-// import GoogleBlockly from 'blockly/core';
-//
-// export default class CdoFieldTextInput extends GoogleBlockly.FieldTextInput {
-//   showEditor_(opt_event, opt_quietInput) {
-//     this.workspace_ = this.sourceBlock_.workspace;
-//     const quietInput = opt_quietInput || false;
-//     this.showInlineEditor_(quietInput);
-//   }
-// }
+import GoogleBlockly from 'blockly/core';
+
+// Override to prevent opening a mobile-specific editor.
+// Derived from logic here:
+// https://github.com/google/blockly/blob/34634ea57cd43dac9028f1a28e4beb761e60eef6/core/field_textinput.ts#L290-L292
+export function noMobileShowEditorOverride(opt_event, opt_quietInput) {
+  this.workspace_ = this.sourceBlock_.workspace;
+  const quietInput = opt_quietInput || false;
+  this.showInlineEditor_(quietInput);
+}
+
+export default class CdoFieldTextInput extends GoogleBlockly.FieldTextInput {
+  showEditor_ = noMobileShowEditorOverride;
+}

--- a/apps/src/blockly/addons/cdoFieldVariable.js
+++ b/apps/src/blockly/addons/cdoFieldVariable.js
@@ -4,7 +4,7 @@ import msg from '@cdo/locale';
 const RENAME_THIS_ID = 'RENAME_THIS_ID';
 const RENAME_ALL_ID = 'RENAME_ALL_ID';
 
-export default class FieldVariable extends GoogleBlockly.FieldVariable {
+export default class CdoFieldVariable extends GoogleBlockly.FieldVariable {
   /**
    * Handle the selection of an item in the variable dropdown menu.
    * Special case the 'Rename all' and 'Rename this' options to prompt the user
@@ -20,7 +20,7 @@ export default class FieldVariable extends GoogleBlockly.FieldVariable {
       switch (id) {
         case RENAME_ALL_ID:
           // Rename all instances of this variable.
-          FieldVariable.modalPromptName(
+          CdoFieldVariable.modalPromptName(
             msg.renameAllPromptTitle({variableName: oldVar}),
             msg.rename(),
             oldVar,
@@ -33,7 +33,7 @@ export default class FieldVariable extends GoogleBlockly.FieldVariable {
           break;
         case RENAME_THIS_ID:
           // Rename just this variable.
-          FieldVariable.modalPromptName(
+          CdoFieldVariable.modalPromptName(
             msg.renameThisPromptTitle(),
             msg.create(),
             '',
@@ -52,7 +52,7 @@ export default class FieldVariable extends GoogleBlockly.FieldVariable {
     }
   }
   menuGenerator_ = function() {
-    const options = FieldVariable.dropdownCreate.call(this);
+    const options = CdoFieldVariable.dropdownCreate.call(this);
 
     // Remove the last two options (Delete and Rename)
     options.pop();
@@ -76,7 +76,7 @@ export default class FieldVariable extends GoogleBlockly.FieldVariable {
  * @param {string} defaultText default input text for window prompt
  * @param {Function} callback with parameter (text) of new name
  */
-FieldVariable.modalPromptName = function(
+CdoFieldVariable.modalPromptName = function(
   promptText,
   confirmButtonLabel,
   defaultText,

--- a/apps/src/blockly/googleBlocklyWrapper.js
+++ b/apps/src/blockly/googleBlocklyWrapper.js
@@ -71,7 +71,7 @@ const BlocklyWrapper = function(blocklyInstance) {
   /**
    * Override core Blockly fields with Code.org customized versions,
    * and sets the field on our wrapper for use by our code.
-   * @param {array} fields (elements are arrays of shape [fieldRegistryName, fieldClassName, fieldClass])
+   * @param {array} overrides (elements are arrays of shape [fieldRegistryName, fieldClassName, fieldClass])
    */
   this.overrideFields = function(overrides) {
     overrides.forEach(override => {
@@ -179,6 +179,8 @@ function initializeBlocklyWrapper(blocklyInstance) {
   blocklyWrapper.wrapReadOnlyProperty('WorkspaceSvg');
   blocklyWrapper.wrapReadOnlyProperty('Xml');
 
+  // elements in this list should be structured as follows:
+  // [field registry name for field, class name of field being overridden, class to use as override]
   const fieldOverrides = [
     ['field_variable', 'FieldVariable', CdoFieldVariable],
     ['field_dropdown', 'FieldDropdown', CdoFieldDropdown],

--- a/apps/src/blockly/googleBlocklyWrapper.js
+++ b/apps/src/blockly/googleBlocklyWrapper.js
@@ -9,6 +9,7 @@ import initializeCdoConstants from './addons/cdoConstants';
 import CdoFieldButton from './addons/cdoFieldButton';
 import CdoFieldDropdown from './addons/cdoFieldDropdown';
 import {CdoFieldImageDropdown} from './addons/cdoFieldImageDropdown';
+import CdoFieldNumber from './addons/cdoFieldNumber';
 import CdoFieldVariable from './addons/cdoFieldVariable';
 import FunctionEditor from './addons/functionEditor';
 import initializeGenerator from './addons/cdoGenerator';
@@ -103,7 +104,7 @@ function initializeBlocklyWrapper(blocklyInstance) {
   blocklyWrapper.wrapReadOnlyProperty('FieldIcon');
   blocklyWrapper.wrapReadOnlyProperty('FieldImage');
   blocklyWrapper.wrapReadOnlyProperty('FieldLabel');
-  blocklyWrapper.wrapReadOnlyProperty('FieldNumber');
+  // blocklyWrapper.wrapReadOnlyProperty('FieldNumber');
   blocklyWrapper.wrapReadOnlyProperty('FieldParameter');
   blocklyWrapper.wrapReadOnlyProperty('FieldRectangularDropdown');
   blocklyWrapper.wrapReadOnlyProperty('FieldTextInput');
@@ -167,15 +168,25 @@ function initializeBlocklyWrapper(blocklyInstance) {
     'field_dropdown',
     CdoFieldDropdown
   );
+  // may want to override fieldnumber for standard blockly -- how do we make sure string is right?
+  // //  make sure this string is right
+  // blocklyWrapper.blockly_.fieldRegistry.unregister('field_text_input');
+  // blocklyWrapper.blockly_.fieldRegistry.register(
+  //   'field_text_input',
+  //   CdoFieldTextInput
+  // );
 
   // Overrides applied directly to core blockly
   blocklyWrapper.blockly_.FunctionEditor = FunctionEditor;
   blocklyWrapper.blockly_.Trashcan = CdoTrashcan;
 
+  // should these just be settable properties?
   // Additions for when our wrapper is accessed in /apps code
   blocklyWrapper.FieldButton = CdoFieldButton;
   blocklyWrapper.FieldDropdown = CdoFieldDropdown;
   blocklyWrapper.FieldImageDropdown = CdoFieldImageDropdown;
+  // blocklyWrapper.FieldTextInput = CdoFieldTextInput;
+  blocklyWrapper.FieldNumber = CdoFieldNumber;
   blocklyWrapper.FieldVariable = CdoFieldVariable;
 
   blocklyWrapper.blockly_.registry.register(

--- a/apps/src/blockly/googleBlocklyWrapper.js
+++ b/apps/src/blockly/googleBlocklyWrapper.js
@@ -69,21 +69,22 @@ const BlocklyWrapper = function(blocklyInstance) {
   };
 
   /**
-   * Overrides core Blockly fields with Code.org customized overrides,
+   * Override core Blockly fields with Code.org customized versions,
    * and sets the field on our wrapper for use by our code.
-   * @param {array} overrides (elements are arrays of shape [fieldName, fieldClass])
+   * @param {array} fields (elements are arrays of shape [fieldRegistryName, fieldClassName, fieldClass])
    */
   this.overrideFields = function(overrides) {
     overrides.forEach(override => {
-      const fieldName = override[0];
-      const fieldClass = override[1];
+      const fieldRegistryName = override[0];
+      const fieldClassName = override[1];
+      const fieldClass = override[2];
 
       // Force Google Blockly to use our custom versions of fields
-      this.blockly_.fieldRegistry.unregister(fieldName);
-      this.blockly_.fieldRegistry.register(fieldName, fieldClass);
+      this.blockly_.fieldRegistry.unregister(fieldRegistryName);
+      this.blockly_.fieldRegistry.register(fieldRegistryName, fieldClass);
 
       // Add each field for when our wrapper is accessed in /apps code
-      this[fieldName] = fieldClass;
+      this[fieldClassName] = fieldClass;
     });
   };
 };
@@ -179,14 +180,14 @@ function initializeBlocklyWrapper(blocklyInstance) {
   blocklyWrapper.wrapReadOnlyProperty('Xml');
 
   const fieldOverrides = [
-    ['field_variable', CdoFieldVariable],
-    ['field_dropdown', CdoFieldDropdown],
+    ['field_variable', 'FieldVariable', CdoFieldVariable],
+    ['field_dropdown', 'FieldDropdown', CdoFieldDropdown],
     // Overrides required for a customization of FieldTextInput
-    // and its child classes
-    ['field_input', CdoFieldTextInput],
-    ['field_number', CdoFieldNumber],
-    ['field_angle', CdoFieldAngle],
-    ['field_multilinetext', CdoFieldMultilineInput]
+    // and its child classes.
+    ['field_input', 'FieldTextInput', CdoFieldTextInput],
+    ['field_number', 'FieldNumber', CdoFieldNumber],
+    ['field_angle', 'FieldAngle', CdoFieldAngle],
+    ['field_multilinetext', 'FieldMultilineInput', CdoFieldMultilineInput]
   ];
   blocklyWrapper.overrideFields(fieldOverrides);
 

--- a/apps/src/blockly/googleBlocklyWrapper.js
+++ b/apps/src/blockly/googleBlocklyWrapper.js
@@ -10,6 +10,7 @@ import CdoFieldButton from './addons/cdoFieldButton';
 import CdoFieldDropdown from './addons/cdoFieldDropdown';
 import {CdoFieldImageDropdown} from './addons/cdoFieldImageDropdown';
 import CdoFieldNumber from './addons/cdoFieldNumber';
+import CdoFieldTextInput from './addons/cdoFieldTextInput';
 import CdoFieldVariable from './addons/cdoFieldVariable';
 import FunctionEditor from './addons/functionEditor';
 import initializeGenerator from './addons/cdoGenerator';
@@ -104,10 +105,8 @@ function initializeBlocklyWrapper(blocklyInstance) {
   blocklyWrapper.wrapReadOnlyProperty('FieldIcon');
   blocklyWrapper.wrapReadOnlyProperty('FieldImage');
   blocklyWrapper.wrapReadOnlyProperty('FieldLabel');
-  // blocklyWrapper.wrapReadOnlyProperty('FieldNumber');
   blocklyWrapper.wrapReadOnlyProperty('FieldParameter');
   blocklyWrapper.wrapReadOnlyProperty('FieldRectangularDropdown');
-  blocklyWrapper.wrapReadOnlyProperty('FieldTextInput');
   blocklyWrapper.wrapReadOnlyProperty('fish_locale');
   blocklyWrapper.wrapReadOnlyProperty('Flyout');
   blocklyWrapper.wrapReadOnlyProperty('FunctionalBlockUtils');
@@ -168,13 +167,17 @@ function initializeBlocklyWrapper(blocklyInstance) {
     'field_dropdown',
     CdoFieldDropdown
   );
-  // may want to override fieldnumber for standard blockly -- how do we make sure string is right?
-  // //  make sure this string is right
-  // blocklyWrapper.blockly_.fieldRegistry.unregister('field_text_input');
-  // blocklyWrapper.blockly_.fieldRegistry.register(
-  //   'field_text_input',
-  //   CdoFieldTextInput
-  // );
+  //  make sure this string is right
+  blocklyWrapper.blockly_.fieldRegistry.unregister('field_number');
+  blocklyWrapper.blockly_.fieldRegistry.register(
+    'field_number',
+    CdoFieldNumber
+  );
+  blocklyWrapper.blockly_.fieldRegistry.unregister('field_text_input');
+  blocklyWrapper.blockly_.fieldRegistry.register(
+    'field_text_input',
+    CdoFieldTextInput
+  );
 
   // Overrides applied directly to core blockly
   blocklyWrapper.blockly_.FunctionEditor = FunctionEditor;
@@ -185,8 +188,8 @@ function initializeBlocklyWrapper(blocklyInstance) {
   blocklyWrapper.FieldButton = CdoFieldButton;
   blocklyWrapper.FieldDropdown = CdoFieldDropdown;
   blocklyWrapper.FieldImageDropdown = CdoFieldImageDropdown;
-  // blocklyWrapper.FieldTextInput = CdoFieldTextInput;
   blocklyWrapper.FieldNumber = CdoFieldNumber;
+  blocklyWrapper.FieldTextInput = CdoFieldTextInput;
   blocklyWrapper.FieldVariable = CdoFieldVariable;
 
   blocklyWrapper.blockly_.registry.register(

--- a/apps/src/blockly/googleBlocklyWrapper.js
+++ b/apps/src/blockly/googleBlocklyWrapper.js
@@ -10,7 +10,7 @@ import CdoFieldAngle from './addons/cdoFieldAngle';
 import CdoFieldButton from './addons/cdoFieldButton';
 import CdoFieldDropdown from './addons/cdoFieldDropdown';
 import {CdoFieldImageDropdown} from './addons/cdoFieldImageDropdown';
-import CdoFieldMultilineInput from './addons/CdoFieldMultilineInput';
+import CdoFieldMultilineInput from './addons/cdoFieldMultilineInput';
 import CdoFieldNumber from './addons/cdoFieldNumber';
 import CdoFieldTextInput from './addons/cdoFieldTextInput';
 import CdoFieldVariable from './addons/cdoFieldVariable';

--- a/apps/test/unit/blockly/googleBlocklyWrapperTest.js
+++ b/apps/test/unit/blockly/googleBlocklyWrapperTest.js
@@ -53,7 +53,6 @@ describe('Google Blockly Wrapper', () => {
       'FieldLabel',
       'FieldParameter',
       'FieldRectangularDropdown',
-      'FieldTextInput',
       'fish_locale',
       'Flyout',
       'FunctionalBlockUtils',


### PR DESCRIPTION
We observed while bug bashing Google Blockly Dance Party on iPad that a new modal appeared when editing text fields (eg, the number in "after 4 measures" here:

https://studio.code.org/s/dance-2019/lessons/1/levels/4?blocklyVersion=Google

We also noticed that, after opening this modal, audio would no longer play after you hit "Run" until you refreshed the page.

This PR removes overrides the mobile-specific modal for all FieldTextInput fields (and applies this override to subclasses that are listed in the [Blockly docs](https://developers.google.com/blockly/reference/js/blockly)).

Also does a little refactor to make sure that every time we unregister/register a field for core Blockly, we also make it accessible to our code on the wrapper.

Strings representing each class in the field registry weren't listed in Google Blockly's docs, but Mike looked them up by searching for `fieldRegistry.register('` in their repo (thanks Mike!)

## Links

- jira ticket: [SL-364](https://codedotorg.atlassian.net/browse/SL-364)
- jira ticket: [SL-363](https://codedotorg.atlassian.net/browse/SL-363)

## Testing story

I tested via ngrok that the issue we observed on iPad no longer repros after this change on the level 4 link above. The field in "after 4 measures" is actually a `FieldNumber`, which subclasses `FieldTextInput`. I found an actual `FieldTextInput` on the project level for Dance (/projects/dance/new, with the google blockly URL param) in the name of a function block (by default, "do something") -- I was able to edit this without issue on my laptop/iPad.

