### PR TITLE
RP Landing Page Workshop Wording Updates

### DIFF
--- a/apps/src/templates/RegionalPartnerSearch.jsx
+++ b/apps/src/templates/RegionalPartnerSearch.jsx
@@ -137,6 +137,8 @@ class RegionalPartnerSearch extends Component {
 
     let workshopCollections = [
       {
+        key: 'CSD',
+        name: ActiveCourseWorkshops.CSD,
         heading: `${ActiveCourseWorkshops.CSD} Workshops`,
         workshops:
           partnerInfo &&
@@ -145,6 +147,8 @@ class RegionalPartnerSearch extends Component {
           )
       },
       {
+        key: 'CSP',
+        name: ActiveCourseWorkshops.CSP,
         heading: `${ActiveCourseWorkshops.CSP} Workshops`,
         workshops:
           partnerInfo &&
@@ -153,6 +157,8 @@ class RegionalPartnerSearch extends Component {
           )
       },
       {
+        key: 'CSA',
+        name: ActiveCourseWorkshops.CSA,
         heading: `${ActiveCourseWorkshops.CSA} Workshops`,
         workshops:
           partnerInfo &&
@@ -308,31 +314,58 @@ class RegionalPartnerSearch extends Component {
                   collection => collection.workshops.length === 0
                 ) &&
                   workshopCollections.map((collection, collectionIndex) => {
-                    // If the partner is not offering CSA workshops, we display a different message
-                    if (
-                      collection.workshops.length === 0 &&
-                      collection.heading ===
-                        `${ActiveCourseWorkshops.CSA} Workshops`
-                    ) {
-                      return (
-                        <div
-                          key={collectionIndex}
-                          style={{
-                            ...styles.workshopCollection,
-                            ...workshopCollectionStyle
-                          }}
-                        >
-                          <h4>{collection.heading}</h4>
-                          <div>
-                            This Regional Partner is not offering CSA workshops
-                            at this time, but Code.org has a solution for you!
-                            Please complete the professional learning
-                            application, and a Code.org staff member will be in
-                            touch.
+                    // If no current workshops for a course
+                    if (collection.workshops.length === 0) {
+                      if (
+                        !partnerInfo.pl_programs_offered.includes(
+                          collection.key
+                        )
+                      ) {
+                        // If a program is offered but a workshop hasn't been scheduled yet
+                        return (
+                          <div
+                            key={collectionIndex}
+                            style={{
+                              ...styles.workshopCollection,
+                              ...workshopCollectionStyle
+                            }}
+                          >
+                            <h4>
+                              {collection.name} Workshop details are coming
+                              soon!
+                            </h4>
+                            <div>
+                              The Regional Partner is hard at work locking down
+                              the details of the workshops for this program. You
+                              can still apply and the Regional Partner will
+                              inform you when the workshop details are
+                              available.
+                            </div>
                           </div>
-                        </div>
-                      );
+                        );
+                      } else {
+                        // If a program is not offered
+                        return (
+                          <div
+                            key={collectionIndex}
+                            style={{
+                              ...styles.workshopCollection,
+                              ...workshopCollectionStyle
+                            }}
+                          >
+                            <h4>{collection.heading}</h4>
+                            <div>
+                              This Regional Partner is not offering{' '}
+                              {collection.name} workshops at this time. Code.org
+                              will review your application and contact you with
+                              options for joining the program hosted by a
+                              Regional Partner from a different region.
+                            </div>
+                          </div>
+                        );
+                      }
                     } else if (collection.workshops.length > 0) {
+                      // If workshops present for the given course
                       return (
                         <div
                           key={collectionIndex}

--- a/apps/src/templates/RegionalPartnerSearch.jsx
+++ b/apps/src/templates/RegionalPartnerSearch.jsx
@@ -14,6 +14,23 @@ import PropTypes from 'prop-types';
 import queryString from 'query-string';
 import $ from 'jquery';
 
+const WorkshopCard = props => {
+  return (
+    <div
+      style={{
+        ...styles.workshopCollection,
+        ...props.style
+      }}
+    >
+      {props.content}
+    </div>
+  );
+};
+WorkshopCard.propTypes = {
+  style: PropTypes.object,
+  content: PropTypes.element
+};
+
 class RegionalPartnerSearch extends Component {
   static propTypes = {
     responsiveSize: PropTypes.oneOf(['lg', 'md', 'sm', 'xs']).isRequired,
@@ -314,64 +331,67 @@ class RegionalPartnerSearch extends Component {
                     ) {
                       // If a program is offered but a workshop hasn't been scheduled yet
                       return (
-                        <div
+                        <WorkshopCard
                           key={collectionIndex}
-                          style={{
-                            ...styles.workshopCollection,
-                            ...workshopCollectionStyle
-                          }}
-                        >
-                          <h4>
-                            {collection.name} Workshop details are coming soon!
-                          </h4>
-                          <div>
-                            The Regional Partner is hard at work locking down
-                            the details of the workshops for this program. You
-                            can still apply and the Regional Partner will inform
-                            you when the workshop details are available.
-                          </div>
-                        </div>
+                          style={workshopCollectionStyle}
+                          content={
+                            <>
+                              <h4>
+                                {collection.name} Workshop details are coming
+                                soon!
+                              </h4>
+                              <div>
+                                The Regional Partner is hard at work locking
+                                down the details of the workshops for this
+                                program. You can still apply and the Regional
+                                Partner will inform you when the workshop
+                                details are available.
+                              </div>
+                            </>
+                          }
+                        />
                       );
                     } else {
                       // If a program is not offered
                       return (
-                        <div
+                        <WorkshopCard
                           key={collectionIndex}
-                          style={{
-                            ...styles.workshopCollection,
-                            ...workshopCollectionStyle
-                          }}
-                        >
-                          <h4>{collection.heading}</h4>
-                          <div>
-                            This Regional Partner is not offering{' '}
-                            {collection.name} workshops at this time. Code.org
-                            will review your application and contact you with
-                            options for joining the program hosted by a Regional
-                            Partner from a different region.
-                          </div>
-                        </div>
+                          style={workshopCollectionStyle}
+                          content={
+                            <>
+                              <h4>{collection.heading}</h4>
+                              <div>
+                                This Regional Partner is not offering{' '}
+                                {collection.name} workshops at this time.
+                                Code.org will review your application and
+                                contact you with options for joining the program
+                                hosted by a Regional Partner from a different
+                                region.
+                              </div>
+                            </>
+                          }
+                        />
                       );
                     }
                   } else if (collection.workshops.length > 0) {
                     // If workshops present for the given course
                     return (
-                      <div
+                      <WorkshopCard
                         key={collectionIndex}
-                        style={{
-                          ...styles.workshopCollection,
-                          ...workshopCollectionStyle
-                        }}
-                      >
-                        <h4>{collection.heading}</h4>
-                        {collection.workshops.map((workshop, index) => (
-                          <div key={index} style={styles.workshop}>
-                            <div>{workshop.workshop_date_range_string}</div>
-                            <div>{workshop.location_name}</div>
-                            <div>{workshop.location_address}</div>
-                          </div>
-                        ))}
-                      </div>
+                        style={workshopCollectionStyle}
+                        content={
+                          <>
+                            <h4>{collection.heading}</h4>
+                            {collection.workshops.map((workshop, index) => (
+                              <div key={index} style={styles.workshop}>
+                                <div>{workshop.workshop_date_range_string}</div>
+                                <div>{workshop.location_name}</div>
+                                <div>{workshop.location_address}</div>
+                              </div>
+                            ))}
+                          </>
+                        }
+                      />
                     );
                   }
                 })}

--- a/apps/src/templates/RegionalPartnerSearch.jsx
+++ b/apps/src/templates/RegionalPartnerSearch.jsx
@@ -306,66 +306,34 @@ class RegionalPartnerSearch extends Component {
             {appState !== WorkshopApplicationStates.now_closed && (
               <div>
                 <h3>Workshop information (hosted by {partnerInfo.name}):</h3>
-                {workshopCollections.every(
-                  collection => collection.workshops.length === 0
-                ) && <div>Workshop details coming soon!</div>}
-
-                {!workshopCollections.every(
-                  collection => collection.workshops.length === 0
-                ) &&
-                  workshopCollections.map((collection, collectionIndex) => {
+                {workshopCollections.map((collection, collectionIndex) => {
+                  if (collection.workshops.length === 0) {
                     // If no current workshops for a course
-                    if (collection.workshops.length === 0) {
-                      if (
-                        !partnerInfo.pl_programs_offered.includes(
-                          collection.key
-                        )
-                      ) {
-                        // If a program is offered but a workshop hasn't been scheduled yet
-                        return (
-                          <div
-                            key={collectionIndex}
-                            style={{
-                              ...styles.workshopCollection,
-                              ...workshopCollectionStyle
-                            }}
-                          >
-                            <h4>
-                              {collection.name} Workshop details are coming
-                              soon!
-                            </h4>
-                            <div>
-                              The Regional Partner is hard at work locking down
-                              the details of the workshops for this program. You
-                              can still apply and the Regional Partner will
-                              inform you when the workshop details are
-                              available.
-                            </div>
+                    if (
+                      partnerInfo.pl_programs_offered.includes(collection.key)
+                    ) {
+                      // If a program is offered but a workshop hasn't been scheduled yet
+                      return (
+                        <div
+                          key={collectionIndex}
+                          style={{
+                            ...styles.workshopCollection,
+                            ...workshopCollectionStyle
+                          }}
+                        >
+                          <h4>
+                            {collection.name} Workshop details are coming soon!
+                          </h4>
+                          <div>
+                            The Regional Partner is hard at work locking down
+                            the details of the workshops for this program. You
+                            can still apply and the Regional Partner will inform
+                            you when the workshop details are available.
                           </div>
-                        );
-                      } else {
-                        // If a program is not offered
-                        return (
-                          <div
-                            key={collectionIndex}
-                            style={{
-                              ...styles.workshopCollection,
-                              ...workshopCollectionStyle
-                            }}
-                          >
-                            <h4>{collection.heading}</h4>
-                            <div>
-                              This Regional Partner is not offering{' '}
-                              {collection.name} workshops at this time. Code.org
-                              will review your application and contact you with
-                              options for joining the program hosted by a
-                              Regional Partner from a different region.
-                            </div>
-                          </div>
-                        );
-                      }
-                    } else if (collection.workshops.length > 0) {
-                      // If workshops present for the given course
+                        </div>
+                      );
+                    } else {
+                      // If a program is not offered
                       return (
                         <div
                           key={collectionIndex}
@@ -375,17 +343,38 @@ class RegionalPartnerSearch extends Component {
                           }}
                         >
                           <h4>{collection.heading}</h4>
-                          {collection.workshops.map((workshop, index) => (
-                            <div key={index} style={styles.workshop}>
-                              <div>{workshop.workshop_date_range_string}</div>
-                              <div>{workshop.location_name}</div>
-                              <div>{workshop.location_address}</div>
-                            </div>
-                          ))}
+                          <div>
+                            This Regional Partner is not offering{' '}
+                            {collection.name} workshops at this time. Code.org
+                            will review your application and contact you with
+                            options for joining the program hosted by a Regional
+                            Partner from a different region.
+                          </div>
                         </div>
                       );
                     }
-                  })}
+                  } else if (collection.workshops.length > 0) {
+                    // If workshops present for the given course
+                    return (
+                      <div
+                        key={collectionIndex}
+                        style={{
+                          ...styles.workshopCollection,
+                          ...workshopCollectionStyle
+                        }}
+                      >
+                        <h4>{collection.heading}</h4>
+                        {collection.workshops.map((workshop, index) => (
+                          <div key={index} style={styles.workshop}>
+                            <div>{workshop.workshop_date_range_string}</div>
+                            <div>{workshop.location_name}</div>
+                            <div>{workshop.location_address}</div>
+                          </div>
+                        ))}
+                      </div>
+                    );
+                  }
+                })}
               </div>
             )}
 


### PR DESCRIPTION
If a teacher is viewing available PD workshops based on their regional partner, they are currently shown an entry for available workshops of each type and (if CSA is not being offered) an entry stating CSA is not being offered:
![c782f8f0-9791-433b-8491-becb920e3e77](https://user-images.githubusercontent.com/56283563/201726302-1fa6ae3a-ede3-4363-87da-17f1af884b81.png)

The goal of this PR is to provide more details on what is being offered. If the Regional Partner is offering a workshop but has not scheduled it yet, the Regional Partner landing page will not notify the user that the workshop details will be coming soon. And if the Regional Partner is not offering a given course (not just CSA), the user will be notified of that as well. Here are some different scenarios to show the 3 versions of a workshop entry (offered and scheduled, offered but not scheduled, and not offered):

### RP offering CSD, CSP, and CSA with scheduled workshops for all 3
![AllScheduled](https://user-images.githubusercontent.com/56283563/201750047-c79ba027-3303-4e26-bdc4-b1dd7715569b.PNG)

### RP offering CSD and CSP but has only scheduled CSD
![Offer2Schedule1](https://user-images.githubusercontent.com/56283563/201750056-31c64f07-3dd7-4f4e-b0e6-463e0353c04e.PNG)

### RP offering only CSD but has not scheduled it yet
![JustCSD](https://user-images.githubusercontent.com/56283563/201750068-e8877862-41a7-4754-b9b9-b737a3dc906a.PNG)

### RP is not offering any workshops at this time
![NoneOffered](https://user-images.githubusercontent.com/56283563/201750086-47834b7d-0080-41c0-bf35-78be6fd0faf6.PNG)

## Links
Spec: [here](https://docs.google.com/document/d/19jnaa1_9WYZ32tY6IGrrHmHTTYcao9cRkDzeHWq3-8I/edit#heading=h.3yj978pk57yq)
Jira ticket: [here](https://codedotorg.atlassian.net/browse/ACQ-179?atlOrigin=eyJpIjoiMjgwYzc4MWUwYWNmNDkwOGIyOTg2YTVkYjcyM2FkMDIiLCJwIjoiaiJ9)

## Testing story
Local testing and drone build passing.

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
