### PR TITLE
Adding i18n for AI lab dataset metadata

### DIFF
--- a/bin/i18n/sync-in.rb
+++ b/bin/i18n/sync-in.rb
@@ -122,11 +122,26 @@ def localize_external_sources
   Dir.glob(dataset_files).each do |dataset_file|
     original_dataset = JSON.parse(File.read(dataset_file))
 
-    # Currently only including fields for translation.
-    # Use field id as unique identifier.
-    fields_as_hash = original_dataset["fields"].map {|field| [field["id"], field]}.to_h
+    # Converts array to map and uses the field id as a unique identifier.
+    fields_as_hash = original_dataset["fields"].map do |field|
+      [
+        field["id"],
+        {
+          "id" => field["id"],
+          "description" => field["description"]
+        }
+      ]
+    end.to_h
+
     final_dataset = {
-      "fields" => fields_as_hash
+      "fields" => fields_as_hash,
+      "card" => {
+        "description" => original_dataset.dig("card", "description"),
+        "context" => {
+          "potentialUses" => original_dataset.dig("card", "context", "potentialUses"),
+          "potentialMisuses" => original_dataset.dig("card", "context", "potentialMisuses")
+        }
+      }
     }
 
     File.open(dataset_file, "w") do |f|


### PR DESCRIPTION
In AI Lab, students can play around with large datasets (CSV's). These datasets have metadata which describe various things about the data in plain language. [Here is an example of the metadata for the Abalone dataset.](https://github.com/code-dot-org/ml-playground/blob/main/public/datasets/abalone.json)
This PR makes theses fields available for translators so students in other languages can also understand more about the data they are using.
* Remove `type` from the translatable metadata. This is not a field displayed directly to users.
* Add dataset `description`,`potentialUses`, and `potentialMisuses` to the i18n sync.
* Add field `description` to the i18n sync.

## Links
* [JIRA](https://codedotorg.atlassian.net/browse/FND-2096)

## Testing story
* Manually ran the sync-in and confirmed it works as intended.
