### PR TITLE
Use Ruby 2.7 for FastSnapshotRestore Lambda

### DIFF
--- a/aws/cloudformation/lambda.yml.erb
+++ b/aws/cloudformation/lambda.yml.erb
@@ -252,7 +252,7 @@ Resources:
       FunctionName: FastSnapshotRestore
       Code: <%=lambda_zip 'fast_snapshot_restore.rb', 'cfn_response.rb' %>
       Handler: fast_snapshot_restore.handler
-      Runtime: ruby2.5
+      Runtime: ruby2.7
       MemorySize: 1024
       Timeout: 30
       Role: !GetAtt FastSnapshotRestoreRole.Arn


### PR DESCRIPTION
We use this to quickly launch new frontends as part of a deploy, from the AMI-builder-created snapshot. I doubt it really matters which version of Ruby this lambda uses, but I am speculatively updating it anyway just to maintain consistency while we're updating all the rest of our site to use 2.7

## Links

- https://github.com/code-dot-org/code-dot-org/pull/47864
- [Slack thread](https://codedotorg.slack.com/archives/C03CK49G9/p1668456071953919)

## Testing story

I attempted to test this by spinning up a full-stack adhoc with `RAILS_ENV=adhoc bundle exec rake adhoc:full_stac
k:start`, but got an unrelated error about the secrets `adhoc/cdo/db_cluster_id`and `adhoc/cdo/db_writer_endpoint` already existing. We should follow up on that just so that full-stack adhocs can work again, but this change is rudimentary enough that it's probably not worth doing just for this.

I'm planning at this point to merge this change untested; if it does fail, it will do so in a way that's obvious and we can quickly follow up with a revert. Please let me know if you have a better idea, though!

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
