### PR TITLE
testing Use Ruby 2.7 for FastSnapshotRestore Lambda

### DIFF
--- a/aws/cloudformation/lambda.yml.erb
+++ b/aws/cloudformation/lambda.yml.erb
@@ -252,7 +252,7 @@ Resources:
       FunctionName: FastSnapshotRestore
       Code: <%=lambda_zip 'fast_snapshot_restore.rb', 'cfn_response.rb' %>
       Handler: fast_snapshot_restore.handler
-      Runtime: ruby2.5
+      Runtime: ruby2.7
       MemorySize: 1024
       Timeout: 30
       Role: !GetAtt FastSnapshotRestoreRole.Arn


### PR DESCRIPTION
shorter branch name for adhoc testing of https://github.com/code-dot-org/code-dot-org/pull/49118:

`LoadBalancer name [adhoc-use-Ruby-2-7-for-FastSnapshotRestore] cannot be longer than 32 characters`

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
