### PR TITLE
Migrate LibraryTable story

### DIFF
--- a/apps/src/templates/projects/LibraryTable.story.jsx
+++ b/apps/src/templates/projects/LibraryTable.story.jsx
@@ -1,6 +1,13 @@
 import React from 'react';
 import {action} from '@storybook/addon-actions';
 import {UnconnectedLibraryTable as LibraryTable} from './LibraryTable';
+import {reduxStore} from '../../../.storybook/decorators';
+import {Provider} from 'react-redux';
+
+export default {
+  title: 'LibraryTable',
+  component: LibraryTable
+};
 
 const personalProjectsList = [
   {
@@ -36,22 +43,15 @@ const DEFAULT_PROPS = {
   unpublishProjectLibrary: action('unpublishing')
 };
 
-export default storybook => {
-  storybook
-    .storiesOf('Projects/LibraryTable', module)
-    .withReduxStore()
-    .addStoryTable([
-      {
-        name: 'Libraries',
-        description: 'Table of currently published project libraries',
-        story: () => <LibraryTable {...DEFAULT_PROPS} />
-      },
-      {
-        name: 'No libraries',
-        description: 'Display when the user has no published project libraries',
-        story: () => (
-          <LibraryTable {...DEFAULT_PROPS} personalProjectsList={[]} />
-        )
-      }
-    ]);
+const Template = args => (
+  <Provider store={reduxStore()}>
+    <LibraryTable {...DEFAULT_PROPS} {...args} />
+  </Provider>
+);
+
+export const Default = Template.bind({});
+
+export const NoLibraries = Template.bind({});
+NoLibraries.args = {
+  personalProjectsList: []
 };


### PR DESCRIPTION
Migarte LibraryStory to new Storybook API:
<img width="1083" alt="image" src="https://user-images.githubusercontent.com/43474485/201787636-700bfb99-919a-4d1e-bfe2-37dece4100e2.png">
<img width="1083" alt="image" src="https://user-images.githubusercontent.com/43474485/201787661-8af9178d-f086-48ad-9f80-416e09a35905.png">

## Links
Refer to [this PR](https://github.com/code-dot-org/code-dot-org/pull/47777) for context.
[This spreadsheet](https://docs.google.com/spreadsheets/d/1z8r10AcR0v3GimV_-28dJ6QaiaQ3CJoo9yXqa7U_bKs/edit#gid=0)  keeps track of all migrations.
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
