### PR TITLE
Updated Personal Projects Table Story

### DIFF
--- a/apps/.storybook/decorators.js
+++ b/apps/.storybook/decorators.js
@@ -1,9 +1,7 @@
 import {createStore, combineReducers} from 'redux';
 import isRtl from '@cdo/apps/code-studio/isRtlRedux';
 import responsive from '@cdo/apps/code-studio/responsiveRedux';
-import publishDialog from '@cdo/apps/templates/projects/publishDialog/publishDialogRedux';
-import deleteDialog from '@cdo/apps/templates/projects/deleteDialog/deleteProjectDialogRedux';
 
 export const reduxStore = (reducers = {}, state = {}) => {
-  return createStore(combineReducers({isRtl, responsive, publishDialog, deleteDialog, ...reducers}), state);
+  return createStore(combineReducers({isRtl, responsive, ...reducers}), state);
 };

--- a/apps/.storybook/decorators.js
+++ b/apps/.storybook/decorators.js
@@ -1,7 +1,9 @@
 import {createStore, combineReducers} from 'redux';
 import isRtl from '@cdo/apps/code-studio/isRtlRedux';
 import responsive from '@cdo/apps/code-studio/responsiveRedux';
+import publishDialog from '@cdo/apps/templates/projects/publishDialog/publishDialogRedux';
+import deleteDialog from '@cdo/apps/templates/projects/deleteDialog/deleteProjectDialogRedux';
 
 export const reduxStore = (reducers = {}, state = {}) => {
-  return createStore(combineReducers({isRtl, responsive, ...reducers}), state);
+  return createStore(combineReducers({isRtl, responsive, publishDialog, deleteDialog, ...reducers}), state);
 };

--- a/apps/src/templates/projects/PersonalProjectsTable.story.jsx
+++ b/apps/src/templates/projects/PersonalProjectsTable.story.jsx
@@ -3,6 +3,8 @@ import {UnconnectedPersonalProjectsTable as PersonalProjectsTable} from './Perso
 import {stubFakePersonalProjectData} from './generateFakeProjects';
 import {Provider} from 'react-redux';
 import {reduxStore} from '@cdo/storybook/decorators';
+import publishDialog from '@cdo/apps/templates/projects/publishDialog/publishDialogRedux';
+import deleteDialog from '@cdo/apps/templates/projects/deleteDialog/deleteProjectDialogRedux';
 
 export default {
   title: 'PersonalProjectsTable',
@@ -10,7 +12,7 @@ export default {
 };
 
 const Template = args => (
-  <Provider store={reduxStore()}>
+  <Provider store={reduxStore({publishDialog, deleteDialog})}>
     <PersonalProjectsTable {...args} />
   </Provider>
 );

--- a/apps/src/templates/projects/PersonalProjectsTable.story.jsx
+++ b/apps/src/templates/projects/PersonalProjectsTable.story.jsx
@@ -1,47 +1,32 @@
 import React from 'react';
 import {UnconnectedPersonalProjectsTable as PersonalProjectsTable} from './PersonalProjectsTable';
-import publishDialog from '@cdo/apps/templates/projects/publishDialog/publishDialogRedux';
-import deleteDialog from '@cdo/apps/templates/projects/deleteDialog/deleteProjectDialogRedux';
 import {stubFakePersonalProjectData} from './generateFakeProjects';
+import {Provider} from 'react-redux';
+import {reduxStore} from '@cdo/storybook/decorators';
 
-const initialState = {
-  publishDialog: {
-    isOpen: false,
-    isPublishPending: false
-  },
-  deleteDialog: {
-    isOpen: false
-  }
+export default {
+  title: 'PersonalProjectsTable',
+  component: PersonalProjectsTable
 };
 
-export default storybook => {
-  storybook
-    .storiesOf('Projects/PersonalProjectsTable', module)
-    .withReduxStore({publishDialog, deleteDialog}, initialState)
-    .addStoryTable([
-      {
-        name: 'Personal Project Table',
-        description: 'Table of personal projects',
-        story: () => (
-          <PersonalProjectsTable
-            personalProjectsList={stubFakePersonalProjectData}
-            isLoadingPersonalProjectsList={false}
-            isUserSignedIn={true}
-            canShare={true}
-          />
-        )
-      },
-      {
-        name: 'Empty Personal Project Table',
-        description: 'Table when there are 0 personal projects',
-        story: () => (
-          <PersonalProjectsTable
-            personalProjectsList={[]}
-            isLoadingPersonalProjectsList={false}
-            isUserSignedIn={true}
-            canShare={true}
-          />
-        )
-      }
-    ]);
+const Template = args => (
+  <Provider store={reduxStore()}>
+    <PersonalProjectsTable {...args} />
+  </Provider>
+);
+
+export const WithProjects = Template.bind({});
+WithProjects.args = {
+  personalProjectsList: stubFakePersonalProjectData,
+  isLoadingPersonalProjectsList: false,
+  isUserSignedIn: true,
+  canShare: true
+};
+
+export const WithoutProjects = Template.bind({});
+WithoutProjects.args = {
+  personalProjectsList: [],
+  isLoadingPersonalProjectsList: false,
+  isUserSignedIn: true,
+  canShare: true
 };


### PR DESCRIPTION
Updated the storybook entry for the PersonalProjectsTable story to work on the newer versions of Storybook.

We may want to consider deleting this one as it's not a reusable component. However, updating it was good practice and it now works, so keeping it around for now.
