### PR TITLE
[StoryBook Refactor] MiniViewTopRow

### DIFF
--- a/apps/src/code-studio/components/progress/MiniViewTopRow.story.jsx
+++ b/apps/src/code-studio/components/progress/MiniViewTopRow.story.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import MiniViewTopRow from './MiniViewTopRow';
 import progress from '@cdo/apps/code-studio/progressRedux';
+import {Provider} from 'react-redux';
+import {reduxStore} from '@cdo/storybook/decorators';
 
 const initialState = {
   progress: {
@@ -16,25 +18,21 @@ const initialState = {
   }
 };
 
-export default storybook =>
-  storybook
-    .storiesOf('MiniViewTopRow', module)
-    .withReduxStore({progress}, initialState)
-    .addStoryTable([
-      {
-        name: 'basic',
-        story: () => (
-          <div style={{width: 635, position: 'relative'}}>
-            <MiniViewTopRow scriptName="course1" />
-          </div>
-        )
-      },
-      {
-        name: 'no lines of text',
-        story: () => (
-          <div style={{width: 635, position: 'relative'}}>
-            <MiniViewTopRow scriptName="course1" />
-          </div>
-        )
-      }
-    ]);
+export default {
+  title: 'MiniViewTopRow',
+  component: MiniViewTopRow
+};
+
+// Template
+const Template = args => (
+  <Provider store={reduxStore({progress}, initialState)}>
+    <div style={{width: 635, position: 'relative'}}>
+      <MiniViewTopRow {...args} />
+    </div>
+  </Provider>
+);
+
+export const Default = Template.bind({});
+Default.args = {
+  scriptName: 'course1'
+};


### PR DESCRIPTION
Part of the StoryBook Refactor

This PR translates just the MiniViewTopRow. Particularly, only one of the two stories, as they test the same scenario - screenshot below - as we no longer display the lines of text (as of this [PR](https://github.com/code-dot-org/code-dot-org/pull/46934)).

![Screenshot from 2022-11-14 18-07-37](https://user-images.githubusercontent.com/2959170/201809483-75c26f3d-5f17-4f30-a291-ef85f40fc844.png)
