### PR TITLE
[StoryBook Refactor] CourseCard, ResourceCard, ImageResourceCard, VerticalImageResourceCard

### DIFF
--- a/apps/src/templates/VerticalImageResourceCard.story.jsx
+++ b/apps/src/templates/VerticalImageResourceCard.story.jsx
@@ -25,7 +25,6 @@ export default {
   component: VerticalImageResourceCard
 };
 
-// Template
 const Template = args => (
   <Provider store={reduxStore()}>
     <VerticalImageResourceCard {...args} />

--- a/apps/src/templates/VerticalImageResourceCard.story.jsx
+++ b/apps/src/templates/VerticalImageResourceCard.story.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import VerticalImageResourceCard from './VerticalImageResourceCard';
+import {Provider} from 'react-redux';
+import {reduxStore} from '@cdo/storybook/decorators';
 
 const exampleCard = {
   title: 'CS Fundamentals Express',
@@ -9,64 +11,41 @@ const exampleCard = {
   link: '/s/express'
 };
 
-export default storybook => {
-  return storybook
-    .storiesOf('Cards/VerticalImageResourceCard', module)
-    .withReduxStore()
-    .addStoryTable([
-      {
-        name: 'Vertical Image Resource Card',
-        description: `This is an example card that fits 3 across on desktop and has an image stacked above a desctription and button. It's used here to promote a course`,
-        story: () => (
-          <VerticalImageResourceCard
-            title={exampleCard.title}
-            description={exampleCard.description}
-            buttonText={exampleCard.buttonText}
-            link={exampleCard.link}
-            image="csf-express"
-          />
-        )
-      },
-      {
-        name: 'Vertical Image Resource Card - Jumbo',
-        description: `This is an example card that fits 2 across on desktop and has an image stacked above a desctription and button. It's used here to promote a course`,
-        story: () => (
-          <VerticalImageResourceCard
-            title={exampleCard.title}
-            description={exampleCard.description}
-            buttonText={exampleCard.buttonText}
-            link={exampleCard.link}
-            jumbo={true}
-            image="codeorg-teacher"
-          />
-        )
-      },
-      {
-        name: 'Vertical Image Resource Card - RTL',
-        description: `This is an example vertical image resource card that can be used with in RTL styling`,
-        story: () => (
-          <VerticalImageResourceCard
-            title={exampleCard.title}
-            description={exampleCard.description}
-            buttonText={exampleCard.buttonText}
-            link={exampleCard.link}
-            image="csf-express"
-          />
-        )
-      },
-      {
-        name: 'Minecraft Vertical Image Resource Card',
-        description: `This is an example Minecraft Vertical Image Resource Card, includes share link for Minecraft education`,
-        story: () => (
-          <VerticalImageResourceCard
-            title="Minecraft Education"
-            description="Copy the link below to continue programming with Minecraft."
-            buttonText="Go to Minecraft"
-            link="https://minecraft.net/en-us/"
-            MCShareLink="code.org/sharelink"
-            image="new-minecraft"
-          />
-        )
-      }
-    ]);
+const minecraftCard = {
+  title: 'Minecraft Education',
+  description: 'Copy the link below to continue programming with Minecraft.',
+  buttonText: 'Go to Minecraft',
+  link: 'https://minecraft.net/en-us/',
+  MCShareLink: 'code.org/sharelink',
+  image: 'old-minecraft'
+};
+
+export default {
+  title: 'VerticalImageResourceCard',
+  component: VerticalImageResourceCard
+};
+
+// Template
+const Template = args => (
+  <Provider store={reduxStore()}>
+    <VerticalImageResourceCard {...args} />
+  </Provider>
+);
+
+export const Default = Template.bind({});
+Default.args = {
+  ...exampleCard,
+  image: 'csf-express'
+};
+
+export const Jumbo = Template.bind({});
+Jumbo.args = {
+  ...exampleCard,
+  jumbo: true,
+  image: 'codeorg-teacher'
+};
+
+export const Minecraft = Template.bind({});
+Minecraft.args = {
+  ...minecraftCard
 };

--- a/apps/src/templates/studioHomepages/CourseCard.story.jsx
+++ b/apps/src/templates/studioHomepages/CourseCard.story.jsx
@@ -21,7 +21,6 @@ export default {
   component: CourseCard
 };
 
-// Template
 const Template = args => (
   <Provider store={reduxStore()}>
     <CourseCard {...args} />

--- a/apps/src/templates/studioHomepages/CourseCard.story.jsx
+++ b/apps/src/templates/studioHomepages/CourseCard.story.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import CourseCard from './CourseCard';
+import {Provider} from 'react-redux';
+import {reduxStore} from '@cdo/storybook/decorators';
 
 const exampleCard = {
   title: 'CSP Unit 2 - Digital Information',
@@ -14,33 +16,25 @@ const examplePLCard = {
   link: 'studio.code.org/s/self-paced-pl-csd1-2021'
 };
 
-export default storybook => {
-  return storybook
-    .storiesOf('Cards/CourseCard', module)
-    .withReduxStore()
-    .addStoryTable([
-      {
-        name: 'Course Card - Student Course',
-        description: `This is an example course card that can show information about a course or unit.`,
-        story: () => (
-          <CourseCard
-            title={exampleCard.title}
-            description={exampleCard.description}
-            link={exampleCard.link}
-          />
-        )
-      },
-      {
-        name: 'Course Card - Professional Learning Course',
-        description: `This is an example course card for a professional learning course that can show information about a course or unit.`,
-        story: () => (
-          <CourseCard
-            title={examplePLCard.title}
-            description={examplePLCard.description}
-            link={examplePLCard.link}
-            isProfessionalLearningCourse={true}
-          />
-        )
-      }
-    ]);
+export default {
+  title: 'CourseCard',
+  component: CourseCard
+};
+
+// Template
+const Template = args => (
+  <Provider store={reduxStore()}>
+    <CourseCard {...args} />
+  </Provider>
+);
+
+export const StudentCourseCard = Template.bind({});
+StudentCourseCard.args = {
+  ...exampleCard
+};
+
+export const PLCourseCard = Template.bind({});
+PLCourseCard.args = {
+  ...examplePLCard,
+  isProfessionalLearningCourse: true
 };

--- a/apps/src/templates/studioHomepages/ImageResourceCard.story.jsx
+++ b/apps/src/templates/studioHomepages/ImageResourceCard.story.jsx
@@ -8,7 +8,6 @@ export default {
   component: ImageResourceCard
 };
 
-// Template
 const Template = args => (
   <Provider store={reduxStore()}>
     <ImageResourceCard {...args} />

--- a/apps/src/templates/studioHomepages/ImageResourceCard.story.jsx
+++ b/apps/src/templates/studioHomepages/ImageResourceCard.story.jsx
@@ -1,23 +1,26 @@
 import React from 'react';
 import ImageResourceCard from './ImageResourceCard';
+import {Provider} from 'react-redux';
+import {reduxStore} from '@cdo/storybook/decorators';
 
-export default storybook => {
-  return storybook
-    .storiesOf('Cards/ImageResourceCard', module)
-    .withReduxStore()
-    .addStoryTable([
-      {
-        name: 'basic resource card',
-        description: `This is an example resource card.`,
-        story: () => (
-          <ImageResourceCard
-            title="Teacher Community"
-            description="Ask questions about curriculum, share ideas from your lessons, and get help from other teachers"
-            image="teachercommunity.png"
-            buttonText="Connect Today"
-            link="link to teacher community"
-          />
-        )
-      }
-    ]);
+export default {
+  title: 'ImageResourceCard',
+  component: ImageResourceCard
+};
+
+// Template
+const Template = args => (
+  <Provider store={reduxStore()}>
+    <ImageResourceCard {...args} />
+  </Provider>
+);
+
+export const Default = Template.bind({});
+Default.args = {
+  title: 'Teacher Community',
+  description:
+    'Ask questions about curriculum, share ideas from your lessons, and get help from other teachers',
+  image: 'teachercommunity.png',
+  buttonText: 'Connect Today',
+  link: 'link to teacher community'
 };

--- a/apps/src/templates/studioHomepages/ResourceCard.story.jsx
+++ b/apps/src/templates/studioHomepages/ResourceCard.story.jsx
@@ -8,7 +8,6 @@ export default {
   component: ResourceCard
 };
 
-// Template
 const Template = args => (
   <Provider store={reduxStore()}>
     <ResourceCard

--- a/apps/src/templates/studioHomepages/ResourceCard.story.jsx
+++ b/apps/src/templates/studioHomepages/ResourceCard.story.jsx
@@ -22,7 +22,6 @@ const Template = args => (
 );
 
 export const ToolCard = Template.bind({});
-ToolCard.args = {};
 
 export const ToolCardWithWrap = Template.bind({});
 ToolCardWithWrap.args = {

--- a/apps/src/templates/studioHomepages/ResourceCard.story.jsx
+++ b/apps/src/templates/studioHomepages/ResourceCard.story.jsx
@@ -1,35 +1,30 @@
 import React from 'react';
 import ResourceCard from './ResourceCard';
+import {Provider} from 'react-redux';
+import {reduxStore} from '@cdo/storybook/decorators';
 
-export default storybook => {
-  return storybook
-    .storiesOf('Cards/ResourceCard', module)
-    .withReduxStore()
-    .addStoryTable([
-      {
-        name: 'tool card',
-        description: `This is an example tool card.`,
-        story: () => (
-          <ResourceCard
-            title="Teacher Community"
-            description="Ask questions about curriculum, share ideas from your lessons, and get help from other teachers"
-            buttonText="Connect Today"
-            link="link to teacher community"
-          />
-        )
-      },
-      {
-        name: 'tool card - allow wrap',
-        description: `This is an example tool card that allows the title to wrap.`,
-        story: () => (
-          <ResourceCard
-            title="Teacher Community"
-            description="Ask questions about curriculum, share ideas from your lessons, and get help from other teachers"
-            buttonText="Connect Today"
-            link="link to teacher community"
-            allowWrap={true}
-          />
-        )
-      }
-    ]);
+export default {
+  title: 'ResourceCard',
+  component: ResourceCard
+};
+
+// Template
+const Template = args => (
+  <Provider store={reduxStore()}>
+    <ResourceCard
+      title="Teacher Community"
+      description="Ask questions about curriculum, share ideas from your lessons, and get help from other teachers"
+      buttonText="Connect Today"
+      link="link to teacher community"
+      {...args}
+    />
+  </Provider>
+);
+
+export const ToolCard = Template.bind({});
+ToolCard.args = {};
+
+export const ToolCardWithWrap = Template.bind({});
+ToolCardWithWrap.args = {
+  allowWrap: true
 };


### PR DESCRIPTION
Part of the StoryBook Refactor.

This PR approaches 4 of our card styles. Most of these are pretty straightforward changes and the screenshots below illustrate the updated stories. The VerticalImageResourceCard has one small additional change, which is removing the 'RTL' story. This is no longer handled in the component ([as of this PR](https://github.com/code-dot-org/code-dot-org/pull/46782)) so the story was a duplicate.

CourseCard:
![Screenshot from 2022-11-14 18-17-30](https://user-images.githubusercontent.com/2959170/201810399-705ee027-182f-4669-b2c4-cfa860c7bf90.png)

ResourceCard:
![Screenshot from 2022-11-14 18-18-10](https://user-images.githubusercontent.com/2959170/201810413-89047d88-f363-40d9-a333-81826a9e1951.png)

ImageResourceCard:
![Screenshot from 2022-11-14 18-18-19](https://user-images.githubusercontent.com/2959170/201810439-824b1303-f3fd-46b0-92a3-df960655fd72.png)

VerticalImageResourceCard:
![Screenshot from 2022-11-14 18-18-34](https://user-images.githubusercontent.com/2959170/201810464-9d92be46-9cc7-41ac-a146-f8c267923f92.png)



