### PR TITLE
Do not modify status if principal approval has been completed

### DIFF
--- a/dashboard/app/controllers/api/v1/pd/application/teacher_applications_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/application/teacher_applications_controller.rb
@@ -1,6 +1,7 @@
 module Api::V1::Pd::Application
   class TeacherApplicationsController < Api::V1::Pd::FormsController
     include Pd::Application::ApplicationConstants
+    include Pd::TeacherApplicationConstants
     include Pd::Application::ActiveApplicationModels
 
     load_and_authorize_resource class: TEACHER_APPLICATION_CLASS.name, instance_name: 'application'
@@ -12,6 +13,9 @@ module Api::V1::Pd::Application
     end
 
     def new_status
+      # Do not modify status if the principal approval has already been completed.
+      return if @application.principal_approval_state&.include?(PRINCIPAL_APPROVAL_STATE[:complete])
+
       return 'incomplete' if ActiveModel::Type::Boolean.new.cast(params[:isSaving])
 
       regional_partner_id = @application.form_data_hash['regionalPartnerId']

--- a/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
@@ -138,6 +138,21 @@ module Api::V1::Pd::Application
       assert_equal 'awaiting_admin_approval', TEACHER_APPLICATION_CLASS.last.status
     end
 
+    test 'updating an application with RP requiring admin approval is \'unreviewed\' if the principal approval is complete'  do
+      sign_in @applicant
+      application = create TEACHER_APPLICATION_FACTORY, form_data_hash: @hash_with_admin_approval, user: @applicant, status: 'awaiting_admin_approval'
+      assert_equal 'awaiting_admin_approval', TEACHER_APPLICATION_CLASS.last.status
+
+      application.update!(status: 'reopened')
+      assert_equal 'reopened', TEACHER_APPLICATION_CLASS.last.status
+
+      # while the application is reopened, the principal approval gets submitted
+      create :pd_principal_approval_application, teacher_application: application
+      put :update, params: {id: application.id}
+      assert_response :success
+      assert_equal 'unreviewed', TEACHER_APPLICATION_CLASS.last.status
+    end
+
     test 'creating an application on an existing form renders conflict' do
       sign_in @applicant
       application = create TEACHER_APPLICATION_FACTORY, user: @applicant


### PR DESCRIPTION
This fulfills https://codedotorg.atlassian.net/browse/ACQ-227, which was a bug from the bug bash.

If principal approval gets submitted, that should dictate the status of an application that is re-submitted after re-opening, not the RP email setting.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
