### PR TITLE
Refactor ProjectCardGrid story

### DIFF
--- a/apps/src/templates/projects/ProjectCardGrid.story.jsx
+++ b/apps/src/templates/projects/ProjectCardGrid.story.jsx
@@ -103,6 +103,7 @@ export const PublicGalleryWithoutStudentInfo = Template.bind(
   Galleries.PUBLIC,
   {}
 );
+
 PublicGalleryWithoutStudentInfo.args = {
   projectLists: generateFakePublicProjectsWithoutStudentInfo(),
   galleryType: 'public'

--- a/apps/src/templates/projects/ProjectCardGrid.story.jsx
+++ b/apps/src/templates/projects/ProjectCardGrid.story.jsx
@@ -87,30 +87,32 @@ export default {
   component: ProjectCardGrid
 };
 
-const Template = (galleryType, args) => (
-  <Provider store={createProjectsStore(galleryType)}>
-    <ProjectCardGrid {...args} />
+const Template = args => (
+  <Provider store={createProjectsStore(args.selectedGallery)}>
+    <ProjectCardGrid
+      projectLists={args.projectLists}
+      galleryType={args.galleryType}
+    />
   </Provider>
 );
 
-export const PublicGalleryWithStudentInfo = Template.bind(Galleries.PUBLIC, {});
+export const PublicGalleryWithStudentInfo = Template.bind({});
 PublicGalleryWithStudentInfo.args = {
+  selectedGallery: Galleries.PUBLIC,
   projectLists: generateFakePublicProjectsWithStudentInfo(),
   galleryType: 'public'
 };
 
-export const PublicGalleryWithoutStudentInfo = Template.bind(
-  Galleries.PUBLIC,
-  {}
-);
-
+export const PublicGalleryWithoutStudentInfo = Template.bind({});
 PublicGalleryWithoutStudentInfo.args = {
+  selectedGallery: Galleries.PUBLIC,
   projectLists: generateFakePublicProjectsWithoutStudentInfo(),
   galleryType: 'public'
 };
 
-export const PersonalGallery = Template.bind(Galleries.PUBlIC, {});
+export const PersonalGallery = Template.bind({});
 PersonalGallery.args = {
+  selectedGallery: Galleries.PUBLIC,
   projectLists: generateFakePersonalProjects(),
   galleryType: 'personal'
 };

--- a/apps/src/templates/projects/ProjectCardGrid.story.jsx
+++ b/apps/src/templates/projects/ProjectCardGrid.story.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import ProjectCardGrid from './ProjectCardGrid';
 import _ from 'lodash';
-import projects, {selectGallery} from './projectsRedux';
-import {createStore, combineReducers} from 'redux';
+import projects from './projectsRedux';
+import {reduxStore} from '@cdo/storybook/decorators';
 import {Provider} from 'react-redux';
 import {Galleries} from './projectConstants';
+import ProjectCardGrid from './ProjectCardGrid';
 
 let projectTypes = ['applab', 'gamelab', 'artist', 'playlab'];
 
@@ -78,61 +78,38 @@ function generateFakePersonalProjects() {
   return personalProjects;
 }
 
-const createProjectsStore = function() {
-  return createStore(combineReducers({projects}));
+const createProjectsStore = function(galleryType) {
+  return reduxStore({projects}, {projects: {selectedGallery: galleryType}});
 };
 
-export default storybook => {
-  storybook.storiesOf('Projects/ProjectCardGrid', module).addStoryTable([
-    {
-      name: 'Public Gallery with student info',
-      description:
-        'Public gallery, with shortened student names and student age ranges.',
-      story: () => {
-        const store = createProjectsStore();
-        store.dispatch(selectGallery(Galleries.PUBlIC));
-        return (
-          <Provider store={store}>
-            <ProjectCardGrid
-              projectLists={generateFakePublicProjectsWithStudentInfo()}
-              galleryType="public"
-            />
-          </Provider>
-        );
-      }
-    },
-    {
-      name: 'Public Gallery without student info',
-      description: 'Public gallery, without student name and age.',
-      story: () => {
-        const store = createProjectsStore();
-        store.dispatch(selectGallery(Galleries.PUBlIC));
-        return (
-          <Provider store={store}>
-            <ProjectCardGrid
-              projectLists={generateFakePublicProjectsWithoutStudentInfo()}
-              galleryType="public"
-            />
-          </Provider>
-        );
-      }
-    },
-    {
-      name: 'Personal Gallery',
-      description:
-        'Personal gallery, showing full names and the "quick action" dropdowns',
-      story: () => {
-        const store = createProjectsStore();
-        store.dispatch(selectGallery(Galleries.PUBlIC));
-        return (
-          <Provider store={store}>
-            <ProjectCardGrid
-              projectLists={generateFakePersonalProjects()}
-              galleryType="personal"
-            />
-          </Provider>
-        );
-      }
-    }
-  ]);
+export default {
+  title: 'ProjectCardGrid',
+  component: ProjectCardGrid
+};
+
+const Template = (galleryType, args) => (
+  <Provider store={createProjectsStore(galleryType)}>
+    <ProjectCardGrid {...args} />
+  </Provider>
+);
+
+export const PublicGalleryWithStudentInfo = Template.bind(Galleries.PUBLIC, {});
+PublicGalleryWithStudentInfo.args = {
+  projectLists: generateFakePublicProjectsWithStudentInfo(),
+  galleryType: 'public'
+};
+
+export const PublicGalleryWithoutStudentInfo = Template.bind(
+  Galleries.PUBLIC,
+  {}
+);
+PublicGalleryWithoutStudentInfo.args = {
+  projectLists: generateFakePublicProjectsWithoutStudentInfo(),
+  galleryType: 'public'
+};
+
+export const PersonalGallery = Template.bind(Galleries.PUBlIC, {});
+PersonalGallery.args = {
+  projectLists: generateFakePersonalProjects(),
+  galleryType: 'personal'
 };


### PR DESCRIPTION
Refactor `ProjectCardGrid` to the new storybook format. This refactor includes an example of seeding the redux store for each story, although it turned out I could have hard-coded it because all the stories use the same value in redux. However, I thought it was useful to keep the example in there for future reference.

## Testing story
Tested in storybook, it works!

