### PR TITLE
Hoc2022 - Hide the CS Leaders Prize announcement box

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/views/announcements.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/announcements.haml
@@ -1,11 +1,12 @@
--# HoC 2022 - CS Leaders Prize million dollar promo code starts below.
-%aside.announcement.cs-leaders-prize
-  %h1
-    Expand access to computer science at your school, win $10,000!
-  %img{src: "/images/hoc2022-cs-leaders-prize-money-bag.png", alt:"Icon of a green bag with a purple dollar sign on it surrounded by gold coins"}
-  %a{href: "https://code.org/prize", target: "_blank", rel: "noopener noreferrer"}
-    %button
-      Learn more
+-# The HoC 2022 CS Leaders Prize promo submissions end as of 11/21/22
+-# Hiding this box for now — we'll use similar code again in the future
+  %aside.announcement.cs-leaders-prize
+    %h1
+      Expand access to computer science at your school, win $10,000!
+    %img{src: "/images/hoc2022-cs-leaders-prize-money-bag.png", alt:"Icon of a green bag with a purple dollar sign on it surrounded by gold coins"}
+    %a{href: "https://code.org/prize", target: "_blank", rel: "noopener noreferrer"}
+      %button
+        Learn more
 
 -# CSEdWeek Callout
 %aside.announcement.cs-ed-week


### PR DESCRIPTION
CS Leaders Prize submissions end as of 11/21/22 so we want to remove the announcement box from the https://hourofcode.com homepage next to the form. 

_Note:_ We'll want to use similar code again for future announcement promos so I commented it out in lieu of deleting it. 

**Relevant info:** [Asana task](https://app.asana.com/0/1202764401306810/1203366554590931/f)

----

### Before
<img width="1303" alt="Before" src="https://user-images.githubusercontent.com/9256643/202017219-4ff06b4d-0407-4180-93ce-8ac0278124bd.png">

### After
<img width="1304" alt="After" src="https://user-images.githubusercontent.com/9256643/202017299-03d25bcf-395b-4bd0-985e-3bccefeddfe6.png">
