### PR TITLE
Do not show auto-email text by default

### DIFF
--- a/apps/src/code-studio/pd/application_dashboard/constants.js
+++ b/apps/src/code-studio/pd/application_dashboard/constants.js
@@ -65,7 +65,7 @@ export const ScholarshipStatusRequiredStatuses = ['accepted'];
  * Valid statuses for this year's applications.
  * Format per application type is {value: label}
  */
-export function getApplicationStatuses(type, addAutoEmail = true) {
+export function getApplicationStatuses(type, addAutoEmail = false) {
   if (type === 'teacher') {
     return {
       incomplete: 'Incomplete',


### PR DESCRIPTION
Removes the auto-email text by default, fulfilliing https://codedotorg.atlassian.net/browse/ACQ-229.

This constant is used in 6 components:
<img width="1194" alt="image" src="https://user-images.githubusercontent.com/9142121/202238896-2a072a40-2a0d-42e7-9b99-36ac1721cab1.png">

The only place where the `addAutoEmail` param is used is in DetailViewContents https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/code-studio/pd/application_dashboard/detail_view_contents.jsx#L238 and https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/code-studio/pd/application_dashboard/detail_view_contents.jsx#L619. This is great because we only want the `auto-email` text to show in the detail view, and only for certain applications based on their email settings. For all other views, we do *not* want the text to show.


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
