### PR TITLE
Add missing close eyes statement in Teacher App eyes test

### DIFF
--- a/dashboard/test/ui/features/acquisition_products/pd/teacher_application.feature
+++ b/dashboard/test/ui/features/acquisition_products/pd/teacher_application.feature
@@ -116,6 +116,7 @@ Scenario: Teacher saves, re-opens, and submits an application
   Then I am on "http://studio.code.org/pd/application/teacher"
   Then I wait until element "p" contains text "We found an application you started! Your saved responses have been loaded."
   And I see no difference for "Viewing previously-saved teacher application"
+  Then I close my eyes
 
   # Finish Section 2 which was started
   And I complete Section 2 of the teacher PD application


### PR DESCRIPTION
Teacher app eyes test was consistently failing due to a missing statement to close eyes, as discussed in [this thread](https://codedotorg.slack.com/archives/C04540KNGDQ/p1668539643935629).

I put the close eyes statement at the end of the last application section that uses eyes checks rather than at the end of the last eyes test. Please let me know if it should be at the end of the whole test rather than just after the last "and I see no difference" statement!

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
