### PR TITLE
Add `rubocop-rails-accessibility`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,7 @@ inherit_from:
 require:
   - rubocop-performance
   - rubocop-rails
+  - rubocop-rails-accessibility
 
 AllCops:
   SuggestExtensions: false

--- a/Gemfile
+++ b/Gemfile
@@ -246,6 +246,7 @@ group :development, :staging, :levelbuilder do
   gem 'rubocop', '1.28', require: false
   gem 'rubocop-performance', require: false
   gem 'rubocop-rails', require: false
+  gem 'rubocop-rails-accessibility', require: false
   gem 'scss_lint', require: false
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -767,6 +767,8 @@ GEM
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 1.7.0, < 2.0)
+    rubocop-rails-accessibility (0.2.0)
+      rubocop (>= 1.0.0)
     ruby-openid (2.7.0)
     ruby-prof (0.15.9)
     ruby-progressbar (1.11.0)
@@ -1041,6 +1043,7 @@ DEPENDENCIES
   rubocop (= 1.28)
   rubocop-performance
   rubocop-rails
+  rubocop-rails-accessibility
   ruby-prof
   ruby-progressbar
   ruby_dep (~> 1.3.1)

--- a/dashboard/app/helpers/application_helper.rb
+++ b/dashboard/app/helpers/application_helper.rb
@@ -47,11 +47,6 @@ module ApplicationHelper
     end
   end
 
-  def check_mark_html
-    #raw "&#x2714;"
-    image_tag(image_url('white-checkmark.png'))
-  end
-
   def activity_css_class(user_level)
     best_activity_css_class([user_level])
   end


### PR DESCRIPTION
This came out of our "Accessibility Linter" discussion. We simply add the existing rubocop linter plugin for accessibility concerns.

There was only a single violation of those new rules, but it's not currently used anywhere. The [last reference to it being used that I could find](https://github.com/code-dot-org/code-dot-org/blob/10f80982f8ca339e8a80a4369e92e03ef44f2041/dashboard/app/views/shared/_user_stats.html.haml#L57) was removed by some earlier cleanup work in https://github.com/code-dot-org/code-dot-org/pull/34470, so rather than fixing the violation I removed it.

## Links

- https://github.com/github/rubocop-rails-accessibility
- https://docs.google.com/document/d/1gbeioiUGy9alFX1ytwLZQ74dqpaoHSeHBsm2ai2vGOY/edit

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
