### PR TITLE
Add Basic DOTD Script Self-Check

### DIFF
--- a/bin/dotd
+++ b/bin/dotd
@@ -166,7 +166,7 @@ def dotd_menu_prompt
 
         #{bold 'A'}: Show all options.
 
-      Honeybadger:
+      Misc:
 
         #{bold 'H'}: Retrieve #{underline 'H'}oneybadger issues.
 
@@ -197,9 +197,10 @@ def dotd_menu_prompt_all
 
         #{bold 'D'}: Show default (limited) options.
 
-      Honeybadger:
+      Misc:
 
         #{bold 'H'}: Retrieve #{underline 'H'}oneybadger issues.
+        #{bold 'C'}: Perform self-#{underline 'c'}heck diagnostic.
 
       DTS:
 
@@ -242,6 +243,7 @@ def dotd_menu(dotd_name)
       menu.choice(:A) {show_full_menu = true}
       menu.choice(:D) {show_full_menu = false}
       menu.choice(:H) {get_honeybadger_issues}
+      menu.choice(:C) {perform_self_check}
       menu.choice(:S) do
         if run_on 'staging', "staging/bin/content-push --name=\"#{@dotd_name}\""
           @logger.info 'commits content on staging'
@@ -463,6 +465,24 @@ def get_honeybadger_issues
   end
   puts '' if issues.count > 0
   @logger.info 'gets honeybadger issues'
+end
+
+# Performs a diagnostic self-check to make sure the local environment is
+# properly set up for all standard Dev of the Day operations.
+def perform_self_check
+  puts "Checking access to internal servers"
+  %w(staging test levelbuilder-staging production-console).each do |environment|
+    run_on(environment, "echo 'successfully connected to #{environment}'")
+  end
+
+  puts "Checking access to GitHub"
+  puts "latest staging commit is: #{GitHub.sha('staging', true)}"
+
+  puts "Checking access to Slack"
+  puts "current Developer of the Day is: #{DevelopersTopic.dotd}"
+
+  puts "Checking access to Honeybadger"
+  puts "TODO"
 end
 
 # Creates a new branch with the given name from the given commit on the test

--- a/bin/dotd
+++ b/bin/dotd
@@ -481,8 +481,12 @@ def perform_self_check
   puts "Checking access to Slack"
   puts "current Developer of the Day is: #{DevelopersTopic.dotd}"
 
-  puts "Checking access to Honeybadger"
-  puts "TODO"
+  # We forego checking access to Honeybadger here; in part because Honeybadger
+  # access is not required for standard Dev of the Day operations but mostly
+  # because we don't really have a good way to do so. We could call
+  # Honeybadger.get_recent_issues, but probably we should create a
+  # more-targeted method on the Honeybadger class we can call to check
+  # connectivity. Saving that as a problem for a future developer.
 end
 
 # Creates a new branch with the given name from the given commit on the test


### PR DESCRIPTION
Adds a basic self-check to the Dev of the Day script, primarily intended for use by devs running the script on their system for the first time to confirm that their local environment is configured correctly to enable all necessary script functionality.

I also updated the documentation at https://docs.google.com/document/d/166j9G-Kn_PeHoV4RRX9l-x-42NlahPn0sT6tTFTX5LY/edit# to recommend this check to new Devs of the Day

## Testing story

Tested locally:

```
Your Choice: A, D, H, C, S, DTS, DTT, G, R, K, DTP, L, DTL or Q?  C
Checking access to internal servers
successfully connected to staging
Connection to ip-10-0-128-226.ec2.internal closed.
Connection to gateway.code.org closed.
successfully connected to test
Connection to ip-10-0-0-254.ec2.internal closed.
Connection to gateway.code.org closed.
successfully connected to levelbuilder-staging
Connection to ip-10-0-0-250.ec2.internal closed.
Connection to gateway.code.org closed.
successfully connected to production-console
Connection to ip-10-0-1-51.ec2.internal closed.
Connection to gateway.code.org closed.
Checking access to GitHub
latest staging commit is: 0f76173d
Checking access to Slack
current Developer of the Day is: elijah
Checking access to Honeybadger
TODO
```

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
