### PR TITLE
Music: dynamic timeline event heights

### DIFF
--- a/apps/src/music/Timeline.jsx
+++ b/apps/src/music/Timeline.jsx
@@ -89,6 +89,9 @@ export default class Timeline extends React.Component {
       ? (currentAudioElapsedTime * barWidth) / convertMeasureToSeconds(1)
       : null;
 
+    // Leave some vertical space between each event block.
+    const eventVerticalSpace = 2;
+
     return (
       <div
         id="timeline"
@@ -158,6 +161,7 @@ export default class Timeline extends React.Component {
                   style={{
                     width: barWidth * this.getLengthForId(eventData.id) - 4,
                     position: 'absolute',
+                    boxSizing: 'border-box',
                     left: barWidth * eventData.when,
                     top: 20 + this.getVerticalOffsetForEventId(eventData.id),
                     backgroundColor: this.getColorsForEventId(eventData.id)
@@ -166,7 +170,7 @@ export default class Timeline extends React.Component {
                       'solid 2px ' +
                       this.getColorsForEventId(eventData.id).border,
                     borderRadius: 8,
-                    height: this.getEventHeight() - 6
+                    height: this.getEventHeight() - eventVerticalSpace
                   }}
                 >
                   &nbsp;

--- a/apps/src/music/Timeline.jsx
+++ b/apps/src/music/Timeline.jsx
@@ -13,7 +13,28 @@ export default class Timeline extends React.Component {
     sounds: PropTypes.array
   };
 
-  getUniqueIndexForEventId = id => {
+  getEventHeight = () => {
+    const numUniqueSounds = this.getUniqueSounds().length;
+    const actualHeight = 110;
+
+    // While we might not actually have this many rows to show,
+    // we will limit each row's height to the size that would allow
+    // this many to be shown at once.
+    const minVisible = 5;
+
+    const maxVisible = 10;
+
+    // We might not actually have this many rows to show, but
+    // we will size the bars so that this many rows would show.
+    const numSoundsToShow = Math.max(
+      Math.min(numUniqueSounds, maxVisible),
+      minVisible
+    );
+
+    return Math.floor(actualHeight / numSoundsToShow);
+  };
+
+  getUniqueSounds = () => {
     // Each unique sound gets its own color/row.
     const uniqueSounds = [];
     for (const songEvent of this.props.songData.events) {
@@ -22,12 +43,15 @@ export default class Timeline extends React.Component {
         uniqueSounds.push(id);
       }
     }
+    return uniqueSounds;
+  };
 
-    return uniqueSounds.indexOf(id);
+  getUniqueIndexForEventId = id => {
+    return this.getUniqueSounds().indexOf(id);
   };
 
   getVerticalOffsetForEventId = id => {
-    return this.getUniqueIndexForEventId(id) * 24;
+    return this.getUniqueIndexForEventId(id) * this.getEventHeight();
   };
 
   getColorsForEventId = id => {
@@ -142,7 +166,7 @@ export default class Timeline extends React.Component {
                       'solid 2px ' +
                       this.getColorsForEventId(eventData.id).border,
                     borderRadius: 8,
-                    height: 18
+                    height: this.getEventHeight() - 6
                   }}
                 >
                   &nbsp;


### PR DESCRIPTION
A small change so that the Music Lab timeline dynamically adjusts the height of the event bars to suit how many individual rows we want to show.  Currently we pick a height that at its maximum is equivalent to showing 5 rows, and the height gets smaller as we get to 10 rows.  More than 10 rows are not shown.  These two values can be easily changed as we observe usage.

Here's a collection of screenshots from 1-10 rows:

<img width="1017" alt="Screenshot 2022-11-17 at 9 52 29 AM" src="https://user-images.githubusercontent.com/2205926/202525194-dea5dbe2-6efe-4ee8-85b9-3eb2bbaafc45.png">
<img width="1017" alt="Screenshot 2022-11-17 at 9 52 39 AM" src="https://user-images.githubusercontent.com/2205926/202525213-ccdaa43f-2cbc-4c82-a9ea-f2ecab847877.png">
<img width="1017" alt="Screenshot 2022-11-17 at 9 52 43 AM" src="https://user-images.githubusercontent.com/2205926/202525231-f851bc67-33fa-4955-8972-2f93a6e56c8c.png">
<img width="1017" alt="Screenshot 2022-11-17 at 9 52 48 AM" src="https://user-images.githubusercontent.com/2205926/202525247-dada4ead-509b-4a27-8236-a6ebfd1a9074.png">
<img width="1017" alt="Screenshot 2022-11-17 at 9 52 54 AM" src="https://user-images.githubusercontent.com/2205926/202525251-1f03170e-6929-4b8d-bcdc-3841f3b6936a.png">
<img width="1017" alt="Screenshot 2022-11-17 at 9 52 58 AM" src="https://user-images.githubusercontent.com/2205926/202525264-849d4e73-a2d5-4383-88d8-55843baadc78.png">
<img width="1017" alt="Screenshot 2022-11-17 at 9 53 01 AM" src="https://user-images.githubusercontent.com/2205926/202525285-f9c8b5fb-bf26-4d50-af16-fd95f7b6f1bf.png">
<img width="1017" alt="Screenshot 2022-11-17 at 9 53 04 AM" src="https://user-images.githubusercontent.com/2205926/202525292-6cb9271d-faa0-402b-bc24-60f45579e5fc.png">
<img width="1017" alt="Screenshot 2022-11-17 at 9 53 08 AM" src="https://user-images.githubusercontent.com/2205926/202525306-1fb4942d-8d98-4d76-b816-b4439770fece.png">
<img width="1017" alt="Screenshot 2022-11-17 at 9 53 13 AM" src="https://user-images.githubusercontent.com/2205926/202525314-5b59f387-a8de-4542-944b-74304a074966.png">

