### PR TITLE
Reordering MC Express Script Level order

### DIFF
--- a/dashboard/config/scripts_json/express-2022.script_json
+++ b/dashboard/config/scripts_json/express-2022.script_json
@@ -20,7 +20,7 @@
     },
     "new_name": null,
     "family_name": "express",
-    "serialized_at": "2022-09-07 16:57:03 UTC",
+    "serialized_at": "2022-11-17 16:57:03 UTC",
     "published_state": "stable",
     "instruction_type": "teacher_led",
     "instructor_audience": "teacher",

--- a/dashboard/config/scripts_json/express-2022.script_json
+++ b/dashboard/config/scripts_json/express-2022.script_json
@@ -9979,31 +9979,6 @@
       "assessment": false,
       "properties": {
         "level_keys": [
-          "Overworld Powered Minecart2022"
-        ],
-        "progression": "Skill Building"
-      },
-      "bonus": false,
-      "seeding_key": {
-        "script_level.level_keys": [
-          "Overworld Powered Minecart2022"
-        ],
-        "lesson.key": "Looking Ahead with Minecraft",
-        "lesson_group.key": "csf_conditionals",
-        "script.name": "express-2022",
-        "activity_section.key": "83daad31-f1c9-4d21-897b-a291d39f55df"
-      },
-      "level_keys": [
-        "Overworld Powered Minecart2022"
-      ]
-    },
-    {
-      "chapter": 182,
-      "position": 10,
-      "activity_section_position": 10,
-      "assessment": false,
-      "properties": {
-        "level_keys": [
           "Underground Mining Coal2022"
         ],
         "progression": "Skill Building"
@@ -10020,6 +9995,31 @@
       },
       "level_keys": [
         "Underground Mining Coal2022"
+      ]
+    },
+    {
+      "chapter": 182,
+      "position": 10,
+      "activity_section_position": 10,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "Underground Iron2022"
+        ],
+        "progression": "Skill Building"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Underground Iron2022"
+        ],
+        "lesson.key": "Looking Ahead with Minecraft",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2022",
+        "activity_section.key": "83daad31-f1c9-4d21-897b-a291d39f55df"
+      },
+      "level_keys": [
+        "Underground Iron2022"
       ]
     },
     {
@@ -10081,14 +10081,14 @@
       "assessment": false,
       "properties": {
         "level_keys": [
-          "Underground Iron2022"
+          "Overworld Powered Minecart2022"
         ],
         "progression": "Challenge"
       },
       "bonus": false,
       "seeding_key": {
         "script_level.level_keys": [
-          "Underground Iron2022"
+          "Overworld Powered Minecart2022"
         ],
         "lesson.key": "Looking Ahead with Minecraft",
         "lesson_group.key": "csf_conditionals",
@@ -10096,7 +10096,7 @@
         "activity_section.key": "47b5c27a-db1c-4abd-a3c9-4d90561d7d79"
       },
       "level_keys": [
-        "Underground Iron2022"
+        "Overworld Powered Minecart2022"
       ]
     },
     {
@@ -16869,9 +16869,9 @@
     },
     {
       "seeding_key": {
-        "level.key": "Overworld Powered Minecart2022",
+        "level.key": "Underground Mining Coal2022",
         "script_level.level_keys": [
-          "Overworld Powered Minecart2022"
+          "Underground Mining Coal2022"
         ],
         "lesson.key": "Looking Ahead with Minecraft",
         "lesson_group.key": "csf_conditionals",
@@ -16881,9 +16881,9 @@
     },
     {
       "seeding_key": {
-        "level.key": "Underground Mining Coal2022",
+        "level.key": "Underground Iron2022",
         "script_level.level_keys": [
-          "Underground Mining Coal2022"
+          "Underground Iron2022"
         ],
         "lesson.key": "Looking Ahead with Minecraft",
         "lesson_group.key": "csf_conditionals",
@@ -16917,9 +16917,9 @@
     },
     {
       "seeding_key": {
-        "level.key": "Underground Iron2022",
+        "level.key": "Overworld Powered Minecart2022",
         "script_level.level_keys": [
-          "Underground Iron2022"
+          "Overworld Powered Minecart2022"
         ],
         "lesson.key": "Looking Ahead with Minecraft",
         "lesson_group.key": "csf_conditionals",


### PR DESCRIPTION
This repeats the work done in https://github.com/code-dot-org/code-dot-org/pull/45414, but for the 2022 version of the express course. 

I made progress on some of the affected levels and one of the neighbor levels to double check that progress was not lost in the reordering. 

9 -> 13
10 -> 9
13 -> 10

<img width="628" alt="Screen Shot 2022-11-17 at 4 34 44 PM" src="https://user-images.githubusercontent.com/37230822/202591602-eb70171d-a305-49cc-bf8b-9fc17ebd87c8.png">
<img width="621" alt="Screen Shot 2022-11-17 at 4 50 03 PM" src="https://user-images.githubusercontent.com/37230822/202591612-004e4e30-48d2-44fe-ac19-548f9136eb54.png">


## Links


- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/TEACH-88

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
