### PR TITLE
Hide scrollbar on CSA skinny banner on Windows OS

### DIFF
--- a/shared/css/csa_skinny_banner.scss
+++ b/shared/css/csa_skinny_banner.scss
@@ -9,7 +9,7 @@ $width-xs: 360px;
 .csa-skinny-banner {
   box-sizing: content-box;
   height: 120px;
-  overflow: auto;
+  overflow: hidden;
   margin: 4em auto 5em;
   padding: 0 2.5em;
   background: url('/images/csa/csa-skinny-banner-bg.svg') top left no-repeat;


### PR DESCRIPTION
Windows machines are showing a scrollbar on the CSA skinny banner on https://code.org/educate/professional-learning/middle-high 

- Tested this in Chrome Dev Tools w/ Molly P. who has a Windows machine 

----

### Before:
![image](https://user-images.githubusercontent.com/9256643/202761334-080ff353-8b5b-4117-8572-51bab55dafb7.png)

### After:
<img width="1034" alt="Screenshot 2022-11-18 at 9 05 48 AM" src="https://user-images.githubusercontent.com/9256643/202761389-3763ef9b-102e-4643-8c26-7b299a89b08d.png">



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203401455834392