### PR TITLE
[Storybook Refactor] Update NewProjectButtons, PublishDialog, and FeaturedProjectsTable

### DIFF
--- a/apps/src/templates/projects/FeaturedProjectsTable.story.jsx
+++ b/apps/src/templates/projects/FeaturedProjectsTable.story.jsx
@@ -21,6 +21,6 @@ FeaturedProjectTableArchive.args = {
 };
 
 export default {
-  title: 'Featured Projects Table',
+  title: 'FeaturedProjectsTable',
   component: FeaturedProjectsTable
 };

--- a/apps/src/templates/projects/FeaturedProjectsTable.story.jsx
+++ b/apps/src/templates/projects/FeaturedProjectsTable.story.jsx
@@ -6,29 +6,21 @@ import {
 } from './generateFakeProjects';
 import {featuredProjectTableTypes} from './projectConstants';
 
-export default storybook => {
-  return storybook
-    .storiesOf('Projects/FeaturedProjectsTable', module)
-    .addStoryTable([
-      {
-        name: 'Featured Project Table - current',
-        description: 'Table of currently featured projects projects',
-        story: () => (
-          <FeaturedProjectsTable
-            projectList={stubFakeFeaturedProjectData}
-            tableVersion={featuredProjectTableTypes.current}
-          />
-        )
-      },
-      {
-        name: 'Featured Project Table - archive',
-        description: 'Table of projects that have previously been featured',
-        story: () => (
-          <FeaturedProjectsTable
-            projectList={stubFakeUnfeaturedProjectData}
-            tableVersion={featuredProjectTableTypes.archived}
-          />
-        )
-      }
-    ]);
+const Template = args => <FeaturedProjectsTable {...args} />;
+
+export const FeaturedProjectTableCurrent = Template.bind({});
+FeaturedProjectTableCurrent.args = {
+  projectList: stubFakeFeaturedProjectData,
+  tableVersion: featuredProjectTableTypes.current
+};
+
+export const FeaturedProjectTableArchive = Template.bind({});
+FeaturedProjectTableArchive.args = {
+  projectList: stubFakeUnfeaturedProjectData,
+  tableVersion: featuredProjectTableTypes.archived
+};
+
+export default {
+  title: 'Featured Projects Table',
+  component: FeaturedProjectsTable
 };

--- a/apps/src/templates/projects/NewProjectButtons.story.jsx
+++ b/apps/src/templates/projects/NewProjectButtons.story.jsx
@@ -31,6 +31,6 @@ MinecraftProjectButtons.args = {
 };
 
 export default {
-  title: 'New Project Buttons',
+  title: 'NewProjectButtons',
   component: NewProjectButtons
 };

--- a/apps/src/templates/projects/NewProjectButtons.story.jsx
+++ b/apps/src/templates/projects/NewProjectButtons.story.jsx
@@ -1,59 +1,36 @@
 import React from 'react';
+import {Provider} from 'react-redux';
+import i18n from '@cdo/locale';
+import {reduxStore} from '@cdo/storybook/decorators';
 import NewProjectButtons from './NewProjectButtons';
 
-export default storybook => {
-  storybook
-    .storiesOf('Buttons/NewProjectButtons', module)
-    .withReduxStore()
-    .addStoryTable([
-      {
-        name: 'Default project buttons',
-        description:
-          'Buttons to make a new App Lab, Game Lab, Play Lab and Artist project',
-        story: () => <NewProjectButtons />
-      },
-      {
-        name: 'Modified project buttons',
-        description:
-          'Buttons to make a new Web Lab, App Lab, Calc and Eval project',
-        story: () => (
-          <NewProjectButtons
-            projectTypes={['weblab', 'applab', 'calc', 'eval']}
-          />
-        )
-      },
-      {
-        name: 'Brand project buttons',
-        description:
-          'Buttons to make a new Frozen, Starwars, and both Minecraft projects',
-        story: () => (
-          <NewProjectButtons
-            projectTypes={[
-              'frozen',
-              'starwars',
-              'minecraft_adventurer',
-              'minecraft_designer'
-            ]}
-          />
-        )
-      },
-      {
-        name: 'More options',
-        description: 'Buttons for Starwars Blocks, Flappy, Sports, Basketball',
-        story: () => (
-          <NewProjectButtons
-            projectTypes={['starwarsblocks', 'flappy', 'sports', 'basketball']}
-          />
-        )
-      },
-      {
-        name: 'Even more options',
-        description: 'Buttons for Bounce, Infinity, Ice Age, Gumball',
-        story: () => (
-          <NewProjectButtons
-            projectTypes={['bounce', 'infinity', 'iceage', 'gumball']}
-          />
-        )
-      }
-    ]);
+const Template = args => (
+  <Provider store={reduxStore()}>
+    <NewProjectButtons {...args} />
+  </Provider>
+);
+
+const DEFAULT_PROJECT_TYPES_BASIC = ['spritelab', 'artist', 'dance', 'playlab'];
+
+const MINECRAFT_PROJECT_TYPES = [
+  'minecraft_adventurer',
+  'minecraft_designer',
+  'minecraft_hero',
+  'minecraft_aquatic'
+];
+
+export const DefaultProjectButtons = Template.bind({});
+DefaultProjectButtons.args = {
+  projectTypes: DEFAULT_PROJECT_TYPES_BASIC
+};
+
+export const MinecraftProjectButtons = Template.bind({});
+MinecraftProjectButtons.args = {
+  projectTypes: MINECRAFT_PROJECT_TYPES,
+  description: i18n.projectGroupMinecraft()
+};
+
+export default {
+  title: 'New Project Buttons',
+  component: NewProjectButtons
 };

--- a/apps/src/templates/projects/publishDialog/PublishDialog.story.jsx
+++ b/apps/src/templates/projects/publishDialog/PublishDialog.story.jsx
@@ -19,7 +19,6 @@ const Template = overrides => (
 );
 
 export const DialogOpen = Template.bind({});
-DialogOpen.args = {};
 
 export const DialogOpenPublishPending = Template.bind({});
 DialogOpenPublishPending.args = {

--- a/apps/src/templates/projects/publishDialog/PublishDialog.story.jsx
+++ b/apps/src/templates/projects/publishDialog/PublishDialog.story.jsx
@@ -14,14 +14,15 @@ const publishDialogDefaultProps = {
   onClose: action('close')
 };
 
-const Template = args => <PublishDialog {...args} />;
+const Template = overrides => (
+  <PublishDialog {...publishDialogDefaultProps} {...overrides} />
+);
 
 export const DialogOpen = Template.bind({});
-DialogOpen.args = {...publishDialogDefaultProps};
+DialogOpen.args = {};
 
 export const DialogOpenPublishPending = Template.bind({});
 DialogOpenPublishPending.args = {
-  ...publishDialogDefaultProps,
   isPublishPending: true
 };
 

--- a/apps/src/templates/projects/publishDialog/PublishDialog.story.jsx
+++ b/apps/src/templates/projects/publishDialog/PublishDialog.story.jsx
@@ -1,39 +1,31 @@
 import React from 'react';
-import {UnconnectedPublishDialog as PublishDialog} from './PublishDialog';
 import {action} from '@storybook/addon-actions';
+import {UnconnectedPublishDialog as PublishDialog} from './PublishDialog';
 
 const PROJECT_ID = 'MY_PROJECT_ID';
 const PROJECT_TYPE = 'MY_PROJECT_TYPE';
 
-export default storybook => {
-  return storybook.storiesOf('Dialogs/PublishDialog', module).addStoryTable([
-    {
-      name: 'dialog open',
-      description: '',
-      story: () => (
-        <PublishDialog
-          isOpen={true}
-          isPublishPending={false}
-          projectId={PROJECT_ID}
-          projectType={PROJECT_TYPE}
-          onConfirmPublish={action('publish')}
-          onClose={action('close')}
-        />
-      )
-    },
-    {
-      name: 'dialog open with publish pending',
-      description: '',
-      story: () => (
-        <PublishDialog
-          isOpen={true}
-          isPublishPending={true}
-          projectId={PROJECT_ID}
-          projectType={PROJECT_TYPE}
-          onConfirmPublish={action('publish')}
-          onClose={action('close')}
-        />
-      )
-    }
-  ]);
+const publishDialogDefaultProps = {
+  isOpen: true,
+  isPublishPending: false,
+  projectId: PROJECT_ID,
+  projectType: PROJECT_TYPE,
+  onConfirmPublish: action('publish'),
+  onClose: action('close')
+};
+
+const Template = args => <PublishDialog {...args} />;
+
+export const DialogOpen = Template.bind({});
+DialogOpen.args = {...publishDialogDefaultProps};
+
+export const DialogOpenPublishPending = Template.bind({});
+DialogOpenPublishPending.args = {
+  ...publishDialogDefaultProps,
+  isPublishPending: true
+};
+
+export default {
+  title: 'PublishDialog',
+  component: PublishDialog
 };


### PR DESCRIPTION
Refactored NewProjectButtons, PublishDialog, and FeaturedProjectsTable from https://docs.google.com/spreadsheets/d/1z8r10AcR0v3GimV_-28dJ6QaiaQ3CJoo9yXqa7U_bKs/edit#gid=0. 

All rendered properly locally. 

Notes:
1. The `NewProjectButtons` file seemed to have a lot of stories that were a little bit redundant (see https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/templates/projects/NewProjectButtons.story.jsx#L50). I cut the number rendered down to two and copied the constants for `DEFAULT_PROJECT_TYPES_BASIC` and `MINECRAFT_PROJECT_TYPES` from https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/templates/projects/StartNewProject.jsx. 

## Links

Storybook files to refactor spreadsheet here: https://docs.google.com/spreadsheets/d/1z8r10AcR0v3GimV_-28dJ6QaiaQ3CJoo9yXqa7U_bKs/edit#gid=0

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
