### PR TITLE
[Web Lab] Fix documentation link in help menu

### DIFF
--- a/lib/cdo/help_header.rb
+++ b/lib/cdo/help_header.rb
@@ -56,12 +56,6 @@ class HelpHeader
         url: "https://studio.code.org/docs/ide/weblab/",
         id: "weblab-docs"
       }
-
-      entries << {
-        title: I18n.t("#{loc_prefix}web_lab_tutorials"),
-        url: CDO.code_org_url('/educate/weblab'),
-        id: "weblab-tutorials"
-      }
     end
 
     entries << {

--- a/lib/cdo/help_header.rb
+++ b/lib/cdo/help_header.rb
@@ -53,8 +53,14 @@ class HelpHeader
     if options[:level] && options[:level].game == Game.weblab
       entries << {
         title: I18n.t("#{loc_prefix}web_lab_documentation"),
-        url: "https://studio.code.org/docs/weblab/ol/",
+        url: "https://studio.code.org/docs/ide/weblab/",
         id: "weblab-docs"
+      }
+
+      entries << {
+        title: I18n.t("#{loc_prefix}web_lab_tutorials"),
+        url: CDO.code_org_url('/educate/weblab'),
+        id: "weblab-tutorials"
       }
     end
 


### PR DESCRIPTION
The help link for Web Lab documentation is always taking users directly to the page about ordered lists. 

Slack context from @dancodedotorg:
> Based on some digging from a ZenDesk ticket, a feature request for the ? menu in Web Lab levels/projects:
> The Web Lab Documentation link looks to be hard-coded to Ordered Lists - can we change this to the general Web Lab documentation page?

The correct link is https://studio.code.org/docs/ide/weblab/

This dropdown menu option was originally created here: 
- https://github.com/code-dot-org/code-dot-org/pull/36756

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
