### PR TITLE
Move logToCloud calls from CdoBramble to WebLab

### DIFF
--- a/apps/src/weblab/CdoBramble.js
+++ b/apps/src/weblab/CdoBramble.js
@@ -759,7 +759,7 @@ export default class CdoBramble {
   }
 
   logAction(actionName, value = {}) {
-    logToCloud.addPageAction(actionName, value);
+    this.api.addPageAction(actionName, value);
   }
 
   isHtml(path) {

--- a/apps/src/weblab/WebLab.js
+++ b/apps/src/weblab/WebLab.js
@@ -26,6 +26,7 @@ import {queryParams} from '@cdo/apps/code-studio/utils';
 import {reload} from '../utils';
 import firehoseClient from '../lib/util/firehose';
 import {getCurrentId} from '../code-studio/initApp/project';
+import logToCloud from '../logToCloud';
 
 export const WEBLAB_FOOTER_HEIGHT = 30;
 
@@ -653,6 +654,15 @@ WebLab.prototype.redux = function() {
   };
 };
 
+/**
+ * Expose New Relic page action hook for use by the enclosed Bramble application.
+ * Defined here instead of in CdoBramble.js because logToCloud relies on window.newrelic
+ * being set. Bramble is hosted within an iframe, so window is different in that context.
+ */
+WebLab.prototype.addPageAction = function(...args) {
+  logToCloud.addPageAction(...args);
+};
+
 WebLab.prototype.syncBrambleFiles = function(callback = () => {}) {
   this.brambleHost?.syncFiles(
     this.getCurrentFileEntries(),
@@ -689,6 +699,7 @@ WebLab.prototype.onBrambleReady = function() {
 
 WebLab.prototype.brambleApi = function() {
   return {
+    addPageAction: this.addPageAction.bind(this),
     changeProjectFile: this.changeProjectFile.bind(this),
     deleteProjectFile: this.deleteProjectFile.bind(this),
     getCurrentFileEntries: this.getCurrentFileEntries.bind(this),


### PR DESCRIPTION
Basically reimplements the change in #25271 because I broke it in #39845.

Bramble is hosted in an iframe, so when CdoBramble.js is loaded, its `window` object is different than the rest of our application. Our New Relic code in logToCloud.js relies on `window.newrelic` being set (and no-ops if it isn't set), so our calls to `logToCloud.addPageAction` were no-oping because `window.newrelic` doesn't exist within the Bramble iframe.

https://github.com/code-dot-org/code-dot-org/blob/5c8b24674d1c2f7e51e85dd32124e113dc423d84/apps/src/logToCloud.js#L38-L80

This PR fixes it so that WebLab.js calls `logToCloud.addPageAction` again instead since `window.newrelic` will be set in that context.