### PR TITLE
removed extra certificate links for korean

### DIFF
--- a/apps/src/templates/certificates/Congrats.jsx
+++ b/apps/src/templates/certificates/Congrats.jsx
@@ -32,7 +32,7 @@ export default function Congrats(props) {
    */
   const renderExtraCertificateLinks = (language, tutorial) => {
     let extraLinkUrl, extraLinkText;
-
+    // If Adding extra links see this PR: https://github.com/code-dot-org/code-dot-org/pull/48515
     if (!extraLinkUrl || !extraLinkText) {
       // There are no extra links to render.
       return;

--- a/apps/src/templates/certificates/Congrats.jsx
+++ b/apps/src/templates/certificates/Congrats.jsx
@@ -5,7 +5,6 @@ import StudentsBeyondHoc from './StudentsBeyondHoc';
 import TeachersBeyondHoc from './TeachersBeyondHoc';
 import PetitionCallToAction from '@cdo/apps/templates/certificates/petition/PetitionCallToAction';
 import styleConstants from '../../styleConstants';
-import {pegasus} from '@cdo/apps/lib/util/urlHelpers';
 import color from '../../util/color';
 import GraduateToNextLevel from '@cdo/apps/templates/certificates/GraduateToNextLevel';
 
@@ -33,19 +32,7 @@ export default function Congrats(props) {
    */
   const renderExtraCertificateLinks = (language, tutorial) => {
     let extraLinkUrl, extraLinkText;
-    // In order to remove the certificate links remove or comment the following section -------------------------------
-    if (language === 'ko') {
-      if (/oceans/.test(tutorial)) {
-        extraLinkUrl = pegasus('/files/online-coding-party-2021-oceans.pdf');
-        extraLinkText =
-          '온라인 코딩 파티 인증서 받으러 가기! (과학기술정보통신부 인증)';
-      } else if (/dance/.test(tutorial)) {
-        extraLinkUrl = pegasus('/files/online-coding-party-2021-dance.pdf');
-        extraLinkText =
-          '온라인 코딩 파티 인증서 받으러 가기! (과학기술정보통신부 인증)';
-      }
-    }
-    // End of section to be removed or commented ----------------------------------------------------------------------
+
     if (!extraLinkUrl || !extraLinkText) {
       // There are no extra links to render.
       return;


### PR DESCRIPTION
South Korea is hosting their national Online Coding Party campaign again from October 11 through November 21, and they just reached out to me and asked us to link to their campaign certificates for Dance Party and AI for Oceans again.

Certificate Links were added on October 11th ([in this PR](https://github.com/code-dot-org/code-dot-org/pull/48515)) now they need to be removed.

## Links
- jira ticket: [FND-2107](https://codedotorg.atlassian.net/browse/FND-2107)

## Testing story
Before:
![Screen Shot 2022-10-10 at 00 21 54](https://user-images.githubusercontent.com/66776217/203401885-6148e341-aa0d-4903-a1f1-546aacdfafbe.png)
![Screen Shot 2022-10-10 at 00 21 46](https://user-images.githubusercontent.com/66776217/203401886-1ef19ebc-1fca-4788-9900-1d9bc8a13d95.png)

After:
![Screenshot 2022-11-22 at 12 49 25](https://user-images.githubusercontent.com/66776217/203401694-e444f008-1638-4404-8c5e-32d91b6c28b6.png)
![Screenshot 2022-11-22 at 12 48 50](https://user-images.githubusercontent.com/66776217/203401699-c1ba22c1-f379-4035-a88d-cb758437c22d.png)


## Follow-up work
Due to the time bound nature of this events, it has been hard to create a long term solution. Specially since we do not know if or when this events will take place.

It would be worth exploring a solution to do this better/with less overhead in the future.

## PR Checklist:


- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
