### PR TITLE
Filter featured projects with abuse_score greater than 0

### DIFF
--- a/dashboard/lib/projects_list.rb
+++ b/dashboard/lib/projects_list.rb
@@ -227,6 +227,7 @@ module ProjectsList
           state: 'active'
         ).
         exclude(published_at: nil).
+        exclude(abuse_score: 0...).
         order(Sequel.desc(:published_at)).limit(8).all.shuffle!
       extract_data_for_featured_project_cards(project_featured_project_user_combo_data)
     end


### PR DESCRIPTION
Currently, featured projects with abuse scores greater than zero (indicative of a banned/abusive project) are still displayed (with a broken thumbnail). We want to err on the side of reducing abuse potential, so we are filtering these projects out from being displayed.

In the code, I added an `exclude` to `fetch_featured_projects_by_type` to filter out abusive/banned projects.

Before, 'Lemonade' and 'Forest' are featured projects. 'Forest' has an abuse score of 70. Both are displayed.
![Screenshot from 2022-11-21 16-46-52](https://user-images.githubusercontent.com/2959170/203187301-6593cc79-5b11-49c7-9138-bb1a8608447a.png)

After,  'Lemonade' and 'Forest' are featured projects. 'Forest' has an abuse score of 70. Only 'Lemonade' is displayed.
![Screenshot from 2022-11-21 16-45-49](https://user-images.githubusercontent.com/2959170/203187399-e774700d-2c22-4e4b-9e82-abcbab670303.png)


Testing story: I'm working on getting this tested, but it's turning out to be a non-trivial test to write! See slack thread: https://codedotorg.slack.com/archives/C0T10HG6N/p1669134858512679 Discussed with @dju90 and we decided to move forward with this change, as manually tested, and follow-up with a test once we figure out how to do that.