### PR TITLE
Remove facilitator and principal application Gatekeeper flags

### DIFF
--- a/dashboard/app/controllers/pd/application/facilitator_application_controller.rb
+++ b/dashboard/app/controllers/pd/application/facilitator_application_controller.rb
@@ -7,12 +7,6 @@ module Pd::Application
     end
 
     def new
-      # Block on production until we're ready to release and publicize the url
-      # TODO: Andrew - remove this, and the associated Gatekeeper key, after we go live
-      if Rails.env.production? && !current_user.try(:workshop_admin?) && Gatekeeper.disallows('pd_facilitator_application')
-        return head :not_found
-      end
-
       return render :logged_out unless current_user
       return render :not_teacher unless current_user.teacher?
 

--- a/dashboard/app/controllers/pd/application/principal_approval_application_controller.rb
+++ b/dashboard/app/controllers/pd/application/principal_approval_application_controller.rb
@@ -4,10 +4,10 @@ module Pd::Application
     include ActiveApplicationModels
 
     def new
-      # Temporary security settings
-      # TODO: Mehal - remove this and associated Gatekeeper key after going to prod
-      if Rails.env.production? && !current_user.try(:workshop_admin?) && Gatekeeper.disallows('pd_principal_approval_application')
-        return render :not_available
+      # Block on production until we're ready to release and publicize the url for teacher applications
+      # Allow workshop admins to preview
+      if Rails.env.production? && !current_user.try(:workshop_admin?) && Gatekeeper.disallows('pd_teacher_application')
+        return head :not_found
       end
 
       teacher_application = TEACHER_APPLICATION_CLASS.find_by(application_guid: params[:application_guid])

--- a/dashboard/test/controllers/pd/application/principal_approval_application_controller_test.rb
+++ b/dashboard/test/controllers/pd/application/principal_approval_application_controller_test.rb
@@ -32,13 +32,5 @@ module Pd::Application
       assert_equal teacher_application.applicant_name, assigns(:teacher_application)[:name]
       assert_equal 'Computer Science Principles', assigns(:teacher_application)[:course]
     end
-
-    test 'renders not available on production' do
-      Rails.env.stubs(:production?).returns(true)
-      get :new, params: {application_guid: 'some_guid'}
-      assert_template :not_available
-      assert_response :success
-      Rails.env.unstub(:production)
-    end
   end
 end


### PR DESCRIPTION
Both facilitator and principal application flags were used while those features were in development. Now, we can remove them.

The principal approval will open and close at the same time as teacher applications, so we'll use that flag instead of the principal flag.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

Once this gets merged in, I'll go into Gatekeeper and remove the flags.

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
