### PR TITLE
Move temp logging to Weblab API

### DIFF
--- a/apps/src/weblab/CdoBramble.js
+++ b/apps/src/weblab/CdoBramble.js
@@ -6,37 +6,6 @@ import logToCloud from '../logToCloud';
 import {Buffer} from 'buffer';
 
 import testImageAccess from '../code-studio/url_test';
-import firehoseClient from '../lib/util/firehose';
-
-// Some temporary logging to diagnose possible loading issues.
-function tempLog(event, data = null) {
-  firehoseClient.putRecord(
-    {
-      study: 'weblab_loading_investigation_2022',
-      event: event,
-      data_json: data === null ? null : JSON.stringify(data)
-    },
-    {includeUserId: true}
-  );
-}
-
-// Test for whether we can reach the servers hosting the downloadable
-// JS and saving work.  Images are used to avoid CORS restrictions.
-function testReach() {
-  testImageAccess(
-    'https://downloads.computinginthecore.org/favicon.ico' +
-      '?' +
-      Math.random(),
-    () => tempLog('reachDownloads', true),
-    () => tempLog('reachDownloads', false)
-  );
-
-  testImageAccess(
-    'https://codeprojects.org/favicon.ico' + '?' + Math.random(),
-    () => tempLog('reachProjects', true),
-    () => tempLog('reachProjects', false)
-  );
-}
 
 const PageAction = makeEnum(
   logToCloud.PageAction.BrambleError,
@@ -84,15 +53,15 @@ export default class CdoBramble {
     let currentInitState = 'none';
 
     // Temporarily log the state.
-    tempLog('init');
+    this.tempLog('init');
 
     // Temporarily log the current state after 20 seconds.
     setTimeout(() => {
-      tempLog('after20', currentInitState);
+      this.tempLog('after20', currentInitState);
     }, 20 * 1000);
 
     // Temporarily test domain reachability.
-    testReach();
+    this.testReach();
 
     this.Bramble.load('#bramble', this.config());
 
@@ -104,7 +73,7 @@ export default class CdoBramble {
         });
 
         // Temporarily log and store the state.
-        tempLog('mountable');
+        this.tempLog('mountable');
         currentInitState = 'mountable';
       }
     });
@@ -117,7 +86,7 @@ export default class CdoBramble {
       this.invokeAll(this.onReadyCallbacks);
 
       // Temporarily log and store the state.
-      tempLog('ready');
+      this.tempLog('ready');
       currentInitState = 'ready';
     });
   }
@@ -729,7 +698,7 @@ export default class CdoBramble {
         });
 
         // Temporarily log the error.
-        tempLog('fileresetfail', err.message);
+        this.tempLog('fileresetfail', err.message);
       } else {
         this.logAction(PageAction.BrambleFilesystemResetSuccess);
       }
@@ -748,7 +717,7 @@ export default class CdoBramble {
     this.logAction(PageAction.BrambleError, {error: message});
 
     // Temporarily log the error.
-    tempLog('error', {message, code});
+    this.tempLog('error', {message, code});
 
     this.api.openFatalErrorDialog(
       message,
@@ -760,6 +729,29 @@ export default class CdoBramble {
 
   logAction(actionName, value = {}) {
     this.api.addPageAction(actionName, value);
+  }
+
+  // Some temporary logging to diagnose possible loading issues.
+  tempLog(event, data = null) {
+    this.api.tempLog(event, data);
+  }
+
+  // Test for whether we can reach the servers hosting the downloadable
+  // JS and saving work.  Images are used to avoid CORS restrictions.
+  testReach() {
+    testImageAccess(
+      'https://downloads.computinginthecore.org/favicon.ico' +
+        '?' +
+        Math.random(),
+      () => this.tempLog('reachDownloads', true),
+      () => this.tempLog('reachDownloads', false)
+    );
+
+    testImageAccess(
+      'https://codeprojects.org/favicon.ico' + '?' + Math.random(),
+      () => this.tempLog('reachProjects', true),
+      () => this.tempLog('reachProjects', false)
+    );
   }
 
   isHtml(path) {

--- a/apps/src/weblab/WebLab.js
+++ b/apps/src/weblab/WebLab.js
@@ -663,6 +663,18 @@ WebLab.prototype.addPageAction = function(...args) {
   logToCloud.addPageAction(...args);
 };
 
+// Some temporary logging to diagnose possible loading issues.
+WebLab.prototype.tempLog = function(event, data = null) {
+  firehoseClient.putRecord(
+    {
+      study: 'weblab_loading_investigation_2022',
+      event: event,
+      data_json: data === null ? null : JSON.stringify(data)
+    },
+    {includeUserId: true}
+  );
+};
+
 WebLab.prototype.syncBrambleFiles = function(callback = () => {}) {
   this.brambleHost?.syncFiles(
     this.getCurrentFileEntries(),
@@ -713,7 +725,8 @@ WebLab.prototype.brambleApi = function() {
     openFatalErrorDialog: this.openFatalErrorDialog.bind(this),
     registerBeforeFirstWriteHook: this.registerBeforeFirstWriteHook.bind(this),
     redux: this.redux.bind(this),
-    renameProjectFile: this.renameProjectFile.bind(this)
+    renameProjectFile: this.renameProjectFile.bind(this),
+    tempLog: this.tempLog.bind(this)
   };
 };
 


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

We noticed that the user ID was not getting reported to Firehose with the temp logging we added. This was because the Firehose client tries to grab the user ID from the current redux store, which doesn't exist in the context of CdoBramble. This is fixed by calling the firehose client in the WebLab API layer (similar to https://github.com/code-dot-org/code-dot-org/pull/49228).

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Confirmed that user ID gets included in the payload that will get reported to Firehose on production.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
