### PR TITLE
Update Teacher Application Detail View

### DIFF
--- a/apps/src/code-studio/pd/application/teacher/AdditionalDemographicInformation.jsx
+++ b/apps/src/code-studio/pd/application/teacher/AdditionalDemographicInformation.jsx
@@ -99,6 +99,16 @@ AdditionalDemographicInformation.associatedFields = [
   ...Object.keys(PageLabels.additionalDemographicInformation)
 ];
 
+AdditionalDemographicInformation.getDynamicallyRequiredFields = data => {
+  const requiredFields = [];
+
+  if (data.program === PROGRAM_CSA) {
+    requiredFields.push(['csaAlreadyKnow', 'csaPhoneScreen']);
+  }
+
+  return requiredFields;
+};
+
 export default AdditionalDemographicInformation;
 
 const styles = {

--- a/apps/src/code-studio/pd/application/teacher/ImplementationPlan.jsx
+++ b/apps/src/code-studio/pd/application/teacher/ImplementationPlan.jsx
@@ -166,12 +166,7 @@ ImplementationPlan.associatedFields = [
 const uniqueRequiredFields = {
   [PROGRAM_CSD]: ['csdWhichGrades'],
   [PROGRAM_CSP]: ['cspWhichGrades', 'cspHowOffer'],
-  [PROGRAM_CSA]: [
-    'csaWhichGrades',
-    'csaHowOffer',
-    'csaAlreadyKnow',
-    'csaPhoneScreen'
-  ]
+  [PROGRAM_CSA]: ['csaWhichGrades', 'csaHowOffer']
 };
 
 ImplementationPlan.getDynamicallyRequiredFields = data => {

--- a/apps/src/code-studio/pd/application/teacher/ImplementationPlan.jsx
+++ b/apps/src/code-studio/pd/application/teacher/ImplementationPlan.jsx
@@ -4,7 +4,8 @@ import color from '@cdo/apps/util/color';
 import {
   PROGRAM_CSD,
   PROGRAM_CSP,
-  PROGRAM_CSA
+  PROGRAM_CSA,
+  getProgramInfo
 } from './TeacherApplicationConstants';
 import {
   PageLabels,
@@ -20,19 +21,6 @@ import {
   LabeledRadioButtons,
   LabeledRadioButtonsWithAdditionalTextFields
 } from '../../form_components_func/labeled/LabeledRadioButtons';
-
-const getProgramInfo = program => {
-  switch (program) {
-    case PROGRAM_CSD:
-      return {name: 'CS Discoveries', shortName: 'CSD', minCourseHours: 25};
-    case PROGRAM_CSP:
-      return {name: 'CS Principles', shortName: 'CSP', minCourseHours: 100};
-    case PROGRAM_CSA:
-      return {name: 'CSA', shortName: 'CSA', minCourseHours: 140};
-    default:
-      return {name: 'CS Program', shortName: null, minCourseHours: 0};
-  }
-};
 
 const WhichGradesSelector = props => {
   return (

--- a/apps/src/code-studio/pd/application/teacher/TeacherApplicationConstants.js
+++ b/apps/src/code-studio/pd/application/teacher/TeacherApplicationConstants.js
@@ -35,4 +35,17 @@ const styles = {
   }
 };
 
-export {PROGRAM_CSD, PROGRAM_CSP, PROGRAM_CSA, styles};
+function getProgramInfo(program) {
+  switch (program) {
+    case PROGRAM_CSD:
+      return {name: 'CS Discoveries', shortName: 'CSD', minCourseHours: 25};
+    case PROGRAM_CSP:
+      return {name: 'CS Principles', shortName: 'CSP', minCourseHours: 100};
+    case PROGRAM_CSA:
+      return {name: 'CSA', shortName: 'CSA', minCourseHours: 140};
+    default:
+      return {name: 'CS Program', shortName: null, minCourseHours: 0};
+  }
+}
+
+export {PROGRAM_CSD, PROGRAM_CSP, PROGRAM_CSA, styles, getProgramInfo};

--- a/apps/src/code-studio/pd/application_dashboard/detail_view_contents.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/detail_view_contents.jsx
@@ -1011,9 +1011,10 @@ export class DetailViewContents extends React.Component {
 
   renderDetailViewTableLayout = () => {
     const sectionsToRemove =
-      this.props.applicationData.application_type === ApplicationTypes.teacher
-        ? ['additionalDemographicInformation']
-        : ['submission'];
+      this.props.applicationData.application_type !== ApplicationTypes.teacher
+        ? ['submission']
+        : [];
+    const questionsToRemove = ['genderIdentity', 'race'];
 
     return (
       <div>
@@ -1023,7 +1024,10 @@ export class DetailViewContents extends React.Component {
               <h3>{this.sectionHeaders[header]}</h3>
               <Table style={styles.detailViewTable} striped bordered>
                 <tbody>
-                  {Object.keys(this.pageLabels[header]).map((key, j) => {
+                  {_.pull(
+                    Object.keys(this.pageLabels[header]),
+                    ...questionsToRemove
+                  ).map((key, j) => {
                     return (
                       // For most fields, render them only when they have values.
                       // For explicitly listed fields, render them regardless of their values.

--- a/apps/src/code-studio/pd/application_dashboard/detail_view_contents.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/detail_view_contents.jsx
@@ -52,6 +52,12 @@ import PrincipalApprovalButtons from './principal_approval_buttons';
 import DetailViewWorkshopAssignmentResponse from './detail_view_workshop_assignment_response';
 import ChangeLog from './detail_view/change_log';
 import InlineMarkdown from '@cdo/apps/templates/InlineMarkdown';
+import {
+  PROGRAM_CSD,
+  PROGRAM_CSP,
+  PROGRAM_CSA,
+  getProgramInfo
+} from '../application/teacher/TeacherApplicationConstants';
 
 const NA = 'N/A';
 
@@ -61,6 +67,12 @@ const DEFAULT_NOTES =
 const WORKSHOP_REQUIRED = `Please assign a summer workshop to this applicant before setting this
                           applicant's status to "Accepted". This status will trigger an automated
                           email with a registration link to their assigned workshop.`;
+
+const PROGRAM_MAP = {
+  csd: PROGRAM_CSD,
+  csp: PROGRAM_CSP,
+  csa: PROGRAM_CSA
+};
 
 export class DetailViewContents extends React.Component {
   static propTypes = {
@@ -1028,6 +1040,25 @@ export class DetailViewContents extends React.Component {
                     Object.keys(this.pageLabels[header]),
                     ...questionsToRemove
                   ).map((key, j) => {
+                    // If the enoughCourseHours question, insert variable values.
+                    // Otherwise, just show the question's label.
+                    const questionLabel =
+                      key === 'enoughCourseHours'
+                        ? this.labelOverrides[key]
+                            .replace(
+                              '{{CS program}}',
+                              getProgramInfo(
+                                PROGRAM_MAP[this.props.applicationData.course]
+                              ).name
+                            )
+                            .replace(
+                              '{{min hours}}',
+                              getProgramInfo(
+                                PROGRAM_MAP[this.props.applicationData.course]
+                              ).minCourseHours
+                            )
+                        : this.labelOverrides[key] ||
+                          this.pageLabels[header][key];
                     return (
                       // For most fields, render them only when they have values.
                       // For explicitly listed fields, render them regardless of their values.
@@ -1037,12 +1068,7 @@ export class DetailViewContents extends React.Component {
                           'schoolStatsAndPrincipalApprovalSection') && (
                         <tr key={j}>
                           <td style={styles.questionColumn}>
-                            <InlineMarkdown
-                              markdown={
-                                this.labelOverrides[key] ||
-                                this.pageLabels[header][key]
-                              }
-                            />
+                            <InlineMarkdown markdown={questionLabel} />
                           </td>
                           <td style={styles.answerColumn}>
                             {this.renderAnswer(

--- a/dashboard/app/models/pd/application/teacher_application.rb
+++ b/dashboard/app/models/pd/application/teacher_application.rb
@@ -1001,6 +1001,7 @@ module Pd::Application
           responses[:previous_yearlong_cdo_pd].include?('Computer Science A (CSA)') ? NO : YES
       end
 
+      meets_minimum_criteria_scores[:enough_course_hours] = responses[:enough_course_hours] == options[:enough_course_hours].first ? YES : NO
       meets_minimum_criteria_scores[:replace_existing] =
         if responses[:replace_existing] == YES
           NO

--- a/dashboard/app/models/pd/application/teacher_application.rb
+++ b/dashboard/app/models/pd/application/teacher_application.rb
@@ -992,13 +992,14 @@ module Pd::Application
       elsif course == 'csp'
         meets_minimum_criteria_scores[:csp_which_grades] =
           (responses[:csp_which_grades] & options[:csp_which_grades].first(4)).any? ? YES : NO
-        meets_minimum_criteria_scores[:previous_yearlong_cdo_pd] =
-          responses[:previous_yearlong_cdo_pd].include?('CS Principles') ? NO : YES
+        took_csp_course =
+          responses[:previous_yearlong_cdo_pd].include?('CS Principles')
+        meets_minimum_criteria_scores[:previous_yearlong_cdo_pd] = took_csp_course ? NO : YES
       elsif course == 'csa'
         meets_minimum_criteria_scores[:csa_which_grades] =
           (responses[:csa_which_grades] & options[:csa_which_grades].first(4)).any? ? YES : NO
-        meets_minimum_criteria_scores[:previous_yearlong_cdo_pd] =
-          responses[:previous_yearlong_cdo_pd].include?('Computer Science A (CSA)') ? NO : YES
+        took_csa_course = responses[:previous_yearlong_cdo_pd].include?('Computer Science A (CSA)')
+        meets_minimum_criteria_scores[:previous_yearlong_cdo_pd] = took_csa_course ? NO : YES
       end
 
       meets_minimum_criteria_scores[:enough_course_hours] = responses[:enough_course_hours] == options[:enough_course_hours].first ? YES : NO

--- a/dashboard/app/models/pd/application/teacher_application.rb
+++ b/dashboard/app/models/pd/application/teacher_application.rb
@@ -695,6 +695,7 @@ module Pd::Application
           required << :csa_which_grades
           required << :csa_how_offer
           required << :csa_already_know
+          required << :csa_phone_screen
         end
 
         if hash[:regional_partner_workshop_ids].presence
@@ -978,6 +979,7 @@ module Pd::Application
       # Section 4
       if course == 'csa'
         meets_minimum_criteria_scores[:csa_already_know] = responses[:csa_already_know] == options[:csa_already_know].first ? YES : NO
+        meets_minimum_criteria_scores[:csa_phone_screen] = responses[:csa_phone_screen] == options[:csa_phone_screen].first ? YES : NO
       end
 
       # Section 6

--- a/dashboard/app/models/pd/application/teacher_application.rb
+++ b/dashboard/app/models/pd/application/teacher_application.rb
@@ -975,17 +975,28 @@ module Pd::Application
       meets_minimum_criteria_scores = {}
       meets_scholarship_criteria_scores = {}
 
-      # Section 2
+      # Section 4
+      if course == 'csa'
+        meets_minimum_criteria_scores[:csa_already_know] = responses[:csa_already_know] == options[:csa_already_know].first ? YES : NO
+      end
+
+      # Section 6
       if course == 'csd'
         meets_minimum_criteria_scores[:csd_which_grades] =
           (responses[:csd_which_grades] & options[:csd_which_grades].first(5)).any? ? YES : NO
+        took_csd_course =
+          responses[:previous_yearlong_cdo_pd].include?('CS Discoveries')
+        meets_minimum_criteria_scores[:previous_yearlong_cdo_pd] = took_csd_course ? NO : YES
       elsif course == 'csp'
         meets_minimum_criteria_scores[:csp_which_grades] =
           (responses[:csp_which_grades] & options[:csp_which_grades].first(4)).any? ? YES : NO
+        meets_minimum_criteria_scores[:previous_yearlong_cdo_pd] =
+          responses[:previous_yearlong_cdo_pd].include?('CS Principles') ? NO : YES
       elsif course == 'csa'
-        meets_minimum_criteria_scores[:csa_already_know] = responses[:csa_already_know] == options[:csa_already_know].first ? YES : NO
         meets_minimum_criteria_scores[:csa_which_grades] =
           (responses[:csa_which_grades] & options[:csa_which_grades].first(4)).any? ? YES : NO
+        meets_minimum_criteria_scores[:previous_yearlong_cdo_pd] =
+          responses[:previous_yearlong_cdo_pd].include?('Computer Science A (CSA)') ? NO : YES
       end
 
       meets_minimum_criteria_scores[:replace_existing] =
@@ -997,20 +1008,7 @@ module Pd::Application
           YES
         end
 
-      # Section 3
-      if course == 'csd'
-        took_csd_course =
-          responses[:previous_yearlong_cdo_pd].include?('CS Discoveries')
-        meets_minimum_criteria_scores[:previous_yearlong_cdo_pd] = took_csd_course ? NO : YES
-      elsif course == 'csp'
-        meets_minimum_criteria_scores[:previous_yearlong_cdo_pd] =
-          responses[:previous_yearlong_cdo_pd].include?('CS Principles') ? NO : YES
-      elsif course == 'csa'
-        meets_minimum_criteria_scores[:previous_yearlong_cdo_pd] =
-          responses[:previous_yearlong_cdo_pd].include?('Computer Science A (CSA)') ? NO : YES
-      end
-
-      # Section 4
+      # Section 7
       meets_minimum_criteria_scores[:committed] = responses[:committed] == options[:committed].first ? YES : NO
 
       # Principal Approval

--- a/dashboard/test/factories/pd_factories.rb
+++ b/dashboard/test/factories/pd_factories.rb
@@ -842,6 +842,7 @@ FactoryGirl.define do
       csa_which_grades ['11', '12']
       csa_how_offer 'As an AP course'
       csa_already_know 'Yes'
+      csa_phone_screen 'Yes'
     end
   end
 

--- a/dashboard/test/models/pd/application/teacher_application_test.rb
+++ b/dashboard/test/models/pd/application/teacher_application_test.rb
@@ -539,6 +539,7 @@ module Pd::Application
       application_hash = build :pd_teacher_application_hash,
         program: Pd::Application::TeacherApplication::PROGRAMS[:csd],
         csd_which_grades: ['6'],
+        enough_course_hours: options[:enough_course_hours].first,
         previous_yearlong_cdo_pd: ['CS Principles'],
         replace_existing: options[:replace_existing].second,
         committed: options[:committed].first,
@@ -556,6 +557,7 @@ module Pd::Application
         {
           meets_minimum_criteria_scores: {
             csd_which_grades: YES,
+            enough_course_hours: YES,
             committed: YES,
             previous_yearlong_cdo_pd: YES,
             replace_existing: YES,
@@ -578,6 +580,7 @@ module Pd::Application
       application_hash = build :pd_teacher_application_hash,
         program: Pd::Application::TeacherApplication::PROGRAMS[:csp],
         csp_which_grades: ['12'],
+        enough_course_hours: options[:enough_course_hours].first,
         previous_yearlong_cdo_pd: ['CS Discoveries'],
         csp_how_offer: options[:csp_how_offer].last,
         replace_existing: options[:replace_existing].second,
@@ -596,6 +599,7 @@ module Pd::Application
         {
           meets_minimum_criteria_scores: {
             csp_which_grades: YES,
+            enough_course_hours: YES,
             committed: YES,
             previous_yearlong_cdo_pd: YES,
             replace_existing: YES,
@@ -618,7 +622,9 @@ module Pd::Application
       application_hash = build :pd_teacher_application_hash,
         program: Pd::Application::TeacherApplication::PROGRAMS[:csa],
         csa_already_know: options[:csa_already_know].first,
+        csa_phone_screen: options[:csa_phone_screen].first,
         csa_which_grades: ['12'],
+        enough_course_hours: options[:enough_course_hours].first,
         previous_yearlong_cdo_pd: ['CS Principles'],
         csa_how_offer: options[:csa_how_offer].last,
         replace_existing: options[:replace_existing].second,
@@ -637,7 +643,9 @@ module Pd::Application
         {
           meets_minimum_criteria_scores: {
             csa_already_know: YES,
+            csa_phone_screen: YES,
             csa_which_grades: YES,
+            enough_course_hours: YES,
             committed: YES,
             previous_yearlong_cdo_pd: YES,
             replace_existing: YES,
@@ -659,6 +667,7 @@ module Pd::Application
       application_hash = build :pd_teacher_application_hash,
         program: Pd::Application::TeacherApplication::PROGRAMS[:csp],
         csp_which_grades: ['12'],
+        enough_course_hours: options[:enough_course_hours].first,
         previous_yearlong_cdo_pd: ['CS Discoveries'],
         csp_how_offer: options[:csp_how_offer].last,
         replace_existing: options[:replace_existing].second,
@@ -672,6 +681,7 @@ module Pd::Application
         {
           meets_minimum_criteria_scores: {
             csp_which_grades: YES,
+            enough_course_hours: YES,
             committed: YES,
             previous_yearlong_cdo_pd: YES,
             replace_existing: YES,
@@ -689,6 +699,7 @@ module Pd::Application
       application_hash = build :pd_teacher_application_hash,
         program: Pd::Application::TeacherApplication::PROGRAMS[:csd],
         csd_which_grades: %w(11 12),
+        enough_course_hours: options[:enough_course_hours].last,
         previous_yearlong_cdo_pd: ['CS Discoveries'],
         replace_existing: options[:replace_existing].first,
         committed: options[:committed].last,
@@ -706,6 +717,7 @@ module Pd::Application
         {
           meets_minimum_criteria_scores: {
             csd_which_grades: NO,
+            enough_course_hours: NO,
             committed: NO,
             previous_yearlong_cdo_pd: NO,
             replace_existing: NO,
@@ -728,6 +740,7 @@ module Pd::Application
       application_hash = build :pd_teacher_application_hash,
         program: Pd::Application::TeacherApplication::PROGRAMS[:csp],
         csp_which_grades: [options[:csp_which_grades].last],
+        enough_course_hours: options[:enough_course_hours].last,
         previous_yearlong_cdo_pd: 'CS Principles',
         csp_how_offer: options[:csp_how_offer].first,
         replace_existing: options[:replace_existing].first,
@@ -746,6 +759,7 @@ module Pd::Application
         {
           meets_minimum_criteria_scores: {
             csp_which_grades: NO,
+            enough_course_hours: NO,
             committed: NO,
             previous_yearlong_cdo_pd: NO,
             replace_existing: NO,
@@ -768,7 +782,9 @@ module Pd::Application
       application_hash = build :pd_teacher_application_hash,
         program: Pd::Application::TeacherApplication::PROGRAMS[:csa],
         csa_already_know: options[:csa_already_know].last,
+        csa_phone_screen: options[:csa_phone_screen].last,
         csa_which_grades: [options[:csa_which_grades].last],
+        enough_course_hours: options[:enough_course_hours].last,
         previous_yearlong_cdo_pd: 'Computer Science A (CSA)',
         csa_how_offer: options[:csa_how_offer].first,
         replace_existing: options[:replace_existing].first,
@@ -788,6 +804,8 @@ module Pd::Application
           meets_minimum_criteria_scores: {
             csa_already_know: NO,
             csa_which_grades: NO,
+            csa_phone_screen: NO,
+            enough_course_hours: NO,
             committed: NO,
             previous_yearlong_cdo_pd: NO,
             replace_existing: NO,

--- a/lib/cdo/shared_constants/pd/teacher_application_constants.rb
+++ b/lib/cdo/shared_constants/pd/teacher_application_constants.rb
@@ -166,6 +166,11 @@ module Pd
         csd_which_grades: "To which grades does your school plan to offer CS Discoveries in the #{YEAR} school year?",
         csp_which_grades: "To which grades does your school plan to offer CS Principles in the #{YEAR} school year?",
         csa_which_grades: "To which grades does your school plan to offer CSA in the #{YEAR} school year?",
+        csa_already_know: "Have you previously taught CS or have you learned CS yourself?",
+        csa_phone_screen: clean_multiline(
+          'Are you able to independently write a function (or procedure) with one or more
+          parameters and that uses conditional logic, loops, and an array (or list)?'
+        ),
         enough_course_hours: "Will you have more than {{min hours}} hours with your {{CS program}} section(s)?",
         replace_existing: "Will this course replace an existing computer science course in the master schedule? (Teacher's response)",
         previous_yearlong_cdo_pd: "Have you participated in previous yearlong Code.org Professional Learning Programs?",
@@ -261,6 +266,8 @@ module Pd
       csd_which_grades: YES_NO,
       csp_which_grades: YES_NO,
       csa_which_grades: YES_NO,
+      csa_already_know: YES_NO,
+      csa_phone_screen: YES_NO,
       committed: YES_NO,
       enough_course_hours: YES_NO,
       previous_yearlong_cdo_pd: YES_NO,
@@ -298,6 +305,7 @@ module Pd
       ],
       criteria_score_questions_csa: [
         :csa_already_know,
+        :csa_phone_screen,
         :csa_which_grades,
         :enough_course_hours,
         :committed,


### PR DESCRIPTION
From the [mini teacher application bug bash](https://docs.google.com/document/d/1ldGJHBvzgQcpwSDCpx-JMX881f46TVHJxMxYX7hVFtI/edit#heading=h.zdvvaf1ej0c3), a few work items were listed for the teacher application detail view. This PR resolves items 1 and 3 from the [Summary of Bug Bash 2](https://docs.google.com/document/d/1ldGJHBvzgQcpwSDCpx-JMX881f46TVHJxMxYX7hVFtI/edit#heading=h.zdvvaf1ej0c3).

### Item 1
Previously, when the teacher application was 4 pages instead of 7, the Additional Demographic Information section asked the user about their race, gender identity, and how they heard about Code.org's PD program (things the application reviewer would not need to know). Because of this, that section was simply omitted from the details view for the reviewer. However, since the application has been restructured, the Additional Demographics Information section contains questions the reviewer needs (i.e. the applicant's current school role and their previous experience in CS) so now that section is shown but still filters out the race and gender identity questions.

#### New:
CSD and CSP:
![DemoInfo_ExCSD_CSP](https://user-images.githubusercontent.com/56283563/203442045-896e8cc0-3586-40ce-9ec2-3fdbcab0cd72.JPG)

CSA:
![DemoInfo_ExCSA](https://user-images.githubusercontent.com/56283563/203442039-1bd1ce04-8de4-41d3-9b32-fdc909ea4268.JPG)

### Item 3
The shared information of courses mapped to their short names and the minimum required hours was moved to `TeacherApplicationConstants.js` for ease of access. Then, in `detail_view_contents.jsx`, the label for the question was updated to replace the variable names with the appropriate values for the `enoughCourseHours` question the same way it's done in other parts of the application (otherwise, the label will just print the question's text).

#### Original:
![OriginalVariables](https://user-images.githubusercontent.com/56283563/203442903-d09c5277-2af9-435a-a6d1-d13d71f58c4f.png)

#### New:
CSD:
![CSD_hours](https://user-images.githubusercontent.com/56283563/203441985-7052646f-7774-495b-adc2-5c4ee30daa80.JPG)

CSP:
![CSP_hours](https://user-images.githubusercontent.com/56283563/203441973-74a631cb-d718-4903-94e7-be1c29b1ba31.JPG)

CSA:
![CSA_hours](https://user-images.githubusercontent.com/56283563/203441994-ca8f62d3-9a10-4cfb-ba47-f59d5ff764e1.JPG)

## Links
Spec: [from the mini bug bash](https://docs.google.com/document/d/1ldGJHBvzgQcpwSDCpx-JMX881f46TVHJxMxYX7hVFtI/edit#heading=h.zdvvaf1ej0c3)
Jira tickets:
- [Item 1: Show Additional Demographics question responses](https://codedotorg.atlassian.net/browse/ACQ-235?atlOrigin=eyJpIjoiNTgwOTc5ZDk0YzliNDJiZTg1ZTYxZDZhYTdkYjgwZjgiLCJwIjoiaiJ9)
- [Item 3: Make sure `enoughCourseHours` question doesn't show variable names](https://codedotorg.atlassian.net/browse/ACQ-238?atlOrigin=eyJpIjoiOWM0YjcyNzRmMTA5NDMyMWI0MGI5ODVlZjRiM2JiYTYiLCJwIjoiaiJ9)

## Testing story
Local testing and drone tests.

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
