### PR TITLE
Fix 'Make a Copy' dropdown spacing

### DIFF
--- a/apps/src/templates/lessonOverview/ResourceList.jsx
+++ b/apps/src/templates/lessonOverview/ResourceList.jsx
@@ -107,15 +107,18 @@ export default class ResourceList extends Component {
         </span>
       )}
       {isGDocsUrl(resource.url) && (
-        <DropdownButton
-          text={i18n.makeACopy()}
-          color={Button.ButtonColor.gray}
-          size={Button.ButtonSize.small}
-        >
-          <a href={gDocsPdfUrl(resource.url)}>PDF</a>
-          <a href={gDocsMsOfficeUrl(resource.url)}>Microsoft Office</a>
-          <a href={gDocsCopyUrl(resource.url)}>Google Docs</a>
-        </DropdownButton>
+        <span>
+          {' '}
+          <DropdownButton
+            text={i18n.makeACopy()}
+            color={Button.ButtonColor.gray}
+            size={Button.ButtonSize.small}
+          >
+            <a href={gDocsPdfUrl(resource.url)}>PDF</a>
+            <a href={gDocsMsOfficeUrl(resource.url)}>Microsoft Office</a>
+            <a href={gDocsCopyUrl(resource.url)}>Google Docs</a>
+          </DropdownButton>
+        </span>
       )}
     </li>
   );


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

The "Make a Copy" dropdown in `ResourceList` was missing a single space for padding from the words to its left, in some cases.


<details><summary>Screenshot before</summary>

![image](https://user-images.githubusercontent.com/1382374/203629936-6aacbb77-9d9f-457e-8179-8edc8f52147b.png)
</details>

<details><summary>Screenshot after</summary>

![image](https://user-images.githubusercontent.com/1382374/203630023-9ca2620a-89bf-4d0a-aaab-c148d3fab078.png)
</details>

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [TEACH-98](https://codedotorg.atlassian.net/browse/TEACH-98), [TEACH-79](https://codedotorg.atlassian.net/browse/TEACH-79)

