### PR TITLE
Test application button on regional partner search

### DIFF
--- a/apps/src/templates/RegionalPartnerSearch.jsx
+++ b/apps/src/templates/RegionalPartnerSearch.jsx
@@ -10,6 +10,7 @@ import Notification from '@cdo/apps/templates/Notification';
 import * as color from '../util/color';
 import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
 import {studio} from '@cdo/apps/lib/util/urlHelpers';
+import {currentLocation} from '@cdo/apps/utils';
 import PropTypes from 'prop-types';
 import queryString from 'query-string';
 import $ from 'jquery';
@@ -45,9 +46,9 @@ class RegionalPartnerSearch extends Component {
     let error = false;
     let loading = false;
 
-    const partnerId = queryString.parse(window.location.search).partner;
-    const zip = queryString.parse(window.location.search).zip;
-    const nominated = queryString.parse(window.location.search).nominated;
+    const partnerId = queryString.parse(currentLocation().search).partner;
+    const zip = queryString.parse(currentLocation().search).zip;
+    const nominated = queryString.parse(currentLocation().search).nominated;
 
     if (partnerId) {
       if (partnerId === '0') {

--- a/apps/test/unit/templates/RegionalPartnerSearchTest.js
+++ b/apps/test/unit/templates/RegionalPartnerSearchTest.js
@@ -1,7 +1,10 @@
 import React from 'react';
 import {shallow} from 'enzyme';
-import {expect} from '../../util/deprecatedChai';
 import {UnconnectedRegionalPartnerSearch as RegionalPartnerSearch} from '@cdo/apps/templates/RegionalPartnerSearch';
+import {WorkshopApplicationStates} from '@cdo/apps/generated/pd/sharedWorkshopConstants';
+import {expect} from '../../util/reconfiguredChai';
+import sinon from 'sinon';
+import * as utils from '@cdo/apps/utils';
 
 const MINIMUM_PROPS = {
   responsiveSize: 'md'
@@ -12,5 +15,32 @@ describe('RegionalPartnerSearch', () => {
     const wrapper = shallow(<RegionalPartnerSearch {...MINIMUM_PROPS} />);
     expect(wrapper.find('form')).not.to.be.null;
     expect(wrapper.find('form').text()).to.contain('ZIP');
+  });
+  it('shows StartApplicationButton once zip is entered and applications are open', () => {
+    sinon.stub(utils, 'currentLocation').returns({search: '?zip=11111'});
+
+    const response = {
+      application_state: {
+        state: WorkshopApplicationStates.currently_open
+      },
+      summer_workshops: [],
+      pl_programs_offered: ['CSD', 'CSP', 'CSA']
+    };
+    let server;
+    server = sinon.fakeServer.create();
+    server.respondWith(
+      /.*regional_partners\/find\?zip_code.*/,
+      JSON.stringify(response)
+    );
+    server.respondWith(
+      /.*pd\/application\/applications_closed.*/,
+      JSON.stringify(false)
+    );
+
+    const wrapper = shallow(<RegionalPartnerSearch {...MINIMUM_PROPS} />);
+    server.respond();
+    expect(wrapper.find('StartApplicationButton')).not.to.be.null;
+    utils.currentLocation.restore();
+    server.restore();
   });
 });

--- a/apps/test/unit/templates/RegionalPartnerSearchTest.js
+++ b/apps/test/unit/templates/RegionalPartnerSearchTest.js
@@ -10,6 +10,29 @@ const MINIMUM_PROPS = {
   responsiveSize: 'md'
 };
 
+const createServerResponses = (server, hasRP, applicationsClosed) => {
+  const responseWithRP = {
+    application_state: {
+      state: WorkshopApplicationStates.currently_open
+    },
+    summer_workshops: [],
+    pl_programs_offered: ['CSD', 'CSP', 'CSA']
+  };
+
+  const responseWithoutRP = {
+    error: 'no_partner'
+  };
+
+  server.respondWith(
+    /.*regional_partners\/find\?zip_code.*/,
+    JSON.stringify(hasRP ? responseWithRP : responseWithoutRP)
+  );
+  server.respondWith(
+    /.*pd\/application\/applications_closed.*/,
+    JSON.stringify(applicationsClosed)
+  );
+};
+
 describe('RegionalPartnerSearch', () => {
   let server;
   beforeEach(() => {
@@ -28,22 +51,7 @@ describe('RegionalPartnerSearch', () => {
     expect(wrapper.find('form').text()).to.contain('ZIP');
   });
   it('shows StartApplicationButton if RP found and applications are open', () => {
-    const response = {
-      application_state: {
-        state: WorkshopApplicationStates.currently_open
-      },
-      summer_workshops: [],
-      pl_programs_offered: ['CSD', 'CSP', 'CSA']
-    };
-    server.respondWith(
-      /.*regional_partners\/find\?zip_code.*/,
-      JSON.stringify(response)
-    );
-    server.respondWith(
-      /.*pd\/application\/applications_closed.*/,
-      JSON.stringify(false)
-    );
-
+    createServerResponses(server, true, false);
     const wrapper = shallow(<RegionalPartnerSearch {...MINIMUM_PROPS} />);
     server.respond();
     expect(wrapper.find('StartApplicationButton')).not.to.be.null;

--- a/apps/test/unit/templates/RegionalPartnerSearchTest.js
+++ b/apps/test/unit/templates/RegionalPartnerSearchTest.js
@@ -11,14 +11,23 @@ const MINIMUM_PROPS = {
 };
 
 describe('RegionalPartnerSearch', () => {
+  let server;
+  beforeEach(() => {
+    sinon.stub(utils, 'currentLocation').returns({search: '?zip=11111'});
+    server = sinon.fakeServer.create();
+  });
+
+  afterEach(() => {
+    utils.currentLocation.restore();
+    server.restore();
+  });
+
   it('renders form for zip code', () => {
     const wrapper = shallow(<RegionalPartnerSearch {...MINIMUM_PROPS} />);
     expect(wrapper.find('form')).not.to.be.null;
     expect(wrapper.find('form').text()).to.contain('ZIP');
   });
-  it('shows StartApplicationButton once zip is entered and applications are open', () => {
-    sinon.stub(utils, 'currentLocation').returns({search: '?zip=11111'});
-
+  it('shows StartApplicationButton if RP found and applications are open', () => {
     const response = {
       application_state: {
         state: WorkshopApplicationStates.currently_open
@@ -26,8 +35,6 @@ describe('RegionalPartnerSearch', () => {
       summer_workshops: [],
       pl_programs_offered: ['CSD', 'CSP', 'CSA']
     };
-    let server;
-    server = sinon.fakeServer.create();
     server.respondWith(
       /.*regional_partners\/find\?zip_code.*/,
       JSON.stringify(response)
@@ -40,7 +47,5 @@ describe('RegionalPartnerSearch', () => {
     const wrapper = shallow(<RegionalPartnerSearch {...MINIMUM_PROPS} />);
     server.respond();
     expect(wrapper.find('StartApplicationButton')).not.to.be.null;
-    utils.currentLocation.restore();
-    server.restore();
   });
 });

--- a/apps/test/unit/templates/RegionalPartnerSearchTest.js
+++ b/apps/test/unit/templates/RegionalPartnerSearchTest.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import {expect} from '../../util/deprecatedChai';
+import {UnconnectedRegionalPartnerSearch as RegionalPartnerSearch} from '@cdo/apps/templates/RegionalPartnerSearch';
+
+const MINIMUM_PROPS = {
+  responsiveSize: 'md'
+};
+
+describe('RegionalPartnerSearch', () => {
+  it('renders form for zip code', () => {
+    const wrapper = shallow(<RegionalPartnerSearch {...MINIMUM_PROPS} />);
+    expect(wrapper.find('form')).not.to.be.null;
+    expect(wrapper.find('form').text()).to.contain('ZIP');
+  });
+});

--- a/apps/test/unit/templates/RegionalPartnerSearchTest.js
+++ b/apps/test/unit/templates/RegionalPartnerSearchTest.js
@@ -13,7 +13,9 @@ const MINIMUM_PROPS = {
 const createServerResponses = (server, hasRP, applicationsClosed) => {
   const responseWithRP = {
     application_state: {
-      state: WorkshopApplicationStates.currently_open
+      state: applicationsClosed
+        ? WorkshopApplicationStates.opening_at
+        : WorkshopApplicationStates.currently_open
     },
     summer_workshops: [],
     pl_programs_offered: ['CSD', 'CSP', 'CSA']
@@ -55,5 +57,23 @@ describe('RegionalPartnerSearch', () => {
     const wrapper = shallow(<RegionalPartnerSearch {...MINIMUM_PROPS} />);
     server.respond();
     expect(wrapper.find('StartApplicationButton')).not.to.be.null;
+  });
+  it('shows StartApplicationButton if no RP found and applications are open', () => {
+    createServerResponses(server, false, false);
+    const wrapper = shallow(<RegionalPartnerSearch {...MINIMUM_PROPS} />);
+    server.respond();
+    expect(wrapper.find('StartApplicationButton')).not.to.be.null;
+  });
+  it('shows notify button if RP found and applications are closed', () => {
+    createServerResponses(server, true, true);
+    const wrapper = shallow(<RegionalPartnerSearch {...MINIMUM_PROPS} />);
+    server.respond();
+    expect(wrapper.find('button').text()).to.contain('Notify me');
+  });
+  it('shows no button if no RP found and applications are closed', () => {
+    createServerResponses(server, false, true);
+    const wrapper = shallow(<RegionalPartnerSearch {...MINIMUM_PROPS} />);
+    server.respond();
+    expect(wrapper.find('button')).to.have.length(0);
   });
 });


### PR DESCRIPTION
This does not provide full test coverage of RegionalPartnerSearch (https://code.org/educate/professional-learning/program-information), but it does ensure that the Call to Action to submit an application appears when applications are open, and the Call to Action to notify when applications are open appears when the applications are closed and there's an RP in the region.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

I added unit tests, but we do not have UI tests for this feature.

Since I changed the window lookup by using a util (for stubbing purposes), I did test this manually by navigating to http://localhost.code.org:3000/educate/professional-learning/program-information?zip=23333 and seeing (as an admin, which has applications open):

<img width="1037" alt="image" src="https://user-images.githubusercontent.com/9142121/204300197-3be4c821-61a8-4dde-adea-c5ede2b516be.png">


<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
