### PR TITLE
[SpriteLab] update bounceOff logic

### DIFF
--- a/apps/src/p5lab/spritelab/commands/actionCommands.js
+++ b/apps/src/p5lab/spritelab/commands/actionCommands.js
@@ -48,11 +48,13 @@ export const commands = {
       targets.forEach(target => {
         if (sprite.isTouching(target)) {
           sprite.direction = (sprite.direction + 180) % 360;
-          target.direction = (target.direction + 180) % 360;
-          sprite.x += 1 * Math.cos((sprite.direction * Math.PI) / 180);
-          sprite.y += 1 * Math.sin((sprite.direction * Math.PI) / 180);
-          target.x += 1 * Math.cos((target.direction * Math.PI) / 180);
-          target.y += 1 * Math.sin((target.direction * Math.PI) / 180);
+          let angle = Math.atan2(target.y - sprite.y, target.x - sprite.x);
+          if (!isNaN(angle)) {
+            let dy = Math.sin(angle) * -(sprite.speed + 1);
+            let dx = Math.cos(angle) * -(sprite.speed + 1);
+            sprite.x += dx;
+            sprite.y += dy;
+          }
         }
       });
     });

--- a/apps/src/p5lab/spritelab/commands/actionCommands.js
+++ b/apps/src/p5lab/spritelab/commands/actionCommands.js
@@ -47,9 +47,12 @@ export const commands = {
     sprites.forEach(sprite => {
       targets.forEach(target => {
         if (sprite.isTouching(target)) {
+          // Reverse the movement direction of the sprite
           sprite.direction = (sprite.direction + 180) % 360;
+          // Calculate the angle between x axis and a line between the sprites.
           let angle = Math.atan2(target.y - sprite.y, target.x - sprite.x);
           if (!isNaN(angle)) {
+            // Move the sprite back from the target, based on the calculated angle.
             let dy = Math.sin(angle) * -(sprite.speed + 1);
             let dx = Math.cos(angle) * -(sprite.speed + 1);
             sprite.x += dx;

--- a/apps/test/unit/p5lab/spritelab/actionCommandsTest.js
+++ b/apps/test/unit/p5lab/spritelab/actionCommandsTest.js
@@ -103,6 +103,7 @@ describe('Action Commands', () => {
         'direction',
         180
       ]);
+      commands.setProp.apply(coreLibrary, [{name: 'spriteName1'}, 'speed', 10]);
       coreLibrary.addSprite({name: 'spriteName2', location: {x: 200, y: 200}});
       commands.bounceOff.apply(coreLibrary, [
         {name: 'spriteName1'},
@@ -116,16 +117,7 @@ describe('Action Commands', () => {
       ).to.equal(0);
       expect(
         spriteCommands.getProp.apply(coreLibrary, [{name: 'spriteName1'}, 'x'])
-      ).to.equal(201);
-      expect(
-        spriteCommands.getProp.apply(coreLibrary, [
-          {name: 'spriteName2'},
-          'direction'
-        ])
-      ).to.equal(180);
-      expect(
-        spriteCommands.getProp.apply(coreLibrary, [{name: 'spriteName2'}, 'x'])
-      ).to.equal(199);
+      ).to.equal(189);
     });
 
     it('does not change direction if sprites are not touching', () => {

--- a/dashboard/config/programming_expressions/spritelab/bounce-off.json
+++ b/dashboard/config/programming_expressions/spritelab/bounce-off.json
@@ -4,7 +4,7 @@
   "category": "Sprites",
   "category_key": "actions",
   "block_name": "gamelab_bounceOff",
-  "content": "If the first  sprite is touching the second sprite, then the movement direction of each sprite changes by 180º, and then both sprites move 1 pixel away from each other.",
+  "content": "If the first  sprite is touching the second sprite, then the first sprite moves away from the second sprite. The movement direction of the first sprite also changes by 180 degrees.",
   "examples": [
     {
       "name": "Example 2",
@@ -24,7 +24,7 @@
     }
   ],
   "image_url": "https://curriculum.code.org/media/blocks/Screen_Shot_2020-07-01_at_11.36.45_AM_vYv2bHl.png",
-  "short_description": "If the first  sprite is touching the second sprite, then the movement direction of each sprite changes by 180º, and then both sprites move 1 pixel away from each other.",
+  "short_description": "If the first  sprite is touching the second sprite, then the first sprite moves away from the second sprite. The movement direction of the first sprite also changes by 180 degrees.",
   "syntax": "bounceOff",
-  "tips": "* If a sprite’s is programmed with [`move in direction`(#5ef3ff)](/docs/spritelab/gamelab_moveInDirection/) blocks, this block does not change those directions in the code. This block will not affect the direction of sprites moving with behaviors such as “moving east”.\r\n* This block works best under the [`sprite touches sprite`(#62fc94)](/docs/spritelab/gamelab_whenTouching/) event for sprites with behaviors that use the [`move forward`(#5ef3ff)](/docs/spritelab/gamelab_moveForward/) block such as “wandering” or “swimming left and right”.\r\n"
+  "tips": "* This block works best under the [`sprite touches sprite`(#62fc94)](/docs/spritelab/gamelab_whenTouching/) event for sprites with behaviors that use the [`move forward`(#5ef3ff)](/docs/spritelab/gamelab_moveForward/) block such as “wandering” or “swimming left and right”.\r\n* If a sprite is programmed with [`move in direction`(#5ef3ff)](/docs/spritelab/gamelab_moveInDirection/) blocks, this block does not change the selected direction. \r\n"
 }


### PR DESCRIPTION
# Context
The `bounces off` block currently does the following:
> If the first sprite is touching the second sprite, then the movement direction of each sprite changes by 180º, and then both sprites move 1 pixel away from each other.

In the simplest intended use case, this works basically as expected:

https://user-images.githubusercontent.com/43474485/204374952-f766fbe8-d160-4a81-8abb-5b0533a2c27a.mp4

# Problem
However, some users have been frustrated because this only creates a "bounce" effect when the sprites are moving according to their `direction` property. For example, a sprite that is `moving east` will not bounce as the movement logic is essentially `sprite.x++`:

https://user-images.githubusercontent.com/43474485/204376905-3b3e8fbc-41be-4d5a-a01f-6f314a9825ac.mp4

There are also other issues with the current behavior, such as that if a sprite "bounces" twice in one frame, the effects cancel each other out. There is also no real need for the second target sprite to move at all, based on the behavior of `.bounceOff()` found in [Game Lab](https://studio.code.org/docs/ide/gamelab/expressions/bounceOff).

# Solution
We can rework the "bounces off" with the following differences:
* Continue inverting the movement direction, but only for the subject sprite.
* Stop moving the sprites by 1 pixel.
* Move the subject sprite away from the object sprite

New behavior with a sprite `moving east`:

https://user-images.githubusercontent.com/43474485/204378135-1b908279-ff5f-4c8f-afca-5863bbabfe0a.mp4

Note that this also creates a logically expected difference when the sprites are reversed:

https://user-images.githubusercontent.com/43474485/204378224-02338685-d9b1-4e77-9621-4cccd043e26f.mp4

# Other use cases:

## Second sprite should not move

Before:

https://user-images.githubusercontent.com/43474485/204378406-d4539a40-d22e-4af2-8942-f96403c57310.mp4

After:

https://user-images.githubusercontent.com/43474485/204378429-fec29233-c335-4134-a595-b155a7adce2e.mp4

## Lots of sprites
* Apple moves south and bounces off rock.
* Bunnies wander and bounce off any other sprite.
* 
Before:

https://user-images.githubusercontent.com/43474485/204378530-a92fd5bb-2e82-4718-ab68-3d9642ad1de8.mp4

After:

https://user-images.githubusercontent.com/43474485/204379373-2f36aecc-3e5b-4c9c-be96-f202b4ac4b39.mp4

## Sprites with no initial movement
Before:

https://user-images.githubusercontent.com/43474485/204379452-c4bfeeb2-0a78-478a-8feb-ed855c133a72.mp4

After:

https://user-images.githubusercontent.com/43474485/204379487-76b063a1-8e45-4fcc-b9c3-3485d661d1c9.mp4

## Block Documentation

Before:
<img width="749" alt="image" src="https://user-images.githubusercontent.com/43474485/204379929-1679b496-869d-4d82-b1cd-6f860051d594.png">
<img width="784" alt="image" src="https://user-images.githubusercontent.com/43474485/204379961-153f41e5-7e29-44b0-b0da-a317a806a118.png">

After:
<img width="743" alt="image" src="https://user-images.githubusercontent.com/43474485/204380785-c2ca2d26-08ae-48db-8cb1-c0bc736faffa.png">
<img width="764" alt="image" src="https://user-images.githubusercontent.com/43474485/204380809-59d12b59-5b90-4231-9f34-fb3edc2fe252.png">

## Testing story

Updates the existing unit test to check for the new logic.

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

