### PR TITLE
pause content pipeline during Hour of Code lockdown

### DIFF
--- a/cookbooks/cdo-apps/templates/default/crontab.erb
+++ b/cookbooks/cdo-apps/templates/default/crontab.erb
@@ -57,16 +57,16 @@
       cronjob at:'*/2 * * * *', do:pegasus_dir('sites','virtual','collate_pdfs')
       cronjob at:'0 14,15 * * *', do:deploy_dir('bin', 'cron', 'update_dotd')
       cronjob at:'0 * * * *', do:deploy_dir('bin', 'cron', 'start_broken_link_checker'), notify:'dev+crontab@code.org'
-      cronjob at:'30 7 * * 1-5', do:deploy_dir('bin', 'cron', 'commit_content')
+      # cronjob at:'30 7 * * 1-5', do:deploy_dir('bin', 'cron', 'commit_content')
       cronjob at:'*/1 * * * *', do:deploy_dir('bin', 'cron', 'update_dts')
       cronjob at:'0 17 * * *', do:deploy_dir('bin', 'cron', 'commit_trusted_proxies')
       # This should be run after the commit_content job that happens on both the levelbuilder
       # and staging environments
       # merge_lb_to_staging is also known as DTS or "deploy to staging"
-      cronjob at:'35 7 * * 1-5', do:deploy_dir('bin', 'cron', 'merge_lb_to_staging')
+      # cronjob at:'35 7 * * 1-5', do:deploy_dir('bin', 'cron', 'merge_lb_to_staging')
       # This should be run after the commit_content job that happens on the levelbuilder
       # environment.
-      cronjob at:'20 9 * * 1-5', do:deploy_dir('bin', 'cron', 'deploy_to_levelbuilder')
+      # cronjob at:'20 9 * * 1-5', do:deploy_dir('bin', 'cron', 'deploy_to_levelbuilder')
     end
 
     if node.chef_environment == 'test' && node.name == 'staging-next'
@@ -79,10 +79,10 @@
       cronjob at:'*/5 * * * *', do:deploy_dir('bin', 'snapshot')
     end
 
-    if node.chef_environment == 'levelbuilder'
-      cronjob at:'30 7 * * 1-5', do:deploy_dir('bin', 'cron', 'commit_content')
-      cronjob at:'18 9 * * 1-5', do:deploy_dir('bin', 'cron', 'commit_content')
-    end
+    # if node.chef_environment == 'levelbuilder'
+    #   cronjob at:'30 7 * * 1-5', do:deploy_dir('bin', 'cron', 'commit_content')
+    #   cronjob at:'18 9 * * 1-5', do:deploy_dir('bin', 'cron', 'commit_content')
+    # end
 
     if node.chef_environment == 'production' # production daemon
       cronjob at:'30 14 * * *', do:dashboard_dir('bin','scheduled_pd_workshop_emails')


### PR DESCRIPTION
Ensure that no levelbuilder/curriculum and no staging content changes enter our code pipeline unless explicitly approved by our Restricted Deploy Triage team.

https://codedotorg.atlassian.net/browse/INF-703

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

1. Merge Pull Request and verify that `staging` build is successful
2. Verify `test` build is successful
3. Deploy latest successful ("Green") test commit to `level builder` if/when `test` build completes.

## Follow-up work

Re-enable these jobs when lockdown period completes.

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
