### PR TITLE
Re-Insert Apply to Professional Learning Banner

### DIFF
--- a/apps/src/sites/code.org/pages/public/yourschool.js
+++ b/apps/src/sites/code.org/pages/public/yourschool.js
@@ -37,6 +37,9 @@ function showYourSchool() {
         hideMap={yourschoolElement.data('parameters-hide-map')}
         prefillData={prefillData}
         currentCensusYear={yourschoolElement.data('parameters-school-year')}
+        showProfessionalLearningBanner={yourschoolElement.data(
+          'parameters-show-professional-learning-banner'
+        )}
         teacherApplicationMode={yourschoolElement.data(
           'parameters-teacher-application-mode'
         )}

--- a/apps/src/templates/census2017/YourSchool.jsx
+++ b/apps/src/templates/census2017/YourSchool.jsx
@@ -13,6 +13,7 @@ import {SpecialAnnouncementActionBlock} from '../studioHomepages/TwoColumnAction
 import i18n from '@cdo/locale';
 import SchoolAutocompleteDropdown from '../SchoolAutocompleteDropdown';
 import CensusMapReplacement from './CensusMapReplacement';
+import ProfessionalLearningApplyBanner from '../ProfessionalLearningApplyBanner';
 
 class YourSchool extends Component {
   static propTypes = {
@@ -23,6 +24,7 @@ class YourSchool extends Component {
     prefillData: censusFormPrefillDataShape,
     hideMap: PropTypes.bool,
     currentCensusYear: PropTypes.number,
+    showProfessionalLearningBanner: PropTypes.bool,
     teacherApplicationMode: PropTypes.string
   };
 
@@ -98,6 +100,14 @@ class YourSchool extends Component {
               width="100%"
             />
           )}
+        {this.props.showProfessionalLearningBanner && (
+          <ProfessionalLearningApplyBanner
+            nominated={false}
+            style={styles.banner}
+            linkSuffix={'program-information'}
+            teacherApplicationMode={this.props.teacherApplicationMode}
+          />
+        )}
         <h1 style={styles.heading}>{i18n.yourSchoolHeading()}</h1>
         <h3 style={styles.description}>{i18n.yourSchoolDescription()}</h3>
         <YourSchoolResources />

--- a/cookbooks/Berksfile.lock
+++ b/cookbooks/Berksfile.lock
@@ -68,7 +68,7 @@ GRAPH
   cdo-analytics (0.1.10)
     apt (>= 0.0.0)
     ark (>= 0.0.0)
-  cdo-apps (0.2.534)
+  cdo-apps (0.2.535)
     apt (>= 0.0.0)
     build-essential (>= 0.0.0)
     cdo-analytics (>= 0.0.0)

--- a/cookbooks/cdo-apps/metadata.rb
+++ b/cookbooks/cdo-apps/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'will@code.org'
 license          'All rights reserved'
 description      'Installs/Configures cdo-apps'
 long_description File.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.2.534'
+version          '0.2.535'
 
 depends 'apt'
 depends 'build-essential'

--- a/cookbooks/cdo-apps/templates/default/crontab.erb
+++ b/cookbooks/cdo-apps/templates/default/crontab.erb
@@ -57,16 +57,19 @@
       cronjob at:'*/2 * * * *', do:pegasus_dir('sites','virtual','collate_pdfs')
       cronjob at:'0 14,15 * * *', do:deploy_dir('bin', 'cron', 'update_dotd')
       cronjob at:'0 * * * *', do:deploy_dir('bin', 'cron', 'start_broken_link_checker'), notify:'dev+crontab@code.org'
-      cronjob at:'30 7 * * 1-5', do:deploy_dir('bin', 'cron', 'commit_content')
+      # Disabled during HoC
+      # cronjob at:'30 7 * * 1-5', do:deploy_dir('bin', 'cron', 'commit_content')
       cronjob at:'*/1 * * * *', do:deploy_dir('bin', 'cron', 'update_dts')
       cronjob at:'0 17 * * *', do:deploy_dir('bin', 'cron', 'commit_trusted_proxies')
       # This should be run after the commit_content job that happens on both the levelbuilder
       # and staging environments
       # merge_lb_to_staging is also known as DTS or "deploy to staging"
-      cronjob at:'35 7 * * 1-5', do:deploy_dir('bin', 'cron', 'merge_lb_to_staging')
+      # Disabled during HoC
+      # cronjob at:'35 7 * * 1-5', do:deploy_dir('bin', 'cron', 'merge_lb_to_staging')
       # This should be run after the commit_content job that happens on the levelbuilder
       # environment.
-      cronjob at:'20 9 * * 1-5', do:deploy_dir('bin', 'cron', 'deploy_to_levelbuilder')
+      # Disabled during HoC
+      # cronjob at:'20 9 * * 1-5', do:deploy_dir('bin', 'cron', 'deploy_to_levelbuilder')
     end
 
     if node.chef_environment == 'test' && node.name == 'staging-next'
@@ -78,11 +81,11 @@
       cronjob at:'*/2 * * * 1-5', do:deploy_dir('bin', 'cron', 'deploy_to_test')
       cronjob at:'*/5 * * * *', do:deploy_dir('bin', 'snapshot')
     end
-
-    if node.chef_environment == 'levelbuilder'
-      cronjob at:'30 7 * * 1-5', do:deploy_dir('bin', 'cron', 'commit_content')
-      cronjob at:'18 9 * * 1-5', do:deploy_dir('bin', 'cron', 'commit_content')
-    end
+    # Disabled during HoC
+    # if node.chef_environment == 'levelbuilder'
+    #   cronjob at:'30 7 * * 1-5', do:deploy_dir('bin', 'cron', 'commit_content')
+    # cronjob at:'18 9 * * 1-5', do:deploy_dir('bin', 'cron', 'commit_content')
+    # end
 
     if node.chef_environment == 'production' # production daemon
       cronjob at:'30 14 * * *', do:dashboard_dir('bin','scheduled_pd_workshop_emails')

--- a/pegasus/sites.v3/code.org/public/administrators.erb
+++ b/pegasus/sites.v3/code.org/public/administrators.erb
@@ -3,7 +3,9 @@ title: Computer science in your school or district
 theme: responsive
 video_player: true
 ---
+
 <%= view :professional_learning_marketing_banner, audience_text: 'educators', link_address: '/educate/professional-learning', button_label: 'Learn more' %>
+<%= view :professional_learning_apply_banner, :custom_text => "Learn about our Professional Learning program for teachers new to computer science", :button_text => "Learn more" %>
 
 <h1>Bring computer science to your school or district with Code.org</h1>
 

--- a/pegasus/sites.v3/code.org/public/educate/curriculum/high-school.md.erb
+++ b/pegasus/sites.v3/code.org/public/educate/curriculum/high-school.md.erb
@@ -7,6 +7,7 @@ theme: responsive
 <link href="/css/afe-promo-box.css" rel="stylesheet">
 
 <%= view :professional_learning_marketing_banner, audience_text: 'you', link_address: '/educate/professional-learning/middle-high', button_label: 'Learn more' %>
+<%= view :professional_learning_apply_banner, :link_suffix => "program-information" %>
 
 [solid-block-header]
 

--- a/pegasus/sites.v3/code.org/public/educate/curriculum/middle-school.md.erb
+++ b/pegasus/sites.v3/code.org/public/educate/curriculum/middle-school.md.erb
@@ -7,6 +7,7 @@ theme: responsive
 <link href="/css/afe-promo-box.css" rel="stylesheet">
 
 <%= view :professional_learning_marketing_banner, audience_text: 'you', link_address: '/educate/professional-learning/middle-high', button_label: 'Learn more' %>
+<%= view :professional_learning_apply_banner, :link_suffix => "program-information" %>
 
 [solid-block-header]
 

--- a/pegasus/sites.v3/code.org/public/educate/professional-learning/middle-high.md.erb
+++ b/pegasus/sites.v3/code.org/public/educate/professional-learning/middle-high.md.erb
@@ -21,6 +21,7 @@ theme: responsive
 <%= view :professional_learning_marketing_banner, audience_text: 'you', link_address: '/educate/professional-learning/program-information', button_label: 'Apply now' %>
 <% end %>
 
+<%= view :professional_learning_apply_banner, :link_suffix => "program-information", :style => {"padding-bottom" => "32px"} %>
 
 <a name="scholarships"></a>
 <div class="col-50">

--- a/pegasus/sites.v3/code.org/public/yourschool.haml
+++ b/pegasus/sites.v3/code.org/public/yourschool.haml
@@ -28,6 +28,7 @@ social:
 - census_announcement['school_year'] = current_census_year
 - census_announcement['locale'] = request.locale
 - teacher_application_mode  = DCDO.get("teacher_application_mode", CDO.default_teacher_application_mode)
+- census_announcement['show_professional_learning_banner'] = (request.locale == 'en-US' && %w(open closing-soon).include?(teacher_application_mode)).to_s
 - census_announcement['teacher_application_mode'] = teacher_application_mode
 
 = inline_css 'trophy_announcement_sparkle.css'

--- a/pegasus/src/homepage.rb
+++ b/pegasus/src/homepage.rb
@@ -542,13 +542,6 @@ class Homepage
     false
   end
 
-  def self.professional_learning_banner_text
-    teacher_apps_closing_soon = DCDO.get("teacher_application_mode", CDO.default_teacher_application_mode) == "closing-soon"
-    closing_soon_text = "2021 Professional Learning applications are closing soon! Sign up now."
-    sign_up_text = "Sign up for Professional Learning! Middle and High School applications now open."
-    teacher_apps_closing_soon ? closing_soon_text : sign_up_text
-  end
-
   def self.show_courses_banner(request)
     false
   end


### PR DESCRIPTION
The Professional Learning Banner was removed in https://github.com/code-dot-org/code-dot-org/pull/44847 to make room for a superhero banner. TBD if this should permanently replace the other banner –– if so, how should it interact with the `teacher_application_mode` flag?

If we want to keep this banner, the code itself should not be removed so that we can rely on DCDO flags to hide/show these at the appropriate times. I used the files changed in https://github.com/code-dot-org/code-dot-org/pull/44847 to create this PR, and we are *not* currently displaying the `professional_learning_marketing_banner` page due to this line https://github.com/code-dot-org/code-dot-org/blob/staging-next/pegasus/sites.v3/code.org/views/professional_learning_marketing_banner.haml#L1.

I tested locally by setting `teacher_application_mode` to `open` in the `config.yml.erb` file.

Administrator page:
<img width="1119" alt="Screen Shot 2022-11-29 at 9 17 04 AM" src="https://user-images.githubusercontent.com/9142121/204557000-9cd7c082-50da-4068-b945-7ee3455c6063.png">

Middle school page:
<img width="1080" alt="Screen Shot 2022-11-29 at 9 11 29 AM" src="https://user-images.githubusercontent.com/9142121/204557219-3aeda7fb-38d7-4e66-abca-42ae7c8eb6a8.png">

High school page:
<img width="1096" alt="Screen Shot 2022-11-29 at 9 15 22 AM" src="https://user-images.githubusercontent.com/9142121/204557274-e3b40b91-59d3-455c-b665-b599c6343a2d.png">

Professional learning page:
<img width="1066" alt="Screen Shot 2022-11-29 at 9 17 40 AM" src="https://user-images.githubusercontent.com/9142121/204557401-93c6f422-9ad4-478b-9077-d2e47f839395.png">

Your School page:
<img width="1072" alt="image" src="https://user-images.githubusercontent.com/9142121/204557452-6a064062-1684-460b-9e7c-1b8b7be54c29.png">

IF we want to show it on the home page:
<img width="1254" alt="image" src="https://user-images.githubusercontent.com/9142121/204567203-33b900fb-caf7-4b20-b422-c05b05a76aaa.png">

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

- Make consistent how we're showing PL banners –– we are using both DCDO flags and in-line logic to do this right now.
- Clean up the `nominated` logic in ProfessionalLearningApplyBanner.
- If we want to permanently remove the plane banner, remove `professional_learning_apply_banner.haml` and all files associated with it, including `/images/professional-learning/plane.png`
- Investigate the utility of the `teacher_application_mode` flag. If it's not needed, remove it.

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
