### PR TITLE
Remove Ableist Term from Comment

### DIFF
--- a/dashboard/app/views/plc/user_course_enrollments/index.html.haml
+++ b/dashboard/app/views/plc/user_course_enrollments/index.html.haml
@@ -7,7 +7,7 @@
   - user_course_enrollments.each do |user_course_enrollment|
     %h3.course_title
       = user_course_enrollment.plc_course.name
-    -# Lame that we have to do this but Firefox doesn't support multiline flexboxes
+    -# Adjust because Firefox doesn't support multiline flexboxes
     - user_course_enrollment.plc_unit_assignments.each_slice(2).to_a.each do |unit_group|
       .course_unit_sections
         - unit_group.each do |unit_enrollment|


### PR DESCRIPTION
Inspired by [this discussion](https://codedotorg.slack.com/archives/C9MB4CL07/p1669770504316679?thread_ts=1669769682.856389&cid=C9MB4CL07) in Slack, I did a quick search and found this in a comment. Let's go ahead and remove it!

https://www.learningforjustice.org/magazine/lets-stop-using-the-word-lame