### PR TITLE
Regional Partner Set Teacher PD Scholarship Req Guardrails

### DIFF
--- a/dashboard/app/controllers/regional_partners_controller.rb
+++ b/dashboard/app/controllers/regional_partners_controller.rb
@@ -155,6 +155,8 @@ class RegionalPartnersController < ApplicationController
       :cohort_capacity_csp,
       :apps_open_date_teacher,
       :apps_close_date_teacher,
+      :urg_guardrail_percent,
+      :frl_guardrail_percent,
       :apps_open_date_csd_facilitator,
       :apps_open_date_csp_facilitator,
       :apps_close_date_csd_facilitator,

--- a/dashboard/app/models/pd/application/teacher_application.rb
+++ b/dashboard/app/models/pd/application/teacher_application.rb
@@ -1042,7 +1042,14 @@ module Pd::Application
         free_lunch_percent = responses[:principal_free_lunch_percent].present? ?
                                responses[:principal_free_lunch_percent].to_i :
                                school_stats&.frl_eligible_percent
-        free_lunch_percent_cutoff = school_stats&.rural_school? ? 40 : 50
+        free_lunch_percent_cutoff =
+          if regional_partner&.frl_guardrail_percent
+            regional_partner&.frl_guardrail_percent.to_i
+          elsif school_stats&.rural_school?
+            40
+          else
+            50
+          end
 
         meets_scholarship_criteria_scores[:free_lunch_percent] =
           if free_lunch_percent
@@ -1054,10 +1061,13 @@ module Pd::Application
         urg_percent = responses[:principal_underrepresented_minority_percent].present? ?
                         responses[:principal_underrepresented_minority_percent].to_i :
                         school_stats&.urm_percent
+        urg_percent_cutoff = regional_partner&.urg_guardrail_percent ?
+                              regional_partner&.urg_guardrail_percent.to_i :
+                              50
 
         meets_scholarship_criteria_scores[:underrepresented_minority_percent] =
           if urg_percent
-            urg_percent >= 50 ? YES : NO
+            urg_percent >= urg_percent_cutoff ? YES : NO
           else
             nil
           end

--- a/dashboard/app/models/regional_partner.rb
+++ b/dashboard/app/models/regional_partner.rb
@@ -49,6 +49,8 @@ class RegionalPartner < ApplicationRecord
     apps_close_date_csd_facilitator
     apps_close_date_csp_facilitator
     apps_priority_deadline_date
+    urg_guardrail_percent
+    frl_guardrail_percent
     applications_principal_approval
     applications_decision_emails
     link_to_partner_application

--- a/dashboard/app/views/regional_partners/_form.html.haml
+++ b/dashboard/app/views/regional_partners/_form.html.haml
@@ -26,6 +26,12 @@
     = f.label nil, "Apps Close Date (YYYY-MM-DD)"
     = f.text_field :apps_close_date_teacher
   .field
+    = f.label nil, "Underrepresented Group Guardrail Percent"
+    = f.number_field :urg_guardrail_percent, :in => 0..100
+  .field
+    = f.label nil, "Free and Reduced Lunch Guardrail Percent"
+    = f.number_field :frl_guardrail_percent, :in => 0..100
+  .field
     = f.label nil, "Applications Administrator/School Leader Approval", {style: 'margin-top: 20px'}
     .applications_principal_approval
       %label

--- a/dashboard/app/views/regional_partners/show.html.haml
+++ b/dashboard/app/views/regional_partners/show.html.haml
@@ -44,6 +44,12 @@
   %strong Apps close date for teachers:
   = @regional_partner.apps_close_date_teacher
 %p
+  %strong Underrepresented Group Guardrail Percent:
+  = @regional_partner.urg_guardrail_percent + '%'
+%p
+  %strong Free and Reduced Lunch Guardrail Percent:
+  = @regional_partner.frl_guardrail_percent + '%'
+%p
   %strong Link to Partner's Application:
   = @regional_partner.link_to_partner_application
 %p

--- a/dashboard/app/views/regional_partners/show.html.haml
+++ b/dashboard/app/views/regional_partners/show.html.haml
@@ -45,10 +45,10 @@
   = @regional_partner.apps_close_date_teacher
 %p
   %strong Underrepresented Group Guardrail Percent:
-  = @regional_partner.urg_guardrail_percent + '%'
+  = @regional_partner.urg_guardrail_percent
 %p
   %strong Free and Reduced Lunch Guardrail Percent:
-  = @regional_partner.frl_guardrail_percent + '%'
+  = @regional_partner.frl_guardrail_percent
 %p
   %strong Link to Partner's Application:
   = @regional_partner.link_to_partner_application


### PR DESCRIPTION
This PR does 2 things with regional partner guardrail settings:
1. Adds 2 fields to the Regional Partner edit page: Free and Reduced Lunch Guardrail Percent and Under Represented Group Guardrail Percent (expected to be whole numbers 0..100). These set the minimum percent of students needed for those two fields for scholarship eligibility for the teacher PD applicant (applying within that regional partner's region).
2. Uses these new fields to automatically determine if an application meets the scholarship criteria. An application meets the Free and Reduced Lunch Criteria if the school's FRL % is equal to or great than the guardrail % for that regional partner. Same for the Under Represented Group (URG) percents. If a region has not set their guardrails or the application is assigned 'No Partner', use the national guardrails to calculate. If the given school's reported percent is greater than or equal to the guardrail, then that field is marked YES, otherwise NO.

## Questions on Regional Partner pages
Edit page:
![Edit_Page](https://user-images.githubusercontent.com/56283563/204892629-8fd8a07e-8afc-4e6e-a1ec-b5fbce2e4f98.JPG)

Demo showing only whole numbers 0..100 work for percent entries: [demo video](https://user-images.githubusercontent.com/56283563/204892755-4de19c27-2b33-4536-a37a-30f8e7fffcad.mp4)

Show page:
![Show_Page](https://user-images.githubusercontent.com/56283563/204892682-2572f6b0-e57b-4124-9ebc-2906d4b47c92.JPG)

## Automatically calculates if applicant meets scholarship criteria
If set to 'No Partner' for RP (default to 50% for both guardrails):
![No_Partner](https://user-images.githubusercontent.com/56283563/204892955-cbbd34f2-533f-4af4-8dea-bd9f49185089.JPG)

If assigned RP (in this case, Reggie Partner), but RP has not explicitly set guardrails (default to 50% for both guardrails):
![Partner_not_set](https://user-images.githubusercontent.com/56283563/204892966-354531e0-509e-4a44-9207-dccb722ca9f3.JPG)

If assigned RP (in this case, Reggie Partner, and RP has set guardrails (URG - 48%, FRL - 55%):
![Partner_set](https://user-images.githubusercontent.com/56283563/204892987-fab29a1b-a03c-4492-bce5-85b5817a1d5f.JPG)

## Links
Jira tasks: [create RP fields](https://codedotorg.atlassian.net/browse/ACQ-260?atlOrigin=eyJpIjoiNTE4ZjdmNzA4NDBkNDlkMWIwMDllOTc0MTc3ZTEwZjMiLCJwIjoiaiJ9) and [use fields to determine scholarship criteria](https://codedotorg.atlassian.net/browse/ACQ-261?atlOrigin=eyJpIjoiZTJlYTI1ZTM0MTFkNGRkOGEwNTliNTFjMzVkYzMwN2MiLCJwIjoiaiJ9)

## Testing story
Added unit tests, local testing, and drone tests.

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
