### PR TITLE
Fix Hebrew block text localization that breaks hello-world-space-2022 hoc module.

### DIFF
--- a/dashboard/config/locales/blocks.he-IL.yml
+++ b/dashboard/config/locales/blocks.he-IL.yml
@@ -1453,7 +1453,7 @@ he:
             '"when"': כאשר
             '"while"': כל עוד
       gamelab_spriteSay:
-        text: אמור
+        text: "{SPRITE} אמור {SPEECH}"
       gamelab_subjectSpritePointer:
         text: "{SPRITE}"
       gamelab_turn:


### PR DESCRIPTION
Just a quick hot-fix (that won't stick if the localization changes) to get the hello world space 2022 hoc module to complete in Hebrew.

**NOTE**: I'm requesting a merge into `staging` as this fixes broken HoC content.

## Testing story

Manual effort! See image below.

## Follow-up work

The translation team (@jorge, et al) should fix the `gamelab_spriteSay` text to read what is in the change here (same as the bottom text in the image below)

![image](https://user-images.githubusercontent.com/31674/204902184-23f2455d-4f31-4143-ac0f-800abc1539c7.png)

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
