### PR TITLE
Remove replace_existing Question from Rubric in Teacher App

### DIFF
--- a/dashboard/app/models/pd/application/teacher_application.rb
+++ b/dashboard/app/models/pd/application/teacher_application.rb
@@ -1002,14 +1002,6 @@ module Pd::Application
       end
 
       meets_minimum_criteria_scores[:enough_course_hours] = responses[:enough_course_hours] == options[:enough_course_hours].first ? YES : NO
-      meets_minimum_criteria_scores[:replace_existing] =
-        if responses[:replace_existing] == YES
-          NO
-        elsif responses[:replace_existing] == TEXT_FIELDS[:i_dont_know_explain]
-          nil
-        else
-          YES
-        end
 
       # Section 7
       meets_minimum_criteria_scores[:committed] = responses[:committed] == options[:committed].first ? YES : NO
@@ -1026,15 +1018,6 @@ module Pd::Application
             NO
           else
             nil
-          end
-
-        meets_minimum_criteria_scores[:replace_existing] =
-          if responses[:principal_wont_replace_existing_course].start_with?(YES)
-            NO
-          elsif responses[:principal_wont_replace_existing_course] == TEXT_FIELDS[:i_dont_know_explain]
-            nil
-          else
-            YES
           end
 
         school_stats = get_latest_school_stats(school_id)

--- a/dashboard/test/models/pd/application/teacher_application_test.rb
+++ b/dashboard/test/models/pd/application/teacher_application_test.rb
@@ -548,14 +548,12 @@ module Pd::Application
         csd_which_grades: ['6'],
         enough_course_hours: options[:enough_course_hours].first,
         previous_yearlong_cdo_pd: ['CS Principles'],
-        replace_existing: options[:replace_existing].second,
         committed: options[:committed].first,
         race: options[:race].first(2),
         principal_approval: principal_options[:do_you_approve].first,
         principal_schedule_confirmed: principal_options[:committed_to_master_schedule].first,
         principal_free_lunch_percent: 50,
-        principal_underrepresented_minority_percent: 50,
-        principal_wont_replace_existing_course: principal_options[:replace_course].second
+        principal_underrepresented_minority_percent: 50
 
       application = create :pd_teacher_application, regional_partner: (create :regional_partner), form_data_hash: application_hash
       application.auto_score!
@@ -567,7 +565,6 @@ module Pd::Application
             enough_course_hours: YES,
             committed: YES,
             previous_yearlong_cdo_pd: YES,
-            replace_existing: YES,
             principal_approval: YES,
             principal_schedule_confirmed: YES,
           },
@@ -590,14 +587,12 @@ module Pd::Application
         enough_course_hours: options[:enough_course_hours].first,
         previous_yearlong_cdo_pd: ['CS Discoveries'],
         csp_how_offer: options[:csp_how_offer].last,
-        replace_existing: options[:replace_existing].second,
         committed: options[:committed].first,
         race: options[:race].first(2),
         principal_approval: principal_options[:do_you_approve].first,
         principal_schedule_confirmed: principal_options[:committed_to_master_schedule].first,
         principal_free_lunch_percent: 50,
-        principal_underrepresented_minority_percent: 50,
-        principal_wont_replace_existing_course: principal_options[:replace_course].second
+        principal_underrepresented_minority_percent: 50
 
       application = create :pd_teacher_application, regional_partner: (create :regional_partner), form_data_hash: application_hash
       application.auto_score!
@@ -609,7 +604,6 @@ module Pd::Application
             enough_course_hours: YES,
             committed: YES,
             previous_yearlong_cdo_pd: YES,
-            replace_existing: YES,
             principal_approval: YES,
             principal_schedule_confirmed: YES,
           },
@@ -634,14 +628,12 @@ module Pd::Application
         enough_course_hours: options[:enough_course_hours].first,
         previous_yearlong_cdo_pd: ['CS Principles'],
         csa_how_offer: options[:csa_how_offer].last,
-        replace_existing: options[:replace_existing].second,
         committed: options[:committed].first,
         race: options[:race].first(2),
         principal_approval: principal_options[:do_you_approve].first,
         principal_schedule_confirmed: principal_options[:committed_to_master_schedule].first,
         principal_free_lunch_percent: 50,
-        principal_underrepresented_minority_percent: 50,
-        principal_wont_replace_existing_course: principal_options[:replace_course].second
+        principal_underrepresented_minority_percent: 50
 
       application = create :pd_teacher_application, regional_partner: (create :regional_partner), form_data_hash: application_hash
       application.auto_score!
@@ -655,7 +647,6 @@ module Pd::Application
             enough_course_hours: YES,
             committed: YES,
             previous_yearlong_cdo_pd: YES,
-            replace_existing: YES,
             principal_approval: YES,
             principal_schedule_confirmed: YES,
           },
@@ -677,7 +668,6 @@ module Pd::Application
         enough_course_hours: options[:enough_course_hours].first,
         previous_yearlong_cdo_pd: ['CS Discoveries'],
         csp_how_offer: options[:csp_how_offer].last,
-        replace_existing: options[:replace_existing].second,
         committed: options[:committed].first,
         race: [options[:race].second]
 
@@ -691,7 +681,6 @@ module Pd::Application
             enough_course_hours: YES,
             committed: YES,
             previous_yearlong_cdo_pd: YES,
-            replace_existing: YES,
           },
           meets_scholarship_criteria_scores: {},
         }.deep_stringify_keys,
@@ -708,14 +697,12 @@ module Pd::Application
         csd_which_grades: %w(11 12),
         enough_course_hours: options[:enough_course_hours].last,
         previous_yearlong_cdo_pd: ['CS Discoveries'],
-        replace_existing: options[:replace_existing].first,
         committed: options[:committed].last,
         race: [options[:race].first],
         principal_approval: principal_options[:do_you_approve].last,
         principal_schedule_confirmed: principal_options[:committed_to_master_schedule].third,
         principal_free_lunch_percent: 49,
-        principal_underrepresented_minority_percent: 49,
-        principal_wont_replace_existing_course: principal_options[:replace_course].first
+        principal_underrepresented_minority_percent: 49
 
       application = create :pd_teacher_application, regional_partner: nil, form_data_hash: application_hash
       application.auto_score!
@@ -727,7 +714,6 @@ module Pd::Application
             enough_course_hours: NO,
             committed: NO,
             previous_yearlong_cdo_pd: NO,
-            replace_existing: NO,
             principal_approval: NO,
             principal_schedule_confirmed: NO,
           },
@@ -750,14 +736,12 @@ module Pd::Application
         enough_course_hours: options[:enough_course_hours].last,
         previous_yearlong_cdo_pd: 'CS Principles',
         csp_how_offer: options[:csp_how_offer].first,
-        replace_existing: options[:replace_existing].first,
         committed: options[:committed].last,
         race: [options[:race].first],
         principal_approval: principal_options[:do_you_approve].last,
         principal_schedule_confirmed: principal_options[:committed_to_master_schedule].third,
         principal_free_lunch_percent: 49,
-        principal_underrepresented_minority_percent: 49,
-        principal_wont_replace_existing_course: principal_options[:replace_course].first
+        principal_underrepresented_minority_percent: 49
 
       application = create :pd_teacher_application, regional_partner: nil, form_data_hash: application_hash
       application.auto_score!
@@ -769,7 +753,6 @@ module Pd::Application
             enough_course_hours: NO,
             committed: NO,
             previous_yearlong_cdo_pd: NO,
-            replace_existing: NO,
             principal_approval: NO,
             principal_schedule_confirmed: NO,
           },
@@ -794,14 +777,12 @@ module Pd::Application
         enough_course_hours: options[:enough_course_hours].last,
         previous_yearlong_cdo_pd: 'Computer Science A (CSA)',
         csa_how_offer: options[:csa_how_offer].first,
-        replace_existing: options[:replace_existing].first,
         committed: options[:committed].last,
         race: [options[:race].first],
         principal_approval: principal_options[:do_you_approve].last,
         principal_schedule_confirmed: principal_options[:committed_to_master_schedule].third,
         principal_free_lunch_percent: 49,
-        principal_underrepresented_minority_percent: 49,
-        principal_wont_replace_existing_course: principal_options[:replace_course].first
+        principal_underrepresented_minority_percent: 49
 
       application = create :pd_teacher_application, regional_partner: nil, form_data_hash: application_hash
       application.auto_score!
@@ -815,7 +796,6 @@ module Pd::Application
             enough_course_hours: NO,
             committed: NO,
             previous_yearlong_cdo_pd: NO,
-            replace_existing: NO,
             principal_approval: NO,
             principal_schedule_confirmed: NO,
           },
@@ -828,106 +808,13 @@ module Pd::Application
       )
     end
 
-    test 'autoscore principal responses override teacher responses' do
-      options = Pd::Application::TeacherApplication.options
-      principal_options = Pd::Application::PrincipalApprovalApplication.options
-
-      application_hash = build :pd_teacher_application_hash,
-        replace_existing: options[:replace_existing].first
-
-      application = create :pd_teacher_application, form_data_hash: application_hash
-
-      application.auto_score!
-
-      assert_equal NO,
-        application.response_scores_hash[:meets_minimum_criteria_scores][:replace_existing]
-
-      application.update_form_data_hash(
-        {
-          principal_approval: principal_options[:do_you_approve].first,
-          principal_wont_replace_existing_course: principal_options[:replace_course].second
-        }
-      )
-
-      application.auto_score!
-
-      assert_equal YES,
-        application.response_scores_hash[:meets_minimum_criteria_scores][:replace_existing]
-    end
-
-    test 'autoscore principal responses for replace_existing question' do
-      principal_options = Pd::Application::PrincipalApprovalApplication.options
-
-      test_cases = [
-        # If the answer for replace_course is 'Yes', the application does not meet requirement
-        {
-          principal_answers: {replace_course: principal_options[:replace_course].first},
-          meet_requirement: NO
-        },
-        {
-          principal_answers: {
-            replace_course: principal_options[:replace_course].first
-          },
-          meet_requirement: NO
-        },
-        # If the answer for replace_course is 'No...', the application meets requirement
-        {
-          principal_answers: {replace_course: principal_options[:replace_course].second},
-          meet_requirement: YES
-        },
-        {
-          principal_answers: {replace_course: principal_options[:replace_course].third},
-          meet_requirement: YES
-        },
-        # If the answer for replace_course is 'I don't know...', the verdict is inconclusive
-        {
-          principal_answers: {replace_course: principal_options[:replace_course].last},
-          meet_requirement: nil
-        }
-      ]
-
-      # Creates a teacher application with an inconclusive replace_existing answer.
-      # The principal's responses will override teacher's responses anyway.
-      application = build :pd_teacher_application,
-        form_data_hash: (
-        build :pd_teacher_application_hash, replace_existing: TEXT_FIELDS[:i_dont_know_explain]
-        )
-      application.auto_score!
-      assert_nil application.response_scores_hash[:meets_minimum_criteria_scores][:replace_existing]
-
-      # For each test case, creates an principal approval application and re-scores the
-      # teacher application.
-      test_cases.each_with_index do |test_case, index|
-        principal_approval = build :pd_principal_approval_application,
-          teacher_application: application,
-          form_data_hash: (
-          build :pd_principal_approval_application_hash_common, test_case[:principal_answers]
-          )
-
-        # Updates the application with principal's responses and run auto_score! again
-        application.on_successful_principal_approval_create(principal_approval)
-
-        # Written as a conditional to address Minitest 6 deprecation: `DEPRECATED: Use assert_nil if expecting nil`
-        if test_case[:meet_requirement]
-          assert application.response_scores_hash[:meets_minimum_criteria_scores][:replace_existing],
-                 "Test case index #{index} failed"
-        else
-          refute application.response_scores_hash[:meets_minimum_criteria_scores][:replace_existing],
-                 "Test case index #{index} failed"
-        end
-      end
-    end
-
     test 'autoscore nil results when applicable' do
-      options = Pd::Application::TeacherApplication.options
       principal_options = Pd::Application::PrincipalApprovalApplication.options
 
       application_hash = build :pd_teacher_application_hash,
         program: Pd::Application::TeacherApplication::PROGRAMS[:csp],
-        replace_existing: options[:replace_existing].first,
         principal_approval: principal_options[:do_you_approve].first,
-        principal_schedule_confirmed: principal_options[:committed_to_master_schedule].fourth,
-        principal_wont_replace_existing_course: principal_options[:replace_course].last
+        principal_schedule_confirmed: principal_options[:committed_to_master_schedule].fourth
 
       application = create :pd_teacher_application, form_data_hash: application_hash
 
@@ -936,7 +823,6 @@ module Pd::Application
       response_scores_hash = application.response_scores_hash
 
       assert_nil response_scores_hash[:meets_minimum_criteria_scores][:principal_schedule_confirmed]
-      assert_nil response_scores_hash[:meets_minimum_criteria_scores][:replace_existing]
     end
 
     test 'principal_approval_state' do

--- a/lib/cdo/shared_constants/pd/teacher_application_constants.rb
+++ b/lib/cdo/shared_constants/pd/teacher_application_constants.rb
@@ -271,7 +271,6 @@ module Pd
       committed: YES_NO,
       enough_course_hours: YES_NO,
       previous_yearlong_cdo_pd: YES_NO,
-      replace_existing: YES_NO,
       principal_approval: YES_NO,
       principal_schedule_confirmed: YES_NO,
       # Scholarship requirements
@@ -290,7 +289,6 @@ module Pd
         :enough_course_hours,
         :committed,
         :previous_yearlong_cdo_pd,
-        :replace_existing,
         :principal_approval,
         :principal_schedule_confirmed,
       ],
@@ -299,7 +297,6 @@ module Pd
         :enough_course_hours,
         :committed,
         :previous_yearlong_cdo_pd,
-        :replace_existing,
         :principal_approval,
         :principal_schedule_confirmed,
       ],
@@ -310,7 +307,6 @@ module Pd
         :enough_course_hours,
         :committed,
         :previous_yearlong_cdo_pd,
-        :replace_existing,
         :principal_approval,
         :principal_schedule_confirmed,
       ]


### PR DESCRIPTION
Removes the "Will this course replace an existing computer science course in the master schedule? *" (associated with field `replace_existing`) from the teacher PD application rubric. To clarify, the question still exists and is required, we just no longer want this question's response to affect the auto-scoring of the application.

### Original (had rubric auto-score in "Meets Guidelines")
![Original_replace_existing](https://user-images.githubusercontent.com/56283563/204904831-2b682677-e324-42b1-b8b7-f5dea2d0e133.JPG)

### New (shows response without "Meets Guidelines")
![Removed_replace_existing](https://user-images.githubusercontent.com/56283563/204904836-2895b8cc-a147-4677-a7b4-2f844cb24251.JPG)

## Links
Jira task: [here](https://codedotorg.atlassian.net/browse/ACQ-264?atlOrigin=eyJpIjoiY2M1MTNiZDEzMGE3NGVhYTkzNmQ5NTEwMDFlNmUzMjYiLCJwIjoiaiJ9)

## Testing story
Updated unit tests (including removing 2 tests that specifically tested the rubric analysis of that question), local testing, and drone tests.

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
