### PR TITLE
Google Blockly: use unit tests instead of integration tests in function blocks

### DIFF
--- a/apps/src/blockly/addons/functionEditor.js
+++ b/apps/src/blockly/addons/functionEditor.js
@@ -1,3 +1,5 @@
+import xml from '@cdo/apps/xml';
+
 // This class is not yet implemented. It is used for the modal function editor,
 // which is used by Sprite Lab and Artist.
 export default class FunctionEditor {
@@ -38,8 +40,11 @@ export default class FunctionEditor {
  */
 export function flyoutCategory(workspace) {
   // TODO: Add "Create a Function" button
-  const newFunctionDefinitionBlock = newDefinitionBlock();
+  const newFunctionDefinitionBlock = newDefinitionBlock(
+    Blockly.Msg['PROCEDURES_DEFNORETURN_PROCEDURE']
+  );
   console.warn('The modal function editor has not been fully implemented yet.');
+
   // Find all user-created procedure definitions in the workspace.
   // allProcedures returns a pair of arrays, but we only need the first.
   // The second contains procedures with return variables which we don't support.
@@ -56,17 +61,19 @@ export function allCallBlocks(procedures) {
   for (let i = 0; i < procedures.length; i++) {
     const name = procedures[i][0];
     const args = procedures[i][1];
-    const block = Blockly.utils.xml.createElement('block');
+
+    const block = xml.parseElement('<block></block>', true);
     block.setAttribute('type', 'procedures_callnoreturn');
     block.setAttribute('gap', 16);
-    const mutation = Blockly.utils.xml.createElement('mutation');
+
+    const mutation = xml.parseElement('<mutation></mutation>', true);
     mutation.setAttribute('name', name);
     block.appendChild(mutation);
+
     // The argument list is likely empty as we don't currently support
     // functions with parameters. This loop is needed if that changes.
     for (let j = 0; j < args.length; j++) {
-      const arg = Blockly.utils.xml.createElement('arg');
-      arg.setAttribute('name', args[j]);
+      const arg = xml.parseElement(`<arg name="${args[j]}></arg>`, true);
       mutation.appendChild(arg);
     }
     blockElements.push(block);
@@ -74,22 +81,22 @@ export function allCallBlocks(procedures) {
   return blockElements;
 }
 
-export function newDefinitionBlock() {
+export function newDefinitionBlock(localizedNewFunctionString) {
   // Create a block with the following XML:
   // <block type="procedures_defnoreturn" gap="24">
   //     <field name="NAME">do something</field>
   // </block>
-  const blockElement = Blockly.utils.xml.createElement('block');
+  const blockElement = xml.parseElement('<block></block>', true);
   blockElement.setAttribute('type', 'procedures_defnoreturn');
   // Add slightly larger gap between system blocks and user calls.
   blockElement.setAttribute('gap', 24);
-  const nameField = Blockly.utils.xml.createElement('field');
-  nameField.setAttribute('name', 'NAME');
-  nameField.appendChild(
-    Blockly.utils.xml.createTextNode(
-      Blockly.Msg['PROCEDURES_DEFNORETURN_PROCEDURE']
-    )
+
+  const nameField = xml.parseElement(
+    `<field>${localizedNewFunctionString}</field>`,
+    true
   );
+  nameField.setAttribute('name', 'NAME');
   blockElement.appendChild(nameField);
+
   return blockElement;
 }

--- a/apps/src/blockly/addons/functionEditor.js
+++ b/apps/src/blockly/addons/functionEditor.js
@@ -73,7 +73,7 @@ export function allCallBlocks(procedures) {
     // The argument list is likely empty as we don't currently support
     // functions with parameters. This loop is needed if that changes.
     for (let j = 0; j < args.length; j++) {
-      const arg = xml.parseElement(`<arg name="${args[j]}></arg>`, true);
+      const arg = xml.parseElement(`<arg name="${args[j]}"></arg>`, true);
       mutation.appendChild(arg);
     }
     blockElements.push(block);

--- a/apps/src/xml.js
+++ b/apps/src/xml.js
@@ -5,15 +5,16 @@ exports.serialize = function(node) {
 };
 
 /**
- * Parses a single root element string, wrapping it in an <xml/> element.
+ * Parses a single root element string, optionally wrapping it in an <xml/> element.
  * @param {string} text
+ * @param {?boolean} noWrap if true, don't wrap in <xml/> element
  * @return {Element}
  */
-exports.parseElement = function(text) {
+exports.parseElement = function(text, noWrap = false) {
   var parser = new DOMParser();
   text = text.trim();
   var dom =
-    text.indexOf('<xml') === 0
+    text.indexOf('<xml') === 0 || noWrap
       ? parser.parseFromString(text, 'text/xml')
       : parser.parseFromString('<xml>' + text + '</xml>', 'text/xml');
   var errors = dom.getElementsByTagName('parsererror');

--- a/apps/test/unit/blockly/customFunctionsTest.js
+++ b/apps/test/unit/blockly/customFunctionsTest.js
@@ -1,56 +1,34 @@
-/* global Blockly */
-import sinon from 'sinon';
-import GoogleBlockly from 'blockly/core';
-import initializeGoogleBlocklyWrapper from '@cdo/apps/blockly/googleBlocklyWrapper';
 import {expect} from '../../util/reconfiguredChai';
-import '@cdo/apps/flappy/flappy'; // Importing the app forces the test to load Blockly
 import {
   newDefinitionBlock,
   allCallBlocks
 } from '../../../src/blockly/addons/functionEditor.js';
+import xml from '@cdo/apps/xml';
 
 describe('Custom Functions', () => {
-  const cdoBlockly = Blockly;
-  // Reset context menu registry.
-  const registry = JSON.parse(
-    JSON.stringify(GoogleBlockly.ContextMenuRegistry.registry.registry_)
-  );
-  beforeEach(() => {
-    GoogleBlockly.JavaScript = sinon.spy();
-    Blockly = initializeGoogleBlocklyWrapper(GoogleBlockly); // eslint-disable-line no-global-assign
-  });
-  afterEach(() => {
-    // Reset Blockly for other tests.
-    Blockly = cdoBlockly; // eslint-disable-line no-global-assign
-    // Reset context menu for other tests.
-    GoogleBlockly.ContextMenuRegistry.registry.registry_ = JSON.parse(
-      JSON.stringify(registry)
-    );
-  });
-
   it('Can create a blank function definition block', () => {
-    const defBlock = newDefinitionBlock();
+    const defBlock = newDefinitionBlock('new function');
     const expectedXML =
-      '<block type="procedures_defnoreturn" gap="24"><field name="NAME">undefined</field></block>';
-    expect(defBlock.outerHTML).to.equal(expectedXML);
+      '<block type="procedures_defnoreturn" gap="24"><field name="NAME">new function</field></block>';
+    expect(defBlock.isEqualNode(xml.parseElement(expectedXML, true))).to.be
+      .true;
   });
 
   it('Does not create call blocks if there are no defined functions', () => {
     const definedFunctions = [];
     const callBlocks = allCallBlocks(definedFunctions);
-    const callBlocksXML = callBlocks.map(element => element.outerHTML).join();
-    const expectedXML = '';
-    expect(callBlocksXML).to.equal(expectedXML);
+    expect(callBlocks).to.be.empty;
   });
 
   it('Can create a call block for one defined function', () => {
     const definedFunctions = [['myTestFunction', [], false]];
     const callBlock = allCallBlocks(definedFunctions);
-    const callBlocksXML = callBlock.map(element => element.outerHTML).join();
     const expectedXML = [
       '<block type="procedures_callnoreturn" gap="16"><mutation name="myTestFunction"></mutation></block>'
-    ].join();
-    expect(callBlocksXML).to.equal(expectedXML);
+    ];
+
+    expect(callBlock[0].isEqualNode(xml.parseElement(expectedXML[0], true))).to
+      .be.true;
   });
 
   it('Can create call blocks for multiple defined functions', () => {
@@ -60,12 +38,15 @@ describe('Custom Functions', () => {
       ['myThirdTestFunction', [], false]
     ];
     const callBlocks = allCallBlocks(definedFunctions);
-    const callBlocksXML = callBlocks.map(element => element.outerHTML).join();
     const expectedXML = [
       '<block type="procedures_callnoreturn" gap="16"><mutation name="myFirstTestFunction"></mutation></block>',
       '<block type="procedures_callnoreturn" gap="16"><mutation name="mySecondTestFunction"></mutation></block>',
       '<block type="procedures_callnoreturn" gap="16"><mutation name="myThirdTestFunction"></mutation></block>'
-    ].join();
-    expect(callBlocksXML).to.equal(expectedXML);
+    ];
+
+    callBlocks.forEach((block, index) => {
+      expect(block.isEqualNode(xml.parseElement(expectedXML[index], true))).to
+        .be.true;
+    });
   });
 });


### PR DESCRIPTION
An example of refactoring Blockly "unit" tests to not require Blockly. We were just using Blockly to generate XML elements, so I used our own util instead of theirs, which made testing simpler.

## Testing story

Tests passing. Tested manually on ~~Dance project level~~ Poetry allthethings level (/s/allthethings/lessons/45/levels/4) that I could define and use custom functions.