### PR TITLE
Make game lab grid checkbox accessible

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1971,6 +1971,7 @@
   "showBlocksHeader": "Show Blocks",
   "showCodeHeader": "Show Code",
   "showGeneratedCode": "Show code",
+  "showGrid": "Show grid",
   "showOlderComments": "Show older comments",
   "showPicture": "Show picture",
   "showSection": "Show Section",

--- a/apps/src/p5lab/P5LabVisualizationColumn.jsx
+++ b/apps/src/p5lab/P5LabVisualizationColumn.jsx
@@ -139,11 +139,12 @@ class P5LabVisualizationColumn extends React.Component {
   renderGridCheckbox() {
     return (
       <div>
-        <label>
+        <label style={styles.checkboxLabel}>
           <input
             id="grid-checkbox"
             type="checkbox"
             onChange={() => this.props.toggleShowGrid(!this.props.showGrid)}
+            style={styles.checkbox}
           />
           {i18n.showGrid()}
         </label>
@@ -246,6 +247,16 @@ const styles = {
   },
   selectStyle: {
     width: APP_WIDTH
+  },
+  checkbox: {
+    flex: 'none',
+    marginBottom: 3,
+    marginRight: 4
+  },
+  checkboxLabel: {
+    display: 'flex',
+    alignItems: 'center',
+    fontSize: 13
   }
 };
 

--- a/apps/src/p5lab/P5LabVisualizationColumn.jsx
+++ b/apps/src/p5lab/P5LabVisualizationColumn.jsx
@@ -96,10 +96,8 @@ class P5LabVisualizationColumn extends React.Component {
     // Use jQuery to turn on and off the grid since it lives in a protected div
     if (nextProps.showGrid !== this.props.showGrid) {
       if (nextProps.showGrid) {
-        $('#grid-checkbox')[0].className = 'fa fa-check-square-o';
         $('#grid-overlay')[0].style.display = '';
       } else {
-        $('#grid-checkbox')[0].className = 'fa fa-square-o';
         $('#grid-overlay')[0].style.display = 'none';
       }
     }
@@ -140,16 +138,18 @@ class P5LabVisualizationColumn extends React.Component {
 
   renderGridCheckbox() {
     return (
-      <div
-        style={{textAlign: 'left'}}
-        onClick={() => this.props.toggleShowGrid(!this.props.showGrid)}
-      >
-        <i id="grid-checkbox" className="fa fa-square-o" style={{width: 14}} />
-        <span style={{marginLeft: 5}}>Show grid</span>
+      <div>
+        <label>
+          <input
+            id="grid-checkbox"
+            type="checkbox"
+            onChange={() => this.props.toggleShowGrid(!this.props.showGrid)}
+          />
+          {i18n.showGrid()}
+        </label>
       </div>
     );
   }
-
   render() {
     const {isResponsive, isShareView, isRtl} = this.props;
     const divGameLabStyle = {


### PR DESCRIPTION
Convert the game lab "show grid" checkbox from an icon to an actual checkbox. This change causes minor visual differences because we are switching from a font-awesome icon to a checkbox element. However, now it is tab-navigable and accessible. It also was not previously translated, I also made it translatable.

## Before
<img width="103" alt="Screen Shot 2022-11-30 at 3 40 14 PM" src="https://user-images.githubusercontent.com/33666587/204931538-3a8fa59b-5007-49b3-a3f4-16d329740d87.png">
<img width="103" alt="Screen Shot 2022-11-30 at 3 39 26 PM" src="https://user-images.githubusercontent.com/33666587/204931543-0a4664f8-727f-40bc-bb00-aebbc904ec0e.png">

## After
![Screen Shot 2022-11-30 at 3 40 22 PM](https://user-images.githubusercontent.com/33666587/204931552-1a56c359-0003-4484-87f6-bcd88a12c493.png)
![Screen Shot 2022-11-30 at 3 39 09 PM](https://user-images.githubusercontent.com/33666587/204931561-d0a29010-3936-4c84-a14e-fac40035d367.png)


## Links
- jira ticket: [SL-336](https://codedotorg.atlassian.net/browse/SL-336) I split this out as a PR from this ticket because it will cause eyes diffs.

## Testing story
Tested locally
