### PR TITLE
resume DTL

### DIFF
--- a/cookbooks/cdo-apps/templates/default/crontab.erb
+++ b/cookbooks/cdo-apps/templates/default/crontab.erb
@@ -61,15 +61,16 @@
       # cronjob at:'30 7 * * 1-5', do:deploy_dir('bin', 'cron', 'commit_content')
       cronjob at:'*/1 * * * *', do:deploy_dir('bin', 'cron', 'update_dts')
       cronjob at:'0 17 * * *', do:deploy_dir('bin', 'cron', 'commit_trusted_proxies')
+      
       # This should be run after the commit_content job that happens on both the levelbuilder
       # and staging environments
       # merge_lb_to_staging is also known as DTS or "deploy to staging"
       # Disabled during HoC
       # cronjob at:'35 7 * * 1-5', do:deploy_dir('bin', 'cron', 'merge_lb_to_staging')
+      
       # This should be run after the commit_content job that happens on the levelbuilder
       # environment.
-      # Disabled during HoC
-      # cronjob at:'20 9 * * 1-5', do:deploy_dir('bin', 'cron', 'deploy_to_levelbuilder')
+      cronjob at:'20 9 * * 1-5', do:deploy_dir('bin', 'cron', 'deploy_to_levelbuilder')
     end
 
     if node.chef_environment == 'test' && node.name == 'staging-next'
@@ -81,10 +82,11 @@
       cronjob at:'*/2 * * * 1-5', do:deploy_dir('bin', 'cron', 'deploy_to_test')
       cronjob at:'*/5 * * * *', do:deploy_dir('bin', 'snapshot')
     end
+
     # Disabled during HoC
     # if node.chef_environment == 'levelbuilder'
     #   cronjob at:'30 7 * * 1-5', do:deploy_dir('bin', 'cron', 'commit_content')
-    # cronjob at:'18 9 * * 1-5', do:deploy_dir('bin', 'cron', 'commit_content')
+    #   cronjob at:'18 9 * * 1-5', do:deploy_dir('bin', 'cron', 'commit_content')
     # end
 
     if node.chef_environment == 'production' # production daemon


### PR DESCRIPTION
Content was not successfuly paused by #49302 because we paused the DTL before the crontab change could go out.

This PR resumes the DTL, which can remain active for the duration of hour of code, to keep Levelbuilder in sync with Staging.

This PR will also effectively pause the commit_content task on Levelbuilder.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
