### PR TITLE
Remove __useDeprecatedTag from PublishDialog

### DIFF
--- a/apps/src/templates/Button.jsx
+++ b/apps/src/templates/Button.jsx
@@ -96,9 +96,12 @@ class Button extends React.Component {
       throw new Error('Expect at least one of href/onClick');
     }
 
+    let buttonStyle = style;
     let Tag = 'button';
     if (__useDeprecatedTag) {
       Tag = href ? 'a' : 'div';
+    } else {
+      buttonStyle = {...style, boxShadow: 'none'};
     }
 
     if (download && Tag !== 'a') {
@@ -140,7 +143,7 @@ class Button extends React.Component {
     return (
       <Tag
         className={className}
-        style={{...style}}
+        style={{...buttonStyle}}
         href={disabled ? '#' : href}
         target={target}
         rel={rel}

--- a/apps/src/templates/projects/publishDialog/PublishDialog.jsx
+++ b/apps/src/templates/projects/publishDialog/PublishDialog.jsx
@@ -56,20 +56,20 @@ class PublishDialog extends Component {
         </div>
         <DialogFooter>
           <Button
-            __useDeprecatedTag
             text={i18n.dialogCancel()}
             onClick={this.close}
             color={Button.ButtonColor.gray}
             className="no-mc"
+            style={{boxShadow: 'none'}}
           />
           <Button
-            __useDeprecatedTag
             text={i18n.publish()}
             onClick={this.confirm}
             color={Button.ButtonColor.orange}
             className="no-mc"
             isPending={this.props.isPublishPending}
             pendingText={i18n.publishPending()}
+            style={{boxShadow: 'none'}}
             id="publish-dialog-publish-button"
           />
         </DialogFooter>

--- a/apps/src/templates/projects/publishDialog/PublishDialog.jsx
+++ b/apps/src/templates/projects/publishDialog/PublishDialog.jsx
@@ -60,7 +60,7 @@ class PublishDialog extends Component {
             onClick={this.close}
             color={Button.ButtonColor.gray}
             className="no-mc"
-            style={{boxShadow: 'none'}}
+            style={{margin: 0}}
           />
           <Button
             text={i18n.publish()}
@@ -69,7 +69,7 @@ class PublishDialog extends Component {
             className="no-mc"
             isPending={this.props.isPublishPending}
             pendingText={i18n.publishPending()}
-            style={{boxShadow: 'none'}}
+            style={{margin: 0}}
             id="publish-dialog-publish-button"
           />
         </DialogFooter>


### PR DESCRIPTION
Two small changes to our publish dialog.

By removing the __useDeprecatedTag, we move this component from a clickable div to a button! This is an accessibility win because it moves us closer to properly using semantic HTML and more easily identifies this as a 'button' to assistive technology.

This is part of a larger movement to remove the `__useDeprecatedTag` so that we can edit `Button.jsx` to no longer allow Clickable Divs.

The only additional change needed here was to remove the boxShadow to keep the visuals on this button as close as possible.

(I'm still not able to upload images to GitHub - super confusing! But I added screenshots to this doc: https://docs.google.com/document/d/1PwnfYWtCyhC6g-2H0vNmamTeFsDqmYVgtbRJhcgcM3Y/)