### PR TITLE
Clean Up Regional Partner Guardrail Field Changes

### DIFF
--- a/dashboard/app/models/pd/application/teacher_application.rb
+++ b/dashboard/app/models/pd/application/teacher_application.rb
@@ -1029,9 +1029,9 @@ module Pd::Application
           if regional_partner&.frl_guardrail_percent
             regional_partner&.frl_guardrail_percent.to_i
           elsif school_stats&.rural_school?
-            40
+            REGIONAL_PARTNER_DEFAULT_GUARDRAILS[:frl_rural]
           else
-            50
+            REGIONAL_PARTNER_DEFAULT_GUARDRAILS[:frl_not_rural]
           end
 
         meets_scholarship_criteria_scores[:free_lunch_percent] =
@@ -1046,7 +1046,7 @@ module Pd::Application
                         school_stats&.urm_percent
         urg_percent_cutoff = regional_partner&.urg_guardrail_percent ?
                               regional_partner&.urg_guardrail_percent.to_i :
-                              50
+                              REGIONAL_PARTNER_DEFAULT_GUARDRAILS[:urg]
 
         meets_scholarship_criteria_scores[:underrepresented_minority_percent] =
           if urg_percent

--- a/dashboard/app/views/regional_partners/_form.html.haml
+++ b/dashboard/app/views/regional_partners/_form.html.haml
@@ -26,11 +26,11 @@
     = f.label nil, "Apps Close Date (YYYY-MM-DD)"
     = f.text_field :apps_close_date_teacher
   .field
-    = f.label nil, "Underrepresented Group Guardrail Percent"
-    = f.number_field :urg_guardrail_percent, :in => 0..100
-  .field
     = f.label nil, "Free and Reduced Lunch Guardrail Percent"
     = f.number_field :frl_guardrail_percent, :in => 0..100
+  .field
+    = f.label nil, "Underrepresented Group Guardrail Percent"
+    = f.number_field :urg_guardrail_percent, :in => 0..100
   .field
     = f.label nil, "Applications Administrator/School Leader Approval", {style: 'margin-top: 20px'}
     .applications_principal_approval

--- a/dashboard/app/views/regional_partners/show.html.haml
+++ b/dashboard/app/views/regional_partners/show.html.haml
@@ -44,11 +44,11 @@
   %strong Apps close date for teachers:
   = @regional_partner.apps_close_date_teacher
 %p
-  %strong Underrepresented Group Guardrail Percent:
-  = @regional_partner.urg_guardrail_percent
-%p
   %strong Free and Reduced Lunch Guardrail Percent:
   = @regional_partner.frl_guardrail_percent
+%p
+  %strong Underrepresented Group Guardrail Percent:
+  = @regional_partner.urg_guardrail_percent
 %p
   %strong Link to Partner's Application:
   = @regional_partner.link_to_partner_application

--- a/dashboard/test/models/pd/application/teacher_application_test.rb
+++ b/dashboard/test/models/pd/application/teacher_application_test.rb
@@ -849,7 +849,7 @@ module Pd::Application
       assert application.reload.principal_approval_state.include? 'Complete - Admin said Yes on'
     end
 
-    test 'scholarship criteria for rp guardrail percents rp set fields' do
+    test 'scholarship criteria uses regional partner set fields when specified' do
       regional_partner = build :regional_partner, frl_guardrail_percent: 52, urg_guardrail_percent: 48
 
       # Does not meet Free and Reduced Lunch criteria but does meet Underrepresented Group criteria
@@ -869,7 +869,7 @@ module Pd::Application
       assert_equal(YES, application.response_scores_hash[:meets_scholarship_criteria_scores][:underrepresented_minority_percent])
     end
 
-    test 'scholarship criteria for rp guardrail percents rp did not specify guardrails' do
+    test 'scholarship criteria uses default guardrails when regaionl partner does not specify' do
       regional_partner = build :regional_partner
 
       # Meets Free and Reduced Lunch criteria but not Underrepresented Group criteria
@@ -878,8 +878,8 @@ module Pd::Application
         principal_approval: principal_options[:do_you_approve].first,
         principal_schedule_confirmed: principal_options[:committed_to_master_schedule].first,
         principal_wont_replace_existing_course: principal_options[:replace_course].first,
-        principal_free_lunch_percent: 50,
-        principal_underrepresented_minority_percent: 49
+        principal_free_lunch_percent: REGIONAL_PARTNER_DEFAULT_GUARDRAILS[:frl_not_rural],
+        principal_underrepresented_minority_percent: REGIONAL_PARTNER_DEFAULT_GUARDRAILS[:urg] - 1
 
       application = create :pd_teacher_application, regional_partner: regional_partner, form_data_hash: application_hash
       application.auto_score!
@@ -889,15 +889,15 @@ module Pd::Application
       assert_equal(NO, application.response_scores_hash[:meets_scholarship_criteria_scores][:underrepresented_minority_percent])
     end
 
-    test 'scholarship criteria for rp guardrail percents no partner' do
+    test 'scholarship criteria uses default guardrails when matched to No Partner' do
       # Meets Free and Reduced Lunch criteria but not Underrepresented Group criteria
       principal_options = Pd::Application::PrincipalApprovalApplication.options
       application_hash = build :pd_teacher_application_hash,
         principal_approval: principal_options[:do_you_approve].first,
         principal_schedule_confirmed: principal_options[:committed_to_master_schedule].first,
         principal_wont_replace_existing_course: principal_options[:replace_course].first,
-        principal_free_lunch_percent: 50,
-        principal_underrepresented_minority_percent: 49
+        principal_free_lunch_percent: REGIONAL_PARTNER_DEFAULT_GUARDRAILS[:frl_not_rural],
+        principal_underrepresented_minority_percent: REGIONAL_PARTNER_DEFAULT_GUARDRAILS[:urg] - 1
 
       application = create :pd_teacher_application, regional_partner: nil, form_data_hash: application_hash
       application.auto_score!

--- a/dashboard/test/models/pd/application/teacher_application_test.rb
+++ b/dashboard/test/models/pd/application/teacher_application_test.rb
@@ -850,7 +850,9 @@ module Pd::Application
     end
 
     test 'scholarship criteria uses regional partner set fields when specified' do
-      regional_partner = build :regional_partner, frl_guardrail_percent: 52, urg_guardrail_percent: 48
+      regional_partner = build :regional_partner,
+        frl_guardrail_percent: REGIONAL_PARTNER_DEFAULT_GUARDRAILS[:frl_not_rural] + 2,
+        urg_guardrail_percent: REGIONAL_PARTNER_DEFAULT_GUARDRAILS[:urg] - 2
 
       # Does not meet Free and Reduced Lunch criteria but does meet Underrepresented Group criteria
       principal_options = Pd::Application::PrincipalApprovalApplication.options
@@ -858,8 +860,8 @@ module Pd::Application
         principal_approval: principal_options[:do_you_approve].first,
         principal_schedule_confirmed: principal_options[:committed_to_master_schedule].first,
         principal_wont_replace_existing_course: principal_options[:replace_course].first,
-        principal_free_lunch_percent: 51,
-        principal_underrepresented_minority_percent: 49
+        principal_free_lunch_percent: REGIONAL_PARTNER_DEFAULT_GUARDRAILS[:frl_not_rural] + 1,
+        principal_underrepresented_minority_percent: REGIONAL_PARTNER_DEFAULT_GUARDRAILS[:urg] - 1
 
       application = create :pd_teacher_application, regional_partner: regional_partner, form_data_hash: application_hash
       application.auto_score!
@@ -869,7 +871,7 @@ module Pd::Application
       assert_equal(YES, application.response_scores_hash[:meets_scholarship_criteria_scores][:underrepresented_minority_percent])
     end
 
-    test 'scholarship criteria uses default guardrails when regaionl partner does not specify' do
+    test 'scholarship criteria uses default guardrails when regional partner does not specify' do
       regional_partner = build :regional_partner
 
       # Meets Free and Reduced Lunch criteria but not Underrepresented Group criteria

--- a/dashboard/test/models/pd/application/teacher_application_test.rb
+++ b/dashboard/test/models/pd/application/teacher_application_test.rb
@@ -866,7 +866,7 @@ module Pd::Application
       application = create :pd_teacher_application, regional_partner: regional_partner, form_data_hash: application_hash
       application.auto_score!
 
-      # Regional partner defined guardrails: FRL - 52%, URG - 48%
+      # Regional partner defined guardrails: FRL = (default + 2)%, URG = (default - 2)%
       assert_equal(NO, application.response_scores_hash[:meets_scholarship_criteria_scores][:free_lunch_percent])
       assert_equal(YES, application.response_scores_hash[:meets_scholarship_criteria_scores][:underrepresented_minority_percent])
     end

--- a/lib/cdo/shared_constants/pd/teacher_application_constants.rb
+++ b/lib/cdo/shared_constants/pd/teacher_application_constants.rb
@@ -15,6 +15,12 @@ module Pd
 
     YEAR = SharedApplicationConstants::APPLICATION_CURRENT_YEAR
 
+    REGIONAL_PARTNER_DEFAULT_GUARDRAILS = {
+      frl_rural: 40,
+      frl_not_rural: 50,
+      urg: 50
+    }
+
     SECTION_HEADERS = {
       choose_your_program: 'Choose Your Program',
       find_your_region: 'Find Your Region',


### PR DESCRIPTION
This PR responds to comments made on [this PR](https://github.com/code-dot-org/code-dot-org/pull/49318) and cleans up the changes made there and the surrounding code. That PR was merged into `staging` and was urgent so these changes weren't made previously in case it slowed down its deploy. This PR will just be merged into `staging-next` since most of the changes are for readability and consistency.

Changes made:

- On the Regional Partners page, flip ordering of URG and FRL fields here since FRL appears before URG in the other spots they are listed.
- For the application scholarship requirements calculations, move hard-coded values (such as '50%' into default constants).
- Update test names to be clearer about desired behavior

Here's the behavior from [the previous PR](https://github.com/code-dot-org/code-dot-org/pull/49318) and this one to show it is still consistent despite the changes:

## Questions on Regional Partner Pages
### Edit Page
Previous:
![Edit_Page](https://user-images.githubusercontent.com/56283563/204892629-8fd8a07e-8afc-4e6e-a1ec-b5fbce2e4f98.JPG)
New:
![FRL now on top EDIT](https://user-images.githubusercontent.com/56283563/205350211-127ae5c8-886a-4faa-86ff-3405872802ef.PNG)

## Show Page
Previous:
![Show_Page](https://user-images.githubusercontent.com/56283563/204892682-2572f6b0-e57b-4124-9ebc-2906d4b47c92.JPG)
New:
![FRL now on top SHOW](https://user-images.githubusercontent.com/56283563/205350233-b04630b5-090d-424a-bde7-03fae01d715a.PNG)

## Automatically calculates if applicant meets scholarship criteria
### If set to 'No Partner' for RP (default to 50% for both guardrails)
Previous:
![No_Partner](https://user-images.githubusercontent.com/56283563/204892955-cbbd34f2-533f-4af4-8dea-bd9f49185089.JPG)
New:
![No_Partner](https://user-images.githubusercontent.com/56283563/205350251-711034e3-32d4-438b-9de4-337e08eb4fcd.PNG)

### If assigned RP (in this case, Reggie Partner), but RP has not explicitly set guardrails (default to 50% for both guardrails)
Previous:
![Partner_not_set](https://user-images.githubusercontent.com/56283563/204892966-354531e0-509e-4a44-9207-dccb722ca9f3.JPG)
New:
![Partner_not_set](https://user-images.githubusercontent.com/56283563/205350270-eefedd53-fbde-41f0-a2bd-888ba86374ab.PNG)

### If assigned RP (in this case, Reggie Partner, and RP has set guardrails (URG - 48%, FRL - 55%)
Previous:
![Partner_set](https://user-images.githubusercontent.com/56283563/204892987-fab29a1b-a03c-4492-bce5-85b5817a1d5f.JPG)
New:
![Partner_set](https://user-images.githubusercontent.com/56283563/205350288-adfcd827-c63d-4b9e-b14a-16141c52aa66.PNG)

## Links
PR with original changes: [here](https://github.com/code-dot-org/code-dot-org/pull/49318)
Jira ticket: [here](https://codedotorg.atlassian.net/browse/ACQ-266?atlOrigin=eyJpIjoiMjA1YmNmZDk1N2Q4NGFhYTg1NDU2MzNkNWJhNDQ2YjgiLCJwIjoiaiJ9)

## Testing story
Local testing to ensure same behavior and drone tests.

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
