### PR TITLE
Adjust Spacing on Version Year

### DIFF
--- a/apps/src/code-studio/components/SmallFooter.jsx
+++ b/apps/src/code-studio/components/SmallFooter.jsx
@@ -176,6 +176,9 @@ export default class SmallFooter extends React.Component {
       },
       awsLogo: {
         width: 190
+      },
+      version: {
+        margin: 'auto 0'
       }
     };
 
@@ -200,7 +203,7 @@ export default class SmallFooter extends React.Component {
           {this.renderI18nDropdown()}
           {this.renderCopyright()}
           {!!this.props.unitYear && yearIsNumeric && (
-            <p>
+            <p style={styles.version}>
               {i18n.version()}: {this.props.unitYear}
             </p>
           )}


### PR DESCRIPTION
Jira ticket: https://codedotorg.atlassian.net/browse/TEACH-80?atlOrigin=eyJpIjoiYTQ5N2ZhNGFlNTVmNDA3ZWFhYjc3MzNlYzJhODMwZDMiLCJwIjoiaiJ9

I am still not able to add images to GitHub, so I added images to the Jira ticket.

Small change, I adjusted the margins here to better center the text, but I did not adjust the sizing. For [accessibility best practices](https://accessibility.psu.edu/fontsizehtml/), I try not to adjust below 12px.

@tess323 @dju90 - Please take a look at the screenshots and let me know if this still meets our goals here.