### PR TITLE
Improve exit_survey mailer logging

### DIFF
--- a/dashboard/app/mailers/pd/workshop_mailer.rb
+++ b/dashboard/app/mailers/pd/workshop_mailer.rb
@@ -241,9 +241,6 @@ class Pd::WorkshopMailer < ActionMailer::Base
     @enrollment = enrollment
     @survey_url = enrollment.exit_survey_url
 
-    # Don't send if there's no associated survey
-    return unless @survey_url
-
     content_type = 'text/html'
     if @workshop.course == Pd::Workshop::COURSE_CSF
       attachments['certificate.jpg'] = generate_csf_certificate

--- a/dashboard/app/mailers/pd/workshop_mailer.rb
+++ b/dashboard/app/mailers/pd/workshop_mailer.rb
@@ -250,8 +250,6 @@ class Pd::WorkshopMailer < ActionMailer::Base
       content_type = 'multipart/mixed'
     end
 
-    @enrollment.update!(survey_sent_at: Time.zone.now)
-
     mail content_type: content_type,
       from: from_survey,
       subject: "Help us improve Code.org #{@workshop.course} workshops!",

--- a/dashboard/app/models/pd/enrollment.rb
+++ b/dashboard/app/models/pd/enrollment.rb
@@ -221,7 +221,10 @@ class Pd::Enrollment < ApplicationRecord
 
     return unless should_send_exit_survey?
 
-    Pd::WorkshopMailer.exit_survey(self).deliver_now
+    return unless (mailer = Pd::WorkshopMailer.exit_survey(self))
+
+    mailer.deliver_now
+    update!(survey_sent_at: Time.zone.now)
   end
 
   # TODO: Once we're satisfied with the first/last name split data,

--- a/dashboard/app/models/pd/enrollment.rb
+++ b/dashboard/app/models/pd/enrollment.rb
@@ -221,6 +221,9 @@ class Pd::Enrollment < ApplicationRecord
 
     return unless should_send_exit_survey?
 
+    # Don't send if there's no associated survey
+    return unless exit_survey_url
+
     return unless (mailer = Pd::WorkshopMailer.exit_survey(self))
 
     mailer.deliver_now

--- a/dashboard/test/mailers/pd/workshop_mailer_test.rb
+++ b/dashboard/test/mailers/pd/workshop_mailer_test.rb
@@ -57,26 +57,6 @@ class WorkshopMailerTest < ActionMailer::TestCase
     end
   end
 
-  test 'exit survey emails are skipped for workshops without exit surveys' do
-    workshop = create :workshop, :ended
-    enrollment = create :pd_enrollment, workshop: workshop
-    Pd::Enrollment.any_instance.expects(:exit_survey_url).returns(nil)
-
-    assert_emails 0 do
-      Pd::WorkshopMailer.exit_survey(enrollment).deliver_now
-    end
-  end
-
-  test 'exit survey emails are not skipped for academic year workshops' do
-    workshop = create :csp_academic_year_workshop, :ended
-    enrollment = create :pd_enrollment, workshop: workshop
-    Pd::Enrollment.any_instance.expects(:exit_survey_url).returns('a url')
-
-    assert_emails 1 do
-      Pd::WorkshopMailer.exit_survey(enrollment).deliver_now
-    end
-  end
-
   test 'reminders are not sent for workshops with suppress_email attribute' do
     workshop = create :csp_summer_workshop, suppress_email: true
     facilitator = workshop.facilitators.first

--- a/dashboard/test/models/pd/enrollment_test.rb
+++ b/dashboard/test/models/pd/enrollment_test.rb
@@ -169,13 +169,23 @@ class Pd::EnrollmentTest < ActiveSupport::TestCase
     enrollment.send_exit_survey
   end
 
-  test 'send_exit_survey sends email' do
+  test 'send_exit_survey tries to send email and, if successful, updates survey_sent_at ' do
     enrollment = create :pd_enrollment, user: create(:teacher)
 
     mock_mail = stub(deliver_now: nil)
     Pd::WorkshopMailer.expects(:exit_survey).once.returns(mock_mail)
 
     enrollment.send_exit_survey
+    assert_not_nil enrollment.reload.survey_sent_at
+  end
+
+  test 'send_exit_survey tries to send email and, if unsuccessful, does not update survey_sent_at' do
+    enrollment = create :pd_enrollment, user: create(:teacher)
+
+    Pd::WorkshopMailer.expects(:exit_survey).once.returns(nil)
+
+    enrollment.send_exit_survey
+    assert_nil enrollment.reload.survey_sent_at
   end
 
   test 'name is deprecated and calls through to full_name' do

--- a/dashboard/test/models/pd/enrollment_test.rb
+++ b/dashboard/test/models/pd/enrollment_test.rb
@@ -169,6 +169,15 @@ class Pd::EnrollmentTest < ActiveSupport::TestCase
     enrollment.send_exit_survey
   end
 
+  test 'send_exit_survey does not send mail for workshops without exit survey URL' do
+    enrollment = create :pd_enrollment, user: create(:teacher)
+
+    Pd::Enrollment.any_instance.expects(:exit_survey_url).returns(nil)
+    Pd::WorkshopMailer.expects(:exit_survey).never
+
+    enrollment.send_exit_survey
+  end
+
   test 'send_exit_survey tries to send email and, if successful, updates survey_sent_at ' do
     enrollment = create :pd_enrollment, user: create(:teacher)
 


### PR DESCRIPTION
Some exit survey mailers were not sending a while back, and we needed an "urgent" fix for it. That lives here https://github.com/code-dot-org/code-dot-org/pull/48215/files. We needed to add survey URLs for the mailers to get sent.

In it, we moved the `update!(survey_sent_at: Time.zone.now)` from inside the enrollment model to instead be close to the mailer, because there's logic inside the mailer method https://github.com/code-dot-org/code-dot-org/blob/staging-next/dashboard/app/mailers/pd/workshop_mailer.rb#L245 that exits without returning the mail content, which the update call from the enrollment model was not adjusting for –– it would log that the survey was sent regardless.

Here, there are three refactors:
1) Move any logic that interrupts the mailer into the enrollment model, so that we don't need to look at both the enrollment model and the mailer.
2) Move the `update!(survey_sent_at: Time.zone.now)` call back into the enrollment model, but only execute it if mail content is actually returned. (I thought about also doing a `begin / rescue` block, but didn't see evidence that the `mail` method will ever throw errors. –– happy for pushback on this)
3) Add test coverage for when the `survey_sent_at` does and does not get updated, and move all test coverage for when exit_survey mailers do and do not get sent into the enrollment model.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

I added and/or moved unit tests. Additionally, I tested locally that exit surveys are still being sent as expected:
<img width="1036" alt="image" src="https://user-images.githubusercontent.com/9142121/205381819-af67fcf2-fe76-4cfa-ae71-410e363f6366.png">


## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
