### PR TITLE
Put mailcatcher info in one place

### DIFF
--- a/dashboard/config/environments/development.rb
+++ b/dashboard/config/environments/development.rb
@@ -46,6 +46,8 @@ Dashboard::Application.configure do
   end
   # and run:
   #   `gem install mailcatcher`
+  # If installation fails on Mac, see https://github.com/sj26/mailcatcher/issues/430#issuecomment-737040499
+  # And run this each time you need to start mailcatcher in the background again:
   #   `mailcatcher --ip=0.0.0.0`
 
   # Print deprecation notices to the Rails logger.

--- a/locals.yml.default
+++ b/locals.yml.default
@@ -107,11 +107,7 @@ use_my_apps: true
 
 
 # Specify `use_mailcatcher: true` if you are running mailcatcher on localhost.
-# You should have also run this once:
-#   `gem install mailcatcher`
-# If installation fails on Catalina, see https://github.com/sj26/mailcatcher/issues/430#issuecomment-700207954
-# And this each time you need to start mailcatcher in the background again:
-#   `mailcatcher --ip=0.0.0.0`
+# See development.rb file for information about how to use mailcatcher.
 #use_mailcatcher: true
 
 


### PR DESCRIPTION
There were two places that contained mailcatcher info, and some of the instructions for the Mac were out of date. This PR does two things:
1) From the `locals.yml.default` file, refer to the `development.rb` file so that we only need to keep one up to date.
2) Update the comment about the Mac installation –– environments later than Catalina still need the fix, and I updated the link to the comment that uses the one liner to install.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
