### PR TITLE
Hoc2022 - Hoc.com add registrations closed blurb under map

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -427,6 +427,7 @@
   signup_registration_not_required: "You don't need to register to participate! The Hour of Code activities are available year-round. <a href='%{hoc_activities_url}'>Try an activity</a> or read our <a href='%{howto_guide_url}'>How-to guide</a> to plan an event for your class."
   signup_registration_not_required_markdown: "You don't need to register to participate! The Hour of Code activities are available year-round. [Try an activity](%{hoc_activities_url}) or read our [How-to guide](%{howto_guide_url}) to plan an event for your class."
   signup_registration_closed: "And every year in December, your class can join millions of students around the world celebrating Computer Science Education Week with the Hour of Code. We'll open registration for the annual celebration in October."
+  signup_registration_closed_2022_markdown: "Registration for this year's Hour of Code event map is currently closed, but you can still [host an Hour of Code](%{hoc_activities_url}) and join in the celebration on social media! Post fun pictures or video of your event using the #HourOfCode hashtag!"
   signup_header: 'Organize an Hour of Code during %{campaign_date}, and register it here.'
   signup_name_label: 'Your name'
   signup_name_error: 'Name is required.'

--- a/pegasus/sites.v3/hourofcode.com/public/css/front-page.scss
+++ b/pegasus/sites.v3/hourofcode.com/public/css/front-page.scss
@@ -103,6 +103,10 @@ section.join-us {
     line-height: 1.4;
     margin: 0 auto;
     max-width: 820px;
+
+    @media screen and (max-width: $width-sm){
+      font-size: 16px;
+    }
   }
 
   .row {

--- a/pegasus/sites.v3/hourofcode.com/public/css/front-page.scss
+++ b/pegasus/sites.v3/hourofcode.com/public/css/front-page.scss
@@ -37,11 +37,10 @@ section {
     }
   }
 
-  h3, h4 {
+  h3 {
     margin: 0 auto;
     line-height: 1.4;
     text-align: center;
-    font-size: 18px;
 
     @media screen and (max-width: $width-sm) {
       font-size: 16px;
@@ -92,8 +91,17 @@ section.map {
 // Join us / Signup form
 section.join-us {
 
-  h3, h4 {
+  h3 {
     margin-bottom: 2em;
+    max-width: 820px;
+  }
+
+  p.signup-closed {
+    font-size: 18px;
+    font-family: $gotham-bold;
+    text-align: center;
+    line-height: 1.4;
+    margin: 0 auto;
     max-width: 820px;
   }
 

--- a/pegasus/sites.v3/hourofcode.com/public/css/front-page.scss
+++ b/pegasus/sites.v3/hourofcode.com/public/css/front-page.scss
@@ -41,6 +41,7 @@ section {
     margin: 0 auto;
     line-height: 1.4;
     text-align: center;
+    font-size: 18px;
 
     @media screen and (max-width: $width-sm) {
       font-size: 16px;
@@ -94,10 +95,6 @@ section.join-us {
   h3, h4 {
     margin-bottom: 2em;
     max-width: 820px;
-  }
-
-  h4 {
-    font-size: 18px;
   }
 
   .row {

--- a/pegasus/sites.v3/hourofcode.com/public/css/front-page.scss
+++ b/pegasus/sites.v3/hourofcode.com/public/css/front-page.scss
@@ -37,7 +37,7 @@ section {
     }
   }
 
-  h3 {
+  h3, h4 {
     margin: 0 auto;
     line-height: 1.4;
     text-align: center;
@@ -91,9 +91,13 @@ section.map {
 // Join us / Signup form
 section.join-us {
 
-  h3 {
+  h3, h4 {
     margin-bottom: 2em;
     max-width: 820px;
+  }
+
+  h4 {
+    font-size: 18px;
   }
 
   .row {

--- a/pegasus/sites.v3/hourofcode.com/public/index.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/index.haml
@@ -95,8 +95,7 @@ social:
     .wrapper
       %h2=hoc_s(:hoc_live_join_us)
       %h3=hoc_s(:hoc_homepage_join_the_movement_description)
-      -if ["pre-hoc", "soon-hoc"].include?(hoc_mode)
-        = view :home_signup, hoc_mode: hoc_mode
+      = view :home_signup, hoc_mode: hoc_mode
 
   -# What is HoC?
   -# This section remains evergreen, and the video no longer moves next to the signup form during different hoc_modes.

--- a/pegasus/sites.v3/hourofcode.com/views/home_signup.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/home_signup.haml
@@ -4,9 +4,7 @@
 %a#hocsignupform{name: 'signup'}
 #join-us-header=hoc_s(:front_join_us_button)
 - if ["actual-hoc", "post-hoc", false].include?(hoc_mode)
-  #signup-closed
-    !=hoc_s(:signup_registration_not_required_markdown, markdown: :inline, locals: {hoc_activities_url: resolve_url('/learn'), howto_guide_url: resolve_url('/how-to')})
-    =hoc_s(:signup_registration_closed)
+  %h4=hoc_s(:signup_registration_closed_2022_markdown, markdown: :inline, locals: {hoc_activities_url: resolve_url('/learn')})
 - else
   %h1#thanks-header{style: "display:none;"}=hoc_s(:census_thanks)
   %div

--- a/pegasus/sites.v3/hourofcode.com/views/home_signup.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/home_signup.haml
@@ -4,7 +4,7 @@
 %a#hocsignupform{name: 'signup'}
 #join-us-header=hoc_s(:front_join_us_button)
 - if ["actual-hoc", "post-hoc", false].include?(hoc_mode)
-  %h4=hoc_s(:signup_registration_closed_2022_markdown, markdown: :inline, locals: {hoc_activities_url: resolve_url('/learn')})
+  %p.signup-closed=hoc_s(:signup_registration_closed_2022_markdown, markdown: :inline, locals: {hoc_activities_url: resolve_url('/learn')})
 - else
   %h1#thanks-header{style: "display:none;"}=hoc_s(:census_thanks)
   %div


### PR DESCRIPTION
During `actual-hoc` and `post-hoc` modes the registration form is hidden due to technical and cost restraints ([Slack convo](https://codedotorg.slack.com/archives/C5V9YCXTR/p1669918951131149)), but we've gotten many support requests from teachers about adding events. 

Ideally we'd like to show the form, but for now I've added this blurb that links to https://hourofcode.com/learn and asks folks to post on social media. 

**Relevant info:** [Asana task](https://app.asana.com/0/1202764401306810/1203496090574799/f) • [Slack convo](https://codedotorg.slack.com/archives/C5V9YCXTR/p1670267833983419)

----

### Before:
<img width="1242" alt="Before" src="https://user-images.githubusercontent.com/9256643/205747174-e083275b-39ff-43da-86a8-ea736d1c48fd.png">

### After:
<img width="1234" alt="After" src="https://user-images.githubusercontent.com/9256643/205747191-778c6c41-e478-4878-a286-683d054a59c4.png">
