### PR TITLE
Translating Storybook Stories to new API

### DIFF
--- a/apps/src/templates/progress/ProgressLegend.story.jsx
+++ b/apps/src/templates/progress/ProgressLegend.story.jsx
@@ -1,37 +1,30 @@
 import React from 'react';
 import ProgressLegend from './ProgressLegend';
 
-export default storybook => {
-  storybook.storiesOf('Progress/ProgressLegend', module).addStoryTable([
-    {
-      name: 'progress legend - CSF',
-      story: () => (
-        <div style={{width: 970}}>
-          <ProgressLegend includeCsfColumn={true} />
-        </div>
-      )
-    },
+export default {
+  title: 'ProgressLegend',
+  component: ProgressLegend
+};
 
-    {
-      name: 'progress legend - CSP',
-      story: () => (
-        <div style={{width: 970}}>
-          <ProgressLegend includeCsfColumn={false} />
-        </div>
-      )
-    },
+const Template = args => (
+  <div style={{width: 970}}>
+    <ProgressLegend {...args} />
+  </div>
+);
 
-    {
-      name: 'progress legend - full',
-      story: () => (
-        <div style={{width: 970}}>
-          <ProgressLegend
-            includeCsfColumn
-            includeProgressNotApplicable
-            includeReviewStates
-          />
-        </div>
-      )
-    }
-  ]);
+export const CSF = Template.bind({});
+CSF.args = {
+  includeCsfColumn: true
+};
+
+export const CSP = Template.bind({});
+CSP.args = {
+  includeCsfColumn: false
+};
+
+export const FullLegend = Template.bind({});
+FullLegend.args = {
+  includeCsfColumn: true,
+  includeProgressNotApplicable: true,
+  includeReviewStates: true
 };

--- a/apps/src/templates/progress/ProgressLessonContent.story.jsx
+++ b/apps/src/templates/progress/ProgressLessonContent.story.jsx
@@ -2,68 +2,54 @@ import React from 'react';
 import ProgressLessonContent from './ProgressLessonContent';
 import {fakeLevels, fakeLevel} from './progressTestHelpers';
 import {LevelStatus} from '@cdo/apps/util/sharedConstants';
+import {reduxStore} from '@cdo/storybook/decorators';
+import {Provider} from 'react-redux';
 
-export default storybook => {
-  storybook
-    .storiesOf('Progress/ProgressLessonContent', module)
-    .withReduxStore()
-    .addStoryTable([
-      {
-        name: 'progress lesson content',
-        story: () => (
-          <ProgressLessonContent
-            disabled={false}
-            levels={fakeLevels(5).map((level, index) => ({
-              ...level,
-              status: index === 1 ? LevelStatus.perfect : LevelStatus.not_tried,
-              name: 'Progression'
-            }))}
-          />
-        )
-      },
-      {
-        name: 'with unplugged lesson',
-        description: 'pill should say unplugged, because of first level',
-        story: () => (
-          <ProgressLessonContent
-            disabled={false}
-            levels={[fakeLevel({isUnplugged: true}), ...fakeLevels(5)].map(
-              level => ({...level, name: 'Progression'})
-            )}
-          />
-        )
-      },
-      {
-        name: 'with named unplugged lesson',
-        description:
-          'First pill should say unplugged. second should say level 1-5',
-        story: () => (
-          <ProgressLessonContent
-            disabled={false}
-            levels={[
-              {
-                ...fakeLevel({isUnplugged: true}),
-                name: 'Fun unplugged/named level'
-              },
-              ...fakeLevels(5, {named: false})
-            ]}
-          />
-        )
-      },
-      {
-        name: 'with no named levels',
-        description: 'no pills',
-        story: () => (
-          <ProgressLessonContent
-            disabled={false}
-            levels={[
-              {
-                ...fakeLevel({isUnplugged: true, name: undefined})
-              },
-              ...fakeLevels(5, {named: false})
-            ]}
-          />
-        )
-      }
-    ]);
+export default {
+  title: 'ProgressLessonContent',
+  component: ProgressLessonContent
+};
+
+const Template = args => (
+  <Provider store={reduxStore()}>
+    <ProgressLessonContent disabled={false} {...args} />
+  </Provider>
+);
+
+export const ProgressLessonExample = Template.bind({});
+ProgressLessonExample.args = {
+  levels: fakeLevels(5).map((level, index) => ({
+    ...level,
+    status: index === 1 ? LevelStatus.perfect : LevelStatus.not_tried,
+    name: 'Progression'
+  }))
+};
+
+export const WithUnpluggedLesson = Template.bind({});
+WithUnpluggedLesson.args = {
+  levels: [fakeLevel({isUnplugged: true}), ...fakeLevels(5)].map(level => ({
+    ...level,
+    name: 'Progression'
+  }))
+};
+
+export const WithNamedUnpluggedLesson = Template.bind({});
+WithNamedUnpluggedLesson.args = {
+  levels: [
+    {
+      ...fakeLevel({isUnplugged: true}),
+      name: 'Fun unplugged/named level'
+    },
+    ...fakeLevels(5, {named: false})
+  ]
+};
+
+export const WithNoNamedLevels = Template.bind({});
+WithNoNamedLevels.args = {
+  levels: [
+    {
+      ...fakeLevel({isUnplugged: true, name: undefined})
+    },
+    ...fakeLevels(5, {named: false})
+  ]
 };

--- a/apps/src/templates/sectionAssessments/MatchDetailsDialog.story.jsx
+++ b/apps/src/templates/sectionAssessments/MatchDetailsDialog.story.jsx
@@ -1,25 +1,20 @@
 import React from 'react';
-import {UnconnectedMatchDetailsDialog} from './MatchDetailsDialog';
+import {UnconnectedMatchDetailsDialog as MatchDetailsDialog} from './MatchDetailsDialog';
 
-export default storybook => {
-  return storybook
-    .storiesOf('Dialogs/MatchDetailsDialog', module)
-    .addStoryTable([
-      {
-        name: 'MatchDetailsDialog',
-        description: 'Detail view of a match question',
-        story: () => (
-          <UnconnectedMatchDetailsDialog
-            isDialogOpen={true}
-            closeDialog={() => {}}
-            questionAndAnswers={{
-              question: 'Which of these go together?',
-              questionType: 'Match',
-              answers: ["I'm an answer", "I'm another answer"],
-              options: ["I'm an option", "I'm another option"]
-            }}
-          />
-        )
-      }
-    ]);
+export default {
+  title: 'MatchDetailsDialog',
+  component: MatchDetailsDialog
 };
+
+export const DetailView = () => (
+  <MatchDetailsDialog
+    isDialogOpen={true}
+    closeDialog={() => {}}
+    questionAndAnswers={{
+      question: 'Which of these go together?',
+      questionType: 'Match',
+      answers: ["I'm an answer", "I'm another answer"],
+      options: ["I'm an option", "I'm another option"]
+    }}
+  />
+);


### PR DESCRIPTION
MatchDetailsDialog is a visually interesting UI with only one story, but there's no corresponding unit test so I think we should keep it. 

Here's what it looks like:
<img width="1210" alt="Screen Shot 2022-12-05 at 3 30 51 PM" src="https://user-images.githubusercontent.com/37230822/205767276-b4957ed3-7966-40f7-b4bb-0890bb551e81.png">

The ProgressLegend is another helpful story because the component has a lot of ui versatility. Here is an example:
<img width="1038" alt="Screen Shot 2022-12-06 at 9 41 20 AM" src="https://user-images.githubusercontent.com/37230822/205983490-1849ccc0-5cd4-4bb0-91f6-553d1f6b8fc5.png">

And finally, ProgressLessonContent is also a good candidate as there are many potential UI states. Example:
<img width="515" alt="Screen Shot 2022-12-06 at 12 23 29 PM" src="https://user-images.githubusercontent.com/37230822/206015126-6c76fc70-4aa7-40b6-a143-dc21253e0f2d.png">


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
