### PR TITLE
[Amplitude] Instrument login type selected

### DIFF
--- a/apps/src/templates/teacherDashboard/LoginTypePicker.jsx
+++ b/apps/src/templates/teacherDashboard/LoginTypePicker.jsx
@@ -36,7 +36,7 @@ class LoginTypePicker extends Component {
 
   reportLoginTypeSelection = provider => {
     analyticsReporter.sendEvent(LOGIN_TYPE_SELECTED_EVENT, {
-      'login type': provider
+      loginType: provider
     });
   };
 

--- a/apps/src/templates/teacherDashboard/LoginTypePicker.jsx
+++ b/apps/src/templates/teacherDashboard/LoginTypePicker.jsx
@@ -14,6 +14,9 @@ import LoginTypeCard from './LoginTypeCard';
 import Button from '../Button';
 import {OAuthSectionTypes} from '@cdo/apps/lib/ui/accounts/constants';
 import styleConstants from '../../styleConstants';
+import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
+
+const LOGIN_TYPE_SELECTED_EVENT = 'Login Type Selected';
 
 /**
  * UI for selecting the login type of a class section:
@@ -31,14 +34,26 @@ class LoginTypePicker extends Component {
     providers: PropTypes.arrayOf(PropTypes.string)
   };
 
+  reportLoginTypeSelection = provider => {
+    analyticsReporter.sendEvent(LOGIN_TYPE_SELECTED_EVENT, {
+      'login type': provider
+    });
+  };
+
   openImportDialog = provider => {
+    this.reportLoginTypeSelection(provider);
     this.props.setRosterProvider(provider);
     this.props.handleCancel(); // close this dialog
     this.props.handleImportOpen(); // open the roster dialog
   };
 
+  onLoginTypeSelect = provider => {
+    this.reportLoginTypeSelection(provider);
+    this.props.setLoginType(provider);
+  };
+
   render() {
-    const {title, providers, setLoginType, handleCancel, disabled} = this.props;
+    const {title, providers, handleCancel, disabled} = this.props;
     const withGoogle =
       providers && providers.includes(OAuthSectionTypes.google_classroom);
     const withMicrosoft =
@@ -95,9 +110,9 @@ class LoginTypePicker extends Component {
               <MicrosoftClassroomCard onClick={this.openImportDialog} />
             )}
             {withClever && <CleverCard onClick={this.openImportDialog} />}
-            <PictureLoginCard onClick={setLoginType} />
-            <WordLoginCard onClick={setLoginType} />
-            <EmailLoginCard onClick={setLoginType} />
+            <PictureLoginCard onClick={this.onLoginTypeSelect} />
+            <WordLoginCard onClick={this.onLoginTypeSelect} />
+            <EmailLoginCard onClick={this.onLoginTypeSelect} />
           </CardContainer>
           {!hasThirdParty && (
             <div>

--- a/apps/test/unit/templates/teacherDashboard/LoginTypePickerTest.jsx
+++ b/apps/test/unit/templates/teacherDashboard/LoginTypePickerTest.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import sinon from 'sinon';
+import {expect} from '../../../util/reconfiguredChai';
+import {UnconnectedLoginTypePicker as LoginTypePicker} from '@cdo/apps/templates/teacherDashboard/LoginTypePicker';
+import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
+
+describe('LoginTypePicker', () => {
+  it('sends analytic event when a login type is selected', () => {
+    const wrapper = shallow(
+      <LoginTypePicker
+        title="title"
+        setLoginType={() => {}}
+        handleCancel={() => {}}
+        providers={['picture', 'word', 'email']}
+      />
+    );
+    const sendEventSpy = sinon.stub(analyticsReporter, 'sendEvent');
+
+    wrapper.find('PictureLoginCard').simulate('click');
+
+    expect(sendEventSpy).to.be.calledOnce;
+    expect(sendEventSpy).calledWith('Login Type Selected');
+
+    analyticsReporter.sendEvent.restore();
+  });
+});


### PR DESCRIPTION
Sends information about the login type selected to Amplitude. See the [jira task](https://codedotorg.atlassian.net/browse/TEACH-132) for more info.

Unfortunately, `LoginTypePicker` didn't have any unit tests. I added a file here with one unit test to test this functionality and added a [jira task](https://codedotorg.atlassian.net/browse/TEACH-137) to add these tests in the future.


This PR relies on https://github.com/code-dot-org/code-dot-org/pull/49442 being merged first.

## Testing story

unit test

In this case, I also tested this with the amplitude platform. In the future, this shouldn't be necessary once we have confidence in `AnalyticsReporter`.




## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
