### PR TITLE
P20-12 i18n docummentation content

### DIFF
--- a/bin/i18n/sync-in.rb
+++ b/bin/i18n/sync-in.rb
@@ -31,6 +31,7 @@ def sync_in
   localize_external_sources
   redact_level_content
   redact_block_content
+  redact_docs
   redact_script_and_course_content
   redact_labs_content
   localize_markdown_content
@@ -87,27 +88,95 @@ def localize_standards
   end
 end
 
-# This function localizes all content in studio.code.org/docs
+# This function localizes content in studio.code.org/docs
 def localize_docs
-  puts "Preparing docs content"
-  docs_content_file = File.join(I18N_SOURCE_DIR, "docs", "programming_environments.json")
-  programming_env_docs = {}
-  ProgrammingEnvironment.all.each do |env|
-    name = env.name
-    programming_env_docs[name] = {
+  puts "Preparing /docs content"
+
+  # TODO: Adding spritelab and Javalab to translation pipeline
+  # Currently supporting translations for applab, gamelab and weblab. NOT translating javalab and spritelab.
+  # Javalab documentations exists in a different table because it has a different structure, more align with java.
+  # Spritlab uses trasnlatable block names, unlike JavaScript blocks.
+  localized_environments = %w(applab gamelab weblab)
+
+  ### Localize Programming Environments
+  # For each programming environment, name is used as key, title is used as name
+  ProgrammingEnvironment.all.sort.each do |env|
+    next unless localized_environments.include?(env.name)
+
+    # In the sync-in, each environment is store in an individual file.
+    # Files are merged during the sync-out in programming_environments.{locale}.json
+    docs_content_file = File.join(I18N_SOURCE_DIR, "docs", env.name + ".json")
+
+    programming_env_docs = {}
+    programming_env_docs[env.name] = {
       'name' => env.properties["title"],
       'description' => env.properties["description"],
       'categories' => {},
     }
-    env.categories_for_navigation.each do |category|
-      programming_env_docs[name]["categories"].store(
-        category[:key], {'name' => category[:name]}
+    ### Localize Categories for Navigation
+    # Programming environment has a method defined in the programming_environment model that returns the
+    # categories for navigation. The method is used to obtain the current categories existing in the database.
+    categories_data = programming_env_docs[env.name]["categories"]
+    env.categories_for_navigation.each do |category_for_navigation|
+      category_key = category_for_navigation[:key]
+      categories_data.store(
+        category_key, {
+          'name' => category_for_navigation[:name],
+          'expressions' => {}
+        }
       )
+
+      ### localize Programming Expressions
+      # expression_docs.properties["syntax"] is not translated as it is the JavaScript exprerssion syntax
+      expressions_data = categories_data[category_key]["expressions"]
+      category_for_navigation[:docs].each do |expression|
+        expression_key = expression[:key]
+        expression_docs = ProgrammingExpression.find_by_id(expression[:id])
+        expressions_data.store(
+          expression_key, {
+            'content' => expression_docs.properties["content"],
+            'examples' => ({} unless expression_docs.properties['examples'].nil?),
+            'palette_params' => ({} unless expression_docs.properties["palette_params"].nil?),
+            'return_value' => expression_docs.properties["return_value"],
+            'short_description' => expression_docs.properties["short_description"],
+            'tips' => expression_docs.properties["tips"]
+          }.compact
+        )
+
+        ### Localize Examples
+        # Programming expresions may have 0 or more examples.
+        # Only example["name"] and example["description"] are translated. example["code"] is NOT translated.
+        example_docs = expressions_data[expression_key]["examples"]
+        expression_docs.properties['examples']&.each do |example|
+          unless example["name"].nil_or_empty? && example["description"].nil_or_empty?
+            example_docs.store(
+              example["name"], {
+                'name' => (example["name"] if example["name"]),
+                'description' => (example["description"] if example["description"]),
+              }.compact
+            )
+          end
+        end
+
+        ### localize Parameters
+        # Programming expresions may have 0 or more parameters.
+        # Parameter name (param["name"]) is not translated as it needs to match the JavaScript expression syntax.
+        param_docs = expressions_data[expression_key]["palette_params"]
+        expression_docs.properties["palette_params"]&.each do |param|
+          param_docs.store(
+            param["name"], {
+              'type' => (param["type"] if param["type"]),
+              'description' => (param["description"] if param["description"])
+            }.compact
+          )
+        end
+      end
     end
-  end
-  FileUtils.mkdir_p(File.dirname(docs_content_file))
-  File.open(docs_content_file, "w") do |file|
-    file.write(JSON.pretty_generate(programming_env_docs))
+    # Generate a file containing the string of each Programming Environment.
+    FileUtils.mkdir_p(File.dirname(docs_content_file))
+    File.open(docs_content_file, "w") do |file|
+      file.write(JSON.pretty_generate(programming_env_docs.compact))
+    end
   end
 end
 
@@ -591,6 +660,17 @@ def redact_level_file(source_path)
 
   File.open(source_path, 'w') do |source_file|
     source_file.write(JSON.pretty_generate(source_data.deep_merge(redacted_data)))
+  end
+end
+
+def redact_docs
+  puts "Redacting /docs content"
+
+  Dir.glob(File.join(I18N_SOURCE_DIR, "docs", "*.json")).each do |source|
+    backup = source.sub("source", "original")
+    FileUtils.mkdir_p(File.dirname(backup))
+    FileUtils.cp(source, backup)
+    RedactRestoreUtils.redact(source, source, ['visualCodeBlock', 'link', 'resourceLink'])
   end
 end
 

--- a/bin/i18n/sync-in.rb
+++ b/bin/i18n/sync-in.rb
@@ -127,7 +127,7 @@ def localize_docs
       )
 
       ### localize Programming Expressions
-      # expression_docs.properties["syntax"] is not translated as it is the JavaScript exprerssion syntax
+      # expression_docs.properties["syntax"] is not translated as it is the JavaScript expression syntax
       expressions_data = categories_data[category_key]["expressions"]
       category_for_navigation[:docs].each do |expression|
         expression_key = expression[:key]
@@ -144,7 +144,7 @@ def localize_docs
         )
 
         ### Localize Examples
-        # Programming expresions may have 0 or more examples.
+        # Programming expressions may have 0 or more examples.
         # Only example["name"] and example["description"] are translated. example["code"] is NOT translated.
         example_docs = expressions_data[expression_key]["examples"]
         expression_docs.properties['examples']&.each do |example|

--- a/bin/i18n/sync-in.rb
+++ b/bin/i18n/sync-in.rb
@@ -135,7 +135,7 @@ def localize_docs
         expressions_data.store(
           expression_key, {
             'content' => expression_docs.properties["content"],
-            'examples' => ({} unless expression_docs.properties['examples'].nil?),
+            'examples' => ({} unless expression_docs.properties["examples"].nil?),
             'palette_params' => ({} unless expression_docs.properties["palette_params"].nil?),
             'return_value' => expression_docs.properties["return_value"],
             'short_description' => expression_docs.properties["short_description"],
@@ -147,7 +147,7 @@ def localize_docs
         # Programming expressions may have 0 or more examples.
         # Only example["name"] and example["description"] are translated. example["code"] is NOT translated.
         example_docs = expressions_data[expression_key]["examples"]
-        expression_docs.properties['examples']&.each do |example|
+        expression_docs.properties["examples"]&.each do |example|
           unless example["name"].nil_or_empty? && example["description"].nil_or_empty?
             example_docs.store(
               example["name"], {

--- a/bin/i18n/sync-in.rb
+++ b/bin/i18n/sync-in.rb
@@ -95,7 +95,7 @@ def localize_docs
   # TODO: Adding spritelab and Javalab to translation pipeline
   # Currently supporting translations for applab, gamelab and weblab. NOT translating javalab and spritelab.
   # Javalab documentations exists in a different table because it has a different structure, more align with java.
-  # Spritlab uses trasnlatable block names, unlike JavaScript blocks.
+  # Spritelab uses translatable block names, unlike JavaScript blocks.
   localized_environments = %w(applab gamelab weblab)
 
   ### Localize Programming Environments

--- a/bin/i18n/sync-out.rb
+++ b/bin/i18n/sync-out.rb
@@ -181,6 +181,10 @@ def restore_redacted_files
           plugins << 'vocabularyDefinition'
         elsif original_path.starts_with? "i18n/locales/original/curriculum_content"
           plugins.push(*Services::I18n::CurriculumSyncUtils::REDACT_RESTORE_PLUGINS)
+        elsif original_path.starts_with? "i18n/locales/original/docs"
+          plugins << 'visualCodeBlock'
+          plugins << 'link'
+          plugins << 'resourceLink'
         elsif %w(applab gamelab weblab).include?(File.basename(original_path, '.json'))
           plugins << 'link'
         end
@@ -459,16 +463,22 @@ def distribute_translations(upload_manifests)
 
     ### Docs
     Dir.glob("i18n/locales/#{locale}/docs/*.json") do |loc_file|
+      # Each programing environment file gets merged into programming_environments.{locale}.json
       relative_path = loc_file.delete_prefix(locale_dir)
       next unless file_changed?(locale, relative_path)
 
-      basename = File.basename(loc_file, '.json')
-      destination = "dashboard/config/locales/#{basename}.#{locale}.json"
-
-      # JSON files in this directory need the root key to be set to the locale
       loc_data = JSON.parse(File.read(loc_file))
-      loc_data = wrap_with_locale(loc_data, locale, basename)
-      sanitize_data_and_write(loc_data, destination)
+      next if loc_data.empty?
+
+      programming_env = File.basename(loc_file, '.json')
+      destination = "dashboard/config/locales/programming_environments.#{locale}.json"
+      programming_env_data = File.exist?(destination) ?
+                               parse_file(destination).dig(locale, "data", "programming_environments") || {} :
+                               {}
+      programming_env_data[programming_env] = loc_data[programming_env]
+      # JSON files in this directory need the root key to be set to the locale
+      programming_env_data = wrap_with_locale(programming_env_data, locale, "programming_environments")
+      sanitize_data_and_write(programming_env_data, destination)
     end
 
     ### Standards

--- a/bin/i18n/sync-out.rb
+++ b/bin/i18n/sync-out.rb
@@ -463,7 +463,7 @@ def distribute_translations(upload_manifests)
 
     ### Docs
     Dir.glob("i18n/locales/#{locale}/docs/*.json") do |loc_file|
-      # Each programing environment file gets merged into programming_environments.{locale}.json
+      # Each programming environment file gets merged into programming_environments.{locale}.json
       relative_path = loc_file.delete_prefix(locale_dir)
       next unless file_changed?(locale, relative_path)
 

--- a/dashboard/app/models/programming_expression.rb
+++ b/dashboard/app/models/programming_expression.rb
@@ -197,15 +197,23 @@ class ProgrammingExpression < ApplicationRecord
       id: id,
       name: name,
       blockName: block_name,
-      category: programming_environment_category&.name,
+      category: get_localized_property(
+        :name,
+        [:data,
+         :programming_environments,
+         programming_environment&.name,
+         :categories,
+         programming_environment_category&.key],
+        programming_environment_category&.name
+      ),
       color: get_color,
       externalDocumentation: external_documentation,
-      content: content,
-      syntax: syntax,
-      returnValue: return_value,
-      tips: tips,
-      parameters: palette_params,
-      examples: examples,
+      content: get_localized_property(:content, expression_scope, content),
+      syntax: get_localized_property(:syntax, expression_scope, syntax),
+      returnValue: get_localized_property(:return_value, expression_scope, return_value),
+      tips: get_localized_property(:tips,  expression_scope, tips),
+      parameters: get_localized_params,
+      examples: get_localized_examples,
       video: video_key.blank? ? nil : Video.current_locale.find_by_key(video_key)&.summarize(false),
       imageUrl: image_url
     }
@@ -243,6 +251,69 @@ class ProgrammingExpression < ApplicationRecord
       categoryName: programming_environment_category&.name,
       editPath: edit_programming_expression_path(self)
     }
+  end
+
+  def expression_scope
+    [:data,
+     :programming_environments,
+     programming_environment&.name,
+     :categories,
+     programming_environment_category&.key,
+     :expressions,
+     key]
+  end
+
+  def get_localized_examples
+    localized_examples = examples.deep_dup
+    i18n_examples = I18n.t(
+      :examples,
+      scope: expression_scope,
+      default: examples,
+      smart: true
+    )
+    if i18n_examples != localized_examples
+      localized_examples&.each do |example|
+        example_key = example['name'].to_sym
+        unless i18n_examples[example_key].nil?
+          example['name'] = i18n_examples[example_key][:name] unless i18n_examples[example_key][:name].nil?
+          # code sections are not translated until expression names are marked "do not translate" in crowdin.
+          # example['code'] = i18n_examples[example_key][:code] unless i18n_examples[example_key][:code].nil?
+          example['description'] = i18n_examples[example_key][:description] unless i18n_examples[example_key][:description].nil?
+        end
+      end
+    end
+    localized_examples
+  end
+
+  def get_localized_params
+    localized_params = palette_params.deep_dup
+    i18n_params = I18n.t(
+      :palette_params,
+      scope: expression_scope,
+      default: palette_params,
+      smart: true
+    )
+    if i18n_params != localized_params
+      localized_params&.each do |param|
+        param_key = param['name'].to_sym
+        unless i18n_params[param_key].nil?
+          # parameter names are not translated since they are part of the code
+          # param['name'] = i18n_params[param_key][:name] unless i18n_params[param_key][:name].nil?
+          param['type'] = i18n_params[param_key][:type] unless i18n_params[param_key][:type].nil?
+          param['description'] = i18n_params[param_key][:description] unless i18n_params[param_key][:description].nil?
+        end
+      end
+    end
+    localized_params
+  end
+
+  def get_localized_property(property_name,  scope, default_value)
+    I18n.t(
+      property_name,
+      scope: scope,
+      default: default_value,
+      smart: true
+    )
   end
 
   def get_blocks

--- a/dashboard/test/integration/curriculum_docs_test.rb
+++ b/dashboard/test/integration/curriculum_docs_test.rb
@@ -188,7 +188,7 @@ class CurriculumDocsTest < ActionDispatch::IntegrationTest
     end
 
     test "environment get_summary_by_name query count" do
-      assert_queries(7) do
+      assert_queries(8) do
         get get_summary_by_name_programming_environment_path(@programming_environment.name)
       end
       assert_response :success


### PR DESCRIPTION
**What:** This PR adds documentation of applab, gamelab and webal to the sync. 
**Why:** Part of the documentation was already made translatable in a [previous PR](https://github.com/code-dot-org/code-dot-org/pull/47511) but the actual content regarding programming expressions was not translatable yet.
**How:** Each programming environment is sync-in, from the database to individual files located in `i18n/source/docs`. This maintains modularity of the programming environments and allows different redaction/restoration approaches depending on the environment. 
During the sync out, redacted files are restored and merged into a single file `programming_environments.{locale}.json` that is distributed for each locale.
In the model `programming_expressions.rb` the recurrent scope needed to localize the content is served through `expression_scope` and a function `get_localized_property` optimizes the calls to the `I18n` function.

Both `sync-in` and `programming_expressions` model incorporate nested code according to the structure of the database.

**Note:** This PR substitutes [PR #47868](https://github.com/code-dot-org/code-dot-org/pull/47868)

## Links

- jira ticket: [P20-12](https://codedotorg.atlassian.net/browse/P20-12)/[FND-2060](https://codedotorg.atlassian.net/browse/FND-2060)
- tested links: `http://localhost-studio.code.org:3000/docs/ide/applab/expressions/button`

## Testing story

Sync ran successfully. Screenshots include examples of newly added content.

![Screenshot 2022-12-06 at 23 34 56](https://user-images.githubusercontent.com/66776217/206097058-7ec37171-5c41-49da-b5ea-7a9472b0c0a2.png)

For languages with no available translation, the webpage still renders english content.

![Screenshot 2022-12-06 at 23 35 56](https://user-images.githubusercontent.com/66776217/206097204-6efa4832-8cfb-41ea-8fee-cf4e9cb28e95.png)

## Deployment strategy

Merge with staging after HoC restricted deployment.

## Follow-up work

- Javalab and Spritelab need to be added to the sync.

## PR Checklist:


- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
