### PR TITLE
Update incorrect text on express course marketing page

### DIFF
--- a/pegasus/sites.v3/code.org/public/educate/curriculum/express-course.md.erb
+++ b/pegasus/sites.v3/code.org/public/educate/curriculum/express-course.md.erb
@@ -39,7 +39,7 @@ social:
 <p>Anyone with a free teacher account can also view lesson plans, join our teacher forums, and get access to even more resources.</p>
 
 # <strong>Need a translated course?</strong>
-<p>Express courses are currently only available in English, Hindi, Italian, and Spanish. For other languages, we recommend our 20-hour <a href="https://studio.code.org/s/20-hour">Accelerated Course</a>. To see what's available in your language, visit our <a href="https://studio.code.org/courses">course catalog</a>.</p>
+<p>Express courses are available in 30 languages! To see what's available in your language, visit our <a href="https://studio.code.org/courses">course catalog</a>.</p>
 
 # <strong>Examples of student creations</strong>
 


### PR DESCRIPTION
Text on the express course page (https://code.org/educate/curriculum/express-course) was incorrect. The express course is now translated into 30 languages so this updates that text.

Verified with international team here: https://codedotorg.slack.com/archives/CBE8U2QCB/p1670431774573759
