### PR TITLE
Hide incomplete row if not workshop admin

### DIFF
--- a/apps/src/code-studio/pd/application_dashboard/summary.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/summary.jsx
@@ -97,6 +97,7 @@ export class Summary extends React.Component {
               caption="CS Discoveries Teachers"
               data={this.state.applications['csd_teachers']}
               path="csd_teachers"
+              isWorkshopAdmin={this.props.isWorkshopAdmin}
             />
           </Col>
           <Col sm={6}>
@@ -105,6 +106,7 @@ export class Summary extends React.Component {
               caption="CS Principles Teachers"
               data={this.state.applications['csp_teachers']}
               path="csp_teachers"
+              isWorkshopAdmin={this.props.isWorkshopAdmin}
             />
           </Col>
           <Col sm={6}>
@@ -113,6 +115,7 @@ export class Summary extends React.Component {
               caption="Computer Science A Teachers"
               data={this.state.applications['csa_teachers']}
               path="csa_teachers"
+              isWorkshopAdmin={this.props.isWorkshopAdmin}
             />
           </Col>
         </Row>

--- a/apps/src/code-studio/pd/application_dashboard/summary_table.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/summary_table.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {Table, Button} from 'react-bootstrap';
 import {StatusColors, getApplicationStatuses} from './constants';
-import _ from 'lodash';
+import {difference, upperFirst} from 'lodash';
 import color from '@cdo/apps/util/color';
 
 const ApplicationDataPropType = PropTypes.shape({
@@ -16,11 +16,10 @@ const ApplicationDataPropType = PropTypes.shape({
 export class SummaryTable extends React.Component {
   static propTypes = {
     caption: PropTypes.string.isRequired,
-
-    // keys are available statuses: {status: ApplicationDataPropType}
     data: PropTypes.objectOf(ApplicationDataPropType),
     path: PropTypes.string.isRequired,
-    id: PropTypes.string
+    id: PropTypes.string,
+    isWorkshopAdmin: PropTypes.bool
   };
 
   static contextTypes = {
@@ -33,17 +32,20 @@ export class SummaryTable extends React.Component {
       all: 0
     };
 
-    const statusesInOrder = [
-      'incomplete',
-      'reopened',
-      'awaiting_admin_approval',
-      'unreviewed',
-      'pending',
-      'pending_space_availability',
-      'accepted',
-      'declined',
-      'withdrawn'
-    ];
+    const statusesInOrder = difference(
+      [
+        'incomplete',
+        'reopened',
+        'awaiting_admin_approval',
+        'unreviewed',
+        'pending',
+        'pending_space_availability',
+        'accepted',
+        'declined',
+        'withdrawn'
+      ],
+      this.props.isWorkshopAdmin ? [] : ['incomplete']
+    );
 
     const categoryRows = statusesInOrder.map((status, i) => {
       const statusData = this.props.data[status];
@@ -54,7 +56,7 @@ export class SummaryTable extends React.Component {
       return (
         <tr key={i}>
           <td style={{...styles.statusCell[status]}}>
-            {getApplicationStatuses()[status] || -_.upperFirst(status)}
+            {getApplicationStatuses()[status] || upperFirst(status)}
           </td>
           <td>{currentTotal}</td>
         </tr>

--- a/apps/test/unit/code-studio/pd/application_dashboard/summary_table_test.jsx
+++ b/apps/test/unit/code-studio/pd/application_dashboard/summary_table_test.jsx
@@ -1,8 +1,12 @@
 import React from 'react';
 import {shallow} from 'enzyme';
 import {assert} from 'chai';
+import {expect} from '../../../../util/reconfiguredChai';
 import {SummaryTable} from '../../../../../src/code-studio/pd/application_dashboard/summary_table';
 import {getApplicationStatuses} from '@cdo/apps/code-studio/pd/application_dashboard/constants';
+
+const getTableContents = wrapper =>
+  wrapper.find('td').map(tableContent => tableContent.text());
 
 describe('SummaryTable', () => {
   it('computes total applications', () => {
@@ -37,6 +41,18 @@ describe('SummaryTable', () => {
       ),
       'Totals row computes correct sum'
     );
+  });
+  it('does not show incomplete status by default', () => {
+    const wrapper = customShallow(<SummaryTable {...DEFAULT_PROPS} />);
+
+    expect(getTableContents(wrapper)).not.to.contain('Incomplete');
+  });
+  it('shows incomplete status if a workshop admin', () => {
+    const wrapper = customShallow(
+      <SummaryTable {...DEFAULT_PROPS} isWorkshopAdmin />
+    );
+
+    expect(getTableContents(wrapper)).to.contain('Incomplete');
   });
 });
 


### PR DESCRIPTION
Right now, incomplete rows are showing even if not a workshop admin. This work hides that row if someone is not a workshop admin.

The good news is that the incomplete applications data was never being passed in for non-workshop-admins –– so the row was staying at 0.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

I added unit tests to the summary table, and here are screenshots of what it looks like:
As admin:
<img width="1169" alt="image" src="https://user-images.githubusercontent.com/9142121/206514848-4f9e9d33-843f-4b7b-8b9e-f97ea2a131ec.png">

Without admin:
<img width="1297" alt="image" src="https://user-images.githubusercontent.com/9142121/206515003-bb37180f-284b-476d-8caa-f6dd368b307c.png">

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
