### PR TITLE
Show Workshop Exit Survey for Yearlong PLCs

### DIFF
--- a/dashboard/app/models/pd/enrollment.rb
+++ b/dashboard/app/models/pd/enrollment.rb
@@ -161,6 +161,8 @@ class Pd::Enrollment < ApplicationRecord
     # do not use Foorm for survey completion); CSF Deep Dive workshops before 9/1/2020 (they do not use Foorm for
     # survey completion); and Admin + Admin/Counselor workshops (they should not receive exit surveys at all).
     foorm_enrollments = enrollments.select do |enrollment|
+      enrollment.workshop.course != Pd::Workshop::COURSE_ADMIN &&
+      enrollment.workshop.course != Pd::Workshop::COURSE_ADMIN_COUNSELOR &&
       !(enrollment.workshop.workshop_ending_date < Date.new(2020, 5, 8) &&
         (enrollment.workshop.csf_intro? || enrollment.workshop.local_summer? || enrollment.workshop.csp_wfrt?)) &&
         !(enrollment.workshop.workshop_ending_date < Date.new(2020, 9, 1) && enrollment.workshop.csf_201?)

--- a/dashboard/app/models/pd/enrollment.rb
+++ b/dashboard/app/models/pd/enrollment.rb
@@ -157,8 +157,9 @@ class Pd::Enrollment < ApplicationRecord
     raise 'Expected enrollments to be an Enumerable list of Pd::Enrollment objects' unless
         enrollments.is_a?(Enumerable) && enrollments.all?(Pd::Enrollment)
 
-    # Filter out Local summer, CSP Workshop for Returning Teachers, and CSF Intro workshops before 5/8/2020 and
-    # CSF Deep Dive workshops before 9/1/2020 as they do not use Foorm for survey completion.
+    # Filter out Local summer, CSP Workshop for Returning Teachers, and CSF Intro workshops before 5/8/2020 (they
+    # do not use Foorm for survey completion); CSF Deep Dive workshops before 9/1/2020 (they do not use Foorm for
+    # survey completion); and Admin + Admin/Counselor workshops (they should not receive exit surveys at all).
     foorm_enrollments = enrollments.select do |enrollment|
       !(enrollment.workshop.workshop_ending_date < Date.new(2020, 5, 8) &&
         (enrollment.workshop.csf_intro? || enrollment.workshop.local_summer? || enrollment.workshop.csp_wfrt?)) &&

--- a/dashboard/test/factories/workshop_factories.rb
+++ b/dashboard/test/factories/workshop_factories.rb
@@ -210,6 +210,22 @@ FactoryGirl.define do
         subject Pd::Workshop::SUBJECT_CSD_WORKSHOP_1
       end
       factory(:csd_academic_year_workshop) {csd}
+
+      # CSD Academic Year Workshops
+      trait :csa do
+        course Pd::Workshop::COURSE_CSA
+        location_name 'Greendale Community College'
+
+        # Possible subjects:
+        # Pd::Workshop::SUBJECT_CSD_WORKSHOP_1
+        # Pd::Workshop::SUBJECT_CSD_WORKSHOP_2
+        # Pd::Workshop::SUBJECT_CSD_WORKSHOP_3
+        # Pd::Workshop::SUBJECT_CSD_WORKSHOP_4
+        # Pd::Workshop::SUBJECT_CSD_WORKSHOP_1_2 (2-day)
+        # Pd::Workshop::SUBJECT_CSD_WORKSHOP_3_4 (2-day)
+        subject Pd::Workshop::SUBJECT_CSA_WORKSHOP_1
+      end
+      factory(:csa_academic_year_workshop) {csa}
     end
 
     # 5-day local summer workshops

--- a/dashboard/test/factories/workshop_factories.rb
+++ b/dashboard/test/factories/workshop_factories.rb
@@ -211,18 +211,18 @@ FactoryGirl.define do
       end
       factory(:csd_academic_year_workshop) {csd}
 
-      # CSD Academic Year Workshops
+      # CSA Academic Year Workshops
       trait :csa do
         course Pd::Workshop::COURSE_CSA
         location_name 'Greendale Community College'
 
         # Possible subjects:
-        # Pd::Workshop::SUBJECT_CSD_WORKSHOP_1
-        # Pd::Workshop::SUBJECT_CSD_WORKSHOP_2
-        # Pd::Workshop::SUBJECT_CSD_WORKSHOP_3
-        # Pd::Workshop::SUBJECT_CSD_WORKSHOP_4
-        # Pd::Workshop::SUBJECT_CSD_WORKSHOP_1_2 (2-day)
-        # Pd::Workshop::SUBJECT_CSD_WORKSHOP_3_4 (2-day)
+        # Pd::Workshop::SUBJECT_CSA_WORKSHOP_1
+        # Pd::Workshop::SUBJECT_CSA_WORKSHOP_2
+        # Pd::Workshop::SUBJECT_CSA_WORKSHOP_3
+        # Pd::Workshop::SUBJECT_CSA_WORKSHOP_4
+        # Pd::Workshop::SUBJECT_CSA_WORKSHOP_1_2 (2-day)
+        # Pd::Workshop::SUBJECT_CSA_WORKSHOP_3_4 (2-day)
         subject Pd::Workshop::SUBJECT_CSA_WORKSHOP_1
       end
       factory(:csa_academic_year_workshop) {csa}

--- a/dashboard/test/models/pd/enrollment_test.rb
+++ b/dashboard/test/models/pd/enrollment_test.rb
@@ -336,13 +336,28 @@ class Pd::EnrollmentTest < ActiveSupport::TestCase
     assert_equal [], Pd::Enrollment.filter_for_survey_completion([enrollment], false)
   end
 
-  test 'academic year survey filter' do
+  test 'csd academic year survey not filtered out' do
+    workshop = create :csd_academic_year_workshop
+    teacher = create :teacher
+    enrollment = create :pd_enrollment, :from_user, user: teacher, workshop: workshop
+
+    assert_equal [enrollment], Pd::Enrollment.filter_for_survey_completion([enrollment], false)
+  end
+
+  test 'csp academic year survey not filtered out' do
     workshop = create :csp_academic_year_workshop
     teacher = create :teacher
     enrollment = create :pd_enrollment, :from_user, user: teacher, workshop: workshop
 
-    # academic year surveys should always return [] since we do not show post-surveys in the dashboard
-    assert_equal [], Pd::Enrollment.filter_for_survey_completion([enrollment], false)
+    assert_equal [enrollment], Pd::Enrollment.filter_for_survey_completion([enrollment], false)
+  end
+
+  test 'csa academic year survey not filtered out' do
+    workshop = create :csa_academic_year_workshop
+    teacher = create :teacher
+    enrollment = create :pd_enrollment, :from_user, user: teacher, workshop: workshop
+
+    assert_equal [enrollment], Pd::Enrollment.filter_for_survey_completion([enrollment], false)
   end
 
   test 'enrolling in class automatically enrolls in online learning' do


### PR DESCRIPTION
As per [this Zendesk ticket](https://codeorg.zendesk.com/agent/tickets/410526) and [this Slack thread](https://codedotorg.slack.com/archives/C04540KNGDQ/p1665767131316839), teachers in yearlong workshops were not able to view the element containing the button to send them to the post-workshop survey. A valid link is confirmed created and emailed to them, but their Professional Learning pages would not show the button sending them to said link.

The issue came up because it turns out `self.filter_for_survey_completion` in `enrollment.rb` was intentionally filtering out those courses. This PR updates this logic so that any workshops with surveys show that button.

### Original behavior with missing button:
![No Survey Link](https://user-images.githubusercontent.com/56283563/206774257-daf376d3-585f-4c52-972a-146ae62fb412.JPG)

### New behavior with button:
![Yearlong WORKS](https://user-images.githubusercontent.com/56283563/207468445-d2f349e6-4972-4e33-acc4-ab8c472f6e1a.PNG)

## Links
Jira task: [here](https://codedotorg.atlassian.net/browse/ACQ-224?atlOrigin=eyJpIjoiMDYyNjIzNGM0MjU1NDQyZDk4NTg0MjQxNDU5NmM5MDMiLCJwIjoiaiJ9)
Threads where issue was discussed: [here first](https://codedotorg.slack.com/archives/C04540KNGDQ/p1665767131316839) and [here second](https://codedotorg.slack.com/archives/C04540KNGDQ/p1670283960092409)

## Testing story
Updated unit tests, local + adhoc testing, and drone tests.

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
