### PR TITLE
Syntax fix for GradeBand in CSTA Form

### DIFF
--- a/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerEligibilityForm.jsx
+++ b/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerEligibilityForm.jsx
@@ -94,7 +94,7 @@ export default class AmazonFutureEngineerEligibilityForm extends React.Component
   handleMultiSelectGradeBands = index => {
     let gradeBands = [...this.state.gradeBands];
     gradeBands[index] = !gradeBands[index];
-    this.setState(gradeBands);
+    this.setState({gradeBands});
   };
 
   resetSchool = () =>


### PR DESCRIPTION
Oof, very small change here. While adjusting some things in the CSTA form, I somehow lost the curly brackets in setState. This was preventing us from correctly setting the state. Adding those back now.