### PR TITLE
Deeper Learning Bug Fix, Updates Time Display

### DIFF
--- a/dashboard/app/views/peer_reviews/_viewer.html.haml
+++ b/dashboard/app/views/peer_reviews/_viewer.html.haml
@@ -4,7 +4,7 @@
     .peer-review-content{class: peer_review.css_classes}
       %p.peer-review-title
         %strong= peer_review.from_instructor ? t('peer_review.instructor_feedback') : t('peer_review.peer_feedback')
-        = "\u2022 added #{time_ago_in_words(peer_review.updated_at)} ago"
+        = "\u2022 added at #{peer_review.updated_at}"
       %p.peer-review-status= peer_review.localized_status_description
       %p= peer_review.data
       - unless peer_review.current?


### PR DESCRIPTION
Remade PR https://github.com/code-dot-org/code-dot-org/pull/49383

The infamous Deeper Learning bug has been reported for users trying to view their Deeper Learning responses that have been peer reviewed. Those urls return sadbees. However, users are still able to view their non-reviewed submissions, and the peer reviews they submitted (both of which cases do not have a timestamp of the time of review displayed. 

The honeybadger error references the method ["time_ago_in_words"](https://apidock.com/rails/ActionView/Helpers/DateHelper/time_ago_in_words), an operation that turns the peer_review.updated_at time into a user-friendly string. 

This PR updates the display to a less user friendly timestamp, which provides the same functionality but does not rely on the method causing the error. Images below include the honeybadger error, and a before and after of the time display (which is working locally). Because we cannot recreate the issue locally, this is a speculative fix. However, worst case- they still see sadbees. Best case, deeper learning peer reviews are unblocked and they will see a slightly less friendly time display!

Honeybadger error:
<img width="1207" alt="Screen Shot 2022-12-05 at 3 11 49 PM" src="https://user-images.githubusercontent.com/37230822/205996368-39b81407-e7da-4f1a-8ae9-4b4965c9adf2.png">

Before (pretty datetime):
<img width="909" alt="Screen Shot 2022-12-06 at 10 45 15 AM" src="https://user-images.githubusercontent.com/37230822/205996396-3f6e3fa5-bb15-4f96-b9b0-4d939b39b6bb.png">

After (less pretty but still functional):
<img width="822" alt="Screen Shot 2022-12-06 at 10 42 31 AM" src="https://user-images.githubusercontent.com/37230822/205996410-adaf389a-5865-45d2-8728-6f1e046d71b9.png">




## Links



- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/TEACH-82

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
