### PR TITLE
Show PL Program Info Page even without Programs Offered

### DIFF
--- a/apps/src/templates/RegionalPartnerSearch.jsx
+++ b/apps/src/templates/RegionalPartnerSearch.jsx
@@ -153,35 +153,18 @@ class RegionalPartnerSearch extends Component {
   render() {
     const partnerInfo = this.state.partnerInfo;
 
-    let courseWorkshops = [
-      {
-        key: 'CSD',
-        name: ActiveCourseWorkshops.CSD,
-        heading: `${ActiveCourseWorkshops.CSD} Workshops`,
-        isOffered: partnerInfo?.pl_programs_offered?.includes(this.courseKey),
+    let courseWorkshops = [];
+    Object.keys(ActiveCourseWorkshops).forEach(courseKey => {
+      courseWorkshops.push({
+        key: courseKey,
+        name: ActiveCourseWorkshops[courseKey],
+        heading: `${ActiveCourseWorkshops[courseKey]} Workshops`,
+        isOffered: partnerInfo?.pl_programs_offered?.includes(courseKey),
         summerWorkshops: partnerInfo?.summer_workshops?.filter(
-          workshop => workshop.course === ActiveCourseWorkshops.CSD
+          workshop => workshop.course === ActiveCourseWorkshops[courseKey]
         )
-      },
-      {
-        key: 'CSP',
-        name: ActiveCourseWorkshops.CSP,
-        heading: `${ActiveCourseWorkshops.CSP} Workshops`,
-        isOffered: partnerInfo?.pl_programs_offered?.includes(this.courseKey),
-        summerWorkshops: partnerInfo?.summer_workshops?.filter(
-          workshop => workshop.course === ActiveCourseWorkshops.CSP
-        )
-      },
-      {
-        key: 'CSA',
-        name: ActiveCourseWorkshops.CSA,
-        heading: `${ActiveCourseWorkshops.CSA} Workshops`,
-        isOffered: partnerInfo?.pl_programs_offered?.includes(this.courseKey),
-        summerWorkshops: partnerInfo?.summer_workshops?.filter(
-          workshop => workshop.course === ActiveCourseWorkshops.CSA
-        )
-      }
-    ];
+      });
+    });
 
     const workshopCollectionStyle =
       this.props.responsiveSize === 'lg' ? styles.halfWidth : styles.fullWidth;

--- a/apps/src/templates/RegionalPartnerSearch.jsx
+++ b/apps/src/templates/RegionalPartnerSearch.jsx
@@ -321,39 +321,62 @@ class RegionalPartnerSearch extends Component {
                 )}
             </div>
 
-            {appState !== WorkshopApplicationStates.now_closed && (
-              <div>
-                <h3>Workshop information (hosted by {partnerInfo.name}):</h3>
-                {workshopCollections.map((collection, collectionIndex) => {
-                  if (collection.workshops.length === 0) {
-                    // If no current workshops for a course
-                    if (
-                      partnerInfo.pl_programs_offered.includes(collection.key)
-                    ) {
-                      // If a program is offered but a workshop hasn't been scheduled yet
-                      return (
-                        <WorkshopCard
-                          key={collectionIndex}
-                          style={workshopCollectionStyle}
-                          content={
-                            <>
-                              <h4>
-                                {collection.name} Workshop details are coming
-                                soon!
-                              </h4>
-                              <div>
-                                The Regional Partner is hard at work locking
-                                down the details of the workshops for this
-                                program. You can still apply and the Regional
-                                Partner will inform you when the workshop
-                                details are available.
-                              </div>
-                            </>
-                          }
-                        />
-                      );
-                    } else {
-                      // If a program is not offered
+            {appState !== WorkshopApplicationStates.now_closed &&
+              partnerInfo.pl_programs_offered && (
+                <div>
+                  <h3>Workshop information (hosted by {partnerInfo.name}):</h3>
+                  {workshopCollections.map((collection, collectionIndex) => {
+                    if (collection.workshops.length === 0) {
+                      // If no current workshops for a course
+                      if (
+                        partnerInfo.pl_programs_offered.includes(collection.key)
+                      ) {
+                        // If a program is offered but a workshop hasn't been scheduled yet
+                        return (
+                          <WorkshopCard
+                            key={collectionIndex}
+                            style={workshopCollectionStyle}
+                            content={
+                              <>
+                                <h4>
+                                  {collection.name} Workshop details are coming
+                                  soon!
+                                </h4>
+                                <div>
+                                  The Regional Partner is hard at work locking
+                                  down the details of the workshops for this
+                                  program. You can still apply and the Regional
+                                  Partner will inform you when the workshop
+                                  details are available.
+                                </div>
+                              </>
+                            }
+                          />
+                        );
+                      } else {
+                        // If a program is not offered
+                        return (
+                          <WorkshopCard
+                            key={collectionIndex}
+                            style={workshopCollectionStyle}
+                            content={
+                              <>
+                                <h4>{collection.heading}</h4>
+                                <div>
+                                  This Regional Partner is not offering{' '}
+                                  {collection.name} workshops at this time.
+                                  Code.org will review your application and
+                                  contact you with options for joining the
+                                  program hosted by a Regional Partner from a
+                                  different region.
+                                </div>
+                              </>
+                            }
+                          />
+                        );
+                      }
+                    } else if (collection.workshops.length > 0) {
+                      // If workshops present for the given course
                       return (
                         <WorkshopCard
                           key={collectionIndex}
@@ -361,43 +384,23 @@ class RegionalPartnerSearch extends Component {
                           content={
                             <>
                               <h4>{collection.heading}</h4>
-                              <div>
-                                This Regional Partner is not offering{' '}
-                                {collection.name} workshops at this time.
-                                Code.org will review your application and
-                                contact you with options for joining the program
-                                hosted by a Regional Partner from a different
-                                region.
-                              </div>
+                              {collection.workshops.map((workshop, index) => (
+                                <div key={index} style={styles.workshop}>
+                                  <div>
+                                    {workshop.workshop_date_range_string}
+                                  </div>
+                                  <div>{workshop.location_name}</div>
+                                  <div>{workshop.location_address}</div>
+                                </div>
+                              ))}
                             </>
                           }
                         />
                       );
                     }
-                  } else if (collection.workshops.length > 0) {
-                    // If workshops present for the given course
-                    return (
-                      <WorkshopCard
-                        key={collectionIndex}
-                        style={workshopCollectionStyle}
-                        content={
-                          <>
-                            <h4>{collection.heading}</h4>
-                            {collection.workshops.map((workshop, index) => (
-                              <div key={index} style={styles.workshop}>
-                                <div>{workshop.workshop_date_range_string}</div>
-                                <div>{workshop.location_name}</div>
-                                <div>{workshop.location_address}</div>
-                              </div>
-                            ))}
-                          </>
-                        }
-                      />
-                    );
-                  }
-                })}
-              </div>
-            )}
+                  })}
+                </div>
+              )}
 
             <div style={styles.clear} />
 

--- a/apps/src/templates/RegionalPartnerSearch.jsx
+++ b/apps/src/templates/RegionalPartnerSearch.jsx
@@ -153,36 +153,33 @@ class RegionalPartnerSearch extends Component {
   render() {
     const partnerInfo = this.state.partnerInfo;
 
-    let workshopCollections = [
+    let courseWorkshops = [
       {
         key: 'CSD',
         name: ActiveCourseWorkshops.CSD,
         heading: `${ActiveCourseWorkshops.CSD} Workshops`,
-        workshops:
-          partnerInfo &&
-          partnerInfo.summer_workshops.filter(
-            workshop => workshop.course === ActiveCourseWorkshops.CSD
-          )
+        isOffered: partnerInfo?.pl_programs_offered?.includes(this.courseKey),
+        summerWorkshops: partnerInfo?.summer_workshops?.filter(
+          workshop => workshop.course === ActiveCourseWorkshops.CSD
+        )
       },
       {
         key: 'CSP',
         name: ActiveCourseWorkshops.CSP,
         heading: `${ActiveCourseWorkshops.CSP} Workshops`,
-        workshops:
-          partnerInfo &&
-          partnerInfo.summer_workshops.filter(
-            workshop => workshop.course === ActiveCourseWorkshops.CSP
-          )
+        isOffered: partnerInfo?.pl_programs_offered?.includes(this.courseKey),
+        summerWorkshops: partnerInfo?.summer_workshops?.filter(
+          workshop => workshop.course === ActiveCourseWorkshops.CSP
+        )
       },
       {
         key: 'CSA',
         name: ActiveCourseWorkshops.CSA,
         heading: `${ActiveCourseWorkshops.CSA} Workshops`,
-        workshops:
-          partnerInfo &&
-          partnerInfo.summer_workshops.filter(
-            workshop => workshop.course === ActiveCourseWorkshops.CSA
-          )
+        isOffered: partnerInfo?.pl_programs_offered?.includes(this.courseKey),
+        summerWorkshops: partnerInfo?.summer_workshops?.filter(
+          workshop => workshop.course === ActiveCourseWorkshops.CSA
+        )
       }
     ];
 
@@ -325,21 +322,19 @@ class RegionalPartnerSearch extends Component {
               partnerInfo.pl_programs_offered && (
                 <div>
                   <h3>Workshop information (hosted by {partnerInfo.name}):</h3>
-                  {workshopCollections.map((collection, collectionIndex) => {
-                    if (collection.workshops.length === 0) {
-                      // If no current workshops for a course
-                      if (
-                        partnerInfo.pl_programs_offered.includes(collection.key)
-                      ) {
+                  {courseWorkshops.map((currCourse, currCourseIndex) => {
+                    if (currCourse.summerWorkshops.length === 0) {
+                      // If no current workshops for the given course
+                      if (currCourse.isOffered) {
                         // If a program is offered but a workshop hasn't been scheduled yet
                         return (
                           <WorkshopCard
-                            key={collectionIndex}
+                            key={currCourseIndex}
                             style={workshopCollectionStyle}
                             content={
                               <>
                                 <h4>
-                                  {collection.name} Workshop details are coming
+                                  {currCourse.name} Workshop details are coming
                                   soon!
                                 </h4>
                                 <div>
@@ -357,14 +352,14 @@ class RegionalPartnerSearch extends Component {
                         // If a program is not offered
                         return (
                           <WorkshopCard
-                            key={collectionIndex}
+                            key={currCourseIndex}
                             style={workshopCollectionStyle}
                             content={
                               <>
-                                <h4>{collection.heading}</h4>
+                                <h4>{currCourse.heading}</h4>
                                 <div>
                                   This Regional Partner is not offering{' '}
-                                  {collection.name} workshops at this time.
+                                  {currCourse.name} workshops at this time.
                                   Code.org will review your application and
                                   contact you with options for joining the
                                   program hosted by a Regional Partner from a
@@ -375,24 +370,26 @@ class RegionalPartnerSearch extends Component {
                           />
                         );
                       }
-                    } else if (collection.workshops.length > 0) {
+                    } else if (currCourse.summerWorkshops.length > 0) {
                       // If workshops present for the given course
                       return (
                         <WorkshopCard
-                          key={collectionIndex}
+                          key={currCourseIndex}
                           style={workshopCollectionStyle}
                           content={
                             <>
-                              <h4>{collection.heading}</h4>
-                              {collection.workshops.map((workshop, index) => (
-                                <div key={index} style={styles.workshop}>
-                                  <div>
-                                    {workshop.workshop_date_range_string}
+                              <h4>{currCourse.heading}</h4>
+                              {currCourse.summerWorkshops.map(
+                                (workshop, index) => (
+                                  <div key={index} style={styles.workshop}>
+                                    <div>
+                                      {workshop.workshop_date_range_string}
+                                    </div>
+                                    <div>{workshop.location_name}</div>
+                                    <div>{workshop.location_address}</div>
                                   </div>
-                                  <div>{workshop.location_name}</div>
-                                  <div>{workshop.location_address}</div>
-                                </div>
-                              ))}
+                                )
+                              )}
                             </>
                           }
                         />

--- a/apps/src/templates/RegionalPartnerSearch.jsx
+++ b/apps/src/templates/RegionalPartnerSearch.jsx
@@ -319,7 +319,7 @@ class RegionalPartnerSearch extends Component {
             </div>
 
             {appState !== WorkshopApplicationStates.now_closed &&
-              partnerInfo.pl_programs_offered && (
+              partnerInfo.pl_programs_offered?.length > 0 && (
                 <div>
                   <h3>Workshop information (hosted by {partnerInfo.name}):</h3>
                   {courseWorkshops.map((currCourse, currCourseIndex) => {

--- a/apps/test/unit/templates/RegionalPartnerSearchTest.js
+++ b/apps/test/unit/templates/RegionalPartnerSearchTest.js
@@ -10,15 +10,30 @@ const MINIMUM_PROPS = {
   responsiveSize: 'md'
 };
 
-const createServerResponses = (server, hasRP, applicationsClosed) => {
+// const testSummerWorkshop = courseKey => {
+//   return {
+//     course: ActiveCourseWorkshops[courseKey],
+//     workshop_date_range_string: 'Test dates',
+//     location_name: 'Test location',
+//     location_address: 'Test address'
+//   };
+// };
+
+const createServerResponses = (
+  server,
+  hasRP,
+  applicationsClosed,
+  programsOffered,
+  summerWorkshops
+) => {
   const responseWithRP = {
     application_state: {
       state: applicationsClosed
         ? WorkshopApplicationStates.opening_at
         : WorkshopApplicationStates.currently_open
     },
-    summer_workshops: [],
-    pl_programs_offered: ['CSD', 'CSP', 'CSA']
+    summer_workshops: summerWorkshops || [],
+    pl_programs_offered: programsOffered || []
   };
 
   const responseWithoutRP = {
@@ -76,4 +91,47 @@ describe('RegionalPartnerSearch', () => {
     server.respond();
     expect(wrapper.find('button')).to.have.length(0);
   });
+  it('shows no workshop cards if RP not found', () => {
+    createServerResponses(server, false, false);
+    const wrapper = shallow(<RegionalPartnerSearch {...MINIMUM_PROPS} />);
+    server.respond();
+    expect(wrapper.find('WorkshopCard')).to.have.length(0);
+  });
+  it('shows no workshop cards if RP is found but applications are closed', () => {
+    createServerResponses(server, true, true);
+    const wrapper = shallow(<RegionalPartnerSearch {...MINIMUM_PROPS} />);
+    server.respond();
+    expect(wrapper.find('h3')[0].text()).to.equal('aa');
+  });
+
+  // it('shows no workshop cards if RP is found and applications are open, but RP is not offering programs', () => {
+  //   createServerResponses(server, true, false, []);
+  //   const wrapper = shallow(<RegionalPartnerSearch {...MINIMUM_PROPS} />);
+  //   server.respond();
+  //   expect(wrapper.find('WorkshopCard')).to.have.length(0);
+  // });
+  // it('shows workshop cards if RP found, applications are open, and RP is offering programs', () => {
+  //   createServerResponses(server, true, false);
+  //   const wrapper = shallow(<RegionalPartnerSearch {...MINIMUM_PROPS} />);
+  //   server.respond();
+  //   expect(wrapper.find('h3')).to.have.length(2);
+  //   expect(wrapper.find('WorkshopCard')).to.have.length(3);
+  // });
+  // it('shows Not Offering note on workshop card(s) for the program(s) not being offered when other programs are offered', () => {
+  //   createServerResponses(
+  //     server,
+  //     true,
+  //     false,
+  //     ['CSD', 'CSP'],
+  //     [testSummerWorkshop('CSD')]
+  //   );
+  //   const wrapper = shallow(<RegionalPartnerSearch {...MINIMUM_PROPS} />);
+  //   server.respond();
+  //   const workshopCards = wrapper.find('WorkshopCard');
+  //   expect(workshopCards[0].content).to.contain('Workshop details are coming soon');
+  // });
+  // it('shows Details Coming Soon note on workshop card(s) for offered program(s) that do not currently have summer workshops', () => {
+  // });
+  // it('shows summer workshop details on workshop cards for offered programs with summer workshops', () => {
+  // });
 });

--- a/apps/test/unit/templates/RegionalPartnerSearchTest.js
+++ b/apps/test/unit/templates/RegionalPartnerSearchTest.js
@@ -29,7 +29,7 @@ const createServerResponses = (
   const responseWithRP = {
     application_state: {
       state: applicationsClosed
-        ? WorkshopApplicationStates.opening_at
+        ? WorkshopApplicationStates.now_closed
         : WorkshopApplicationStates.currently_open
     },
     summer_workshops: summerWorkshops || [],
@@ -101,22 +101,20 @@ describe('RegionalPartnerSearch', () => {
     createServerResponses(server, true, true);
     const wrapper = shallow(<RegionalPartnerSearch {...MINIMUM_PROPS} />);
     server.respond();
-    expect(wrapper.find('h3')[0].text()).to.equal('aa');
+    expect(wrapper.find('WorkshopCard')).to.have.length(0);
   });
-
-  // it('shows no workshop cards if RP is found and applications are open, but RP is not offering programs', () => {
-  //   createServerResponses(server, true, false, []);
-  //   const wrapper = shallow(<RegionalPartnerSearch {...MINIMUM_PROPS} />);
-  //   server.respond();
-  //   expect(wrapper.find('WorkshopCard')).to.have.length(0);
-  // });
-  // it('shows workshop cards if RP found, applications are open, and RP is offering programs', () => {
-  //   createServerResponses(server, true, false);
-  //   const wrapper = shallow(<RegionalPartnerSearch {...MINIMUM_PROPS} />);
-  //   server.respond();
-  //   expect(wrapper.find('h3')).to.have.length(2);
-  //   expect(wrapper.find('WorkshopCard')).to.have.length(3);
-  // });
+  it('shows no workshop cards if RP is found and applications are open, but RP is not offering programs', () => {
+    createServerResponses(server, true, false);
+    const wrapper = shallow(<RegionalPartnerSearch {...MINIMUM_PROPS} />);
+    server.respond();
+    expect(wrapper.find('WorkshopCard')).to.have.length(0);
+  });
+  it('shows workshop cards if RP found, applications are open, and RP is offering programs', () => {
+    createServerResponses(server, true, false, ['CSD', 'CSP']);
+    const wrapper = shallow(<RegionalPartnerSearch {...MINIMUM_PROPS} />);
+    server.respond();
+    expect(wrapper.find('WorkshopCard')).to.have.length(3);
+  });
   // it('shows Not Offering note on workshop card(s) for the program(s) not being offered when other programs are offered', () => {
   //   createServerResponses(
   //     server,
@@ -125,10 +123,20 @@ describe('RegionalPartnerSearch', () => {
   //     ['CSD', 'CSP'],
   //     [testSummerWorkshop('CSD')]
   //   );
-  //   const wrapper = shallow(<RegionalPartnerSearch {...MINIMUM_PROPS} />);
-  //   server.respond();
-  //   const workshopCards = wrapper.find('WorkshopCard');
-  //   expect(workshopCards[0].content).to.contain('Workshop details are coming soon');
+  //   const wrapper = isolateComponent(
+  //     <RegionalPartnerSearch {...MINIMUM_PROPS} />
+  //   );
+  //   wrapper.setState({
+  //     partnerInfo: {
+  //       name: 'Reggie Partner',
+  //       application_state: {state: WorkshopApplicationStates.currently_open},
+  //       pl_programs_offered: ['CSD', 'CSP'],
+  //       summer_workshops: [testSummerWorkshop('CSD')]
+  //     },
+  //     applicationsClosed: false
+  //   });
+  //   console.log(wrapper.debug());
+  //   expect(wrapper.findAll('WorkshopCard')).to.have.length(3);
   // });
   // it('shows Details Coming Soon note on workshop card(s) for offered program(s) that do not currently have summer workshops', () => {
   // });


### PR DESCRIPTION
A bug on the Professional Learning Program Information page [was discovered](https://codedotorg.slack.com/archives/C04540KNGDQ/p1670533658800409?thread_ts=1670364985.705729&cid=C04540KNGDQ) where no information was being shown for regional partners not offering a program at that time (which was throwing an error in console). It's a bug from [this PR](https://github.com/code-dot-org/code-dot-org/pull/49108) where it would try to load the workshop cards but not find any programs offered.

This PR just adds a check to make sure there are programs before trying to render cards for them. If there are no programs offered, it will just show the rest of the information without the workshop cards.

### Bug behavior for no programs offered
![Original not show PR info](https://user-images.githubusercontent.com/56283563/206769014-76fcc49d-461d-4f86-bba7-4e4e1e13b7e4.JPG)

### With fix behavior for no programs offered
![Show RP info](https://user-images.githubusercontent.com/56283563/206768997-bfb944ef-c1e0-4f45-8989-19189b3c5044.JPG)


## Links
Slack thread this was brought up: [here](https://codedotorg.slack.com/archives/C04540KNGDQ/p1670533658800409?thread_ts=1670364985.705729&cid=C04540KNGDQ)

## Testing story
Local testing.

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
