### PR TITLE
use custom drone ami

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -10,7 +10,7 @@ steps:
   - name: clone
     image: docker:git
     commands:
-      - hostname=$(curl -s --max-time 3 http://169.254.169.254/latest/meta-data/public-hostname || echo $DRONE_RUNNER_HOSTNAME); echo "Running on $hostname"
+      - hostname=$(wget -O - http://169.254.169.254/latest/meta-data/public-hostname || echo $DRONE_RUNNER_HOSTNAME); echo "Running on $hostname"
       - git clone --branch $DRONE_SOURCE_BRANCH  --depth 200 $DRONE_GIT_HTTP_URL .
       - git reset --hard $DRONE_COMMIT
       # Also fetch the target branch (which is staging for pull requests.) We need this for determining which tests to run based on changed files.

--- a/.drone.yml
+++ b/.drone.yml
@@ -10,6 +10,7 @@ steps:
   - name: clone
     image: docker:git
     commands:
+      - hostname=$(curl -s --max-time 3 http://169.254.169.254/latest/meta-data/public-hostname || echo $DRONE_RUNNER_HOSTNAME); echo "Running on $hostname"
       - git clone --branch $DRONE_SOURCE_BRANCH  --depth 200 $DRONE_GIT_HTTP_URL .
       - git reset --hard $DRONE_COMMIT
       # Also fetch the target branch (which is staging for pull requests.) We need this for determining which tests to run based on changed files.

--- a/.drone.yml
+++ b/.drone.yml
@@ -10,7 +10,7 @@ steps:
   - name: clone
     image: docker:git
     commands:
-      - hostname=$(wget -O - http://169.254.169.254/latest/meta-data/public-hostname || echo $DRONE_RUNNER_HOSTNAME); echo "Running on $hostname"
+      - hostname=$(wget -O - http://169.254.169.254/latest/meta-data/public-hostname 2> /dev/null || echo $DRONE_RUNNER_HOSTNAME); echo "Running on $hostname"
       - git clone --branch $DRONE_SOURCE_BRANCH  --depth 200 $DRONE_GIT_HTTP_URL .
       - git reset --hard $DRONE_COMMIT
       # Also fetch the target branch (which is staging for pull requests.) We need this for determining which tests to run based on changed files.

--- a/aws/cloudformation/drone-stack.yml
+++ b/aws/cloudformation/drone-stack.yml
@@ -32,7 +32,7 @@ Parameters:
   WorkerInstanceAMI:
     Type: String
     Description: Amazon Machine Image that Autoscaler uses to launch Worker EC2 Instances.
-    Default: ami-0aab355e1bfa1e72e
+    Default: ami-09b347c7ebb552ae2
   WorkerInstanceType:
     Type: String
     Description: EC2 Instance Type that Autoscaler provisions to run Builds.


### PR DESCRIPTION
The default ami used by drone appears to introduce a bug where the s3-cache plugin cannot use imds v2 because the hopcount is set to 1. This ami will hopefully force imdsv2 and have a hopcount of 2.

## Links

Slack thread: https://codedotorg.slack.com/archives/C0T0PNTM3/p1670523704752159

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

This stack is deployed manually. If deployment is successful, merge this PR.

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
