### PR TITLE
Music: rudimentary menu page

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -585,6 +585,7 @@ describe('entry tests', () => {
     'lessons/student_lesson_plan':
       './src/sites/studio/pages/lessons/student_lesson_plan.js',
     'musiclab/index': './src/sites/studio/pages/musiclab/index.js',
+    'musiclab/menu': './src/sites/studio/pages/musiclab/menu.js',
     'print_certificates/batch':
       './src/sites/studio/pages/print_certificates/batch.js',
     'programming_classes/show':

--- a/apps/src/musicMenu/MusicMenu.jsx
+++ b/apps/src/musicMenu/MusicMenu.jsx
@@ -167,7 +167,7 @@ export default class MusicMenu extends React.Component {
 
   render() {
     return (
-      <div>
+      <div className="main" style={{maxWidth: 970, margin: '0 auto 80px auto'}}>
         <h1>Music Lab options</h1>
         {this.renderResults()}
         {this.renderOptions()}

--- a/apps/src/musicMenu/MusicMenu.jsx
+++ b/apps/src/musicMenu/MusicMenu.jsx
@@ -4,6 +4,14 @@ const baseUrl = window.location.origin + '/musiclab';
 
 const optionsList = [
   {
+    name: 'blocks',
+    type: 'radio',
+    values: [
+      {value: 'advanced', description: 'The default set of advanced blocks.'},
+      {value: 'simple', description: 'A simple set of blocks.'}
+    ]
+  },
+  {
     name: 'instructions-position',
     type: 'radio',
     values: [
@@ -16,6 +24,14 @@ const optionsList = [
     name: 'library',
     type: 'string',
     description: 'Use a specific music library file.'
+  },
+  {
+    name: 'show-upload',
+    type: 'radio',
+    values: [
+      {value: 'false', description: "Default: don't show upload option."},
+      {value: 'true', description: 'Show upload option.'}
+    ]
   }
 ];
 

--- a/apps/src/musicMenu/MusicMenu.jsx
+++ b/apps/src/musicMenu/MusicMenu.jsx
@@ -1,0 +1,146 @@
+import React from 'react';
+
+const baseUrl = window.location.origin + '/musiclab';
+
+const optionsList = [
+  {
+    name: 'instructions-position',
+    type: 'radio',
+    values: [
+      {value: 'top', description: 'Instructions begin at the top.'},
+      {value: 'left', description: 'Instructions begin on the left.'},
+      {value: 'right', description: 'Instructions begin on the right.'}
+    ]
+  },
+  {
+    name: 'library',
+    type: 'string',
+    description: 'Use a specific music library file.'
+  }
+];
+
+export default class MusicMenu extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      checked: {},
+      values: {}
+    };
+  }
+
+  handleCheckChange(e) {
+    const name = e.target.name;
+    const isChecked = e.target.checked;
+
+    let checked = {...this.state.checked};
+    if (isChecked) {
+      checked[name] = true;
+    } else {
+      delete checked[name];
+    }
+    this.setState({checked});
+  }
+
+  handleRadioChange = e => {
+    const name = e.target.name;
+    const value = e.target.value;
+
+    let values = {...this.state.values};
+    values[name] = value;
+    this.setState({values});
+  };
+
+  handleStringChange = e => {
+    const name = e.target.name;
+    const value = e.target.value;
+
+    let values = {...this.state.values};
+    values[name] = value;
+    this.setState({values});
+  };
+
+  renderRadio(option) {
+    return (
+      <div>
+        {option.values.map(value => {
+          return (
+            <div key={value.value}>
+              <input
+                type="radio"
+                style={{marginTop: -3, marginRight: 5}}
+                name={option.name}
+                value={value.value}
+                onChange={this.handleRadioChange}
+              />
+              <b>{value.value}</b>: {value.description}
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
+
+  renderString(option) {
+    return (
+      <div>
+        <input
+          type="text"
+          style={{marginRight: 10}}
+          name={option.name}
+          value={this.state.values[option.name]}
+          onChange={this.handleStringChange}
+        />
+        {option.description}
+      </div>
+    );
+  }
+
+  renderResults() {
+    return (
+      <div style={{fontSize: 18, margin: '20px 0'}}>
+        {baseUrl}?
+        {optionsList
+          .map(option => {
+            return (
+              this.state.checked[option.name] &&
+              option.name + '=' + this.state.values[option.name]
+            );
+          })
+          .filter(entry => entry)
+          .join('&')}
+      </div>
+    );
+  }
+
+  renderOptions() {
+    return optionsList.map(option => {
+      return (
+        <div key={option.name}>
+          <input
+            type="checkbox"
+            name={option.name}
+            checked={this.state.checked[option.name]}
+            style={{marginTop: -3, marginRight: 5}}
+            onChange={e => this.handleCheckChange(e)}
+          />
+          {option.name}
+          <div style={{padding: 10}}>
+            {option.type === 'radio' && this.renderRadio(option)}
+            {option.type === 'string' && this.renderString(option)}
+          </div>
+        </div>
+      );
+    });
+  }
+
+  render() {
+    return (
+      <div>
+        <h1>Music Lab options</h1>
+        {this.renderResults()}
+        {this.renderOptions()}
+      </div>
+    );
+  }
+}

--- a/apps/src/musicMenu/MusicMenu.jsx
+++ b/apps/src/musicMenu/MusicMenu.jsx
@@ -29,7 +29,7 @@ const optionsList = [
     name: 'show-upload',
     type: 'radio',
     values: [
-      {value: 'false', description: "Default: don't show upload option."},
+      {value: 'false', description: "Don't show upload option."},
       {value: 'true', description: 'Show upload option.'}
     ]
   }
@@ -81,15 +81,17 @@ export default class MusicMenu extends React.Component {
       <div>
         {option.values.map(value => {
           return (
-            <div key={value.value}>
-              <input
-                type="radio"
-                style={{marginTop: -3, marginRight: 5}}
-                name={option.name}
-                value={value.value}
-                onChange={this.handleRadioChange}
-              />
-              <b>{value.value}</b>: {value.description}
+            <div key={value.value} style={{paddingBottom: 3}}>
+              <label>
+                <input
+                  type="radio"
+                  style={{marginTop: -3, marginRight: 5}}
+                  name={option.name}
+                  value={value.value}
+                  onChange={this.handleRadioChange}
+                />
+                {value.value}: {value.description}
+              </label>
             </div>
           );
         })}
@@ -114,7 +116,14 @@ export default class MusicMenu extends React.Component {
 
   renderResults() {
     return (
-      <div style={{fontSize: 18, margin: '20px 0'}}>
+      <div
+        style={{
+          fontSize: 18,
+          lineHeight: 1.5,
+          margin: '20px 0',
+          userSelect: 'all'
+        }}
+      >
         {baseUrl}?
         {optionsList
           .map(option => {
@@ -130,24 +139,30 @@ export default class MusicMenu extends React.Component {
   }
 
   renderOptions() {
-    return optionsList.map(option => {
-      return (
-        <div key={option.name}>
-          <input
-            type="checkbox"
-            name={option.name}
-            checked={this.state.checked[option.name]}
-            style={{marginTop: -3, marginRight: 5}}
-            onChange={e => this.handleCheckChange(e)}
-          />
-          {option.name}
-          <div style={{padding: 10}}>
-            {option.type === 'radio' && this.renderRadio(option)}
-            {option.type === 'string' && this.renderString(option)}
-          </div>
-        </div>
-      );
-    });
+    return (
+      <div style={{userSelect: 'none'}}>
+        {optionsList.map(option => {
+          return (
+            <div key={option.name}>
+              <label>
+                <input
+                  type="checkbox"
+                  name={option.name}
+                  checked={this.state.checked[option.name]}
+                  style={{marginTop: -3, marginRight: 5}}
+                  onChange={e => this.handleCheckChange(e)}
+                />
+                {option.name}
+              </label>
+              <div style={{padding: '5px 10px 15px 18px'}}>
+                {option.type === 'radio' && this.renderRadio(option)}
+                {option.type === 'string' && this.renderString(option)}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    );
   }
 
   render() {

--- a/apps/src/sites/studio/pages/musiclab/menu.js
+++ b/apps/src/sites/studio/pages/musiclab/menu.js
@@ -1,0 +1,11 @@
+import $ from 'jquery';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import MusicMenu from '@cdo/apps/musicMenu/MusicMenu';
+
+$(document).ready(function() {
+  ReactDOM.render(
+    <MusicMenu />,
+    document.getElementById('musiclab-menu-container')
+  );
+});

--- a/dashboard/app/controllers/musiclab_controller.rb
+++ b/dashboard/app/controllers/musiclab_controller.rb
@@ -6,6 +6,10 @@ class MusiclabController < ApplicationController
     @body_classes = "music-black"
   end
 
+  def menu
+    view_options(full_width: false, responsive_content: true, no_padding_container: true)
+  end
+
   # TODO: This is a temporary addition to serve the analytics API key
   # specifically for Music Lab. When we start using Amplitude for other
   # applications, we should create a dedicated controller/util that serves

--- a/dashboard/app/controllers/musiclab_controller.rb
+++ b/dashboard/app/controllers/musiclab_controller.rb
@@ -7,7 +7,7 @@ class MusiclabController < ApplicationController
   end
 
   def menu
-    view_options(full_width: false, responsive_content: true, no_padding_container: true)
+    view_options(full_width: true, responsive_content: true, no_padding_container: true)
   end
 
   # TODO: This is a temporary addition to serve the analytics API key

--- a/dashboard/app/views/musiclab/menu.html.haml
+++ b/dashboard/app/views/musiclab/menu.html.haml
@@ -1,0 +1,4 @@
+#musiclab-menu-container
+
+- content_for(:head) do
+  %script{src: webpack_asset_path('js/musiclab/menu.js')}

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -38,6 +38,7 @@ Dashboard::Application.routes.draw do
 
     get "/incubator", to: "incubator#index"
     get "/musiclab", to: "musiclab#index"
+    get "/musiclab/menu", to: "musiclab#menu"
     get "/musiclab/analytics_key", to: "musiclab#get_analytics_key"
 
     resources :activity_hints, only: [:update]


### PR DESCRIPTION
This adds a very rudimentary Music Lab menu page to https://studio.code.org/musiclab/menu which allows for the interactive creation of a URL with the desired parameters.  This is useful as we experiment with a variety of feature sets.

It's quite easy to add a new feature.

Longer-term, it seems possible this UI could be improved, generate JSON, and then integrated into levelbuilder authoring.

<img width="1038" alt="Screenshot 2022-12-14 at 7 34 10 PM" src="https://user-images.githubusercontent.com/2205926/207546036-40354905-754b-411b-9c36-119373ae765a.png">


