### PR TITLE
[MERGE AFTER staging-next MERGE] SL-413: Update default_hoc_mode in config.yml.erb to post-hoc

### DIFF
--- a/config.yml.erb
+++ b/config.yml.erb
@@ -416,7 +416,7 @@ levelbuilder_mode:
 # make it easier to tell the difference
 use_local_header_color:
 
-default_hoc_mode: soon-hoc   # overridden by 'hoc_mode' DCDO param, except in :test
+default_hoc_mode: post-hoc  # overridden by 'hoc_mode' DCDO param, except in :test
 default_hoc_launch: ''      # overridden by 'hoc_launch' DCDO param, except in :test
 
 # teacher_application_mode values: 'open', 'closing-soon', 'closed'


### PR DESCRIPTION
This PR sets the CDO default_hoc_mode to "post-hoc" because we can't change the DCDO flag on the test machine, but UI tests rely on hourofcode.com being in a hoc_mode consistent with production.