### PR TITLE
A11Y-1: Use empty alt tag for thumbnail images on projects page

### DIFF
--- a/apps/src/templates/projects/NewProjectButtons.jsx
+++ b/apps/src/templates/projects/NewProjectButtons.jsx
@@ -150,7 +150,7 @@ class NewProjectButtons extends React.Component {
                     <img
                       style={thumbnailStyle}
                       src={PROJECT_INFO[projectType].thumbnail}
-                      alt={PROJECT_INFO[projectType].label}
+                      alt=""
                     />
                     <div style={styles.label}>
                       {PROJECT_INFO[projectType].label}


### PR DESCRIPTION
On [Projects - Code.org](https://studio.code.org/projects/public), the New Project Buttons have alt text that is repeated in the button. This PR removes the alt text from the images so they will only be read by a screen reader once.

Note: The original ticket just cites the four buttons above the "View Full List" button, but it appears this is an issue with all of them. This PR should apply to all New Project Buttons, whether viewing the full list or not. 

## Links

Jira ticket: https://codedotorg.atlassian.net/browse/A11Y-1

## Testing story

Tested manually locally. See screenshots below for screenreader input before and after. 

**BEFORE**
<img width="1512" alt="Screen Shot 2022-12-12 at 11 53 57 AM" src="https://user-images.githubusercontent.com/26844240/207141520-84a9892f-d8b6-42a1-a449-0a3b0d842fe5.png">
<img width="1512" alt="Screen Shot 2022-12-12 at 11 53 41 AM" src="https://user-images.githubusercontent.com/26844240/207141555-403b0615-010e-45b6-9ac3-8fc5de9377bf.png">

**AFTER**
<img width="1512" alt="Screen Shot 2022-12-12 at 11 49 39 AM" src="https://user-images.githubusercontent.com/26844240/207141574-b42c0d8c-a2c0-40a4-bca3-ca91652750aa.png">
<img width="1512" alt="Screen Shot 2022-12-12 at 11 49 22 AM" src="https://user-images.githubusercontent.com/26844240/207141588-c833d9d7-cd6a-474a-9c90-d2bf42f63265.png">
