### PR TITLE
Convert JoinSection clickable div to button

### DIFF
--- a/apps/src/templates/studioHomepages/JoinSection.jsx
+++ b/apps/src/templates/studioHomepages/JoinSection.jsx
@@ -122,7 +122,6 @@ class JoinSection extends React.Component {
             placeholder={i18n.joinSectionPlaceholder()}
           />
           <Button
-            __useDeprecatedTag
             onClick={this.joinSection}
             className="ui-test-join-section"
             color={Button.ButtonColor.gray}

--- a/dashboard/test/ui/features/teacher_tools/pl_sections.feature
+++ b/dashboard/test/ui/features/teacher_tools/pl_sections.feature
@@ -150,10 +150,10 @@ Feature: Professional learning Sections
     Then I create a teacher named "Teacher"
     And I sign in as "Teacher" and go home
 
-    And I wait until element "div.ui-test-join-section" is visible
-    And I scroll the "div.ui-test-join-section" element into view
+    And I wait until element "button.ui-test-join-section" is visible
+    And I scroll the "button.ui-test-join-section" element into view
     And I enter the section code into "input.ui-test-join-section"
-    And I click selector "div.ui-test-join-section"
+    And I click selector "button.ui-test-join-section"
     Then the professional learning joined sections table should have 1 row
 
   Scenario: Teacher tries to join professional learning section for facilitators
@@ -165,10 +165,10 @@ Feature: Professional learning Sections
     Then I create a teacher named "Teacher"
     And I sign in as "Teacher" and go home
 
-    And I wait until element "div.ui-test-join-section" is visible
-    And I scroll the "div.ui-test-join-section" element into view
+    And I wait until element "button.ui-test-join-section" is visible
+    And I scroll the "button.ui-test-join-section" element into view
     And I enter the section code into "input.ui-test-join-section"
-    And I click selector "div.ui-test-join-section"
+    And I click selector "button.ui-test-join-section"
     Then I wait until element ".announcement-notification" is visible
     And element ".announcement-notification" contains text matching "You do not have the permissions to join section"
 
@@ -183,10 +183,10 @@ Feature: Professional learning Sections
     And I get facilitator access
     And I reload the page
 
-    And I wait until element "div.ui-test-join-section" is visible
-    And I scroll the "div.ui-test-join-section" element into view
+    And I wait until element "button.ui-test-join-section" is visible
+    And I scroll the "button.ui-test-join-section" element into view
     And I enter the section code into "input.ui-test-join-section"
-    And I click selector "div.ui-test-join-section"
+    And I click selector "button.ui-test-join-section"
     Then the professional learning joined sections table should have 1 row
 
   Scenario: Facilitator tries to join professional learning section for facilitators
@@ -200,10 +200,10 @@ Feature: Professional learning Sections
     And I get facilitator access
     And I reload the page
 
-    And I wait until element "div.ui-test-join-section" is visible
-    And I scroll the "div.ui-test-join-section" element into view
+    And I wait until element "button.ui-test-join-section" is visible
+    And I scroll the "button.ui-test-join-section" element into view
     And I enter the section code into "input.ui-test-join-section"
-    And I click selector "div.ui-test-join-section"
+    And I click selector "button.ui-test-join-section"
     Then the professional learning joined sections table should have 1 row
 
   Scenario: Universal Instructor tries to join professional learning section for teachers
@@ -217,10 +217,10 @@ Feature: Professional learning Sections
     And I get universal instructor access
     And I reload the page
 
-    And I wait until element "div.ui-test-join-section" is visible
-    And I scroll the "div.ui-test-join-section" element into view
+    And I wait until element "button.ui-test-join-section" is visible
+    And I scroll the "button.ui-test-join-section" element into view
     And I enter the section code into "input.ui-test-join-section"
-    And I click selector "div.ui-test-join-section"
+    And I click selector "button.ui-test-join-section"
     Then the professional learning joined sections table should have 1 row
 
   Scenario: Universal Instructor tries to join professional learning section for facilitators
@@ -234,8 +234,8 @@ Feature: Professional learning Sections
     And I get universal instructor access
     And I reload the page
 
-    And I wait until element "div.ui-test-join-section" is visible
-    And I scroll the "div.ui-test-join-section" element into view
+    And I wait until element "button.ui-test-join-section" is visible
+    And I scroll the "button.ui-test-join-section" element into view
     And I enter the section code into "input.ui-test-join-section"
-    And I click selector "div.ui-test-join-section"
+    And I click selector "button.ui-test-join-section"
     Then the professional learning joined sections table should have 1 row

--- a/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_dashboard/teacher_dashboard.feature
@@ -229,17 +229,17 @@ Feature: Using the teacher dashboard
 
   Scenario: Attempt to join an invalid section through the homepage
     Given I am a teacher and go home
-    And I wait until element "div.ui-test-join-section" is visible
+    And I wait until element "button.ui-test-join-section" is visible
     And I press keys "INVALID" for element "input.ui-test-join-section"
-    And I click selector "div.ui-test-join-section"
+    And I click selector "button.ui-test-join-section"
     Then I wait until element ".announcement-notification" is visible
     And element ".announcement-notification" contains text matching "Section INVALID doesn't exist"
 
   Scenario: Attempt to join a section you own from teacher dashboard provides notification
     Given I am a teacher
     And I create a new student section and go home
-    And I wait until element "div.ui-test-join-section" is visible
+    And I wait until element "button.ui-test-join-section" is visible
     And I enter the section code into "input.ui-test-join-section"
-    And I click selector "div.ui-test-join-section"
+    And I click selector "button.ui-test-join-section"
     Then I wait until element ".announcement-notification" is visible
     And element ".announcement-notification" contains text matching "You are already the owner of section"


### PR DESCRIPTION
This is a standard case of just removing the useDeprecated tag! The button looks mostly the same before and after (pics below) but now I'm able to tab over to it and I added a pic of the inspect/devtool so that you can see now it's nested in a button! I also tested valid and invalid join codes to make sure the click function works.

In these images, the only difference I can detect is this minor shadow/highlight in the two versions.

Before (disabled, then not):
<img width="1108" alt="Screen Shot 2022-12-12 at 12 36 47 PM" src="https://user-images.githubusercontent.com/37230822/207149545-b2e7347c-556d-4c82-b539-6e1d9f9b8e3e.png">

<img width="1026" alt="Screen Shot 2022-12-12 at 12 18 24 PM" src="https://user-images.githubusercontent.com/37230822/207147628-217eccf0-6370-4f82-8d46-9bef8ed0d62a.png">


After (disabled, then not):
<img width="1070" alt="Screen Shot 2022-12-12 at 12 36 53 PM" src="https://user-images.githubusercontent.com/37230822/207149550-fd34f7dd-d46b-44b6-a105-9dd1f77f5664.png">

<img width="1039" alt="Screen Shot 2022-12-12 at 12 24 55 PM" src="https://user-images.githubusercontent.com/37230822/207147649-5d953f34-e9b5-426b-8632-39676c1fe676.png">


Fun bonus pic of the new button tag:

<img width="645" alt="Screen Shot 2022-12-12 at 12 25 07 PM" src="https://user-images.githubusercontent.com/37230822/207147654-880b238f-cab8-4663-b250-3abdd60797b0.png">


## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/A11Y-78

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
