### PR TITLE
A11Y-2: Add label to language dropdown

### DIFF
--- a/dashboard/app/views/layouts/_footer.html.haml
+++ b/dashboard/app/views/layouts/_footer.html.haml
@@ -38,6 +38,6 @@
         -# user input or to persist data without also updating it to enforce UTF-8
         = form_tag(locale_url, method: :post, id: 'localeForm', style: 'margin-bottom: 0px;', enforce_utf8: false) do
           = hidden_field_tag :user_return_to, request.url
-          = select_tag :locale, options_for_select(options_for_locale_select, locale), { onchange: 'this.form.submit();', 'aria-label':  t('footer.locale_select') }
+          = select_tag :locale, options_for_select(options_for_locale_select, locale), { onchange: 'this.form.submit();', 'aria-label':  t('footer.locale_select', default: 'Select language') }
         %small.dim
           !="&copy; Code.org, #{Time.now.year}"

--- a/dashboard/app/views/layouts/_footer.html.haml
+++ b/dashboard/app/views/layouts/_footer.html.haml
@@ -38,6 +38,6 @@
         -# user input or to persist data without also updating it to enforce UTF-8
         = form_tag(locale_url, method: :post, id: 'localeForm', style: 'margin-bottom: 0px;', enforce_utf8: false) do
           = hidden_field_tag :user_return_to, request.url
-          = select_tag :locale, options_for_select(options_for_locale_select, locale), { onchange: 'this.form.submit();', 'aria-label':  I18n.t('footer_locale_select') }
+          = select_tag :locale, options_for_select(options_for_locale_select, locale), { onchange: 'this.form.submit();', 'aria-label':  t('footer_locale_select') }
         %small.dim
           !="&copy; Code.org, #{Time.now.year}"

--- a/dashboard/app/views/layouts/_footer.html.haml
+++ b/dashboard/app/views/layouts/_footer.html.haml
@@ -38,6 +38,6 @@
         -# user input or to persist data without also updating it to enforce UTF-8
         = form_tag(locale_url, method: :post, id: 'localeForm', style: 'margin-bottom: 0px;', enforce_utf8: false) do
           = hidden_field_tag :user_return_to, request.url
-          = select_tag :locale, options_for_select(options_for_locale_select, locale), { onchange: 'this.form.submit();', 'aria-label':  t('footer_locale_select') }
+          = select_tag :locale, options_for_select(options_for_locale_select, locale), { onchange: 'this.form.submit();', 'aria-label':  t('footer.locale_select') }
         %small.dim
           !="&copy; Code.org, #{Time.now.year}"

--- a/dashboard/app/views/layouts/_footer.html.haml
+++ b/dashboard/app/views/layouts/_footer.html.haml
@@ -38,6 +38,6 @@
         -# user input or to persist data without also updating it to enforce UTF-8
         = form_tag(locale_url, method: :post, id: 'localeForm', style: 'margin-bottom: 0px;', enforce_utf8: false) do
           = hidden_field_tag :user_return_to, request.url
-          = select_tag :locale, options_for_select(options_for_locale_select, locale), onchange: 'this.form.submit();'
+          = select_tag :locale, options_for_select(options_for_locale_select, locale), { onchange: 'this.form.submit();', 'aria-label':  I18n.t('footer_locale_select') }
         %small.dim
           !="&copy; Code.org, #{Time.now.year}"

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -627,6 +627,7 @@ en:
     store: 'Store'
     cookie_notice: 'Cookie Notice'
     view_code: 'View Code'
+    locale_select: "Select language"
   reference_area:
     title: 'Need help?'
     subtitle: 'See these videos and hints'


### PR DESCRIPTION
This PR adds a translated `aria-label` to the `select` element that allows the user to choose the page language in the studio.code.org footer.

<img width="1236" alt="Screen Shot 2022-12-14 at 10 45 42 AM" src="https://user-images.githubusercontent.com/26844240/207685391-851afcd8-27a8-419b-82f9-c61c190110c1.png">

<img width="1291" alt="Screen Shot 2022-12-14 at 10 44 55 AM" src="https://user-images.githubusercontent.com/26844240/207685413-c49b1589-20af-4bce-b066-e3005f4d5892.png">

## Links

Jira ticket: https://codedotorg.atlassian.net/browse/A11Y-2

## Testing story

Tested locally with VoiceOver, see screenshots above. 