### PR TITLE
Remove calc and eval from list of project types

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1613,7 +1613,6 @@
   "projectGroupEvents": "Games with Events",
   "projectGroupEventsAllProjects": "All Games with Events",
   "projectGroupEventsViewMore": "View more games with events",
-  "projectGroupMath": "Math",
   "projectGroupMinecraft": "Minecraft",
   "projectGroupMinecraftAllProjects": "All Minecraft Projects",
   "projectGroupMinecraftViewMore": "View more Minecraft projects",

--- a/apps/src/templates/projects/StartNewProject.jsx
+++ b/apps/src/templates/projects/StartNewProject.jsx
@@ -76,8 +76,6 @@ export default class StartNewProject extends React.Component {
 
     const PREREADER_PROJECT_TYPES = ['playlab_k1', 'artist_k1'];
 
-    const MATH_PROJECT_TYPES = ['calc', 'eval'];
-
     return (
       <div>
         <div style={styles.headingStartNew}>{i18n.projectStartNew()}</div>
@@ -129,12 +127,6 @@ export default class StartNewProject extends React.Component {
               description={i18n.projectGroupPreReader()}
               projectTypes={PREREADER_PROJECT_TYPES}
             />
-            {canViewAdvancedTools && (
-              <NewProjectButtons
-                description={i18n.projectGroupMath()}
-                projectTypes={MATH_PROJECT_TYPES}
-              />
-            )}
           </div>
         )}
         <div style={styles.spacer} />


### PR DESCRIPTION
We are deprecating calc and eval (see PRs with banners [here](https://github.com/code-dot-org/code-dot-org/pull/49398) and [here](https://github.com/code-dot-org/code-dot-org/pull/49413)). To avoid confusion, we are also hiding calc and eval from the list of project types on `/projects` and `/home`. Users can still directly create a new project with `/projects/calc/new` and `projects/eval/new`

## Before
![Screen Shot 2022-12-12 at 1 24 21 PM](https://user-images.githubusercontent.com/33666587/207158486-9a1761a8-ed5d-421a-948a-45b1bbcc6897.png)

## After
![Screen Shot 2022-12-12 at 1 24 33 PM](https://user-images.githubusercontent.com/33666587/207158467-29cee9ad-d3e3-48ae-8f5b-bb331a3f3ca5.png)

## Links
- jira ticket: [SL-438](https://codedotorg.atlassian.net/browse/SL-438)


## Testing story
Tested locally

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
