### PR TITLE
A11Y-4: Assign tall course blocks an empty alt tag

### DIFF
--- a/dashboard/app/views/shared/_course_tall_block.haml
+++ b/dashboard/app/views/shared/_course_tall_block.haml
@@ -6,7 +6,7 @@
 - if block_data
   .courseblock-span3.courseblock-tall
     = link_to block_data[:url] do
-      = image_tag block_data[:image_url], height: '120px', width: '100%'
+      = image_tag block_data[:image_url], { height: '120px', width: '100%', alt: '' }
       .course-container
         %h3.heading= block_data[:title]
         - if block_data[:audience]


### PR DESCRIPTION
These images on the sign-in page were missing an alt tag.

<img width="931" alt="Screen Shot 2022-12-12 at 3 06 23 PM" src="https://user-images.githubusercontent.com/26844240/207179935-e6a8deee-4bcb-45c1-a166-e0c9b148b671.png">

This fix assigns these images and all images in `_course_tall_blocks` an empty alt tag by default. I do not know all of the places that this is component is used, but it seems logical to me that the images in these "course blocks" are decorative, because the course information is contained in the block. 

Note: The screenreader doesn't seem to read these images anyway (see image below for what my reader reads), so I suspect this might not actually be having an effect. 

<img width="1512" alt="Screen Shot 2022-12-12 at 2 44 08 PM" src="https://user-images.githubusercontent.com/26844240/207180589-7a79f67a-81f3-4658-a144-e4d8c88c4f0c.png">

## Links

Jira ticket: https://codedotorg.atlassian.net/browse/A11Y-4

## Testing story

Tested manually locally by inspecting console output (since reader doesn't reach this element), see below. 

<img width="674" alt="Screen Shot 2022-12-12 at 2 51 04 PM" src="https://user-images.githubusercontent.com/26844240/207180740-c1d371b3-602c-4f3f-8a37-f79b02440f8b.png">

Note: Since [the value of an empty attribute is implicitly the empty string](https://html.spec.whatwg.org/multipage/syntax.html#attributes-2) (thanks @Hamms!), `<image alt>` and `<image alt="">` are equivalent. 