### PR TITLE
[Accessibility Hackathon] Remove _useDeprecatedTag - Section Management Components

### DIFF
--- a/apps/src/templates/teacherDashboard/EditSectionForm.jsx
+++ b/apps/src/templates/teacherDashboard/EditSectionForm.jsx
@@ -99,13 +99,6 @@ class EditSectionForm extends Component {
     });
   };
 
-  isOauthType(loginType) {
-    return [
-      SectionLoginType.google_classroom,
-      SectionLoginType.clever
-    ].includes(loginType);
-  }
-
   recordAutoplayToggleEvent = ttsAutoplayEnabled => {
     firehoseClient.putRecord(
       {
@@ -267,21 +260,21 @@ class EditSectionForm extends Component {
         </div>
         <DialogFooter>
           <Button
-            __useDeprecatedTag
             onClick={handleClose}
             text={i18n.dialogCancel()}
             size={Button.ButtonSize.large}
             color={Button.ButtonColor.gray}
             disabled={isSaveInProgress}
+            style={{margin: 0}}
           />
           <Button
-            __useDeprecatedTag
             className="uitest-saveButton"
             onClick={this.onSaveClick}
             text={i18n.save()}
             size={Button.ButtonSize.large}
             color={Button.ButtonColor.orange}
             disabled={isSaveInProgress}
+            style={{margin: 0}}
           />
         </DialogFooter>
         {this.state.showHiddenUnitWarning && (

--- a/apps/src/templates/teacherDashboard/LoginTypePicker.jsx
+++ b/apps/src/templates/teacherDashboard/LoginTypePicker.jsx
@@ -118,7 +118,6 @@ class LoginTypePicker extends Component {
             </a>
           </div>
           <Button
-            __useDeprecatedTag
             onClick={handleCancel}
             text={i18n.dialogCancel()}
             size={Button.ButtonSize.large}

--- a/apps/src/templates/teacherDashboard/OwnedSections.jsx
+++ b/apps/src/templates/teacherDashboard/OwnedSections.jsx
@@ -85,7 +85,6 @@ class OwnedSections extends React.Component {
             <div style={styles.buttonContainer}>
               {hiddenSectionIds.length > 0 && (
                 <Button
-                  __useDeprecatedTag
                   className="ui-test-show-hide"
                   onClick={this.toggleViewHidden}
                   icon={viewHidden ? 'caret-up' : 'caret-down'}

--- a/apps/src/templates/teacherDashboard/SectionActionDropdown.jsx
+++ b/apps/src/templates/teacherDashboard/SectionActionDropdown.jsx
@@ -166,18 +166,18 @@ class SectionActionDropdown extends Component {
           <div>{i18n.deleteSectionArchiveSuggestion()}</div>
           <DialogFooter>
             <Button
-              __useDeprecatedTag
               class="ui-test-cancel-delete"
               text={i18n.dialogCancel()}
               onClick={this.onCancelDelete}
               color="gray"
+              style={{margin: 0}}
             />
             <Button
-              __useDeprecatedTag
               class="ui-test-confirm-delete"
               text={i18n.delete()}
               onClick={this.onConfirmDelete}
               color="red"
+              style={{margin: 0}}
             />
           </DialogFooter>
         </BaseDialog>


### PR DESCRIPTION
Since these are just a few lines each, I combined a bunch of components into one PR.
In each component, I remove '__useDeprecatedTag' from the Button.jsx component. This flips from using a clickable <div> to a <button>, per this document: https://docs.google.com/document/d/1PwnfYWtCyhC6g-2H0vNmamTeFsDqmYVgtbRJhcgcM3Y/edit#heading=h.daelm8hu89cf

No functional change, only visual change is removing shadows from buttons. Buttons still have visual change on hover.

Before and After Images:

OwnedSections
![Screenshot from 2022-12-12 14-07-26](https://user-images.githubusercontent.com/2959170/207189396-6e4431bb-409f-4b58-957f-6ae868a23e62.png)
![Screenshot from 2022-12-12 14-06-44](https://user-images.githubusercontent.com/2959170/207189400-8442a0e0-cd74-44c0-b8a3-e38fa0912cb6.png)

SectionActionDropdown
![Screenshot from 2022-12-12 13-58-46](https://user-images.githubusercontent.com/2959170/207189405-ff9d26da-5870-4bda-92b1-e78d1889af53.png)
![Screenshot from 2022-12-12 13-58-37](https://user-images.githubusercontent.com/2959170/207189410-7de29519-3b7e-4742-8a43-82c757b5c2f9.png)

LoginTypePicker
![Screenshot from 2022-12-12 13-47-34](https://user-images.githubusercontent.com/2959170/207189417-0343bf77-c5e5-4655-88bd-900b90b1a094.png)
![Screenshot from 2022-12-12 13-46-17](https://user-images.githubusercontent.com/2959170/207189422-c4ca4c77-e9e2-4d85-ac3c-ecf506b8476a.png)

EditSectionForm
![Screenshot from 2022-12-12 13-34-42](https://user-images.githubusercontent.com/2959170/207189427-e5aa4ef0-ec7b-4668-b74d-76dde93173bc.png)
![Screenshot from 2022-12-12 13-32-15](https://user-images.githubusercontent.com/2959170/207189430-56b28d6d-5b81-492e-b08e-d92b2304be74.png)
