### PR TITLE
Make level buttons accessible

### DIFF
--- a/dashboard/app/views/levels/_curriculum_reference.haml
+++ b/dashboard/app/views/levels/_curriculum_reference.haml
@@ -10,5 +10,5 @@
     - else
       #iframe-loading.loading
       %iframe{id: 'curriculum-reference', width: '100%', frameborder: 0, src: level.href, onload: 'window.curriculumReference.onload()', style: "display: none;" }
-    %a.btn.btn-large.btn-primary.next-lesson.submitButton.pull-right= t('continue')
+    = button_tag t('continue'), class: "btn btn-large btn-primary next-lesson submitButton pull-right"
   = render partial: 'levels/teacher_markdown', locals: {data: level.properties}

--- a/dashboard/app/views/levels/_dialog.html.haml
+++ b/dashboard/app/views/levels/_dialog.html.haml
@@ -4,20 +4,15 @@
 - unless app == 'external'
   .buttons{class: @level.properties['submittable'] == 'true' ? 'submittable' : nil}
     - if local_assigns[:previous_button]
-      %a.btn.btn-large.btn-primary.previousPageButton
-        =t('previous_page')
+      = button_tag t('previous_page'), class: "btn btn-large btn-primary previousPageButton"
     - if local_assigns[:next_button]
-      %a.btn.btn-large.btn-primary.nextPageButton
-        =t('next_page')
+      = button_tag t('next_page'), class: "btn btn-large btn-primary nextPageButton"
     - elsif local_assigns[:continue_button]
-      %a.btn.btn-large.btn-primary.next-lesson.submitButton
-        =t('continue')
+      = button_tag t('continue'), class: "btn btn-large btn-primary next-lesson submitButton"
     - else
-      %a.btn.btn-large.btn-primary.next-lesson.submitButton
-        =t('submit')
+      = button_tag t('submit'), class: "btn btn-large btn-primary next-lesson submitButton"
       - if @level.properties['submittable'] && !Policies::InlineAnswer.visible_for_script_level?(current_user, @script_level)
-        %a.btn.btn-large.btn-primary.unsubmitButton{style: 'display: none'}
-          =t('unsubmit')
+        = button_tag t('unsubmit'), class: "btn btn-large btn-primary unsubmitButton"
 .clear
 
 %script{src: webpack_asset_path('js/levels/_dialog.js')}

--- a/dashboard/app/views/levels/_external.html.haml
+++ b/dashboard/app/views/levels/_external.html.haml
@@ -19,7 +19,7 @@
       - if @script.try(:old_professional_learning_course?) && @script_level
         = link_to @script_level.end_of_lesson? ? t('done_with_module') : t('next_resource'), @script_level.next_level_or_redirect_path_for_user(current_user), class: 'btn btn-large pull-right btn-primary submitButton'
       - elsif !(video && use_large_video_player)
-        %a.btn.btn-large.btn-primary.next-lesson.submitButton.pull-right= t('continue')
+        = button_tag t('continue'), class: "btn btn-large btn-primary next-lesson submitButton pull-right"
 
   = render partial: 'levels/content', locals: {app: 'external', data: level.properties, content_class: level.properties['options'].try(:[], 'css'), postcontent: postcontent, source_level: level}
   = render partial: 'levels/teacher_markdown', locals: {data: {'teacher_markdown' => level.localized_teacher_markdown}}

--- a/dashboard/app/views/levels/_single_match.html.haml
+++ b/dashboard/app/views/levels/_single_match.html.haml
@@ -3,8 +3,7 @@
 
   - if standalone && !(level.properties['options'].try(:[], 'hide_submit'))
     .buttons
-      %a.btn.btn-large.btn-primary.next-lesson.submitButton
-        =t('submit')
+      = button_tag t('submit'), class: "btn btn-large btn-primary next-lesson submitButton"
 
   %br/
 


### PR DESCRIPTION
Tackles https://codedotorg.atlassian.net/browse/A11Y-153 from the Accessibility Hackathon by making buttons on the following four level types tab navigable:
1) Curriculum Reference: http://localhost-studio.code.org:3000/s/allthethings/lessons/35/levels/1?noautoplay=true, https://user-images.githubusercontent.com/9142121/207218129-2a33fea6-cba5-41e8-a131-9e42a7b29f83.mov
2) External: http://localhost-studio.code.org:3000/s/self-paced-pl-csd5-2022/lessons/5/levels/3, https://user-images.githubusercontent.com/9142121/207218016-c0042678-0af4-463f-9dbd-9b0997fec630.mov
3) Dialog: http://localhost-studio.code.org:3000/s/csa2-2022/lessons/1/levels/6, https://user-images.githubusercontent.com/9142121/207218057-887b80a7-fa0d-4dd0-8b70-6c32b3da48f7.mov
4) Match: http://localhost-studio.code.org:3000/s/csa2-2022/lessons/1/levels/3, https://user-images.githubusercontent.com/9142121/207218083-a40eb0ea-2871-405e-b7ed-60c157fc0b77.mov

The box shadow on hover now appears –– should I work to remove that? I wasn't sure, as standalone_video (e.g. https://levelbuilder-studio.code.org/levels/42684), as well as other pages (login_code and sections/show) all have the box shadow on hover as well.

With the shadow:
<img width="174" alt="Screen Shot 2022-12-12 at 10 10 02 PM" src="https://user-images.githubusercontent.com/9142121/207317715-0775a592-4fed-447a-ac54-114e38dc9387.png">

No shadow:
<img width="184" alt="Screen Shot 2022-12-12 at 10 10 28 PM" src="https://user-images.githubusercontent.com/9142121/207317741-c0cee793-cd4d-4861-a52a-464b8fa0086b.png">

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

If you do a search for "%a.btn" in our repo, you'll see there are more instances of fake buttons –– this work is tracked at https://codedotorg.atlassian.net/browse/A11Y-207.

There are also multiple choice answers that are not tab navigable –– tracked at https://codedotorg.atlassian.net/browse/A11Y-206.

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
