### PR TITLE
Alt text for images on /about and middle and high school curriculum pages

### DIFF
--- a/pegasus/sites.v3/code.org/public/educate/curriculum/high-school.md.erb
+++ b/pegasus/sites.v3/code.org/public/educate/curriculum/high-school.md.erb
@@ -48,7 +48,7 @@ Artificial intelligence (AI) and machine learning (ML) are shaping the world aro
 
 <div class="col-40" style="padding-right: 10px;">
 
-<img src="/images/fill-380x215/code20hr.jpg" style="max-width: 100%">
+<img src="/images/fill-380x215/code20hr.jpg" style="max-width: 100%" alt>
 
 </div>
 

--- a/pegasus/sites.v3/code.org/public/educate/curriculum/middle-school.md.erb
+++ b/pegasus/sites.v3/code.org/public/educate/curriculum/middle-school.md.erb
@@ -79,7 +79,7 @@ For a lightweight option that can be integrated as a unit in an existing technol
 
 <div class="col-40" style="padding-right: 10px;">
 
-<img src="<%= CDO.shared_image_url("courses/logo_science.png") %>" style="max-width: 100%">
+<img src="<%= CDO.shared_image_url("courses/logo_science.png") %>" style="max-width: 100%" alt>
 
 </div>
 

--- a/pegasus/sites.v3/code.org/views/csa_information.md.erb
+++ b/pegasus/sites.v3/code.org/views/csa_information.md.erb
@@ -1,5 +1,5 @@
 <div class="col-40" style="padding-right: 10px;">
-<img src="/shared/images/teacher-announcement/csa-upsell.png" style="max-width: 95%">
+<img src="/shared/images/teacher-announcement/csa-upsell.png" style="max-width: 95%" alt>
 </div>
 <div class="col-60">
 <p>Computer Science A (CSA) introduces students to software engineering and object-oriented design while learning the Java programming language. The Code.org CSA curriculum is recommended for any high school student who wants to continue their computer science education after completing an introductory course, such as CS Principles or CS Discoveries. Students expand their programming skills by developing solutions in the Java programming language, building on the knowledge they acquired from their previous introductory computer science course.</p>

--- a/pegasus/sites.v3/code.org/views/testimonials.haml
+++ b/pegasus/sites.v3/code.org/views/testimonials.haml
@@ -1,16 +1,16 @@
 .row#infobottom{style: "font-weight: 400; font-size: 16px; color: #ea7717; margin-left: 10px; margin-right: 10px; margin-top: 20px;"}
 
   .col-33{style: "text-align:center; margin-top: 20px;"}
-    %img{src: "/images/stats-kid1.jpg", style: "width: 70%"}
+    %img{src: "/images/stats-kid1.jpg", style: "width: 70%", alt: ""}
     %br/
     !=I18n.t :stats_nina_markdown, markdown: :inline
 
   .col-33{style: "text-align:center; margin-top: 20px;"}
-    %img{src: "/images/stats-kid2.jpg", style: "width: 70%"}
+    %img{src: "/images/stats-kid2.jpg", style: "width: 70%", alt: ""}
     %br/
     !=I18n.t :stats_student_markdown, markdown: :inline
 
   .col-33{style: "text-align:center; margin-top: 20px;"}
-    %img{src: "/images/stats-kid3.jpg", style: "width: 70%"}
+    %img{src: "/images/stats-kid3.jpg", style: "width: 70%", alt: ""}
     %br/
     !=I18n.t :stats_michael_markdown, markdown: :inline


### PR DESCRIPTION
Three blank alt text updates -- images are decorative, screenshots in tickets below.

- https://codedotorg.atlassian.net/browse/A11Y-22
- https://codedotorg.atlassian.net/browse/A11Y-21
- https://codedotorg.atlassian.net/browse/A11Y-3

## Testing story

Looked at each page, and confirmed presence of blank alt text tag on appropriate images.