### PR TITLE
Add a label to the Javalab file explorer button

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -962,6 +962,7 @@
   "feedbackSaveError": "There's been an error saving your feedback. Please try to save again.",
   "fewerNumberOfBlocks": "Fewer than {numBlocks, plural, one {1 block} other {# blocks}} used!",
   "fields": "Fields",
+  "fileExplorer": "File explorer",
   "filter": "Filter",
   "filterByStudent": "Filter by student:",
   "filterByStage": "Filter by lesson:",

--- a/apps/src/javalab/JavalabFileExplorer.jsx
+++ b/apps/src/javalab/JavalabFileExplorer.jsx
@@ -64,6 +64,7 @@ class JavalabFileExplorer extends Component {
     return (
       <div style={styles.main}>
         <button
+          aria-label="File explorer"
           type="button"
           onClick={this.toggleDropdown}
           style={{

--- a/apps/src/javalab/JavalabFileExplorer.jsx
+++ b/apps/src/javalab/JavalabFileExplorer.jsx
@@ -5,6 +5,7 @@ import onClickOutside from 'react-onclickoutside';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
 import JavalabDropdown from './components/JavalabDropdown';
 import {DisplayTheme} from './DisplayTheme';
+import i18n from '@cdo/locale';
 
 /**
  * A button that drops down to a set of clickable file names, and closes itself if
@@ -64,7 +65,7 @@ class JavalabFileExplorer extends Component {
     return (
       <div style={styles.main}>
         <button
-          aria-label="File explorer"
+          aria-label={i18n.fileExplorer()}
           type="button"
           onClick={this.toggleDropdown}
           style={{


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Add a label to the file explorer button in Javalab. I used what looked like the simplest approach in this [article on accessible icon buttons](https://www.sarasoueidan.com/blog/accessible-icon-buttons/), and a label text that matches the component name. Let me know if you think I should change any of that!

![image](https://user-images.githubusercontent.com/1382374/207414894-e6941b82-2d7e-43b6-9e30-3642fc086d30.png)

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [A11Y-12](https://codedotorg.atlassian.net/browse/A11Y-12)

