### PR TITLE
Add label and aria-expanded for Javalab file options toggle button

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -966,6 +966,7 @@
   "fewerNumberOfBlocks": "Fewer than {numBlocks, plural, one {1 block} other {# blocks}} used!",
   "fields": "Fields",
   "fileExplorer": "File explorer",
+  "fileOptions": "File options",
   "filter": "Filter",
   "filterByStudent": "Filter by student:",
   "filterByStage": "Filter by lesson:",

--- a/apps/src/javalab/JavalabEditor.jsx
+++ b/apps/src/javalab/JavalabEditor.jsx
@@ -35,7 +35,7 @@ import JavalabEditorTabMenu from './JavalabEditorTabMenu';
 import JavalabFileExplorer from './JavalabFileExplorer';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
 import _ from 'lodash';
-import msg from '@cdo/locale';
+import i18n from '@cdo/locale';
 import javalabMsg from '@cdo/javalab/locale';
 import {
   getDefaultFileContents,
@@ -640,7 +640,7 @@ class JavalabEditor extends React.Component {
 
   editorHeaderText = () =>
     this.props.isReadOnlyWorkspace
-      ? msg.readonlyWorkspaceHeader()
+      ? i18n.readonlyWorkspaceHeader()
       : javalabMsg.editor();
 
   render() {
@@ -714,7 +714,7 @@ class JavalabEditor extends React.Component {
                     <span>{fileMetadata[tabKey]}</span>
                     {activeTabKey === tabKey && !isReadOnlyWorkspace && (
                       <button
-                        aria-label="File options"
+                        aria-label={i18n.fileOptions()}
                         ref={`${tabKey}-file-toggle`}
                         type="button"
                         className={classNames(

--- a/apps/src/javalab/JavalabEditor.jsx
+++ b/apps/src/javalab/JavalabEditor.jsx
@@ -714,6 +714,7 @@ class JavalabEditor extends React.Component {
                     <span>{fileMetadata[tabKey]}</span>
                     {activeTabKey === tabKey && !isReadOnlyWorkspace && (
                       <button
+                        aria-label="File options"
                         ref={`${tabKey}-file-toggle`}
                         type="button"
                         className={classNames(

--- a/apps/src/javalab/JavalabEditor.jsx
+++ b/apps/src/javalab/JavalabEditor.jsx
@@ -715,6 +715,7 @@ class JavalabEditor extends React.Component {
                     {activeTabKey === tabKey && !isReadOnlyWorkspace && (
                       <button
                         aria-label={i18n.fileOptions()}
+                        aria-expanded={contextTarget === tabKey ? true : false}
                         ref={`${tabKey}-file-toggle`}
                         type="button"
                         className={classNames(

--- a/apps/src/javalab/JavalabEditor.jsx
+++ b/apps/src/javalab/JavalabEditor.jsx
@@ -715,7 +715,7 @@ class JavalabEditor extends React.Component {
                     {activeTabKey === tabKey && !isReadOnlyWorkspace && (
                       <button
                         aria-label={i18n.fileOptions()}
-                        aria-expanded={contextTarget === tabKey ? true : false}
+                        aria-expanded={contextTarget === tabKey}
                         ref={`${tabKey}-file-toggle`}
                         type="button"
                         className={classNames(


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Add a label to the file explorer button in Javalab. I used what looked like the simplest approach in this [article on accessible icon buttons](https://www.sarasoueidan.com/blog/accessible-icon-buttons/), and a label text that matches the behavior of the button. Let me know if you think I should change any of that!

![image](https://user-images.githubusercontent.com/1382374/207416923-6996b80d-2402-436f-bf52-4c791ee0d5fb.png)


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [A11Y-13](https://codedotorg.atlassian.net/browse/A11Y-13)

