### PR TITLE
Add aria-label to progress bubble links

### DIFF
--- a/apps/src/templates/progress/BubbleFactory.jsx
+++ b/apps/src/templates/progress/BubbleFactory.jsx
@@ -93,6 +93,7 @@ export function BubbleLink({url, onClick, children, a11y_description}) {
       onClick={onClick}
       className="progress-bubble-link"
       title={a11y_description}
+      aria-label={a11y_description}
     >
       {children}
     </a>


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

The progress bubble `BubbleLink` component already has an `a11y_description` prop that's being exposed through a `title` attribute in the `a` tag. This works for some screenreaders (e.g. JAWS, NVDA), but not all of them (e.g. chrome screenreader extension). This PR adds the same text in an `aria-label` attribute, to support those missing screenreaders. I tested with JAWS and NVDA, and confirmed it does not read the label twice when this change is in place.

![image](https://user-images.githubusercontent.com/1382374/207424712-37a6e148-90c9-47bf-aafa-04a49c2a2df0.png)

In this Javalab example (link in JIRA task), the descriptions look like "Level 2 Lesson Java Lab". They do not contain information about the completion status, so that information remains inaccessible since it's only represented by color. If we want to try adding that here too, I'm happy to do so.


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->


- jira ticket: [A11Y-17](https://codedotorg.atlassian.net/browse/A11Y-17)

