### PR TITLE
Label manage students link

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1336,6 +1336,7 @@
   "manageLinkedAccounts_rosteredSectionTooltip": "You cannot disconnect from this linked account because it is tied to one of your sections.",
   "manageLinkedAccounts_makerAuthError": "This action cannot be done from the Maker App. Please return to your default browser and try again.",
   "manageStudents": "Manage Students",
+  "manageStudentsAriaLabel": "{numStudents} students in this section. Manage students",
   "manageStudentsNotificationFailure": "Something went wrong.",
   "manageStudentsNotificationCannotAdd": "You could not add {numStudents, plural, one {1 student} other {# students}} to your section. Please try again or refresh the page.",
   "manageStudentsNotificationCannotVerb": "The {numStudents, plural, one {student} other {students}} couldn't be {verb, select, copy {copied} move {moved} other {added}} to this section",

--- a/apps/src/templates/teacherDashboard/OwnedSectionsTable.jsx
+++ b/apps/src/templates/teacherDashboard/OwnedSectionsTable.jsx
@@ -111,7 +111,13 @@ export const studentsFormatter = function(studentCount, {rowData}) {
         color={Button.ButtonColor.gray}
       />
     ) : (
-      <a style={tableLayoutStyles.link} href={manageStudentsUrl}>
+      <a
+        style={tableLayoutStyles.link}
+        href={manageStudentsUrl}
+        aria-label={i18n.manageStudentsAriaLabel({
+          numStudents: studentCount
+        })}
+      >
         {rowData.studentCount}
       </a>
     );


### PR DESCRIPTION
The sections table on /home for teachers lists a number of students, which can be clicked to visit the manage students page for that section.

Label text based on this recommendation:

https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA8

```
Per the Accessible Name and Description Computation and the HTML to Platform Accessibility APIs Implementation Guide, the aria-label text will override the text supplied within the link. As such the text supplied will be used instead of the link text by AT. 

Due to this it is recommended to start the text used in aria-label with the text used within the link. This will allow consistent communication between users.
```

## Links

- https://codedotorg.atlassian.net/browse/A11Y-38

## Testing story

Tested with screen reader that I heard text listed in aria label.