### PR TITLE
Add empty alt text to avatars on leadership page

### DIFF
--- a/pegasus/sites.v3/code.org/views/about_headshots.haml
+++ b/pegasus/sites.v3/code.org/views/about_headshots.haml
@@ -7,12 +7,12 @@
         - unless person[:url_s].nil_or_empty?
           %a{:href=>person[:url_s], :target=>"_self"}
             - unless avatar_url.nil_or_empty?
-              %img{:src=>avatar_url, :style=>'max-height: 200px; border-radius: 100px;'}
+              %img{:src=>avatar_url, :alt=>"", :style=>'max-height: 200px; border-radius: 100px;'}
             %h3{:style=>'min-height: 20px'}
               = person[:name_s]
         - else
           - unless avatar_url.nil_or_empty?
-            %img{:src=>avatar_url, :style=>'max-height: 200px; border-radius: 100px;'}
+            %img{:src=>avatar_url, :alt=>"", :style=>'max-height: 200px; border-radius: 100px;'}
           %h3{:style=>'min-height: 20px;'}
             = person[:name_s]
         -unless person[:title_s].nil_or_empty?


### PR DESCRIPTION
Addresses https://codedotorg.atlassian.net/browse/A11Y-5, putting empty alt text on these avatars. I don't feel comfortable describing someone's photo for alt text –– we could consider getting folks to describe their own images, but for now, empty alt text I think is best.

A recording of what happens: https://user-images.githubusercontent.com/9142121/207444010-17008c4c-2258-4ab8-8d8a-15a33eb8d027.mov



## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
