### PR TITLE
AccHack - Add alt text to Microsoft logo on /ai page

### DIFF
--- a/pegasus/sites.v3/code.org/views/ai_microsoft_block.erb
+++ b/pegasus/sites.v3/code.org/views/ai_microsoft_block.erb
@@ -1,24 +1,24 @@
 <style>
     .microsoft-partnership {
-        font-size: 24px;
-        text-align: center;
-        margin-top: 40px;
+      font-size: 24px;
+      text-align: center;
+      margin-top: 40px;
     }
 
     .microsoft-thanks {
-        font-size: 14px;
-        text-align: center;
-        padding-top: 20px;
-        margin-bottom: 80px;
-        margin-left: 18%;
-        margin-right: 18%;
+      font-size: 14px;
+      text-align: center;
+      padding-top: 20px;
+      margin-bottom: 80px;
+      margin-left: 18%;
+      margin-right: 18%;
     }
 </style>
 
 <div class="microsoft-partnership">
   <%= I18n.t("ai_in_partnership_with", default: "In partnership with") %>
   &nbsp;
-  <img src="images/fit-240/avatars/microsoft.png">
+  <img src="images/fit-240/avatars/microsoft.png" alt="<%= I18n.t("microsoft_logo_alt", default: "Microsoft logo")%>" >
 </div>
 <div class="microsoft-thanks">
   <%= I18n.t("ai_microsoft_thanks", default: "We thank Microsoft for supporting our vision and mission to ensure every child has the opportunity to learn computer science and the skills to succeed in the 21st century.") %>


### PR DESCRIPTION
Add alt text to the Microsoft logo on https://code.org/ai

**Jira ticket:** https://codedotorg.atlassian.net/browse/A11Y-33

----

#### Tested by checking in the inspector:
<img width="538" alt="Screenshot 2022-12-13 at 3 35 06 PM" src="https://user-images.githubusercontent.com/9256643/207469501-18c2a669-c911-44ed-96ce-ba3171edbb43.png">

