### PR TITLE
Fix Violations of and Reenable `Style/SlicingWithRange`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -612,11 +612,6 @@ Style/RescueStandardError:
   Enabled: false
 
 # Offense count: 38
-# This cop supports unsafe auto-correction (--auto-correct-all).
-Style/SlicingWithRange:
-  Enabled: false
-
-# Offense count: 38
 # This cop supports safe auto-correction (--auto-correct).
 # Configuration parameters: AllowModifier.
 Style/SoleNestedConditional:

--- a/bin/dashboard-csv
+++ b/bin/dashboard-csv
@@ -11,7 +11,7 @@ class DB < ActiveRecord::Base
     host:     DashboardDbUri.host,
     username: DashboardDbUri.user,
     password: DashboardDbUri.password,
-    database: DashboardDbUri.path[1..-1],
+    database: DashboardDbUri.path[1..],
     strict:   true
   )
 end

--- a/bin/pegasus-csv
+++ b/bin/pegasus-csv
@@ -11,7 +11,7 @@ class DB < ActiveRecord::Base
     host:     PegasusDbUri.host,
     username: PegasusDbUri.user,
     password: PegasusDbUri.password,
-    database: PegasusDbUri.path[1..-1],
+    database: PegasusDbUri.path[1..],
     strict:   true
   )
 end

--- a/cookbooks/cdo-home-ubuntu/recipes/default.rb
+++ b/cookbooks/cdo-home-ubuntu/recipes/default.rb
@@ -10,14 +10,14 @@
   '.vimrc'
 ].each do |file|
   template "/home/#{node[:current_user]}/#{file}" do
-    source "#{file[1..-1]}.erb"
+    source "#{file[1..]}.erb"
     mode '0644'
     user node[:current_user]
     group node[:current_user]
   end
 
   template "/root/#{file}" do
-    source "#{file[1..-1]}.erb"
+    source "#{file[1..]}.erb"
     mode '0644'
     user 'root'
     group 'root'

--- a/cookbooks/cdo-users/recipes/default.rb
+++ b/cookbooks/cdo-users/recipes/default.rb
@@ -47,7 +47,7 @@ node['cdo-users'].each_pair do |user_name, user_data|
   ].each do |dotfile|
     template File.join(home_directory, dotfile) do
       action :create_if_missing
-      source "#{dotfile[1..-1]}.erb"
+      source "#{dotfile[1..]}.erb"
       #variables( )
       owner user_name
       group user_name

--- a/dashboard/app/models/levels/widget.rb
+++ b/dashboard/app/models/levels/widget.rb
@@ -72,7 +72,7 @@ class Widget < Level
     path = Rails.root.join('app', 'views', 'levels', File.basename(href))
 
     # Ensure we are looking for a 'haml' template, if it isn't already one.
-    if File.extname(path)[1..-1] == "html"
+    if File.extname(path)[1..] == "html"
       path = "#{path}.haml"
     end
 
@@ -82,7 +82,7 @@ class Widget < Level
     # If it exists, then the haml file should be preferred, so return it without
     # the underscore.
     if File.exist?(path)
-      return "levels/" + File.basename(path)[1..-1]
+      return "levels/" + File.basename(path)[1..]
     end
 
     # Otherwise, we assume the widget exists within the public path.
@@ -91,6 +91,6 @@ class Widget < Level
 
   # Determines the type of template being rendered for this widget.
   def template_type
-    File.extname(template)[1..-1].to_sym
+    File.extname(template)[1..].to_sym
   end
 end

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1241,7 +1241,7 @@ class User < ApplicationRecord
       script_level_index = last_script_level.chapter - 1 if last_script_level
     end
 
-    next_unpassed = script.script_levels[script_level_index..-1].try(:detect) do |script_level|
+    next_unpassed = script.script_levels[script_level_index..].try(:detect) do |script_level|
       user_levels = script_level.level_ids.map {|id| ul_with_sl[id]}
       unpassed_progression_level?(script_level, user_levels)
     end

--- a/dashboard/db/migrate/20160818190145_add_unique_constraint_to_pd_workshop_attendance.rb
+++ b/dashboard/db/migrate/20160818190145_add_unique_constraint_to_pd_workshop_attendance.rb
@@ -12,7 +12,7 @@ class AddUniqueConstraintToPdWorkshopAttendance < ActiveRecord::Migration[4.2]
         duplicate_attendance_values.each do |pd_session_id, teacher_id|
           Pd::Attendance.with_deleted.
             where(pd_session_id: pd_session_id, teacher_id: teacher_id).
-            order(id: :desc)[1..-1].
+            order(id: :desc)[1..].
             each(&:destroy)
         end
       end

--- a/dashboard/lib/pd/foorm/helper.rb
+++ b/dashboard/lib/pd/foorm/helper.rb
@@ -29,7 +29,7 @@ module Pd::Foorm
         # any other pre-survey, return 0
         return 0
       elsif survey_key.include?("Day")
-        return 100 + survey_key[4..-1].to_i
+        return 100 + survey_key[4..].to_i
       elsif survey_key.start_with? "Post Workshop - Module"
         # last character will be the module number, use that as an index
         return 1000 + survey_key[-1].to_i

--- a/dashboard/lib/single_sign_on.rb
+++ b/dashboard/lib/single_sign_on.rb
@@ -67,7 +67,7 @@ class SingleSignOn
       # custom.
       #
       if k[0..6] == "custom."
-        field = k[7..-1]
+        field = k[7..]
         sso.custom_fields[field] = v
       end
     end

--- a/dashboard/scripts/generate_fixtures.rb
+++ b/dashboard/scripts/generate_fixtures.rb
@@ -98,7 +98,7 @@ def yamlize(hsh)
       v['properties'] = v['properties'].to_json
     end
   end
-  return hsh.to_yaml[4..-1]
+  return hsh.to_yaml[4..]
 end
 
 prefix = Rails.root.join('test/fixtures/')

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -952,7 +952,7 @@ FactoryGirl.define do
       props = {}
       # If multiple levels are specified, mark all but the first as inactive
       if script_level.levels.length > 1
-        script_level.levels[1..-1].each do |level|
+        script_level.levels[1..].each do |level|
           props[level.name] = {active: false}
         end
       end

--- a/dashboard/test/models/pd/application/teacher_application_test.rb
+++ b/dashboard/test/models/pd/application/teacher_application_test.rb
@@ -207,7 +207,7 @@ module Pd::Application
         regional_partner_workshop_ids: workshops.map(&:id),
         able_to_attend_multiple: (
         # Select all but the first. Expect the first selected to be returned below
-        workshops[1..-1].map do |workshop|
+        workshops[1..].map do |workshop|
           "#{workshop.friendly_date_range} in #{workshop.location_address} hosted by Code.org"
         end
         )

--- a/dashboard/test/models/user_script_test.rb
+++ b/dashboard/test/models/user_script_test.rb
@@ -45,7 +45,7 @@ class UserScriptTest < ActiveSupport::TestCase
     end
 
     # attempt some levels
-    @script_levels[8..-1].each do |script_level|
+    @script_levels[8..].each do |script_level|
       complete_level(script_level, 10)
     end
 

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -1116,7 +1116,7 @@ def press_keys(element, key)
 end
 
 def convert_keys(keys)
-  return keys[1..-1].to_sym if keys.start_with?(':')
+  return keys[1..].to_sym if keys.start_with?(':')
   keys.gsub!(/([^\\])\\n/, "\\1\n") # Cucumber does not convert captured \n to newline.
   keys.gsub!(/\\\\n/, "\\n") # Fix up escaped newline
   # Convert newlines to :enter keys.

--- a/dashboard/test/ui/runner.rb
+++ b/dashboard/test/ui/runner.rb
@@ -559,7 +559,7 @@ def output_synopsis(output_text, log_prefix)
 
   failing_scenarios = lines.rindex("Failing Scenarios:\n")
   if failing_scenarios
-    return lines[failing_scenarios..-1].map {|line| "#{log_prefix}#{line}"}.join
+    return lines[failing_scenarios..].map {|line| "#{log_prefix}#{line}"}.join
   else
     return lines.last(3).map {|line| "#{log_prefix}#{line}"}.join
   end

--- a/lib/cdo/data/csv_to_sql_table.rb
+++ b/lib/cdo/data/csv_to_sql_table.rb
@@ -51,7 +51,7 @@ class CsvToSqlTable
     (0..keys.count - 1).each do |i|
       key_name = keys[i].to_s
       value =
-        case key_name[key_name.rindex('_')..-1]
+        case key_name[key_name.rindex('_')..]
         when '_b'
           values[i].to_bool
         when '_f'
@@ -92,11 +92,11 @@ class CsvToSqlTable
     end
 
     if name.ends_with?('!') || name.ends_with?('*')
-      type_flag = name[-1..-1]
+      type_flag = name[-1..]
       name = name[0..-2]
     end
 
-    type_info = name[i..-1]
+    type_info = name[i..]
 
     type = {
       '_b' => {type: 'boolean'},

--- a/lib/cdo/markdown/renderer.rb
+++ b/lib/cdo/markdown/renderer.rb
@@ -26,7 +26,7 @@ module Cdo
           value = $1
           if value[0] == '#'
             attribute = 'id'
-            value = value[1..-1]
+            value = value[1..]
           else
             attribute = 'class'
           end

--- a/lib/cdo/mysql_console_helper.rb
+++ b/lib/cdo/mysql_console_helper.rb
@@ -4,7 +4,7 @@ module MysqlConsoleHelper
       --user=#{db.user}
       --host=#{db.host}
     )
-    database = db.path[1..-1]
+    database = db.path[1..]
     opts << "--database=#{database}" if database
     opts << "--port=#{db.port}" if db.port
     opts << "--password=#{db.password}" if db.password

--- a/lib/cdo/pegasus/graphics.rb
+++ b/lib/cdo/pegasus/graphics.rb
@@ -40,7 +40,7 @@ end
 def process_image(path, ext_names, language=nil, site=nil)
   extname = File.extname(path).downcase
   return nil unless ext_names.include?(extname)
-  image_format = extname[1..-1]
+  image_format = extname[1..]
 
   basename = File.basename(path, extname)
   dirname = File.dirname(path)
@@ -60,7 +60,7 @@ def process_image(path, ext_names, language=nil, site=nil)
   end
 
   # Assume we are returning the same resolution as we're reading.
-  retina_in = retina_out = basename[-3..-1] == '_2x'
+  retina_in = retina_out = basename[-3..] == '_2x'
 
   path = nil
   if site == 'hourofcode.com'

--- a/lib/cdo/pegasus/string.rb
+++ b/lib/cdo/pegasus/string.rb
@@ -1,7 +1,7 @@
 class String
   # Returns true if the string ends with the string passed
   def ends_with?(s)
-    self[-s.length..-1] == s
+    self[-s.length..] == s
   end
 
   # Returns true if the string contains any one of the strings passed

--- a/lib/cdo/poste.rb
+++ b/lib/cdo/poste.rb
@@ -112,7 +112,7 @@ module Poste
   class Template
     def initialize(path)
       @path = path
-      @template_type = File.extname(path)[1..-1]
+      @template_type = File.extname(path)[1..]
       @header, @html, @text = parse_template(File.read(path))
     end
 

--- a/lib/cdo/slack.rb
+++ b/lib/cdo/slack.rb
@@ -202,7 +202,7 @@ class Slack
   private_class_method def self.slackify(message)
     message_copy = message.dup
     message_copy.strip!
-    message_copy = "```#{message_copy[7..-1]}```" if /^\/quote /.match?(message_copy)
+    message_copy = "```#{message_copy[7..]}```" if /^\/quote /.match?(message_copy)
     message_copy.
       gsub(/<\/?i>/, '_').
       gsub(/<\/?b>/, '*').

--- a/lib/rake/circle.rake
+++ b/lib/rake/circle.rake
@@ -106,7 +106,7 @@ namespace :circle do
     end
     RakeUtils.wait_for_url('http://localhost-studio.code.org:3000')
     Dir.chdir('dashboard/test/ui') do
-      container_features = `find ./features -name '*.feature' | sort`.split("\n").map {|f| f[2..-1]}
+      container_features = `find ./features -name '*.feature' | sort`.split("\n").map {|f| f[2..]}
       eyes_features = `grep -lr '@eyes' features`.split("\n")
       container_eyes_features = container_features & eyes_features
       RakeUtils.system_stream_output "bundle exec ./runner.rb" \

--- a/lib/rake/test.rake
+++ b/lib/rake/test.rake
@@ -150,7 +150,7 @@ namespace :test do
         seed_file = Tempfile.new(['db_seed', '.sql'])
         auto_inc = 's/ AUTO_INCREMENT=[0-9]*\b//'
         writer = URI.parse(CDO.dashboard_db_writer || 'mysql://root@localhost/dashboard_test')
-        database = writer.path[1..-1]
+        database = writer.path[1..]
         writer.path = ''
         opts = MysqlConsoleHelper.options(writer)
         mysqldump_opts = "mysqldump #{opts} --skip-comments --set-gtid-purged=OFF"

--- a/pegasus/router.rb
+++ b/pegasus/router.rb
@@ -195,7 +195,7 @@ class Documents < Sinatra::Base
   def update_actionview_assigns
     view_assigns = {}
     instance_variables.each do |name|
-      view_assigns[name[1..-1]] = instance_variable_get(name)
+      view_assigns[name[1..]] = instance_variable_get(name)
     end
     @actionview.assign(view_assigns)
   end
@@ -522,7 +522,7 @@ class Documents < Sinatra::Base
 
         path = resolve_template('public', settings.non_static_extnames, File.join(parent, 'splat'), true)
         if path
-          request.env[:splat_path_info] = uri[parent.length..-1]
+          request.env[:splat_path_info] = uri[parent.length..]
           return path
         end
 
@@ -562,7 +562,7 @@ class Documents < Sinatra::Base
           # Symbolize the keys of the locals hash; previously, we supported
           # using either symbols or strings in locals hashes but ActionView
           # only allows symbols.
-          result = @actionview.render(inline: result, type: extension[1..-1], locals: locals.symbolize_keys)
+          result = @actionview.render(inline: result, type: extension[1..], locals: locals.symbolize_keys)
         when '.fetch'
           cache_file = cache_dir('fetch', request.site, request.path_info)
           unless File.file?(cache_file) && File.mtime(cache_file) > settings.launched_at

--- a/pegasus/src/text_render.rb
+++ b/pegasus/src/text_render.rb
@@ -129,7 +129,7 @@ module TextRender
           value = $1
           if value[0] == '#'
             attribute = 'id'
-            value = value[1..-1]
+            value = value[1..]
           else
             attribute = 'class'
           end

--- a/shared/middleware/shared_resources.rb
+++ b/shared/middleware/shared_resources.rb
@@ -73,14 +73,14 @@ class SharedResources < Sinatra::Base
     pass unless settings.javascript_extnames.include?(extname)
 
     if File.file?(path)
-      content_type extname[1..-1].to_sym
+      content_type extname[1..].to_sym
       cache :static
       send_file(path)
     end
 
     erb_path = "#{path}.erb"
     if File.file?(erb_path)
-      content_type extname[1..-1].to_sym
+      content_type extname[1..].to_sym
       cache :static
       return ERB.new(File.read(erb_path)).result
     end


### PR DESCRIPTION
> Checks that arrays are sliced with endless ranges instead of `ary` on Ruby 2.6+.

Fix applied automatically with `bundle exec rubocop --auto-correct-all --only Style/SlicingWithRange`. I then manually examined each instance to confirm that the receivers are indeed of a valid type (mostly Strings and Arrays)

## Links

- https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/SlicingWithRange
- https://docs.rubocop.org/rubocop/cops_style.html#styleslicingwithrange

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
