### PR TITLE
Button.jsx - Switch style order to allow override

### DIFF
--- a/apps/src/templates/Button.jsx
+++ b/apps/src/templates/Button.jsx
@@ -101,7 +101,8 @@ class Button extends React.Component {
     if (__useDeprecatedTag) {
       Tag = href ? 'a' : 'div';
     } else {
-      buttonStyle = {...style, boxShadow: 'none'};
+      // boxShadow should default to none, unless otherwise overridden
+      buttonStyle = {boxShadow: 'none', ...style};
     }
 
     if (download && Tag !== 'a') {


### PR DESCRIPTION
Switching the order of these elements allows us to default to boxShadow, unless overridden by the component specific styling passed in as a property.