### PR TITLE
Make header "more/less" button accessible

### DIFF
--- a/apps/src/code-studio/components/header/HeaderPopup.jsx
+++ b/apps/src/code-studio/components/header/HeaderPopup.jsx
@@ -1,10 +1,11 @@
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
-import color from '@cdo/apps/util/color';
 import progress from '../../progress';
 import MiniView from '../progress/MiniView';
 import i18n from '@cdo/locale';
 import firehoseClient from '@cdo/apps/lib/util/firehose';
+import styles from './header-popup.module.scss';
+import classNames from 'classnames';
 
 export default class HeaderPopup extends Component {
   static propTypes = {
@@ -67,24 +68,28 @@ export default class HeaderPopup extends Component {
 
   render() {
     return (
-      <div style={styles.container}>
+      <div>
         {!this.state.open && (
-          <div
-            style={styles.headerItem}
-            className="header_popup_link"
+          <button
+            type="button"
+            className={classNames('header_popup_link', styles.headerItem)}
             onClick={this.handleClickOpen}
           >
-            <i className="fa fa-caret-down" style={styles.caret} />
-            <div style={styles.more}>{i18n.moreAllCaps()}</div>
-          </div>
+            <i className={classNames('fa fa-caret-down', styles.caret)} />
+            <div className={styles.more}>{i18n.moreAllCaps()}</div>
+          </button>
         )}
 
         {this.state.open && (
           <div>
-            <div style={styles.headerItem} onClick={this.handleClickClose}>
-              <i className="fa fa-caret-up" style={styles.caret} />
-              <div style={styles.more}>{i18n.lessAllCaps()}</div>
-            </div>
+            <button
+              type="button"
+              className={styles.headerItem}
+              onClick={this.handleClickClose}
+            >
+              <i className={classNames('fa fa-caret-up', styles.caret)} />
+              <div className={styles.more}>{i18n.lessAllCaps()}</div>
+            </button>
 
             <div className="header_popup" ref="headerPopup">
               <div
@@ -104,19 +109,3 @@ export default class HeaderPopup extends Component {
     );
   }
 }
-
-const styles = {
-  headerItem: {
-    textAlign: 'center',
-    cursor: 'pointer'
-  },
-  caret: {
-    fontSize: 40,
-    color: color.orange,
-    lineHeight: '10px'
-  },
-  more: {
-    fontSize: 10,
-    lineHeight: '10px'
-  }
-};

--- a/apps/src/code-studio/components/header/HeaderPopup.jsx
+++ b/apps/src/code-studio/components/header/HeaderPopup.jsx
@@ -88,7 +88,11 @@ export default class HeaderPopup extends Component {
           <div>
             <button
               type="button"
-              className={classNames('no-mc', styles.headerItem)}
+              className={classNames(
+                'no-mc',
+                styles.headerItem,
+                styles.headerItemLess
+              )}
               onClick={this.handleClickClose}
             >
               <i className={classNames('fa fa-caret-up', styles.caret)} />

--- a/apps/src/code-studio/components/header/HeaderPopup.jsx
+++ b/apps/src/code-studio/components/header/HeaderPopup.jsx
@@ -72,7 +72,11 @@ export default class HeaderPopup extends Component {
         {!this.state.open && (
           <button
             type="button"
-            className={classNames('header_popup_link', styles.headerItem)}
+            className={classNames(
+              'no-mc',
+              'header_popup_link',
+              styles.headerItem
+            )}
             onClick={this.handleClickOpen}
           >
             <i className={classNames('fa fa-caret-down', styles.caret)} />
@@ -84,7 +88,7 @@ export default class HeaderPopup extends Component {
           <div>
             <button
               type="button"
-              className={styles.headerItem}
+              className={classNames('no-mc', styles.headerItem)}
               onClick={this.handleClickClose}
             >
               <i className={classNames('fa fa-caret-up', styles.caret)} />

--- a/apps/src/code-studio/components/header/header-popup.module.scss
+++ b/apps/src/code-studio/components/header/header-popup.module.scss
@@ -4,7 +4,7 @@
   text-align: center;
   cursor: pointer;
   background-color: transparent;
-  padding: 0 0 2px 0;
+  padding: 2px 0 2px 0;
   border: none;
   color: color.$orange;
   &:hover {
@@ -12,6 +12,10 @@
     box-shadow: none;
     color: color.$white;
   }
+}
+
+.headerItemLess {
+  padding: 2px;
 }
 
 .caret {

--- a/apps/src/code-studio/components/header/header-popup.module.scss
+++ b/apps/src/code-studio/components/header/header-popup.module.scss
@@ -4,7 +4,7 @@
   text-align: center;
   cursor: pointer;
   background-color: transparent;
-  padding: 0;
+  padding: 0 0 2px 0;
   border: none;
   color: color.$orange;
   &:hover {

--- a/apps/src/code-studio/components/header/header-popup.module.scss
+++ b/apps/src/code-studio/components/header/header-popup.module.scss
@@ -1,0 +1,26 @@
+@use "color.scss";
+
+.headerItem {
+  text-align: center;
+  cursor: pointer;
+  background-color: transparent;
+  padding: 0;
+  border: none;
+  color: color.$orange;
+  &:hover {
+    cursor: pointer;
+    box-shadow: none;
+    color: color.$white;
+  }
+}
+
+.caret {
+  font-size: 40px;
+  line-height: 10px;
+}
+
+.more {
+  font-size: 10px;
+  line-height: 10px;
+  color: color.$white;
+}


### PR DESCRIPTION
Redo of #49373, which caused some unexpected eyes diffs. This will still cause some very minor eyes diffs, but the change is not visible to me without the eyes diff pointing it out so I think it is safe to check in. This should be merged post-dtp because it will likely require approving  a lot of minor eyes changes. The "more" version is the only one with eyes diffs, "less" should be the same.

## Expected Eyes Diff
![Screen Shot 2022-12-13 at 5 04 19 PM](https://user-images.githubusercontent.com/33666587/207480012-91788915-d80b-45a3-9a79-bd9fb76e9890.png)
(there is just a tiny diff on the "R" of "MORE")

## Default State of Button
![Screen Shot 2022-12-13 at 5 06 33 PM](https://user-images.githubusercontent.com/33666587/207480101-bb6a88a2-d1ef-47bc-a6de-b058f7d805ad.png)
![Screen Shot 2022-12-13 at 5 06 38 PM](https://user-images.githubusercontent.com/33666587/207480106-03f6983c-93a5-4652-993f-2998ee13e3d4.png)


## Hover State of Button
![Screen Shot 2022-12-13 at 5 06 44 PM](https://user-images.githubusercontent.com/33666587/207480114-a3700e3d-1bd8-4688-80e6-0dac1c05c713.png)
![Screen Shot 2022-12-13 at 5 06 49 PM](https://user-images.githubusercontent.com/33666587/207480119-7e3f7da4-f103-48a6-817c-079141b09dda.png)



## Links

- jira ticket: [SL-439](https://codedotorg.atlassian.net/browse/SL-439), duplicate in accessibility hackathon: [A11Y-166](https://codedotorg.atlassian.net/browse/A11Y-166)


## Testing story
Tested locally and spot checked some eyes tests that were previously failing. Some pass and some fail with the tiny diff above.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
