### PR TITLE
Remove _useDeprecatedTag from StartNewProject Component

### DIFF
--- a/apps/src/templates/projects/StartNewProject.jsx
+++ b/apps/src/templates/projects/StartNewProject.jsx
@@ -85,7 +85,6 @@ export default class StartNewProject extends React.Component {
 
         {canViewFullList && (
           <Button
-            __useDeprecatedTag
             id="uitest-view-full-list"
             onClick={this.toggleShowFullList}
             color={Button.ButtonColor.gray}
@@ -146,7 +145,8 @@ export default class StartNewProject extends React.Component {
 const styles = {
   button: {
     float: 'right',
-    marginRight: 1
+    margin: '0 1px 0 0',
+    padding: '0 24px'
   },
   headingStartNew: {
     paddingRight: 10,


### PR DESCRIPTION
This removes the `_useDeprecatedTag` from the Button component that is in StartNewProject.

I compared the styling to production.

- On prod: 
<img width="642" alt="Screen Shot 2022-12-13 at 8 29 37 PM" src="https://user-images.githubusercontent.com/9142121/207483175-8bea4901-3ce7-4e77-a89b-046fa02e2785.png">

- On development:
<img width="595" alt="Screen Shot 2022-12-13 at 8 29 25 PM" src="https://user-images.githubusercontent.com/9142121/207483216-2394c1ca-1dff-4bd9-84e7-3655b9e6e037.png">

Video showing the hover state and the tab navigability:
https://user-images.githubusercontent.com/9142121/207485103-8322dd1d-b4b1-45af-8732-b4482f887a2b.mov



## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
