### PR TITLE
Add keys to the scripts for teacher application and summer workshop exports

### DIFF
--- a/bin/cron/summer_workshops_to_gdrive
+++ b/bin/cron/summer_workshops_to_gdrive
@@ -36,7 +36,7 @@ def get_rows
 end
 
 def main
-  sheet = Google::Sheet.new CDO.applications_2022_2023_gsheet_key
+  sheet = Google::Sheet.new CDO.applications_2023_2024_gsheet_key
   sheet.export(tab_name: 'summer_workshops', rows: get_rows)
 end
 

--- a/bin/cron/teacher_applications_to_gdrive
+++ b/bin/cron/teacher_applications_to_gdrive
@@ -65,7 +65,7 @@ def main
   allowed_list = DCDO.get('external_emails_with_application_data_access', [])
 
   # Uses a Google Cloud service account to access Google Drive
-  sheet = Google::Sheet.new CDO.applications_2022_2023_gsheet_key
+  sheet = Google::Sheet.new CDO.applications_2023_2024_gsheet_key
   sheet.export(tab_name: 'all_apps', rows: get_rows)
   sheet.notify_of_external_sharing(allowed_list)
 end


### PR DESCRIPTION
The last PR https://github.com/code-dot-org/code-dot-org/pull/49381, which created a Google Sheet and added keys for it, didn't cause any pipeline errors! Good news.

Here, I added the keys to the scripts for teacher application and summer workshop exports. We should start seeing the results at https://docs.google.com/spreadsheets/d/1hyF__4aDzCveA0j2VvckgskEqaeBHd-VfKgAzxARuVU/edit#gid=632721666 once it's merged into prod.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
