### PR TITLE
A11Y-7: Add alt text to careers page images

### DIFF
--- a/pegasus/sites.v3/code.org/public/about/careers.md.erb
+++ b/pegasus/sites.v3/code.org/public/about/careers.md.erb
@@ -106,8 +106,8 @@ Code.org is based in Seattle, but many of our team members are remote; remote ca
 <a href="https://github.com/code-dot-org">Check out our GitHub</a>
 
 <div class="careers__team-photos">
-    <img src="../images/careers-at-code/all-hands-2020.jpg">
-    <img src="../images/careers-at-code/code-pride.jpg">
+    <img src="../images/careers-at-code/all-hands-2020.jpg" alt="">
+    <img src="../images/careers-at-code/code-pride.jpg" alt="<%= hoc_s(:careers_page_code_pride_alt_text)%>">
 </div>
 
 _We embrace diverse perspectives, ideas, and backgrounds at Code.org. We are committed to providing an equal opportunity to all employees and applicants. We do not discriminate on the basis of race, religion, color, national origin, gender, sexual orientation, age, marital status, veteran status, or disability (mental and physical) status._

--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -7255,7 +7255,7 @@
 
   language_label: "Language"
 
-  careers_page_code_pride_alt_text: "Two female-presenting employees smile while holding the ends of a Code.org-branded rainbow banner. Behind them, several people are wearing Code.org shirts and waving rainbow flags while walking alongside a multi-colored Volkswagon bug."
+  careers_page_code_pride_alt_text: "Two feminine-presenting employees smile while holding the ends of a Code.org-branded rainbow banner. Behind them, several people are wearing Code.org shirts and waving rainbow flags while walking alongside a multi-colored Volkswagen bug."
 
   language_code:
     ar: "Arabic"

--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -7255,6 +7255,8 @@
 
   language_label: "Language"
 
+  careers_page_code_pride_alt_text: "Two female-presenting employees smile while holding the ends of a Code.org-branded rainbow banner. Behind them, several people are wearing Code.org shirts and waving rainbow flags while walking alongside a multi-colored Volkswagon bug."
+
   language_code:
     ar: "Arabic"
     az: "Azerbaijani"


### PR DESCRIPTION
This PR adds alt text for these two images. I decided to give the all-employee photo empty alt text because it doesn't feel like it conveys anything in particular, but the Code.org pride photo feels worth explaining.

<img width="814" alt="Screen Shot 2022-12-14 at 10 29 36 AM" src="https://user-images.githubusercontent.com/26844240/207679909-e2a4fb23-3e97-4ea6-b382-b63b5fe53886.png">
 
## Links

Jira ticket: https://codedotorg.atlassian.net/browse/A11Y-7

## Testing story

Tested locally with VoiceOver (see output below).

<img width="624" alt="Screen Shot 2022-12-14 at 10 27 13 AM" src="https://user-images.githubusercontent.com/26844240/207680243-4e8e3b38-ee12-4658-ac54-92b657d2f083.png">
