### PR TITLE
Revert "Revert "Make the Game Lab/App Lab instructions panel tabs keyboard navigable (#49404)" (#49490)"

### DIFF
--- a/apps/src/mixins.scss
+++ b/apps/src/mixins.scss
@@ -1,0 +1,20 @@
+// Removes (most) default button styling. Useful for retaining a clickable component's
+// original presentation when converting it to a <button>
+@mixin remove-button-styles {
+  color: inherit;
+  font-size: inherit;
+  line-height: inherit;
+  margin: 0;
+  padding: 0;
+  border: none;
+  border-radius: 0;
+  background-color: transparent;
+
+  &:hover {
+    box-shadow: none;
+  }
+
+  &:active {
+    border: none !important;
+  }
+}

--- a/apps/src/mixins.scss
+++ b/apps/src/mixins.scss
@@ -1,9 +1,22 @@
 // Removes (most) default button styling. Useful for retaining a clickable component's
 // original presentation when converting it to a <button>
-@mixin remove-button-styles {
-  color: inherit;
-  font-size: inherit;
-  line-height: inherit;
+@mixin remove-button-styles(
+  $color: false,
+  $font-size: false,
+  $line-height: false
+) {
+  @if $color {
+    color: $color;
+  }
+
+  @if $font-size {
+    font-size: $font-size;
+  }
+
+  @if $line-height {
+    line-height: $line-height;
+  }
+
   margin: 0;
   padding: 0;
   border: none;

--- a/apps/src/templates/CollapserIcon.jsx
+++ b/apps/src/templates/CollapserIcon.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import moduleStyles from './collapser-icon.module.scss';
 
 const styles = {
   icon: {
@@ -21,12 +22,18 @@ function CollapserIcon({
   const iconClass = isCollapsed ? collapsedIconClass : expandedIconClass;
 
   return (
-    <i
+    <button
       id={id}
       onClick={onClick}
       role="button"
-      className={classNames(iconClass + ' fa', className)}
+      className={classNames(
+        iconClass + ' fa',
+        className,
+        moduleStyles.collapserIcon,
+        'no-mc'
+      )}
       style={{...style, ...styles.icon}}
+      type="button"
     />
   );
 }

--- a/apps/src/templates/collapser-icon.module.scss
+++ b/apps/src/templates/collapser-icon.module.scss
@@ -1,0 +1,5 @@
+@import "../mixins.scss";
+
+.collapserIcon {
+  @include remove-button-styles;
+}

--- a/apps/src/templates/collapser-icon.module.scss
+++ b/apps/src/templates/collapser-icon.module.scss
@@ -1,5 +1,5 @@
 @import "../mixins.scss";
 
 .collapserIcon {
-  @include remove-button-styles;
+  @include remove-button-styles(inherit);
 }

--- a/apps/src/templates/instructions/InlineAudio.jsx
+++ b/apps/src/templates/instructions/InlineAudio.jsx
@@ -6,6 +6,8 @@ import {connect} from 'react-redux';
 import trackEvent from '../../util/trackEvent';
 import color from '../../util/color';
 import firehoseClient from '@cdo/apps/lib/util/firehose';
+import moduleStyles from './inline-audio.module.scss';
+import classNames from 'classnames';
 
 // TODO (elijah): have these constants shared w/dashboard
 const VOICES = {
@@ -260,12 +262,13 @@ class InlineAudio extends React.Component {
       this.getAudioSrc()
     ) {
       return (
-        <div
-          className="inline-audio"
+        <button
+          className={classNames('inline-audio', moduleStyles.inlineAudioButton)}
           style={[styles.wrapper, this.props.style && this.props.style.wrapper]}
           onMouseOver={this.toggleHover}
           onMouseOut={this.toggleHover}
           onClick={this.toggleAudio}
+          type="button"
         >
           <div
             style={[
@@ -301,7 +304,7 @@ class InlineAudio extends React.Component {
               ]}
             />
           </div>
-        </div>
+        </button>
       );
     }
     return null;

--- a/apps/src/templates/instructions/InstructionsTab.jsx
+++ b/apps/src/templates/instructions/InstructionsTab.jsx
@@ -44,6 +44,7 @@ export default class InstructionsTab extends Component {
     };
     const combinedStyle = {
       ...this.props.style,
+      ...styles.text,
       ...(this.props.selected
         ? this.props.teacherOnly
           ? styles.teacherHighlighted
@@ -54,7 +55,7 @@ export default class InstructionsTab extends Component {
         ? styles.teacherText
         : this.props.isMinecraft
         ? craftStyles.text
-        : styles.text)
+        : styles.defaultText)
     };
     return (
       <button
@@ -96,11 +97,14 @@ const styles = {
   },
   tabWrapper: {
     overflow: 'hidden',
-    textOverflow: 'ellipsis',
     display: 'flex'
   },
-  text: {
+  defaultText: {
     color: color.charcoal
+  },
+  text: {
+    textOverflow: 'ellipsis',
+    overflow: 'hidden'
   },
   teacherText: {
     color: color.lightest_cyan

--- a/apps/src/templates/instructions/InstructionsTab.jsx
+++ b/apps/src/templates/instructions/InstructionsTab.jsx
@@ -1,6 +1,8 @@
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import color from '../../util/color';
+import classNames from 'classnames';
+import moduleStyles from './instructions-tab.module.scss';
 
 const craftStyles = {
   text: {
@@ -55,16 +57,20 @@ export default class InstructionsTab extends Component {
         : styles.text)
     };
     return (
-      <div style={wrapperStyle}>
+      <button
+        style={wrapperStyle}
+        onClick={this.props.onClick}
+        className={classNames(moduleStyles.tabButton, 'no-mc')}
+        type="button"
+      >
         <a
           className={this.props.className}
-          onClick={this.props.onClick}
           style={combinedStyle}
           title={this.props.text}
         >
           {this.props.text}
         </a>
-      </div>
+      </button>
     );
   }
 }
@@ -90,7 +96,8 @@ const styles = {
   },
   tabWrapper: {
     overflow: 'hidden',
-    textOverflow: 'ellipsis'
+    textOverflow: 'ellipsis',
+    display: 'flex'
   },
   text: {
     color: color.charcoal

--- a/apps/src/templates/instructions/TopInstructionsHeader.jsx
+++ b/apps/src/templates/instructions/TopInstructionsHeader.jsx
@@ -64,17 +64,16 @@ function TopInstructionsHeader(props) {
       isMinecraft={isMinecraft}
     >
       <div style={styles.paneHeaderOverride}>
-        {/* For CSF contained levels we use the same audio button location as CSD/CSP*/}
-        {tabSelected === TabType.INSTRUCTIONS &&
-          ttsLongInstructionsUrl &&
-          (hasContainedLevels || isCSDorCSP) && (
-            <InlineAudio
-              src={ttsLongInstructionsUrl}
-              style={{
-                ...styles.audio,
-                ...(isRtl ? styles.audioRTL : styles.audioLTR)
-              }}
-              autoplayTriggerElementId="codeApp"
+        {/* For CSF contained levels we use the same collapse function as CSD/CSP*/}
+        {collapsible &&
+          !isEmbedView &&
+          (isCSDorCSP || hasContainedLevels) &&
+          !dynamicInstructions && (
+            <CollapserIcon
+              id="ui-test-collapser"
+              isCollapsed={isCollapsed}
+              onClick={handleClickCollapser}
+              style={collapserIconStyles}
             />
           )}
         {documentationUrl && tabSelected !== TabType.COMMENTS && (
@@ -168,16 +167,17 @@ function TopInstructionsHeader(props) {
             isRtl={isRtl}
           />
         )}
-        {/* For CSF contained levels we use the same collapse function as CSD/CSP*/}
-        {collapsible &&
-          !isEmbedView &&
-          (isCSDorCSP || hasContainedLevels) &&
-          !dynamicInstructions && (
-            <CollapserIcon
-              id="ui-test-collapser"
-              isCollapsed={isCollapsed}
-              onClick={handleClickCollapser}
-              style={collapserIconStyles}
+        {/* For CSF contained levels we use the same audio button location as CSD/CSP*/}
+        {tabSelected === TabType.INSTRUCTIONS &&
+          ttsLongInstructionsUrl &&
+          (hasContainedLevels || isCSDorCSP) && (
+            <InlineAudio
+              src={ttsLongInstructionsUrl}
+              style={{
+                ...styles.audio,
+                ...(isRtl ? styles.audioRTL : styles.audioLTR)
+              }}
+              autoplayTriggerElementId="codeApp"
             />
           )}
       </div>

--- a/apps/src/templates/instructions/inline-audio.module.scss
+++ b/apps/src/templates/instructions/inline-audio.module.scss
@@ -1,5 +1,5 @@
 @import "../../mixins.scss";
 
 .inlineAudioButton {
-  @include remove-button-styles;
+  @include remove-button-styles(inherit, inherit, inherit);
 }

--- a/apps/src/templates/instructions/inline-audio.module.scss
+++ b/apps/src/templates/instructions/inline-audio.module.scss
@@ -1,0 +1,5 @@
+@import "../../mixins.scss";
+
+.inlineAudioButton {
+  @include remove-button-styles;
+}

--- a/apps/src/templates/instructions/instructions-tab.module.scss
+++ b/apps/src/templates/instructions/instructions-tab.module.scss
@@ -1,5 +1,5 @@
 @import "../../mixins.scss";
 
 .tabButton {
-  @include remove-button-styles;
+  @include remove-button-styles(inherit, inherit, inherit);
 }

--- a/apps/src/templates/instructions/instructions-tab.module.scss
+++ b/apps/src/templates/instructions/instructions-tab.module.scss
@@ -1,0 +1,5 @@
+@import "../../mixins.scss";
+
+.tabButton {
+  @include remove-button-styles;
+}

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableStudentName.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableStudentName.jsx
@@ -115,6 +115,8 @@ const styles = {
     paddingRight: 8,
     fontSize: 20,
     verticalAlign: 'middle',
-    width: 11
+    width: 11,
+    boxSizing: 'content-box',
+    textAlign: 'left'
   }
 };


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Redo of #49404. Fixed a few regressions that were caught by eyes tests.

Javalab collapser icon and instructions text ellipses:
![Screen Shot 2022-12-14 at 12 35 01 PM](https://user-images.githubusercontent.com/85528507/207708483-211c58aa-b93b-428c-b71a-422db3617241.png)

Collapser icon in teacher dashboard:
![Screen Shot 2022-12-14 at 12 35 53 PM](https://user-images.githubusercontent.com/85528507/207708510-ecb57519-1544-47a7-8055-db7411f490c2.png)

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
