### PR TITLE
Updating semantics of census buttons

### DIFF
--- a/apps/src/templates/census2017/CensusForm.jsx
+++ b/apps/src/templates/census2017/CensusForm.jsx
@@ -843,7 +843,6 @@ class CensusForm extends Component {
             <div style={styles.errors}>{i18n.censusRequired()}</div>
           )}
           <Button
-            __useDeprecatedTag
             id="submit-button"
             onClick={() => this.validateSubmission()}
             color={Button.ButtonColor.orange}

--- a/apps/src/templates/census2017/CensusInaccuracyReviewDetails.jsx
+++ b/apps/src/templates/census2017/CensusInaccuracyReviewDetails.jsx
@@ -145,7 +145,6 @@ export default class CensusInaccuracyReviewDetails extends Component {
           {school.name} ({school.city}, {school.state})
         </h2>
         <Button
-          __useDeprecatedTag
           onClick={this.returnToMainList}
           size="large"
           text="Back to main list"
@@ -222,14 +221,12 @@ export default class CensusInaccuracyReviewDetails extends Component {
           {this.state.notes && (
             <div>
               <Button
-                __useDeprecatedTag
                 onClick={this.submitInvestigationWithOverride}
                 size="large"
                 text={overrideText}
               />
               <br />
               <Button
-                __useDeprecatedTag
                 onClick={this.submitInvestigationWithoutOverride}
                 size="large"
                 text="Resolve without override"

--- a/apps/src/templates/census2017/CensusInaccuracyReviewTable.jsx
+++ b/apps/src/templates/census2017/CensusInaccuracyReviewTable.jsx
@@ -41,7 +41,6 @@ export default class CensusInaccuracyReviewTable extends Component {
     } else {
       return (
         <Button
-          __useDeprecatedTag
           onClick={() => {
             this.props.onStartReview(data.rowData);
           }}


### PR DESCRIPTION
Real talk: how often do we use the census reviewer page? Seems worth auditing. It's also very very hard to repro locally. 

CensusForm.jsx (only box shadow difference)
Before:
<img width="638" alt="Screen Shot 2022-12-14 at 1 55 49 PM" src="https://user-images.githubusercontent.com/37230822/207723823-86985d43-b473-4fc9-a0b1-e07e40cad8b4.png">

After:
<img width="538" alt="Screen Shot 2022-12-14 at 1 56 14 PM" src="https://user-images.githubusercontent.com/37230822/207723839-e980eef9-a58d-480a-9d5d-98ce0d713d38.png">


I don't even want to talk about or admit HOW MANY HOURS it took me to create enough false data to actually see these forms. What matters? I got these screenshots and was able to verify that removing these lines doesn't change the buttons apart from the box shadows.

TableBefore:
<img width="1032" alt="Screen Shot 2022-12-14 at 3 44 13 PM" src="https://user-images.githubusercontent.com/37230822/207750218-8d11b221-9773-4c5b-870c-85e6c56bc187.png">

TableAfter:
<img width="1008" alt="Screen Shot 2022-12-14 at 3 44 46 PM" src="https://user-images.githubusercontent.com/37230822/207750224-108a338c-4182-494f-b584-cf69a715f280.png">

ReviewDetailsBefore:
<img width="615" alt="Screen Shot 2022-12-14 at 5 17 48 PM" src="https://user-images.githubusercontent.com/37230822/207750242-4fad9dcc-ad71-4ffc-a879-2d82bd5fa459.png">
<img width="650" alt="Screen Shot 2022-12-14 at 5 18 02 PM" src="https://user-images.githubusercontent.com/37230822/207750270-83ac93a2-ab0e-4e17-a177-f3df9a9001d1.png">

ReviewDetailsAfter:
<img width="660" alt="Screen Shot 2022-12-14 at 5 18 52 PM" src="https://user-images.githubusercontent.com/37230822/207750297-be445bc9-28bb-442d-aad3-6833f2ecb7c4.png">
<img width="646" alt="Screen Shot 2022-12-14 at 5 18 43 PM" src="https://user-images.githubusercontent.com/37230822/207750302-c1f1de63-8977-47a0-b7ea-1cb6a40dacc4.png">


## Links


- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/A11Y-115
- https://codedotorg.atlassian.net/browse/A11Y-117
- https://codedotorg.atlassian.net/browse/A11Y-116

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
