### PR TITLE
Temporarily enable MySQL binary logging to support schema change on large table

### DIFF
--- a/aws/cloudformation/db_parameters.yml.erb
+++ b/aws/cloudformation/db_parameters.yml.erb
@@ -8,8 +8,18 @@
 
 # System variables for the Aurora DB cluster.
 AuroraCluster: &aurora
-  # Disable binary logging to improve write performance.
-  binlog_format: 'OFF'
+  # When using row-based logging, the primary database writes events to the binary log that indicate how individual table rows are changed.
+  # Replication of the primary database to a replica works by copying the events representing the changes to the table rows to the replica.
+  # ROW required for DMS Change Data Capture:
+  # https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Source.MySQL.html#CHAP_Source.MySQL.AmazonManaged
+  # ROW also required to use gh-ost to carry out online schema changes on large tables:
+  # https://github.com/github/gh-ost/blob/master/doc/requirements-and-limitations.md
+  binlog_format: ROW
+  # When enabled, this variable causes the primary database to write a checksum for each event in the binary log.
+  # When disabled (value NONE), write and check the event length (rather than a checksum) for each event.
+  # NONE required for DMS Change Data Capture:
+  # https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Source.MySQL.html#CHAP_Source.MySQL.AmazonManaged
+  binlog_checksum: NONE
 
   # Enable GTIDs: https://aws.amazon.com/blogs/database/amazon-aurora-for-mysql-compatibility-now-supports-global-transaction-identifiers-gtids-replication/
   gtid-mode: ON_PERMISSIVE


### PR DESCRIPTION
In preparation for [changing the datatype](https://codedotorg.atlassian.net/browse/INF-127) of the `pegasus.hoc_activities.id` column from `int` to `bigint`, enable binary logging on the Aurora cluster on every "managed" environment (staging, test, levelbuilder, production). Binary logging must be enabled for the `gh-ost` utility.

The standard `aws/ci_build` process will apply this change to the Aurora cluster's ParameterGroup in any environment whose branch this change is merged into, but the change will [not take effect until the writer database is restarted](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_LogAccess.MySQL.BinaryFormat.html) (via manual action). 



## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

**WARNING** - It turns out changing a static ParameterGroup setting triggers restart of all database instances in the cluster. This type of change may be best applied manually, so we can control and monitor the brief system downtime.

## Follow-up work

Implement the schema change for non-production environments with a Pegasus/Sequel migration.
Implement the schema change in the production environment using `gh-ost`.
Potentially disable binary logging again when the schema change is complete in production, unless it does not degrade write performance.

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
