### PR TITLE
AccHack - Remove empty h1 tags on /views/tutorial_promo2

### DIFF
--- a/pegasus/sites.v3/code.org/views/tutorial_promo2.html
+++ b/pegasus/sites.v3/code.org/views/tutorial_promo2.html
@@ -3,9 +3,6 @@
   <div class="img-container">
     <img class="background-img" height="671" src="%background_image%" alt="%alt_text%" width="1940"/>
   </div>
-  <h1 class="tutorial-heading">
-    %heading%
-  </h1>
   <div class="col-25 specific-tutorial left-tutorial col-rtl-right">
     <div class="tutorial-box" style="background-color: %box_background_color%">
       <h2 class="specific-tutorial-heading" style="color: %text_color%">


### PR DESCRIPTION
Remove the empty and unused h1 tag from the `tutorial_promo2` header view that's used on https://code.org/thebadguys and https://code.org/poetry

Note: I did a full repo search for where the `tutorial_promo2` view is being used and these were the only two pages that came up that are still being used. 

**Jira ticket:** https://codedotorg.atlassian.net/browse/A11Y-29

----

### /thebadguys
#### Before
![BG_Before](https://user-images.githubusercontent.com/9256643/207727554-63585e70-e222-40b4-83ad-959045a6236c.png)

#### After
<img width="973" alt="BG_After" src="https://user-images.githubusercontent.com/9256643/207727568-77779880-4d4a-4d32-b205-5319393ede7f.png">

----

### /poetry
#### Before
<img width="974" alt="P_Before" src="https://user-images.githubusercontent.com/9256643/207727615-d3bb1395-3d25-429f-8c9c-fd1ce176b03b.png">

#### After
<img width="973" alt="P_After" src="https://user-images.githubusercontent.com/9256643/207727634-ec626d0b-5b6d-40f0-98f6-0ab0de2a7006.png">
