### PR TITLE
Tab navigable javalab settings

### DIFF
--- a/apps/src/javalab/JavalabSettings.jsx
+++ b/apps/src/javalab/JavalabSettings.jsx
@@ -130,8 +130,8 @@ export class UnconnectedJavalabSettings extends Component {
   renderDropdown = () => {
     return (
       <div className={classNames(style.settingsDropdown)}>
-        {this.renderSwitchThemeButton()}
         {this.renderFontSizeSelector()}
+        {this.renderSwitchThemeButton()}
       </div>
     );
   };
@@ -141,7 +141,6 @@ export class UnconnectedJavalabSettings extends Component {
 
     return (
       <div className={style.main}>
-        {dropdownOpen && this.renderDropdown()}
         <JavalabButton
           icon={<FontAwesome icon="cog" />}
           text={msg.settings()}
@@ -152,6 +151,7 @@ export class UnconnectedJavalabSettings extends Component {
           onClick={this.toggleDropdown}
           isHorizontal
         />
+        {dropdownOpen && this.renderDropdown()}
       </div>
     );
   }

--- a/apps/src/javalab/javalab-settings.module.scss
+++ b/apps/src/javalab/javalab-settings.module.scss
@@ -17,6 +17,7 @@
   @extend %dropdown;
   bottom: 40px;
   margin-left: -47px;
+  flex-direction: column-reverse;
 }
 
 .item {


### PR DESCRIPTION
Turns out the settings menu in Javalab was already tab-navigable, but was confusing because you had to shift+tab to get to the menu options once you opened it (b/c the menu options were rendered before the button in the DOM).

Moving the menu options to after the button itself did not affect their positioning. I also set the flex direction of the container to be reversed so that when tab navigating, you get to the font size settings first.

**Javalab Settings (no visible change)**

<img width="1033" alt="image" src="https://user-images.githubusercontent.com/25372625/207743832-89a89ee7-5df4-4e7b-a2bf-edb235572fe4.png">

## Links

- https://codedotorg.atlassian.net/browse/A11Y-25

## Testing story

Tested manually on /projects/javalab/new