### PR TITLE
Add labels to buttons on courses page

### DIFF
--- a/apps/src/templates/Button.jsx
+++ b/apps/src/templates/Button.jsx
@@ -39,6 +39,7 @@ const ButtonHeight = {
 class Button extends React.Component {
   static propTypes = {
     className: PropTypes.string,
+    ariaLabel: PropTypes.string,
     href: PropTypes.string,
     text: PropTypes.string,
     children: PropTypes.node,
@@ -72,6 +73,7 @@ class Button extends React.Component {
   render() {
     const {
       href,
+      ariaLabel,
       text,
       styleAsText,
       icon,
@@ -154,6 +156,7 @@ class Button extends React.Component {
         onKeyDown={this.onKeyDown}
         tabIndex={tabIndex}
         id={id}
+        aria-label={ariaLabel}
       >
         <div style={_.pick(style, ['textAlign'])}>
           {icon && (

--- a/apps/src/templates/studioHomepages/TwoColumnActionBlock.jsx
+++ b/apps/src/templates/studioHomepages/TwoColumnActionBlock.jsx
@@ -23,7 +23,8 @@ export class UnconnectedTwoColumnActionBlock extends Component {
         url: PropTypes.string.isRequired,
         text: PropTypes.string.isRequired,
         target: PropTypes.string,
-        id: PropTypes.string
+        id: PropTypes.string,
+        ariaLabel: PropTypes.string
       })
     ),
     backgroundColor: PropTypes.string,
@@ -81,8 +82,8 @@ export class UnconnectedTwoColumnActionBlock extends Component {
               {buttons.map((button, index) => (
                 <span key={index}>
                   <Button
-                    __useDeprecatedTag
                     href={button.url}
+                    ariaLabel={button.ariaLabel}
                     color={Button.ButtonColor.gray}
                     text={button.text}
                     target={button.target}
@@ -171,7 +172,8 @@ export class CscInfoActionBlock extends Component {
           {
             id: 'course_info_csc',
             url: pegasus('/educate/csc'),
-            text: i18n.learnMore()
+            text: i18n.learnMore(),
+            ariaLabel: i18n.learnMoreCsJourneys()
           }
         ]}
       />

--- a/apps/src/templates/studioHomepages/TwoColumnActionBlock.jsx
+++ b/apps/src/templates/studioHomepages/TwoColumnActionBlock.jsx
@@ -60,7 +60,7 @@ export class UnconnectedTwoColumnActionBlock extends Component {
         <div style={styles.container}>
           {responsiveSize === 'lg' && (
             <div style={{float, width}}>
-              <img src={imageUrl} style={styles.image} alt={heading} />
+              <img src={imageUrl} style={styles.image} alt="" />
               {imageExtra}
             </div>
           )}

--- a/apps/test/unit/code-studio/pd/professional_learning_landing/landingPageTest.js
+++ b/apps/test/unit/code-studio/pd/professional_learning_landing/landingPageTest.js
@@ -84,7 +84,6 @@ describe('LastWorkshopSurveyBanner', () => {
     expect(
       wrapper.containsMatchingElement(
         <Button
-          __useDeprecatedTag
           href={TEST_SURVEY_URL}
           target="_blank"
           text={i18n.plLandingStartSurvey()}

--- a/apps/test/unit/templates/studioHomepages/MarketingAnnouncementBannerTest.jsx
+++ b/apps/test/unit/templates/studioHomepages/MarketingAnnouncementBannerTest.jsx
@@ -114,7 +114,7 @@ describe('MarketingAnnouncementBanner', () => {
     const firehoseSpy = sinon.spy(firehoseClient, 'putRecord');
 
     const wrapper = setUp();
-    wrapper.find('a#announcement-button').simulate('click');
+    wrapper.find('button#announcement-button').simulate('click');
     expect(firehoseSpy.calledOnce);
     firehoseSpy.calledWith({
       study: 'teacher_signedin_homepage',

--- a/shared/haml/course_explorer_table.haml
+++ b/shared/haml/course_explorer_table.haml
@@ -220,12 +220,12 @@
                   %br/
                   =course[:description2]
             - if course[:link]
-              %a.linktag{id: "link-#{course[:id]}", href: course[:link], style: "text-decoration: none"}
+              %a.linktag{id: "link-#{course[:id]}", href: course[:link], style: "text-decoration: none", 'aria-label': "Learn more about #{course[:name]}"}
                 %button.launch{style: "font-size: 12px"}
                   Learn more
             - if course[:course_link]
               &nbsp;
-              %a.linktag{id: "course-link-#{course[:id]}", href: course[:course_link]}
+              %a.linktag{id: "course-link-#{course[:id]}", href: course[:course_link], 'aria-label': "View course #{course[:name]}"}
                 %button.course-explorer-gray-button{style: "font-size: 12px"}
                   View course
         .arrow_box_close{style: "position: absolute; right: 10px; top: 0px; cursor: pointer", data: {courseindex: course[:regular_order]}}
@@ -260,7 +260,7 @@
           .title
             Professional Learning
         .right{style: 'float:right; margin-top: -26px;'}
-          %a.linktag#professional-learning{:href => CDO.code_org_url('/educate/professional-learning')}
+          %a.linktag#professional-learning{:href => CDO.code_org_url('/educate/professional-learning'), :'aria-label' => "Learn more about Professional Learning Opportunities"}
             .course-explorer-gray-button.professional-learning-button.mobile-button
               Learn more
     .cleardiv{style: "clear: both"}
@@ -324,7 +324,5 @@
         .title
           Professional Learning for all grade levels
       .right{style: 'float:right; margin-top: -26px;'}
-        %a.linktag#professional-learning-nonresponsive{:href => CDO.code_org_url('/educate/professional-learning')}
-          .course-explorer-gray-button.professional-learning-button
-            Learn more
+        %a.course-explorer-gray-button.professional-learning-button#professional-learning-nonresponsive{:href => CDO.code_org_url('/educate/professional-learning'), :style => "padding-top: 8px; padding-bottom: 8px; color: #5b6770", :'aria-label' => "Learn more about Professional Learning Opportunities"} Learn more
   .cleardiv{style: "clear: both"}


### PR DESCRIPTION
I updated two parts of the https://studio.code.org/courses?view=teacher, addressing https://codedotorg.atlassian.net/browse/A11Y-47 and https://codedotorg.atlassian.net/browse/A11Y-46.

Some callouts:
1) Rather than changing the text of the buttons, I used aria labels.
1) I added an `aria-label` prop to our Button component –– if we don't set it, it will be blank and thus not read.
1) The `TwoColumnActionBlock` component was using the `Button` component with the `__useDeprecatedTag`. I removed that usage from this component.
1) These might be more suitable to `a` tags than `button` tags? But we were already using the `Button` component and I didn't want to change more than needed –– I tracked that question here https://codedotorg.atlassian.net/browse/A11Y-212.
1) The "Course Explorer" table doesn't have great styling (see screenshots below), but I didn't tackle that here.
1) The "Course Explorer" table is not translated from what I can see. Thus, I added aria labels in a non-translatable way –– if we eventually translate this view, we'll need to create separate strings for each course for translatability.
1) There are lots of other parts of the "Course Explorer" table that are not tab navigable. Tracked here https://codedotorg.atlassian.net/browse/A11Y-213.

See video recording of the labels being read: 
https://user-images.githubusercontent.com/9142121/207757733-73ada0b2-0632-48f7-bcfb-39792e6d68ab.mov

On production the "Course Explorer" table doesn't look great (mobile then Desktop shown):
<img width="481" alt="Screen Shot 2022-12-14 at 3 39 06 PM" src="https://user-images.githubusercontent.com/9142121/207757927-90a6384c-add0-4df7-b35a-154ee3a11a7b.png">
<img width="1151" alt="Screen Shot 2022-12-14 at 3 39 19 PM" src="https://user-images.githubusercontent.com/9142121/207757943-94fd9c49-99e3-4201-bf35-8488e21c57c7.png">

I tried to match styling locally:
<img width="642" alt="Screen Shot 2022-12-14 at 3 39 37 PM" src="https://user-images.githubusercontent.com/9142121/207757802-09033ec9-566d-4669-88da-21572b2b3e7e.png">
<img width="1167" alt="Screen Shot 2022-12-14 at 3 39 28 PM" src="https://user-images.githubusercontent.com/9142121/207757837-ca2c14fd-c101-437a-97fc-75af00861146.png">

CS Connections block on prod:
<img width="1068" alt="image" src="https://user-images.githubusercontent.com/9142121/207758021-0ac45035-1182-488d-9317-6a73d273a7a0.png">

And locally:
<img width="1019" alt="image" src="https://user-images.githubusercontent.com/9142121/207758368-0f509dc6-244d-453f-ab17-14f3c704fa5f.png">


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
