### PR TITLE
Revert "Temporarily enable MySQL binary logging to support schema change on large table"

### DIFF
--- a/aws/cloudformation/db_parameters.yml.erb
+++ b/aws/cloudformation/db_parameters.yml.erb
@@ -8,18 +8,8 @@
 
 # System variables for the Aurora DB cluster.
 AuroraCluster: &aurora
-  # When using row-based logging, the primary database writes events to the binary log that indicate how individual table rows are changed.
-  # Replication of the primary database to a replica works by copying the events representing the changes to the table rows to the replica.
-  # ROW required for DMS Change Data Capture:
-  # https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Source.MySQL.html#CHAP_Source.MySQL.AmazonManaged
-  # ROW also required to use gh-ost to carry out online schema changes on large tables:
-  # https://github.com/github/gh-ost/blob/master/doc/requirements-and-limitations.md
-  binlog_format: ROW
-  # When enabled, this variable causes the primary database to write a checksum for each event in the binary log.
-  # When disabled (value NONE), write and check the event length (rather than a checksum) for each event.
-  # NONE required for DMS Change Data Capture:
-  # https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Source.MySQL.html#CHAP_Source.MySQL.AmazonManaged
-  binlog_checksum: NONE
+  # Disable binary logging to improve write performance.
+  binlog_format: 'OFF'
 
   # Enable GTIDs: https://aws.amazon.com/blogs/database/amazon-aurora-for-mysql-compatibility-now-supports-global-transaction-identifiers-gtids-replication/
   gtid-mode: ON_PERMISSIVE


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#49527

Enabling binary logging is possibly causing some Pegasus tests to fail with the error:

`Statement violates GTID consistency`

Example:

```
Poste Routes::GET /unsubscribe/:email
  test_0002_noops with 200 for non-existing contact              ERROR (0.03s)
Minitest::UnexpectedError:         ActiveRecord::StatementInvalid: Mysql2::Error: Statement violates GTID consistency: CREATE TEMPORARY TABLE and DROP TEMPORARY TABLE can only be executed outside transactional context.  These statements are also not allowed in a function or trigger because functions and triggers are also considered to be multi-statement transactions.
            /var/lib/gems/2.7.0/gems/mysql2-0.5.4/lib/mysql2/client.rb:148:in `_query'
            /var/lib/gems/2.7.0/gems/mysql2-0.5.4/lib/mysql2/client.rb:148:in `block in query'
            /var/lib/gems/2.7.0/gems/mysql2-0.5.4/lib/mysql2/client.rb:147:in `handle_interrupt'
            /var/lib/gems/2.7.0/gems/mysql2-0.5.4/lib/mysql2/client.rb:147:in `query'
            /var/lib/gems/2.7.0/gems/activerecord-6.0.4.1/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:201:in `block (2 levels) in execute'
            /var/lib/gems/2.7.0/gems/activesupport-6.0.4.1/lib/active_support/dependencies/interlock.rb:48:in `block in permit_concurrent_loads'
            /var/lib/gems/2.7.0/gems/activesupport-6.0.4.1/lib/active_support/concurrency/share_lock.rb:187:in `yield_shares'
            /var/lib/gems/2.7.0/gems/activesupport-6.0.4.1/lib/active_support/dependencies/interlock.rb:47:in `permit_concurrent_loads'
            /var/lib/gems/2.7.0/gems/activerecord-6.0.4.1/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:200:in `block in execute'
            /var/lib/gems/2.7.0/gems/activerecord-6.0.4.1/lib/active_record/connection_adapters/abstract_adapter.rb:728:in `block (2 levels) in log'
            /var/lib/gems/2.7.0/gems/activesupport-6.0.4.1/lib/active_support/concurrency/load_interlock_aware_monitor.rb:26:in `block (2 levels) in synchronize'
            /var/lib/gems/2.7.0/gems/activesupport-6.0.4.1/lib/active_support/concurrency/load_interlock_aware_monitor.rb:25:in `handle_interrupt'
            /var/lib/gems/2.7.0/gems/activesupport-6.0.4.1/lib/active_support/concurrency/load_interlock_aware_monitor.rb:25:in `block in synchronize'
            /var/lib/gems/2.7.0/gems/activesupport-6.0.4.1/lib/active_support/concurrency/load_interlock_aware_monitor.rb:21:in `handle_interrupt'
            /var/lib/gems/2.7.0/gems/activesupport-6.0.4.1/lib/active_support/concurrency/load_interlock_aware_monitor.rb:21:in `synchronize'
            /var/lib/gems/2.7.0/gems/activerecord-6.0.4.1/lib/active_record/connection_adapters/abstract_adapter.rb:727:in `block in log'
            /var/lib/gems/2.7.0/gems/activesupport-6.0.4.1/lib/active_support/notifications/instrumenter.rb:24:in `instrument'
            /var/lib/gems/2.7.0/gems/activerecord-6.0.4.1/lib/active_record/connection_adapters/abstract_adapter.rb:718:in `log'
            /var/lib/gems/2.7.0/gems/activerecord-6.0.4.1/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:199:in `execute'
            /var/lib/gems/2.7.0/gems/activerecord-6.0.4.1/lib/active_record/connection_adapters/mysql/database_statements.rb:41:in `execute'
            /var/lib/gems/2.7.0/gems/activerecord-6.0.4.1/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:328:in `drop_table'
            /var/lib/gems/2.7.0/gems/activerecord-6.0.4.1/lib/active_record/connection_adapters/abstract/schema_statements.rb:312:in `create_table'
            /var/lib/gems/2.7.0/gems/activerecord-6.0.4.1/lib/active_record/connection_adapters/mysql/schema_statements.rb:81:in `create_table'
            /home/ubuntu/test/pegasus/test/fixtures/fake_dashboard.rb:244:in `create_table'
            /home/ubuntu/test/pegasus/test/fixtures/fake_dashboard.rb:260:in `create_table'
            /var/lib/gems/2.7.0/gems/activerecord-6.0.4.1/lib/active_record/migration.rb:890:in `block in method_missing'
            /var/lib/gems/2.7.0/gems/activerecord-6.0.4.1/lib/active_record/migration.rb:858:in `block in say_with_time'
            /usr/lib/ruby/2.7.0/benchmark.rb:293:in `measure'
            /var/lib/gems/2.7.0/gems/activerecord-6.0.4.1/lib/active_record/migration.rb:858:in `say_with_time'
            /var/lib/gems/2.7.0/gems/activerecord-6.0.4.1/lib/active_record/migration.rb:879:in `method_missing'
            /home/ubuntu/test/dashboard/db/schema.rb:428:in `block in <top (required)>'
            /var/lib/gems/2.7.0/gems/activerecord-6.0.4.1/lib/active_record/schema.rb:50:in `instance_eval'
            /var/lib/gems/2.7.0/gems/activerecord-6.0.4.1/lib/active_record/schema.rb:50:in `define'
            /var/lib/gems/2.7.0/gems/activerecord-6.0.4.1/lib/active_record/schema.rb:46:in `define'
            /home/ubuntu/test/dashboard/db/schema.rb:13:in `<top (required)>'
            /home/ubuntu/test/pegasus/test/fixtures/fake_dashboard.rb:312:in `require_relative'
            /home/ubuntu/test/pegasus/test/fixtures/fake_dashboard.rb:312:in `block in create_fake_dashboard_db'
            /var/lib/gems/2.7.0/gems/activerecord-6.0.4.1/lib/active_record/connection_adapters/abstract/database_statements.rb:280:in `block in transaction'
            /var/lib/gems/2.7.0/gems/activerecord-6.0.4.1/lib/active_record/connection_adapters/abstract/transaction.rb:280:in `block in within_new_transaction'
            /var/lib/gems/2.7.0/gems/activesupport-6.0.4.1/lib/active_support/concurrency/load_interlock_aware_monitor.rb:26:in `block (2 levels) in synchronize'
            /var/lib/gems/2.7.0/gems/activesupport-6.0.4.1/lib/active_support/concurrency/load_interlock_aware_monitor.rb:25:in `handle_interrupt'
            /var/lib/gems/2.7.0/gems/activesupport-6.0.4.1/lib/active_support/concurrency/load_interlock_aware_monitor.rb:25:in `block in synchronize'
            /var/lib/gems/2.7.0/gems/activesupport-6.0.4.1/lib/active_support/concurrency/load_interlock_aware_monitor.rb:21:in `handle_interrupt'
            /var/lib/gems/2.7.0/gems/activesupport-6.0.4.1/lib/active_support/concurrency/load_interlock_aware_monitor.rb:21:in `synchronize'
            /var/lib/gems/2.7.0/gems/activerecord-6.0.4.1/lib/active_record/connection_adapters/abstract/transaction.rb:278:in `within_new_transaction'
            /var/lib/gems/2.7.0/gems/activerecord-6.0.4.1/lib/active_record/connection_adapters/abstract/database_statements.rb:280:in `transaction'
```