### PR TITLE
Add empty alt text to run/reset buttons

### DIFF
--- a/apps/src/templates/GameButtons.jsx
+++ b/apps/src/templates/GameButtons.jsx
@@ -26,7 +26,7 @@ export const RunButton = Radium(props => (
     style={props.style}
   >
     <div>{props.runButtonText || msg.runProgram()}</div>
-    <img src={blankImg} className="run26" />
+    <img src={blankImg} className="run26" alt="" />
   </button>
 ));
 RunButton.propTypes = {
@@ -50,7 +50,7 @@ export const ResetButton = Radium(props => (
     style={[commonStyles.hidden, props.style]}
   >
     <div>{!props.hideText && msg.resetProgram()}</div>
-    <img src={blankImg} className="reset26" />
+    <img src={blankImg} className="reset26" alt="" />
   </button>
 ));
 ResetButton.propTypes = {


### PR DESCRIPTION
Add empty alt text to the run/reset buttons, since these buttons already have text explaining themselves. The ticket was just for the app lab run button, but I updated reset as well since it's the same file. This component is used in many labs, not just App Lab.

## Links

- jira ticket: [A11Y-34](https://codedotorg.atlassian.net/browse/A11Y-34)

## Testing story
Tested locally that empty alt text was now in the html and there were no visible changes.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
