### PR TITLE
Fix tab-navigation for ContentContainer links

### DIFF
--- a/apps/src/templates/ContentContainer.jsx
+++ b/apps/src/templates/ContentContainer.jsx
@@ -97,9 +97,9 @@ class Link extends Component {
         <a href={link}>
           {isRtl && <FontAwesome icon={icon} style={styles.chevronRtl} />}
           <div style={styles.linkToViewAll}>{linkText}</div>
-        </a>
-        <a href={link} style={{textDecoration: 'none'}}>
-          {!isRtl && <FontAwesome icon={icon} style={styles.chevron} />}
+          <span style={{display: 'inline-block'}}>
+            {!isRtl && <FontAwesome icon={icon} style={styles.chevron} />}
+          </span>
         </a>
       </div>
     );

--- a/apps/src/templates/ContentContainer.jsx
+++ b/apps/src/templates/ContentContainer.jsx
@@ -95,7 +95,9 @@ class Link extends Component {
     return (
       <div style={linkBoxStyle}>
         <a href={link}>
-          {isRtl && <FontAwesome icon={icon} style={styles.chevronRtl} />}
+          <span style={{display: 'inline-block'}}>
+            {isRtl && <FontAwesome icon={icon} style={styles.chevronRtl} />}
+          </span>
           <div style={styles.linkToViewAll}>{linkText}</div>
           <span style={{display: 'inline-block'}}>
             {!isRtl && <FontAwesome icon={icon} style={styles.chevron} />}


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Moves the chevron inside the same link as the text, and renders it "inline-block" so it doesn't get underlined on hover.

LTR:
![image](https://user-images.githubusercontent.com/1382374/207928392-77612935-4a58-48dc-a672-7b4ae67ce4f1.png)

RTL:
![image](https://user-images.githubusercontent.com/1382374/207929666-c1e2adce-e205-46ce-8037-50604906ab47.png)


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
-->
- jira ticket: [A11Y-24](https://codedotorg.atlassian.net/browse/A11Y-24)

