### PR TITLE
Add alt text to SectionLoginInfo images

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1246,6 +1246,7 @@
   "loginInfo_joinTitle": "Joining Your Section (one-time only)",
   "loginInfo_joinBody": "If a student has not yet joined your section, please ask them to perform the following steps. Note that they only need to do this once. By joining your section, students will be able see the course assigned to them and you will be able to track the progress of the work they complete while they are signed in.",
   "loginInfo_joinStep1": "Create a Code.org account if they haven’t already done so. They can do this at {url}. Note that they can either sign up with an email address and password, or sign up through Google, Facebook, or Microsoft by clicking on one of these buttons:",
+  "loginInfo_joinStep1Buttons": "Screenshot of three buttons, reading 'Continue with Google', 'Continue with Facebook', and 'Continue with Microsoft'",
   "loginInfo_joinStep2": "Sign in to their Code.org account.",
   "loginInfo_joinStep3": "Navigate to {url} and type in their section code: {code}.",
   "loginInfo_joinStep4": "Once they press the \"Go\" button, they should be added to your section.",

--- a/apps/src/templates/teacherDashboard/SectionLoginInfo.jsx
+++ b/apps/src/templates/teacherDashboard/SectionLoginInfo.jsx
@@ -148,7 +148,10 @@ class EmailLogins extends React.Component {
               url: `${studioUrlPrefix}/users/sign_up`
             })}
             <br />
-            <img src={oauthSignInButtons} />
+            <img
+              src={oauthSignInButtons}
+              alt={i18n.loginInfo_joinStep1Buttons()}
+            />
           </li>
           <li>{i18n.loginInfo_joinStep2()}</li>
           <li>
@@ -332,6 +335,7 @@ class LoginCard extends React.Component {
             <br />
             <img
               src={pegasus(`/images/${student.secretPicturePath}`)}
+              alt={student.secretPictureName}
               style={styles.img}
             />
             <br />

--- a/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
+++ b/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
@@ -1283,6 +1283,7 @@ export const studentFromServerStudent = (serverStudent, sectionId) => ({
   name: serverStudent.name,
   sharingDisabled: serverStudent.sharing_disabled,
   secretPicturePath: serverStudent.secret_picture_path,
+  secretPictureName: serverStudent.secret_picture_name,
   secretWords: serverStudent.secret_words
 });
 


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Add alt text to two images in the SectionLoginInfo component that were missing it.

The first is a screenshot of oauth login buttons that's part of the login instructions:

![oauthSignInButtons](https://user-images.githubusercontent.com/1382374/207941927-fbd62425-8f60-4f04-91df-fbce07b3691c.png)

The second is the secret image, which now has the secret image name, e.g. "ninja":

![image](https://user-images.githubusercontent.com/1382374/207941758-4833eee9-dfc4-4a1c-81f1-64f59d7bdcd4.png)

Note the secret image name will not be translated; I'm not sure there's a way around that.


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
-->
- jira ticket: [A11Y-198](https://codedotorg.atlassian.net/browse/A11Y-198)

