### PR TITLE
Make input marker in debug console a <label>

### DIFF
--- a/apps/src/lib/tools/jsdebugger/DebugConsole.jsx
+++ b/apps/src/lib/tools/jsdebugger/DebugConsole.jsx
@@ -7,6 +7,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';
+import i18n from '@cdo/locale';
 
 import {KeyCodes} from '../../../constants';
 import {
@@ -357,9 +358,9 @@ export default connect(
                 : style.debugInputWrapper
             }
           >
-            <span style={style.debugInputPrompt} onClick={this.focus}>
+            <label htmlFor="debug-input" style={style.debugInputPrompt}>
               &gt;
-            </span>
+            </label>
             <input
               type="text"
               spellCheck="false"
@@ -368,6 +369,7 @@ export default connect(
               style={style.debugInput}
               ref={el => (this._debugInput = el)}
               onKeyDown={this.onInputKeyDown}
+              aria-label={i18n.debugConsoleHeader()}
             />
           </div>
         </div>


### PR DESCRIPTION
Makes the ">" marking input in Applab/Gamelab's debug console a label for the input, which makes it auto-focus when clicked (this was the goal of a pre-existing onclick). Add an aria-label to the input itself, since the ">" label isn't helpful from a screenreader perspective.

**Debug console in Applab (UI unaffected by this change)**

<img width="1222" alt="image" src="https://user-images.githubusercontent.com/25372625/207959305-0d594d99-fb95-4e51-8229-f5d0be8c134e.png">

## Links

https://codedotorg.atlassian.net/browse/A11Y-164

## Testing story

Tested clicking on ">" focuses input, and using a screen reader resulted in reading the aria label when visited via tab navigation.