### PR TITLE
Adding graceful handling of doc examples not having a unique name

### DIFF
--- a/dashboard/app/models/programming_expression.rb
+++ b/dashboard/app/models/programming_expression.rb
@@ -19,6 +19,8 @@
 #  index_programming_expressions_on_programming_environment_id  (programming_environment_id)
 #  programming_environment_key                                  (programming_environment_id,key) UNIQUE
 #
+require 'honeybadger/ruby'
+
 class ProgrammingExpression < ApplicationRecord
   include CurriculumHelper
   include SerializedProperties
@@ -273,6 +275,10 @@ class ProgrammingExpression < ApplicationRecord
     )
     if i18n_examples != localized_examples
       localized_examples&.each do |example|
+        if example['name'].nil?
+          report_error_get_localized_examples_no_name(example)
+          next
+        end
         example_key = example['name'].to_sym
         unless i18n_examples[example_key].nil?
           example['name'] = i18n_examples[example_key][:name] unless i18n_examples[example_key][:name].nil?
@@ -283,6 +289,15 @@ class ProgrammingExpression < ApplicationRecord
       end
     end
     localized_examples
+  end
+
+  def report_error_get_localized_examples_no_name(example)
+    Honeybadger.notify(
+      "example needs a unique 'name', otherwise a translation cannot be shown",
+      context: {
+        example: example
+      }
+    )
   end
 
   def get_localized_params


### PR DESCRIPTION
**bug** - When visiting https://studio.code.org/docs/ide/applab/expressions/appendItem the user gets a "Sad Bee" page.
**cause** - `nullMethodError` exception because we tried to load the unique name of an `example`, but there is no `name` defined.
**fix** - Skip translating the example if there is no unique identifier, but still log an error so the team knows a name needs to be added.

## Links
* [HoneyBadger](https://app.honeybadger.io/projects/3240/faults/91779229)

## Testing story
* Visited http://localhost-studio.code.org:3000/docs/ide/applab/expressions/appendItem and confirmed the page loaded successfully. I also checked `dashboard/log/development.log` to make sure HoneyBadger was trying to log an error.

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Follow-up work
* The teacher tools team has a task to make sure no new documentation examples get added without a unique name: https://codedotorg.atlassian.net/browse/TEACH-1?atlOrigin=eyJpIjoiZjczNGVlYjQ4NzY3NGI0MTllYjcxZThmODFiMzNkZGUiLCJwIjoiamlyYS1zbGFjay1pbnQifQ
