### PR TITLE
Updating and restyling buttons on unit overview page

### DIFF
--- a/apps/src/templates/progress/HiddenForSectionToggle.jsx
+++ b/apps/src/templates/progress/HiddenForSectionToggle.jsx
@@ -30,7 +30,6 @@ class HiddenForSectionToggle extends React.Component {
     return (
       <div style={mainStyle} className="uitest-togglehidden">
         <Button
-          __useDeprecatedTag
           onClick={() => !disabled && onChange('visible')}
           text={i18n.visible()}
           color={Button.ButtonColor.gray}
@@ -39,7 +38,6 @@ class HiddenForSectionToggle extends React.Component {
           style={{...styles.button, ...styles.leftButton}}
         />
         <Button
-          __useDeprecatedTag
           onClick={() => !disabled && onChange('hidden')}
           text={i18n.hidden()}
           color={Button.ButtonColor.gray}
@@ -55,9 +53,7 @@ class HiddenForSectionToggle extends React.Component {
 const styles = {
   main: {
     wrap: 'nowrap',
-    marginTop: 5,
-    marginLeft: 15,
-    marginRight: 15
+    margin: '5px 15px'
   },
   disabled: {
     opacity: 0.5
@@ -67,7 +63,8 @@ const styles = {
     paddingLeft: 0,
     paddingRight: 0,
     boxSizing: 'border-box',
-    width: '50%'
+    width: '50%',
+    margin: '5px 0px'
   },
   leftButton: {
     borderTopRightRadius: 0,

--- a/apps/src/templates/progress/LessonLock.jsx
+++ b/apps/src/templates/progress/LessonLock.jsx
@@ -48,6 +48,7 @@ const styles = {
     marginLeft: 15,
     marginRight: 15
   },
+  // Using 'margin' instead of 'marginTop' intentionally to override styling
   button: {
     paddingLeft: 0,
     paddingRight: 0,

--- a/apps/src/templates/progress/LessonLock.jsx
+++ b/apps/src/templates/progress/LessonLock.jsx
@@ -15,7 +15,6 @@ const LessonLock = ({unitId, lessonId, isHidden}) => {
     <div style={styles.main}>
       <div style={styles.buttonContainer} className="uitest-locksettings">
         <Button
-          __useDeprecatedTag
           onClick={() => setDialogOpen(true)}
           color={Button.ButtonColor.gray}
           text={i18n.lockSettings()}
@@ -52,7 +51,8 @@ const styles = {
   button: {
     paddingLeft: 0,
     paddingRight: 0,
-    width: '100%'
+    width: '100%',
+    margin: '5px 0px 0px 0px'
   }
 };
 

--- a/apps/src/templates/progress/ProgressLessonTeacherInfo.jsx
+++ b/apps/src/templates/progress/ProgressLessonTeacherInfo.jsx
@@ -102,7 +102,6 @@ class ProgressLessonTeacherInfo extends React.Component {
         {lesson.lesson_plan_html_url && (
           <div style={styles.buttonContainer}>
             <Button
-              __useDeprecatedTag
               href={lesson.lesson_plan_html_url}
               text={i18n.viewLessonPlan()}
               icon="file-text"
@@ -115,7 +114,6 @@ class ProgressLessonTeacherInfo extends React.Component {
         {lesson.student_lesson_plan_html_url && (
           <div style={styles.buttonContainer}>
             <Button
-              __useDeprecatedTag
               href={lesson.student_lesson_plan_html_url}
               text={i18n.studentResources()}
               icon="file-text"
@@ -147,7 +145,6 @@ class ProgressLessonTeacherInfo extends React.Component {
         {lesson.lesson_feedback_url && (
           <div style={styles.buttonContainer}>
             <Button
-              __useDeprecatedTag
               href={lesson.lesson_feedback_url}
               text={i18n.rateThisLesson()}
               icon="bar-chart"
@@ -177,6 +174,7 @@ const styles = {
   },
   button: {
     width: '100%',
+    margin: '5px 0px 0px 0px',
     paddingLeft: 0,
     paddingRight: 0
   }

--- a/apps/src/templates/progress/ProgressLessonTeacherInfo.jsx
+++ b/apps/src/templates/progress/ProgressLessonTeacherInfo.jsx
@@ -172,6 +172,7 @@ const styles = {
     marginLeft: 15,
     marginRight: 15
   },
+  // Using 'margin' instead of 'marginTop' intentionally to override styling
   button: {
     width: '100%',
     margin: '5px 0px 0px 0px',

--- a/apps/src/templates/progress/SendLesson.jsx
+++ b/apps/src/templates/progress/SendLesson.jsx
@@ -45,7 +45,6 @@ export default class SendLesson extends React.Component {
     return (
       <div className="uitest-sendlesson">
         <Button
-          __useDeprecatedTag
           onClick={this.openDialog}
           text={i18n.sendLessonButton()}
           icon="share-square-o"

--- a/apps/test/unit/templates/progress/HiddenForSectionToggleTest.jsx
+++ b/apps/test/unit/templates/progress/HiddenForSectionToggleTest.jsx
@@ -14,14 +14,12 @@ describe('HiddenForSectionToggle', () => {
     expect(wrapper).to.containMatchingElement(
       <div>
         <Button
-          __useDeprecatedTag
           text={i18n.visible()}
           color={Button.ButtonColor.gray}
           disabled={true}
           icon="eye"
         />
         <Button
-          __useDeprecatedTag
           text={i18n.hidden()}
           color={Button.ButtonColor.gray}
           disabled={false}
@@ -34,8 +32,8 @@ describe('HiddenForSectionToggle', () => {
     wrapper.setProps({hidden: true});
     expect(wrapper).to.containMatchingElement(
       <div>
-        <Button __useDeprecatedTag text={i18n.visible()} disabled={false} />
-        <Button __useDeprecatedTag text={i18n.hidden()} disabled={true} />
+        <Button text={i18n.visible()} disabled={false} />
+        <Button text={i18n.hidden()} disabled={true} />
       </div>
     );
   });


### PR DESCRIPTION
This reworks the styling of the unit overview page and the included buttons. I couldn't do one button without fixing the others or the page would look wonky! This also makes all these buttons tab navigable:)

I also ended up editing the margins of that section (for both surveys and not) to fix the top and bottom spacing- first and last buttons were not evenly spaced.

See before and after photos for details:)

Before:
<img width="1069" alt="Screen Shot 2022-12-15 at 12 54 20 PM" src="https://user-images.githubusercontent.com/37230822/207973376-cd30c1f9-e2c3-4c62-842f-fa82a4d62b2f.png">

After:
<img width="1012" alt="Screen Shot 2022-12-15 at 1 37 41 PM" src="https://user-images.githubusercontent.com/37230822/207973365-2e5a00a3-cea9-4ccc-9624-8c258792f347.png">

## Links


- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/A11Y-103
- https://codedotorg.atlassian.net/browse/A11Y-215
- https://codedotorg.atlassian.net/browse/A11Y-102
- https://codedotorg.atlassian.net/browse/A11Y-100
- https://codedotorg.atlassian.net/browse/A11Y-152

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
