### PR TITLE
Make the immersive reader button tabbable

### DIFF
--- a/apps/src/templates/instructions/ImmersiveReaderButton.jsx
+++ b/apps/src/templates/instructions/ImmersiveReaderButton.jsx
@@ -32,6 +32,7 @@ class ImmersiveReaderButton extends Component {
 
     return (
       <div
+        tabIndex="0"
         ref={el => (this.container = el)}
         className={'immersive-reader-button'}
         data-button-style={'icon'}

--- a/apps/src/templates/instructions/ImmersiveReaderButton.jsx
+++ b/apps/src/templates/instructions/ImmersiveReaderButton.jsx
@@ -21,6 +21,14 @@ class ImmersiveReaderButton extends Component {
     }
   }
 
+  handleKeyDown(event, locale, title, text) {
+    // should trigger button press on enter or space pressed
+    if (event.key === 'Enter' || event.key === ' ') {
+      handleLaunchImmersiveReader(locale, title, text);
+      event.preventDefault();
+    }
+  }
+
   render() {
     const {title, text} = this.props;
     // Get the current language from the language cookie.
@@ -32,7 +40,8 @@ class ImmersiveReaderButton extends Component {
 
     return (
       <div
-        tabIndex="0"
+        tabIndex={0}
+        role="button"
         ref={el => (this.container = el)}
         className={'immersive-reader-button'}
         data-button-style={'icon'}
@@ -40,6 +49,7 @@ class ImmersiveReaderButton extends Component {
         onClick={function() {
           handleLaunchImmersiveReader(locale, title, text);
         }}
+        onKeyDown={e => this.handleKeyDown(e, locale, title, text)}
       />
     );
   }


### PR DESCRIPTION
Make the immersive reader button reachable via keyboard navigation. This unfortunately needs to stay a div because that is what the immersive reader api [expects](https://learn.microsoft.com/en-us/azure/applied-ai-services/immersive-reader/reference).

## Links
- jira ticket: [A11Y-159](https://codedotorg.atlassian.net/browse/A11Y-159) This ticket covers the immersive reader portion, the tts portion is covered by [Sanchit's PR](https://github.com/code-dot-org/code-dot-org/pull/49521)


## Testing story
Tested that the button is now reachable by tabbing

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
