### PR TITLE
Make project rename input/submit keyboard accessible

### DIFF
--- a/apps/src/code-studio/components/header/EditableProjectName.jsx
+++ b/apps/src/code-studio/components/header/EditableProjectName.jsx
@@ -16,7 +16,8 @@ import NameFailureError from '../../NameFailureError';
 export const styles = {
   buttonWrapper: {
     float: 'left',
-    display: 'flex'
+    display: 'flex',
+    margin: 0
   },
   buttonSpacing: {
     marginTop: 0,
@@ -72,6 +73,23 @@ class UnconnectedEditProjectName extends React.Component {
     savingName: false
   };
 
+  componentDidMount() {
+    this.nameChangeInput.focus();
+
+    // Cancel when ESC key is released.
+    this.nameChangeInput.addEventListener('keyup', this.onCancel);
+  }
+
+  componentWillUnmount() {
+    this.nameChangeInput.removeEventListener('keyup', this.onCancel);
+  }
+
+  onCancel = event => {
+    if (event.code === 'Escape') {
+      this.props.finishEdit();
+    }
+  };
+
   saveNameChange = () => {
     if (this.state.savingName) {
       return;
@@ -106,37 +124,44 @@ class UnconnectedEditProjectName extends React.Component {
       });
   };
 
+  onSubmit = event => {
+    event.preventDefault();
+    this.saveNameChange();
+  };
+
   render() {
     // Use an uncontrolled input for the "rename" operation so our UI tests
     // can easily interface with it
     return (
-      <div style={styles.buttonWrapper}>
-        <div className="project_name_wrapper header_text">
-          <input
-            type="text"
-            className="project_name header_input"
-            maxLength="100"
-            defaultValue={this.props.projectName}
-            ref={input => {
-              this.nameChangeInput = input;
-            }}
-          />
-        </div>
-        <button
-          type="button"
-          className="project_save header_button header_button_light no-mc"
-          onClick={this.saveNameChange}
-          disabled={this.state.savingName}
-          style={styles.buttonSpacing}
-        >
-          {i18n.save()}
-        </button>
+      <>
+        <form onSubmit={this.onSubmit} style={styles.buttonWrapper}>
+          <div className="project_name_wrapper header_text">
+            <input
+              type="text"
+              className="project_name header_input"
+              maxLength="100"
+              defaultValue={this.props.projectName}
+              ref={input => {
+                this.nameChangeInput = input;
+              }}
+            />
+          </div>
+          <button
+            type="button"
+            className="project_save header_button header_button_light no-mc"
+            onClick={this.saveNameChange}
+            disabled={this.state.savingName}
+            style={styles.buttonSpacing}
+          >
+            {i18n.save()}
+          </button>
+        </form>
         <NameFailureDialog
           flaggedText={this.props.projectNameFailure}
           isOpen={!!this.props.projectNameFailure}
           handleClose={this.props.unsetNameFailure}
         />
-      </div>
+      </>
     );
   }
 }


### PR DESCRIPTION
Improves the keyboard accessibility of the project rename functionality:

<img width="501" alt="Screen Shot 2022-12-15 at 2 45 51 PM" src="https://user-images.githubusercontent.com/9812299/207983349-1bdf1f4e-fb43-430b-8f67-eee7af07752d.png">

Before, when you clicked "Rename," your cursor was in an undiscoverable location. Now:

- The project rename input is focused when you click "Rename"
- The input and submit button are a `<form>`, which is semantically correct, and means the user can hit "Enter" to submit and rename the project
- Hitting "Escape" will cancel the rename action. Previously, there was no way to cancel -- once you clicked "Rename" you had to click "Save" or reload the page to cancel.

## Links

- [A11Y-44](https://codedotorg.atlassian.net/browse/A11Y-44)
