### PR TITLE
Stop testing java lab on mobile

### DIFF
--- a/dashboard/test/ui/features/javalab/finish_button.feature
+++ b/dashboard/test/ui/features/javalab/finish_button.feature
@@ -1,4 +1,4 @@
-# Item to track renabling this: https://codedotorg.atlassian.net/browse/SL-375
+# We don't support Java Lab on mobile.
 @no_circle @no_phone
 Feature: Finish Button
 


### PR DESCRIPTION
Just a quick update to close out https://codedotorg.atlassian.net/browse/SL-375. We don't care about testing Java Lab on mobile, so noting that in the tests.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
