### PR TITLE
Remove _useDeprecated tag from PersonalProjectsPublishedCell

### DIFF
--- a/apps/src/templates/projects/PersonalProjectsPublishedCell.jsx
+++ b/apps/src/templates/projects/PersonalProjectsPublishedCell.jsx
@@ -33,7 +33,6 @@ class PersonalProjectsPublishedCell extends Component {
       <div>
         {showPublishButton && (
           <Button
-            __useDeprecatedTag
             onClick={this.onPublish}
             color={Button.ButtonColor.gray}
             text={i18n.publish()}
@@ -42,7 +41,6 @@ class PersonalProjectsPublishedCell extends Component {
         )}
         {showUnpublishButton && (
           <Button
-            __useDeprecatedTag
             onClick={this.onUnpublish}
             color={Button.ButtonColor.gray}
             text={i18n.unpublish()}


### PR DESCRIPTION
Removes _useDeprecated tag from PersonalProjectsPublishedCell. The only visual change was a bit of shading on the button went away, which I think is acceptable because now these buttons match the "View full list" button that is above them.
## Before

<img width="165" alt="Screen Shot 2022-12-15 at 3 28 18 PM" src="https://user-images.githubusercontent.com/33666587/207989566-8a4a8120-a372-409d-9e88-9e4ce9943dbd.png">

## After
<img width="165" alt="Screen Shot 2022-12-15 at 3 28 44 PM" src="https://user-images.githubusercontent.com/33666587/207989577-e5cc8adf-3f6e-4df6-a8f4-d986a1f9f306.png">


## View full list button
<img width="165" alt="Screen Shot 2022-12-15 at 3 40 18 PM" src="https://user-images.githubusercontent.com/33666587/207989604-8b4ba4fe-bd71-42ed-a0f9-bb357999b9b6.png">



## Links

- jira ticket: [A11Y-96](https://codedotorg.atlassian.net/browse/A11Y-96)

## Testing story
Tested locally

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
