### PR TITLE
<button> instead of <div> in hoc /learn filters

### DIFF
--- a/apps/src/tutorialExplorer/filterGroupHeaderSelection.jsx
+++ b/apps/src/tutorialExplorer/filterGroupHeaderSelection.jsx
@@ -47,13 +47,14 @@ export default class FilterGroupHeaderSelection extends React.Component {
       <div style={{...styles.container, ...this.props.containerStyle}}>
         <div style={styles.flexContainer}>
           {this.props.filterGroup.entries.map((item, index) => (
-            <div
+            <button
               key={item.name}
+              type="button"
               onClick={this.handleChange.bind(this, item.name)}
               style={{...styles.item, ...this.itemStyle(index)}}
             >
               {item.text}
-            </div>
+            </button>
           ))}
         </div>
       </div>
@@ -66,7 +67,6 @@ const styles = {
     display: 'inline-block',
     marginTop: 6,
     overflow: 'hidden',
-    height: 34,
     lineHeight: '34px',
     border: 'solid 1px #a2a2a2',
     borderRadius: 5
@@ -86,7 +86,12 @@ const styles = {
     flex: 1,
     userSelect: 'none',
     boxSizing: 'border-box',
-    borderLeft: 'solid 1px white'
+    border: 'none',
+    borderLeft: 'solid 1px white',
+    borderRadius: 0,
+    padding: 0,
+    display: 'flex',
+    justifyContent: 'center'
   },
   select: {
     backgroundColor: '#2799a4',


### PR DESCRIPTION
Uses buttons instead of divs in the grade level and experience filters on hourofcode.com/learn.

**New (left) and old (right)** -- very slightly taller in new version, container was overflowing
![image](https://user-images.githubusercontent.com/25372625/207996484-ec142036-bace-43ac-befa-9abdf6d4cfcf.png)

## Links

https://codedotorg.atlassian.net/browse/A11Y-68

## Testing story

Tested manually that I could tab navigate and hit enter to select each filter.