### PR TITLE
Remove gender selection

### DIFF
--- a/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
+++ b/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
@@ -15,7 +15,6 @@ const TEACHER_ONLY_FIELDS = [
 ];
 const STUDENT_ONLY_FIELDS = [
   '#student-name-label',
-  '#gender-dropdown',
   '#age-dropdown',
   '#student-consent',
   '#parent-email-container',

--- a/dashboard/app/views/devise/registrations/_finish_sign_up.html.haml
+++ b/dashboard/app/views/devise/registrations/_finish_sign_up.html.haml
@@ -98,14 +98,6 @@
       .span5
         = f.select :age, age_options, include_blank: true
 
-    .row#gender-dropdown{style: "display: none;"}
-      .span3.signup-field-label
-        = f.label :gender, t('signup_form.gender')
-      - if @user.errors[:gender].present?
-        %span.error= @user.errors[:gender].join(', ')
-      .span5
-        = f.select :gender, gender_options
-
     .row#school-info-section{style: "display: none;"}
       .span10
         -# Mount point for React SchoolInfoInputs component.

--- a/dashboard/app/views/devise/registrations/edit.html.haml
+++ b/dashboard/app/views/devise/registrations/edit.html.haml
@@ -62,9 +62,6 @@
       = f.password_field :current_password, maxlength: 255
   - if !resource.teacher?
     .field
-      = f.label t('signup_form.gender'), class: "label-bold"
-      = f.select :gender, gender_options
-    .field
       = f.label t('signup_form.age'), class: "label-bold"
       = f.select :age, User::AGE_DROPDOWN_OPTIONS
   - if resource.teacher?

--- a/dashboard/app/views/followers/student_user_new.html.haml
+++ b/dashboard/app/views/followers/student_user_new.html.haml
@@ -81,10 +81,6 @@
                 .labelblock
                   = t('signup_form.age')
                 = f.select :age, User::AGE_DROPDOWN_OPTIONS, include_blank: true, class: 'fieldblock'
-              .itemblock
-                .labelblock
-                  = t('signup_form.gender')
-                = f.select :gender, gender_options
             %br/
             = submit_tag 'Register', class: 'btn btn-primary'
 


### PR DESCRIPTION
This PR removes the Gender selection from the Account Sign-up pages and the Edit Account Details pages, as per internal thread. This PR will probably be reverted in favor of a longer term solution.

## Testing story
* Went through the student account creation flow and confirmed gender is not shown.
* Went to the Edit User Account page, confirmed gender is not shown, and confirmed you can successfully update your other attributes.
* Test the account creation flow through the Join a Section page. http://studio.code.org/join

