### PR TITLE
Music: add repeat to simple blocks set

### DIFF
--- a/apps/src/music/blockly/toolbox.js
+++ b/apps/src/music/blockly/toolbox.js
@@ -224,6 +224,23 @@ const baseToolboxSimple = {
         {
           kind: 'block',
           type: BlockTypes.SET_CURRENT_LOCATION_NEXT_MEASURE
+        },
+        {
+          kind: 'block',
+          type: 'controls_repeat_ext',
+          fields: {
+            OP: 'TIMES'
+          },
+          inputs: {
+            TIMES: {
+              shadow: {
+                type: 'math_number',
+                fields: {
+                  NUM: 2
+                }
+              }
+            }
+          }
         }
       ]
     }


### PR DESCRIPTION
This adds the regular Blockly "repeat" block to the simple blocks set, which can be seen when the URL contains `blocks=simple`.

Follow-up to https://github.com/code-dot-org/code-dot-org/pull/49220.  

<img width="906" alt="Screenshot 2022-12-16 at 9 53 56 PM" src="https://user-images.githubusercontent.com/2205926/208083796-aa74ffd4-f07e-470c-ad3e-3cb29037db49.png">
