### PR TITLE
Revert "Updating and restyling buttons on unit overview page"

### DIFF
--- a/apps/src/templates/progress/HiddenForSectionToggle.jsx
+++ b/apps/src/templates/progress/HiddenForSectionToggle.jsx
@@ -30,6 +30,7 @@ class HiddenForSectionToggle extends React.Component {
     return (
       <div style={mainStyle} className="uitest-togglehidden">
         <Button
+          __useDeprecatedTag
           onClick={() => !disabled && onChange('visible')}
           text={i18n.visible()}
           color={Button.ButtonColor.gray}
@@ -38,6 +39,7 @@ class HiddenForSectionToggle extends React.Component {
           style={{...styles.button, ...styles.leftButton}}
         />
         <Button
+          __useDeprecatedTag
           onClick={() => !disabled && onChange('hidden')}
           text={i18n.hidden()}
           color={Button.ButtonColor.gray}
@@ -53,7 +55,9 @@ class HiddenForSectionToggle extends React.Component {
 const styles = {
   main: {
     wrap: 'nowrap',
-    margin: '5px 15px'
+    marginTop: 5,
+    marginLeft: 15,
+    marginRight: 15
   },
   disabled: {
     opacity: 0.5
@@ -63,8 +67,7 @@ const styles = {
     paddingLeft: 0,
     paddingRight: 0,
     boxSizing: 'border-box',
-    width: '50%',
-    margin: '5px 0px'
+    width: '50%'
   },
   leftButton: {
     borderTopRightRadius: 0,

--- a/apps/src/templates/progress/LessonLock.jsx
+++ b/apps/src/templates/progress/LessonLock.jsx
@@ -15,6 +15,7 @@ const LessonLock = ({unitId, lessonId, isHidden}) => {
     <div style={styles.main}>
       <div style={styles.buttonContainer} className="uitest-locksettings">
         <Button
+          __useDeprecatedTag
           onClick={() => setDialogOpen(true)}
           color={Button.ButtonColor.gray}
           text={i18n.lockSettings()}
@@ -48,12 +49,10 @@ const styles = {
     marginLeft: 15,
     marginRight: 15
   },
-  // Using 'margin' instead of 'marginTop' intentionally to override styling
   button: {
     paddingLeft: 0,
     paddingRight: 0,
-    width: '100%',
-    margin: '5px 0px 0px 0px'
+    width: '100%'
   }
 };
 

--- a/apps/src/templates/progress/ProgressLessonTeacherInfo.jsx
+++ b/apps/src/templates/progress/ProgressLessonTeacherInfo.jsx
@@ -102,6 +102,7 @@ class ProgressLessonTeacherInfo extends React.Component {
         {lesson.lesson_plan_html_url && (
           <div style={styles.buttonContainer}>
             <Button
+              __useDeprecatedTag
               href={lesson.lesson_plan_html_url}
               text={i18n.viewLessonPlan()}
               icon="file-text"
@@ -114,6 +115,7 @@ class ProgressLessonTeacherInfo extends React.Component {
         {lesson.student_lesson_plan_html_url && (
           <div style={styles.buttonContainer}>
             <Button
+              __useDeprecatedTag
               href={lesson.student_lesson_plan_html_url}
               text={i18n.studentResources()}
               icon="file-text"
@@ -145,6 +147,7 @@ class ProgressLessonTeacherInfo extends React.Component {
         {lesson.lesson_feedback_url && (
           <div style={styles.buttonContainer}>
             <Button
+              __useDeprecatedTag
               href={lesson.lesson_feedback_url}
               text={i18n.rateThisLesson()}
               icon="bar-chart"
@@ -172,10 +175,8 @@ const styles = {
     marginLeft: 15,
     marginRight: 15
   },
-  // Using 'margin' instead of 'marginTop' intentionally to override styling
   button: {
     width: '100%',
-    margin: '5px 0px 0px 0px',
     paddingLeft: 0,
     paddingRight: 0
   }

--- a/apps/src/templates/progress/SendLesson.jsx
+++ b/apps/src/templates/progress/SendLesson.jsx
@@ -45,6 +45,7 @@ export default class SendLesson extends React.Component {
     return (
       <div className="uitest-sendlesson">
         <Button
+          __useDeprecatedTag
           onClick={this.openDialog}
           text={i18n.sendLessonButton()}
           icon="share-square-o"

--- a/apps/test/unit/templates/progress/HiddenForSectionToggleTest.jsx
+++ b/apps/test/unit/templates/progress/HiddenForSectionToggleTest.jsx
@@ -14,12 +14,14 @@ describe('HiddenForSectionToggle', () => {
     expect(wrapper).to.containMatchingElement(
       <div>
         <Button
+          __useDeprecatedTag
           text={i18n.visible()}
           color={Button.ButtonColor.gray}
           disabled={true}
           icon="eye"
         />
         <Button
+          __useDeprecatedTag
           text={i18n.hidden()}
           color={Button.ButtonColor.gray}
           disabled={false}
@@ -32,8 +34,8 @@ describe('HiddenForSectionToggle', () => {
     wrapper.setProps({hidden: true});
     expect(wrapper).to.containMatchingElement(
       <div>
-        <Button text={i18n.visible()} disabled={false} />
-        <Button text={i18n.hidden()} disabled={true} />
+        <Button __useDeprecatedTag text={i18n.visible()} disabled={false} />
+        <Button __useDeprecatedTag text={i18n.hidden()} disabled={true} />
       </div>
     );
   });


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#49559

Discussion in Slack: https://codedotorg.slack.com/archives/C0T0PNTM3/p1671434885175189
tldr: Signed-in Teachers were not able to click the 'Lesson Plan' button. Reverting to re-enable that action. Original PR scope is styling, so this feels safe to do.

Cause: The "Lesson Plan" buttons are actually 'links', so the behavior of removing '__useDeprecatedTag' is not the same as for the "buttons which are actually clickable divs" and should keep "__useDeprecatedTag".