### PR TITLE
Fix Typing regex characters in Game Lab watcher breaks page

### DIFF
--- a/apps/src/templates/watchers/Watchers.jsx
+++ b/apps/src/templates/watchers/Watchers.jsx
@@ -2,10 +2,13 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import Immutable from 'immutable';
 import {connect} from 'react-redux';
+import TetherComponent from 'react-tether';
+
 import i18n from '@cdo/locale';
 import {add, update, remove} from '../../redux/watchedExpressions';
-import TetherComponent from 'react-tether';
 import AutocompleteSelector from './AutocompleteSelector';
+
+import escapeSpecialCharactersForRegExp from '@cdo/apps/util/escapeSpecialCharactersForRegExp';
 
 const WATCH_VALUE_NOT_RUNNING = 'undefined';
 const OPTIONS_GAMELAB = [
@@ -276,9 +279,10 @@ class Watchers extends React.Component {
   }
 
   filterOptions = () => {
-    const text = this.state.text;
+    const text = escapeSpecialCharactersForRegExp(this.state.text);
+    const regexpToCheck = new RegExp(text, 'i');
     const filteredOptions = this.defaultAutocompleteOptions.filter(option =>
-      option.match(new RegExp(text, 'i'))
+      option.match(regexpToCheck)
     );
     const completeMatch =
       filteredOptions.length === 1 && filteredOptions[0] === text;

--- a/apps/src/util/escapeSpecialCharactersForRegExp.js
+++ b/apps/src/util/escapeSpecialCharactersForRegExp.js
@@ -1,0 +1,3 @@
+const escapeRegExp = text => text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
+
+export default escapeRegExp;


### PR DESCRIPTION
### Fix Typing regex characters in Game Lab watcher breaks page
* add escapeSpecialCharactersForRegExp.js
* fix apps/src/templates/watchers/Watchers.jsx failing because of special characters in regexp

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
[SL-433](https://codedotorg.atlassian.net/browse/SL-433?atlOrigin=eyJpIjoiZGUwYTYxNzVlOWE1NDk1NThiNjc1YWMxYzEyMzIwMjkiLCJwIjoiaiJ9)

## Testing story


## Deployment strategy

## Follow-up work


## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
