### PR TITLE
Translates Stories to new storybook api

### DIFF
--- a/apps/src/templates/progress/ProgressBubble.story.jsx
+++ b/apps/src/templates/progress/ProgressBubble.story.jsx
@@ -4,126 +4,117 @@ import {LevelKind, LevelStatus} from '@cdo/apps/util/sharedConstants';
 
 const statuses = Object.values(LevelStatus);
 
-export default storybook => {
-  storybook.storiesOf('Progress/ProgressBubble', module).addStoryTable(
-    statuses
-      .map(status => ({
-        name: `bubble status: ${status}`,
-        story: () => (
-          <ProgressBubble
-            level={{
-              id: '1',
-              levelNumber: 3,
-              bubbleText: '3',
-              kind: [
-                LevelStatus.completed_assessment,
-                LevelStatus.submitted
-              ].includes(status)
-                ? LevelKind.assessment
-                : LevelKind.puzzle,
-              status: status,
-              isLocked: false,
-              url: '/foo/bar',
-              icon: 'fa-document'
-            }}
-            disabled={false}
-          />
-        )
-      }))
-      .concat([
-        {
-          name: 'concept assessment - not_tried',
-          description: 'Should show diamond with checkmark',
-          story: () => (
-            <ProgressBubble
-              level={{
-                id: '1',
-                levelNumber: 3,
-                bubbleText: '1',
-                status: LevelStatus.not_tried,
-                kind: LevelKind.assessment,
-                isConceptLevel: true,
-                isLocked: false,
-                url: '/foo/bar',
-                icon: 'fa-document'
-              }}
-              disabled={false}
-            />
-          )
-        },
-        {
-          name: 'concept assessment - submitted',
-          description: 'Should show diamond with checkmark',
-          story: () => (
-            <ProgressBubble
-              level={{
-                id: '1',
-                levelNumber: 3,
-                bubbleText: '1',
-                status: LevelStatus.submitted,
-                kind: LevelKind.assessment,
-                isConceptLevel: true,
-                isLocked: false,
-                url: '/foo/bar',
-                icon: 'fa-document'
-              }}
-              disabled={false}
-            />
-          )
-        },
-        {
-          name: 'bubble with no url',
-          story: () => (
-            <ProgressBubble
-              level={{
-                id: '1',
-                levelNumber: 1,
-                bubbleText: '1',
-                status: LevelStatus.perfect,
-                isLocked: false,
-                icon: 'fa-document'
-              }}
-              disabled={false}
-            />
-          )
-        },
-        {
-          name: 'disabled bubble',
-          description: 'Should not be clickable or show progress',
-          story: () => (
-            <ProgressBubble
-              level={{
-                id: '1',
-                levelNumber: 3,
-                bubbleText: '1',
-                status: LevelStatus.perfect,
-                isLocked: false,
-                url: '/foo/bar',
-                icon: 'fa-document'
-              }}
-              disabled={true}
-            />
-          )
-        },
-        {
-          name: 'hidden tooltips bubble',
-          description: 'should not have tooltips',
-          story: () => (
-            <ProgressBubble
-              level={{
-                id: '1',
-                levelNumber: 3,
-                bubbleText: '3',
-                status: LevelStatus.perfect,
-                isLocked: false,
-                url: '/foo/bar',
-                icon: 'fa-document'
-              }}
-              hideToolTips={true}
-              disabled={false}
-            />
-          )
-        }
-      ])
-  );
+const defaultExport = {
+  title: 'ProgressBubble',
+  component: ProgressBubble
+};
+
+const Template = args => <ProgressBubble {...args} />;
+
+const stories = {};
+statuses.map(status => {
+  const story = Template.bind({});
+  story.args = {
+    level: {
+      id: '1',
+      levelNumber: 3,
+      bubbleText: '3',
+      kind: [LevelStatus.completed_assessment, LevelStatus.submitted].includes(
+        status
+      )
+        ? LevelKind.assessment
+        : LevelKind.puzzle,
+      status: status,
+      isLocked: false,
+      url: '/foo/bar',
+      icon: 'fa-document'
+    },
+    disabled: false
+  };
+  stories[`BubbleStatus-${status}`] = story;
+});
+
+// And the other stories that need representing outside of status variety
+const ConceptAssessmentNotTried = Template.bind({});
+ConceptAssessmentNotTried.args = {
+  level: {
+    id: '1',
+    levelNumber: 3,
+    bubbleText: '1',
+    status: LevelStatus.not_tried,
+    kind: LevelKind.assessment,
+    isConceptLevel: true,
+    isLocked: false,
+    url: '/foo/bar',
+    icon: 'fa-document'
+  },
+  disabled: false
+};
+stories[`ConceptAssessmentNotTried`] = ConceptAssessmentNotTried;
+
+const ConceptAssessmentSubmitted = Template.bind({});
+ConceptAssessmentSubmitted.args = {
+  level: {
+    id: '1',
+    levelNumber: 3,
+    bubbleText: '1',
+    status: LevelStatus.submitted,
+    kind: LevelKind.assessment,
+    isConceptLevel: true,
+    isLocked: false,
+    url: '/foo/bar',
+    icon: 'fa-document'
+  },
+  disabled: false
+};
+stories[`ConceptAssessmentSubmitted`] = ConceptAssessmentSubmitted;
+
+const BubbleNoUrl = Template.bind({});
+BubbleNoUrl.args = {
+  level: {
+    id: '1',
+    levelNumber: 1,
+    bubbleText: '1',
+    status: LevelStatus.perfect,
+    isLocked: false,
+    icon: 'fa-document'
+  },
+  disabled: false
+};
+stories[`BubbleNoUrl`] = BubbleNoUrl;
+
+const DisabledBubble = Template.bind({});
+DisabledBubble.args = {
+  level: {
+    id: '1',
+    levelNumber: 3,
+    bubbleText: '1',
+    status: LevelStatus.perfect,
+    isLocked: false,
+    url: '/foo/bar',
+    icon: 'fa-document'
+  },
+  disabled: true
+};
+stories[`DisabledBubble`] = DisabledBubble;
+
+const HiddenTooltipsBubble = Template.bind({});
+HiddenTooltipsBubble.args = {
+  level: {
+    id: '1',
+    levelNumber: 3,
+    bubbleText: '3',
+    status: LevelStatus.perfect,
+    isLocked: false,
+    url: '/foo/bar',
+    icon: 'fa-document'
+  },
+  hideToolTips: true,
+  disabled: false
+};
+stories[`HiddenTooltipsBubble`] = HiddenTooltipsBubble;
+
+module.exports = {
+  ...stories,
+  default: defaultExport
 };

--- a/apps/src/templates/progress/ProgressLevelSet.story.jsx
+++ b/apps/src/templates/progress/ProgressLevelSet.story.jsx
@@ -2,68 +2,64 @@ import React from 'react';
 import {UnconnectedProgressLevelSet as ProgressLevelSet} from './ProgressLevelSet';
 import {LevelStatus} from '@cdo/apps/util/sharedConstants';
 import {fakeLevels, fakeLevel} from './progressTestHelpers';
+import {reduxStore} from '@cdo/storybook/decorators';
+import {Provider} from 'react-redux';
+
+export default {
+  title: 'ProgressLevelSet',
+  component: ProgressLevelSet
+};
+
+const Template = args => (
+  <Provider store={reduxStore()}>
+    <ProgressLevelSet {...args} />
+  </Provider>
+);
 
 const levels = fakeLevels(5).map((level, index) => ({
   ...level,
   status: index === 0 ? LevelStatus.perfect : level.status
 }));
 
-export default storybook => {
-  storybook
-    .storiesOf('Progress/ProgressLevelSet', module)
-    .withReduxStore()
-    .addStoryTable([
-      {
-        name: 'single puzzle step',
-        story: () => (
-          <ProgressLevelSet
-            name="Images, Pixels, and RGB"
-            levels={levels.slice(0, 1)}
-            disabled={false}
-          />
-        )
-      },
-      {
-        name: 'multiple puzzle step',
-        story: () => (
-          <ProgressLevelSet
-            name="Writing Exercises"
-            levels={levels}
-            disabled={false}
-          />
-        )
-      },
-      {
-        name: 'non first step',
-        story: () => (
-          <ProgressLevelSet
-            name="Writing Exercises"
-            levels={fakeLevels(5, 4)}
-            disabled={false}
-          />
-        )
-      },
-      {
-        name: 'disabled',
-        story: () => (
-          <ProgressLevelSet name="Assessment" levels={levels} disabled={true} />
-        )
-      },
-      {
-        name: 'Unnamed progression',
-        story: () => <ProgressLevelSet levels={levels} disabled={false} />
-      },
-      {
-        name: 'with unplugged level',
-        story: () => (
-          <ProgressLevelSet
-            name={undefined}
-            levels={[fakeLevel({isUnplugged: true}), ...fakeLevels(5)].map(
-              level => ({...level, name: undefined})
-            )}
-            disabled={false}
-          />
-        )
-      }
-    ]);
+export const SinglePuzzleStep = Template.bind({});
+SinglePuzzleStep.args = {
+  name: 'Images, Pixels, and RGB',
+  levels: levels.slice(0, 1),
+  disabled: false
+};
+
+export const MultiplePuzzleStep = Template.bind({});
+MultiplePuzzleStep.args = {
+  name: 'multiple puzzle step',
+  levels: levels,
+  disabled: false
+};
+
+export const NonFirstStep = Template.bind({});
+NonFirstStep.args = {
+  name: 'Writing Exercises',
+  levels: fakeLevels(5, 4),
+  disabled: false
+};
+
+export const Disabled = Template.bind({});
+Disabled.args = {
+  name: 'Assessment',
+  levels: levels,
+  disabled: true
+};
+
+export const UnnamedProgression = Template.bind({});
+UnnamedProgression.args = {
+  levels: levels,
+  disabled: false
+};
+
+export const WithUnpluggedLevel = Template.bind({});
+WithUnpluggedLevel.args = {
+  levels: [fakeLevel({isUnplugged: true}), ...fakeLevels(5)].map(level => ({
+    ...level,
+    name: undefined
+  })),
+  disabled: false
 };


### PR DESCRIPTION
These are two great storybook applications because there's huge variety in UI displays. It's helpful to view them all at once! 

The ProgressBubble uses a new concept for the storybook translation that attempts to mimic the functionality of .map() in the old api. I merged the stories at the end (outside of the map portion) into the same list so they could all be exported together. Happy to hear feedback if there are ideas on how else to approach this! It isn't quite as clean as some of the other storybook translations, but it's certainly more efficient than enumerating each possible variety. Thank you Emily for your problem solving genius!

Here's an example of one of them in the new storybook for ProgressLevelSet:

<img width="529" alt="Screen Shot 2023-01-03 at 2 53 14 PM" src="https://user-images.githubusercontent.com/37230822/210455439-8683fc98-6a57-45df-a0b1-334daafd8362.png">


## Links


- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/TEACH-160

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
