### PR TITLE
Add warning about changing binary logging config

### DIFF
--- a/aws/cloudformation/db_parameters.yml.erb
+++ b/aws/cloudformation/db_parameters.yml.erb
@@ -8,6 +8,11 @@
 
 # System variables for the Aurora DB cluster.
 AuroraCluster: &aurora
+  # WARNING: Static configuration setting. Merging a change to this setting triggers a restart of all db instances in
+  # the cluster during the build process.
+  # Also, in conjunction with GTID, enabling binary logging causes Pegasus tests that utilize fake dashboard to fail
+  # because they create/drop temporary tables within a transaction:
+  # https://github.com/code-dot-org/code-dot-org/blob/654d0cf90dd65848fdd045df3b9e4f85903d9f68/pegasus/test/fixtures/fake_dashboard.rb#L257-L271
   # Disable binary logging to improve write performance.
   binlog_format: 'OFF'
 


### PR DESCRIPTION
#49527 caused all database instances in the cluster to restart on each environment during the CloudFormation Stack Update task in the build process because `binlog_format` is a static configuration setting (requires a restart).

Also, binary logging and GTID together are incompatible with some Pegasus tests that create/drop temporary tables within a transaction, so binary logging currently can't be enabled on the `test` environment.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
