### PR TITLE
[DO NOT MERGE]  Investigation - App lab: touch and mouse events

### DIFF
--- a/apps/src/applab/EventSandboxer.js
+++ b/apps/src/applab/EventSandboxer.js
@@ -117,15 +117,15 @@ EventSandboxer.prototype.sandboxEvent = function(event) {
 
     if (newEvent.type === 'mousedown') {
       console.log('touch event - touchstart');
-      console.log(mouseEvent + '\n');
+      console.log(mouseEvent);
     }
     if (newEvent.type === 'mouseup') {
       console.log('touch event - touchend');
-      console.log(mouseEvent + '\n');
+      console.log(mouseEvent);
     }
     if (newEvent.type === 'mousemove') {
       console.log('touch event - touchmove');
-      console.log(mouseEvent + '\n');
+      console.log(mouseEvent);
     }
 
     // Calculate and assign values that can be missing when touch is used.
@@ -176,35 +176,29 @@ EventSandboxer.prototype.sandboxEvent = function(event) {
     // The browser supports movementX and movementY natively.
     newEvent.movementX = mouseEvent.movementX;
     newEvent.movementY = mouseEvent.movementY;
+  } else if (newEvent.type === 'mousemove') {
+    //console.log('inside newEvent.type === mousemove');
+    var currentTargetId = event.currentTarget && event.currentTarget.id;
+    var lastEvent = this.lastMouseMoveEventMap_[currentTargetId];
+    // if (lastEvent) {
+    //   console.log('lastEvent.type');
+    //   console.log(lastEvent.type);
+    // }
+    if (currentTargetId && lastEvent) {
+      // Compute movementX and movementY from clientX and clientY.
+      newEvent.movementX = mouseEvent.clientX - lastEvent.clientX;
+      newEvent.movementY = mouseEvent.clientY - lastEvent.clientY;
+    } else {
+      // There has been no mousemove event on this element since the most recent
+      // mouseout event, or this element does not have an element id.
+      newEvent.movementX = 0;
+      newEvent.movementY = 0;
+    }
+    if (currentTargetId) {
+      this.lastMouseMoveEventMap_[currentTargetId] = mouseEvent;
+    }
   }
-  // else if (newEvent.type === 'mousemove') {
-  //   //console.log('inside newEvent.type === mousemove');
-  //   var currentTargetId = event.currentTarget && event.currentTarget.id;
-  //   var lastEvent = this.lastMouseMoveEventMap_[currentTargetId];
-  //   if (lastEvent) {
-  //     console.log('lastEvent.type');
-  //     console.log(lastEvent.type);
-  //   }
-  //   if (currentTargetId && lastEvent) {
-  //     // Compute movementX and movementY from clientX and clientY.
-  //     newEvent.movementX = mouseEvent.clientX - lastEvent.clientX;
-  //     newEvent.movementY = mouseEvent.clientY - lastEvent.clientY;
-  //   } else {
-  //     // There has been no mousemove event on this element since the most recent
-  //     // mouseout event, or this element does not have an element id.
-  //     newEvent.movementX = 0;
-  //     newEvent.movementY = 0;
-  //   }
-  //   if (currentTargetId) {
-  //     this.lastMouseMoveEventMap_[currentTargetId] = mouseEvent;
-  //   }
-  // } else if (mouseEvent.type === 'mousemove') {
-  //   console.log('mouseEvent.type === mousemove');
-  //   var currTargetId = event.currentTarget && event.currentTarget.id;
-  //   var laEvent = this.lastMouseMoveEventMap_[currTargetId];
-  //   console.log('lastEvent');
-  //   console.log(laEvent);
-  // }
+  // else if (mouseEvent.type === 'mousemove') {
   // Replace DOM elements with IDs and then add them to applabEvent:
   [
     'fromElement',

--- a/apps/src/applab/EventSandboxer.js
+++ b/apps/src/applab/EventSandboxer.js
@@ -177,13 +177,8 @@ EventSandboxer.prototype.sandboxEvent = function(event) {
     newEvent.movementX = mouseEvent.movementX;
     newEvent.movementY = mouseEvent.movementY;
   } else if (newEvent.type === 'mousemove') {
-    //console.log('inside newEvent.type === mousemove');
     var currentTargetId = event.currentTarget && event.currentTarget.id;
     var lastEvent = this.lastMouseMoveEventMap_[currentTargetId];
-    // if (lastEvent) {
-    //   console.log('lastEvent.type');
-    //   console.log(lastEvent.type);
-    // }
     if (currentTargetId && lastEvent) {
       // Compute movementX and movementY from clientX and clientY.
       newEvent.movementX = mouseEvent.clientX - lastEvent.clientX;
@@ -198,7 +193,7 @@ EventSandboxer.prototype.sandboxEvent = function(event) {
       this.lastMouseMoveEventMap_[currentTargetId] = mouseEvent;
     }
   }
-  // else if (mouseEvent.type === 'mousemove') {
+
   // Replace DOM elements with IDs and then add them to applabEvent:
   [
     'fromElement',

--- a/apps/src/applab/EventSandboxer.js
+++ b/apps/src/applab/EventSandboxer.js
@@ -115,6 +115,19 @@ EventSandboxer.prototype.sandboxEvent = function(event) {
     newEvent.type = touchEvents[event.type];
     mouseEvent = event.changedTouches[0];
 
+    if (newEvent.type === 'mousedown') {
+      console.log('touch event - touchstart');
+      console.log(mouseEvent + '\n');
+    }
+    if (newEvent.type === 'mouseup') {
+      console.log('touch event - touchend');
+      console.log(mouseEvent + '\n');
+    }
+    if (newEvent.type === 'mousemove') {
+      console.log('touch event - touchmove');
+      console.log(mouseEvent + '\n');
+    }
+
     // Calculate and assign values that can be missing when touch is used.
     // We treat mouseEvent as read-only, so we will go ahead and write these
     // to the desired destination: newEvent.
@@ -126,6 +139,19 @@ EventSandboxer.prototype.sandboxEvent = function(event) {
     }
   } else {
     mouseEvent = event;
+
+    if (mouseEvent.type === 'mousedown') {
+      console.log('mouseEvent not touch event - mouse down');
+      console.log(mouseEvent);
+    }
+    if (mouseEvent.type === 'mouseup') {
+      console.log('mouseEvent not touch event - mouse up');
+      console.log(mouseEvent);
+    }
+    if (mouseEvent.type === 'mousemove') {
+      console.log('mouseEvent not touch event - mouse move');
+      console.log(mouseEvent);
+    }
   }
 
   // Convert x coordinates and then pass through to applabEvent:
@@ -150,23 +176,35 @@ EventSandboxer.prototype.sandboxEvent = function(event) {
     // The browser supports movementX and movementY natively.
     newEvent.movementX = mouseEvent.movementX;
     newEvent.movementY = mouseEvent.movementY;
-  } else if (newEvent.type === 'mousemove') {
-    var currentTargetId = event.currentTarget && event.currentTarget.id;
-    var lastEvent = this.lastMouseMoveEventMap_[currentTargetId];
-    if (currentTargetId && lastEvent) {
-      // Compute movementX and movementY from clientX and clientY.
-      newEvent.movementX = mouseEvent.clientX - lastEvent.clientX;
-      newEvent.movementY = mouseEvent.clientY - lastEvent.clientY;
-    } else {
-      // There has been no mousemove event on this element since the most recent
-      // mouseout event, or this element does not have an element id.
-      newEvent.movementX = 0;
-      newEvent.movementY = 0;
-    }
-    if (currentTargetId) {
-      this.lastMouseMoveEventMap_[currentTargetId] = mouseEvent;
-    }
   }
+  // else if (newEvent.type === 'mousemove') {
+  //   //console.log('inside newEvent.type === mousemove');
+  //   var currentTargetId = event.currentTarget && event.currentTarget.id;
+  //   var lastEvent = this.lastMouseMoveEventMap_[currentTargetId];
+  //   if (lastEvent) {
+  //     console.log('lastEvent.type');
+  //     console.log(lastEvent.type);
+  //   }
+  //   if (currentTargetId && lastEvent) {
+  //     // Compute movementX and movementY from clientX and clientY.
+  //     newEvent.movementX = mouseEvent.clientX - lastEvent.clientX;
+  //     newEvent.movementY = mouseEvent.clientY - lastEvent.clientY;
+  //   } else {
+  //     // There has been no mousemove event on this element since the most recent
+  //     // mouseout event, or this element does not have an element id.
+  //     newEvent.movementX = 0;
+  //     newEvent.movementY = 0;
+  //   }
+  //   if (currentTargetId) {
+  //     this.lastMouseMoveEventMap_[currentTargetId] = mouseEvent;
+  //   }
+  // } else if (mouseEvent.type === 'mousemove') {
+  //   console.log('mouseEvent.type === mousemove');
+  //   var currTargetId = event.currentTarget && event.currentTarget.id;
+  //   var laEvent = this.lastMouseMoveEventMap_[currTargetId];
+  //   console.log('lastEvent');
+  //   console.log(laEvent);
+  // }
   // Replace DOM elements with IDs and then add them to applabEvent:
   [
     'fromElement',

--- a/apps/src/applab/commands.js
+++ b/apps/src/applab/commands.js
@@ -456,6 +456,7 @@ applabCommands.dot = function(opts) {
 
 applabCommands.penUp = function(opts) {
   var ctx = applabTurtle.getTurtleContext();
+  console.log('penUp() called');
   if (ctx) {
     if (ctx.strokeStyle !== 'rgba(255, 255, 255, 0)') {
       Applab.turtle.penUpColor = ctx.strokeStyle;
@@ -466,6 +467,7 @@ applabCommands.penUp = function(opts) {
 
 applabCommands.penDown = function(opts) {
   var ctx = applabTurtle.getTurtleContext();
+  console.log('penDown() called');
   if (ctx && Applab.turtle.penUpColor) {
     ctx.strokeStyle = Applab.turtle.penUpColor;
     delete Applab.turtle.penUpColor;

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -9,7 +9,7 @@ Dashboard::Application.routes.draw do
     get '/weblab/footer', to: 'projects#weblab_footer'
   end
 
-  constraints host: /.*code.org.*|.*hourofcode.com.*/ do
+  constraints host: "192.168.1.232" do
     # React-router will handle sub-routes on the client.
     get 'teacher_dashboard/sections/:section_id/parent_letter', to: 'teacher_dashboard#parent_letter'
     get 'teacher_dashboard/sections/:section_id/*path', to: 'teacher_dashboard#show', via: :all


### PR DESCRIPTION
This is an investigation based on this [jira ticket](https://codedotorg.atlassian.net/browse/SL-432). I am not requesting to merge these changes. I include the changed files to share the console statements I used in this investigation.

The video below shows a user interacting with an [App Lab project ](https://studio.code.org/projects/applab/XANKEJHXS8BNsuIZ1KLkqg/view)- the program includes an event handler for 'mousedown' (`moveTo(Mouse.x, Mouse.y)` and then `penDown` function is called), event handler for 'mousemove' (`moveTo(Mouse.x, Mouse.y)` is called), and event handler for 'mouseup' (`penup` function is called). 

In [this prior PR](https://github.com/code-dot-org/code-dot-org/pull/34215) touch events were mapped to mouse events. 

However, for iPhones on version 16.1.x or lower, there is a bug. When the user lifts their finger and then places it on a different location, the pen continues to draw. Below is a user on iPhone 12, version 16.1.1:


https://user-images.githubusercontent.com/107423305/212784536-b5812f89-767b-4461-a892-18ae928109b5.mp4



On iPhones on version 16.2.x (latest version as of 1/4/23), iPads, and Android devices, this bug does not occur.
Below is a user on iPhone 12, version 16.2. :


https://user-images.githubusercontent.com/107423305/212784553-011c07d0-fa5e-45bb-9287-fc25f92798a5.mp4



The initial premise was that the 'mouseup' event was no longer triggered. However, this is not the case.
I added console.log statements within `EventSandboxer.js` that print whether an event is a 'touchup', 'touchmove', or 'touchdown' before being mapped to a mouse event. I also added print statements for mouse events that are not mapped from a touch event: 'mousedown', 'mousemove', or 'mouseup'. 
Lastly, I added print statements when the functions `penup` and `pendown` are called.

I was able to compare the console output with two different iPhone 12 devices - one using iOS 16.1 and the other using iOS 16.2. The events (other than the xy coordinates and number of 'touchmove' events) and sequences of events were the same - the mouse and touch events are firing as expected.

Here is a screenshot of when the user lifts finger after drawing a short line, then touches screen on different location on the iPhone on iOS 16.1. The touch events are registering as expected including 'touchend' and `penUp` which is called last.

![Screen Shot 2023-01-04 at 2 07 07 PM](https://user-images.githubusercontent.com/107423305/210640747-e49c07f2-dc2b-48a7-b135-2324014fba36.png)

Here are videos of the console for the two iPhones. 

Console of iPhone 12 on 16.1 - user touches color button, then draws:

https://user-images.githubusercontent.com/107423305/210639637-4f2d46ae-0bc7-4e44-bd44-003d75241733.mp4



Console of iPhone 12 on 16.2 user touches color button, then draws:


https://user-images.githubusercontent.com/107423305/210639670-19a8fa78-4476-44bb-a802-6103d9174cb0.mp4


You can see that the output is very similar (other than the xy coordinates and number of 'touchmove' events)!

There was an unexpected result I observed on BOTH iPhone on 16.1 and iPhone on 16.2: When a user taps on one of the color buttons, mouse events occur after the touch events. Below is a screenshot of the console when a user taps the color buttons on the iPhone on iOS 16.1. You can see that both mouse and touch event are registered. However, the `penUp` function is called last after either a 'mouseup' or a 'touchend' event.

![Screen Shot 2023-01-04 at 2 06 40 PM](https://user-images.githubusercontent.com/107423305/210640563-719364f2-d94d-4f0f-aaf1-8a89472801fa.png)

Note that the release of iOS 16.2 includes a new [drawing app called FreeForm](https://www.macrumors.com/guide/ios-16-2-features/) so that perhaps Apple improved the handling of touch events. At this point, I am unsure about next steps and open to suggestions for addressing this bug for iPhones using 16.1.x and below. 

UPDATE 1/18/23: Met with @breville, and he suggested looking at the `moveTo` commands in `applab/commands.js` file.
UPDATE 1/16/23: Found that the issue was a [Safari bug with HTML5 Canvas `strokeStyle`](https://bugs.webkit.org/show_bug.cgi?id=246498)! [See PR for fix.](https://github.com/code-dot-org/code-dot-org/pull/49726)
## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
