### PR TITLE
Revert "Remove `poise-python` Cookbooks Dependency"

### DIFF
--- a/cookbooks/cdo-awscli/metadata.rb
+++ b/cookbooks/cdo-awscli/metadata.rb
@@ -7,4 +7,5 @@ long_description File.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.1.25'
 
 depends 'apt'
+depends 'poise-python'
 depends 'sudo-user'

--- a/cookbooks/cdo-awscli/recipes/default.rb
+++ b/cookbooks/cdo-awscli/recipes/default.rb
@@ -3,25 +3,16 @@
 # Recipe:: default
 #
 
-# Install AWS CLI, based on the instructions at:
-# https://docs.aws.amazon.com/cli/v1/userguide/install-linux.html#install-linux-bundled
-
-apt_package 'python2.7'
-
-remote_file '/tmp/awscli-bundle.zip' do
-  source "https://s3.amazonaws.com/aws-cli/awscli-bundle-#{node['cdo-awscli']['version']}.zip"
+python_runtime '2' do
+  # Workaround for https://github.com/poise/poise-python/issues/133
+  get_pip_url 'https://github.com/pypa/get-pip/raw/f88ab195ecdf2f0001ed21443e247fb32265cabb/get-pip.py'
+  pip_version '18.0'
 end
 
-archive_file '/tmp/awscli-bundle.zip' do
-  destination '/tmp/'
+python_package 'awscli' do
+  version node['cdo-awscli']['version']
+  action :upgrade
 end
-
-execute 'install AWS CLI' do
-  cwd '/tmp/awscli-bundle'
-  command '/usr/bin/python2.7 install -i /usr/local/aws -b /usr/local/bin/aws'
-end
-
-# Configure AWS CLI after installation
 
 directory "#{node[:home]}/.aws"
 


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#49253; this failed in staging with `STDERR: /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/mixlib-shellout-3.2.7/lib/mixlib/shellout/unix.rb:187:in ``chdir': No such file or directory @ dir_s_chdir - /tmp/awscli-bundle (Errno::ENOENT)`

See https://codedotorg.slack.com/archives/C03CK8E51/p1672862823468059?thread_ts=1672862407.870549&cid=C03CK8E51 for more