### PR TITLE
Add weatherapi.com to App Lab allow list

### DIFF
--- a/dashboard/app/controllers/xhr_proxy_controller.rb
+++ b/dashboard/app/controllers/xhr_proxy_controller.rb
@@ -114,6 +114,7 @@ class XhrProxyController < ApplicationController
     theunitedstates.io
     transitchicago.com
     vpic.nhtsa.dot.gov
+    weatherapi.com
     wikipedia.org
     worldclockapi.com
     worldtimeapi.org

--- a/dashboard/app/controllers/xhr_proxy_controller.rb
+++ b/dashboard/app/controllers/xhr_proxy_controller.rb
@@ -61,6 +61,7 @@ class XhrProxyController < ApplicationController
     api.uclassify.com
     api.waqi.info
     api.weather.gov
+    api.weatherapi.com
     api.wolframalpha.com
     api.zippopotam.us
     bible-api.com
@@ -114,7 +115,6 @@ class XhrProxyController < ApplicationController
     theunitedstates.io
     transitchicago.com
     vpic.nhtsa.dot.gov
-    weatherapi.com
     wikipedia.org
     worldclockapi.com
     worldtimeapi.org


### PR DESCRIPTION
Adds weatherapi.com to App Lab allow list, tested locally in App Lab (see screenshot below).

<img width="1662" alt="Screen Shot 2023-01-19 at 10 10 02 AM" src="https://user-images.githubusercontent.com/26844240/213526007-4b177263-2f55-4085-89b9-166fb4b01e23.png">

## Links

API: https://www.weatherapi.com/
Zendesk ticket: https://codeorg.zendesk.com/agent/tickets/421239

