### PR TITLE
Update visualization column in App Lab so it doesn't scroll for touchmove event

### DIFF
--- a/apps/src/applab/ApplabVisualizationColumn.jsx
+++ b/apps/src/applab/ApplabVisualizationColumn.jsx
@@ -37,6 +37,30 @@ class ApplabVisualizationColumn extends React.Component {
     widgetMode: PropTypes.bool
   };
 
+  componentDidMount() {
+    this.visualizationColumn.addEventListener(
+      'touchmove',
+      this.preventBehavior,
+      {
+        passive: false
+      }
+    );
+  }
+
+  componentWillUnmount() {
+    this.visualizationColumn.removeEventListener(
+      'touchmove',
+      this.preventBehavior,
+      {
+        passive: false
+      }
+    );
+  }
+
+  preventBehavior = e => {
+    e.preventDefault();
+  };
+
   getClassNames() {
     const {
       visualizationHasPadding,
@@ -120,6 +144,9 @@ class ApplabVisualizationColumn extends React.Component {
         id="visualizationColumn"
         className={this.getClassNames()}
         style={maxWidth}
+        ref={el => {
+          this.visualizationColumn = el;
+        }}
       >
         {!isReadOnlyWorkspace && (
           <PlaySpaceHeader

--- a/apps/test/unit/applab/ApplabVisualizationColumnTest.js
+++ b/apps/test/unit/applab/ApplabVisualizationColumnTest.js
@@ -7,7 +7,8 @@ import {WIDGET_WIDTH} from '@cdo/apps/applab/constants';
 describe('AppLabVisualizationColumn', () => {
   describe('in widget mode', () => {
     let visualizationColumn;
-
+    let options = {};
+    options.disableLifecycleMethods = true;
     beforeEach(() => {
       visualizationColumn = shallow(
         <UnconnectedApplabVisualizationColumn
@@ -28,7 +29,8 @@ describe('AppLabVisualizationColumn', () => {
           widgetMode
           isIframeEmbed
           playspacePhoneFrame
-        />
+        />,
+        options
       );
     });
 

--- a/apps/test/unit/applab/ApplabVisualizationColumnTest.js
+++ b/apps/test/unit/applab/ApplabVisualizationColumnTest.js
@@ -7,8 +7,6 @@ import {WIDGET_WIDTH} from '@cdo/apps/applab/constants';
 describe('AppLabVisualizationColumn', () => {
   describe('in widget mode', () => {
     let visualizationColumn;
-    let options = {};
-    options.disableLifecycleMethods = true;
     beforeEach(() => {
       visualizationColumn = shallow(
         <UnconnectedApplabVisualizationColumn
@@ -30,7 +28,7 @@ describe('AppLabVisualizationColumn', () => {
           isIframeEmbed
           playspacePhoneFrame
         />,
-        options
+        {disableLifecycleMethods: true}
       );
     });
 


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR prevents scrolling on the visualization column in App Lab in response to a 'touchmove' event. This change is in response to when the share view of the app is scrolled up or down, the ink is draw above or below where the touch point is. 

I added an event listener in `ApplabVisualizationColumn.jsx` to the visualization column which prevents default behavior of 'touchmove'. 

I was considering adding an event listener to the visualization column in `StudioApp.js` which contains other event listeners, but @madelynkasula pointed out the visualizationColumn element is separate from the logic that controls it, which adds a dependency between `StudioApp.js` and `ApplabVisualizationColumn.jsx`. The code in `StudioApp.js` will likely also trigger errors if #visualizationColumn doesn’t exist. This implementation also follows [best practices](https://developer.mozilla.org/en-US/docs/Web/API/Touch_events/Using_Touch_Events#best_practices) when using touch events documented in mdn web docs.

Screencast before update on iPhone 12- the visualization column in share view is scrollable based on 'touchmove':

https://user-images.githubusercontent.com/107423305/210844308-eb7ed484-2833-4546-bd32-978573cf0a86.mp4


Screencast after update on iPhone 12- the visualization column in share view is not scrollable based on 'touchmove':

https://user-images.githubusercontent.com/107423305/210844319-2d6a6fad-0900-4074-9fe2-07e945e37188.mp4


Screencast after update on iPad (8th gen) - after showing share view, I go to edit view and can still scroll up/down within the Toolbox and in Workspace. I can also drag blocks within Workspace.


https://user-images.githubusercontent.com/107423305/210846576-c5be8683-5b59-4f7a-9583-a3ae49ddafd7.mp4


I also tested on an Android device (LG Q7+) and the no scrolling worked on the visualization column. 

However, the drawing bug described in the [jira ticket](https://codedotorg.atlassian.net/browse/SL-432) persisted locally for all devices. More about this bug in the Follow-up Work section below.

## Links
[jira ticket](https://codedotorg.atlassian.net/browse/SL-432)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work
This is addressing one issue described in this [jira ticket](https://codedotorg.atlassian.net/browse/SL-432). The other issue is that the ink continues to draw even after the 'touchend' event is triggered on iPhones using iOS 12.1 and below. You can read more about this issue in [this investigation](https://github.com/code-dot-org/code-dot-org/pull/49636).

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
