### PR TITLE
Add new Maker course offering category

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -498,6 +498,7 @@
   "courseOfferingAIML": "AI/ML",
   "courseOfferingHOC": "Hour of Code",
   "courseOfferingCSFInternational": "CS Fundamentals International",
+  "courseOfferingMaker": "Maker",
   "courseOfferingMath": "Math",
   "courseOfferingTwentyHour": "20-hour",
   "courseOfferingOther": "Other",

--- a/apps/src/templates/teacherDashboard/AssignmentSelectorHelpers.jsx
+++ b/apps/src/templates/teacherDashboard/AssignmentSelectorHelpers.jsx
@@ -8,6 +8,7 @@ export const translatedCourseOfferingCategories = {
   full_course: i18n.courseOfferingFullCourse(),
   csf: i18n.courseOfferingCSF(),
   csc: i18n.courseOfferingCSC(),
+  maker: i18n.courseOfferingMaker(),
   aiml: i18n.courseOfferingAIML(),
   hoc: i18n.courseOfferingHOC(),
   csf_international: i18n.courseOfferingCSFInternational(),

--- a/lib/cdo/shared_constants/curriculum/shared_course_constants.rb
+++ b/lib/cdo/shared_constants/curriculum/shared_course_constants.rb
@@ -69,6 +69,7 @@ module Curriculum
       csf
       csc
       aiml
+      maker
       hoc
       csf_international
       math


### PR DESCRIPTION
Add new Maker Course Offering category as option in the dropdown.

![Screenshot 2023-01-06 at 12 17 47 PM](https://user-images.githubusercontent.com/208083/211063719-bd87d773-8cfe-4277-b72a-94576265ccd3.png)

Category shows up in the section setup course dropdown

![Screenshot 2023-01-06 at 12 19 40 PM](https://user-images.githubusercontent.com/208083/211063995-e398a083-1ec2-41fa-892f-c1b023f41301.png)

