### PR TITLE
Add video field to javalab levelbuilder editor

### DIFF
--- a/dashboard/app/views/levels/editors/_javalab.html.haml
+++ b/dashboard/app/views/levels/editors/_javalab.html.haml
@@ -1,5 +1,6 @@
 = render partial: 'levels/editors/fields/instructions_area', locals: {f: f}
 = render partial: 'levels/editors/fields/teacher_only_markdown', locals: {f: f}
+= render partial: 'levels/editors/fields/video', locals: {f: f}
 = render partial: 'levels/editors/fields/bubble_choice_sublevel', locals: {f: f}
 = render partial: 'levels/editors/fields/special_level_types', locals: {f: f}
 = render partial: 'levels/editors/fields/csa_fields', locals: {f: f}


### PR DESCRIPTION
Adds the ability for levelbuilders to include a video as the first resource listed in the "Help and Tips" tab on Javalab levels. When a user clicks the video link, the YouTube video is opened as a modal on the same page.

This is what the field looks like on the levelbuilder edit page:
<img width="484" alt="Screen Shot 2023-01-06 at 1 13 03 PM" src="https://user-images.githubusercontent.com/9812299/211102722-95703a09-e81a-4a2c-b1ee-aa2d4f918354.png">

This is what the "Help and Tips" tab looks like after adding a video (pre-existing Weblab video) to a Javalab level that already had a resource:
<img width="609" alt="Screen Shot 2023-01-06 at 1 13 28 PM" src="https://user-images.githubusercontent.com/9812299/211102733-f9bb5afd-da6b-414b-bd74-316ba9d27fbd.png">

When the link is clicked:
<img width="1440" alt="Screen Shot 2023-01-06 at 1 13 39 PM" src="https://user-images.githubusercontent.com/9812299/211102728-e9b6d22b-178f-4072-b0a7-5f21d960ef1c.png">


## Links

- [SL-326](https://codedotorg.atlassian.net/browse/SL-326)