### PR TITLE
Revert "Revert "Updating and restyling buttons on unit overview page""

### DIFF
--- a/apps/src/templates/progress/HiddenForSectionToggle.jsx
+++ b/apps/src/templates/progress/HiddenForSectionToggle.jsx
@@ -30,7 +30,6 @@ class HiddenForSectionToggle extends React.Component {
     return (
       <div style={mainStyle} className="uitest-togglehidden">
         <Button
-          __useDeprecatedTag
           onClick={() => !disabled && onChange('visible')}
           text={i18n.visible()}
           color={Button.ButtonColor.gray}
@@ -39,7 +38,6 @@ class HiddenForSectionToggle extends React.Component {
           style={{...styles.button, ...styles.leftButton}}
         />
         <Button
-          __useDeprecatedTag
           onClick={() => !disabled && onChange('hidden')}
           text={i18n.hidden()}
           color={Button.ButtonColor.gray}
@@ -55,9 +53,7 @@ class HiddenForSectionToggle extends React.Component {
 const styles = {
   main: {
     wrap: 'nowrap',
-    marginTop: 5,
-    marginLeft: 15,
-    marginRight: 15
+    margin: '5px 15px'
   },
   disabled: {
     opacity: 0.5
@@ -67,7 +63,8 @@ const styles = {
     paddingLeft: 0,
     paddingRight: 0,
     boxSizing: 'border-box',
-    width: '50%'
+    width: '50%',
+    margin: '5px 0px'
   },
   leftButton: {
     borderTopRightRadius: 0,

--- a/apps/src/templates/progress/LessonLock.jsx
+++ b/apps/src/templates/progress/LessonLock.jsx
@@ -15,7 +15,6 @@ const LessonLock = ({unitId, lessonId, isHidden}) => {
     <div style={styles.main}>
       <div style={styles.buttonContainer} className="uitest-locksettings">
         <Button
-          __useDeprecatedTag
           onClick={() => setDialogOpen(true)}
           color={Button.ButtonColor.gray}
           text={i18n.lockSettings()}
@@ -49,10 +48,12 @@ const styles = {
     marginLeft: 15,
     marginRight: 15
   },
+  // Using 'margin' instead of 'marginTop' intentionally to override styling
   button: {
     paddingLeft: 0,
     paddingRight: 0,
-    width: '100%'
+    width: '100%',
+    margin: '5px 0px 0px 0px'
   }
 };
 

--- a/apps/src/templates/progress/ProgressLessonTeacherInfo.jsx
+++ b/apps/src/templates/progress/ProgressLessonTeacherInfo.jsx
@@ -102,7 +102,6 @@ class ProgressLessonTeacherInfo extends React.Component {
         {lesson.lesson_plan_html_url && (
           <div style={styles.buttonContainer}>
             <Button
-              __useDeprecatedTag
               href={lesson.lesson_plan_html_url}
               text={i18n.viewLessonPlan()}
               icon="file-text"
@@ -115,7 +114,6 @@ class ProgressLessonTeacherInfo extends React.Component {
         {lesson.student_lesson_plan_html_url && (
           <div style={styles.buttonContainer}>
             <Button
-              __useDeprecatedTag
               href={lesson.student_lesson_plan_html_url}
               text={i18n.studentResources()}
               icon="file-text"
@@ -147,7 +145,6 @@ class ProgressLessonTeacherInfo extends React.Component {
         {lesson.lesson_feedback_url && (
           <div style={styles.buttonContainer}>
             <Button
-              __useDeprecatedTag
               href={lesson.lesson_feedback_url}
               text={i18n.rateThisLesson()}
               icon="bar-chart"
@@ -175,8 +172,10 @@ const styles = {
     marginLeft: 15,
     marginRight: 15
   },
+  // Using 'margin' instead of 'marginTop' intentionally to override styling
   button: {
     width: '100%',
+    margin: '5px 0px 0px 0px',
     paddingLeft: 0,
     paddingRight: 0
   }

--- a/apps/src/templates/progress/ProgressLessonTeacherInfo.jsx
+++ b/apps/src/templates/progress/ProgressLessonTeacherInfo.jsx
@@ -102,6 +102,7 @@ class ProgressLessonTeacherInfo extends React.Component {
         {lesson.lesson_plan_html_url && (
           <div style={styles.buttonContainer}>
             <Button
+              __useDeprecatedTag
               href={lesson.lesson_plan_html_url}
               text={i18n.viewLessonPlan()}
               icon="file-text"
@@ -114,6 +115,7 @@ class ProgressLessonTeacherInfo extends React.Component {
         {lesson.student_lesson_plan_html_url && (
           <div style={styles.buttonContainer}>
             <Button
+              __useDeprecatedTag
               href={lesson.student_lesson_plan_html_url}
               text={i18n.studentResources()}
               icon="file-text"
@@ -145,6 +147,7 @@ class ProgressLessonTeacherInfo extends React.Component {
         {lesson.lesson_feedback_url && (
           <div style={styles.buttonContainer}>
             <Button
+              __useDeprecatedTag
               href={lesson.lesson_feedback_url}
               text={i18n.rateThisLesson()}
               icon="bar-chart"
@@ -168,16 +171,17 @@ class ProgressLessonTeacherInfo extends React.Component {
 
 const styles = {
   buttonContainer: {
-    marginTop: 5,
-    marginLeft: 15,
-    marginRight: 15
+    margin: '10px 15px 0px 15px',
+    // Have to set line height to 0 to remove additional 5px bottom margin
+    lineHeight: '0px'
   },
-  // Using 'margin' instead of 'marginTop' intentionally to override styling
+  // Setting 0px margin here intentionally to override styling
   button: {
     width: '100%',
-    margin: '5px 0px 0px 0px',
+    margin: '0px',
     paddingLeft: 0,
-    paddingRight: 0
+    paddingRight: 0,
+    boxShadow: 'none'
   }
 };
 

--- a/apps/src/templates/progress/SendLesson.jsx
+++ b/apps/src/templates/progress/SendLesson.jsx
@@ -45,7 +45,6 @@ export default class SendLesson extends React.Component {
     return (
       <div className="uitest-sendlesson">
         <Button
-          __useDeprecatedTag
           onClick={this.openDialog}
           text={i18n.sendLessonButton()}
           icon="share-square-o"

--- a/apps/test/unit/templates/progress/HiddenForSectionToggleTest.jsx
+++ b/apps/test/unit/templates/progress/HiddenForSectionToggleTest.jsx
@@ -14,14 +14,12 @@ describe('HiddenForSectionToggle', () => {
     expect(wrapper).to.containMatchingElement(
       <div>
         <Button
-          __useDeprecatedTag
           text={i18n.visible()}
           color={Button.ButtonColor.gray}
           disabled={true}
           icon="eye"
         />
         <Button
-          __useDeprecatedTag
           text={i18n.hidden()}
           color={Button.ButtonColor.gray}
           disabled={false}
@@ -34,8 +32,8 @@ describe('HiddenForSectionToggle', () => {
     wrapper.setProps({hidden: true});
     expect(wrapper).to.containMatchingElement(
       <div>
-        <Button __useDeprecatedTag text={i18n.visible()} disabled={false} />
-        <Button __useDeprecatedTag text={i18n.hidden()} disabled={true} />
+        <Button text={i18n.visible()} disabled={false} />
+        <Button text={i18n.hidden()} disabled={true} />
       </div>
     );
   });


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#49608, meaning another attempt at https://github.com/code-dot-org/code-dot-org/pull/49559, with fix

This work updates the accessibility of the buttons on this page (the original PR goal), while leaving the links as-is, but fixing the styling so all the buttons play together nicely.

This page has a couple buttons from components (lesson lock and hidden/visible toggle), plus standard buttons (send lesson), plus links styled to look like buttons (resources). The styling updates are to make sure each of these appear identically, with no box shadow and standard spacing. This is an overall move toward 'flat' buttons, and an improvement over the current spacing of the buttons on the page. I've added comments where appropriate- when the styling updates could use clarification.

I've tested the buttons- all work as expected. 

Before:
<img width="1121" alt="Screen Shot 2023-01-10 at 3 31 20 PM" src="https://user-images.githubusercontent.com/37230822/211683917-8a46718e-218a-4bd1-9918-d1e78b4ade1e.png">


After:
<img width="1052" alt="Screen Shot 2023-01-10 at 3 20 11 PM" src="https://user-images.githubusercontent.com/37230822/211683700-6bf19563-e428-4d6c-9805-fce3a31af725.png">

