### PR TITLE
Music: save code to local storage per block mode

### DIFF
--- a/apps/src/music/blockly/MusicBlocklyWorkspace.js
+++ b/apps/src/music/blockly/MusicBlocklyWorkspace.js
@@ -116,8 +116,20 @@ export default class MusicBlocklyWorkspace {
     return this.workspace.getAllBlocks();
   }
 
+  getLocalStorageKeyName() {
+    // Save code for each block mode in a different local storage item.
+    // This way, switching block modes will load appropriate user code.
+    // The default is "Advanced".
+
+    const blockMode = AppConfig.getValue('blocks');
+    const blockModeUpperFirst = blockMode
+      ? blockMode.replace(/^./, str => str.toUpperCase())
+      : 'Advanced';
+    return 'musicLabSavedCode' + blockModeUpperFirst;
+  }
+
   loadCode() {
-    const existingCode = localStorage.getItem('musicLabSavedCode');
+    const existingCode = localStorage.getItem(this.getLocalStorageKeyName());
     if (existingCode) {
       const exitingCodeJson = JSON.parse(existingCode);
       Blockly.blockly_.serialization.workspaces.load(
@@ -132,7 +144,7 @@ export default class MusicBlocklyWorkspace {
   saveCode() {
     const code = Blockly.blockly_.serialization.workspaces.save(this.workspace);
     const codeJson = JSON.stringify(code);
-    localStorage.setItem('musicLabSavedCode', codeJson);
+    localStorage.setItem(this.getLocalStorageKeyName(), codeJson);
   }
 
   resetCode() {


### PR DESCRIPTION
Code is still saved to local storage but with now with a different key per block mode.  This way, switching between block modes will load appropriate code, be it starter code or the user's last saved code.

The local storage key name will be `musicLabSavedCodeSimple`, `musicLabSavedCodeAdvanced`, etc.  The default, when no block mode is specified, is the `Advanced` one.
