### PR TITLE
Add role to admin/counselor enrollment form

### DIFF
--- a/apps/src/code-studio/pd/workshop_enrollment/enroll_form.jsx
+++ b/apps/src/code-studio/pd/workshop_enrollment/enroll_form.jsx
@@ -23,6 +23,7 @@ const DISTRICT = SubjectNames.SUBJECT_CSF_DISTRICT;
 const DEEP_DIVE = SubjectNames.SUBJECT_CSF_201;
 
 const CSP = 'CS Principles';
+const ADMINCOUNSELOR = 'Admin/Counselor Workshop';
 
 const VALIDATION_STATE_ERROR = 'error';
 
@@ -40,12 +41,14 @@ const DESCRIBE_ROLES = [
   'Other'
 ];
 
-const ROLES = [
+const CSF_ROLES = [
   'Classroom Teacher',
   'Media Specialist',
   'Tech Teacher',
   'Librarian'
 ].concat(DESCRIBE_ROLES);
+
+const ADMIN_COUNSELOR_ROLES = ['Administrator', 'Counselor', 'Other'];
 
 const GRADES_TEACHING = [
   'Pre-K',
@@ -378,6 +381,12 @@ export default class EnrollForm extends React.Component {
       'I don’t have experience teaching any of these courses'
     ]);
 
+    const roles =
+      (this.props.workshop_course === CSF &&
+        CSF_ROLES.map(r => ({value: r, label: r}))) ||
+      (this.props.workshop_course === ADMINCOUNSELOR &&
+        ADMIN_COUNSELOR_ROLES.map(r => ({value: r, label: r})));
+
     return (
       <form id="enroll-form">
         <p>
@@ -451,7 +460,8 @@ export default class EnrollForm extends React.Component {
           school_info={this.state.school_info}
           errors={this.state.errors}
         />
-        {this.props.workshop_course === CSF && (
+        {(this.props.workshop_course === CSF ||
+          this.props.workshop_course === ADMINCOUNSELOR) && (
           <FormGroup>
             <FormGroup
               validationState={
@@ -470,7 +480,7 @@ export default class EnrollForm extends React.Component {
                 placeholder={null}
                 value={this.state.role}
                 onChange={this.handleRoleChange}
-                options={ROLES.map(r => ({value: r, label: r}))}
+                options={roles}
               />
               <HelpBlock>{this.state.errors.role}</HelpBlock>
               {this.state && DESCRIBE_ROLES.includes(this.state.role) && (

--- a/apps/src/code-studio/pd/workshop_enrollment/enroll_form.jsx
+++ b/apps/src/code-studio/pd/workshop_enrollment/enroll_form.jsx
@@ -382,10 +382,8 @@ export default class EnrollForm extends React.Component {
     ]);
 
     const roles =
-      (this.props.workshop_course === CSF &&
-        CSF_ROLES.map(r => ({value: r, label: r}))) ||
-      (this.props.workshop_course === ADMINCOUNSELOR &&
-        ADMIN_COUNSELOR_ROLES.map(r => ({value: r, label: r})));
+      (this.props.workshop_course === CSF && CSF_ROLES) ||
+      (this.props.workshop_course === ADMINCOUNSELOR && ADMIN_COUNSELOR_ROLES);
 
     return (
       <form id="enroll-form">
@@ -480,7 +478,7 @@ export default class EnrollForm extends React.Component {
                 placeholder={null}
                 value={this.state.role}
                 onChange={this.handleRoleChange}
-                options={roles}
+                options={roles.map(r => ({value: r, label: r}))}
               />
               <HelpBlock>{this.state.errors.role}</HelpBlock>
               {this.state && DESCRIBE_ROLES.includes(this.state.role) && (

--- a/apps/test/unit/code-studio/pd/workshop_enrollment/enroll_formTest.js
+++ b/apps/test/unit/code-studio/pd/workshop_enrollment/enroll_formTest.js
@@ -236,6 +236,39 @@ describe('Enroll Form', () => {
     });
   });
 
+  describe('Admin/Counselor Enroll Form', () => {
+    let enrollForm;
+    before(() => {
+      enrollForm = shallow(
+        <EnrollForm
+          workshop_id={props.workshop_id}
+          workshop_course="Admin/Counselor Workshop"
+          first_name={props.first_name}
+          email={props.email}
+          previous_courses={props.previous_courses}
+          onSubmissionComplete={props.onSubmissionComplete}
+        />
+      );
+    });
+
+    it('displays role question', () => {
+      assert(enrollForm.exists('#role'));
+    });
+
+    it('displays describe role question after answered as other', () => {
+      enrollForm.setState({role: 'Other'});
+      expect(enrollForm.find('#describe_role')).to.have.length(1);
+    });
+
+    it('does not display describe role question after answered as counselor or admin', () => {
+      enrollForm.setState({role: 'Administrator'});
+      expect(enrollForm.find('#describe_role')).to.have.length(0);
+
+      enrollForm.setState({role: 'Counselor'});
+      expect(enrollForm.find('#describe_role')).to.have.length(0);
+    });
+  });
+
   describe('Enroll Form', () => {
     let enrollForm;
     beforeEach(() => {


### PR DESCRIPTION
Adds role to admin/counselor on enrollment form. The `role` is already a [serialized attribute in the enrollment model](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/models/pd/enrollment.rb#L76), so on the backend, the enrollment looks like
```
=> #<Pd::Enrollment id: 39, ..., properties: {"role"=>"Administrator", "grades_teaching"=>["Grade 9-12"]}, application_id: nil>
```

The dropdown:
<img width="502" alt="Screenshot 2023-01-09 at 3 16 15 PM" src="https://user-images.githubusercontent.com/9142121/211402302-259d4030-2d7f-4003-ba79-507b4df1a2c7.png">

When you select 'Other', a text box appears prompting for more info:
<img width="514" alt="Screenshot 2023-01-09 at 3 16 32 PM" src="https://user-images.githubusercontent.com/9142121/211402401-d3e4eb9b-192d-4dce-9673-d63702690b2a.png">


## Links

- Jira Ticket: https://codedotorg.atlassian.net/browse/ACQ-327

## Testing story

Added unit tests, and tested locally by adding workshops at http://localhost-studio.code.org:3000/pd/workshop_dashboard

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

We have a ticket to add UI tests for these enrollment forms.

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
