### PR TITLE
Music Lab: add trigger functionality to tracks model

### DIFF
--- a/apps/src/music/blockly/MusicBlocklyWorkspace.js
+++ b/apps/src/music/blockly/MusicBlocklyWorkspace.js
@@ -108,9 +108,11 @@ export default class MusicBlocklyWorkspace {
       }
 
       if (
-        [BlockTypes.TRIGGERED_AT, BlockTypes.TRIGGERED_AT_SIMPLE].includes(
-          block.type
-        )
+        [
+          BlockTypes.TRIGGERED_AT,
+          BlockTypes.TRIGGERED_AT_SIMPLE,
+          BlockTypes.NEW_TRACK_ON_TRIGGER
+        ].includes(block.type)
       ) {
         const id = block.getFieldValue('trigger');
         events[this.triggerIdToEvent(id)] = {

--- a/apps/src/music/blockly/blockTypes.js
+++ b/apps/src/music/blockly/blockTypes.js
@@ -8,6 +8,7 @@ export const BlockTypes = {
   SET_CURRENT_LOCATION_NEXT_MEASURE: 'set_current_location_next_measure',
   NEW_TRACK_AT_START: 'new_track_at_start',
   NEW_TRACK_AT_MEASURE: 'new_track_at_measure',
+  NEW_TRACK_ON_TRIGGER: 'new_track_on_trigger',
   PLAY_SOUND_IN_TRACK: 'play_sound_in_track',
   REST_IN_TRACK: 'rest_in_track'
 };

--- a/apps/src/music/blockly/blocks/samples.js
+++ b/apps/src/music/blockly/blocks/samples.js
@@ -21,7 +21,11 @@ const getCurrentTrackId = ctx => {
         block.type
       )
     ) {
-      return block.id;
+      return `"${block.id}"`;
+    }
+
+    if (block.type === BlockTypes.NEW_TRACK_ON_TRIGGER) {
+      return `"${block.id}" + "--" + getTriggerCount()`;
     }
   }
 
@@ -172,6 +176,37 @@ export const newTrackAtMeasure = {
   }
 };
 
+export const newTrackOnTrigger = {
+  definition: {
+    type: BlockTypes.NEW_TRACK_ON_TRIGGER,
+    message0: 'new track %1 when %2 triggered',
+    args0: [
+      {
+        type: 'field_input',
+        name: 'trackName',
+        text: 'my track'
+      },
+      {
+        type: 'input_dummy',
+        name: 'trigger'
+      }
+    ],
+    inputsInline: true,
+    nextStatement: null,
+    colour: 150,
+    tooltip: 'new track',
+    helpUrl: '',
+    extensions: ['default_track_name_extension', 'dynamic_trigger_extension']
+  },
+  generator: ctx => {
+    return `MusicPlayer.createTrack("${
+      ctx.id
+    }" + "--" + getTriggerCount(), "${ctx.getFieldValue(
+      'trackName'
+    )}", Math.ceil(MusicPlayer.getPlayheadPosition()), false);\n`;
+  }
+};
+
 export const playSoundInTrack = {
   definition: {
     type: BlockTypes.PLAY_SOUND_IN_TRACK,
@@ -194,10 +229,11 @@ export const playSoundInTrack = {
     tooltip: 'play sound',
     helpUrl: ''
   },
-  generator: ctx =>
-    `MusicPlayer.addSoundToTrack("${getCurrentTrackId(
+  generator: ctx => {
+    return `MusicPlayer.addSoundToTrack(${getCurrentTrackId(
       ctx
-    )}", "${ctx.getFieldValue('sound')}");\n`
+    )}, "${ctx.getFieldValue('sound')}");\n`;
+  }
 };
 
 export const restInTrack = {
@@ -216,9 +252,9 @@ export const restInTrack = {
     colour: 50
   },
   generator: ctx =>
-    `MusicPlayer.addRestToTrack("${getCurrentTrackId(
+    `MusicPlayer.addRestToTrack(${getCurrentTrackId(
       ctx
-    )}", ${Blockly.JavaScript.valueToCode(
+    )}, ${Blockly.JavaScript.valueToCode(
       ctx,
       'measures',
       Blockly.JavaScript.ORDER_ASSIGNMENT

--- a/apps/src/music/blockly/musicBlocks.js
+++ b/apps/src/music/blockly/musicBlocks.js
@@ -1,6 +1,7 @@
 import {
   newTrackAtMeasure,
   newTrackAtStart,
+  newTrackOnTrigger,
   playSound,
   playSoundAtCurrentLocation,
   playSoundInTrack,
@@ -21,6 +22,7 @@ const blockList = [
   forLoop,
   newTrackAtStart,
   newTrackAtMeasure,
+  newTrackOnTrigger,
   playSoundInTrack,
   restInTrack
 ];

--- a/apps/src/music/blockly/toolbox.js
+++ b/apps/src/music/blockly/toolbox.js
@@ -67,6 +67,10 @@ const toolboxBlocks = {
       }
     }
   },
+  [BlockTypes.NEW_TRACK_ON_TRIGGER]: {
+    kind: 'block',
+    type: BlockTypes.NEW_TRACK_ON_TRIGGER
+  },
   [BlockTypes.TRIGGERED_AT]: {
     kind: 'block',
     type: BlockTypes.TRIGGERED_AT
@@ -266,7 +270,11 @@ export function getToolbox() {
 
   if (AppConfig.getValue('blocks') === 'tracks') {
     return generateToolbox({
-      Tracks: [BlockTypes.NEW_TRACK_AT_START, BlockTypes.NEW_TRACK_AT_MEASURE],
+      Tracks: [
+        BlockTypes.NEW_TRACK_AT_START,
+        BlockTypes.NEW_TRACK_AT_MEASURE,
+        BlockTypes.NEW_TRACK_ON_TRIGGER
+      ],
       Play: [BlockTypes.PLAY_SOUND_IN_TRACK, BlockTypes.REST_IN_TRACK],
       Control: ['controls_repeat_ext'],
       Math: ['math_arithmetic', 'math_random_int', 'math_modulo'],

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -51,6 +51,9 @@ class UnconnectedMusicView extends React.Component {
     this.codeHooks = {};
     this.musicBlocklyWorkspace = new MusicBlocklyWorkspace();
     this.soundUploader = new SoundUploader(this.player);
+    // Increments every time a trigger is pressed;
+    // used to differentiate tracks created on the same trigger
+    this.triggerCount = 0;
 
     // Set default for instructions position.
     let instructionsPosIndex = 1;
@@ -213,6 +216,7 @@ class UnconnectedMusicView extends React.Component {
     }
     this.analyticsReporter.onButtonClicked('trigger', {id});
     this.musicBlocklyWorkspace.executeTrigger(id);
+    this.triggerCount++;
   };
 
   toggleInstructions = fromKeyboardShortcut => {
@@ -227,7 +231,8 @@ class UnconnectedMusicView extends React.Component {
 
   executeSong = () => {
     this.musicBlocklyWorkspace.executeSong({
-      MusicPlayer: this.player
+      MusicPlayer: this.player,
+      getTriggerCount: () => this.triggerCount
     });
   };
 
@@ -255,6 +260,7 @@ class UnconnectedMusicView extends React.Component {
     this.player.clearTriggeredEvents();
 
     this.setState({isPlaying: false});
+    this.triggerCount = 0;
   };
 
   stopAllSoundsStillToPlay = () => {

--- a/apps/src/music/views/TimelineTrackEvents.jsx
+++ b/apps/src/music/views/TimelineTrackEvents.jsx
@@ -12,10 +12,16 @@ const TimelineTrackEvents = ({
   getLengthForId
 }) => {
   const playerUtils = useContext(PlayerUtilsContext);
-  const soundEvents = playerUtils.getSoundEvents();
-  const tracksMetadata = playerUtils.getTracksMetadata();
+  // useMemo() compares dependency using Object.is() comparison, which won't work correctly
+  // for arrays and objects, as it will consider object/arrays with different contents the same
+  // if they are the same object/array reference. These values are relatively small and simple
+  // so convert to JSON strings to get around this.
+  const soundEventsJson = JSON.stringify(playerUtils.getSoundEvents());
+  const tracksMetadataJson = JSON.stringify(playerUtils.getTracksMetadata());
 
-  const organizeSoundsByTracks = (soundEvents, tracksMetadata) => {
+  const organizeSoundsByTracks = (soundEventsJson, tracksMetadataJson) => {
+    const soundEvents = JSON.parse(soundEventsJson);
+    const tracksMetadata = JSON.parse(tracksMetadataJson);
     const tracksToSounds = {};
 
     soundEvents.forEach(event => {
@@ -37,8 +43,8 @@ const TimelineTrackEvents = ({
   };
 
   const tracksToSounds = useMemo(
-    () => organizeSoundsByTracks(soundEvents, tracksMetadata),
-    [soundEvents, tracksMetadata]
+    () => organizeSoundsByTracks(soundEventsJson, tracksMetadataJson),
+    [soundEventsJson, tracksMetadataJson]
   );
 
   const numTracks = Object.keys(tracksToSounds).length;


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Adds trigger functionality to the tracks model via a "new track when x triggered" block. This will queue a new track at the next measure when the trigger is pressed.

If the same trigger is pressed multiple times, it will just create a new track (rather than add to the same track). I decided to do this to keep the model simple since I wasn't sure how to handle adding to the same track (should it overwrite the existing contents? should it start where the previous track left off?). This is definitely something we can tweak though as we play around with this model.

https://user-images.githubusercontent.com/85528507/211441316-ec7d4bb7-16fd-4da2-a7e6-0f17c5e8a2e3.mov

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
