### PR TITLE
Refactor Applab Turtle pen and drawing commands to avoid Safari strokeStyle bug

### DIFF
--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -1052,7 +1052,7 @@ Applab.resetTurtle = function() {
   Applab.turtle.heading = 0;
   Applab.turtle.x = Applab.appWidth / 2;
   Applab.turtle.y = Applab.appHeight / 2;
-  Applab.turtle.penDown = true; // turtle defaults to penDown on reset
+  Applab.turtle.isPenDown = true; // turtle defaults to penDown on reset
 };
 
 /**

--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -1052,6 +1052,7 @@ Applab.resetTurtle = function() {
   Applab.turtle.heading = 0;
   Applab.turtle.x = Applab.appWidth / 2;
   Applab.turtle.y = Applab.appHeight / 2;
+  Applab.turtle.penDown = true; // turtle defaults to penDown on reset
 };
 
 /**

--- a/apps/src/applab/applabTurtle.js
+++ b/apps/src/applab/applabTurtle.js
@@ -21,7 +21,7 @@ applabTurtle.getTurtleContext = function() {
     });
     canvas = document.getElementById('turtleCanvas');
 
-    // And create the turtle (defaults to visible):
+    // Create the turtleImage (turtle image defaults to visible):
     Applab.turtle.visible = true;
     var turtleImage = document.createElement('img');
     turtleImage.src = turtleImageSrc;

--- a/apps/src/applab/commands.js
+++ b/apps/src/applab/commands.js
@@ -434,6 +434,7 @@ applabCommands.getDirection = function(opts) {
 };
 
 // whether or not Turtle pen is down, executing command will result in drawing a 'dot'
+// with color stored by `penColorInternal`
 applabCommands.dot = function(opts) {
   apiValidateTypeAndRange(opts, 'dot', 'radius', opts.radius, 'number', 0.0001);
   var ctx = applabTurtle.getTurtleContext();
@@ -472,6 +473,7 @@ applabCommands.penWidth = function(opts) {
   }
 };
 
+// the default color of ctx.strokeStyle and ctx.fillStyle is 'black'
 applabCommands.penColorInternal = function(rgbstring) {
   var ctx = applabTurtle.getTurtleContext();
   if (ctx) {

--- a/apps/src/applab/commands.js
+++ b/apps/src/applab/commands.js
@@ -31,7 +31,6 @@ import i18n from '@cdo/applab/locale';
 var XHR_PROXY_PATH = '//' + location.host + '/xhr';
 
 import {ICON_PREFIX_REGEX} from './constants';
-import Applab from './applab';
 
 var applabCommands = {};
 export default applabCommands;

--- a/apps/src/applab/commands.js
+++ b/apps/src/applab/commands.js
@@ -365,8 +365,6 @@ applabCommands.turnTo = function(opts) {
 // if opts.counterclockwise, the center point is 90 degrees counterclockwise
 
 applabCommands.arcRight = function(opts) {
-  console.log('inside arcright');
-  console.log(Applab.turtle.isPenDown);
   apiValidateType(opts, 'arcRight', 'angle', opts.degrees, 'number');
   apiValidateType(opts, 'arcRight', 'radius', opts.radius, 'number');
 
@@ -456,7 +454,6 @@ applabCommands.dot = function(opts) {
       // reset pen so that Applab.turtle pen is actually up.
       Applab.turtle.isPenDown = false;
     }
-    console.log(Applab.turtle.isPenDown);
     ctx.lineWidth = savedLineWidth;
     return true;
   }

--- a/apps/src/applab/commands.js
+++ b/apps/src/applab/commands.js
@@ -602,7 +602,7 @@ applabCommands.line = function(opts) {
   apiValidateType(opts, 'line', 'y1', opts.y1, 'number');
   apiValidateType(opts, 'line', 'y2', opts.y2, 'number');
   var ctx = Applab.activeCanvas && Applab.activeCanvas.getContext('2d');
-  if (ctx && Applab.turtle.isPenDown) {
+  if (ctx) {
     ctx.beginPath();
     ctx.moveTo(opts.x1, opts.y1);
     ctx.lineTo(opts.x2, opts.y2);
@@ -620,7 +620,7 @@ applabCommands.circle = function(opts) {
   apiValidateType(opts, 'circle', 'centerY', opts.y, 'number');
   apiValidateType(opts, 'circle', 'radius', opts.radius, 'number');
   var ctx = Applab.activeCanvas && Applab.activeCanvas.getContext('2d');
-  if (ctx && Applab.turtle.isPenDown) {
+  if (ctx) {
     ctx.beginPath();
     ctx.arc(opts.x, opts.y, opts.radius, 0, 2 * Math.PI);
     ctx.fill();
@@ -639,7 +639,7 @@ applabCommands.rect = function(opts) {
   apiValidateType(opts, 'rect', 'width', opts.width, 'number');
   apiValidateType(opts, 'rect', 'height', opts.height, 'number');
   var ctx = Applab.activeCanvas && Applab.activeCanvas.getContext('2d');
-  if (ctx && Applab.turtle.isPenDown) {
+  if (ctx) {
     ctx.beginPath();
     ctx.rect(opts.x, opts.y, opts.width, opts.height);
     ctx.fill();

--- a/apps/src/applab/commands.js
+++ b/apps/src/applab/commands.js
@@ -390,7 +390,7 @@ applabCommands.arcRight = function(opts) {
         (Applab.turtle.heading + (opts.counterclockwise ? 0 : 180))) /
       360;
     var endAngle = startAngle + (2 * Math.PI * clockwiseDegrees) / 360;
-    if (!Applab.turtle.isPenDown) {
+    if (Applab.turtle.isPenDown) {
       ctx.beginPath();
       ctx.arc(
         centerX,

--- a/apps/src/applab/commands.js
+++ b/apps/src/applab/commands.js
@@ -274,8 +274,10 @@ applabCommands.moveTo = function(opts) {
     ctx.moveTo(Applab.turtle.x, Applab.turtle.y);
     Applab.turtle.x = opts.x;
     Applab.turtle.y = opts.y;
-    ctx.lineTo(Applab.turtle.x, Applab.turtle.y);
-    ctx.stroke();
+    if (Applab.turtle.penDown) {
+      ctx.lineTo(Applab.turtle.x, Applab.turtle.y);
+      ctx.stroke();
+    }
     applabTurtle.updateTurtleImage();
   }
 };
@@ -455,21 +457,11 @@ applabCommands.dot = function(opts) {
 };
 
 applabCommands.penUp = function(opts) {
-  var ctx = applabTurtle.getTurtleContext();
-  if (ctx) {
-    if (ctx.strokeStyle !== 'rgba(255, 255, 255, 0)') {
-      Applab.turtle.penUpColor = ctx.strokeStyle;
-      ctx.strokeStyle = 'rgba(255, 255, 255, 0)';
-    }
-  }
+  Applab.turtle.penDown = false;
 };
 
 applabCommands.penDown = function(opts) {
-  var ctx = applabTurtle.getTurtleContext();
-  if (ctx && Applab.turtle.penUpColor) {
-    ctx.strokeStyle = Applab.turtle.penUpColor;
-    delete Applab.turtle.penUpColor;
-  }
+  Applab.turtle.penDown = true;
 };
 
 applabCommands.penWidth = function(opts) {
@@ -490,14 +482,9 @@ applabCommands.penWidth = function(opts) {
 applabCommands.penColorInternal = function(rgbstring) {
   var ctx = applabTurtle.getTurtleContext();
   if (ctx) {
-    if (Applab.turtle.penUpColor) {
-      // pen is currently up, store this color for pen down
-      Applab.turtle.penUpColor = rgbstring;
-    } else {
-      ctx.strokeStyle = rgbstring;
-    }
-    ctx.fillStyle = rgbstring;
+    ctx.strokeStyle = rgbstring;
   }
+  ctx.fillStyle = rgbstring;
 };
 
 applabCommands.penColor = function(opts) {

--- a/apps/src/applab/commands.js
+++ b/apps/src/applab/commands.js
@@ -433,26 +433,17 @@ applabCommands.getDirection = function(opts) {
   return Applab.turtle.heading;
 };
 
+// whether or not Turtle pen is down, executing command will result in drawing a 'dot'
 applabCommands.dot = function(opts) {
   apiValidateTypeAndRange(opts, 'dot', 'radius', opts.radius, 'number', 0.0001);
   var ctx = applabTurtle.getTurtleContext();
-  var isPenDown = Applab.turtle.isPenDown;
   if (ctx && opts.radius > 0) {
-    if (!isPenDown) {
-      // If Applab.turtle pen is up, temporarily set Applab.turtle pen down to draw dot
-      Applab.turtle.isPenDown = true;
-    }
     ctx.beginPath();
     var savedLineWidth = ctx.lineWidth;
     ctx.lineWidth = 1;
     ctx.arc(Applab.turtle.x, Applab.turtle.y, opts.radius, 0, 2 * Math.PI);
     ctx.fill();
     ctx.stroke();
-    if (!isPenDown) {
-      // If Applab.turtle pen is supposed to be up (stored in local variable isPenDown),
-      // reset pen so that Applab.turtle pen is actually up.
-      Applab.turtle.isPenDown = false;
-    }
     ctx.lineWidth = savedLineWidth;
     return true;
   }

--- a/apps/src/applab/commands.js
+++ b/apps/src/applab/commands.js
@@ -433,8 +433,8 @@ applabCommands.getDirection = function(opts) {
   return Applab.turtle.heading;
 };
 
-// whether or not Turtle pen is down, executing command will result in drawing a 'dot'
-// with color stored by `penColorInternal`
+// Whether or not Turtle pen is down, executing command will result in drawing a 'dot'
+// with color stored by `penColorInternal`.
 applabCommands.dot = function(opts) {
   apiValidateTypeAndRange(opts, 'dot', 'radius', opts.radius, 'number', 0.0001);
   var ctx = applabTurtle.getTurtleContext();
@@ -473,7 +473,6 @@ applabCommands.penWidth = function(opts) {
   }
 };
 
-// the default color of ctx.strokeStyle and ctx.fillStyle is 'black'
 applabCommands.penColorInternal = function(rgbstring) {
   var ctx = applabTurtle.getTurtleContext();
   if (ctx) {

--- a/apps/src/applab/commands.js
+++ b/apps/src/applab/commands.js
@@ -274,7 +274,7 @@ applabCommands.moveTo = function(opts) {
     ctx.moveTo(Applab.turtle.x, Applab.turtle.y);
     Applab.turtle.x = opts.x;
     Applab.turtle.y = opts.y;
-    if (Applab.turtle.penDown) {
+    if (Applab.turtle.isPenDown) {
       ctx.lineTo(Applab.turtle.x, Applab.turtle.y);
       ctx.stroke();
     }
@@ -457,11 +457,11 @@ applabCommands.dot = function(opts) {
 };
 
 applabCommands.penUp = function(opts) {
-  Applab.turtle.penDown = false;
+  Applab.turtle.isPenDown = false;
 };
 
 applabCommands.penDown = function(opts) {
-  Applab.turtle.penDown = true;
+  Applab.turtle.isPenDown = true;
 };
 
 applabCommands.penWidth = function(opts) {

--- a/apps/src/applab/commands.js
+++ b/apps/src/applab/commands.js
@@ -439,11 +439,11 @@ applabCommands.dot = function(opts) {
   var ctx = applabTurtle.getTurtleContext();
   var isPenDown = Applab.turtle.isPenDown;
   if (ctx && opts.radius > 0) {
-    ctx.beginPath();
     if (!isPenDown) {
       // If Applab.turtle pen is up, temporarily set Applab.turtle pen down to draw dot
       Applab.turtle.isPenDown = true;
     }
+    ctx.beginPath();
     var savedLineWidth = ctx.lineWidth;
     ctx.lineWidth = 1;
     ctx.arc(Applab.turtle.x, Applab.turtle.y, opts.radius, 0, 2 * Math.PI);

--- a/apps/src/applab/commands.js
+++ b/apps/src/applab/commands.js
@@ -483,8 +483,8 @@ applabCommands.penColorInternal = function(rgbstring) {
   var ctx = applabTurtle.getTurtleContext();
   if (ctx) {
     ctx.strokeStyle = rgbstring;
+    ctx.fillStyle = rgbstring;
   }
-  ctx.fillStyle = rgbstring;
 };
 
 applabCommands.penColor = function(opts) {


### PR DESCRIPTION
## Summary
This PR refactors Applab Turtle pen and drawing commands in `applab/commands.js` to avoid multiple assignments to [HTML5 2D Canvas](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D) `strokestyle`. That the Canvas `strokeStyle` does not always get properly applied on Safari was logged by this [WebKit Bugzilla report](https://bugs.webkit.org/show_bug.cgi?id=246498). The recent iOS release (16.2) includes [a fix](https://github.com/WebKit/WebKit/pull/4560) to this bug.

[tl;dr](https://github.com/code-dot-org/code-dot-org/pull/49726#pullrequestreview-1252629400) When we were moving the turtle without drawing because the "pen is up", we were still drawing a transparent line on the canvas. Unfortunately, older versions of iOS Safari were incorrectly drawing that invisible line as solid. Now when we are moving the turtle but the "pen is up", we don't draw anything, which works around that Safari bug.

## Details
The `Canvas` bug is evident in this [App lab drawing program](https://studio.code.org/projects/applab/m1mTBYlSr_QOwM8_rKWs_Q) which includes an event handler for 'mousedown' (`moveTo(Mouse.x, Mouse.y)` and then `penDown` is called), event handler for 'mousemove' (`moveTo(Mouse.x, Mouse.y)` is called), and event handler for 'mouseup' (`penup` is called). 

FYI - in [this prior PR](https://github.com/code-dot-org/code-dot-org/pull/34215) touch events were mapped to mouse events. 

The expected behavior on a touchscreen device is that when the user touches the screen and drags their finger across the screen, a line is draw. Once the user lifts their finger, the drawing stops. Then the user can touch a different location and from that point, a line is drawn.  This expected behavior is seen on Android devices and iPads. Interestingly, it's seen on iPhones with iOS version 16.2.

On iPhones with iOS version 16.1 or lower, after the user draws a line, when they touch a different location on the screen, a line continued to be drawn from the last 'touchend' event and the subsequent 'touchstart' event.

Below is a user on iPhone 12, iOS version 16.1 - drawing bug exists:


https://user-images.githubusercontent.com/107423305/212784456-9289e6e1-6ca8-4c22-aaf7-8fb88ae3ff06.mp4


Below is a user on iPhone 12, iOS version 16.2. Note that drawing bug does not occur:


https://user-images.githubusercontent.com/107423305/212784492-4767af12-e0d1-4613-a978-23db0ef93b6d.mp4



Initially as reported in this [jira ticket](https://codedotorg.atlassian.net/browse/SL-432), the premise was that the 'mouseup' event was no longer triggering correctly. However, through [this investigation](https://github.com/code-dot-org/code-dot-org/pull/49636), it was clear that mouse and touch events were firing as expected. I did note that when a user tapped on one of the color buttons to change the color of the ink, both touch and mouse events were registered. However, the commands `penUp` and `penDown` were called in the expected sequence and did not account for the drawing bug.

At this point, I was really stumped! @breville suggested looking more closely at the `moveTo` command in `applab/commands.js`; he had a hunch that there was an issue with this `moveTo` command. We didn't find a bug, but we found it really interesting that in [this Turtle function](https://github.com/code-dot-org/code-dot-org/blob/0b684db769265748ae8e5d20665d984c58bd2bc7/apps/src/applab/commands.js#L272-278) a line is always drawn whether the 'pen' is up (invisible line) or down (visible line). The variable `ctx` is a [`CanvasRenderingContext2D`](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D) object. 
```
 var ctx = applabTurtle.getTurtleContext();
  if (ctx) {
    ctx.beginPath();
    ctx.moveTo(Applab.turtle.x, Applab.turtle.y);
    Applab.turtle.x = opts.x;
    Applab.turtle.y = opts.y;
    ctx.lineTo(Applab.turtle.x, Applab.turtle.y);
    ctx.stroke();
```
Currently in the Applab Turtle `penUp`function definition, `ctx.strokeStyle` is assigned a transparent color `rgba(255, 255, 255, 0)` and the current pen color is stored at `Applab.turtle.penUpColor`.  In the Applab Turtle `penDown` function definition, `ctx.strokeStyle` is assigned the stored color at `Applab.turtle.penUpColor`, and then the variable `Applab.turtle.penUpColor` is deleted.

To avoid having to set `ctx.strokeStyle` multiple times, I assigned a new variable `Applab.turtle.isPenDown` to `true` in `applab.js` which is the default behavior for Applab Turtle commands. Then this value `isPenDown` is set by the functions `penUp` and `penDown`. Within the`moveTo` function, only if `isPenDown` is `true` is the line drawn by the `Canvas` commands `lineTo` and `stroke`. However, `Applab.turtle.x` and `Applab.turtle.y` are still updated appropriately.

With these updates, `strokeStyle` is assigned in only two functions - `penColorInternal` and `setStrokeColor`.

I also updated the Turtle drawing command `arcRight` to draw only if `Applab.turtle.isPenDown` is true. Similar to the `moveTo` command, `Applab.turtle.x` and `Applab.turtle.y` are changed appropriately even if the arc is not drawn. Note that `arcLeft` did not need to be modified because it calls on `arcRight` but with the 'counterclockwise' direction.

I handled the Turtle `dot`command a bit differently because whether or not the Turtle pen is up or down, the `dot` command will draw a filled in circle on the canvas. This is the current behavior on production. 

These changes avoid multiple reassignments to the Canvas `strokeStyle` which [does not always get applied correctly](https://bugs.webkit.org/show_bug.cgi?id=246498) as noted in the Summary above when `penUp` and `penDown` are called. This ensures that even on an iPhone with iOS v16.1 or lower using a Safari browser, lines are drawn when the Turtle pen is down and not drawn when the Turtle pen is up.  

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

[jira ticket - iOS: Fix mouse drag events on App Lab to enable drawing on touch screens](https://codedotorg.atlassian.net/browse/SL-432)
Note that [this PR](https://github.com/code-dot-org/code-dot-org/pull/49645) includes updates to prevent scrolling on the visualization column in app lab in response to a 'touchmove' event, the 2nd bug reported in the jira ticket.


## Testing story
I tested locally on two different iPhones, one with iOS v16.1 and the other with iOS v16.2. I also tested locally on an Android device and iPad. Interestingly, the bug did not exist on an iPad whose iOS version was <16.2. 

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
