### PR TITLE
Change the help text on the school search to suggest zip code

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1826,7 +1826,7 @@
   "scanQRCode": "Scan this code with your phone camera:",
   "scatterPlot": "Scatter Plot",
   "searchForCountry": "Search for your country.",
-  "searchForSchool": "Enter your school name, city, or zip code to search",
+  "searchForSchool": "Enter your zip code to search",
   "searchForSchoolPrompt": "e.g. \"Lincoln Elementary\" or \"Lincoln Elementary Lynwood\" or \"Lynwood\"",
   "seeFullLevel": "See Full Level",
   "seeFullQuestion": " ...see full question",


### PR DESCRIPTION
The school search does not work well when you try to search for some schools by name. 

Example:

Try to find "B F DAY ELEMENTARY SCHOOL"
It doesn't show up if I type in:
B F Day
BF Day (as its known locally)
Type in "B F Day Elementary" it shows up at the bottom of a long list of schools with names that are much looser matches.
Type "98103", the zip code, it does show up.

It is most reliable when you use zip code to search. In order to hopefully make people more successful at finding their school in the school search this updates the suggestion text to tell them to search by zip code. 

![Screenshot 2023-01-10 at 12 54 53 PM](https://user-images.githubusercontent.com/208083/211626293-a651a4a1-336c-4aff-924c-21e951b3aad5.png)

Longer term we will look at ways to make this process more streamlined and easier to find your school.


## Links

https://codedotorg.atlassian.net/browse/ACQ-324

## Testing story

- Tested locally. See screenshot above