### PR TITLE
Java Lab: Add NO_AUDIO signal to theater

### DIFF
--- a/apps/src/javalab/constants.js
+++ b/apps/src/javalab/constants.js
@@ -86,7 +86,9 @@ export const TheaterSignalType = {
   // This message contains the url to a visual element
   VISUAL_URL: 'VISUAL_URL',
   // Get an image from the user via Prompter
-  GET_IMAGE: 'GET_IMAGE'
+  GET_IMAGE: 'GET_IMAGE',
+  // There is no audio
+  NO_AUDIO: 'NO_AUDIO'
 };
 
 export const StatusMessageType = {

--- a/apps/src/javalab/theater/Theater.js
+++ b/apps/src/javalab/theater/Theater.js
@@ -29,9 +29,9 @@ export default class Theater {
     switch (data.value) {
       case TheaterSignalType.AUDIO_URL: {
         // Wait for the audio to load before starting playback
-        this.getAudioElement().oncanplaythrough = () => this.startPlayback();
         this.getAudioElement().src =
           data.detail.url + this.getCacheBustSuffix();
+        this.getAudioElement().oncanplaythrough = () => this.startPlayback();
         break;
       }
       case TheaterSignalType.VISUAL_URL: {
@@ -57,7 +57,6 @@ export default class Theater {
   }
 
   startPlayback() {
-    console.log(`in startPlayback`);
     this.loadEventsFinished++;
     // We expect exactly 2 responses from Javabuilder. One for audio (or the NO_AUDIO signal) and one for video.
     // Wait for both to respond and load before starting playback.

--- a/apps/src/javalab/theater/Theater.js
+++ b/apps/src/javalab/theater/Theater.js
@@ -29,9 +29,9 @@ export default class Theater {
     switch (data.value) {
       case TheaterSignalType.AUDIO_URL: {
         // Wait for the audio to load before starting playback
+        this.getAudioElement().oncanplaythrough = () => this.startPlayback();
         this.getAudioElement().src =
           data.detail.url + this.getCacheBustSuffix();
-        this.getAudioElement().oncanplaythrough = () => this.startPlayback();
         break;
       }
       case TheaterSignalType.VISUAL_URL: {
@@ -46,14 +46,20 @@ export default class Theater {
         this.openPhotoPrompter(data.detail.prompt);
         break;
       }
+      case TheaterSignalType.NO_AUDIO: {
+        // there is no audio associated with the video, trigger startPlayback so we don't wait for the audio file
+        this.startPlayback();
+        break;
+      }
       default:
         break;
     }
   }
 
   startPlayback() {
+    console.log(`in startPlayback`);
     this.loadEventsFinished++;
-    // We expect exactly 2 responses from Javabuilder. One for audio and one for video.
+    // We expect exactly 2 responses from Javabuilder. One for audio (or the NO_AUDIO signal) and one for video.
     // Wait for both to respond and load before starting playback.
     if (this.loadEventsFinished > 1) {
       this.getImgElement().style.visibility = 'visible';

--- a/apps/src/javalab/theater/Theater.js
+++ b/apps/src/javalab/theater/Theater.js
@@ -23,12 +23,14 @@ export default class Theater {
     this.onJavabuilderMessage = onJavabuilderMessage;
     this.loadEventsFinished = 0;
     this.prompterUploadUrl = null;
+    this.hasAudio = false;
   }
 
   handleSignal(data) {
     switch (data.value) {
       case TheaterSignalType.AUDIO_URL: {
         // Wait for the audio to load before starting playback
+        this.hasAudio = true;
         this.getAudioElement().src =
           data.detail.url + this.getCacheBustSuffix();
         this.getAudioElement().oncanplaythrough = () => this.startPlayback();
@@ -48,6 +50,7 @@ export default class Theater {
       }
       case TheaterSignalType.NO_AUDIO: {
         // there is no audio associated with the video, trigger startPlayback so we don't wait for the audio file
+        this.hasAudio = false;
         this.startPlayback();
         break;
       }
@@ -62,7 +65,9 @@ export default class Theater {
     // Wait for both to respond and load before starting playback.
     if (this.loadEventsFinished > 1) {
       this.getImgElement().style.visibility = 'visible';
-      this.getAudioElement().play();
+      if (this.hasAudio) {
+        this.getAudioElement().play();
+      }
     }
   }
 
@@ -83,6 +88,7 @@ export default class Theater {
     audioElement.pause();
     audioElement.src = '';
     this.getImgElement().src = '';
+    this.hasAudio = false;
   }
 
   getImgElement() {


### PR DESCRIPTION
We were seeing issues where Safari would not process our [empty audio file](https://github.com/code-dot-org/javabuilder/blob/31a7806859a3b68a95ddd5c0addeebbf2bd77ae0/org-code-javabuilder/media/src/main/java/org/code/media/support/AudioWriter.java#L77) for Theater projects without audio, which meant if a Theater project did not have audio, it would never show the gif on Safari. Since we wanted to add a `NO_AUDIO` signal anyway, this PR adds a `NO_AUDIO` signal to the frontend and counts that as a signal that is ready for playback. Once this is deployed I will merge the Javabuilder-side PR that sends a `NO_AUDIO` signal instead of an empty audio file.


## Links

- jira ticket: [SL-314](https://codedotorg.atlassian.net/browse/SL-314)


## Testing story
In testing this I found that Safari also seems to have issues with how we create audio files locally, so testing on Safari against localhost Javabuilder for a theater project with audio does not work (it won't play because it doesn't get a `oncanplaythrough` event). However, I tested against a deployed version of Javabuilder and that worked fine.

I tested that now Safari, Firefox and Chrome will play a theater project with and without audio, against a dev deploy of Javabuilder with a new `NO_AUDIO` signal. They also will continue to act as expected against the current version of Javabuilder.

## Deployment strategy
This change must be deployed before the corresponding Javabuilder change, otherwise theater projects without audio will not work.

## Follow-up work
This will be followed up by the Javabuilder-side change to add a `NO_AUDIO` signal.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
