### PR TITLE
Fix send Accepted emails bug

### DIFF
--- a/dashboard/bin/scheduled_pd_application_emails
+++ b/dashboard/bin/scheduled_pd_application_emails
@@ -5,27 +5,35 @@ abort 'Script already running' unless only_one_running?(__FILE__)
 require_relative '../config/environment'
 
 def queue_pd_reminder_emails
-  # For each teacher application, queue up one reminder email if their principal
+  puts "Started queueing"
+  # For each teacher application, queue up one reminder email if their admin
   # hasn't yet responded.
   Pd::Application::TeacherApplication.where(
     application_year: Pd::Application::ActiveApplicationModels::APPLICATION_CURRENT_YEAR
   ).find_each do |teacher_application|
-    if teacher_application.allow_sending_principal_approval_teacher_reminder_email?
-      teacher_application.queue_email :principal_approval_teacher_reminder
+    if teacher_application.allow_sending_admin_approval_teacher_reminder_email?
+      teacher_application.queue_email :admin_approval_teacher_reminder
     end
   end
+
+  puts "Reminder if no principal response"
 
   # Queue reminder emails for teachers that have been accepted but have not yet
   # registered for a workshop.
   Services::RegistrationReminder.queue_registration_reminders!
 
+  puts "Accepted reminder email"
+
   # Queue reminder emails for teachers who have started an application but
   # have not completed it
   Services::CompleteApplicationReminder.queue_complete_application_reminders!
+  puts "App reminder emails"
 end
 
 # First, add PD reminder emails to the queue.
 queue_pd_reminder_emails
+puts "Add PD reminder emails to queue"
 
 # Second, send all queued emails.
 Pd::Application::Email.send_all_queued_emails
+puts "All done!"

--- a/dashboard/bin/scheduled_pd_application_emails
+++ b/dashboard/bin/scheduled_pd_application_emails
@@ -5,7 +5,6 @@ abort 'Script already running' unless only_one_running?(__FILE__)
 require_relative '../config/environment'
 
 def queue_pd_reminder_emails
-  puts "Started queueing"
   # For each teacher application, queue up one reminder email if their admin
   # hasn't yet responded.
   Pd::Application::TeacherApplication.where(
@@ -16,24 +15,17 @@ def queue_pd_reminder_emails
     end
   end
 
-  puts "Reminder if no principal response"
-
   # Queue reminder emails for teachers that have been accepted but have not yet
   # registered for a workshop.
   Services::RegistrationReminder.queue_registration_reminders!
 
-  puts "Accepted reminder email"
-
   # Queue reminder emails for teachers who have started an application but
   # have not completed it
   Services::CompleteApplicationReminder.queue_complete_application_reminders!
-  puts "App reminder emails"
 end
 
 # First, add PD reminder emails to the queue.
 queue_pd_reminder_emails
-puts "Add PD reminder emails to queue"
 
 # Second, send all queued emails.
 Pd::Application::Email.send_all_queued_emails
-puts "All done!"


### PR DESCRIPTION
From [this thread](https://codedotorg.slack.com/archives/C04540KNGDQ/p1673372115360019), we found that no "Accepted" emails were being sent to teacher applicants who had been accepted and no "Reminder" emails were being sent to applicants who had not worked on their application for at least 1 week (nor the followup "Reminder" emails after 2 weeks of inactivity).

From the transition of switching "Principal" to "Admin(istrator/School Leader)", this script was missed so it was trying to send emails whose names no longer existed (i.e. they contained "principal" in their names). With this fix, we should start seeing "Reminder" and "Accepted" emails being sent automatically from the plc-emails@code.org email.

For emails that had been previously queued but never sent due to this error:
- We manually sent the "Accepted" emails
- The "Reminder" emails will be automatically sent out once this is merged

## Links
Slack thread where discussed: [here](https://codedotorg.slack.com/archives/C04540KNGDQ/p1673382437307139)

## Testing story
Locally re-running the script with queued emails, now with successful results.

## Follow-up work
Ensuring we see automatically-sent ["Accepted" emails](https://test-studio.code.org/rails/mailers/pd_teacher_application_mailer/accepted__with_partner) and ["Reminder" emails](https://test-studio.code.org/rails/mailers/pd_teacher_application_mailer/complete_application_initial_reminder__with_partner) from the plc-emails@code.org email.

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
