### PR TITLE
A11y 48 remove duplicate help site button link

### DIFF
--- a/pegasus/sites.v3/code.org/public/css/common.css
+++ b/pegasus/sites.v3/code.org/public/css/common.css
@@ -403,7 +403,7 @@ button {
   margin-top: 10px;
 }
 
-.button {
+.link-button {
   color: white;
   display: inline-block;
   background-color: #ffa400;

--- a/pegasus/sites.v3/code.org/public/css/common.css
+++ b/pegasus/sites.v3/code.org/public/css/common.css
@@ -403,6 +403,20 @@ button {
   margin-top: 10px;
 }
 
+.button {
+  color: white;
+  display: inline-block;
+  background-color: #ffa400;
+  border-radius: 5px;
+  padding: 7px 14px;
+  font-size: 14px;
+  line-height: 20px;
+  box-sizing: border-box;
+  float: left;
+  cursor: pointer;
+  margin-top: -6px;
+}
+
 #map .mapboxgl-popup-close-button {
   margin-top: 0px;
   background-color: #ffa400;

--- a/pegasus/sites.v3/code.org/public/css/common.css
+++ b/pegasus/sites.v3/code.org/public/css/common.css
@@ -403,18 +403,15 @@ button {
   margin-top: 10px;
 }
 
-.link-button {
-  color: white;
+a.link-button {
   display: inline-block;
+  color: white;
   background-color: #ffa400;
-  border-radius: 5px;
-  padding: 7px 14px;
+  border-radius: 4px;
+  padding: 6px 12px;
   font-size: 14px;
-  line-height: 20px;
-  box-sizing: border-box;
-  float: left;
-  cursor: pointer;
-  margin-top: -6px;
+  font-family: 'Gotham 4r', sans-serif;
+  text-decoration: none;
 }
 
 #map .mapboxgl-popup-close-button {

--- a/pegasus/sites.v3/code.org/public/help.md
+++ b/pegasus/sites.v3/code.org/public/help.md
@@ -22,13 +22,6 @@ style_min: true
     width: 75px !important;
     margin: 7px -10px;
   }
-
-  .button {
-    paddingLeft: 0;
-    paddingRight: 0;
-    width: 100%;
-    margin: 5px 0px 0px 0px
-  }
 </style>
 
 # How to Help

--- a/pegasus/sites.v3/code.org/public/help.md
+++ b/pegasus/sites.v3/code.org/public/help.md
@@ -36,8 +36,7 @@ style_min: true
 ## Make a generous donation
 We're working to give every student the opportunity to learn computer science — online and in schools where we’ll establish permanent courses and train teachers. For every dollar you donate, one child will be introduced to computer science.
 
-<button onclick="window.location.href='https://donate.code.org/give/172233/#!/donation/checkout';">Donate now</button> <button onclick="window.location.href='https://donate.code.org/campaign/computer-science-education/c142257';">Start a fundraiser</button>
-<a href=https://donate.code.org/give/172233/#!/donation/checkout class="button">Donate now</a>
+<a class="button" href=https://donate.code.org/give/172233/#!/donation/checkout>Donate now</a> <a class="button" href="https://donate.code.org/campaign/computer-science-education/c142257">Start a fundraiser</a>
 
 
 

--- a/pegasus/sites.v3/code.org/public/help.md
+++ b/pegasus/sites.v3/code.org/public/help.md
@@ -29,14 +29,14 @@ style_min: true
 ## Make a generous donation
 We're working to give every student the opportunity to learn computer science — online and in schools where we’ll establish permanent courses and train teachers. For every dollar you donate, one child will be introduced to computer science.
 
-<a class="link-button" href=https://donate.code.org/give/172233/#!/donation/checkout>Donate now</a> <a class="link-button" href="https://donate.code.org/campaign/computer-science-education/c142257">Start a fundraiser</a>
+<a class="link-button" href="https://donate.code.org/give/172233/#!/donation/checkout">Donate now</a> <a class="link-button" href="https://donate.code.org/campaign/computer-science-education/c142257">Start a fundraiser</a>
 
 
 
 ## Have Amazon make a donation for you
 If you shop on Amazon, use [AmazonSmile](/donate/amazonsmile) and choose Code.org as your charity to donate a percent of all your purchases to Code.org.
 
-[<button>Donate with AmazonSmile</button>](/donate/amazonsmile)
+<a class="link-button" href="/donate/amazonsmile">Donate with AmazonSmile</a>
 
 
 ## Donate through DAF Direct
@@ -48,19 +48,19 @@ Donate through your donor advised fund with Fidelity Charitable, Schwab Charitab
 ## Ask your school to teach computer science
 Encourage your local school to start teaching computer science. To make it easier, Code.org offers [courses for every grade level](https://studio.code.org/courses?view=teacher) from kindergarten through high school at no cost. And, teachers can enroll in our [hands-on professional learning workshops](/educate/professional-learning) offered locally across the United States.
 
-[<button>Sample letter</button>](/promote/letter)&nbsp;&nbsp; [<button>Resources for schools</button>](/yourschool)
+<a class="link-button" href="/promote/letter">Sample letter</a>&nbsp;&nbsp; <a class="link-button" href="/yourschool">Resources for schools</a>
 
 ## Help us spread the word
 Follow us [on Facebook](http://facebook.com/Code.org) or [on Twitter](http://twitter.com/codeorg) and re-share our posts.  Or stay in touch with our [quarterly email updates](http://go.pardot.com/l/153401/2018-01-12/k555vp).
 
 Petition your state to allow computer science to count towards math or science high school graduation credits. And promote computer science in your area with these [stats, quotes and videos](/promote).
 
-[<button>Add your support</button>](/promote)
+<a class="link-button" href="/promote">Add your support</a>
 
 ## Teach an online course to your child, or in any classroom
 Code.org's online platform [Code Studio](https://studio.code.org/courses?view=teacher) enables students to learn the basic concepts of computer science as early as kindergarten. You don't need any prior experience to get started - you can learn along with your children. If you do know some programming, try [App Lab](/educate/applab), a JavaScript programming environment for high school students to create apps.
 
-[<button>Find a course</button>](https://studio.code.org/courses?view=teacher)
+<a class="link-button" href="https://studio.code.org/courses?view=teacher">Find a course</a>
 
 ## Buy a CODE hat or t-shirt
 Support our work and wear the movement with pride. Our hats have been worn by President Obama and celebrities too.
@@ -70,7 +70,7 @@ Support our work and wear the movement with pride. Our hats have been worn by Pr
 ![Code.org t-shirt](/images//fit-160/swag10.jpg)
 ![Code.org stickers](/images//fit-160/swag8.jpg)
 
-[<button>Shop</button>](/shop)
+<a class="link-button" href="/shop">Shop</a>
 
 ## Learn about our advocacy efforts in your state
 Learn more about [Code.org's advocacy work](https://advocacy.code.org) across the U.S. and the nine policies we recommend states adopt to make computer science foundational for all students. And, find out how you can drive change in your state.
@@ -78,18 +78,18 @@ Learn more about [Code.org's advocacy work](https://advocacy.code.org) across th
 ## Host an Hour of Code - at work, in your community, or local school
 Millions of people of all ages have learned an [Hour of Code](https://hourofcode.com), a one-hour introductory course designed to demystify computer science and show that anybody can learn the basics. Anybody, anywhere, anytime can learn an Hour of Code.
 
-[<button>Host an Hour of Code</button>](https://hourofcode.com/how-to)
+<a class="link-button" href="https://hourofcode.com/how-to">Host an Hour of Code</a>
 
 ## Translate our tutorials
 Volunteers have translated our tutorials in over 45 languages. Help us continue to expand our tutorials for students around the world!
 
-[<button>Translate tutorials</button>](/translate)
+<a class="link-button" href="/translate">Translate tutorials</a>
 
 ## Are you a software engineer? Volunteer in a classroom
 ### Even an hour makes a difference
 Volunteer to teach the Hour of Code or be a guest speaker in a local classroom. Sign up to hear about opportunities near you.
 
-[<button>Volunteer in a classroom</button>](/volunteer)
+<a class="link-button" href="/volunteer">Volunteer in a classroom</a>
 
 ### Volunteer weekly with these great organizations
 [col-33]
@@ -111,5 +111,5 @@ Volunteer to teach the Hour of Code or be a guest speaker in a local classroom. 
 ## Become a Code.org Partner
 Code.org works with nonprofit organizations, as partners, to help spread computer science in a local, sustainable fashion. Learn more about our program.
 
-[<button>United States</button>](/educate/regional-partner)
-[<button>International</button>](/international)
+<a class="link-button" href="/educate/regional-partner">United States</a>
+<a class="link-button" href="/international">International</a>

--- a/pegasus/sites.v3/code.org/public/help.md
+++ b/pegasus/sites.v3/code.org/public/help.md
@@ -29,7 +29,7 @@ style_min: true
 ## Make a generous donation
 We're working to give every student the opportunity to learn computer science — online and in schools where we’ll establish permanent courses and train teachers. For every dollar you donate, one child will be introduced to computer science.
 
-<a class="button" href=https://donate.code.org/give/172233/#!/donation/checkout>Donate now</a> <a class="button" href="https://donate.code.org/campaign/computer-science-education/c142257">Start a fundraiser</a>
+<a class="link-button" href=https://donate.code.org/give/172233/#!/donation/checkout>Donate now</a> <a class="link-button" href="https://donate.code.org/campaign/computer-science-education/c142257">Start a fundraiser</a>
 
 
 

--- a/pegasus/sites.v3/code.org/public/help.md
+++ b/pegasus/sites.v3/code.org/public/help.md
@@ -22,6 +22,13 @@ style_min: true
     width: 75px !important;
     margin: 7px -10px;
   }
+
+  .button {
+    paddingLeft: 0;
+    paddingRight: 0;
+    width: 100%;
+    margin: 5px 0px 0px 0px
+  }
 </style>
 
 # How to Help
@@ -29,7 +36,10 @@ style_min: true
 ## Make a generous donation
 We're working to give every student the opportunity to learn computer science — online and in schools where we’ll establish permanent courses and train teachers. For every dollar you donate, one child will be introduced to computer science.
 
-[<button>Donate now</button>](https://donate.code.org/give/172233/#!/donation/checkout)     [<button>Start a fundraiser</button>](https://donate.code.org/campaign/computer-science-education/c142257)
+<button onclick="window.location.href='https://donate.code.org/give/172233/#!/donation/checkout';">Donate now</button> <button onclick="window.location.href='https://donate.code.org/campaign/computer-science-education/c142257';">Start a fundraiser</button>
+<a href=https://donate.code.org/give/172233/#!/donation/checkout class="button">Donate now</a>
+
+
 
 ## Have Amazon make a donation for you
 If you shop on Amazon, use [AmazonSmile](/donate/amazonsmile) and choose Code.org as your charity to donate a percent of all your purchases to Code.org.


### PR DESCRIPTION
As a part of our Accessibility effort, we are trying to make our pages more screen reader and tab navigation friendly, and compliant with WCAG standards.
A screen reader  on [How to help](https://code.org/help) reads out each button twice, once for the link and once for the button. 

This PR removes the redundancy, turning buttons with links into links with a button-like style. 
For this purpose, a `link-button` style has been added to the common Style Sheet, and to class attribute of updated links. This approach represents a better overall design as new styles are available across other pages, rather than specified in each markdown/html/haml file.

## Links

- jira ticket: [A11Y-48](https://codedotorg.atlassian.net/browse/A11Y-48)

## Testing story

Tested manually that all links redirect correctly.

Production vs Development comparative image.
![image](https://user-images.githubusercontent.com/66776217/216675133-aa640ac1-be1d-4e25-9ae9-d6281469c8c5.png)
 
The following video captures the behavior of the previous buttons vs new links using tab navigation and a screen reader.
Note that buttons are cover twice when navigating the page with keyboard (tab navigation)  
https://user-images.githubusercontent.com/66776217/216675344-8dbdc0f1-8aad-43b9-9ac3-149567fc061b.mov


## Deployment strategy
This PR will result in failing eyes test as there is a slight change in the buttons position.

## Follow-up work
Updating any other button with links in other parts of pegasus code (more specifically in markdowns) 
The following list contains some pages with button and links that need to be updated.
- https://code.org/donate/amazonsmile
- https://code.org/promote
- https://hourofcode.com/us/es/how-to
- https://code.org/international

## PR Checklist:


- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
