### PR TITLE
Updating accessibility of Manage Code Groups button

### DIFF
--- a/apps/src/templates/manageStudents/CodeReviewGroupsDialog.jsx
+++ b/apps/src/templates/manageStudents/CodeReviewGroupsDialog.jsx
@@ -130,11 +130,9 @@ export default function CodeReviewGroupsDialog({
 
   return (
     <div style={{...styles.buttonContainer, ...buttonContainerStyle}}>
-      {/* use div instead of button HTML element via __useDeprecatedTag
-          for consistent spacing with other "buttons" in ManageStudentsTable header */}
       <Button
         id="uitest-code-review-groups-button"
-        __useDeprecatedTag
+        style={styles.button}
         onClick={openDialog}
         color={Button.ButtonColor.gray}
         text={i18n.manageCodeReviewGroups()}
@@ -177,5 +175,9 @@ const styles = {
   errorMessageContainer: {
     fontFamily: '"Gotham 5r", sans-serif',
     color: color.red
+  },
+  button: {
+    boxShadow: 'inset 0 2px 0 0 rgba(255, 255, 255, 0.8)',
+    marginTop: 0
   }
 };


### PR DESCRIPTION
This makes the "Manage Code Review Groups" button accessible, without sacrificing the styling benefits of the clickable div.

I didn't like that the button was never left-aligned with the button above. I thought at first that the space was to account for all the buttons lining up nicely with widescreens, but that doesn't ever seem to happen (I think there's a fixed width). Should I mess with the margins to make it actually left aligned (an explicit change)?

I tested that the button still works as expected:)

Before:
<img width="1025" alt="Screen Shot 2023-01-11 at 4 25 06 PM" src="https://user-images.githubusercontent.com/37230822/211948027-0b838ccd-dc15-4caa-8a1c-c642f75e46b5.png">

After:
<img width="1131" alt="Screen Shot 2023-01-11 at 4 35 39 PM" src="https://user-images.githubusercontent.com/37230822/211948057-0553e581-c553-4930-885b-09eaa4046bc3.png">


## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/A11Y-105

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
