### PR TITLE
Replace Hadi's email with support email

### DIFF
--- a/dashboard/app/mailers/parent_mailer.rb
+++ b/dashboard/app/mailers/parent_mailer.rb
@@ -1,5 +1,6 @@
 class ParentMailer < ActionMailer::Base
   default from: 'Hadi Partovi <hadi_partovi@code.org>'
+  default reply_to: 'Code.org <support@code.org>'
 
   # Email a parent when a student upgrades to a username/password account by adding a parent email
   def student_associated_with_parent_email(parent_email, student)

--- a/dashboard/app/mailers/parent_mailer.rb
+++ b/dashboard/app/mailers/parent_mailer.rb
@@ -1,5 +1,5 @@
 class ParentMailer < ActionMailer::Base
-  default from: 'Hadi Partovi <support@code.org>'
+  default from: 'Hadi Partovi <hadi_partovi@code.org>'
 
   # Email a parent when a student upgrades to a username/password account by adding a parent email
   def student_associated_with_parent_email(parent_email, student)

--- a/dashboard/app/mailers/parent_mailer.rb
+++ b/dashboard/app/mailers/parent_mailer.rb
@@ -1,5 +1,5 @@
 class ParentMailer < ActionMailer::Base
-  default from: 'Hadi Partovi <hadi_partovi@code.org>'
+  default from: 'Hadi Partovi <support@code.org>'
 
   # Email a parent when a student upgrades to a username/password account by adding a parent email
   def student_associated_with_parent_email(parent_email, student)

--- a/dashboard/app/mailers/teacher_mailer.rb
+++ b/dashboard/app/mailers/teacher_mailer.rb
@@ -1,5 +1,6 @@
 class TeacherMailer < ActionMailer::Base
   default from: 'Hadi Partovi <hadi_partovi@code.org>'
+  default reply_to: 'Code.org <support@code.org>'
 
   # Send newly registered teachers a welcome email
   def new_teacher_email(teacher, teacher_locale = 'en-US')

--- a/dashboard/app/mailers/teacher_mailer.rb
+++ b/dashboard/app/mailers/teacher_mailer.rb
@@ -1,5 +1,5 @@
 class TeacherMailer < ActionMailer::Base
-  default from: 'Hadi Partovi <support@code.org>'
+  default from: 'Hadi Partovi <hadi_partovi@code.org>'
 
   # Send newly registered teachers a welcome email
   def new_teacher_email(teacher, teacher_locale = 'en-US')

--- a/dashboard/app/mailers/teacher_mailer.rb
+++ b/dashboard/app/mailers/teacher_mailer.rb
@@ -1,5 +1,5 @@
 class TeacherMailer < ActionMailer::Base
-  default from: 'Hadi Partovi <hadi_partovi@code.org>'
+  default from: 'Hadi Partovi <support@code.org>'
 
   # Send newly registered teachers a welcome email
   def new_teacher_email(teacher, teacher_locale = 'en-US')

--- a/dashboard/test/mailers/parent_mailer_test.rb
+++ b/dashboard/test/mailers/parent_mailer_test.rb
@@ -9,6 +9,7 @@ class ParentMailerTest < ActionMailer::TestCase
     assert_equal I18n.t('parent_mailer.student_associated_subject'), mail.subject
     assert_equal [parent_email], mail.to
     assert_equal ['hadi_partovi@code.org'], mail.from
+    assert_equal ['support@code.org'], mail.reply_to
     assert links_are_complete_urls?(mail)
   end
 
@@ -20,6 +21,7 @@ class ParentMailerTest < ActionMailer::TestCase
     assert_equal I18n.t('parent_mailer.parent_email_added_subject'), mail.subject
     assert_equal [parent_email], mail.to
     assert_equal ['hadi_partovi@code.org'], mail.from
+    assert_equal ['support@code.org'], mail.reply_to
     assert links_are_complete_urls?(mail)
   end
 end

--- a/dashboard/test/mailers/parent_mailer_test.rb
+++ b/dashboard/test/mailers/parent_mailer_test.rb
@@ -8,7 +8,7 @@ class ParentMailerTest < ActionMailer::TestCase
 
     assert_equal I18n.t('parent_mailer.student_associated_subject'), mail.subject
     assert_equal [parent_email], mail.to
-    assert_equal ['support@code.org'], mail.from
+    assert_equal ['hadi_partovi@code.org'], mail.from
     assert links_are_complete_urls?(mail)
   end
 
@@ -19,7 +19,7 @@ class ParentMailerTest < ActionMailer::TestCase
 
     assert_equal I18n.t('parent_mailer.parent_email_added_subject'), mail.subject
     assert_equal [parent_email], mail.to
-    assert_equal ['support@code.org'], mail.from
+    assert_equal ['hadi_partovi@code.org'], mail.from
     assert links_are_complete_urls?(mail)
   end
 end

--- a/dashboard/test/mailers/parent_mailer_test.rb
+++ b/dashboard/test/mailers/parent_mailer_test.rb
@@ -8,7 +8,7 @@ class ParentMailerTest < ActionMailer::TestCase
 
     assert_equal I18n.t('parent_mailer.student_associated_subject'), mail.subject
     assert_equal [parent_email], mail.to
-    assert_equal ['hadi_partovi@code.org'], mail.from
+    assert_equal ['support@code.org'], mail.from
     assert links_are_complete_urls?(mail)
   end
 
@@ -19,7 +19,7 @@ class ParentMailerTest < ActionMailer::TestCase
 
     assert_equal I18n.t('parent_mailer.parent_email_added_subject'), mail.subject
     assert_equal [parent_email], mail.to
-    assert_equal ['hadi_partovi@code.org'], mail.from
+    assert_equal ['support@code.org'], mail.from
     assert links_are_complete_urls?(mail)
   end
 end

--- a/dashboard/test/mailers/teacher_mailer_test.rb
+++ b/dashboard/test/mailers/teacher_mailer_test.rb
@@ -9,6 +9,7 @@ class TeacherMailerTest < ActionMailer::TestCase
     assert_equal I18n.t('teacher_mailer.new_teacher_subject', locale: 'en-US'), mail.subject
     assert_equal [teacher.email], mail.to
     assert_equal ['hadi_partovi@code.org'], mail.from
+    assert_equal ['support@code.org'], mail.reply_to
     assert_match /Hello/, mail.body.encoded
     assert links_are_complete_urls?(mail)
   end

--- a/dashboard/test/mailers/teacher_mailer_test.rb
+++ b/dashboard/test/mailers/teacher_mailer_test.rb
@@ -8,7 +8,7 @@ class TeacherMailerTest < ActionMailer::TestCase
 
     assert_equal I18n.t('teacher_mailer.new_teacher_subject', locale: 'en-US'), mail.subject
     assert_equal [teacher.email], mail.to
-    assert_equal ['support@code.org'], mail.from
+    assert_equal ['hadi_partovi@code.org'], mail.from
     assert_match /Hello/, mail.body.encoded
     assert links_are_complete_urls?(mail)
   end

--- a/dashboard/test/mailers/teacher_mailer_test.rb
+++ b/dashboard/test/mailers/teacher_mailer_test.rb
@@ -8,7 +8,7 @@ class TeacherMailerTest < ActionMailer::TestCase
 
     assert_equal I18n.t('teacher_mailer.new_teacher_subject', locale: 'en-US'), mail.subject
     assert_equal [teacher.email], mail.to
-    assert_equal ['hadi_partovi@code.org'], mail.from
+    assert_equal ['support@code.org'], mail.from
     assert_match /Hello/, mail.body.encoded
     assert links_are_complete_urls?(mail)
   end

--- a/lib/cdo/poste.rb
+++ b/lib/cdo/poste.rb
@@ -532,7 +532,7 @@ module Poste2
       pd@code.org
       noreply@code.org
       teacher@code.org
-      hadi_partovi@code.org
+      support@code.org
       survey@code.org
       facilitators@code.org
       volunteers@code.org

--- a/lib/cdo/poste.rb
+++ b/lib/cdo/poste.rb
@@ -532,7 +532,7 @@ module Poste2
       pd@code.org
       noreply@code.org
       teacher@code.org
-      support@code.org
+      hadi_partovi@code.org
       survey@code.org
       facilitators@code.org
       volunteers@code.org

--- a/pegasus/emails/census_form_receipt.md
+++ b/pegasus/emails/census_form_receipt.md
@@ -1,5 +1,6 @@
 ---
 from: 'Hadi Partovi (Code.org) <hadi_partovi@code.org>'
+reply-to: 'Code.org <support@code.org>'
 subject: "Your local school’s computer science program"
 ---
 Thank you for sharing information about your school’s computer science program and your continued support of our mission to give every student the opportunity to learn computer science.

--- a/pegasus/emails/census_form_receipt.md
+++ b/pegasus/emails/census_form_receipt.md
@@ -1,5 +1,5 @@
 ---
-from: 'Hadi Partovi (Code.org) <support@code.org>'
+from: 'Hadi Partovi (Code.org) <hadi_partovi@code.org>'
 subject: "Your local school’s computer science program"
 ---
 Thank you for sharing information about your school’s computer science program and your continued support of our mission to give every student the opportunity to learn computer science.

--- a/pegasus/emails/census_form_receipt.md
+++ b/pegasus/emails/census_form_receipt.md
@@ -1,5 +1,5 @@
 ---
-from: 'Hadi Partovi (Code.org) <hadi_partovi@code.org>'
+from: 'Hadi Partovi (Code.org) <support@code.org>'
 subject: "Your local school’s computer science program"
 ---
 Thank you for sharing information about your school’s computer science program and your continued support of our mission to give every student the opportunity to learn computer science.

--- a/pegasus/emails/class_submission_receipt.md
+++ b/pegasus/emails/class_submission_receipt.md
@@ -1,5 +1,6 @@
 ---
 from: '"Hadi Partovi (Code.org)" <hadi_partovi@code.org>'
+reply-to: '"Code.org" <support@code.org>'
 subject: Submission Received
 ---
 <% edit_link = "http://#{CDO.canonical_hostname('code.org')}/schools/edit/#{form.secret}" %>

--- a/pegasus/emails/class_submission_receipt.md
+++ b/pegasus/emails/class_submission_receipt.md
@@ -1,5 +1,5 @@
 ---
-from: '"Hadi Partovi (Code.org)" <hadi_partovi@code.org>'
+from: '"Hadi Partovi (Code.org)" <support@code.org>'
 subject: Submission Received
 ---
 <% edit_link = "http://#{CDO.canonical_hostname('code.org')}/schools/edit/#{form.secret}" %>

--- a/pegasus/emails/class_submission_receipt.md
+++ b/pegasus/emails/class_submission_receipt.md
@@ -1,5 +1,5 @@
 ---
-from: '"Hadi Partovi (Code.org)" <support@code.org>'
+from: '"Hadi Partovi (Code.org)" <hadi_partovi@code.org>'
 subject: Submission Received
 ---
 <% edit_link = "http://#{CDO.canonical_hostname('code.org')}/schools/edit/#{form.secret}" %>

--- a/pegasus/emails/hoc_census_2017_pledge_receipt.md
+++ b/pegasus/emails/hoc_census_2017_pledge_receipt.md
@@ -1,5 +1,6 @@
 ---
 from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
+reply-to: "Code.org <support@code.org>"
 subject: "Go beyond an hour!"
 ---
   <% codedotorg = CDO.canonical_hostname('code.org') %>

--- a/pegasus/emails/hoc_census_2017_pledge_receipt.md
+++ b/pegasus/emails/hoc_census_2017_pledge_receipt.md
@@ -1,5 +1,5 @@
 ---
-from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
+from: "Hadi Partovi (Code.org) <support@code.org>"
 subject: "Go beyond an hour!"
 ---
   <% codedotorg = CDO.canonical_hostname('code.org') %>

--- a/pegasus/emails/hoc_census_2017_pledge_receipt.md
+++ b/pegasus/emails/hoc_census_2017_pledge_receipt.md
@@ -1,5 +1,5 @@
 ---
-from: "Hadi Partovi (Code.org) <support@code.org>"
+from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
 subject: "Go beyond an hour!"
 ---
   <% codedotorg = CDO.canonical_hostname('code.org') %>

--- a/pegasus/emails/hoc_hardware_prizes_2015_receipt.md
+++ b/pegasus/emails/hoc_hardware_prizes_2015_receipt.md
@@ -1,5 +1,6 @@
 ---
 from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
+reply-to: "Code.org <support@code.org>"
 subject: "Thanks for signing up for a chance to win the $10,000 Hardware Prize"
 ---
 <% hostname = CDO.canonical_hostname('hourofcode.com') %>

--- a/pegasus/emails/hoc_hardware_prizes_2015_receipt.md
+++ b/pegasus/emails/hoc_hardware_prizes_2015_receipt.md
@@ -1,5 +1,5 @@
 ---
-from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
+from: "Hadi Partovi (Code.org) <support@code.org>"
 subject: "Thanks for signing up for a chance to win the $10,000 Hardware Prize"
 ---
 <% hostname = CDO.canonical_hostname('hourofcode.com') %>

--- a/pegasus/emails/hoc_hardware_prizes_2015_receipt.md
+++ b/pegasus/emails/hoc_hardware_prizes_2015_receipt.md
@@ -1,5 +1,5 @@
 ---
-from: "Hadi Partovi (Code.org) <support@code.org>"
+from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
 subject: "Thanks for signing up for a chance to win the $10,000 Hardware Prize"
 ---
 <% hostname = CDO.canonical_hostname('hourofcode.com') %>

--- a/pegasus/emails/hoc_signup_2014_receipt.md
+++ b/pegasus/emails/hoc_signup_2014_receipt.md
@@ -1,5 +1,6 @@
 ---
 from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
+reply-to: "Code.org <support@code.org>"
 subject: "Thanks for signing up to host an Hour of Code!"
 ---
 <% hostname = CDO.canonical_hostname('hourofcode.com') %>

--- a/pegasus/emails/hoc_signup_2014_receipt.md
+++ b/pegasus/emails/hoc_signup_2014_receipt.md
@@ -1,5 +1,5 @@
 ---
-from: "Hadi Partovi (Code.org) <support@code.org>"
+from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
 subject: "Thanks for signing up to host an Hour of Code!"
 ---
 <% hostname = CDO.canonical_hostname('hourofcode.com') %>

--- a/pegasus/emails/hoc_signup_2014_receipt.md
+++ b/pegasus/emails/hoc_signup_2014_receipt.md
@@ -1,5 +1,5 @@
 ---
-from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
+from: "Hadi Partovi (Code.org) <support@code.org>"
 subject: "Thanks for signing up to host an Hour of Code!"
 ---
 <% hostname = CDO.canonical_hostname('hourofcode.com') %>

--- a/pegasus/emails/hoc_signup_2015_receipt.md
+++ b/pegasus/emails/hoc_signup_2015_receipt.md
@@ -1,5 +1,6 @@
 ---
 from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
+reply-to: "Code.org <support@code.org>"
 subject: "Thanks for signing up to host an Hour of Code!"
 ---
 <% hostname = CDO.canonical_hostname('hourofcode.com') %>

--- a/pegasus/emails/hoc_signup_2015_receipt.md
+++ b/pegasus/emails/hoc_signup_2015_receipt.md
@@ -1,5 +1,5 @@
 ---
-from: "Hadi Partovi (Code.org) <support@code.org>"
+from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
 subject: "Thanks for signing up to host an Hour of Code!"
 ---
 <% hostname = CDO.canonical_hostname('hourofcode.com') %>

--- a/pegasus/emails/hoc_signup_2015_receipt.md
+++ b/pegasus/emails/hoc_signup_2015_receipt.md
@@ -1,5 +1,5 @@
 ---
-from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
+from: "Hadi Partovi (Code.org) <support@code.org>"
 subject: "Thanks for signing up to host an Hour of Code!"
 ---
 <% hostname = CDO.canonical_hostname('hourofcode.com') %>

--- a/pegasus/emails/hoc_signup_2017_receipt_en.md
+++ b/pegasus/emails/hoc_signup_2017_receipt_en.md
@@ -1,5 +1,6 @@
 ---
 from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
+reply-to: "Code.org <support@code.org>"
 subject: "Get ready for the Hour of Code"
 ---
   <% hourofcode = CDO.canonical_hostname('hourofcode.com') %>

--- a/pegasus/emails/hoc_signup_2017_receipt_en.md
+++ b/pegasus/emails/hoc_signup_2017_receipt_en.md
@@ -1,5 +1,5 @@
 ---
-from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
+from: "Hadi Partovi (Code.org) <support@code.org>"
 subject: "Get ready for the Hour of Code"
 ---
   <% hourofcode = CDO.canonical_hostname('hourofcode.com') %>

--- a/pegasus/emails/hoc_signup_2017_receipt_en.md
+++ b/pegasus/emails/hoc_signup_2017_receipt_en.md
@@ -1,5 +1,5 @@
 ---
-from: "Hadi Partovi (Code.org) <support@code.org>"
+from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
 subject: "Get ready for the Hour of Code"
 ---
   <% hourofcode = CDO.canonical_hostname('hourofcode.com') %>

--- a/pegasus/emails/hoc_signup_2018_receipt_en.md
+++ b/pegasus/emails/hoc_signup_2018_receipt_en.md
@@ -1,5 +1,6 @@
 ---
 from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
+reply-to: "Code.org <support@code.org>"
 subject: "Get ready for the Hour of Code"
 ---
   <% hourofcode = CDO.canonical_hostname('hourofcode.com') %>

--- a/pegasus/emails/hoc_signup_2018_receipt_en.md
+++ b/pegasus/emails/hoc_signup_2018_receipt_en.md
@@ -1,5 +1,5 @@
 ---
-from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
+from: "Hadi Partovi (Code.org) <support@code.org>"
 subject: "Get ready for the Hour of Code"
 ---
   <% hourofcode = CDO.canonical_hostname('hourofcode.com') %>

--- a/pegasus/emails/hoc_signup_2018_receipt_en.md
+++ b/pegasus/emails/hoc_signup_2018_receipt_en.md
@@ -1,5 +1,5 @@
 ---
-from: "Hadi Partovi (Code.org) <support@code.org>"
+from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
 subject: "Get ready for the Hour of Code"
 ---
   <% hourofcode = CDO.canonical_hostname('hourofcode.com') %>

--- a/pegasus/emails/hoc_signup_2018_receipt_es.md
+++ b/pegasus/emails/hoc_signup_2018_receipt_es.md
@@ -1,5 +1,6 @@
 ---
 from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
+reply-to: "Code.org <support@code.org>"
 subject: "¡Gracias por inscribirte para ser anfitrión de una Hora de Código!"
 ---
   <% hostname = CDO.canonical_hostname('hourofcode.com') %>

--- a/pegasus/emails/hoc_signup_2018_receipt_es.md
+++ b/pegasus/emails/hoc_signup_2018_receipt_es.md
@@ -1,5 +1,5 @@
 ---
-from: "Hadi Partovi (Code.org) <support@code.org>"
+from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
 subject: "¡Gracias por inscribirte para ser anfitrión de una Hora de Código!"
 ---
   <% hostname = CDO.canonical_hostname('hourofcode.com') %>

--- a/pegasus/emails/hoc_signup_2018_receipt_es.md
+++ b/pegasus/emails/hoc_signup_2018_receipt_es.md
@@ -1,5 +1,5 @@
 ---
-from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
+from: "Hadi Partovi (Code.org) <support@code.org>"
 subject: "¡Gracias por inscribirte para ser anfitrión de una Hora de Código!"
 ---
   <% hostname = CDO.canonical_hostname('hourofcode.com') %>

--- a/pegasus/emails/hoc_signup_2018_receipt_pt.md
+++ b/pegasus/emails/hoc_signup_2018_receipt_pt.md
@@ -1,5 +1,6 @@
 ---
 from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
+reply-to: "Code.org <support@code.org>"
 subject: "Obrigado por se inscrever para sediar a Hora do Código!"
 ---
   <% hostname = CDO.canonical_hostname('hourofcode.com') %>

--- a/pegasus/emails/hoc_signup_2018_receipt_pt.md
+++ b/pegasus/emails/hoc_signup_2018_receipt_pt.md
@@ -1,5 +1,5 @@
 ---
-from: "Hadi Partovi (Code.org) <support@code.org>"
+from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
 subject: "Obrigado por se inscrever para sediar a Hora do Código!"
 ---
   <% hostname = CDO.canonical_hostname('hourofcode.com') %>

--- a/pegasus/emails/hoc_signup_2018_receipt_pt.md
+++ b/pegasus/emails/hoc_signup_2018_receipt_pt.md
@@ -1,5 +1,5 @@
 ---
-from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
+from: "Hadi Partovi (Code.org) <support@code.org>"
 subject: "Obrigado por se inscrever para sediar a Hora do Código!"
 ---
   <% hostname = CDO.canonical_hostname('hourofcode.com') %>

--- a/pegasus/emails/hoc_signup_2019_receipt_en.md
+++ b/pegasus/emails/hoc_signup_2019_receipt_en.md
@@ -1,5 +1,6 @@
 ---
 from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
+reply-to: "Code.org <support@code.org>"
 subject: "Get ready for the Hour of Code"
 ---
   <% hourofcode = CDO.canonical_hostname('hourofcode.com') %>

--- a/pegasus/emails/hoc_signup_2019_receipt_en.md
+++ b/pegasus/emails/hoc_signup_2019_receipt_en.md
@@ -1,5 +1,5 @@
 ---
-from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
+from: "Hadi Partovi (Code.org) <support@code.org>"
 subject: "Get ready for the Hour of Code"
 ---
   <% hourofcode = CDO.canonical_hostname('hourofcode.com') %>

--- a/pegasus/emails/hoc_signup_2019_receipt_en.md
+++ b/pegasus/emails/hoc_signup_2019_receipt_en.md
@@ -1,5 +1,5 @@
 ---
-from: "Hadi Partovi (Code.org) <support@code.org>"
+from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
 subject: "Get ready for the Hour of Code"
 ---
   <% hourofcode = CDO.canonical_hostname('hourofcode.com') %>

--- a/pegasus/emails/hoc_signup_2019_receipt_es.md
+++ b/pegasus/emails/hoc_signup_2019_receipt_es.md
@@ -1,5 +1,6 @@
 ---
 from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
+reply-to: "Code.org <support@code.org>"
 subject: "¡Gracias por inscribirte para ser anfitrión de una Hora de Código!"
 ---
   <% hostname = CDO.canonical_hostname('hourofcode.com') %>

--- a/pegasus/emails/hoc_signup_2019_receipt_es.md
+++ b/pegasus/emails/hoc_signup_2019_receipt_es.md
@@ -1,5 +1,5 @@
 ---
-from: "Hadi Partovi (Code.org) <support@code.org>"
+from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
 subject: "¡Gracias por inscribirte para ser anfitrión de una Hora de Código!"
 ---
   <% hostname = CDO.canonical_hostname('hourofcode.com') %>

--- a/pegasus/emails/hoc_signup_2019_receipt_es.md
+++ b/pegasus/emails/hoc_signup_2019_receipt_es.md
@@ -1,5 +1,5 @@
 ---
-from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
+from: "Hadi Partovi (Code.org) <support@code.org>"
 subject: "¡Gracias por inscribirte para ser anfitrión de una Hora de Código!"
 ---
   <% hostname = CDO.canonical_hostname('hourofcode.com') %>

--- a/pegasus/emails/hoc_signup_2019_receipt_pt.md
+++ b/pegasus/emails/hoc_signup_2019_receipt_pt.md
@@ -1,5 +1,6 @@
 ---
 from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
+reply-to: "Code.org <support@code.org>"
 subject: "Obrigado por se inscrever para sediar a Hora do Código!"
 ---
   <% hostname = CDO.canonical_hostname('hourofcode.com') %>

--- a/pegasus/emails/hoc_signup_2019_receipt_pt.md
+++ b/pegasus/emails/hoc_signup_2019_receipt_pt.md
@@ -1,5 +1,5 @@
 ---
-from: "Hadi Partovi (Code.org) <support@code.org>"
+from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
 subject: "Obrigado por se inscrever para sediar a Hora do Código!"
 ---
   <% hostname = CDO.canonical_hostname('hourofcode.com') %>

--- a/pegasus/emails/hoc_signup_2019_receipt_pt.md
+++ b/pegasus/emails/hoc_signup_2019_receipt_pt.md
@@ -1,5 +1,5 @@
 ---
-from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
+from: "Hadi Partovi (Code.org) <support@code.org>"
 subject: "Obrigado por se inscrever para sediar a Hora do Código!"
 ---
   <% hostname = CDO.canonical_hostname('hourofcode.com') %>

--- a/pegasus/emails/hoc_signup_2020_receipt_en.md
+++ b/pegasus/emails/hoc_signup_2020_receipt_en.md
@@ -1,5 +1,6 @@
 ---
 from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
+reply-to: "Code.org <support@code.org>"
 subject: "You’re signed up for the Hour of Code!"
 ---
   <% hourofcode = CDO.canonical_hostname('hourofcode.com') %>

--- a/pegasus/emails/hoc_signup_2020_receipt_en.md
+++ b/pegasus/emails/hoc_signup_2020_receipt_en.md
@@ -1,5 +1,5 @@
 ---
-from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
+from: "Hadi Partovi (Code.org) <support@code.org>"
 subject: "You’re signed up for the Hour of Code!"
 ---
   <% hourofcode = CDO.canonical_hostname('hourofcode.com') %>

--- a/pegasus/emails/hoc_signup_2020_receipt_en.md
+++ b/pegasus/emails/hoc_signup_2020_receipt_en.md
@@ -1,5 +1,5 @@
 ---
-from: "Hadi Partovi (Code.org) <support@code.org>"
+from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
 subject: "You’re signed up for the Hour of Code!"
 ---
   <% hourofcode = CDO.canonical_hostname('hourofcode.com') %>

--- a/pegasus/emails/hoc_signup_2020_receipt_es.md
+++ b/pegasus/emails/hoc_signup_2020_receipt_es.md
@@ -1,5 +1,6 @@
 ---
 from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
+reply-to: "Code.org <support@code.org>"
 subject: "¡Gracias por inscribirte para ser anfitrión de una Hora de Código!"
 ---
   <% hostname = CDO.canonical_hostname('hourofcode.com') %>

--- a/pegasus/emails/hoc_signup_2020_receipt_es.md
+++ b/pegasus/emails/hoc_signup_2020_receipt_es.md
@@ -1,5 +1,5 @@
 ---
-from: "Hadi Partovi (Code.org) <support@code.org>"
+from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
 subject: "¡Gracias por inscribirte para ser anfitrión de una Hora de Código!"
 ---
   <% hostname = CDO.canonical_hostname('hourofcode.com') %>

--- a/pegasus/emails/hoc_signup_2020_receipt_es.md
+++ b/pegasus/emails/hoc_signup_2020_receipt_es.md
@@ -1,5 +1,5 @@
 ---
-from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
+from: "Hadi Partovi (Code.org) <support@code.org>"
 subject: "¡Gracias por inscribirte para ser anfitrión de una Hora de Código!"
 ---
   <% hostname = CDO.canonical_hostname('hourofcode.com') %>

--- a/pegasus/emails/hoc_signup_2020_receipt_pt.md
+++ b/pegasus/emails/hoc_signup_2020_receipt_pt.md
@@ -1,5 +1,6 @@
 ---
 from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
+reply-to: "Code.org <support@code.org>"
 subject: "Obrigado por se inscrever para sediar a Hora do Código!"
 ---
   <% hostname = CDO.canonical_hostname('hourofcode.com') %>

--- a/pegasus/emails/hoc_signup_2020_receipt_pt.md
+++ b/pegasus/emails/hoc_signup_2020_receipt_pt.md
@@ -1,5 +1,5 @@
 ---
-from: "Hadi Partovi (Code.org) <support@code.org>"
+from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
 subject: "Obrigado por se inscrever para sediar a Hora do Código!"
 ---
   <% hostname = CDO.canonical_hostname('hourofcode.com') %>

--- a/pegasus/emails/hoc_signup_2020_receipt_pt.md
+++ b/pegasus/emails/hoc_signup_2020_receipt_pt.md
@@ -1,5 +1,5 @@
 ---
-from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
+from: "Hadi Partovi (Code.org) <support@code.org>"
 subject: "Obrigado por se inscrever para sediar a Hora do Código!"
 ---
   <% hostname = CDO.canonical_hostname('hourofcode.com') %>

--- a/pegasus/emails/hoc_signup_2021_receipt_en.md
+++ b/pegasus/emails/hoc_signup_2021_receipt_en.md
@@ -1,5 +1,6 @@
 ---
 from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
+reply-to: "Code.org <support@code.org>"
 subject: "You’re signed up for the Hour of Code!"
 ---
   <% hourofcode = CDO.canonical_hostname('hourofcode.com') %>

--- a/pegasus/emails/hoc_signup_2021_receipt_en.md
+++ b/pegasus/emails/hoc_signup_2021_receipt_en.md
@@ -1,5 +1,5 @@
 ---
-from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
+from: "Hadi Partovi (Code.org) <support@code.org>"
 subject: "You’re signed up for the Hour of Code!"
 ---
   <% hourofcode = CDO.canonical_hostname('hourofcode.com') %>

--- a/pegasus/emails/hoc_signup_2021_receipt_en.md
+++ b/pegasus/emails/hoc_signup_2021_receipt_en.md
@@ -1,5 +1,5 @@
 ---
-from: "Hadi Partovi (Code.org) <support@code.org>"
+from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
 subject: "You’re signed up for the Hour of Code!"
 ---
   <% hourofcode = CDO.canonical_hostname('hourofcode.com') %>

--- a/pegasus/emails/hoc_signup_2021_receipt_es.md
+++ b/pegasus/emails/hoc_signup_2021_receipt_es.md
@@ -1,5 +1,6 @@
 ---
 from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
+reply-to: "Code.org <support@code.org>"
 subject: "¡Gracias por inscribirte para ser anfitrión de una Hora de Código!"
 ---
   <% hostname = CDO.canonical_hostname('hourofcode.com') %>

--- a/pegasus/emails/hoc_signup_2021_receipt_es.md
+++ b/pegasus/emails/hoc_signup_2021_receipt_es.md
@@ -1,5 +1,5 @@
 ---
-from: "Hadi Partovi (Code.org) <support@code.org>"
+from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
 subject: "¡Gracias por inscribirte para ser anfitrión de una Hora de Código!"
 ---
   <% hostname = CDO.canonical_hostname('hourofcode.com') %>

--- a/pegasus/emails/hoc_signup_2021_receipt_es.md
+++ b/pegasus/emails/hoc_signup_2021_receipt_es.md
@@ -1,5 +1,5 @@
 ---
-from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
+from: "Hadi Partovi (Code.org) <support@code.org>"
 subject: "¡Gracias por inscribirte para ser anfitrión de una Hora de Código!"
 ---
   <% hostname = CDO.canonical_hostname('hourofcode.com') %>

--- a/pegasus/emails/hoc_signup_2021_receipt_pt.md
+++ b/pegasus/emails/hoc_signup_2021_receipt_pt.md
@@ -1,5 +1,6 @@
 ---
 from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
+reply-to: "Code.org <support@code.org>"
 subject: "Obrigado por se inscrever para sediar a Hora do Código!"
 ---
   <% hostname = CDO.canonical_hostname('hourofcode.com') %>

--- a/pegasus/emails/hoc_signup_2021_receipt_pt.md
+++ b/pegasus/emails/hoc_signup_2021_receipt_pt.md
@@ -1,5 +1,5 @@
 ---
-from: "Hadi Partovi (Code.org) <support@code.org>"
+from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
 subject: "Obrigado por se inscrever para sediar a Hora do Código!"
 ---
   <% hostname = CDO.canonical_hostname('hourofcode.com') %>

--- a/pegasus/emails/hoc_signup_2021_receipt_pt.md
+++ b/pegasus/emails/hoc_signup_2021_receipt_pt.md
@@ -1,5 +1,5 @@
 ---
-from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
+from: "Hadi Partovi (Code.org) <support@code.org>"
 subject: "Obrigado por se inscrever para sediar a Hora do Código!"
 ---
   <% hostname = CDO.canonical_hostname('hourofcode.com') %>

--- a/pegasus/emails/hoc_signup_2022_receipt_es.md
+++ b/pegasus/emails/hoc_signup_2022_receipt_es.md
@@ -1,5 +1,6 @@
 ---
 from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
+reply-to: "Code.org <support@code.org>"
 subject: "¡Gracias por inscribirte para ser anfitrión de una Hora de Código!"
 ---
   <% hostname = CDO.canonical_hostname('hourofcode.com') %>

--- a/pegasus/emails/hoc_signup_2022_receipt_es.md
+++ b/pegasus/emails/hoc_signup_2022_receipt_es.md
@@ -1,5 +1,5 @@
 ---
-from: "Hadi Partovi (Code.org) <support@code.org>"
+from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
 subject: "¡Gracias por inscribirte para ser anfitrión de una Hora de Código!"
 ---
   <% hostname = CDO.canonical_hostname('hourofcode.com') %>

--- a/pegasus/emails/hoc_signup_2022_receipt_es.md
+++ b/pegasus/emails/hoc_signup_2022_receipt_es.md
@@ -1,5 +1,5 @@
 ---
-from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
+from: "Hadi Partovi (Code.org) <support@code.org>"
 subject: "¡Gracias por inscribirte para ser anfitrión de una Hora de Código!"
 ---
   <% hostname = CDO.canonical_hostname('hourofcode.com') %>

--- a/pegasus/emails/hoc_signup_2022_receipt_pt.md
+++ b/pegasus/emails/hoc_signup_2022_receipt_pt.md
@@ -1,5 +1,6 @@
 ---
 from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
+reply-to: "Code.org <support@code.org>"
 subject: "Obrigado por se inscrever para sediar a Hora do Código!"
 ---
   <% hostname = CDO.canonical_hostname('hourofcode.com') %>

--- a/pegasus/emails/hoc_signup_2022_receipt_pt.md
+++ b/pegasus/emails/hoc_signup_2022_receipt_pt.md
@@ -1,5 +1,5 @@
 ---
-from: "Hadi Partovi (Code.org) <support@code.org>"
+from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
 subject: "Obrigado por se inscrever para sediar a Hora do Código!"
 ---
   <% hostname = CDO.canonical_hostname('hourofcode.com') %>

--- a/pegasus/emails/hoc_signup_2022_receipt_pt.md
+++ b/pegasus/emails/hoc_signup_2022_receipt_pt.md
@@ -1,5 +1,5 @@
 ---
-from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
+from: "Hadi Partovi (Code.org) <support@code.org>"
 subject: "Obrigado por se inscrever para sediar a Hora do Código!"
 ---
   <% hostname = CDO.canonical_hostname('hourofcode.com') %>

--- a/pegasus/emails/hoc_survey_2014_receipt.md
+++ b/pegasus/emails/hoc_survey_2014_receipt.md
@@ -1,5 +1,6 @@
 ---
 from: 'Hadi Partovi (Code.org) <hadi_partovi@code.org>'
+reply-to: 'Code.org <support@code.org>'
 subject: "Your gift code"
 ---
 ## Thank you! Use this code to redeem your gift:

--- a/pegasus/emails/hoc_survey_2014_receipt.md
+++ b/pegasus/emails/hoc_survey_2014_receipt.md
@@ -1,5 +1,5 @@
 ---
-from: 'Hadi Partovi (Code.org) <support@code.org>'
+from: 'Hadi Partovi (Code.org) <hadi_partovi@code.org>'
 subject: "Your gift code"
 ---
 ## Thank you! Use this code to redeem your gift:

--- a/pegasus/emails/hoc_survey_2014_receipt.md
+++ b/pegasus/emails/hoc_survey_2014_receipt.md
@@ -1,5 +1,5 @@
 ---
-from: 'Hadi Partovi (Code.org) <hadi_partovi@code.org>'
+from: 'Hadi Partovi (Code.org) <support@code.org>'
 subject: "Your gift code"
 ---
 ## Thank you! Use this code to redeem your gift:

--- a/pegasus/emails/petition_receipt.md
+++ b/pegasus/emails/petition_receipt.md
@@ -1,5 +1,6 @@
 ---
 from: 'Hadi Partovi (Code.org) <hadi_partovi@code.org>'
+reply-to: 'Code.org <support@code.org>'
 subject: 'Thanks!'
 ---
 

--- a/pegasus/emails/petition_receipt.md
+++ b/pegasus/emails/petition_receipt.md
@@ -1,5 +1,5 @@
 ---
-from: 'Hadi Partovi (Code.org) <support@code.org>'
+from: 'Hadi Partovi (Code.org) <hadi_partovi@code.org>'
 subject: 'Thanks!'
 ---
 

--- a/pegasus/emails/petition_receipt.md
+++ b/pegasus/emails/petition_receipt.md
@@ -1,5 +1,5 @@
 ---
-from: 'Hadi Partovi (Code.org) <hadi_partovi@code.org>'
+from: 'Hadi Partovi (Code.org) <support@code.org>'
 subject: 'Thanks!'
 ---
 

--- a/pegasus/test/fixtures/deliverer/expected/census_form_receipt/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/census_form_receipt/header.yaml
@@ -1,3 +1,4 @@
 ---
 from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
+reply-to: Code.org <support@code.org>
 subject: Your local school’s computer science program

--- a/pegasus/test/fixtures/deliverer/expected/census_form_receipt/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/census_form_receipt/header.yaml
@@ -1,3 +1,3 @@
 ---
-from: Hadi Partovi (Code.org) <support@code.org>
+from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
 subject: Your local school’s computer science program

--- a/pegasus/test/fixtures/deliverer/expected/census_form_receipt/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/census_form_receipt/header.yaml
@@ -1,3 +1,3 @@
 ---
-from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
+from: Hadi Partovi (Code.org) <support@code.org>
 subject: Your local school’s computer science program

--- a/pegasus/test/fixtures/deliverer/expected/class_submission_receipt/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/class_submission_receipt/header.yaml
@@ -1,3 +1,4 @@
 ---
 from: '"Hadi Partovi (Code.org)" <hadi_partovi@code.org>'
+reply-to: '"Code.org" <support@code.org>'
 subject: Submission Received

--- a/pegasus/test/fixtures/deliverer/expected/class_submission_receipt/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/class_submission_receipt/header.yaml
@@ -1,3 +1,3 @@
 ---
-from: '"Hadi Partovi (Code.org)" <hadi_partovi@code.org>'
+from: '"Hadi Partovi (Code.org)" <support@code.org>'
 subject: Submission Received

--- a/pegasus/test/fixtures/deliverer/expected/class_submission_receipt/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/class_submission_receipt/header.yaml
@@ -1,3 +1,3 @@
 ---
-from: '"Hadi Partovi (Code.org)" <support@code.org>'
+from: '"Hadi Partovi (Code.org)" <hadi_partovi@code.org>'
 subject: Submission Received

--- a/pegasus/test/fixtures/deliverer/expected/hoc_census_2017_pledge_receipt/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/hoc_census_2017_pledge_receipt/header.yaml
@@ -1,3 +1,4 @@
 ---
 from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
+reply-to: Code.org <support@code.org>
 subject: Go beyond an hour!

--- a/pegasus/test/fixtures/deliverer/expected/hoc_census_2017_pledge_receipt/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/hoc_census_2017_pledge_receipt/header.yaml
@@ -1,3 +1,3 @@
 ---
-from: Hadi Partovi (Code.org) <support@code.org>
+from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
 subject: Go beyond an hour!

--- a/pegasus/test/fixtures/deliverer/expected/hoc_census_2017_pledge_receipt/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/hoc_census_2017_pledge_receipt/header.yaml
@@ -1,3 +1,3 @@
 ---
-from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
+from: Hadi Partovi (Code.org) <support@code.org>
 subject: Go beyond an hour!

--- a/pegasus/test/fixtures/deliverer/expected/hoc_hardware_prizes_2015_receipt/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/hoc_hardware_prizes_2015_receipt/header.yaml
@@ -1,3 +1,4 @@
 ---
 from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
+reply-to: Code.org <support@code.org>
 subject: Thanks for signing up for a chance to win the $10,000 Hardware Prize

--- a/pegasus/test/fixtures/deliverer/expected/hoc_hardware_prizes_2015_receipt/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/hoc_hardware_prizes_2015_receipt/header.yaml
@@ -1,3 +1,3 @@
 ---
-from: Hadi Partovi (Code.org) <support@code.org>
+from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
 subject: Thanks for signing up for a chance to win the $10,000 Hardware Prize

--- a/pegasus/test/fixtures/deliverer/expected/hoc_hardware_prizes_2015_receipt/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/hoc_hardware_prizes_2015_receipt/header.yaml
@@ -1,3 +1,3 @@
 ---
-from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
+from: Hadi Partovi (Code.org) <support@code.org>
 subject: Thanks for signing up for a chance to win the $10,000 Hardware Prize

--- a/pegasus/test/fixtures/deliverer/expected/hoc_signup_2014_receipt/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/hoc_signup_2014_receipt/header.yaml
@@ -1,3 +1,4 @@
 ---
 from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
+reply-to: Code.org <support@code.org>
 subject: Thanks for signing up to host an Hour of Code!

--- a/pegasus/test/fixtures/deliverer/expected/hoc_signup_2014_receipt/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/hoc_signup_2014_receipt/header.yaml
@@ -1,3 +1,3 @@
 ---
-from: Hadi Partovi (Code.org) <support@code.org>
+from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
 subject: Thanks for signing up to host an Hour of Code!

--- a/pegasus/test/fixtures/deliverer/expected/hoc_signup_2014_receipt/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/hoc_signup_2014_receipt/header.yaml
@@ -1,3 +1,3 @@
 ---
-from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
+from: Hadi Partovi (Code.org) <support@code.org>
 subject: Thanks for signing up to host an Hour of Code!

--- a/pegasus/test/fixtures/deliverer/expected/hoc_signup_2015_receipt/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/hoc_signup_2015_receipt/header.yaml
@@ -1,3 +1,4 @@
 ---
 from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
+reply-to: Code.org <support@code.org>
 subject: Thanks for signing up to host an Hour of Code!

--- a/pegasus/test/fixtures/deliverer/expected/hoc_signup_2015_receipt/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/hoc_signup_2015_receipt/header.yaml
@@ -1,3 +1,3 @@
 ---
-from: Hadi Partovi (Code.org) <support@code.org>
+from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
 subject: Thanks for signing up to host an Hour of Code!

--- a/pegasus/test/fixtures/deliverer/expected/hoc_signup_2015_receipt/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/hoc_signup_2015_receipt/header.yaml
@@ -1,3 +1,3 @@
 ---
-from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
+from: Hadi Partovi (Code.org) <support@code.org>
 subject: Thanks for signing up to host an Hour of Code!

--- a/pegasus/test/fixtures/deliverer/expected/hoc_signup_2017_receipt_en/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/hoc_signup_2017_receipt_en/header.yaml
@@ -1,3 +1,4 @@
 ---
 from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
+reply-to: Code.org <support@code.org>
 subject: Get ready for the Hour of Code

--- a/pegasus/test/fixtures/deliverer/expected/hoc_signup_2017_receipt_en/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/hoc_signup_2017_receipt_en/header.yaml
@@ -1,3 +1,3 @@
 ---
-from: Hadi Partovi (Code.org) <support@code.org>
+from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
 subject: Get ready for the Hour of Code

--- a/pegasus/test/fixtures/deliverer/expected/hoc_signup_2017_receipt_en/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/hoc_signup_2017_receipt_en/header.yaml
@@ -1,3 +1,3 @@
 ---
-from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
+from: Hadi Partovi (Code.org) <support@code.org>
 subject: Get ready for the Hour of Code

--- a/pegasus/test/fixtures/deliverer/expected/hoc_signup_2018_receipt_en/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/hoc_signup_2018_receipt_en/header.yaml
@@ -1,3 +1,4 @@
 ---
 from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
+reply-to: Code.org <support@code.org>
 subject: Get ready for the Hour of Code

--- a/pegasus/test/fixtures/deliverer/expected/hoc_signup_2018_receipt_en/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/hoc_signup_2018_receipt_en/header.yaml
@@ -1,3 +1,3 @@
 ---
-from: Hadi Partovi (Code.org) <support@code.org>
+from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
 subject: Get ready for the Hour of Code

--- a/pegasus/test/fixtures/deliverer/expected/hoc_signup_2018_receipt_en/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/hoc_signup_2018_receipt_en/header.yaml
@@ -1,3 +1,3 @@
 ---
-from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
+from: Hadi Partovi (Code.org) <support@code.org>
 subject: Get ready for the Hour of Code

--- a/pegasus/test/fixtures/deliverer/expected/hoc_signup_2018_receipt_es/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/hoc_signup_2018_receipt_es/header.yaml
@@ -1,3 +1,4 @@
 ---
 from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
+reply-to: Code.org <support@code.org>
 subject: "¡Gracias por inscribirte para ser anfitrión de una Hora de Código!"

--- a/pegasus/test/fixtures/deliverer/expected/hoc_signup_2018_receipt_es/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/hoc_signup_2018_receipt_es/header.yaml
@@ -1,3 +1,3 @@
 ---
-from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
+from: Hadi Partovi (Code.org) <support@code.org>
 subject: "¡Gracias por inscribirte para ser anfitrión de una Hora de Código!"

--- a/pegasus/test/fixtures/deliverer/expected/hoc_signup_2018_receipt_es/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/hoc_signup_2018_receipt_es/header.yaml
@@ -1,3 +1,3 @@
 ---
-from: Hadi Partovi (Code.org) <support@code.org>
+from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
 subject: "¡Gracias por inscribirte para ser anfitrión de una Hora de Código!"

--- a/pegasus/test/fixtures/deliverer/expected/hoc_signup_2018_receipt_pt/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/hoc_signup_2018_receipt_pt/header.yaml
@@ -1,3 +1,4 @@
 ---
 from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
+reply-to: Code.org <support@code.org>
 subject: Obrigado por se inscrever para sediar a Hora do Código!

--- a/pegasus/test/fixtures/deliverer/expected/hoc_signup_2018_receipt_pt/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/hoc_signup_2018_receipt_pt/header.yaml
@@ -1,3 +1,3 @@
 ---
-from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
+from: Hadi Partovi (Code.org) <support@code.org>
 subject: Obrigado por se inscrever para sediar a Hora do Código!

--- a/pegasus/test/fixtures/deliverer/expected/hoc_signup_2018_receipt_pt/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/hoc_signup_2018_receipt_pt/header.yaml
@@ -1,3 +1,3 @@
 ---
-from: Hadi Partovi (Code.org) <support@code.org>
+from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
 subject: Obrigado por se inscrever para sediar a Hora do Código!

--- a/pegasus/test/fixtures/deliverer/expected/hoc_signup_2019_receipt_en/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/hoc_signup_2019_receipt_en/header.yaml
@@ -1,3 +1,4 @@
 ---
 from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
+reply-to: Code.org <support@code.org>
 subject: Get ready for the Hour of Code

--- a/pegasus/test/fixtures/deliverer/expected/hoc_signup_2019_receipt_en/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/hoc_signup_2019_receipt_en/header.yaml
@@ -1,3 +1,3 @@
 ---
-from: Hadi Partovi (Code.org) <support@code.org>
+from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
 subject: Get ready for the Hour of Code

--- a/pegasus/test/fixtures/deliverer/expected/hoc_signup_2019_receipt_en/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/hoc_signup_2019_receipt_en/header.yaml
@@ -1,3 +1,3 @@
 ---
-from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
+from: Hadi Partovi (Code.org) <support@code.org>
 subject: Get ready for the Hour of Code

--- a/pegasus/test/fixtures/deliverer/expected/hoc_signup_2019_receipt_es/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/hoc_signup_2019_receipt_es/header.yaml
@@ -1,3 +1,4 @@
 ---
 from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
+reply-to: Code.org <support@code.org>
 subject: "¡Gracias por inscribirte para ser anfitrión de una Hora de Código!"

--- a/pegasus/test/fixtures/deliverer/expected/hoc_signup_2019_receipt_es/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/hoc_signup_2019_receipt_es/header.yaml
@@ -1,3 +1,3 @@
 ---
-from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
+from: Hadi Partovi (Code.org) <support@code.org>
 subject: "¡Gracias por inscribirte para ser anfitrión de una Hora de Código!"

--- a/pegasus/test/fixtures/deliverer/expected/hoc_signup_2019_receipt_es/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/hoc_signup_2019_receipt_es/header.yaml
@@ -1,3 +1,3 @@
 ---
-from: Hadi Partovi (Code.org) <support@code.org>
+from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
 subject: "¡Gracias por inscribirte para ser anfitrión de una Hora de Código!"

--- a/pegasus/test/fixtures/deliverer/expected/hoc_signup_2019_receipt_pt/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/hoc_signup_2019_receipt_pt/header.yaml
@@ -1,3 +1,4 @@
 ---
 from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
+reply-to: Code.org <support@code.org>
 subject: Obrigado por se inscrever para sediar a Hora do Código!

--- a/pegasus/test/fixtures/deliverer/expected/hoc_signup_2019_receipt_pt/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/hoc_signup_2019_receipt_pt/header.yaml
@@ -1,3 +1,3 @@
 ---
-from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
+from: Hadi Partovi (Code.org) <support@code.org>
 subject: Obrigado por se inscrever para sediar a Hora do Código!

--- a/pegasus/test/fixtures/deliverer/expected/hoc_signup_2019_receipt_pt/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/hoc_signup_2019_receipt_pt/header.yaml
@@ -1,3 +1,3 @@
 ---
-from: Hadi Partovi (Code.org) <support@code.org>
+from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
 subject: Obrigado por se inscrever para sediar a Hora do Código!

--- a/pegasus/test/fixtures/deliverer/expected/hoc_signup_2020_receipt_en/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/hoc_signup_2020_receipt_en/header.yaml
@@ -1,3 +1,4 @@
 ---
 from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
+reply-to: Code.org <support@code.org>
 subject: You’re signed up for the Hour of Code!

--- a/pegasus/test/fixtures/deliverer/expected/hoc_signup_2020_receipt_en/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/hoc_signup_2020_receipt_en/header.yaml
@@ -1,3 +1,3 @@
 ---
-from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
+from: Hadi Partovi (Code.org) <support@code.org>
 subject: You’re signed up for the Hour of Code!

--- a/pegasus/test/fixtures/deliverer/expected/hoc_signup_2020_receipt_en/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/hoc_signup_2020_receipt_en/header.yaml
@@ -1,3 +1,3 @@
 ---
-from: Hadi Partovi (Code.org) <support@code.org>
+from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
 subject: You’re signed up for the Hour of Code!

--- a/pegasus/test/fixtures/deliverer/expected/hoc_signup_2020_receipt_es/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/hoc_signup_2020_receipt_es/header.yaml
@@ -1,3 +1,4 @@
 ---
 from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
+reply-to: Code.org <support@code.org>
 subject: "¡Gracias por inscribirte para ser anfitrión de una Hora de Código!"

--- a/pegasus/test/fixtures/deliverer/expected/hoc_signup_2020_receipt_es/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/hoc_signup_2020_receipt_es/header.yaml
@@ -1,3 +1,3 @@
 ---
-from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
+from: Hadi Partovi (Code.org) <support@code.org>
 subject: "¡Gracias por inscribirte para ser anfitrión de una Hora de Código!"

--- a/pegasus/test/fixtures/deliverer/expected/hoc_signup_2020_receipt_es/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/hoc_signup_2020_receipt_es/header.yaml
@@ -1,3 +1,3 @@
 ---
-from: Hadi Partovi (Code.org) <support@code.org>
+from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
 subject: "¡Gracias por inscribirte para ser anfitrión de una Hora de Código!"

--- a/pegasus/test/fixtures/deliverer/expected/hoc_signup_2020_receipt_pt/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/hoc_signup_2020_receipt_pt/header.yaml
@@ -1,3 +1,4 @@
 ---
 from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
+reply-to: Code.org <support@code.org>
 subject: Obrigado por se inscrever para sediar a Hora do Código!

--- a/pegasus/test/fixtures/deliverer/expected/hoc_signup_2020_receipt_pt/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/hoc_signup_2020_receipt_pt/header.yaml
@@ -1,3 +1,3 @@
 ---
-from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
+from: Hadi Partovi (Code.org) <support@code.org>
 subject: Obrigado por se inscrever para sediar a Hora do Código!

--- a/pegasus/test/fixtures/deliverer/expected/hoc_signup_2020_receipt_pt/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/hoc_signup_2020_receipt_pt/header.yaml
@@ -1,3 +1,3 @@
 ---
-from: Hadi Partovi (Code.org) <support@code.org>
+from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
 subject: Obrigado por se inscrever para sediar a Hora do Código!

--- a/pegasus/test/fixtures/deliverer/expected/hoc_signup_2021_receipt_en/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/hoc_signup_2021_receipt_en/header.yaml
@@ -1,3 +1,4 @@
 ---
 from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
+reply-to: Code.org <support@code.org>
 subject: You’re signed up for the Hour of Code!

--- a/pegasus/test/fixtures/deliverer/expected/hoc_signup_2021_receipt_en/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/hoc_signup_2021_receipt_en/header.yaml
@@ -1,3 +1,3 @@
 ---
-from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
+from: Hadi Partovi (Code.org) <support@code.org>
 subject: You’re signed up for the Hour of Code!

--- a/pegasus/test/fixtures/deliverer/expected/hoc_signup_2021_receipt_en/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/hoc_signup_2021_receipt_en/header.yaml
@@ -1,3 +1,3 @@
 ---
-from: Hadi Partovi (Code.org) <support@code.org>
+from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
 subject: You’re signed up for the Hour of Code!

--- a/pegasus/test/fixtures/deliverer/expected/hoc_signup_2021_receipt_es/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/hoc_signup_2021_receipt_es/header.yaml
@@ -1,3 +1,4 @@
 ---
 from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
+reply-to: Code.org <support@code.org>
 subject: "¡Gracias por inscribirte para ser anfitrión de una Hora de Código!"

--- a/pegasus/test/fixtures/deliverer/expected/hoc_signup_2021_receipt_es/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/hoc_signup_2021_receipt_es/header.yaml
@@ -1,3 +1,3 @@
 ---
-from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
+from: Hadi Partovi (Code.org) <support@code.org>
 subject: "¡Gracias por inscribirte para ser anfitrión de una Hora de Código!"

--- a/pegasus/test/fixtures/deliverer/expected/hoc_signup_2021_receipt_es/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/hoc_signup_2021_receipt_es/header.yaml
@@ -1,3 +1,3 @@
 ---
-from: Hadi Partovi (Code.org) <support@code.org>
+from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
 subject: "¡Gracias por inscribirte para ser anfitrión de una Hora de Código!"

--- a/pegasus/test/fixtures/deliverer/expected/hoc_signup_2021_receipt_pt/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/hoc_signup_2021_receipt_pt/header.yaml
@@ -1,3 +1,4 @@
 ---
 from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
+reply-to: Code.org <support@code.org>
 subject: Obrigado por se inscrever para sediar a Hora do Código!

--- a/pegasus/test/fixtures/deliverer/expected/hoc_signup_2021_receipt_pt/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/hoc_signup_2021_receipt_pt/header.yaml
@@ -1,3 +1,3 @@
 ---
-from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
+from: Hadi Partovi (Code.org) <support@code.org>
 subject: Obrigado por se inscrever para sediar a Hora do Código!

--- a/pegasus/test/fixtures/deliverer/expected/hoc_signup_2021_receipt_pt/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/hoc_signup_2021_receipt_pt/header.yaml
@@ -1,3 +1,3 @@
 ---
-from: Hadi Partovi (Code.org) <support@code.org>
+from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
 subject: Obrigado por se inscrever para sediar a Hora do Código!

--- a/pegasus/test/fixtures/deliverer/expected/hoc_signup_2022_receipt_es/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/hoc_signup_2022_receipt_es/header.yaml
@@ -1,3 +1,4 @@
 ---
 from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
+reply-to: Code.org <support@code.org>
 subject: "¡Gracias por inscribirte para ser anfitrión de una Hora de Código!"

--- a/pegasus/test/fixtures/deliverer/expected/hoc_signup_2022_receipt_es/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/hoc_signup_2022_receipt_es/header.yaml
@@ -1,3 +1,3 @@
 ---
-from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
+from: Hadi Partovi (Code.org) <support@code.org>
 subject: "¡Gracias por inscribirte para ser anfitrión de una Hora de Código!"

--- a/pegasus/test/fixtures/deliverer/expected/hoc_signup_2022_receipt_es/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/hoc_signup_2022_receipt_es/header.yaml
@@ -1,3 +1,3 @@
 ---
-from: Hadi Partovi (Code.org) <support@code.org>
+from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
 subject: "¡Gracias por inscribirte para ser anfitrión de una Hora de Código!"

--- a/pegasus/test/fixtures/deliverer/expected/hoc_signup_2022_receipt_pt/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/hoc_signup_2022_receipt_pt/header.yaml
@@ -1,3 +1,4 @@
 ---
 from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
+reply-to: Code.org <support@code.org>
 subject: Obrigado por se inscrever para sediar a Hora do Código!

--- a/pegasus/test/fixtures/deliverer/expected/hoc_signup_2022_receipt_pt/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/hoc_signup_2022_receipt_pt/header.yaml
@@ -1,3 +1,3 @@
 ---
-from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
+from: Hadi Partovi (Code.org) <support@code.org>
 subject: Obrigado por se inscrever para sediar a Hora do Código!

--- a/pegasus/test/fixtures/deliverer/expected/hoc_signup_2022_receipt_pt/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/hoc_signup_2022_receipt_pt/header.yaml
@@ -1,3 +1,3 @@
 ---
-from: Hadi Partovi (Code.org) <support@code.org>
+from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
 subject: Obrigado por se inscrever para sediar a Hora do Código!

--- a/pegasus/test/fixtures/deliverer/expected/hoc_survey_2014_receipt/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/hoc_survey_2014_receipt/header.yaml
@@ -1,3 +1,4 @@
 ---
 from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
+reply-to: Code.org <support@code.org>
 subject: Your gift code

--- a/pegasus/test/fixtures/deliverer/expected/hoc_survey_2014_receipt/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/hoc_survey_2014_receipt/header.yaml
@@ -1,3 +1,3 @@
 ---
-from: Hadi Partovi (Code.org) <support@code.org>
+from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
 subject: Your gift code

--- a/pegasus/test/fixtures/deliverer/expected/hoc_survey_2014_receipt/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/hoc_survey_2014_receipt/header.yaml
@@ -1,3 +1,3 @@
 ---
-from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
+from: Hadi Partovi (Code.org) <support@code.org>
 subject: Your gift code

--- a/pegasus/test/fixtures/deliverer/expected/petition_receipt/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/petition_receipt/header.yaml
@@ -1,3 +1,4 @@
 ---
 from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
+reply-to: Code.org <support@code.org>
 subject: Thanks!

--- a/pegasus/test/fixtures/deliverer/expected/petition_receipt/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/petition_receipt/header.yaml
@@ -1,3 +1,3 @@
 ---
-from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
+from: Hadi Partovi (Code.org) <support@code.org>
 subject: Thanks!

--- a/pegasus/test/fixtures/deliverer/expected/petition_receipt/header.yaml
+++ b/pegasus/test/fixtures/deliverer/expected/petition_receipt/header.yaml
@@ -1,3 +1,3 @@
 ---
-from: Hadi Partovi (Code.org) <support@code.org>
+from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
 subject: Thanks!


### PR DESCRIPTION
Adds a support email in the `reply_to` field wherever we send from Hadi's email address.

I did a find for Hadi's email and added a `reply_to` field based on the formatting of the `from` field

## Links

Ticket: https://codedotorg.atlassian.net/browse/ACQ-149

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
