### PR TITLE
Adding bottom margin if no visibility toggle

### DIFF
--- a/apps/src/templates/progress/ProgressLessonTeacherInfo.jsx
+++ b/apps/src/templates/progress/ProgressLessonTeacherInfo.jsx
@@ -145,7 +145,12 @@ class ProgressLessonTeacherInfo extends React.Component {
           </div>
         )}
         {lesson.lesson_feedback_url && (
-          <div style={styles.buttonContainer}>
+          <div
+            style={{
+              marginBottom: !!showHiddenForSectionToggle ? '0px' : '10px',
+              ...styles.buttonContainer
+            }}
+          >
             <Button
               __useDeprecatedTag
               href={lesson.lesson_feedback_url}
@@ -171,7 +176,9 @@ class ProgressLessonTeacherInfo extends React.Component {
 
 const styles = {
   buttonContainer: {
-    margin: '10px 15px 0px 15px',
+    marginTop: '10px',
+    marginRight: '15px',
+    marginLeft: '15px',
     // Have to set line height to 0 to remove additional 5px bottom margin
     lineHeight: '0px'
   },


### PR DESCRIPTION
This adds a small margin to the bottom of the rate lesson link (styled as button) when there is no visibility toggle below (therefore, it's the last bit of the list). This only happens when a unit doesn't allow the hiding functionality, or a teacher doesn't yet have any sections and the lesson view has a short enough description or is collapsed.


<img width="752" alt="Screen Shot 2023-01-12 at 12 10 27 PM" src="https://user-images.githubusercontent.com/37230822/212170516-845c8c5b-d953-48ec-9e0b-76446481219b.png">

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
