### PR TITLE
Assume Database is Aurora when Configuring ProxySQL

### DIFF
--- a/cookbooks/cdo-mysql/recipes/proxy.rb
+++ b/cookbooks/cdo-mysql/recipes/proxy.rb
@@ -52,7 +52,7 @@ template 'proxysql.cnf' do
       {reporting => [3]}
     ],
     data_dir: data_dir,
-    is_aurora: lazy {!!CDO.db_cluster_id},
+    is_aurora: true, # All environments that have ProxySQL enabled used Aurora.
     admin: admin,
     port: proxy_port,
     reporting_port: reporting_port


### PR DESCRIPTION
Assume (if Chef is provisioning ProxySQL on a web application server) that the database is an Aurora cluster. This reduces our dependency on `CDO` configuration settings in Chef cookbooks, so we can hopefully eliminate the loading `/deployment.rb` during execution of the `cdo-secrets` cookbook. Currently #48809 modifies the `CDO` config / secrets functionality enough to break initialization of the `CDO` object when it’s loaded by Chef.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Only production currently uses ProxySQL. We may need to provision an adhoc with ProxySQL to test this change.

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
