### PR TITLE
Add calibrate compass button and display when connected

### DIFF
--- a/apps/i18n/applab/en_us.json
+++ b/apps/i18n/applab/en_us.json
@@ -355,6 +355,8 @@
   "makerSetupBoardBadResponse": "We found a board but it didn't respond properly when we tried to connect to it.",
   "makerSetupBrowserTitle": "Code.org Browser",
   "makerSetupBrowserSupported": "Using a supported browser",
+  "makerSetupCalibrateCompass": "Calibrate Compass",
+  "makerSetupCalibrateCompassDescription": "Calibrate the micro:bit for accurate readings",
   "makerSetupCheck": "Setup Check",
   "makerSetupCheckInternetConnection": "Please make sure you are connected to the internet, and [https://downloads.code.org](https://downloads.code.org/index.html) is reachable from your network.",
   "makerSetupChromebook": "Maker Toolkit works on Chromebooks without any installations or extensions. You should be able to plug in your board and get started right away!",

--- a/apps/src/lib/kits/maker/boards/microBit/MBFirmataWrapper.js
+++ b/apps/src/lib/kits/maker/boards/microBit/MBFirmataWrapper.js
@@ -93,4 +93,10 @@ export default class MicrobitFirmataWrapper extends MBFirmataClient {
       callback(pin, this.digitalInput[pin] + 1);
     }
   }
+
+  compassCalibration() {
+    // Request that the micro:bit perform a compass calibration cycle
+    super.compassCalibration();
+    this.myPort.close();
+  }
 }

--- a/apps/src/lib/kits/maker/boards/microBit/MicroBitBoard.js
+++ b/apps/src/lib/kits/maker/boards/microBit/MicroBitBoard.js
@@ -267,6 +267,18 @@ export default class MicroBitBoard extends EventEmitter {
       false /* shouldDestroyComponents */
     );
   }
+
+  calibrateCompass() {
+    return (
+      Promise.resolve()
+        .then(() => this.openSerialPort())
+        .then(serialPort => this.boardClient_.connectBoard(serialPort))
+        // Delay for 0.1 seconds to ensure time to establish port with micro:bit
+        .then(() => delayPromise(100))
+        .then(() => this.boardClient_.compassCalibration())
+        .catch(err => Promise.reject(err))
+    );
+  }
 }
 
 const delayPromise = t => new Promise(resolve => setTimeout(resolve, t));

--- a/apps/src/lib/kits/maker/ui/SetupChecklist.jsx
+++ b/apps/src/lib/kits/maker/ui/SetupChecklist.jsx
@@ -46,6 +46,15 @@ const initialState = {
 };
 
 export default class SetupChecklist extends Component {
+  constructor(props) {
+    super(props);
+    const {webSerialPort} = this.props;
+    const wrappedSerialPort = webSerialPort
+      ? new WebSerialPortWrapper(webSerialPort)
+      : null;
+    this.setupChecker = new SetupChecker(wrappedSerialPort);
+  }
+
   state = {...initialState};
 
   static propTypes = {
@@ -70,11 +79,6 @@ export default class SetupChecklist extends Component {
   }
 
   detect() {
-    const {webSerialPort} = this.props;
-    const wrappedSerialPort = webSerialPort
-      ? new WebSerialPortWrapper(webSerialPort)
-      : null;
-    const setupChecker = new SetupChecker(wrappedSerialPort);
     this.setState({...initialState, isDetecting: true});
 
     Promise.resolve()
@@ -82,7 +86,7 @@ export default class SetupChecklist extends Component {
       // Are we using a compatible browser?
       .then(() =>
         this.detectStep(STATUS_SUPPORTED_BROWSER, () =>
-          setupChecker.detectSupportedBrowser()
+          this.setupChecker.detectSupportedBrowser()
         )
       )
 
@@ -93,22 +97,22 @@ export default class SetupChecklist extends Component {
           (isChromeOS() || isChrome()) &&
           !shouldUseWebSerial() &&
           this.detectStep(STATUS_APP_INSTALLED, () =>
-            setupChecker.detectChromeAppInstalled()
+            this.setupChecker.detectChromeAppInstalled()
           )
       )
 
       // Is board plugged in?
       .then(() =>
         this.detectStep(STATUS_BOARD_PLUG, () =>
-          setupChecker.detectBoardPluggedIn()
+          this.setupChecker.detectBoardPluggedIn()
         )
       )
 
       // What type of board is this?
       .then(() => {
-        this.setState({boardTypeDetected: setupChecker.detectBoardType()});
+        this.setState({boardTypeDetected: this.setupChecker.detectBoardType()});
         if (experiments.isEnabled('microbit')) {
-          console.log('Board detected: ' + setupChecker.detectBoardType());
+          console.log('Board detected: ' + this.setupChecker.detectBoardType());
         }
         Promise.resolve();
       })
@@ -116,7 +120,7 @@ export default class SetupChecklist extends Component {
       // Can we talk to the firmware?
       .then(() =>
         this.detectStep(STATUS_BOARD_CONNECT, () =>
-          setupChecker.detectCorrectFirmware(this.state.boardTypeDetected)
+          this.setupChecker.detectCorrectFirmware(this.state.boardTypeDetected)
         )
       )
 
@@ -124,7 +128,7 @@ export default class SetupChecklist extends Component {
       .then(() => {
         if (this.state.boardTypeDetected !== BOARD_TYPE.MICROBIT) {
           return this.detectStep(STATUS_BOARD_COMPONENTS, () =>
-            setupChecker.detectComponentsInitialize()
+            this.setupChecker.detectComponentsInitialize()
           );
         }
         return Promise.resolve();
@@ -138,7 +142,7 @@ export default class SetupChecklist extends Component {
             : STATUS_BOARD_COMPONENTS
         )
       )
-      .then(() => setupChecker.celebrate())
+      .then(() => this.setupChecker.celebrate())
       .then(() => this.succeed(STATUS_BOARD_COMPONENTS))
       .then(() => trackEvent('MakerSetup', 'ConnectionSuccess'))
 
@@ -155,7 +159,7 @@ export default class SetupChecklist extends Component {
 
       // Finally...
       .then(() => {
-        setupChecker.teardown();
+        this.setupChecker.teardown();
         this.setState({isDetecting: false});
       });
   }
@@ -309,6 +313,18 @@ export default class SetupChecklist extends Component {
             onClick={this.redetect.bind(this)}
             disabled={this.state.isDetecting}
           />
+          {experiments.isEnabled('microbit') &&
+            this.state.boardTypeDetected === BOARD_TYPE.MICROBIT &&
+            this.state[STATUS_BOARD_CONNECT] === Status.CELEBRATING && (
+              <input
+                style={{marginLeft: 9, marginTop: -4, outline: 'none'}}
+                className="btn"
+                type="button"
+                value={applabI18n.makerSetupCalibrateCompass()}
+                onClick={() => this.setupChecker.calibrateCompass()}
+                title={applabI18n.makerSetupCalibrateCompassDescription()}
+              />
+            )}
         </h2>
         <div className="setup-status">
           {this.renderPlatformSpecificSteps()}

--- a/apps/src/lib/kits/maker/util/SetupChecker.js
+++ b/apps/src/lib/kits/maker/util/SetupChecker.js
@@ -112,4 +112,15 @@ export default class SetupChecker {
       releaseRefs();
     }
   }
+
+  calibrateCompass() {
+    findPortWithViableDevice()
+      .then(port => {
+        this.port = port;
+      })
+      .then(() => {
+        this.boardController = new MicroBitBoard(this.port);
+        return this.boardController.calibrateCompass();
+      });
+  }
 }

--- a/apps/src/third-party/maker/MBFirmataClient.js
+++ b/apps/src/third-party/maker/MBFirmataClient.js
@@ -532,6 +532,12 @@ class MicrobitFirmataClient {
       this.SYSEX_END]);
   }
 
+  compassCalibration() {
+    // Request that the micro:bit perform a compass calibration cycle
+
+    this.myPort.write([this.SYSEX_START, this.MB_COMPASS_CALIBRATE, this.SYSEX_END]);
+  }
+
   enableLightSensor() {
     // Enable the light sensor.
     // Note: When running, the light sensor monopolizes the A/D converter, preventing

--- a/apps/src/third-party/maker/MBFirmataClient.js
+++ b/apps/src/third-party/maker/MBFirmataClient.js
@@ -112,6 +112,7 @@ class MicrobitFirmataClient {
     this.MB_SCROLL_INTEGER			= 0x05
     this.MB_SET_TOUCH_MODE			= 0x06
     this.MB_DISPLAY_ENABLE			= 0x07
+    this.MB_COMPASS_CALIBRATE   = 0x08
     // 0x08-0x0C reserved for additional micro:bit messages
     this.MB_REPORT_EVENT			= 0x0D
     this.MB_DEBUG_STRING			= 0x0E
@@ -188,6 +189,18 @@ class MicrobitFirmataClient {
       }
       return null;
     })
+  }
+
+  isConnected() {
+    // Return true or false if port connected
+
+    if (this.myPort) {
+      console.log('Is Connected True', this.myPort.path);
+      return true;
+    } else {
+      console.log('Is Connected False', this.myPort.path);
+      return false;
+    }
   }
 
   disconnect() {


### PR DESCRIPTION
This PR is closed because the compass feature is not being supported. Another PR will update our local copy of `MBFirmataClient.js`. 

## Summary
This PR:
- updates our local copy of `MBFirmataClient.js` so it contains latest changes added to its [upstream](https://github.com/microbit-foundation/microbit-firmata),
- adds the `calibrateCompass` function in `MicroBitBoard.js` and `SetupChecker.js` and the `compassCalibration` function in `MBFirmataWrapper.js`,
- and adds a 'Calibrate Compass' button to the 'maker/setup' page which displays if the board detected is micro:bit and the board successfully connected.

## Details
Although we eventually would like to use [microbit-foundation/microbit-firmata's](https://github.com/microbit-foundation/microbit-firmata) version of [`MBFirmataClient.js`](https://github.com/microbit-foundation/microbit-firmata/blob/master/client/MBFirmataClient.js), until the changes proposed in [this PR](https://github.com/microbit-foundation/microbit-firmata/pull/3) are accepted, we have a local copy of [`MBFirmataClient.js`](https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/third-party/maker/MBFirmataClient.js) in our code-dot-org repo. See Follow-up section for more on this.

There were two PRs from Code.org that were merged to [microbit-foundationmicrobit-firmata](https://github.com/microbit-foundation/microbit-firmata) in 2022: 1) [Add isConnected function](https://github.com/microbit-foundation/microbit-firmata/pull/13) and 2) [[Code.org Integration] Compass Calibration Placeholder](https://github.com/microbit-foundation/microbit-firmata/pull/14). This PR adds these updates to our local `MBFirmataClient.js` which includes the `compassCalibration` function and `isConnected` function. 

This PR also adds the `calibrateCompass` function in `MicroBitBoard.js` and `SetupChecker.js` and then adds a 'Calibrate Compass' button to `SetupChecklist.js`. @epeach created [this branch](https://github.com/code-dot-org/code-dot-org/tree/mb-compass-calibration) as a mockup for the 'Calibrate Compass' button on which I based my work (thanks Erin!). I made a few changes including changing `setupChecker` from a local to instance variable and adding another condition `  this.state[STATUS_BOARD_CONNECT] === Status.CELEBRATING` for the 'Calibrate Compass' button. Note that I did not need to call on the `isConnected` function because there already exists a state variable `[STATUS_BOARD_CONNECT]` that is set to `Status.CELEBRATING` after the micro:bit successfully connects. This is checked by the function `checkExpectedFirmware`. 
 
Here is a screencast video with the changes described above. I first connect a micro:bit, then I switch and connect to a circuit playground express. For the micro:bit, [only 3 checks are needed](https://github.com/code-dot-org/code-dot-org/pull/44954) and the Calibrate Compass button is displayed. The 'celebration' sound will be added once the `celebrateSuccessfulConnection` function [is updated](https://codedotorg.atlassian.net/browse/SL-400).  I then connected to a circuit playground express and click on the 'Re-detect' button. Both devices are checked successfully.

https://user-images.githubusercontent.com/107423305/212122299-67c9afe3-a216-4290-a3ba-24c713b75216.mp4


As noted above, I used as a starting point for this PR this [mock-up branch](https://github.com/code-dot-org/code-dot-org/tree/mb-compass-calibration). Within `MicroBitBoard.js` and `SetupChecker.js` I made changes to the`calibrateCompass`function after I observed the following errors in the console.

If I clicked on the 'Calibrate Compass' button twice after successfully connecting the micro:bit -
<img width="1275" alt="Screen Shot 2023-01-11 at 3 16 10 PM" src="https://user-images.githubusercontent.com/107423305/212123212-b5b1915b-7859-4961-92d5-9a01c918da4d.png">

If I clicked on the 'Re-detect' button after clicking on 'Calibrate Compass' button:
<img width="1265" alt="Screen Shot 2023-01-11 at 3 16 43 PM" src="https://user-images.githubusercontent.com/107423305/212123228-ffcf34de-d776-4f82-b59e-460e3755fa4d.png">

The error message 'Error Resource temporarily unavailable Cannot lock port' indicated that we needed to close the port after calibrating the compass. I attempted to close the port in `MicroBitBoard.js`, but `boardClient_` is declared private variable in `MicroBitBoard.js`. Thus, I added the`compassCalibration` function in `MBFirmataWrapper.js` which calls on the `compassCalibration` function in `MBFirmataClient`, and then closes the port. 

 I don't call on `checkExpectedFirmware` in the `calibrateCompass`, but instead fleshed out `calibrateCompass` within `MicroBitBoard.js` to not affect state values in `SetupChecker.js` and shorten the time delay. Now if a user clicks on the 'Calibrate Compass' button multiple times in succession, there is no error displayed and they can click on 'Re-detect' successfully. 

Screencast video below:

https://user-images.githubusercontent.com/107423305/212137625-da98875c-c864-437e-8389-d473037b3bed.mp4

## Links
[jira ticket - After micro:bit adds 'isConnected' function, check in setupChecklist.js](https://codedotorg.atlassian.net/browse/SL-48)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
I tested the changes locally using a Micro:Bit and a Circuit Playground Express.
Note: I closed [this PR](https://github.com/code-dot-org/code-dot-org/pull/49759) due to failed unit tests in `SetupChecklistTest.js`. As I was debugging the tests, I created [this branch](alice/mb-calibrateCompass-2) with the same code changes and the tests are  passing on the Drone build. I am unsure why the [other branch](alice/mb-calibrateCompass) failed on the Drone build. The unit tests do pass locally on both branches.
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work
In a discussion with Erin, she suggested that since [her PR - Code.org Integration #3](https://github.com/microbit-foundation/microbit-firmata/pull/3) has not been approved (submitted Dec 2019), we could consider implementing these changes in `MBFirmataWrapper.js` so that we can use the upstream version of `MBFirmataClient.js`. 

Also, I consulted with @moneppo about displaying confirmation text to the user after they click on the 'Calibrate Compass' button and here is the [jira ticket](https://codedotorg.atlassian.net/browse/SL-508) for that task. 

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
