### PR TITLE
[AnimationList Investigation] Fix i18n error to load page

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -893,6 +893,7 @@
   "errorFindingClassLibraries": "Unable to load your class libraries at this time. Please check your internet connection and try again.",
   "errorIncompleteBlockInFunction": "Click \"edit\" to make sure you don't have any blocks missing inside your function definition.",
   "errorGenericLintError": "Your program contains an editor warning that needs to be corrected. Hover over the icons near the line numbers in the editor to learn more.",
+  "errorLoadingAnimation": "It looks like we are having trouble loading your animation \"{animationName}\". Make sure you have a good internet connection and try reloading the page. If this problem persists, it is possible that this animation is broken. In this case, you may need to continue by removing the animation.",
   "errorLoadingDocumentation": "An error occurred while loading documentation.",
   "errorLoadingRosteredSections": "Oops, there was a problem grabbing your sections from {type}.",
   "errorLoadingRosteredSectionsSupport": "If the problem persists, click here for troubleshooting tips.",

--- a/apps/i18n/gamelab/en_us.json
+++ b/apps/i18n/gamelab/en_us.json
@@ -62,7 +62,6 @@
   "dropletBlock_remove_param0_description": "The sprite to be removed.",
   "dropletBlock_x_description": "X coordinate of sprite.",
   "dropletBlock_y_description": "Y coordinate of sprite.",
-  "errorLoadingAnimation": "It looks like we are having trouble loading your animation \"{animationName}\". Make sure you have a good internet connection and try reloading the page. If this problem persists, it is possible that this animation is broken. In this case, you may need to continue by removing the animation.",
   "reinfFeedbackMsg": "You're finished! Click \"Continue\" to move on to the next level.",
   "shareGame": "Share your game:"
 }

--- a/apps/i18n/spritelab/en_us.json
+++ b/apps/i18n/spritelab/en_us.json
@@ -84,7 +84,6 @@
   "didntMoveRight": "Your sprite did not move right.",
   "didntMoveUp": "Your sprite did not move up.",
   "didntPressKey": "Make sure to press an arrow key after pressing *\"Run\"*. You can click the orange buttons under the play area or press the keys on your keyboard.",
-  "errorLoadingAnimation": "It looks like we are having trouble loading your animation \"{animationName}\". Make sure you have a good internet connection and try reloading the page. If this problem persists, it is possible that this animation is broken. In this case, you may need to continue by removing the animation.",
   "eventNotDetected": "The event wasn't detected. Make sure you have the correct event blocks in your workspace and that you have chosen the correct *costume* in each block of code. \n <xml><block type=\"gamelab_allSpritesWithAnimation\"><title name=\"ANIMATION\">\"default\"</title></block></xml>",
   "eventsOneChange": "Your sprite changed, but only once. Test your program by pressing the key a few times, and make sure to use the correct block. \n <xml><block type=\"gamelab_changePropBy\"><title name=\"PROPERTY\">\"scale\"</title><value name=\"SPRITE\"><block type=\"gamelab_allSpritesWithAnimation\"><title name=\"ANIMATION\">\"creature_10_1\"</title></block></value><value name=\"VAL\"><block type=\"math_number\"><title name=\"NUM\">10</title></block></value></block></xml>",
   "eventsWrongBehaviors": "Your sprite should have exactly 3 behaviors. Try moving the `stops everything` block to a different place in your code.",

--- a/apps/src/p5lab/ErrorDialogStack.jsx
+++ b/apps/src/p5lab/ErrorDialogStack.jsx
@@ -5,7 +5,6 @@ import * as actions from './redux/errorDialogStack';
 import {connect} from 'react-redux';
 import BaseDialog from '@cdo/apps/templates/BaseDialog.jsx';
 import {pegasus} from '@cdo/apps/lib/util/urlHelpers';
-var labMsg = require('@cdo/gamelab/locale') || require('@cdo/spritelab/locale');
 import msg from '@cdo/locale';
 import Button from '@cdo/apps/templates/Button';
 import DialogFooter from '@cdo/apps/templates/teacherDashboard/DialogFooter';
@@ -87,9 +86,7 @@ class ErrorDialogStack extends React.Component {
             information and choice to reload the page or delete the animation */}
         {error.error_type === 'anim_load' && (
           <div>
-            <p>
-              {labMsg.errorLoadingAnimation({animationName: animationName})}
-            </p>
+            <p>{msg.errorLoadingAnimation({animationName: animationName})}</p>
             <p>
               {msg.contactWithoutEmail()}{' '}
               <a


### PR DESCRIPTION
A step in the right direction, surfacing intended behavior here.

The large issue here is that there are issues loading (at least one) specific animation. The intended behavior here is surfacing a dialog that says, "Hey this animation didn't load - please reload or delete it". However, somewhere along the way our translation for that dialog was broken, which meant that we got caught on that error and didn't load anything.

This PR fixes that translation error (and de-dupes along the way!). The core issue (animation not loading) still exists, but at least now we are given a message that something is wrong with potential fixes. This change should not wait to be merged while we continue to investigate what is causing the core issue.

I am stilllllll unable to upload images to GitHub, so please see [this thread ](https://codedotorg.slack.com/archives/C03DBDN67B7/p1673485292826299)on slack for a screenshot of the dialog and restored behavior.