### PR TITLE
Fix Violations of and Reenable `Performance/TimesMap`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -185,11 +185,6 @@ Performance/Detect:
 Performance/MethodObjectAsBlock:
   Enabled: false
 
-# Offense count: 20
-# This cop supports safe auto-correction (--auto-correct).
-Performance/TimesMap:
-  Enabled: false
-
 # Offense count: 7
 # This cop supports safe auto-correction (--auto-correct).
 Rails/ApplicationMailer:

--- a/bin/i18n/translation_monitor/config_helper.rb
+++ b/bin/i18n/translation_monitor/config_helper.rb
@@ -61,7 +61,7 @@ module ConfigHelper
     shared_data = file_content['shared_data']
 
     limit = file_content['limit'] || data.size
-    limit.times.map do |i|
+    Array.new(limit) do |i|
       # Explict config data will overwrite the shared data
       config = shared_data.merge(data[i])
 

--- a/dashboard/test/controllers/activities_controller_test.rb
+++ b/dashboard/test/controllers/activities_controller_test.rb
@@ -882,7 +882,7 @@ class ActivitiesControllerTest < ActionController::TestCase
 
   test "milestone with multiple pairings creates multiple new user levels" do
     section = create(:follower, student_user: @user).section
-    pairings = 3.times.map {create(:follower, section: section).student_user}
+    pairings = Array.new(3) {create(:follower, section: section).student_user}
     session[:pairings] = pairings.map(&:id)
     session[:pairing_section_id] = section.id
 

--- a/dashboard/test/helpers/pd/application/pd_workshop_helper_test.rb
+++ b/dashboard/test/helpers/pd/application/pd_workshop_helper_test.rb
@@ -93,7 +93,7 @@ module Pd::Application
 
     test 'prefetch scales without additional queries' do
       workshops = create_list :workshop, 10
-      applications = 10.times.map do |i|
+      applications = Array.new(10) do |i|
         create TEACHER_APPLICATION_FACTORY, pd_workshop_id: workshops[i].id
       end
 

--- a/dashboard/test/helpers/pd/page_helper_test.rb
+++ b/dashboard/test/helpers/pd/page_helper_test.rb
@@ -91,7 +91,7 @@ class Pd::PageHelperTest < ActionView::TestCase
     mock_params.expects(:permit).with([:allow, :page_size]).returns({})
     mock_params.expects(:[], :page_size).returns(nil)
 
-    page_size_buttons = 3.times.map {mock}
+    page_size_buttons = Array.new(3) {mock}
     expects(:new_page_size_button).with('25', {}).returns(page_size_buttons[0])
     expects(:new_page_size_button).with('50', {}).returns(page_size_buttons[1])
     expects(:new_page_size_button).with('All', {}).returns(page_size_buttons[2])

--- a/dashboard/test/lib/pd/jot_form/form_questions_test.rb
+++ b/dashboard/test/lib/pd/jot_form/form_questions_test.rb
@@ -197,13 +197,13 @@ module Pd
       end
 
       test 'deserialize' do
-        fake_questions_array = 5.times.map do |i|
+        fake_questions_array = Array.new(5) do |i|
           {type: "fake type #{i}"}
         end
 
         # Each question hash is passed to the constructor of the appropriate Question sub-class,
         # and then the array of Questions are passed to the FormQuestions constructor
-        mock_constructed_questions = 5.times.map {mock}
+        mock_constructed_questions = Array.new(5) {mock}
         5.times do |i|
           mock_question_class = mock do |c|
             c.expects(:new).with({type: "fake type #{i}"}).returns(mock_constructed_questions[i])

--- a/dashboard/test/models/concerns/pd/jot_form_backed_form_test.rb
+++ b/dashboard/test/models/concerns/pd/jot_form_backed_form_test.rb
@@ -178,7 +178,7 @@ module Pd
     end
 
     test 'fill_placeholders syncs each placeholder' do
-      mock_placeholders = 2.times.map do
+      mock_placeholders = Array.new(2) do
         mock {|mock_placeholder| mock_placeholder.expects(:sync_from_jotform)}
       end
 
@@ -194,7 +194,7 @@ module Pd
 
     test 'fill_placeholders collects errors and re-raises at the end' do
       form_id = get_form_id
-      failed_submission_ids = 2.times.map {get_submission_id}
+      failed_submission_ids = Array.new(2) {get_submission_id}
 
       mock_placeholders = [
         mock {|_mock_successful_placeholder| expects(:sync_from_jotform)},
@@ -303,7 +303,7 @@ module Pd
     end
 
     test 'sync_from_jotform with no args syncs all forms' do
-      all_form_ids = 2.times.map {get_form_id}
+      all_form_ids = Array.new(2) {get_form_id}
       DummyForm.expects(:all_form_ids).returns(all_form_ids)
       DummyForm.expects(:_sync_from_jotform).with(all_form_ids)
 
@@ -319,7 +319,7 @@ module Pd
     end
 
     test 'jotform sync gets questions syncs new answers for each form' do
-      form_ids = 2.times.map {get_form_id}
+      form_ids = Array.new(2) {get_form_id}
       last_submission_id = get_submission_id
       min_date = Date.today
       form_ids.each do |form_id|
@@ -363,7 +363,7 @@ module Pd
 
       # 3 batches (batch limit == 5)
       mock_translations = [5, 5, 1].each_with_index.map do |result_count, i|
-        mock_submissions = result_count.times.map do
+        mock_submissions = Array.new(result_count) do
           submission_id = get_submission_id
           mock_questions.expects(:update!).with(last_submission_id: submission_id)
           mock do |mock_submission|
@@ -463,7 +463,7 @@ module Pd
         mock {expects(:last_submission_id).returns(nil).at_least_once}
       )
 
-      mock_submissions = 2.times.map do |i|
+      mock_submissions = Array.new(2) do |i|
         submission_id = get_submission_id
         mock do |mock_submission|
           expects(:[]).with(:submission_id).returns(submission_id)
@@ -490,7 +490,7 @@ module Pd
       e = assert_raises do
         DummyForm.sync_from_jotform form_id
       end
-      2.times.map do |i|
+      Array.new(2) do |i|
         assert e.message.include? "Process error #{i}"
       end
       assert e.message.include? 'Submission all: Entire batch failed. Aborting'

--- a/dashboard/test/models/pd/session_test.rb
+++ b/dashboard/test/models/pd/session_test.rb
@@ -53,7 +53,7 @@ class Pd::SessionTest < ActiveSupport::TestCase
   end
 
   test 'assign unique 4 character codes' do
-    sessions = 10.times.map do
+    sessions = Array.new(10) do
       create :pd_session, :with_assigned_code
     end
 

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -583,7 +583,7 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
 
   test 'order_by_start' do
     # 5 workshops in date order, each with 1-5 sessions (only the first matters)
-    workshops = 5.times.map do |i|
+    workshops = Array.new(5) do |i|
       build :workshop, num_sessions: rand(1..5), sessions_from: Date.today + i.days
     end
     # save out of order
@@ -883,7 +883,7 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     end
 
     # 2 enrollments without attendance
-    enrollments = 2.times.map do
+    enrollments = Array.new(2) do
       create :pd_enrollment, workshop: @workshop
     end
 

--- a/dashboard/test/models/sections/section_test.rb
+++ b/dashboard/test/models/sections/section_test.rb
@@ -53,7 +53,7 @@ class SectionTest < ActiveSupport::TestCase
   end
 
   test "create assigns unique section codes" do
-    sections = 3.times.map do
+    sections = Array.new(3) do
       # Repeatedly seed the RNG so we get the same "random" codes.
       srand 1
       Section.create!(@default_attrs)

--- a/lib/cdo/aws/glue.rb
+++ b/lib/cdo/aws/glue.rb
@@ -46,7 +46,7 @@ module Cdo
     # @return [Array<Aws::Glue::Types::Partition>]
     def self.get_partitions(database, table)
       self.glue_client ||= Aws::Glue::Client.new
-      GET_PARTITION_SEGMENTS.times.map do |i|
+      Array.new(GET_PARTITION_SEGMENTS) do |i|
         Concurrent::Future.execute do
           glue_client.get_partitions(
             database_name: database,

--- a/lib/rake/test.rake
+++ b/lib/rake/test.rake
@@ -190,7 +190,7 @@ namespace :test do
           require 'parallel_tests'
           procs = ParallelTests.determine_number_of_processes(nil)
           CDO.log.info "Test data modified, cloning across #{procs} databases..."
-          databases = procs.times.map {|i| "#{database}#{i + 1}"}
+          databases = Array.new(procs) {|i| "#{database}#{i + 1}"}
           databases.each do |db|
             recreate_db = "DROP DATABASE IF EXISTS #{db}; CREATE DATABASE IF NOT EXISTS #{db};"
             RakeUtils.system_stream_output "echo '#{recreate_db}' | mysql #{opts}"

--- a/lib/test/cdo/test_code_generation.rb
+++ b/lib/test/cdo/test_code_generation.rb
@@ -7,7 +7,7 @@ end
 class CodeGenerationTest < Minitest::Test
   describe 'random unique code' do
     it 'does not generate vowels' do
-      codes = 10.times.map {CodeGeneration.random_unique_code}
+      codes = Array.new(10) {CodeGeneration.random_unique_code}
       assert codes.grep(/[AEIOU]/).empty?
     end
 


### PR DESCRIPTION
Fix applied automatically with `bundle exec rubocop --auto-correct-all --only Performance/TimesMap`

> Checks for `.times.map` calls. In most cases such calls can be replaced with an explicit array creation.

## Links

- https://rubydoc.info/gems/rubocop/0.39.0/RuboCop/Cop/Performance/TimesMap
- https://docs.rubocop.org/rubocop-performance/cops_performance.html#performancetimesmap

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
