### PR TITLE
Fix Violations of and Reenable `Style/FileRead` and `Style/FileWrite`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -377,11 +377,6 @@ Style/ExplicitBlockArgument:
 Style/FetchEnvVar:
   Enabled: false
 
-# Offense count: 30
-# This cop supports safe auto-correction (--auto-correct).
-Style/FileWrite:
-  Enabled: false
-
 # Offense count: 2
 # This cop supports unsafe auto-correction (--auto-correct-all).
 # Configuration parameters: EnforcedStyle.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -377,11 +377,6 @@ Style/ExplicitBlockArgument:
 Style/FetchEnvVar:
   Enabled: false
 
-# Offense count: 4
-# This cop supports safe auto-correction (--auto-correct).
-Style/FileRead:
-  Enabled: false
-
 # Offense count: 30
 # This cop supports safe auto-correction (--auto-correct).
 Style/FileWrite:

--- a/bin/animation_assets/manifest_builder.rb
+++ b/bin/animation_assets/manifest_builder.rb
@@ -64,9 +64,7 @@ class ManifestBuilder
     output_file = @options[:spritelab] ? SPRITELAB_OUTPUT_FILE : DEFAULT_OUTPUT_FILE
 
     # Write result to file
-    File.open(output_file, 'w') do |file|
-      file.write(generate_json(animation_metadata, alias_map, category_map))
-    end
+    File.write(output_file, generate_json(animation_metadata, alias_map, category_map))
 
     @warnings.each {|warning| warn "#{bold 'Warning:'} #{warning}"}
 

--- a/bin/animation_assets/rebuild_default_sprites.rb
+++ b/bin/animation_assets/rebuild_default_sprites.rb
@@ -36,16 +36,15 @@ def main
     props_by_key[key] = props
   end
 
-  File.open(OUTPUT_FILE, 'w') do |file|
-    file.write(
-      JSON.pretty_generate(
-        {
-          orderedKeys: ordered_keys,
-          propsByKey: props_by_key
-        }
-      )
+  File.write(
+    OUTPUT_FILE,
+    JSON.pretty_generate(
+      {
+        orderedKeys: ordered_keys,
+        propsByKey: props_by_key
+      }
     )
-  end
+  )
 end
 
 main

--- a/bin/i18n-codeorg/lib/csv-to-yml.rb
+++ b/bin/i18n-codeorg/lib/csv-to-yml.rb
@@ -9,8 +9,6 @@ CSV.foreach(ARGV[0], {headers: true}) do |row|
   code_string_pairs[row["code"]] = row["string"]
 end
 
-File.open(ARGV[1], 'w+') do |f|
-  f.write(({"en-US" => code_string_pairs}).to_yaml(line_width: -1))
-end
+File.write(ARGV[1], ({"en-US" => code_string_pairs}).to_yaml(line_width: -1))
 
 puts "#{ARGV[0]} => #{ARGV[1]}"

--- a/bin/i18n-codeorg/lib/merge-all-locales.rb
+++ b/bin/i18n-codeorg/lib/merge-all-locales.rb
@@ -61,9 +61,7 @@ if file_type == "yml"
     prev_translation.values[0]
   )
 
-  File.open(prev_translation_path, 'w+') do |f|
-    f.write(new_translation.to_yaml)
-  end
+  File.write(prev_translation_path, new_translation.to_yaml)
 else
   en_translation = JSON.parse(File.read(en_translation_path))
   new_translation = JSON.parse(File.read(new_translation_path))
@@ -76,9 +74,7 @@ else
     prev_translation
   )
 
-  File.open(prev_translation_path, 'w+') do |f|
-    f.write(JSON.pretty_generate(new_translation))
-  end
+  File.write(prev_translation_path, JSON.pretty_generate(new_translation))
 end
 
 puts "#{new_translation_path} + #{en_translation_path} => #{prev_translation_path}"

--- a/bin/i18n/sync-in.rb
+++ b/bin/i18n/sync-in.rb
@@ -82,9 +82,7 @@ def localize_standards
 
   # Then, for each framework, generate a file for it.
   frameworks.keys.each do |framework|
-    File.open(File.join(standards_content_path, "#{framework}.json"), "w") do |file|
-      file.write(JSON.pretty_generate(frameworks[framework]))
-    end
+    File.write(File.join(standards_content_path, "#{framework}.json"), JSON.pretty_generate(frameworks[framework]))
   end
 end
 
@@ -174,9 +172,7 @@ def localize_docs
     end
     # Generate a file containing the string of each Programming Environment.
     FileUtils.mkdir_p(File.dirname(docs_content_file))
-    File.open(docs_content_file, "w") do |file|
-      file.write(JSON.pretty_generate(programming_env_docs.compact))
-    end
+    File.write(docs_content_file, JSON.pretty_generate(programming_env_docs.compact))
   end
 end
 
@@ -223,9 +219,7 @@ def localize_external_sources
     dataset_name = dataset_names[original_dataset['name']]
     final_dataset["name"] = dataset_name if dataset_name
 
-    File.open(dataset_file, "w") do |f|
-      f.write(JSON.pretty_generate(final_dataset))
-    end
+    File.write(dataset_file, JSON.pretty_generate(final_dataset))
   end
 end
 
@@ -475,9 +469,7 @@ def localize_project_content(variable_strings, parameter_strings)
     end
     project_strings.delete_if {|_, value| value.blank?}
 
-    File.open(project_content_file, "w") do |file|
-      file.write(JSON.pretty_generate(project_strings))
-    end
+    File.write(project_content_file, JSON.pretty_generate(project_strings))
   end
 end
 
@@ -591,9 +583,7 @@ def localize_block_content
     blocks[name]['options'] = args_with_options unless args_with_options.empty?
   end
 
-  File.open("dashboard/config/locales/blocks.en.yml", "w+") do |f|
-    f.write(I18nScriptUtils.to_crowdin_yaml({"en" => {"data" => {"blocks" => blocks}}}))
-  end
+  File.write("dashboard/config/locales/blocks.en.yml", I18nScriptUtils.to_crowdin_yaml({"en" => {"data" => {"blocks" => blocks}}}))
 end
 
 def localize_animation_library
@@ -613,9 +603,7 @@ def localize_shared_functions
   shared_functions.sort.each do |func|
     hash[func] = func
   end
-  File.open("i18n/locales/source/dashboard/shared_functions.yml", "w+") do |f|
-    f.write(I18nScriptUtils.to_crowdin_yaml({"en" => {"data" => {"shared_functions" => hash}}}))
-  end
+  File.write("i18n/locales/source/dashboard/shared_functions.yml", I18nScriptUtils.to_crowdin_yaml({"en" => {"data" => {"shared_functions" => hash}}}))
 end
 
 # Aggregate every CourseOffering record's `key` as the translation key, and
@@ -631,9 +619,7 @@ def localize_course_offerings
 end
 
 def write_dashboard_json(location, hash)
-  File.open(File.join(I18N_SOURCE_DIR, "dashboard/#{location}.json"), "w+") do |f|
-    f.write(JSON.pretty_generate(hash))
-  end
+  File.write(File.join(I18N_SOURCE_DIR, "dashboard/#{location}.json"), JSON.pretty_generate(hash))
 end
 
 def select_redactable(i18n_strings)
@@ -672,15 +658,11 @@ def redact_level_file(source_path)
 
   backup_path = source_path.sub("source", "original")
   FileUtils.mkdir_p File.dirname(backup_path)
-  File.open(backup_path, "w") do |file|
-    file.write(JSON.pretty_generate(redactable_data))
-  end
+  File.write(backup_path, JSON.pretty_generate(redactable_data))
 
   redacted_data = RedactRestoreUtils.redact_data(redactable_data, ['blockly'])
 
-  File.open(source_path, 'w') do |source_file|
-    source_file.write(JSON.pretty_generate(source_data.deep_merge(redacted_data)))
-  end
+  File.write(source_path, JSON.pretty_generate(source_data.deep_merge(redacted_data)))
 end
 
 def redact_docs

--- a/bin/i18n/sync-out.rb
+++ b/bin/i18n/sync-out.rb
@@ -167,9 +167,7 @@ def restore_redacted_files
         # data doesn't get lost
         restored_data = RedactRestoreUtils.restore_file(original_path, translated_path, ['blockly'])
         translated_data = JSON.parse(File.read(translated_path))
-        File.open(translated_path, "w") do |file|
-          file.write(JSON.pretty_generate(translated_data.deep_merge(restored_data)))
-        end
+        File.write(translated_path, JSON.pretty_generate(translated_data.deep_merge(restored_data)))
       else
         # Everything else is differentiated only by the plugins used
         plugins = []
@@ -252,9 +250,7 @@ def sanitize_data_and_write(data, dest_path)
     end
 
   FileUtils.mkdir_p(File.dirname(dest_path))
-  File.open(dest_path, 'w+') do |f|
-    f.write(dest_data)
-  end
+  File.write(dest_path, dest_data)
 end
 
 # Wraps hash in correct format to be loaded by our i18n backend.

--- a/bin/i18n/translation_monitor/data_io_helper.rb
+++ b/bin/i18n/translation_monitor/data_io_helper.rb
@@ -9,9 +9,7 @@ module DataIOHelper
   # @param data [Hash]
   # @param file_name [string]
   def write_to_json(data, file_name)
-    File.open(file_name, 'w') do |f|
-      f.write JSON.pretty_generate(data)
-    end
+    File.write(file_name, JSON.pretty_generate(data))
   end
 
   # @param file_name [string]

--- a/bin/remove_script_remnants
+++ b/bin/remove_script_remnants
@@ -78,9 +78,7 @@ def main
   data = get_all_progress(script_id)
 
   # Write the data to a JSON file.
-  File.open("/tmp/all_progress_#{script_id}.json", 'w') do |f|
-    f.write(JSON.pretty_generate(data))
-  end
+  File.write("/tmp/all_progress_#{script_id}.json", JSON.pretty_generate(data))
 
   # Delete the data (if requested).
   print "Should all user progress (" \

--- a/dashboard/app/controllers/pd/workshop_enrollment_controller.rb
+++ b/dashboard/app/controllers/pd/workshop_enrollment_controller.rb
@@ -52,7 +52,7 @@ class Pd::WorkshopEnrollmentController < ApplicationController
           name: facilitator.name,
           email: facilitator.email,
           image_path: File.exist?(image_file) ? CDO.code_org_url("/images/affiliate-images/fit-150/#{facilitator.id}.jpg") : nil,
-          bio: File.exist?(bio_file) ? File.open(bio_file, "r").read : nil
+          bio: File.exist?(bio_file) ? File.read(bio_file) : nil
         }
       end
 

--- a/dashboard/legacy/test/middleware/test_assets.rb
+++ b/dashboard/legacy/test/middleware/test_assets.rb
@@ -468,7 +468,7 @@ class AssetsTest < FilesApiTestBase
     FilesApi.any_instance.stubs(:max_app_size).returns(2000)
 
     # gradient.png's file size is 1559. Upload should only be successful if it is downsampled.
-    _, filetodelete1 = post_asset_file(@api, "existingFile.jpg", File.open("./test/fixtures/gradient.png").read, 'image/png')
+    _, filetodelete1 = post_asset_file(@api, "existingFile.jpg", File.read("./test/fixtures/gradient.png"), 'image/png')
     assert successful?, "Downsampled file upload is successful."
     @api.delete_object(filetodelete1)
 

--- a/dashboard/scripts/archive/count_lines
+++ b/dashboard/scripts/archive/count_lines
@@ -26,4 +26,4 @@ results[:all] = today_sum + archive_sum # Append existing count.
 
 puts results.to_json
 
-File.open(FILE, "wb") {|f| f.write Marshal.dump(sum_cache)}
+File.binwrite(FILE, Marshal.dump(sum_cache))

--- a/dashboard/test/lib/image_lib_test.rb
+++ b/dashboard/test/lib/image_lib_test.rb
@@ -76,9 +76,7 @@ class ImageLibTest < ActiveSupport::TestCase
     png = ImageLib.to_png(original_jpg)
 
     tmp_path = '/tmp/image.png'
-    File.open(tmp_path, 'wb') do |file|
-      file.write png
-    end
+    File.binwrite(tmp_path, png)
 
     assert_equal 'PNG', MiniMagick::Image.read(png).info(:format)
 

--- a/dashboard/test/ui/runner.rb
+++ b/dashboard/test/ui/runner.rb
@@ -440,8 +440,9 @@ end
 def generate_status_page(suite_start_time)
   test_status_template = File.read('test_status.haml')
   haml_engine = Haml::Engine.new(test_status_template)
-  File.open(status_page_filename, 'w') do |file|
-    file.write haml_engine.render(
+  File.write(
+    status_page_filename,
+    haml_engine.render(
       Object.new,
       {
         api_origin: CDO.studio_url('', scheme_for_environment),
@@ -454,7 +455,7 @@ def generate_status_page(suite_start_time)
         browser_features: browser_features
       }
     )
-  end
+  )
   ChatClient.log "A <a href=\"#{status_page_url}\">status page</a> has been generated for this #{test_type} test run."
 end
 

--- a/lib/cdo/poste.rb
+++ b/lib/cdo/poste.rb
@@ -482,7 +482,7 @@ module Poste2
         # Prevent saving certificates - they are unecessarily filling storage.
         next if name.include?('certificate')
         filename = File.expand_path "#{attachment_dir}/#{timestamp}-#{name}"
-        File.open(filename, 'w+b') {|f| f.write content}
+        File.binwrite(filename, content)
         saved[name] = filename
       end
     end

--- a/lib/cdo/rake_utils.rb
+++ b/lib/cdo/rake_utils.rb
@@ -305,7 +305,7 @@ module RakeUtils
 
     destination_local_pathname = Pathname(destination_local_path)
     FileUtils.mkdir_p(File.dirname(destination_local_pathname))
-    File.open(destination_local_pathname, 'w') {|f| f.write(new_fetchable_url)}
+    File.write(destination_local_pathname, new_fetchable_url)
     new_fetchable_url
   end
 

--- a/lib/cdo/test_flakiness.rb
+++ b/lib/cdo/test_flakiness.rb
@@ -83,7 +83,7 @@ class TestFlakiness
   # for calculating flakiness.
   # @param timestamp [Integer] Unix timestamp (e.g., Time.now.to_i)
   def self.reset(timestamp)
-    File.open(FLAKINESS_TIMESTAMP_FILENAME, "w") {|f| f.write({timestamp: timestamp}.to_json)}
+    File.write(FLAKINESS_TIMESTAMP_FILENAME, {timestamp: timestamp}.to_json)
   end
 
   CACHE_FILENAME = (File.dirname(__FILE__) + "/../../dashboard/tmp/cache/test_summary.json").freeze

--- a/lib/dynamic_config/adapters/json_file_adapter.rb
+++ b/lib/dynamic_config/adapters/json_file_adapter.rb
@@ -60,9 +60,7 @@ class JSONFileDatastoreAdapter
   end
 
   def write_to_file
-    File.open(@file_path, "w") do |f|
-      f.write(JSON.dump(@hash))
-    end
+    File.write(@file_path, JSON.dump(@hash))
   end
 
   def clear

--- a/lib/dynamic_config/loaders/dcdo_loader.rb
+++ b/lib/dynamic_config/loaders/dcdo_loader.rb
@@ -49,7 +49,7 @@ module DCDOLoader
   # Load yaml file into DCDO
   # @param filepath [String]
   def self.load(filepath)
-    yaml = File.open(filepath, 'r').read
+    yaml = File.read(filepath)
     commands = yaml_to_commands(yaml)
     apply_commands(commands)
   end

--- a/lib/dynamic_config/loaders/gatekeeper_loader.rb
+++ b/lib/dynamic_config/loaders/gatekeeper_loader.rb
@@ -77,7 +77,7 @@ module GatekeeperLoader
   # Load yaml file into gatekeeper
   # @param filepath [String]
   def self.load(filepath)
-    yaml = File.open(filepath, 'r').read
+    yaml = File.read(filepath)
     commands = yaml_to_commands(yaml)
     apply_commands(commands)
   end

--- a/shared/test/test_s3_packaging.rb
+++ b/shared/test/test_s3_packaging.rb
@@ -14,10 +14,10 @@ class S3PackagingTest < Minitest::Test
     target_location = Dir.mktmpdir
     Dir.chdir(source_location) do
       FileUtils.mkdir('src')
-      File.open('src/one.js', 'w') {|file| file.write("file one")}
-      File.open('src/two.js', 'w') {|file| file.write("file two")}
+      File.write('src/one.js', "file one")
+      File.write('src/two.js', "file two")
       FileUtils.mkdir('build')
-      File.open('build/output.js', 'w') {|file| file.write("output")}
+      File.write('build/output.js', "output")
     end
     packager = RakeUtils.stub(:git_folder_hash, commit_hash) do
       S3Packaging.new('test-package', source_location, target_location).tap do |s3|

--- a/tools/scripts/rebuildSoundLibraryManifest.rb
+++ b/tools/scripts/rebuildSoundLibraryManifest.rb
@@ -69,31 +69,30 @@ class ManifestBuilder
     info "Mapped #{category_map.size} categories"
 
     # Write result to file
-    File.open(DEFAULT_OUTPUT_FILE, 'w') do |file|
-      file.write(
-        JSON.pretty_generate(
-          {
-            # JSON-style file comment
-            '//': [
-              'Sound Library Manifest',
-              'GENERATED FILE: DO NOT MODIFY DIRECTLY',
-              'See tools/scripts/rebuildSoundLibraryManifest.rb for more information.'
-            ],
+    File.write(
+      DEFAULT_OUTPUT_FILE,
+      JSON.pretty_generate(
+        {
+          # JSON-style file comment
+          '//': [
+            'Sound Library Manifest',
+            'GENERATED FILE: DO NOT MODIFY DIRECTLY',
+            'See tools/scripts/rebuildSoundLibraryManifest.rb for more information.'
+          ],
 
-            # Strip aliases from metadata - they're no longer needed since they
-            #   are represented in the alias map.
-            # Also sort for stable updates
-            metadata: sound_metadata.hmap {|k, v| [k, v.omit!('aliases')]}.sort.to_h,
+          # Strip aliases from metadata - they're no longer needed since they
+          #   are represented in the alias map.
+          # Also sort for stable updates
+          metadata: sound_metadata.hmap {|k, v| [k, v.omit!('aliases')]}.sort.to_h,
 
-            # Sort category map for stable updates
-            categories: category_map.sort.to_h,
+          # Sort category map for stable updates
+          categories: category_map.sort.to_h,
 
-            # Sort alias map for stable updates
-            aliases: alias_map.sort.to_h
-          }
-        )
+          # Sort alias map for stable updates
+          aliases: alias_map.sort.to_h
+        }
       )
-    end
+    )
 
     @warnings.each {|warning| warn "#{bold 'Warning:'} #{warning}"}
 


### PR DESCRIPTION
Fixes applied automatically with `bundle exec rubocop --auto-correct-all --only Style/FileRead` and  `bundle exec rubocop --auto-correct-all --only Style/FileWrite`. I then manually applied a few indentation fixes.

> Favor `File.(bin)read` convenience methods.
> Favor `File.(bin)write` convenience methods.

## Links

- https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/FileWrite
- https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/FileRead
- https://docs.rubocop.org/rubocop/cops_style.html#stylefilewrite
- https://docs.rubocop.org/rubocop/cops_style.html#stylefileread

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
