### PR TITLE
[Google Blockly] Prioritize styles in block config over colors

### DIFF
--- a/apps/src/block_utils.js
+++ b/apps/src/block_utils.js
@@ -915,6 +915,7 @@ exports.createJsWrapperBlockCreator = function(
   return (
     {
       color,
+      style,
       func,
       expression,
       orderPrecedence,
@@ -1017,10 +1018,17 @@ exports.createJsWrapperBlockCreator = function(
     blockly.Blocks[blockName] = {
       helpUrl: '',
       init: function() {
-        if (color) {
+        // Styles should be used over hard-coded colors in Google Blockly blocks
+        if (style && this.setStyle) {
+          this.setStyle(style);
+        } else if (color) {
           Blockly.cdoUtils.setHSV(this, ...color);
         } else if (!returnType) {
-          Blockly.cdoUtils.setHSV(this, ...DEFAULT_COLOR);
+          if (this.setStyle) {
+            this.setStyle('default');
+          } else {
+            Blockly.cdoUtils.setHSV(this, ...DEFAULT_COLOR);
+          }
         }
 
         if (returnType) {


### PR DESCRIPTION
Google Blockly supports a `style` property for blocks. Core Blockly blocks (e.g. loops, logic, variables) already have defined styles which we override in our theme. Blocks can also have a `colour` (HSV values). Hard-coded colors are not compatible with themes, so we want to shift our practices to using styles instead. Styles are currently defined (or overridden) in https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/blockly/addons/cdoTheme.js

Actually editing the block config files will be addressed in a follow-up PR.

## Links

- [SL-442: [Google Blockly] Use style property instead of color for blocks](https://codedotorg.atlassian.net/browse/SL-442)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

- [SL-443: [Google Blockly] Block editor and index should use Google Blockly for certain pools](https://codedotorg.atlassian.net/browse/SL-443)
- [SL-472: Support Google and CDO Blockly on block editing pages](https://codedotorg.atlassian.net/browse/SL-472)
- 
Blocks defined in pools are typically edited on levelbuilder. This editor is not presently using Google Blockly, so blocks will appear to not support styles until that is addressed. However, once the block config is saved, the block will indeed use that style once loaded into the Google Blockly lab.

Block in block editor with hard-coded color (CDO Blockly):
<img width="827" alt="image" src="https://user-images.githubusercontent.com/43474485/212361676-75e179d6-7fbe-4c94-8124-33d509c5b313.png">

Block in a workspace with hard-coded color (Google Blockly): 
<img width="593" alt="image" src="https://user-images.githubusercontent.com/43474485/212361257-e5833e90-7a1a-45e4-ba25-cbe59aca2f50.png">


Block in block editor with style (CDO Blockly): 
<img width="816" alt="image" src="https://user-images.githubusercontent.com/43474485/212361824-55bba531-1798-41a1-a389-d9fa87971dcb.png">

Block in a workspace with style (Google Blockly):
<img width="593" alt="image" src="https://user-images.githubusercontent.com/43474485/212362154-debae921-4f00-4c1b-b993-bc3f1c7de108.png">

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
