### PR TITLE
Upgrade SauceLabs Safari to 13

### DIFF
--- a/dashboard/test/ui/browsers.json
+++ b/dashboard/test/ui/browsers.json
@@ -1,4 +1,4 @@
-/* saucelabs browser configurator: https://docs.saucelabs.com/reference/platforms-configurator/#/ */
+/* saucelabs browser configurator: https://saucelabs.com/platform/platform-configurator */
 
 [
   {
@@ -12,8 +12,8 @@
   {
     "name": "Safari",
     "browserName": "Safari",
-    "platform": "macOS 10.14",
-    "version": "12.0",
+    "platform": "macOS 10.15",
+    "version": "13",
     "w3c": true
   },
   {


### PR DESCRIPTION
## Context

We are discussing updating our IT requirements so that we no longer support some older versions of Mobile Safari. Currently, we support Desktop Safari 13 and Mobile Safari 11. Version 13 introduced [Pointer Events](https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent#browser_compatibility), which are standard in our other modern browsers. Pointer Events are going to be required for new versions of Google Blockly, which will be required for migrating our labs and to do other things like improve accessibility of our K5 labs. 

### Google Analytics
In the last week, Safari browsers represent about 11.09% of all users.
![image](https://user-images.githubusercontent.com/43474485/212376007-5d45a22f-a61c-4a82-afb5-aa8fcfb6aeca.png)
Of all Safari users, 3.83% are using Safari 11 or 12. In total, 0.432% of all users are using a Safari 11 or 12. The portion of these users that are on Mobile Safari are currently using a supported browser for which we are looking to end support.

According to Google Analytics and some quick calculations, it looks like about 4% of Safari users are on version 10-12 (We can't differentiate mobile vs desktop). This is about 0.46% of all users. Safari 13 was released in September 2019, so schools would have needed to update browsers in the last 3ish years to be on a compatible version.
Slack thread: https://codedotorg.slack.com/archives/C0T0TPL9W/p1673475443171329

## Strategy
I used the SauceLabs platform configurator (now at https://saucelabs.com/platform/platform-configurator) to find the oldest version of MacOS that supports Safari 13, which turned out to be Catalina. This brings our tests up to parity with our existing IT requirements for Desktop Safari, and bumps past what is currently recommended for Mobile Safari. See https://code.org/educate/it

I verified that SauceLabs was using Safari 13 after this change by taking control of a test running through my SauceLabs tunnel.
<img width="1299" alt="image" src="https://user-images.githubusercontent.com/43474485/212374100-76fa2a9d-bef8-4a1d-a16f-e1f698206fb6.png">
