### PR TITLE
prune family names from list in script constants

### DIFF
--- a/dashboard/app/models/unit.rb
+++ b/dashboard/app/models/unit.rb
@@ -344,7 +344,7 @@ class Unit < ApplicationRecord
 
     def family_names
       Rails.cache.fetch('script/family_names', force: !Unit.should_cache?) do
-        (CourseVersion.course_offering_keys('Unit') + ScriptConstants::FAMILY_NAMES).uniq.sort
+        (CourseVersion.course_offering_keys('Unit') + ScriptConstants::DEPRECATED_FAMILY_NAMES).uniq.sort
       end
     end
 

--- a/dashboard/lib/script_constants.rb
+++ b/dashboard/lib/script_constants.rb
@@ -226,18 +226,9 @@ module ScriptConstants
 
   DEFAULT_VERSION_YEAR = '2017'
 
-  # An allowlist of all family names for scripts.
-  FAMILY_NAMES = [
-    # CSF
-    COURSEA = 'coursea'.freeze,
-    COURSEB = 'courseb'.freeze,
-    COURSEC = 'coursec'.freeze,
-    COURSED = 'coursed'.freeze,
-    COURSEE = 'coursee'.freeze,
-    COURSEF = 'coursef'.freeze,
-    EXPRESS = 'express'.freeze,
-    PREEXPRESS = 'pre-express'.freeze,
-
+  # An allowlist of all family names which are not course offerings.
+  # This list is deprecated. Do not add to this list.
+  DEPRECATED_FAMILY_NAMES = [
     # CSP
     CSP1 = 'csp1'.freeze,
     CSP2 = 'csp2'.freeze,
@@ -260,15 +251,6 @@ module ScriptConstants
     CSD4 = "csd4".freeze,
     CSD5 = "csd5".freeze,
     CSD6 = "csd6".freeze,
-
-    # AIML
-    AIML = "aiml".freeze,
-
-    # Testing
-    #
-    # note that this constant is hard to rename from 'script' to 'unit' because
-    # doing so causes the course version to change, causing seeding to fail.
-    TEST = 'ui-test-versioned-script'.freeze
   ].freeze
 
   def self.unit_in_category?(category, script)

--- a/dashboard/lib/script_constants.rb
+++ b/dashboard/lib/script_constants.rb
@@ -17,6 +17,16 @@ module ScriptConstants
   CSP17_UNIT2_NAME = 'csp2-2017'.freeze
   CSP17_UNIT3_NAME = 'csp3-2017'.freeze
 
+  # CSF family names
+  COURSEA = 'coursea'.freeze
+  COURSEB = 'courseb'.freeze
+  COURSEC = 'coursec'.freeze
+  COURSED = 'coursed'.freeze
+  COURSEE = 'coursee'.freeze
+  COURSEF = 'coursef'.freeze
+  EXPRESS = 'express'.freeze
+  PREEXPRESS = 'pre-express'.freeze
+
   # The order here matters. The first category a script appears under will be
   # the category it belongs to in course dropdowns. The order of scripts within
   # a category will be the order in which they appear in the dropdown, and the

--- a/dashboard/test/controllers/script_levels_controller_test.rb
+++ b/dashboard/test/controllers/script_levels_controller_test.rb
@@ -1895,22 +1895,24 @@ class ScriptLevelsControllerTest < ActionController::TestCase
   end
 
   test 'should redirect to 2017 version in script family' do
-    cats1 = create :script, name: 'cats1', family_name: 'ui-test-versioned-script', version_year: '2017'
+    cats1 = create :script, name: 'cats1', family_name: 'cats', version_year: '2017', is_course: true
+    CourseOffering.add_course_offering(cats1)
 
     assert_raises ActiveRecord::RecordNotFound do
-      get :show, params: {script_id: 'ui-test-versioned-script', lesson_position: 1, id: 1}
+      get :show, params: {script_id: 'cats', lesson_position: 1, id: 1}
     end
 
     cats1.update!(published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)
-    get :show, params: {script_id: 'ui-test-versioned-script', lesson_position: 1, id: 1}
+    get :show, params: {script_id: 'cats', lesson_position: 1, id: 1}
     assert_redirected_to "/s/cats1/lessons/1/levels/1"
 
-    create :script, name: 'cats2', family_name: 'ui-test-versioned-script', version_year: '2018', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable
-    get :show, params: {script_id: 'ui-test-versioned-script', lesson_position: 1, id: 1}
+    cats2 = create :script, name: 'cats2', family_name: 'cats', version_year: '2018', is_course: true, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable
+    CourseOffering.add_course_offering(cats2)
+    get :show, params: {script_id: 'cats', lesson_position: 1, id: 1}
     assert_redirected_to "/s/cats2/lessons/1/levels/1"
 
     # next redirects to latest version in a script family
-    get :next, params: {script_id: 'ui-test-versioned-script'}
+    get :next, params: {script_id: 'cats'}
     assert_redirected_to "/s/cats2/next"
   end
 

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -1640,23 +1640,25 @@ class ScriptsControllerTest < ActionController::TestCase
   test 'should redirect to latest stable version in unit family for student without progress or assignment' do
     sign_in create(:student)
 
-    dogs1 = create :script, name: 'dogs1', family_name: 'ui-test-versioned-script', version_year: '1901', is_course: true
+    dogs1 = create :script, name: 'dogs1', family_name: 'dogs', version_year: '1901', is_course: true
     CourseOffering.add_course_offering(dogs1)
 
     assert_raises ActiveRecord::RecordNotFound do
-      get :show, params: {id: 'ui-test-versioned-script'}
+      get :show, params: {id: 'dogs'}
     end
 
     dogs1.update!(published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable)
-    get :show, params: {id: 'ui-test-versioned-script'}
+    get :show, params: {id: 'dogs'}
     assert_redirected_to "/s/dogs1"
 
-    create :script, name: 'dogs2', family_name: 'ui-test-versioned-script', version_year: '1902', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable
-    get :show, params: {id: 'ui-test-versioned-script'}
+    dogs2 = create :script, name: 'dogs2', family_name: 'dogs', version_year: '1902', is_course: true, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable
+    CourseOffering.add_course_offering(dogs2)
+    get :show, params: {id: 'dogs'}
     assert_redirected_to "/s/dogs2"
 
-    create :script, name: 'dogs3', family_name: 'ui-test-versioned-script', version_year: '1899', published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable
-    get :show, params: {id: 'ui-test-versioned-script'}
+    dogs3 = create :script, name: 'dogs3', family_name: 'dogs', version_year: '1899', is_course: true, published_state: Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable
+    CourseOffering.add_course_offering(dogs3)
+    get :show, params: {id: 'dogs'}
     assert_redirected_to "/s/dogs2"
   end
 


### PR DESCRIPTION
Follow-up from https://github.com/code-dot-org/code-dot-org/pull/49755/files/d73237b9c14c3b4ea34a4ca57c56fc3999f6462a#r1069930260 . This list was misleading because it had some cruft in it, and the comment implied that new family names needed to be added to it. This PR removes the cruft and fixes the comment.

## Testing story

* Manually verified that the result of `CourseVersion.course_offering_keys('Unit').sort.join("\n")` contains the removed family names:
  * on staging, the result contains `aiml` and all the CSF family names
  * on test, the result contains `ui-test-versioned-script` 
* UI tests cover the removal of `ui-test-versioned-script`: https://github.com/code-dot-org/code-dot-org/blob/9cdbffefd6aaa26cd297a78273db897e429b7fe7/dashboard/test/ui/features/teacher_tools/course_versions.feature#L144-L146 
* verified that the following redirects stills work
  * http://localhost-studio.code.org:3000/s/coursea
  * http://localhost-studio.code.org:3000/s/express
  * http://localhost-studio.code.org:3000/s/aiml