### PR TITLE
Fix Enrollments by only linking teacher applications

### DIFF
--- a/bin/oneoff/remove_non_teacher_application_ids.rb
+++ b/bin/oneoff/remove_non_teacher_application_ids.rb
@@ -1,0 +1,26 @@
+#!/usr/bin/env ruby
+
+require_relative '../../dashboard/config/environment'
+
+puts "Removing application ids that are not teacher applications ..."
+modified_enrollments = []
+
+Pd::Enrollment.where.not(application_id: nil).each do |enrollment|
+  original_app_id = enrollment.application_id
+
+  begin
+    application = Pd::Application::ApplicationBase.find(original_app_id)
+    if application.type != "Pd::Application::TeacherApplication"
+      # The method set_application_id is triggered before a save
+      # Save the enrollment to re-compute set_application_id
+      enrollment.save!
+      modified_enrollments << enrollment.id
+    end
+  rescue ActiveRecord::SubclassNotFound # Happens with Facilitator applications
+    enrollment.save!
+    modified_enrollments << enrollment.id
+  end
+end
+
+puts "modified #{modified_enrollments.length} enrollments"
+puts "enrollments modified: #{modified_enrollments}"

--- a/dashboard/app/models/pd/enrollment.rb
+++ b/dashboard/app/models/pd/enrollment.rb
@@ -310,7 +310,7 @@ class Pd::Enrollment < ApplicationRecord
     application_id = nil
     # Finds application from the school year of the workshop. Assumes workshops start after 6/1
     # because workshop.school_year assumes 6/1 is the start of the school year
-    Pd::Application::ApplicationBase.where(user_id: user_id, application_year: workshop&.school_year).each do |application|
+    Pd::Application::TeacherApplication.where(user_id: user_id, application_year: workshop&.school_year).each do |application|
       application_id = application.id if course_match.call(application) || pd_match.call(application)
       break if application_id
     end
@@ -319,7 +319,7 @@ class Pd::Enrollment < ApplicationRecord
 
   def application
     return nil unless application_id
-    Pd::Application::ApplicationBase.find_by(id: application_id)
+    Pd::Application::TeacherApplication.find_by(id: application_id)
   end
 
   # Removes the name and email information stored within this Pd::Enrollment.

--- a/dashboard/app/models/pd/enrollment.rb
+++ b/dashboard/app/models/pd/enrollment.rb
@@ -37,6 +37,7 @@ class Pd::Enrollment < ApplicationRecord
   include Pd::WorkshopSurveyConstants
   include SerializedProperties
   include Pd::Application::ActiveApplicationModels
+  include Pd::Application::ApplicationConstants
   include Pd::WorkshopSurveyFoormConstants
 
   acts_as_paranoid # Use deleted_at column instead of deleting rows.
@@ -304,7 +305,7 @@ class Pd::Enrollment < ApplicationRecord
   # workshop id
   # @return [Integer, nil] application id or nil if cannot find any application
   def set_application_id
-    course_match = ->(application) {Pd::Application::ApplicationBase::COURSE_NAME_MAP[application.try(:course)&.to_sym] == workshop.try(:course)}
+    course_match = ->(application) {COURSE_NAME_MAP[application.try(:course)&.to_sym] == workshop.try(:course)}
     pd_match = ->(application) {application.try(:pd_workshop_id) == pd_workshop_id}
 
     application_id = nil


### PR DESCRIPTION
We were getting some [HoneyBadger errors](https://app.honeybadger.io/projects/3240/faults/92357934) associated with the deprecation of facilitator models. Enrollments were setting the `application_id` to *any* application that a user sent in, including principal approval and facilitator applications, rather than only their teacher application.

There is follow-up work to be done to ensure facilitator applications can't be accessed in Rails now that our model is deleted, tracked [here](https://codedotorg.atlassian.net/browse/ACQ-348).

Once this is hits production, I will run the oneoff script from production-daemon.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

After changing the `set_application_id` method, I ran the oneoff script on the adhoc with the following results:
```
Removing application ids that are not teacher applications ...
modified 872 enrollments
enrollments modified: [60106, 60434, 60496, 61211, 61217, 61238, 61239, 61329, 61330, 61551, 61707, 61713, 62206, 62239, 62240, 62241, 62242, 62243, 62245, 62246, 62247, 62248, 62249, 62254, 62255, 62256, 62257, 62260, 62261, 62262, 62263, 62266, 62267, 62268, 62273, 62276, 62282, 62283, 62285, 62289, 62299, 62300, 62301, 62302, 62333, 62334, 62390, 62599, 62600, 62840, 62841, 62843, 62934, 62935, 63002, 63590, 63591, 63608, 63610, 63833, 63864, 63869, 63924, 63927, 64221, 64223, 64225, 64345, 64355, 64386, 64528, 64530, 64531, 64533, 64923, 64925, 64930, 64931, 64936, 64939, 64940, 64941, 64942, 64959, 64962, 64973, 64976, 64977, 64990, 64993, 64999, 65003, 65014, 65022, 65029, 65031, 65137, 65158, 65163, 65166, 65181, 65183, 65187, 65205, 65226, 65263, 65351, 65442, 65546, 65612, 65701, 65719, 65841, 65898, 65908, 65977, 65992, 66030, 66111, 66112, 66406, 66642, 66653, 66661, 66698, 66718, 66744, 66784, 66799, 66834, 67183, 67184, 67186, 67212, 67265, 67347, 67701, 67721, 67760, 67802, 67883, 67917, 68031, 68314, 68315, 68325, 68326, 68429, 68733, 68845, 68932, 69050, 69588, 69789, 69917, 69923, 69949, 70155, 70179, 70367, 70988, 71405, 71644, 71710, 71793, 71945, 71952, 72000, 72051, 72217, 73108, 73112, 73165, 73242, 73353, 73377, 73452, 73453, 73547, 73997, 74065, 74093, 74225, 74652, 74797, 74902, 74907, 74939, 74942, 74955, 74957, 74967, 74968, 74971, 74984, 74985, 74986, 75009, 75011, 75020, 75039, 75042, 75044, 75047, 75052, 75057, 75076, 75079, 75102, 75107, 75127, 75133, 75147, 75155, 75157, 75159, 75160, 75674, 75782, 76007, 76021, 76188, 76190, 76191, 76192, 76193, 76194, 76195, 76197, 76199, 76200, 76211, 76226, 76241, 76251, 76292, 76378, 76380, 76790, 76794, 76795, 76796, 76797, 77080, 77082, 77083, 77084, 77085, 77086, 77087, 77088, 77089, 77090, 77091, 77092, 77093, 77094, 77095, 77096, 77097, 77098, 77099, 77100, 77101, 77102, 77103, 77104, 77105, 77106, 77107, 77108, 77109, 77110, 77111, 77112, 77113, 77114, 77115, 77116, 77117, 77118, 77119, 77120, 77121, 77122, 77123, 77124, 77125, 77126, 77127, 77128, 77129, 77130, 77131, 77132, 77133, 77134, 77135, 77136, 77137, 77138, 77139, 77144, 77232, 77737, 77738, 77768, 77799, 78027, 78170, 78201, 78536, 78537, 78538, 78539, 78815, 79007, 79026, 79032, 79050, 79051, 79059, 79062, 79068, 79077, 79086, 79094, 79103, 79104, 79109, 79110, 79123, 79124, 79128, 79132, 79133, 79163, 79170, 79172, 79177, 79189, 79192, 79195, 79218, 79223, 79227, 79237, 79238, 79255, 79256, 79267, 79274, 79310, 79373, 79404, 79418, 79426, 79435, 79499, 79528, 79603, 79745, 79746, 79763, 79824, 79978, 79999, 80001, 80169, 80495, 80499, 80508, 80510, 80513, 80517, 80526, 81319, 81321, 81323, 81324, 81328, 81331, 81332, 81333, 81336, 81338, 81339, 81340, 81341, 81342, 81344, 81345, 81346, 81347, 81348, 81350, 81352, 81353, 81355, 81360, 81363, 81364, 81365, 81366, 81370, 81373, 81375, 81378, 81380, 81383, 81385, 81387, 81391, 81394, 81395, 81396, 81398, 81412, 81413, 81414, 81415, 81416, 81417, 81419, 81421, 81422, 81423, 81434, 81456, 81462, 81464, 81466, 81472, 81484, 81514, 81515, 81521, 81775, 81781, 81782, 81783, 82178, 82189, 82588, 82612, 82666, 82692, 82803, 82836, 82837, 82838, 82840, 82884, 83268, 83735, 83736, 84027, 84028, 84400, 84402, 84404, 84533, 84682, 84735, 84898, 85088, 85231, 85481, 85633, 85719, 85752, 85772, 85887, 86030, 86051, 86075, 86301, 86735, 86862, 86913, 86914, 86916, 86917, 87227, 87280, 87498, 87573, 87647, 87846, 87848, 87849, 87963, 88270, 88329, 88341, 89069, 89169, 89178, 89179, 89309, 89445, 89702, 89808, 89811, 89818, 89897, 89901, 90212, 90354, 90703, 90959, 91010, 91011, 91013, 91151, 91152, 91164, 91165, 91166, 91208, 91211, 91212, 91561, 91869, 92344, 92351, 92440, 92609, 92744, 92790, 93029, 93334, 93441, 93515, 93869, 94108, 94426, 94563, 94680, 94778, 95213, 95256, 95515, 95726, 95832, 95873, 95999, 96403, 96479, 96555, 96584, 96610, 96677, 96715, 97043, 97581, 97641, 97645, 97767, 97769, 97824, 97964, 98027, 98094, 98096, 98563, 98599, 98650, 98664, 98701, 98976, 99106, 99123, 99595, 99635, 99726, 99909, 99959, 100434, 100476, 101270, 101707, 101776, 101904, 102064, 108628, 108705, 108706, 108727, 109245, 109263, 109468, 109858, 109876, 109928, 110203, 110317, 110768, 110795, 111005, 111627, 111700, 111937, 112045, 112134, 112141, 112533, 112551, 112776, 113443, 113504, 114026, 114282, 114410, 114434, 114616, 115684, 116579, 116933, 117348, 117479, 117518, 117647, 117649, 117663, 117675, 117676, 117678, 117679, 117682, 117683, 117706, 117734, 117919, 117932, 117934, 117938, 117939, 117940, 117941, 118051, 118052, 118068, 118216, 118225, 118226, 118388, 118389, 118476, 118477, 118548, 118549, 118604, 118606, 118756, 118820, 118821, 118919, 119101, 119104, 119105, 119106, 119647, 119648, 119651, 119670, 119677, 119705, 119740, 119836, 119842, 119843, 119845, 119849, 119856, 119857, 119862, 119871, 119872, 119875, 119881, 119884, 119887, 119888, 119889, 119891, 119896, 119906, 119908, 119923, 119924, 119930, 119931, 119932, 119935, 119936, 119942, 119943, 119945, 119955, 119974, 119982, 119984, 119993, 119994, 119995, 119996, 119997, 120004, 120006, 120012, 120014, 120018, 120023, 120025, 120026, 120028, 120030, 120032, 120033, 120034, 120035, 120037, 120041, 120045, 120058, 120060, 120062, 120064, 120067, 120068, 120069, 120071, 120073, 120091, 120111, 120150, 120151, 120153, 120155, 120156, 120157, 120159, 120162, 120164, 120167, 120176, 120177, 120178, 120348, 120386, 120388, 120408, 120409, 120491, 120493, 120563, 120564, 120704, 120705, 121075, 121105, 121340, 121354, 121430, 121519, 121534, 121544, 121546, 121574, 121575, 121607, 121651, 121722, 121823, 121825, 121827, 121829, 121831, 121849, 121965, 122024, 122524, 122601, 122756, 123124, 123133, 123293, 123294, 123408, 123686, 123735, 123848, 123950, 123975, 124816, 125116, 125154, 125632, 125708, 125780, 125782, 125822, 125954, 125958, 125959, 126050, 126364, 126365, 126366, 126367, 126626, 126867, 127108, 127109, 127110, 127111, 127135, 128891, 130637, 131391, 131392, 131430, 131749, 131783, 131818, 131867, 132822, 132831, 132854, 133489, 133640, 133701, 133963, 134547, 135030, 135268, 135706, 136821, 137785, 138389, 138544, 138916, 139043, 139099, 139173, 139495, 140109, 140160, 140161, 140191, 140594, 140634, 141370, 143291, 143406, 143887, 145040, 145086, 145920, 145927, 146819, 147158, 147257, 148262, 148263, 148401, 148421, 148431, 148488, 148785, 148855]
```

I spot checked a few of these:
```
Pd::Enrollment.find(148855)
=> #<Pd::Enrollment id: 148855, pd_workshop_id: 8803, ... , application_id: nil>
```

```
[adhoc] dashboard > Pd::Enrollment.find(74797)
=> #<Pd::Enrollment id: 74797, pd_workshop_id: 4704, ... , application_id: 15251>
[adhoc] dashboard > Pd::Application::ApplicationBase.find(15251).type
=> "Pd::Application::TeacherApplication"
```

## Deployment strategy

## Follow-up work

https://codedotorg.atlassian.net/browse/ACQ-348 –– Remove applications that can't be accessed via rails with a soft delete

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
