### PR TITLE
Amplitude- Instrumenting cancel button from login_type selection page

### DIFF
--- a/apps/src/templates/teacherDashboard/LoginTypePicker.jsx
+++ b/apps/src/templates/teacherDashboard/LoginTypePicker.jsx
@@ -17,6 +17,8 @@ import styleConstants from '../../styleConstants';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 
 const LOGIN_TYPE_SELECTED_EVENT = 'Login Type Selected';
+const CANCELLED_EVENT = 'Section Setup Cancelled';
+const SELECT_LOGIN_TYPE = 'Login Type Selection';
 
 /**
  * UI for selecting the login type of a class section:
@@ -40,6 +42,12 @@ class LoginTypePicker extends Component {
     });
   };
 
+  recordSectionSetupExitEvent = eventName => {
+    analyticsReporter.sendEvent(eventName, {
+      source: SELECT_LOGIN_TYPE
+    });
+  };
+
   openImportDialog = provider => {
     this.reportLoginTypeSelection(provider);
     this.props.setRosterProvider(provider);
@@ -52,8 +60,13 @@ class LoginTypePicker extends Component {
     this.props.setLoginType(provider);
   };
 
+  cancel = () => {
+    this.recordSectionSetupExitEvent(CANCELLED_EVENT);
+    this.props.handleCancel();
+  };
+
   render() {
-    const {title, providers, handleCancel, disabled} = this.props;
+    const {title, providers, disabled} = this.props;
     const withGoogle =
       providers && providers.includes(OAuthSectionTypes.google_classroom);
     const withMicrosoft =
@@ -133,7 +146,7 @@ class LoginTypePicker extends Component {
             </a>
           </div>
           <Button
-            onClick={handleCancel}
+            onClick={this.cancel}
             text={i18n.dialogCancel()}
             size={Button.ButtonSize.large}
             color={Button.ButtonColor.gray}


### PR DESCRIPTION
This update adds a section creation cancel event to the login type selection page. I added the field source: 'Login Type Selection' so that we can tell where the user cancelled in Amplitude.

Tested by clicking the cancel button locally and watching to ensure the payload looks right:
<img width="477" alt="Screen Shot 2023-01-17 at 4 24 55 PM" src="https://user-images.githubusercontent.com/37230822/213046274-78037a2c-0c7b-4185-b6ad-e3461f324200.png">


## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/TEACH-177

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
