### PR TITLE
Music: unique instructions per block mode

### DIFF
--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -112,7 +112,10 @@ class UnconnectedMusicView extends React.Component {
     });
 
     this.loadInstructions().then(instructions => {
-      this.setState({instructions});
+      this.setState({
+        instructions: instructions,
+        showInstructions: !!instructions
+      });
     });
   }
 
@@ -150,10 +153,19 @@ class UnconnectedMusicView extends React.Component {
   };
 
   loadInstructions = async () => {
-    const libraryFilename = 'music-instructions.json';
-    const response = await fetch(baseUrl + libraryFilename);
-    const library = await response.json();
-    return library;
+    const blockMode = AppConfig.getValue('blocks');
+    const instructionsFilename =
+      !blockMode || blockMode === 'advanced'
+        ? 'music-instructions.json'
+        : `'music-instructions-${blockMode}.json'`;
+    const response = await fetch(baseUrl + instructionsFilename);
+    let instructions;
+    try {
+      instructions = await response.json();
+    } catch (error) {
+      instructions = null;
+    }
+    return instructions;
   };
 
   clearCode = () => {

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -157,7 +157,7 @@ class UnconnectedMusicView extends React.Component {
     const instructionsFilename =
       !blockMode || blockMode === 'advanced'
         ? 'music-instructions.json'
-        : `'music-instructions-${blockMode}.json'`;
+        : `music-instructions-${blockMode}.json`;
     const response = await fetch(baseUrl + instructionsFilename);
     let instructions;
     try {


### PR DESCRIPTION
Unique instructions are now loaded per block mode.  

If block mode is `"advanced"` or not explicitly specified, which is the same thing, then the previous `music-instructions.json` is loaded.  

Otherwise, we load a new variant of instructions, e.g. for `"simple"` we load `music-instructions-simple.json`.

If the instructions file is not found, the instructions are toggled to be hidden.