### PR TITLE
Fix oauth in development environments and improve testing amplitude for oauth

### DIFF
--- a/apps/src/lib/util/AnalyticsReporter.js
+++ b/apps/src/lib/util/AnalyticsReporter.js
@@ -109,7 +109,7 @@ class AnalyticsReporter {
     if (hostname.includes('localhost') || hostname.includes('127.0.0.1')) {
       return Environments.development;
     }
-    if (hostname.includes('code.org')) {
+    if (hostname === 'code.org' || hostname === 'studio.code.org') {
       return Environments.production;
     }
     return Environments.unknown;

--- a/apps/src/lib/util/AnalyticsReporter.js
+++ b/apps/src/lib/util/AnalyticsReporter.js
@@ -106,7 +106,7 @@ class AnalyticsReporter {
     if (hostname.includes('staging')) {
       return Environments.staging;
     }
-    if (hostname.includes('localhost')) {
+    if (hostname.includes('localhost') || hostname.includes('127.0.0.1')) {
       return Environments.development;
     }
     if (hostname.includes('code.org')) {

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -9,7 +9,8 @@ Dashboard::Application.routes.draw do
     get '/weblab/footer', to: 'projects#weblab_footer'
   end
 
-  constraints host: /^((?!#{CDO.codeprojects_hostname}).)*$/ do
+  # This matches any host that is not the codeprojects hostname
+  constraints host: /^(?!#{CDO.codeprojects_hostname})/ do
     # React-router will handle sub-routes on the client.
     get 'teacher_dashboard/sections/:section_id/parent_letter', to: 'teacher_dashboard#parent_letter'
     get 'teacher_dashboard/sections/:section_id/*path', to: 'teacher_dashboard#show', via: :all

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -9,7 +9,7 @@ Dashboard::Application.routes.draw do
     get '/weblab/footer', to: 'projects#weblab_footer'
   end
 
-  constraints host: /.*code.org.*|.*hourofcode.com.*/ do
+  constraints host: /^((?!#{CDO.codeprojects_hostname}).)*$/ do
     # React-router will handle sub-routes on the client.
     get 'teacher_dashboard/sections/:section_id/parent_letter', to: 'teacher_dashboard#parent_letter'
     get 'teacher_dashboard/sections/:section_id/*path', to: 'teacher_dashboard#show', via: :all


### PR DESCRIPTION
This PR does two things:
1. Restricts most dashboard routes to only not be served on codeprojects. This is to unblock oauth testing in development. See the [discussion in Slack](https://codedotorg.slack.com/archives/C03CK49G9/p1665415159283389) (from a while ago)
2. Expands the definition of "development" on the client-side for the purpose of amplitude testing. 

