### PR TITLE
Add workaround for reminder mailer if application has no first name

### DIFF
--- a/dashboard/app/views/pd/application/teacher_application_mailer/complete_application_final_reminder.html.haml
+++ b/dashboard/app/views/pd/application/teacher_application_mailer/complete_application_final_reminder.html.haml
@@ -1,8 +1,11 @@
 - registration_url = "https://studio.code.org/pd/application/teacher"
 
 %p
-  Hello
-  = @application.first_name + ","
+  - if !!@application.first_name&.present?
+    Hello
+    = @application.first_name + ","
+  - else
+    Hello,
 
 %p
   We noticed that you still have not completed your application. We just wanted to check in

--- a/dashboard/app/views/pd/application/teacher_application_mailer/complete_application_initial_reminder.html.haml
+++ b/dashboard/app/views/pd/application/teacher_application_mailer/complete_application_initial_reminder.html.haml
@@ -1,8 +1,11 @@
 - registration_url = "https://studio.code.org/pd/application/teacher"
 
 %p
-  Hello
-  = @application.first_name + ","
+  - if !!@application.first_name&.present?
+    Hello
+    = @application.first_name + ","
+  - else
+    Hello,
 
 %p
   We are excited you are interested in the Code.org Professional Learning Program!


### PR DESCRIPTION
Our reminder emails aren't being sent out as expected. One problem is that our templates use `@application.first_name` which will fail if the user has not entered a first name.

This adds an if/else block so that it doesn't error out. I'm not convinced this will fix *all* the problems, but it's a good first step –– I'll investigate again once this is merged in, and I've manually sent those that are sendable (i.e. the template doesn't error out).

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

I tested this locally. When the first name is not present, I see the email being sent out as 
```
<p>
Hello,
</p>
...
```
When the first name is present, I see it being sent as 
```
<p>
Hello
meg,
</p>
```
which is consistent with previous behavior of 
```
<p>
Hello
Lindsey,
</p>
…
```

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
