### PR TITLE
Amplitude event update with version year, new curriculum event

### DIFF
--- a/apps/src/templates/teacherDashboard/EditSectionForm.jsx
+++ b/apps/src/templates/teacherDashboard/EditSectionForm.jsx
@@ -153,14 +153,16 @@ class EditSectionForm extends Component {
       initialCourseOfferingId,
       initialCourseVersionId
     } = this.props;
-    const versionYear =
-      courseOfferings[section.courseOfferingId].course_versions[
-        section.courseVersionId
-      ].key;
-    const initialVersionYear =
-      courseOfferings[initialCourseOfferingId].course_versions[
-        initialCourseVersionId
-      ].key;
+    const versionYear = section.courseOfferingId
+      ? courseOfferings[section.courseOfferingId].course_versions[
+          section.courseVersionId
+        ].key
+      : '';
+    const initialVersionYear = initialCourseOfferingId
+      ? courseOfferings[initialCourseOfferingId].course_versions[
+          initialCourseVersionId
+        ].key
+      : '';
     const course = courseOfferings.hasOwnProperty(section.courseOfferingId)
       ? courseOfferings[section.courseOfferingId]
       : null;

--- a/apps/src/templates/teacherDashboard/EditSectionForm.jsx
+++ b/apps/src/templates/teacherDashboard/EditSectionForm.jsx
@@ -48,6 +48,8 @@ class EditSectionForm extends Component {
     //Comes from redux
     initialUnitId: PropTypes.number,
     initialCourseId: PropTypes.number,
+    initialCourseOfferingId: PropTypes.number,
+    initialCourseVersionId: PropTypes.number,
     courseOfferings: PropTypes.objectOf(assignmentCourseOfferingShape)
       .isRequired,
     section: sectionShape.isRequired,
@@ -147,12 +149,17 @@ class EditSectionForm extends Component {
       section,
       courseOfferings,
       isNewSection,
-      initialCourseId,
-      initialUnitId
+      initialUnitId,
+      initialCourseOfferingId,
+      initialCourseVersionId
     } = this.props;
     const versionYear =
       courseOfferings[section.courseOfferingId].course_versions[
         section.courseVersionId
+      ].key;
+    const initialVersionYear =
+      courseOfferings[initialCourseOfferingId].course_versions[
+        initialCourseVersionId
       ].key;
     const course = courseOfferings.hasOwnProperty(section.courseOfferingId)
       ? courseOfferings[section.courseOfferingId]
@@ -173,12 +180,14 @@ class EditSectionForm extends Component {
     }
     if (
       eventName === COMPLETED_EVENT &&
-      ((section.courseId && section.courseId !== initialCourseId) ||
+      ((section.courseOfferingId &&
+        section.courseOfferingId !== initialCourseOfferingId) ||
         (section.unitId && section.unitId !== initialUnitId))
     ) {
       analyticsReporter.sendEvent(CURRICULUM_ASSIGNED, {
         previousUnitId: initialUnitId,
-        previousCourseId: initialCourseId,
+        previousCourseId: initialCourseOfferingId,
+        previousVersionYear: initialVersionYear,
         newUnitId: section.unitId,
         newCourseId: section.courseOfferingId,
         newVersionYear: versionYear
@@ -609,6 +618,8 @@ YesNoDropdown.propTypes = FieldProps;
 let defaultPropsFromState = state => ({
   initialCourseId: state.teacherSections.initialCourseId,
   initialUnitId: state.teacherSections.initialUnitId,
+  initialCourseOfferingId: state.teacherSections.initialCourseOfferingId,
+  initialCourseVersionId: state.teacherSections.initialCourseVersionId,
   courseOfferings: state.teacherSections.courseOfferings,
   section: state.teacherSections.sectionBeingEdited,
   isSaveInProgress: state.teacherSections.saveInProgress,

--- a/apps/src/templates/teacherDashboard/EditSectionForm.jsx
+++ b/apps/src/templates/teacherDashboard/EditSectionForm.jsx
@@ -157,12 +157,12 @@ class EditSectionForm extends Component {
       ? courseOfferings[section.courseOfferingId].course_versions[
           section.courseVersionId
         ].key
-      : '';
+      : null;
     const initialVersionYear = initialCourseOfferingId
       ? courseOfferings[initialCourseOfferingId].course_versions[
           initialCourseVersionId
         ].key
-      : '';
+      : null;
     const course = courseOfferings.hasOwnProperty(section.courseOfferingId)
       ? courseOfferings[section.courseOfferingId]
       : null;

--- a/apps/src/templates/teacherDashboard/EditSectionForm.jsx
+++ b/apps/src/templates/teacherDashboard/EditSectionForm.jsx
@@ -171,11 +171,10 @@ class EditSectionForm extends Component {
         sectionPairProgramSelection: section.pairingAllowed
       });
     }
-    // Are there times when a unit is assigned without a course?
     if (
       eventName === COMPLETED_EVENT &&
-      section.courseId &&
-      section.courseId !== initialCourseId
+      ((section.courseId && section.courseId !== initialCourseId) ||
+        (section.unitId && section.unitId !== initialUnitId))
     ) {
       analyticsReporter.sendEvent(CURRICULUM_ASSIGNED, {
         previousUnitId: initialUnitId,

--- a/apps/src/templates/teacherDashboard/EditSectionForm.jsx
+++ b/apps/src/templates/teacherDashboard/EditSectionForm.jsx
@@ -34,6 +34,7 @@ import GetVerifiedBanner from './GetVerifiedBanner';
 
 const COMPLETED_EVENT = 'Section Setup Completed';
 const CANCELLED_EVENT = 'Section Setup Cancelled';
+const CURRICULUM_ASSIGNED = 'Section Curriculum Assigned';
 
 /**
  * UI for editing section details: Name, grade, assigned course, etc.
@@ -81,6 +82,7 @@ class EditSectionForm extends Component {
     const scriptId = section.unitId;
 
     this.recordSectionSetupExitEvent(COMPLETED_EVENT);
+    this.recordCurriculumChangeEvent;
 
     const isScriptHidden =
       sectionId &&
@@ -140,6 +142,29 @@ class EditSectionForm extends Component {
     );
   };
 
+  recordCurriculumChangeEvent = () => {
+    const {
+      section,
+      courseOfferings,
+      initialCourseId,
+      initialUnitId
+    } = this.props;
+    // Are there times when a course is assigned without a unit assigned?
+    if (section.unitId && section.unitId !== initialUnitId) {
+      analyticsReporter.sendEvent(CURRICULUM_ASSIGNED),
+        {
+          previousUnitId: initialUnitId,
+          previousCourseId: initialCourseId,
+          newUnitId: section.unitId,
+          newCourseId: section.courseId,
+          newVersionYear:
+            courseOfferings[section.courseOfferingId].courseVersions[
+              section.courseVersionId
+            ].key
+        };
+    }
+  };
+
   // valid event names: 'Section Setup Complete', 'Section Setup Cancelled'.
   recordSectionSetupExitEvent = eventName => {
     const {section, courseOfferings, isNewSection} = this.props;
@@ -152,8 +177,13 @@ class EditSectionForm extends Component {
 
     if (isNewSection) {
       analyticsReporter.sendEvent(eventName, {
+        sectionUnitId: section.unitId,
         sectionCurriculumLocalizedName: courseName,
-        sectionCurriculum: courseId,
+        sectionCurriculum: courseId, //this is course Offering id
+        sectionCurriculumVersionYear:
+          courseOfferings[section.courseOfferingId].courseVersions[
+            section.courseVersionId
+          ].key,
         sectionGrade: section.grade,
         sectionLockSelection: section.restrictSection,
         sectionName: section.name,

--- a/apps/test/unit/templates/teacherDashboard/EditSectionFormTest.js
+++ b/apps/test/unit/templates/teacherDashboard/EditSectionFormTest.js
@@ -409,7 +409,7 @@ describe('EditSectionForm', () => {
     assert.equal(lessonExtrasField.length, 1);
   });
 
-  it('sends completed event when save is clicked', () => {
+  it('sends completed events when save is clicked', () => {
     const wrapper = shallow(
       <EditSectionForm
         isNewSection={true}
@@ -432,16 +432,30 @@ describe('EditSectionForm', () => {
     const analyticsSpy = sinon.spy(analyticsReporter, 'sendEvent');
 
     wrapper.find('Button[text="Save"]').simulate('click');
-    assert(analyticsSpy.calledOnce);
+    assert(analyticsSpy.calledTwice);
     assert.equal(analyticsSpy.getCall(0).firstArg, 'Section Setup Completed');
     assert.deepEqual(analyticsSpy.getCall(0).lastArg, {
       sectionCurriculum: courseOfferings[testSection.courseOfferingId].id,
       sectionCurriculumLocalizedName:
         courseOfferings[testSection.courseOfferingId].display_name,
+      sectionCurriculumVersionYear: '2017',
       sectionGrade: testSection.grade,
       sectionLockSelection: testSection.restrictSection,
       sectionName: testSection.name,
-      sectionPairProgramSelection: testSection.pairingAllowed
+      sectionPairProgramSelection: testSection.pairingAllowed,
+      sectionUnitId: null
+    });
+
+    assert.equal(
+      analyticsSpy.getCall(1).firstArg,
+      'Section Curriculum Assigned'
+    );
+    assert.deepEqual(analyticsSpy.getCall(1).lastArg, {
+      previousUnitId: undefined,
+      previousCourseId: undefined,
+      newUnitId: null,
+      newCourseId: courseOfferings[testSection.courseOfferingId].id,
+      newVersionYear: '2017'
     });
 
     analyticsSpy.restore();
@@ -476,10 +490,12 @@ describe('EditSectionForm', () => {
       sectionCurriculum: courseOfferings[testSection.courseOfferingId].id,
       sectionCurriculumLocalizedName:
         courseOfferings[testSection.courseOfferingId].display_name,
+      sectionCurriculumVersionYear: '2017',
       sectionGrade: testSection.grade,
       sectionLockSelection: testSection.restrictSection,
       sectionName: testSection.name,
-      sectionPairProgramSelection: testSection.pairingAllowed
+      sectionPairProgramSelection: testSection.pairingAllowed,
+      sectionUnitId: null
     });
 
     analyticsSpy.restore();

--- a/apps/test/unit/templates/teacherDashboard/EditSectionFormTest.js
+++ b/apps/test/unit/templates/teacherDashboard/EditSectionFormTest.js
@@ -413,6 +413,9 @@ describe('EditSectionForm', () => {
     const wrapper = shallow(
       <EditSectionForm
         isNewSection={true}
+        initialUnitId={7}
+        initialCourseVersionId={5}
+        initialCourseOfferingId={3}
         title="Create a new section"
         handleSave={async () => {}}
         handleClose={() => {}}
@@ -451,8 +454,9 @@ describe('EditSectionForm', () => {
       'Section Curriculum Assigned'
     );
     assert.deepEqual(analyticsSpy.getCall(1).lastArg, {
-      previousUnitId: undefined,
-      previousCourseId: undefined,
+      previousUnitId: 7,
+      previousCourseId: 3,
+      previousVersionYear: '2022',
       newUnitId: null,
       newCourseId: courseOfferings[testSection.courseOfferingId].id,
       newVersionYear: '2017'
@@ -465,6 +469,9 @@ describe('EditSectionForm', () => {
     const wrapper = shallow(
       <EditSectionForm
         isNewSection={true}
+        initialUnitId={7}
+        initialCourseVersionId={5}
+        initialCourseOfferingId={3}
         title="Create a new section"
         handleSave={async () => {}}
         handleClose={() => {}}


### PR DESCRIPTION
This PR sets up the amplitude reporting for 'add curriculum'. It also adds version year to the existing section setup log. This will be a coordinated release with Bethany's pr, which should send the same curriculum event from the assign button on the unit overview page. 

I'm doing both these tickets at once because they exist in the same dialog.

Here is an example of the output when I changed the curriculum from CSD to CSA:
<img width="538" alt="Screen Shot 2023-01-31 at 1 13 04 PM" src="https://user-images.githubusercontent.com/37230822/215884489-f42a7487-d92c-4fb3-bfce-e57ebd509c6a.png">

And here's what it looked like when I switched to a prior year and the next unit within the same CSD course:
<img width="539" alt="Screen Shot 2023-01-31 at 1 15 35 PM" src="https://user-images.githubusercontent.com/37230822/215884970-fff41b85-1811-4f02-8117-4f46e94d92d9.png">

In the future, we should implement the amplitude batch api for cases that are more complex than this. For now, I am sending these two sequentially. Here is the link for the amplitude api: https://www.docs.developers.amplitude.com/analytics/apis/batch-event-upload-api/

Bethany and I looked into the amplitude codebase to see if 'track' is already set up to handle multiple amplitude event calls, and couldn't find anything.

## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/TEACH-180
- https://codedotorg.atlassian.net/browse/TEACH-179

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
