### PR TITLE
Refactor PhoneFrame & ScreenSelector to CSS modules

### DIFF
--- a/apps/src/applab/PhoneFrame.jsx
+++ b/apps/src/applab/PhoneFrame.jsx
@@ -1,16 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Radium from 'radium'; // eslint-disable-line no-restricted-imports
-import color from '../util/color';
-import ScreenSelector, {styles as ScreenSelectorStyles} from './ScreenSelector';
+import classNames from 'classnames';
+import style from './phone-frame.module.scss';
+import ScreenSelector from './ScreenSelector';
 import {RunButton, ResetButton} from '../templates/GameButtons';
 import {styles as CompletionButtonStyles} from '../templates/CompletionButton';
 import FontAwesome from '../templates/FontAwesome';
 
-const RADIUS = 30;
-const FRAME_HEIGHT = 60;
-
-class PhoneFrame extends React.Component {
+export default class PhoneFrame extends React.Component {
   static propTypes = {
     isDark: PropTypes.bool.isRequired,
     screenIds: PropTypes.array.isRequired,
@@ -32,14 +29,14 @@ class PhoneFrame extends React.Component {
       <span id="phoneFrame">
         <div id="phoneFrameWrapper">
           <div
-            style={[
-              styles.phoneFrame,
-              styles.phoneFrameTop,
-              isDark && styles.phoneFrameDark
-            ]}
+            className={classNames(
+              style.phoneFrame,
+              style.phoneFrameTop,
+              isDark && style.phoneFrameDark
+            )}
           >
             {showSelector && (
-              <div style={styles.screenSelector}>
+              <div className={style.screenSelector}>
                 <ScreenSelector
                   screenIds={screenIds}
                   onCreate={onScreenCreate}
@@ -47,21 +44,21 @@ class PhoneFrame extends React.Component {
               </div>
             )}
             {isPaused && (
-              <div style={[styles.centeredInFrame, styles.paused]}>
-                <FontAwesome icon="pause" style={styles.pauseIcon} />
+              <div className={classNames(style.centeredInFrame, style.paused)}>
+                <FontAwesome icon="pause" className={style.pauseIcon} />
                 PAUSED
               </div>
             )}
           </div>
           {this.props.children}
           <div
-            style={[
-              styles.phoneFrame,
-              styles.phoneFrameBottom,
-              isDark && styles.phoneFrameDark
-            ]}
+            className={classNames(
+              style.phoneFrame,
+              style.phoneFrameBottom,
+              isDark && style.phoneFrameDark
+            )}
           >
-            <div style={styles.centeredInFrame}>
+            <div className={style.centeredInFrame}>
               <RunButton hidden={false} style={styles.buttonMinWidth} />
               <ResetButton style={styles.buttonMinWidth} />
             </div>
@@ -73,48 +70,7 @@ class PhoneFrame extends React.Component {
 }
 
 const styles = {
-  phoneFrame: {
-    display: 'block',
-    height: FRAME_HEIGHT,
-    backgroundColor: color.lighter_gray
-  },
-  phoneFrameDark: {
-    backgroundColor: color.charcoal
-  },
-  phoneFrameTop: {
-    borderTopLeftRadius: RADIUS,
-    borderTopRightRadius: RADIUS
-  },
-  phoneFrameBottom: {
-    borderBottomLeftRadius: RADIUS,
-    borderBottomRightRadius: RADIUS
-  },
-  screenSelector: {
-    marginLeft: 'auto',
-    marginRight: 'auto',
-    paddingTop: (FRAME_HEIGHT - ScreenSelectorStyles.dropdown.height) / 2,
-    width: '80%'
-  },
-  centeredInFrame: {
-    marginLeft: 'auto',
-    marginRight: 'auto',
-    width: '100%',
-    textAlign: 'center',
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    height: FRAME_HEIGHT
-  },
-  paused: {
-    color: 'white',
-    fontSize: 20
-  },
-  pauseIcon: {
-    marginRight: 5
-  },
   buttonMinWidth: {
     minWidth: CompletionButtonStyles.phoneFrameButton.minWidth
   }
 };
-
-export default Radium(PhoneFrame);

--- a/apps/src/applab/ScreenSelector.jsx
+++ b/apps/src/applab/ScreenSelector.jsx
@@ -1,24 +1,12 @@
 /** @file Dropdown for selecting design mode screens */
 import PropTypes from 'prop-types';
 import React from 'react';
-import Radium from 'radium'; // eslint-disable-line no-restricted-imports
-import color from '../util/color';
-import commonStyles from '../commonStyles';
 import * as constants from './constants';
 import {connect} from 'react-redux';
+import classNames from 'classnames';
+import style from './screen-selector.module.scss';
 import * as elementUtils from './designElements/elementUtils';
 import * as screens from './redux/screens';
-
-export const styles = {
-  dropdown: {
-    display: 'inline-block',
-    verticalAlign: 'top',
-    width: '100%',
-    height: 28,
-    marginBottom: 6,
-    borderColor: color.light_gray
-  }
-};
 
 /**
  * The dropdown that appears above the visualization in design mode, used
@@ -82,10 +70,10 @@ class ScreenSelector extends React.Component {
     return (
       <select
         id="screenSelector"
-        style={[
-          styles.dropdown,
-          !this.props.hasDesignMode && commonStyles.hidden
-        ]}
+        className={classNames(
+          style.dropdown,
+          !this.props.hasDesignMode && style.hidden
+        )}
         value={this.props.currentScreenId || ''}
         onChange={this.handleChange}
         disabled={this.props.isRunning}
@@ -117,4 +105,4 @@ export default connect(
       }
     };
   }
-)(Radium(ScreenSelector));
+)(ScreenSelector);

--- a/apps/src/applab/ScreenSelector.jsx
+++ b/apps/src/applab/ScreenSelector.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import * as constants from './constants';
 import {connect} from 'react-redux';
-import classNames from 'classnames';
 import style from './screen-selector.module.scss';
 import * as elementUtils from './designElements/elementUtils';
 import * as screens from './redux/screens';
@@ -40,6 +39,10 @@ class ScreenSelector extends React.Component {
   };
 
   render() {
+    if (!this.props.hasDesignMode) {
+      return null;
+    }
+
     const options = this.props.screenIds.map(function(item) {
       return (
         <option key={item} value={item}>
@@ -70,10 +73,7 @@ class ScreenSelector extends React.Component {
     return (
       <select
         id="screenSelector"
-        className={classNames(
-          style.dropdown,
-          !this.props.hasDesignMode && style.hidden
-        )}
+        className={style.dropdown}
         value={this.props.currentScreenId || ''}
         onChange={this.handleChange}
         disabled={this.props.isRunning}

--- a/apps/src/applab/phone-frame.module.scss
+++ b/apps/src/applab/phone-frame.module.scss
@@ -1,0 +1,50 @@
+@use "sass:math";
+@use "color.scss";
+
+$border-radius: 30px;
+$frame-height: 60px;
+
+.phoneFrame {
+  display: block;
+  height: $frame-height;
+  background-color: color.$lighter_gray;
+
+  &Dark {
+    background-color: color.$charcoal;
+  }
+
+  &Top {
+    border-radius: $border-radius $border-radius 0 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  &Bottom {
+    border-radius: 0 0 $border-radius $border-radius;
+  }
+}
+
+.screenSelector {
+  width: 80%;
+}
+
+.centeredInFrame {
+  margin-left: auto;
+  margin-right: auto;
+  width: 100%;
+  text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: $frame-height;
+}
+
+.paused {
+  color: color.$white;
+  font-size: 20px;
+}
+
+.pauseIcon {
+  margin-right: 5px;
+}

--- a/apps/src/applab/screen-selector.module.scss
+++ b/apps/src/applab/screen-selector.module.scss
@@ -6,7 +6,3 @@
   margin: 0;
   border-color: color.$light_gray;
 }
-
-.hidden {
-  display: none;
-}

--- a/apps/src/applab/screen-selector.module.scss
+++ b/apps/src/applab/screen-selector.module.scss
@@ -1,0 +1,12 @@
+@use "color.scss";
+
+.dropdown {
+  width: 100%;
+  height: 28px;
+  margin: 0;
+  border-color: color.$light_gray;
+}
+
+.hidden {
+  display: none;
+}

--- a/apps/test/unit/applab/ScreenSelectorTest.js
+++ b/apps/test/unit/applab/ScreenSelectorTest.js
@@ -41,11 +41,7 @@ describe('The ScreenSelector component', () => {
         hasDesignMode: true
       })
     );
-    expect(
-      render()
-        .find('select')
-        .props().style.display
-    ).not.to.equal('none');
+    expect(render().find('select')).to.have.length(1);
   });
 
   it('will be hidden on pages without design mode', () => {
@@ -54,11 +50,7 @@ describe('The ScreenSelector component', () => {
         hasDesignMode: false
       })
     );
-    expect(
-      render()
-        .find('select')
-        .props().style.display
-    ).to.equal('none');
+    expect(render().find('select')).to.have.length(0);
   });
 
   it('will not be hidden on readonly pages', () => {
@@ -68,10 +60,6 @@ describe('The ScreenSelector component', () => {
         isReadOnlyWorkspace: true
       })
     );
-    expect(
-      render()
-        .find('select')
-        .props().style.display
-    ).not.to.equal('none');
+    expect(render().find('select')).to.have.length(1);
   });
 });


### PR DESCRIPTION
Refactoring the PhoneFrame and ScreenSelector in Applab to use CSS modules instead of Radium styles. There are visual changes, but for context, here is a screenshot:
<img width="259" alt="Screen Shot 2023-01-18 at 3 46 08 PM" src="https://user-images.githubusercontent.com/9812299/213319791-250c3725-856c-4957-bbc9-ee10f08a33ac.png">
