### PR TITLE
Only log Amplitude in staging and production

### DIFF
--- a/apps/src/lib/util/AnalyticsReporter.js
+++ b/apps/src/lib/util/AnalyticsReporter.js
@@ -81,10 +81,10 @@ class AnalyticsReporter {
     if (alwaysPut) {
       return true;
     }
-    if (this.isTestEnvironment() || this.isDevelopmentEnvironment()) {
-      return false;
+    if (this.isProductionEnvironment() || this.isStagingEnvironment()) {
+      return true;
     }
-    return true;
+    return false;
   }
 
   /**
@@ -115,12 +115,8 @@ class AnalyticsReporter {
     return Environments.unknown;
   }
 
-  isTestEnvironment() {
-    return this.getEnvironment() === Environments.test;
-  }
-
-  isDevelopmentEnvironment() {
-    return this.getEnvironment() === Environments.development;
+  isStagingEnvironment() {
+    return this.getEnvironment() === Environments.staging;
   }
 
   isProductionEnvironment() {


### PR DESCRIPTION
I noticed errors in the levelbuilder environment related to amplitude. We shouldn't be logging in the levelbuilder environment (at least not yet!) so I adjusted the check to determine whether we try to connect to Amplitude. Instead of having a block list of environments, I switched to an allow list of environments to log in.


## Testing story

existing tests should cover the major requirements

