### PR TITLE
Remove duplicate $dark_purple variable

### DIFF
--- a/shared/css/color.scss
+++ b/shared/css/color.scss
@@ -28,7 +28,6 @@ $lightish_teal: #80d6de;
 $lighter_teal: #a6e3e8;
 $lightest_teal: #d9f3f5;
 
-$dark_purple: #5c3f7f;
 $purple: #7665a0;
 $light_purple: #a69bc1;
 $lighter_purple: #cfc9de;


### PR DESCRIPTION
There are two `$dark_purple` color variables on `color.scss` — speculative fix for scss error showing on https://staging.hourofcode.com:

<img width="1481" alt="Screenshot 2023-01-19 at 12 23 12 PM" src="https://user-images.githubusercontent.com/9256643/213559211-0eca40ef-f62f-4adc-b4dc-2d596d5fb7d7.png">
