### PR TITLE
Revert "Update visualization column in App Lab so it doesn't scroll for touchmove event"

### DIFF
--- a/apps/src/applab/ApplabVisualizationColumn.jsx
+++ b/apps/src/applab/ApplabVisualizationColumn.jsx
@@ -37,30 +37,6 @@ class ApplabVisualizationColumn extends React.Component {
     widgetMode: PropTypes.bool
   };
 
-  componentDidMount() {
-    this.visualizationColumn.addEventListener(
-      'touchmove',
-      this.preventBehavior,
-      {
-        passive: false
-      }
-    );
-  }
-
-  componentWillUnmount() {
-    this.visualizationColumn.removeEventListener(
-      'touchmove',
-      this.preventBehavior,
-      {
-        passive: false
-      }
-    );
-  }
-
-  preventBehavior = e => {
-    e.preventDefault();
-  };
-
   getClassNames() {
     const {
       visualizationHasPadding,
@@ -144,9 +120,6 @@ class ApplabVisualizationColumn extends React.Component {
         id="visualizationColumn"
         className={this.getClassNames()}
         style={maxWidth}
-        ref={el => {
-          this.visualizationColumn = el;
-        }}
       >
         {!isReadOnlyWorkspace && (
           <PlaySpaceHeader

--- a/apps/test/unit/applab/ApplabVisualizationColumnTest.js
+++ b/apps/test/unit/applab/ApplabVisualizationColumnTest.js
@@ -7,6 +7,7 @@ import {WIDGET_WIDTH} from '@cdo/apps/applab/constants';
 describe('AppLabVisualizationColumn', () => {
   describe('in widget mode', () => {
     let visualizationColumn;
+
     beforeEach(() => {
       visualizationColumn = shallow(
         <UnconnectedApplabVisualizationColumn
@@ -27,8 +28,7 @@ describe('AppLabVisualizationColumn', () => {
           widgetMode
           isIframeEmbed
           playspacePhoneFrame
-        />,
-        {disableLifecycleMethods: true}
+        />
       );
     });
 


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#49645

Preventing the default behavior for 'touchmove' causes a regression - user is unable to change the slider position in App Lab on a mobile device as reported in this [ZenDesk ticket](https://codeorg.zendesk.com/agent/tickets/424123).