### PR TITLE
Remove __useDeprecatedTag from LibraryTable

### DIFF
--- a/apps/src/templates/projects/LibraryTable.jsx
+++ b/apps/src/templates/projects/LibraryTable.jsx
@@ -202,7 +202,6 @@ class LibraryTable extends React.Component {
   actionsFormatter = (_, {rowData}) => {
     return (
       <Button
-        __useDeprecatedTag
         text={i18n.unpublish()}
         color={Button.ButtonColor.orange}
         onClick={() => {


### PR DESCRIPTION
Remove __useDeprecatedTag from LibraryTable, it was previously on the "Unpublish" button in that table.
This caused minor visual changes, but the button now looks like the other buttons on that page so I think they are a good change.
### Before
<img width="135" alt="Screenshot 2023-01-20 at 3 53 14 PM" src="https://user-images.githubusercontent.com/33666587/213825391-1c3211cf-0f22-417e-b672-f4d7a466c962.png">

### After
<img width="135" alt="Screenshot 2023-01-20 at 3 52 41 PM" src="https://user-images.githubusercontent.com/33666587/213825425-9de5fa04-b461-4d7b-b357-d73ccfad550d.png">


### Other buttons on the page 
<img width="151" alt="Screenshot 2023-01-20 at 3 54 05 PM" src="https://user-images.githubusercontent.com/33666587/213825428-b851f82d-724e-4ccf-9968-ea8b51cfb37c.png">
<img width="117" alt="Screenshot 2023-01-20 at 3 53 57 PM" src="https://user-images.githubusercontent.com/33666587/213825429-bc876169-bf8f-4d88-a5b2-069b22dc5160.png">


## Links
- jira ticket: [A11Y-95](https://codedotorg.atlassian.net/browse/A11Y-95)

## Testing story
Tested locally

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
