### PR TITLE
Add index for slow query in projects table

### DIFF
--- a/dashboard/app/models/project.rb
+++ b/dashboard/app/models/project.rb
@@ -18,10 +18,11 @@
 #
 # Indexes
 #
-#  storage_apps_project_type_index  (project_type)
-#  storage_apps_published_at_index  (published_at)
-#  storage_apps_standalone_index    (standalone)
-#  storage_apps_storage_id_index    (storage_id)
+#  index_project_on_storage_id_and_state  (storage_id,state)
+#  storage_apps_project_type_index        (project_type)
+#  storage_apps_published_at_index        (published_at)
+#  storage_apps_standalone_index          (standalone)
+#  storage_apps_storage_id_index          (storage_id)
 #
 class Project < ApplicationRecord
   belongs_to :project_storage, foreign_key: 'storage_id', optional: true

--- a/dashboard/app/models/project.rb
+++ b/dashboard/app/models/project.rb
@@ -18,11 +18,11 @@
 #
 # Indexes
 #
-#  index_project_on_storage_id_and_state  (storage_id,state)
-#  storage_apps_project_type_index        (project_type)
-#  storage_apps_published_at_index        (published_at)
-#  storage_apps_standalone_index          (standalone)
-#  storage_apps_storage_id_index          (storage_id)
+#  storage_apps_project_type_index      (project_type)
+#  storage_apps_published_at_index      (published_at)
+#  storage_apps_standalone_index        (standalone)
+#  storage_apps_storage_id_index        (storage_id)
+#  storage_apps_storage_id_state_index  (storage_id,state)
 #
 class Project < ApplicationRecord
   belongs_to :project_storage, foreign_key: 'storage_id', optional: true

--- a/dashboard/db/migrate/20230123114202_create_project_state_and_storage_id_index.rb
+++ b/dashboard/db/migrate/20230123114202_create_project_state_and_storage_id_index.rb
@@ -1,0 +1,9 @@
+class CreateProjectStateAndStorageIdIndex < ActiveRecord::Migration[6.0]
+  def up
+    add_index :projects, [:storage_id, :state], name: "index_project_on_storage_id_and_state"
+  end
+
+  def down
+    remove_index :projects, [:storage_id, :state]
+  end
+end

--- a/dashboard/db/migrate/20230124093901_create_project_state_and_storage_id_index.rb
+++ b/dashboard/db/migrate/20230124093901_create_project_state_and_storage_id_index.rb
@@ -1,6 +1,6 @@
 class CreateProjectStateAndStorageIdIndex < ActiveRecord::Migration[6.0]
   def up
-    add_index :projects, [:storage_id, :state], name: "index_project_on_storage_id_and_state"
+    add_index :projects, [:storage_id, :state], name: "storage_apps_storage_id_state_index"
   end
 
   def down

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_01_23_114202) do
+ActiveRecord::Schema.define(version: 2023_01_24_093901) do
 
   create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -1486,7 +1486,7 @@ ActiveRecord::Schema.define(version: 2023_01_23_114202) do
     t.index ["project_type"], name: "storage_apps_project_type_index", length: 191
     t.index ["published_at"], name: "storage_apps_published_at_index"
     t.index ["standalone"], name: "storage_apps_standalone_index"
-    t.index ["storage_id", "state"], name: "index_project_on_storage_id_and_state"
+    t.index ["storage_id", "state"], name: "storage_apps_storage_id_state_index"
     t.index ["storage_id"], name: "storage_apps_storage_id_index"
   end
 

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_10_24_233909) do
+ActiveRecord::Schema.define(version: 2023_01_23_114202) do
 
   create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -1486,6 +1486,7 @@ ActiveRecord::Schema.define(version: 2022_10_24_233909) do
     t.index ["project_type"], name: "storage_apps_project_type_index", length: 191
     t.index ["published_at"], name: "storage_apps_published_at_index"
     t.index ["standalone"], name: "storage_apps_standalone_index"
+    t.index ["storage_id", "state"], name: "index_project_on_storage_id_and_state"
     t.index ["storage_id"], name: "storage_apps_storage_id_index"
   end
 


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Adding a new index to help with some slow queries

<img width="1542" alt="image" src="https://user-images.githubusercontent.com/108825710/214144146-0251b5c0-c813-47a3-82e7-e46309365189.png">


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story


| projects | CREATE TABLE `projects` (
  `id` int(11) NOT NULL AUTO_INCREMENT,
  `storage_id` int(11) DEFAULT NULL,
  `value` mediumtext,
  `updated_at` datetime NOT NULL,
  `updated_ip` varchar(39) NOT NULL,
  `state` varchar(50) NOT NULL DEFAULT 'active',
  `created_at` datetime DEFAULT NULL,
  `abuse_score` int(11) DEFAULT NULL,
  `project_type` varchar(255) DEFAULT NULL,
  `published_at` datetime DEFAULT NULL,
  `standalone` tinyint(1) DEFAULT '1',
  `remix_parent_id` int(11) DEFAULT NULL,
  `skip_content_moderation` tinyint(1) DEFAULT NULL,
  PRIMARY KEY (`id`),
  KEY `storage_apps_project_type_index` (`project_type`(191)),
  KEY `storage_apps_published_at_index` (`published_at`),
  KEY `storage_apps_standalone_index` (`standalone`),
  KEY `storage_apps_storage_id_index` (`storage_id`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 |


explain select * from projects where storage_id = 1 and state = 'active';
+----+-------------+----------+------------+------+-------------------------------+-------------------------------+---------+-------+------+----------+-------------+
| id | select_type | table    | partitions | type | possible_keys                 | key                           | key_len | ref   | rows | filtered | Extra       |
+----+-------------+----------+------------+------+-------------------------------+-------------------------------+---------+-------+------+----------+-------------+
|  1 | SIMPLE      | projects | NULL       | ref  | storage_apps_storage_id_index | storage_apps_storage_id_index | 5       | const |    1 |   100.00 | Using where |
+----+-------------+----------+------------+------+-------------------------------+-------------------------------+---------+-------+------+----------+-------------+
1 row in set, 1 warning (0.00 sec)



➜  dashboard git:(create_index_project_table) ✗ bundle exec rake db:migrate           
GetSecretValue: development/cdo/slack_bot_token
== 20230123114202 CreateProjectStateAndStorageIdIndex: migrating ==============
-- add_index(:projects, [:storage_id, :state], {:name=>"index_project_on_storage_id_and_state"})
   -> 0.1787s
== 20230123114202 CreateProjectStateAndStorageIdIndex: migrated (0.1788s) =====

Finished set_annotation_options (less than 1 second)
GetSecretValue: development/cdo/pardot_private_key
Annotated (1): app/models/project.rb




************* After *************

Index was enabled and query plan seem to be working 

| projects | CREATE TABLE `projects` (
  `id` int(11) NOT NULL AUTO_INCREMENT,
  `storage_id` int(11) DEFAULT NULL,
  `value` mediumtext,
  `updated_at` datetime NOT NULL,
  `updated_ip` varchar(39) NOT NULL,
  `state` varchar(50) NOT NULL DEFAULT 'active',
  `created_at` datetime DEFAULT NULL,
  `abuse_score` int(11) DEFAULT NULL,
  `project_type` varchar(255) DEFAULT NULL,
  `published_at` datetime DEFAULT NULL,
  `standalone` tinyint(1) DEFAULT '1',
  `remix_parent_id` int(11) DEFAULT NULL,
  `skip_content_moderation` tinyint(1) DEFAULT NULL,
  PRIMARY KEY (`id`),
  KEY `storage_apps_project_type_index` (`project_type`(191)),
  KEY `storage_apps_published_at_index` (`published_at`),
  KEY `storage_apps_standalone_index` (`standalone`),
  KEY `storage_apps_storage_id_index` (`storage_id`),
  KEY `index_project_on_storage_id_and_state` (`storage_id`,`state`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 |

+----+-------------+----------+------------+------+---------------------------------------------------------------------+-------------------------------+---------+-------+------+----------+-------------+
| id | select_type | table    | partitions | type | possible_keys                                                       | key                           | key_len | ref   | rows | filtered | Extra       |
+----+-------------+----------+------------+------+---------------------------------------------------------------------+-------------------------------+---------+-------+------+----------+-------------+
|  1 | SIMPLE      | projects | NULL       | ref  | storage_apps_storage_id_index,index_project_on_storage_id_and_state | storage_apps_storage_id_index | 5       | const |    1 |   100.00 | Using where |
+----+-------------+----------+------------+------+---------------------------------------------------------------------+-------------------------------+---------+-------+------+----------+-------------+



<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
