### PR TITLE
Remove admin/counselor reminder previews

### DIFF
--- a/dashboard/test/mailers/previews/pd_workshop_mailer_preview.rb
+++ b/dashboard/test/mailers/previews/pd_workshop_mailer_preview.rb
@@ -54,6 +54,10 @@ class PdWorkshopMailerPreview < ActionMailer::Preview
     mail :teacher_enrollment_receipt, Pd::Workshop::COURSE_ADMIN_COUNSELOR, Pd::Workshop::SUBJECT_ADMIN_COUNSELOR_SLP_CALL1
   end
 
+  def teacher_enrollment_receipt__counselor
+    mail :teacher_enrollment_receipt, Pd::Workshop::COURSE_ADMIN_COUNSELOR, Pd::Workshop::SUBJECT_ADMIN_COUNSELOR_SLP_CALL1
+  end
+
   def teacher_enrollment_receipt__csp_for_returning_teachers
     mail :teacher_enrollment_receipt, Pd::Workshop::COURSE_CSP, Pd::Workshop::SUBJECT_CSP_FOR_RETURNING_TEACHERS
   end
@@ -68,18 +72,6 @@ class PdWorkshopMailerPreview < ActionMailer::Preview
     NOTES
 
     mail :teacher_enrollment_receipt, workshop_params: {notes: notes}
-  end
-
-  def teacher_enrollment_reminder__admin
-    mail :teacher_enrollment_reminder, Pd::Workshop::COURSE_ADMIN_COUNSELOR, Pd::Workshop::SUBJECT_ADMIN_COUNSELOR_SLP_CALL1
-  end
-
-  def teacher_enrollment_receipt__counselor
-    mail :teacher_enrollment_receipt, Pd::Workshop::COURSE_ADMIN_COUNSELOR, Pd::Workshop::SUBJECT_ADMIN_COUNSELOR_SLP_CALL1
-  end
-
-  def teacher_enrollment_reminder__counselor
-    mail :teacher_enrollment_reminder, Pd::Workshop::COURSE_ADMIN_COUNSELOR, Pd::Workshop::SUBJECT_ADMIN_COUNSELOR_SLP_CALL1
   end
 
   def teacher_enrollment_receipt__facilitator


### PR DESCRIPTION
Reminder previews for admin/counselor workshops are not rendering properly at https://staging-studio.code.org/rails/mailers.

Reminder emails do not get sent if we are [suppressing reminders](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/mailers/pd/workshop_mailer.rb#L135) for that workshop.

All admin/counselor workshops have subjects that get suppressed in [this constant](https://github.com/code-dot-org/code-dot-org/blob/staging/lib/cdo/shared_constants/pd/shared_workshop_constants.rb#L164), which is used for suppressing reminders.

Since admin/counselor reminders are not sent, I'm removing those two previews from our list.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
