### PR TITLE
Enable custom Rails Database Connection Timeout

### DIFF
--- a/dashboard/config/database.yml
+++ b/dashboard/config/database.yml
@@ -39,7 +39,7 @@ mysql_defaults: &mysql_defaults
   # You can set the value so that a lost connection can be detected earlier than the TCP/IP Close_Wait_Timeout value of 10 minutes.
   #
   # NOTE: mysql2 reuses this variable as a query timeout without retry, so set it to the maximum query execution time.
-  read_timeout: 30
+  read_timeout:  <%= unless ENV['db_read_timeout'].nil && ENV['db_read_timeout'] > 0 ? ENV['db_read_timeout']   : 30 %>
 
   # `MYSQL_OPT_WRITE_TIMEOUT`: The timeout in seconds for each attempt to write to the server.
   # There is a retry if necessary, so the total effective timeout value is two times the option value.

--- a/dashboard/config/database.yml
+++ b/dashboard/config/database.yml
@@ -39,7 +39,7 @@ mysql_defaults: &mysql_defaults
   # You can set the value so that a lost connection can be detected earlier than the TCP/IP Close_Wait_Timeout value of 10 minutes.
   #
   # NOTE: mysql2 reuses this variable as a query timeout without retry, so set it to the maximum query execution time.
-  read_timeout:  <%= unless ENV['db_read_timeout'].nil && ENV['db_read_timeout'] > 0 ? ENV['db_read_timeout']   : 30 %>
+  read_timeout:  <%= ENV['DB_READ_TIMEOUT'] || 30 %>
 
   # `MYSQL_OPT_WRITE_TIMEOUT`: The timeout in seconds for each attempt to write to the server.
   # There is a retry if necessary, so the total effective timeout value is two times the option value.

--- a/dashboard/lib/tasks/setup_or_migrate.rake
+++ b/dashboard/lib/tasks/setup_or_migrate.rake
@@ -14,7 +14,7 @@ namespace :db do
 
   timed_task_with_logging :setup_or_migrate do
     db_exists = database_exists?
-    ENV['db_read_timeout'] = 30
+    ENV['db_read_timeout'] = 300
     Rake::Task["db:load_config"].invoke
     if db_exists
       Rake::Task["db:migrate"].invoke

--- a/dashboard/lib/tasks/setup_or_migrate.rake
+++ b/dashboard/lib/tasks/setup_or_migrate.rake
@@ -14,7 +14,7 @@ namespace :db do
 
   timed_task_with_logging :setup_or_migrate do
     db_exists = database_exists?
-    ENV['DB_READ_TIMEOUT'] = 300
+    ENV['DB_READ_TIMEOUT'] = '300'
     Rake::Task["db:load_config"].invoke
     if db_exists
       Rake::Task["db:migrate"].invoke

--- a/dashboard/lib/tasks/setup_or_migrate.rake
+++ b/dashboard/lib/tasks/setup_or_migrate.rake
@@ -14,7 +14,7 @@ namespace :db do
 
   timed_task_with_logging :setup_or_migrate do
     db_exists = database_exists?
-    ENV['db_read_timeout'] = 300
+    ENV['DB_READ_TIMEOUT'] = 300
     Rake::Task["db:load_config"].invoke
     if db_exists
       Rake::Task["db:migrate"].invoke

--- a/dashboard/lib/tasks/setup_or_migrate.rake
+++ b/dashboard/lib/tasks/setup_or_migrate.rake
@@ -14,6 +14,7 @@ namespace :db do
 
   timed_task_with_logging :setup_or_migrate do
     db_exists = database_exists?
+    ENV['db_read_timeout'] = 30
     Rake::Task["db:load_config"].invoke
     if db_exists
       Rake::Task["db:migrate"].invoke


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This increases the timeout when creating a database (and indexing) using an environment variable..

This will affect all environments but only when doing db:setup_migrate

Note: I am still not sure if I chose the right parameter to increase (db_read_timeout)


This is done because the DB is timing out while create a [new index](https://github.com/code-dot-org/code-dot-org/pull/49918)

```
buntu@production-daemon:~/production/dashboard$ RAILS_ENV=production RACK_ENV=production bundle exec rake db:setup_or_migrate --trace
GetSecretValue: production/cdo/slack_token
GetSecretValue: production/cdo/slack_bot_token
GetSecretValue: production/cdo/mapbox_access_token
** Invoke db:setup_or_migrate (first_time)
** Execute db:setup_or_migrate
** Invoke environment (first_time)
** Execute environment
GetSecretValue: production/cdo/dashboard_devise_secret
GetSecretValue: production/cdo/dashboard_devise_pepper
GetSecretValue: production/cdo/dashboard_facebook_key
GetSecretValue: production/cdo/dashboard_facebook_secret
GetSecretValue: production/cdo/dashboard_google_key
GetSecretValue: production/cdo/dashboard_google_secret
GetSecretValue: production/cdo/dashboard_windowslive_key
GetSecretValue: production/cdo/dashboard_windowslive_secret
GetSecretValue: production/cdo/dashboard_clever_key
GetSecretValue: production/cdo/dashboard_clever_secret
GetSecretValue: production/cdo/dashboard_schoolproject_key
GetSecretValue: production/cdo/dashboard_schoolproject_secret
GetSecretValue: production/cdo/recaptcha_site_key
GetSecretValue: production/cdo/recaptcha_secret_key
GetSecretValue: production/cdo/dashboard_secret_key_base
GetSecretValue: production/cdo/zendesk_dev_token
GetSecretValue: production/cdo/dashboard_honeybadger_api_key
Ignoring db/schema_cache.yml because it has expired. The current schema version is 20221024233909, but the one in the cache is 20230124093901.
** Invoke db:load_config (first_time)
** Invoke environment 
** Execute db:load_config
** Invoke db:migrate (first_time)
** Invoke db:load_config 
** Execute db:migrate
== 20230124093901 CreateProjectStateAndStorageIdIndex: migrating ==============
-- add_index(:projects, [:storage_id, :state], {:name=>"storage_apps_storage_id_state_index"})
rake aborted!
StandardError: An error has occurred, all later migrations canceled:

Mysql2::Error::TimeoutError: Timeout waiting for a response from the last query. (waited 30 seconds)
```


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
