### PR TITLE
Getting gender and birthday when a user creates an account using Clever

### DIFF
--- a/dashboard/app/controllers/omniauth_callbacks_controller.rb
+++ b/dashboard/app/controllers/omniauth_callbacks_controller.rb
@@ -176,6 +176,10 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
       auth_hash = extract_microsoft_data(auth_hash)
     end
 
+    if provider == AuthenticationOption::CLEVER
+      auth_hash = inject_clever_data(auth_hash)
+    end
+
     user = User.from_omniauth(auth_hash, auth_params, session)
 
     prepare_locale_cookie user
@@ -257,6 +261,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     SignUpTracking.begin_sign_up_tracking(session, split_test: false)
     SignUpTracking.log_oauth_callback AuthenticationOption::CLEVER, session
 
+    auth_hash = inject_clever_data(auth_hash())
     user = User.from_omniauth(auth_hash, auth_params, session)
     prepare_locale_cookie user
 
@@ -340,6 +345,17 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     )
 
     auth.info.merge!(microsoft_data)
+    auth
+  end
+
+  # Moves non-standard attributes from the extra Clever OAuth data and puts it in the location we
+  # expect it to be in the AuthHash. Example attributes: gender, date of birth.
+  def inject_clever_data(auth)
+    return if auth.nil?
+    dob = auth.dig(:extra, :raw_info, :canonical, :data, :dob)
+    gender = auth.dig(:extra, :raw_info, :canonical, :data, :gender)
+    clever_data = OmniAuth::AuthHash.new(dob: dob, gender: gender)
+    auth.info&.merge!(clever_data)
     auth
   end
 

--- a/dashboard/app/controllers/omniauth_callbacks_controller.rb
+++ b/dashboard/app/controllers/omniauth_callbacks_controller.rb
@@ -352,8 +352,8 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   # expect it to be in the AuthHash. Example attributes: gender, date of birth.
   def inject_clever_data(auth)
     return if auth.nil?
-    dob = auth.dig(:extra, :raw_info, :canonical, :data, :dob)
-    gender = auth.dig(:extra, :raw_info, :canonical, :data, :gender)
+    dob = auth[:dob] || auth.dig(:extra, :raw_info, :canonical, :data, :dob)
+    gender = auth[:gender] || auth.dig(:extra, :raw_info, :canonical, :data, :gender)
     clever_data = OmniAuth::AuthHash.new(dob: dob, gender: gender)
     auth.info&.merge!(clever_data)
     auth

--- a/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
+++ b/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
@@ -161,19 +161,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
   end
 
   test "login: authorizing with unknown clever student account creates student" do
-    auth = OmniAuth::AuthHash.new(
-      uid: '111133',
-      provider: 'clever',
-      info: {
-        nickname: '',
-        name: {'first' => 'Hat', 'last' => 'Cat'},
-        email: nil,
-        user_type: 'student',
-        dob: Date.today - 10.years,
-        gender: 'f'
-      },
-    )
-    @request.env['omniauth.auth'] = auth
+    @request.env['omniauth.auth'] = TEST_CLEVER_STUDENT_DATA
     @request.env['omniauth.params'] = {}
 
     assert_creates(User) do
@@ -182,10 +170,10 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
 
     user = User.last
     assert_equal 'clever', user.primary_contact_info.credential_type
-    assert_equal 'Hat Cat', user.name
+    assert_equal 'Elizabeth Smith', user.name
     assert_equal User::TYPE_STUDENT, user.user_type
-    assert_equal 10, user.age
-    assert_equal 'f', user.gender
+    assert_equal "21+", user.age
+    assert_equal 'm', user.gender
     assert_equal user.id, signed_in_user_id
   end
 
@@ -1733,4 +1721,80 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
         oauth_refresh_token: oauth_hash.credentials.refresh_token
       }
   end
+
+  # This is a sample AuthHash provided by omniauth-clever plugin
+  TEST_CLEVER_STUDENT_DATA = OmniAuth::AuthHash.new(JSON.parse('
+{
+  "provider": "clever",
+  "uid": "5966ed736b21538e3c000006",
+  "info": {
+    "name": "Elizabeth Smith",
+    "first_name": "Elizabeth",
+    "last_name": "Smith",
+    "user_type": "student"
+  },
+  "credentials": {
+    "token": "faketoken123455678",
+    "expires": false
+  },
+  "extra": {
+    "raw_info": {
+      "me": {
+        "type": "student",
+        "data": {
+          "id": "5966ed736b21538e3c000006",
+          "district": "59484d29ae5dee0001fd3291",
+          "type": "student",
+          "authorized_by": "district"
+        },
+        "links": [
+          {
+            "rel": "self",
+            "uri": "/me"
+          },
+          {
+            "rel": "canonical",
+            "uri": "/v2.1/students/5966ed736b21538e3c000006"
+          },
+          {
+            "rel": "district",
+            "uri": "/v2.1/districts/59484d29ae5dee0001fd3291"
+          }
+        ]
+      },
+      "canonical": {
+        "data": {
+          "created": "2017-07-13T03:48:03.512Z",
+          "district": "59484d29ae5dee0001fd3291",
+          "dob": "2000-05-21T00:00:00.000Z",
+          "enrollments": [],
+          "gender": "M",
+          "hispanic_ethnicity": "",
+          "last_modified": "2017-11-02T00:49:40.504Z",
+          "name": {
+            "first": "Elizabeth",
+            "last": "Smith",
+            "middle": ""
+          },
+          "race": "",
+          "school": "5966ed6cf9d478523c000004",
+          "schools": [
+            "5966ed6cf9d478523c000004"
+          ],
+          "sis_id": "202",
+          "id": "5966ed736b21538e3c000006"
+        },
+        "links": [
+          {
+            "rel": "self",
+            "uri": "/v2.1/students/5966ed736b21538e3c000006"
+          }
+        ]
+      }
+    }
+  }
+}
+'
+  )
+  )
 end


### PR DESCRIPTION
Bug: When a student logs in to Code.org using their Clever account for the first time, our website prompts them for their age.
Cause: We migrated to Clever v2.1 API, but were not grabbing the student's age or gender.
Fix: When a user logs in using Clever, extract the age and gender information.

**Why are we getting the gender if that isn't related to the bug?**
This was some information we were previously gathering, so we I wanted to add this missing information as well.

## Links
* [JIRA](https://codedotorg.atlassian.net/browse/P20-25)

## Testing story
* Unit tests
* Manually logged in with a student account using clever and confirmed they are not prompted for information. I also checked their account details and confirmed the right age and gender were added.
