### PR TITLE
[Student Learning] [Phase 1] Fix the issue with get started button accessibility on small screen

### DIFF
--- a/apps/src/templates/studioHomepages/Courses.jsx
+++ b/apps/src/templates/studioHomepages/Courses.jsx
@@ -96,6 +96,7 @@ class Courses extends Component {
             <Button
               __useDeprecatedTag
               href="/users/sign_up"
+              className="bannerContentButton"
               color={Button.ButtonColor.gray}
               style={styles.headerButton}
               text={buttonText}

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -410,6 +410,11 @@ img.video_thumbnail {
 
 #header-banner-overflow {
   margin: 16px;
+
+  .bannerContentButton {
+    // !important is used here to overwrite inline styles of button.
+    border-color: $neutral_dark !important;
+  }
 }
 
 #header-banner, #header-banner-overflow {


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
### Fix the issue with get started button accessibility on small screen
After phase 1 update, when browsing the courses (signed out page) on small screens it's hard to understand that 'Get started' button is a button actually. This PR adds a border to the button for small screens (large screens will remail the same as before, white button on the blue background).

Before:
 
![Screenshot from 2023-01-26 21-40-50](https://user-images.githubusercontent.com/22244040/214936802-0d233af8-2766-4463-8a44-73712fecc47c.png)

After: 
![Screenshot from 2023-01-26 21-51-00](https://user-images.githubusercontent.com/22244040/214936824-1dc7729d-56f7-4be5-8dbb-c337ea8cb29f.png)

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
