### PR TITLE
Upgrade SauceLabs Safari to 14

### DIFF
--- a/dashboard/test/ui/browsers.json
+++ b/dashboard/test/ui/browsers.json
@@ -12,8 +12,8 @@
   {
     "name": "Safari",
     "browserName": "Safari",
-    "platform": "macOS 10.15",
-    "version": "13",
+    "platform": "macOS 11.00",
+    "version": "14",
     "w3c": true
   },
   {

--- a/dashboard/test/ui/browsers.json
+++ b/dashboard/test/ui/browsers.json
@@ -1,4 +1,4 @@
-/* saucelabs browser configurator: https://docs.saucelabs.com/reference/platforms-configurator/#/ */
+/* saucelabs browser configurator: https://saucelabs.com/platform/platform-configurator */
 
 [
   {
@@ -12,8 +12,8 @@
   {
     "name": "Safari",
     "browserName": "Safari",
-    "platform": "macOS 10.14",
-    "version": "12.0",
+    "platform": "macOS 10.15",
+    "version": "13",
     "w3c": true
   },
   {

--- a/dashboard/test/ui/features/star_labs/gamelab/export_animations.feature
+++ b/dashboard/test/ui/features/star_labs/gamelab/export_animations.feature
@@ -1,7 +1,7 @@
 @as_student
 Feature: Game Lab Export
 
-@no_mobile
+@no_mobile @no_safari
 Scenario: Export library animation
   Given I start a new Game Lab project
   And I switch to the animation tab

--- a/dashboard/test/ui/features/star_labs/gamelab/export_animations.feature
+++ b/dashboard/test/ui/features/star_labs/gamelab/export_animations.feature
@@ -2,6 +2,7 @@
 Feature: Game Lab Export
 
 @no_mobile @no_safari
+# Safari 14 on SauceLabs is not configured to allow downloads.
 Scenario: Export library animation
   Given I start a new Game Lab project
   And I switch to the animation tab


### PR DESCRIPTION
# Upgrade SauceLabs Safari to 14
Alternative to:
- https://github.com/code-dot-org/code-dot-org/pull/49983

Includes revert of code-dot-org/code-dot-org#49951 which reverts https://github.com/code-dot-org/code-dot-org/pull/49799
Additional context is available at:
* https://github.com/code-dot-org/code-dot-org/pull/49799

When attempting to merge the change above, we began consistently failing a handful of Safari Tests during the DTT. This wasn't caught ahead of time as drone apparently only runs UI tests on Chrome on our feature branches. Slack thread: https://codedotorg.slack.com/archives/C03CM903Y/p1674762476708329

There were two primary reasons for the new test failures:

### Click Issue
First, and most common, is an issue where Selenium tests break on Safari 13 due to the SafariDriver being unable to click elements on the page: https://bugs.webkit.org/show_bug.cgi?id=202589
Unfortunately, all versions of Safari 13 seem to have this issue (tested through 13.1.2 on the test machine). Here is a slack thread that walks through my use of the test machine to confirm this: https://codedotorg.slack.com/archives/C0T0PNTM3/p1674938970913389
I believe this gives us 3 options:
**1. (This PR) Update browsers.json to use a newer safari. (but we'll lose that v13 coverage).** 
2. (Alternative PR) Tell the affected tests to skip using Safari as long as we are testing on v13.
3. Update our When /^I click selector to use JS to do the click. We probably don't want to change every .click reference just for a safari 13 workaround.  Secondly, if we need to do this, every time somebody adds a new UI test, they'd need to know about .click not working, and to use this workaround instead.

_Pros/Cons of option 1:_ This option changes fewer files but does mean we lose coverage for Safari 13 in our UI tests. As of today, we still list Safari 13 as a supported browser. No workarounds need to be communicated to other engineers who write new tests.

### Downloading Files Issue
The second type of test failure seen seems to be due to the browser’s website preferences not being set up to automatically allow downloading files: https://app.saucelabs.com/tests/d34b131c16274ef795495db540b29c4d#61 The test is the `gamelab_export_animations` UI test. The test is still a valid, working test for browsers other than Safari, so we can skip this test on Safari for now.
