### PR TITLE
Skip runValidationCode in levelbuilder editBlocks mode

### DIFF
--- a/apps/src/p5lab/spritelab/SpriteLab.js
+++ b/apps/src/p5lab/spritelab/SpriteLab.js
@@ -160,4 +160,15 @@ export default class SpriteLab extends P5Lab {
   getReinfFeedbackMsg(isFinalFreePlayLevel) {
     return isFinalFreePlayLevel ? null : this.getMsg().reinfFeedbackMsg();
   }
+
+  runValidationCode() {
+    // Skip validation code in 'editBlocks' mode (i.e., a levelbuilder is
+    // editing start blocks for the level).
+    if (this.level.editBlocks) {
+      this.onPuzzleComplete(false /* submit */);
+      return;
+    }
+
+    super.runValidationCode();
+  }
 }


### PR DESCRIPTION
This makes it so that validation code isn't run when levelbuilders are editing start blocks for a Spritelab level. Previously, every time a levelbuilder clicked "Run," they had to wait for the validation code to finish before their changes were saved. (It's a little easier to understand if you watch the before/after videos.)

**Before:**

https://user-images.githubusercontent.com/9812299/214963594-68016825-88dd-4630-a28a-555f064aeb71.mov


**After:**


https://user-images.githubusercontent.com/9812299/214963638-8b8e06bf-656e-4e8e-829d-f4d86f7a9e2d.mov



## Links

- [SL-419](https://codedotorg.atlassian.net/browse/SL-419)