### PR TITLE
Use `assert_nil` if Expecting `nil`

### DIFF
--- a/dashboard/test/controllers/api/v1/users_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/users_controller_test.rb
@@ -226,7 +226,8 @@ class Api::V1::UsersControllerTest < ActionController::TestCase
     get :get_school_name, params: {user_id: @user.id}
     assert_response :success
     response = JSON.parse(@response.body)
-    assert_equal @user.school, response["school_name"]
+    assert_nil @user.school
+    assert_nil response["school_name"]
   end
 
   test "school name is not returned for a user that is not signed in" do

--- a/dashboard/test/lib/projects_list_test.rb
+++ b/dashboard/test/lib/projects_list_test.rb
@@ -32,7 +32,8 @@ class ProjectsListTest < ActionController::TestCase
 
   test 'get_project_row_data correctly parses student and project data' do
     project_row = ProjectsList.send(:get_project_row_data, @student_project, @channel_id, @student)
-    assert_equal @channel_id, project_row['channel']
+    assert_nil @channel_id
+    assert_nil project_row['channel']
     assert_equal 'Bobs App', project_row['name']
     assert_equal @student.name, project_row['studentName']
     assert_equal 'applab', project_row['type']
@@ -45,7 +46,8 @@ class ProjectsListTest < ActionController::TestCase
 
   test 'get_project_row_data still correctly parses project data even if no student is passed' do
     project_row = ProjectsList.send(:get_project_row_data, @student_project, @channel_id)
-    assert_equal @channel_id, project_row['channel']
+    assert_nil @channel_id
+    assert_nil project_row['channel']
     assert_equal 'Bobs App', project_row['name']
     assert_equal 'applab', project_row['type']
     assert_equal '2017-01-25T17:48:12.358-08:00', project_row['updatedAt']
@@ -237,8 +239,8 @@ class ProjectsListTest < ActionController::TestCase
     assert_equal fake_project[:published_at], returned_project["publishedAt"]
     assert_equal UserHelpers.initial(fake_project[:name]),
       returned_project["studentName"]
-    assert_equal UserHelpers.age_range_from_birthday(fake_project[:birthday]),
-      returned_project["studentAgeRange"]
+    assert_nil UserHelpers.age_range_from_birthday(fake_project[:birthday])
+    assert_nil returned_project["studentAgeRange"]
   end
 
   test "include_featured combines featured project data and published projects data correctly" do
@@ -318,11 +320,11 @@ class ProjectsListTest < ActionController::TestCase
       @storage_id => 4,
       @teacher_storage_id => 6
     }
-    User = Struct.new(:id, :name)
-    teacher = User.new(6, teacher_name)
-    student = User.new(4, student_name)
-    Section = Struct.new(:students, :user, :id, :name, :user_id)
-    section = Section.new([student], teacher, 321, 'sectionName', teacher.id)
+    mock_user = Struct.new(:id, :name)
+    teacher = mock_user.new(6, teacher_name)
+    student = mock_user.new(4, student_name)
+    mock_section = Struct.new(:students, :user, :id, :name, :user_id)
+    section = mock_section.new([student], teacher, 321, 'sectionName', teacher.id)
 
     ProjectsList.stubs(:get_user_ids_by_storage_ids).returns(stub_users)
     Projects.stubs(:table).returns(library_db_result(stub_projects))
@@ -356,11 +358,11 @@ class ProjectsListTest < ActionController::TestCase
     stub_users = {
       @storage_id => 4
     }
-    User = Struct.new(:id, :name, :user_type)
-    section_owner = User.new(6, section_owner_name, 'teacher')
-    section_participant = User.new(4, section_participant_name, 'teacher')
-    Section = Struct.new(:students, :user, :id, :name, :user_id)
-    section = Section.new([section_participant], section_owner, 321, 'sectionName', section_owner.id)
+    mock_user = Struct.new(:id, :name, :user_type)
+    section_owner = mock_user.new(6, section_owner_name, 'teacher')
+    section_participant = mock_user.new(4, section_participant_name, 'teacher')
+    mock_section = Struct.new(:students, :user, :id, :name, :user_id)
+    section = mock_section.new([section_participant], section_owner, 321, 'sectionName', section_owner.id)
 
     ProjectsList.stubs(:get_user_ids_by_storage_ids).returns(stub_users)
     Projects.stubs(:table).returns(library_db_result(stub_projects))
@@ -403,10 +405,10 @@ class ProjectsListTest < ActionController::TestCase
     stub_users = {
       @storage_id => 4
     }
-    User = Struct.new(:id, :name)
-    teacher = User.new(4, teacher_name)
-    Section = Struct.new(:students, :user, :id, :name, :user_id)
-    section = Section.new([], teacher, 321, 'sectionName', teacher.id)
+    mock_user = Struct.new(:id, :name)
+    teacher = mock_user.new(4, teacher_name)
+    mock_section = Struct.new(:students, :user, :id, :name, :user_id)
+    section = mock_section.new([], teacher, 321, 'sectionName', teacher.id)
 
     ProjectsList.stubs(:get_user_ids_by_storage_ids).returns(stub_users)
     Projects.stubs(:table).returns(library_db_result(stub_projects))

--- a/dashboard/test/models/concerns/curriculum/course_types_test.rb
+++ b/dashboard/test/models/concerns/curriculum/course_types_test.rb
@@ -236,7 +236,7 @@ class CourseTypesTests < ActiveSupport::TestCase
 
   test 'get_family_courses should return nil if there is no family name' do
     unit_without_family_name = create :script, name: 'no-family-name'
-    assert_equal unit_without_family_name.get_family_courses, nil
+    assert_nil unit_without_family_name.get_family_courses
   end
 
   # (Dani) Commenting out while we turn the validation off to update the audience on some courses

--- a/dashboard/test/models/level_test.rb
+++ b/dashboard/test/models/level_test.rb
@@ -777,7 +777,7 @@ class LevelTest < ActiveSupport::TestCase
     assert_equal level.localized_rubric_property('rubric_key_concept'), "first english markdown"
     assert_equal level.localized_rubric_property('rubric_performance_level_1'), "second english markdown"
     # Should return nil on a non-existing property
-    assert_equal level.localized_rubric_property('rubric_performance_level_9'), nil
+    assert_nil level.localized_rubric_property('rubric_performance_level_9')
   end
 
   test 'create unplugged level from level builder' do

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -2178,7 +2178,12 @@ class UserTest < ActiveSupport::TestCase
     end
 
     user.reload
-    assert_equal original_primary_contact_info, user.primary_contact_info
+    if original_primary_contact_info.nil?
+      # starting in Minitest 6, don't use assert_equal to compare nil values
+      assert_nil user.primary_contact_info
+    else
+      assert_equal original_primary_contact_info, user.primary_contact_info
+    end
   end
 
   def upgrade_to_personal_login_params(**args)


### PR DESCRIPTION
Specifically, resolve all instances of the warning:

> DEPRECATED: Use assert_nil if expecting nil from <filepath>. This will fail in Minitest 6.

Also resolve a few instances of `warning: already initialized constant` while I'm in the neighborhood, using local variables instead.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
