### PR TITLE
Redo Upgrade SauceLabs Safari to 13

### DIFF
--- a/dashboard/test/ui/browsers.json
+++ b/dashboard/test/ui/browsers.json
@@ -12,8 +12,8 @@
   {
     "name": "Safari",
     "browserName": "Safari",
-    "platform": "macOS 10.14",
-    "version": "12.0",
+    "platform": "macOS 10.15",
+    "version": "13",
     "w3c": true
   },
   {

--- a/dashboard/test/ui/features/acquisition_products/pd/teacher_application.feature
+++ b/dashboard/test/ui/features/acquisition_products/pd/teacher_application.feature
@@ -145,6 +145,7 @@ Scenario: Teacher saves, re-opens, and submits an application
   And I complete Section 7 of the teacher PD application
   And I press the first "button[type='submit']" element
 
+@no_safari
 Scenario: Teacher starts a new csp application and submits it
   Given I create a teacher named "Severus"
   And I am on "http://studio.code.org/pd/application/teacher"
@@ -184,6 +185,7 @@ Scenario: Teacher starts a new csp application and submits it
   # Confirmation page
   Then I wait until element "h1" contains text "Thank you for submitting your application!"
 
+@no_safari
 Scenario: Teacher starts a new csa application and submits it
   Given I create a teacher named "Severus"
   And I am on "http://studio.code.org/pd/application/teacher"

--- a/dashboard/test/ui/features/star_labs/gamelab/export_animations.feature
+++ b/dashboard/test/ui/features/star_labs/gamelab/export_animations.feature
@@ -1,7 +1,7 @@
 @as_student
 Feature: Game Lab Export
 
-@no_mobile
+@no_mobile @no_safari
 Scenario: Export library animation
   Given I start a new Game Lab project
   And I switch to the animation tab

--- a/dashboard/test/ui/features/teacher_tools/levelbuilder/lesson_edit_page.feature
+++ b/dashboard/test/ui/features/teacher_tools/levelbuilder/lesson_edit_page.feature
@@ -21,6 +21,7 @@ Feature: Using the Lesson Edit Page
 
     And I delete the temp unit with lessons
 
+  @no_safari
   Scenario: Save changes using the lesson edit page
     Given I create a levelbuilder named "Levi"
     And I create a temp migrated unit with lessons

--- a/dashboard/test/ui/features/teacher_tools/pl_sections.feature
+++ b/dashboard/test/ui/features/teacher_tools/pl_sections.feature
@@ -1,5 +1,6 @@
 @no_mobile
 Feature: Professional learning Sections
+  @no_safari
   Scenario: Create new professional learning section as levelbuilder
     Given I create an authorized teacher-associated student named "Sally"
     When I sign in as "Teacher_Sally" and go home
@@ -32,6 +33,7 @@ Feature: Professional learning Sections
     And I wait until element "a:contains(My Section of Teachers)" is visible
     And the href of selector "a:contains(My Section of Teachers)" contains "/teacher_dashboard/sections/"
 
+  @no_safari
   Scenario: Create new professional learning section as universal instructor
     Given I create an authorized teacher-associated student named "Sally"
     When I sign in as "Teacher_Sally" and go home
@@ -64,6 +66,7 @@ Feature: Professional learning Sections
     And I wait until element "a:contains(My Section of Teachers)" is visible
     And the href of selector "a:contains(My Section of Teachers)" contains "/teacher_dashboard/sections/"
 
+  @no_safari
   Scenario: Create new professional learning section as plc reviewer
     Given I create an authorized teacher-associated student named "Sally"
     When I sign in as "Teacher_Sally" and go home
@@ -96,6 +99,7 @@ Feature: Professional learning Sections
     And I wait until element "a:contains(My Section of Teachers)" is visible
     And the href of selector "a:contains(My Section of Teachers)" contains "/teacher_dashboard/sections/"
 
+  @no_safari
   Scenario: Create new professional learning section as facilitator
     Given I create an authorized teacher-associated student named "Sally"
     When I sign in as "Teacher_Sally" and go home
@@ -128,6 +132,7 @@ Feature: Professional learning Sections
     And I wait until element "a:contains(My Section of Teachers)" is visible
     And the href of selector "a:contains(My Section of Teachers)" contains "/teacher_dashboard/sections/"
 
+  @no_safari
   Scenario: Teacher can not create professional learning section
     Given I create a teacher named "Teacher"
     And I sign in as "Teacher" and go home

--- a/dashboard/test/ui/features/teacher_tools/projects/personal_project_gallery.feature
+++ b/dashboard/test/ui/features/teacher_tools/projects/personal_project_gallery.feature
@@ -22,6 +22,7 @@ Scenario: Can Publish and Unpublish a Project (Button Version)
   Then I click selector ".ui-personal-projects-unpublish-button"
   And I wait until element ".ui-personal-projects-publish-button" is visible
 
+@no_safari
 Scenario: Can Rename a Project
   Given I make a "playlab" project named "Old Name"
   Given I am on "http://studio.code.org/projects"
@@ -38,6 +39,7 @@ Scenario: Can Rename a Project
   And I wait until element ".ui-projects-rename-save" is not visible
   And the first project in the table is named "New Name"
 
+@no_safari
 Scenario: Can Remix a Project
   Given I make a "playlab" project named "Remix Template"
   Given I am on "http://studio.code.org/projects"
@@ -50,6 +52,7 @@ Scenario: Can Remix a Project
   And I press the child number 1 of class ".pop-up-menu-item"
   And I wait until current URL contains "/edit"
 
+@no_safari
 Scenario: Can Delete a Project
   Given I make a "playlab" project named "To Be Deleted"
   Given I am on "http://studio.code.org/projects"

--- a/dashboard/test/ui/features/teacher_tools/section_action_dropdown.feature
+++ b/dashboard/test/ui/features/teacher_tools/section_action_dropdown.feature
@@ -1,4 +1,5 @@
 @single_session
+@no_safari
 Feature: Using the SectionActionDropdown
 
   # * Check that we get redirected to the right page

--- a/dashboard/test/ui/features/teacher_tools/teacher_homepage.feature
+++ b/dashboard/test/ui/features/teacher_tools/teacher_homepage.feature
@@ -90,6 +90,7 @@ Feature: Using the teacher homepage sections feature
     And I wait until element "#script-title" is visible
     And element ".uitest-sectionselect" has value ""
 
+  @no_safari
   Scenario: Assign hidden unit to section
     Given I am on "http://studio.code.org/home"
     And I create a new student section with course "Computer Science Principles", version "'17-'18" and unit "CSP Unit 1 - The Internet ('17-'18)"
@@ -128,6 +129,7 @@ Feature: Using the teacher homepage sections feature
     And I wait until element ".uitest-CourseScript" is visible
     Then unit "CSP Unit 2 - Digital Information ('17-'18)" is marked as visible
 
+  @no_safari
   Scenario: Assign a Course assigns first Unit in Course by default
     Given I am on "http://studio.code.org/home"
     When I see the section set up box
@@ -135,6 +137,7 @@ Feature: Using the teacher homepage sections feature
     Then the student section table should have 1 rows
     And the section table row at index 0 has secondary assignment path "/s/csp1-2017"
 
+  @no_safari
   Scenario: Assign a CSF course with multiple versions
     Given I am on "http://studio.code.org/home"
     When I see the section set up box
@@ -153,6 +156,7 @@ Feature: Using the teacher homepage sections feature
     Then I should see the student section table
     And the section table row at index 0 has primary assignment path "/s/coursea-2019"
 
+  @no_safari
   Scenario: Navigate to course pages with course versions enabled
     Given I am on "http://studio.code.org/home"
     When I see the section set up box
@@ -179,6 +183,7 @@ Feature: Using the teacher homepage sections feature
 
     And the href of selector ".uitest-CourseScript:contains(CSP Unit 2) .uitest-go-to-unit-button" contains the section id
 
+  @no_safari
   Scenario: Loading the print certificates page for a section
     Given I create a teacher-associated student named "Sally"
     And I sign in as "Teacher_Sally" and go home


### PR DESCRIPTION
# Redo Upgrade SauceLabs Safari to 13
Alternative to:
- https://github.com/code-dot-org/code-dot-org/pull/49955

Redoes https://github.com/code-dot-org/code-dot-org/pull/49799 with additional changes to failing UI tests
Additional context is available at:
* https://github.com/code-dot-org/code-dot-org/pull/49799

When attempting to merge the change above, we began consistently failing a handful of Safari Tests during the DTT. This wasn't caught ahead of time as drone apparently only runs UI tests on Chrome on our feature branches. Slack thread: https://codedotorg.slack.com/archives/C03CM903Y/p1674762476708329

There were two primary reasons for the new test failures:

### Click Issue
First, and most common, is an issue where Selenium tests break on Safari 13 due to the SafariDriver being unable to click elements on the page: https://bugs.webkit.org/show_bug.cgi?id=202589
Unfortunately, all versions of Safari 13 seem to have this issue (tested through 13.1.2 on the test machine). Here is a slack thread that walks through my use of the test machine to confirm this: https://codedotorg.slack.com/archives/C0T0PNTM3/p1674938970913389
I believe this gives us 3 options:
1. (Alternative PR) Update browsers.json to use a newer safari. (but we'll lose that v13 coverage).
2. **(This PR) Tell the affected tests to skip using Safari as long as we are testing on v13.**
3. Update our When /^I click selector to use JS to do the click. We probably don't want to change every .click reference just for a safari 13 workaround.  Secondly, if we need to do this, every time somebody adds a new UI test, they'd need to know about .click not working, and to use this workaround instead.

_Pros/Cons of option 2:_ This option keeps SauceLabs Safari on a lower version that matches the current minimum recommend browsers for users. However, it does mean we lose test coverage for a good handful of tests, primarily in the Teacher Tools space. If we later move to Safari 14, we can stop skipping these tests. If new similar tests are written they will likely fail in Safari unless we handle clicks in a different way.

### Downloading Files Issue
The second type of test failure seen seems to be due to the browser’s website preferences not being set up to automatically allow downloading files: https://app.saucelabs.com/tests/d34b131c16274ef795495db540b29c4d#61 The test is the `gamelab_export_animations` UI test. The test is still a valid, working test for browsers other than Safari, so we can skip this test on Safari for now.
