### PR TITLE
Revert "[Student Learning]  Fix droplet toolbox for rtl language appearance"

### DIFF
--- a/apps/style/common.scss
+++ b/apps/style/common.scss
@@ -390,20 +390,6 @@ html[dir="rtl"] .editor-column {
   background-position: 2px 2px;
 }
 
-html[dir="rtl"] {
-  // !Important is used to overwrite droplet.min styling for RTL languages support.
-  #codeTextbox {
-    .droplet-wrapper-div {
-      left: 0 !important;
-    }
-    .droplet-palette-wrapper {
-      right: 0 !important;
-      left: unset !important;
-      z-index: 1;
-    }
-  }
-}
-
 #visualizationResizeBar {
   position: absolute;
   top: 0;


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#49954

This didn't work as expected in [code mode](https://codedotorg.slack.com/archives/C03DBDN67B7/p1675111160009859?thread_ts=1675108830.037389&cid=C03DBDN67B7)