### PR TITLE
Sprite Lab: hide subtype dropdown for dance and poetry in levelbuilder

### DIFF
--- a/dashboard/app/views/levels/editors/fields/_special_level_types.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_special_level_types.html.haml
@@ -56,8 +56,8 @@
       #plusAnswerContainedLevel
         %i.fa.fa-plus-circle
 
-  -# Only show subtype for basic Sprite Lab, not Dance or Poetry. Poetry has a separate selector, and Dance does not
-  -# have a subtype concept.
+  -# Only show subtype for basic Sprite Lab, not Dance or Poetry. Poetry has a separate selector,
+  -# and Dance does not have a subtype concept.
   - if @level.is_a?(GamelabJr) && !(@level.is_a?(Dancelab) || @level.is_a?(Poetry))
     .field
       = f.label :standalone_app_name, 'Level Subtype'

--- a/dashboard/app/views/levels/editors/fields/_special_level_types.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_special_level_types.html.haml
@@ -56,7 +56,9 @@
       #plusAnswerContainedLevel
         %i.fa.fa-plus-circle
 
-  - if (@level.is_a?(GamelabJr))
+  -# Only show subtype for basic Sprite Lab, not Dance or Poetry. Poetry has a separate selector, and Dance does not
+  -# have a subtype concept.
+  - if @level.is_a?(GamelabJr) && !(@level.is_a?(Dancelab) || @level.is_a?(Poetry))
     .field
       = f.label :standalone_app_name, 'Level Subtype'
       %p Select the subtype for the level. This will determine which blocks are available in the share/remix version of the level.


### PR DESCRIPTION
This dropdown is not relevant for dance levels, and is repeated on a different part of the edit page for poetry levels.

We may want to use the dropdown for poetry now that we have it, but I thought it was better to hide it for now to avoid weird behavior.


## Testing story
Tested locally


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
