### PR TITLE
Fix workshop year constant

### DIFF
--- a/bin/cron/summer_workshops_to_gdrive
+++ b/bin/cron/summer_workshops_to_gdrive
@@ -11,7 +11,7 @@ require 'cdo/google/sheet'
 # by our programs team.
 #
 
-WORKSHOP_YEAR = Pd::Application::ActiveApplicationModels::APPLICATION_CURRENT_YEAR.partition('-').last.to_i
+WORKSHOP_YEAR = Pd::Application::ActiveApplicationModels::APPLICATION_CURRENT_YEAR.partition('-').first.to_i
 EARLIEST_WORKSHOP_START_DATE = Date.new(WORKSHOP_YEAR, 5, 1)
 LATEST_WORKSHOP_START_DATE = Date.new(WORKSHOP_YEAR, 9, 16)
 


### PR DESCRIPTION
In this PR https://github.com/code-dot-org/code-dot-org/pull/49679/files, I meant change the workshop summer start year from 2022 to 2023. But I got confused and changed it to 2024 –– my bad! This fixes it.

For reference, applications in the 2023-2024 cycle (this current application cycle) have applications that are submitted in 2022. But they're applying for summer workshops that start in 2023, and workshops that in general go until the spring of 2024. (My confusion was that the summer workshops start the summer *after* the 2023-2024 school year –– not the case!)

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
