### PR TITLE
Deprecating upload_non_en_videos.rb

### DIFF
--- a/bin/oneoff/upload_non_en_videos.rb
+++ b/bin/oneoff/upload_non_en_videos.rb
@@ -1,6 +1,7 @@
 # This script is used to batch upload non-EN videos, with the assumption that
 # we will frequently get these in batches. They will be uploaded to YouTube
 # and S3 as well as added to videos.csv.
+# This script is currently deprecated and archived, to serve as a reference.
 
 require 'google/apis'
 require 'google-apis-youtube_v3'
@@ -14,7 +15,8 @@ require 'optparse'
 
 APPLICATION_NAME = 'Dubbed Video Batch Upload'
 
-# This is the URI so that we can authorize from a browser. Don't change this.
+# This is the URI so that we can authorize from a browser. Out Of Band flow is not supported by Google anymore. A new
+# authentication method would need to be implemented. Calls to this API will return an Error 400: invalid_request
 REDIRECT_URI = 'urn:ietf:wg:oauth:2.0:oob'
 
 SCOPE = Google::Apis::YoutubeV3::AUTH_YOUTUBE_UPLOAD
@@ -146,7 +148,13 @@ def main(options)
   puts "uploaded #{uploaded_videos} videos"
 end
 
+def deprecation_message(options)
+  puts "DEPRECATION MESSAGE: This script is currently deprecated and archived to serve as reference.
+  This script uses OAuth out-of-band (OOB) flow, OOB requests to Google’s OAuth 2.0 authorization endpoint for existing clients are blocked, and will return an Error 400: invalid_request."
+end
+
 options = parse_options(ARGV)
 # Move this after parse_options so that --help is fast
 require_relative '../../dashboard/config/environment'
-main(options)
+# main(options)
+deprecation_message(options)


### PR DESCRIPTION
The script upload_non_en_videos.rb uses a Google OAuth out-of-band (OOB) flow. This type of authentication has been deprecated by Google on October 3, 2022. The OOB flow poses a remote phishing risk and clients must migrate to an alternative method to protect against this vulnerability.

This script is a one-off script used to upload multiple videos to our Youtube channel as per request of the International team.

Due to the low usage of the script, this update represents a low priority, although deprecation of the current script is necessary to avoid future usage without the appropriate updates.

### The approach taken was: 

- Shut down the corresponding google cloud project.
- Archive the script to use as a reference in future work.
- Commenting out the main usage of the script and printing a deprecation message insteas.

## Links

- jira ticket: [P20-9](https://codedotorg.atlassian.net/browse/P20-9)


## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

Update the authentication method to use a different method than OOB flow. 
Alternative options could be using the [YoutubeAPI](https://developers.google.com/youtube/v3/code_samples/ruby) 
See Jira ticket P20-9 for more details.

## PR Checklist:


- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
