### PR TITLE
disable update_census_mapbox cronjob

### DIFF
--- a/cookbooks/cdo-apps/templates/default/crontab.erb
+++ b/cookbooks/cdo-apps/templates/default/crontab.erb
@@ -66,13 +66,13 @@
       cronjob at:'30 7 * * 1-5', do:deploy_dir('bin', 'cron', 'commit_content')
       cronjob at:'*/1 * * * *', do:deploy_dir('bin', 'cron', 'update_dts')
       cronjob at:'0 17 * * *', do:deploy_dir('bin', 'cron', 'commit_trusted_proxies')
-      
+
       # This should be run after the commit_content job that happens on both the levelbuilder
       # and staging environments
       # merge_lb_to_staging is also known as DTS or "deploy to staging"
       cronjob at:'35 7 * * 1-5', do:deploy_dir('bin', 'cron', 'merge_lb_to_staging')
 
-      
+
       # This should be run after the commit_content job that happens on the levelbuilder
       # environment.
       cronjob at:'20 9 * * 1-5', do:deploy_dir('bin', 'cron', 'deploy_to_levelbuilder')
@@ -102,7 +102,6 @@
       cronjob at:'*/30 * * * *', do:dashboard_dir('bin', 'sync_jotforms')
       cronjob at:'0 6 * * *', do:deploy_dir('bin', 'cron', 'process_foorm_data')
       cronjob at:'25 7 * * *', do:deploy_dir('bin', 'cron', 'update_hoc_map')
-      cronjob at:'49 5 * * *', do:deploy_dir('bin', 'cron', 'update_census_mapbox')
       cronjob at:'0 9 * * 1-5', do:deploy_dir('bin', 'cron', 'check_for_census_inaccuracy_reports')
       cronjob at:'*/10 * * * *', do:deploy_dir('bin', 'cron', 'delete_twilio_data')
       cronjob at:'* * * * *', do:deploy_dir('bin', 'cron', 'confirm_usage')


### PR DESCRIPTION
The current [Access Report eng plan](https://docs.google.com/document/d/1t4jAC90ASgqIdUiKErGyI1kNdM4oaynql8wn7q3ZPIc/edit#heading=h.td9dkkgv7vp9) is to turn off the algorithm by disabling and eventually deleting the cronjob. This PR finishes https://codedotorg.atlassian.net/browse/ACQ-271 by disabling the cronjob. We don't expect to turn it back on, but are planning to wait a bit before removing it, to give RED team a bit more time to uncover any roadblocks which might lead to us continuing to use this cronjob. 

## Testing story

not much to test here