### PR TITLE
increase tolerance when netsim tests match against current time

### DIFF
--- a/apps/test/unit/netsim/NetSimLogEntry.js
+++ b/apps/test/unit/netsim/NetSimLogEntry.js
@@ -44,7 +44,7 @@ describe('NetSimLogEntry', function() {
     assert.equal(row.status, NetSimLogEntry.LogStatus.SUCCESS);
 
     assert.property(row, 'timestamp');
-    assert.closeTo(row.timestamp, Date.now(), 10);
+    assert.closeTo(row.timestamp, Date.now(), 100);
 
     assert.property(row, 'sentBy');
     assert.equal(row.sentBy, '');
@@ -123,7 +123,7 @@ describe('NetSimLogEntry', function() {
         assert.equal(rowBinary, binary);
         assert.equal(row.status, status);
         assert.equal(row.sentBy, sentBy);
-        assert.closeTo(row.timestamp, Date.now(), 10);
+        assert.closeTo(row.timestamp, Date.now(), 100);
       });
     });
 

--- a/apps/test/unit/netsim/NetSimRouterNode.js
+++ b/apps/test/unit/netsim/NetSimRouterNode.js
@@ -282,7 +282,7 @@ describe('NetSimRouterNode', function() {
     assert.isUndefined(row.routerNumber);
 
     assertOwnProperty(row, 'creationTime');
-    assert.closeTo(row.creationTime, Date.now(), 10);
+    assert.closeTo(row.creationTime, Date.now(), 100);
 
     assertOwnProperty(row, 'dnsMode');
     assert.strictEqual(row.dnsMode, DnsMode.NONE);


### PR DESCRIPTION
the staging build failed twice in a row today due to `NetSimLogEntry` failing on assert.closeTo. the assertion checks that the time is within 10ms but the logs indicate that the times differed by 14ms and 19ms respectively. the same tests have failed intermittently in the past. my proposed solution is to increase the tolerance of these checks to 100ms.

## Testing story

