### PR TITLE
Fix Violations of and Reenable `Rails/WhereExists`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -286,13 +286,6 @@ Rails/TimeZone:
 Rails/WhereEquals:
   Enabled: false
 
-# Offense count: 25
-# This cop supports safe auto-correction (--auto-correct).
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: exists, where
-Rails/WhereExists:
-  Enabled: false
-
 # Offense count: 2
 Security/MarshalLoad:
   Enabled: false

--- a/dashboard/app/controllers/discourse_sso_controller.rb
+++ b/dashboard/app/controllers/discourse_sso_controller.rb
@@ -30,7 +30,7 @@ class DiscourseSsoController < ApplicationController
     end
 
     FACILITATOR_COURSE_NAMES_TO_GROUP_NAMES.each do |course_name, group_name|
-      if Pd::CourseFacilitator.where(facilitator: current_user, course: course_name).exists?
+      if Pd::CourseFacilitator.exists?(facilitator: current_user, course: course_name)
         add_groups << group_name
       else
         remove_groups << group_name

--- a/dashboard/app/controllers/pd/session_attendance_controller.rb
+++ b/dashboard/app/controllers/pd/session_attendance_controller.rb
@@ -36,7 +36,7 @@ class Pd::SessionAttendanceController < ApplicationController
     enrollment_code = params.require(:enrollment_code)
 
     enrollment = Pd::Enrollment.find_by(code: enrollment_code)
-    if enrollment.nil? || Pd::Attendance.for_workshop(@session.workshop).where(enrollment: enrollment).exists?
+    if enrollment.nil? || Pd::Attendance.for_workshop(@session.workshop).exists?(enrollment: enrollment)
       # This has already been claimed
       flash[:error] = "#{params[:safe_name] || 'This name'} has been claimed. Please look again."
       redirect_to action: :attend, session_code: @session.code

--- a/dashboard/app/helpers/survey_results_helper.rb
+++ b/dashboard/app/helpers/survey_results_helper.rb
@@ -43,7 +43,7 @@ module SurveyResultsHelper
   end
 
   def existing_survey_result?(kind)
-    SurveyResult.where(user_id: current_user.id, kind: kind).exists?
+    SurveyResult.exists?(user_id: current_user.id, kind: kind)
   end
 
   def country_us?

--- a/dashboard/app/models/pd/application/teacher_application.rb
+++ b/dashboard/app/models/pd/application/teacher_application.rb
@@ -780,7 +780,7 @@ module Pd::Application
       return false if reminder_emails.any?
 
       # Only if we've sent at least one principal approval email before.
-      return false unless emails.where(email_type: 'admin_approval').exists?
+      return false unless emails.exists?(email_type: 'admin_approval')
 
       # If it's valid to send another principal email at this time.
       return allow_sending_principal_email?

--- a/dashboard/app/models/pd/enrollment.rb
+++ b/dashboard/app/models/pd/enrollment.rb
@@ -382,8 +382,7 @@ class Pd::Enrollment < ApplicationRecord
       form_name = POST_SURVEY_CONFIG_PATHS[workshop.subject]
       Pd::WorkshopSurveyFoormSubmission.where(pd_workshop: workshop, user: enrollment.user).
         joins(:foorm_submission).
-        where(foorm_submissions: {form_name: form_name}).
-        exists?
+        exists?(foorm_submissions: {form_name: form_name})
     end
 
     select_completed ? completed_surveys : uncompleted_surveys

--- a/dashboard/app/models/peer_review.rb
+++ b/dashboard/app/models/peer_review.rb
@@ -130,12 +130,12 @@ class PeerReview < ApplicationRecord
   end
 
   def self.create_for_submission(user_level, level_source_id)
-    return if PeerReview.where(
+    return if PeerReview.exists?(
       submitter: user_level.user,
       level: user_level.level,
       from_instructor: true,
       status: :accepted
-    ).exists?
+    )
 
     transaction do
       # Remove old unassigned reviews for this submitter+script+level combination

--- a/dashboard/app/serializers/api/v1/pd/enrollment_flat_attendance_serializer.rb
+++ b/dashboard/app/serializers/api/v1/pd/enrollment_flat_attendance_serializer.rb
@@ -23,7 +23,7 @@ class Api::V1::Pd::EnrollmentFlatAttendanceSerializer < ActiveModel::Serializer
     super(requested_attrs, reload).tap do |data|
       object.workshop.sessions.each_with_index do |session, i|
         data["session_#{i + 1}_date".to_sym] = session.formatted_date
-        data["session_#{i + 1}_attendance".to_sym] = session.attendances.where(pd_enrollment_id: object.id).exists?
+        data["session_#{i + 1}_attendance".to_sym] = session.attendances.exists?(pd_enrollment_id: object.id)
       end
     end
   end

--- a/dashboard/app/serializers/api/v1/pd/session_attendance_serializer.rb
+++ b/dashboard/app/serializers/api/v1/pd/session_attendance_serializer.rb
@@ -30,8 +30,8 @@ class Api::V1::Pd::SessionAttendanceSerializer < ActiveModel::Serializer
   end
 
   def attended?(enrollment)
-    return true if enrollment && object.attendances.where(pd_enrollment_id: enrollment.id).exists?
-    return true if enrollment.user && object.attendances.where(teacher_id: enrollment.user.id).exists?
+    return true if enrollment && object.attendances.exists?(pd_enrollment_id: enrollment.id)
+    return true if enrollment.user && object.attendances.exists?(teacher_id: enrollment.user.id)
     false
   end
 end

--- a/dashboard/test/controllers/api/v1/pd/workshop_attendance_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshop_attendance_controller_test.rb
@@ -244,7 +244,7 @@ class Api::V1::Pd::WorkshopAttendanceControllerTest < ::ActionDispatch::Integrat
       assert_response :success
     end
 
-    refute Pd::Attendance.where(session: @session, teacher: teacher).exists?
+    refute Pd::Attendance.exists?(session: @session, teacher: teacher)
   end
 
   test 'create delete and create restores the original record' do
@@ -302,7 +302,7 @@ class Api::V1::Pd::WorkshopAttendanceControllerTest < ::ActionDispatch::Integrat
       assert_response :success
     end
 
-    refute Pd::Attendance.where(session: @session, enrollment: enrollment).exists?
+    refute Pd::Attendance.exists?(session: @session, enrollment: enrollment)
   end
 
   private

--- a/dashboard/test/controllers/api/v1/teacher_scores_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/teacher_scores_controller_test.rb
@@ -51,7 +51,7 @@ class Api::V1::TeacherScoresControllerTest < ActionDispatch::IntegrationTest
 
     sign_in teacher
     post '/dashboardapi/v1/teacher_scores', params: {section_id: section.id, lesson_scores: [{lesson_id: lesson.id, score: 100}]}
-    assert TeacherScore.where(teacher_id: teacher.id).exists?
+    assert TeacherScore.exists?(teacher_id: teacher.id)
     assert_response :no_content
   end
 
@@ -75,7 +75,7 @@ class Api::V1::TeacherScoresControllerTest < ActionDispatch::IntegrationTest
     destroyed_lesson = create :lesson
     destroyed_lesson.destroy
     post '/dashboardapi/v1/teacher_scores', params: {section_id: section.id, lesson_scores: [{lesson_id: lesson.id, score: 100}, {lesson_id: destroyed_lesson.id, score: 0}]}
-    refute TeacherScore.where(teacher_id: teacher.id).exists?
+    refute TeacherScore.exists?(teacher_id: teacher.id)
     assert_response :forbidden
   end
 

--- a/dashboard/test/controllers/hint_view_requests_controller_test.rb
+++ b/dashboard/test/controllers/hint_view_requests_controller_test.rb
@@ -54,9 +54,9 @@ class HintViewRequestsControllerTest < ActionController::TestCase
       post :create, params: params, format: :json
     end
 
-    assert HintViewRequest.where(user_id: @student.id).exists?
-    assert HintViewRequest.where(user_id: classmate_1.id).exists?
-    assert HintViewRequest.where(user_id: classmate_2.id).exists?
+    assert HintViewRequest.exists?(user_id: @student.id)
+    assert HintViewRequest.exists?(user_id: classmate_1.id)
+    assert HintViewRequest.exists?(user_id: classmate_2.id)
 
     assert_response :created
   end

--- a/dashboard/test/controllers/levels_controller_test.rb
+++ b/dashboard/test/controllers/levels_controller_test.rb
@@ -769,7 +769,7 @@ class LevelsControllerTest < ActionController::TestCase
 
   test "should prevent rename of stanadalone project level" do
     level_name = ProjectsController::STANDALONE_PROJECTS.values.first[:name]
-    create(:level, name: level_name) unless Level.where(name: level_name).exists?
+    create(:level, name: level_name) unless Level.exists?(name: level_name)
     level = Level.find_by(name: level_name)
 
     get :edit, params: {id: level.id}

--- a/dashboard/test/controllers/projects_controller_test.rb
+++ b/dashboard/test/controllers/projects_controller_test.rb
@@ -24,7 +24,7 @@ class ProjectsControllerTest < ActionController::TestCase
     # doesn't set them up as actual project template levels, much less give
     # them specific content.
     ProjectsController::STANDALONE_PROJECTS.each do |type, config|
-      next if Level.where(name: config[:name]).exists?
+      next if Level.exists?(name: config[:name])
       factory = FactoryGirl.factories.registered?(type) ? type : :level
       create(factory, name: config[:name])
     end

--- a/dashboard/test/helpers/delete_accounts_helper_test.rb
+++ b/dashboard/test/helpers/delete_accounts_helper_test.rb
@@ -1460,9 +1460,9 @@ class DeleteAccountsHelperTest < ActionView::TestCase
 
     assert_equal 0, SurveyResult.where(user_id: teacher_a.id).count
     assert_equal 1, SurveyResult.where(user_id: teacher_b.id).count
-    refute SurveyResult.where(id: survey_result_a.id).exists?
-    refute SurveyResult.where(id: survey_result_b.id).exists?
-    assert SurveyResult.where(id: survey_result_c.id).exists?
+    refute SurveyResult.exists?(id: survey_result_a.id)
+    refute SurveyResult.exists?(id: survey_result_b.id)
+    assert SurveyResult.exists?(id: survey_result_c.id)
   end
 
   #
@@ -2138,7 +2138,7 @@ class DeleteAccountsHelperTest < ActionView::TestCase
     # even if the user doesn't have the related permission.
     program_manager.delete_permission UserPermission::PROGRAM_MANAGER
 
-    assert RegionalPartnerProgramManager.where(program_manager_id: program_manager.id).exists?
+    assert RegionalPartnerProgramManager.exists?(program_manager_id: program_manager.id)
     refute program_manager.permission? UserPermission::PROGRAM_MANAGER
 
     err = assert_raises DeleteAccountsHelper::SafetyConstraintViolation do
@@ -2162,7 +2162,7 @@ class DeleteAccountsHelperTest < ActionView::TestCase
     # even if the user doesn't have the related permission.
     program_manager.delete_permission UserPermission::PROGRAM_MANAGER
 
-    assert RegionalPartnerProgramManager.where(program_manager_id: program_manager.id).exists?
+    assert RegionalPartnerProgramManager.exists?(program_manager_id: program_manager.id)
     refute program_manager.permission? UserPermission::PROGRAM_MANAGER
 
     unsafe_purge_user program_manager

--- a/dashboard/test/lib/expired_deleted_account_purger_test.rb
+++ b/dashboard/test/lib/expired_deleted_account_purger_test.rb
@@ -274,7 +274,7 @@ class ExpiredDeletedAccountPurgerTest < ActiveSupport::TestCase
     refute_nil autoretryable.purged_at
 
     # The autoretryable queued account purge record should be gone
-    refute QueuedAccountPurge.where(id: qap.id).exists?
+    refute QueuedAccountPurge.exists?(id: qap.id)
   end
 
   test 'moves account to queue when purge fails' do

--- a/dashboard/test/models/peer_review_test.rb
+++ b/dashboard/test/models/peer_review_test.rb
@@ -520,7 +520,7 @@ class PeerReviewTest < ActiveSupport::TestCase
     end
 
     assert original_peer_reviews == PeerReview.where(level_id: @level.id)
-    refute PeerReview.where(level_source_id: new_level_source.id).exists?
+    refute PeerReview.exists?(level_source_id: new_level_source.id)
   end
 
   private


### PR DESCRIPTION
Fix applied automatically with `bundle exec rubocop --auto-correct-all --only Rails/WhereExists`

> This cop enforces consistent style when using `exists?`.
>
> Two styles are supported for this cop. When EnforcedStyle is 'exists' then the cop enforces `exists?(…)` over `where(…).exists?`.
>
> When EnforcedStyle is 'where' then the cop enforces `where(…).exists?` over `exists?(…)`.

EnforcedStyle defaults to 'exists', so that's the style we apply.


<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->
- https://www.rubydoc.info/gems/rubocop-rails/2.8.1/RuboCop/Cop/Rails/WhereExists
- https://docs.rubocop.org/rubocop-rails/cops_rails.html#railswhereexists

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
