### PR TITLE
Removing clickable div from LessonGroupInfoDialog

### DIFF
--- a/apps/src/templates/progress/LessonGroupInfoDialog.jsx
+++ b/apps/src/templates/progress/LessonGroupInfoDialog.jsx
@@ -32,7 +32,6 @@ export default class LessonGroupInfoDialog extends Component {
         />
         <DialogFooter rightAlign>
           <Button
-            __useDeprecatedTag
             text={i18n.closeDialog()}
             onClick={this.props.closeDialog}
             color={Button.ButtonColor.orange}


### PR DESCRIPTION
A simple update! I tested to make sure the hover still looks right and the button still works.

Before:
<img width="827" alt="Screen Shot 2023-02-01 at 2 25 24 PM" src="https://user-images.githubusercontent.com/37230822/216178618-6ef25a8c-4b27-420e-b9be-c2b2f5eb9919.png">

After:
<img width="835" alt="Screen Shot 2023-02-01 at 2 26 06 PM" src="https://user-images.githubusercontent.com/37230822/216178641-9f9cd0de-eed6-49bb-bf9a-c272f31ed7d6.png">


## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/A11Y-101

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
