### PR TITLE
Add Amplitude calls when curriculum is assigned 

### DIFF
--- a/apps/src/lib/util/AnalyticsConstants.js
+++ b/apps/src/lib/util/AnalyticsConstants.js
@@ -20,7 +20,10 @@ const EVENTS = {
   APPLICATION_SAVED_EVENT: 'Application Saved',
   APPLICATION_SUBMITTED_EVENT: 'Application Submitted',
   ADMIN_APPROVAL_RECEIVED_EVENT: 'Administrator Approval Received',
-  SUBMIT_RP_CONTACT_FORM_EVENT: 'Submit Regional Partner Contact Form'
+  SUBMIT_RP_CONTACT_FORM_EVENT: 'Submit Regional Partner Contact Form',
+
+  // Sections
+  CURRICULUM_ASSIGNED: 'Section Curriculum Assigned'
 };
 
 export {EVENTS};

--- a/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
+++ b/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
@@ -254,6 +254,9 @@ export const assignToSection = (
       section.unitId !== unitId
     ) {
       analyticsReporter.sendEvent(EVENTS.CURRICULUM_ASSIGNED, {
+        sectionName: section.name,
+        sectionId,
+        sectionLoginType: section.loginType,
         previousUnitId: section.unitId,
         previousCourseId: section.courseOfferingId,
         newUnitId: unitId,
@@ -289,6 +292,9 @@ export const unassignSection = (sectionId, location) => (
   // Only log if the section had something assigned
   if (!!section.courseOfferingId) {
     analyticsReporter.sendEvent(EVENTS.CURRICULUM_ASSIGNED, {
+      sectionName: section.name,
+      sectionId,
+      sectionLoginType: section.loginType,
       previousUnitId: section.unitId,
       previousCourseId: section.courseOfferingId,
       newUnitId: null,

--- a/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
+++ b/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
@@ -250,8 +250,8 @@ export const assignToSection = (
     // Only log if the assignment is changing.
     // We need an OR here because unitId will be null for standalone units
     if (
-      section.courseOfferingId !== courseOfferingId ||
-      section.unitId !== unitId
+      (courseOfferingId && section.courseOfferingId !== courseOfferingId) ||
+      (unitId && section.unitId !== unitId)
     ) {
       analyticsReporter.sendEvent(EVENTS.CURRICULUM_ASSIGNED, {
         sectionName: section.name,
@@ -287,20 +287,7 @@ export const unassignSection = (sectionId, location) => (
   getState
 ) => {
   dispatch(beginEditingSection(sectionId, true));
-  const {initialCourseId, initialUnitId, sections} = getState().teacherSections;
-  const section = sections[sectionId];
-  // Only log if the section had something assigned
-  if (!!section.courseOfferingId) {
-    analyticsReporter.sendEvent(EVENTS.CURRICULUM_ASSIGNED, {
-      sectionName: section.name,
-      sectionId,
-      sectionLoginType: section.loginType,
-      previousUnitId: section.unitId,
-      previousCourseId: section.courseOfferingId,
-      newUnitId: null,
-      newCourseId: null
-    });
-  }
+  const {initialCourseId, initialUnitId} = getState().teacherSections;
 
   dispatch(
     editSectionProperties({


### PR DESCRIPTION
When curriculum is assigned ~or unassigned~ from the course and unit overview pages, we want to log an event with Amplitude.


## Testing story

tested locally


## Follow-up work
There is a time crunch on this change, so I'm giving myself three followups: 
1. tests were a bit tricky so I'll add them in a follow-up PR
2. version year was also tricky to get from this page. I'm going to timebox a follow up to look into that.
3. more on the clean up side, I plan to move all of our existing events to using the shared file 
