### PR TITLE
Adding section fields to curriculum assigned event

### DIFF
--- a/apps/src/templates/teacherDashboard/EditSectionForm.jsx
+++ b/apps/src/templates/teacherDashboard/EditSectionForm.jsx
@@ -187,6 +187,9 @@ class EditSectionForm extends Component {
         (section.unitId && section.unitId !== initialUnitId))
     ) {
       analyticsReporter.sendEvent(CURRICULUM_ASSIGNED, {
+        sectionName: section.name,
+        sectionId: section.id,
+        sectionLoginType: section.loginType,
         previousUnitId: initialUnitId,
         previousCourseId: initialCourseOfferingId,
         previousVersionYear: initialVersionYear,

--- a/apps/test/unit/templates/teacherDashboard/EditSectionFormTest.js
+++ b/apps/test/unit/templates/teacherDashboard/EditSectionFormTest.js
@@ -454,6 +454,9 @@ describe('EditSectionForm', () => {
       'Section Curriculum Assigned'
     );
     assert.deepEqual(analyticsSpy.getCall(1).lastArg, {
+      sectionName: testSection.name,
+      sectionId: testSection.id,
+      sectionLoginType: testSection.loginType,
       previousUnitId: 7,
       previousCourseId: 3,
       previousVersionYear: '2022',


### PR DESCRIPTION
Here's a screenshot of an example of all the data parameters now:
<img width="538" alt="Screen Shot 2023-02-01 at 3 33 24 PM" src="https://user-images.githubusercontent.com/37230822/216192149-bf2bc638-0d74-45b8-aa37-3fb601f9c3dc.png">


And I updated the test to check that these extra fields are sent correctly.


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
