### PR TITLE
Header: add Incubator link

### DIFF
--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -232,7 +232,7 @@ img.video_thumbnail {
     }
   }
 
-  @media screen and (max-width: 1023px) {
+  @media screen and (max-width: 1100px) {
     .create_menu {
       display: none !important;
     }

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -393,6 +393,7 @@ en:
       help_us: "Help Us"
       teach: "Teach"
       about: "About"
+      incubator: "Incubator"
       legal: "Privacy & Legal"
       legal_privacy: "Privacy Policy"
       legal_cookie_notice: "Cookie Notice"

--- a/lib/cdo/hamburger.rb
+++ b/lib/cdo/hamburger.rb
@@ -113,11 +113,26 @@ class Hamburger
       entry[:title] = I18n.t("#{loc_prefix}#{entry[:title]}")
     end
 
-    if  options[:language] == "en"
+    if options[:language] == "en"
       if options[:user_type] == "teacher"
         teacher_entries << {
           title: I18n.t("#{loc_prefix}professional_learning"),
           url: CDO.studio_url("/my-professional-learning"),
+        }
+
+        teacher_entries << {
+          title: I18n.t("#{loc_prefix}incubator"),
+          url: CDO.studio_url("/incubator"),
+        }
+      elsif options[:user_type] == "student"
+        student_entries << {
+          title: I18n.t("#{loc_prefix}incubator"),
+          url: CDO.studio_url("/incubator"),
+        }
+      else
+        signed_out_entries << {
+          title: I18n.t("#{loc_prefix}incubator"),
+          url: CDO.studio_url("/incubator"),
         }
       end
     else
@@ -268,13 +283,18 @@ class Hamburger
     ]
 
     en_teacher = [
-      {title: I18n.t("#{loc_prefix}professional_learning"), url: CDO.studio_url("/my-professional-learning"), id: "header-teacher-professional-learning"}
+      {title: I18n.t("#{loc_prefix}professional_learning"), url: CDO.studio_url("/my-professional-learning"), id: "header-teacher-professional-learning"},
+      {title: I18n.t("#{loc_prefix}incubator"), url: CDO.studio_url("/incubator"), id: "header-incubator"},
     ]
 
-    student_links = [
+    any_student_links = [
       {title: I18n.t("#{loc_prefix}my_dashboard"), url: CDO.studio_url("/home"), id: "header-student-home"},
       {title: I18n.t("#{loc_prefix}course_catalog"), url: CDO.studio_url("/courses"), id: "header-student-courses"},
       {title: I18n.t("#{loc_prefix}project_gallery"), url: CDO.studio_url("/projects"), id: "header-student-projects"}
+    ]
+
+    en_student = [
+      {title: I18n.t("#{loc_prefix}incubator"), url: CDO.studio_url("/incubator"), id: "header-incubator"},
     ]
 
     en_signed_out_links = [
@@ -285,6 +305,7 @@ class Hamburger
       {title: I18n.t("#{loc_prefix}project_gallery"), url: CDO.studio_url("/projects/public"), id: "header-en-projects"},
       {title: I18n.t("#{loc_prefix}stats"), url: CDO.code_org_url("/promote"), id: "header-en-stats"},
       {title: I18n.t("#{loc_prefix}help_us"), url: CDO.code_org_url("/help"), id: "header-en-help"},
+      {title: I18n.t("#{loc_prefix}incubator"), url: CDO.studio_url("/incubator"), id: "header-en-incubator"},
       {title: I18n.t("#{loc_prefix}about"), url: CDO.code_org_url("/about"), id: "header-en-about"},
     ]
 
@@ -305,8 +326,10 @@ class Hamburger
         header_links.concat(about_intl)
       end
     elsif options[:user_type] == "student"
-      header_links = student_links
-      if options[:language] != "en"
+      header_links = any_student_links
+      if options[:language] == "en"
+        header_links.concat(en_student)
+      else
         header_links.concat(about_intl)
       end
     else

--- a/lib/cdo/hamburger.rb
+++ b/lib/cdo/hamburger.rb
@@ -119,18 +119,11 @@ class Hamburger
           title: I18n.t("#{loc_prefix}professional_learning"),
           url: CDO.studio_url("/my-professional-learning"),
         }
+      end
 
-        teacher_entries << {
-          title: I18n.t("#{loc_prefix}incubator"),
-          url: CDO.studio_url("/incubator"),
-        }
-      elsif options[:user_type] == "student"
-        student_entries << {
-          title: I18n.t("#{loc_prefix}incubator"),
-          url: CDO.studio_url("/incubator"),
-        }
-      else
-        signed_out_entries << {
+      entries = [teacher_entries, student_entries, signed_out_entries]
+      entries.each do |entry|
+        entry << {
           title: I18n.t("#{loc_prefix}incubator"),
           url: CDO.studio_url("/incubator"),
         }

--- a/shared/css/hamburger.scss
+++ b/shared/css/hamburger.scss
@@ -170,7 +170,7 @@
         html[dir=rtl], .rtl & {
           float: left;
         }
-        
+
       }
       .arrow-up {
         font-size: 30px;

--- a/shared/css/header.scss
+++ b/shared/css/header.scss
@@ -141,7 +141,7 @@
     }
   }
 
-  @media screen and (max-width: 1023px) {
+  @media screen and (max-width: 1100px) {
     .create_menu {
       display: none !important;
     }


### PR DESCRIPTION
This change adds a link to the Incubator (https://studio.code.org/incubator) to our header and hamburger across the site, for all "en" visitors. 

It shows for signed-out users, as well as signed-in students and teachers.  It's shown in the header along with other options, or in the hamburger on narrower displays.  To prevent overlaps, the "Create" button in the header is now shown for browser widths of 1101px of wider, up from 1024px before.

Signed-in teacher on pegasus, full width:
<img width="1102" alt="Screenshot 2023-02-01 at 6 15 20 PM" src="https://user-images.githubusercontent.com/2205926/216214504-749003f8-1595-450a-976e-586da6943fb4.png">

Signed-in teacher on pegasus, medium width:
<img width="970" alt="Screenshot 2023-02-01 at 6 16 33 PM" src="https://user-images.githubusercontent.com/2205926/216214683-7f4604de-2ed9-40bc-b681-c19c4cfda116.png">

Signed in-teacher on pegasus, narrow width:
<img width="815" alt="Screenshot 2023-02-01 at 6 17 35 PM" src="https://user-images.githubusercontent.com/2205926/216214805-344696c3-f486-4fe0-a705-7a3e7aed90f6.png">

Signed-in teacher on dashboard, full width:
<img width="1103" alt="Screenshot 2023-02-01 at 6 18 39 PM" src="https://user-images.githubusercontent.com/2205926/216215237-076f3c08-5d0f-44eb-bd64-c7a8112187e9.png">

Signed-in teacher on dashboard, medium width:
<img width="970" alt="Screenshot 2023-02-01 at 6 19 09 PM" src="https://user-images.githubusercontent.com/2205926/216215235-4dfc67c9-0096-427d-af96-e1e7377b68f9.png">

Signed-in teacher on dashboard, narrow width:
<img width="830" alt="Screenshot 2023-02-01 at 6 20 19 PM" src="https://user-images.githubusercontent.com/2205926/216215233-f4009224-e0f0-4ad1-bb7a-3d969018ca35.png">

Signed-out, full width:
<img width="1129" alt="Screenshot 2023-02-01 at 6 24 02 PM" src="https://user-images.githubusercontent.com/2205926/216215937-97848df9-f15b-4d79-aaf3-cf2d36e51c39.png">

Signed-out, narrow width:
<img width="833" alt="Screenshot 2023-02-01 at 6 25 17 PM" src="https://user-images.githubusercontent.com/2205926/216215932-6d329809-782c-4ec0-9890-a77f6b51dd15.png">

Signed-in student, full width:
<img width="1109" alt="Screenshot 2023-02-01 at 6 30 47 PM" src="https://user-images.githubusercontent.com/2205926/216216700-e2f9ffa0-0057-497f-8926-411ae4276c60.png">

Signed-in student, narrow width:
<img width="882" alt="Screenshot 2023-02-01 at 6 31 02 PM" src="https://user-images.githubusercontent.com/2205926/216216723-98496f66-55a1-4558-9a7c-9cee9b6d48c9.png">




