### PR TITLE
P20 31 fix gender input data

### DIFF
--- a/dashboard/app/controllers/followers_controller.rb
+++ b/dashboard/app/controllers/followers_controller.rb
@@ -41,7 +41,7 @@ class FollowersController < ApplicationController
       return
     else
       gender = params.dig(:user, :gender)
-      gender_input_type = gender_input_type?(request, session.id.to_s)
+      gender_input_type = gender_input_type?(request, session)
       Retryable.retryable on: [Mysql2::Error, ActiveRecord::RecordNotUnique], matching: /Duplicate entry/ do
         if @user.save && @section&.add_student(@user)
           SignUpTracking.log_gender_input_type_account_created(session, gender, gender_input_type, request.locale, 'section_signup', @user)

--- a/dashboard/app/controllers/followers_controller.rb
+++ b/dashboard/app/controllers/followers_controller.rb
@@ -44,7 +44,7 @@ class FollowersController < ApplicationController
       gender_input_type = gender_input_type?(request, session.id.to_s)
       Retryable.retryable on: [Mysql2::Error, ActiveRecord::RecordNotUnique], matching: /Duplicate entry/ do
         if @user.save && @section&.add_student(@user)
-          SignUpTracking.log_gender_input_type_account_created(session, gender, gender_input_type, request.locale, 'section_signup', @user.user_type)
+          SignUpTracking.log_gender_input_type_account_created(session, gender, gender_input_type, request.locale, 'section_signup', @user)
           sign_in(:user, @user)
           @user.increment_section_attempts
           # Check for an exiting user, and redirect to course if found

--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -123,7 +123,7 @@ class RegistrationsController < Devise::RegistrationsController
       storage_id = take_storage_id_ownership_from_cookie(current_user.id)
       current_user.generate_progress_from_storage_id(storage_id) if storage_id
       PartialRegistration.delete session
-      SignUpTracking.log_gender_input_type_account_created(session, gender, gender_input_type, request.locale, 'email_signup', current_user.user_type)
+      SignUpTracking.log_gender_input_type_account_created(session, gender, gender_input_type, request.locale, 'email_signup', current_user)
     end
 
     SignUpTracking.log_sign_up_result resource, session

--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -102,7 +102,7 @@ class RegistrationsController < Devise::RegistrationsController
   #
   def create
     gender = params.dig(:user, :gender)
-    gender_input_type = gender_input_type?(request, session.id.to_s)
+    gender_input_type = gender_input_type?(request, session)
 
     Retryable.retryable on: [Mysql2::Error, ActiveRecord::RecordNotUnique], matching: /Duplicate entry/ do |retries, exception|
       if retries > 0

--- a/dashboard/app/helpers/user/gender_experiment_helper.rb
+++ b/dashboard/app/helpers/user/gender_experiment_helper.rb
@@ -15,9 +15,7 @@ module User::GenderExperimentHelper
     country_code = request.params['country_code'] || location&.country_code.to_s
     # This experiment is limited to the US. 'RD' is the code returned for localhost.
     us_country = country_code && ['US', 'RD'].include?(country_code.upcase)
-    us_country &&
-      experiment_value('gender_input_exp') &&
-      gender_input_type?(request, session_id) != GENDER_INPUT_TYPE_NONE
+    us_country && experiment_value('gender_input_exp')
   end
 
   GENDER_INPUT_TYPE_NONE = 'none'

--- a/dashboard/app/helpers/user/gender_experiment_helper.rb
+++ b/dashboard/app/helpers/user/gender_experiment_helper.rb
@@ -36,9 +36,10 @@ module User::GenderExperimentHelper
   # }
   # With the above configuration, 50% of users will get the 'none' experience, 30% the 'dropdown'
   # experience, and 20% the 'text' experience.
-  # @param session_id {String} A hexadecimal number identifying the user's browser session
-  def gender_input_type?(request, session_id)
+  def gender_input_type?(request, session)
     return request.params['gender_input'] if request.params['gender_input'].present?
+    # If we have already determined the experience for the user, then show it again.
+    return session[:gender_input_type] if session[:gender_input_type]
     weights = experiment_value('gender_input_exp_weights', {})
     none_weight = weights[GENDER_INPUT_TYPE_NONE] || 0
     text_weight = weights[GENDER_INPUT_TYPE_TEXT] || 0
@@ -47,13 +48,15 @@ module User::GenderExperimentHelper
     # If there is no configuration, default to showing nothing.
     return GENDER_INPUT_TYPE_NONE if total_weight == 0
 
-    experience = session_id.to_i(16) % total_weight
-    if experience < text_weight
-      GENDER_INPUT_TYPE_TEXT
-    elsif  experience < (dropdown_weight + text_weight)
-      GENDER_INPUT_TYPE_DROPDOWN
-    else
-      GENDER_INPUT_TYPE_NONE
-    end
+    experience = Random.rand(total_weight)
+    gender_input_type = if experience < text_weight
+                          GENDER_INPUT_TYPE_TEXT
+                        elsif  experience < (dropdown_weight + text_weight)
+                          GENDER_INPUT_TYPE_DROPDOWN
+                        else
+                          GENDER_INPUT_TYPE_NONE
+                        end
+    # Save the experience for this session so it is the same if the user refreshes the page.
+    session[:gender_input_type] = gender_input_type
   end
 end

--- a/dashboard/app/views/devise/registrations/_finish_sign_up.html.haml
+++ b/dashboard/app/views/devise/registrations/_finish_sign_up.html.haml
@@ -98,7 +98,7 @@
         = f.select :age, age_options, include_blank: true
 
     - if ask_gender_experiment?(request, session.id.to_s)
-      - gender_input_type = gender_input_type?(request, session.id.to_s)
+      - gender_input_type = gender_input_type?(request, session)
       - SignUpTracking.log_gender_input_type_started(session, gender_input_type, request.locale, 'email_signup')
       - if gender_input_type != User::GenderExperimentHelper::GENDER_INPUT_TYPE_NONE
         .row#gender-dropdown{style: "display: none;"}

--- a/dashboard/app/views/followers/student_user_new.html.haml
+++ b/dashboard/app/views/followers/student_user_new.html.haml
@@ -82,7 +82,7 @@
                   = t('signup_form.age')
                 = f.select :age, User::AGE_DROPDOWN_OPTIONS, include_blank: true, class: 'fieldblock'
               - if ask_gender_experiment?(request, session.id.to_s)
-                - gender_input_type = gender_input_type?(request, session.id.to_s)
+                - gender_input_type = gender_input_type?(request, session)
                 - SignUpTracking.log_gender_input_type_started(session, gender_input_type, request.locale, 'section_signup')
                 - if gender_input_type != User::GenderExperimentHelper::GENDER_INPUT_TYPE_NONE
                   .itemblock

--- a/dashboard/lib/sign_up_tracking.rb
+++ b/dashboard/lib/sign_up_tracking.rb
@@ -157,7 +157,7 @@ module SignUpTracking
       :analysis,
       {
         study: 'gender-input-type',
-        study_group: 'v1',
+        study_group: 'v2',
         event: 'input_seen',
         data_string: session[:gender_input_uid],
         data_json: {
@@ -176,7 +176,7 @@ module SignUpTracking
       :analysis,
       {
         study: 'gender-input-type',
-        study_group: 'v1',
+        study_group: 'v2',
         event: 'account_created',
         data_string: session[:gender_input_uid],
         data_json: {

--- a/dashboard/lib/sign_up_tracking.rb
+++ b/dashboard/lib/sign_up_tracking.rb
@@ -185,12 +185,14 @@ module SignUpTracking
           locale: locale,
           flow: flow,
           user_type: user&.user_type,
-          age: user&.age
+          age: user&.age,
+          user_id: user&.id
         }.to_json
       }
     )
     # This is the last event for creating an account, so delete the tracking information.
     session.delete(:gender_input_uid)
     session.delete(:gender_input_uid_expiration)
+    session.delete(:gender_input_type)
   end
 end

--- a/dashboard/lib/sign_up_tracking.rb
+++ b/dashboard/lib/sign_up_tracking.rb
@@ -169,7 +169,7 @@ module SignUpTracking
     )
   end
 
-  def self.log_gender_input_type_account_created(session, gender, gender_input_type, locale, flow, user_type)
+  def self.log_gender_input_type_account_created(session, gender, gender_input_type, locale, flow, user)
     # Limit the gender to 100 characters, this should be sufficient for all languages.
     gender = gender&.truncate(100, omission: '')
     FirehoseClient.instance.put_record(
@@ -184,7 +184,8 @@ module SignUpTracking
           gender: gender,
           locale: locale,
           flow: flow,
-          user_type: user_type
+          user_type: user&.user_type,
+          age: user&.age
         }.to_json
       }
     )


### PR DESCRIPTION
This PR has a few bug fixes and feature requests for running the gender input experiment. It could be easier to review this PR by looking through each small commit.
* [Bug] Fixed an issue where the "none" experience was never logged to redshift
* [Feature] Logging the User's age and user_id to redshift.
* [Bug] Changing the experiment experience randomization to be based on a random number rather than the session ID because session ID wasn't resulting in an even, random distribution.
* [Feature] Starting a new user flow record whenever the user changes the way they are trying to create an account.
## Links
* [JIRA](https://codedotorg.atlassian.net/browse/P20-31)

## Testing story
* Manually tested through
  * http://localhost-studio.code.org:3000/join
  * http://localhost-studio.code.org:3000/users/sign_in