### PR TITLE
Set Dashboard & Pegasus domain names from CloudFormation Stack parameters

### DIFF
--- a/aws/cloudformation/bootstrap_chef_stack.sh.erb
+++ b/aws/cloudformation/bootstrap_chef_stack.sh.erb
@@ -12,7 +12,7 @@ BRANCH=${Branch}
 BASE_DOMAIN_NAME=${BaseDomainName}
 DASHBOARD_SUB_DOMAIN_NAME=${DashboardSubDomainName}
 PEGASUS_SUB_DOMAIN_NAME=${PegasusSubDomainName}
-# Bash and CloudFormation use the same string interpolation syntax. Escape "${" with "!" to ensure CloudFormation
+# Bash and CloudFormation use the same string interpolation syntax. Escape with "!" to ensure CloudFormation
 # does not modify the bash syntax.
 DASHBOARD_DOMAIN_NAME="${!DASHBOARD_SUB_DOMAIN_NAME}.${!BASE_DOMAIN_NAME}"
 # In production the fully qualified Pegasus domain name is just "code.org"; detect if the Pegasus sub domain is empty.

--- a/aws/cloudformation/bootstrap_chef_stack.sh.erb
+++ b/aws/cloudformation/bootstrap_chef_stack.sh.erb
@@ -12,7 +12,7 @@ BRANCH=${Branch}
 BASE_DOMAIN_NAME=${BaseDomainName}
 DASHBOARD_SUB_DOMAIN_NAME=${DashboardSubDomainName}
 PEGASUS_SUB_DOMAIN_NAME=${PegasusSubDomainName}
-# Bash and CloudFormation use the same string interpolation syntax. Escape "${" with "${!" to ensure CloudFormation
+# Bash and CloudFormation use the same string interpolation syntax. Escape "${" with "!" to ensure CloudFormation
 # does not modify the bash syntax.
 DASHBOARD_DOMAIN_NAME="${!DASHBOARD_SUB_DOMAIN_NAME}.${!BASE_DOMAIN_NAME}"
 # In production the fully qualified Pegasus domain name is just "code.org"; detect if the Pegasus sub domain is empty.

--- a/aws/cloudformation/bootstrap_chef_stack.sh.erb
+++ b/aws/cloudformation/bootstrap_chef_stack.sh.erb
@@ -4,10 +4,25 @@ unattended-upgrade
 apt-get -y install python3-pip curl
 test "$(pip3 show awscli)" || pip3 install awscli
 
+# Environment variables set via CloudFormation string substitution: !Sub encloses the output of this ERB template
+# https://github.com/code-dot-org/code-dot-org/blob/1f98f3403ff1f1f1c64b94eeb4c70c9584ae62aa/aws/cloudformation/cloud_formation_stack.yml.erb#L535-L543
 STACK=${AWS::StackName}
-CHEF_VERSION=<%=CHEF_VERSION%>
 REGION=${AWS::Region}
 BRANCH=${Branch}
+BASE_DOMAIN_NAME=${BaseDomainName}
+DASHBOARD_SUB_DOMAIN_NAME=${DashboardSubDomainName}
+PEGASUS_SUB_DOMAIN_NAME=${PegasusSubDomainName}
+# Bash and CloudFormation use the same string interpolation syntax. Escape "${" with "${!" to ensure CloudFormation
+# does not modify the bash syntax.
+DASHBOARD_DOMAIN_NAME="${!DASHBOARD_SUB_DOMAIN_NAME}.${!BASE_DOMAIN_NAME}"
+# In production the fully qualified Pegasus domain name is just "code.org"; detect if the Pegasus sub domain is empty.
+[ -z "$PEGASUS_SUB_DOMAIN_NAME" ] && PEGASUS_DOMAIN_NAME=$BASE_DOMAIN_NAME || PEGASUS_DOMAIN_NAME="${!PEGASUS_SUB_DOMAIN_NAME}.${!BASE_DOMAIN_NAME}"
+# TODO: Remove these debug statements.
+echo $PEGASUS_DOMAIN_NAME
+echo $DASHBOARD_DOMAIN_NAME
+
+# These environment variables are NOT set with CloudFormation string substitution.
+CHEF_VERSION=<%=CHEF_VERSION%>
 S3_BUCKET=<%=S3_BUCKET%>
 ENVIRONMENT=<%=environment%>
 RUN_LIST='<%=run_list.join(',')%>'

--- a/aws/cloudformation/bootstrap_chef_stack.sh.erb
+++ b/aws/cloudformation/bootstrap_chef_stack.sh.erb
@@ -17,9 +17,6 @@ PEGASUS_SUBDOMAIN_NAME=${PegasusSubdomainName}
 DASHBOARD_DOMAIN_NAME="${!DASHBOARD_SUBDOMAIN_NAME}.${!BASE_DOMAIN_NAME}"
 # In production the fully qualified Pegasus domain name is just "code.org"; detect if the Pegasus sub domain is empty.
 [ -z "$PEGASUS_SUBDOMAIN_NAME" ] && PEGASUS_DOMAIN_NAME=$BASE_DOMAIN_NAME || PEGASUS_DOMAIN_NAME="${!PEGASUS_SUBDOMAIN_NAME}.${!BASE_DOMAIN_NAME}"
-# TODO: Remove these debug statements.
-echo $PEGASUS_DOMAIN_NAME
-echo $DASHBOARD_DOMAIN_NAME
 
 # These environment variables are NOT set with CloudFormation string substitution.
 CHEF_VERSION=<%=CHEF_VERSION%>

--- a/aws/cloudformation/bootstrap_chef_stack.sh.erb
+++ b/aws/cloudformation/bootstrap_chef_stack.sh.erb
@@ -10,13 +10,13 @@ STACK=${AWS::StackName}
 REGION=${AWS::Region}
 BRANCH=${Branch}
 BASE_DOMAIN_NAME=${BaseDomainName}
-DASHBOARD_SUB_DOMAIN_NAME=${DashboardSubDomainName}
-PEGASUS_SUB_DOMAIN_NAME=${PegasusSubDomainName}
+DASHBOARD_SUBDOMAIN_NAME=${DashboardSubdomainName}
+PEGASUS_SUBDOMAIN_NAME=${PegasusSubdomainName}
 # Bash and CloudFormation use the same string interpolation syntax. Escape with "!" to ensure CloudFormation
 # does not modify the bash syntax.
-DASHBOARD_DOMAIN_NAME="${!DASHBOARD_SUB_DOMAIN_NAME}.${!BASE_DOMAIN_NAME}"
+DASHBOARD_DOMAIN_NAME="${!DASHBOARD_SUBDOMAIN_NAME}.${!BASE_DOMAIN_NAME}"
 # In production the fully qualified Pegasus domain name is just "code.org"; detect if the Pegasus sub domain is empty.
-[ -z "$PEGASUS_SUB_DOMAIN_NAME" ] && PEGASUS_DOMAIN_NAME=$BASE_DOMAIN_NAME || PEGASUS_DOMAIN_NAME="${!PEGASUS_SUB_DOMAIN_NAME}.${!BASE_DOMAIN_NAME}"
+[ -z "$PEGASUS_SUBDOMAIN_NAME" ] && PEGASUS_DOMAIN_NAME=$BASE_DOMAIN_NAME || PEGASUS_DOMAIN_NAME="${!PEGASUS_SUBDOMAIN_NAME}.${!BASE_DOMAIN_NAME}"
 # TODO: Remove these debug statements.
 echo $PEGASUS_DOMAIN_NAME
 echo $DASHBOARD_DOMAIN_NAME

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -8,11 +8,11 @@ Parameters:
     Description: Base domain name.
   DashboardSubDomainName:
     Type: String
-    Default: !Sub "<%=rack_env?(:production) ? 'studio' : 'studio-${AWS::StackName}' %>"
+    Default: !Sub "<%=rack_env?(:production) ? 'studio' : '#{stack_name}-studio' %>"
     Description: Sub domain name for learning platform ("Dashboard").
   PegasusSubDomainName:
     Type: String
-    Default: !Sub "<%=rack_env?(:production) ? '' : '${AWS::StackName}' %>"
+    Default: !Sub "<%=rack_env?(:production) ? '' : stack_name %>"
     Description: Sub domain name for corporate web site ("Pegasus").
   InstanceType:
     Type: String
@@ -23,7 +23,7 @@ Parameters:
 <% if database -%>
   DatabaseUsername:
     Type: String
-    Default: master
+    Default: masterzoom
     MaxLength: 16
   DBInstanceType:
     Type: String

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -6,11 +6,11 @@ Parameters:
     Type: String
     Default: code.org
     Description: Base domain name.
-  DashboardSubDomainName:
+  DashboardSubdomainName:
     Type: String
     Default: <%=rack_env?(:production) ? 'studio' : "#{stack_name}-studio" %>
     Description: Sub domain name for learning platform ("Dashboard").
-  PegasusSubDomainName:
+  PegasusSubdomainName:
     Type: String
     Default: <%=rack_env?(:production) ? '' : stack_name %>
     Description: Sub domain name for corporate web site ("Pegasus").

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -9,11 +9,11 @@ Parameters:
   DashboardSubdomainName:
     Type: String
     Default: <%=rack_env?(:production) ? 'studio' : "#{stack_name}-studio" %>
-    Description: Sub domain name for learning platform ("Dashboard").
+    Description: Subdomain name for learning platform ("Dashboard").
   PegasusSubdomainName:
     Type: String
     Default: <%=rack_env?(:production) ? '' : stack_name %>
-    Description: Sub domain name for corporate web site ("Pegasus").
+    Description: Subdomain name for corporate web site ("Pegasus").
   InstanceType:
     Type: String
     Default: <%=INSTANCE_TYPE%>

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -8,11 +8,11 @@ Parameters:
     Description: Base domain name.
   DashboardSubDomainName:
     Type: String
-    Default: !Sub "<%=rack_env?(:production) ? 'studio' : '#{stack_name}-studio' %>"
+    Default: <%=rack_env?(:production) ? 'studio' : "#{stack_name}-studio" %>
     Description: Sub domain name for learning platform ("Dashboard").
   PegasusSubDomainName:
     Type: String
-    Default: !Sub "<%=rack_env?(:production) ? '' : stack_name %>"
+    Default: <%=rack_env?(:production) ? '' : stack_name %>
     Description: Sub domain name for corporate web site ("Pegasus").
   InstanceType:
     Type: String

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -23,7 +23,7 @@ Parameters:
 <% if database -%>
   DatabaseUsername:
     Type: String
-    Default: masterzoom
+    Default: master
     MaxLength: 16
   DBInstanceType:
     Type: String

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -43,8 +43,6 @@ Parameters:
   ConsoleInstanceType:
     Type: String
 <% end -%>
-Conditions:
-  IsProductionCondition: !And [!Equals [!Ref BaseDomainName, "code.org"], !Equals [!Ref DashboardSubDomainName, "studio"]]
 Resources:
   # Stack-specific IAM permissions applied to both daemon and frontends.
   CDOPolicy:

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -2,6 +2,18 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: AWS CloudFormation Template for Code.org application
 Parameters:
+  BaseDomainName:
+    Type: String
+    Default: code.org
+    Description: Base domain name.
+  DashboardSubDomainName:
+    Type: String
+    Default: !Sub "<%=rack_env?(:production) ? 'studio' : 'studio-${AWS::StackName}' %>"
+    Description: Sub domain name for learning platform ("Dashboard").
+  PegasusSubDomainName:
+    Type: String
+    Default: !Sub "<%=rack_env?(:production) ? '' : '${AWS::StackName}' %>"
+    Description: Sub domain name for corporate web site ("Pegasus").
   InstanceType:
     Type: String
     Default: <%=INSTANCE_TYPE%>
@@ -31,6 +43,8 @@ Parameters:
   ConsoleInstanceType:
     Type: String
 <% end -%>
+Conditions:
+  IsProductionCondition: !And [!Equals [!Ref BaseDomainName, "code.org"], !Equals [!Ref DashboardSubDomainName, "studio"]]
 Resources:
   # Stack-specific IAM permissions applied to both daemon and frontends.
   CDOPolicy:


### PR DESCRIPTION
We currently use [complex Ruby logic](https://github.com/code-dot-org/code-dot-org/blob/45a0579327fcbf2614eefa7e442ed9a3ca6ba13f/lib/cdo/cloud_formation/cdo_app.rb#L105-L113) during execution of our Rake Stack (deployment) tasks and during execution of our continuous integration process (`aws/ci_build`) to determine the fully qualified domain names of each of the sites operated by the system being built (`test-studio.code.org` for Dashboard, `test.code.org` for Pegasus, `advocacy.test.code.org`, `test.hourofcode.com`, etc.).

Start specifying the system base domain and Pegasus / Dashboard sub-domains as CloudFormation Stack parameters and pass those values to the EC2 Instance UserData CloudInit script to configure the Ruby web application server.

This supports #49880 which in turn supports #48809 which in turn supports setting RDS Proxy database credentials.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

``` 
$ bundle exec rake adhoc:start RAILS_ENV=adhoc
```

Generates the following Stack parameters:

```
  BaseDomainName:
    Type: String
    Default: code.org
    Description: Base domain name.
  DashboardSubdomainName:
    Type: String
    Default: adhoc-set-domain-names-from-stack-parameters-studio
    Description: Subdomain name for learning platform ("Dashboard").
  PegasusSubdomainName:
    Type: String
    Default: adhoc-set-domain-names-from-stack-parameters
    Description: Sub domain name for corporate web site ("Pegasus").
```

Debug output from UserData / CloudInit script:

```
+ BASE_DOMAIN_NAME=code.org
+ DASHBOARD_SUBDOMAIN_NAME=adhoc-set-domain-names-from-stack-parameters-studio
+ PEGASUS_SUBDOMAIN_NAME=adhoc-set-domain-names-from-stack-parameters
+ DASHBOARD_DOMAIN_NAME=adhoc-set-domain-names-from-stack-parameters-studio.code.org
+ '[' -z adhoc-set-domain-names-from-stack-parameters ']'
+ PEGASUS_DOMAIN_NAME=adhoc-set-domain-names-from-stack-parameters.code.org
+ echo adhoc-set-domain-names-from-stack-parameters.code.org
adhoc-set-domain-names-from-stack-parameters.code.org
+ echo adhoc-set-domain-names-from-stack-parameters-studio.code.org
adhoc-set-domain-names-from-stack-parameters-studio.code.org
```

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
