### PR TITLE
Fix Violations of and Reenable `Rails/WhereEquals`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -281,11 +281,6 @@ Rails/SquishedSQLHeredocs:
 Rails/TimeZone:
   Enabled: false
 
-# Offense count: 16
-# This cop supports safe auto-correction (--auto-correct).
-Rails/WhereEquals:
-  Enabled: false
-
 # Offense count: 2
 Security/MarshalLoad:
   Enabled: false

--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -117,9 +117,9 @@ class LevelsController < ApplicationController
     # Gather filtered search results
     @levels = @levels.order(updated_at: :desc)
     @levels = @levels.where('levels.name LIKE ?', "%#{params[:name]}%").or(@levels.where('levels.level_num LIKE ?', "%#{params[:name]}%")) if params[:name]
-    @levels = @levels.where('levels.type = ?', params[:level_type]) if params[:level_type].present?
-    @levels = @levels.joins(:script_levels).where('script_levels.script_id = ?', params[:script_id]) if params[:script_id].present?
-    @levels = @levels.left_joins(:user).where('levels.user_id = ?', params[:owner_id]) if params[:owner_id].present?
+    @levels = @levels.where(levels: {type: params[:level_type]}) if params[:level_type].present?
+    @levels = @levels.joins(:script_levels).where(script_levels: {script_id: params[:script_id]}) if params[:script_id].present?
+    @levels = @levels.left_joins(:user).where(levels: {user_id: params[:owner_id]}) if params[:owner_id].present?
   end
 
   # GET /levels/1

--- a/dashboard/app/models/census/census_submission.rb
+++ b/dashboard/app/models/census/census_submission.rb
@@ -113,7 +113,7 @@ class Census::CensusSubmission < ApplicationRecord
   def self.unresolved_reported_inaccuracies
     left_joins(:census_inaccuracy_investigations).
       where(inaccuracy_reported: true).
-      where('census_inaccuracy_investigations.id is null')
+      where(census_inaccuracy_investigations: {id: nil})
   end
 
   def submitter_email_address=(value)

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -381,7 +381,7 @@ class Level < ApplicationRecord
 
   def self.where_we_want_to_calculate_ideal_level_source
     where.not(type: TYPES_WITHOUT_IDEAL_LEVEL_SOURCE).
-    where('ideal_level_source_id is null').
+    where(ideal_level_source_id: nil).
     to_a.reject {|level| level.try(:free_play)}
   end
 

--- a/dashboard/db/migrate/20131029225428_create_level_sources.rb
+++ b/dashboard/db/migrate/20131029225428_create_level_sources.rb
@@ -11,7 +11,7 @@ class CreateLevelSources < ActiveRecord::Migration[4.2]
 
     add_column :activities, :level_source_id, :int
 
-    Activity.where('level_source_id is null').includes(:level).find_each do |activity|
+    Activity.where(level_source_id: nil).includes(:level).find_each do |activity|
       activity.update!(level_source: LevelSource.find_identical_or_create(activity.level, activity.data))
     end
 

--- a/dashboard/db/migrate/20170308012502_add_contact_regional_partner_to_workshops.rb
+++ b/dashboard/db/migrate/20170308012502_add_contact_regional_partner_to_workshops.rb
@@ -2,7 +2,7 @@ class AddContactRegionalPartnerToWorkshops < ActiveRecord::Migration[5.0]
   def up
     # at time of creation, there are ~1500 PdWorkshops in the production
     # db, meaning that even this one-at-time migration should be just fine.
-    Pd::Workshop.where("regional_partner_id IS NULL").each do |workshop|
+    Pd::Workshop.where(regional_partner_id: nil).each do |workshop|
       partner = RegionalPartner.find_by_contact_id(workshop.organizer.id)
       next unless partner
 

--- a/dashboard/db/migrate/20170426010410_populate_pd_workshop_on_map_and_funded.rb
+++ b/dashboard/db/migrate/20170426010410_populate_pd_workshop_on_map_and_funded.rb
@@ -2,7 +2,7 @@ class PopulatePdWorkshopOnMapAndFunded < ActiveRecord::Migration[5.0]
   def up
     # at time of creation, there are ~1800 PdWorkshops in the production
     # db, meaning that even this one-at-time migration should be just fine.
-    Pd::Workshop.where("on_map IS NULL").each do |workshop|
+    Pd::Workshop.where(on_map: nil).each do |workshop|
       workshop.try(:set_on_map_and_funded_from_workshop_type)
       workshop.save
     end

--- a/dashboard/db/migrate/20170427221156_remove_pd_workshop_type.rb
+++ b/dashboard/db/migrate/20170427221156_remove_pd_workshop_type.rb
@@ -8,7 +8,7 @@ class RemovePdWorkshopType < ActiveRecord::Migration[5.0]
     add_column :pd_workshops, :workshop_type, :string, null: true
 
     # populate with derived data
-    Pd::Workshop.where("workshop_type IS NULL").each do |workshop|
+    Pd::Workshop.where(workshop_type: nil).each do |workshop|
       workshop.workshop_type =
         if workshop.funded
           workshop.on_map ? "Public" : "Private"

--- a/dashboard/db/migrate/20210907200327_convert_application_classes.rb
+++ b/dashboard/db/migrate/20210907200327_convert_application_classes.rb
@@ -22,11 +22,11 @@ class ConvertApplicationClasses < ActiveRecord::Migration[5.2]
         ActiveRecord::Base.transaction do
           Pd::Application::ApplicationBase.
             with_deleted.
-            where("type in (?)", TEACHER_APPLICATION_CLASSES.values).
+            where(type: TEACHER_APPLICATION_CLASSES.values).
             update_all(type: "Pd::Application::TeacherApplication")
           Pd::Application::ApplicationBase.
             with_deleted.
-            where("type in (?)", PRINCIPAL_APPROVAL_APPLICATION_CLASSES.values).
+            where(type: PRINCIPAL_APPROVAL_APPLICATION_CLASSES.values).
             update_all(type: "Pd::Application::PrincipalApprovalApplication")
         end
       end

--- a/dashboard/lib/queries/script_activity.rb
+++ b/dashboard/lib/queries/script_activity.rb
@@ -2,7 +2,7 @@ class Queries::ScriptActivity
   # Retrieve all scripts this user has started but not yet completed
   # return [Unit]
   def self.working_on_units(user)
-    user.scripts.where('user_scripts.completed_at is null').map(&:cached).select(&:launched?)
+    user.scripts.where(user_scripts: {completed_at: nil}).map(&:cached).select(&:launched?)
   end
 
   # Retrieve all scripts this user has started but not yet completed
@@ -24,7 +24,7 @@ class Queries::ScriptActivity
   #
   # return [UserScript]
   def self.working_on_user_scripts(user)
-    user.user_scripts.where('user_scripts.completed_at is null')
+    user.user_scripts.where(user_scripts: {completed_at: nil})
   end
 
   # Retrieve all UserScripts for scripts this user has completed

--- a/dashboard/lib/services/registration_reminder.rb
+++ b/dashboard/lib/services/registration_reminder.rb
@@ -27,7 +27,7 @@ class Services::RegistrationReminder
     # Not enrolled in a workshop since the 'accepted' email was sent
     applications_awaiting_enrollment.
       where("accepted.sent_at <= ?", 1.week.ago).
-      where("registration_reminder.id is null")
+      where(registration_reminder: {id: nil})
   end
 
   # Locate all applications that are eligible to receive their second workshop registration
@@ -68,7 +68,7 @@ class Services::RegistrationReminder
         and pd_enrollments.created_at >= accepted.sent_at
       SQL
       where("pd_applications.created_at >= ?", REMINDER_START_DATE).
-      where('pd_enrollments.id is null').
+      where(pd_enrollments: {id: nil}).
       distinct
   end
 end

--- a/dashboard/scripts/ideal_level_sources_to_test_json.rb
+++ b/dashboard/scripts/ideal_level_sources_to_test_json.rb
@@ -12,7 +12,7 @@ LEVEL_TYPES_WITH_ILS = %w(Craft Studio Karel Eval Maze Calc Blockly StudioEC Art
 
 def main
   levels_to_test = Level.
-      where('type in (?)', LEVEL_TYPES_WITH_ILS).
+      where(type: LEVEL_TYPES_WITH_ILS).
       where.not(ideal_level_source_id: nil).
       all.reject {|level| level.try(:free_play) || !level.is_a?(Blockly) || !level.custom?}
 


### PR DESCRIPTION
Fix applied automatically with `bundle exec rubocop --auto-correct-all --only Rails/WhereEquals`. I then reran `bundle exec rubocop --auto-correct` to automatically fix up some introduced formatting problems.

> This cop identifies places where manually constructed SQL in `where` can be replaced with `where(attribute: value)`.
>
> This cop’s autocorrection is unsafe because is may change SQL. See: https://github.com/rubocop/rubocop-rails/issues/403

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->
- https://docs.rubocop.org/rubocop-rails/cops_rails.html#railswhereequals
- https://www.rubydoc.info/gems/rubocop-rails/2.9.1/RuboCop/Cop/Rails/WhereEquals

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
