### PR TITLE
Fix Violations of and Reenable `Style/CaseLikeIf`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -296,11 +296,6 @@ Security/MarshalLoad:
 Style/AccessModifierDeclarations:
   Enabled: false
 
-# Offense count: 62
-# This cop supports unsafe auto-correction (--auto-correct-all).
-Style/CaseLikeIf:
-  Enabled: false
-
 # Offense count: 27
 # This cop supports safe auto-correction (--auto-correct).
 # Configuration parameters: IgnoredMethods.

--- a/bin/i18n/sync-in.rb
+++ b/bin/i18n/sync-in.rb
@@ -235,10 +235,11 @@ end
 def get_i18n_strings(level)
   i18n_strings = {}
 
-  if level.is_a?(DSLDefined)
+  case level
+  when DSLDefined
     text = level.dsl_text
     i18n_strings["dsls"] = level.class.dsl_class.parse(text, '')[1] if text
-  elsif level.is_a?(Level)
+  when Level
     %w(
       display_name
       bubble_choice_description

--- a/bin/oneoff/backfill_data/backfill_scholarship_course
+++ b/bin/oneoff/backfill_data/backfill_scholarship_course
@@ -26,9 +26,10 @@ def course_from_current_teacher_lsw_enrollment(si)
       puts "user #{si.user_id} new facilitator, app #{Pd::Application::Facilitator1920Application.find_by(user_id: si.user_id).id}"
       next
     end
-    if e.workshop.course == "CS Discoveries"
+    case e.workshop.course
+    when 'CS Discoveries'
       course = 'csd'
-    elsif e.workshop.course == 'CS Principles'
+    when 'CS Principles'
       course = 'csp'
     end
     break

--- a/bin/oneoff/backfill_data/principalapproval1920_application_pay_fee_changes.rb
+++ b/bin/oneoff/backfill_data/principalapproval1920_application_pay_fee_changes.rb
@@ -11,9 +11,10 @@ ActiveRecord::Base.transaction do
     print '.'
     pay_fee = application.form_data_hash["payFee"]
 
-    if pay_fee == 'Yes, my school or teacher will be able to pay the full program fee.'
+    case pay_fee
+    when 'Yes, my school or teacher will be able to pay the full program fee.'
       new_pay_fee = 'Yes, my school will be able to pay the full program fee.'
-    elsif pay_fee == 'No, my school or teacher will not be able to pay the program fee. We would like to be considered for a scholarship.'
+    when 'No, my school or teacher will not be able to pay the program fee. We would like to be considered for a scholarship.'
       new_pay_fee = 'No, my school will not be able to pay the program fee. We would like to be considered for a scholarship.'
     else
       next

--- a/bin/oneoff/backfill_data/teacher1920_application_pay_fee_changes
+++ b/bin/oneoff/backfill_data/teacher1920_application_pay_fee_changes
@@ -9,13 +9,14 @@ Pd::Application::TeacherApplication.find_each do |application|
   print '.'
   pay_fee = application.form_data_hash["payFee"]
 
-  if pay_fee == 'Yes, my school or I will be able to pay the full program fee.'
+  case pay_fee
+  when 'Yes, my school or I will be able to pay the full program fee.'
     new_pay_fee = 'Yes, my school will be able to pay the full program fee.'
-  elsif pay_fee == 'No, my school or I will not be able to pay the program fee. I would like to be considered for a scholarship.'
+  when 'No, my school or I will not be able to pay the program fee. I would like to be considered for a scholarship.'
     new_pay_fee = 'No, my school will not be able to pay the program fee. I would like to be considered for a scholarship.'
-  elsif pay_fee == 'Not applicable: there is no program fee for teachers in my region.'
+  when 'Not applicable: there is no program fee for teachers in my region.'
     new_pay_fee = nil
-  elsif pay_fee == 'Not applicable: there is no Regional Partner in my region.'
+  when 'Not applicable: there is no Regional Partner in my region.'
     new_pay_fee = nil
   else
     next

--- a/bin/oneoff/data_fix/fix_bad_school_info_in_users
+++ b/bin/oneoff/data_fix/fix_bad_school_info_in_users
@@ -75,9 +75,10 @@ CSV.open(csv_file, 'w') do |csv|
     users = User.where("user_type = 'teacher' AND school_info_id = ?", school_info_id)
     next unless users.with_deleted.count > 1
 
-    if options[:deleted_filter].eql?('WITH')
+    case options[:deleted_filter]
+    when 'WITH'
       users = users.with_deleted
-    elsif options[:deleted_filter].eql?('ONLY')
+    when 'ONLY'
       users = users.only_deleted
     end
 

--- a/dashboard/app/controllers/api/v1/regional_partners_controller.rb
+++ b/dashboard/app/controllers/api/v1/regional_partners_controller.rb
@@ -87,9 +87,10 @@ class Api::V1::RegionalPartnersController < ApplicationController
     unless ['none', 'all'].include? regional_partner_value
       partner_id = regional_partner_value ? regional_partner_value : current_user.regional_partners.first
       regional_partner = RegionalPartner.find_by(id: partner_id)
-      if role == 'csd_teachers'
+      case role
+      when 'csd_teachers'
         return regional_partner&.cohort_capacity_csd
-      elsif role == 'csp_teachers'
+      when 'csp_teachers'
         return regional_partner&.cohort_capacity_csp
       end
     end

--- a/dashboard/app/controllers/api/v1/sections_controller.rb
+++ b/dashboard/app/controllers/api/v1/sections_controller.rb
@@ -277,14 +277,15 @@ class Api::V1::SectionsController < Api::V1::JSONApiController
       course_version = CourseVersion.find_by_id(params[:course_version_id])
       return head :bad_request unless course_version
 
-      if course_version.content_root_type == 'UnitGroup'
+      case course_version.content_root_type
+      when 'UnitGroup'
         course_id = course_version.content_root_id
         @course = UnitGroup.get_from_cache(course_id)
         return head :bad_request unless @course
         return head :forbidden unless @course.course_assignable?(current_user)
         @unit = params[:unit_id] ? Unit.get_from_cache(params[:unit_id]) : nil
         return head :bad_request if @unit && @course.id != @unit.unit_group.try(:id)
-      elsif course_version.content_root_type == 'Unit'
+      when 'Unit'
         unit_id = course_version.content_root_id
         @unit = Unit.get_from_cache(unit_id)
         return head :bad_request unless @unit

--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -186,12 +186,13 @@ class RegistrationsController < Devise::RegistrationsController
 
   def sign_up_params
     super.tap do |params|
-      if params[:user_type] == "teacher"
+      case params[:user_type]
+      when 'teacher'
         params[:email_preference_opt_in_required] = true
         params[:email_preference_request_ip] = request.ip
         params[:email_preference_source] = EmailPreference::ACCOUNT_SIGN_UP
         params[:email_preference_form_kind] = "0"
-      elsif params[:user_type] == "student"
+      when 'student'
         params[:parent_email_preference_request_ip] = request.ip
         params[:parent_email_preference_source] = EmailPreference::ACCOUNT_SIGN_UP
       end

--- a/dashboard/app/controllers/sms_controller.rb
+++ b/dashboard/app/controllers/sms_controller.rb
@@ -40,10 +40,11 @@ class SmsController < ApplicationController
     )
     head :ok
   rescue Twilio::REST::RestError => e
-    if /The message From\/To pair violates a blacklist rule./.match?(e.message)
+    case e.message
+    when /The message From\/To pair violates a blacklist rule./
       # recipient unsubscribed from twilio, pretend it succeeded
       head :ok
-    elsif /The \'To\' number .* is not a valid phone number\./.match?(e.message)
+    when /The \'To\' number .* is not a valid phone number\./
       head :bad_request
     else
       raise

--- a/dashboard/app/models/concerns/curriculum/course_types.rb
+++ b/dashboard/app/models/concerns/curriculum/course_types.rb
@@ -64,11 +64,12 @@ module Curriculum::CourseTypes
     return false if user.student?
     return true if user.permission?(UserPermission::UNIVERSAL_INSTRUCTOR) || user.permission?(UserPermission::LEVELBUILDER)
 
-    if instructor_audience == 'plc_reviewer'
+    case instructor_audience
+    when 'plc_reviewer'
       return user.permission?(UserPermission::PLC_REVIEWER)
-    elsif instructor_audience == 'facilitator'
+    when 'facilitator'
       return user.permission?(UserPermission::FACILITATOR)
-    elsif instructor_audience == 'teacher'
+    when 'teacher'
       return user.teacher?
     end
 
@@ -87,11 +88,12 @@ module Curriculum::CourseTypes
     return false if !user && participant_audience != 'student'
     return false if can_be_instructor?(user)
 
-    if participant_audience == 'facilitator'
+    case participant_audience
+    when 'facilitator'
       return user.permission?(UserPermission::FACILITATOR)
-    elsif participant_audience == 'teacher'
+    when 'teacher'
       return user.teacher?
-    elsif participant_audience == 'student'
+    when 'student'
       return true #if participant audience is student let anyone join
     end
 

--- a/dashboard/app/models/levels/blockly.rb
+++ b/dashboard/app/models/levels/blockly.rb
@@ -187,14 +187,15 @@ class Blockly < Level
     default_category = category_node = Nokogiri::XML("<category name='Default'>").child
     xml.child << default_category
     xml.xpath('/xml/block').each do |block|
-      if block.attr('type') == 'category'
+      case block.attr('type')
+      when 'category'
         category_name = block.xpath(tag).text
         category_node = Nokogiri::XML("<category name='#{category_name}'>").child
         category_node['custom'] = 'PROCEDURE' if category_name == 'Functions'
         category_node['custom'] = 'VARIABLE' if category_name == 'Variables'
         xml.child << category_node
         block.remove
-      elsif block.attr('type') == 'custom_category'
+      when 'custom_category'
         custom_type = block.xpath(tag).text
         category_name = CATEGORY_CUSTOM_NAMES[custom_type.to_sym]
         category_node = Nokogiri::XML("<category name='#{category_name}'>").child

--- a/dashboard/app/models/pd/application/application_base.rb
+++ b/dashboard/app/models/pd/application/application_base.rb
@@ -236,9 +236,10 @@ module Pd::Application
     def self.answer_with_additional_text(hash, field_name, option = OTHER_WITH_TEXT, additional_text_field_name = nil)
       additional_text_field_name ||= "#{field_name}_other".to_sym
       answer = hash[field_name]
-      if answer.is_a? String
+      case answer
+      when String
         answer = [option, hash[additional_text_field_name]].flatten.join(' ') if answer == option
-      elsif answer.is_a? Array
+      when Array
         index = answer.index(option)
         answer[index] = [option, hash[additional_text_field_name]].flatten.join(' ') if index
       end

--- a/dashboard/app/models/pd/application/teacher_application.rb
+++ b/dashboard/app/models/pd/application/teacher_application.rb
@@ -789,7 +789,8 @@ module Pd::Application
     # memoize in a hash, per course
     FILTERED_LABELS = Hash.new do |h, key|
       labels_to_remove = (
-      if key == 'csd'
+      case key
+      when 'csd'
         [
           :csp_which_grades,
           :csp_how_offer,
@@ -799,7 +800,7 @@ module Pd::Application
           :csa_already_know,
           :csa_phone_screen
         ]
-      elsif key == 'csp'
+      when 'csp'
         [
           :csd_which_grades,
           :csa_which_grades,
@@ -807,7 +808,7 @@ module Pd::Application
           :csa_already_know,
           :csa_phone_screen
         ]
-      elsif key == 'csa'
+      when 'csa'
         [
           :csp_which_grades,
           :csp_how_offer,
@@ -834,7 +835,8 @@ module Pd::Application
 
     # List of columns to be filtered out based on selected program (course)
     def self.columns_to_remove(course)
-      if course == 'csd'
+      case course
+      when 'csd'
         {
           teacher: [
             :csp_which_grades,
@@ -850,7 +852,7 @@ module Pd::Application
             :csa_implementation
           ]
         }
-      elsif course == 'csp'
+      when 'csp'
         {
           teacher: [
             :csd_which_grades,
@@ -864,7 +866,7 @@ module Pd::Application
             :csa_implementation
           ]
         }
-      elsif course == 'csa'
+      when 'csa'
         {
           teacher: [
             :csp_which_grades,
@@ -982,19 +984,20 @@ module Pd::Application
       end
 
       # Section 6
-      if course == 'csd'
+      case course
+      when 'csd'
         meets_minimum_criteria_scores[:csd_which_grades] =
           (responses[:csd_which_grades] & options[:csd_which_grades].first(5)).any? ? YES : NO
         took_csd_course =
           responses[:previous_yearlong_cdo_pd].include?('CS Discoveries')
         meets_minimum_criteria_scores[:previous_yearlong_cdo_pd] = took_csd_course ? NO : YES
-      elsif course == 'csp'
+      when 'csp'
         meets_minimum_criteria_scores[:csp_which_grades] =
           (responses[:csp_which_grades] & options[:csp_which_grades].first(4)).any? ? YES : NO
         took_csp_course =
           responses[:previous_yearlong_cdo_pd].include?('CS Principles')
         meets_minimum_criteria_scores[:previous_yearlong_cdo_pd] = took_csp_course ? NO : YES
-      elsif course == 'csa'
+      when 'csa'
         meets_minimum_criteria_scores[:csa_which_grades] =
           (responses[:csa_which_grades] & options[:csa_which_grades].first(4)).any? ? YES : NO
         took_csa_course = responses[:previous_yearlong_cdo_pd].include?('Computer Science A (CSA)')

--- a/dashboard/app/models/pd/international_opt_in.rb
+++ b/dashboard/app/models/pd/international_opt_in.rb
@@ -125,15 +125,16 @@ class Pd::InternationalOptIn < ApplicationRecord
   # @override
   def dynamic_required_fields(hash)
     [].tap do |required|
-      if hash[:school_country] == "Colombia"
+      case hash[:school_country]
+      when 'Colombia'
         required << :school_department
         required << :school_municipality
         required << :school_city
-      elsif hash[:school_country] == "Chile"
+      when 'Chile'
         required << :school_department
         required << :school_commune
         required << :school_id
-      elsif hash[:school_country] == "Uzbekistan"
+      when 'Uzbekistan'
         required << :school_department
         required << :school_municipality
       else

--- a/dashboard/app/models/school_info.rb
+++ b/dashboard/app/models/school_info.rb
@@ -265,11 +265,12 @@ class SchoolInfo < ApplicationRecord
   def validate_school_district_without_country
     return if school_type == SCHOOL_TYPE_CHARTER && zip.present?
     return if school_type == SCHOOL_TYPE_PRIVATE && zip.present?
-    if school_type == SCHOOL_TYPE_PUBLIC
+    case school_type
+    when SCHOOL_TYPE_PUBLIC
       return if state == SCHOOL_STATE_OTHER
       return if state.present? && school_district_id.present?
       return if state.present? && school_district_id.blank? && school_district_other.present?
-    elsif school_type == SCHOOL_TYPE_OTHER
+    when SCHOOL_TYPE_OTHER
       return if state == SCHOOL_STATE_OTHER
       return if state.present? && school_district_id.present?
       return if state.present? && school_district_id.blank? && school_district_other.present?

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -701,16 +701,17 @@ class ScriptLevel < ApplicationRecord
         # Java Lab levels use levels rather than projects as their example, so the URL is much more clearly
         # defined and is directly set on the level. Because of this, the value of "example" is already in its
         # final state - a string representation of the URL of the exemplar level: studio.code.org/s/<course>/...
-        if level.is_a?(Dancelab)
+        case level
+        when Dancelab
           send("#{'dance'}_project_view_projects_url".to_sym, channel_id: example, host: 'studio.code.org', port: 443, protocol: :https)
-        elsif level.is_a?(Poetry)
+        when Poetry
           send("#{level.standalone_app_name}_project_view_projects_url".to_sym, channel_id: example, host: 'studio.code.org', port: 443, protocol: :https)
-        elsif level.is_a?(GamelabJr)
+        when GamelabJr
           send("#{level.standalone_app_name_or_default}_project_view_projects_url".to_sym, channel_id: example, host: 'studio.code.org', port: 443, protocol: :https)
-        elsif level.is_a?(Artist)
+        when Artist
           artist_type = ['elsa', 'anna'].include?(level.skin) ? 'frozen' : 'artist'
           send("#{artist_type}_project_view_projects_url".to_sym, channel_id: example, host: 'studio.code.org', port: 443, protocol: :https)
-        elsif level.is_a?(Studio) # playlab
+        when Studio # playlab
           send("#{'playlab'}_project_view_projects_url".to_sym, channel_id: example, host: 'studio.code.org', port: 443, protocol: :https)
         else
           send("#{level.game.app}_project_view_projects_url".to_sym, channel_id: example, host: 'studio.code.org', port: 443, protocol: :https)

--- a/dashboard/app/models/user_proficiency.rb
+++ b/dashboard/app/models/user_proficiency.rb
@@ -77,124 +77,135 @@ class UserProficiency < ApplicationRecord
   # @return [Integer] the number of levels the user has passed with the
   #   specified concept and the specified difficulty or higher.
   def get_level_count(concept, difficulty)
-    if concept == ConceptDifficulties::SEQUENCING
-      if difficulty == 1
+    case concept
+    when ConceptDifficulties::SEQUENCING
+      case difficulty
+      when 1
         return sequencing_d1_count + sequencing_d2_count + sequencing_d3_count + sequencing_d4_count + sequencing_d5_count
-      elsif difficulty == 2
+      when 2
         return sequencing_d2_count + sequencing_d3_count + sequencing_d4_count + sequencing_d5_count
-      elsif difficulty == 3
+      when 3
         return sequencing_d3_count + sequencing_d4_count + sequencing_d5_count
-      elsif difficulty == 4
+      when 4
         return sequencing_d4_count + sequencing_d5_count
-      elsif difficulty == 5
+      when 5
         return sequencing_d5_count
       end
-    elsif concept == ConceptDifficulties::DEBUGGING
-      if difficulty == 1
+    when ConceptDifficulties::DEBUGGING
+      case difficulty
+      when 1
         return debugging_d1_count + debugging_d2_count + debugging_d3_count + debugging_d4_count + debugging_d5_count
-      elsif difficulty == 2
+      when 2
         return debugging_d2_count + debugging_d3_count + debugging_d4_count + debugging_d5_count
-      elsif difficulty == 3
+      when 3
         return debugging_d3_count + debugging_d4_count + debugging_d5_count
-      elsif difficulty == 4
+      when 4
         return debugging_d4_count + debugging_d5_count
-      elsif difficulty == 5
+      when 5
         return debugging_d5_count
       end
-    elsif concept == ConceptDifficulties::REPEAT_LOOPS
-      if difficulty == 1
+    when ConceptDifficulties::REPEAT_LOOPS
+      case difficulty
+      when 1
         return repeat_loops_d1_count + repeat_loops_d2_count + repeat_loops_d3_count + repeat_loops_d4_count + repeat_loops_d5_count
-      elsif difficulty == 2
+      when 2
         return repeat_loops_d2_count + repeat_loops_d3_count + repeat_loops_d4_count + repeat_loops_d5_count
-      elsif difficulty == 3
+      when 3
         return repeat_loops_d3_count + repeat_loops_d4_count + repeat_loops_d5_count
-      elsif difficulty == 4
+      when 4
         return repeat_loops_d4_count + repeat_loops_d5_count
-      elsif difficulty == 5
+      when 5
         return repeat_loops_d5_count
       end
-    elsif concept == ConceptDifficulties::REPEAT_UNTIL_WHILE
-      if difficulty == 1
+    when ConceptDifficulties::REPEAT_UNTIL_WHILE
+      case difficulty
+      when 1
         return repeat_until_while_d1_count + repeat_until_while_d2_count + repeat_until_while_d3_count + repeat_until_while_d4_count + repeat_until_while_d5_count
-      elsif difficulty == 2
+      when 2
         return repeat_until_while_d2_count + repeat_until_while_d3_count + repeat_until_while_d4_count + repeat_until_while_d5_count
-      elsif difficulty == 3
+      when 3
         return repeat_until_while_d3_count + repeat_until_while_d4_count + repeat_until_while_d5_count
-      elsif difficulty == 4
+      when 4
         return repeat_until_while_d4_count + repeat_until_while_d5_count
-      elsif difficulty == 5
+      when 5
         return repeat_until_while_d5_count
       end
-    elsif concept == ConceptDifficulties::FOR_LOOPS
-      if difficulty == 1
+    when ConceptDifficulties::FOR_LOOPS
+      case difficulty
+      when 1
         return for_loops_d1_count + for_loops_d2_count + for_loops_d3_count + for_loops_d4_count + for_loops_d5_count
-      elsif difficulty == 2
+      when 2
         return for_loops_d2_count + for_loops_d3_count + for_loops_d4_count + for_loops_d5_count
-      elsif difficulty == 3
+      when 3
         return for_loops_d3_count + for_loops_d4_count + for_loops_d5_count
-      elsif difficulty == 4
+      when 4
         return for_loops_d4_count + for_loops_d5_count
-      elsif difficulty == 5
+      when 5
         return for_loops_d5_count
       end
-    elsif concept == ConceptDifficulties::EVENTS
-      if difficulty == 1
+    when ConceptDifficulties::EVENTS
+      case difficulty
+      when 1
         return events_d1_count + events_d2_count + events_d3_count + events_d4_count + events_d5_count
-      elsif difficulty == 2
+      when 2
         return events_d2_count + events_d3_count + events_d4_count + events_d5_count
-      elsif difficulty == 3
+      when 3
         return events_d3_count + events_d4_count + events_d5_count
-      elsif difficulty == 4
+      when 4
         return events_d4_count + events_d5_count
-      elsif difficulty == 5
+      when 5
         return events_d5_count
       end
-    elsif concept == ConceptDifficulties::VARIABLES
-      if difficulty == 1
+    when ConceptDifficulties::VARIABLES
+      case difficulty
+      when 1
         return variables_d1_count + variables_d2_count + variables_d3_count + variables_d4_count + variables_d5_count
-      elsif difficulty == 2
+      when 2
         return variables_d2_count + variables_d3_count + variables_d4_count + variables_d5_count
-      elsif difficulty == 3
+      when 3
         return variables_d3_count + variables_d4_count + variables_d5_count
-      elsif difficulty == 4
+      when 4
         return variables_d4_count + variables_d5_count
-      elsif difficulty == 5
+      when 5
         return variables_d5_count
       end
-    elsif concept == ConceptDifficulties::FUNCTIONS
-      if difficulty == 1
+    when ConceptDifficulties::FUNCTIONS
+      case difficulty
+      when 1
         return functions_d1_count + functions_d2_count + functions_d3_count + functions_d4_count + functions_d5_count
-      elsif difficulty == 2
+      when 2
         return functions_d2_count + functions_d3_count + functions_d4_count + functions_d5_count
-      elsif difficulty == 3
+      when 3
         return functions_d3_count + functions_d4_count + functions_d5_count
-      elsif difficulty == 4
+      when 4
         return functions_d4_count + functions_d5_count
-      elsif difficulty == 5
+      when 5
         return functions_d5_count
       end
-    elsif concept == ConceptDifficulties::FUNCTIONS_WITH_PARAMS
-      if difficulty == 1
+    when ConceptDifficulties::FUNCTIONS_WITH_PARAMS
+      case difficulty
+      when 1
         return functions_with_params_d1_count + functions_with_params_d2_count + functions_with_params_d3_count + functions_with_params_d4_count + functions_with_params_d5_count
-      elsif difficulty == 2
+      when 2
         return functions_with_params_d2_count + functions_with_params_d3_count + functions_with_params_d4_count + functions_with_params_d5_count
-      elsif difficulty == 3
+      when 3
         return functions_with_params_d3_count + functions_with_params_d4_count + functions_with_params_d5_count
-      elsif difficulty == 4
+      when 4
         return functions_with_params_d4_count + functions_with_params_d5_count
-      elsif difficulty == 5
+      when 5
         return functions_with_params_d5_count
       end
-    elsif concept == ConceptDifficulties::CONDITIONALS
-      if difficulty == 1
+    when ConceptDifficulties::CONDITIONALS
+      case difficulty
+      when 1
         return conditionals_d1_count + conditionals_d2_count + conditionals_d3_count + conditionals_d4_count + conditionals_d5_count
-      elsif difficulty == 2
+      when 2
         return conditionals_d2_count + conditionals_d3_count + conditionals_d4_count + conditionals_d5_count
-      elsif difficulty == 3
+      when 3
         return conditionals_d3_count + conditionals_d4_count + conditionals_d5_count
-      elsif difficulty == 4
+      when 4
         return conditionals_d4_count + conditionals_d5_count
-      elsif difficulty == 5
+      when 5
         return conditionals_d5_count
       end
     end
@@ -207,124 +218,135 @@ class UserProficiency < ApplicationRecord
   # @param concept [String] the concept to increment.
   # @param difficulty [Integer] the difficulty level to increment.
   def increment_level_count(concept, difficulty)
-    if concept == ConceptDifficulties::SEQUENCING
-      if difficulty == 1
+    case concept
+    when ConceptDifficulties::SEQUENCING
+      case difficulty
+      when 1
         self.sequencing_d1_count += 1
-      elsif difficulty == 2
+      when 2
         self.sequencing_d2_count += 1
-      elsif difficulty == 3
+      when 3
         self.sequencing_d3_count += 1
-      elsif difficulty == 4
+      when 4
         self.sequencing_d4_count += 1
-      elsif difficulty == 5
+      when 5
         self.sequencing_d5_count += 1
       end
-    elsif concept == ConceptDifficulties::DEBUGGING
-      if difficulty == 1
+    when ConceptDifficulties::DEBUGGING
+      case difficulty
+      when 1
         self.debugging_d1_count += 1
-      elsif difficulty == 2
+      when 2
         self.debugging_d2_count += 1
-      elsif difficulty == 3
+      when 3
         self.debugging_d3_count += 1
-      elsif difficulty == 4
+      when 4
         self.debugging_d4_count += 1
-      elsif difficulty == 5
+      when 5
         self.debugging_d5_count += 1
       end
-    elsif concept == ConceptDifficulties::REPEAT_LOOPS
-      if difficulty == 1
+    when ConceptDifficulties::REPEAT_LOOPS
+      case difficulty
+      when 1
         self.repeat_loops_d1_count += 1
-      elsif difficulty == 2
+      when 2
         self.repeat_loops_d2_count += 1
-      elsif difficulty == 3
+      when 3
         self.repeat_loops_d3_count += 1
-      elsif difficulty == 4
+      when 4
         self.repeat_loops_d4_count += 1
-      elsif difficulty == 5
+      when 5
         self.repeat_loops_d5_count += 1
       end
-    elsif concept == ConceptDifficulties::REPEAT_UNTIL_WHILE
-      if difficulty == 1
+    when ConceptDifficulties::REPEAT_UNTIL_WHILE
+      case difficulty
+      when 1
         self.repeat_until_while_d1_count += 1
-      elsif difficulty == 2
+      when 2
         self.repeat_until_while_d2_count += 1
-      elsif difficulty == 3
+      when 3
         self.repeat_until_while_d3_count += 1
-      elsif difficulty == 4
+      when 4
         self.repeat_until_while_d4_count += 1
-      elsif difficulty == 5
+      when 5
         self.repeat_until_while_d5_count += 1
       end
-    elsif concept == ConceptDifficulties::FOR_LOOPS
-      if difficulty == 1
+    when ConceptDifficulties::FOR_LOOPS
+      case difficulty
+      when 1
         self.for_loops_d1_count += 1
-      elsif difficulty == 2
+      when 2
         self.for_loops_d2_count += 1
-      elsif difficulty == 3
+      when 3
         self.for_loops_d3_count += 1
-      elsif difficulty == 4
+      when 4
         self.for_loops_d4_count += 1
-      elsif difficulty == 5
+      when 5
         self.for_loops_d5_count += 1
       end
-    elsif concept == ConceptDifficulties::EVENTS
-      if difficulty == 1
+    when ConceptDifficulties::EVENTS
+      case difficulty
+      when 1
         self.events_d1_count += 1
-      elsif difficulty == 2
+      when 2
         self.events_d2_count += 1
-      elsif difficulty == 3
+      when 3
         self.events_d3_count += 1
-      elsif difficulty == 4
+      when 4
         self.events_d4_count += 1
-      elsif difficulty == 5
+      when 5
         self.events_d5_count += 1
       end
-    elsif concept == ConceptDifficulties::VARIABLES
-      if difficulty == 1
+    when ConceptDifficulties::VARIABLES
+      case difficulty
+      when 1
         self.variables_d1_count += 1
-      elsif difficulty == 2
+      when 2
         self.variables_d2_count += 1
-      elsif difficulty == 3
+      when 3
         self.variables_d3_count += 1
-      elsif difficulty == 4
+      when 4
         self.variables_d4_count += 1
-      elsif difficulty == 5
+      when 5
         self.variables_d5_count += 1
       end
-    elsif concept == ConceptDifficulties::FUNCTIONS
-      if difficulty == 1
+    when ConceptDifficulties::FUNCTIONS
+      case difficulty
+      when 1
         self.functions_d1_count += 1
-      elsif difficulty == 2
+      when 2
         self.functions_d2_count += 1
-      elsif difficulty == 3
+      when 3
         self.functions_d3_count += 1
-      elsif difficulty == 4
+      when 4
         self.functions_d4_count += 1
-      elsif difficulty == 5
+      when 5
         self.functions_d5_count += 1
       end
-    elsif concept == ConceptDifficulties::FUNCTIONS_WITH_PARAMS
-      if difficulty == 1
+    when ConceptDifficulties::FUNCTIONS_WITH_PARAMS
+      case difficulty
+      when 1
         self.functions_with_params_d1_count += 1
-      elsif difficulty == 2
+      when 2
         self.functions_with_params_d2_count += 1
-      elsif difficulty == 3
+      when 3
         self.functions_with_params_d3_count += 1
-      elsif difficulty == 4
+      when 4
         self.functions_with_params_d4_count += 1
-      elsif difficulty == 5
+      when 5
         self.functions_with_params_d5_count += 1
       end
-    elsif concept == ConceptDifficulties::CONDITIONALS
-      if difficulty == 1
+    when ConceptDifficulties::CONDITIONALS
+      case difficulty
+      when 1
         self.conditionals_d1_count += 1
-      elsif difficulty == 2
+      when 2
         self.conditionals_d2_count += 1
-      elsif difficulty == 3
+      when 3
         self.conditionals_d3_count += 1
-      elsif difficulty == 4
+      when 4
         self.conditionals_d4_count += 1
-      elsif difficulty == 5
+      when 5
         self.conditionals_d5_count += 1
       end
     end

--- a/dashboard/db/migrate/20140624203113_convert_stringified_boolean_properties.rb
+++ b/dashboard/db/migrate/20140624203113_convert_stringified_boolean_properties.rb
@@ -3,9 +3,10 @@ class ConvertStringifiedBooleanProperties < ActiveRecord::Migration[4.2]
     Level.all.each do |level|
       next unless level.is_a? Blockly
 
-      if level.is_k1 == '0'
+      case level.is_k1
+      when '0'
         level.is_k1 = 'false'
-      elsif level.is_k1 == '1'
+      when '1'
         level.is_k1 = 'true'
       else
         next

--- a/dashboard/legacy/middleware/animation_library_api.rb
+++ b/dashboard/legacy/middleware/animation_library_api.rb
@@ -167,9 +167,10 @@ class AnimationLibraryApi < Sinatra::Base
   #
   # Retrieve the metadata for the default sprite list from S3
   get %r{/api/v1/animation-library/default-spritelab-metadata/(levelbuilder|production)} do |env|
-    if env == 'production'
+    case env
+    when 'production'
       env_path = ANIMATION_DEFAULT_MANIFEST_JSON
-    elsif env == 'levelbuilder'
+    when 'levelbuilder'
       env_path = ANIMATION_DEFAULT_MANIFEST_JSON_LEVELBUILDER
     else
       bad_request
@@ -194,9 +195,10 @@ class AnimationLibraryApi < Sinatra::Base
     dont_cache
     if request.content_type == 'application/json'
       body = request.body.string
-      if env == 'production'
+      case env
+      when 'production'
         key = ANIMATION_DEFAULT_MANIFEST_JSON
-      elsif env == 'levelbuilder'
+      when 'levelbuilder'
         key = ANIMATION_DEFAULT_MANIFEST_JSON_LEVELBUILDER
       else
         bad_request

--- a/dashboard/lib/certificate_image.rb
+++ b/dashboard/lib/certificate_image.rb
@@ -196,9 +196,10 @@ class CertificateImage
 
   def self.certificate_template_for(course)
     if ScriptConstants.unit_in_category?(:minecraft, course)
-      if course == ScriptConstants::MINECRAFT_HERO_NAME
+      case course
+      when ScriptConstants::MINECRAFT_HERO_NAME
         'MC_Hour_Of_Code_Certificate_Hero.png'
-      elsif course == ScriptConstants::MINECRAFT_AQUATIC_NAME
+      when ScriptConstants::MINECRAFT_AQUATIC_NAME
         'MC_Hour_Of_Code_Certificate_Aquatic.png'
       else
         'MC_Hour_Of_Code_Certificate.png'

--- a/dashboard/lib/pd/jot_form/translation.rb
+++ b/dashboard/lib/pd/jot_form/translation.rb
@@ -167,11 +167,12 @@ module Pd
       # For each non-datetime hash, also remove "\\" pairs from each string as
       # well, which are appearing in strings such as "I\\'m a teacher."
       def strip_answer(answer)
-        if answer.is_a? String
+        case answer
+        when String
           answer.strip
-        elsif answer.is_a? Array
+        when Array
           answer.map(&:strip)
-        elsif answer.is_a? Hash
+        when Hash
           if ["month", "day", "year"].all? {|k| answer.key?(k)}
             answer = answer.values_at("month", "day", "year").join("/")
           else

--- a/dashboard/scripts/ideal_level_sources_to_test_json.rb
+++ b/dashboard/scripts/ideal_level_sources_to_test_json.rb
@@ -29,9 +29,10 @@ def main
       }]
     }
 
-    if level.type == "Artist"
+    case level.type
+    when "Artist"
       level_hash[:app] = "turtle"
-    elsif level.type == "Karel"
+    when "Karel"
       level_hash[:app] = "maze"
       level_hash[:skinId] = level_hash[:levelDefinition]['skin']
     else

--- a/dashboard/test/ui/features/step_definitions/dropdown.rb
+++ b/dashboard/test/ui/features/step_definitions/dropdown.rb
@@ -15,9 +15,10 @@ And /^I press dropdown number (\d+)$/ do |n|
 end
 
 Then /^the dropdown is (.*)$/ do |visibility|
-  if visibility == "visible"
+  case visibility
+  when "visible"
     expected = 'block'
-  elsif visibility == "hidden"
+  when "hidden"
     expected = 'none'
   else
     raise "unexpected visibility"

--- a/dashboard/test/ui/features/step_definitions/progress.rb
+++ b/dashboard/test/ui/features/step_definitions/progress.rb
@@ -15,19 +15,20 @@ end
 # displays 'not_tried'. Passing no_wait=true skips all waits and immediately verifies
 # the bubble.
 def verify_progress(selector, test_result, no_wait=false)
-  if test_result == 'perfect'
+  case test_result
+  when 'perfect'
     background_color = color_string('perfect')
     border_color = color_string('perfect')
-  elsif test_result == 'attempted'
+  when 'attempted'
     background_color = color_string('not_tried')
     border_color = color_string('perfect')
-  elsif test_result == 'not_tried'
+  when 'not_tried'
     background_color = color_string('not_tried')
     border_color = color_string('lighter_gray')
-  elsif test_result == 'perfect_assessment'
+  when 'perfect_assessment'
     background_color = color_string('assessment')
     border_color = color_string('assessment')
-  elsif test_result == 'attempted_assessment'
+  when 'attempted_assessment'
     background_color = color_string('not_tried')
     border_color = color_string('assessment')
   end
@@ -55,9 +56,10 @@ def verify_bubble_color(selector, background_color, border_color)
 end
 
 def verify_bubble_type(selector, type)
-  if type == "concept"
+  case type
+  when "concept"
     border_radius = "2px"
-  elsif type == "activity"
+  when "activity"
     border_radius = "9px"
   else
     raise "Unexpected bubble type"

--- a/dashboard/test/ui/utils/selenium_browser.rb
+++ b/dashboard/test/ui/utils/selenium_browser.rb
@@ -5,11 +5,12 @@ module SeleniumBrowser
   def self.local(headless=true, browser=:chrome)
     browser = browser.to_sym
     options = {}
-    if browser == :chrome
+    case browser
+    when :chrome
       options[:options] = Selenium::WebDriver::Chrome::Options.new
       options[:options].add_argument('headless') if headless
       options[:options].add_argument('window-size=1280,1024')
-    elsif browser == :firefox
+    when :firefox
       options[:options] = Selenium::WebDriver::Firefox::Options.new
       options[:options].headless! if headless
       options[:options].add_argument('window-size=1280,1024')

--- a/lib/cdo/hamburger.rb
+++ b/lib/cdo/hamburger.rb
@@ -30,9 +30,10 @@ class Hamburger
       # The header is taken over by level-related UI, so we need the hamburger
       # to show whatever would show up in the header at desktop (and mobile) widths.
 
-      if options[:user_type] == "teacher"
+      case options[:user_type]
+      when 'teacher'
         show_teacher_options = SHOW_ALWAYS
-      elsif options[:user_type] == "student"
+      when 'student'
         show_student_options = SHOW_ALWAYS
       else
         show_signed_out_options = SHOW_ALWAYS
@@ -48,9 +49,10 @@ class Hamburger
 
       # The header is available for showing whichever options we want, but they should
       # appear in the hamburger at mobile widths.
-      if options[:user_type] == "teacher"
+      case options[:user_type]
+      when 'teacher'
         show_teacher_options = SHOW_MOBILE
-      elsif options[:user_type] == "student"
+      when 'student'
         show_student_options = SHOW_MOBILE
       else
         show_signed_out_options = SHOW_MOBILE
@@ -188,10 +190,11 @@ class Hamburger
 
     # user_type-specific.
 
-    if options[:user_type] == "teacher"
+    case options[:user_type]
+    when 'teacher'
       entries = entries.concat teacher_entries.each {|e| e[:class] = visibility[:show_teacher_options]}
       entries << {type: "divider", class: get_divider_visibility(visibility[:show_teacher_options], visibility[:show_help_options]), id: "after-teacher"}
-    elsif options[:user_type] == "student"
+    when 'student'
       entries = entries.concat student_entries.each {|e| e[:class] = visibility[:show_student_options]}
       entries << {type: "divider", class: get_divider_visibility(visibility[:show_student_options], visibility[:show_help_options]), id: "after-student"}
     else

--- a/lib/cdo/i18n_backend.rb
+++ b/lib/cdo/i18n_backend.rb
@@ -65,7 +65,8 @@ module Cdo
       def translate(locale, key, options = ::I18n::EMPTY_HASH)
         translation = super(locale, key, options.except(:markdown))
         markdown = options.fetch(:markdown, false)
-        if markdown == true
+        case markdown
+        when true
           # The safe_links_only just makes sure that the URL is a "safe" web
           # one which starts with: "#", "/", "http://", "https://", "ftp://",
           # "mailto:" However, it isn't good enough because it ignores URLS
@@ -79,7 +80,7 @@ module Cdo
           # redacting all URLs in strings given to outside translators.
           @renderer ||= Redcarpet::Markdown.new(Redcarpet::Render::Safe.new(safe_links_only: false))
           @renderer.render(translation)
-        elsif markdown == :inline
+        when :inline
           @inline_renderer ||= Redcarpet::Markdown.new(Redcarpet::Render::Inline.new(filter_html: true))
           @inline_renderer.render(translation)
         else

--- a/lib/cdo/lesson_import_helper.rb
+++ b/lib/cdo/lesson_import_helper.rb
@@ -164,17 +164,18 @@ module LessonImportHelper
     sections = []
     name = ''
     sorted_matches.each do |match|
-      if match[:type] == 'tip'
+      case match[:type]
+      when 'tip'
         activity_section = ActivitySection.new
         key = match[:match][3]&.strip || "#{match[:match][1]}-0"
         activity_section.tips = [create_tip(key, match[:match][1] || "tip", match[:match][4])]
         activity_section.key ||= SecureRandom.uuid
         activity_sections = [activity_section]
         match[:activity_section_key] = activity_section.key
-      elsif match[:type] == 'name'
+      when 'name'
         name = match[:match][1]
         next
-      elsif match[:type] == 'pullthrough'
+      when 'pullthrough'
         next if levels.empty?
         pullthrough_match = match[:match]
         # If the syntax takes the form of [code-studio], [code-studio 1-<length>], or [code-studio 2-<length>],
@@ -185,7 +186,7 @@ module LessonImportHelper
           levels.clear
         end
         next
-      elsif match[:type] == 'remark'
+      when 'remark'
         activity_sections = [create_activity_section_with_remark(match[:match], tip_match_map)]
       else
         activity_sections = create_activity_sections_from_markdown(match[:substring].strip, tip_match_map)

--- a/pegasus/src/social_metadata.rb
+++ b/pegasus/src/social_metadata.rb
@@ -223,9 +223,10 @@ def get_social_metadata_for_page(request)
   # Additional hoc variants.
   extension = ""
   hoc_launch = DCDO.get("hoc_launch", CDO.default_hoc_launch)
-  if hoc_launch == "mc"
+  case hoc_launch
+  when "mc"
     extension = "-mc"
-  elsif hoc_launch == "dance"
+  when "dance"
     extension = "-dance"
   end
 
@@ -236,13 +237,14 @@ def get_social_metadata_for_page(request)
 
   output = {}
   social_tag_set.each do |name, value|
-    if name == :image
+    case name
+    when :image
       output["og:image"] = "https://#{request.host}#{value[:path]}"
       output["twitter:image:src"] = "https://#{request.host}#{value[:path]}"
       output["og:image:width"] = value[:width]
       output["og:image:height"] = value[:height]
       output["twitter:card"] = "photo"
-    elsif name == :video
+    when :video
       output["og:video:url"] = "http://youtube.com/v/#{value[:youtube_key]}"
       output["og:video:secure_url"] = "https://youtube.com/v/#{value[:youtube_key]}"
       output["og:video:type"] = "video/mp4"
@@ -252,13 +254,13 @@ def get_social_metadata_for_page(request)
       output["twitter:player:width"] = value[:width]
       output["twitter:player:height"] = value[:height]
       output["twitter:card"] = "player"
-    elsif name == :title
+    when :title
       output["og:title"] = value
       output["twitter:title"] = value
-    elsif name == :description
+    when :description
       output["og:description"] = value
       output["twitter:description"] = value
-    elsif name == :description_twitter
+    when :description_twitter
       output["twitter:description"] = value
     end
   end


### PR DESCRIPTION
Fix applied automatically with `bundle exec rubocop --auto-correct-all --only Style/CaseLikeIf`

> Identifies places where `if-elsif` constructions can be replaced with `case-when`.

This is a potentially controversial one; there are arguments to be made for using `if` statements everywhere (consistency, familiarity, etc), but Ruby's style guide directly recommends using `case` over `if-elsif` when consistently comparing against the same value: https://rubystyle.guide/#case-vs-if-else

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

- https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/CaseLikeIf
- https://docs.rubocop.org/rubocop/cops_style.html#stylecaselikeif

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
