### PR TITLE
Catch enrollment errors

### DIFF
--- a/apps/src/code-studio/pd/workshop_enrollment/enroll_form.jsx
+++ b/apps/src/code-studio/pd/workshop_enrollment/enroll_form.jsx
@@ -121,7 +121,7 @@ export default class EnrollForm extends React.Component {
       isSubmitting: false,
       errors: {},
       showFormErrorMessage: false,
-      showSubmissionErrorMessage: false
+      submissionErrorMessage: ''
     };
   }
 
@@ -162,7 +162,7 @@ export default class EnrollForm extends React.Component {
 
   handleClickRegister = () => {
     this.setState({showFormErrorMessage: false});
-    this.setState({showSubmissionErrorMessage: false});
+    this.setState({submissionErrorMessage: ''});
     if (this.validateRequiredFields()) {
       this.setState({isSubmitting: true});
       this.submit();
@@ -292,7 +292,10 @@ export default class EnrollForm extends React.Component {
       complete: result => {
         this.setState({isSubmitting: false});
         result?.responseJSON?.workshop_enrollment_status === 'error' &&
-          this.setState({showSubmissionErrorMessage: true});
+          this.setState({
+            submissionErrorMessage:
+              result?.responseJSON?.error_message || 'unknown error'
+          });
         this.props.onSubmissionComplete(result);
       }
     });
@@ -770,12 +773,12 @@ export default class EnrollForm extends React.Component {
             Form errors found. Please check your responses above.
           </p>
         )}
-        {this.state.showSubmissionErrorMessage && (
+        {this.state.submissionErrorMessage && (
           <Alert bsStyle="danger" style={{marginTop: 10}}>
             <p>
-              Sorry, an error occurred upon submission and we were unable to
-              enroll you in this workshop. Double check your responses, and if
-              the problem persists, please contact{' '}
+              Sorry, we were unable to enroll you in this workshop because
+              {' ' + this.state.submissionErrorMessage}. Please double check
+              your responses, and if the problem persists, contact{' '}
               <a href="mailto:support@code.org">support@code.org</a>.
             </p>
           </Alert>

--- a/apps/src/code-studio/pd/workshop_enrollment/enroll_form.jsx
+++ b/apps/src/code-studio/pd/workshop_enrollment/enroll_form.jsx
@@ -15,6 +15,7 @@ import Select from 'react-select';
 import {ButtonList} from '../form_components/ButtonList.jsx';
 import FieldGroup from '../form_components/FieldGroup';
 import QuestionsTable from '../form_components/QuestionsTable';
+import color from '@cdo/apps/util/color';
 import {isEmail} from '@cdo/apps/util/formatValidation';
 import SchoolAutocompleteDropdownWithCustomFields from '../components/schoolAutocompleteDropdownWithCustomFields';
 import {SubjectNames} from '@cdo/apps/generated/pd/sharedWorkshopConstants';
@@ -98,8 +99,6 @@ const REPLACE_EXISTING_OPTIONS = [
   'No, this will be the only computer science course on the master schedule',
   'I don’t know'
 ];
-
-const ERROR_COLOR = '#a94442'; // Error color used in 'react-bootstrap'
 
 export default class EnrollForm extends React.Component {
   static propTypes = {
@@ -767,7 +766,7 @@ export default class EnrollForm extends React.Component {
           Register
         </Button>
         {this.state.showFormErrorMessage && (
-          <p style={{color: ERROR_COLOR}}>
+          <p style={{color: color.bootstrap_v3_error_text}}>
             Form errors found. Please check your responses above.
           </p>
         )}

--- a/apps/src/code-studio/pd/workshop_enrollment/enroll_form.jsx
+++ b/apps/src/code-studio/pd/workshop_enrollment/enroll_form.jsx
@@ -4,7 +4,13 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import $ from 'jquery';
-import {FormGroup, Button, ControlLabel, HelpBlock} from 'react-bootstrap';
+import {
+  FormGroup,
+  Button,
+  ControlLabel,
+  HelpBlock,
+  Alert
+} from 'react-bootstrap';
 import Select from 'react-select';
 import {ButtonList} from '../form_components/ButtonList.jsx';
 import FieldGroup from '../form_components/FieldGroup';
@@ -93,6 +99,8 @@ const REPLACE_EXISTING_OPTIONS = [
   'I don’t know'
 ];
 
+const ERROR_COLOR = '#a94442'; // Error color used in 'react-bootstrap'
+
 export default class EnrollForm extends React.Component {
   static propTypes = {
     workshop_id: PropTypes.number.isRequired,
@@ -112,7 +120,9 @@ export default class EnrollForm extends React.Component {
       first_name: this.props.first_name,
       email: this.props.email,
       isSubmitting: false,
-      errors: {}
+      errors: {},
+      showFormErrorMessage: false,
+      showSubmissionErrorMessage: false
     };
   }
 
@@ -152,9 +162,13 @@ export default class EnrollForm extends React.Component {
   };
 
   handleClickRegister = () => {
+    this.setState({showFormErrorMessage: false});
+    this.setState({showSubmissionErrorMessage: false});
     if (this.validateRequiredFields()) {
       this.setState({isSubmitting: true});
       this.submit();
+    } else {
+      this.setState({showFormErrorMessage: true});
     }
   };
 
@@ -278,6 +292,8 @@ export default class EnrollForm extends React.Component {
       data: JSON.stringify(params),
       complete: result => {
         this.setState({isSubmitting: false});
+        result?.responseJSON?.workshop_enrollment_status === 'error' &&
+          this.setState({showSubmissionErrorMessage: true});
         this.props.onSubmissionComplete(result);
       }
     });
@@ -750,6 +766,21 @@ export default class EnrollForm extends React.Component {
         >
           Register
         </Button>
+        {this.state.showFormErrorMessage && (
+          <p style={{color: ERROR_COLOR}}>
+            Form errors found. Please check your responses above.
+          </p>
+        )}
+        {this.state.showSubmissionErrorMessage && (
+          <Alert bsStyle="danger" style={{marginTop: 10}}>
+            <p>
+              Sorry, an error occurred upon submission and we were unable to
+              enroll you in this workshop. Double check your responses, and if
+              the problem persists, please contact{' '}
+              <a href="mailto:support@code.org">support@code.org</a>.
+            </p>
+          </Alert>
+        )}
         <br />
         <br />
         <br />

--- a/apps/src/code-studio/pd/workshop_enrollment/workshop_enrollment.jsx
+++ b/apps/src/code-studio/pd/workshop_enrollment/workshop_enrollment.jsx
@@ -124,18 +124,6 @@ export default class WorkshopEnrollment extends React.Component {
     );
   }
 
-  renderUnknownError() {
-    return (
-      <div>
-        <p>
-          Sorry, an error occurred and we were unable to enroll you in this
-          workshop. Please contact{' '}
-          <a href="mailto:support@code.org">support@code.org</a>.
-        </p>
-      </div>
-    );
-  }
-
   renderSuccess() {
     analyticsReporter.sendEvent(EVENTS.WORKSHOP_ENROLLMENT_COMPLETED_EVENT, {
       'regional partner': this.props.workshop.regional_partner?.name,
@@ -179,7 +167,19 @@ export default class WorkshopEnrollment extends React.Component {
 
   render() {
     switch (this.state.workshopEnrollmentStatus) {
-      case SUBMISSION_STATUSES.UNSUBMITTED:
+      case SUBMISSION_STATUSES.DUPLICATE:
+        return this.renderDuplicate();
+      case SUBMISSION_STATUSES.OWN:
+        return this.renderOwn();
+      case SUBMISSION_STATUSES.CLOSED:
+        return this.renderClosed();
+      case SUBMISSION_STATUSES.FULL:
+        return this.renderFull();
+      case SUBMISSION_STATUSES.NOT_FOUND:
+        return this.renderNotFound();
+      case SUBMISSION_STATUSES.SUCCESS:
+        return this.renderSuccess();
+      default:
         return (
           <div>
             <h1>{`Register for a ${this.props.workshop.course} workshop`}</h1>
@@ -226,20 +226,6 @@ export default class WorkshopEnrollment extends React.Component {
             </div>
           </div>
         );
-      case SUBMISSION_STATUSES.DUPLICATE:
-        return this.renderDuplicate();
-      case SUBMISSION_STATUSES.OWN:
-        return this.renderOwn();
-      case SUBMISSION_STATUSES.CLOSED:
-        return this.renderClosed();
-      case SUBMISSION_STATUSES.FULL:
-        return this.renderFull();
-      case SUBMISSION_STATUSES.NOT_FOUND:
-        return this.renderNotFound();
-      case SUBMISSION_STATUSES.SUCCESS:
-        return this.renderSuccess();
-      default:
-        return this.renderUnknownError();
     }
   }
 }

--- a/dashboard/app/controllers/api/v1/pd/workshop_enrollments_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshop_enrollments_controller.rb
@@ -72,6 +72,8 @@ class Api::V1::Pd::WorkshopEnrollmentsController < ApplicationController
         }
       rescue ActiveRecord::ValueTooLong
         render_unsuccessful RESPONSE_MESSAGES[:ERROR], {error_message: 'a response is too long'}
+      rescue ActiveRecord::RecordInvalid => invalid
+        render_unsuccessful RESPONSE_MESSAGES[:ERROR], {error_message: invalid.message}
       end
     end
   end

--- a/dashboard/app/controllers/api/v1/pd/workshop_enrollments_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshop_enrollments_controller.rb
@@ -70,8 +70,8 @@ class Api::V1::Pd::WorkshopEnrollmentsController < ApplicationController
           sign_up_url: url_for('/users/sign_up'),
           cancel_url: url_for(action: :cancel, controller: '/pd/workshop_enrollment', code: enrollment.code)
         }
-      rescue ActiveRecord::ActiveRecordError
-        render_unsuccessful RESPONSE_MESSAGES[:ERROR]
+      rescue ActiveRecord::ValueTooLong
+        render_unsuccessful RESPONSE_MESSAGES[:ERROR], {error_message: 'a response is too long'}
       end
     end
   end

--- a/dashboard/app/controllers/api/v1/pd/workshop_enrollments_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshop_enrollments_controller.rb
@@ -56,9 +56,10 @@ class Api::V1::Pd::WorkshopEnrollmentsController < ApplicationController
     elsif workshop_full?
       render_unsuccessful RESPONSE_MESSAGES[:FULL]
     else
-      enrollment = ::Pd::Enrollment.new workshop: @workshop
-      enrollment.school_info_attributes = school_info_params
-      if enrollment.update enrollment_params
+      ActiveRecord::Base.transaction do
+        enrollment = ::Pd::Enrollment.new workshop: @workshop
+        enrollment.update!(enrollment_params.merge(school_info_attributes: school_info_params))
+
         user&.update_school_info(enrollment.school_info)
         Pd::WorkshopMailer.teacher_enrollment_receipt(enrollment).deliver_now
         Pd::WorkshopMailer.organizer_enrollment_receipt(enrollment).deliver_now
@@ -69,7 +70,7 @@ class Api::V1::Pd::WorkshopEnrollmentsController < ApplicationController
           sign_up_url: url_for('/users/sign_up'),
           cancel_url: url_for(action: :cancel, controller: '/pd/workshop_enrollment', code: enrollment.code)
         }
-      else
+      rescue ActiveRecord::ActiveRecordError
         render_unsuccessful RESPONSE_MESSAGES[:ERROR]
       end
     end

--- a/shared/css/color.scss
+++ b/shared/css/color.scss
@@ -110,6 +110,7 @@ $bootstrap_button_blue: #337ab7;
 $bootstrap_button_red: #d9534f;
 $bootstrap_error_background: #f2dede;
 $bootstrap_error_text: #b94a48;
+$bootstrap_v3_error_text:  #a94442;
 $bootstrap_error_border: #ebccd1;
 $bootstrap_warning_background: #fcf8e3;
 $bootstrap_warning_text: #c09853;


### PR DESCRIPTION
On the enrollment form for workshops, adds (1) text at the bottom of the page when there are server-side errors, and (2) catches some client-side errors and gives error message on the page rather than redirecting to a different page.

Demo shows development on left-hand browser and staging on right-hand browser:
https://user-images.githubusercontent.com/9142121/216694388-9ed4ad31-e534-4b1d-881e-b4e2c2fd885c.mov

New error messages:
<img width="439" alt="image" src="https://user-images.githubusercontent.com/9142121/217972012-b2eaddad-9a65-4f8d-8f19-2989bc473b73.png">

<img width="438" alt="image" src="https://user-images.githubusercontent.com/9142121/217972105-8b1f9b37-e2fa-4dd4-a9ae-02a69d38e76d.png">


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

- Testing story with frontend mount tests, tracked at https://codedotorg.atlassian.net/browse/ACQ-173
- Catch errors before loading form, tracked at https://codedotorg.atlassian.net/browse/ACQ-364

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
