### PR TITLE
Disable prevent_report_abuse_spam in Safari

### DIFF
--- a/dashboard/test/ui/features/teacher_tools/projects/prevent_report_abuse_spam.feature
+++ b/dashboard/test/ui/features/teacher_tools/projects/prevent_report_abuse_spam.feature
@@ -1,6 +1,7 @@
 @dashboard_db_access
 @no_mobile
 @no_firefox
+@no_safari
 Feature: Prevent Report Abuse Spam
 
 # If someone has already reported abuse on a specific project, we hide the


### PR DESCRIPTION
`Report Abuse link hidden if the user already reported AppLab project - studio` at least seems to have started failing since the Safari 14 upgrade. Skipping the whole test suite in Safari for now to unblock the DTT while I investigate.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
