### PR TITLE
Fix margin-bottom on responsive_full_width theme

### DIFF
--- a/pegasus/sites.v3/code.org/public/css/container-responsive-full-width.css
+++ b/pegasus/sites.v3/code.org/public/css/container-responsive-full-width.css
@@ -15,9 +15,11 @@
   allowing each section to be full-width.
 */
 
-
+/* Removes the gap between the top nav bar and page content if
+  there's a hero banner; if there's no hero banner, the section
+  element has top-padding that will add white space */
 #pageheader-wrapper #pageheader {
-  margin-bottom: 0;
+  margin-bottom: 0 !important;
 }
 
 .container_responsive_full_width {


### PR DESCRIPTION
This removes the gap between the top nav bar and page content if there's a hero banner. If there's no hero banner, the `section` element has top-padding that will add any desired white space. 

**Related PR:**
- https://github.com/code-dot-org/code-dot-org/pull/50030