### PR TITLE
[Amplitude] Send Record on Teacher Login

### DIFF
--- a/apps/src/lib/util/AnalyticsConstants.js
+++ b/apps/src/lib/util/AnalyticsConstants.js
@@ -2,6 +2,7 @@ const EVENTS = {
   // Sign-up flow
   ACCOUNT_TYPE_PICKED_EVENT: 'Account Type Picked',
   SIGN_UP_FINISHED_EVENT: 'Sign Up Finished',
+  TEACHER_LOGIN_EVENT: 'Teacher Login',
 
   // Course/Unit info
   COURSE_OVERVIEW_PAGE_VISITED_EVENT: 'Course Overview Page Visited',

--- a/apps/src/sites/studio/pages/home/_homepage.js
+++ b/apps/src/sites/studio/pages/home/_homepage.js
@@ -19,6 +19,11 @@ import {initializeHiddenScripts} from '@cdo/apps/code-studio/hiddenLessonRedux';
 import {updateQueryParam} from '@cdo/apps/code-studio/utils';
 import locales, {setLocaleCode} from '@cdo/apps/redux/localesRedux';
 import mapboxReducer, {setMapboxAccessToken} from '@cdo/apps/redux/mapbox';
+import {tryGetLocalStorage, trySetLocalStorage} from '@cdo/apps/utils';
+import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
+import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
+
+const LOGGED_TEACHER_SESSION = 'logged_teacher_session';
 
 $(document).ready(showHomepage);
 
@@ -36,6 +41,19 @@ function showHomepage() {
   store.dispatch(initializeHiddenScripts(homepageData.hiddenScripts));
   store.dispatch(setPageType(pageTypes.homepage));
   store.dispatch(setLocaleCode(homepageData.localeCode));
+
+  // Send one analytics event when a teacher logs in. Use session storage to determine
+  // whether they've just logged in.
+  if (
+    isTeacher &&
+    tryGetLocalStorage(LOGGED_TEACHER_SESSION, 'false') !== 'true'
+  ) {
+    trySetLocalStorage(LOGGED_TEACHER_SESSION, 'true');
+
+    analyticsReporter.sendEvent(EVENTS.TEACHER_LOGIN_EVENT, {
+      'user id': homepageData.currentUserId
+    });
+  }
 
   // DCDO Flag - show/hide Lock Section field
   store.dispatch(setShowLockSectionField(homepageData.showLockSectionField));

--- a/apps/src/sites/studio/pages/home/_homepage.js
+++ b/apps/src/sites/studio/pages/home/_homepage.js
@@ -19,11 +19,6 @@ import {initializeHiddenScripts} from '@cdo/apps/code-studio/hiddenLessonRedux';
 import {updateQueryParam} from '@cdo/apps/code-studio/utils';
 import locales, {setLocaleCode} from '@cdo/apps/redux/localesRedux';
 import mapboxReducer, {setMapboxAccessToken} from '@cdo/apps/redux/mapbox';
-import {tryGetLocalStorage, trySetLocalStorage} from '@cdo/apps/utils';
-import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
-import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
-
-const LOGGED_TEACHER_SESSION = 'logged_teacher_session';
 
 $(document).ready(showHomepage);
 
@@ -41,19 +36,6 @@ function showHomepage() {
   store.dispatch(initializeHiddenScripts(homepageData.hiddenScripts));
   store.dispatch(setPageType(pageTypes.homepage));
   store.dispatch(setLocaleCode(homepageData.localeCode));
-
-  // Send one analytics event when a teacher logs in. Use session storage to determine
-  // whether they've just logged in.
-  if (
-    isTeacher &&
-    tryGetLocalStorage(LOGGED_TEACHER_SESSION, 'false') !== 'true'
-  ) {
-    trySetLocalStorage(LOGGED_TEACHER_SESSION, 'true');
-
-    analyticsReporter.sendEvent(EVENTS.TEACHER_LOGIN_EVENT, {
-      'user id': homepageData.currentUserId
-    });
-  }
 
   // DCDO Flag - show/hide Lock Section field
   store.dispatch(setShowLockSectionField(homepageData.showLockSectionField));
@@ -121,6 +103,7 @@ function showHomepage() {
             specialAnnouncement={specialAnnouncement}
             hasFeedback={homepageData.hasFeedback}
             showIncubatorBanner={homepageData.showIncubatorBanner}
+            currentUserId={homepageData.currentUserId}
           />
         )}
         {!isTeacher && (

--- a/apps/src/templates/studioHomepages/TeacherHomepage.jsx
+++ b/apps/src/templates/studioHomepages/TeacherHomepage.jsx
@@ -21,6 +21,11 @@ import BorderedCallToAction from '@cdo/apps/templates/studioHomepages/BorderedCa
 import Button from '@cdo/apps/templates/Button';
 import ParticipantFeedbackNotification from '@cdo/apps/templates/feedback/ParticipantFeedbackNotification';
 import IncubatorBanner from './IncubatorBanner';
+import {tryGetLocalStorage, trySetLocalStorage} from '@cdo/apps/utils';
+import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
+import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
+
+const LOGGED_TEACHER_SESSION = 'logged_teacher_session';
 
 export const UnconnectedTeacherHomepage = ({
   announcement,
@@ -47,7 +52,8 @@ export const UnconnectedTeacherHomepage = ({
   topPlCourse,
   beginGoogleImportRosterFlow,
   hasFeedback,
-  showIncubatorBanner
+  showIncubatorBanner,
+  currentUserId
 }) => {
   const censusBanner = useRef(null);
   const teacherReminders = useRef(null);
@@ -148,6 +154,19 @@ export const UnconnectedTeacherHomepage = ({
   const backgroundUrl = '/shared/images/banners/teacher-homepage-hero.jpg';
 
   const showDonorBanner = isEnglish && donorBannerName;
+
+  // Send one analytics event when a teacher logs in. Use session storage to determine
+  // whether they've just logged in.
+  if (
+    !!currentUserId &&
+    tryGetLocalStorage(LOGGED_TEACHER_SESSION, 'false') !== 'true'
+  ) {
+    trySetLocalStorage(LOGGED_TEACHER_SESSION, 'true');
+
+    analyticsReporter.sendEvent(EVENTS.TEACHER_LOGIN_EVENT, {
+      'user id': currentUserId
+    });
+  }
 
   return (
     <div>
@@ -303,7 +322,8 @@ UnconnectedTeacherHomepage.propTypes = {
   topPlCourse: shapes.topCourse,
   beginGoogleImportRosterFlow: PropTypes.func,
   hasFeedback: PropTypes.bool,
-  showIncubatorBanner: PropTypes.bool
+  showIncubatorBanner: PropTypes.bool,
+  currentUserId: PropTypes.number
 };
 
 const styles = {

--- a/apps/src/templates/studioHomepages/TeacherHomepage.jsx
+++ b/apps/src/templates/studioHomepages/TeacherHomepage.jsx
@@ -21,7 +21,7 @@ import BorderedCallToAction from '@cdo/apps/templates/studioHomepages/BorderedCa
 import Button from '@cdo/apps/templates/Button';
 import ParticipantFeedbackNotification from '@cdo/apps/templates/feedback/ParticipantFeedbackNotification';
 import IncubatorBanner from './IncubatorBanner';
-import {tryGetLocalStorage, trySetLocalStorage} from '@cdo/apps/utils';
+import {tryGetSessionStorage, trySetSessionStorage} from '@cdo/apps/utils';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 
@@ -159,9 +159,9 @@ export const UnconnectedTeacherHomepage = ({
   // whether they've just logged in.
   if (
     !!currentUserId &&
-    tryGetLocalStorage(LOGGED_TEACHER_SESSION, 'false') !== 'true'
+    tryGetSessionStorage(LOGGED_TEACHER_SESSION, 'false') !== 'true'
   ) {
-    trySetLocalStorage(LOGGED_TEACHER_SESSION, 'true');
+    trySetSessionStorage(LOGGED_TEACHER_SESSION, 'true');
 
     analyticsReporter.sendEvent(EVENTS.TEACHER_LOGIN_EVENT, {
       'user id': currentUserId

--- a/apps/test/unit/templates/studioHomepages/StudentHomepageTest.js
+++ b/apps/test/unit/templates/studioHomepages/StudentHomepageTest.js
@@ -60,7 +60,7 @@ describe('StudentHomepage', () => {
     });
   });
 
-  it('does not log an Amplitude event for teacher signing-in', () => {
+  it('does not log an Amplitude event for student signing-in', () => {
     const analyticsSpy = sinon.spy(analyticsReporter, 'sendEvent');
     shallow(<StudentHomepage {...TEST_PROPS} />);
 

--- a/apps/test/unit/templates/studioHomepages/StudentHomepageTest.js
+++ b/apps/test/unit/templates/studioHomepages/StudentHomepageTest.js
@@ -6,6 +6,9 @@ import HeaderBanner from '@cdo/apps/templates/HeaderBanner';
 import {courses, topCourse, joinedSections} from './homepagesTestData';
 import Notification from '@cdo/apps/templates/Notification';
 import i18n from '@cdo/locale';
+import sinon from 'sinon';
+import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
+import {expect} from '../../../util/reconfiguredChai';
 
 describe('StudentHomepage', () => {
   const TEST_PROPS = {
@@ -55,6 +58,13 @@ describe('StudentHomepage', () => {
     assert.deepEqual(joinSectionArea.props(), {
       initialJoinedStudentSections: joinedSections
     });
+  });
+
+  it('does not log an Amplitude event for teacher signing-in', () => {
+    const analyticsSpy = sinon.spy(analyticsReporter, 'sendEvent');
+    shallow(<StudentHomepage {...TEST_PROPS} />);
+
+    expect(analyticsSpy).not.to.have.been.called;
   });
 
   it('shows the special announcement for English', () => {

--- a/apps/test/unit/templates/studioHomepages/StudentHomepageTest.js
+++ b/apps/test/unit/templates/studioHomepages/StudentHomepageTest.js
@@ -65,6 +65,7 @@ describe('StudentHomepage', () => {
     shallow(<StudentHomepage {...TEST_PROPS} />);
 
     expect(analyticsSpy).not.to.have.been.called;
+    analyticsSpy.restore();
   });
 
   it('shows the special announcement for English', () => {


### PR DESCRIPTION
Part of our Amplitude project.
Triggers when a teacher renders the homepage, but only once per session (to emulate the 'on login' experience).

Includes testing. 