### PR TITLE
Add test to check if authorized users can take down projects

### DIFF
--- a/apps/src/code-studio/components/ReportAbuseForm.jsx
+++ b/apps/src/code-studio/components/ReportAbuseForm.jsx
@@ -118,6 +118,7 @@ export default class ReportAbuseForm extends React.Component {
             style={{width: INPUT_WIDTH}}
             defaultValue={this.props.abuseUrl}
             name="abuse_url"
+            id="uitest-abuse-url"
           />
 
           <div>

--- a/dashboard/test/ui/features/step_definitions/project_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/project_steps.rb
@@ -62,8 +62,8 @@ Then(/^I report abuse on the project$/) do
   steps %Q{
     Then I switch tabs
     Then I wait until current URL contains "report_abuse"
-    And I wait until element "#uitest-email" is visible
-    And I type "abuse_reporter@school.edu" into "#uitest-email"
+    And I wait until element "#uitest-abuse-url" is visible
+    And I type "abuse_reporter@school.edu" into "#uitest-email" if I see it
     And I select the "Other" option in dropdown "uitest-abuse-type"
     And I type "I just don't like it." into "#uitest-abuse-detail"
     Then I click selector "#uitest-submit-report-abuse" once I see it

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -543,6 +543,17 @@ When /^I type '([^']*)' into "([^"]*)"$/ do |input_text, selector|
   type_into_selector("\'#{input_text}\'", selector)
 end
 
+When /^I type "([^"]*)" into "([^"]*)" if I see it$/ do |input_text, selector|
+  type_into_selector("\"#{input_text}\"", selector)
+
+  wait_until(5) do
+    @browser.execute_script("return $(\"#{selector}:visible\").length != 0;")
+  end
+  type_into_selector("\"#{input_text}\"", selector)
+rescue Selenium::WebDriver::Error::TimeOutError
+  # Element never appeared, ignore it
+end
+
 # The selector should be wrapped in appropriate quotes when passed into here.
 def type_into_selector(input_text, selector)
   wait_for_jquery
@@ -629,13 +640,6 @@ Then /^I wait to see a dialog containing text "((?:[^"\\]|\\.)*)"$/ do |expected
   steps %{
     Then I wait to see a ".modal-body"
     And element ".modal-body" contains text "#{expected_text}"
-  }
-end
-
-Then /^I wait to see a modal containing text "((?:[^"\\]|\\.)*)"$/ do |expected_text|
-  steps %{
-    Then I wait to see a ".modal"
-    And element ".modal" contains text "#{expected_text}"
   }
 end
 

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -643,6 +643,13 @@ Then /^I wait to see a dialog containing text "((?:[^"\\]|\\.)*)"$/ do |expected
   }
 end
 
+Then /^I wait to see a modal containing text "((?:[^"\\]|\\.)*)"$/ do |expected_text|
+  steps %{
+    Then I wait to see a ".modal"
+    And element ".modal" contains text "#{expected_text}"
+  }
+end
+
 Then /^I wait to see a congrats dialog with title containing "((?:[^"\\]|\\.)*)"$/ do |expected_text|
   steps %{
     Then I wait to see a ".congrats"

--- a/dashboard/test/ui/features/teacher_tools/projects/prevent_report_abuse_spam.feature
+++ b/dashboard/test/ui/features/teacher_tools/projects/prevent_report_abuse_spam.feature
@@ -64,31 +64,22 @@ Scenario: Report Abuse link hidden if the user already reported Game Lab project
   And element ".ui-test-how-it-works" is visible
   And element ".ui-test-report-abuse" is not visible
 
-@skip
-Scenario: Abuse reports block a project for other viewers
-  Given I create a student named "Creator"
+Scenario: Abuse reports from verified teachers block a project for other viewers
+  Given I create a teacher named "Creator"
   And I make a "applab" project named "Regular Project"
   And I click selector ".project_share"
   And I wait until element "#sharing-dialog-copy-button" is visible
   And I save the share URL
   Then I sign out
 
-  Given I create a student named "Spammer"
+  Given I create a teacher named "Teacher_1"
+  And I give user "Teacher_1" authorized teacher permission
   And I navigate to the last shared URL
   Then I open the small footer menu
   And element ".ui-test-report-abuse" is visible
   And I press menu item "Report Abuse"
   And I report abuse on the project
   Then I close the current tab
-  Then I sign out
-
-  Given I create a student named "Spammer2"
-  And I delete the cookie named "reported_abuse"
-  And I navigate to the last shared URL
-  Then I open the small footer menu
-  And element ".ui-test-report-abuse" is visible
-  And I press menu item "Report Abuse"
-  And I report abuse on the project
   Then I sign out
 
   Given I create a student named "Viewer"
@@ -104,22 +95,14 @@ Scenario: Projects made by project validators are protected from abuse reports
   And I save the share URL
   Then I sign out
 
-  Given I create a student named "Spammer3"
+  Given I create a teacher named "Teacher_1"
+  And I give user "Teacher_1" authorized teacher permission
   And I navigate to the last shared URL
   Then I open the small footer menu
   And element ".ui-test-report-abuse" is visible
   And I press menu item "Report Abuse"
   And I report abuse on the project
   Then I close the current tab
-  Then I sign out
-
-  Given I create a student named "Spammer4"
-  And I delete the cookie named "reported_abuse"
-  And I navigate to the last shared URL
-  Then I open the small footer menu
-  And element ".ui-test-report-abuse" is visible
-  And I press menu item "Report Abuse"
-  And I report abuse on the project
   Then I sign out
 
   Given I create a student named "Viewer2"


### PR DESCRIPTION
Finishing off updating the report abuse UI test by adding a test to check if authorized teachers can increase abuse score. (Credit: I used @pablo-code-org test from #49839). I also updated the test that checks that projects by project validators can not be taken down to use an authorized user.

