### PR TITLE
stop replicating most census tables to redshift

### DIFF
--- a/aws/dms/tasks.yml
+++ b/aws/dms/tasks.yml
@@ -64,12 +64,6 @@ cron:
 - dashboard.user_permissions
 - dashboard.level_concept_difficulties
 - dashboard.user_scripts
-- dashboard.ap_cs_offerings
-- dashboard.ib_cs_offerings
-- dashboard.state_cs_offerings
-- dashboard.census_summaries
-- dashboard.ib_school_codes
-- dashboard.ap_school_codes
 - dashboard.census_submissions:
     remove_column:
     - submitter_email_address


### PR DESCRIPTION
Finishes [ACQ-370](https://codedotorg.atlassian.net/browse/ACQ-370). see [eng plan](https://docs.google.com/document/d/1t4jAC90ASgqIdUiKErGyI1kNdM4oaynql8wn7q3ZPIc/edit#).

With the move of the Access Report algorithm from engineering to the RED team, we should be able to stop replicating these census-related tables into redshift: https://github.com/code-dot-org/code-dot-org/blob/9e9f6e808967457c6e2d9b85b7bbc0f0b434ffd5/aws/dms/tasks.yml#L67-L72

this will allow the engineering team to remove dead code and processes from our system. 

this table will still be available in redshift: https://github.com/code-dot-org/code-dot-org/blob/9e9f6e808967457c6e2d9b85b7bbc0f0b434ffd5/aws/dms/tasks.yml#L73

@sureshc , can you confirm that this PR will stop updating the affected tables, but will not actually remove the existing data from redshift?

@angelakwon-code and @bakerfranke , can we do this today without breaking anything on your side? if you are not sure, can we add these tables to the list for you to review soon to see if they are being used by any tableau dashboards?
