### PR TITLE
Disable test in Safari while Teacher Tools team investigates

### DIFF
--- a/dashboard/test/ui/features/teacher_tools/student_lesson_plan.feature
+++ b/dashboard/test/ui/features/teacher_tools/student_lesson_plan.feature
@@ -1,3 +1,6 @@
+# 2/6/23: Temporarily disabling in Safari because the 'When I switch tabs' step is failing after
+# upgrading to Safari 14.
+@no_safari
 @no_mobile
 Feature: Student Lesson Plan
 


### PR DESCRIPTION
Related to #50068. See [Slack thread](https://codedotorg.slack.com/archives/C0T0PNTM3/p1675710552371899) for more details.

'When I switch tabs' step is failing in Safari with the following error:
<img width="1413" alt="Screen Shot 2023-02-06 at 11 05 09 AM" src="https://user-images.githubusercontent.com/9812299/217077284-6938bd11-fa4f-4dd8-b26d-b7a7a75ff58b.png">

In Saucelabs, you can see `handle` is `null` instead of a string.