### PR TITLE
Remove grades_teaching question from Admin/Counselor workshop enrollment form

### DIFF
--- a/apps/src/code-studio/pd/workshop_enrollment/enroll_form.jsx
+++ b/apps/src/code-studio/pd/workshop_enrollment/enroll_form.jsx
@@ -490,22 +490,24 @@ export default class EnrollForm extends React.Component {
                 />
               )}
             </FormGroup>
-            <ButtonList
-              id="grades_teaching"
-              key="grades_teaching"
-              answers={gradesTeaching}
-              groupName="grades_teaching"
-              label={gradesLabel}
-              onChange={this.handleChange}
-              selectedItems={this.state.grades_teaching}
-              validationState={
-                this.state.errors.hasOwnProperty('grades_teaching')
-                  ? VALIDATION_STATE_ERROR
-                  : null
-              }
-              errorText={this.state.errors.grades_teaching}
-              type="check"
-            />
+            {this.props.workshop_course !== ADMINCOUNSELOR && (
+              <ButtonList
+                id="grades_teaching"
+                key="grades_teaching"
+                answers={gradesTeaching}
+                groupName="grades_teaching"
+                label={gradesLabel}
+                onChange={this.handleChange}
+                selectedItems={this.state.grades_teaching}
+                validationState={
+                  this.state.errors.hasOwnProperty('grades_teaching')
+                    ? VALIDATION_STATE_ERROR
+                    : null
+                }
+                errorText={this.state.errors.grades_teaching}
+                type="check"
+              />
+            )}
           </FormGroup>
         )}
         {this.props.workshop_course === CSF &&

--- a/apps/test/unit/code-studio/pd/workshop_enrollment/enroll_formTest.js
+++ b/apps/test/unit/code-studio/pd/workshop_enrollment/enroll_formTest.js
@@ -255,6 +255,10 @@ describe('Enroll Form', () => {
       assert(enrollForm.exists('#role'));
     });
 
+    it('does not display grades_teaching question', () => {
+      assert(!enrollForm.exists('#grades_teaching'));
+    });
+
     it('displays describe role question after answered as other', () => {
       enrollForm.setState({role: 'Other'});
       expect(enrollForm.find('#describe_role')).to.have.length(1);


### PR DESCRIPTION
This PR remove the `grades_teaching` question from just the Admin/Counselor workshop enrollment form (not other forms that also use the question).

### Previously showed the grades_teaching question in the Admin/Counselor workshop enrollment form
![Previously_Shows_Grades](https://user-images.githubusercontent.com/56283563/217099010-5052ba85-f3bf-4ef1-be17-61c9eafd9609.JPG)

### Now does not show the grades_teaching question in the Admin/Counselor workshop enrollment form
![Now_Doesnt_Show_Grades](https://user-images.githubusercontent.com/56283563/217099040-f9dd75a9-073a-480e-ba5f-487b412f020b.JPG)

### Still shows the grades_teaching question in other forms that use it
![Still_shows_for_other_forms_that_use_question](https://user-images.githubusercontent.com/56283563/217099051-75e88c30-16f3-42de-8719-8e1e43d67070.JPG)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/browse/ACQ-356?atlOrigin=eyJpIjoiMGI4Y2I4ZDA5MGQ2NGMyNDljZmZjYmYyYTAxZmUzMjgiLCJwIjoiaiJ9)

## Testing story
Local testing and updating unit tests.

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
