### PR TITLE
Implementing feedback analytics call

### DIFF
--- a/apps/src/lib/util/AnalyticsConstants.js
+++ b/apps/src/lib/util/AnalyticsConstants.js
@@ -29,7 +29,8 @@ const EVENTS = {
   PROGRESS_VIEWED: 'Section Progress Viewed',
   PROGRESS_TOGGLE: 'Section Progress Toggled',
   PROGRESS_CHANGE_UNIT: 'Section Progress Unit Changed',
-  PROGRESS_JUMP_TO_LESSON: 'Section Progress Jump to Lesson'
+  PROGRESS_JUMP_TO_LESSON: 'Section Progress Jump to Lesson',
+  FEEDBACK_SUBMITTED: 'Level Feedback Submitted'
 };
 
 export {EVENTS};

--- a/apps/src/lib/util/AnalyticsConstants.js
+++ b/apps/src/lib/util/AnalyticsConstants.js
@@ -30,6 +30,8 @@ const EVENTS = {
   PROGRESS_TOGGLE: 'Section Progress Toggled',
   PROGRESS_CHANGE_UNIT: 'Section Progress Unit Changed',
   PROGRESS_JUMP_TO_LESSON: 'Section Progress Jump to Lesson',
+
+  // Levels
   FEEDBACK_SUBMITTED: 'Level Feedback Submitted'
 };
 

--- a/apps/src/templates/instructions/teacherFeedback/EditableTeacherFeedback.jsx
+++ b/apps/src/templates/instructions/teacherFeedback/EditableTeacherFeedback.jsx
@@ -14,6 +14,8 @@ import {
 } from '@cdo/apps/templates/instructions/teacherFeedback/types';
 import {ReviewStates} from '@cdo/apps/templates/feedback/types';
 import firehoseClient from '@cdo/apps/lib/util/firehose';
+import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
+import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 import {queryUserProgress} from '@cdo/apps/code-studio/progressRedux';
 import {loadLevelsWithProgress} from '@cdo/apps/code-studio/teacherPanelRedux';
 import {updateTeacherFeedback} from '@cdo/apps/templates/instructions/teacherFeedback/teacherFeedbackDataApi';
@@ -155,6 +157,10 @@ export class EditableTeacherFeedback extends Component {
           submitting: false
         });
       });
+    analyticsReporter.sendEvent(EVENTS.FEEDBACK_SUBMITTED, {
+      sectionId: this.props.selectedSectionId,
+      unitId: this.props.serverScriptId
+    });
   };
 
   didFeedbackChange = () => {

--- a/apps/src/templates/instructions/teacherFeedback/EditableTeacherFeedback.jsx
+++ b/apps/src/templates/instructions/teacherFeedback/EditableTeacherFeedback.jsx
@@ -159,7 +159,8 @@ export class EditableTeacherFeedback extends Component {
       });
     analyticsReporter.sendEvent(EVENTS.FEEDBACK_SUBMITTED, {
       sectionId: this.props.selectedSectionId,
-      unitId: this.props.serverScriptId
+      unitId: this.props.serverScriptId,
+      levelId: this.props.serverLevelId
     });
   };
 

--- a/apps/test/unit/templates/instructions/teacherFeedback/EditableTeacherFeedbackTest.jsx
+++ b/apps/test/unit/templates/instructions/teacherFeedback/EditableTeacherFeedbackTest.jsx
@@ -103,6 +103,8 @@ describe('EditableTeacherFeedback', () => {
         analyticsSpy.getCall(0).firstArg,
         'Level Feedback Submitted'
       );
+
+      analyticsSpy.restore();
     });
   });
 

--- a/apps/test/unit/templates/instructions/teacherFeedback/EditableTeacherFeedbackTest.jsx
+++ b/apps/test/unit/templates/instructions/teacherFeedback/EditableTeacherFeedbackTest.jsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import {shallow} from 'enzyme';
-import {expect} from '../../../../util/reconfiguredChai';
+import {expect, assert} from '../../../../util/reconfiguredChai';
 import {UnconnectedEditableTeacherFeedback as EditableTeacherFeedback} from '@cdo/apps/templates/instructions/teacherFeedback/EditableTeacherFeedback';
 import Comment from '@cdo/apps/templates/instructions/teacherFeedback/Comment';
 import EditableReviewState from '@cdo/apps/templates/instructions/teacherFeedback/EditableReviewState';
 import EditableFeedbackStatus from '@cdo/apps/templates/instructions/teacherFeedback/EditableFeedbackStatus';
 import Rubric from '@cdo/apps/templates/instructions/teacherFeedback/Rubric';
 import {ReviewStates} from '@cdo/apps/templates/feedback/types';
+import sinon from 'sinon';
+import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 
 const DEFAULT_PROPS = {
   user: 5,
@@ -89,6 +91,18 @@ describe('EditableTeacherFeedback', () => {
       const keepWorkingComponent = wrapper.find(EditableReviewState);
       expect(keepWorkingComponent).to.have.length(1);
       expect(keepWorkingComponent.props().latestReviewState).to.equal(null);
+    });
+
+    it('sends analytics event when feedback submitted', () => {
+      const wrapper = setUp();
+      const analyticsSpy = sinon.spy(analyticsReporter, 'sendEvent');
+
+      wrapper.find('Button[id="ui-test-submit-feedback"]').simulate('click');
+      assert(analyticsSpy.calledOnce);
+      assert.equal(
+        analyticsSpy.getCall(0).firstArg,
+        'Level Feedback Submitted'
+      );
     });
   });
 


### PR DESCRIPTION
Adds an amplitude call when a teacher submits feedback on a level. 

Here is a pic of the console log when called:
<img width="536" alt="Screen Shot 2023-02-07 at 10 45 56 AM" src="https://user-images.githubusercontent.com/37230822/217337432-834c711d-7dd0-4c0a-8946-1e0fd3acd9e0.png">


I tested this on this level (to illustrate!): http://localhost-studio.code.org:3000/s/csd1-2022/lessons/7/levels/2?section_id=40&user_id=92
<img width="734" alt="Screen Shot 2023-02-06 at 2 59 03 PM" src="https://user-images.githubusercontent.com/37230822/217106521-8d00d3c8-2051-4e0d-b826-ee309101600a.png">



## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/TEACH-193

## Testing story

Added a test to ensure that the amplitude call happens when submit is pressed.

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
