### PR TITLE
Direct Several `summarize` Methods to Read Replica

### DIFF
--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -306,80 +306,82 @@ class ScriptLevel < ApplicationRecord
   end
 
   def summarize(include_prev_next=true, for_edit: false, user_id: nil)
-    ids = level_ids
-    active_id = oldest_active_level.id
-    inactive_ids = ids - [active_id]
+    ActiveRecord::Base.connected_to(role: :reading) do
+      ids = level_ids
+      active_id = oldest_active_level.id
+      inactive_ids = ids - [active_id]
 
-    levels.each do |l|
-      ids.concat(l.contained_levels.map(&:id))
-    end
-
-    summary = {
-      ids: ids.map(&:to_s),
-      activeId: active_id.to_s,
-      inactiveIds: inactive_ids.map(&:to_s),
-      position: position,
-      kind: kind,
-      icon: level.icon,
-      is_concept_level: level.concept_level?,
-      title: level_display_text,
-      url: build_script_level_url(self),
-      freePlay: level.try(:free_play) == "true",
-      bonus: bonus,
-      display_as_unplugged: level.display_as_unplugged?
-    }
-
-    if progression
-      summary[:progression] = progression
-      localized_progression_name = I18n.t("data.progressions.#{progression}", default: progression)
-      summary[:progression_display_name] = localized_progression_name
-    end
-
-    if named_level
-      summary[:name] = level.display_name || level.name
-    end
-
-    if bubble_choice?
-      summary[:sublevels] = level.summarize_sublevels(script_level: self, user_id: user_id)
-    end
-
-    if for_edit
-      summary[:key] = level.key
-      summary[:skin] = level.try(:skin)
-      summary[:videoKey] = level.video_key
-      summary[:concepts] = level.summarize_concepts
-      summary[:conceptDifficulty] = level.summarize_concept_difficulty
-      summary[:assessment] = !!assessment
-      summary[:challenge] = !!challenge
-      summary[:instructor_in_training] = !!instructor_in_training
-    end
-
-    if include_prev_next
-      # Add a previous pointer if it's not the obvious (level-1)
-      if previous_level
-        if previous_level.lesson.absolute_position != lesson.absolute_position
-          summary[:previous] = [previous_level.lesson.absolute_position, previous_level.position]
-        end
-      else
-        # This is the first level in the script
-        summary[:previous] = false
+      levels.each do |l|
+        ids.concat(l.contained_levels.map(&:id))
       end
 
-      # Add a next pointer if it's not the obvious (level+1)
-      if end_of_lesson?
-        if next_level
-          summary[:next] = [next_level.lesson.absolute_position, next_level.position]
+      summary = {
+        ids: ids.map(&:to_s),
+        activeId: active_id.to_s,
+        inactiveIds: inactive_ids.map(&:to_s),
+        position: position,
+        kind: kind,
+        icon: level.icon,
+        is_concept_level: level.concept_level?,
+        title: level_display_text,
+        url: build_script_level_url(self),
+        freePlay: level.try(:free_play) == "true",
+        bonus: bonus,
+        display_as_unplugged: level.display_as_unplugged?
+      }
+
+      if progression
+        summary[:progression] = progression
+        localized_progression_name = I18n.t("data.progressions.#{progression}", default: progression)
+        summary[:progression_display_name] = localized_progression_name
+      end
+
+      if named_level
+        summary[:name] = level.display_name || level.name
+      end
+
+      if bubble_choice?
+        summary[:sublevels] = level.summarize_sublevels(script_level: self, user_id: user_id)
+      end
+
+      if for_edit
+        summary[:key] = level.key
+        summary[:skin] = level.try(:skin)
+        summary[:videoKey] = level.video_key
+        summary[:concepts] = level.summarize_concepts
+        summary[:conceptDifficulty] = level.summarize_concept_difficulty
+        summary[:assessment] = !!assessment
+        summary[:challenge] = !!challenge
+        summary[:instructor_in_training] = !!instructor_in_training
+      end
+
+      if include_prev_next
+        # Add a previous pointer if it's not the obvious (level-1)
+        if previous_level
+          if previous_level.lesson.absolute_position != lesson.absolute_position
+            summary[:previous] = [previous_level.lesson.absolute_position, previous_level.position]
+          end
         else
-          # This is the final level in the script
-          summary[:next] = false
-          if script.wrapup_video
-            summary[:wrapupVideo] = script.wrapup_video.summarize
+          # This is the first level in the script
+          summary[:previous] = false
+        end
+
+        # Add a next pointer if it's not the obvious (level+1)
+        if end_of_lesson?
+          if next_level
+            summary[:next] = [next_level.lesson.absolute_position, next_level.position]
+          else
+            # This is the final level in the script
+            summary[:next] = false
+            if script.wrapup_video
+              summary[:wrapupVideo] = script.wrapup_video.summarize
+            end
           end
         end
       end
-    end
 
-    summary
+      summary
+    end
   end
 
   def summarize_for_lesson_show(can_view_teacher_markdown, current_user)

--- a/dashboard/app/models/sections/section.rb
+++ b/dashboard/app/models/sections/section.rb
@@ -317,75 +317,77 @@ class Section < ApplicationRecord
   # Provides some information about a section. This is consumed by our SectionsAsStudentTable
   # React component on the teacher homepage and student homepage
   def summarize(include_students: true)
-    base_url = CDO.studio_url('/teacher_dashboard/sections/')
+    ActiveRecord::Base.connected_to(role: :reading) do
+      base_url = CDO.studio_url('/teacher_dashboard/sections/')
 
-    title = ''
-    link_to_assigned = base_url
-    title_of_current_unit = ''
-    link_to_current_unit = ''
-    course_version_name = nil
+      title = ''
+      link_to_assigned = base_url
+      title_of_current_unit = ''
+      link_to_current_unit = ''
+      course_version_name = nil
 
-    if unit_group
-      title = unit_group.localized_title
-      link_to_assigned = course_path(unit_group)
-      course_version_name = unit_group.name
-      if script_id
-        title_of_current_unit = script.title_for_display
-        link_to_current_unit = script_path(script)
+      if unit_group
+        title = unit_group.localized_title
+        link_to_assigned = course_path(unit_group)
+        course_version_name = unit_group.name
+        if script_id
+          title_of_current_unit = script.title_for_display
+          link_to_current_unit = script_path(script)
+        end
+      elsif script_id
+        title = script.title_for_display
+        link_to_assigned = script_path(script)
+        course_version_name = script.name
       end
-    elsif script_id
-      title = script.title_for_display
-      link_to_assigned = script_path(script)
-      course_version_name = script.name
+
+      # Remove ordering from scope when not including full
+      # list of students, in order to improve query performance.
+      unique_students = include_students ?
+        students.distinct(&:id) :
+        students.unscope(:order).distinct(&:id)
+      num_students = unique_students.size
+
+      {
+        id: id,
+        name: name,
+        createdAt: created_at,
+        teacherName: teacher.name,
+        linkToProgress: "#{base_url}#{id}/progress",
+        assignedTitle: title,
+        linkToAssigned: link_to_assigned,
+        currentUnitTitle: title_of_current_unit,
+        linkToCurrentUnit: link_to_current_unit,
+        courseVersionName: course_version_name,
+        numberOfStudents: num_students,
+        linkToStudents: "#{base_url}#{id}/manage_students",
+        code: code,
+        lesson_extras: lesson_extras,
+        pairing_allowed: pairing_allowed,
+        tts_autoplay_enabled: tts_autoplay_enabled,
+        sharing_disabled: sharing_disabled?,
+        login_type: login_type,
+        participant_type: participant_type,
+        course_offering_id: unit_group ? unit_group&.course_version&.course_offering&.id : script&.course_version&.course_offering&.id,
+        course_version_id: unit_group ? unit_group&.course_version&.id : script&.course_version&.id,
+        unit_id: unit_group ? script_id : nil,
+        course_id: course_id,
+        script: {
+          id: script_id,
+          name: script.try(:name),
+          project_sharing: script.try(:project_sharing)
+        },
+        studentCount: num_students,
+        grade: grade,
+        providerManaged: provider_managed?,
+        hidden: hidden,
+        students: include_students ? unique_students.map(&:summarize) : nil,
+        restrict_section: restrict_section,
+        is_assigned_csa: assigned_csa?,
+        # this will be true when we are in emergency mode, for the scripts returned by ScriptConfig.hoc_scripts and ScriptConfig.csf_scripts
+        post_milestone_disabled: !!script && !Gatekeeper.allows('postMilestone', where: {script_name: script.name}, default: true),
+        code_review_expires_at: code_review_expires_at
+      }
     end
-
-    # Remove ordering from scope when not including full
-    # list of students, in order to improve query performance.
-    unique_students = include_students ?
-      students.distinct(&:id) :
-      students.unscope(:order).distinct(&:id)
-    num_students = unique_students.size
-
-    {
-      id: id,
-      name: name,
-      createdAt: created_at,
-      teacherName: teacher.name,
-      linkToProgress: "#{base_url}#{id}/progress",
-      assignedTitle: title,
-      linkToAssigned: link_to_assigned,
-      currentUnitTitle: title_of_current_unit,
-      linkToCurrentUnit: link_to_current_unit,
-      courseVersionName: course_version_name,
-      numberOfStudents: num_students,
-      linkToStudents: "#{base_url}#{id}/manage_students",
-      code: code,
-      lesson_extras: lesson_extras,
-      pairing_allowed: pairing_allowed,
-      tts_autoplay_enabled: tts_autoplay_enabled,
-      sharing_disabled: sharing_disabled?,
-      login_type: login_type,
-      participant_type: participant_type,
-      course_offering_id: unit_group ? unit_group&.course_version&.course_offering&.id : script&.course_version&.course_offering&.id,
-      course_version_id: unit_group ? unit_group&.course_version&.id : script&.course_version&.id,
-      unit_id: unit_group ? script_id : nil,
-      course_id: course_id,
-      script: {
-        id: script_id,
-        name: script.try(:name),
-        project_sharing: script.try(:project_sharing)
-      },
-      studentCount: num_students,
-      grade: grade,
-      providerManaged: provider_managed?,
-      hidden: hidden,
-      students: include_students ? unique_students.map(&:summarize) : nil,
-      restrict_section: restrict_section,
-      is_assigned_csa: assigned_csa?,
-      # this will be true when we are in emergency mode, for the scripts returned by ScriptConfig.hoc_scripts and ScriptConfig.csf_scripts
-      post_milestone_disabled: !!script && !Gatekeeper.allows('postMilestone', where: {script_name: script.name}, default: true),
-      code_review_expires_at: code_review_expires_at
-    }
   end
 
   def provider_managed?

--- a/dashboard/app/models/teacher_feedback.rb
+++ b/dashboard/app/models/teacher_feedback.rb
@@ -149,21 +149,23 @@ class TeacherFeedback < ApplicationRecord
 
   # TODO: update to use camelcase
   def summarize(is_latest = false)
-    {
-      id: id,
-      student_id: student_id,
-      script_id: script_id,
-      level_id: level_id,
-      comment: comment,
-      performance: performance,
-      created_at: created_at,
-      student_seen_feedback: student_seen_feedback,
-      review_state: review_state,
-      student_last_updated: user_level&.updated_at,
-      seen_on_feedback_page_at: seen_on_feedback_page_at,
-      student_first_visited_at: student_first_visited_at,
-      is_awaiting_teacher_review: awaiting_teacher_review?(is_latest)
-    }
+    ActiveRecord::Base.connected_to(role: :reading) do
+      {
+        id: id,
+        student_id: student_id,
+        script_id: script_id,
+        level_id: level_id,
+        comment: comment,
+        performance: performance,
+        created_at: created_at,
+        student_seen_feedback: student_seen_feedback,
+        review_state: review_state,
+        student_last_updated: user_level&.updated_at,
+        seen_on_feedback_page_at: seen_on_feedback_page_at,
+        student_first_visited_at: student_first_visited_at,
+        is_awaiting_teacher_review: awaiting_teacher_review?(is_latest)
+      }
+    end
   end
 
   def summarize_for_csv(level, script_level, student, sublevel_index = nil)

--- a/dashboard/app/models/unit.rb
+++ b/dashboard/app/models/unit.rb
@@ -1475,109 +1475,111 @@ class Unit < ApplicationRecord
   end
 
   def summarize(include_lessons = true, user = nil, include_bonus_levels = false, locale_code = 'en-us')
-    # TODO: Set up peer reviews to be more consistent with the rest of the system
-    # so that they don't need a bunch of one off cases (example peer reviews
-    # don't have a lesson group in the database right now)
-    if has_peer_reviews? && !only_instructor_review_required?
-      levels = []
-      peer_reviews_to_complete.times do |x|
-        levels << {
-          ids: [x],
-          kind: LEVEL_KIND.peer_review,
-          title: '',
-          url: '',
-          name: I18n.t('peer_review.reviews_unavailable'),
-          icon: 'fa-lock',
-          locked: true
+    ActiveRecord::Base.connected_to(role: :reading) do
+      # TODO: Set up peer reviews to be more consistent with the rest of the system
+      # so that they don't need a bunch of one off cases (example peer reviews
+      # don't have a lesson group in the database right now)
+      if has_peer_reviews? && !only_instructor_review_required?
+        levels = []
+        peer_reviews_to_complete.times do |x|
+          levels << {
+            ids: [x],
+            kind: LEVEL_KIND.peer_review,
+            title: '',
+            url: '',
+            name: I18n.t('peer_review.reviews_unavailable'),
+            icon: 'fa-lock',
+            locked: true
+          }
+        end
+
+        peer_review_lesson_info = {
+          name: I18n.t('peer_review.review_count', review_count: peer_reviews_to_complete),
+          lesson_group_display_name: 'Peer Review',
+          levels: levels,
+          lockable: false
         }
       end
 
-      peer_review_lesson_info = {
-        name: I18n.t('peer_review.review_count', review_count: peer_reviews_to_complete),
-        lesson_group_display_name: 'Peer Review',
-        levels: levels,
-        lockable: false
+      has_older_course_progress = unit_group.try(:has_older_version_progress?, user)
+      has_older_unit_progress = has_older_version_progress?(user)
+      user_unit = user && user_scripts.find_by(user: user)
+
+      # If the current user is assigned to this unit, get the section
+      # that assigned it.
+      assigned_section_id = user&.assigned_script?(self) ? user.section_for_script(self)&.id : nil
+
+      summary = {
+        id: id,
+        name: name,
+        title: title_for_display,
+        description: Services::MarkdownPreprocessor.process(localized_description),
+        studentDescription: Services::MarkdownPreprocessor.process(localized_student_description),
+        course_id: unit_group.try(:id),
+        publishedState: get_published_state,
+        instructionType: get_instruction_type,
+        instructorAudience: get_instructor_audience,
+        participantAudience: get_participant_audience,
+        loginRequired: login_required,
+        plc: old_professional_learning_course?,
+        hideable_lessons: hideable_lessons?,
+        disablePostMilestone: disable_post_milestone?,
+        csf: csf?,
+        isCsd: csd?,
+        isCsp: csp?,
+        only_instructor_review_required: only_instructor_review_required?,
+        peerReviewsRequired: peer_reviews_to_complete || 0,
+        peerReviewLessonInfo: peer_review_lesson_info,
+        student_detail_progress_view: student_detail_progress_view?,
+        project_widget_visible: project_widget_visible?,
+        project_widget_types: project_widget_types,
+        teacher_resources: resources.sort_by(&:name).map(&:summarize_for_resources_dropdown),
+        student_resources: student_resources.sort_by(&:name).map(&:summarize_for_resources_dropdown),
+        lesson_extras_available: lesson_extras_available,
+        has_verified_resources: has_verified_resources?,
+        curriculum_path: curriculum_path,
+        announcements: localized_announcements,
+        age_13_required: logged_out_age_13_required?,
+        show_course_unit_version_warning: !unit_group&.has_dismissed_version_warning?(user) && has_older_course_progress,
+        show_script_version_warning: !user_unit&.version_warning_dismissed && !has_older_course_progress && has_older_unit_progress,
+        course_versions: summarize_course_versions(user, locale_code),
+        supported_locales: supported_locales,
+        section_hidden_unit_info: section_hidden_unit_info(user),
+        pilot_experiment: get_pilot_experiment,
+        editor_experiment: editor_experiment,
+        show_assign_button: course_assignable?(user),
+        project_sharing: project_sharing,
+        curriculum_umbrella: curriculum_umbrella,
+        family_name: family_name,
+        version_year: version_year,
+        assigned_section_id: assigned_section_id,
+        hasStandards: has_standards_associations?,
+        tts: tts?,
+        deprecated: deprecated?,
+        is_course: is_course?,
+        is_migrated: is_migrated?,
+        scriptPath: script_path(self),
+        showCalendar: is_migrated ? show_calendar : false, #prevent calendar from showing for non-migrated units for now
+        weeklyInstructionalMinutes: weekly_instructional_minutes,
+        includeStudentLessonPlans: is_migrated ? include_student_lesson_plans : false,
+        useLegacyLessonPlans: is_migrated && use_legacy_lesson_plans,
+        courseVersionId: get_course_version&.id,
+        courseOfferingId: get_course_version&.course_offering&.id,
+        scriptOverviewPdfUrl: get_unit_overview_pdf_url,
+        scriptResourcesPdfUrl: get_unit_resources_pdf_url,
+        updated_at: updated_at.to_s,
+        isPlCourse: pl_course?
       }
+
+      #TODO: lessons should be summarized through lesson groups in the future
+      summary[:lessonGroups] = lesson_groups.map(&:summarize)
+      summary[:lessons] = lessons.map {|lesson| lesson.summarize(include_bonus_levels)} if include_lessons
+      summary[:deeperLearningCourse] = professional_learning_course if old_professional_learning_course?
+      summary[:wrapupVideo] = wrapup_video.key if wrapup_video
+      summary[:calendarLessons] = lessons.map(&:summarize_for_calendar)
+
+      summary
     end
-
-    has_older_course_progress = unit_group.try(:has_older_version_progress?, user)
-    has_older_unit_progress = has_older_version_progress?(user)
-    user_unit = user && user_scripts.find_by(user: user)
-
-    # If the current user is assigned to this unit, get the section
-    # that assigned it.
-    assigned_section_id = user&.assigned_script?(self) ? user.section_for_script(self)&.id : nil
-
-    summary = {
-      id: id,
-      name: name,
-      title: title_for_display,
-      description: Services::MarkdownPreprocessor.process(localized_description),
-      studentDescription: Services::MarkdownPreprocessor.process(localized_student_description),
-      course_id: unit_group.try(:id),
-      publishedState: get_published_state,
-      instructionType: get_instruction_type,
-      instructorAudience: get_instructor_audience,
-      participantAudience: get_participant_audience,
-      loginRequired: login_required,
-      plc: old_professional_learning_course?,
-      hideable_lessons: hideable_lessons?,
-      disablePostMilestone: disable_post_milestone?,
-      csf: csf?,
-      isCsd: csd?,
-      isCsp: csp?,
-      only_instructor_review_required: only_instructor_review_required?,
-      peerReviewsRequired: peer_reviews_to_complete || 0,
-      peerReviewLessonInfo: peer_review_lesson_info,
-      student_detail_progress_view: student_detail_progress_view?,
-      project_widget_visible: project_widget_visible?,
-      project_widget_types: project_widget_types,
-      teacher_resources: resources.sort_by(&:name).map(&:summarize_for_resources_dropdown),
-      student_resources: student_resources.sort_by(&:name).map(&:summarize_for_resources_dropdown),
-      lesson_extras_available: lesson_extras_available,
-      has_verified_resources: has_verified_resources?,
-      curriculum_path: curriculum_path,
-      announcements: localized_announcements,
-      age_13_required: logged_out_age_13_required?,
-      show_course_unit_version_warning: !unit_group&.has_dismissed_version_warning?(user) && has_older_course_progress,
-      show_script_version_warning: !user_unit&.version_warning_dismissed && !has_older_course_progress && has_older_unit_progress,
-      course_versions: summarize_course_versions(user, locale_code),
-      supported_locales: supported_locales,
-      section_hidden_unit_info: section_hidden_unit_info(user),
-      pilot_experiment: get_pilot_experiment,
-      editor_experiment: editor_experiment,
-      show_assign_button: course_assignable?(user),
-      project_sharing: project_sharing,
-      curriculum_umbrella: curriculum_umbrella,
-      family_name: family_name,
-      version_year: version_year,
-      assigned_section_id: assigned_section_id,
-      hasStandards: has_standards_associations?,
-      tts: tts?,
-      deprecated: deprecated?,
-      is_course: is_course?,
-      is_migrated: is_migrated?,
-      scriptPath: script_path(self),
-      showCalendar: is_migrated ? show_calendar : false, #prevent calendar from showing for non-migrated units for now
-      weeklyInstructionalMinutes: weekly_instructional_minutes,
-      includeStudentLessonPlans: is_migrated ? include_student_lesson_plans : false,
-      useLegacyLessonPlans: is_migrated && use_legacy_lesson_plans,
-      courseVersionId: get_course_version&.id,
-      courseOfferingId: get_course_version&.course_offering&.id,
-      scriptOverviewPdfUrl: get_unit_overview_pdf_url,
-      scriptResourcesPdfUrl: get_unit_resources_pdf_url,
-      updated_at: updated_at.to_s,
-      isPlCourse: pl_course?
-    }
-
-    #TODO: lessons should be summarized through lesson groups in the future
-    summary[:lessonGroups] = lesson_groups.map(&:summarize)
-    summary[:lessons] = lessons.map {|lesson| lesson.summarize(include_bonus_levels)} if include_lessons
-    summary[:deeperLearningCourse] = professional_learning_course if old_professional_learning_course?
-    summary[:wrapupVideo] = wrapup_video.key if wrapup_video
-    summary[:calendarLessons] = lessons.map(&:summarize_for_calendar)
-
-    summary
   end
 
   def unit_without_lesson_plans?

--- a/dashboard/app/models/unit_group.rb
+++ b/dashboard/app/models/unit_group.rb
@@ -293,39 +293,41 @@ class UnitGroup < ApplicationRecord
   end
 
   def summarize(user = nil, for_edit: false, locale_code: nil)
-    {
-      name: name,
-      id: id,
-      title: localized_title,
-      assignment_family_title: localized_assignment_family_title,
-      family_name: family_name,
-      version_year: version_year,
-      published_state: published_state,
-      instruction_type: instruction_type,
-      instructor_audience: instructor_audience,
-      participant_audience: participant_audience,
-      pilot_experiment: pilot_experiment,
-      description_short: I18n.t("data.course.name.#{name}.description_short", default: ''),
-      description_student: Services::MarkdownPreprocessor.process(I18n.t("data.course.name.#{name}.description_student", default: '')),
-      description_teacher: Services::MarkdownPreprocessor.process(I18n.t("data.course.name.#{name}.description_teacher", default: '')),
-      version_title: I18n.t("data.course.name.#{name}.version_title", default: ''),
-      scripts: units_for_user(user).map do |unit|
-        include_lessons = false
-        unit.summarize(include_lessons, user).merge!(unit.summarize_i18n_for_display)
-      end,
-      teacher_resources: resources.sort_by(&:name).map(&:summarize_for_resources_dropdown),
-      student_resources: student_resources.sort_by(&:name).map(&:summarize_for_resources_dropdown),
-      is_migrated: has_migrated_unit?,
-      has_verified_resources: has_verified_resources?,
-      has_numbered_units: has_numbered_units?,
-      course_versions: summarize_course_versions(user, locale_code),
-      show_assign_button: course_assignable?(user),
-      announcements: announcements,
-      course_offering_id: course_version&.course_offering&.id,
-      course_version_id: course_version&.id,
-      course_path: link,
-      course_offering_edit_path: for_edit && course_version ? edit_course_offering_path(course_version.course_offering.key) : nil
-    }
+    ActiveRecord::Base.connected_to(role: :reading) do
+      {
+        name: name,
+        id: id,
+        title: localized_title,
+        assignment_family_title: localized_assignment_family_title,
+        family_name: family_name,
+        version_year: version_year,
+        published_state: published_state,
+        instruction_type: instruction_type,
+        instructor_audience: instructor_audience,
+        participant_audience: participant_audience,
+        pilot_experiment: pilot_experiment,
+        description_short: I18n.t("data.course.name.#{name}.description_short", default: ''),
+        description_student: Services::MarkdownPreprocessor.process(I18n.t("data.course.name.#{name}.description_student", default: '')),
+        description_teacher: Services::MarkdownPreprocessor.process(I18n.t("data.course.name.#{name}.description_teacher", default: '')),
+        version_title: I18n.t("data.course.name.#{name}.version_title", default: ''),
+        scripts: units_for_user(user).map do |unit|
+          include_lessons = false
+          unit.summarize(include_lessons, user).merge!(unit.summarize_i18n_for_display)
+        end,
+        teacher_resources: resources.sort_by(&:name).map(&:summarize_for_resources_dropdown),
+        student_resources: student_resources.sort_by(&:name).map(&:summarize_for_resources_dropdown),
+        is_migrated: has_migrated_unit?,
+        has_verified_resources: has_verified_resources?,
+        has_numbered_units: has_numbered_units?,
+        course_versions: summarize_course_versions(user, locale_code),
+        show_assign_button: course_assignable?(user),
+        announcements: announcements,
+        course_offering_id: course_version&.course_offering&.id,
+        course_version_id: course_version&.id,
+        course_path: link,
+        course_offering_edit_path: for_edit && course_version ? edit_course_offering_path(course_version.course_offering.key) : nil
+      }
+    end
   end
 
   def summarize_for_rollup(user = nil)

--- a/dashboard/app/models/video.rb
+++ b/dashboard/app/models/video.rb
@@ -150,15 +150,17 @@ class Video < ApplicationRecord
   end
 
   def summarize(autoplay = true)
-    # Note: similar video info is also set in javascript at levels/_blockly.html.haml
-    {
-      src: youtube_url(autoplay: autoplay ? 1 : 0),
-      key: key,
-      name: localized_name,
-      download: download,
-      thumbnail: thumbnail_path,
-      enable_fallback: true,
-      autoplay: autoplay,
-    }
+    ActiveRecord::Base.connected_to(role: :reading) do
+      # Note: similar video info is also set in javascript at levels/_blockly.html.haml
+      {
+        src: youtube_url(autoplay: autoplay ? 1 : 0),
+        key: key,
+        name: localized_name,
+        download: download,
+        thumbnail: thumbnail_path,
+        enable_fallback: true,
+        autoplay: autoplay,
+      }
+    end
   end
 end


### PR DESCRIPTION
We have a number of model methods intended to serialize model data into Hashes, usually so they can be converted to JSON for clientside use.  These methods often call other summarize methods, several layers deep, and in some circumstances a single `summarize` call can result in hundreds of database queries.

As a minor performance optimization, start directing these queries to the read replica.

I recommend reviewing [with whitespace changes disabled](https://github.com/code-dot-org/code-dot-org/pull/50107/files?w=1)

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

This change is unfortunately very difficult to test automatically, as none of our test environments are property configured with read/write splitting.

I've manually inspected all affected functionality to confirm that none of them appear to be causing any writes as side effects, and have manually tested loading some relevant pages on a local instance configured with read/write splitting.

## Deployment strategy

We should plan to carefully monitor our various channels for user-facing errors when this is deployed, and have a revert prepped if anything does come up.

Note that we do have [a gatekeeper setting](https://github.com/code-dot-org/code-dot-org/blob/26fc785380ebc14ce0d3f66af931d620db89c904/dashboard/app/helpers/read_replica_helper.rb#L14) we can use to temporarily disable read/write splitting in the event that this starts causing issues; that isn't a situation we want to remain in for long, but it should be possible for the writer to handle all operations for as long as it takes us to get the revert deployed.

## Follow-up work

We should also plan to carefully check our relative usage of the writer and reader databases after this change has been deployed for a few days. I'm not sure how significant of a difference we should expect this to make; I'm expecting a noticeable change, but probably not *too* significant of a one.

There are a few more `summarize` methods in our codebase - including various "summarize_for_specific_circumstance" methods -  which have more-complex logic but are functionally similar to the ones updated in this PR. I left those alone for now, but depending on the magnitude of change we see we could consider also redirecting those to the read replica.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
