### PR TITLE
Moving microbit 2022 back to in_development

### DIFF
--- a/dashboard/config/scripts_json/microbit-2022.script_json
+++ b/dashboard/config/scripts_json/microbit-2022.script_json
@@ -16,7 +16,7 @@
     "new_name": null,
     "family_name": "microbit",
     "serialized_at": "2023-02-01 10:54:35 UTC",
-    "published_state": "beta",
+    "published_state": "in_development",
     "instruction_type": "teacher_led",
     "instructor_audience": "teacher",
     "participant_audience": "student",


### PR DESCRIPTION
Updates published state for microbit 2022 back to in development. Tested locally by seeding the script on my branch and on staging and everything worked!

command:
bundle exec rake seed:single_script SCRIPT_NAME=microbit-2022

for the record, had to run these first: 
bundle exec rake seed:custom_levels
bundle exec rake seed:dsls

## Links


- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/TEACH-232

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
