### PR TITLE
Fix Violations of and Reenable `Lint/RedundantSafeNavigation`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -115,13 +115,6 @@ Lint/OrAssignmentToConstant:
 Lint/RaiseException:
   Enabled: false
 
-# Offense count: 5
-# This cop supports unsafe auto-correction (--auto-correct-all).
-# Configuration parameters: AllowedMethods.
-# AllowedMethods: instance_of?, kind_of?, is_a?, eql?, respond_to?, equal?
-Lint/RedundantSafeNavigation:
-  Enabled: false
-
 # Offense count: 56
 Lint/RescueException:
   Enabled: false

--- a/dashboard/app/controllers/api/v1/user_school_infos_controller.rb
+++ b/dashboard/app/controllers/api/v1/user_school_infos_controller.rb
@@ -18,7 +18,7 @@ class Api::V1::UserSchoolInfosController < ApplicationController
 
     school_info_params.delete(:full_address) if school_info_params[:full_address].blank?
 
-    if school_info_params[:country]&.downcase&.eql? 'united states'
+    if school_info_params[:country]&.downcase.eql? 'united states'
       school_info_params[:country] = 'US'
     end
 

--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -141,7 +141,7 @@ class LevelsController < ApplicationController
   # GET /levels/1/edit
   def edit
     # Make sure that the encrypted property is a boolean
-    if @level.properties['encrypted']&.is_a?(String)
+    if @level.properties['encrypted'].is_a?(String)
       @level.properties['encrypted'] = @level.properties['encrypted'].to_bool
     end
     bubble_choice_parents = BubbleChoice.parent_levels(@level.name)

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -170,7 +170,7 @@ class Ability
         # Only allow a student to view another student's project
         # only on levels where we have our peer review feature.
         # For now, that's only Javalab.
-        if level_to_view&.is_a?(Javalab)
+        if level_to_view.is_a?(Javalab)
           project_level_id = level_to_view.project_template_level.try(:id) ||
             level_to_view.id
 

--- a/dashboard/app/models/levels/blockly.rb
+++ b/dashboard/app/models/levels/blockly.rb
@@ -948,7 +948,7 @@ class Blockly < Level
   end
 
   def update_goal_override
-    if goal_override&.is_a?(String)
+    if goal_override.is_a?(String)
       self.goal_override = JSON.parse(goal_override)
     end
   end

--- a/dashboard/lib/pd/payment/payment_factory.rb
+++ b/dashboard/lib/pd/payment/payment_factory.rb
@@ -1,7 +1,7 @@
 module Pd::Payment
   module PaymentFactory
     def self.get_payment(workshop)
-      raise 'Workshop required.' unless workshop&.is_a?(Pd::Workshop)
+      raise 'Workshop required.' unless workshop.is_a?(Pd::Workshop)
       get_calculator_class(workshop).instance.calculate(workshop)
     end
 


### PR DESCRIPTION
Fix applied automatically with `bundle exec rubocop --auto-correct-all --only Lint/RedundantSafeNavigation`

> Checks for redundant safe navigation calls. `instance_of?`, `kind_of?`, `is_a?`, `eql?`, `respond_to?`, and `equal?` methods are checked by default. These are customizable with `AllowedMethods` option.

## Links

- https://rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/RedundantSafeNavigation
- https://docs.rubocop.org/rubocop/cops_lint.html#lintredundantsafenavigation

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
