### PR TITLE
[CDO Blockly] Bump blockly version to 4.0.6

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -53,7 +53,7 @@
     "@babel/preset-react": "^7.18.6",
     "@cdo/interpreted": "link:../dashboard/config/libraries",
     "@code-dot-org/artist": "0.2.1",
-    "@code-dot-org/blockly": "4.0.5",
+    "@code-dot-org/blockly": "4.0.6",
     "@code-dot-org/craft": "0.2.2",
     "@code-dot-org/dance-party": "1.0.5",
     "@code-dot-org/js-interpreter-tyrant": "0.2.2",

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -1320,10 +1320,10 @@
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/@code-dot-org/artist/-/artist-0.2.1.tgz#fcfe7ea5cfb3f19ddb6b912e70e922ba4b7ef0b1"
 
-"@code-dot-org/blockly@4.0.5":
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/@code-dot-org/blockly/-/blockly-4.0.5.tgz#6e083239936db32d63531c484b6accc79b95e2c5"
-  integrity sha512-VGj8OfMDVgLr20DiarlZpftnAhvDNQ78TNQ9zSH8t1Z+2Q9oY91I9a9wvfuBFgv+mXlS3rZOIBDNKKbdBPx0KA==
+"@code-dot-org/blockly@4.0.6":
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/@code-dot-org/blockly/-/blockly-4.0.6.tgz#70ec691789dd660cfe9e1dc7c6778984d952d9b3"
+  integrity sha512-fCeTdXMwN8wj7YoPYfjY8G5iU8kUPRmR8kVSLQJKyVRrGnZHunTKG5sfhjjJqDTIkqx++tM1PnNt6KI2oEYtbw==
 
 "@code-dot-org/craft@0.2.2":
   version "0.2.2"


### PR DESCRIPTION
This new version of our in-house Blockly contains a layout change for a custom field type, made in https://github.com/code-dot-org/blockly/pull/308.

Version bump in the blockly repo: https://github.com/code-dot-org/blockly/commit/c21d50a67a43d93115a09a52ea5afd141b1c5e80