### PR TITLE
Add breakpoints.scss to shared/css

### DIFF
--- a/pegasus/sites.v3/code.org/public/css/careers-greenhouse.scss
+++ b/pegasus/sites.v3/code.org/public/css/careers-greenhouse.scss
@@ -1,4 +1,4 @@
-@import 'imports/_breakpoints.scss';
+@import 'breakpoints.scss';
 
 #wrapper, #app_body {
   color: #292F36;

--- a/pegasus/sites.v3/code.org/public/css/cs-leaders-prize.scss
+++ b/pegasus/sites.v3/code.org/public/css/cs-leaders-prize.scss
@@ -1,4 +1,4 @@
-@import 'font.scss', 'color.scss', 'imports/_breakpoints.scss';
+@import 'font.scss', 'color.scss', 'breakpoints.scss';
 
 html {
   scroll-behavior: smooth;

--- a/pegasus/sites.v3/code.org/public/css/hoc-banner.scss
+++ b/pegasus/sites.v3/code.org/public/css/hoc-banner.scss
@@ -1,4 +1,4 @@
-@import 'color.scss', 'font.scss', 'imports/_breakpoints.scss';
+@import 'color.scss', 'font.scss', 'breakpoints.scss';
 
 // Code.org HoC homepage banner
 #bars {

--- a/pegasus/sites.v3/code.org/public/css/hoc-skinny-banner.scss
+++ b/pegasus/sites.v3/code.org/public/css/hoc-skinny-banner.scss
@@ -1,4 +1,4 @@
-@import 'color.scss', 'font.scss', 'imports/_breakpoints.scss';
+@import 'color.scss', 'font.scss', 'breakpoints.scss';
 
 aside.hoc-skinny-banner {
   background: url("/images/hoc2022-skinny-banner-bg.png") no-repeat center center;

--- a/pegasus/sites.v3/code.org/public/css/hoc2022-landing-page.scss
+++ b/pegasus/sites.v3/code.org/public/css/hoc2022-landing-page.scss
@@ -1,4 +1,4 @@
-@import "color.scss", "font.scss", "imports/_breakpoints.scss";
+@import "color.scss", "font.scss", "breakpoints.scss";
 
 html {
   scroll-behavior: smooth;

--- a/pegasus/sites.v3/code.org/public/css/imports/_breakpoints.scss
+++ b/pegasus/sites.v3/code.org/public/css/imports/_breakpoints.scss
@@ -1,7 +1,0 @@
-// Breakpoints
-$width-xxl: 2560px; // Desktop - 2XL
-$width-xl: 1920px; // Desktop - extra large
-$width-lg: 1024px; // Desktop
-$width-md: 992px; // Tablet
-$width-sm: 640px; // Mobile
-$width-xs: 374px; // Mobile - extra small

--- a/pegasus/sites.v3/code.org/public/css/maker-skinny-banner.scss
+++ b/pegasus/sites.v3/code.org/public/css/maker-skinny-banner.scss
@@ -1,4 +1,4 @@
-@import "color.scss", "font.scss", "imports/_breakpoints.scss";
+@import "color.scss", "font.scss", "breakpoints.scss";
 
 .maker-skinny-banner {
   box-sizing: content-box;

--- a/pegasus/sites.v3/code.org/public/css/pl-hero-banner.scss
+++ b/pegasus/sites.v3/code.org/public/css/pl-hero-banner.scss
@@ -1,4 +1,4 @@
-@import 'color.scss', 'font.scss', 'imports/_breakpoints.scss';
+@import 'color.scss', 'font.scss', 'breakpoints.scss';
 
 .pl-banner-superhero.homepage {
   max-width: 1020px;

--- a/pegasus/sites.v3/code.org/public/css/posters.scss
+++ b/pegasus/sites.v3/code.org/public/css/posters.scss
@@ -1,4 +1,4 @@
-@import 'imports/_breakpoints.scss';
+@import 'breakpoints.scss';
 
 section {
   display: flex;

--- a/pegasus/sites.v3/hourofcode.com/public/css/front-page.scss
+++ b/pegasus/sites.v3/hourofcode.com/public/css/front-page.scss
@@ -1,4 +1,4 @@
-@import 'color.scss', 'font.scss', 'imports/_breakpoints.scss';
+@import 'color.scss', 'font.scss', 'breakpoints.scss';
 
 html, body {
   height: 100%;

--- a/pegasus/sites.v3/hourofcode.com/public/css/highlights-homepage.scss
+++ b/pegasus/sites.v3/hourofcode.com/public/css/highlights-homepage.scss
@@ -1,4 +1,4 @@
-@import 'color.scss', 'font.scss', 'imports/_breakpoints.scss';
+@import 'color.scss', 'font.scss', 'breakpoints.scss';
 
 .section-wrapper {
   margin-top: 4em;

--- a/pegasus/sites.v3/hourofcode.com/public/css/hoc-banner.scss
+++ b/pegasus/sites.v3/hourofcode.com/public/css/hoc-banner.scss
@@ -1,4 +1,4 @@
-@import 'color.scss', 'font.scss', 'imports/_breakpoints.scss';
+@import 'color.scss', 'font.scss', 'breakpoints.scss';
 
 #fullwidth {
   overflow: hidden;

--- a/pegasus/sites.v3/hourofcode.com/public/css/imports/_breakpoints.scss
+++ b/pegasus/sites.v3/hourofcode.com/public/css/imports/_breakpoints.scss
@@ -1,4 +1,0 @@
-$width-lg: 1024px; // Laptop
-$width-md: 992px; // Tablet
-$width-sm: 640px; // Mobile
-$width-xs: 374px; // Mobile - extra small

--- a/shared/css/breakpoints.scss
+++ b/shared/css/breakpoints.scss
@@ -1,4 +1,6 @@
-// Breakpoints
+// Common site-wide breakpoints for responsive styling,
+// put here for easy access from all scss files
+
 $width-xxl: 2560px; // Desktop - 2XL
 $width-xl: 1920px; // Desktop - extra large
 $width-lg: 1024px; // Desktop

--- a/shared/css/breakpoints.scss
+++ b/shared/css/breakpoints.scss
@@ -1,0 +1,7 @@
+// Breakpoints
+$width-xxl: 2560px; // Desktop - 2XL
+$width-xl: 1920px; // Desktop - extra large
+$width-lg: 1024px; // Desktop
+$width-md: 992px; // Tablet
+$width-sm: 640px; // Mobile
+$width-xs: 374px; // Mobile - extra small


### PR DESCRIPTION
Adding a shared breakpoints.scss file w/ common breakpoints for more streamlined responsive styling when using Sass. Has a similar use case to the [color.scss](https://github.com/code-dot-org/code-dot-org/blob/staging/shared/css/color.scss) and [font.scss](https://github.com/code-dot-org/code-dot-org/blob/staging/shared/css/font.scss) files that are used across our sites.

- Desktop - 2XL - `$width-xxl: 2560px;`
- Desktop - extra large - `$width-xl: 1920px;` 
- Desktop - `$width-lg: 1024px;` 
- Tablet - `$width-md: 992px;` 
- Mobile - `$width-sm: 640px;`
- Mobile - extra small - `$width-xs: 374px;`

[Asana task](https://app.asana.com/0/1202773141567416/1203923163307677/f)