### PR TITLE
Update confirmation email for Admin/Counselor workshop enrollment

### DIFF
--- a/dashboard/app/views/pd/workshop_mailer/teacher_enrollment_receipt.html.haml
+++ b/dashboard/app/views/pd/workshop_mailer/teacher_enrollment_receipt.html.haml
@@ -16,12 +16,14 @@
     curriculum.
 - elsif @workshop.ayw? || ([Pd::Workshop::COURSE_COUNSELOR, Pd::Workshop::COURSE_ADMIN].include? @workshop.course)
   %p
-    Thanks for enrolling in
-    = "#{@workshop.organizer.name}’#{@workshop.organizer.name.ends_with?('s') ? '' : 's'} "
-    = @workshop.subject
-    on the Code.org
-    = @workshop.course
-    curriculum.
+    Thank you so much for enrolling in the School Leadership
+    Program for 2023-2024! This program is part of the Equity
+    in AP Computer Science Principles study. Therefore, we are
+    asking you to complete this survey that tells us about your
+    thoughts and beliefs about computer science as well as the
+    state of computer science education at your school. To
+    complete the survey prior to the Introduction Workshop, visit
+    = link_to 'https://studio.code.org/form/2022_baseline_school_leadership.', 'https://studio.code.org/form/2022_baseline_school_leadership', target: "_blank", rel: "noopener noreferrer"
 - elsif Pd::Workshop::COURSE_FACILITATOR == @workshop.course
   %p
     Thanks for enrolling in your Facilitator workshop. We look

--- a/dashboard/app/views/pd/workshop_mailer/teacher_enrollment_receipt.html.haml
+++ b/dashboard/app/views/pd/workshop_mailer/teacher_enrollment_receipt.html.haml
@@ -14,7 +14,7 @@
     5-day Summer workshop on the Code.org
     = @workshop.course
     curriculum.
-- elsif @workshop.ayw? || ([Pd::Workshop::COURSE_COUNSELOR, Pd::Workshop::COURSE_ADMIN].include? @workshop.course)
+- elsif [Pd::Workshop::COURSE_COUNSELOR, Pd::Workshop::COURSE_ADMIN].include? @workshop.course
   %p
     Thank you so much for enrolling in the School Leadership
     Program for 2023-2024! This program is part of the Equity
@@ -24,6 +24,14 @@
     state of computer science education at your school. To
     complete the survey prior to the Introduction Workshop, visit
     = link_to 'https://studio.code.org/form/2022_baseline_school_leadership.', 'https://studio.code.org/form/2022_baseline_school_leadership', target: "_blank", rel: "noopener noreferrer"
+- elsif @workshop.ayw?
+  %p
+    Thanks for enrolling in
+    = "#{@workshop.organizer.name}’#{@workshop.organizer.name.ends_with?('s') ? '' : 's'} "
+    = @workshop.subject
+    on the Code.org
+    = @workshop.course
+    curriculum.
 - elsif Pd::Workshop::COURSE_FACILITATOR == @workshop.course
   %p
     Thanks for enrolling in your Facilitator workshop. We look


### PR DESCRIPTION
This PR updates the confirmation email for Admin/Counselor workshop enrollment. Instead of adding the paragraph as a new paragraph, I replaced the previous sentence that named the organizer since they are already listed below in the workshop details and the rest of the information is already covered in the new paragraph.

Can be viewed locally at http://localhost-studio.code.org:3000/rails/mailers/pd_workshop_mailer/teacher_enrollment_receipt__counselor

## Original
![Original](https://user-images.githubusercontent.com/56283563/217340857-78669f19-a273-4764-b344-db92a987b333.JPG)

## New
![Mailer_update](https://user-images.githubusercontent.com/56283563/217340268-c2a17c7c-09b5-4430-b553-94122cba9c6f.JPG)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/browse/ACQ-357?atlOrigin=eyJpIjoiZGE1OGFiNzM0NGU4NGQ4OTk4ZWFlMDJhOTE4ODg4NzciLCJwIjoiaiJ9)

## Testing story
Local testing.

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
