### PR TITLE
Update `annotate` Gem to 3.2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,7 @@ gem 'memory_profiler'
 gem 'rack-mini-profiler'
 
 group :development do
-  gem 'annotate', '~> 3.1.1'
+  gem 'annotate', '~> 3.2.0'
   gem 'aws-google', '~> 0.2.0'
   gem 'web-console'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -235,8 +235,8 @@ GEM
       public_suffix (>= 2.0.2, < 6.0)
     aes_key_wrap (1.0.1)
     afm (0.2.2)
-    annotate (3.1.1)
-      activerecord (>= 3.2, < 7.0)
+    annotate (3.2.0)
+      activerecord (>= 3.2, < 8.0)
       rake (>= 10.4, < 14.0)
     ansi (1.5.0)
     ast (2.4.2)
@@ -942,7 +942,7 @@ DEPENDENCIES
   activerecord-import (~> 1.0.3)
   acts_as_list
   addressable
-  annotate (~> 3.1.1)
+  annotate (~> 3.2.0)
   auto_strip_attributes (~> 2.1)
   aws-google (~> 0.2.0)
   aws-sdk-acm

--- a/dashboard/config/application.rb
+++ b/dashboard/config/application.rb
@@ -156,15 +156,6 @@ module Dashboard
     config.autoload_paths << Rails.root.join('app', 'models', 'sections')
     config.autoload_paths << Rails.root.join('../lib/cdo/shared_constants')
 
-    # Make sure to explicitly cast all autoload paths to strings; the gem we use to
-    # annotate model files with schema descriptions doesn't know how to deal with
-    # Pathnames. See https://github.com/ctran/annotate_models/issues/758
-    #
-    # We have a PR opened with a fix at https://github.com/ctran/annotate_models/pull/848;
-    # once a version of the gem is released which includes that change, we can get rid of
-    # this line.
-    config.autoload_paths.map!(&:to_s)
-
     # Also make sure some of these directories are always loaded up front in production
     # environments.
     #


### PR DESCRIPTION
Specifically to pick up the fix we opened to resolve an issue with including Pathnames rather than Strings in the `autoload_paths`. Also remove the line we added to work around that issue until we could pick up said fix. Hooray!

## Links

https://github.com/ctran/annotate_models/releases/tag/v3.2.0

## Testing story

Manually ran `bundle exec annotate` to confirm that it still works

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
