### PR TITLE
Update jquery.simulate to generate PointerEvents

### DIFF
--- a/dashboard/vendor/assets/javascripts/jquery.simulate.js
+++ b/dashboard/vendor/assets/javascripts/jquery.simulate.js
@@ -89,14 +89,13 @@
     pointerEvent: function(type, options) {
       options = $.extend(
         {
-          pointerType: 'mouse',
+          pointerType: "mouse",
           pointerId: 1,
-          isPrimary: true,
+          isPrimary: true
         },
         options
       );
       return new PointerEvent(type, options);
-
     },
 
     mouseEvent: function(type, options) {
@@ -371,7 +370,7 @@
       }
 
       if ($.contains(document, target)) {
-        this.simulateEvent(target, "pointerup", eventOptions);
+        this.simulateEvent(target.ownerDocument, "pointerup", eventOptions);
         this.simulateEvent(target, "click", eventOptions);
       } else {
         this.simulateEvent(document, "pointerup", eventOptions);

--- a/dashboard/vendor/assets/javascripts/jquery.simulate.js
+++ b/dashboard/vendor/assets/javascripts/jquery.simulate.js
@@ -350,8 +350,9 @@
         dx = options.dx || (options.x !== undefined ? options.x - x : 0),
         dy = options.dy || (options.y !== undefined ? options.y - y : 0),
         moves = options.moves || 3;
+      const eventType = Blockly?.version === "Google" ? "pointer" : "mouse";
 
-      this.simulateEvent(target, "pointerdown", eventOptions);
+      this.simulateEvent(target, eventType + "down", eventOptions);
 
       for (; i < moves; i++) {
         x += dx / moves;
@@ -362,7 +363,11 @@
           clientY: Math.round(y)
         };
 
-        this.simulateEvent(target.ownerDocument, "pointermove", eventOptions);
+        this.simulateEvent(
+          target.ownerDocument,
+          eventType + "move",
+          eventOptions
+        );
       }
 
       if (options.skipDrop) {
@@ -370,10 +375,14 @@
       }
 
       if ($.contains(document, target)) {
-        this.simulateEvent(target.ownerDocument, "pointerup", eventOptions);
+        this.simulateEvent(
+          target.ownerDocument,
+          eventType + "up",
+          eventOptions
+        );
         this.simulateEvent(target, "click", eventOptions);
       } else {
-        this.simulateEvent(document, "pointerup", eventOptions);
+        this.simulateEvent(document, eventType + "up", eventOptions);
       }
     }
   });

--- a/dashboard/vendor/assets/javascripts/jquery.simulate.js
+++ b/dashboard/vendor/assets/javascripts/jquery.simulate.js
@@ -11,7 +11,8 @@
 
 (function($, undefined) {
   var rkeyEvent = /^key/,
-    rmouseEvent = /^(?:mouse|contextmenu|touch|pointer|MSPointer)|click/;
+    rmouseEvent = /^(?:mouse|contextmenu|touch)|click/,
+    rpointerEvent = /^pointer/;
 
   $.fn.simulate = function(type, options) {
     return this.each(function() {
@@ -79,6 +80,23 @@
       if (rmouseEvent.test(type)) {
         return this.mouseEvent(type, options);
       }
+
+      if (rpointerEvent.test(type)) {
+        return this.pointerEvent(type, options);
+      }
+    },
+
+    pointerEvent: function(type, options) {
+      options = $.extend(
+        {
+          pointerType: 'mouse',
+          pointerId: 1,
+          isPrimary: true,
+        },
+        options
+      );
+      return new PointerEvent(type, options);
+
     },
 
     mouseEvent: function(type, options) {
@@ -329,7 +347,7 @@
           options.handle === "corner" ? findCorner(target) : findCenter(target),
         x = Math.floor(center.x),
         y = Math.floor(center.y),
-        eventOptions = { clientX: x, clientY: y, pointerType: 'mouse', pointerId: 1 },
+        eventOptions = { clientX: x, clientY: y },
         dx = options.dx || (options.x !== undefined ? options.x - x : 0),
         dy = options.dy || (options.y !== undefined ? options.y - y : 0),
         moves = options.moves || 3;
@@ -342,9 +360,7 @@
 
         eventOptions = {
           clientX: Math.round(x),
-          clientY: Math.round(y),
-          pointerType: 'mouse',
-          pointerId: 1
+          clientY: Math.round(y)
         };
 
         this.simulateEvent(target.ownerDocument, "pointermove", eventOptions);


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Attempt at updating jquery.simulate to work with pointer events
- Removes the `touchMappings` piece and just directly always use pointer events. This assumes that
    1. all tested browsers support PointerEvents - this should be true for the versions you are now testing
    2. both Google Blockly and cdo Blockly support pointer events - this is true for google blockly and has been for a while, but I haven't checked on the cdo fork. If it's not, we can get more clever but figured the simple way was worth trying first
- Creates a new check for event types that start with `pointer` and create PointerEvents
    - Previously, the code was creating a `MouseEvent` with type `pointermove`. That's weird but doesn't seem to break... it probably mostly works because we (Blockly) do a lot of checking for the event type, and not checking `instanceof PointerEvent` which would fail. The reason we can't keep doing this is because `MouseEvent`s don't have the pointer-specific attributes needed (discussed further below)
    - The existing code that creates MouseEvents is fairly complicated because it's doing a lot of browser-specific quirk checking. I'm not doing that and just hoping browsers are actually implementing the spec, so my code is simpler.
    - The new code also sets the `pointerType` and `pointerId` attributes on the event. I think/hope most likely these being missing was causing the problems in 9.2 since we now assume all events are pointer events and thus have these properties.
        - Note that the current code always sets it to `1` so if you have any tests that test multitouch (dragging with multiple fingers or something) this probably won't work, and you'd have to pass in a unique id for each touch. If you're not doing that this should be fine.

The actual code path is fairly simple now and you don't really need to have this code all be in this modified jQuery file. You could simplify things by moving parts of this code to your own test helper rather than conflating it with this `simulate` library. But doing it in here allows you to avoid changing all of your tests, so it seemed the easiest way to unblock.

I obviously can't run/test this code, so fingers crossed it works or is a good starting point.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  4.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked


@mikeharv 
