### PR TITLE
Add columns to gdrive

### DIFF
--- a/bin/cron/teacher_applications_to_gdrive
+++ b/bin/cron/teacher_applications_to_gdrive
@@ -10,9 +10,10 @@ require 'honeybadger/ruby'
 # a spreadsheet in Google Drive (with permissions locked down to our organization) for exploration
 # by our programs team.
 def get_rows
-  applications = [%w(course regional_partner status scholarship_status school_type pay_fee email created_at
-                     meets_minimum_requirements meets_scholarship_criteria registered_for_workshop rural_status
-                     free_reduced_lunch_percent urm_percent accepted_at accepted race community_type two_or_more_races)]
+  applications = [%w(course regional_partner status scholarship_status school_type school_name district_name pay_fee
+                     email created_at meets_minimum_requirements meets_scholarship_criteria registered_for_workshop
+                     rural_status free_reduced_lunch_percent urm_percent accepted_at accepted race community_type
+                     two_or_more_races)]
   Pd::Application::TeacherApplication.where(
     application_year: Pd::Application::ActiveApplicationModels::APPLICATION_CURRENT_YEAR
   ).where.not(status: 'incomplete').find_each do |app|

--- a/bin/cron/teacher_applications_to_gdrive
+++ b/bin/cron/teacher_applications_to_gdrive
@@ -39,6 +39,8 @@ def get_rows
       app.status,
       app.scholarship_status,
       app.school_type,
+      app.school_name,
+      app.district_name,
       pay_fee,
       app.email,
       app.created_at,


### PR DESCRIPTION
Eric F in marketing requested two more columns on our gdrive export: the school name and the school district. Luckily, those are both methods defined in our TeacherApplication model.

I tested this in production, running the script manually –– can see the results here: https://docs.google.com/spreadsheets/d/1hyF__4aDzCveA0j2VvckgskEqaeBHd-VfKgAzxARuVU/edit#gid=1332401829

<img width="853" alt="image" src="https://user-images.githubusercontent.com/9142121/217574627-968746fa-d17f-4261-9a01-a9188839049e.png">


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
