### PR TITLE
[WebSerial] [Chromium] [Micro:Bit] Complete WebSerial pathway for Micro:Bit

### DIFF
--- a/apps/src/lib/kits/maker/WebSerialPortWrapper.js
+++ b/apps/src/lib/kits/maker/WebSerialPortWrapper.js
@@ -29,17 +29,16 @@ export default class WebSerialPortWrapper extends EventEmitter {
     if (this.portOpen) {
       throw new Error(`Requested port is already open.`);
     }
-    return this.port
-      .open({baudRate: SERIAL_BAUD})
-      .then(() => {
-        this.portOpen = true;
-        this.emit('open');
-        this.writer = this.port.writable.getWriter();
-        this.reader = this.port.readable.getReader();
-
-        this.readLoop();
-      })
-      .catch(error => Promise.reject('Failure to open port: ' + error));
+    try {
+      await this.port.open({baudRate: SERIAL_BAUD});
+      this.portOpen = true;
+      this.writer = this.port.writable.getWriter();
+      this.reader = this.port.readable.getReader();
+      this.emit('open');
+      this.readLoop();
+    } catch (error) {
+      return Promise.reject('Failure to open port: ' + error);
+    }
   }
 
   // Opens the serial port from Circuit Playground and starts reading from port.

--- a/apps/src/lib/kits/maker/WebSerialPortWrapper.js
+++ b/apps/src/lib/kits/maker/WebSerialPortWrapper.js
@@ -39,7 +39,6 @@ export default class WebSerialPortWrapper extends EventEmitter {
 
         this.readLoop();
       })
-      .then(() => this)
       .catch(error => Promise.reject('Failure to open port: ' + error));
   }
 
@@ -57,7 +56,6 @@ export default class WebSerialPortWrapper extends EventEmitter {
         this.emit('open');
         this.readLoop();
       })
-      .then(() => this)
       .catch(error => Promise.reject('Failure to open port: ' + error));
   }
 

--- a/apps/src/lib/kits/maker/WebSerialPortWrapper.js
+++ b/apps/src/lib/kits/maker/WebSerialPortWrapper.js
@@ -68,19 +68,19 @@ export default class WebSerialPortWrapper extends EventEmitter {
   }
 
   async readLoop() {
-    try {
-      while (this.port.readable.locked && this.portOpen) {
+    while (this.port.readable?.locked) {
+      try {
         const {value, done} = await this.reader.read();
         if (done) {
           this.reader.releaseLock();
           break;
         }
         this.emit('data', Buffer.from(value));
-      }
-    } catch (e) {
-      console.error(e);
-      if (e.code === DEVICE_LOST_ERROR_CODE) {
-        this.emit('disconnect');
+      } catch (e) {
+        console.error(e);
+        if (e.code === DEVICE_LOST_ERROR_CODE) {
+          this.emit('disconnect');
+        }
       }
     }
   }

--- a/apps/src/lib/kits/maker/WebSerialPortWrapper.js
+++ b/apps/src/lib/kits/maker/WebSerialPortWrapper.js
@@ -24,12 +24,7 @@ export default class WebSerialPortWrapper extends EventEmitter {
     // TODO - not sure if this is used in Maker Toolkit yet
   }
 
-  /** Opens the serial port from Micro:Bit and starts reading from port.
-   * We are opening the port here and not reading from or writing to the port at this point in
-   * implementation. Later on when the entire Micro:WebSerial pathway is implemented,
-   * this function may be removed logic added for the MB in the open() function below,
-   * if appropriate.
-   */
+  // Opens the serial port from Micro:Bit and starts reading from port.
   async openMBPort() {
     if (this.portOpen) {
       throw new Error(`Requested port is already open.`);
@@ -49,11 +44,10 @@ export default class WebSerialPortWrapper extends EventEmitter {
   }
 
   // Opens the serial port from Circuit Playground and starts reading from port.
-  async open() {
+  async openCPPort() {
     if (this.portOpen) {
       throw new Error(`Requested port is already open.`);
     }
-
     this.port
       .open({baudRate: SERIAL_BAUD})
       .then(() => {

--- a/apps/src/lib/kits/maker/boards/circuitPlayground/CircuitPlaygroundBoard.js
+++ b/apps/src/lib/kits/maker/boards/circuitPlayground/CircuitPlaygroundBoard.js
@@ -407,7 +407,7 @@ export default class CircuitPlaygroundBoard extends EventEmitter {
    * @return {Promise<SerialPort>}
    */
   static openSerialPortWebSerial(port) {
-    return port.open().then(() => {
+    return port.openCPPort().then(() => {
       this.createPendingQueue(port);
       return port;
     });

--- a/apps/src/lib/kits/maker/boards/microBit/MBFirmataWrapper.js
+++ b/apps/src/lib/kits/maker/boards/microBit/MBFirmataWrapper.js
@@ -49,6 +49,14 @@ export default class MicrobitFirmataWrapper extends MBFirmataClient {
     }
   }
 
+  // Create and return a copy of this MBFirmataClient with references to the WebSerialPortWrapper removed.
+  getBoardClientWithoutPort() {
+    const boardClientWithoutPort = Object.assign({}, this);
+    delete boardClientWithoutPort.serialPortWebSerial;
+    delete boardClientWithoutPort.myPort;
+    return boardClientWithoutPort;
+  }
+
   async disconnect() {
     // Close and discard the serial port.
     if (!isWebSerialPort(this.myPort)) {

--- a/apps/src/lib/kits/maker/boards/microBit/MBFirmataWrapper.js
+++ b/apps/src/lib/kits/maker/boards/microBit/MBFirmataWrapper.js
@@ -49,7 +49,11 @@ export default class MicrobitFirmataWrapper extends MBFirmataClient {
     }
   }
 
-  // Create and return a copy of this MBFirmataClient with references to the WebSerialPortWrapper removed.
+  // Create and return a copy of this MBFirmataClient with references to the WebSerialPortWrapper
+  // removed. This copy is assigned to the key 'board' in the prewiredComponents object in MicroBitBoard.js
+  // Removing the references to the port avoids hitting a recursive loop (due to the emit functionality
+  // that's included in the WebSerialPortWrapper) when we attempt to marshall the MBFirmataClient
+  // object across to the interpreter.
   getBoardClientWithoutPort() {
     const boardClientWithoutPort = Object.assign({}, this);
     delete boardClientWithoutPort.serialPortWebSerial;

--- a/apps/src/lib/kits/maker/boards/microBit/MBFirmataWrapper.js
+++ b/apps/src/lib/kits/maker/boards/microBit/MBFirmataWrapper.js
@@ -25,8 +25,6 @@ export default class MicrobitFirmataWrapper extends MBFirmataClient {
   // Used in setSerialPort, which is copied from setSerialPort in MBFirmataClient,
   // as a wrapper. Lifted into its own function because of linting.
   dataReceived(data) {
-    console.log('dataReceived function - data', data);
-    console.log('this', this);
     if (this.inbufCount + data.length < this.inbuf.length) {
       this.inbuf.set(data, this.inbufCount);
       this.inbufCount += data.length;

--- a/apps/src/lib/kits/maker/boards/microBit/MicroBitBoard.js
+++ b/apps/src/lib/kits/maker/boards/microBit/MicroBitBoard.js
@@ -327,7 +327,6 @@ export default class MicroBitBoard extends EventEmitter {
       this.boardClient_.reset();
     }
     this.boardClient_ = null;
-    this.boardClientWithoutPort = null;
 
     return Promise.resolve();
   }

--- a/apps/src/lib/kits/maker/boards/microBit/MicroBitBoard.js
+++ b/apps/src/lib/kits/maker/boards/microBit/MicroBitBoard.js
@@ -163,6 +163,10 @@ export default class MicroBitBoard extends EventEmitter {
    * @throws {Error} if called before connecting to firmware
    */
   initializeComponents() {
+    // Create a copy of boardClient_ but remove references to the WebSerialPortWrapper.
+    // This avoids hitting a recursive loop (due to the emit functionality that's included
+    // in the WebSerialPortWrapper) when we attempt to marshall the object across to
+    // the interpreter.
     this.boardClientWithoutPort = Object.assign({}, this.boardClient_);
     delete this.boardClientWithoutPort.serialPortWebSerial;
     delete this.boardClientWithoutPort.myPort;

--- a/apps/src/lib/kits/maker/boards/microBit/MicroBitBoard.js
+++ b/apps/src/lib/kits/maker/boards/microBit/MicroBitBoard.js
@@ -163,17 +163,13 @@ export default class MicroBitBoard extends EventEmitter {
    * @throws {Error} if called before connecting to firmware
    */
   initializeComponents() {
-    // Create a copy of boardClient_ but remove references to the WebSerialPortWrapper.
-    // This avoids hitting a recursive loop (due to the emit functionality that's included
-    // in the WebSerialPortWrapper) when we attempt to marshall the object across to
-    // the interpreter.
-    this.boardClientWithoutPort = Object.assign({}, this.boardClient_);
-    delete this.boardClientWithoutPort.serialPortWebSerial;
-    delete this.boardClientWithoutPort.myPort;
-
     return createMicroBitComponents(this.boardClient_).then(components => {
       this.prewiredComponents_ = {
-        board: this.boardClientWithoutPort,
+        // board is assigned a copy of boardClient_ but with references to the WebSerialPortWrapper
+        // removed. This avoids hitting a recursive loop (due to the emit functionality that's included
+        // in the WebSerialPortWrapper) when we attempt to marshall the object across to the
+        // interpreter.
+        board: this.boardClient_.getBoardClientWithoutPort(),
         ...components
       };
     });

--- a/apps/src/lib/kits/maker/boards/microBit/MicroBitBoard.js
+++ b/apps/src/lib/kits/maker/boards/microBit/MicroBitBoard.js
@@ -48,7 +48,6 @@ export default class MicroBitBoard extends EventEmitter {
 
     /** @private {MicrobitFirmataClient} serial port controller */
     this.boardClient_ = new MBFirmataWrapper(portType);
-    this.boardClientWithoutPort = null;
 
     /** @private {Array} List of dynamically-created component controllers. */
     this.dynamicComponents_ = [];

--- a/apps/src/lib/kits/maker/boards/microBit/MicroBitBoard.js
+++ b/apps/src/lib/kits/maker/boards/microBit/MicroBitBoard.js
@@ -129,7 +129,27 @@ export default class MicroBitBoard extends EventEmitter {
       // webserial pathway
       return this.openSerialPortWebSerial(this.port)
         .then(serialPort => {
-          this.boardClient_.connectBoard(serialPort);
+          return this.boardClient_.connectBoard(serialPort);
+        })
+        .then(() => {
+          // Delay for 0.25 seconds to ensure we have time to receive the firmware version.
+          return delayPromise(250);
+        })
+        .then(() => {
+          if (
+            this.boardClient_.firmwareVersion.includes(
+              MICROBIT_FIRMWARE_VERSION
+            )
+          ) {
+            return Promise.resolve();
+          } else {
+            if (this.boardClient_.firmwareVersion === '') {
+              console.warn(
+                'Firmware version not detected in time. Try refreshing the page.'
+              );
+            }
+            return Promise.reject('Incorrect firmware detected');
+          }
         })
         .catch(err => Promise.reject(err));
     }

--- a/apps/src/lib/kits/maker/boards/microBit/MicroBitBoard.js
+++ b/apps/src/lib/kits/maker/boards/microBit/MicroBitBoard.js
@@ -48,7 +48,7 @@ export default class MicroBitBoard extends EventEmitter {
 
     /** @private {MicrobitFirmataClient} serial port controller */
     this.boardClient_ = new MBFirmataWrapper(portType);
-    this.boardClientWithoutSerialPort = null;
+    this.boardClientWithoutPort = null;
 
     /** @private {Array} List of dynamically-created component controllers. */
     this.dynamicComponents_ = [];
@@ -163,13 +163,13 @@ export default class MicroBitBoard extends EventEmitter {
    * @throws {Error} if called before connecting to firmware
    */
   initializeComponents() {
-    this.boardClientWithoutSerialPort = Object.assign({}, this.boardClient_);
-    delete this.boardClientWithoutSerialPort.serialPortWebSerial;
-    delete this.boardClientWithoutSerialPort.myPort;
+    this.boardClientWithoutPort = Object.assign({}, this.boardClient_);
+    delete this.boardClientWithoutPort.serialPortWebSerial;
+    delete this.boardClientWithoutPort.myPort;
 
     return createMicroBitComponents(this.boardClient_).then(components => {
       this.prewiredComponents_ = {
-        board: this.boardClientWithoutSerialPort,
+        board: this.boardClientWithoutPort,
         ...components
       };
     });
@@ -328,7 +328,7 @@ export default class MicroBitBoard extends EventEmitter {
       this.boardClient_.reset();
     }
     this.boardClient_ = null;
-    this.boardClientWithoutSerialPort = null;
+    this.boardClientWithoutPort = null;
 
     return Promise.resolve();
   }

--- a/apps/src/lib/kits/maker/boards/microBit/MicroBitBoard.js
+++ b/apps/src/lib/kits/maker/boards/microBit/MicroBitBoard.js
@@ -48,6 +48,7 @@ export default class MicroBitBoard extends EventEmitter {
 
     /** @private {MicrobitFirmataClient} serial port controller */
     this.boardClient_ = new MBFirmataWrapper(portType);
+    this.boardClientWithoutSerialPort = null;
 
     /** @private {Array} List of dynamically-created component controllers. */
     this.dynamicComponents_ = [];
@@ -162,9 +163,13 @@ export default class MicroBitBoard extends EventEmitter {
    * @throws {Error} if called before connecting to firmware
    */
   initializeComponents() {
+    this.boardClientWithoutSerialPort = Object.assign({}, this.boardClient_);
+    delete this.boardClientWithoutSerialPort.serialPortWebSerial;
+    delete this.boardClientWithoutSerialPort.myPort;
+
     return createMicroBitComponents(this.boardClient_).then(components => {
       this.prewiredComponents_ = {
-        board: this.boardClient_,
+        board: this.boardClientWithoutSerialPort,
         ...components
       };
     });
@@ -323,6 +328,7 @@ export default class MicroBitBoard extends EventEmitter {
       this.boardClient_.reset();
     }
     this.boardClient_ = null;
+    this.boardClientWithoutSerialPort = null;
 
     return Promise.resolve();
   }


### PR DESCRIPTION
## Summary
This PR completes the WebSerial pathway for Micro:Bit so that a user can connect their Micro:Bit (MB) through a Chromium browser (including Chromebook users). It is a follow-up to [this PR](https://github.com/code-dot-org/code-dot-org/pull/49972) which opened and then closed the WebSerial SerialPort if connected to a MB. In this PR I add the ability to read from and write to the WebSerial SerialPort.

Note that to currently run an App Lab program using the browser on [this adhoc instance](https://adhoc-alice-webserial-studio.cdn-code.org/), you must enable the experiment. (enableExperiments=microbit).

Here is the 'setup/maker' page on a Chromebook:


https://user-images.githubusercontent.com/107423305/217658951-220503f8-1075-424e-a7c2-c7e004becca3.mp4


Here is an App Lab project begin run on a Chromebook:

https://user-images.githubusercontent.com/107423305/217658975-01385c6e-832a-44f2-8b2b-85b7ff09e6b1.mp4



## Details
Within `WebSerialPortWrapper.js`, I added a helper function `readLoop` which continuously reads and emits data received from the MB via the SerialPort. Thus, both versions of the 'open' function call on `readLoop`. I had to maintain the `openMBPort` function separate from the `openCPPort` function which is called in `CircuitPlaygroundBoard.js` because the Circuit Playground (CP) does not work when `return` is added in front of `this.port.open` but `return` is required for the MB. Looking at `connectToFirmware` in `CircuitPlaygroundBoard.js`, after the WebSerialPortWrapper is returned, the CP's board and components are initialized. This is not the case for the MB. In addition, `CircuitPlaygroundBoard.js` includes a `createPendingRequest` function while `MicroBitBoard.js` does not. Here is [the PR](https://github.com/code-dot-org/code-dot-org/pull/31395) related to this CP function. I am still uncertain why `return` is causing an error for the CP - this is still an open question.

In `WebSerialPortWrapper.js` I also added a check in the `write` function if `buffer` is an `ArrayBuffer` which is the required data type to write to the WebSerial SerialPort. In `MBFirmataClient.js` (a file we [don't want to edit](https://github.com/microbit-foundation/microbit-firmata/blob/master/client/MBFirmataClient.js)), the functions which write to `myPort` use arrays to send data. 

In `MBFirmataWrapper.js`,  I added the calls to request information from the MB and added a `disconnect` function to allow a small time delay to close the WebSerial SerialPort. This is similarly done by the `destroy` function in `CircuitPlaygroundBoard.js`.

In `MicroBitBoard.js`, I added the calls to read from and write to the port and check for the correct firmware version.
At this point, the '/maker/setup' was successful including the execution of `celebrateSuccessfulConnection`.

However, when I opened an App Lab project and attempted to run a program connect to the MB, I received the following error:
![Screen Shot 2023-02-07 at 11 23 47 AM](https://user-images.githubusercontent.com/107423305/217650272-ef0bd9d7-e234-46af-8a67-dc079a4a3035.png)

I pinpointed the problem to [`installOnInterpreter`](https://github.com/code-dot-org/code-dot-org/blob/81b986411e93ad043f35c1ea52c1489ed6d0e185/apps/src/lib/kits/maker/boards/microBit/MicroBitBoard.js#L335) in `MicroBitBoard.js`. When `jsInterpreter.createGlobalProperty(key, this.prewiredComponents_[key])` is called with the key `board`, the value is the `MBFirmataWrapper`. Then we attempt to marshall this object across to the interpreter and hit an infinite loop with the emit functionality that's included in our WebSerialPortWrapper. Thanks to @breville for walking through this part of the code base with me.

The reason why this doesn't happen for the CP is that  in `CircuitPlaygroundBoard.js`, the `prewiredComponents_`'s `board` is assigned to `this.fiveBoard_` [here](https://github.com/code-dot-org/code-dot-org/blob/bcf7f39633628a0247f2807e166dbb6940836fb2/apps/src/lib/kits/maker/boards/circuitPlayground/CircuitPlaygroundBoard.js#L166), and `this.fiveBoard` does NOT include a reference to the WebSerialPortWrapper. 

Thus, to circumvent this recursive rabbit hole, I created a copy of the `boardClient_` called `boardClientWithoutPort` and removed the references to the WebSerialPortWrapper. This copy was used to assign the `prewiredComponents_`. Afterwards, I was able to run an App Lab program successfully.



## Links
[jira ticket - [WebSerial] Micro:bit on WebSerial on ChromeOS](https://codedotorg.atlassian.net/browse/SL-58)
[jira ticket - https://codedotorg.atlassian.net/browse/SL-58](https://codedotorg.atlassian.net/browse/SL-530)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
I tested locally. But then tested via an [adhoc instance](https://adhoc-alice-webserial-studio.cdn-code.org/home) on a Chromebook, and on Windows/PC. Thanks to @molly-moen who helped me create the adhoc!
Note that the drone build is passing [here](https://github.com/code-dot-org/code-dot-org/pull/50152).

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work
As noted above, the MB WebSerial pathway is somewhat different from the CP WebSerial pathway so that there are two different open functions in `WebSerialPortWrapper.js`. Follow-up work will include an investigation into the differences between the two devices so that a possible refactor could simplify the code within this file.
[jira ticket](https://codedotorg.atlassian.net/browse/SL-571)

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
