### PR TITLE
[Amplitude] Mini-rubric submission

### DIFF
--- a/apps/src/lib/util/AnalyticsConstants.js
+++ b/apps/src/lib/util/AnalyticsConstants.js
@@ -32,7 +32,8 @@ const EVENTS = {
   PROGRESS_JUMP_TO_LESSON: 'Section Progress Jump to Lesson',
 
   // Levels
-  FEEDBACK_SUBMITTED: 'Level Feedback Submitted'
+  FEEDBACK_SUBMITTED: 'Level Feedback Submitted',
+  RUBRIC_LEVEL_VIEWED_EVENT: 'Rubric Level Viewed'
 };
 
 export {EVENTS};

--- a/apps/src/templates/instructions/teacherFeedback/EditableTeacherFeedback.jsx
+++ b/apps/src/templates/instructions/teacherFeedback/EditableTeacherFeedback.jsx
@@ -160,7 +160,8 @@ export class EditableTeacherFeedback extends Component {
     analyticsReporter.sendEvent(EVENTS.FEEDBACK_SUBMITTED, {
       sectionId: this.props.selectedSectionId,
       unitId: this.props.serverScriptId,
-      levelId: this.props.serverLevelId
+      levelId: this.props.serverLevelId,
+      isRubric: this.props.rubric
     });
   };
 

--- a/apps/src/templates/instructions/teacherFeedback/EditableTeacherFeedback.jsx
+++ b/apps/src/templates/instructions/teacherFeedback/EditableTeacherFeedback.jsx
@@ -64,6 +64,13 @@ export class EditableTeacherFeedback extends Component {
 
   componentDidMount = () => {
     window.addEventListener('beforeunload', this.onUnload);
+    if (this.props.rubric) {
+      analyticsReporter.sendEvent(EVENTS.RUBRIC_LEVEL_VIEWED_EVENT, {
+        sectionId: this.props.selectedSectionId,
+        unitId: this.props.serverScriptId,
+        levelId: this.props.serverLevelId
+      });
+    }
   };
 
   componentWillUnmount() {

--- a/apps/test/unit/templates/instructions/teacherFeedback/EditableTeacherFeedbackTest.jsx
+++ b/apps/test/unit/templates/instructions/teacherFeedback/EditableTeacherFeedbackTest.jsx
@@ -53,6 +53,23 @@ describe('EditableTeacherFeedback', () => {
     expect(wrapper.isEmptyRender()).to.be.true;
   });
 
+  it('logs Amplitude message when rubric level viewed', () => {
+    const analyticsSpy = sinon.spy(analyticsReporter, 'sendEvent');
+    setUp({rubric: RUBRIC});
+
+    expect(analyticsSpy).to.have.been.calledOnce;
+    assert.equal(analyticsSpy.getCall(0).firstArg, 'Rubric Level Viewed');
+    analyticsSpy.restore();
+  });
+
+  it('does not log Amplitude message when non-rubric level viewed', () => {
+    const analyticsSpy = sinon.spy(analyticsReporter, 'sendEvent');
+    setUp();
+
+    expect(analyticsSpy).not.to.have.been.called;
+    analyticsSpy.restore();
+  });
+
   describe('without previous feedback', () => {
     it('does not display EditableFeedbackStatus', () => {
       const wrapper = setUp({rubric: null, latestFeedback: null});


### PR DESCRIPTION
Jira: https://codedotorg.atlassian.net/jira/software/projects/TEACH/boards/65?selectedIssue=TEACH-192

Saves when the mini-rubric feedback style is loaded. Adds an `isRubric` property to the already established analytics reporter event.

@dju90 - does it work for you to sort these submission events by `isRubric`, rather than have a different, separate event?
