### PR TITLE
[Amplitude] Send events for Lesson Overview page views

### DIFF
--- a/apps/src/lib/util/AnalyticsConstants.js
+++ b/apps/src/lib/util/AnalyticsConstants.js
@@ -9,6 +9,9 @@ const EVENTS = {
   UNIT_OVERVIEW_PAGE_VISITED_EVENT: 'Unit Overview Page Visited',
   TRY_NOW_BUTTON_CLICK_EVENT: 'Try Now Button Clicked',
 
+  // Lesson info
+  LESSON_OVERVIEW_PAGE_VISITED_EVENT: 'Lesson Overview Page Visited',
+
   // Workshop enrollment
   WORKSHOP_ENROLLMENT_COMPLETED_EVENT: 'Workshop Enrollment Completed',
 

--- a/apps/src/templates/lessonOverview/LessonOverview.jsx
+++ b/apps/src/templates/lessonOverview/LessonOverview.jsx
@@ -27,6 +27,8 @@ import VerifiedResourcesNotification from '@cdo/apps/templates/courseOverview/Ve
 import {PublishedState} from '@cdo/apps/generated/curriculum/sharedCourseConstants';
 import FontAwesome from '../FontAwesome';
 import CopyrightInfo from '@cdo/apps/templates/CopyrightInfo';
+import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
+import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 
 class LessonOverview extends Component {
   static propTypes = {
@@ -40,6 +42,19 @@ class LessonOverview extends Component {
     isVerifiedInstructor: PropTypes.bool.isRequired,
     hasVerifiedResources: PropTypes.bool.isRequired
   };
+
+  constructor(props) {
+    super(props);
+
+    analyticsReporter.sendEvent(EVENTS.LESSON_OVERVIEW_PAGE_VISITED_EVENT, {
+      lessonId: props.lesson.id,
+      lessonName: props.lesson.displayName,
+      lessonLink: document.location.pathname,
+      referrer: document.referrer,
+      unitName: props.lesson.unit.displayName,
+      unitLink: props.lesson.unit.link
+    });
+  }
 
   recordAndNavigateToPdf = (e, firehoseKey, url) => {
     // Prevent navigation to url until callback

--- a/apps/test/unit/templates/lessonOverview/LessonOverviewTest.js
+++ b/apps/test/unit/templates/lessonOverview/LessonOverviewTest.js
@@ -13,6 +13,9 @@ import {
 } from '../../code-studio/components/progress/FakeAnnouncementsTestData';
 import _ from 'lodash';
 import {PublishedState} from '@cdo/apps/generated/curriculum/sharedCourseConstants';
+import sinon from 'sinon';
+import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
+import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 
 describe('LessonOverview', () => {
   let defaultProps;
@@ -392,5 +395,17 @@ describe('LessonOverview', () => {
     expect(dropdownLinks.map(link => link.props.children)).to.eql([
       'Print Handouts'
     ]);
+  });
+
+  it('logs Amplitude event when rendered', () => {
+    const analyticsSpy = sinon.spy(analyticsReporter, 'sendEvent');
+    shallow(<LessonOverview {...defaultProps} />);
+
+    expect(analyticsSpy).to.have.been.calledOnce;
+    assert.equal(
+      analyticsSpy.getCall(0).firstArg,
+      EVENTS.LESSON_OVERVIEW_PAGE_VISITED_EVENT
+    );
+    analyticsSpy.restore();
   });
 });


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Send Amplitude events for Lesson Overview (Lesson Plan) page views.

I wasn't able to get the `scriptId`, so I substituted the `unitLink`, since I think it can serve the same purpose.

![image](https://user-images.githubusercontent.com/1382374/217658011-68db23fa-7f36-42ce-96ce-50f358058183.png)

Note the referrer will always be blank if they followed a link from the Course Overview page. ([Slack discussion](https://codedotorg.slack.com/archives/C0462BZKHL6/p1675893349856789))


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->


<!--
- spec: []()
-->
- jira ticket: [TEACH-189](https://codedotorg.atlassian.net/browse/TEACH-189)

