### PR TITLE
Change default parameter for ledScreen.display command

### DIFF
--- a/apps/src/lib/kits/maker/dropletConfig.js
+++ b/apps/src/lib/kits/maker/dropletConfig.js
@@ -501,7 +501,7 @@ const microBitBlocks = [
     func: 'ledScreen.display',
     category: MICROBIT_CATEGORY,
     params: [
-      '[\n[1, 0, 1, 0, 1],\n[1, 0, 1, 0, 1],\n[1, 0, 1, 0, 1],\n[0, 1, 0, 1, 0],\n[1, 0, 1, 0, 1]\n]'
+      '[\n[1, 1, 1, 1, 1],\n[1, 1, 1, 1, 1],\n[1, 1, 1, 1, 1],\n[1, 1, 1, 1, 1],\n[1, 1, 1, 1, 1]\n]'
     ],
     paletteParams: ['boardArray']
   },


### PR DESCRIPTION
This PR changes the default parameter for the App Lab command `ledScreen.display` to a 2D array of all 1 values. This change is at the request of curriculum so that it is easier for users to create custom designs by turning off selected LEDs. 

Before:
![image (2)](https://user-images.githubusercontent.com/107423305/217663582-e71710bc-4d4b-4b3d-8852-b6d6607e5a31.png)

After:

https://user-images.githubusercontent.com/107423305/217664147-f2b2e07f-e8b7-47f4-8bb4-57fbb0882d5f.mp4



## Links
[Slack thread discussion](https://codedotorg.slack.com/archives/C04NG4SUCQ0/p1675887679144329)

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
