### PR TITLE
[Amplitude] Send events when resource links are visited

### DIFF
--- a/apps/src/lib/util/AnalyticsConstants.js
+++ b/apps/src/lib/util/AnalyticsConstants.js
@@ -13,6 +13,7 @@ const EVENTS = {
 
   // Lesson info
   LESSON_OVERVIEW_PAGE_VISITED_EVENT: 'Lesson Overview Page Visited',
+  LESSON_RESOURCE_LINK_VISITED_EVENT: 'Lesson Resource Link Visited',
 
   // Workshop enrollment
   WORKSHOP_ENROLLMENT_COMPLETED_EVENT: 'Workshop Enrollment Completed',

--- a/apps/src/templates/lessonOverview/ResourceList.jsx
+++ b/apps/src/templates/lessonOverview/ResourceList.jsx
@@ -99,7 +99,8 @@ export default class ResourceList extends Component {
       resourceType: resource.type,
       resourceUrl: resource.url,
       resourceDownloadUrl: resource.download_url,
-      visitType: visitType
+      visitType: visitType,
+      path: document.location.pathname
     });
   };
 

--- a/apps/src/templates/lessonOverview/ResourceList.jsx
+++ b/apps/src/templates/lessonOverview/ResourceList.jsx
@@ -5,6 +5,8 @@ import firehoseClient from '@cdo/apps/lib/util/firehose';
 import {windowOpen} from '@cdo/apps/utils';
 import DropdownButton from '../DropdownButton';
 import Button from '../Button';
+import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
+import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 import {
   isGDocsUrl,
   gDocsPdfUrl,
@@ -33,6 +35,9 @@ export default class ResourceList extends Component {
 
   downloadResource = (e, resource) => {
     e.preventDefault();
+
+    this.sendLinkVisitedEvent(resource, 'download');
+
     firehoseClient.putRecord(
       {
         study:
@@ -61,6 +66,9 @@ export default class ResourceList extends Component {
 
   openResource = (e, resource) => {
     e.preventDefault();
+
+    this.sendLinkVisitedEvent(resource, 'open');
+
     firehoseClient.putRecord(
       {
         study:
@@ -81,6 +89,18 @@ export default class ResourceList extends Component {
         }
       }
     );
+  };
+
+  sendLinkVisitedEvent = (resource, visitType) => {
+    analyticsReporter.sendEvent(EVENTS.LESSON_RESOURCE_LINK_VISITED_EVENT, {
+      resourceId: resource.id,
+      resourceName: resource.name,
+      resourceAudience: resource.audience,
+      resourceType: resource.type,
+      resourceUrl: resource.url,
+      resourceDownloadUrl: resource.download_url,
+      visitType: visitType
+    });
   };
 
   createResourceListItem = resource => (
@@ -114,9 +134,30 @@ export default class ResourceList extends Component {
             color={Button.ButtonColor.gray}
             size={Button.ButtonSize.small}
           >
-            <a href={gDocsPdfUrl(resource.url)}>PDF</a>
-            <a href={gDocsMsOfficeUrl(resource.url)}>Microsoft Office</a>
-            <a href={gDocsCopyUrl(resource.url)}>Google Docs</a>
+            <a
+              href={gDocsPdfUrl(resource.url)}
+              onClick={e => {
+                this.sendLinkVisitedEvent(resource, `copyPdf`);
+              }}
+            >
+              PDF
+            </a>
+            <a
+              href={gDocsMsOfficeUrl(resource.url)}
+              onClick={e => {
+                this.sendLinkVisitedEvent(resource, `copyMsOffice`);
+              }}
+            >
+              Microsoft Office
+            </a>
+            <a
+              href={gDocsCopyUrl(resource.url)}
+              onClick={e => {
+                this.sendLinkVisitedEvent(resource, `copyGDocs`);
+              }}
+            >
+              Google Docs
+            </a>
           </DropdownButton>
         </span>
       )}

--- a/apps/test/unit/templates/lessonOverview/ResourceListTest.js
+++ b/apps/test/unit/templates/lessonOverview/ResourceListTest.js
@@ -2,6 +2,9 @@ import React from 'react';
 import {shallow} from 'enzyme';
 import {expect} from '../../../util/reconfiguredChai';
 import ResourceList from '@cdo/apps/templates/lessonOverview/ResourceList';
+import sinon from 'sinon';
+import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
+import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 
 describe('ResourceList', () => {
   it('displays resources in bulleted list', () => {
@@ -72,5 +75,34 @@ describe('ResourceList', () => {
         .at(0)
         .contains('Download')
     ).to.false;
+  });
+
+  it('sends amplitude event when resource is clicked', () => {
+    const analyticsSpy = sinon.spy(analyticsReporter, 'sendEvent');
+    const wrapper = shallow(
+      <ResourceList
+        resources={[
+          {
+            key: 'student-resource',
+            name: 'Student Resource',
+            url: 'https://docs.google.com/document/d/fake/url',
+            download_url: 'download.fake.url',
+            type: 'Activity Guide'
+          }
+        ]}
+        pageType="teacher-lesson-plan"
+      />
+    );
+
+    const num_links = 5;
+    expect(wrapper.find('a').length).to.equal(num_links);
+    wrapper.find('a').forEach(link => {
+      link.simulate('click', {preventDefault() {}});
+    });
+    expect(analyticsSpy.callCount).to.equal(num_links);
+    expect(analyticsSpy.getCall(0).firstArg).to.equal(
+      EVENTS.LESSON_RESOURCE_LINK_VISITED_EVENT
+    );
+    analyticsSpy.restore();
   });
 });


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Send Amplitude events from Lesson Overview pages when a Resource Link is "visited". "Visits" are differentiated by type:

* open
* download
* copyPdf
* copyMsOffice
* copyGDocs

![image](https://user-images.githubusercontent.com/1382374/217670909-8baa7ec1-ecb5-481e-bea1-74e6cc9c54e7.png)


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
-->
- based on pr: #50156 
- jira ticket: [TEACH-189](https://codedotorg.atlassian.net/browse/TEACH-189)

