### PR TITLE
Removing useDeprecatedTag from unit calendar button

### DIFF
--- a/apps/src/code-studio/components/progress/UnitCalendarButton.jsx
+++ b/apps/src/code-studio/components/progress/UnitCalendarButton.jsx
@@ -43,11 +43,11 @@ export default class UnitCalendarButton extends React.Component {
     return (
       <div>
         <Button
-          __useDeprecatedTag
           onClick={this.openDialog}
           text={i18n.viewCalendarButton()}
           icon="calendar"
           color={Button.ButtonColor.blue}
+          style={styles.button}
         />
         {this.state.isDialogOpen && (
           <UnitCalendarDialog
@@ -64,3 +64,10 @@ export default class UnitCalendarButton extends React.Component {
     );
   }
 }
+
+const styles = {
+  button: {
+    margin: 0,
+    boxShadow: 'inset 0 2px 0 0 rgb(255 255 255 / 40%)'
+  }
+};


### PR DESCRIPTION
This makes the button tab navigable, and adds styling to maintain consistency with the neighboring buttons!

Before:
<img width="797" alt="Screen Shot 2023-02-08 at 3 33 17 PM" src="https://user-images.githubusercontent.com/37230822/217676959-721d5a83-c5f9-4e6c-848b-73d3c6937acf.png">


After:
<img width="837" alt="Screen Shot 2023-02-08 at 3 41 17 PM" src="https://user-images.githubusercontent.com/37230822/217676968-47e330b2-b9d0-45b7-97ff-40256d4e6d79.png">


## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/A11Y-136


## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
