### PR TITLE
Add guard against improper URLs in the i18n string tracking (P20-33)

### DIFF
--- a/lib/cdo/i18n_string_url_tracker.rb
+++ b/lib/cdo/i18n_string_url_tracker.rb
@@ -190,7 +190,16 @@ class I18nStringUrlTracker
   # not interested in.
   def allowed(url)
     return false unless url
-    parsed_url = URI(url)
+
+    # It is possible that a translation happens before a page is rejected, and some URLs are
+    # not technically valid. For instance, a bogus project via a channel id with a bracket:
+    # "https://studio.code.org/projects/gamelab/ppcBSUtL9w4W2QOjLEsOpFClplmt4vhuAi8gVrS_6o0]"
+    # So, we need to just ignore any invalid URLs and not log the translation.
+    begin
+      parsed_url = URI(url)
+    rescue URI::InvalidURIError
+      return false
+    end
 
     # Include any non-studio.code.org URLs e.g. code.org, hourofcode.com, etc
     return true unless parsed_url.host&.match(/.*studio\.code\.org.*/)
@@ -208,6 +217,7 @@ class I18nStringUrlTracker
     SIMPLE_PATHS.each do |page|
       return true if parsed_url.path&.match(/^\/#{page}.*/)
     end
+
     # Otherwise this URL should not be recorded
     false
   end


### PR DESCRIPTION
Simple PR to prevent 500s from happening if the i18n string tracker receives an improper URL.

Apparently, some routes are more permissive and the string tracker happens before a 404 halts the page render for the projects URL.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

- jira ticket: [P20-33](https://codedotorg.atlassian.net/browse/P20-33)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

Simple manual test by enabling the `I18nStringUrlTracker::I18N_STRING_TRACKING_DCDO_KEY` experiment flag and navigating to `/projects/gamelab/ppcBSUtL9w4W2QOjLEsOpFClplmt4vhuAi8gVrS_6o0]` (with the bracket). It 500s without the fix and 404s properly with it.

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
