### PR TITLE
[Amplitude] Log teachers viewing student work

### DIFF
--- a/apps/src/code-studio/levels/multi.js
+++ b/apps/src/code-studio/levels/multi.js
@@ -8,9 +8,7 @@ import {
 import {sourceForLevel} from '../clientState';
 import Sounds from '../../Sounds';
 import {LegacyTooFewDialog} from '@cdo/apps/lib/ui/LegacyDialogContents';
-import {queryParams} from '@cdo/apps/code-studio/utils';
-import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
-import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
+import {reportTeacherReviewingStudentDslLevel} from '@cdo/apps/lib/util/analyticsUtils';
 
 var Multi = function(
   levelId,
@@ -149,12 +147,10 @@ Multi.prototype.ready = function() {
     if (window.appOptions.submitted) {
       // show the Unsubmit button.
       $('#' + this.id + ' .unsubmitButton').show();
-    } else if (!!queryParams('user_id')) {
-      analyticsReporter.sendEvent(EVENTS.TEACHER_VIEWING_STUDENT_WORK, {
-        unitId: window.appOptions.serverScriptId,
-        levelId: window.appOptions.serverLevelId,
-        sectionId: queryParams('section_id')
-      });
+    }
+
+    if (this.standalone) {
+      reportTeacherReviewingStudentDslLevel();
     }
   }
 

--- a/apps/src/code-studio/levels/multi.js
+++ b/apps/src/code-studio/levels/multi.js
@@ -8,6 +8,9 @@ import {
 import {sourceForLevel} from '../clientState';
 import Sounds from '../../Sounds';
 import {LegacyTooFewDialog} from '@cdo/apps/lib/ui/LegacyDialogContents';
+import {queryParams} from '@cdo/apps/code-studio/utils';
+import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
+import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 
 var Multi = function(
   levelId,
@@ -146,6 +149,12 @@ Multi.prototype.ready = function() {
     if (window.appOptions.submitted) {
       // show the Unsubmit button.
       $('#' + this.id + ' .unsubmitButton').show();
+    } else if (!!queryParams('user_id')) {
+      analyticsReporter.sendEvent(EVENTS.TEACHER_VIEWING_STUDENT_WORK, {
+        unitId: window.appOptions.serverScriptId,
+        levelId: window.appOptions.serverLevelId,
+        sectionId: queryParams('section_id')
+      });
     }
   }
 

--- a/apps/src/code-studio/levels/multi.js
+++ b/apps/src/code-studio/levels/multi.js
@@ -8,7 +8,7 @@ import {
 import {sourceForLevel} from '../clientState';
 import Sounds from '../../Sounds';
 import {LegacyTooFewDialog} from '@cdo/apps/lib/ui/LegacyDialogContents';
-import {reportTeacherReviewingStudentDslLevel} from '@cdo/apps/lib/util/analyticsUtils';
+import {reportTeacherReviewingStudentNonLabLevel} from '@cdo/apps/lib/util/analyticsUtils';
 
 var Multi = function(
   levelId,
@@ -150,7 +150,7 @@ Multi.prototype.ready = function() {
     }
 
     if (this.standalone) {
-      reportTeacherReviewingStudentDslLevel();
+      reportTeacherReviewingStudentNonLabLevel();
     }
   }
 

--- a/apps/src/code-studio/levels/textMatch.js
+++ b/apps/src/code-studio/levels/textMatch.js
@@ -1,5 +1,6 @@
 import $ from 'jquery';
 import {registerGetResult, onAnswerChanged} from './codeStudioLevels';
+import {reportTeacherReviewingStudentDslLevel} from '@cdo/apps/lib/util/analyticsUtils';
 
 var TextMatch = function(levelId, id, app, standalone, answers, lastAttempt) {
   // The dashboard levelId.
@@ -42,6 +43,8 @@ TextMatch.prototype.ready = function() {
   textarea.on('input', null, null, () => {
     onAnswerChanged(this.levelId, false);
   });
+
+  reportTeacherReviewingStudentDslLevel();
 };
 
 TextMatch.prototype.getAppName = function() {

--- a/apps/src/code-studio/levels/textMatch.js
+++ b/apps/src/code-studio/levels/textMatch.js
@@ -1,6 +1,6 @@
 import $ from 'jquery';
 import {registerGetResult, onAnswerChanged} from './codeStudioLevels';
-import {reportTeacherReviewingStudentDslLevel} from '@cdo/apps/lib/util/analyticsUtils';
+import {reportTeacherReviewingStudentNonLabLevel} from '@cdo/apps/lib/util/analyticsUtils';
 
 var TextMatch = function(levelId, id, app, standalone, answers, lastAttempt) {
   // The dashboard levelId.
@@ -44,7 +44,7 @@ TextMatch.prototype.ready = function() {
     onAnswerChanged(this.levelId, false);
   });
 
-  reportTeacherReviewingStudentDslLevel();
+  reportTeacherReviewingStudentNonLabLevel();
 };
 
 TextMatch.prototype.getAppName = function() {

--- a/apps/src/lib/util/AnalyticsConstants.js
+++ b/apps/src/lib/util/AnalyticsConstants.js
@@ -39,7 +39,8 @@ const EVENTS = {
 
   // Levels
   FEEDBACK_SUBMITTED: 'Level Feedback Submitted',
-  RUBRIC_LEVEL_VIEWED_EVENT: 'Rubric Level Viewed'
+  RUBRIC_LEVEL_VIEWED_EVENT: 'Rubric Level Viewed',
+  TEACHER_VIEWING_STUDENT_WORK: 'Teacher Viewing Student Work'
 };
 
 export {EVENTS};

--- a/apps/src/lib/util/analyticsUtils.js
+++ b/apps/src/lib/util/analyticsUtils.js
@@ -3,7 +3,7 @@ import {queryParams} from '@cdo/apps/code-studio/utils';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 
-export const reportTeacherReviewingStudentDslLevel = (
+export const reportTeacherReviewingStudentNonLabLevel = (
   additionalPayload = {}
 ) => {
   if (!appOptions) {

--- a/apps/src/lib/util/analyticsUtils.js
+++ b/apps/src/lib/util/analyticsUtils.js
@@ -12,6 +12,7 @@ export const reportTeacherReviewingStudentDslLevel = (
   if (
     appOptions.readonlyWorkspace &&
     !appOptions.submitted &&
+    !appOptions.isCodeReviewing &&
     !!queryParams('user_id')
   ) {
     analyticsReporter.sendEvent(EVENTS.TEACHER_VIEWING_STUDENT_WORK, {

--- a/apps/src/lib/util/analyticsUtils.js
+++ b/apps/src/lib/util/analyticsUtils.js
@@ -1,0 +1,21 @@
+/* global appOptions */
+import {queryParams} from '@cdo/apps/code-studio/utils';
+import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
+import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
+
+export const reportTeacherReviewingStudentDslLevel = () => {
+  if (!appOptions) {
+    return;
+  }
+  if (
+    appOptions.readonlyWorkspace &&
+    !appOptions.submitted &&
+    !!queryParams('user_id')
+  ) {
+    analyticsReporter.sendEvent(EVENTS.TEACHER_VIEWING_STUDENT_WORK, {
+      unitId: appOptions.serverScriptId,
+      levelId: appOptions.serverLevelId,
+      sectionId: queryParams('section_id')
+    });
+  }
+};

--- a/apps/src/lib/util/analyticsUtils.js
+++ b/apps/src/lib/util/analyticsUtils.js
@@ -3,7 +3,9 @@ import {queryParams} from '@cdo/apps/code-studio/utils';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 
-export const reportTeacherReviewingStudentDslLevel = () => {
+export const reportTeacherReviewingStudentDslLevel = (
+  additionalPayload = {}
+) => {
   if (!appOptions) {
     return;
   }
@@ -13,6 +15,7 @@ export const reportTeacherReviewingStudentDslLevel = () => {
     !!queryParams('user_id')
   ) {
     analyticsReporter.sendEvent(EVENTS.TEACHER_VIEWING_STUDENT_WORK, {
+      ...additionalPayload,
       unitId: appOptions.serverScriptId,
       levelId: appOptions.serverLevelId,
       sectionId: queryParams('section_id')

--- a/apps/src/sites/studio/pages/levels/_bubble_choice.js
+++ b/apps/src/sites/studio/pages/levels/_bubble_choice.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import BubbleChoice from '@cdo/apps/code-studio/components/BubbleChoice';
-import {reportTeacherReviewingStudentDslLevel} from '@cdo/apps/lib/util/analyticsUtils';
+import {reportTeacherReviewingStudentNonLabLevel} from '@cdo/apps/lib/util/analyticsUtils';
 
 const script = document.querySelector('script[data-bubblechoice]');
 const data = JSON.parse(script.dataset.bubblechoice);
@@ -13,7 +13,7 @@ level.sublevels = data.level.sublevels.map(sublevel => {
 });
 level.id = level.id.toString();
 
-reportTeacherReviewingStudentDslLevel();
+reportTeacherReviewingStudentNonLabLevel();
 
 ReactDOM.render(
   <BubbleChoice level={level} />,

--- a/apps/src/sites/studio/pages/levels/_bubble_choice.js
+++ b/apps/src/sites/studio/pages/levels/_bubble_choice.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import BubbleChoice from '@cdo/apps/code-studio/components/BubbleChoice';
+import {reportTeacherReviewingStudentDslLevel} from '@cdo/apps/lib/util/analyticsUtils';
 
 const script = document.querySelector('script[data-bubblechoice]');
 const data = JSON.parse(script.dataset.bubblechoice);
@@ -11,6 +12,8 @@ level.sublevels = data.level.sublevels.map(sublevel => {
   return sublevel;
 });
 level.id = level.id.toString();
+
+reportTeacherReviewingStudentDslLevel();
 
 ReactDOM.render(
   <BubbleChoice level={level} />,

--- a/apps/src/sites/studio/pages/levels/_content.js
+++ b/apps/src/sites/studio/pages/levels/_content.js
@@ -7,6 +7,7 @@ import {convertXmlToBlockly} from '@cdo/apps/templates/instructions/utils';
 import commonBlocks from '@cdo/apps/blocksCommon';
 import getScriptData, {hasScriptData} from '@cdo/apps/util/getScriptData';
 import logToCloud from '@cdo/apps/logToCloud';
+import {reportTeacherReviewingStudentDslLevel} from '@cdo/apps/lib/util/analyticsUtils';
 
 $(document).ready(() => {
   // Load app specific Blockly blocks. This will enable level creators to write
@@ -41,6 +42,8 @@ $(document).ready(() => {
       });
     }
   }
+
+  reportTeacherReviewingStudentDslLevel();
 
   // Render Markdown
   $('.content-level > .markdown-container').each(function() {

--- a/apps/src/sites/studio/pages/levels/_content.js
+++ b/apps/src/sites/studio/pages/levels/_content.js
@@ -7,7 +7,6 @@ import {convertXmlToBlockly} from '@cdo/apps/templates/instructions/utils';
 import commonBlocks from '@cdo/apps/blocksCommon';
 import getScriptData, {hasScriptData} from '@cdo/apps/util/getScriptData';
 import logToCloud from '@cdo/apps/logToCloud';
-import {reportTeacherReviewingStudentDslLevel} from '@cdo/apps/lib/util/analyticsUtils';
 
 $(document).ready(() => {
   // Load app specific Blockly blocks. This will enable level creators to write
@@ -42,8 +41,6 @@ $(document).ready(() => {
       });
     }
   }
-
-  reportTeacherReviewingStudentDslLevel();
 
   // Render Markdown
   $('.content-level > .markdown-container').each(function() {

--- a/apps/src/sites/studio/pages/levels/_contract_match.js
+++ b/apps/src/sites/studio/pages/levels/_contract_match.js
@@ -5,6 +5,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import {LegacyContractMatchErrorDialog} from '@cdo/apps/lib/ui/LegacyDialogContents';
 import i18n from '@cdo/locale';
+import {reportTeacherReviewingStudentDslLevel} from '@cdo/apps/lib/util/analyticsUtils';
 
 $(window).load(function() {
   $.widget('custom.coloriconselectmenu', $.ui.selectmenu, {
@@ -26,6 +27,8 @@ $(window).load(function() {
       addSquareIconToButton(this.element);
     }
   });
+
+  reportTeacherReviewingStudentDslLevel();
 
   /**
    * @param {string} color

--- a/apps/src/sites/studio/pages/levels/_contract_match.js
+++ b/apps/src/sites/studio/pages/levels/_contract_match.js
@@ -5,7 +5,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import {LegacyContractMatchErrorDialog} from '@cdo/apps/lib/ui/LegacyDialogContents';
 import i18n from '@cdo/locale';
-import {reportTeacherReviewingStudentDslLevel} from '@cdo/apps/lib/util/analyticsUtils';
+import {reportTeacherReviewingStudentNonLabLevel} from '@cdo/apps/lib/util/analyticsUtils';
 
 $(window).load(function() {
   $.widget('custom.coloriconselectmenu', $.ui.selectmenu, {
@@ -28,7 +28,7 @@ $(window).load(function() {
     }
   });
 
-  reportTeacherReviewingStudentDslLevel();
+  reportTeacherReviewingStudentNonLabLevel();
 
   /**
    * @param {string} color

--- a/apps/src/sites/studio/pages/levels/_curriculum_reference.js
+++ b/apps/src/sites/studio/pages/levels/_curriculum_reference.js
@@ -5,6 +5,7 @@ import {registerGetResult} from '@cdo/apps/code-studio/levels/codeStudioLevels';
 import {onContinue} from '@cdo/apps/code-studio/levels/postOnContinue';
 import getScriptData from '@cdo/apps/util/getScriptData';
 import ReferenceGuide from '@cdo/apps/templates/referenceGuides/ReferenceGuide';
+import {reportTeacherReviewingStudentDslLevel} from '@cdo/apps/lib/util/analyticsUtils';
 
 $(document).ready(() => {
   registerGetResult();
@@ -24,6 +25,8 @@ $(document).ready(() => {
       refGuideElement
     );
   }
+
+  reportTeacherReviewingStudentDslLevel();
 });
 
 /**

--- a/apps/src/sites/studio/pages/levels/_curriculum_reference.js
+++ b/apps/src/sites/studio/pages/levels/_curriculum_reference.js
@@ -5,7 +5,7 @@ import {registerGetResult} from '@cdo/apps/code-studio/levels/codeStudioLevels';
 import {onContinue} from '@cdo/apps/code-studio/levels/postOnContinue';
 import getScriptData from '@cdo/apps/util/getScriptData';
 import ReferenceGuide from '@cdo/apps/templates/referenceGuides/ReferenceGuide';
-import {reportTeacherReviewingStudentDslLevel} from '@cdo/apps/lib/util/analyticsUtils';
+import {reportTeacherReviewingStudentNonLabLevel} from '@cdo/apps/lib/util/analyticsUtils';
 
 $(document).ready(() => {
   registerGetResult();
@@ -26,7 +26,7 @@ $(document).ready(() => {
     );
   }
 
-  reportTeacherReviewingStudentDslLevel();
+  reportTeacherReviewingStudentNonLabLevel();
 });
 
 /**

--- a/apps/src/sites/studio/pages/levels/_external.js
+++ b/apps/src/sites/studio/pages/levels/_external.js
@@ -1,6 +1,7 @@
 import $ from 'jquery';
 import {registerGetResult} from '@cdo/apps/code-studio/levels/codeStudioLevels';
 import {onContinue} from '@cdo/apps/code-studio/levels/postOnContinue';
+import {reportTeacherReviewingStudentDslLevel} from '@cdo/apps/lib/util/analyticsUtils';
 
 $(document).ready(() => {
   const script = document.querySelector('script[data-external]');
@@ -13,6 +14,8 @@ $(document).ready(() => {
   }
 
   registerGetResult();
+
+  reportTeacherReviewingStudentDslLevel();
 
   // Handle click on the continue button (results in navigating to next puzzle)
   // Note: We're using this pattern instead of

--- a/apps/src/sites/studio/pages/levels/_external.js
+++ b/apps/src/sites/studio/pages/levels/_external.js
@@ -1,7 +1,7 @@
 import $ from 'jquery';
 import {registerGetResult} from '@cdo/apps/code-studio/levels/codeStudioLevels';
 import {onContinue} from '@cdo/apps/code-studio/levels/postOnContinue';
-import {reportTeacherReviewingStudentDslLevel} from '@cdo/apps/lib/util/analyticsUtils';
+import {reportTeacherReviewingStudentNonLabLevel} from '@cdo/apps/lib/util/analyticsUtils';
 
 $(document).ready(() => {
   const script = document.querySelector('script[data-external]');
@@ -15,7 +15,7 @@ $(document).ready(() => {
 
   registerGetResult();
 
-  reportTeacherReviewingStudentDslLevel();
+  reportTeacherReviewingStudentNonLabLevel();
 
   // Handle click on the continue button (results in navigating to next puzzle)
   // Note: We're using this pattern instead of

--- a/apps/src/sites/studio/pages/levels/_external_link.js
+++ b/apps/src/sites/studio/pages/levels/_external_link.js
@@ -1,10 +1,10 @@
 import {processResults} from '@cdo/apps/code-studio/levels/dialogHelper';
 import {registerGetResult} from '@cdo/apps/code-studio/levels/codeStudioLevels';
-import {reportTeacherReviewingStudentDslLevel} from '@cdo/apps/lib/util/analyticsUtils';
+import {reportTeacherReviewingStudentNonLabLevel} from '@cdo/apps/lib/util/analyticsUtils';
 
 registerGetResult();
 
-reportTeacherReviewingStudentDslLevel();
+reportTeacherReviewingStudentNonLabLevel();
 
 $(document).on('click', '.submitButton', () => {
   const submitButton = $('.submitButton');

--- a/apps/src/sites/studio/pages/levels/_external_link.js
+++ b/apps/src/sites/studio/pages/levels/_external_link.js
@@ -1,7 +1,10 @@
 import {processResults} from '@cdo/apps/code-studio/levels/dialogHelper';
 import {registerGetResult} from '@cdo/apps/code-studio/levels/codeStudioLevels';
+import {reportTeacherReviewingStudentDslLevel} from '@cdo/apps/lib/util/analyticsUtils';
 
 registerGetResult();
+
+reportTeacherReviewingStudentDslLevel();
 
 $(document).on('click', '.submitButton', () => {
   const submitButton = $('.submitButton');

--- a/apps/src/sites/studio/pages/levels/_free_response.js
+++ b/apps/src/sites/studio/pages/levels/_free_response.js
@@ -5,7 +5,7 @@ import ReactDOM from 'react-dom';
 import getScriptData from '@cdo/apps/util/getScriptData';
 import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
 import Attachments from '@cdo/apps/code-studio/components/Attachments';
-import {reportTeacherReviewingStudentDslLevel} from '@cdo/apps/lib/util/analyticsUtils';
+import {reportTeacherReviewingStudentNonLabLevel} from '@cdo/apps/lib/util/analyticsUtils';
 
 $(document).ready(() => {
   const data = getScriptData('freeresponse');
@@ -23,7 +23,7 @@ $(document).ready(() => {
   });
 
   if (!appOptions.hasContainedLevels) {
-    reportTeacherReviewingStudentDslLevel();
+    reportTeacherReviewingStudentNonLabLevel();
   }
 
   const attachmentsMountPoint = document.querySelector('#free-response-upload');

--- a/apps/src/sites/studio/pages/levels/_free_response.js
+++ b/apps/src/sites/studio/pages/levels/_free_response.js
@@ -5,6 +5,9 @@ import ReactDOM from 'react-dom';
 import getScriptData from '@cdo/apps/util/getScriptData';
 import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
 import Attachments from '@cdo/apps/code-studio/components/Attachments';
+import {queryParams} from '@cdo/apps/code-studio/utils';
+import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
+import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 
 $(document).ready(() => {
   const data = getScriptData('freeresponse');
@@ -20,6 +23,18 @@ $(document).ready(() => {
       container
     );
   });
+
+  if (
+    window.appOptions.readonlyWorkspace &&
+    !window.appOptions.submitted &&
+    !!queryParams('user_id')
+  ) {
+    analyticsReporter.sendEvent(EVENTS.TEACHER_VIEWING_STUDENT_WORK, {
+      unitId: appOptions.serverScriptId,
+      levelId: appOptions.serverLevelId,
+      sectionId: queryParams('section_id')
+    });
+  }
 
   const attachmentsMountPoint = document.querySelector('#free-response-upload');
   const attachmentsProps = data.attachments_props;

--- a/apps/src/sites/studio/pages/levels/_free_response.js
+++ b/apps/src/sites/studio/pages/levels/_free_response.js
@@ -5,9 +5,7 @@ import ReactDOM from 'react-dom';
 import getScriptData from '@cdo/apps/util/getScriptData';
 import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
 import Attachments from '@cdo/apps/code-studio/components/Attachments';
-import {queryParams} from '@cdo/apps/code-studio/utils';
-import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
-import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
+import {reportTeacherReviewingStudentDslLevel} from '@cdo/apps/lib/util/analyticsUtils';
 
 $(document).ready(() => {
   const data = getScriptData('freeresponse');
@@ -24,16 +22,8 @@ $(document).ready(() => {
     );
   });
 
-  if (
-    window.appOptions.readonlyWorkspace &&
-    !window.appOptions.submitted &&
-    !!queryParams('user_id')
-  ) {
-    analyticsReporter.sendEvent(EVENTS.TEACHER_VIEWING_STUDENT_WORK, {
-      unitId: appOptions.serverScriptId,
-      levelId: appOptions.serverLevelId,
-      sectionId: queryParams('section_id')
-    });
+  if (!appOptions.hasContainedLevels) {
+    reportTeacherReviewingStudentDslLevel();
   }
 
   const attachmentsMountPoint = document.querySelector('#free-response-upload');

--- a/apps/src/sites/studio/pages/levels/_level_group.js
+++ b/apps/src/sites/studio/pages/levels/_level_group.js
@@ -13,7 +13,7 @@ window.Multi = require('@cdo/apps/code-studio/levels/multi.js');
 window.TextMatch = require('@cdo/apps/code-studio/levels/textMatch.js');
 var saveAnswers = require('@cdo/apps/code-studio/levels/saveAnswers.js')
   .saveAnswers;
-import {reportTeacherReviewingStudentDslLevel} from '@cdo/apps/lib/util/analyticsUtils';
+import {reportTeacherReviewingStudentNonLabLevel} from '@cdo/apps/lib/util/analyticsUtils';
 
 $(document).ready(() => {
   const levelData = getScriptData('levelData');
@@ -28,7 +28,7 @@ $(document).ready(() => {
     );
   }
 
-  reportTeacherReviewingStudentDslLevel({page: initData?.page});
+  reportTeacherReviewingStudentNonLabLevel({page: initData?.page});
 });
 
 function initLevelGroup(levelCount, currentPage, lastAttempt) {

--- a/apps/src/sites/studio/pages/levels/_level_group.js
+++ b/apps/src/sites/studio/pages/levels/_level_group.js
@@ -13,14 +13,11 @@ window.Multi = require('@cdo/apps/code-studio/levels/multi.js');
 window.TextMatch = require('@cdo/apps/code-studio/levels/textMatch.js');
 var saveAnswers = require('@cdo/apps/code-studio/levels/saveAnswers.js')
   .saveAnswers;
-import {queryParams} from '@cdo/apps/code-studio/utils';
-import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
-import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
+import {reportTeacherReviewingStudentDslLevel} from '@cdo/apps/lib/util/analyticsUtils';
 
 $(document).ready(() => {
   const levelData = getScriptData('levelData');
   const initData = getScriptData('initData');
-  const userData = getScriptData('userData');
   window.levelData = levelData;
 
   if (initData) {
@@ -31,18 +28,7 @@ $(document).ready(() => {
     );
   }
 
-  if (userData) {
-    if (
-      userData.currentUserType === 'teacher' &&
-      userData.currentUserId !== userData.viewAsId
-    ) {
-      analyticsReporter.sendEvent(EVENTS.TEACHER_VIEWING_STUDENT_WORK, {
-        unitId: window.appOptions.serverScriptId,
-        levelId: window.appOptions.serverLevelId,
-        sectionId: queryParams('section_id')
-      });
-    }
-  }
+  reportTeacherReviewingStudentDslLevel({page: initData?.page});
 });
 
 function initLevelGroup(levelCount, currentPage, lastAttempt) {

--- a/apps/src/sites/studio/pages/levels/_level_group.js
+++ b/apps/src/sites/studio/pages/levels/_level_group.js
@@ -13,10 +13,14 @@ window.Multi = require('@cdo/apps/code-studio/levels/multi.js');
 window.TextMatch = require('@cdo/apps/code-studio/levels/textMatch.js');
 var saveAnswers = require('@cdo/apps/code-studio/levels/saveAnswers.js')
   .saveAnswers;
+import {queryParams} from '@cdo/apps/code-studio/utils';
+import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
+import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 
 $(document).ready(() => {
   const levelData = getScriptData('levelData');
   const initData = getScriptData('initData');
+  const userData = getScriptData('userData');
   window.levelData = levelData;
 
   if (initData) {
@@ -25,6 +29,19 @@ $(document).ready(() => {
       initData.page,
       initData.last_attempt
     );
+  }
+
+  if (userData) {
+    if (
+      userData.currentUserType === 'teacher' &&
+      userData.currentUserId !== userData.viewAsId
+    ) {
+      analyticsReporter.sendEvent(EVENTS.TEACHER_VIEWING_STUDENT_WORK, {
+        unitId: window.appOptions.serverScriptId,
+        levelId: window.appOptions.serverLevelId,
+        sectionId: queryParams('section_id')
+      });
+    }
   }
 });
 

--- a/apps/src/sites/studio/pages/levels/_match.js
+++ b/apps/src/sites/studio/pages/levels/_match.js
@@ -2,6 +2,7 @@
 import React from 'react';
 import {showDialog} from '@cdo/apps/code-studio/levels/dialogHelper';
 import {LegacyMatchAngiGifDialog} from '@cdo/apps/lib/ui/LegacyDialogContents';
+import {reportTeacherReviewingStudentDslLevel} from '@cdo/apps/lib/util/analyticsUtils';
 
 import Match from '@cdo/apps/code-studio/levels/match';
 window.Match = Match;
@@ -12,4 +13,6 @@ $(function() {
     // Note: This dialog depends on the presence of some haml, found in _dialog.html.haml
     window.setTimeout(() => showDialog(<LegacyMatchAngiGifDialog />), 1000);
   }
+
+  reportTeacherReviewingStudentDslLevel();
 });

--- a/apps/src/sites/studio/pages/levels/_match.js
+++ b/apps/src/sites/studio/pages/levels/_match.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import {showDialog} from '@cdo/apps/code-studio/levels/dialogHelper';
 import {LegacyMatchAngiGifDialog} from '@cdo/apps/lib/ui/LegacyDialogContents';
-import {reportTeacherReviewingStudentDslLevel} from '@cdo/apps/lib/util/analyticsUtils';
+import {reportTeacherReviewingStudentNonLabLevel} from '@cdo/apps/lib/util/analyticsUtils';
 
 import Match from '@cdo/apps/code-studio/levels/match';
 window.Match = Match;
@@ -14,5 +14,5 @@ $(function() {
     window.setTimeout(() => showDialog(<LegacyMatchAngiGifDialog />), 1000);
   }
 
-  reportTeacherReviewingStudentDslLevel();
+  reportTeacherReviewingStudentNonLabLevel();
 });

--- a/apps/src/sites/studio/pages/levels/_standalone_video.js
+++ b/apps/src/sites/studio/pages/levels/_standalone_video.js
@@ -3,7 +3,7 @@ import {registerGetResult} from '@cdo/apps/code-studio/levels/codeStudioLevels';
 import {onContinue} from '@cdo/apps/code-studio/levels/postOnContinue';
 import {createVideoWithFallback} from '@cdo/apps/code-studio/videos';
 import getScriptData from '@cdo/apps/util/getScriptData';
-import {reportTeacherReviewingStudentDslLevel} from '@cdo/apps/lib/util/analyticsUtils';
+import {reportTeacherReviewingStudentNonLabLevel} from '@cdo/apps/lib/util/analyticsUtils';
 import React from 'react';
 import ReactDom from 'react-dom';
 import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
@@ -21,7 +21,7 @@ $(document).ready(() => {
   const notes = $('.notes-content');
   const video = $('.video-content');
 
-  reportTeacherReviewingStudentDslLevel();
+  reportTeacherReviewingStudentNonLabLevel();
 
   showNotes.click(() => {
     showNotes.hide();

--- a/apps/src/sites/studio/pages/levels/_standalone_video.js
+++ b/apps/src/sites/studio/pages/levels/_standalone_video.js
@@ -3,6 +3,7 @@ import {registerGetResult} from '@cdo/apps/code-studio/levels/codeStudioLevels';
 import {onContinue} from '@cdo/apps/code-studio/levels/postOnContinue';
 import {createVideoWithFallback} from '@cdo/apps/code-studio/videos';
 import getScriptData from '@cdo/apps/util/getScriptData';
+import {reportTeacherReviewingStudentDslLevel} from '@cdo/apps/lib/util/analyticsUtils';
 import React from 'react';
 import ReactDom from 'react-dom';
 import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
@@ -19,6 +20,8 @@ $(document).ready(() => {
   const showVideo = $('.show-video');
   const notes = $('.notes-content');
   const video = $('.video-content');
+
+  reportTeacherReviewingStudentDslLevel();
 
   showNotes.click(() => {
     showNotes.hide();

--- a/apps/src/sites/studio/pages/levels/_widget.js
+++ b/apps/src/sites/studio/pages/levels/_widget.js
@@ -14,6 +14,7 @@ import {
   LegacyStartOverDialog,
   LegacyInstructionsDialog
 } from '@cdo/apps/lib/ui/LegacyDialogContents';
+import {reportTeacherReviewingStudentDslLevel} from '@cdo/apps/lib/util/analyticsUtils';
 import i18n from '@cdo/locale';
 
 export function showInstructionsDialog() {
@@ -53,4 +54,6 @@ window.dashboard.widget = {
 // On load (note - widget-specific setup may happen before this!)
 $(document).ready(function() {
   $('#bubble').click(showInstructionsDialog);
+
+  reportTeacherReviewingStudentDslLevel();
 });

--- a/apps/src/sites/studio/pages/levels/_widget.js
+++ b/apps/src/sites/studio/pages/levels/_widget.js
@@ -14,7 +14,7 @@ import {
   LegacyStartOverDialog,
   LegacyInstructionsDialog
 } from '@cdo/apps/lib/ui/LegacyDialogContents';
-import {reportTeacherReviewingStudentDslLevel} from '@cdo/apps/lib/util/analyticsUtils';
+import {reportTeacherReviewingStudentNonLabLevel} from '@cdo/apps/lib/util/analyticsUtils';
 import i18n from '@cdo/locale';
 
 export function showInstructionsDialog() {
@@ -55,5 +55,5 @@ window.dashboard.widget = {
 $(document).ready(function() {
   $('#bubble').click(showInstructionsDialog);
 
-  reportTeacherReviewingStudentDslLevel();
+  reportTeacherReviewingStudentNonLabLevel();
 });

--- a/apps/test/unit/lib/util/analyticsUtilsTest.js
+++ b/apps/test/unit/lib/util/analyticsUtilsTest.js
@@ -1,0 +1,23 @@
+import {expect} from '../../../util/reconfiguredChai';
+import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
+import {reportTeacherReviewingStudentDslLevel} from '@cdo/apps/lib/util/analyticsUtils';
+import * as utils from '@cdo/apps/code-studio/utils';
+import sinon from 'sinon';
+
+describe('AnalyticsUtils', () => {
+  it('reports teacher viewing student work on a dsl level when needed', () => {
+    window.appOptions = {
+      readonlyWorkspace: true,
+      submitted: false
+    };
+    const queryParamsSpy = sinon.stub(utils, 'queryParams');
+    queryParamsSpy.withArgs('user_id').returns('123');
+    const analyticsSpy = sinon.spy(analyticsReporter, 'sendEvent');
+
+    reportTeacherReviewingStudentDslLevel();
+    expect(analyticsSpy).to.be.called.once;
+
+    utils.queryParams.restore();
+    analyticsSpy.restore();
+  });
+});

--- a/apps/test/unit/lib/util/analyticsUtilsTest.js
+++ b/apps/test/unit/lib/util/analyticsUtilsTest.js
@@ -1,6 +1,6 @@
 import {expect} from '../../../util/reconfiguredChai';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
-import {reportTeacherReviewingStudentDslLevel} from '@cdo/apps/lib/util/analyticsUtils';
+import {reportTeacherReviewingStudentNonLabLevel} from '@cdo/apps/lib/util/analyticsUtils';
 import * as utils from '@cdo/apps/code-studio/utils';
 import sinon from 'sinon';
 
@@ -14,7 +14,7 @@ describe('AnalyticsUtils', () => {
     queryParamsSpy.withArgs('user_id').returns('123');
     const analyticsSpy = sinon.spy(analyticsReporter, 'sendEvent');
 
-    reportTeacherReviewingStudentDslLevel();
+    reportTeacherReviewingStudentNonLabLevel();
     expect(analyticsSpy).to.be.called.once;
 
     utils.queryParams.restore();

--- a/dashboard/app/views/levels/_level_group.haml
+++ b/dashboard/app/views/levels/_level_group.haml
@@ -1,6 +1,5 @@
 - app = 'level_group'
 - data = @level.properties
-- user_data = {currentUserId: current_user&.id, currentUserType: current_user&.user_type, viewAsId: params[:user_id]}
 - parsed_last_attempt = JSON.parse(@last_attempt || '{}')
 
 = render partial: 'levels/common_audio'
@@ -60,4 +59,4 @@
   - unless @script_level.nil?
     - init_data = { total_level_count: @total_level_count, page: current_page.to_i || -1, last_attempt: parsed_last_attempt}
 
-  %script{src: webpack_asset_path('js/levels/_level_group.js'), data: {levelData: data.to_json, initData: init_data.to_json, userData: user_data.to_json}}
+  %script{src: webpack_asset_path('js/levels/_level_group.js'), data: {levelData: data.to_json, initData: init_data.to_json}}

--- a/dashboard/app/views/levels/_level_group.haml
+++ b/dashboard/app/views/levels/_level_group.haml
@@ -1,5 +1,6 @@
 - app = 'level_group'
 - data = @level.properties
+- user_data = {currentUserId: current_user&.id, currentUserType: current_user&.user_type, viewAsId: params[:user_id]}
 - parsed_last_attempt = JSON.parse(@last_attempt || '{}')
 
 = render partial: 'levels/common_audio'
@@ -59,4 +60,4 @@
   - unless @script_level.nil?
     - init_data = { total_level_count: @total_level_count, page: current_page.to_i || -1, last_attempt: parsed_last_attempt}
 
-  %script{src: webpack_asset_path('js/levels/_level_group.js'), data: {levelData: data.to_json, initData: init_data.to_json}}
+  %script{src: webpack_asset_path('js/levels/_level_group.js'), data: {levelData: data.to_json, initData: init_data.to_json, userData: user_data.to_json}}


### PR DESCRIPTION
Completes [TEACH-191](https://codedotorg.atlassian.net/browse/TEACH-191). Logging an event when a teacher is viewing student work. There is one change to log this event for all apps (eg applab, weblab, playlab, etc), but each DSL level needed a separate change to log this event. I might have gone a little overboard with which levels will log an event (it is not interesting to see a student's work on a `CurriculumReference` level), but decided more was better, especially once I extracted the logic into a helper function.

[Two level types](https://github.com/code-dot-org/code-dot-org/blob/680ca56bbcb9357513ba4cdb4f28f0b8ff67724a/dashboard/app/views/levels/_contained_levels.html.haml#L14) can be contained in other levels: multi and free_response. I tested those two both in standalone levels and as contained levels to ensure they logged events exactly once.

For level groups, I decided to also log the page as they may look like duplicate events other wise.

Example from level group:
```
[AMPLITUDE ANALYTICS EVENT]: Teacher Viewing Student Work. Payload: {"payload": {"page":1,"unitId":1139,"levelId":33438,"sectionId":"217"}}
```

Example from other level types:
```
[AMPLITUDE ANALYTICS EVENT]: Teacher Viewing Student Work. Payload: {"payload":{"unitId":1139,"levelId":427,"sectionId":"217"}}
```

I ended up going through almost every lesson on the allthethings unit and spot testing levels. They all worked as expected.

