### PR TITLE
Incubator PropType Fix

### DIFF
--- a/apps/src/templates/studioHomepages/IncubatorBanner.jsx
+++ b/apps/src/templates/studioHomepages/IncubatorBanner.jsx
@@ -18,7 +18,7 @@ const IncubatorBanner = () => {
             text: i18n.seeIncubatorProjects()
           }
         ]}
-        marginBottom={0}
+        marginBottom={'0'}
       />
     </ContentContainer>
   );


### PR DESCRIPTION
Micro-fix to remove an error that was popping up while I've been testing things on the teacher homepage. An error was popping up in the dev-console because the props were expecting a string, but was receiving a number. Changed the type. No visible changes and the error disappeared.