### PR TITLE
Remove compass from onBoardEvent dropdown

### DIFF
--- a/apps/src/lib/kits/maker/boards/microBit/MicroBitConstants.js
+++ b/apps/src/lib/kits/maker/boards/microBit/MicroBitConstants.js
@@ -32,7 +32,7 @@ export const MB_COMPONENTS = [
 ];
 
 export const MB_BUTTON_VARS = ['buttonA', 'buttonB'];
-export const MB_SENSOR_VARS = ['lightSensor', 'tempSensor', 'compass'];
+export const MB_SENSOR_VARS = ['lightSensor', 'tempSensor'];
 
 // milliseconds between samples for sensors
 export const SAMPLE_INTERVAL = 50;

--- a/apps/test/unit/lib/kits/maker/dropletConfigTest.js
+++ b/apps/test/unit/lib/kits/maker/dropletConfigTest.js
@@ -121,15 +121,6 @@ describe('maker/dropletConfig.js', () => {
         )
       ).to.deep.equal(['"down"', '"up"']);
     });
-
-    it('compass dropdown', () => {
-      expect(
-        dropletConfig.getBoardEventDropdownForParam(
-          'compass',
-          MB_COMPONENT_EVENTS
-        )
-      ).to.deep.equal(['"change"', '"data"']);
-    });
   });
 
   describe('stringifySong', () => {


### PR DESCRIPTION
Since we are not supporting the compass feature on the Micro:Bit, this PR removes compass from the dropdown menu for the `onBoardEvent` command. 

Before:
![Screen Shot 2023-02-09 at 3 02 34 PM](https://user-images.githubusercontent.com/107423305/217943707-ccfecdf9-feee-4161-b2c9-540e7599bbfc.png)

After:
![Screen Shot 2023-02-09 at 3 02 20 PM](https://user-images.githubusercontent.com/107423305/217943718-3def6063-9c7d-4032-8cec-0dc3530a173c.png)

## Links
[Slack discussion](https://codedotorg.slack.com/archives/C04NG4SUCQ0/p1675972535702209)

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
I tested locally. In addition, I removed one unit test from `dropletConfigTest.js` that involved the 'compass' dropdown.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
