### PR TITLE
[Storybook] LessonProgress, CourseRollup, LevelDetailsDialog

### DIFF
--- a/apps/src/templates/courseRollupPages/CourseRollup.story.jsx
+++ b/apps/src/templates/courseRollupPages/CourseRollup.story.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import CourseRollup from '@cdo/apps/templates/courseRollupPages/CourseRollup';
 import UnitRollup from '@cdo/apps/templates/courseRollupPages/UnitRollup';
+import {Provider} from 'react-redux';
+import {reduxStore} from '@cdo/storybook/decorators';
 
 const defaultProps = {
   objectToRollUp: 'Vocabulary',
@@ -193,66 +195,63 @@ const defaultProps = {
   }
 };
 
-export default storybook => {
-  storybook
-    .storiesOf('CourseRollup', module)
-    .withReduxStore()
-    .addStoryTable([
-      {
-        name: 'Course Vocabulary',
-        story: () => <CourseRollup {...defaultProps} />
-      },
-      {
-        name: 'Course Code',
-        story: () => <CourseRollup {...defaultProps} objectToRollUp={'Code'} />
-      },
-      {
-        name: 'Course Resources',
-        story: () => (
-          <CourseRollup {...defaultProps} objectToRollUp={'Resources'} />
-        )
-      },
-      {
-        name: 'Course Standards',
-        story: () => (
-          <CourseRollup {...defaultProps} objectToRollUp={'Standards'} />
-        )
-      },
-      {
-        name: 'Unit Vocabulary',
-        story: () => (
-          <UnitRollup
-            unit={defaultProps.course.units[0]}
-            objectToRollUp={defaultProps.objectToRollUp}
-          />
-        )
-      },
-      {
-        name: 'Unit Code',
-        story: () => (
-          <UnitRollup
-            unit={defaultProps.course.units[0]}
-            objectToRollUp={'Code'}
-          />
-        )
-      },
-      {
-        name: 'Unit Resources',
-        story: () => (
-          <UnitRollup
-            unit={defaultProps.course.units[0]}
-            objectToRollUp={'Resources'}
-          />
-        )
-      },
-      {
-        name: 'Unit Standards',
-        story: () => (
-          <UnitRollup
-            unit={defaultProps.course.units[0]}
-            objectToRollUp={'Standards'}
-          />
-        )
-      }
-    ]);
+export default {
+  title: 'CourseRollup',
+  component: CourseRollup
+};
+
+const CourseTemplate = args => {
+  return (
+    <Provider store={reduxStore()}>
+      <CourseRollup {...defaultProps} {...args} />
+    </Provider>
+  );
+};
+
+const UnitTemplate = args => {
+  return (
+    <Provider store={reduxStore()}>
+      <UnitRollup unit={defaultProps.course.units[0]} {...args} />
+    </Provider>
+  );
+};
+
+export const CourseVocabularyExample = CourseTemplate.bind({});
+CourseVocabularyExample.args = {
+  objectToRollUp: defaultProps.objectToRollUp
+};
+
+export const CourseCodeExample = CourseTemplate.bind({});
+CourseCodeExample.args = {
+  objectToRollUp: 'Code'
+};
+
+export const CourseResourceExample = CourseTemplate.bind({});
+CourseResourceExample.args = {
+  objectToRollUp: 'Resources'
+};
+
+export const CourseStandardsExample = CourseTemplate.bind({});
+CourseStandardsExample.args = {
+  objectToRollUp: 'Standards'
+};
+
+export const UnitVocabularyExample = UnitTemplate.bind({});
+UnitVocabularyExample.args = {
+  objectToRollUp: defaultProps.objectToRollUp
+};
+
+export const UnitCodeExample = UnitTemplate.bind({});
+UnitCodeExample.args = {
+  objectToRollUp: 'Code'
+};
+
+export const UnitResourceExample = UnitTemplate.bind({});
+UnitResourceExample.args = {
+  objectToRollUp: 'Resources'
+};
+
+export const UnitStandardsExample = UnitTemplate.bind({});
+UnitStandardsExample.args = {
+  objectToRollUp: 'Standards'
 };

--- a/apps/src/templates/lessonOverview/activities/LevelDetailsDialog.story.jsx
+++ b/apps/src/templates/lessonOverview/activities/LevelDetailsDialog.story.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import {UnconnectedLevelDetailsDialog as LevelDetailsDialog} from './LevelDetailsDialog';
 import {Provider} from 'react-redux';
-import {getStore} from '@cdo/apps/code-studio/redux';
 import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
+import {reduxStore} from '@cdo/storybook/decorators';
 
 const defaultProps = {
   handleClose: () => {
@@ -128,80 +128,51 @@ const levelWithContainedLevel = {
   }
 };
 
-export default storybook => {
-  storybook
-    .storiesOf('LevelDetailsDialog', module)
-    .withReduxStore()
-    .addStoryTable([
-      {
-        name: 'StandaloneVideo',
-        story: () => (
-          <LevelDetailsDialog
-            {...defaultProps}
-            scriptLevel={standaloneVideoScriptLevel}
-          />
-        )
-      },
-      {
-        name: 'External',
-        story: () => (
-          <LevelDetailsDialog
-            {...defaultProps}
-            scriptLevel={externalMarkdownScriptLevel}
-          />
-        )
-      },
-      {
-        name: 'LevelGroup',
-        story: () => (
-          <LevelDetailsDialog
-            {...defaultProps}
-            scriptLevel={levelGroupScriptLevel}
-          />
-        )
-      },
-      {
-        name: 'BubbleChoice',
-        story: () => (
-          <LevelDetailsDialog
-            {...defaultProps}
-            scriptLevel={bubbleChoiceScriptLevel}
-          />
-        )
-      },
-      {
-        name: 'Contained Levels',
-        story: () => (
-          <Provider store={getStore()}>
-            <LevelDetailsDialog
-              {...defaultProps}
-              scriptLevel={levelWithContainedLevel}
-            />
-          </Provider>
-        )
-      },
-      {
-        name: 'TopInstructions',
-        story: () => (
-          <Provider store={getStore()}>
-            <LevelDetailsDialog
-              {...defaultProps}
-              scriptLevel={levelWithInstructions}
-            />
-          </Provider>
-        )
-      },
-      {
-        name: 'TopInstructions RTL',
-        story: () => (
-          <Provider store={getStore()}>
-            <LevelDetailsDialog
-              {...defaultProps}
-              isRtl
-              scriptLevel={levelWithInstructions}
-            />
-          </Provider>
-        )
-      }
-    ]);
+export default {
+  title: 'LevelDetailsDialog',
+  component: LevelDetailsDialog
+};
+
+const Template = args => {
+  return (
+    <Provider store={reduxStore()}>
+      <LevelDetailsDialog {...defaultProps} {...args} />
+    </Provider>
+  );
+};
+
+export const StandaloneVideoExample = Template.bind({});
+StandaloneVideoExample.args = {
+  scriptLevel: standaloneVideoScriptLevel
+};
+
+export const ExternalExample = Template.bind({});
+ExternalExample.args = {
+  scriptLevel: externalMarkdownScriptLevel
+};
+
+export const LevelGroupExample = Template.bind({});
+LevelGroupExample.args = {
+  scriptLevel: levelGroupScriptLevel
+};
+
+export const BubbleChoiceExample = Template.bind({});
+BubbleChoiceExample.args = {
+  scriptLevel: bubbleChoiceScriptLevel
+};
+
+export const ContainedExample = Template.bind({});
+ContainedExample.args = {
+  scriptLevel: levelWithContainedLevel
+};
+
+export const TopInstructionsExample = Template.bind({});
+TopInstructionsExample.args = {
+  scriptLevel: levelWithInstructions
+};
+
+export const TopInstructionsRTLExample = Template.bind({});
+TopInstructionsRTLExample.args = {
+  scriptLevel: levelWithInstructions,
+  isRtl: true
 };


### PR DESCRIPTION
Storybook Refactor for LessonProgress, CourseRollups (and implicitly UnitRollups), and LevelDetailsDialog. Each has multiple stories, so I've just captured a smattering in screenshots below.

Lesson Progress:
![Screenshot from 2023-02-09 18-01-48](https://user-images.githubusercontent.com/2959170/217982093-2f059837-c174-4521-903b-3b696ebdf994.png)
![Screenshot from 2023-02-09 18-02-00](https://user-images.githubusercontent.com/2959170/217982100-06f4e6f0-82e0-45f9-b8ba-12b24574b61f.png)

LevelDetailsDialog:
![Screenshot from 2023-02-09 18-03-01](https://user-images.githubusercontent.com/2959170/217982097-f1049707-b07f-4490-a222-35fb57fdfd0c.png)
![Screenshot from 2023-02-09 18-03-12](https://user-images.githubusercontent.com/2959170/217982106-aec5cf40-64d2-4e44-a02d-fa882e3398d7.png)

CourseRollup/UnitRollup
![Screenshot from 2023-02-09 18-02-42](https://user-images.githubusercontent.com/2959170/217982099-a9da60ae-e2e9-41e2-85b1-b5871db0c0a2.png)
![Screenshot from 2023-02-09 18-02-29](https://user-images.githubusercontent.com/2959170/217982103-746a57ff-c946-471b-87e2-d9dcf4f91019.png)
