### PR TITLE
Fix Violations of and Reenable `Style/RedundantArgument`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -71,6 +71,11 @@ Lint/AmbiguousRegexpLiteral:
 Lint/ConstantDefinitionInBlock:
   Enabled: false
 
+# Offense count: 40
+# Configuration parameters: IgnoreLiteralBranches, IgnoreConstantBranches.
+Lint/DuplicateBranch:
+  Enabled: false
+
 # Offense count: 146
 # Configuration parameters: AllowComments, AllowEmptyLambdas.
 Lint/EmptyBlock:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -71,11 +71,6 @@ Lint/AmbiguousRegexpLiteral:
 Lint/ConstantDefinitionInBlock:
   Enabled: false
 
-# Offense count: 40
-# Configuration parameters: IgnoreLiteralBranches, IgnoreConstantBranches.
-Lint/DuplicateBranch:
-  Enabled: false
-
 # Offense count: 146
 # Configuration parameters: AllowComments, AllowEmptyLambdas.
 Lint/EmptyBlock:
@@ -482,12 +477,6 @@ Style/OptionalBooleanParameter:
 # Configuration parameters: EnforcedStyle.
 # SupportedStyles: same_as_string_literals, single_quotes, double_quotes
 Style/QuotedSymbols:
-  Enabled: false
-
-# Offense count: 17
-# This cop supports unsafe auto-correction (--auto-correct-all).
-# Configuration parameters: Methods.
-Style/RedundantArgument:
   Enabled: false
 
 # Offense count: 14

--- a/bin/curriculum/import_unit_details.rb
+++ b/bin/curriculum/import_unit_details.rb
@@ -300,7 +300,7 @@ def canonicalize(str)
   str = match&.captures&.last if match
   str.gsub!(/[-:]/, ' ')
   # deduplicate spaces
-  str = str.split(' ').compact.join(' ')
+  str = str.split.compact.join(' ')
   str.downcase.strip
 end
 

--- a/bin/terminate_build
+++ b/bin/terminate_build
@@ -47,7 +47,7 @@ process_list = execute_system_command("ps -C sh -o pid,pgid,args")
 # Remove the first line of output (column headers) and find the line representing the parent build process.
 build_process_info = process_list.lines.drop(1).select {|line| line.include? BUILD_COMMAND}.first
 raise "The aws/ci_build process is not currently running" unless build_process_info
-process_id, process_group_id = build_process_info.delete_suffix(BUILD_COMMAND + "\n").split(' ')
+process_id, process_group_id = build_process_info.delete_suffix(BUILD_COMMAND + "\n").split
 raise "Process ID of the parent build process - #(process_id} - should be the same as the Process Group ID - #{process_group_id}" unless process_id == process_group_id
 
 CDO.log.info 'Killing the following aws/ci_build process and all of its child processes:'

--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -200,7 +200,7 @@ class LevelsController < ApplicationController
     should_use_solution_blocks = ['required_blocks', 'recommended_blocks'].include?(type)
     if can_use_solution_blocks && should_use_solution_blocks
       blocks = @level.get_solution_blocks + ["<block type=\"pick_one\"></block>"]
-      toolbox_blocks = "<xml>#{blocks.join('')}</xml>"
+      toolbox_blocks = "<xml>#{blocks.join}</xml>"
     end
 
     validation = @level.respond_to?(:validation) ? @level.validation : nil

--- a/dashboard/app/controllers/plc/user_course_enrollments_controller.rb
+++ b/dashboard/app/controllers/plc/user_course_enrollments_controller.rb
@@ -61,7 +61,7 @@ class Plc::UserCourseEnrollmentsController < ApplicationController
   end
 
   def listify(user_list)
-    user_list.map {|user| "<li>#{user}</li>"}.join ''
+    user_list.map {|user| "<li>#{user}</li>"}.join
   end
 
   # Never trust parameters from the scary internet, only allow the white list through.

--- a/dashboard/app/models/pd/application/teacher_application.rb
+++ b/dashboard/app/models/pd/application/teacher_application.rb
@@ -277,7 +277,7 @@ module Pd::Application
         {
           country: 'US',
           # Take the first word in school type, downcased. E.g. "Public school" -> "public"
-          school_type: hash[:school_type].split(' ').first.downcase,
+          school_type: hash[:school_type].split.first.downcase,
           state: hash[:school_state],
           zip: hash[:school_zip_code],
           school_name: hash[:school_name],

--- a/dashboard/legacy/middleware/helpers/user_helpers.rb
+++ b/dashboard/legacy/middleware/helpers/user_helpers.rb
@@ -8,7 +8,7 @@ module UserHelpers
   USERNAME_MAX_LENGTH = 20
 
   def self.generate_username(queryable, name)
-    prefix = name.split(' ').first.downcase.
+    prefix = name.split.first.downcase.
       gsub(/[^#{USERNAME_ALLOWED_CHARACTERS.source}]+/, ' ')[0..USERNAME_MAX_LENGTH - 5].
       squish.
       tr(' ', '_')

--- a/dashboard/scripts/update_tts_i18n.rb
+++ b/dashboard/scripts/update_tts_i18n.rb
@@ -7,7 +7,7 @@ def clean(value)
   elsif value.instance_of? String
     return value.gsub(/\s+/, '')
   elsif value.instance_of? Array
-    return clean(value.join(''))
+    return clean(value.join)
   elsif value.instance_of? Hash
     return clean(value.values)
   end

--- a/dashboard/test/controllers/levels_controller_test.rb
+++ b/dashboard/test/controllers/levels_controller_test.rb
@@ -722,8 +722,8 @@ class LevelsControllerTest < ActionController::TestCase
     get :edit, params: {id: level.id}
 
     assert_equal level_path, assigns(:level).filename
-    assert_equal "name", assigns(:level).dsl_text.split("\n").first.split(" ").first
-    assert_equal "encrypted", assigns(:level).dsl_text.split("\n")[1].split(" ").first
+    assert_equal "name", assigns(:level).dsl_text.split("\n").first.split.first
+    assert_equal "encrypted", assigns(:level).dsl_text.split("\n")[1].split.first
   end
 
   test "should allow rename of new level" do

--- a/lib/cdo/i18n_backend.rb
+++ b/lib/cdo/i18n_backend.rb
@@ -26,7 +26,7 @@ module Cdo
         # which periods in a key name can be mistakenly interpreted as separators
         if options.key?(:scope) && !options.key?(:separator)
           combined_key = [key] + options.fetch(:scope, [])
-          options[:separator] = get_valid_separator(combined_key.join(""))
+          options[:separator] = get_valid_separator(combined_key.join)
         end
 
         options

--- a/lib/cdo/tempfile.rb
+++ b/lib/cdo/tempfile.rb
@@ -5,7 +5,7 @@ require 'pathname'
 class Tempfile
   # Note: must retain reference to tempfile, or Ruby GC may delete it
   def self.from_url(url)
-    as_valid_filename = Pathname(url).each_filename.to_a.last.split(' ').last
+    as_valid_filename = Pathname(url).each_filename.to_a.last.split.last
     tempfile = Tempfile.new([as_valid_filename, File.extname(as_valid_filename)])
     tempfile.binmode
     remote_data = URI.parse(url).open(allow_redirections: :safe).read

--- a/lib/test/cdo/test_i18n_backend.rb
+++ b/lib/test/cdo/test_i18n_backend.rb
@@ -29,7 +29,7 @@ class I18nSmartTranslateTest < Minitest::Test
     end
 
     # cannot accomodate strings that include all possible separators
-    all_test_string = test_strings.join('')
+    all_test_string = test_strings.join
     assert_nil Cdo::I18n::SmartTranslate.get_valid_separator all_test_string
   end
 

--- a/pegasus/router.rb
+++ b/pegasus/router.rb
@@ -291,14 +291,14 @@ class Documents < Sinatra::Base
     unless ['', 'none'].include?(layout)
       template = resolve_template('layouts', settings.template_extnames, layout)
       raise Exception, "'#{layout}' layout not found." unless template
-      body render_template(template, {body: body.join('').html_safe})
+      body render_template(template, {body: body.join.html_safe})
     end
 
     theme = @header['theme'] || 'default'
     unless ['', 'none'].include?(theme)
       template = resolve_template('themes', settings.template_extnames, theme)
       raise Exception, "'#{theme}' theme not found." unless template
-      body render_template(template, {body: body.join('').html_safe})
+      body render_template(template, {body: body.join.html_safe})
     end
   end
 

--- a/tools/github/analyze_reverts.rb
+++ b/tools/github/analyze_reverts.rb
@@ -11,7 +11,7 @@ dates = []
 revert_dates.split("\n").each do |revert_date|
   # Expected format:
   # Thu Oct 2 16:05:32 2014 -0700
-  parts = revert_date.split(' ')
+  parts = revert_date.split
   raise "Unexpected date string format #{revert_date}" unless parts.length == 6
   dates << Date.parse([parts[1], parts[2], parts[4]].join(' '))
 end

--- a/tools/scripts/college_board_data.rb
+++ b/tools/scripts/college_board_data.rb
@@ -269,7 +269,7 @@ def get_row_from_column_row(column_row)
   one_based_row = column_row.
     chars.
     reject {|c| c.ord >= 'A'.ord && c.ord <= 'Z'.ord}.
-    join('').
+    join.
     to_i
   one_based_row - 1
 end
@@ -281,7 +281,7 @@ def get_column_from_column_row(column_row)
   column_as_string = column_row.
     chars.
     reject {|c| c.ord >= '0'.ord && c.ord <= '9'.ord}.
-    join('')
+    join
   convert_column_to_integer(column_as_string)
 end
 


### PR DESCRIPTION
> Checks for a redundant argument passed to certain methods.

Fix applied automatically with `bundle exec rubocop --auto-correct-all --only Style/RedundantArgument`

I'm not entirely sure how I feel about this one; on the one hand, explicit is better than implicit. On the other hand, it is cleaner without. What do folks think, yes or no on this one?

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

- https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/RedundantArgument
- https://docs.rubocop.org/rubocop/cops_style.html#styleredundantargument

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked