### PR TITLE
[Storybook] SeeMoreCourses, ParticipantSections, TwoColumnActionBlock

### DIFF
--- a/apps/src/templates/studioHomepages/ParticipantSections.story.jsx
+++ b/apps/src/templates/studioHomepages/ParticipantSections.story.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import ParticipantSections from './ParticipantSections';
 import {action} from '@storybook/addon-actions';
+import {reduxStore} from '@cdo/storybook/decorators';
+import {Provider} from 'react-redux';
 
 const sections = [
   {
@@ -35,62 +37,44 @@ const sections = [
   }
 ];
 
-export default storybook =>
-  storybook
-    .storiesOf('Homepages/Students/ParticipantSections', module)
-    .withReduxStore()
-    .addStoryTable([
-      {
-        name: 'Sections - student, no sections yet',
-        description:
-          'shows a join sections component with attention-grabbing dashed border',
-        story: () => (
-          <ParticipantSections
-            sections={[]}
-            updateSectionsResult={action('update sections result')}
-            updateSections={action('update sections')}
-          />
-        )
-      },
-      {
-        name: 'Sections - student, enrolled in sections',
-        description:
-          'shows a sections table, no column for leave buttons, and a solid border join section component',
-        story: () => (
-          <ParticipantSections
-            sections={sections}
-            updateSectionsResult={action('update sections result')}
-            updateSections={action('update sections')}
-          />
-        )
-      },
-      {
-        name:
-          'Sections - teacher, enrolled in sections as a student and does have permission to leave the sections',
-        description:
-          'shows a sections table, including a column for leave buttons, and a solid border join section component',
-        story: () => (
-          <ParticipantSections
-            sections={sections}
-            isTeacher={true}
-            updateSectionsResult={action('update sections result')}
-            updateSections={action('update sections')}
-          />
-        )
-      },
-      {
-        name:
-          'PL Sections - teacher, enrolled in sections as a student and does have permission to leave the sections',
-        description:
-          'shows a sections table, including a column for leave buttons, and a solid border join section component',
-        story: () => (
-          <ParticipantSections
-            sections={sections}
-            isTeacher={true}
-            updateSectionsResult={action('update sections result')}
-            updateSections={action('update sections')}
-            isPlSections={true}
-          />
-        )
-      }
-    ]);
+export default {
+  title: 'ParticipantSections',
+  component: ParticipantSections
+};
+
+const Template = args => {
+  return (
+    <Provider store={reduxStore()}>
+      <ParticipantSections
+        updateSectionsResult={action('update sections result')}
+        updateSections={action('update sections')}
+        {...args}
+      />
+    </Provider>
+  );
+};
+
+export const StudentNoSectionsExample = Template.bind({});
+StudentNoSectionsExample.args = {
+  sections: []
+};
+
+export const StudentEnrolledInSectionsExample = Template.bind({});
+StudentEnrolledInSectionsExample.args = {
+  sections: sections
+};
+
+export const TeacherEnrolledAsStudentsWithPermissionExample = Template.bind({});
+TeacherEnrolledAsStudentsWithPermissionExample.args = {
+  sections: sections,
+  isTeacher: true
+};
+
+export const PLTeacherEnrolledAsStudentsWithPermissionExample = Template.bind(
+  {}
+);
+PLTeacherEnrolledAsStudentsWithPermissionExample.args = {
+  sections: sections,
+  isTeacher: true,
+  isPlSections: true
+};

--- a/apps/src/templates/studioHomepages/SeeMoreCourses.story.jsx
+++ b/apps/src/templates/studioHomepages/SeeMoreCourses.story.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import SeeMoreCourses from './SeeMoreCourses';
+import {Provider} from 'react-redux';
+import {reduxStore} from '@cdo/storybook/decorators';
 
 const courses = [
   {
@@ -21,15 +23,17 @@ const courses = [
   }
 ];
 
-export default storybook => {
-  return storybook
-    .storiesOf('Homepages/SeeMoreCourses', module)
-    .withReduxStore()
-    .addStoryTable([
-      {
-        name: 'See More Courses for homepages',
-        description: `If a teacher has progress in more than 4 courses or a student in more than 5, they will see a "View More" button. When they click button, they will see the remainder of their courses.`,
-        story: () => <SeeMoreCourses courses={courses} />
-      }
-    ]);
+export default {
+  title: 'SeeMoreCourse',
+  component: SeeMoreCourses
 };
+
+const Template = args => {
+  return (
+    <Provider store={reduxStore()}>
+      <SeeMoreCourses courses={courses} />
+    </Provider>
+  );
+};
+
+export const SeeMoreCoursesExamples = Template.bind({});

--- a/apps/src/templates/studioHomepages/TwoColumnActionBlock.story.jsx
+++ b/apps/src/templates/studioHomepages/TwoColumnActionBlock.story.jsx
@@ -1,23 +1,37 @@
 import React from 'react';
 import {
   LocalClassActionBlock,
-  AdministratorResourcesActionBlock
+  AdministratorResourcesActionBlock,
+  TwoColumnActionBlock
 } from './TwoColumnActionBlock';
+import {Provider} from 'react-redux';
+import {reduxStore} from '@cdo/storybook/decorators';
 
-export default storybook => {
-  return storybook
-    .storiesOf('TwoColumnActionBlock', module)
-    .withReduxStore()
-    .addStoryTable([
-      {
-        name: 'Local Class Action Block',
-        description: 'Example LocalClassActionBlock',
-        story: () => <LocalClassActionBlock showHeading={true} />
-      },
-      {
-        name: 'Administrator Resources Action Block',
-        description: 'Example AdministratorResourcesActionBlock',
-        story: () => <AdministratorResourcesActionBlock showHeading={true} />
-      }
-    ]);
+export default {
+  title: 'TwoColumnActionBlock',
+  component: TwoColumnActionBlock
 };
+
+const LocalClassActionBlockTemplate = args => {
+  return (
+    <Provider store={reduxStore()}>
+      <LocalClassActionBlock showHeading={true} />
+    </Provider>
+  );
+};
+
+const AdministratorResourcesActionBlockTemplate = args => {
+  return (
+    <Provider store={reduxStore()}>
+      <AdministratorResourcesActionBlock showHeading={true} />
+    </Provider>
+  );
+};
+
+export const LocalClassActionBlockExamples = LocalClassActionBlockTemplate.bind(
+  {}
+);
+
+export const AdministratorResourcesActionBlockExamples = AdministratorResourcesActionBlockTemplate.bind(
+  {}
+);


### PR DESCRIPTION
Storybooks translations for SeeMoreCourse, ParticipantSections, and TwoColumnActionBlock.

Smattering of screenshots shown below.

Note: I was really back and forth on whether `SeeMoreCourses` should be deleted or translated. It's just one story, but it's a pretty unique one - after clicking the button, the course cards are displayed. So I decided to keep it - happy to hear thoughts on that!

TwoColumnActionBlock
![Screenshot from 2023-02-09 15-34-53](https://user-images.githubusercontent.com/2959170/217980599-14653fd7-4a01-4bd6-b587-385a0d55991b.png)

SeeMoreCourses (Before click)
![Screenshot from 2023-02-09 15-35-09](https://user-images.githubusercontent.com/2959170/217980604-a75fe8a9-544e-4781-abef-86434c420141.png)
SeeMoreCourses (After click)
![Screenshot from 2023-02-09 15-35-22](https://user-images.githubusercontent.com/2959170/217980606-7b460b65-6fbd-440a-890f-6b56e71167de.png)

Participant Sections
![Screenshot from 2023-02-09 15-36-04](https://user-images.githubusercontent.com/2959170/217980605-3d2ce30d-e3d5-46f5-9199-bb6e89204657.png)
![Screenshot from 2023-02-09 15-35-51](https://user-images.githubusercontent.com/2959170/217980609-58d4842a-bdfc-4049-b311-52701aa2b271.png)
