### PR TITLE
Add Idempotence Guard Clause to `awscli` Install

### DIFF
--- a/cookbooks/cdo-awscli/recipes/default.rb
+++ b/cookbooks/cdo-awscli/recipes/default.rb
@@ -22,6 +22,7 @@ end
 execute 'install AWS CLI' do
   cwd '/tmp/awscli/awscli-bundle'
   command '/usr/bin/python2.7 install -i /usr/local/aws -b /usr/local/bin/aws'
+  not_if {::File.exist?('/usr/local/bin/aws')}
 end
 
 # Configure AWS CLI after installation


### PR DESCRIPTION
Rather than reinstalling `awscli` every time we run Chef, only install it if the executable doesn't already exist.

## Links

- https://codedotorg.slack.com/archives/C03CK49G9/p1675992597589819?thread_ts=1675992588.609039&cid=C03CK49G9
- https://docs.chef.io/resources/execute/

## Testing story

Tested on an adhoc; I ran `sudo /opt/chef/bin/chef-client -z -o 'recipe[cdo-awscli::default]'` from `/var/chef/cookbooks`.

Specifically, I ran it once to perform the initial install, since this cookbook is not executed by default on adhocs:

```
Recipe: cdo-awscli::default
  * apt_package[python2.7] action install
    - install version 2.7.17-1~18.04ubuntu1.10 of package python2.7
  * remote_file[/tmp/awscli-bundle.zip] action create
    - create new file /tmp/awscli-bundle.zip
    - update content in file /tmp/awscli-bundle.zip from none to d4c30a
    (file sizes exceed 10000000 bytes, diff output suppressed)
  * archive_file[/tmp/awscli-bundle.zip] action extract
    - create directory /tmp/awscli
    - extract /tmp/awscli-bundle.zip to /tmp/awscli
  * execute[install AWS CLI] action run (skipped due to not_if)
  * directory[/home/ubuntu/.aws] action create
    - create new directory /home/ubuntu/.aws
  * template[/home/ubuntu/.aws/config] action create
    - create new file /home/ubuntu/.aws/config
    - update content in file /home/ubuntu/.aws/config from none to 479498
    --- /home/ubuntu/.aws/config        2023-02-10 22:07:43.183841218 +0000
    +++ /home/ubuntu/.aws/.chef-config20230210-8169-a00wpd      2023-02-10 22:07:43.183841218 +0000
    @@ -1 +1,7 @@
    +[default]
    +region = us-east-1
    +metadata_service_num_attempts = 3
    +metadata_service_timeout = 5
    +
    +
    - change owner from '' to 'ubuntu'
    - change group from '' to 'ubuntu'
```

Then ran it again and confirmed that all operations got skipped:

```
Recipe: cdo-awscli::default
  * apt_package[python2.7] action install (up to date)
  * remote_file[/tmp/awscli-bundle.zip] action create (up to date)
  * archive_file[/tmp/awscli-bundle.zip] action extract (up to date)
  * execute[install AWS CLI] action run (skipped due to not_if)
  * directory[/home/ubuntu/.aws] action create (up to date)
  * template[/home/ubuntu/.aws/config] action create (up to date)
```

I then removed the aws executable with `sudo rm /usr/local/bin/aws` and ran it again, and confirmed that we do indeed reinstall the executable:

```
Recipe: cdo-awscli::default
  * apt_package[python2.7] action install (up to date)
  * remote_file[/tmp/awscli-bundle.zip] action create (up to date)
  * archive_file[/tmp/awscli-bundle.zip] action extract (up to date)
  * execute[install AWS CLI] action run
    - execute /usr/bin/python2.7 install -i /usr/local/aws -b /usr/local/bin/aws
  * directory[/home/ubuntu/.aws] action create (up to date)
  * template[/home/ubuntu/.aws/config] action create (up to date)
```

And, finally, one last run to confirm that it again skips everything:

```
Recipe: cdo-awscli::default
  * apt_package[python2.7] action install (up to date)
  * remote_file[/tmp/awscli-bundle.zip] action create (up to date)
  * archive_file[/tmp/awscli-bundle.zip] action extract (up to date)
  * execute[install AWS CLI] action run (skipped due to not_if)
  * directory[/home/ubuntu/.aws] action create (up to date)
  * template[/home/ubuntu/.aws/config] action create (up to date)
```

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
