### PR TITLE
print INVALID FILENAME warnings to content editors slack channel

### DIFF
--- a/bin/cron/check_invalid_staging_filenames
+++ b/bin/cron/check_invalid_staging_filenames
@@ -1,0 +1,17 @@
+#!/usr/bin/env ruby
+require_relative 'only_one'
+
+abort 'Script already running' unless only_one_running?(__FILE__)
+
+require_relative "../../deployment"
+
+require 'cdo/chat_client'
+require 'cdo/developers_topic'
+require_relative '../../tools/hooks/hooks_utils'
+
+HooksUtils.get_unstaged_files.each do |filename|
+  next unless HooksUtils.prohibited?(filename)
+  msg = "INVALID FILENAME: #{filename}"
+  ChatClient.log("<@#{DevelopersTopic.dotd}> #{msg}", color: 'red')
+  ChatClient.message('content-editors', msg, color: 'red')
+end

--- a/bin/cron/sync_dropbox
+++ b/bin/cron/sync_dropbox
@@ -40,7 +40,6 @@ TOTAL_SECONDS = 55 - INTERVAL_SECONDS
 
 logger = HighFrequencyReporter.new(Slack, 'sync-dropbox-staging', '/home/ubuntu/dropbox_sync_error_log.csv')
 logger.load # load errors from most recent sync
-first_attempt = true
 
 while (Time.now - SCRIPT_START) < TOTAL_SECONDS
   attempt_start = Time.now
@@ -60,21 +59,12 @@ while (Time.now - SCRIPT_START) < TOTAL_SECONDS
     ERROR_MSG
     logger.record error_message
   end
-  if first_attempt && Time.now.min % 5 == 0
-    HooksUtils.get_unstaged_files.each do |filename|
-      next unless HooksUtils.prohibited?(filename)
-      msg = "INVALID FILENAME: #{filename}"
-      ChatClient.log("<@#{DevelopersTopic.dotd}> #{msg}", color: 'red')
-      ChatClient.message('content-editors', msg, color: 'red')
-    end
-  end
   current_time = Time.now
   logger.save
   while current_time - attempt_start < INTERVAL_SECONDS && (current_time - SCRIPT_START) < TOTAL_SECONDS
     sleep 0.1
     current_time = Time.now
   end
-  first_attempt = false
 end
 
 # Reports to Slack if current minute is a multiple of 1

--- a/bin/cron/sync_dropbox
+++ b/bin/cron/sync_dropbox
@@ -51,7 +51,10 @@ while (Time.now - SCRIPT_START) < TOTAL_SECONDS
     stdout, stderr, _ = Open3.capture3(command)
     if stdout == "" && stderr == ""
       HooksUtils.get_unstaged_files.each do |filename|
-        ChatClient.log("<@#{DevelopersTopic.dotd}> INVALID FILENAME: #{filename}", color: 'red') if HooksUtils.prohibited?(filename) && Time.now.sec % 59 == 0
+        next unless HooksUtils.prohibited?(filename) && Time.now.sec % 59 == 0
+        msg = "INVALID FILENAME: #{filename}"
+        ChatClient.log("<@#{DevelopersTopic.dotd}> #{msg}", color: 'red')
+        ChatClient.message('content-editors', msg, color: 'red')
       end
     else
       error_message = <<~ERROR_MSG

--- a/bin/cron/sync_dropbox
+++ b/bin/cron/sync_dropbox
@@ -60,11 +60,13 @@ while (Time.now - SCRIPT_START) < TOTAL_SECONDS
     ERROR_MSG
     logger.record error_message
   end
-  HooksUtils.get_unstaged_files.each do |filename|
-    next unless HooksUtils.prohibited?(filename) && first_attempt && Time.now.min % 5 == 0
-    msg = "INVALID FILENAME: #{filename}"
-    ChatClient.log("<@#{DevelopersTopic.dotd}> #{msg}", color: 'red')
-    ChatClient.message('content-editors', msg, color: 'red')
+  if first_attempt && Time.now.min % 5 == 0
+    HooksUtils.get_unstaged_files.each do |filename|
+      next unless HooksUtils.prohibited?(filename)
+      msg = "INVALID FILENAME: #{filename}"
+      ChatClient.log("<@#{DevelopersTopic.dotd}> #{msg}", color: 'red')
+      ChatClient.message('content-editors', msg, color: 'red')
+    end
   end
   current_time = Time.now
   logger.save

--- a/bin/cron/sync_dropbox
+++ b/bin/cron/sync_dropbox
@@ -40,6 +40,7 @@ TOTAL_SECONDS = 55 - INTERVAL_SECONDS
 
 logger = HighFrequencyReporter.new(Slack, 'sync-dropbox-staging', '/home/ubuntu/dropbox_sync_error_log.csv')
 logger.load # load errors from most recent sync
+first_attempt = true
 
 while (Time.now - SCRIPT_START) < TOTAL_SECONDS
   attempt_start = Time.now
@@ -60,7 +61,7 @@ while (Time.now - SCRIPT_START) < TOTAL_SECONDS
     logger.record error_message
   end
   HooksUtils.get_unstaged_files.each do |filename|
-    next unless HooksUtils.prohibited?(filename) && Time.now.sec % 59 == 0
+    next unless HooksUtils.prohibited?(filename) && first_attempt && Time.now.min % 5 == 0
     msg = "INVALID FILENAME: #{filename}"
     ChatClient.log("<@#{DevelopersTopic.dotd}> #{msg}", color: 'red')
     ChatClient.message('content-editors', msg, color: 'red')
@@ -71,6 +72,7 @@ while (Time.now - SCRIPT_START) < TOTAL_SECONDS
     sleep 0.1
     current_time = Time.now
   end
+  first_attempt = false
 end
 
 # Reports to Slack if current minute is a multiple of 1

--- a/bin/cron/sync_dropbox
+++ b/bin/cron/sync_dropbox
@@ -49,23 +49,21 @@ while (Time.now - SCRIPT_START) < TOTAL_SECONDS
     # For full details, see unison's man page. Docs are also here: https://www.cis.upenn.edu/~bcpierce/unison/download/releases/stable/unison-manual.html
     command = "unison /home/ubuntu/Dropbox/Shared/#{key} /home/ubuntu/staging/pegasus/#{value} -silent -ignore \"Name .dropbox\" -auto -perms 0 -dontchmod -log -logfile /home/ubuntu/unison.log"
     stdout, stderr, _ = Open3.capture3(command)
-    if stdout == "" && stderr == ""
-      HooksUtils.get_unstaged_files.each do |filename|
-        next unless HooksUtils.prohibited?(filename) && Time.now.sec % 59 == 0
-        msg = "INVALID FILENAME: #{filename}"
-        ChatClient.log("<@#{DevelopersTopic.dotd}> #{msg}", color: 'red')
-        ChatClient.message('content-editors', msg, color: 'red')
-      end
-    else
-      error_message = <<~ERROR_MSG
-        <!here> Error syncing Dropbox and staging
-        Dropbox directory: #{key}
-        pegasus directory: #{value}
-        stdout: #{stdout}
-        stderr: #{stderr}
-      ERROR_MSG
-      logger.record error_message
-    end
+    next unless stdout == "" && stderr == ""
+    error_message = <<~ERROR_MSG
+      <!here> Error syncing Dropbox and staging
+      Dropbox directory: #{key}
+      pegasus directory: #{value}
+      stdout: #{stdout}
+      stderr: #{stderr}
+    ERROR_MSG
+    logger.record error_message
+  end
+  HooksUtils.get_unstaged_files.each do |filename|
+    next unless HooksUtils.prohibited?(filename) && Time.now.sec % 59 == 0
+    msg = "INVALID FILENAME: #{filename}"
+    ChatClient.log("<@#{DevelopersTopic.dotd}> #{msg}", color: 'red')
+    ChatClient.message('content-editors', msg, color: 'red')
   end
   current_time = Time.now
   logger.save

--- a/cookbooks/cdo-apps/templates/default/crontab.erb
+++ b/cookbooks/cdo-apps/templates/default/crontab.erb
@@ -58,6 +58,7 @@
       cronjob at:'*/5 * * * *', do:deploy_dir('bin', 'cron', 'import_google_sheets')
       cronjob at:'*/5 * * * *', do:deploy_dir('bin', 'cron', 'test_access_report_import')
       cronjob at:'* * * * *', do:deploy_dir('bin', 'cron', 'sync_dropbox')
+      cronjob at:'*/5 * * * *', do:deploy_dir('bin', 'cron', 'check_invalid_staging_filenames')
       cronjob at:'*/2 * * * *', do:deploy_dir('bin', 'cron', 'run_server_generate_pdfs')
       cronjob at:'*/2 * * * *', do:pegasus_dir('sites','virtual','run_server_generate_curriculum_pdfs')
       cronjob at:'*/2 * * * *', do:pegasus_dir('sites','virtual','collate_pdfs')

--- a/lib/cdo/slack.rb
+++ b/lib/cdo/slack.rb
@@ -13,6 +13,7 @@ class Slack
   }.freeze
 
   CHANNEL_MAP = {
+    'content-editors' => 'content-editors',
     'server operations' => 'server-operations',
     'staging' => 'infra-staging',
     'test' => 'infra-test',
@@ -21,6 +22,7 @@ class Slack
 
   # Common channel name to ID mappings
   CHANNEL_IDS = {
+    'content-editors' => 'C03A2LG1JLQ',
     'developers' => 'C0T0PNTM3',
     'deploy-status' => 'C7GS8NE8L',
     'infra-staging' => 'C03CK8E51',


### PR DESCRIPTION
Finishes https://codedotorg.atlassian.net/browse/ACQ-369 by also printing INVALID FILENAME warnings to #content-editors. 

the logic for when to print the warnings wasn't working very well for 2 reasons:
* warns only if we are running at 59 seconds, which is highly unpredictable
* warns [repeatedly](https://codedotorg.slack.com/archives/C03CK8E51/p1675649819579469) when it does warn (as many times as the number of `FOLDERS` we can iterate through in 1 second)

Rather than try to break back out of the dropbox sync timing logic, it seems simpler to just have this be its own cronjob so that we can easily tune the frequency in the future.

## Testing story

* patched this into staging, added a bogus file, and verified that a warning is printed once every 5 minutes to both #infra-staging and #content-editors