### PR TITLE
Music: change default renderer to Thrasos

### DIFF
--- a/apps/src/music/blockly/FieldSounds.js
+++ b/apps/src/music/blockly/FieldSounds.js
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import SoundsPanel from '../views/SoundsPanel';
 import GoogleBlockly from 'blockly/core';
+import experiments from '@cdo/apps/util/experiments';
 
 class FieldSounds extends GoogleBlockly.Field {
   constructor(options) {
@@ -40,7 +41,9 @@ class FieldSounds extends GoogleBlockly.Field {
       this.borderRect_.setAttribute('fill', 'transparent');
     }
     if (this.textElement_) {
-      this.textElement_.style.fill = 'white';
+      if (experiments.isEnabled('zelos')) {
+        this.textElement_.style.fill = 'white';
+      }
     }
   }
 

--- a/apps/src/music/blockly/MusicBlocklyWorkspace.js
+++ b/apps/src/music/blockly/MusicBlocklyWorkspace.js
@@ -70,12 +70,12 @@ export default class MusicBlocklyWorkspace {
       toolbox: getToolbox(),
       grid: {spacing: 20, length: 0, colour: '#444', snap: true},
       theme: musicLabDarkTheme,
-      renderer: experiments.isEnabled('thrasos')
-        ? 'cdo_renderer_thrasos'
-        : 'cdo_renderer_zelos',
+      renderer: experiments.isEnabled('zelos')
+        ? 'cdo_renderer_zelos'
+        : 'cdo_renderer_thrasos',
       noFunctionBlockFrame: true,
       zoom: {
-        startScale: 0.675
+        startScale: experiments.isEnabled('zelos') ? 0.9 : 1
       }
     });
 

--- a/apps/src/music/blockly/themes.js
+++ b/apps/src/music/blockly/themes.js
@@ -6,7 +6,7 @@ const blockStyles = cdoBlockStyles;
 const categoryStyles = {};
 const componentStyles = {
   toolboxBackgroundColour: '#424242', // gray-800
-  flyoutBackgroundColour: '#9e9e9e', // gray-500
+  flyoutBackgroundColour: '#121212',
   workspaceBackgroundColour: '#212121' // gray-900
 };
 
@@ -18,8 +18,7 @@ export const musicLabDarkTheme = GoogleBlockly.Theme.defineTheme(
     categoryStyles,
     componentStyles,
     fontStyle: {
-      family: '"Gotham 4r", sans-serif',
-      size: 16
+      family: '"Gotham 4r", sans-serif'
     }
   }
 );

--- a/apps/src/music/blockly/themes.js
+++ b/apps/src/music/blockly/themes.js
@@ -6,6 +6,9 @@ const blockStyles = cdoBlockStyles;
 const categoryStyles = {};
 const componentStyles = {
   toolboxBackgroundColour: '#424242', // gray-800
+  // The flyout background is especially dark so that workspace blocks
+  // underneath the flyout (which is semi-transparent) are obscured enough
+  // to make the blocks in the flyout easy to see.
   flyoutBackgroundColour: '#121212',
   workspaceBackgroundColour: '#212121' // gray-900
 };


### PR DESCRIPTION
By default, Music Lab now uses the Thrasos renderer.  

<img width="637" alt="Screenshot 2023-02-09 at 11 41 56 PM" src="https://user-images.githubusercontent.com/2205926/218032108-97712a98-2d1b-4c99-b51f-13db080932be.png">

It's still possible to use the previous Zelos renderer with`?enableExperiments=zelos`.

<img width="599" alt="Screenshot 2023-02-09 at 11 41 16 PM" src="https://user-images.githubusercontent.com/2205926/218032098-91a19772-7a5a-41e4-8fc2-1860ed017159.png">


