### PR TITLE
Only show updated Admin/Counselor email for the SLP Intro workshop

### DIFF
--- a/dashboard/app/views/pd/workshop_mailer/teacher_enrollment_receipt.html.haml
+++ b/dashboard/app/views/pd/workshop_mailer/teacher_enrollment_receipt.html.haml
@@ -14,7 +14,7 @@
     5-day Summer workshop on the Code.org
     = @workshop.course
     curriculum.
-- elsif [Pd::Workshop::COURSE_COUNSELOR, Pd::Workshop::COURSE_ADMIN].include? @workshop.course
+- elsif Pd::Workshop::COURSE_ADMIN_COUNSELOR == @workshop.course && Pd::Workshop::SUBJECT_ADMIN_COUNSELOR_SLP_INTRO == @workshop.subject
   %p
     Thank you so much for enrolling in the School Leadership
     Program for 2023-2024! This program is part of the Equity
@@ -24,7 +24,7 @@
     state of computer science education at your school. To
     complete the survey prior to the Introduction Workshop, visit
     = link_to 'https://studio.code.org/form/2022_baseline_school_leadership.', 'https://studio.code.org/form/2022_baseline_school_leadership', target: "_blank", rel: "noopener noreferrer"
-- elsif @workshop.ayw?
+- elsif @workshop.ayw? || Pd::Workshop::COURSE_ADMIN_COUNSELOR == @workshop.course
   %p
     Thanks for enrolling in
     = "#{@workshop.organizer.name}’#{@workshop.organizer.name.ends_with?('s') ? '' : 's'} "


### PR DESCRIPTION
This follows up the update made in [this PR](https://github.com/code-dot-org/code-dot-org/pull/50123) but modifies the logic so that it will only show the new content if it's the SLP Intro Subject (the other subjects in the course will just show the general Admin/Counselor content).

Original:
![Old_AdminCounselorReceipt](https://user-images.githubusercontent.com/56283563/218188232-f97b9402-025c-49a5-af96-50d5e3b15e47.JPG)

New (for non-SLP-Intro subjects):
![New_not_intro](https://user-images.githubusercontent.com/56283563/218188240-db4c197e-a2ba-4e9c-8e82-3a4a8a459a20.JPG)

New (for SLP-Intro subject):
![New_intro](https://user-images.githubusercontent.com/56283563/218188253-30e8b372-7f35-4e5d-aaef-e747427433b6.JPG)


## Links
PR this builds on: [here](https://github.com/code-dot-org/code-dot-org/pull/50123)
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?modal=detail&selectedIssue=ACQ-357&assignee=60d62161f65054006980bd71)

## Testing story
Local testing.

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
