### PR TITLE
Fix Maker blocks appearing incorrectly in curriculum levels

### DIFF
--- a/apps/src/lib/kits/maker/dropletConfig.js
+++ b/apps/src/lib/kits/maker/dropletConfig.js
@@ -76,7 +76,7 @@ function createMakerPinProps(defaultParam) {
 }
 
 /**
- * LED-related blocks that we'll reuse in multiple categories
+ * Color LED-related blocks that we'll reuse in multiple categories
  *
  * Note: in order to differentiate blocks between different categories, we can prepend
  * the blockPrefix to the func name directly, as blocks with the same func name are
@@ -86,7 +86,7 @@ function createMakerPinProps(defaultParam) {
  * Once we've stopped using the old versions of these blocks (without the prefix directly in
  * the func name), we can remove this flag.
  */
-function sharedLedBlocks({
+function sharedColorLedBlocks({
   category,
   blockPrefix,
   objectDropdown,
@@ -141,7 +141,7 @@ function sharedLedBlocks({
 }
 
 /**
- * Generic Johnny-Five / Firmata blocks
+ * Maker drawer blocks used by both Circuit Playground and Micro:Bit
  */
 export function getMakerBlocks(boardType) {
   let defaultPin = '"A6"';
@@ -210,13 +210,13 @@ export function getMakerBlocks(boardType) {
       docFunc: 'createLed'
     },
 
-    ...sharedLedBlocks({
+    ...sharedColorLedBlocks({
       category: MAKER_CATEGORY,
       blockPrefix: emptySocketPrefix,
       includePrefixInFunc: true
     }),
 
-    ...sharedLedBlocks({
+    ...sharedColorLedBlocks({
       category: MAKER_CATEGORY,
       blockPrefix: emptySocketPrefix,
       includePrefixInFunc: false
@@ -282,14 +282,14 @@ const circuitPlaygroundBlocks = [
 
   {func: 'colorLeds', category: CIRCUIT_CATEGORY, type: 'readonlyproperty'},
 
-  ...sharedLedBlocks({
+  ...sharedColorLedBlocks({
     category: CIRCUIT_CATEGORY,
     blockPrefix: colorLedBlockPrefix,
     objectDropdown: {options: colorPixelVariables},
     includePrefixInFunc: true
   }),
 
-  ...sharedLedBlocks({
+  ...sharedColorLedBlocks({
     category: CIRCUIT_CATEGORY,
     blockPrefix: colorLedBlockPrefix,
     objectDropdown: {options: colorPixelVariables},

--- a/apps/src/lib/kits/maker/dropletConfig.js
+++ b/apps/src/lib/kits/maker/dropletConfig.js
@@ -75,36 +75,51 @@ function createMakerPinProps(defaultParam) {
   };
 }
 
-// LED-related blocks that we'll reuse in multiple categories
-function sharedLedBlocks({category, blockPrefix, objectDropdown}) {
+/**
+ * LED-related blocks that we'll reuse in multiple categories
+ *
+ * Note: in order to differentiate blocks between different categories, we can prepend
+ * the blockPrefix to the func name directly, as blocks with the same func name are
+ * considered the same block. However, in order to not break existing levels, we also
+ * temporarily need to support versions of these blocks without the blockPrefix prepended
+ * directly. We can use the {@param includePrefixInFunc} flag to support both these versions.
+ * Once we've stopped using the old versions of these blocks (without the prefix directly in
+ * the func name), we can remove this flag.
+ */
+function sharedLedBlocks({
+  category,
+  blockPrefix,
+  objectDropdown,
+  includePrefixInFunc
+}) {
   return [
     {
-      func: 'on',
-      blockPrefix,
+      func: `${includePrefixInFunc ? blockPrefix : ''}on`,
+      blockPrefix: includePrefixInFunc ? undefined : blockPrefix,
       category,
       tipPrefix: pixelType,
       modeOptionName: '*.on',
       objectDropdown
     },
     {
-      func: 'off',
-      blockPrefix,
+      func: `${includePrefixInFunc ? blockPrefix : ''}off`,
+      blockPrefix: includePrefixInFunc ? undefined : blockPrefix,
       category,
       tipPrefix: pixelType,
       modeOptionName: '*.off',
       objectDropdown
     },
     {
-      func: 'toggle',
-      blockPrefix,
+      func: `${includePrefixInFunc ? blockPrefix : ''}toggle`,
+      blockPrefix: includePrefixInFunc ? undefined : blockPrefix,
       category,
       tipPrefix: pixelType,
       modeOptionName: '*.toggle',
       objectDropdown
     },
     {
-      func: 'blink',
-      blockPrefix,
+      func: `${includePrefixInFunc ? blockPrefix : ''}blink`,
+      blockPrefix: includePrefixInFunc ? undefined : blockPrefix,
       category,
       paletteParams: ['interval'],
       params: ['100'],
@@ -113,8 +128,8 @@ function sharedLedBlocks({category, blockPrefix, objectDropdown}) {
       objectDropdown
     },
     {
-      func: 'pulse',
-      blockPrefix,
+      func: `${includePrefixInFunc ? blockPrefix : ''}pulse`,
+      blockPrefix: includePrefixInFunc ? undefined : blockPrefix,
       category,
       paletteParams: ['interval'],
       params: ['300'],
@@ -197,7 +212,14 @@ export function getMakerBlocks(boardType) {
 
     ...sharedLedBlocks({
       category: MAKER_CATEGORY,
-      blockPrefix: emptySocketPrefix
+      blockPrefix: emptySocketPrefix,
+      includePrefixInFunc: true
+    }),
+
+    ...sharedLedBlocks({
+      category: MAKER_CATEGORY,
+      blockPrefix: emptySocketPrefix,
+      includePrefixInFunc: false
     }),
 
     {
@@ -263,7 +285,15 @@ const circuitPlaygroundBlocks = [
   ...sharedLedBlocks({
     category: CIRCUIT_CATEGORY,
     blockPrefix: colorLedBlockPrefix,
-    objectDropdown: {options: colorPixelVariables}
+    objectDropdown: {options: colorPixelVariables},
+    includePrefixInFunc: true
+  }),
+
+  ...sharedLedBlocks({
+    category: CIRCUIT_CATEGORY,
+    blockPrefix: colorLedBlockPrefix,
+    objectDropdown: {options: colorPixelVariables},
+    includePrefixInFunc: false
   }),
 
   {

--- a/lib/cdo/shared_constants.rb
+++ b/lib/cdo/shared_constants.rb
@@ -305,11 +305,16 @@ module SharedConstants
       "var mySensor = createCapacitiveTouchSensor": null,
 
       // Circuit Playground
-      "on": null,
-      "off": null,
-      "toggle": null,
-      "blink": null,
-      "pulse": null,
+      "__.on": null,
+      "__.off": null,
+      "__.toggle": null,
+      "__.blink": null,
+      "__.pulse": null,
+      "colorLeds[0].on": null,
+      "colorLeds[0].off": null,
+      "colorLeds[0].toggle": null,
+      "colorLeds[0].blink": null,
+      "colorLeds[0].pulse": null,
       "stop": null,
       "color": null,
       "intensity": null,
@@ -341,9 +346,6 @@ module SharedConstants
       "onBoardEvent": null,
 
       // micro:bit
-      "on": null,
-      "off": null,
-      "toggle": null,
       "ledScreen.on": null,
       "ledScreen.off": null,
       "ledScreen.toggle": null,


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

### Root Cause and Resolution

This fixes an issue where Maker blocks were incorrectly appearing in certain curriculum levels (see JIRA for more background). The fix ended up being pretty simple, but want to make sure all the context was captured, so detailed writeup is below!

There were a set of blocks (`on`, `off`, `toggle`, `blink`, `pulse`) that were meant to be shared between the Maker and Circuit categories in physical computing levels. In order to share these blocks, we added the same set of blocks but with different prefixes and under different categories (https://github.com/code-dot-org/code-dot-org/pull/47021). However, our system treats blocks with the same `func` property as the same blocks (see code [here](https://github.com/code-dot-org/code-dot-org/blob/5aa0145d5f87959989c24db143e5b1531376a477/apps/src/dropletUtils.js#L408)), and as a result, when searching for blocks to populate the palette with (based on blocks on the level provided via `codeFunctions`), we would end up including both versions of each block.

To fix this, I just added the `blockPrefix` value directly to the `func` name, so the `func` names would be different for the Circuit and Maker categories. For example, the `"on"` block would become `"colorLeds[0].on"` for Circuit, and `"__.on"` for Maker. I've also left the original versions of each block in place to not break existing levels, but levels that use these versions of the block will still have the same inconsistent behavior until they've been migrated to the new block formats. I spoke to Dan, and this seems to be an okay tradeoff as new curriculum is being written.

As far as I can tell, the `blockPrefix` value is only read [here](https://github.com/code-dot-org/code-dot-org/blob/5aa0145d5f87959989c24db143e5b1531376a477/apps/src/dropletUtils.js#L561), and if none is provided, we would just use the `func` name directly, so there should in theory be no functional change to the behavior of the blocks.

Edit Droplet Palette (levelbuilder) dropdown:
<img width="432" alt="Screenshot 2023-02-10 at 12 01 38 PM" src="https://user-images.githubusercontent.com/85528507/218194753-a763dfa4-1dcc-41d1-b232-3a11e692fecc.png">

Edit Droplet Palette (levelbuilder) editor:
<img width="322" alt="Screenshot 2023-02-10 at 12 02 14 PM" src="https://user-images.githubusercontent.com/85528507/218194804-a3dc81d1-f6ff-466b-8380-e3c1f40d3ea9.png">

Level toolbox (using the block list above)
<img width="284" alt="Screenshot 2023-02-10 at 12 03 13 PM" src="https://user-images.githubusercontent.com/85528507/218194839-77be1dbd-e28d-485b-b4ba-86c588614593.png">

Level toolbox using Maker blocks (`"__.on", "__.off", "__.toggle", "__.blink"`)
<img width="283" alt="Screenshot 2023-02-10 at 2 58 04 PM" src="https://user-images.githubusercontent.com/85528507/218196437-2928e497-7284-4f66-8a05-ff4ac242bc54.png">

#### Block Color Issues

As a note, there is a separate issue where the block colors for these blocks don't match their categories. This is due to a similar reason, but slightly trickier to fix. In order to determine the properties of a node (i.e. block), Droplet [looks up the name](https://github.com/droplet-editor/droplet/blob/bc724da8880b278388051e5f0f7f2ddd36e005fc/src/languages/javascript.coffee#L178) of the node in the config that it's been provided by us. The keys of this config are either the `func` name, or the `modeOptionName` value on each block definition (generated [here](https://github.com/code-dot-org/code-dot-org/blob/1393765ba42970c1593749dff0da65a289837301/apps/src/dropletUtils.js#L944)). Using the `modeOptionName` allows us to create a key with a wildcard format (for example [here](https://github.com/code-dot-org/code-dot-org/blob/5aa0145d5f87959989c24db143e5b1531376a477/apps/src/lib/kits/maker/dropletConfig.js#L86)) to match various versions of the node, not just the exact one specified by the `func` name. However, for this case, this becomes an issue since both versions of the `on` block (`colorLeds[0].on` and `__.on`) have a `modeOptionName` of `*.on`. I wasn't able to figure out a good way to create separate `modeOptionName`s for each version of the block because once the block is modified from its initial state, it's not clear which version it should be treated as. 
For example, in the following code
```
var myLED = colorLed[3];
myLED.on();
```
Should `myLED.on()` be treated as a `colorLed[0].on` (i.e. Circuit) or a `__.on` (i.e. Maker) block? With the `modeOptionName` of `*.on`, Droplet can at least figure out that the node `myLED.on()` maps to `*.on`, but if Circuit and Maker versions are both provided in the config, it'll end up picking the first one (usually Circuit), and display the Circuit color, even if the block was originally in the Maker category. All this being said, after talking to Dan this isn't a huge issue, and seems more important to solve to original issue of the blocks appearing in both categories, but I wanted to make sure the root cause was captured.

## Links

JIRA: https://codedotorg.atlassian.net/browse/SL-517

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
