### PR TITLE
Revert "Update `annotate` Gem to 3.2.0"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,7 @@ gem 'memory_profiler'
 gem 'rack-mini-profiler'
 
 group :development do
-  gem 'annotate', '~> 3.2.0'
+  gem 'annotate', '~> 3.1.1'
   gem 'aws-google', '~> 0.2.0'
   gem 'web-console'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -235,8 +235,8 @@ GEM
       public_suffix (>= 2.0.2, < 6.0)
     aes_key_wrap (1.0.1)
     afm (0.2.2)
-    annotate (3.2.0)
-      activerecord (>= 3.2, < 8.0)
+    annotate (3.1.1)
+      activerecord (>= 3.2, < 7.0)
       rake (>= 10.4, < 14.0)
     ansi (1.5.0)
     ast (2.4.2)
@@ -942,7 +942,7 @@ DEPENDENCIES
   activerecord-import (~> 1.0.3)
   acts_as_list
   addressable
-  annotate (~> 3.2.0)
+  annotate (~> 3.1.1)
   auto_strip_attributes (~> 2.1)
   aws-google (~> 0.2.0)
   aws-sdk-acm

--- a/dashboard/config/application.rb
+++ b/dashboard/config/application.rb
@@ -156,6 +156,15 @@ module Dashboard
     config.autoload_paths << Rails.root.join('app', 'models', 'sections')
     config.autoload_paths << Rails.root.join('../lib/cdo/shared_constants')
 
+    # Make sure to explicitly cast all autoload paths to strings; the gem we use to
+    # annotate model files with schema descriptions doesn't know how to deal with
+    # Pathnames. See https://github.com/ctran/annotate_models/issues/758
+    #
+    # We have a PR opened with a fix at https://github.com/ctran/annotate_models/pull/848;
+    # once a version of the gem is released which includes that change, we can get rid of
+    # this line.
+    config.autoload_paths.map!(&:to_s)
+
     # Also make sure some of these directories are always loaded up front in production
     # environments.
     #


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#50132

Still not sure why, but this update seems to have broken one of our dashboard unit tests. Specifically:

```
=========[0m[1000D[KERROR["test_from_omniauth", "OmniAuthSectionTest", 41.074696023002616]
 test_from_omniauth#OmniAuthSectionTest (41.07s)
Minitest::UnexpectedError:         RuntimeError: Neutered Exception ActiveRecord::RecordNotFound: Couldn't find OmniAuthSection with 'id'=2 [WHERE `sections`.`login_type` = ?]
            test/models/sections/omni_auth_section_test.rb:22:in `block in <class:OmniAuthSectionTest>'
            test/testing/setup_all_and_teardown_all.rb:36:in `run'

==[0m[1000D[KERROR["test_from_omniauth_takeover_by_different_owner_after_account_deletion", "OmniAuthSectionTest", 41.213377502001094]
 test_from_omniauth_takeover_by_different_owner_after_account_deletion#OmniAuthSectionTest (41.21s)
Minitest::UnexpectedError:         RuntimeError: Neutered Exception ActiveRecord::RecordNotFound: Couldn't find OmniAuthSection with 'id'=3 [WHERE `sections`.`login_type` = ?]
            test/models/sections/omni_auth_section_test.rb:78:in `block in <class:OmniAuthSectionTest>'
            test/testing/setup_all_and_teardown_all.rb:36:in `run'
```

See slack threads at https://codedotorg.slack.com/archives/C0T0PNTM3/p1676012052664189 and https://codedotorg.slack.com/archives/C03CM903Y/p1676055566682219 for more.

I identified that this change was the culprit with `git bisect` and `RAILS_ENV=test RACK_ENV=test TZ=UTC bundle exec ruby -Itest test/models/sections/omni_auth_section_test.rb`