### PR TITLE
Remove 'Unit Overview Page Visited' Amplitude event

### DIFF
--- a/apps/src/code-studio/components/progress/UnitOverview.jsx
+++ b/apps/src/code-studio/components/progress/UnitOverview.jsx
@@ -23,8 +23,6 @@ import UnitCalendar from './UnitCalendar';
 import color from '@cdo/apps/util/color';
 import EndOfLessonDialog from '@cdo/apps/templates/EndOfLessonDialog';
 import {PublishedState} from '@cdo/apps/generated/curriculum/sharedCourseConstants';
-import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
-import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 
 /**
  * Lesson progress component used in level header and script overview.
@@ -74,10 +72,6 @@ class UnitOverview extends React.Component {
     const showRedirectDialog =
       props.redirectScriptUrl && props.redirectScriptUrl.length > 0;
     this.state = {showRedirectDialog};
-
-    analyticsReporter.sendEvent(EVENTS.UNIT_OVERVIEW_PAGE_VISITED_EVENT, {
-      'unit name': props.scriptName
-    });
   }
 
   onCloseRedirectDialog = () => {

--- a/apps/src/lib/util/AnalyticsConstants.js
+++ b/apps/src/lib/util/AnalyticsConstants.js
@@ -8,7 +8,6 @@ const EVENTS = {
 
   // Course/Unit info
   COURSE_OVERVIEW_PAGE_VISITED_EVENT: 'Course Overview Page Visited',
-  UNIT_OVERVIEW_PAGE_VISITED_EVENT: 'Unit Overview Page Visited',
   TRY_NOW_BUTTON_CLICK_EVENT: 'Try Now Button Clicked',
 
   // Lesson info


### PR DESCRIPTION
The sheer volume of "Unit Overview Page Visited" events in Amplitude is consuming a large portion of what we are allotted by our plan with Amplitude. To save on resources and focus on other events, that event is being removed.

## Links
Amplitude event: [here](https://data.amplitude.com/code-org/Code.org%20Tracking%20Plan/events/main/latest/Unit%20Overview%20Page%20Visited)

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
