### PR TITLE
Redo "[Sprite Lab] Dynamic width for Backgrounds mode button"

### DIFF
--- a/apps/src/p5lab/P5LabVisualizationHeader.jsx
+++ b/apps/src/p5lab/P5LabVisualizationHeader.jsx
@@ -82,6 +82,7 @@ class P5LabVisualizationHeader extends React.Component {
             <ToggleGroup
               selected={interfaceMode}
               onChange={this.changeInterfaceMode}
+              flex={true}
             >
               <button
                 style={styles.buttonFocus}

--- a/apps/src/p5lab/P5LabVisualizationHeader.jsx
+++ b/apps/src/p5lab/P5LabVisualizationHeader.jsx
@@ -107,7 +107,14 @@ class P5LabVisualizationHeader extends React.Component {
                 this.props.isBlockly &&
                 experiments.isEnabled('backgroundsTab') && (
                   <button
-                    style={styles.buttonFocus}
+                    style={{
+                      ...styles.buttonFocus,
+                      // All truncation if the visualize column is very small
+                      // or if translated strings are longer than English.
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap'
+                    }}
                     type="button"
                     value={P5LabInterfaceMode.BACKGROUND}
                     id="backgroundMode"

--- a/apps/src/templates/ToggleGroup.jsx
+++ b/apps/src/templates/ToggleGroup.jsx
@@ -43,7 +43,10 @@ class ToggleGroup extends Component {
   render() {
     // Reverse children order if locale is RTL
     const {isRtl} = this.props;
-    const spanStyle = isRtl ? styles.buttonReverse : null;
+    const spanStyle = {
+      ...styles.buttons,
+      flexDirection: isRtl ? 'row-reverse' : 'row'
+    };
 
     return <span style={spanStyle}>{this.renderChildren()}</span>;
   }
@@ -80,9 +83,8 @@ class ToggleGroup extends Component {
 }
 
 const styles = {
-  buttonReverse: {
-    display: 'flex',
-    flexDirection: 'row-reverse'
+  buttons: {
+    display: 'flex'
   }
 };
 

--- a/apps/src/templates/ToggleGroup.jsx
+++ b/apps/src/templates/ToggleGroup.jsx
@@ -10,6 +10,7 @@ class ToggleGroup extends Component {
     selected: PropTypes.string,
     activeColor: PropTypes.string,
     onChange: PropTypes.func.isRequired,
+    flex: PropTypes.bool,
     children(props, propName, componentName) {
       const prop = props[propName];
       let error;
@@ -42,11 +43,10 @@ class ToggleGroup extends Component {
 
   render() {
     // Reverse children order if locale is RTL
-    const {isRtl} = this.props;
-    const spanStyle = {
-      ...styles.buttons,
-      flexDirection: isRtl ? 'row-reverse' : 'row'
-    };
+    const {isRtl, flex} = this.props;
+    const spanStyle = isRtl
+      ? styles.flexButtonReverse
+      : flex && styles.flexButtons;
 
     return <span style={spanStyle}>{this.renderChildren()}</span>;
   }
@@ -83,8 +83,12 @@ class ToggleGroup extends Component {
 }
 
 const styles = {
-  buttons: {
+  flexButtons: {
     display: 'flex'
+  },
+  flexButtonReverse: {
+    display: 'flex',
+    flexDirection: 'row-reverse'
   }
 };
 


### PR DESCRIPTION
Redo of:
* https://github.com/code-dot-org/code-dot-org/pull/50204

Problem: `ToggleGroup` is used in many other contexts so we need to be more careful about changing how it is styled. This PR adds `flex` as a new optional React property so that there are no regressions caused.
![image (53)](https://user-images.githubusercontent.com/43474485/218492328-eec1d6b2-428e-47f4-a084-2687eff6b972.png)
![image (54)](https://user-images.githubusercontent.com/43474485/218492345-a5f784e4-46ec-4e50-ba86-affccce3f492.png)

**After this change:**
No regressions found:
<img width="807" alt="image" src="https://user-images.githubusercontent.com/43474485/218492535-980d7c0d-24c8-4de5-9410-c1f06eacff55.png">

New/expected behavior for backgrounds tab:
![2023-02-13 09-58-51 2023-02-13 09_59_28](https://user-images.githubusercontent.com/43474485/218492939-bb5ad739-30a4-4baf-b7d5-927170de79ca.gif)


Reverts code-dot-org/code-dot-org#50219


Possible follow-up conversation: Outside of this new feature, why do we only want  `display: flex`  for `ToggleGroup` in RTL situations?