### PR TITLE
Refactor ShareAllowedDialog story

### DIFF
--- a/apps/src/code-studio/components/ShareAllowedDialog.story.jsx
+++ b/apps/src/code-studio/components/ShareAllowedDialog.story.jsx
@@ -1,317 +1,125 @@
 import React from 'react';
 import {UnconnectedShareAllowedDialog as ShareAllowedDialog} from './ShareAllowedDialog';
+import {Provider} from 'react-redux';
+import {reduxStore} from '@cdo/storybook/decorators';
 import {action} from '@storybook/addon-actions';
 import publishDialog from '@cdo/apps/templates/projects/publishDialog/publishDialogRedux';
 import pageConstants from '@cdo/apps/redux/pageConstants';
 import shareDialog from '@cdo/apps/code-studio/components/shareDialogRedux';
 
-export default storybook => {
-  storybook
-    .storiesOf('ShareAllowedDialog', module)
-    .withReduxStore({
-      publishDialog,
-      pageConstants,
-      shareDialog
-    })
-    .addStoryTable([
-      {
-        name: 'basic example',
-        story: () => {
-          return (
-            <ShareAllowedDialog
-              isOpen={true}
-              canPublish={false}
-              isPublished={false}
-              isUnpublishPending={false}
-              onClose={action('close')}
-              onShowPublishDialog={action('show publish dialog')}
-              onUnpublish={action('unpublish')}
-              openLibraryCreationDialog={action('open library creation dialog')}
-              hideBackdrop={true}
-              shareUrl="https://studio.code.org/projects/applab/GmBgH7e811sZP7-5bALAxQ"
-              isAbusive={false}
-              channelId="some-id"
-              appType="gamelab"
-              canShareSocial={true}
-              onClickPopup={action('onClickPopup')}
-            />
-          );
-        }
-      },
-      {
-        name: 'with thumbnail',
-        story: () => {
-          return (
-            <ShareAllowedDialog
-              isOpen={true}
-              canPrint={true}
-              canPublish={false}
-              isPublished={false}
-              isUnpublishPending={false}
-              onClose={action('close')}
-              onShowPublishDialog={action('show publish dialog')}
-              onUnpublish={action('unpublish')}
-              openLibraryCreationDialog={action('open library creation dialog')}
-              hideBackdrop={true}
-              shareUrl="https://studio.code.org/projects/applab/GmBgH7e811sZP7-5bALAxQ"
-              thumbnailUrl="https://studio.code.org/v3/files/eDTsqHl7lQygvEa1j3HSwlUFHAu507gI54D_PUy5mWE/.metadata/thumbnail.png"
-              isAbusive={false}
-              channelId="some-id"
-              appType="gamelab"
-              canShareSocial={true}
-              onClickPopup={action('onClickPopup')}
-            />
-          );
-        }
-      },
-      {
-        name: 'applab',
-        description: `The applab version has an advanced sharing dialog with more options`,
-        story: () => {
-          return (
-            <ShareAllowedDialog
-              isOpen={true}
-              canPublish={false}
-              isPublished={false}
-              isUnpublishPending={false}
-              onClose={action('close')}
-              onShowPublishDialog={action('show publish dialog')}
-              onUnpublish={action('unpublish')}
-              openLibraryCreationDialog={action('open library creation dialog')}
-              hideBackdrop={true}
-              shareUrl="https://studio.code.org/projects/applab/GmBgH7e811sZP7-5bALAxQ"
-              isAbusive={false}
-              channelId="some-id"
-              appType="applab"
-              canShareSocial={true}
-              onClickPopup={action('onClickPopup')}
-            />
-          );
-        }
-      },
-      {
-        name: 'with export for web',
-        description: `The Export for Web section appears in advanced options with an Export button.`,
-        story: () => {
-          return (
-            <ShareAllowedDialog
-              isOpen={true}
-              canPublish={false}
-              isPublished={false}
-              isUnpublishPending={false}
-              onClose={action('close')}
-              onShowPublishDialog={action('show publish dialog')}
-              onUnpublish={action('unpublish')}
-              openLibraryCreationDialog={action('open library creation dialog')}
-              hideBackdrop={true}
-              shareUrl="https://studio.code.org/projects/applab/GmBgH7e811sZP7-5bALAxQ"
-              isAbusive={false}
-              channelId="some-id"
-              appType="applab"
-              canShareSocial={true}
-              onClickPopup={action('onClickPopup')}
-              exportApp={action('onClickExport')}
-            />
-          );
-        }
-      },
-      {
-        name: 'with under 13 warning',
-        description: `We hide social sharing buttons and display a warning for users under 13`,
-        story: () => {
-          return (
-            <ShareAllowedDialog
-              isOpen={true}
-              canPublish={false}
-              isPublished={false}
-              isUnpublishPending={false}
-              onClose={action('close')}
-              onShowPublishDialog={action('show publish dialog')}
-              onUnpublish={action('unpublish')}
-              openLibraryCreationDialog={action('open library creation dialog')}
-              hideBackdrop={true}
-              shareUrl="https://studio.code.org/projects/applab/GmBgH7e811sZP7-5bALAxQ"
-              isAbusive={false}
-              channelId="some-id"
-              canShareSocial={false}
-              appType="gamelab"
-              onClickPopup={action('onClickPopup')}
-            />
-          );
-        }
-      },
-      {
-        name: 'abusive',
-        description: `The abusive version shows a warning message`,
-        story: () => {
-          return (
-            <ShareAllowedDialog
-              isOpen={true}
-              canPublish={false}
-              isPublished={false}
-              isUnpublishPending={false}
-              onClose={action('close')}
-              onShowPublishDialog={action('show publish dialog')}
-              onUnpublish={action('unpublish')}
-              openLibraryCreationDialog={action('open library creation dialog')}
-              hideBackdrop={true}
-              shareUrl="https://studio.code.org/projects/applab/GmBgH7e811sZP7-5bALAxQ"
-              isAbusive={true}
-              channelId="some-id"
-              canShareSocial={true}
-              appType="gamelab"
-              onClickPopup={action('onClickPopup')}
-            />
-          );
-        }
-      },
-      {
-        name: 'with icon',
-        description: `An icon can be specified for the dialog`,
-        story: () => {
-          return (
-            <ShareAllowedDialog
-              isOpen={true}
-              canPublish={false}
-              isPublished={false}
-              isUnpublishPending={false}
-              onClose={action('close')}
-              onShowPublishDialog={action('show publish dialog')}
-              onUnpublish={action('unpublish')}
-              openLibraryCreationDialog={action('open library creation dialog')}
-              hideBackdrop={true}
-              icon="https://studio.code.org/blockly/media/skins/pvz/static_avatar.png"
-              shareUrl="https://studio.code.org/projects/applab/GmBgH7e811sZP7-5bALAxQ"
-              isAbusive={false}
-              channelId="some-id"
-              canShareSocial={true}
-              appType="gamelab"
-              onClickPopup={action('onClickPopup')}
-            />
-          );
-        }
-      },
-      {
-        name: 'with publish button',
-        story: () => {
-          return (
-            <ShareAllowedDialog
-              isOpen={true}
-              canPublish={true}
-              isPublished={false}
-              isUnpublishPending={false}
-              onClose={action('close')}
-              onShowPublishDialog={action('show publish dialog')}
-              onUnpublish={action('unpublish')}
-              openLibraryCreationDialog={action('open library creation dialog')}
-              hideBackdrop={true}
-              shareUrl="https://studio.code.org/projects/applab/GmBgH7e811sZP7-5bALAxQ"
-              thumbnailUrl="https://studio.code.org/v3/files/eDTsqHl7lQygvEa1j3HSwlUFHAu507gI54D_PUy5mWE/.metadata/thumbnail.png"
-              isAbusive={false}
-              channelId="some-id"
-              appType="gamelab"
-              canShareSocial={true}
-              onClickPopup={action('onClickPopup')}
-            />
-          );
-        }
-      },
-      {
-        name: 'with disabled publish button',
-        story: () => {
-          return (
-            <ShareAllowedDialog
-              isOpen={true}
-              canPublish={true}
-              isPublished={false}
-              isUnpublishPending={false}
-              onClose={action('close')}
-              onShowPublishDialog={action('show publish dialog')}
-              onUnpublish={action('unpublish')}
-              openLibraryCreationDialog={action('open library creation dialog')}
-              hideBackdrop={true}
-              shareUrl="https://studio.code.org/projects/applab/GmBgH7e811sZP7-5bALAxQ"
-              isAbusive={false}
-              channelId="some-id"
-              appType="gamelab"
-              canShareSocial={true}
-              onClickPopup={action('onClickPopup')}
-            />
-          );
-        }
-      },
-      {
-        name: 'with unpublish button',
-        story: () => {
-          return (
-            <ShareAllowedDialog
-              isOpen={true}
-              canPublish={true}
-              isPublished={true}
-              isUnpublishPending={false}
-              onClose={action('close')}
-              onShowPublishDialog={action('show publish dialog')}
-              onUnpublish={action('unpublish')}
-              openLibraryCreationDialog={action('open library creation dialog')}
-              hideBackdrop={true}
-              shareUrl="https://studio.code.org/projects/applab/GmBgH7e811sZP7-5bALAxQ"
-              isAbusive={false}
-              channelId="some-id"
-              appType="gamelab"
-              canShareSocial={true}
-              onClickPopup={action('onClickPopup')}
-            />
-          );
-        }
-      },
-      {
-        name: 'with unpublish pending',
-        story: () => {
-          return (
-            <ShareAllowedDialog
-              isOpen={true}
-              canPublish={true}
-              isPublished={true}
-              isUnpublishPending={true}
-              onClose={action('close')}
-              onShowPublishDialog={action('show publish dialog')}
-              onUnpublish={action('unpublish')}
-              openLibraryCreationDialog={action('open library creation dialog')}
-              hideBackdrop={true}
-              shareUrl="https://studio.code.org/projects/applab/GmBgH7e811sZP7-5bALAxQ"
-              isAbusive={false}
-              channelId="some-id"
-              appType="gamelab"
-              canShareSocial={true}
-              onClickPopup={action('onClickPopup')}
-            />
-          );
-        }
-      },
-      {
-        name: 'with sharing for user disabled',
-        story: () => {
-          return (
-            <ShareAllowedDialog
-              isOpen={true}
-              canPublish={true}
-              isPublished={true}
-              isUnpublishPending={true}
-              onClose={action('close')}
-              onShowPublishDialog={action('show publish dialog')}
-              onUnpublish={action('unpublish')}
-              openLibraryCreationDialog={action('open library creation dialog')}
-              hideBackdrop={true}
-              shareUrl="https://studio.code.org/projects/applab/GmBgH7e811sZP7-5bALAxQ"
-              isAbusive={false}
-              channelId="some-id"
-              appType="gamelab"
-              canShareSocial={true}
-              onClickPopup={action('onClickPopup')}
-              userSharingDisabled={true}
-            />
-          );
-        }
-      }
-    ]);
+export default {
+  title: 'ShareAllowedDialog',
+  component: ShareAllowedDialog
+};
+
+const defaultArgs = {
+  isOpen: true,
+  canPublish: false,
+  isPublished: false,
+  isUnpublishPending: false,
+  onClose: action('close'),
+  onShowPublishDialog: action('show publish dialog'),
+  onUnpublish: action('unpublish'),
+  openLibraryCreationDialog: action('open library creation dialog'),
+  hideBackdrop: true,
+  shareUrl: 'https://studio.code.org/projects/applab/GmBgH7e811sZP7-5bALAxQ',
+  isAbusive: false,
+  channelId: 'some-id',
+  appType: 'gamelab',
+  canShareSocial: true,
+  onClickPopup: action('onClickPopup')
+};
+
+const Template = args => (
+  <Provider store={reduxStore({publishDialog, pageConstants, shareDialog})}>
+    {/* ShareAllowedDialog has a marginLeft of -360 so it shows up correctly on the page.
+        Nesting inside a div so it appears in storybook correctly */}
+    <div style={{marginLeft: 360}}>
+      <ShareAllowedDialog {...args} />
+    </div>
+  </Provider>
+);
+
+export const SpriteLab = Template.bind({});
+SpriteLab.args = {
+  ...defaultArgs,
+  appType: 'spritelab'
+};
+
+export const WithThumbnail = Template.bind({});
+WithThumbnail.args = {
+  ...defaultArgs,
+  canPrint: true,
+  thumbnailUrl:
+    'https://studio.code.org/v3/files/eDTsqHl7lQygvEa1j3HSwlUFHAu507gI54D_PUy5mWE/.metadata/thumbnail.png'
+};
+
+export const AppLab = Template.bind({});
+AppLab.args = {
+  ...defaultArgs,
+  appType: 'applab'
+};
+
+export const WithExportForWeb = Template.bind({});
+WithExportForWeb.args = {
+  ...defaultArgs,
+  appType: 'applab',
+  canShareSocial: true,
+  exportApp: action('onClickExport')
+};
+
+export const WithUnder13Warning = Template.bind({});
+WithUnder13Warning.args = {
+  ...defaultArgs,
+  canShareSocial: false
+};
+
+export const Abusive = Template.bind({});
+Abusive.args = {
+  ...defaultArgs,
+  isAbusive: true
+};
+
+export const WithIcon = Template.bind({});
+WithIcon.args = {
+  ...defaultArgs,
+  icon: 'https://studio.code.org/blockly/media/skins/pvz/static_avatar.png'
+};
+
+export const WithPublishButton = Template.bind({});
+WithPublishButton.args = {
+  ...defaultArgs,
+  canPublish: true,
+  thumbnailUrl:
+    'https://studio.code.org/v3/files/eDTsqHl7lQygvEa1j3HSwlUFHAu507gI54D_PUy5mWE/.metadata/thumbnail.png'
+};
+
+export const WithDisabledPublishButton = Template.bind({});
+WithDisabledPublishButton.args = {
+  ...defaultArgs,
+  canPublish: true
+};
+
+export const WithUnpublishButton = Template.bind({});
+WithUnpublishButton.args = {
+  ...defaultArgs,
+  canPublish: true,
+  isPublished: true
+};
+
+export const WithUnpublishPending = Template.bind({});
+WithUnpublishPending.args = {
+  ...defaultArgs,
+  canPublish: true,
+  isPublished: true,
+  isUnpublishPending: true
+};
+
+export const WithSharingForUserDisabled = Template.bind({});
+WithSharingForUserDisabled.args = {
+  ...defaultArgs,
+  canPublish: true,
+  isPublished: true,
+  isUnpublishPending: true,
+  userSharingDisabled: true
 };


### PR DESCRIPTION
Refactor ShareAllowedDialog to use the new storybook format.

The only change I made was to change the "Basic Example" to be "Sprite Lab", as the previous configuration did not have any sprite lab examples (Basic Example was using app type game lab before, but many other stories used game lab).

I noticed that using an icon does not work correctly. The only place I could find that used this component was `ShareDialog`, which just passes through props, and the only place `ShareDialog` is used is in [headerShare](https://github.com/code-dot-org/code-dot-org/blob/4e18b7305c47afec1d897da13e1b9edc752f8167/apps/src/code-studio/headerShare.js#L44), which never uses an icon prop. We may just want to remove this prop if we don't plan to ever use it. That was out of scope of this refactor. I made a follow-up [task](https://codedotorg.atlassian.net/browse/SL-561)

### Screenshot of Icon issue

<img width="744" alt="Screenshot 2023-02-10 at 4 24 54 PM" src="https://user-images.githubusercontent.com/33666587/218226413-5155d06c-7773-40a2-8ac5-45d7f438f4f7.png">

## Links

- [storybook refactor spreadsheet](https://docs.google.com/spreadsheets/d/1z8r10AcR0v3GimV_-28dJ6QaiaQ3CJoo9yXqa7U_bKs/edit#gid=0)


## Testing story
Tested in storybook.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
