### PR TITLE
Remove question from Amazon Future Engineers form

### DIFF
--- a/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerEligibilityForm.jsx
+++ b/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerEligibilityForm.jsx
@@ -74,7 +74,6 @@ export default class AmazonFutureEngineerEligibilityForm extends React.Component
       email: this.props.email,
       inspirationKit: false,
       csta: false,
-      awsEducate: false,
       consentAFE: false,
       consentCSTA: false,
       gradeBands: [false, false, false],
@@ -107,7 +106,6 @@ export default class AmazonFutureEngineerEligibilityForm extends React.Component
       'lastName',
       'inspirationKit',
       'csta',
-      'awsEducate',
       'consentAFE'
     ]);
 
@@ -361,14 +359,6 @@ export default class AmazonFutureEngineerEligibilityForm extends React.Component
               )}
             </div>
           )}
-          <SingleCheckbox
-            name="awsEducate"
-            label="Send me a free membership to Amazon Web Services Educate to access
-              free content and cloud computing credits to help my students learn
-              to build in the cloud."
-            onChange={this.handleChange}
-            value={this.state.awsEducate}
-          />
           <hr style={styles.sectionBreak} />
           <SingleCheckbox
             name="consentAFE"

--- a/dashboard/app/controllers/api/v1/amazon_future_engineer_controller.rb
+++ b/dashboard/app/controllers/api/v1/amazon_future_engineer_controller.rb
@@ -26,7 +26,6 @@ class Api::V1::AmazonFutureEngineerController < ApplicationController
       zip: afe_params['zip'],
       marketing_kit: afe_params['inspirationKit'],
       csta_plus: afe_params['csta'],
-      aws_educate: afe_params['awsEducate'],
       amazon_terms: afe_params['consentAFE'],
       new_code_account: current_user.created_at > 5.minutes.ago
     )
@@ -81,7 +80,6 @@ class Api::V1::AmazonFutureEngineerController < ApplicationController
     schoolId
     inspirationKit
     csta
-    awsEducate
     consentAFE
   )
 

--- a/dashboard/lib/services/afe_enrollment.rb
+++ b/dashboard/lib/services/afe_enrollment.rb
@@ -26,14 +26,12 @@ class Services::AFEEnrollment
   # @param zip [String] Teacher's school's postal code, 5 characters
   # @param marketing_kit [Boolean] Whether the teacher opted in to receiving AFE's marketing kit
   # @param csta_plus [Boolean] Whether the teacher opted in to a free CSTA Plus membership
-  # @param aws_educate [Boolean] Whether the teacher opted in to a free AWS Educate membership
   # @param amazon_terms [Boolean] Whether the teacher agreed to AFE's privacy policy and terms
   #        of service.  Should always be true; we don't submit without this.
   # @param new_code_account [Boolean] Whether the teacher signed up for code.org as part of the
   #        AFE process.
   def self.submit(first_name:, last_name:, email:, nces_id:, street_1:, street_2:,
-    city:, state:, zip:, marketing_kit:, csta_plus:, aws_educate:,
-    amazon_terms:, new_code_account:)
+    city:, state:, zip:, marketing_kit:, csta_plus:, amazon_terms:, new_code_account:)
     submission_body = {
       'traffic-source' => 'AFE-code.org-2020',
       'first-name' => first_name,
@@ -47,7 +45,6 @@ class Services::AFEEnrollment
       'school-zip' => zip,
       'inspirational-marketing-kit' => booleanize(marketing_kit),
       'csta-plus' => booleanize(csta_plus),
-      'aws-educate' => booleanize(aws_educate),
       'amazon-terms' => booleanize(amazon_terms),
       'new-code-account' => booleanize(new_code_account),
       'registration-date-time' => Time.now.iso8601

--- a/dashboard/test/controllers/api/v1/amazon_future_engineer_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/amazon_future_engineer_controller_test.rb
@@ -76,7 +76,6 @@ class Api::V1::AmazonFutureEngineerControllerTest < ActionDispatch::IntegrationT
       zip: '98105',
       marketing_kit: '0',
       csta_plus: '0',
-      aws_educate: '0',
       amazon_terms: '1',
       new_code_account: true
     )
@@ -326,7 +325,6 @@ class Api::V1::AmazonFutureEngineerControllerTest < ActionDispatch::IntegrationT
       'inspirationKit' => '0',
       'csta' => '0',
       'consentCSTA' => '0',
-      'awsEducate' => '0',
       'primaryProfessionalRole' => 'test role with space',
       'gradesTeaching' => 'K-5, 6-8, ',
       'consentAFE' => '1'

--- a/dashboard/test/lib/services/afe_enrollment_test.rb
+++ b/dashboard/test/lib/services/afe_enrollment_test.rb
@@ -30,7 +30,6 @@ class Services::AFEEnrollmentTest < ActiveSupport::TestCase
           'school-zip' => 'test-zip',
           'inspirational-marketing-kit' => '1',
           'csta-plus' => '1',
-          'aws-educate' => '1',
           'amazon-terms' => '1',
           'new-code-account' => '1',
           'registration-date-time' => Time.now.iso8601
@@ -43,35 +42,35 @@ class Services::AFEEnrollmentTest < ActiveSupport::TestCase
   end
 
   test 'false becomes "0" for boolean params' do
-    assert_param_translation({aws_educate: false}, {'aws-educate' => '0'})
+    assert_param_translation({csta_plus: false}, {'csta-plus' => '0'})
   end
 
   test 'the string "false" becomes "0" for boolean params' do
-    assert_param_translation({aws_educate: 'false'}, {'aws-educate' => '0'})
+    assert_param_translation({csta_plus: 'false'}, {'csta-plus' => '0'})
   end
 
   test 'the number 0 becomes "0" for boolean params' do
-    assert_param_translation({aws_educate: 0}, {'aws-educate' => '0'})
+    assert_param_translation({csta_plus: 0}, {'csta-plus' => '0'})
   end
 
   test 'the string "0" becomes "0" for boolean params' do
-    assert_param_translation({aws_educate: '0'}, {'aws-educate' => '0'})
+    assert_param_translation({csta_plus: '0'}, {'csta-plus' => '0'})
   end
 
   test 'true becomes "1" for boolean params' do
-    assert_param_translation({aws_educate: true}, {'aws-educate' => '1'})
+    assert_param_translation({csta_plus: true}, {'csta-plus' => '1'})
   end
 
   test 'the string "true" becomes "1" for boolean params' do
-    assert_param_translation({aws_educate: 'true'}, {'aws-educate' => '1'})
+    assert_param_translation({csta_plus: 'true'}, {'csta-plus' => '1'})
   end
 
   test 'the number 1 becomes "1" for boolean params' do
-    assert_param_translation({aws_educate: 1}, {'aws-educate' => '1'})
+    assert_param_translation({csta_plus: 1}, {'csta-plus' => '1'})
   end
 
   test 'the string "1" becomes "1" for boolean params' do
-    assert_param_translation({aws_educate: '1'}, {'aws-educate' => '1'})
+    assert_param_translation({csta_plus: '1'}, {'csta-plus' => '1'})
   end
 
   test 'raises without submitting if amazon_terms is not true' do
@@ -141,7 +140,6 @@ class Services::AFEEnrollmentTest < ActiveSupport::TestCase
       zip: 'test-zip',
       marketing_kit: true,
       csta_plus: true,
-      aws_educate: true,
       amazon_terms: true,
       new_code_account: true
     }


### PR DESCRIPTION
Removes the AWS Educate checkbox on the Amazon Future Engineers form. In development:
<img width="577" alt="image" src="https://user-images.githubusercontent.com/9142121/218332403-8e0058ef-e914-409b-949c-0e65b3149be7.png">

In prod, it's the last checkbox before the required privacy policy checkbox:
<img width="576" alt="image" src="https://user-images.githubusercontent.com/9142121/218332459-a2cda545-76f7-472a-99f1-fab6cec4f0b1.png">


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Tested this manually:
- Seeded schools: 
    - bundle exec rake seed:schools
- Added school info to my account:
    - UserSchoolInfo.create!(user_id: user.id, school_info_id: SchoolInfo.last.id, start_date: Time.now, last_confirmation_date: Time.now)
- Changed prop `schoolEligible` to hardcode to `true` in [amazon_future_engineer_eligibility.js](https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/sites/code.org/pages/views/amazon_future_engineer_eligibility.js#L37)
- Navigated to http://localhost.code.org:3000/afe, filled out form, submitted successfully:
<img width="771" alt="image" src="https://user-images.githubusercontent.com/9142121/218332496-a6f0e266-20e2-4346-88a6-74e4fe491bce.png">


<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
