### PR TITLE
Add grade_level, header, and curriculum_type to course_offerings

### DIFF
--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -12,7 +12,7 @@
 #  assignable           :boolean          default(TRUE), not null
 #  curriculum_type      :string(255)
 #  marketing_initiative :string(255)
-#  grade_level          :string(255)
+#  grade_levels         :string(255)
 #  header               :string(255)
 #
 # Indexes

--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -2,17 +2,18 @@
 #
 # Table name: course_offerings
 #
-#  id              :integer          not null, primary key
-#  key             :string(255)      not null
-#  display_name    :string(255)      not null
-#  created_at      :datetime         not null
-#  updated_at      :datetime         not null
-#  category        :string(255)      default("other"), not null
-#  is_featured     :boolean          default(FALSE), not null
-#  assignable      :boolean          default(TRUE), not null
-#  grade_level     :string(255)
-#  curriculum_type :string(255)
-#  header          :string(255)
+#  id                   :integer          not null, primary key
+#  key                  :string(255)      not null
+#  display_name         :string(255)      not null
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  category             :string(255)      default("other"), not null
+#  is_featured          :boolean          default(FALSE), not null
+#  assignable           :boolean          default(TRUE), not null
+#  curriculum_type      :string(255)
+#  marketing_initiative :string(255)
+#  grade_level          :string(255)
+#  header               :string(255)
 #
 # Indexes
 #

--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -2,14 +2,17 @@
 #
 # Table name: course_offerings
 #
-#  id           :integer          not null, primary key
-#  key          :string(255)      not null
-#  display_name :string(255)      not null
-#  created_at   :datetime         not null
-#  updated_at   :datetime         not null
-#  category     :string(255)      default("other"), not null
-#  is_featured  :boolean          default(FALSE), not null
-#  assignable   :boolean          default(TRUE), not null
+#  id              :integer          not null, primary key
+#  key             :string(255)      not null
+#  display_name    :string(255)      not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  category        :string(255)      default("other"), not null
+#  is_featured     :boolean          default(FALSE), not null
+#  assignable      :boolean          default(TRUE), not null
+#  grade_level     :string(255)
+#  curriculum_type :string(255)
+#  header          :string(255)
 #
 # Indexes
 #

--- a/dashboard/db/migrate/20230213141358_add_grade_level_curriculum_type_header_to_course_offerings.rb
+++ b/dashboard/db/migrate/20230213141358_add_grade_level_curriculum_type_header_to_course_offerings.rb
@@ -1,7 +1,0 @@
-class AddGradeLevelCurriculumTypeHeaderToCourseOfferings < ActiveRecord::Migration[6.0]
-  def change
-    add_column :course_offerings, :grade_level, :string
-    add_column :course_offerings, :curriculum_type, :string
-    add_column :course_offerings, :header, :string
-  end
-end

--- a/dashboard/db/migrate/20230213141358_add_grade_level_curriculum_type_header_to_course_offerings.rb
+++ b/dashboard/db/migrate/20230213141358_add_grade_level_curriculum_type_header_to_course_offerings.rb
@@ -1,0 +1,7 @@
+class AddGradeLevelCurriculumTypeHeaderToCourseOfferings < ActiveRecord::Migration[6.0]
+  def change
+    add_column :course_offerings, :grade_level, :string
+    add_column :course_offerings, :curriculum_type, :string
+    add_column :course_offerings, :header, :string
+  end
+end

--- a/dashboard/db/migrate/20230214123814_add_grade_level_curriculum_type_marketing_initiative_header_to_course_offerings.rb
+++ b/dashboard/db/migrate/20230214123814_add_grade_level_curriculum_type_marketing_initiative_header_to_course_offerings.rb
@@ -2,7 +2,7 @@ class AddGradeLevelCurriculumTypeMarketingInitiativeHeaderToCourseOfferings < Ac
   def change
     add_column :course_offerings, :curriculum_type, :string
     add_column :course_offerings, :marketing_initiative, :string
-    add_column :course_offerings, :grade_level, :string
+    add_column :course_offerings, :grade_levels, :string
     add_column :course_offerings, :header, :string
   end
 end

--- a/dashboard/db/migrate/20230214123814_add_grade_level_curriculum_type_marketing_initiative_header_to_course_offerings.rb
+++ b/dashboard/db/migrate/20230214123814_add_grade_level_curriculum_type_marketing_initiative_header_to_course_offerings.rb
@@ -1,0 +1,8 @@
+class AddGradeLevelCurriculumTypeMarketingInitiativeHeaderToCourseOfferings < ActiveRecord::Migration[6.0]
+  def change
+    add_column :course_offerings, :curriculum_type, :string
+    add_column :course_offerings, :marketing_initiative, :string
+    add_column :course_offerings, :grade_level, :string
+    add_column :course_offerings, :header, :string
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -424,7 +424,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.boolean "assignable", default: true, null: false
     t.string "curriculum_type"
     t.string "marketing_initiative"
-    t.string "grade_level"
+    t.string "grade_levels"
     t.string "header"
     t.index ["key"], name: "index_course_offerings_on_key", unique: true
   end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_02_13_141358) do
+ActiveRecord::Schema.define(version: 2023_02_14_123814) do
 
   create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -422,8 +422,9 @@ ActiveRecord::Schema.define(version: 2023_02_13_141358) do
     t.string "category", default: "other", null: false
     t.boolean "is_featured", default: false, null: false
     t.boolean "assignable", default: true, null: false
-    t.string "grade_level"
     t.string "curriculum_type"
+    t.string "marketing_initiative"
+    t.string "grade_level"
     t.string "header"
     t.index ["key"], name: "index_course_offerings_on_key", unique: true
   end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_01_24_093901) do
+ActiveRecord::Schema.define(version: 2023_02_13_141358) do
 
   create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -422,6 +422,9 @@ ActiveRecord::Schema.define(version: 2023_01_24_093901) do
     t.string "category", default: "other", null: false
     t.boolean "is_featured", default: false, null: false
     t.boolean "assignable", default: true, null: false
+    t.string "grade_level"
+    t.string "curriculum_type"
+    t.string "header"
     t.index ["key"], name: "index_course_offerings_on_key", unique: true
   end
 


### PR DESCRIPTION
Finishes [TEACH-247](https://codedotorg.atlassian.net/browse/TEACH-247). Adds new fields to the course_offerings table for curriculum quick assign. See [the tech spec](https://docs.google.com/document/d/1WK-k10H3smrmZuILkm-696nIvJirT4wfZ_0JJc_6sqk/edit#).

I don't think we need any indices on these fields but it's possible we will need to add some later. This table is on the order of hundreds of rows, so no special process is needed to get this migration to production.