### PR TITLE
 [Phase 1.5] Update codeworkSpace, Js Debugger icons, modals styling

### DIFF
--- a/apps/src/applab/DesignModeHeaders.jsx
+++ b/apps/src/applab/DesignModeHeaders.jsx
@@ -38,9 +38,9 @@ export default class DesignModeHeaders extends React.Component {
       lineHeight: styleConstants['workspace-headers-height'] + 'px',
       fontSize: 18,
       cursor: 'pointer',
-      color: this.props.isRunning ? color.dark_charcoal : color.lighter_purple,
+      color: color.neutral_white,
       ':hover': {
-        color: color.white
+        color: color.neutral_dark20
       }
     };
 

--- a/apps/src/commonStyles.js
+++ b/apps/src/commonStyles.js
@@ -22,7 +22,7 @@ commonStyles.purpleHeader = {
 
 commonStyles.purpleHeaderUnfocused = {
   backgroundColor: color.lighter_purple,
-  color: color.dark_charcoal
+  color: color.neutral_white
 };
 
 commonStyles.teacherBlueHeader = {

--- a/apps/src/feedback.js
+++ b/apps/src/feedback.js
@@ -34,6 +34,7 @@ import QRCode from 'qrcode.react';
 import firehoseClient from '@cdo/apps/lib/util/firehose';
 import experiments from '@cdo/apps/util/experiments';
 import copyToClipboard from '@cdo/apps/util/copyToClipboard';
+import color from '@cdo/apps/util/color';
 
 // Types of blocks that do not count toward displayed block count. Used
 // by FeedbackUtils.blockShouldBeCounted_
@@ -1267,6 +1268,7 @@ FeedbackUtils.prototype.showGeneratedCode = function(appStrings) {
  * Display the "Clear Puzzle" confirmation dialog.  Takes a parameter to hide
  * the icon.  Calls `callback` if the user confirms they want to clear the puzzle.
  */
+// todo do
 FeedbackUtils.prototype.showClearPuzzleConfirmation = function(
   hideIcon,
   callback
@@ -1306,15 +1308,20 @@ FeedbackUtils.prototype.showClearPuzzleConfirmation = function(
  * @param {onCancelCallback} [options.onCancel] Function to be called after clicking cancel
  */
 FeedbackUtils.prototype.showSimpleDialog = function(options) {
+  const bodyTextStyle = {
+    color: color.neutral_dark,
+    fontSize: '14px'
+  };
+
   var textBoxStyle = {
     marginBottom: 10
   };
   var contentDiv = ReactDOM.render(
     <div>
       {options.headerText && (
-        <p className="dialog-title">{options.headerText}</p>
+        <h5 className="dialog-title">{options.headerText}</h5>
       )}
-      {options.bodyText && <p>{options.bodyText}</p>}
+      {options.bodyText && <p style={bodyTextStyle}>{options.bodyText}</p>}
       {options.prompt && (
         <input style={textBoxStyle} defaultValue={options.promptPrefill} />
       )}

--- a/apps/src/feedback.js
+++ b/apps/src/feedback.js
@@ -1268,7 +1268,6 @@ FeedbackUtils.prototype.showGeneratedCode = function(appStrings) {
  * Display the "Clear Puzzle" confirmation dialog.  Takes a parameter to hide
  * the icon.  Calls `callback` if the user confirms they want to clear the puzzle.
  */
-// todo do
 FeedbackUtils.prototype.showClearPuzzleConfirmation = function(
   hideIcon,
   callback

--- a/apps/src/lib/tools/jsdebugger/js-debugger.module.scss
+++ b/apps/src/lib/tools/jsdebugger/js-debugger.module.scss
@@ -30,7 +30,6 @@
   font-size: 18px;
   :hover {
     cursor: pointer;
-    color: color.$white;
   }
 }
 
@@ -44,7 +43,6 @@
   font-size: 18px;
   &:hover {
     cursor: pointer;
-    color: color.$white;
   }
 }
 
@@ -88,10 +86,15 @@ $debug-header-border-width: 1px;
   color: color.$white;
 
   &:hover {
+    color: color.$neutral_dark20;
     box-shadow: none;
   }
 
   &Unfocused {
-    color: color.$dark-charcoal;
+    color: color.$neutral_white;
+
+    &:hover {
+      color: color.$neutral_dark20;
+    }
   }
 }

--- a/apps/src/lib/ui/settings-cog.module.scss
+++ b/apps/src/lib/ui/settings-cog.module.scss
@@ -6,18 +6,18 @@
   border-width: 0 1px;
   border-color: transparent;
   height: 100%;
-  background-color: $purple;
-  color: $lighter_purple;
+  background-color: transparent;
+  color: $neutral_white;
   display: flex;
   align-items: center;
 
   &Running {
-    background-color: $lighter_purple;
-    color: $dark_charcoal;
+    background-color: transparent;
+    color: $neutral_white;
   }
 
   &:hover {
     box-shadow: none;
-    color: $white;
+    color: $neutral_dark20;
   }
 }

--- a/apps/src/templates/CodeWorkspace.jsx
+++ b/apps/src/templates/CodeWorkspace.jsx
@@ -300,7 +300,10 @@ const styles = {
     fontSize: 18
   },
   runningIcon: {
-    color: color.dark_charcoal
+    color: color.neutral_white,
+    ':hover': {
+      color: color.neutral_dark20
+    }
   },
   oldVersionWarning: {
     zIndex: 99,
@@ -333,11 +336,11 @@ const styles = {
     border: 'none',
     lineHeight: styleConstants['workspace-headers-height'] + 'px',
     backgroundColor: 'transparent',
-    color: color.lighter_purple,
+    color: color.neutral_white,
     fontSize: 18,
     ':hover': {
       cursor: 'pointer',
-      color: color.white,
+      color: color.neutral_dark20,
       boxShadow: 'none'
     }
   },

--- a/apps/src/templates/LegacyButton.jsx
+++ b/apps/src/templates/LegacyButton.jsx
@@ -92,28 +92,6 @@ style.withArrow = {
   }
 };
 
-function buttonStyle(buttonColor, textColor = color.white) {
-  let hoverState = {};
-
-  // color.brand_secondary_default
-  if (buttonColor === '#9660BF') {
-    hoverState = {
-      ':hover': {
-        backgroundColor: color.brand_secondary_dark,
-        borderColor: color.brand_secondary_dark,
-        boxShadow: 'none'
-      }
-    };
-  }
-
-  return {
-    ...hoverState,
-    backgroundColor: buttonColor,
-    borderColor: buttonColor,
-    color: textColor
-  };
-}
-
 export const BUTTON_TYPES = {
   default: {
     style: {
@@ -123,19 +101,46 @@ export const BUTTON_TYPES = {
     }
   },
   cancel: {
-    style: buttonStyle(color.green)
+    style: {
+      backgroundColor: color.neutral_white,
+      border: `2px solid ${color.neutral_dark}`,
+      color: color.neutral_dark,
+      ':hover': {
+        backgroundColor: color.neutral_dark20,
+        boxShadow: 'none'
+      }
+    }
   },
   primary: {
-    style: buttonStyle(color.orange)
-  },
-  brandSecondary: {
-    style: buttonStyle(color.brand_secondary_default)
+    style: {
+      backgroundColor: color.brand_secondary_default,
+      borderColor: color.brand_secondary_default,
+      color: color.neutral_white,
+      ':hover': {
+        backgroundColor: color.brand_secondary_dark,
+        borderColor: color.brand_secondary_dark,
+        boxShadow: 'none'
+      }
+    }
   },
   danger: {
-    style: buttonStyle(color.red)
+    style: {
+      backgroundColor: color.product_negative_default,
+      borderColor: color.product_negative_default,
+      color: color.neutral_white,
+      ':hover': {
+        backgroundColor: color.product_negative_dark,
+        borderColor: color.product_negative_dark,
+        boxShadow: 'none'
+      }
+    }
   },
   action: {
-    style: buttonStyle(color.purple)
+    style: {
+      backgroundColor: color.purple,
+      borderColor: color.purple,
+      color: color.white
+    }
   }
 };
 

--- a/apps/src/templates/LegacyButton.jsx
+++ b/apps/src/templates/LegacyButton.jsx
@@ -93,7 +93,21 @@ style.withArrow = {
 };
 
 function buttonStyle(buttonColor, textColor = color.white) {
+  let hoverState = {};
+
+  // color.brand_secondary_default
+  if (buttonColor === '#9660BF') {
+    hoverState = {
+      ':hover': {
+        backgroundColor: color.brand_secondary_dark,
+        borderColor: color.brand_secondary_dark,
+        boxShadow: 'none'
+      }
+    };
+  }
+
   return {
+    ...hoverState,
     backgroundColor: buttonColor,
     borderColor: buttonColor,
     color: textColor

--- a/apps/src/templates/SpeedSlider.jsx
+++ b/apps/src/templates/SpeedSlider.jsx
@@ -5,12 +5,12 @@ import dom from '../dom';
 
 const style = {
   sliderTrack: {
-    stroke: color.lightest_purple,
+    stroke: color.neutral_white,
     strokeWidth: 4,
     strokeLinecap: 'round'
   },
   sliderKnob: {
-    fill: color.blockly_flyout_gray,
+    fill: color.neutral_white,
     stroke: '#bbc',
     strokeWidth: 1,
     strokeLinejoin: 'round',
@@ -160,11 +160,7 @@ class SpeedSlider extends React.Component {
           </clipPath>
           {/* turtle image */}
           <image
-            xlinkHref={
-              props.hasFocus
-                ? sliderImages.lightTurtle
-                : sliderImages.darkTurtle
-            }
+            xlinkHref={sliderImages.lightTurtle}
             height={12}
             width={22}
             x={2}
@@ -176,11 +172,7 @@ class SpeedSlider extends React.Component {
           </clipPath>
           {/* rabbit image */}
           <image
-            xlinkHref={
-              props.hasFocus
-                ? sliderImages.lightRabbit
-                : sliderImages.darkRabbit
-            }
+            xlinkHref={sliderImages.lightRabbit}
             height={15}
             width={23}
             x={knobXMax - 18}

--- a/apps/src/templates/VersionHistory.jsx
+++ b/apps/src/templates/VersionHistory.jsx
@@ -229,7 +229,7 @@ export default class VersionHistory extends React.Component {
 
     return (
       <div className="modal-content" style={{margin: 0}}>
-        <h1 className="dialog-title">{title}</h1>
+        <h5 className="dialog-title">{title}</h5>
         {body}
         {this.state.statusMessage}
       </div>

--- a/apps/src/templates/instructions/CollapserButton.jsx
+++ b/apps/src/templates/instructions/CollapserButton.jsx
@@ -78,7 +78,11 @@ const styles = {
     backgroundColor: color.neutral_white,
     border: `2px solid ${color.neutral_dark}`,
     color: color.neutral_dark,
-    whiteSpace: 'nowrap'
+    whiteSpace: 'nowrap',
+    ':hover': {
+      backgroundColor: color.neutral_dark20,
+      boxShadow: 'none'
+    }
   },
   collapseIcon: {
     marginRight: 5

--- a/apps/src/templates/instructions/InstructionsCsfMiddleCol.jsx
+++ b/apps/src/templates/instructions/InstructionsCsfMiddleCol.jsx
@@ -168,7 +168,7 @@ class InstructionsCsfMiddleCol extends React.Component {
           {this.props.overlayVisible && (
             <div>
               <hr />
-              <LegacyButton type="brandSecondary" onClick={this.closeOverlay}>
+              <LegacyButton type="primary" onClick={this.closeOverlay}>
                 {i18n.dialogOK()}
               </LegacyButton>
             </div>

--- a/apps/style/common.scss
+++ b/apps/style/common.scss
@@ -575,6 +575,12 @@ button.launch {
   margin-left: 0;
   margin-right: 10px;
 
+  &:hover {
+    background-color: $brand_secondary_dark;
+    border-color: $brand_secondary_dark;
+    box-shadow: none;
+  }
+
   /* Can't use "text-align: start" due to IE. */
   text-align: left;
 }
@@ -596,6 +602,12 @@ button.blocklyLaunch {
 
   border: 1px solid $brand_secondary_default;
   background-color: $brand_secondary_default;
+
+  &:hover {
+    background-color: $brand_secondary_dark;
+    border-color: $brand_secondary_dark;
+    box-shadow: none;
+  }
 
   @media screen and (min-width: 1051px) {
     min-width: 111px;
@@ -628,6 +640,12 @@ button.blocklyLaunch {
   &#resetButton {
     border: 1px solid $brand_secondary_default;
     background-color: $brand_secondary_default;
+
+    &:hover {
+      background-color: $brand_secondary_dark;
+      border-color: $brand_secondary_dark;
+      box-shadow: none;
+    }
   }
 
   &.hideText {

--- a/apps/style/common.scss
+++ b/apps/style/common.scss
@@ -1276,15 +1276,16 @@ $workspace-header-button-margin: ($workspace-headers-height - $workspace-header-
     p {
       font-size: 14px;
       line-height: inherit;
-      color: $charcoal;
+      color: $neutral_dark;
       margin-bottom: 10px;
 
       a {
         font-family: $gotham-extra-bold;
         font-weight: normal;
-        color: $purple;
+        color: $brand_secondary_default;
+        text-decoration: underline;
         &:hover {
-          text-decoration: underline;
+          color: $brand_secondary_dark;
         }
       }
     }

--- a/apps/style/common.scss
+++ b/apps/style/common.scss
@@ -1090,9 +1090,6 @@ $workspace-header-button-margin: ($workspace-headers-height - $workspace-header-
     float: left;
     padding: 0 10px;
     cursor: pointer;
-    #show-toolbox-click-target:hover .fa {
-      color: $white;
-    }
 
     & > span {
       margin: auto auto auto 18px;

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -3032,6 +3032,10 @@ $modal-no-icon-gap: 22px;
   font-weight: normal;
 }
 
+h5.dialog-title {
+  font-size: 1.25em;
+}
+
 #ok-button {
   background-color: $orange;
   border: 1px solid $orange;


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

### [Phase 1.5]Update codeworkSpace, Js Debugger icons styling
Updating codeWorkspace, JS Debugger icons, buttons and modals styling

!!! Please note this PR will be merged into combind PR for [Phase 1.5 ](https://github.com/code-dot-org/code-dot-org/pull/50040)

Before:
<img width="1722" alt="Знімок екрана 2023-02-13 о 21 24 46" src="https://user-images.githubusercontent.com/22244040/218557396-6e200772-30ff-4d3e-bb14-863717e57029.png">
<img width="1680" alt="Знімок екрана 2023-02-13 о 21 30 49" src="https://user-images.githubusercontent.com/22244040/218557429-9237af92-8ce1-48eb-a6cc-7e166cc7d352.png">
<img width="1680" alt="Знімок екрана 2023-02-13 о 21 30 58" src="https://user-images.githubusercontent.com/22244040/218557503-eb2fb465-7387-4421-9abb-4d2f32c3c93f.png">
<img width="1680" alt="Знімок екрана 2023-02-13 о 21 31 09" src="https://user-images.githubusercontent.com/22244040/218557610-3636165f-cfb6-4c5a-90e6-8626a20be394.png">
<img width="1680" alt="Знімок екрана 2023-02-13 о 21 36 50" src="https://user-images.githubusercontent.com/22244040/218557697-4afeb7f1-52ae-4df6-af59-04fc8a061988.png">

After:
<img width="1680" alt="Знімок екрана 2023-02-13 о 21 53 39" src="https://user-images.githubusercontent.com/22244040/218561464-506298e9-5dad-4cc0-a02b-f5b59af1de96.png">
<img width="1680" alt="Знімок екрана 2023-02-13 о 21 54 23" src="https://user-images.githubusercontent.com/22244040/218561577-3ecc5137-b517-4671-8f5c-b478bfa0ffa8.png">
<img width="1680" alt="Знімок екрана 2023-02-13 о 21 54 33" src="https://user-images.githubusercontent.com/22244040/218561598-be128be7-6066-4fd5-9d02-5ebe15d633d0.png">
<img width="1680" alt="Знімок екрана 2023-02-13 о 21 54 43" src="https://user-images.githubusercontent.com/22244040/218561608-b3553970-bd9e-4c3e-b7ed-8c48ee695249.png">
<img width="1680" alt="image" src="https://user-images.githubusercontent.com/22244040/218561753-e5e0be91-9f32-4bd8-a2be-0774280b72aa.png">
<img width="1193" alt="Знімок екрана 2023-02-15 о 18 32 39" src="https://user-images.githubusercontent.com/22244040/219093110-f3d5d4ee-3e9f-4110-9906-258396982577.png">
<img width="1193" alt="Знімок екрана 2023-02-15 о 18 33 01" src="https://user-images.githubusercontent.com/22244040/219093132-9618ce49-6f6d-4cfd-bc2c-fc868a42c596.png">



## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
