### PR TITLE
[Google Blockly] Task: Reorganize CDO theme

### DIFF
--- a/apps/src/blockly/addons/cdoTheme.js
+++ b/apps/src/blockly/addons/cdoTheme.js
@@ -1,10 +1,5 @@
 import GoogleBlockly from 'blockly/core';
 
-export const cdoBlockStyles = {
-  ...coreBlocklyOverrides,
-  ...cdoCustomStyles
-};
-
 // Intentionally overriden styles from Google Blockly.
 // We do not override list, math, text, or variable blocks.
 const coreBlocklyOverrides = {
@@ -17,28 +12,6 @@ const coreBlocklyOverrides = {
   procedure_blocks: {
     colourPrimary: '#509918'
   }
-};
-
-// Standard CDO palette of block colors used across labs
-const cdoCustomStyles = {
-  default: {
-    colourPrimary: '#00b0bc'
-  },
-  comment_blocks: {
-    colourPrimary: '#b2b2b2'
-  },
-  event_blocks: {
-    colourPrimary: '#00bc3e'
-  },
-  setup_blocks: {
-    colourPrimary: '#fca400'
-  },
-  world_blocks: {
-    colourPrimary: '#5b5ba5'
-  },
-  ...spriteLabStyles,
-  ...danceStyles,
-  ...musicLabStyles
 };
 
 // Used for Sprite Lab (and all related level subtypes), and Dance.
@@ -69,6 +42,33 @@ const musicLabStyles = {
   music_blocks: {
     colourPrimary: '#5b67a5'
   }
+};
+
+// Standard CDO palette of block colors used across labs
+const cdoCustomStyles = {
+  default: {
+    colourPrimary: '#00b0bc'
+  },
+  comment_blocks: {
+    colourPrimary: '#b2b2b2'
+  },
+  event_blocks: {
+    colourPrimary: '#00bc3e'
+  },
+  setup_blocks: {
+    colourPrimary: '#fca400'
+  },
+  world_blocks: {
+    colourPrimary: '#5b5ba5'
+  },
+  ...spriteLabStyles,
+  ...danceStyles,
+  ...musicLabStyles
+};
+
+export const cdoBlockStyles = {
+  ...coreBlocklyOverrides,
+  ...cdoCustomStyles
 };
 
 export default GoogleBlockly.Theme.defineTheme('modern', {

--- a/apps/src/blockly/addons/cdoTheme.js
+++ b/apps/src/blockly/addons/cdoTheme.js
@@ -1,7 +1,13 @@
 import GoogleBlockly from 'blockly/core';
 
-// Intentionally override definition from core Blockly
-export const coreBlocklyOverrides = {
+export const cdoBlockStyles = {
+  ...coreBlocklyOverrides,
+  ...cdoCustomStyles
+};
+
+// Intentionally overriden styles from Google Blockly.
+// We do not override list, math, text, or variable blocks.
+const coreBlocklyOverrides = {
   colour_blocks: {
     colourPrimary: '#0093c9'
   },
@@ -13,24 +19,16 @@ export const coreBlocklyOverrides = {
   }
 };
 
-export const cdoCustomStyles = {
+// Standard CDO palette of block colors used across labs
+const cdoCustomStyles = {
   default: {
     colourPrimary: '#00b0bc'
   },
-  behavior_blocks: {
-    colourPrimary: '#20cc4e'
-  },
-  dance_blocks: {
-    colourPrimary: '#7435b2'
+  comment_blocks: {
+    colourPrimary: '#b2b2b2'
   },
   event_blocks: {
     colourPrimary: '#00bc3e'
-  },
-  music_blocks: {
-    colourPrimary: '#5b67a5'
-  },
-  sprite_blocks: {
-    colourPrimary: '#b2353f'
   },
   setup_blocks: {
     colourPrimary: '#fca400'
@@ -38,14 +36,39 @@ export const cdoCustomStyles = {
   world_blocks: {
     colourPrimary: '#5b5ba5'
   },
-  flow_blocks: {
-    colourPrimary: '#418eb6'
+  ...spriteLabStyles,
+  ...danceStyles,
+  ...musicLabStyles
+};
+
+// Used for Sprite Lab (and all related level subtypes), and Dance.
+const spriteLabStyles = {
+  behavior_blocks: {
+    colourPrimary: '#20cc4e'
+  },
+  location_blocks: {
+    colourPrimary: '#ead446'
+  },
+  sprite_blocks: {
+    colourPrimary: '#b2353f'
   }
 };
 
-export const cdoBlockStyles = {
-  ...coreBlocklyOverrides,
-  ...cdoCustomStyles
+// Used only for Dance Party
+const danceStyles = {
+  dance_blocks: {
+    colourPrimary: '#7435b2'
+  }
+};
+
+// Experimental MusicLab styles. Subject to change.
+const musicLabStyles = {
+  flow_blocks: {
+    colourPrimary: '#418eb6'
+  },
+  music_blocks: {
+    colourPrimary: '#5b67a5'
+  }
 };
 
 export default GoogleBlockly.Theme.defineTheme('modern', {


### PR DESCRIPTION
This is essentially a reorganizing/grouping of our standard theme's block color (styles). Changes:
* Pull out lab-specific style into separate objects to improve readability and institutional knowledge sharing
* Adds more Sprite Lab colors that will be need for later migration of that lab
* Better comments
* Only export `cdoBlockStyles` since this is the only thing we'll need for other themes. (Currently used in `musicLabDarkTheme`).

There are no visual differences caused by the changes in this PR.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
