### PR TITLE
Administrators page - update YouTube link

### DIFF
--- a/pegasus/sites.v3/code.org/public/administrators.haml
+++ b/pegasus/sites.v3/code.org/public/administrators.haml
@@ -41,9 +41,9 @@ theme: responsive_full_width
         %li Align with the education-to-workforce priorities of employers and policymakers
       %a{href: "#email-signup-form", class: "link-button"} Become a Code.org District Partner
     %div.col-45{style: "float:right; margin-top: 3px"}
-      %figure.video-responsive
+      %figure.video-responsive{style: "max-width: unset"}
         %div
-          %iframe{src: "https://www.youtube.com/embed/B8w9FHh6nUk", allowFullScreen: 'true', frameborder: '0'}
+          %iframe{src: "https://www.youtube-nocookie.com/embed/B8w9FHh6nUk", allowFullScreen: 'true', frameborder: '0'}
         %figcaption See what state leaders are saying about CS education.
     .clear
 


### PR DESCRIPTION
Update embedded YouTube video link to use `youtube-nocookie.com/embed` ([Slack convo ref](https://codedotorg.slack.com/archives/CFTFD6BPV/p1675289349124029))