### PR TITLE
Add new `StackSecrets` Designation

### DIFF
--- a/lib/cdo/secrets_config.rb
+++ b/lib/cdo/secrets_config.rb
@@ -14,13 +14,6 @@ module Cdo
       "#{prefix}/cdo/#{key}"
     end
 
-    # Generate path to a Secret that was provisioned for a specific CloudFormation Stack. This enables
-    # configuration settings to have different values for different deployments that have the same environment type.
-    def self.stack_specific_secret_path(key)
-      stack = AWS::CloudFormation.current_stack_name
-      stack ? "CfnStack/#{stack}/#{key}" : nil
-    end
-
     # Load a secrets-config hash from specified file.
     # @param filename [String]
     # @return [Hash<String, String|Hash>]
@@ -55,14 +48,54 @@ module Cdo
     private
 
     # Stores a reference to a secret so it can be resolved later.
-    Secret = Struct.new(:key) do
+    #
+    # Specifically, stores a reference to both the unique key which can
+    # identify the secret and a prefix which can identify which environment's
+    # secrets we should use.
+    Secret = Struct.new(:secret_prefix, :secret_key) do
+      def key
+        SecretsConfig.secret_path(secret_prefix, secret_key)
+      end
+
       def to_s
         "${#{key}}"
       end
+
+      # Resolve the secret referenced by this object.
+      def lookup(secrets_manager)
+        secrets_manager.get!(key)
+      end
     end
-    StackSecret = Struct.new(:key) do
-      def to_s
-        "${#{key}}"
+
+    class StackSecret < Secret
+      # Extend the default lookup functionality to support checking for
+      # stack-specific secrets, defaulting to the original functionality if
+      # none are found.
+      def lookup(secrets_manager)
+        # First try looking for a Stack-specific secret.
+        stack_specific_secret_path ? secrets_manager.get!(stack_specific_secret_path) : super
+      rescue Aws::SecretsManager::Errors::ValidationException
+        # We're likely executing in an environment that's not part of a
+        # CloudFormation Stack, so the secret name was invalid (nil). Fall back
+        # to looking up the environment type secret.
+        super
+      rescue Aws::SecretsManager::Errors::ResourceNotFoundException
+        # Fall back to looking up a secret shared by all deployments with the
+        # same environment-type ('development', 'test', 'production', etc.).
+        super
+      end
+
+      # Generate path to a Secret that was provisioned for a specific
+      # CloudFormation Stack. This enables configuration settings to have
+      # different values for different deployments that have the same
+      # environment type.
+      #
+      # Note that we use `secret_key` for this rather than `key`, since the
+      # latter is environment-specific and we want stack-specific overrides to
+      # apply to all environments.
+      def stack_specific_secret_path
+        @stack ||= AWS::CloudFormation.current_stack_name
+        @stack ? "CfnStack/#{@stack}/#{secret_key}" : nil
       end
     end
 
@@ -73,8 +106,9 @@ module Cdo
     # Processes `Secret` references in the provided config hash.
     def process_secrets!(config)
       return if config.nil?
-      config.select {|_, v| v.is_a?(Secret) || v.is_a?(StackSecret)}.each do |key, secret|
-        secret.key ||= SecretsConfig.secret_path(env, key)
+      config.select {|_, v| v.is_a?(Secret)}.each do |key, secret|
+        secret.secret_prefix ||= env
+        secret.secret_key ||= key
       end
     end
 
@@ -88,23 +122,8 @@ module Cdo
       table.select {|_k, v| v.to_s.match(SECRET_REGEX)}.each do |key, value|
         cdo_secrets.required(*value.to_s.scan(SECRET_REGEX).flatten)
         table[key] = Cdo.lazy do
-          case value
-          when StackSecret
-            begin
-              # First try looking for a Stack-specific secret.
-              stack_specific_secret_path = Cdo::SecretsConfig.stack_specific_secret_path(key)
-              stack_specific_secret_path ? cdo_secrets.get!(stack_specific_secret_path) : cdo_secrets.get!(value.key)
-            rescue Aws::SecretsManager::Errors::ValidationException
-              # We're likely executing in an environment that's not part of a CloudFormation Stack, so the secret name was
-              # invalid (nil). Fall back to looking up the environment type secret.
-              cdo_secrets.get!(value.key)
-            rescue Aws::SecretsManager::Errors::ResourceNotFoundException
-              # Fall back to looking up a secret shared by all deployments with the same environment-type
-              # ('development', 'test', 'production', etc.).
-              cdo_secrets.get!(value.key)
-            end
-          when Secret
-            cdo_secrets.get!(value.key)
+          if value.is_a?(Secret)
+            value.lookup(cdo_secrets)
           else
             # TODO: Do we need to modify this use case as well to get a stack specific secret?
             CDO.log.info "This weird code path was used for CDO configuration setting: #{key} / value: #{value}"
@@ -126,7 +145,7 @@ module Cdo
     # Any exceptions or defaults can be re-added later in the YAML document, after secrets have been cleared.
     def clear_secrets
       @secrets ||= []
-      @secrets |= table.select {|_, v| v.is_a?(Secret) || v.is_a?(StackSecret)}.keys.map(&:to_s)
+      @secrets |= table.select {|_, v| v.is_a?(Secret)}.keys.map(&:to_s)
       @secrets.product([nil]).to_h.to_yaml.sub(/^---.*\n/, '')
     end
   end

--- a/lib/test/cdo/test_secrets_config.rb
+++ b/lib/test/cdo/test_secrets_config.rb
@@ -10,6 +10,11 @@ class SecretsConfigTest < Minitest::Test
 
   def setup
     self.config = CdoSecrets.new
+    AWS::CloudFormation.stubs(:current_stack_name).returns('test')
+  end
+
+  def teardown
+    AWS::CloudFormation.unstub(:current_stack_name)
   end
 
   def test_load
@@ -26,6 +31,8 @@ class SecretsConfigTest < Minitest::Test
     config.freeze
   end
 
+  # Helper method which allows tests to easily mock a single secret being
+  # returned by all invocations
   def stub_secret(str)
     client = Aws::SecretsManager::Client.new(
       stub_responses: {
@@ -37,11 +44,53 @@ class SecretsConfigTest < Minitest::Test
     config.cdo_secrets = Cdo::Secrets.new(client: client)
   end
 
+  # Helper method which allows tests to pass a hash of (key,secret) pairs, so
+  # that specific secrets can be returned on specific invocations
+  def stub_multiple_secrets(secret_strings)
+    client = Aws::SecretsManager::Client.new(
+      stub_responses: {
+        get_secret_value: ->(context) do
+          secret_id = context.params[:secret_id]
+          return 'ResourceNotFoundException' unless secret_strings.key?(secret_id)
+          {secret_string: secret_strings[secret_id]}
+        end
+      }
+    )
+    config.cdo_secrets = Cdo::Secrets.new(client: client)
+  end
+
   def test_secret_tag
     stub_secret 'bar!'
     load_configuration <<~YAML
       foo: foo!
       bar: !Secret
+    YAML
+    assert_equal 'foo!', config.foo
+    assert_equal 'bar!', config.bar
+  end
+
+  def test_stack_secret_tag
+    test_secrets = {
+      "/cdo/foo" => "default foo secret",
+      "CfnStack/test/foo" => "stack-specific foo secret (not used)",
+      "/cdo/bar" => "default bar secret (not used)",
+      "CfnStack/test/bar" => "stack-specific bar secret"
+    }
+    stub_multiple_secrets(test_secrets)
+
+    load_configuration <<~YAML
+      foo: !Secret
+      bar: !StackSecret
+    YAML
+    assert_equal 'default foo secret', config.foo
+    assert_equal 'stack-specific bar secret', config.bar
+  end
+
+  def test_stack_secret_tag_falls_back_to_regular_secret
+    stub_secret 'bar!'
+    load_configuration <<~YAML
+      foo: foo!
+      bar: !StackSecret
     YAML
     assert_equal 'foo!', config.foo
     assert_equal 'bar!', config.bar


### PR DESCRIPTION
And split up the existing WIP implementation of stack-aware secrets to make a distinction between secrets that actually want to implement the extra checks required for that awareness and secrets that we want to be exclusively environment-specific and not stack-specific.

I implement this by expanding the minimal `Secrets` class which formerly existed just to encapsulate the secret key values into a functional component which can also own the implementation of the (now much more complex) logic to actually retrieve the secrets. Also update the way that class stores secret key data internally; rather than being initialized with a key which combines both secret and environment data, it's initialized with those two datum directly, and will combine the key where appropriate and use the underlying values directly when necessary.

## Testing story

Add a couple basic unit tests to cover the new functionality.

## Deployment strategy

Note that this PR has been opened not against staging, but against the feature branch https://github.com/code-dot-org/code-dot-org/pull/48809, so deployment will be handled by that feature branch once this one has been merged in.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
