### PR TITLE
[App Lab][Micro:Bit] Add accelerometer as predefined value

### DIFF
--- a/apps/src/lib/kits/maker/boards/microBit/MicroBitConstants.js
+++ b/apps/src/lib/kits/maker/boards/microBit/MicroBitConstants.js
@@ -33,6 +33,7 @@ export const MB_COMPONENTS = [
 
 export const MB_BUTTON_VARS = ['buttonA', 'buttonB'];
 export const MB_SENSOR_VARS = ['lightSensor', 'tempSensor'];
+export const MB_ACCELEROMETER = 'accelerometer';
 
 // milliseconds between samples for sensors
 export const SAMPLE_INTERVAL = 50;

--- a/apps/src/lib/kits/maker/boards/microBit/MicroBitConstants.js
+++ b/apps/src/lib/kits/maker/boards/microBit/MicroBitConstants.js
@@ -33,7 +33,7 @@ export const MB_COMPONENTS = [
 
 export const MB_BUTTON_VARS = ['buttonA', 'buttonB'];
 export const MB_SENSOR_VARS = ['lightSensor', 'tempSensor'];
-export const MB_ACCELEROMETER = 'accelerometer';
+export const MB_ACCELEROMETER_VAR = 'accelerometer';
 
 // milliseconds between samples for sensors
 export const SAMPLE_INTERVAL = 50;

--- a/apps/src/lib/kits/maker/dropletConfig.js
+++ b/apps/src/lib/kits/maker/dropletConfig.js
@@ -13,7 +13,7 @@ import {
 import {
   MB_BUTTON_VARS,
   MB_SENSOR_VARS,
-  MB_ACCELEROMETER,
+  MB_ACCELEROMETER_VAR,
   MB_COMPONENT_EVENTS
 } from './boards/microBit/MicroBitConstants';
 
@@ -592,7 +592,7 @@ export let configMicrobit = {
   additionalPredefValues: [
     ...MB_BUTTON_VARS,
     ...MB_SENSOR_VARS,
-    MB_ACCELEROMETER
+    MB_ACCELEROMETER_VAR
   ]
 };
 

--- a/apps/src/lib/kits/maker/dropletConfig.js
+++ b/apps/src/lib/kits/maker/dropletConfig.js
@@ -13,6 +13,7 @@ import {
 import {
   MB_BUTTON_VARS,
   MB_SENSOR_VARS,
+  MB_ACCELEROMETER,
   MB_COMPONENT_EVENTS
 } from './boards/microBit/MicroBitConstants';
 
@@ -588,7 +589,11 @@ export let configMicrobit = {
     }
   },
   blocks: [...getMakerBlocks(MICROBIT_CATEGORY), ...microBitBlocks],
-  additionalPredefValues: [...MB_BUTTON_VARS, ...MB_SENSOR_VARS]
+  additionalPredefValues: [
+    ...MB_BUTTON_VARS,
+    ...MB_SENSOR_VARS,
+    MB_ACCELEROMETER
+  ]
 };
 
 export let configCircuitPlayground = {


### PR DESCRIPTION
This PR removes the warning displayed when `accelerometer` is selected in `onBoardEvent` by adding it to the list of predefined values.

Before:
![image (5) (1)](https://user-images.githubusercontent.com/107423305/218600277-d21254e7-b8a9-4b2e-b2f6-1f56bf422ab1.png)


After:

<img width="694" alt="Screen Shot 2023-02-13 at 5 53 18 PM" src="https://user-images.githubusercontent.com/107423305/218600835-f4263f7e-ea69-4c0b-8e00-a4376e700944.png">

## Links
[jira ticket](https://codedotorg.atlassian.net/browse/SL-562)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
