### PR TITLE
Administrators page hidden section fix

### DIFF
--- a/pegasus/sites.v3/code.org/public/administrators.haml
+++ b/pegasus/sites.v3/code.org/public/administrators.haml
@@ -18,7 +18,7 @@ theme: responsive_full_width
 - icon_smile = "fa-solid fa-smile"
 - icon_money_check_dollar_pen = "fa-solid fa-money-check-dollar-pen"
 
-%section.hero-banner-basic.bg-neutral-dark
+%section.hero-banner-basic.bg-neutral-dark{style: "display: block !important"}
   .wrapper
     .text-wrapper.col-60
       %h1{style: "color: white"} Code.org District Partner Program
@@ -27,7 +27,7 @@ theme: responsive_full_width
     .clear
     %img{src: "shared/images/banners/admins-hero-students-at-computers.png", alt: ""}
 
-%section.bg-neutral-light
+%section.bg-neutral-light{style: "display: block !important"}
   .wrapper
     %h2 Code.org District Partner Program
     %p As AI and emerging technologies transform nearly every aspect of our lives, Code.org is leading a movement to ensure that K-12 students are equipped to adapt to the realities of a rapidly evolving knowledge economy. For more than a decade, Code.org has partnered with educators to advocate for not just policy change, but the resources necessary to expand access to high quality computer science (CS) curriculum and professional learning experiences.
@@ -47,7 +47,7 @@ theme: responsive_full_width
         %figcaption See what state leaders are saying about CS education.
     .clear
 
-%section
+%section{style: "display: block !important"}
   .wrapper
     %h2 Program Benefits
     %ul.icon-bullet-list
@@ -102,7 +102,7 @@ theme: responsive_full_width
     %div.centered
       %a{href: '#email-signup-form', class: 'link-button'} Become a Code.org District Partner
 
-%section.bg-neutral-light
+%section.bg-neutral-light{style: "display: block !important"}
   .wrapper
     %h2 How does the District Partner Program work?
     %ol.steps-list
@@ -134,18 +134,18 @@ theme: responsive_full_width
     %div.centered
       %a{href: '#email-signup-form', class: 'link-button'} Become a Code.org District Partner
 
-%section.bg-primary
+%section.bg-primary{style: "display: block !important"}
   .wrapper
     %p.callout.no-margin-bottom Want to see how your district stacks up for computer science offerings? Check out the <a href="/yourschool">CS Access Report</a>!
 
 %a{id: 'email-signup-form'}
-%section
+%section{style: "display: block !important"}
   .wrapper
     %h2 Take the next step!
     %p If you are interested in becoming a district partner or have questions about the partnership, fill out the form below and a member of the Code.org team will be in touch.
     = view :admins_email_signup_form
 
-%section
+%section{style: "display: block !important"}
   .wrapper
     %h2 Frequently Asked Questions
     %details
@@ -177,7 +177,7 @@ theme: responsive_full_width
       %summary How do I or my counselors recruit students to take the class?
       %p We have a number of suggestions and materials for encouraging students to take computer science. Find them all at <a href="/educate/resources/recruit">code.org/recruit</a>.
 
-%section
+%section{style: "display: block !important"}
   .wrapper
     %h2 Additional Resources
     .action-block__wrapper.action-block__wrapper--two-col


### PR DESCRIPTION
A bug in the Opentrust CSS is hiding the 6th child section in a div — this fixes the issue for launch. ([Slack context](https://codedotorg.slack.com/archives/C0T0PNTM3/p1676325926350359))