### PR TITLE
Add the POST /abuse/delete endpoint back

### DIFF
--- a/dashboard/app/controllers/report_abuse_controller.rb
+++ b/dashboard/app/controllers/report_abuse_controller.rb
@@ -108,6 +108,7 @@ class ReportAbuseController < ApplicationController
   end
 
   # DELETE /v3/channels/:channel_id/abuse
+  # POST /v3/channels/:channel_id/abuse/delete
   # Clear an abuse score. Requires project_validator permission
   def reset_abuse
     return head :unauthorized unless can?(:destroy_abuse, nil)

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -1020,6 +1020,7 @@ Dashboard::Application.routes.draw do
     # partial ports of legacy v3 APIs
     get '/v3/channels/:channel_id/abuse', to: 'report_abuse#show_abuse'
     delete '/v3/channels/:channel_id/abuse', to: 'report_abuse#reset_abuse'
+    post '/v3/channels/:channel_id/abuse/delete', to: 'report_abuse#reset_abuse'
     patch '/v3/(:endpoint)/:encrypted_channel_id', constraints: {endpoint: /(animations|assets|sources|files|libraries)/}, to: 'report_abuse#update_file_abuse'
 
     # offline-service-worker*.js needs to be loaded the the root level of the


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Apparently the [javascript](https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/code-studio/initApp/clientApi.js#L82-L87) POSTs to `/delete` instead of using the `DELETE` route. I left the `DELETE` route in, in case we want to deprecate the `POST` and update this at some point, and on the off chance the `DELETE` route is used elsewhere.

## Links

Slack: https://codedotorg.slack.com/archives/C0T0PNTM3/p1676385978048829?thread_ts=1676383818.168809&cid=C0T0PNTM3

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

Manually tested locally:

![image](https://user-images.githubusercontent.com/1382374/218779352-eabc0827-d6ac-4e3d-b8f5-4020cc9d6767.png)

