### PR TITLE
SL-478: Catch filesystem error separately and display recommendations

### DIFF
--- a/apps/src/templates/verificationPages/WebLabNetworkCheck.jsx
+++ b/apps/src/templates/verificationPages/WebLabNetworkCheck.jsx
@@ -1,6 +1,10 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
-import {BRAMBLE_READY_STATE, FILE_SYSTEM_ERROR} from '../../weblab/constants';
+import {
+  BRAMBLE_READY_STATE,
+  FILE_SYSTEM_ERROR,
+  SUPPORT_ARTICLE_URL
+} from '../../weblab/constants';
 import ValidationStep, {Status} from '../../lib/ui/ValidationStep';
 import testImageAccess from '../../code-studio/url_test';
 
@@ -174,9 +178,9 @@ class WebLabNetworkCheck extends Component {
         </li>,
         <li key="reset-indexed-db">
           Web Lab depends on a browser feature called the IndexedDB API.
-          Occasionally this feature gets "stuck" and must be reset. We've added
-          a button to the Web Lab error dialog that reads "Reset Web Lab." Try
-          performing this reset and then reloading the page.
+          Occasionally this feature gets "stuck" and must be reset. Try loading
+          a Web Lab level, and if you see an error dialog, click the button that
+          says "Reset Web Lab."
         </li>
       );
     }
@@ -212,10 +216,8 @@ class WebLabNetworkCheck extends Component {
           )}
           <p>
             For more troubleshooting information, see our support article on{' '}
-            <a href="https://support.code.org/hc/en-us/articles/360016804871-Troubleshooting-Web-Lab-problems">
-              Troubleshooting Web Lab problems
-            </a>
-            . You may also contact our Support Team (
+            <a href={SUPPORT_ARTICLE_URL}>Troubleshooting Web Lab problems</a>.
+            You may also contact our Support Team (
             <a href="mailto:support@code.org">support@code.org</a>) for further
             assistance.
           </p>

--- a/apps/src/weblab/brambleHost.js
+++ b/apps/src/weblab/brambleHost.js
@@ -10,6 +10,9 @@ const brambleConfig = JSON.parse(scriptData.dataset.bramble);
 const BRAMBLE_BASE_URL = brambleConfig.baseUrl;
 window.requirejs.config({baseUrl: BRAMBLE_BASE_URL});
 
+const FILE_SYSTEM_ERROR = 'EFILESYSTEMERROR';
+const BRAMBLE_READY_STATE = 'bramble:readyToMount';
+
 // Get the WebLab object from our parent window
 let webLab_;
 if (parent.getWebLab) {
@@ -47,12 +50,21 @@ function loadMinimal(Bramble) {
   Bramble.on('readyStateChange', (_, newState) => {
     if (Bramble.MOUNTABLE === newState) {
       window.parent.postMessage(
-        JSON.stringify({type: 'bramble:readyToMount'}),
+        JSON.stringify({msg: BRAMBLE_READY_STATE}),
         brambleConfig.studioUrl
       );
     }
   });
-  Bramble.on('error', console.log);
+
+  Bramble.on('error', err => {
+    if (err.code === FILE_SYSTEM_ERROR) {
+      window.parent.postMessage(
+        JSON.stringify({msg: FILE_SYSTEM_ERROR}),
+        brambleConfig.studioUrl
+      );
+    }
+    console.log(err);
+  });
 }
 
 // Load bramble.js

--- a/apps/src/weblab/brambleHost.js
+++ b/apps/src/weblab/brambleHost.js
@@ -1,17 +1,14 @@
 /* global requirejs */
 import CdoBramble, {BRAMBLE_CONTAINER} from './CdoBramble';
+import {FILE_SYSTEM_ERROR, BRAMBLE_READY_STATE} from './constants';
 
 /**
  * JS to communicate between Bramble and Code Studio
  */
-
 const scriptData = document.querySelector('script[data-bramble]');
 const brambleConfig = JSON.parse(scriptData.dataset.bramble);
 const BRAMBLE_BASE_URL = brambleConfig.baseUrl;
 window.requirejs.config({baseUrl: BRAMBLE_BASE_URL});
-
-const FILE_SYSTEM_ERROR = 'EFILESYSTEMERROR';
-const BRAMBLE_READY_STATE = 'bramble:readyToMount';
 
 // Get the WebLab object from our parent window
 let webLab_;

--- a/apps/src/weblab/constants.js
+++ b/apps/src/weblab/constants.js
@@ -8,3 +8,6 @@ export const FatalErrorType = makeEnum(
   'LoadFailure',
   'ResetFailure'
 );
+
+export const FILE_SYSTEM_ERROR = 'EFILESYSTEMERROR';
+export const BRAMBLE_READY_STATE = 'bramble:readyToMount';


### PR DESCRIPTION
The following PR addresses https://codedotorg.atlassian.net/browse/SL-478, which was to "add browser filesystem test to Web Lab test page." When I started this ticket, I imagined a scenario in which we checked:
1. That the domains were accessible
2. That Bramble could be mountable
3. That we could load a project with files

But in reality, when Bramble throws an error (`err.code === FILE_SYSTEM_ERROR`) related to the filesystem _before_ it reaches a mountable state, and not having access to the file system is one of the main things that would keep it from reaching a mountable state.

So instead, I haven't changed the number of tests on this page. We still check that
1. The domains are accessible and 
2. That Bramble is mountable

But I "handle" the filesystem error by displaying personalized recommendations for troubleshooting if Bramble doesn't reach a mountable state because it threw a `FILE_SYSTEM_ERROR`.

Two of the things I'm most looking for feedback on in this PR are
- whether that approach seems reasonable, and
- whether the language for the personalized troubleshooting recommendations (visible in screenshots below and the diff) makes sense.

## Links

Jira ticket: https://codedotorg.atlassian.net/browse/SL-478

## Testing story

**When there's a file system error, the user sees recommendations specific to that error.**

<img width="1033" alt="Screen Shot 2023-02-13 at 4 23 29 PM" src="https://user-images.githubusercontent.com/26844240/218868589-0ab24bb4-e09f-4246-bc38-99d70553c852.png">

**When Bramble fails to load for another (unspecified) reason, we give a generic troubleshooting recommendation.**

<img width="939" alt="Screen Shot 2023-02-14 at 1 43 02 PM" src="https://user-images.githubusercontent.com/26844240/218869875-a1a10f28-6dae-4c7e-b455-8bbc3a72c4ca.png">

**Domain access failures now come with their own specific recommendations that will get added to a list with any other recommendations.**

<img width="967" alt="Screen Shot 2023-02-14 at 10 18 45 AM" src="https://user-images.githubusercontent.com/26844240/218868619-f0e06cfa-b1cf-4c77-af0d-ec019245f870.png">

**The success case still looks the same.**

<img width="953" alt="Screen Shot 2023-02-14 at 10 20 19 AM" src="https://user-images.githubusercontent.com/26844240/218868560-3de1c381-f682-4428-ae11-8b3cf4d0a202.png">


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
