### PR TITLE
Add Amplitude event log error handling for empty event names

### DIFF
--- a/apps/src/lib/util/AnalyticsReporter.js
+++ b/apps/src/lib/util/AnalyticsReporter.js
@@ -51,7 +51,7 @@ class AnalyticsReporter {
     if (this.shouldPutRecord(ALWAYS_SEND)) {
       if (!eventName) {
         logToCloud.addPageAction(
-          logToCloud.PageAction.NoValidEventNameLogError,
+          logToCloud.PageAction.NoValidAmplitudeEventNameError,
           {
             payload: payload
           }

--- a/apps/src/lib/util/AnalyticsReporter.js
+++ b/apps/src/lib/util/AnalyticsReporter.js
@@ -6,6 +6,7 @@ import {
   setUserId
 } from '@amplitude/analytics-browser';
 import {currentLocation} from '@cdo/apps/utils';
+import logToCloud from '@cdo/apps/logToCloud';
 
 // A flag that can be toggled to send events regardless of environment
 const ALWAYS_SEND = false;
@@ -48,7 +49,16 @@ class AnalyticsReporter {
 
   sendEvent(eventName, payload) {
     if (this.shouldPutRecord(ALWAYS_SEND)) {
-      track(eventName, payload);
+      if (!eventName) {
+        logToCloud.addPageAction(
+          logToCloud.PageAction.NoValidEventNameLogError,
+          {
+            payload: payload
+          }
+        );
+      } else {
+        track(eventName, payload);
+      }
     } else {
       this.log(`${eventName}. Payload: ${JSON.stringify({payload})}`);
     }

--- a/apps/src/lib/util/AnalyticsReporter.js
+++ b/apps/src/lib/util/AnalyticsReporter.js
@@ -56,7 +56,7 @@ class AnalyticsReporter {
             payload: payload
           }
         );
-        track('EMPTY_EVENT_NAME_ENTERED_ERROR', payload);
+        track('NO_VALID_EVENT_NAME_LOG_ERROR', payload);
       } else {
         track(eventName, payload);
       }

--- a/apps/src/lib/util/AnalyticsReporter.js
+++ b/apps/src/lib/util/AnalyticsReporter.js
@@ -56,6 +56,7 @@ class AnalyticsReporter {
             payload: payload
           }
         );
+        track('EMPTY_EVENT_NAME_ENTERED_ERROR', payload);
       } else {
         track(eventName, payload);
       }

--- a/apps/src/logToCloud.js
+++ b/apps/src/logToCloud.js
@@ -22,7 +22,7 @@ const PageAction = makeEnum(
   'LoadScriptProgressFinished',
   'SectionProgressRenderedWithData',
   'JavabuilderWebSocketConnectionError',
-  'NoValidEventNameLogError'
+  'NoValidAmplitudeEventNameError'
 );
 
 const MAX_FIELD_LENGTH = 4095;

--- a/apps/src/logToCloud.js
+++ b/apps/src/logToCloud.js
@@ -21,7 +21,8 @@ const PageAction = makeEnum(
   'LoadScriptProgressStarted',
   'LoadScriptProgressFinished',
   'SectionProgressRenderedWithData',
-  'JavabuilderWebSocketConnectionError'
+  'JavabuilderWebSocketConnectionError',
+  'NoValidEventNameLogError'
 );
 
 const MAX_FIELD_LENGTH = 4095;


### PR DESCRIPTION
This PR adds error handling in the case of an empty Amplitude event name (if an invalid but not empty event name is passed in, that will still show up in our Amplitude dashboard, it will just be flagged as "unexpected," so the issue is focused on an empty name). In this case, this PR logs an error to NewRelic (including the event's payload which should help narrow down the issue should one come up) and to Amplitude (so it will be clear we should check NewRelic for more details).

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/browse/ACQ-406?atlOrigin=eyJpIjoiYjE5NTNkZTI0N2IzNDI2Y2FhMDQyZThiNzA1ZjA3MWMiLCJwIjoiaiJ9)

## Testing story
As per [this PR](https://github.com/code-dot-org/code-dot-org/pull/47753), "there doesn't seem to be a straightforward way to test publishing New Relic metrics locally or from an adhoc. Comments in the apps/ new relic API seem to suggest that we only publish metrics in production." In simulating giving the analaytics reporter an event with an empty name, this is what appears in the addPageAction call:

![sample_json](https://user-images.githubusercontent.com/56283563/218849655-d590ba18-3934-4cc9-bc66-74dc8c83e2b4.JPG)

Sample Amplitude output for when I set up an event with no name that triggers when I try to sign-up as a teacher:
![Capture](https://user-images.githubusercontent.com/56283563/218880775-6d7c18c2-77f2-4b4b-8cc1-6ca791956f69.JPG)

## Follow-up work
Since this would only log when there's an issue, once this is confirmed working it could be nice to get a slack notification when this error fires.

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
