### PR TITLE
Serialize new course_offerings fields

### DIFF
--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -167,7 +167,11 @@ class CourseOffering < ApplicationRecord
       display_name: display_name,
       category: category,
       is_featured: is_featured,
-      assignable: assignable?
+      assignable: assignable?,
+      curriculum_type: curriculum_type,
+      marketing_initiative: marketing_initiative,
+      grade_levels: grade_levels,
+      header: header
     }
   end
 

--- a/dashboard/config/course_offerings/20-hour.json
+++ b/dashboard/config/course_offerings/20-hour.json
@@ -3,5 +3,9 @@
   "display_name": "Accelerated Intro to CS Course",
   "category": "twenty_hour",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/2018hoc-ab.json
+++ b/dashboard/config/course_offerings/2018hoc-ab.json
@@ -3,5 +3,9 @@
   "display_name": "2018hoc-ab",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/2021-cs-discoveries-deeper-learning-.json
+++ b/dashboard/config/course_offerings/2021-cs-discoveries-deeper-learning-.json
@@ -3,5 +3,9 @@
   "display_name": "2021-cs-discoveries-deeper-learning-",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/2021-cs-principles-deeper-learning.json
+++ b/dashboard/config/course_offerings/2021-cs-principles-deeper-learning.json
@@ -3,5 +3,9 @@
   "display_name": "2021-cs-principles-deeper-learning",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/2021drafting-1.json
+++ b/dashboard/config/course_offerings/2021drafting-1.json
@@ -3,5 +3,9 @@
   "display_name": "2021drafting-1",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/2021drafting.json
+++ b/dashboard/config/course_offerings/2021drafting.json
@@ -3,5 +3,9 @@
   "display_name": "Planning script for CI and CSF 2021",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/ai-classroom-test.json
+++ b/dashboard/config/course_offerings/ai-classroom-test.json
@@ -3,5 +3,9 @@
   "display_name": "ai-classroom-test",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/ai-ethics.json
+++ b/dashboard/config/course_offerings/ai-ethics.json
@@ -3,5 +3,9 @@
   "display_name": "AI Ethics Activity",
   "category": "csc",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/ai-lab.json
+++ b/dashboard/config/course_offerings/ai-lab.json
@@ -3,5 +3,9 @@
   "display_name": "ai-lab",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/ai-unit-pilot.json
+++ b/dashboard/config/course_offerings/ai-unit-pilot.json
@@ -3,5 +3,9 @@
   "display_name": "ai-unit-pilot",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/aiml.json
+++ b/dashboard/config/course_offerings/aiml.json
@@ -3,5 +3,9 @@
   "display_name": "AI and Machine Learning Module",
   "category": "aiml",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/algebra.json
+++ b/dashboard/config/course_offerings/algebra.json
@@ -3,5 +3,9 @@
   "display_name": "Computer Science in Algebra",
   "category": "math",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/algebraa.json
+++ b/dashboard/config/course_offerings/algebraa.json
@@ -3,5 +3,9 @@
   "display_name": "Computer Science in Algebra: Course A",
   "category": "math",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/algebrab.json
+++ b/dashboard/config/course_offerings/algebrab.json
@@ -3,5 +3,9 @@
   "display_name": "Computer Science in Algebra: Course B",
   "category": "math",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/algebrademo.json
+++ b/dashboard/config/course_offerings/algebrademo.json
@@ -3,5 +3,9 @@
   "display_name": "algebrademo",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/all-the-plc-things.json
+++ b/dashboard/config/course_offerings/all-the-plc-things.json
@@ -3,5 +3,9 @@
   "display_name": "all-the-plc-things",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/alltheblocklythings.json
+++ b/dashboard/config/course_offerings/alltheblocklythings.json
@@ -3,5 +3,9 @@
   "display_name": "alltheblocklythings",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/alltheselfpacedplthings.json
+++ b/dashboard/config/course_offerings/alltheselfpacedplthings.json
@@ -3,5 +3,9 @@
   "display_name": "All the Self Paced PL Things",
   "category": "pl_other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/allthesurveys.json
+++ b/dashboard/config/course_offerings/allthesurveys.json
@@ -3,5 +3,9 @@
   "display_name": "allthesurveys",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/allthethingscourse.json
+++ b/dashboard/config/course_offerings/allthethingscourse.json
@@ -3,5 +3,9 @@
   "display_name": "allthethingscourse",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/allthettsthings.json
+++ b/dashboard/config/course_offerings/allthettsthings.json
@@ -3,5 +3,9 @@
   "display_name": "allthettsthings",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/allthevalidation.json
+++ b/dashboard/config/course_offerings/allthevalidation.json
@@ -3,5 +3,9 @@
   "display_name": "allthevalidation",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/amy-playground.json
+++ b/dashboard/config/course_offerings/amy-playground.json
@@ -3,5 +3,9 @@
   "display_name": "amy-playground",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/amys-playground.json
+++ b/dashboard/config/course_offerings/amys-playground.json
@@ -3,5 +3,9 @@
   "display_name": "amys-playground",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/andrea-test-dlp.json
+++ b/dashboard/config/course_offerings/andrea-test-dlp.json
@@ -3,5 +3,9 @@
   "display_name": "andrea-test-dlp",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/andrea-test.json
+++ b/dashboard/config/course_offerings/andrea-test.json
@@ -3,5 +3,9 @@
   "display_name": "andrea-test",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/angelina-playground.json
+++ b/dashboard/config/course_offerings/angelina-playground.json
@@ -3,5 +3,9 @@
   "display_name": "angelina-playground",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/applab-1hour.json
+++ b/dashboard/config/course_offerings/applab-1hour.json
@@ -3,5 +3,9 @@
   "display_name": "applab-1hour",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/applab-2hour.json
+++ b/dashboard/config/course_offerings/applab-2hour.json
@@ -3,5 +3,9 @@
   "display_name": "applab-2hour",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/applab-intro-staging.json
+++ b/dashboard/config/course_offerings/applab-intro-staging.json
@@ -3,5 +3,9 @@
   "display_name": "applab-intro-staging",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/applab-intro.json
+++ b/dashboard/config/course_offerings/applab-intro.json
@@ -3,5 +3,9 @@
   "display_name": "Intro to App Lab",
   "category": "hoc",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/apps-for-good.json
+++ b/dashboard/config/course_offerings/apps-for-good.json
@@ -3,5 +3,9 @@
   "display_name": "apps-for-good",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/aquatic.json
+++ b/dashboard/config/course_offerings/aquatic.json
@@ -3,5 +3,9 @@
   "display_name": "Minecraft: Voyage Aquatic",
   "category": "hoc",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/artist-and-bb8.json
+++ b/dashboard/config/course_offerings/artist-and-bb8.json
@@ -3,5 +3,9 @@
   "display_name": "artist-and-bb8",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/artist.json
+++ b/dashboard/config/course_offerings/artist.json
@@ -3,5 +3,9 @@
   "display_name": "Artist",
   "category": "hoc",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/artistexemplar.json
+++ b/dashboard/config/course_offerings/artistexemplar.json
@@ -3,5 +3,9 @@
   "display_name": "artistexemplar",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/asunplugged.json
+++ b/dashboard/config/course_offerings/asunplugged.json
@@ -3,5 +3,9 @@
   "display_name": "asunplugged",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/aws-demo.json
+++ b/dashboard/config/course_offerings/aws-demo.json
@@ -3,5 +3,9 @@
   "display_name": "aws-demo",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/basketball.json
+++ b/dashboard/config/course_offerings/basketball.json
@@ -3,5 +3,9 @@
   "display_name": "Choose your team and make a basketball game",
   "category": "hoc",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/code-break-staging.json
+++ b/dashboard/config/course_offerings/code-break-staging.json
@@ -3,5 +3,9 @@
   "display_name": "code-break-staging",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/code-break-younger-staging.json
+++ b/dashboard/config/course_offerings/code-break-younger-staging.json
@@ -3,5 +3,9 @@
   "display_name": "code-break-younger-staging",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/code-break-younger.json
+++ b/dashboard/config/course_offerings/code-break-younger.json
@@ -3,5 +3,9 @@
   "display_name": "Code Break for Younger Students",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/code-break.json
+++ b/dashboard/config/course_offerings/code-break.json
@@ -3,5 +3,9 @@
   "display_name": "Code Break",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/codestudiopuzzlechallenge.json
+++ b/dashboard/config/course_offerings/codestudiopuzzlechallenge.json
@@ -3,5 +3,9 @@
   "display_name": "codestudiopuzzlechallenge",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/colehoc17.json
+++ b/dashboard/config/course_offerings/colehoc17.json
@@ -3,5 +3,9 @@
   "display_name": "colehoc17",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/colehoc2017.json
+++ b/dashboard/config/course_offerings/colehoc2017.json
@@ -3,5 +3,9 @@
   "display_name": "colehoc2017",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/contagion-guided-practice-1.json
+++ b/dashboard/config/course_offerings/contagion-guided-practice-1.json
@@ -3,5 +3,9 @@
   "display_name": "contagion-guided-practice-1",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/contagion-guided-practice.json
+++ b/dashboard/config/course_offerings/contagion-guided-practice.json
@@ -3,5 +3,9 @@
   "display_name": "Contagion Guided Practice [Teacher only]",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/contagion-pilot-1.json
+++ b/dashboard/config/course_offerings/contagion-pilot-1.json
@@ -3,5 +3,9 @@
   "display_name": "contagion-pilot-1",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/contagion-pilot.json
+++ b/dashboard/config/course_offerings/contagion-pilot.json
@@ -3,5 +3,9 @@
   "display_name": "Contagion Simulator",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/counting-csc.json
+++ b/dashboard/config/course_offerings/counting-csc.json
@@ -3,5 +3,9 @@
   "display_name": "Counting Activity",
   "category": "csc",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/course-e-2018.json
+++ b/dashboard/config/course_offerings/course-e-2018.json
@@ -3,5 +3,9 @@
   "display_name": "course-e-2018",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/course-f-2018.json
+++ b/dashboard/config/course_offerings/course-f-2018.json
@@ -3,5 +3,9 @@
   "display_name": "course-f-2018",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/course1.json
+++ b/dashboard/config/course_offerings/course1.json
@@ -3,5 +3,9 @@
   "display_name": "Course 1",
   "category": "csf_international",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/course2.json
+++ b/dashboard/config/course_offerings/course2.json
@@ -3,5 +3,9 @@
   "display_name": "Course 2",
   "category": "csf_international",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/course3.json
+++ b/dashboard/config/course_offerings/course3.json
@@ -3,5 +3,9 @@
   "display_name": "Course 3",
   "category": "csf_international",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/course4.json
+++ b/dashboard/config/course_offerings/course4.json
@@ -3,5 +3,9 @@
   "display_name": "Course 4",
   "category": "csf_international",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/course4pre.json
+++ b/dashboard/config/course_offerings/course4pre.json
@@ -3,5 +3,9 @@
   "display_name": "course4pre",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/coursea-draft.json
+++ b/dashboard/config/course_offerings/coursea-draft.json
@@ -3,5 +3,9 @@
   "display_name": "coursea-draft",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/coursea.json
+++ b/dashboard/config/course_offerings/coursea.json
@@ -3,5 +3,9 @@
   "display_name": "Course A",
   "category": "csf",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/courseb-draft.json
+++ b/dashboard/config/course_offerings/courseb-draft.json
@@ -3,5 +3,9 @@
   "display_name": "courseb-draft",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/courseb.json
+++ b/dashboard/config/course_offerings/courseb.json
@@ -3,5 +3,9 @@
   "display_name": "Course B",
   "category": "csf",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/coursec-draft.json
+++ b/dashboard/config/course_offerings/coursec-draft.json
@@ -3,5 +3,9 @@
   "display_name": "coursec-draft",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/coursec.json
+++ b/dashboard/config/course_offerings/coursec.json
@@ -3,5 +3,9 @@
   "display_name": "Course C",
   "category": "csf",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/coursed-draft.json
+++ b/dashboard/config/course_offerings/coursed-draft.json
@@ -3,5 +3,9 @@
   "display_name": "coursed-draft",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/coursed-ramp.json
+++ b/dashboard/config/course_offerings/coursed-ramp.json
@@ -3,5 +3,9 @@
   "display_name": "coursed-ramp",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/coursed.json
+++ b/dashboard/config/course_offerings/coursed.json
@@ -3,5 +3,9 @@
   "display_name": "Course D",
   "category": "csf",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/coursee-draft.json
+++ b/dashboard/config/course_offerings/coursee-draft.json
@@ -3,5 +3,9 @@
   "display_name": "coursee-draft",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/coursee-ramp.json
+++ b/dashboard/config/course_offerings/coursee-ramp.json
@@ -3,5 +3,9 @@
   "display_name": "coursee-ramp",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/coursee.json
+++ b/dashboard/config/course_offerings/coursee.json
@@ -3,5 +3,9 @@
   "display_name": "Course E",
   "category": "csf",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/coursef-2022-pilot.json
+++ b/dashboard/config/course_offerings/coursef-2022-pilot.json
@@ -3,5 +3,9 @@
   "display_name": "coursef-2022-pilot",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/coursef-draft.json
+++ b/dashboard/config/course_offerings/coursef-draft.json
@@ -3,5 +3,9 @@
   "display_name": "coursef-draft",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/coursef-ramp.json
+++ b/dashboard/config/course_offerings/coursef-ramp.json
@@ -3,5 +3,9 @@
   "display_name": "coursef-ramp",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/coursef.json
+++ b/dashboard/config/course_offerings/coursef.json
@@ -3,5 +3,9 @@
   "display_name": "Course F",
   "category": "csf",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/craft17-kiki.json
+++ b/dashboard/config/course_offerings/craft17-kiki.json
@@ -3,5 +3,9 @@
   "display_name": "craft17-kiki",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/craft17.json
+++ b/dashboard/config/course_offerings/craft17.json
@@ -3,5 +3,9 @@
   "display_name": "craft17",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/craft18.json
+++ b/dashboard/config/course_offerings/craft18.json
@@ -3,5 +3,9 @@
   "display_name": "craft18",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/cs-discoveries-deeper-learning-2019---2020.json
+++ b/dashboard/config/course_offerings/cs-discoveries-deeper-learning-2019---2020.json
@@ -3,5 +3,9 @@
   "display_name": "cs-discoveries-deeper-learning-2019---2020",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/cs-discoveries-deeper-learning-2021.json
+++ b/dashboard/config/course_offerings/cs-discoveries-deeper-learning-2021.json
@@ -3,5 +3,9 @@
   "display_name": "cs-discoveries-deeper-learning-2021",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/cs-discoveries-facilitator-in-training-2018-2019.json
+++ b/dashboard/config/course_offerings/cs-discoveries-facilitator-in-training-2018-2019.json
@@ -3,5 +3,9 @@
   "display_name": "cs-discoveries-facilitator-in-training-2018-2019",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/cs-discoveries-facilitator-in-training.json
+++ b/dashboard/config/course_offerings/cs-discoveries-facilitator-in-training.json
@@ -3,5 +3,9 @@
   "display_name": "cs-discoveries-facilitator-in-training",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/cs-discoveries-facilitators-in-training-2018-2019.json
+++ b/dashboard/config/course_offerings/cs-discoveries-facilitators-in-training-2018-2019.json
@@ -3,5 +3,9 @@
   "display_name": "cs-discoveries-facilitators-in-training-2018-2019",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/cs-discoveries-teachercon-novice.json
+++ b/dashboard/config/course_offerings/cs-discoveries-teachercon-novice.json
@@ -3,5 +3,9 @@
   "display_name": "cs-discoveries-teachercon-novice",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/cs-discoviers-teachercon-novice.json
+++ b/dashboard/config/course_offerings/cs-discoviers-teachercon-novice.json
@@ -3,5 +3,9 @@
   "display_name": "cs-discoviers-teachercon-novice",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/cs-in-algebra-legacy.json
+++ b/dashboard/config/course_offerings/cs-in-algebra-legacy.json
@@ -3,5 +3,9 @@
   "display_name": "cs-in-algebra-legacy",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/cs-in-algebra-support.json
+++ b/dashboard/config/course_offerings/cs-in-algebra-support.json
@@ -3,5 +3,9 @@
   "display_name": "cs-in-algebra-support",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/cs-in-science-legacy.json
+++ b/dashboard/config/course_offerings/cs-in-science-legacy.json
@@ -3,5 +3,9 @@
   "display_name": "cs-in-science-legacy",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/cs-in-science-support.json
+++ b/dashboard/config/course_offerings/cs-in-science-support.json
@@ -3,5 +3,9 @@
   "display_name": "cs-in-science-support",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/cs-in-science.json
+++ b/dashboard/config/course_offerings/cs-in-science.json
@@ -3,5 +3,9 @@
   "display_name": "cs-in-science",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/cs-principles-curriculum-training-for-facilitators.json
+++ b/dashboard/config/course_offerings/cs-principles-curriculum-training-for-facilitators.json
@@ -3,5 +3,9 @@
   "display_name": "cs-principles-curriculum-training-for-facilitators",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/cs-principles-deeper-learning-2019---2020.json
+++ b/dashboard/config/course_offerings/cs-principles-deeper-learning-2019---2020.json
@@ -3,5 +3,9 @@
   "display_name": "cs-principles-deeper-learning-2019---2020",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/cs-principles-deeper-learning-2021.json
+++ b/dashboard/config/course_offerings/cs-principles-deeper-learning-2021.json
@@ -3,5 +3,9 @@
   "display_name": "cs-principles-deeper-learning-2021",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/cs-principles-facilitator-in-training-2018-2019.json
+++ b/dashboard/config/course_offerings/cs-principles-facilitator-in-training-2018-2019.json
@@ -3,5 +3,9 @@
   "display_name": "cs-principles-facilitator-in-training-2018-2019",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/cs-principles-facilitator-in-training.json
+++ b/dashboard/config/course_offerings/cs-principles-facilitator-in-training.json
@@ -3,5 +3,9 @@
   "display_name": "cs-principles-facilitator-in-training",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/cs-principles-facilitators-in-training-2018-2019.json
+++ b/dashboard/config/course_offerings/cs-principles-facilitators-in-training-2018-2019.json
@@ -3,5 +3,9 @@
   "display_name": "cs-principles-facilitators-in-training-2018-2019",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/cs-principles-support.json
+++ b/dashboard/config/course_offerings/cs-principles-support.json
@@ -3,5 +3,9 @@
   "display_name": "cs-principles-support",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/cs-principles-teachercon-novice.json
+++ b/dashboard/config/course_offerings/cs-principles-teachercon-novice.json
@@ -3,5 +3,9 @@
   "display_name": "cs-principles-teachercon-novice",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/cs4all-invasive-species.json
+++ b/dashboard/config/course_offerings/cs4all-invasive-species.json
@@ -3,5 +3,9 @@
   "display_name": "cs4all-invasive-species",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csa-async.json
+++ b/dashboard/config/course_offerings/csa-async.json
@@ -3,5 +3,9 @@
   "display_name": "Getting Started Modules CSA",
   "category": "pl_other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csa-backpack-2022.json
+++ b/dashboard/config/course_offerings/csa-backpack-2022.json
@@ -3,5 +3,9 @@
   "display_name": "csa-backpack-2022",
   "category": "other",
   "is_featured": false,
-  "assignable": false
+  "assignable": false,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csa-celebrity-lab.json
+++ b/dashboard/config/course_offerings/csa-celebrity-lab.json
@@ -3,5 +3,9 @@
   "display_name": "AP CSA Consumer Review Lab",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csa-collegeboard-labs.json
+++ b/dashboard/config/course_offerings/csa-collegeboard-labs.json
@@ -3,5 +3,9 @@
   "display_name": "AP CSA Magpie Lab",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csa-data-lab.json
+++ b/dashboard/config/course_offerings/csa-data-lab.json
@@ -3,5 +3,9 @@
   "display_name": "AP CSA Data Lab",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csa-draft-pl.json
+++ b/dashboard/config/course_offerings/csa-draft-pl.json
@@ -3,5 +3,9 @@
   "display_name": "csa-draft-pl",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csa-examples-21.json
+++ b/dashboard/config/course_offerings/csa-examples-21.json
@@ -3,5 +3,9 @@
   "display_name": "csa-examples-21",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csa-examples-22.json
+++ b/dashboard/config/course_offerings/csa-examples-22.json
@@ -3,5 +3,9 @@
   "display_name": "csa-examples-22",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csa-labs.json
+++ b/dashboard/config/course_offerings/csa-labs.json
@@ -3,5 +3,9 @@
   "display_name": "csa-labs",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csa-pilot-extra.json
+++ b/dashboard/config/course_offerings/csa-pilot-extra.json
@@ -3,5 +3,9 @@
   "display_name": "csa-pilot-extra",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csa-pilot-facilitator.json
+++ b/dashboard/config/course_offerings/csa-pilot-facilitator.json
@@ -3,5 +3,9 @@
   "display_name": "CSA Pilot Facilitators",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csa-pl-standalone-code-2022.json
+++ b/dashboard/config/course_offerings/csa-pl-standalone-code-2022.json
@@ -3,5 +3,9 @@
   "display_name": "csa-pl-standalone-code-2022",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csa-preview.json
+++ b/dashboard/config/course_offerings/csa-preview.json
@@ -3,5 +3,9 @@
   "display_name": "csa-preview",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csa-self-paced-pl.json
+++ b/dashboard/config/course_offerings/csa-self-paced-pl.json
@@ -3,5 +3,9 @@
   "display_name": "Navigating Code.org for CSA Pilot Teachers",
   "category": "pl_self_paced",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csa-u6-dev.json
+++ b/dashboard/config/course_offerings/csa-u6-dev.json
@@ -3,5 +3,9 @@
   "display_name": "csa-u6-dev",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csa-u7-dev.json
+++ b/dashboard/config/course_offerings/csa-u7-dev.json
@@ -3,5 +3,9 @@
   "display_name": "csa-u7-dev",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csa-u8-dev.json
+++ b/dashboard/config/course_offerings/csa-u8-dev.json
@@ -3,5 +3,9 @@
   "display_name": "csa-u8-dev",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csa-validation-pilot.json
+++ b/dashboard/config/course_offerings/csa-validation-pilot.json
@@ -3,5 +3,9 @@
   "display_name": "CSA Validation Pilot",
   "category": "full_course",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csa-videos.json
+++ b/dashboard/config/course_offerings/csa-videos.json
@@ -3,5 +3,9 @@
   "display_name": "csa-videos",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csa.json
+++ b/dashboard/config/course_offerings/csa.json
@@ -3,5 +3,9 @@
   "display_name": "Computer Science A",
   "category": "full_course",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csa1-2022-exemplars.json
+++ b/dashboard/config/course_offerings/csa1-2022-exemplars.json
@@ -3,5 +3,9 @@
   "display_name": "csa1-2022-exemplars",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csa1-exemplars.json
+++ b/dashboard/config/course_offerings/csa1-exemplars.json
@@ -3,5 +3,9 @@
   "display_name": "csa1-exemplars",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csa2-2022-exemplars.json
+++ b/dashboard/config/course_offerings/csa2-2022-exemplars.json
@@ -3,5 +3,9 @@
   "display_name": "csa2-2022-exemplars",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csa2-exemplars.json
+++ b/dashboard/config/course_offerings/csa2-exemplars.json
@@ -3,5 +3,9 @@
   "display_name": "csa2-exemplars",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csa3-exemplars.json
+++ b/dashboard/config/course_offerings/csa3-exemplars.json
@@ -3,5 +3,9 @@
   "display_name": "csa3-exemplars",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csa4-exemplars.json
+++ b/dashboard/config/course_offerings/csa4-exemplars.json
@@ -3,5 +3,9 @@
   "display_name": "csa4-exemplars",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csa5-exemplars.json
+++ b/dashboard/config/course_offerings/csa5-exemplars.json
@@ -3,5 +3,9 @@
   "display_name": "csa5-exemplars",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csa6-exemplars.json
+++ b/dashboard/config/course_offerings/csa6-exemplars.json
@@ -3,5 +3,9 @@
   "display_name": "csa6-exemplars",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csa7-exemplars.json
+++ b/dashboard/config/course_offerings/csa7-exemplars.json
@@ -3,5 +3,9 @@
   "display_name": "csa7-exemplars",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csa8-exemplars.json
+++ b/dashboard/config/course_offerings/csa8-exemplars.json
@@ -3,5 +3,9 @@
   "display_name": "csa8-exemplars",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csc-bookcover.json
+++ b/dashboard/config/course_offerings/csc-bookcover.json
@@ -3,5 +3,9 @@
   "display_name": "csc-bookcover",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csc-ecosystems-1.json
+++ b/dashboard/config/course_offerings/csc-ecosystems-1.json
@@ -3,5 +3,9 @@
   "display_name": "csc-ecosystems-1",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csc-ecosystems.json
+++ b/dashboard/config/course_offerings/csc-ecosystems.json
@@ -3,5 +3,9 @@
   "display_name": "Ecosystems Module",
   "category": "csc",
   "is_featured": true,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csc-fables.json
+++ b/dashboard/config/course_offerings/csc-fables.json
@@ -3,5 +3,9 @@
   "display_name": "Storytelling Module",
   "category": "csc",
   "is_featured": true,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csc-function-machines-pilot.json
+++ b/dashboard/config/course_offerings/csc-function-machines-pilot.json
@@ -3,5 +3,9 @@
   "display_name": "csc-function-machines-pilot",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csc-landmarks-pilot.json
+++ b/dashboard/config/course_offerings/csc-landmarks-pilot.json
@@ -3,5 +3,9 @@
   "display_name": "csc-landmarks-pilot",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csc-mappinglandmarks.json
+++ b/dashboard/config/course_offerings/csc-mappinglandmarks.json
@@ -3,5 +3,9 @@
   "display_name": "csc-mappinglandmarks",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csc-pilot-2022-ecosystems.json
+++ b/dashboard/config/course_offerings/csc-pilot-2022-ecosystems.json
@@ -3,5 +3,9 @@
   "display_name": "csc-pilot-2022-ecosystems",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csc-pilot-2022-fables.json
+++ b/dashboard/config/course_offerings/csc-pilot-2022-fables.json
@@ -3,5 +3,9 @@
   "display_name": "csc-pilot-2022-fables",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csc-pilot-2022-starquilts.json
+++ b/dashboard/config/course_offerings/csc-pilot-2022-starquilts.json
@@ -3,5 +3,9 @@
   "display_name": "csc-pilot-2022-starquilts",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csc-pilot-2022-timecapsule.json
+++ b/dashboard/config/course_offerings/csc-pilot-2022-timecapsule.json
@@ -3,5 +3,9 @@
   "display_name": "csc-pilot-2022-timecapsule",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csc-pilot-fa2022-ecosystem.json
+++ b/dashboard/config/course_offerings/csc-pilot-fa2022-ecosystem.json
@@ -3,5 +3,9 @@
   "display_name": "csc-pilot-fa2022-ecosystem",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csc-pilot-fa2022-particles.json
+++ b/dashboard/config/course_offerings/csc-pilot-fa2022-particles.json
@@ -3,5 +3,9 @@
   "display_name": "csc-pilot-fa2022-particles",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csc-pilot-fa2022-timecapsule.json
+++ b/dashboard/config/course_offerings/csc-pilot-fa2022-timecapsule.json
@@ -3,5 +3,9 @@
   "display_name": "csc-pilot-fa2022-timecapsule",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csc-starquilts.json
+++ b/dashboard/config/course_offerings/csc-starquilts.json
@@ -3,5 +3,9 @@
   "display_name": "Star Quilts Module",
   "category": "csc",
   "is_featured": true,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csc-timecapsule.json
+++ b/dashboard/config/course_offerings/csc-timecapsule.json
@@ -3,5 +3,9 @@
   "display_name": "Time Capsule Module",
   "category": "csc",
   "is_featured": true,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csd-bugs.json
+++ b/dashboard/config/course_offerings/csd-bugs.json
@@ -3,5 +3,9 @@
   "display_name": "csd-bugs",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csd-playground.json
+++ b/dashboard/config/course_offerings/csd-playground.json
@@ -3,5 +3,9 @@
   "display_name": "csd-playground",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csd-post-survey.json
+++ b/dashboard/config/course_offerings/csd-post-survey.json
@@ -3,5 +3,9 @@
   "display_name": "CSD Student Post-Course Survey ('18-'19)",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csd-sample-online.json
+++ b/dashboard/config/course_offerings/csd-sample-online.json
@@ -3,5 +3,9 @@
   "display_name": "csd-sample-online",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csd-test-saving-state.json
+++ b/dashboard/config/course_offerings/csd-test-saving-state.json
@@ -3,5 +3,9 @@
   "display_name": "csd-test-saving-state",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csd-tests.json
+++ b/dashboard/config/course_offerings/csd-tests.json
@@ -3,5 +3,9 @@
   "display_name": "csd-tests",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csd-videos.json
+++ b/dashboard/config/course_offerings/csd-videos.json
@@ -3,5 +3,9 @@
   "display_name": "csd-videos",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csd.json
+++ b/dashboard/config/course_offerings/csd.json
@@ -3,5 +3,9 @@
   "display_name": "Computer Science Discoveries",
   "category": "full_course",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csd1-old.json
+++ b/dashboard/config/course_offerings/csd1-old.json
@@ -3,5 +3,9 @@
   "display_name": "csd1-old",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csd1.json
+++ b/dashboard/config/course_offerings/csd1.json
@@ -3,5 +3,9 @@
   "display_name": "csd1",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csd2-old.json
+++ b/dashboard/config/course_offerings/csd2-old.json
@@ -3,5 +3,9 @@
   "display_name": "csd2-old",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csd2-projects-temp.json
+++ b/dashboard/config/course_offerings/csd2-projects-temp.json
@@ -3,5 +3,9 @@
   "display_name": "csd2-projects-temp",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csd2-virtual.json
+++ b/dashboard/config/course_offerings/csd2-virtual.json
@@ -3,5 +3,9 @@
   "display_name": "csd2-virtual",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csd2.json
+++ b/dashboard/config/course_offerings/csd2.json
@@ -3,5 +3,9 @@
   "display_name": "csd2",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csd3-1819draft.json
+++ b/dashboard/config/course_offerings/csd3-1819draft.json
@@ -3,5 +3,9 @@
   "display_name": "csd3-1819draft",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csd3-old.json
+++ b/dashboard/config/course_offerings/csd3-old.json
@@ -3,5 +3,9 @@
   "display_name": "csd3-old",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csd3-virtual.json
+++ b/dashboard/config/course_offerings/csd3-virtual.json
@@ -3,5 +3,9 @@
   "display_name": "Self Paced Introduction to Game Lab",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csd3.json
+++ b/dashboard/config/course_offerings/csd3.json
@@ -3,5 +3,9 @@
   "display_name": "csd3",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csd4-draft.json
+++ b/dashboard/config/course_offerings/csd4-draft.json
@@ -3,5 +3,9 @@
   "display_name": "csd4-draft",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csd4-old.json
+++ b/dashboard/config/course_offerings/csd4-old.json
@@ -3,5 +3,9 @@
   "display_name": "csd4-old",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csd4-preview-2021-1.json
+++ b/dashboard/config/course_offerings/csd4-preview-2021-1.json
@@ -3,5 +3,9 @@
   "display_name": "csd4-preview-2021-1",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csd4-preview-2021.json
+++ b/dashboard/config/course_offerings/csd4-preview-2021.json
@@ -3,5 +3,9 @@
   "display_name": "CSD Unit 4 - The Design Process ('21-'22 Beta Preview)",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csd4.json
+++ b/dashboard/config/course_offerings/csd4.json
@@ -3,5 +3,9 @@
   "display_name": "csd4",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csd5-draft.json
+++ b/dashboard/config/course_offerings/csd5-draft.json
@@ -3,5 +3,9 @@
   "display_name": "csd5-draft",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csd5-old.json
+++ b/dashboard/config/course_offerings/csd5-old.json
@@ -3,5 +3,9 @@
   "display_name": "csd5-old",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csd5-preview-2021-1.json
+++ b/dashboard/config/course_offerings/csd5-preview-2021-1.json
@@ -3,5 +3,9 @@
   "display_name": "csd5-preview-2021-1",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csd5-preview-2021.json
+++ b/dashboard/config/course_offerings/csd5-preview-2021.json
@@ -3,5 +3,9 @@
   "display_name": "CSD Unit 5 - Data and Society ('21-'22 Beta Preview)",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csd5.json
+++ b/dashboard/config/course_offerings/csd5.json
@@ -3,5 +3,9 @@
   "display_name": "csd5",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csd6-draft.json
+++ b/dashboard/config/course_offerings/csd6-draft.json
@@ -3,5 +3,9 @@
   "display_name": "csd6-draft",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csd6-old.json
+++ b/dashboard/config/course_offerings/csd6-old.json
@@ -3,5 +3,9 @@
   "display_name": "csd6-old",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csd6-pilot.json
+++ b/dashboard/config/course_offerings/csd6-pilot.json
@@ -3,5 +3,9 @@
   "display_name": "Physical Computing Pilot (2022)",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csd6-projects.json
+++ b/dashboard/config/course_offerings/csd6-projects.json
@@ -3,5 +3,9 @@
   "display_name": "csd6-projects",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csd6.json
+++ b/dashboard/config/course_offerings/csd6.json
@@ -3,5 +3,9 @@
   "display_name": "csd6",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csd7.json
+++ b/dashboard/config/course_offerings/csd7.json
@@ -3,5 +3,9 @@
   "display_name": "csd7",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csdgraveyard.json
+++ b/dashboard/config/course_offerings/csdgraveyard.json
@@ -3,5 +3,9 @@
   "display_name": "csdgraveyard",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csf-2021-pilot-1.json
+++ b/dashboard/config/course_offerings/csf-2021-pilot-1.json
@@ -3,5 +3,9 @@
   "display_name": "csf-2021-pilot-1",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csf-2021-pilot.json
+++ b/dashboard/config/course_offerings/csf-2021-pilot.json
@@ -3,5 +3,9 @@
   "display_name": "CS Fundamentals 2021 Pilot",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csf-pilot.json
+++ b/dashboard/config/course_offerings/csf-pilot.json
@@ -3,5 +3,9 @@
   "display_name": "csf-pilot",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csf-secret-sample-story.json
+++ b/dashboard/config/course_offerings/csf-secret-sample-story.json
@@ -3,5 +3,9 @@
   "display_name": "csf-secret-sample-story",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csf-secret-sample.json
+++ b/dashboard/config/course_offerings/csf-secret-sample.json
@@ -3,5 +3,9 @@
   "display_name": "csf-secret-sample",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csf2harvey.json
+++ b/dashboard/config/course_offerings/csf2harvey.json
@@ -3,5 +3,9 @@
   "display_name": "csf2harvey",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csl-vn.json
+++ b/dashboard/config/course_offerings/csl-vn.json
@@ -3,5 +3,9 @@
   "display_name": "csl-vn",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csp-ap.json
+++ b/dashboard/config/course_offerings/csp-ap.json
@@ -3,5 +3,9 @@
   "display_name": "csp-ap",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csp-ca-a.json
+++ b/dashboard/config/course_offerings/csp-ca-a.json
@@ -3,5 +3,9 @@
   "display_name": "csp-ca-a",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csp-exam.json
+++ b/dashboard/config/course_offerings/csp-exam.json
@@ -3,5 +3,9 @@
   "display_name": "csp-exam",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csp-mid-survey.json
+++ b/dashboard/config/course_offerings/csp-mid-survey.json
@@ -3,5 +3,9 @@
   "display_name": "CSP Student Mid-year Survey",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csp-online-test.json
+++ b/dashboard/config/course_offerings/csp-online-test.json
@@ -3,5 +3,9 @@
   "display_name": "csp-online-test",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csp-playground.json
+++ b/dashboard/config/course_offerings/csp-playground.json
@@ -3,5 +3,9 @@
   "display_name": "csp-playground",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csp-pre-survey.json
+++ b/dashboard/config/course_offerings/csp-pre-survey.json
@@ -3,5 +3,9 @@
   "display_name": "csp-pre-survey",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csp-support.json
+++ b/dashboard/config/course_offerings/csp-support.json
@@ -3,5 +3,9 @@
   "display_name": "csp-support",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csp.json
+++ b/dashboard/config/course_offerings/csp.json
@@ -3,5 +3,9 @@
   "display_name": "Computer Science Principles",
   "category": "full_course",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csp3-recovery.json
+++ b/dashboard/config/course_offerings/csp3-recovery.json
@@ -3,5 +3,9 @@
   "display_name": "csp3-recovery",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csp3-staging.json
+++ b/dashboard/config/course_offerings/csp3-staging.json
@@ -3,5 +3,9 @@
   "display_name": "csp3-staging",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csp3-virtual.json
+++ b/dashboard/config/course_offerings/csp3-virtual.json
@@ -3,5 +3,9 @@
   "display_name": "Self Paced Introduction to Turtle Programming In App Lab",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csp5-virtual-part2.json
+++ b/dashboard/config/course_offerings/csp5-virtual-part2.json
@@ -3,5 +3,9 @@
   "display_name": "csp5-virtual-part2",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csp5-virtual.json
+++ b/dashboard/config/course_offerings/csp5-virtual.json
@@ -3,5 +3,9 @@
   "display_name": "Event-Driven Programming in App Lab",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csp6.json
+++ b/dashboard/config/course_offerings/csp6.json
@@ -3,5 +3,9 @@
   "display_name": "csp6",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/cspassessment.json
+++ b/dashboard/config/course_offerings/cspassessment.json
@@ -3,5 +3,9 @@
   "display_name": "cspassessment",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/cspexam1-mwu7ildym9.json
+++ b/dashboard/config/course_offerings/cspexam1-mwu7ildym9.json
@@ -3,5 +3,9 @@
   "display_name": "cspexam1-mwu7ildym9",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/cspexam2-akwgah1ac5.json
+++ b/dashboard/config/course_offerings/cspexam2-akwgah1ac5.json
@@ -3,5 +3,9 @@
   "display_name": "cspexam2-akwgah1ac5",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/csplessonsamples.json
+++ b/dashboard/config/course_offerings/csplessonsamples.json
@@ -3,5 +3,9 @@
   "display_name": "csplessonsamples",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/cspoptional.json
+++ b/dashboard/config/course_offerings/cspoptional.json
@@ -3,5 +3,9 @@
   "display_name": "cspoptional",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/cspunit1-support-test.json
+++ b/dashboard/config/course_offerings/cspunit1-support-test.json
@@ -3,5 +3,9 @@
   "display_name": "cspunit1-support-test",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/cspunit1-support.json
+++ b/dashboard/config/course_offerings/cspunit1-support.json
@@ -3,5 +3,9 @@
   "display_name": "cspunit1-support",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/cspunit1.json
+++ b/dashboard/config/course_offerings/cspunit1.json
@@ -3,5 +3,9 @@
   "display_name": "cspunit1",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/cspunit2.json
+++ b/dashboard/config/course_offerings/cspunit2.json
@@ -3,5 +3,9 @@
   "display_name": "cspunit2",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/cspunit3.json
+++ b/dashboard/config/course_offerings/cspunit3.json
@@ -3,5 +3,9 @@
   "display_name": "cspunit3",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/cspunit3temp.json
+++ b/dashboard/config/course_offerings/cspunit3temp.json
@@ -3,5 +3,9 @@
   "display_name": "cspunit3temp",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/cspunit4.json
+++ b/dashboard/config/course_offerings/cspunit4.json
@@ -3,5 +3,9 @@
   "display_name": "cspunit4",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/cspunit4draft.json
+++ b/dashboard/config/course_offerings/cspunit4draft.json
@@ -3,5 +3,9 @@
   "display_name": "cspunit4draft",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/cspunit5.json
+++ b/dashboard/config/course_offerings/cspunit5.json
@@ -3,5 +3,9 @@
   "display_name": "cspunit5",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/cspunit6.json
+++ b/dashboard/config/course_offerings/cspunit6.json
@@ -3,5 +3,9 @@
   "display_name": "cspunit6",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/cspunit6draft.json
+++ b/dashboard/config/course_offerings/cspunit6draft.json
@@ -3,5 +3,9 @@
   "display_name": "cspunit6draft",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/curriculum-sandbox-levels.json
+++ b/dashboard/config/course_offerings/curriculum-sandbox-levels.json
@@ -3,5 +3,9 @@
   "display_name": "curriculum-sandbox-levels",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/dance-2019.json
+++ b/dashboard/config/course_offerings/dance-2019.json
@@ -3,5 +3,9 @@
   "display_name": "Dance Party (2019)",
   "category": "hoc",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/dance-draft.json
+++ b/dashboard/config/course_offerings/dance-draft.json
@@ -3,5 +3,9 @@
   "display_name": "dance-draft",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/dance-extras-2019.json
+++ b/dashboard/config/course_offerings/dance-extras-2019.json
@@ -3,5 +3,9 @@
   "display_name": "Keep On Dancing (2019)",
   "category": "hoc",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/dance-extras-gallery.json
+++ b/dashboard/config/course_offerings/dance-extras-gallery.json
@@ -3,5 +3,9 @@
   "display_name": "dance-extras-gallery",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/dance-extras.json
+++ b/dashboard/config/course_offerings/dance-extras.json
@@ -3,5 +3,9 @@
   "display_name": "Keep On Dancing (2018)",
   "category": "hoc",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/dance-low.json
+++ b/dashboard/config/course_offerings/dance-low.json
@@ -3,5 +3,9 @@
   "display_name": "dance-low",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/dance-unplugged.json
+++ b/dashboard/config/course_offerings/dance-unplugged.json
@@ -3,5 +3,9 @@
   "display_name": "Hour of Code - Dance Party - Unplugged",
   "category": "hoc",
   "is_featured": false,
-  "assignable": false
+  "assignable": false,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/dance.json
+++ b/dashboard/config/course_offerings/dance.json
@@ -3,5 +3,9 @@
   "display_name": "Dance Party (2018)",
   "category": "hoc",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/dani-june-2020-test.json
+++ b/dashboard/config/course_offerings/dani-june-2020-test.json
@@ -3,5 +3,9 @@
   "display_name": "dani-june-2020-test",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/deepdive-debugging.json
+++ b/dashboard/config/course_offerings/deepdive-debugging.json
@@ -3,5 +3,9 @@
   "display_name": "Debugging Lessons for Educators",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/default.json
+++ b/dashboard/config/course_offerings/default.json
@@ -3,5 +3,9 @@
   "display_name": "default",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/denny-science-8.json
+++ b/dashboard/config/course_offerings/denny-science-8.json
@@ -3,5 +3,9 @@
   "display_name": "denny-science-8",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/denny-science-copy.json
+++ b/dashboard/config/course_offerings/denny-science-copy.json
@@ -3,5 +3,9 @@
   "display_name": "denny-science-copy",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/denny-science.json
+++ b/dashboard/config/course_offerings/denny-science.json
@@ -3,5 +3,9 @@
   "display_name": "denny-science",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/devices.json
+++ b/dashboard/config/course_offerings/devices.json
@@ -3,5 +3,9 @@
   "display_name": "Creating Apps for Devices",
   "category": "maker",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/dlp-csd-mod4.json
+++ b/dashboard/config/course_offerings/dlp-csd-mod4.json
@@ -3,5 +3,9 @@
   "display_name": "dlp-csd-mod4",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/dlp-csp-mod4.json
+++ b/dashboard/config/course_offerings/dlp-csp-mod4.json
@@ -3,5 +3,9 @@
   "display_name": "dlp-csp-mod4",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/drafting.json
+++ b/dashboard/config/course_offerings/drafting.json
@@ -3,5 +3,9 @@
   "display_name": "drafting",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/duino.json
+++ b/dashboard/config/course_offerings/duino.json
@@ -3,5 +3,9 @@
   "display_name": "duino",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/e-f-ramp.json
+++ b/dashboard/config/course_offerings/e-f-ramp.json
@@ -3,5 +3,9 @@
   "display_name": "e-f-ramp",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/ecs-support-legacy.json
+++ b/dashboard/config/course_offerings/ecs-support-legacy.json
@@ -3,5 +3,9 @@
   "display_name": "ecs-support-legacy",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/ecs-support.json
+++ b/dashboard/config/course_offerings/ecs-support.json
@@ -3,5 +3,9 @@
   "display_name": "ecs-support",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/edit-code-1.json
+++ b/dashboard/config/course_offerings/edit-code-1.json
@@ -3,5 +3,9 @@
   "display_name": "edit-code-1",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/edit-code.json
+++ b/dashboard/config/course_offerings/edit-code.json
@@ -3,5 +3,9 @@
   "display_name": "Edit Code",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/emma.json
+++ b/dashboard/config/course_offerings/emma.json
@@ -3,5 +3,9 @@
   "display_name": "emma",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/emmas-playground.json
+++ b/dashboard/config/course_offerings/emmas-playground.json
@@ -3,5 +3,9 @@
   "display_name": "emmas-playground",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/equity-support.json
+++ b/dashboard/config/course_offerings/equity-support.json
@@ -3,5 +3,9 @@
   "display_name": "equity-support",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/events.json
+++ b/dashboard/config/course_offerings/events.json
@@ -3,5 +3,9 @@
   "display_name": "events",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/explore-data-1.json
+++ b/dashboard/config/course_offerings/explore-data-1.json
@@ -3,5 +3,9 @@
   "display_name": "Data Activity",
   "category": "csc",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/express.json
+++ b/dashboard/config/course_offerings/express.json
@@ -3,5 +3,9 @@
   "display_name": "Express Course",
   "category": "csf",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/facilitators-in-training-summer-2019.json
+++ b/dashboard/config/course_offerings/facilitators-in-training-summer-2019.json
@@ -3,5 +3,9 @@
   "display_name": "facilitators-in-training-summer-2019",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/facilitators-in-training-summer-reflections-2019.json
+++ b/dashboard/config/course_offerings/facilitators-in-training-summer-reflections-2019.json
@@ -3,5 +3,9 @@
   "display_name": "facilitators-in-training-summer-reflections-2019",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/fancygeometry-pilot.json
+++ b/dashboard/config/course_offerings/fancygeometry-pilot.json
@@ -3,5 +3,9 @@
   "display_name": "fancygeometry-pilot",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/fit-weekend-in-person.json
+++ b/dashboard/config/course_offerings/fit-weekend-in-person.json
@@ -3,5 +3,9 @@
   "display_name": "fit-weekend-in-person",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/fit2019-apprentice-1.json
+++ b/dashboard/config/course_offerings/fit2019-apprentice-1.json
@@ -3,5 +3,9 @@
   "display_name": "fit2019-apprentice-1",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/fit2019-apprentice.json
+++ b/dashboard/config/course_offerings/fit2019-apprentice.json
@@ -3,5 +3,9 @@
   "display_name": "Apprentice Reflections for Summer Workshop 2019",
   "category": "pl_other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/flappy-impact-study.json
+++ b/dashboard/config/course_offerings/flappy-impact-study.json
@@ -3,5 +3,9 @@
   "display_name": "flappy-impact-study",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/flappy.json
+++ b/dashboard/config/course_offerings/flappy.json
@@ -3,5 +3,9 @@
   "display_name": "Flappy Code",
   "category": "hoc",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/fmscsd3preview.json
+++ b/dashboard/config/course_offerings/fmscsd3preview.json
@@ -3,5 +3,9 @@
   "display_name": "fmscsd3preview",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/frequency-analysis.json
+++ b/dashboard/config/course_offerings/frequency-analysis.json
@@ -3,5 +3,9 @@
   "display_name": "frequency-analysis",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/frozen-2018-test-b.json
+++ b/dashboard/config/course_offerings/frozen-2018-test-b.json
@@ -3,5 +3,9 @@
   "display_name": "frozen-2018-test-b",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/frozen-2018-test.json
+++ b/dashboard/config/course_offerings/frozen-2018-test.json
@@ -3,5 +3,9 @@
   "display_name": "frozen-2018-test",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/frozen-2018.json
+++ b/dashboard/config/course_offerings/frozen-2018.json
@@ -3,5 +3,9 @@
   "display_name": "frozen-2018",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/frozen.json
+++ b/dashboard/config/course_offerings/frozen.json
@@ -3,5 +3,9 @@
   "display_name": "Code with Anna and Elsa",
   "category": "hoc",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/gamelab-demo.json
+++ b/dashboard/config/course_offerings/gamelab-demo.json
@@ -3,5 +3,9 @@
   "display_name": "gamelab-demo",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/gamelab-hackathon.json
+++ b/dashboard/config/course_offerings/gamelab-hackathon.json
@@ -3,5 +3,9 @@
   "display_name": "gamelab-hackathon",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/gamelab.json
+++ b/dashboard/config/course_offerings/gamelab.json
@@ -3,5 +3,9 @@
   "display_name": "gamelab",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/gamelabprojects.json
+++ b/dashboard/config/course_offerings/gamelabprojects.json
@@ -3,5 +3,9 @@
   "display_name": "gamelabprojects",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/glj-behavior-test.json
+++ b/dashboard/config/course_offerings/glj-behavior-test.json
@@ -3,5 +3,9 @@
   "display_name": "glj-behavior-test",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/grade5.json
+++ b/dashboard/config/course_offerings/grade5.json
@@ -3,5 +3,9 @@
   "display_name": "grade5",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/gumball.json
+++ b/dashboard/config/course_offerings/gumball.json
@@ -3,5 +3,9 @@
   "display_name": "Gumball Play Lab",
   "category": "hoc",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/haikubot-pilot.json
+++ b/dashboard/config/course_offerings/haikubot-pilot.json
@@ -3,5 +3,9 @@
   "display_name": "haikubot-pilot",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/halloween.json
+++ b/dashboard/config/course_offerings/halloween.json
@@ -3,5 +3,9 @@
   "display_name": "halloween",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/hello-world-animals.json
+++ b/dashboard/config/course_offerings/hello-world-animals.json
@@ -3,5 +3,9 @@
   "display_name": "Hello World: Animals",
   "category": "hoc",
   "is_featured": true,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/hello-world-batman.json
+++ b/dashboard/config/course_offerings/hello-world-batman.json
@@ -3,5 +3,9 @@
   "display_name": "hello-world-batman",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/hello-world-csc.json
+++ b/dashboard/config/course_offerings/hello-world-csc.json
@@ -3,5 +3,9 @@
   "display_name": "hello-world-csc",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/hello-world-emoji.json
+++ b/dashboard/config/course_offerings/hello-world-emoji.json
@@ -3,5 +3,9 @@
   "display_name": "Hello World: Emoji",
   "category": "hoc",
   "is_featured": true,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/hello-world-food.json
+++ b/dashboard/config/course_offerings/hello-world-food.json
@@ -3,5 +3,9 @@
   "display_name": "Hello World: Food",
   "category": "hoc",
   "is_featured": true,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/hello-world-retro.json
+++ b/dashboard/config/course_offerings/hello-world-retro.json
@@ -3,5 +3,9 @@
   "display_name": "Hello World: Retro",
   "category": "hoc",
   "is_featured": true,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/hello-world-soccer.json
+++ b/dashboard/config/course_offerings/hello-world-soccer.json
@@ -3,5 +3,9 @@
   "display_name": "Hello World: Soccer",
   "category": "hoc",
   "is_featured": true,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/hello-world-space.json
+++ b/dashboard/config/course_offerings/hello-world-space.json
@@ -3,5 +3,9 @@
   "display_name": "Hello World: Space",
   "category": "hoc",
   "is_featured": true,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/hero.json
+++ b/dashboard/config/course_offerings/hero.json
@@ -3,5 +3,9 @@
   "display_name": "Minecraft: Hero''s Journey",
   "category": "hoc",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/hoc-encryption.json
+++ b/dashboard/config/course_offerings/hoc-encryption.json
@@ -3,5 +3,9 @@
   "display_name": "Hour of Code: Simple Encryption",
   "category": "hoc",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/hoc-impact-study.json
+++ b/dashboard/config/course_offerings/hoc-impact-study.json
@@ -3,5 +3,9 @@
   "display_name": "hoc-impact-study",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/hour-of-code.json
+++ b/dashboard/config/course_offerings/hour-of-code.json
@@ -3,5 +3,9 @@
   "display_name": "hour-of-code",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/hourofcode.json
+++ b/dashboard/config/course_offerings/hourofcode.json
@@ -3,5 +3,9 @@
   "display_name": "Classic Maze",
   "category": "hoc",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/iceage.json
+++ b/dashboard/config/course_offerings/iceage.json
@@ -3,5 +3,9 @@
   "display_name": "Ice Age Play Lab",
   "category": "hoc",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/infinity.json
+++ b/dashboard/config/course_offerings/infinity.json
@@ -3,5 +3,9 @@
   "display_name": "Disney Infinity Play Lab",
   "category": "hoc",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/jess-test-script-1.json
+++ b/dashboard/config/course_offerings/jess-test-script-1.json
@@ -3,5 +3,9 @@
   "display_name": "jess-test-script-1",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/jess-test-script.json
+++ b/dashboard/config/course_offerings/jess-test-script.json
@@ -3,5 +3,9 @@
   "display_name": "jess-test-script",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/jigsaw.json
+++ b/dashboard/config/course_offerings/jigsaw.json
@@ -3,5 +3,9 @@
   "display_name": "Jigsaw",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/jr-test.json
+++ b/dashboard/config/course_offerings/jr-test.json
@@ -3,5 +3,9 @@
   "display_name": "jr-test",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/k1hoc2017.json
+++ b/dashboard/config/course_offerings/k1hoc2017.json
@@ -3,5 +3,9 @@
   "display_name": "k1hoc2017",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/k5-onlinepd.json
+++ b/dashboard/config/course_offerings/k5-onlinepd.json
@@ -3,5 +3,9 @@
   "display_name": "Teaching Computer Science Fundamentals",
   "category": "pl_self_paced",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/k5-support.json
+++ b/dashboard/config/course_offerings/k5-support.json
@@ -3,5 +3,9 @@
   "display_name": "k5-support",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/k5concepts.json
+++ b/dashboard/config/course_offerings/k5concepts.json
@@ -3,5 +3,9 @@
   "display_name": "k5concepts",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/kaitie-test-script.json
+++ b/dashboard/config/course_offerings/kaitie-test-script.json
@@ -3,5 +3,9 @@
   "display_name": "kaitie-test-script",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/katie-practice.json
+++ b/dashboard/config/course_offerings/katie-practice.json
@@ -3,5 +3,9 @@
   "display_name": "katie-practice",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/katies-playground.json
+++ b/dashboard/config/course_offerings/katies-playground.json
@@ -3,5 +3,9 @@
   "display_name": "katies-playground",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/kindertest.json
+++ b/dashboard/config/course_offerings/kindertest.json
@@ -3,5 +3,9 @@
   "display_name": "kindertest",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/kodea-pd-2021.json
+++ b/dashboard/config/course_offerings/kodea-pd-2021.json
@@ -3,5 +3,9 @@
   "display_name": "kodea-pd-2021",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/mc.json
+++ b/dashboard/config/course_offerings/mc.json
@@ -3,5 +3,9 @@
   "display_name": "Minecraft Hour of Code",
   "category": "hoc",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/microbit-temp.json
+++ b/dashboard/config/course_offerings/microbit-temp.json
@@ -3,5 +3,9 @@
   "display_name": "microbit-temp",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/microbit.json
+++ b/dashboard/config/course_offerings/microbit.json
@@ -3,5 +3,9 @@
   "display_name": "microbit",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/mike-test.json
+++ b/dashboard/config/course_offerings/mike-test.json
@@ -3,5 +3,9 @@
   "display_name": "mike-test",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/minecraft.json
+++ b/dashboard/config/course_offerings/minecraft.json
@@ -3,5 +3,9 @@
   "display_name": "Minecraft Hour of Code Designer",
   "category": "hoc",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/ml-playground.json
+++ b/dashboard/config/course_offerings/ml-playground.json
@@ -3,5 +3,9 @@
   "display_name": "ml-playground",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/moneppo-1.json
+++ b/dashboard/config/course_offerings/moneppo-1.json
@@ -3,5 +3,9 @@
   "display_name": "moneppo-1",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/netsim.json
+++ b/dashboard/config/course_offerings/netsim.json
@@ -3,5 +3,9 @@
   "display_name": "netsim",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/new-d.json
+++ b/dashboard/config/course_offerings/new-d.json
@@ -3,5 +3,9 @@
   "display_name": "new-d",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/new-e.json
+++ b/dashboard/config/course_offerings/new-e.json
@@ -3,5 +3,9 @@
   "display_name": "new-e",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/new-express.json
+++ b/dashboard/config/course_offerings/new-express.json
@@ -3,5 +3,9 @@
   "display_name": "new-express",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/new-f.json
+++ b/dashboard/config/course_offerings/new-f.json
@@ -3,5 +3,9 @@
   "display_name": "new-f",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/new-stages-sept-2017.json
+++ b/dashboard/config/course_offerings/new-stages-sept-2017.json
@@ -3,5 +3,9 @@
   "display_name": "new-stages-sept-2017",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/novice-view.json
+++ b/dashboard/config/course_offerings/novice-view.json
@@ -3,5 +3,9 @@
   "display_name": "novice-view",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/oceans.json
+++ b/dashboard/config/course_offerings/oceans.json
@@ -3,5 +3,9 @@
   "display_name": "AI for Oceans",
   "category": "hoc",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/odometer.json
+++ b/dashboard/config/course_offerings/odometer.json
@@ -3,5 +3,9 @@
   "display_name": "odometer",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/other-plc-course.json
+++ b/dashboard/config/course_offerings/other-plc-course.json
@@ -3,5 +3,9 @@
   "display_name": "other-plc-course",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/outbreak-csc.json
+++ b/dashboard/config/course_offerings/outbreak-csc.json
@@ -3,5 +3,9 @@
   "display_name": "Outbreak",
   "category": "csc",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/outbreak-module.json
+++ b/dashboard/config/course_offerings/outbreak-module.json
@@ -3,5 +3,9 @@
   "display_name": "outbreak-module",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/outbreak.json
+++ b/dashboard/config/course_offerings/outbreak.json
@@ -3,5 +3,9 @@
   "display_name": "Outbreak Simulator",
   "category": "hoc",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/outbreakmodule.json
+++ b/dashboard/config/course_offerings/outbreakmodule.json
@@ -3,5 +3,9 @@
   "display_name": "outbreakmodule",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/peru.json
+++ b/dashboard/config/course_offerings/peru.json
@@ -3,5 +3,9 @@
   "display_name": "peru",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/petgame.json
+++ b/dashboard/config/course_offerings/petgame.json
@@ -3,5 +3,9 @@
   "display_name": "petgame",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/physcomp-temp.json
+++ b/dashboard/config/course_offerings/physcomp-temp.json
@@ -3,5 +3,9 @@
   "display_name": "physcomp-temp",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/pixelation.json
+++ b/dashboard/config/course_offerings/pixelation.json
@@ -3,5 +3,9 @@
   "display_name": "Pixelation",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/pl-csd-bugs.json
+++ b/dashboard/config/course_offerings/pl-csd-bugs.json
@@ -3,5 +3,9 @@
   "display_name": "pl-csd-bugs",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/pl-playground.json
+++ b/dashboard/config/course_offerings/pl-playground.json
@@ -3,5 +3,9 @@
   "display_name": "pl-playground",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/playground.json
+++ b/dashboard/config/course_offerings/playground.json
@@ -3,5 +3,9 @@
   "display_name": "playground",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/playlab.json
+++ b/dashboard/config/course_offerings/playlab.json
@@ -3,5 +3,9 @@
   "display_name": "Play Lab",
   "category": "hoc",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/plc-bugbash-course.json
+++ b/dashboard/config/course_offerings/plc-bugbash-course.json
@@ -3,5 +3,9 @@
   "display_name": "plc-bugbash-course",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/pluralsight.json
+++ b/dashboard/config/course_offerings/pluralsight.json
@@ -3,5 +3,9 @@
   "display_name": "pluralsight",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/poem-art.json
+++ b/dashboard/config/course_offerings/poem-art.json
@@ -3,5 +3,9 @@
   "display_name": "Poem Art",
   "category": "hoc",
   "is_featured": true,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/poembot-hoc.json
+++ b/dashboard/config/course_offerings/poembot-hoc.json
@@ -3,5 +3,9 @@
   "display_name": "poembot-hoc",
   "category": "csc",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/poembot-springforum21.json
+++ b/dashboard/config/course_offerings/poembot-springforum21.json
@@ -3,5 +3,9 @@
   "display_name": "poembot-springforum21",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/poembot.json
+++ b/dashboard/config/course_offerings/poembot.json
@@ -3,5 +3,9 @@
   "display_name": "Poembot",
   "category": "csc",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/poetry-hoc3.json
+++ b/dashboard/config/course_offerings/poetry-hoc3.json
@@ -3,5 +3,9 @@
   "display_name": "poetry-hoc3",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/poetry.json
+++ b/dashboard/config/course_offerings/poetry.json
@@ -3,5 +3,9 @@
   "display_name": "Poetry Module",
   "category": "csc",
   "is_featured": true,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/poster-1.json
+++ b/dashboard/config/course_offerings/poster-1.json
@@ -3,5 +3,9 @@
   "display_name": "poster-1",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/poster-draft.json
+++ b/dashboard/config/course_offerings/poster-draft.json
@@ -3,5 +3,9 @@
   "display_name": "poster-draft",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/poster-experiment.json
+++ b/dashboard/config/course_offerings/poster-experiment.json
@@ -3,5 +3,9 @@
   "display_name": "poster-experiment",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/poster.json
+++ b/dashboard/config/course_offerings/poster.json
@@ -3,5 +3,9 @@
   "display_name": "poster",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/pre-express.json
+++ b/dashboard/config/course_offerings/pre-express.json
@@ -3,5 +3,9 @@
   "display_name": "Pre-reader Express",
   "category": "csf",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/public-key-cryptography.json
+++ b/dashboard/config/course_offerings/public-key-cryptography.json
@@ -3,5 +3,9 @@
   "display_name": "public-key-cryptography",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/pwc.json
+++ b/dashboard/config/course_offerings/pwc.json
@@ -3,5 +3,9 @@
   "display_name": "pwc",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/rbo-reference.json
+++ b/dashboard/config/course_offerings/rbo-reference.json
@@ -3,5 +3,9 @@
   "display_name": "rbo-reference",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/removed19.json
+++ b/dashboard/config/course_offerings/removed19.json
@@ -3,5 +3,9 @@
   "display_name": "removed19",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/sb-pt-cont.json
+++ b/dashboard/config/course_offerings/sb-pt-cont.json
@@ -3,5 +3,9 @@
   "display_name": "sb-pt-cont",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/sb-pt-exp.json
+++ b/dashboard/config/course_offerings/sb-pt-exp.json
@@ -3,5 +3,9 @@
   "display_name": "sb-pt-exp",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/sconyers.json
+++ b/dashboard/config/course_offerings/sconyers.json
@@ -3,5 +3,9 @@
   "display_name": "sconyers",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/self-paced-pl-csa.json
+++ b/dashboard/config/course_offerings/self-paced-pl-csa.json
@@ -3,5 +3,9 @@
   "display_name": "CSA Getting Started Modules",
   "category": "pl_self_paced",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/self-paced-pl-csd-2021.json
+++ b/dashboard/config/course_offerings/self-paced-pl-csd-2021.json
@@ -3,5 +3,9 @@
   "display_name": "Teaching CS Discoveries",
   "category": "pl_self_paced",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/self-paced-pl-csd5.json
+++ b/dashboard/config/course_offerings/self-paced-pl-csd5.json
@@ -3,5 +3,9 @@
   "display_name": "Teaching AI and Machine Learning",
   "category": "pl_self_paced",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/self-paced-pl-csd6-2021.json
+++ b/dashboard/config/course_offerings/self-paced-pl-csd6-2021.json
@@ -3,5 +3,9 @@
   "display_name": "self-paced-pl-csd6-2021",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/self-paced-pl-csd7-2021.json
+++ b/dashboard/config/course_offerings/self-paced-pl-csd7-2021.json
@@ -3,5 +3,9 @@
   "display_name": "self-paced-pl-csd7-2021",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/self-paced-pl-csd8-2021.json
+++ b/dashboard/config/course_offerings/self-paced-pl-csd8-2021.json
@@ -3,5 +3,9 @@
   "display_name": "self-paced-pl-csd8-2021",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/self-paced-pl-csp-2021.json
+++ b/dashboard/config/course_offerings/self-paced-pl-csp-2021.json
@@ -3,5 +3,9 @@
   "display_name": "Teaching CS Principles",
   "category": "pl_self_paced",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/self-paced-pl-physical-computing.json
+++ b/dashboard/config/course_offerings/self-paced-pl-physical-computing.json
@@ -3,5 +3,9 @@
   "display_name": "Teaching Creating Apps with Devices",
   "category": "pl_self_paced",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/soccer.json
+++ b/dashboard/config/course_offerings/soccer.json
@@ -3,5 +3,9 @@
   "display_name": "soccer",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/special-fun.json
+++ b/dashboard/config/course_offerings/special-fun.json
@@ -3,5 +3,9 @@
   "display_name": "special-fun",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/specialseries.json
+++ b/dashboard/config/course_offerings/specialseries.json
@@ -3,5 +3,9 @@
   "display_name": "specialseries",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/spelling-bee.json
+++ b/dashboard/config/course_offerings/spelling-bee.json
@@ -3,5 +3,9 @@
   "display_name": "Spelling Activity",
   "category": "csc",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/sports.json
+++ b/dashboard/config/course_offerings/sports.json
@@ -3,5 +3,9 @@
   "display_name": "Code your own sports game",
   "category": "hoc",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/spritelab-ee.json
+++ b/dashboard/config/course_offerings/spritelab-ee.json
@@ -3,5 +3,9 @@
   "display_name": "spritelab-ee",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/spritelab-simple.json
+++ b/dashboard/config/course_offerings/spritelab-simple.json
@@ -3,5 +3,9 @@
   "display_name": "spritelab-simple",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/spritelab-validated.json
+++ b/dashboard/config/course_offerings/spritelab-validated.json
@@ -3,5 +3,9 @@
   "display_name": "spritelab-validated",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/spritelab.json
+++ b/dashboard/config/course_offerings/spritelab.json
@@ -3,5 +3,9 @@
   "display_name": "spritelab",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/starwars.json
+++ b/dashboard/config/course_offerings/starwars.json
@@ -3,5 +3,9 @@
   "display_name": "Star Wars: Building a Galaxy With Code (Javascript)",
   "category": "hoc",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/starwarsblocks.json
+++ b/dashboard/config/course_offerings/starwarsblocks.json
@@ -3,5 +3,9 @@
   "display_name": "Star Wars: Building a Galaxy With Code (Blockly)",
   "category": "hoc",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/step.json
+++ b/dashboard/config/course_offerings/step.json
@@ -3,5 +3,9 @@
   "display_name": "step",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/subgoal-labels-opt-in.json
+++ b/dashboard/config/course_offerings/subgoal-labels-opt-in.json
@@ -3,5 +3,9 @@
   "display_name": "subgoal-labels-opt-in",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/subgoals-assessment-staging.json
+++ b/dashboard/config/course_offerings/subgoals-assessment-staging.json
@@ -3,5 +3,9 @@
   "display_name": "subgoals-assessment-staging",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/teachercon.json
+++ b/dashboard/config/course_offerings/teachercon.json
@@ -3,5 +3,9 @@
   "display_name": "teachercon",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/tess-test-course.json
+++ b/dashboard/config/course_offerings/tess-test-course.json
@@ -3,5 +3,9 @@
   "display_name": "tess-test-course",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/tesstest921.json
+++ b/dashboard/config/course_offerings/tesstest921.json
@@ -3,5 +3,9 @@
   "display_name": "tesstest921",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/tesstesting.json
+++ b/dashboard/config/course_offerings/tesstesting.json
@@ -3,5 +3,9 @@
   "display_name": "tesstesting",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/test--csp-online-teacher-support.json
+++ b/dashboard/config/course_offerings/test--csp-online-teacher-support.json
@@ -3,5 +3,9 @@
   "display_name": "test--csp-online-teacher-support",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/test-teaching-ap-cs-unit-1.json
+++ b/dashboard/config/course_offerings/test-teaching-ap-cs-unit-1.json
@@ -3,5 +3,9 @@
   "display_name": "test-teaching-ap-cs-unit-1",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/test-wednesday.json
+++ b/dashboard/config/course_offerings/test-wednesday.json
@@ -3,5 +3,9 @@
   "display_name": "test-wednesday",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/testing.json
+++ b/dashboard/config/course_offerings/testing.json
@@ -3,5 +3,9 @@
   "display_name": "testing",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/teststandard.json
+++ b/dashboard/config/course_offerings/teststandard.json
@@ -3,5 +3,9 @@
   "display_name": "teststandard",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/testtess.json
+++ b/dashboard/config/course_offerings/testtess.json
@@ -3,5 +3,9 @@
   "display_name": "testtess",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/text-compression.json
+++ b/dashboard/config/course_offerings/text-compression.json
@@ -3,5 +3,9 @@
   "display_name": "Text Compression",
   "category": "hoc",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/textbook.json
+++ b/dashboard/config/course_offerings/textbook.json
@@ -3,5 +3,9 @@
   "display_name": "textbook",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/time4cs-control.json
+++ b/dashboard/config/course_offerings/time4cs-control.json
@@ -3,5 +3,9 @@
   "display_name": "time4cs-control",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/time4cs-experiment.json
+++ b/dashboard/config/course_offerings/time4cs-experiment.json
@@ -3,5 +3,9 @@
   "display_name": "time4cs-experiment",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/time4csdemo.json
+++ b/dashboard/config/course_offerings/time4csdemo.json
@@ -3,5 +3,9 @@
   "display_name": "time4csdemo",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/transferring-over.json
+++ b/dashboard/config/course_offerings/transferring-over.json
@@ -3,5 +3,9 @@
   "display_name": "transferring-over",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/tutorial-video---code-studio-puzzle-challenge.json
+++ b/dashboard/config/course_offerings/tutorial-video---code-studio-puzzle-challenge.json
@@ -3,5 +3,9 @@
   "display_name": "tutorial-video---code-studio-puzzle-challenge",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/ui-test-versioned-script.json
+++ b/dashboard/config/course_offerings/ui-test-versioned-script.json
@@ -3,5 +3,9 @@
   "display_name": "ui-test-versioned-script",
   "category": "other",
   "is_featured": false,
-  "assignable": false
+  "assignable": false,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/usability.json
+++ b/dashboard/config/course_offerings/usability.json
@@ -3,5 +3,9 @@
   "display_name": "usability",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/valentine.json
+++ b/dashboard/config/course_offerings/valentine.json
@@ -3,5 +3,9 @@
   "display_name": "valentine",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/vigenere.json
+++ b/dashboard/config/course_offerings/vigenere.json
@@ -3,5 +3,9 @@
   "display_name": "vigenere",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/virtual-holding-place.json
+++ b/dashboard/config/course_offerings/virtual-holding-place.json
@@ -3,5 +3,9 @@
   "display_name": "virtual-holding-place",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/virustest.json
+++ b/dashboard/config/course_offerings/virustest.json
@@ -3,5 +3,9 @@
   "display_name": "virustest",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/vpl-csa.json
+++ b/dashboard/config/course_offerings/vpl-csa.json
@@ -3,5 +3,9 @@
   "display_name": "CSA Virtual Professional Learning",
   "category": "pl_virtual",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/vpl-csd-ayw-pilot.json
+++ b/dashboard/config/course_offerings/vpl-csd-ayw-pilot.json
@@ -3,5 +3,9 @@
   "display_name": "CS Discoveries Academic Year Workshops ",
   "category": "pl_virtual",
   "is_featured": true,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/vpl-csd-summer-pilot-ci.json
+++ b/dashboard/config/course_offerings/vpl-csd-summer-pilot-ci.json
@@ -3,5 +3,9 @@
   "display_name": "CS Discoveries Curriculum Investigation",
   "category": "pl_virtual",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/vpl-csd-summer-pilot.json
+++ b/dashboard/config/course_offerings/vpl-csd-summer-pilot.json
@@ -3,5 +3,9 @@
   "display_name": "CS Discoveries Virtual Summer Workshop",
   "category": "pl_virtual",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/vpl-csd.json
+++ b/dashboard/config/course_offerings/vpl-csd.json
@@ -3,5 +3,9 @@
   "display_name": "CS Discoveries Virtual Professional Learning",
   "category": "pl_virtual",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/vpl-csp.json
+++ b/dashboard/config/course_offerings/vpl-csp.json
@@ -3,5 +3,9 @@
   "display_name": "CS Principles Virtual Professional Learning",
   "category": "pl_virtual",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/workshop-gamelab.json
+++ b/dashboard/config/course_offerings/workshop-gamelab.json
@@ -3,5 +3,9 @@
   "display_name": "workshop-gamelab",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/config/course_offerings/workshop-maker.json
+++ b/dashboard/config/course_offerings/workshop-maker.json
@@ -3,5 +3,9 @@
   "display_name": "workshop-maker",
   "category": "other",
   "is_featured": false,
-  "assignable": true
+  "assignable": true,
+  "curriculum_type": null,
+  "marketing_initiative": null,
+  "grade_levels": null,
+  "header": null
 }

--- a/dashboard/test/models/course_offering_test.rb
+++ b/dashboard/test/models/course_offering_test.rb
@@ -438,7 +438,7 @@ class CourseOfferingTest < ActiveSupport::TestCase
   end
 
   test "can serialize and seed course offerings" do
-    course_offering = create :course_offering, key: 'course-offering-1'
+    course_offering = create :course_offering, key: 'course-offering-1', grade_levels: 'K,1,2', curriculum_type: 'Course', marketing_initiative: 'Hour of Test', header: 'Test'
     serialization = course_offering.serialize
     previous_course_offering = course_offering.freeze
     course_offering.destroy!

--- a/dashboard/test/models/course_offering_test.rb
+++ b/dashboard/test/models/course_offering_test.rb
@@ -438,7 +438,7 @@ class CourseOfferingTest < ActiveSupport::TestCase
   end
 
   test "can serialize and seed course offerings" do
-    course_offering = create :course_offering, key: 'course-offering-1', grade_levels: 'K,1,2', curriculum_type: 'Course', marketing_initiative: 'Hour of Test', header: 'Test'
+    course_offering = create :course_offering, key: 'course-offering-1', grade_levels: 'K,1,2', curriculum_type: 'course', marketing_initiative: 'hoc', header: 'popular_media'
     serialization = course_offering.serialize
     previous_course_offering = course_offering.freeze
     course_offering.destroy!

--- a/dashboard/test/models/course_offering_test.rb
+++ b/dashboard/test/models/course_offering_test.rb
@@ -438,7 +438,7 @@ class CourseOfferingTest < ActiveSupport::TestCase
   end
 
   test "can serialize and seed course offerings" do
-    course_offering = create :course_offering, key: 'course-offering-1', grade_levels: 'K,1,2', curriculum_type: 'course', marketing_initiative: 'hoc', header: 'popular_media'
+    course_offering = create :course_offering, key: 'course-offering-1', grade_levels: 'K,1,2', curriculum_type: 'Course', marketing_initiative: 'HOC', header: 'Popular Media'
     serialization = course_offering.serialize
     previous_course_offering = course_offering.freeze
     course_offering.destroy!


### PR DESCRIPTION
This PR updates the serialization of `CourseOffering` to serialize the fields added in https://github.com/code-dot-org/code-dot-org/pull/50230. No updates were needed to seed these new fields as the seed function [automatically matches](https://github.com/code-dot-org/code-dot-org/blob/64b65fc8c9b93aff63921e760a2c90696200f88f/dashboard/app/models/course_offering.rb#L191) the properties in the json blobs to properties of `CourseOffering`. It finishes [TEACH-249](https://codedotorg.atlassian.net/browse/TEACH-249).

I would recommend reviewing the individual commits of this PR:

- 92e68df2842e4f1238532f90ec5dfb3842c75018 updates the `serialize` method in `CourseOffering` to serialize the new fields
- ace2f3c0ea74ddda2c016f6216d38e63ffe4c7e0 updates the existing test to test that these new fields are seeded and serialized correctly
- f04be4b09c64a942a3be6d8f8b7bfa46b469e4ae is the output of running `CourseOffering.all.each(&:write_serialization)` in the Rails console. It's worth spot checking this commit but it doesn't need an in depth review.