### PR TITLE
Add A Checkbox for Levelbuilders to Save and Reset Version History

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -589,6 +589,20 @@ StudioApp.prototype.init = function(config) {
     this.addChangeHandler(this.editDuringRunAlertHandler.bind(this));
   }
 
+  // If url contains `reset=true`, clear the version history of the puzzle, reload page,
+  // and remove `reset` from the url params
+  const url = new URL(document.URL);
+  const params = new URLSearchParams(url.search);
+  if (params.get('reset')) {
+    params.delete('reset');
+    url.search = params.toString();
+
+    let handler = this.handleClearPuzzle.bind(this, config);
+    handler()
+      .then(project.save(true))
+      .then(window.location.replace(url.toString()));
+  }
+
   this.emit('afterInit');
 };
 

--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -288,7 +288,7 @@ class LevelsController < ApplicationController
     @level.log_changes(current_user)
 
     if @level.save
-      reset = !!params["reset"]
+      reset = !!params[:reset]
       redirect = if reset
                    params["redirect"] || level_url(@level, show_callouts: 1, reset: reset)
                  else

--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -288,7 +288,12 @@ class LevelsController < ApplicationController
     @level.log_changes(current_user)
 
     if @level.save
-      redirect = params["redirect"] || level_url(@level, show_callouts: 1)
+      reset = !!params["reset"]
+      redirect = if reset
+                   params["redirect"] || level_url(@level, show_callouts: 1, reset: reset)
+                 else
+                   params["redirect"] || level_url(@level, show_callouts: 1)
+                 end
       render json: {redirect: redirect}
     else
       log_save_error(@level)

--- a/dashboard/app/views/levels/edit.html.haml
+++ b/dashboard/app/views/levels/edit.html.haml
@@ -65,7 +65,9 @@
   .actions{style: "position: fixed; bottom: 0px; width: 100%; background-color: rgb(231, 232, 234); left: 0px; z-index: 900; display: flex; justify-content: flex-end; margin: 0px; align-items: center"}
     %span.publishLevelErrorMessage{style: "display: none; color: red; margin-bottom: 10px; margin-right: 5px; line-height: 35px;"}
       = "There was an error - scroll to the bottom to see"
+    = f.submit 'Save, publish, and reset progress', {:class => 'publishAndResetLevel', :style => "background-color: #E7E8EA; margin-bottom: 10px; margin-right: 10px; height: 35px"}
     = f.submit 'Save and publish your completed work', {:class => 'publishLevel', :style => "background-color: #f0c14b; margin-bottom: 10px; height: 35px"}
+
     %div{style: "display: flex; flex-direction: column; padding: 10px 10px 0px 10px"}
       - if @in_script
         %p Or, save, publish, and return to:
@@ -90,6 +92,11 @@
     });
 
     $('.publishLevel').click(function() {
+      saving = true;
+      $('#level_published').val(true);
+    });
+
+    $('.publishAndResetLevel').click(function() {
       saving = true;
       $('#level_published').val(true);
     });

--- a/dashboard/app/views/levels/edit.html.haml
+++ b/dashboard/app/views/levels/edit.html.haml
@@ -65,7 +65,7 @@
   .actions{style: "position: fixed; bottom: 0px; width: 100%; background-color: rgb(231, 232, 234); left: 0px; z-index: 900; display: flex; justify-content: flex-end; margin: 0px; align-items: center"}
     %span.publishLevelErrorMessage{style: "display: none; color: red; margin-bottom: 10px; margin-right: 5px; line-height: 35px;"}
       = "There was an error - scroll to the bottom to see"
-    = f.submit 'Save, publish, and reset progress', {:class => 'publishAndResetLevel', :style => "background-color: #E7E8EA; margin-bottom: 10px; margin-right: 10px; height: 35px"}
+    = f.submit 'Save, publish, and reset progress', {:class => 'publishAndResetLevel', :name => "reset", :style => "background-color: #E7E8EA; margin-bottom: 10px; margin-right: 10px; height: 35px"}
     = f.submit 'Save and publish your completed work', {:class => 'publishLevel', :style => "background-color: #f0c14b; margin-bottom: 10px; height: 35px"}
 
     %div{style: "display: flex; flex-direction: column; padding: 10px 10px 0px 10px"}

--- a/dashboard/app/views/levels/edit.html.haml
+++ b/dashboard/app/views/levels/edit.html.haml
@@ -65,7 +65,9 @@
   .actions{style: "position: fixed; bottom: 0px; width: 100%; background-color: rgb(231, 232, 234); left: 0px; z-index: 900; display: flex; justify-content: flex-end; margin: 0px; align-items: center"}
     %span.publishLevelErrorMessage{style: "display: none; color: red; margin-bottom: 10px; margin-right: 5px; line-height: 35px;"}
       = "There was an error - scroll to the bottom to see"
-    = f.submit 'Save, publish, and reset progress', {:class => 'publishAndResetLevel', :name => "reset", :style => "background-color: #E7E8EA; margin-bottom: 10px; margin-right: 10px; height: 35px"}
+    %div.resetLevel{:style => "height: 35px; margin: 15px"}
+      = label_tag 'reset', 'Reset version history when saving and loading level', {:style => "display: inline; margin-top: 4px"}
+      = check_box_tag 'reset'
     = f.submit 'Save and publish your completed work', {:class => 'publishLevel', :style => "background-color: #f0c14b; margin-bottom: 10px; height: 35px"}
 
     %div{style: "display: flex; flex-direction: column; padding: 10px 10px 0px 10px"}
@@ -92,11 +94,6 @@
     });
 
     $('.publishLevel').click(function() {
-      saving = true;
-      $('#level_published').val(true);
-    });
-
-    $('.publishAndResetLevel').click(function() {
       saving = true;
       $('#level_published').val(true);
     });


### PR DESCRIPTION
A request from levelbuilders to simplify process. Adds a checkbox to the bottom of the level editing page that says "Reset version history when saving and loading level". User can then select which script to go to. When the level is loaded, it is loaded with the URL param `reset=true`. This triggers the process of clearing project history and reloads the page. When the page is reloaded, the URL param `reset=true` is stripped out so that we don't trigger the process to clear/reload the page.

Slack discussion on turning this from button to checkbox: https://codedotorg.slack.com/archives/C045UAX4WKH/p1676411125268379

cc: @dju90 

Screenshot:
![Screenshot from 2023-02-17 09-30-58](https://user-images.githubusercontent.com/2959170/219820885-91411832-0f66-4e01-a4ef-a2831a300c3d.png)

