### PR TITLE
Rename Some `Pd::Form` Memoized Getter Methods

### DIFF
--- a/bin/cron/teacher_applications_to_gdrive
+++ b/bin/cron/teacher_applications_to_gdrive
@@ -18,20 +18,20 @@ def get_rows
     application_year: Pd::Application::ActiveApplicationModels::APPLICATION_CURRENT_YEAR
   ).where.not(status: 'incomplete').find_each do |app|
     stats = app.get_latest_school_stats(app.school_id)
-    pay_fee = app.sanitize_form_data_hash[:principal_pay_fee] || app.sanitize_form_data_hash[:pay_fee]
+    pay_fee = app.sanitized_form_data_hash[:principal_pay_fee] || app.sanitized_form_data_hash[:pay_fee]
     frl_percent = stats&.frl_eligible_percent
     # principal data is stored as a string with % at the end. Convert to float
-    if app.sanitize_form_data_hash[:principal_free_lunch_percent]
-      frl_percent = app.sanitize_form_data_hash[:principal_free_lunch_percent].to_f
+    if app.sanitized_form_data_hash[:principal_free_lunch_percent]
+      frl_percent = app.sanitized_form_data_hash[:principal_free_lunch_percent].to_f
     end
     urm_percent = stats&.urm_percent
-    if app.sanitize_form_data_hash[:principal_underrepresented_minority_percent]
-      urm_percent = app.sanitize_form_data_hash[:principal_underrepresented_minority_percent].to_f
+    if app.sanitized_form_data_hash[:principal_underrepresented_minority_percent]
+      urm_percent = app.sanitized_form_data_hash[:principal_underrepresented_minority_percent].to_f
     end
     accepted_statuses = %w(accepted)
     accepted = accepted_statuses.include?(app.status) ? 1 : 0
 
-    races = app.sanitize_form_data_hash[:race]
+    races = app.sanitized_form_data_hash[:race]
     two_or_more_races = races.length > 1 ? 1 : 0
 
     applications << [

--- a/bin/oneoff/rescore_taught_in_past
+++ b/bin/oneoff/rescore_taught_in_past
@@ -8,7 +8,7 @@ ActiveRecord::Base.transaction do
   rescored_applications = []
   puts "Rescoring taught_in_past for teacher 1920 applications..."
   Pd::Application::TeacherApplication.find_each do |application|
-    responses = application.sanitize_form_data_hash
+    responses = application.sanitized_form_data_hash
     response_scores = JSON.parse(application.response_scores)
 
     old_taught_in_past_score = response_scores["bonus_points_scores"] ? response_scores["bonus_points_scores"]["taught_in_past"] : nil

--- a/bin/oneoff/update_pd_applications_with_new_capitalization.rb
+++ b/bin/oneoff/update_pd_applications_with_new_capitalization.rb
@@ -14,7 +14,7 @@ Pd::Application::PrincipalApprovalApplication.find_each do |principal_applicatio
       next
     end
 
-    principal_response = principal_application.sanitize_form_data_hash
+    principal_response = principal_application.sanitized_form_data_hash
 
     response = principal_response.values_at(:replace_course, :replace_course_other).compact.join(": ")
     replaced_courses = principal_response.values_at(:replace_which_course_csp, :replace_which_course_csd).compact.join(', ')
@@ -52,7 +52,7 @@ Pd::Application::TeacherApplication.find_each do |teacher_application|
     principal_application = Pd::Application::PrincipalApprovalApplication.where(application_guid: teacher_application.application_guid).first
     if principal_application
 
-      principal_response = principal_application.sanitize_form_data_hash
+      principal_response = principal_application.sanitized_form_data_hash
 
       response = principal_response.values_at(:replace_course, :replace_course_other).compact.join(": ")
       replaced_courses = principal_response.values_at(:replace_which_course_csp, :replace_which_course_csd).compact.join(', ')

--- a/dashboard/app/controllers/pd/application/principal_approval_application_controller.rb
+++ b/dashboard/app/controllers/pd/application/principal_approval_application_controller.rb
@@ -14,7 +14,7 @@ module Pd::Application
 
       return render :not_found unless teacher_application
 
-      application_hash = teacher_application.sanitize_form_data_hash
+      application_hash = teacher_application.sanitized_form_data_hash
 
       @teacher_application = {
         id: teacher_application.id,

--- a/dashboard/app/models/concerns/pd/facilitator_specific_form.rb
+++ b/dashboard/app/models/concerns/pd/facilitator_specific_form.rb
@@ -13,7 +13,7 @@ module Pd::FacilitatorSpecificForm
   end
 
   def validate_required_fields
-    hash = sanitize_form_data_hash
+    hash = sanitized_form_data_hash
 
     if get_facilitator_names.any?
       add_key_error(:who_facilitated) unless hash.key?(:who_facilitated)
@@ -28,7 +28,7 @@ module Pd::FacilitatorSpecificForm
   end
 
   def validate_options
-    hash = sanitize_form_data_hash
+    hash = sanitized_form_data_hash
 
     facilitator_names = get_facilitator_names
     if hash[:who_facilitated] && facilitator_names.any?
@@ -46,7 +46,7 @@ module Pd::FacilitatorSpecificForm
   # our hash. Supports either rails-style keys (underscored symbols) or
   # JSON-style keys (camelCased strings)
   def each_facilitator_field(hash=nil, camel=false)
-    hash ||= camel ? form_data_hash : sanitize_form_data_hash
+    hash ||= camel ? form_data_hash : sanitized_form_data_hash
 
     facilitators = hash.try(:[], camel ? 'whoFacilitated' : :who_facilitated) || []
 

--- a/dashboard/app/models/concerns/pd/form.rb
+++ b/dashboard/app/models/concerns/pd/form.rb
@@ -67,7 +67,7 @@ module Pd::Form
     # its owner has been deleted.
     return if owner_deleted?
 
-    hash = sanitize_and_trim_form_data_hash
+    hash = sanitized_and_trimmed_form_data_hash
 
     # No validation is required if an application is still in progress
     # Check that status is defined because not all forms have status
@@ -92,7 +92,7 @@ module Pd::Form
   end
 
   def validate_with(options)
-    hash = sanitize_and_trim_form_data_hash
+    hash = sanitized_and_trimmed_form_data_hash
 
     hash_with_options = hash.select do |key, _|
       options.key? key
@@ -126,23 +126,23 @@ module Pd::Form
       form_data ? JSON.parse(form_data) : {}
   end
 
-  def sanitize_form_data_hash
+  def sanitized_form_data_hash
     @sanitized_form_data_hash ||=
       form_data_hash.transform_keys {|key| key.underscore.to_sym}
   end
 
-  def sanitize_and_trim_form_data_hash
+  def sanitized_and_trimmed_form_data_hash
     # empty fields may come about when the user selects then unselects an
     # option. They should be treated as if they do not exist
     @sanitized_and_trimmed_form_data_hash ||=
-      sanitize_form_data_hash.reject do |_, value|
+      sanitized_form_data_hash.reject do |_, value|
         value.blank?
       end
   end
 
   def public_sanitized_form_data_hash
     @public_sanitized_form_data_hash ||=
-      sanitize_form_data_hash.select {|key| self.class.public_fields.include? key}
+      sanitized_form_data_hash.select {|key| self.class.public_fields.include? key}
   end
 
   def form_data=(json)

--- a/dashboard/app/models/concerns/pd/jot_form_backed_form.rb
+++ b/dashboard/app/models/concerns/pd/jot_form_backed_form.rb
@@ -433,7 +433,7 @@ module Pd
       end
     end
 
-    def sanitize_form_data_hash
+    def sanitized_form_data_hash
       @sanitized_form_data_hash ||=
         form_data_hash.transform_keys {|key| key.underscore.to_sym}
     end

--- a/dashboard/app/models/pd/application/application_base.rb
+++ b/dashboard/app/models/pd/application/application_base.rb
@@ -120,7 +120,7 @@ module Pd::Application
     end
 
     def formatted_applicant_email
-      applicant_email = user.email.presence || sanitize_form_data_hash[:alternate_email]
+      applicant_email = user.email.presence || sanitized_form_data_hash[:alternate_email]
       if applicant_email.blank?
         raise "invalid email address for application #{id}"
       end
@@ -227,7 +227,7 @@ module Pd::Application
     end
 
     # Get the answers from form_data with additional text appended
-    # @param [Hash] hash - sanitized form data hash (see #sanitize_form_data_hash)
+    # @param [Hash] hash - sanitized form data hash (see #sanitized_form_data_hash)
     # @param [Symbol] field_name - name of the multi-choice option
     # @param [String] option (optional, defaults to "Other:") value for the option that is associated with additional text
     # @param [Symbol] additional_text_field_name (optional, defaults to field_name + "_other")
@@ -260,7 +260,7 @@ module Pd::Application
     # Include additional text for all the multi-select fields that have the option
     def full_answers
       @full_answers ||= begin
-        sanitize_form_data_hash.tap do |hash|
+        sanitized_form_data_hash.tap do |hash|
           additional_text_fields.each do |field_name, option, additional_text_field_name|
             next unless hash.key? field_name
 
@@ -290,7 +290,7 @@ module Pd::Application
     end
 
     def email
-      user.try(:email) || sanitize_form_data_hash[:alternate_email]
+      user.try(:email) || sanitized_form_data_hash[:alternate_email]
     end
 
     def regional_partner_name
@@ -306,7 +306,7 @@ module Pd::Application
     end
 
     def applicant_name
-      "#{sanitize_form_data_hash[:first_name]} #{sanitize_form_data_hash[:last_name]}"
+      "#{sanitized_form_data_hash[:first_name]} #{sanitized_form_data_hash[:last_name]}"
     end
 
     def total_score

--- a/dashboard/app/models/pd/application/principal_approval_application.rb
+++ b/dashboard/app/models/pd/application/principal_approval_application.rb
@@ -65,7 +65,7 @@ module Pd::Application
     end
 
     def underrepresented_minority_percent
-      sanitize_form_data_hash.select do |k, _|
+      sanitized_form_data_hash.select do |k, _|
         [
           :black,
           :hispanic,
@@ -169,7 +169,7 @@ module Pd::Application
 
     # full_answers plus the other fields from form_data
     def csv_data
-      sanitize_form_data_hash.tap do |hash|
+      sanitized_form_data_hash.tap do |hash|
         additional_text_fields.each do |field_name, option, additional_text_field_name|
           next unless hash.key? field_name
 
@@ -182,17 +182,17 @@ module Pd::Application
     end
 
     def school
-      @school ||= School.includes(:school_district).find_by(id: sanitize_form_data_hash[:school])
+      @school ||= School.includes(:school_district).find_by(id: sanitized_form_data_hash[:school])
     end
 
     def district_name
       school ?
         school.try(:school_district).try(:name).try(:titleize) :
-        sanitize_form_data_hash[:school_district_name]
+        sanitized_form_data_hash[:school_district_name]
     end
 
     def school_name
-      school ? school.name.try(:titleize) : sanitize_form_data_hash[:school_name]
+      school ? school.name.try(:titleize) : sanitized_form_data_hash[:school_name]
     end
   end
 end

--- a/dashboard/app/models/pd/application/teacher_application.rb
+++ b/dashboard/app/models/pd/application/teacher_application.rb
@@ -157,45 +157,45 @@ module Pd::Application
     end
 
     def save_partner
-      self.regional_partner_id = sanitize_form_data_hash[:regional_partner_id]
+      self.regional_partner_id = sanitized_form_data_hash[:regional_partner_id]
     end
 
     def program
-      sanitize_form_data_hash[:program]
+      sanitized_form_data_hash[:program]
     end
 
     def zip_code
-      sanitize_form_data_hash[:zip_code]
+      sanitized_form_data_hash[:zip_code]
     end
 
     def state_name
-      sanitize_form_data_hash[:state]
+      sanitized_form_data_hash[:state]
     end
 
     def district_name
       school ?
         school.try(:school_district).try(:name).try(:titleize) :
-        sanitize_form_data_hash[:school_district_name]
+        sanitized_form_data_hash[:school_district_name]
     end
 
     def school_name
-      school ? school.name.try(:titleize) : sanitize_form_data_hash[:school_name]
+      school ? school.name.try(:titleize) : sanitized_form_data_hash[:school_name]
     end
 
     def school_zip_code
-      school ? school.zip : sanitize_form_data_hash[:zip_code]
+      school ? school.zip : sanitized_form_data_hash[:zip_code]
     end
 
     def school_state
       if school
         school.state.try(:upcase)
       else
-        STATE_ABBR_WITH_DC_HASH.key(sanitize_form_data_hash[:state]).try(:to_s)
+        STATE_ABBR_WITH_DC_HASH.key(sanitized_form_data_hash[:state]).try(:to_s)
       end
     end
 
     def school_city
-      school ? school.city.try(:titleize) : sanitize_form_data_hash[:city]
+      school ? school.city.try(:titleize) : sanitized_form_data_hash[:city]
     end
 
     def school_address
@@ -212,22 +212,22 @@ module Pd::Application
         end
         address.titleize
       else
-        sanitize_form_data_hash[:address]
+        sanitized_form_data_hash[:address]
       end
     end
 
     def school_type
-      school ? school.try(:school_type).try(:titleize) : sanitize_form_data_hash[:school_type]
+      school ? school.try(:school_type).try(:titleize) : sanitized_form_data_hash[:school_type]
     end
 
     def first_name
-      hash = sanitize_form_data_hash
+      hash = sanitized_form_data_hash
       hash[:preferred_first_name] || hash[:first_name]
     end
     alias_method :teacher_first_name, :first_name
 
     def last_name
-      sanitize_form_data_hash[:last_name]
+      sanitized_form_data_hash[:last_name]
     end
 
     def state_code
@@ -239,12 +239,12 @@ module Pd::Application
     end
 
     def principal_email
-      sanitize_form_data_hash[:principal_email]
+      sanitized_form_data_hash[:principal_email]
     end
 
     # Title & last name, or full name if no title was provided.
     def principal_greeting
-      hash = sanitize_form_data_hash
+      hash = sanitized_form_data_hash
       title = hash[:principal_title]
       "#{title.presence || hash[:principal_first_name]} #{hash[:principal_last_name]}"
     end
@@ -255,12 +255,12 @@ module Pd::Application
 
     # @override
     # Add account_email (based on the associated user's email) to the sanitized form data hash
-    def sanitize_form_data_hash
+    def sanitized_form_data_hash
       super.merge(account_email: user.email)
     end
 
     def school_id
-      raw_school_id = sanitize_form_data_hash[:school]
+      raw_school_id = sanitized_form_data_hash[:school]
 
       # -1 designates custom school info, in which case return nil
       raw_school_id.to_i == -1 ? nil : raw_school_id
@@ -272,7 +272,7 @@ module Pd::Application
           school_id: school_id
         }
       else
-        hash = sanitize_form_data_hash
+        hash = sanitized_form_data_hash
         return unless hash[:school_type] && hash[:school_state] && hash[:school_zip_code] && hash[:school_name] && hash[:school_address]
         {
           country: 'US',
@@ -293,7 +293,7 @@ module Pd::Application
     end
 
     def get_first_selected_workshop
-      hash = sanitize_form_data_hash
+      hash = sanitized_form_data_hash
       return nil if hash[:teachercon]
 
       workshop_ids = hash[:regional_partner_workshop_ids]
@@ -969,7 +969,7 @@ module Pd::Application
     # principal approval application. It is idempotent, and will not override existing
     # scores on this application
     def auto_score!
-      responses = sanitize_form_data_hash
+      responses = sanitized_form_data_hash
 
       options = self.class.options(year)
       principal_options = Pd::Application::PrincipalApprovalApplication.options(year)
@@ -1126,7 +1126,7 @@ module Pd::Application
     # form data has here, as well as send emails
     def on_successful_principal_approval_create(principal_approval)
       # Approval application created, now score corresponding teacher application
-      principal_response = principal_approval.sanitize_form_data_hash
+      principal_response = principal_approval.sanitized_form_data_hash
 
       replace_course_string = principal_response.values_at(:replace_course, :replace_course_other).compact.join(": ").gsub('::', ':')
 

--- a/dashboard/app/models/pd/international_opt_in.rb
+++ b/dashboard/app/models/pd/international_opt_in.rb
@@ -183,10 +183,10 @@ class Pd::InternationalOptIn < ApplicationRecord
   end
 
   def email_opt_in?
-    sanitize_form_data_hash[:email_opt_in].casecmp?("yes")
+    sanitized_form_data_hash[:email_opt_in].casecmp?("yes")
   end
 
   def email
-    sanitize_form_data_hash[:email]
+    sanitized_form_data_hash[:email]
   end
 end

--- a/dashboard/app/models/pd/pre_workshop_survey.rb
+++ b/dashboard/app/models/pd/pre_workshop_survey.rb
@@ -46,7 +46,7 @@ class Pd::PreWorkshopSurvey < ApplicationRecord
   end
 
   def unit
-    sanitize_form_data_hash[:unit]
+    sanitized_form_data_hash[:unit]
   end
 
   def unit_not_started?
@@ -54,7 +54,7 @@ class Pd::PreWorkshopSurvey < ApplicationRecord
   end
 
   def lesson
-    sanitize_form_data_hash[:lesson]
+    sanitized_form_data_hash[:lesson]
   end
 
   def unit_lesson_short_name
@@ -83,7 +83,7 @@ class Pd::PreWorkshopSurvey < ApplicationRecord
   end
 
   def lessons
-    selected_unit = units_and_lessons.find {|u| u.first == sanitize_form_data_hash[:unit]}
+    selected_unit = units_and_lessons.find {|u| u.first == sanitized_form_data_hash[:unit]}
     selected_unit.try(:last)
   end
 

--- a/dashboard/app/models/pd/regional_partner_mini_contact.rb
+++ b/dashboard/app/models/pd/regional_partner_mini_contact.rb
@@ -30,7 +30,7 @@ class Pd::RegionalPartnerMiniContact < ApplicationRecord
 
   after_create :send_regional_partner_contact_emails
   def send_regional_partner_contact_emails
-    form = sanitize_and_trim_form_data_hash
+    form = sanitized_and_trimmed_form_data_hash
 
     # role is optional, use another word if role not given
     form[:role] = "person" unless form[:role]
@@ -62,19 +62,19 @@ class Pd::RegionalPartnerMiniContact < ApplicationRecord
   end
 
   def email
-    sanitize_form_data_hash[:email]
+    sanitized_form_data_hash[:email]
   end
 
   private
 
   def validate_email
-    hash = sanitize_form_data_hash
+    hash = sanitized_form_data_hash
 
     add_key_error(:email) unless Cdo::EmailValidator.email_address?(hash[:email])
   end
 
   def update_regional_partner
-    hash = sanitize_form_data_hash
+    hash = sanitized_form_data_hash
     zipcode = hash[:zip]
 
     self.regional_partner, _ = RegionalPartner.find_by_zip(zipcode)

--- a/dashboard/app/models/pd/teachercon_survey.rb
+++ b/dashboard/app/models/pd/teachercon_survey.rb
@@ -126,7 +126,7 @@ class Pd::TeacherconSurvey < ApplicationRecord
   def validate_required_fields
     return if owner_deleted?
 
-    hash = sanitize_form_data_hash
+    hash = sanitized_form_data_hash
 
     # validate conditional required fields
     if DISAGREES.include?(hash.try(:[], :personal_learning_needs_met))

--- a/dashboard/app/models/pd/workshop_survey.rb
+++ b/dashboard/app/models/pd/workshop_survey.rb
@@ -125,7 +125,7 @@ class Pd::WorkshopSurvey < ApplicationRecord
   def validate_required_fields
     return if owner_deleted?
 
-    hash = sanitize_form_data_hash
+    hash = sanitized_form_data_hash
 
     # validate conditional required fields
     if hash.try(:[], :will_teach) == NO

--- a/dashboard/app/serializers/api/v1/pd/workshop_enrollment_serializer.rb
+++ b/dashboard/app/serializers/api/v1/pd/workshop_enrollment_serializer.rb
@@ -16,7 +16,7 @@ class Api::V1::Pd::WorkshopEnrollmentSerializer < ActiveModel::Serializer
 
   def alternate_email
     # Note: Use dig instead of [] because RuboCop doesn't like chaining ordinary method call after safe navigation operator.
-    object&.application&.sanitize_form_data_hash&.dig(:alternate_email)
+    object&.application&.sanitized_form_data_hash&.dig(:alternate_email)
   end
 
   def school

--- a/dashboard/test/controllers/api/v1/pd/application/principal_approval_applications_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/application/principal_approval_applications_controller_test.rb
@@ -54,7 +54,7 @@ module Api::V1::Pd::Application
         principal_wont_replace_existing_course: PRINCIPAL_APPROVAL_APPLICATION_CLASS.options[:replace_course][1],
         principal_pay_fee: 'Yes, my school would be able to pay the full program fee.'
       }
-      actual_principal_fields = @teacher_application.sanitize_form_data_hash.slice(*expected_principal_fields.keys)
+      actual_principal_fields = @teacher_application.sanitized_form_data_hash.slice(*expected_principal_fields.keys)
       assert_equal expected_principal_fields, actual_principal_fields
     end
 
@@ -77,7 +77,7 @@ module Api::V1::Pd::Application
 
       assert_equal(
         'Yes',
-        teacher_application.reload.sanitize_form_data_hash[:principal_wont_replace_existing_course]
+        teacher_application.reload.sanitized_form_data_hash[:principal_wont_replace_existing_course]
       )
     end
 
@@ -106,7 +106,7 @@ module Api::V1::Pd::Application
         principal_schedule_confirmed: "Other: this is the other for master schedule",
         principal_wont_replace_existing_course: "I don't know (Please Explain): this is the other for replace course",
       }
-      actual_principal_fields = teacher_application.reload.sanitize_form_data_hash.select do |k, _|
+      actual_principal_fields = teacher_application.reload.sanitized_form_data_hash.select do |k, _|
         expected_principal_fields.key?(k)
       end
 

--- a/dashboard/test/mailers/pd/regional_partner_mini_contact_mailer_test.rb
+++ b/dashboard/test/mailers/pd/regional_partner_mini_contact_mailer_test.rb
@@ -7,7 +7,7 @@ class RegionalPartnerMiniContactMailerTest < ActionMailer::TestCase
   test 'matched links are valid urls' do
     regional_partner = build :regional_partner
     regional_partner_mini_contact = build :pd_regional_partner_mini_contact, regional_partner: regional_partner
-    form = regional_partner_mini_contact.sanitize_and_trim_form_data_hash
+    form = regional_partner_mini_contact.sanitized_and_trimmed_form_data_hash
     rp_pm = build :regional_partner_program_manager
     mail = Pd::RegionalPartnerMiniContactMailer.matched(form, rp_pm)
 
@@ -18,7 +18,7 @@ class RegionalPartnerMiniContactMailerTest < ActionMailer::TestCase
   # TODO: When cc is suported, remove email from unmatched
   test 'unmatched links are valid urls' do
     regional_partner_mini_contact = build :pd_regional_partner_mini_contact
-    form = regional_partner_mini_contact.sanitize_and_trim_form_data_hash
+    form = regional_partner_mini_contact.sanitized_and_trimmed_form_data_hash
     mail = Pd::RegionalPartnerMiniContactMailer.unmatched(form, 'nimisha@code.org')
 
     assert links_are_complete_urls?(mail)
@@ -28,7 +28,7 @@ class RegionalPartnerMiniContactMailerTest < ActionMailer::TestCase
   test 'matched receipt links are valid urls' do
     regional_partner = build :regional_partner
     regional_partner_mini_contact = build :pd_regional_partner_mini_contact, regional_partner: regional_partner
-    form = regional_partner_mini_contact.sanitize_and_trim_form_data_hash
+    form = regional_partner_mini_contact.sanitized_and_trimmed_form_data_hash
     mail = Pd::RegionalPartnerMiniContactMailer.receipt(form, regional_partner_mini_contact.regional_partner)
 
     assert links_are_complete_urls?(mail)
@@ -37,7 +37,7 @@ class RegionalPartnerMiniContactMailerTest < ActionMailer::TestCase
 
   test 'unmatched receipt links are valid urls' do
     regional_partner_mini_contact = build :pd_regional_partner_mini_contact
-    form = regional_partner_mini_contact.sanitize_and_trim_form_data_hash
+    form = regional_partner_mini_contact.sanitized_and_trimmed_form_data_hash
     mail = Pd::RegionalPartnerMiniContactMailer.receipt(form, nil)
 
     assert links_are_complete_urls?(mail)
@@ -47,7 +47,7 @@ class RegionalPartnerMiniContactMailerTest < ActionMailer::TestCase
   test 'default bcc' do
     regional_partner = build :regional_partner
     regional_partner_mini_contact = build :pd_regional_partner_mini_contact, regional_partner: regional_partner
-    form = regional_partner_mini_contact.sanitize_and_trim_form_data_hash
+    form = regional_partner_mini_contact.sanitized_and_trimmed_form_data_hash
     rp_pm = build :regional_partner_program_manager
     mail = Pd::RegionalPartnerMiniContactMailer.matched(form, rp_pm)
 

--- a/dashboard/test/mailers/previews/pd_regional_partner_mini_contact_mailer_preview.rb
+++ b/dashboard/test/mailers/previews/pd_regional_partner_mini_contact_mailer_preview.rb
@@ -28,6 +28,6 @@ class PdRegionalPartnerMiniContactMailerPreview < ActionMailer::Preview
 
   def build_form_data(contact_factory, **factory_options)
     contact = build contact_factory, factory_options
-    contact.sanitize_and_trim_form_data_hash
+    contact.sanitized_and_trimmed_form_data_hash
   end
 end

--- a/dashboard/test/models/concerns/pd/form_test.rb
+++ b/dashboard/test/models/concerns/pd/form_test.rb
@@ -54,7 +54,7 @@ class DummyFormWithDynamicOptions < DummyForm
 
   # Valid options depend on which option_set is selected, determined at runtime
   def dynamic_options
-    case sanitize_form_data_hash[:option_set]
+    case sanitized_form_data_hash[:option_set]
     when '1'
       {
         option: %w(One Two)
@@ -210,7 +210,7 @@ class Pd::FormTest < ActiveSupport::TestCase
     assert_nil form.instance_variable_get(:@form_data_hash)
   end
 
-  test 'memoized sanitize_form_data_hash' do
+  test 'memoized sanitized_form_data_hash' do
     form = DummyForm.new(
       form_data_hash: {
         firstField: 'value1',
@@ -224,14 +224,14 @@ class Pd::FormTest < ActiveSupport::TestCase
     }
 
     assert_nil form.instance_variable_get(:@sanitized_form_data_hash)
-    assert_equal sanitized_form_data_hash, form.sanitize_form_data_hash
+    assert_equal sanitized_form_data_hash, form.sanitized_form_data_hash
     assert_equal sanitized_form_data_hash, form.instance_variable_get(:@sanitized_form_data_hash)
 
     form.form_data = nil
     assert_nil form.instance_variable_get(:@sanitized_form_data_hash)
   end
 
-  test 'memoized sanitize_and_trim_form_data_hash' do
+  test 'memoized sanitized_and_trimmed_form_data_hash' do
     form = DummyForm.new(
       form_data_hash: {
         firstField: 'value1',
@@ -244,7 +244,7 @@ class Pd::FormTest < ActiveSupport::TestCase
     }
 
     assert_nil form.instance_variable_get(:@sanitized_and_trimmed_form_data_hash)
-    assert_equal sanitized_and_trimmed_form_data_hash, form.sanitize_and_trim_form_data_hash
+    assert_equal sanitized_and_trimmed_form_data_hash, form.sanitized_and_trimmed_form_data_hash
     assert_equal sanitized_and_trimmed_form_data_hash, form.instance_variable_get(:@sanitized_and_trimmed_form_data_hash)
 
     form.form_data = nil

--- a/dashboard/test/models/pd/application/application_base_test.rb
+++ b/dashboard/test/models/pd/application/application_base_test.rb
@@ -191,7 +191,7 @@ module Pd::Application
         filtered_question: 'to be removed'
       }
 
-      application.stubs(sanitize_form_data_hash: form_data)
+      application.stubs(sanitized_form_data_hash: form_data)
       ApplicationBase.stubs(filtered_labels: form_data.except(:filtered_question))
 
       expected_full_answers = {
@@ -247,7 +247,7 @@ module Pd::Application
         string_question_with_extra: 'Other:',
         string_question_with_extra_other: 'my other string answer',
       }
-      application.stubs(sanitize_form_data_hash: form_data)
+      application.stubs(sanitized_form_data_hash: form_data)
       ApplicationBase.stubs(filtered_labels: form_data)
 
       expected_full_answers = {
@@ -383,7 +383,7 @@ module Pd::Application
 
       assert teacher_without_email.email.blank?
 
-      formatted_alternate_email = "\"#{application.applicant_full_name}\" <#{application.sanitize_form_data_hash[:alternate_email]}>"
+      formatted_alternate_email = "\"#{application.applicant_full_name}\" <#{application.sanitized_form_data_hash[:alternate_email]}>"
       assert_equal formatted_alternate_email, application.formatted_applicant_email
     end
 
@@ -395,7 +395,7 @@ module Pd::Application
       application_without_email = create :pd_teacher_application, user: teacher_without_email, form_data: application_hash_without_email.to_json
 
       assert teacher_without_email.email.blank?
-      assert application_without_email.sanitize_form_data_hash[:alternate_email].blank?
+      assert application_without_email.sanitized_form_data_hash[:alternate_email].blank?
       assert_raises_matching("invalid email address for application #{application_without_email.id}") do
         application_without_email.formatted_applicant_email
       end

--- a/dashboard/test/models/pd/pre_workshop_survey_test.rb
+++ b/dashboard/test/models/pd/pre_workshop_survey_test.rb
@@ -70,7 +70,7 @@ class Pd::PreWorkshopSurveyTest < ActiveSupport::TestCase
       'Form data lesson'
     ], survey.errors.full_messages
 
-    survey.form_data = survey.sanitize_form_data_hash.merge({unit: UNIT_1}).to_json
+    survey.form_data = survey.sanitized_form_data_hash.merge({unit: UNIT_1}).to_json
     assert survey.valid?
   end
 


### PR DESCRIPTION
In preparation for reenabling the `Naming/MemoizedInstanceVariableName` Rubocop rule, rename two methods which do not match their memoized instance variable name.

The *easier* approach here would obviously be to update the memoized instance variable names to match, but after looking at the way these methods are actually being used, the variable name seems more appropriate. These are getter methods, which by Ruby naming convention should be named so as to represent the underlying data being got; the current names are more appropriate for methods which accept a Hash as an argument and return a processed version of that hash.

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

Also updated relevant tests.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
