### PR TITLE
Add question responses to teacher application detail view

### DIFF
--- a/apps/src/code-studio/pd/application_dashboard/detail_view_contents.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/detail_view_contents.jsx
@@ -720,7 +720,7 @@ export class DetailViewContents extends React.Component {
   };
 
   renderDetailViewTableLayout = () => {
-    const questionsToRemove = ['genderIdentity', 'race', 'currentRole'];
+    const questionsToRemove = ['genderIdentity', 'race'];
 
     return (
       <div>

--- a/apps/src/code-studio/pd/application_dashboard/detail_view_contents.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/detail_view_contents.jsx
@@ -720,69 +720,65 @@ export class DetailViewContents extends React.Component {
   };
 
   renderDetailViewTableLayout = () => {
-    const sectionsToRemove = ['additionalDemographicInformation'];
-    const questionsToRemove = ['genderIdentity', 'race'];
+    const questionsToRemove = ['genderIdentity', 'race', 'currentRole'];
 
     return (
       <div>
-        {_.pull(Object.keys(this.sectionHeaders), ...sectionsToRemove).map(
-          (header, i) => (
-            <div key={i}>
-              <h3>{this.sectionHeaders[header]}</h3>
-              {header === 'administratorInformation' &&
-                this.renderModifyPrincipalApprovalSection()}
-              <Table style={styles.detailViewTable} striped bordered>
-                <tbody>
-                  {_.pull(
-                    Object.keys(this.pageLabels[header]),
-                    ...questionsToRemove
-                  ).map((key, j) => {
-                    // If the enoughCourseHours question, insert variable values.
-                    // Otherwise, just show the question's label.
-                    const questionLabel =
-                      key === 'enoughCourseHours'
-                        ? this.labelOverrides[key]
-                            .replace(
-                              '{{CS program}}',
-                              getProgramInfo(
-                                PROGRAM_MAP[this.props.applicationData.course]
-                              ).name
-                            )
-                            .replace(
-                              '{{min hours}}',
-                              getProgramInfo(
-                                PROGRAM_MAP[this.props.applicationData.course]
-                              ).minCourseHours
-                            )
-                        : this.labelOverrides[key] ||
-                          this.pageLabels[header][key];
-                    return (
-                      // For most fields, render them only when they have values.
-                      // For explicitly listed fields, render them regardless of their values.
-                      (this.props.applicationData.form_data[key] ||
-                        key === 'alternateEmail' ||
-                        header ===
-                          'schoolStatsAndPrincipalApprovalSection') && (
-                        <tr key={j}>
-                          <td style={styles.questionColumn}>
-                            <InlineMarkdown markdown={questionLabel} />
-                          </td>
-                          <td style={styles.answerColumn}>
-                            {this.renderAnswer(
-                              key,
-                              this.props.applicationData.form_data[key]
-                            )}
-                          </td>
-                          {this.renderScoringSection(key)}
-                        </tr>
-                      )
-                    );
-                  })}
-                </tbody>
-              </Table>
-            </div>
-          )
-        )}
+        {Object.keys(this.sectionHeaders).map((header, i) => (
+          <div key={i}>
+            <h3>{this.sectionHeaders[header]}</h3>
+            {header === 'administratorInformation' &&
+              this.renderModifyPrincipalApprovalSection()}
+            <Table style={styles.detailViewTable} striped bordered>
+              <tbody>
+                {_.pull(
+                  Object.keys(this.pageLabels[header]),
+                  ...questionsToRemove
+                ).map((key, j) => {
+                  // If the enoughCourseHours question, insert variable values.
+                  // Otherwise, just show the question's label.
+                  const questionLabel =
+                    key === 'enoughCourseHours'
+                      ? this.labelOverrides[key]
+                          .replace(
+                            '{{CS program}}',
+                            getProgramInfo(
+                              PROGRAM_MAP[this.props.applicationData.course]
+                            ).name
+                          )
+                          .replace(
+                            '{{min hours}}',
+                            getProgramInfo(
+                              PROGRAM_MAP[this.props.applicationData.course]
+                            ).minCourseHours
+                          )
+                      : this.labelOverrides[key] ||
+                        this.pageLabels[header][key];
+                  return (
+                    // For most fields, render them only when they have values.
+                    // For explicitly listed fields, render them regardless of their values.
+                    (this.props.applicationData.form_data[key] ||
+                      key === 'alternateEmail' ||
+                      header === 'schoolStatsAndPrincipalApprovalSection') && (
+                      <tr key={j}>
+                        <td style={styles.questionColumn}>
+                          <InlineMarkdown markdown={questionLabel} />
+                        </td>
+                        <td style={styles.answerColumn}>
+                          {this.renderAnswer(
+                            key,
+                            this.props.applicationData.form_data[key]
+                          )}
+                        </td>
+                        {this.renderScoringSection(key)}
+                      </tr>
+                    )
+                  );
+                })}
+              </tbody>
+            </Table>
+          </div>
+        ))}
       </div>
     );
   };

--- a/lib/cdo/shared_constants/pd/teacher_application_constants.rb
+++ b/lib/cdo/shared_constants/pd/teacher_application_constants.rb
@@ -62,14 +62,14 @@ module Pd
         city: 'Home city',
         state: 'Home state',
         zip_code: 'Home zip code',
-        how_heard: 'How did you hear about this program?',
-        previous_yearlong_cdo_pd: clean_multiline(
-          "Have you participated in previous yearlong Code.org Professional Learning Programs?
-           If so, mark the programs you've participated in."
-        )
+        how_heard: 'How did you hear about this program?'
       },
       additional_demographic_information: {
         current_role: 'What is your current role at your school?',
+        previous_yearlong_cdo_pd: clean_multiline(
+          "Have you participated in previous yearlong Code.org Professional Learning Programs?
+           If so, mark the programs you've participated in."
+        ),
         csa_already_know: 'Have you previously taught CS or have you learned CS yourself?',
         csa_phone_screen: clean_multiline(
           'Are you able to independently write a function (or procedure) with one or more

--- a/lib/cdo/shared_constants/pd/teacher_application_constants.rb
+++ b/lib/cdo/shared_constants/pd/teacher_application_constants.rb
@@ -66,15 +66,15 @@ module Pd
         previous_yearlong_cdo_pd: clean_multiline(
           "Have you participated in previous yearlong Code.org Professional Learning Programs?
            If so, mark the programs you've participated in."
-        ),
-        csa_already_know: 'Have you previously taught CS or have you learned CS yourself?',
-        csa_phone_screen: clean_multiline(
-          'Are you able to independently write a function (or procedure) with one or more
-          parameters and that uses conditional logic, loops, and an array (or list)?'
         )
       },
       additional_demographic_information: {
         current_role: 'What is your current role at your school?',
+        csa_already_know: 'Have you previously taught CS or have you learned CS yourself?',
+        csa_phone_screen: clean_multiline(
+          'Are you able to independently write a function (or procedure) with one or more
+          parameters and that uses conditional logic, loops, and an array (or list)?'
+        ),
         gender_identity: 'Gender identity:',
         race: 'Race or ethnicity:',
       },

--- a/lib/cdo/shared_constants/pd/teacher_application_constants.rb
+++ b/lib/cdo/shared_constants/pd/teacher_application_constants.rb
@@ -66,15 +66,15 @@ module Pd
         previous_yearlong_cdo_pd: clean_multiline(
           "Have you participated in previous yearlong Code.org Professional Learning Programs?
            If so, mark the programs you've participated in."
-        )
-      },
-      additional_demographic_information: {
-        current_role: 'What is your current role at your school?',
+        ),
         csa_already_know: 'Have you previously taught CS or have you learned CS yourself?',
         csa_phone_screen: clean_multiline(
           'Are you able to independently write a function (or procedure) with one or more
           parameters and that uses conditional logic, loops, and an array (or list)?'
-        ),
+        )
+      },
+      additional_demographic_information: {
+        current_role: 'What is your current role at your school?',
         gender_identity: 'Gender identity:',
         race: 'Race or ethnicity:',
       },

--- a/lib/cdo/shared_constants/pd/teacher_application_constants.rb
+++ b/lib/cdo/shared_constants/pd/teacher_application_constants.rb
@@ -62,14 +62,14 @@ module Pd
         city: 'Home city',
         state: 'Home state',
         zip_code: 'Home zip code',
-        how_heard: 'How did you hear about this program?'
-      },
-      additional_demographic_information: {
-        current_role: 'What is your current role at your school?',
+        how_heard: 'How did you hear about this program?',
         previous_yearlong_cdo_pd: clean_multiline(
           "Have you participated in previous yearlong Code.org Professional Learning Programs?
            If so, mark the programs you've participated in."
-        ),
+        )
+      },
+      additional_demographic_information: {
+        current_role: 'What is your current role at your school?',
         csa_already_know: 'Have you previously taught CS or have you learned CS yourself?',
         csa_phone_screen: clean_multiline(
           'Are you able to independently write a function (or procedure) with one or more


### PR DESCRIPTION
Adds four question responses to the detail view of the teacher application:
- 'What is your current role at your school?'
- 'Have you participated in previous yearlong Code.org Professional Learning Programs? If so, mark the programs you've participated in.'
- 'Have you previously taught CS or have you learned CS yourself?'
-  'Are you able to independently write a function (or procedure) with one or more parameters and that uses conditional logic, loops, and an array (or list)?'

The "meets guidelines" portion [is defined in teacher_application.rb](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/models/pd/application/teacher_application.rb#L989) –– in particular:
- the application DOES meet guidelines if the applicant has never taken PD *of this exact course* before. It does NOT meet guidelines if they have taken this course's PD before.
- the application DOES NOT meet guidelines if the applicant answered "no" to either of the CSA screening questions

Tested this locally:
<img width="1170" alt="image" src="https://user-images.githubusercontent.com/9142121/220974838-f71b68e6-8a4c-435e-afb8-5068f81e958d.png">

There are currently no unit tests to ensure individual questions are being shown, and I'm not sure it makes sense to have unit tests, as they're coming through via ruby-defined constants and there's an eyes test that will capture changes. Happy to have more discussion here though.

## Links

See https://codedotorg.atlassian.net/browse/ACQ-350 for link to discussion about this –– we're showing all demographic information, minus race and gender, in a new section.

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
