### PR TITLE
Fix hamburger on homepage

### DIFF
--- a/apps/src/hamburger/hamburger.js
+++ b/apps/src/hamburger/hamburger.js
@@ -1,4 +1,3 @@
-import $ from 'jquery';
 import trackEvent from '../util/trackEvent';
 import {
   getChannelIdFromUrl,
@@ -6,7 +5,7 @@ import {
 } from '@cdo/apps/reportAbuse';
 
 export const initHamburger = function() {
-  $(function() {
+  $(document).ready(function() {
     $('#hamburger-icon').click(function(e) {
       $(this).toggleClass('active');
       $('#hamburger').removeClass('user-is-tabbing');


### PR DESCRIPTION
The hamburger menu, shown on narrow screens, was not opening on the signed-out homepage at https://code.org.

I'm not sure when this stopped working, but the issue appeared to be that the `$` in that file, courtesy of an `import $ from 'jquery'`, was not the real jQuery that is eventually loaded into that page's `window.$`, but a minimal ["shim" jQuery](https://github.com/code-dot-org/code-dot-org/blob/2cafdd4e2b84fcf810fade6fa0fc5e3a2db92e57/pegasus/sites.v3/code.org/views/jquery_shim.js.erb) that the homepage attaches to `window.$` until the real jQuery is loaded into the page in a [deferred](https://github.com/code-dot-org/code-dot-org/blob/2cafdd4e2b84fcf810fade6fa0fc5e3a2db92e57/pegasus/sites.v3/code.org/public/index.haml#L10) [manner](https://github.com/code-dot-org/code-dot-org/blob/2cafdd4e2b84fcf810fade6fa0fc5e3a2db92e57/pegasus/sites.v3/code.org/views/jquery.haml#L7-L9).  Even after `$.window` became the real jQuery, this `$` remained the shim that it apparently picked up from `window.$` earlier.

Of all things, the simplest fix seems to be removing the `import $ from 'jquery'` and then, at least on all my local repros, the real jQuery is used by the hamburger code.

For good measure, I adjusted the hamburger initialization to use `$(document).ready(` so that if only the shim is in place, it should still work.

Verified locally that the hamburger works correctly on https://code.org, https://code.org/about, and https://studio.code.org/courses.