### PR TITLE
Only log 'Unit Overview Page Visited' Amplitude event for teachers

### DIFF
--- a/apps/src/code-studio/components/progress/UnitOverview.jsx
+++ b/apps/src/code-studio/components/progress/UnitOverview.jsx
@@ -66,7 +66,8 @@ class UnitOverview extends React.Component {
     viewAs: PropTypes.oneOf(Object.values(ViewType)).isRequired,
     hiddenLessonState: PropTypes.object,
     selectedSectionId: PropTypes.number,
-    userId: PropTypes.number
+    userId: PropTypes.number,
+    userType: PropTypes.string
   };
 
   constructor(props) {
@@ -75,9 +76,11 @@ class UnitOverview extends React.Component {
       props.redirectScriptUrl && props.redirectScriptUrl.length > 0;
     this.state = {showRedirectDialog};
 
-    analyticsReporter.sendEvent(EVENTS.UNIT_OVERVIEW_PAGE_VISITED_EVENT, {
-      'unit name': props.scriptName
-    });
+    if (props.userType === 'teacher') {
+      analyticsReporter.sendEvent(EVENTS.UNIT_OVERVIEW_PAGE_VISITED_EVENT, {
+        'unit name': props.scriptName
+      });
+    }
   }
 
   onCloseRedirectDialog = () => {

--- a/apps/src/code-studio/components/progress/UnitOverview.jsx
+++ b/apps/src/code-studio/components/progress/UnitOverview.jsx
@@ -77,9 +77,12 @@ class UnitOverview extends React.Component {
     this.state = {showRedirectDialog};
 
     if (props.userType === 'teacher') {
-      analyticsReporter.sendEvent(EVENTS.UNIT_OVERVIEW_PAGE_VISITED_EVENT, {
-        'unit name': props.scriptName
-      });
+      analyticsReporter.sendEvent(
+        EVENTS.UNIT_OVERVIEW_PAGE_VISITED_BY_TEACHER_EVENT,
+        {
+          'unit name': props.scriptName
+        }
+      );
     }
   }
 

--- a/apps/src/lib/util/AnalyticsConstants.js
+++ b/apps/src/lib/util/AnalyticsConstants.js
@@ -13,7 +13,8 @@ const EVENTS = {
 
   // Course/Unit info
   COURSE_OVERVIEW_PAGE_VISITED_EVENT: 'Course Overview Page Visited',
-  UNIT_OVERVIEW_PAGE_VISITED_EVENT: 'Unit Overview Page Visited',
+  UNIT_OVERVIEW_PAGE_VISITED_BY_TEACHER_EVENT:
+    'Unit Overview Page Visited By Teacher',
   TRY_NOW_BUTTON_CLICK_EVENT: 'Try Now Button Clicked',
 
   // Lesson info

--- a/apps/src/sites/studio/pages/scripts/show.js
+++ b/apps/src/sites/studio/pages/scripts/show.js
@@ -120,6 +120,7 @@ function initPage() {
         showAssignButton={scriptData.show_assign_button}
         isProfessionalLearningCourse={scriptData.isPlCourse}
         userId={scriptData.user_id}
+        userType={scriptData.user_type}
         assignedSectionId={scriptData.assigned_section_id}
         showCalendar={scriptData.showCalendar}
         weeklyInstructionalMinutes={scriptData.weeklyInstructionalMinutes}


### PR DESCRIPTION
The sheer volume of "Unit Overview Page Visited" events in Amplitude is consuming a large portion of what we are allotted by our plan with Amplitude. To save on resources, this PR only logs that event when a teacher views the page.

## View as student (doesn't show "Unit Overview Page Visited" event)
![view_as_student](https://user-images.githubusercontent.com/56283563/219112774-51231934-f5a6-4172-8a6f-1d96e03d06ed.JPG)

## View as teacher (shows "Unit Overview Page Visited" event)
![view_as_teacher](https://user-images.githubusercontent.com/56283563/219112766-d43b5d23-0650-4eee-949f-184961a3ce97.JPG)

## Links
Jira task: [here](https://codedotorg.atlassian.net/browse/ACQ-391?atlOrigin=eyJpIjoiZTBkMDJjNTY2MWU0NGZkOWE0ZTdlYzUwYzhiN2I3NjAiLCJwIjoiaiJ9)

## Testing story
Local testing.

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
