### PR TITLE
Javalab: Exit dropdowns using Escape key

### DIFF
--- a/apps/src/javalab/Backpack.jsx
+++ b/apps/src/javalab/Backpack.jsx
@@ -217,6 +217,12 @@ class Backpack extends Component {
     }
   };
 
+  handleKeyDown = event => {
+    if (this.state.dropdownOpen && event.key === 'Escape') {
+      this.collapseDropdown();
+    }
+  };
+
   toggleDropdown = () => {
     if (this.state.dropdownOpen) {
       this.collapseDropdown();
@@ -319,7 +325,10 @@ class Backpack extends Component {
     // to align with other buttons in the JavalabEditor header,
     // which all use PaneButton.
     return (
-      <>
+      <div
+        id="javalab-editor-backpack-container"
+        onKeyDown={this.handleKeyDown}
+      >
         <PaneButton
           id="javalab-editor-backpack"
           icon={backpackIcon}
@@ -456,7 +465,7 @@ class Backpack extends Component {
           displayTheme={displayTheme}
           confirmButtonText={msg.dialogOK()}
         />
-      </>
+      </div>
     );
   }
 }

--- a/apps/src/javalab/Backpack.jsx
+++ b/apps/src/javalab/Backpack.jsx
@@ -325,10 +325,7 @@ class Backpack extends Component {
     // to align with other buttons in the JavalabEditor header,
     // which all use PaneButton.
     return (
-      <div
-        id="javalab-editor-backpack-container"
-        onKeyDown={this.handleKeyDown}
-      >
+      <div onKeyDown={this.handleKeyDown}>
         <PaneButton
           id="javalab-editor-backpack"
           icon={backpackIcon}

--- a/apps/src/javalab/Backpack.jsx
+++ b/apps/src/javalab/Backpack.jsx
@@ -12,6 +12,7 @@ import {DisplayTheme} from './DisplayTheme';
 import {makeEnum} from '@cdo/apps/utils';
 import JavalabDialog from './JavalabDialog';
 import {PaneButton} from '@cdo/apps/templates/PaneHeader';
+import CloseOnEscape from './components/CloseOnEscape';
 
 const Dialog = makeEnum(
   'IMPORT_WARNING',
@@ -217,12 +218,6 @@ class Backpack extends Component {
     }
   };
 
-  handleKeyDown = event => {
-    if (this.state.dropdownOpen && event.key === 'Escape') {
-      this.collapseDropdown();
-    }
-  };
-
   toggleDropdown = () => {
     if (this.state.dropdownOpen) {
       this.collapseDropdown();
@@ -325,7 +320,7 @@ class Backpack extends Component {
     // to align with other buttons in the JavalabEditor header,
     // which all use PaneButton.
     return (
-      <div onKeyDown={this.handleKeyDown}>
+      <CloseOnEscape handleClose={this.handleClickOutside}>
         <PaneButton
           id="javalab-editor-backpack"
           icon={backpackIcon}
@@ -462,7 +457,7 @@ class Backpack extends Component {
           displayTheme={displayTheme}
           confirmButtonText={msg.dialogOK()}
         />
-      </div>
+      </CloseOnEscape>
     );
   }
 }

--- a/apps/src/javalab/JavalabEditor.jsx
+++ b/apps/src/javalab/JavalabEditor.jsx
@@ -372,6 +372,12 @@ class JavalabEditor extends React.Component {
     });
   }
 
+  handleKeyDown = event => {
+    if (this.state.showMenu && event.key === 'Escape') {
+      this.cancelTabMenu();
+    }
+  };
+
   // This moves the active tab to the left in the tab menu
   moveTabLeft() {
     const {activeTabKey, orderedTabKeys} = this.props;
@@ -675,7 +681,7 @@ class JavalabEditor extends React.Component {
       zIndex: 1000
     };
     return (
-      <div>
+      <div onKeyDown={this.handleKeyDown}>
         <JavalabEditorHeader onBackpackImportFile={this.onImportFile} />
         <Tab.Container
           activeKey={activeTabKey}

--- a/apps/src/javalab/JavalabEditor.jsx
+++ b/apps/src/javalab/JavalabEditor.jsx
@@ -49,6 +49,7 @@ import JavalabEditorDialogManager, {
 } from './JavalabEditorDialogManager';
 import JavalabEditorHeader from './JavalabEditorHeader';
 import {java} from '@codemirror/lang-java';
+import CloseOnEscape from './components/CloseOnEscape';
 
 // This is the height of the "editor" header and the file tabs combined
 const HEADER_OFFSET = 63;
@@ -372,12 +373,6 @@ class JavalabEditor extends React.Component {
     });
   }
 
-  handleKeyDown = event => {
-    if (this.state.showMenu && event.key === 'Escape') {
-      this.cancelTabMenu();
-    }
-  };
-
   // This moves the active tab to the left in the tab menu
   moveTabLeft() {
     const {activeTabKey, orderedTabKeys} = this.props;
@@ -681,7 +676,7 @@ class JavalabEditor extends React.Component {
       zIndex: 1000
     };
     return (
-      <div onKeyDown={this.handleKeyDown}>
+      <CloseOnEscape handleClose={this.cancelTabMenu}>
         <JavalabEditorHeader onBackpackImportFile={this.onImportFile} />
         <Tab.Container
           activeKey={activeTabKey}
@@ -818,7 +813,7 @@ class JavalabEditor extends React.Component {
           handleClearPuzzle={handleClearPuzzle}
           isProjectTemplateLevel={isProjectTemplateLevel}
         />
-      </div>
+      </CloseOnEscape>
     );
   }
 }

--- a/apps/src/javalab/JavalabEditorTabMenu.jsx
+++ b/apps/src/javalab/JavalabEditorTabMenu.jsx
@@ -23,10 +23,6 @@ export class JavalabEditorTabMenu extends Component {
     orderedTabKeys: PropTypes.array
   };
 
-  state = {
-    dropdownOpen: false
-  };
-
   dropdownElements = () => {
     const {
       renameFromTabMenu,

--- a/apps/src/javalab/JavalabFileExplorer.jsx
+++ b/apps/src/javalab/JavalabFileExplorer.jsx
@@ -36,6 +36,12 @@ class JavalabFileExplorer extends Component {
     }
   };
 
+  handleKeyDown = event => {
+    if (this.state.dropdownOpen && event.key === 'Escape') {
+      this.collapseDropdown();
+    }
+  };
+
   toggleDropdown = () => {
     if (this.state.dropdownOpen) {
       this.collapseDropdown();
@@ -63,7 +69,7 @@ class JavalabFileExplorer extends Component {
     const files = this.transformFileMetadata();
 
     return (
-      <div style={styles.main}>
+      <div style={styles.main} onKeyDown={this.handleKeyDown}>
         <button
           aria-label={i18n.fileExplorer()}
           type="button"

--- a/apps/src/javalab/JavalabFileExplorer.jsx
+++ b/apps/src/javalab/JavalabFileExplorer.jsx
@@ -6,6 +6,7 @@ import FontAwesome from '@cdo/apps/templates/FontAwesome';
 import JavalabDropdown from './components/JavalabDropdown';
 import {DisplayTheme} from './DisplayTheme';
 import i18n from '@cdo/locale';
+import CloseOnEscape from './components/CloseOnEscape';
 
 /**
  * A button that drops down to a set of clickable file names, and closes itself if
@@ -32,12 +33,6 @@ class JavalabFileExplorer extends Component {
 
   handleClickOutside = () => {
     if (this.state.dropdownOpen) {
-      this.collapseDropdown();
-    }
-  };
-
-  handleKeyDown = event => {
-    if (this.state.dropdownOpen && event.key === 'Escape') {
       this.collapseDropdown();
     }
   };
@@ -69,7 +64,7 @@ class JavalabFileExplorer extends Component {
     const files = this.transformFileMetadata();
 
     return (
-      <div style={styles.main} onKeyDown={this.handleKeyDown}>
+      <CloseOnEscape style={styles.main} handleClose={this.handleClickOutside}>
         <button
           aria-label={i18n.fileExplorer()}
           type="button"
@@ -97,7 +92,7 @@ class JavalabFileExplorer extends Component {
               ))}
           </JavalabDropdown>
         )}
-      </div>
+      </CloseOnEscape>
     );
   }
 }

--- a/apps/src/javalab/JavalabSettings.jsx
+++ b/apps/src/javalab/JavalabSettings.jsx
@@ -48,6 +48,12 @@ export class UnconnectedJavalabSettings extends Component {
     }
   };
 
+  handleKeyDown = event => {
+    if (this.state.dropdownOpen && event.key === 'Escape') {
+      this.collapseDropdown();
+    }
+  };
+
   toggleDropdown = () => {
     if (this.state.dropdownOpen) {
       this.collapseDropdown();
@@ -140,7 +146,7 @@ export class UnconnectedJavalabSettings extends Component {
     const {dropdownOpen} = this.state;
 
     return (
-      <div className={style.main}>
+      <div className={style.main} onKeyDown={this.handleKeyDown}>
         <JavalabButton
           icon={<FontAwesome icon="cog" />}
           text={msg.settings()}

--- a/apps/src/javalab/JavalabSettings.jsx
+++ b/apps/src/javalab/JavalabSettings.jsx
@@ -14,6 +14,7 @@ import {
   increaseEditorFontSize,
   setDisplayTheme
 } from './javalabRedux';
+import CloseOnEscape from './components/CloseOnEscape';
 
 /**
  * Displays the settings options for JavaLab.
@@ -44,12 +45,6 @@ export class UnconnectedJavalabSettings extends Component {
 
   handleClickOutside = () => {
     if (this.state.dropdownOpen) {
-      this.collapseDropdown();
-    }
-  };
-
-  handleKeyDown = event => {
-    if (this.state.dropdownOpen && event.key === 'Escape') {
       this.collapseDropdown();
     }
   };
@@ -146,7 +141,10 @@ export class UnconnectedJavalabSettings extends Component {
     const {dropdownOpen} = this.state;
 
     return (
-      <div className={style.main} onKeyDown={this.handleKeyDown}>
+      <CloseOnEscape
+        className={style.main}
+        handleClose={this.handleClickOutside}
+      >
         <JavalabButton
           icon={<FontAwesome icon="cog" />}
           text={msg.settings()}
@@ -158,7 +156,7 @@ export class UnconnectedJavalabSettings extends Component {
           isHorizontal
         />
         {dropdownOpen && this.renderDropdown()}
-      </div>
+      </CloseOnEscape>
     );
   }
 }

--- a/apps/src/javalab/components/CloseOnEscape.jsx
+++ b/apps/src/javalab/components/CloseOnEscape.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * Utility wrapper component that calls a close function when the Escape key is pressed
+ */
+const CloseOnEscape = ({handleClose, className, children}) => {
+  const handleKeyDown = event => {
+    if (event.key === 'Escape') {
+      handleClose();
+    }
+  };
+
+  return (
+    <div className={className} onKeyDown={handleKeyDown}>
+      {children}
+    </div>
+  );
+};
+
+CloseOnEscape.propTypes = {
+  handleClose: PropTypes.func.isRequired,
+  children: PropTypes.node,
+  className: PropTypes.string
+};
+
+export default CloseOnEscape;

--- a/apps/test/unit/javalab/BackpackTest.js
+++ b/apps/test/unit/javalab/BackpackTest.js
@@ -220,4 +220,17 @@ describe('Java Lab Backpack Test', () => {
     // backpackFilenames should have length 2 (file3 should be gone)
     expect(state.backpackFilenames.length).to.equal(2);
   });
+
+  it('Closes dropdown when Escape pressed', () => {
+    const wrapper = shallow(<Backpack {...defaultProps} />);
+    wrapper.instance().expandDropdown();
+    expect(wrapper.instance().state.dropdownOpen).to.be.true;
+
+    wrapper
+      .find('div')
+      .first()
+      .props()
+      .onKeyDown({key: 'Escape'});
+    expect(wrapper.instance().state.dropdownOpen).to.be.false;
+  });
 });

--- a/apps/test/unit/javalab/BackpackTest.js
+++ b/apps/test/unit/javalab/BackpackTest.js
@@ -220,17 +220,4 @@ describe('Java Lab Backpack Test', () => {
     // backpackFilenames should have length 2 (file3 should be gone)
     expect(state.backpackFilenames.length).to.equal(2);
   });
-
-  it('Closes dropdown when Escape pressed', () => {
-    const wrapper = shallow(<Backpack {...defaultProps} />);
-    wrapper.instance().expandDropdown();
-    expect(wrapper.instance().state.dropdownOpen).to.be.true;
-
-    wrapper
-      .find('div')
-      .first()
-      .props()
-      .onKeyDown({key: 'Escape'});
-    expect(wrapper.instance().state.dropdownOpen).to.be.false;
-  });
 });

--- a/apps/test/unit/javalab/JavalabEditorTest.js
+++ b/apps/test/unit/javalab/JavalabEditorTest.js
@@ -174,6 +174,30 @@ describe('Java Lab Editor Test', () => {
         expect(editor.find('JavalabEditor').instance().state.contextTarget).to
           .be.null;
       });
+
+      it('Closes tab menu when Escape pressed', () => {
+        const editor = createWrapper();
+        editor
+          .find('JavalabEditor')
+          .instance()
+          .setState({
+            showMenu: true,
+            contextTarget: 'file-0',
+            menuPosition: {
+              top: '2px',
+              left: '4px'
+            }
+          });
+
+        editor
+          .find('div')
+          .first()
+          .props()
+          .onKeyDown({key: 'Escape'});
+
+        expect(editor.find('JavalabEditor').instance().state.showMenu).to.be
+          .false;
+      });
     });
 
     describe('Rename', () => {

--- a/apps/test/unit/javalab/JavalabEditorTest.js
+++ b/apps/test/unit/javalab/JavalabEditorTest.js
@@ -174,30 +174,6 @@ describe('Java Lab Editor Test', () => {
         expect(editor.find('JavalabEditor').instance().state.contextTarget).to
           .be.null;
       });
-
-      it('Closes tab menu when Escape pressed', () => {
-        const editor = createWrapper();
-        editor
-          .find('JavalabEditor')
-          .instance()
-          .setState({
-            showMenu: true,
-            contextTarget: 'file-0',
-            menuPosition: {
-              top: '2px',
-              left: '4px'
-            }
-          });
-
-        editor
-          .find('div')
-          .first()
-          .props()
-          .onKeyDown({key: 'Escape'});
-
-        expect(editor.find('JavalabEditor').instance().state.showMenu).to.be
-          .false;
-      });
     });
 
     describe('Rename', () => {

--- a/apps/test/unit/javalab/JavalabSettingsTest.js
+++ b/apps/test/unit/javalab/JavalabSettingsTest.js
@@ -124,17 +124,4 @@ describe('JavalabSettings', () => {
     assert.isTrue(decreaseButton.first().props().disabled);
     assert.isFalse(increaseButton.first().props().disabled);
   });
-
-  it('closes dropdown when Escape pressed', () => {
-    const wrapper = createWrapper();
-    wrapper.instance().toggleDropdown();
-    assert.isTrue(wrapper.instance().state.dropdownOpen);
-
-    wrapper
-      .find('div')
-      .first()
-      .props()
-      .onKeyDown({key: 'Escape'});
-    assert.isFalse(wrapper.instance().state.dropdownOpen);
-  });
 });

--- a/apps/test/unit/javalab/JavalabSettingsTest.js
+++ b/apps/test/unit/javalab/JavalabSettingsTest.js
@@ -124,4 +124,17 @@ describe('JavalabSettings', () => {
     assert.isTrue(decreaseButton.first().props().disabled);
     assert.isFalse(increaseButton.first().props().disabled);
   });
+
+  it('closes dropdown when Escape pressed', () => {
+    const wrapper = createWrapper();
+    wrapper.instance().toggleDropdown();
+    assert.isTrue(wrapper.instance().state.dropdownOpen);
+
+    wrapper
+      .find('div')
+      .first()
+      .props()
+      .onKeyDown({key: 'Escape'});
+    assert.isFalse(wrapper.instance().state.dropdownOpen);
+  });
 });

--- a/apps/test/unit/javalab/components/CloseOnEscapeTest.js
+++ b/apps/test/unit/javalab/components/CloseOnEscapeTest.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import {expect} from '../../../util/reconfiguredChai';
+import sinon from 'sinon';
+import CloseOnEscape from '@cdo/apps/javalab/components/CloseOnEscape';
+
+describe('CloseOnEscape', () => {
+  let wrapper, handleClose, className;
+
+  beforeEach(() => {
+    className = '.class-name';
+    handleClose = sinon.spy();
+    wrapper = shallow(
+      <CloseOnEscape handleClose={handleClose} className={className} />
+    );
+  });
+
+  it('calls handleClose() function when Escape pressed', () => {
+    wrapper
+      .find('div')
+      .first()
+      .props()
+      .onKeyDown({key: 'Escape'});
+
+    sinon.assert.calledOnce(handleClose);
+  });
+
+  it('passes through provided class name', () => {
+    expect(
+      wrapper
+        .find('div')
+        .first()
+        .props().className
+    ).to.equal(className);
+  });
+});


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Quick win - adds an onKeyDown handler to our various dropdowns to close dropdown when the escape key is pressed.

https://user-images.githubusercontent.com/85528507/219129761-32f2ce31-1ef0-4e5f-a976-52590c1120ac.mov

## Links

https://codedotorg.atlassian.net/browse/SL-108

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Tested locally.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
