### PR TITLE
skip pointer blocks if in google blockly

### DIFF
--- a/apps/src/block_utils.js
+++ b/apps/src/block_utils.js
@@ -1110,45 +1110,48 @@ exports.createJsWrapperBlockCreator = function(
           this.initMiniFlyout(miniToolboxXml);
         }
 
-        // Set block to shadow for preview field if needed
-        switch (this.type) {
-          case 'gamelab_clickedSpritePointer':
-            this.setBlockToShadow(
-              root =>
-                root.type === 'gamelab_spriteClicked' &&
-                root.getConnections_()[1] &&
-                root.getConnections_()[1].targetBlock()
-            );
-            break;
-          case 'gamelab_newSpritePointer':
-            this.setBlockToShadow(
-              root =>
-                root.type === 'gamelab_whenSpriteCreated' &&
-                root.getConnections_()[1] &&
-                root.getConnections_()[1].targetBlock()
-            );
-            break;
-          case 'gamelab_subjectSpritePointer':
-            this.setBlockToShadow(
-              root =>
-                root.type === 'gamelab_checkTouching' &&
-                root.getConnections_()[1] &&
-                root.getConnections_()[1].targetBlock()
-            );
-            break;
-          case 'gamelab_objectSpritePointer':
-            this.setBlockToShadow(
-              root =>
-                root.type === 'gamelab_checkTouching' &&
-                root.getConnections_()[2] &&
-                root.getConnections_()[2].targetBlock()
-            );
-            break;
-          default:
-            // Not a pointer block, so no block to shadow
-            break;
+        // These blocks should not be loaded into a Google Blockly level.
+        // In the event that they are, skip this so the page doesn't crash.
+        if (this.setBlockToShadow) {
+          // Set block to shadow for preview field if needed
+          switch (this.type) {
+            case 'gamelab_clickedSpritePointer':
+              this.setBlockToShadow(
+                root =>
+                  root.type === 'gamelab_spriteClicked' &&
+                  root.getConnections_()[1] &&
+                  root.getConnections_()[1].targetBlock()
+              );
+              break;
+            case 'gamelab_newSpritePointer':
+              this.setBlockToShadow(
+                root =>
+                  root.type === 'gamelab_whenSpriteCreated' &&
+                  root.getConnections_()[1] &&
+                  root.getConnections_()[1].targetBlock()
+              );
+              break;
+            case 'gamelab_subjectSpritePointer':
+              this.setBlockToShadow(
+                root =>
+                  root.type === 'gamelab_checkTouching' &&
+                  root.getConnections_()[1] &&
+                  root.getConnections_()[1].targetBlock()
+              );
+              break;
+            case 'gamelab_objectSpritePointer':
+              this.setBlockToShadow(
+                root =>
+                  root.type === 'gamelab_checkTouching' &&
+                  root.getConnections_()[2] &&
+                  root.getConnections_()[2].targetBlock()
+              );
+              break;
+            default:
+              // Not a pointer block, so no block to shadow
+              break;
+          }
         }
-
         interpolateInputs(blockly, this, inputRows, inputTypes, inline);
         this.setInputsInline(inline);
       }


### PR DESCRIPTION
Editing start blocks is currently broken in Poetry levels: https://codedotorg.slack.com/archives/C03DBDN67B7/p1676488273718519

Console error: `this.setBlockToShadow is not a function`
`setBlockToShadow` is a CDO Blockly thing that we use for the event blocks with mini-toolboxes. Those blocks aren’t available in Poetry yet because we haven’t made them work with Google Blockly.
![image (56)](https://user-images.githubusercontent.com/43474485/219140531-803d1484-7a64-4af6-a0a1-1b13dd61c2e2.png)

As a quick fix, before trying to call `setBlockToShadow` we can check whether it exists. If this step is skipped, the blocks are not created correctly, but at least the page doesn't crash. 

This is intended to unblock the curriculum team who are currently developing Poetry levels. 
As follow-up work, we should look into whether this is a regression and make sure that unsupported blocks are not added to start mode toolboxes in the first place.

Start mode now works, albeit with broken blocks that are not yet supported in Google Blockly labs.
![image](https://user-images.githubusercontent.com/43474485/219140957-ebc189f6-a812-4858-a618-f892bdd1eb34.png)

No new regressions in Sprite Lab (pointer blocks work as expected):
![image](https://user-images.githubusercontent.com/43474485/219141957-edcf25b0-f133-4b21-ac2c-2e1473963795.png)


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
