### PR TITLE
Prefactor for student upload

### DIFF
--- a/apps/src/code-studio/components/ShareAllowedDialog.jsx
+++ b/apps/src/code-studio/components/ShareAllowedDialog.jsx
@@ -178,18 +178,34 @@ class ShareAllowedDialog extends React.Component {
   };
 
   render() {
+    const {
+      canPrint,
+      canPublish,
+      isPublished,
+      canShareSocial,
+      icon,
+      appType,
+      selectedSong,
+      shareUrl,
+      isOpen,
+      hideBackdrop,
+      isAbusive,
+      isUnpublishPending,
+      onClickPopup,
+      exportApp,
+      channelId
+    } = this.props;
+
     let image;
     let modalClass = 'modal-content';
-    if (this.props.icon) {
-      image = <img className="modal-image" src={this.props.icon} />;
+    if (icon) {
+      image = <img className="modal-image" src={icon} />;
     } else {
       modalClass += ' no-modal-icon';
     }
 
-    const isDroplet =
-      this.props.appType === 'applab' || this.props.appType === 'gamelab';
-    const artistTwitterHandle =
-      SongTitlesToArtistTwitterHandle[this.props.selectedSong];
+    const isDroplet = appType === 'applab' || appType === 'gamelab';
+    const artistTwitterHandle = SongTitlesToArtistTwitterHandle[selectedSong];
 
     const hasThumbnail = !!this.props.thumbnailUrl;
     const thumbnailUrl = hasThumbnail
@@ -198,7 +214,7 @@ class ShareAllowedDialog extends React.Component {
 
     const facebookShareUrl =
       'https://www.facebook.com/sharer/sharer.php?u=' +
-      encodeURIComponent(this.props.shareUrl);
+      encodeURIComponent(shareUrl);
 
     const tweetText = artistTwitterHandle
       ? `Check out the dance I made featuring @${artistTwitterHandle} on @codeorg!`
@@ -212,13 +228,13 @@ class ShareAllowedDialog extends React.Component {
       'https://twitter.com/intent/tweet?text=' +
       encodeURIComponent(tweetText) +
       '&url=' +
-      encodeURIComponent(this.props.shareUrl) +
+      encodeURIComponent(shareUrl) +
       `&hashtags=${hashtags.join(comma)}` +
       '&related=codeorg';
 
-    const showShareWarning = !this.props.canShareSocial && isDroplet;
+    const showShareWarning = !canShareSocial && isDroplet;
     let embedOptions;
-    if (this.props.appType === 'applab') {
+    if (appType === 'applab') {
       embedOptions = {
         // If you change this width and height, make sure to update the
         // #visualizationColumn.wireframeShare css
@@ -227,7 +243,7 @@ class ShareAllowedDialog extends React.Component {
         // Extra 40 pixels added to account for left and right padding divs (20 px each side)
         iframeWidth: applabConstants.APP_WIDTH + 32 + 40
       };
-    } else if (this.props.appType === 'gamelab') {
+    } else if (appType === 'gamelab') {
       embedOptions = {
         // If you change this width and height, make sure to update the
         // #visualizationColumn.wireframeShare css
@@ -236,14 +252,14 @@ class ShareAllowedDialog extends React.Component {
         iframeWidth: p5labConstants.APP_WIDTH + 40
       };
     }
-    const {canPrint, canPublish, isPublished} = this.props;
+
     return (
       <div>
         <BaseDialog
           style={styles.modal}
-          isOpen={this.props.isOpen}
+          isOpen={isOpen}
           handleClose={this.close}
-          hideBackdrop={this.props.hideBackdrop}
+          hideBackdrop={hideBackdrop}
         >
           {this.sharingDisabled() && (
             <div style={{position: 'relative'}}>
@@ -271,15 +287,13 @@ class ShareAllowedDialog extends React.Component {
                 style={{position: 'relative'}}
               >
                 <p className="dialog-title">{i18n.shareTitle()}</p>
-                {this.props.isAbusive && (
+                {isAbusive && (
                   <AbuseError
                     i18n={{
                       tos: i18n.tosLong({url: 'http://code.org/tos'}),
                       contact_us: i18n.contactUs({
                         url: `https://support.code.org/hc/en-us/requests/new?&description=${encodeURIComponent(
-                          `Abuse error for project at url: ${
-                            this.props.shareUrl
-                          }`
+                          `Abuse error for project at url: ${shareUrl}`
                         )}`
                       })
                     }}
@@ -305,7 +319,7 @@ class ShareAllowedDialog extends React.Component {
                         ...(this.state.hasBeenCopied && styles.copyButtonLight)
                       }}
                       onClick={wrapShareClick(this.copy, 'copy')}
-                      value={this.props.shareUrl}
+                      value={shareUrl}
                     >
                       <FontAwesome icon="clipboard" style={{fontSize: 16}} />
                       <span style={{paddingLeft: 10}}>
@@ -347,7 +361,7 @@ class ShareAllowedDialog extends React.Component {
                   {canPublish && isPublished && (
                     <PendingButton
                       id="share-dialog-unpublish-button"
-                      isPending={this.props.isUnpublishPending}
+                      isPending={isUnpublishPending}
                       onClick={this.unpublish}
                       pendingText={i18n.unpublishPending()}
                       style={styles.button}
@@ -363,7 +377,7 @@ class ShareAllowedDialog extends React.Component {
                     </a>
                   )}
                   {/* prevent buttons from overlapping when unpublish is pending */}
-                  {this.props.canShareSocial && !this.props.isUnpublishPending && (
+                  {canShareSocial && !isUnpublishPending && (
                     <span>
                       {this.state.isFacebookAvailable && (
                         <a
@@ -371,7 +385,7 @@ class ShareAllowedDialog extends React.Component {
                           target="_blank"
                           rel="noopener noreferrer"
                           onClick={wrapShareClick(
-                            this.props.onClickPopup.bind(this),
+                            onClickPopup.bind(this),
                             'facebook'
                           )}
                         >
@@ -384,7 +398,7 @@ class ShareAllowedDialog extends React.Component {
                           target="_blank"
                           rel="noopener noreferrer"
                           onClick={wrapShareClick(
-                            this.props.onClickPopup.bind(this),
+                            onClickPopup.bind(this),
                             'twitter'
                           )}
                         >
@@ -399,17 +413,14 @@ class ShareAllowedDialog extends React.Component {
                     <div style={styles.sendToPhoneContainer}>
                       <div style={styles.sendToPhoneLeft}>
                         <SendToPhone
-                          channelId={this.props.channelId}
-                          appType={this.props.appType}
+                          channelId={channelId}
+                          appType={appType}
                           isLegacyShare={false}
                         />
                       </div>
                       <div style={styles.sendToPhoneRight}>
                         <label>{i18n.scanQRCode()}</label>
-                        <QRCode
-                          value={this.props.shareUrl + '?qr=true'}
-                          size={90}
-                        />
+                        <QRCode value={shareUrl + '?qr=true'} size={90} />
                       </div>
                     </div>
                     <div style={{clear: 'both'}} />
@@ -432,11 +443,11 @@ class ShareAllowedDialog extends React.Component {
                 <div style={{clear: 'both', marginTop: 40}}>
                   {isDroplet && (
                     <AdvancedShareOptions
-                      shareUrl={this.props.shareUrl}
-                      exportApp={this.props.exportApp}
+                      shareUrl={shareUrl}
+                      exportApp={exportApp}
                       expanded={this.state.showAdvancedOptions}
                       onExpand={this.showAdvancedOptions}
-                      channelId={this.props.channelId}
+                      channelId={channelId}
                       embedOptions={embedOptions}
                     />
                   )}
@@ -446,7 +457,7 @@ class ShareAllowedDialog extends React.Component {
           )}
         </BaseDialog>
         <PublishDialog />
-        <LibraryCreationDialog channelId={this.props.channelId} />
+        <LibraryCreationDialog channelId={channelId} />
       </div>
     );
   }

--- a/apps/src/p5lab/AnimationPicker/AnimationPickerBody.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPickerBody.jsx
@@ -226,7 +226,7 @@ export default class AnimationPickerBody extends React.Component {
     const inCategory = categoryQuery !== '';
     const isBackgroundsTab =
       this.props.pickerType === 'backgrounds' &&
-      experiments.isEnabled('backgroundsTab');
+      experiments.isEnabled(experiments.BACKGROUNDS_AND_UPLOAD);
     // Display second "Done" button. Useful for mobile, where the original "done" button might not be on screen when
     // animation picker is loaded. 600 pixels is minimum height of the animation picker.
     const shouldDisplaySecondDoneButton = isMobileDevice();

--- a/apps/src/p5lab/AnimationTab/AnimationTab.jsx
+++ b/apps/src/p5lab/AnimationTab/AnimationTab.jsx
@@ -60,7 +60,8 @@ class AnimationTab extends React.Component {
     }
     const hideCostumes = interfaceMode === P5LabInterfaceMode.BACKGROUND;
     const animationsColumnStyle =
-      labType !== P5LabType.GAMELAB && experiments.isEnabled('backgroundsTab')
+      labType !== P5LabType.GAMELAB &&
+      experiments.isEnabled(experiments.BACKGROUNDS_AND_UPLOAD)
         ? styles.animationsColumnSpritelab
         : styles.animationsColumnGamelab;
     return (

--- a/apps/src/p5lab/P5LabVisualizationHeader.jsx
+++ b/apps/src/p5lab/P5LabVisualizationHeader.jsx
@@ -106,7 +106,7 @@ class P5LabVisualizationHeader extends React.Component {
               )}
               {allowAnimationMode &&
                 this.props.isBlockly &&
-                experiments.isEnabled('backgroundsTab') && (
+                experiments.isEnabled(experiments.BACKGROUNDS_AND_UPLOAD) && (
                   <button
                     style={{
                       ...styles.buttonFocus,

--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -216,7 +216,7 @@ const customInputTypes = {
         getStore().getState().pageConstants &&
         getStore().getState().pageConstants.showAnimationMode
       ) {
-        buttons = experiments.isEnabled('backgroundsTab')
+        buttons = experiments.isEnabled(experiments.BACKGROUNDS_AND_UPLOAD)
           ? [
               {
                 text: i18n.backgroundMode(),

--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -35,6 +35,9 @@ experiments.BYPASS_DIALOG_POPUP = 'bypass-dialog-popup';
 experiments.SPECIAL_TOPIC = 'special-topic';
 experiments.CLEARER_SIGN_UP_USER_TYPE = 'clearerSignUpUserType';
 experiments.OPT_IN_EMAIL_REG_PARTNER = 'optInEmailRegPartner';
+// Experiment for showing a backgrounds tab and enabling student upload
+// for Sprite Lab animations
+experiments.BACKGROUNDS_AND_UPLOAD = 'backgroundsTab';
 
 /**
  * This was a gamified version of the finish dialog, built in 2018,


### PR DESCRIPTION
A couple clean-up changes that will make the sprite lab student upload PR a little smaller:
- add an experiments constant for `backgroundsTab`. We are going to use this to cover both the backgrounds tab and student upload
- extract out constants for various `props` in `ShareAllowedDialog`. The only change in that file is moving from `this.props.<propname>` to `<propname>` (defined as a constant)

## Testing story
Tested locally