### PR TITLE
Remove report inaccuracy ability on /yourschool

### DIFF
--- a/apps/src/templates/census2017/CensusForm.jsx
+++ b/apps/src/templates/census2017/CensusForm.jsx
@@ -14,8 +14,6 @@ import {
 import SchoolAutocompleteDropdownWithLabel from './SchoolAutocompleteDropdownWithLabel';
 import CountryAutocompleteDropdown from '../CountryAutocompleteDropdown';
 import SchoolNotFound from '../SchoolNotFound';
-import FontAwesome from '@cdo/apps/templates/FontAwesome';
-import ReactTooltip from 'react-tooltip';
 import {styles} from './censusFormStyles';
 
 export const censusFormPrefillDataShape = PropTypes.shape({
@@ -35,10 +33,7 @@ class CensusForm extends Component {
     prefillData: censusFormPrefillDataShape,
     initialSchoolYear: PropTypes.number,
     schoolDropdownOption: PropTypes.object,
-    onSchoolDropdownChange: PropTypes.func,
-    showExistingInaccuracy: PropTypes.bool,
-    existingInaccuracy: PropTypes.bool,
-    onExistingInaccuracyChange: PropTypes.func
+    onSchoolDropdownChange: PropTypes.func
   };
 
   constructor(props) {
@@ -74,8 +69,7 @@ class CensusForm extends Component {
         followUpMore: '',
         acceptedPledge: false,
         share: '',
-        optIn: '',
-        existingInaccuracyReason: ''
+        optIn: ''
       },
       errors: {
         invalidEmail: false
@@ -276,13 +270,6 @@ class CensusForm extends Component {
     );
   }
 
-  validateExistingInaccuracyReason() {
-    return (
-      this.props.existingInaccuracy &&
-      this.validateNotBlank(this.state.submission.existingInaccuracyReason)
-    );
-  }
-
   validateSubmission() {
     this.setState(
       {
@@ -300,8 +287,7 @@ class CensusForm extends Component {
           tenHours: this.validateNotBlank(this.state.submission.tenHours),
           twentyHours: this.validateNotBlank(this.state.submission.twentyHours),
           share: this.validateNotBlank(this.state.submission.share),
-          optIn: this.validateNotBlank(this.state.submission.optIn),
-          existingInaccuracyReason: this.validateExistingInaccuracyReason()
+          optIn: this.validateNotBlank(this.state.submission.optIn)
         }
       },
       this.censusFormSubmit
@@ -323,8 +309,7 @@ class CensusForm extends Component {
       !errors.twentyHours &&
       !errors.country &&
       !errors.share &&
-      !errors.optIn &&
-      !errors.existingInaccuracyReason
+      !errors.optIn
     ) {
       $.ajax({
         url: '/dashboardapi/v1/census/CensusYourSchool2017v7',
@@ -367,8 +352,7 @@ class CensusForm extends Component {
       errors.country ||
       errors.nces ||
       errors.share ||
-      errors.optIn ||
-      errors.existingInaccuracyReason
+      errors.optIn
     );
     const US = submission.country === 'United States';
     const prefillData = this.props.prefillData || {};
@@ -381,7 +365,6 @@ class CensusForm extends Component {
       US &&
       (schoolId === '-1' ||
         (schoolDropdownOption && schoolDropdownOption.value === '-1'));
-    const showExistingInaccuracy = this.props.showExistingInaccuracy;
 
     return (
       <div id="form">
@@ -578,74 +561,6 @@ class CensusForm extends Component {
               <span style={styles.otherCS}>{i18n.censusOtherCourse()}</span>
             </label>
           </div>
-
-          {showExistingInaccuracy && (
-            <div>
-              <div style={styles.checkboxLine}>
-                <label style={styles.clickable}>
-                  <input
-                    type="checkbox"
-                    name="inaccuracy_reported"
-                    checked={this.props.existingInaccuracy}
-                    onChange={event =>
-                      this.props.onExistingInaccuracyChange(
-                        event.target.checked
-                      )
-                    }
-                  />
-                  <span style={styles.existingInaccuracy}>
-                    {i18n.censusExistingInaccuracy()}
-                  </span>
-                </label>
-                <span data-tip data-for="existing-inaccuracy">
-                  <FontAwesome icon="question-circle" />
-                </span>
-              </div>
-
-              <ReactTooltip
-                id="existing-inaccuracy"
-                class="react-tooltip-hover-stay"
-                role="tooltip"
-                effect="solid"
-                place="bottom"
-                offset={{bottom: 23, right: 7}}
-                delayHide={1000}
-              >
-                <div style={styles.existingInaccuracyTooltip}>
-                  {i18n.censusExistingInaccuracyTip()}
-                  &nbsp;
-                  <a href="/yourschool/about" target="_blank">
-                    {i18n.censusExistingInaccuracyTipLink()}
-                  </a>
-                </div>
-              </ReactTooltip>
-            </div>
-          )}
-
-          {this.props.existingInaccuracy && (
-            <div>
-              <label>
-                <div style={styles.question}>
-                  {i18n.censusExistingInaccuracyReason()}
-                </div>
-                {errors.existingInaccuracyReason && (
-                  <div style={styles.errors}>
-                    {i18n.censusRequiredExistingInaccuracyReason()}
-                  </div>
-                )}
-                <textarea
-                  type="text"
-                  name="inaccuracy_comment"
-                  value={this.state.submission.existingInaccuracyReason}
-                  onChange={this.handleChange.bind(
-                    this,
-                    'existingInaccuracyReason'
-                  )}
-                  style={styles.textArea}
-                />
-              </label>
-            </div>
-          )}
 
           {showFollowUp && (
             <div>

--- a/apps/src/templates/census2017/CensusMapReplacement.jsx
+++ b/apps/src/templates/census2017/CensusMapReplacement.jsx
@@ -111,17 +111,6 @@ class CensusMapInfoWindow extends Component {
             </a>
           </div>
         </div>
-        {!missingCensusData && (
-          <div className="inaccuracy-link">
-            <a
-              onClick={() =>
-                this.props.onTakeSurveyClick(schoolDropdownOption, true)
-              }
-            >
-              I believe that the categorization for this school is inaccurate.
-            </a>
-          </div>
-        )}
       </div>
     );
   }

--- a/apps/src/templates/census2017/YourSchool.jsx
+++ b/apps/src/templates/census2017/YourSchool.jsx
@@ -27,16 +27,12 @@ class YourSchool extends Component {
   };
 
   state = {
-    schoolDropdownOption: undefined,
-    showExistingInaccuracy: false,
-    existingInaccuracy: false
+    schoolDropdownOption: undefined
   };
 
-  handleTakeSurveyClick = (schoolDropdownOption, existingInaccuracy) => {
+  handleTakeSurveyClick = schoolDropdownOption => {
     this.setState({
-      schoolDropdownOption: schoolDropdownOption,
-      showExistingInaccuracy: existingInaccuracy,
-      existingInaccuracy: existingInaccuracy
+      schoolDropdownOption: schoolDropdownOption
     });
     adjustScroll('form');
   };
@@ -50,15 +46,7 @@ class YourSchool extends Component {
 
   handleSchoolDropdownChange = option => {
     this.setState({
-      schoolDropdownOption: option,
-      showExistingInaccuracy: false,
-      existingInaccuracy: false
-    });
-  };
-
-  handleExistingInaccuracyChange = option => {
-    this.setState({
-      existingInaccuracy: option
+      schoolDropdownOption: option
     });
   };
 
@@ -75,8 +63,6 @@ class YourSchool extends Component {
     if (schoolDropdownOption && schoolId !== '-1') {
       schoolForMap = schoolDropdownOption.school;
     }
-    const showExistingInaccuracy = this.state.showExistingInaccuracy;
-    const existingInaccuracy = this.state.existingInaccuracy;
 
     // Hide the special announcement.
     const showSpecialAnnouncement = false;
@@ -133,9 +119,6 @@ class YourSchool extends Component {
           prefillData={this.props.prefillData}
           schoolDropdownOption={schoolDropdownOption}
           onSchoolDropdownChange={this.handleSchoolDropdownChange}
-          showExistingInaccuracy={showExistingInaccuracy}
-          existingInaccuracy={existingInaccuracy}
-          onExistingInaccuracyChange={this.handleExistingInaccuracyChange}
           initialSchoolYear={this.props.currentCensusYear}
         />
       </div>

--- a/apps/src/templates/census2017/censusFormStyles.js
+++ b/apps/src/templates/census2017/censusFormStyles.js
@@ -40,15 +40,6 @@ export const styles = {
     marginRight: 20,
     marginLeft: 20
   },
-  existingInaccuracy: {
-    fontFamily: '"Gotham 4r", sans-serif',
-    color: color.charcoal,
-    marginRight: 20,
-    marginLeft: 20
-  },
-  existingInaccuracyTooltip: {
-    width: 270
-  },
   option: {
     fontFamily: '"Gotham 4r", sans-serif',
     color: color.charcoal,

--- a/dashboard/app/models/census/README.md
+++ b/dashboard/app/models/census/README.md
@@ -62,7 +62,6 @@ Summaries are recomputed every night via a [cron job](https://github.com/code-do
 
 # Mapping from `census_submissions` column names to census questions
 Topic questions only show up for those who indicated that their school has a 10 or 20 hr class.
-INACCURACY_REPORTED and INACCURACY_COMMENT only show when the user clicks the "I believe that the categorization for this school is inaccurate" link from the map info window.
 
 | Column Name | Question |
 | ----------- | -------- |
@@ -87,8 +86,6 @@ INACCURACY_REPORTED and INACCURACY_COMMENT only show when the user clicks the "I
 | TELL_US_MORE | "Please tell us more about this course." |
 | PLEDGED | "I pledge to expand computer science offerings at my school, and to engage a diverse group of students, to bring opportunity to all." |
 | SHARE_WITH_REGIONAL_PARTNERS | "Share my contact information with the Code.org regional partner in my state so I can be contacted about local professional learning, resources and events." |
-| INACCURACY_REPORTED | "I believe that the computer science categorization for this school is inaccurate" |
-| INACCURACY_COMMENT | "Explain why you think that the categorization for this school is inaccurate" |
 
 # Historic Notes
 


### PR DESCRIPTION
Now that we are no longer having people report inaccuracies with the school data since we do not go back and update past access reports, this PR removes both components of the report school information inaccuracy ability on [code.org/yourschool](http://code.org/yourschool):

## Removes the clickable option
Originally, if you click on a school on the map on [code.org/yourschool](http://code.org/yourschool) it gave you an option to click "I believe that the categorization for this school is inaccurate" at the bottom of the card:
![Previously showed link](https://user-images.githubusercontent.com/56283563/219789296-c96a6258-eccf-4a9a-8b15-17707eba47c3.JPG)

Now that is gone:
![Now_no_show_link](https://user-images.githubusercontent.com/56283563/219789439-a94075cd-8fc7-4805-b1ec-728fe9705129.JPG)

## Removes the checkbox + text input
Originally, when clicking "I believe that the categorization for this school is inaccurate" it adds a checkbox and text input field to the survey below:
![Previously showed textbox and checkbox](https://user-images.githubusercontent.com/56283563/219789264-3410977d-20c2-42cf-a7b2-de337276539a.JPG)

Now that is also gone:
![Now no longer shows extra checkbox for incorrect info](https://user-images.githubusercontent.com/56283563/219789309-e4165623-25cd-466b-bed7-f6042a6ca9df.JPG)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/browse/ACQ-398?atlOrigin=eyJpIjoiNWFjNTkzY2YwNmNkNDk3MmE2ZWY3NDc4MGViZTEyZWQiLCJwIjoiaiJ9)

## Testing story
Local testing.

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
