### PR TITLE
Stub out route to fetch course offerings for quick assign

### DIFF
--- a/dashboard/app/controllers/course_offerings_controller.rb
+++ b/dashboard/app/controllers/course_offerings_controller.rb
@@ -22,6 +22,77 @@ class CourseOfferingsController < ApplicationController
     render(status: :not_acceptable, plain: e.message)
   end
 
+  def quick_assign_course_offerings
+    offerings = {}
+
+    offerings[:elementary] = {
+      Course: {
+        'CS Fundamentals': [
+          CourseOffering.find_by_key('coursea').summarize_for_quick_assign(current_user, request.locale),
+          CourseOffering.find_by_key('courseb').summarize_for_quick_assign(current_user, request.locale),
+          CourseOffering.find_by_key('coursec').summarize_for_quick_assign(current_user, request.locale)
+        ],
+        'Express Courses': [
+          CourseOffering.find_by_key('express').summarize_for_quick_assign(current_user, request.locale),
+          CourseOffering.find_by_key('pre-express').summarize_for_quick_assign(current_user, request.locale)
+        ]
+      },
+      Module: {
+        'CS Connections': [
+          CourseOffering.find_by_key('poetry').summarize_for_quick_assign(current_user, request.locale)
+        ]
+      }
+    }
+
+    offerings[:middle] = {
+      Course: {
+        'Express Courses': [
+          CourseOffering.find_by_key('express').summarize_for_quick_assign(current_user, request.locale),
+          CourseOffering.find_by_key('pre-express').summarize_for_quick_assign(current_user, request.locale)
+        ],
+        'Year-Long Courses': [
+          CourseOffering.find_by_key('csd').summarize_for_quick_assign(current_user, request.locale)
+        ]
+      },
+      'Standalone Unit': {
+        'Self-Paced': [
+          CourseOffering.find_by_key('csd3-virtual').summarize_for_quick_assign(current_user, request.locale),
+          CourseOffering.find_by_key('csp3-virtual').summarize_for_quick_assign(current_user, request.locale)
+        ],
+        'Teacher-Led': [
+          CourseOffering.find_by_key('aiml').summarize_for_quick_assign(current_user, request.locale),
+          CourseOffering.find_by_key('devices').summarize_for_quick_assign(current_user, request.locale)
+        ]
+      }
+    }
+
+    offerings[:high] = {
+      Course: {
+        'Year-Long Courses': [
+          CourseOffering.find_by_key('csa').summarize_for_quick_assign(current_user, request.locale),
+          CourseOffering.find_by_key('csd').summarize_for_quick_assign(current_user, request.locale),
+          CourseOffering.find_by_key('csp').summarize_for_quick_assign(current_user, request.locale)
+        ]
+      },
+      'Standalone Unit': {
+        'CSA Labs': [
+          CourseOffering.find_by_key('csa-collegeboard-labs').summarize_for_quick_assign(current_user, request.locale),
+          CourseOffering.find_by_key('csa-data-lab').summarize_for_quick_assign(current_user, request.locale)
+        ],
+        'Self-Paced': [
+          CourseOffering.find_by_key('csd3-virtual').summarize_for_quick_assign(current_user, request.locale),
+          CourseOffering.find_by_key('csp3-virtual').summarize_for_quick_assign(current_user, request.locale)
+        ],
+        'Teacher-Led': [
+          CourseOffering.find_by_key('aiml').summarize_for_quick_assign(current_user, request.locale),
+          CourseOffering.find_by_key('devices').summarize_for_quick_assign(current_user, request.locale)
+        ]
+      }
+    }
+
+    render :ok, json: offerings.to_json
+  end
+
   private
 
   def course_offering_params

--- a/dashboard/app/controllers/course_offerings_controller.rb
+++ b/dashboard/app/controllers/course_offerings_controller.rb
@@ -26,40 +26,40 @@ class CourseOfferingsController < ApplicationController
     offerings = {}
 
     offerings[:elementary] = {
-      Course: {
-        'CS Fundamentals': [
+      Curriculum::SharedCourseConstants::COURSE_OFFERING_CURRICULUM_TYPES.course => {
+        Curriculum::SharedCourseConstants::COURSE_OFFERING_HEADERS.csf => [
           CourseOffering.find_by_key('coursea').summarize_for_quick_assign(current_user, request.locale),
           CourseOffering.find_by_key('courseb').summarize_for_quick_assign(current_user, request.locale),
           CourseOffering.find_by_key('coursec').summarize_for_quick_assign(current_user, request.locale)
         ],
-        'Express Courses': [
+        Curriculum::SharedCourseConstants::COURSE_OFFERING_HEADERS.express => [
           CourseOffering.find_by_key('express').summarize_for_quick_assign(current_user, request.locale),
           CourseOffering.find_by_key('pre-express').summarize_for_quick_assign(current_user, request.locale)
         ]
       },
-      Module: {
-        'CS Connections': [
+      Curriculum::SharedCourseConstants::COURSE_OFFERING_CURRICULUM_TYPES.module => {
+        Curriculum::SharedCourseConstants::COURSE_OFFERING_HEADERS.csc => [
           CourseOffering.find_by_key('poetry').summarize_for_quick_assign(current_user, request.locale)
         ]
       }
     }
 
     offerings[:middle] = {
-      Course: {
-        'Express Courses': [
+      Curriculum::SharedCourseConstants::COURSE_OFFERING_CURRICULUM_TYPES.course => {
+        Curriculum::SharedCourseConstants::COURSE_OFFERING_HEADERS.express => [
           CourseOffering.find_by_key('express').summarize_for_quick_assign(current_user, request.locale),
           CourseOffering.find_by_key('pre-express').summarize_for_quick_assign(current_user, request.locale)
         ],
-        'Year-Long Courses': [
+        Curriculum::SharedCourseConstants::COURSE_OFFERING_HEADERS.year_long => [
           CourseOffering.find_by_key('csd').summarize_for_quick_assign(current_user, request.locale)
         ]
       },
-      'Standalone Unit': {
-        'Self-Paced': [
+      Curriculum::SharedCourseConstants::COURSE_OFFERING_CURRICULUM_TYPES.standalone_unit => {
+        Curriculum::SharedCourseConstants::COURSE_OFFERING_HEADERS.self_paced => [
           CourseOffering.find_by_key('csd3-virtual').summarize_for_quick_assign(current_user, request.locale),
           CourseOffering.find_by_key('csp3-virtual').summarize_for_quick_assign(current_user, request.locale)
         ],
-        'Teacher-Led': [
+        Curriculum::SharedCourseConstants::COURSE_OFFERING_HEADERS.teacher_led => [
           CourseOffering.find_by_key('aiml').summarize_for_quick_assign(current_user, request.locale),
           CourseOffering.find_by_key('devices').summarize_for_quick_assign(current_user, request.locale)
         ]
@@ -67,23 +67,23 @@ class CourseOfferingsController < ApplicationController
     }
 
     offerings[:high] = {
-      Course: {
-        'Year-Long Courses': [
+      Curriculum::SharedCourseConstants::COURSE_OFFERING_CURRICULUM_TYPES.course => {
+        Curriculum::SharedCourseConstants::COURSE_OFFERING_HEADERS.year_long => [
           CourseOffering.find_by_key('csa').summarize_for_quick_assign(current_user, request.locale),
           CourseOffering.find_by_key('csd').summarize_for_quick_assign(current_user, request.locale),
           CourseOffering.find_by_key('csp').summarize_for_quick_assign(current_user, request.locale)
         ]
       },
-      'Standalone Unit': {
-        'CSA Labs': [
+      Curriculum::SharedCourseConstants::COURSE_OFFERING_CURRICULUM_TYPES.standalone_unit => {
+        Curriculum::SharedCourseConstants::COURSE_OFFERING_HEADERS.csa_labs => [
           CourseOffering.find_by_key('csa-collegeboard-labs').summarize_for_quick_assign(current_user, request.locale),
           CourseOffering.find_by_key('csa-data-lab').summarize_for_quick_assign(current_user, request.locale)
         ],
-        'Self-Paced': [
+        Curriculum::SharedCourseConstants::COURSE_OFFERING_HEADERS.self_paced => [
           CourseOffering.find_by_key('csd3-virtual').summarize_for_quick_assign(current_user, request.locale),
           CourseOffering.find_by_key('csp3-virtual').summarize_for_quick_assign(current_user, request.locale)
         ],
-        'Teacher-Led': [
+        Curriculum::SharedCourseConstants::COURSE_OFFERING_HEADERS.teacher_led => [
           CourseOffering.find_by_key('aiml').summarize_for_quick_assign(current_user, request.locale),
           CourseOffering.find_by_key('devices').summarize_for_quick_assign(current_user, request.locale)
         ]

--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -142,6 +142,15 @@ class CourseOffering < ApplicationRecord
     ]
   end
 
+  def summarize_for_quick_assign(user, locale_code)
+    {
+      id: id,
+      key: key,
+      display_name: any_versions_launched? ? localized_display_name : localized_display_name + ' *',
+      course_versions: course_versions.select {|cv| cv.course_assignable?(user)}.map {|cv| cv.summarize_for_assignment_dropdown(user, locale_code)}.to_h
+    }
+  end
+
   def localized_display_name
     localized_name = I18n.t(
       key,

--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -147,7 +147,7 @@ class CourseOffering < ApplicationRecord
       id: id,
       key: key,
       display_name: any_versions_launched? ? localized_display_name : localized_display_name + ' *',
-      course_versions: course_versions.select {|cv| cv.course_assignable?(user)}.map {|cv| cv.summarize_for_assignment_dropdown(user, locale_code)}.to_h
+      course_versions: course_versions.select {|cv| cv.course_assignable?(user)}.map {|cv| cv.summarize_for_quick_assign(user, locale_code)}
     }
   end
 

--- a/dashboard/app/models/course_version.rb
+++ b/dashboard/app/models/course_version.rb
@@ -184,6 +184,20 @@ class CourseVersion < ApplicationRecord
     ]
   end
 
+  def summarize_for_quick_assign(user, locale_code)
+    {
+      id: id,
+      key: key,
+      version_year: content_root_type == 'UnitGroup' ? content_root.localized_version_title : display_name,
+      name: content_root.localized_title,
+      path: content_root.link,
+      type: content_root_type,
+      is_stable: stable?,
+      is_recommended: recommended?(locale_code),
+      locales: content_root_type == 'UnitGroup' ? ['English'] : content_root.supported_locale_names
+    }
+  end
+
   def self.unit_group_course_versions_with_units(unit_ids)
     CourseVersion.where(content_root_type: 'UnitGroup').all.select {|cv| cv.included_in_units?(unit_ids)}
   end

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -327,7 +327,11 @@ Dashboard::Application.routes.draw do
       end
     end
 
-    resources :course_offerings, only: [:edit, :update], param: 'key'
+    resources :course_offerings, only: [:edit, :update], param: 'key' do
+      collection do
+        get 'quick_assign_course_offerings'
+      end
+    end
 
     get '/course/:course_name', to: redirect('/courses/%{course_name}')
     get '/courses/:course_name/vocab/edit', to: 'vocabularies#edit'


### PR DESCRIPTION
Basic stub of the route to return course offerings for curriculum quick assign. I added some sample data but it's not close to exhaustive.

There's actually a lot in the json blob, largely because the CourseVersion `summarize_for_assignment` returns a lot of stuff. We might eventually want to trim that down but I just re-used the existing function for now.

Without course version information (stubbed to be the empty array), the returned json blob looks like:
```
{
  "elementary":{
    "Course":{
      "CS Fundamentals":[
        {
          "id":1,
          "key":"coursea",
          "display_name":"Course A",
          "course_versions":[
            
          ]
        },
        {
          "id":2,
          "key":"courseb",
          "display_name":"Course B",
          "course_versions":[
            
          ]
        },
        {
          "id":3,
          "key":"coursec",
          "display_name":"Course C",
          "course_versions":[
            
          ]
        }
      ],
      "Express":[
        {
          "id":7,
          "key":"express",
          "display_name":"Express Course",
          "course_versions":[
            
          ]
        },
        {
          "id":8,
          "key":"pre-express",
          "display_name":"Pre-reader Express",
          "course_versions":[
            
          ]
        }
      ]
    },
    "Module":{
      "CS Connections":[
        {
          "id":142,
          "key":"poetry",
          "display_name":"Poetry Module",
          "course_versions":[
            
          ]
        }
      ]
    }
  },
  "middle":{
    "Course":{
      "Express":[
        {
          "id":7,
          "key":"express",
          "display_name":"Express Course",
          "course_versions":[
            
          ]
        },
        {
          "id":8,
          "key":"pre-express",
          "display_name":"Pre-reader Express",
          "course_versions":[
            
          ]
        }
      ],
      "Year-Long Courses":[
        {
          "id":16,
          "key":"csd",
          "display_name":"Computer Science Discoveries",
          "course_versions":[
            
          ]
        }
      ]
    },
    "Standalone Unit":{
      "Self-Paced":[
        {
          "id":90,
          "key":"csd3-virtual",
          "display_name":"Self Paced Introduction to Game Lab",
          "course_versions":[
            
          ]
        },
        {
          "id":92,
          "key":"csp3-virtual",
          "display_name":"Self Paced Introduction to Turtle Programming In App Lab",
          "course_versions":[
            
          ]
        }
      ],
      "Teacher-Led":[
        {
          "id":13,
          "key":"aiml",
          "display_name":"AI and Machine Learning Module",
          "course_versions":[
            
          ]
        },
        {
          "id":500,
          "key":"devices",
          "display_name":"Creating Apps for Devices",
          "course_versions":[
            
          ]
        }
      ]
    }
  },
  "high":{
    "Course":{
      "Year-Long Courses":[
        {
          "id":17,
          "key":"csa",
          "display_name":"Computer Science A",
          "course_versions":[
            
          ]
        },
        {
          "id":16,
          "key":"csd",
          "display_name":"Computer Science Discoveries",
          "course_versions":[
            
          ]
        },
        {
          "id":10,
          "key":"csp",
          "display_name":"Computer Science Principles",
          "course_versions":[
            
          ]
        }
      ]
    },
    "Standalone Unit":{
      "CSA Labs":[
        {
          "id":466,
          "key":"csa-collegeboard-labs",
          "display_name":"AP CSA Magpie Lab",
          "course_versions":[
            
          ]
        },
        {
          "id":479,
          "key":"csa-data-lab",
          "display_name":"AP CSA Data Lab",
          "course_versions":[
            
          ]
        }
      ],
      "Self-Paced":[
        {
          "id":90,
          "key":"csd3-virtual",
          "display_name":"Self Paced Introduction to Game Lab",
          "course_versions":[
            
          ]
        },
        {
          "id":92,
          "key":"csp3-virtual",
          "display_name":"Self Paced Introduction to Turtle Programming In App Lab",
          "course_versions":[
            
          ]
        }
      ],
      "Teacher-Led":[
        {
          "id":13,
          "key":"aiml",
          "display_name":"AI and Machine Learning Module",
          "course_versions":[
            
          ]
        },
        {
          "id":500,
          "key":"devices",
          "display_name":"Creating Apps for Devices",
          "course_versions":[
            
          ]
        }
      ]
    }
  }
}
```

The `course_version` property looks like:
```
"course_versions":[
  {
    "id":923,
    "key":"2017",
    "version_year":"2017",
    "name":"Course A",
    "path":"/s/coursea-2017",
    "type":"Unit",
    "is_stable":true,
    "is_recommended":false,
    "locales":[
      "العربية",
      "Čeština",
      "Deutsch",
      "English",
      "Español (España)",
      "Español (Latinoamérica)",
      "Français",
      "हिन्दी",
      "Bahasa Indonesia",
      "Italiano",
      "日本語",
      "한국어",
      "Монгол хэл",
      "Polski",
      "Português (Brasil)",
      "Português (Portugal)",
      "Română",
      "Русский",
      "Slovenčina",
      "Türkçe",
      "اردو",
      "Oʻzbekcha",
      "Tiếng Việt",
      "简体字",
      "繁體字"
    ]
  },
  {
    "id":924,
    "key":"2018",
    "version_year":"2018",
    "name":"Course A (2018)",
    "path":"/s/coursea-2018",
    "type":"Unit",
    "is_stable":true,
    "is_recommended":false,
    "locales":[
      "English",
      "Italiano",
      "Slovenčina"
    ]
  },
  {
    "id":925,
    "key":"2019",
    "version_year":"2019",
    "name":"Course A (2019)",
    "path":"/s/coursea-2019",
    "type":"Unit",
    "is_stable":true,
    "is_recommended":false,
    "locales":[
      "Čeština",
      "English",
      "Slovenčina"
    ]
  },
  {
    "id":926,
    "key":"2020",
    "version_year":"2020",
    "name":"Course A (2020)",
    "path":"/s/coursea-2020",
    "type":"Unit",
    "is_stable":true,
    "is_recommended":false,
    "locales":[
      "English"
    ]
  },
  {
    "id":927,
    "key":"2021",
    "version_year":"2021",
    "name":"Course A (2021)",
    "path":"/s/coursea-2021",
    "type":"Unit",
    "is_stable":true,
    "is_recommended":false,
    "locales":[
      "العربية",
      "Deutsch",
      "English",
      "Español (España)",
      "Español (Latinoamérica)",
      "Français",
      "हिन्दी",
      "मराठी",
      "بهاس ملايو",
      "Polski",
      "Português (Brasil)",
      "Português (Portugal)",
      "Română",
      "Русский",
      "Slovenčina",
      "ภาษาไทย",
      "Türkçe",
      "اردو",
      "繁體字"
    ]
  },
  {
    "id":928,
    "key":"2022",
    "version_year":"2022",
    "name":"Course A (2022)",
    "path":"/s/coursea-2022",
    "type":"Unit",
    "is_stable":true,
    "is_recommended":true,
    "locales":[
      "English"
    ]
  }
]
```

## Open Questions
- Currently this route is only available to levelbuilders and in levelbuilder mode. That's not the end state we want, of course, but is that okay for now?
- Is the route `/course_offerings/quick_assign_course_offerings` okay? End users shouldn't ever need to use this route.
- Does the format look okay? How about the keys?