### PR TITLE
Backfill course offering fields

### DIFF
--- a/dashboard/config/course_offerings/ai-ethics.json
+++ b/dashboard/config/course_offerings/ai-ethics.json
@@ -4,8 +4,8 @@
   "category": "csc",
   "is_featured": false,
   "assignable": true,
-  "curriculum_type": null,
-  "marketing_initiative": null,
-  "grade_levels": null,
-  "header": null
+  "curriculum_type": "Module",
+  "marketing_initiative": "CSC",
+  "grade_levels": "3,4,5",
+  "header": "CS Connections"
 }

--- a/dashboard/config/course_offerings/aiml.json
+++ b/dashboard/config/course_offerings/aiml.json
@@ -4,8 +4,8 @@
   "category": "aiml",
   "is_featured": false,
   "assignable": true,
-  "curriculum_type": null,
+  "curriculum_type": "Standalone Unit",
   "marketing_initiative": null,
-  "grade_levels": null,
-  "header": null
+  "grade_levels": "6,7,8,9,10,11,12",
+  "header": "Teacher-Led"
 }

--- a/dashboard/config/course_offerings/applab-intro.json
+++ b/dashboard/config/course_offerings/applab-intro.json
@@ -5,7 +5,7 @@
   "is_featured": false,
   "assignable": true,
   "curriculum_type": null,
-  "marketing_initiative": null,
+  "marketing_initiative": "hoc",
   "grade_levels": null,
   "header": null
 }

--- a/dashboard/config/course_offerings/applab-intro.json
+++ b/dashboard/config/course_offerings/applab-intro.json
@@ -5,7 +5,7 @@
   "is_featured": false,
   "assignable": true,
   "curriculum_type": null,
-  "marketing_initiative": "hoc",
+  "marketing_initiative": "HOC",
   "grade_levels": null,
-  "header": null
+  "header": "Labs and Skills"
 }

--- a/dashboard/config/course_offerings/aquatic.json
+++ b/dashboard/config/course_offerings/aquatic.json
@@ -5,7 +5,7 @@
   "is_featured": false,
   "assignable": true,
   "curriculum_type": null,
-  "marketing_initiative": null,
+  "marketing_initiative": "hoc",
   "grade_levels": null,
   "header": null
 }

--- a/dashboard/config/course_offerings/aquatic.json
+++ b/dashboard/config/course_offerings/aquatic.json
@@ -5,7 +5,7 @@
   "is_featured": false,
   "assignable": true,
   "curriculum_type": null,
-  "marketing_initiative": "hoc",
+  "marketing_initiative": "HOC",
   "grade_levels": null,
-  "header": null
+  "header": "Minecraft"
 }

--- a/dashboard/config/course_offerings/artist.json
+++ b/dashboard/config/course_offerings/artist.json
@@ -5,7 +5,7 @@
   "is_featured": false,
   "assignable": true,
   "curriculum_type": null,
-  "marketing_initiative": null,
+  "marketing_initiative": "hoc",
   "grade_levels": null,
   "header": null
 }

--- a/dashboard/config/course_offerings/artist.json
+++ b/dashboard/config/course_offerings/artist.json
@@ -5,7 +5,7 @@
   "is_featured": false,
   "assignable": true,
   "curriculum_type": null,
-  "marketing_initiative": "hoc",
+  "marketing_initiative": "HOC",
   "grade_levels": null,
-  "header": null
+  "header": "Favorites"
 }

--- a/dashboard/config/course_offerings/basketball.json
+++ b/dashboard/config/course_offerings/basketball.json
@@ -5,7 +5,7 @@
   "is_featured": false,
   "assignable": true,
   "curriculum_type": null,
-  "marketing_initiative": null,
+  "marketing_initiative": "hoc",
   "grade_levels": null,
   "header": null
 }

--- a/dashboard/config/course_offerings/basketball.json
+++ b/dashboard/config/course_offerings/basketball.json
@@ -5,7 +5,7 @@
   "is_featured": false,
   "assignable": true,
   "curriculum_type": null,
-  "marketing_initiative": "hoc",
+  "marketing_initiative": "HOC",
   "grade_levels": null,
-  "header": null
+  "header": "Sports"
 }

--- a/dashboard/config/course_offerings/counting-csc.json
+++ b/dashboard/config/course_offerings/counting-csc.json
@@ -4,8 +4,8 @@
   "category": "csc",
   "is_featured": false,
   "assignable": true,
-  "curriculum_type": null,
-  "marketing_initiative": null,
-  "grade_levels": null,
-  "header": null
+  "curriculum_type": "Module",
+  "marketing_initiative": "CSC",
+  "grade_levels": "3,4,5",
+  "header": "CS Connections"
 }

--- a/dashboard/config/course_offerings/coursea.json
+++ b/dashboard/config/course_offerings/coursea.json
@@ -4,8 +4,8 @@
   "category": "csf",
   "is_featured": false,
   "assignable": true,
-  "curriculum_type": null,
-  "marketing_initiative": null,
-  "grade_levels": null,
-  "header": null
+  "curriculum_type": "Course",
+  "marketing_initiative": "CSF",
+  "grade_levels": "K,1",
+  "header": "CS Fundamentals"
 }

--- a/dashboard/config/course_offerings/courseb.json
+++ b/dashboard/config/course_offerings/courseb.json
@@ -4,8 +4,8 @@
   "category": "csf",
   "is_featured": false,
   "assignable": true,
-  "curriculum_type": null,
-  "marketing_initiative": null,
-  "grade_levels": null,
-  "header": null
+  "curriculum_type": "Course",
+  "marketing_initiative": "CSF",
+  "grade_levels": "1,2",
+  "header": "CS Fundamentals"
 }

--- a/dashboard/config/course_offerings/coursec.json
+++ b/dashboard/config/course_offerings/coursec.json
@@ -4,8 +4,8 @@
   "category": "csf",
   "is_featured": false,
   "assignable": true,
-  "curriculum_type": null,
-  "marketing_initiative": null,
-  "grade_levels": null,
-  "header": null
+  "curriculum_type": "Course",
+  "marketing_initiative": "CSF",
+  "grade_levels": "2,3",
+  "header": "CS Fundamentals"
 }

--- a/dashboard/config/course_offerings/coursed.json
+++ b/dashboard/config/course_offerings/coursed.json
@@ -4,8 +4,8 @@
   "category": "csf",
   "is_featured": false,
   "assignable": true,
-  "curriculum_type": null,
-  "marketing_initiative": null,
-  "grade_levels": null,
-  "header": null
+  "curriculum_type": "Course",
+  "marketing_initiative": "CSF",
+  "grade_levels": "3,4",
+  "header": "CS Fundamentals"
 }

--- a/dashboard/config/course_offerings/coursee.json
+++ b/dashboard/config/course_offerings/coursee.json
@@ -4,8 +4,8 @@
   "category": "csf",
   "is_featured": false,
   "assignable": true,
-  "curriculum_type": null,
-  "marketing_initiative": null,
-  "grade_levels": null,
-  "header": null
+  "curriculum_type": "Course",
+  "marketing_initiative": "CSF",
+  "grade_levels": "4,5",
+  "header": "CS Fundamentals"
 }

--- a/dashboard/config/course_offerings/coursef.json
+++ b/dashboard/config/course_offerings/coursef.json
@@ -4,8 +4,8 @@
   "category": "csf",
   "is_featured": false,
   "assignable": true,
-  "curriculum_type": null,
-  "marketing_initiative": null,
-  "grade_levels": null,
-  "header": null
+  "curriculum_type": "Course",
+  "marketing_initiative": "CSF",
+  "grade_levels": "5",
+  "header": "CS Fundamentals"
 }

--- a/dashboard/config/course_offerings/csa.json
+++ b/dashboard/config/course_offerings/csa.json
@@ -4,8 +4,8 @@
   "category": "full_course",
   "is_featured": false,
   "assignable": true,
-  "curriculum_type": null,
+  "curriculum_type": "Course",
   "marketing_initiative": null,
-  "grade_levels": null,
-  "header": null
+  "grade_levels": "9,10,11,12",
+  "header": "Year Long"
 }

--- a/dashboard/config/course_offerings/csc-ecosystems.json
+++ b/dashboard/config/course_offerings/csc-ecosystems.json
@@ -4,8 +4,8 @@
   "category": "csc",
   "is_featured": true,
   "assignable": true,
-  "curriculum_type": null,
-  "marketing_initiative": null,
-  "grade_levels": null,
-  "header": null
+  "curriculum_type": "Module",
+  "marketing_initiative": "CSC",
+  "grade_levels": "3,4,5",
+  "header": "CS Connections"
 }

--- a/dashboard/config/course_offerings/csc-fables.json
+++ b/dashboard/config/course_offerings/csc-fables.json
@@ -4,8 +4,8 @@
   "category": "csc",
   "is_featured": true,
   "assignable": true,
-  "curriculum_type": null,
-  "marketing_initiative": null,
-  "grade_levels": null,
-  "header": null
+  "curriculum_type": "Module",
+  "marketing_initiative": "CSC",
+  "grade_levels": "3,4,5",
+  "header": "CS Connections"
 }

--- a/dashboard/config/course_offerings/csc-starquilts.json
+++ b/dashboard/config/course_offerings/csc-starquilts.json
@@ -4,8 +4,8 @@
   "category": "csc",
   "is_featured": true,
   "assignable": true,
-  "curriculum_type": null,
-  "marketing_initiative": null,
-  "grade_levels": null,
-  "header": null
+  "curriculum_type": "Module",
+  "marketing_initiative": "CSC",
+  "grade_levels": "3,4,5",
+  "header": "CS Connections"
 }

--- a/dashboard/config/course_offerings/csc-timecapsule.json
+++ b/dashboard/config/course_offerings/csc-timecapsule.json
@@ -4,8 +4,8 @@
   "category": "csc",
   "is_featured": true,
   "assignable": true,
-  "curriculum_type": null,
-  "marketing_initiative": null,
-  "grade_levels": null,
-  "header": null
+  "curriculum_type": "Module",
+  "marketing_initiative": "CSC",
+  "grade_levels": "3,4,5",
+  "header": "CS Connections"
 }

--- a/dashboard/config/course_offerings/csd.json
+++ b/dashboard/config/course_offerings/csd.json
@@ -4,8 +4,8 @@
   "category": "full_course",
   "is_featured": false,
   "assignable": true,
-  "curriculum_type": null,
+  "curriculum_type": "Course",
   "marketing_initiative": null,
-  "grade_levels": null,
-  "header": null
+  "grade_levels": "6,7,8,9,10,11,12",
+  "header": "Year Long"
 }

--- a/dashboard/config/course_offerings/csp.json
+++ b/dashboard/config/course_offerings/csp.json
@@ -4,8 +4,8 @@
   "category": "full_course",
   "is_featured": false,
   "assignable": true,
-  "curriculum_type": null,
+  "curriculum_type": "Course",
   "marketing_initiative": null,
-  "grade_levels": null,
-  "header": null
+  "grade_levels": "9,10,11,12",
+  "header": "Year Long"
 }

--- a/dashboard/config/course_offerings/dance-2019.json
+++ b/dashboard/config/course_offerings/dance-2019.json
@@ -5,7 +5,7 @@
   "is_featured": false,
   "assignable": true,
   "curriculum_type": null,
-  "marketing_initiative": null,
+  "marketing_initiative": "hoc",
   "grade_levels": null,
   "header": null
 }

--- a/dashboard/config/course_offerings/dance-2019.json
+++ b/dashboard/config/course_offerings/dance-2019.json
@@ -5,7 +5,7 @@
   "is_featured": false,
   "assignable": true,
   "curriculum_type": null,
-  "marketing_initiative": "hoc",
+  "marketing_initiative": "HOC",
   "grade_levels": null,
-  "header": null
+  "header": "Favorites"
 }

--- a/dashboard/config/course_offerings/dance-extras-2019.json
+++ b/dashboard/config/course_offerings/dance-extras-2019.json
@@ -5,7 +5,7 @@
   "is_featured": false,
   "assignable": true,
   "curriculum_type": null,
-  "marketing_initiative": null,
+  "marketing_initiative": "hoc",
   "grade_levels": null,
   "header": null
 }

--- a/dashboard/config/course_offerings/dance-extras-2019.json
+++ b/dashboard/config/course_offerings/dance-extras-2019.json
@@ -5,7 +5,7 @@
   "is_featured": false,
   "assignable": true,
   "curriculum_type": null,
-  "marketing_initiative": "hoc",
+  "marketing_initiative": "HOC",
   "grade_levels": null,
-  "header": null
+  "header": "Sports"
 }

--- a/dashboard/config/course_offerings/dance-extras.json
+++ b/dashboard/config/course_offerings/dance-extras.json
@@ -5,7 +5,7 @@
   "is_featured": false,
   "assignable": true,
   "curriculum_type": null,
-  "marketing_initiative": null,
+  "marketing_initiative": "hoc",
   "grade_levels": null,
   "header": null
 }

--- a/dashboard/config/course_offerings/dance-extras.json
+++ b/dashboard/config/course_offerings/dance-extras.json
@@ -5,7 +5,7 @@
   "is_featured": false,
   "assignable": true,
   "curriculum_type": null,
-  "marketing_initiative": "hoc",
+  "marketing_initiative": "HOC",
   "grade_levels": null,
-  "header": null
+  "header": "Sports"
 }

--- a/dashboard/config/course_offerings/dance.json
+++ b/dashboard/config/course_offerings/dance.json
@@ -5,7 +5,7 @@
   "is_featured": false,
   "assignable": true,
   "curriculum_type": null,
-  "marketing_initiative": null,
+  "marketing_initiative": "hoc",
   "grade_levels": null,
   "header": null
 }

--- a/dashboard/config/course_offerings/dance.json
+++ b/dashboard/config/course_offerings/dance.json
@@ -5,7 +5,7 @@
   "is_featured": false,
   "assignable": true,
   "curriculum_type": null,
-  "marketing_initiative": "hoc",
+  "marketing_initiative": "HOC",
   "grade_levels": null,
-  "header": null
+  "header": "Favorites"
 }

--- a/dashboard/config/course_offerings/devices.json
+++ b/dashboard/config/course_offerings/devices.json
@@ -4,8 +4,8 @@
   "category": "maker",
   "is_featured": false,
   "assignable": true,
-  "curriculum_type": null,
+  "curriculum_type": "Standalone Unit",
   "marketing_initiative": null,
-  "grade_levels": null,
-  "header": null
+  "grade_levels": "6,7,8,9,10,11,12",
+  "header": "Teacher-Led"
 }

--- a/dashboard/config/course_offerings/explore-data-1.json
+++ b/dashboard/config/course_offerings/explore-data-1.json
@@ -4,8 +4,8 @@
   "category": "csc",
   "is_featured": false,
   "assignable": true,
-  "curriculum_type": null,
-  "marketing_initiative": null,
-  "grade_levels": null,
-  "header": null
+  "curriculum_type": "Module",
+  "marketing_initiative": "CSC",
+  "grade_levels": "3,4,5",
+  "header": "CS Connections"
 }

--- a/dashboard/config/course_offerings/express.json
+++ b/dashboard/config/course_offerings/express.json
@@ -4,8 +4,8 @@
   "category": "csf",
   "is_featured": false,
   "assignable": true,
-  "curriculum_type": null,
-  "marketing_initiative": null,
-  "grade_levels": null,
-  "header": null
+  "curriculum_type": "Course",
+  "marketing_initiative": "CSF",
+  "grade_levels": "4,5,6,7,8",
+  "header": "Express"
 }

--- a/dashboard/config/course_offerings/flappy.json
+++ b/dashboard/config/course_offerings/flappy.json
@@ -5,7 +5,7 @@
   "is_featured": false,
   "assignable": true,
   "curriculum_type": null,
-  "marketing_initiative": null,
+  "marketing_initiative": "hoc",
   "grade_levels": null,
   "header": null
 }

--- a/dashboard/config/course_offerings/flappy.json
+++ b/dashboard/config/course_offerings/flappy.json
@@ -5,7 +5,7 @@
   "is_featured": false,
   "assignable": true,
   "curriculum_type": null,
-  "marketing_initiative": "hoc",
+  "marketing_initiative": "HOC",
   "grade_levels": null,
-  "header": null
+  "header": "Popular Media"
 }

--- a/dashboard/config/course_offerings/frozen.json
+++ b/dashboard/config/course_offerings/frozen.json
@@ -5,7 +5,7 @@
   "is_featured": false,
   "assignable": true,
   "curriculum_type": null,
-  "marketing_initiative": null,
+  "marketing_initiative": "hoc",
   "grade_levels": null,
   "header": null
 }

--- a/dashboard/config/course_offerings/frozen.json
+++ b/dashboard/config/course_offerings/frozen.json
@@ -5,7 +5,7 @@
   "is_featured": false,
   "assignable": true,
   "curriculum_type": null,
-  "marketing_initiative": "hoc",
+  "marketing_initiative": "HOC",
   "grade_levels": null,
-  "header": null
+  "header": "Popular Media"
 }

--- a/dashboard/config/course_offerings/gumball.json
+++ b/dashboard/config/course_offerings/gumball.json
@@ -5,7 +5,7 @@
   "is_featured": false,
   "assignable": true,
   "curriculum_type": null,
-  "marketing_initiative": null,
+  "marketing_initiative": "hoc",
   "grade_levels": null,
   "header": null
 }

--- a/dashboard/config/course_offerings/gumball.json
+++ b/dashboard/config/course_offerings/gumball.json
@@ -5,7 +5,7 @@
   "is_featured": false,
   "assignable": true,
   "curriculum_type": null,
-  "marketing_initiative": "hoc",
+  "marketing_initiative": "HOC",
   "grade_levels": null,
-  "header": null
+  "header": "Popular Media"
 }

--- a/dashboard/config/course_offerings/hello-world-animals.json
+++ b/dashboard/config/course_offerings/hello-world-animals.json
@@ -5,7 +5,7 @@
   "is_featured": true,
   "assignable": true,
   "curriculum_type": null,
-  "marketing_initiative": null,
+  "marketing_initiative": "hoc",
   "grade_levels": null,
   "header": null
 }

--- a/dashboard/config/course_offerings/hello-world-animals.json
+++ b/dashboard/config/course_offerings/hello-world-animals.json
@@ -5,7 +5,7 @@
   "is_featured": true,
   "assignable": true,
   "curriculum_type": null,
-  "marketing_initiative": "hoc",
+  "marketing_initiative": "HOC",
   "grade_levels": null,
-  "header": null
+  "header": "Hello World"
 }

--- a/dashboard/config/course_offerings/hello-world-emoji.json
+++ b/dashboard/config/course_offerings/hello-world-emoji.json
@@ -5,7 +5,7 @@
   "is_featured": true,
   "assignable": true,
   "curriculum_type": null,
-  "marketing_initiative": null,
+  "marketing_initiative": "hoc",
   "grade_levels": null,
   "header": null
 }

--- a/dashboard/config/course_offerings/hello-world-emoji.json
+++ b/dashboard/config/course_offerings/hello-world-emoji.json
@@ -5,7 +5,7 @@
   "is_featured": true,
   "assignable": true,
   "curriculum_type": null,
-  "marketing_initiative": "hoc",
+  "marketing_initiative": "HOC",
   "grade_levels": null,
-  "header": null
+  "header": "Hello World"
 }

--- a/dashboard/config/course_offerings/hello-world-food.json
+++ b/dashboard/config/course_offerings/hello-world-food.json
@@ -5,7 +5,7 @@
   "is_featured": true,
   "assignable": true,
   "curriculum_type": null,
-  "marketing_initiative": null,
+  "marketing_initiative": "hoc",
   "grade_levels": null,
   "header": null
 }

--- a/dashboard/config/course_offerings/hello-world-food.json
+++ b/dashboard/config/course_offerings/hello-world-food.json
@@ -5,7 +5,7 @@
   "is_featured": true,
   "assignable": true,
   "curriculum_type": null,
-  "marketing_initiative": "hoc",
+  "marketing_initiative": "HOC",
   "grade_levels": null,
-  "header": null
+  "header": "Hello World"
 }

--- a/dashboard/config/course_offerings/hello-world-retro.json
+++ b/dashboard/config/course_offerings/hello-world-retro.json
@@ -5,7 +5,7 @@
   "is_featured": true,
   "assignable": true,
   "curriculum_type": null,
-  "marketing_initiative": null,
+  "marketing_initiative": "hoc",
   "grade_levels": null,
   "header": null
 }

--- a/dashboard/config/course_offerings/hello-world-retro.json
+++ b/dashboard/config/course_offerings/hello-world-retro.json
@@ -5,7 +5,7 @@
   "is_featured": true,
   "assignable": true,
   "curriculum_type": null,
-  "marketing_initiative": "hoc",
+  "marketing_initiative": "HOC",
   "grade_levels": null,
-  "header": null
+  "header": "Hello World"
 }

--- a/dashboard/config/course_offerings/hello-world-soccer.json
+++ b/dashboard/config/course_offerings/hello-world-soccer.json
@@ -5,7 +5,7 @@
   "is_featured": true,
   "assignable": true,
   "curriculum_type": null,
-  "marketing_initiative": null,
+  "marketing_initiative": "hoc",
   "grade_levels": null,
   "header": null
 }

--- a/dashboard/config/course_offerings/hello-world-soccer.json
+++ b/dashboard/config/course_offerings/hello-world-soccer.json
@@ -5,7 +5,7 @@
   "is_featured": true,
   "assignable": true,
   "curriculum_type": null,
-  "marketing_initiative": "hoc",
+  "marketing_initiative": "HOC",
   "grade_levels": null,
-  "header": null
+  "header": "Hello World"
 }

--- a/dashboard/config/course_offerings/hello-world-space.json
+++ b/dashboard/config/course_offerings/hello-world-space.json
@@ -5,7 +5,7 @@
   "is_featured": true,
   "assignable": true,
   "curriculum_type": null,
-  "marketing_initiative": null,
+  "marketing_initiative": "hoc",
   "grade_levels": null,
   "header": null
 }

--- a/dashboard/config/course_offerings/hello-world-space.json
+++ b/dashboard/config/course_offerings/hello-world-space.json
@@ -5,7 +5,7 @@
   "is_featured": true,
   "assignable": true,
   "curriculum_type": null,
-  "marketing_initiative": "hoc",
+  "marketing_initiative": "HOC",
   "grade_levels": null,
-  "header": null
+  "header": "Hello World"
 }

--- a/dashboard/config/course_offerings/hero.json
+++ b/dashboard/config/course_offerings/hero.json
@@ -5,7 +5,7 @@
   "is_featured": false,
   "assignable": true,
   "curriculum_type": null,
-  "marketing_initiative": null,
+  "marketing_initiative": "hoc",
   "grade_levels": null,
   "header": null
 }

--- a/dashboard/config/course_offerings/hero.json
+++ b/dashboard/config/course_offerings/hero.json
@@ -5,7 +5,7 @@
   "is_featured": false,
   "assignable": true,
   "curriculum_type": null,
-  "marketing_initiative": "hoc",
+  "marketing_initiative": "HOC",
   "grade_levels": null,
-  "header": null
+  "header": "Minecraft"
 }

--- a/dashboard/config/course_offerings/hoc-encryption.json
+++ b/dashboard/config/course_offerings/hoc-encryption.json
@@ -5,7 +5,7 @@
   "is_featured": false,
   "assignable": true,
   "curriculum_type": null,
-  "marketing_initiative": null,
+  "marketing_initiative": "hoc",
   "grade_levels": null,
   "header": null
 }

--- a/dashboard/config/course_offerings/hoc-encryption.json
+++ b/dashboard/config/course_offerings/hoc-encryption.json
@@ -5,7 +5,7 @@
   "is_featured": false,
   "assignable": true,
   "curriculum_type": null,
-  "marketing_initiative": "hoc",
+  "marketing_initiative": "HOC",
   "grade_levels": null,
-  "header": null
+  "header": "Labs and Skills"
 }

--- a/dashboard/config/course_offerings/hourofcode.json
+++ b/dashboard/config/course_offerings/hourofcode.json
@@ -5,7 +5,7 @@
   "is_featured": false,
   "assignable": true,
   "curriculum_type": null,
-  "marketing_initiative": null,
+  "marketing_initiative": "hoc",
   "grade_levels": null,
   "header": null
 }

--- a/dashboard/config/course_offerings/hourofcode.json
+++ b/dashboard/config/course_offerings/hourofcode.json
@@ -5,7 +5,7 @@
   "is_featured": false,
   "assignable": true,
   "curriculum_type": null,
-  "marketing_initiative": "hoc",
+  "marketing_initiative": "HOC",
   "grade_levels": null,
-  "header": null
+  "header": "Favorites"
 }

--- a/dashboard/config/course_offerings/iceage.json
+++ b/dashboard/config/course_offerings/iceage.json
@@ -5,7 +5,7 @@
   "is_featured": false,
   "assignable": true,
   "curriculum_type": null,
-  "marketing_initiative": null,
+  "marketing_initiative": "hoc",
   "grade_levels": null,
   "header": null
 }

--- a/dashboard/config/course_offerings/iceage.json
+++ b/dashboard/config/course_offerings/iceage.json
@@ -5,7 +5,7 @@
   "is_featured": false,
   "assignable": true,
   "curriculum_type": null,
-  "marketing_initiative": "hoc",
+  "marketing_initiative": "HOC",
   "grade_levels": null,
-  "header": null
+  "header": "Popular Media"
 }

--- a/dashboard/config/course_offerings/infinity.json
+++ b/dashboard/config/course_offerings/infinity.json
@@ -5,7 +5,7 @@
   "is_featured": false,
   "assignable": true,
   "curriculum_type": null,
-  "marketing_initiative": null,
+  "marketing_initiative": "hoc",
   "grade_levels": null,
   "header": null
 }

--- a/dashboard/config/course_offerings/infinity.json
+++ b/dashboard/config/course_offerings/infinity.json
@@ -5,7 +5,7 @@
   "is_featured": false,
   "assignable": true,
   "curriculum_type": null,
-  "marketing_initiative": "hoc",
+  "marketing_initiative": "HOC",
   "grade_levels": null,
-  "header": null
+  "header": "Popular Media"
 }

--- a/dashboard/config/course_offerings/mc.json
+++ b/dashboard/config/course_offerings/mc.json
@@ -5,7 +5,7 @@
   "is_featured": false,
   "assignable": true,
   "curriculum_type": null,
-  "marketing_initiative": null,
+  "marketing_initiative": "hoc",
   "grade_levels": null,
   "header": null
 }

--- a/dashboard/config/course_offerings/mc.json
+++ b/dashboard/config/course_offerings/mc.json
@@ -5,7 +5,7 @@
   "is_featured": false,
   "assignable": true,
   "curriculum_type": null,
-  "marketing_initiative": "hoc",
+  "marketing_initiative": "HOC",
   "grade_levels": null,
-  "header": null
+  "header": "Minecraft"
 }

--- a/dashboard/config/course_offerings/minecraft.json
+++ b/dashboard/config/course_offerings/minecraft.json
@@ -5,7 +5,7 @@
   "is_featured": false,
   "assignable": true,
   "curriculum_type": null,
-  "marketing_initiative": null,
+  "marketing_initiative": "hoc",
   "grade_levels": null,
   "header": null
 }

--- a/dashboard/config/course_offerings/minecraft.json
+++ b/dashboard/config/course_offerings/minecraft.json
@@ -5,7 +5,7 @@
   "is_featured": false,
   "assignable": true,
   "curriculum_type": null,
-  "marketing_initiative": "hoc",
+  "marketing_initiative": "HOC",
   "grade_levels": null,
-  "header": null
+  "header": "Minecraft"
 }

--- a/dashboard/config/course_offerings/oceans.json
+++ b/dashboard/config/course_offerings/oceans.json
@@ -5,7 +5,7 @@
   "is_featured": false,
   "assignable": true,
   "curriculum_type": null,
-  "marketing_initiative": null,
+  "marketing_initiative": "hoc",
   "grade_levels": null,
   "header": null
 }

--- a/dashboard/config/course_offerings/oceans.json
+++ b/dashboard/config/course_offerings/oceans.json
@@ -5,7 +5,7 @@
   "is_featured": false,
   "assignable": true,
   "curriculum_type": null,
-  "marketing_initiative": "hoc",
+  "marketing_initiative": "HOC",
   "grade_levels": null,
-  "header": null
+  "header": "Favorites"
 }

--- a/dashboard/config/course_offerings/outbreak.json
+++ b/dashboard/config/course_offerings/outbreak.json
@@ -5,7 +5,7 @@
   "is_featured": false,
   "assignable": true,
   "curriculum_type": null,
-  "marketing_initiative": null,
+  "marketing_initiative": "hoc",
   "grade_levels": null,
   "header": null
 }

--- a/dashboard/config/course_offerings/outbreak.json
+++ b/dashboard/config/course_offerings/outbreak.json
@@ -5,7 +5,7 @@
   "is_featured": false,
   "assignable": true,
   "curriculum_type": null,
-  "marketing_initiative": "hoc",
+  "marketing_initiative": "HOC",
   "grade_levels": null,
-  "header": null
+  "header": "Favorites"
 }

--- a/dashboard/config/course_offerings/playlab.json
+++ b/dashboard/config/course_offerings/playlab.json
@@ -5,7 +5,7 @@
   "is_featured": false,
   "assignable": true,
   "curriculum_type": null,
-  "marketing_initiative": null,
+  "marketing_initiative": "hoc",
   "grade_levels": null,
   "header": null
 }

--- a/dashboard/config/course_offerings/playlab.json
+++ b/dashboard/config/course_offerings/playlab.json
@@ -5,7 +5,7 @@
   "is_featured": false,
   "assignable": true,
   "curriculum_type": null,
-  "marketing_initiative": "hoc",
+  "marketing_initiative": "HOC",
   "grade_levels": null,
-  "header": null
+  "header": "Labs and Skills"
 }

--- a/dashboard/config/course_offerings/poem-art.json
+++ b/dashboard/config/course_offerings/poem-art.json
@@ -5,7 +5,7 @@
   "is_featured": true,
   "assignable": true,
   "curriculum_type": null,
-  "marketing_initiative": null,
+  "marketing_initiative": "hoc",
   "grade_levels": null,
   "header": null
 }

--- a/dashboard/config/course_offerings/poem-art.json
+++ b/dashboard/config/course_offerings/poem-art.json
@@ -5,7 +5,7 @@
   "is_featured": true,
   "assignable": true,
   "curriculum_type": null,
-  "marketing_initiative": "hoc",
+  "marketing_initiative": "HOC",
   "grade_levels": null,
-  "header": null
+  "header": "Favorites"
 }

--- a/dashboard/config/course_offerings/poetry.json
+++ b/dashboard/config/course_offerings/poetry.json
@@ -4,8 +4,8 @@
   "category": "csc",
   "is_featured": true,
   "assignable": true,
-  "curriculum_type": null,
-  "marketing_initiative": null,
-  "grade_levels": null,
-  "header": null
+  "curriculum_type": "Module",
+  "marketing_initiative": "CSC",
+  "grade_levels": "3,4,5",
+  "header": "CS Connections"
 }

--- a/dashboard/config/course_offerings/pre-express.json
+++ b/dashboard/config/course_offerings/pre-express.json
@@ -4,8 +4,8 @@
   "category": "csf",
   "is_featured": false,
   "assignable": true,
-  "curriculum_type": null,
-  "marketing_initiative": null,
-  "grade_levels": null,
-  "header": null
+  "curriculum_type": "Course",
+  "marketing_initiative": "CSF",
+  "grade_levels": "K,1,2,3",
+  "header": "Express"
 }

--- a/dashboard/config/course_offerings/spelling-bee.json
+++ b/dashboard/config/course_offerings/spelling-bee.json
@@ -4,8 +4,8 @@
   "category": "csc",
   "is_featured": false,
   "assignable": true,
-  "curriculum_type": null,
-  "marketing_initiative": null,
-  "grade_levels": null,
-  "header": null
+  "curriculum_type": "Module",
+  "marketing_initiative": "CSC",
+  "grade_levels": "3,4,5",
+  "header": "CS Connections"
 }

--- a/dashboard/config/course_offerings/sports.json
+++ b/dashboard/config/course_offerings/sports.json
@@ -5,7 +5,7 @@
   "is_featured": false,
   "assignable": true,
   "curriculum_type": null,
-  "marketing_initiative": null,
+  "marketing_initiative": "hoc",
   "grade_levels": null,
   "header": null
 }

--- a/dashboard/config/course_offerings/sports.json
+++ b/dashboard/config/course_offerings/sports.json
@@ -5,7 +5,7 @@
   "is_featured": false,
   "assignable": true,
   "curriculum_type": null,
-  "marketing_initiative": "hoc",
+  "marketing_initiative": "HOC",
   "grade_levels": null,
-  "header": null
+  "header": "Sports"
 }

--- a/dashboard/config/course_offerings/starwars.json
+++ b/dashboard/config/course_offerings/starwars.json
@@ -5,7 +5,7 @@
   "is_featured": false,
   "assignable": true,
   "curriculum_type": null,
-  "marketing_initiative": null,
+  "marketing_initiative": "hoc",
   "grade_levels": null,
   "header": null
 }

--- a/dashboard/config/course_offerings/starwars.json
+++ b/dashboard/config/course_offerings/starwars.json
@@ -5,7 +5,7 @@
   "is_featured": false,
   "assignable": true,
   "curriculum_type": null,
-  "marketing_initiative": "hoc",
+  "marketing_initiative": "HOC",
   "grade_levels": null,
-  "header": null
+  "header": "Popular Media"
 }

--- a/dashboard/config/course_offerings/starwarsblocks.json
+++ b/dashboard/config/course_offerings/starwarsblocks.json
@@ -5,7 +5,7 @@
   "is_featured": false,
   "assignable": true,
   "curriculum_type": null,
-  "marketing_initiative": null,
+  "marketing_initiative": "hoc",
   "grade_levels": null,
   "header": null
 }

--- a/dashboard/config/course_offerings/starwarsblocks.json
+++ b/dashboard/config/course_offerings/starwarsblocks.json
@@ -5,7 +5,7 @@
   "is_featured": false,
   "assignable": true,
   "curriculum_type": null,
-  "marketing_initiative": "hoc",
+  "marketing_initiative": "HOC",
   "grade_levels": null,
-  "header": null
+  "header": "Popular Media"
 }

--- a/dashboard/config/course_offerings/text-compression.json
+++ b/dashboard/config/course_offerings/text-compression.json
@@ -5,7 +5,7 @@
   "is_featured": false,
   "assignable": true,
   "curriculum_type": null,
-  "marketing_initiative": null,
+  "marketing_initiative": "hoc",
   "grade_levels": null,
   "header": null
 }

--- a/dashboard/config/course_offerings/text-compression.json
+++ b/dashboard/config/course_offerings/text-compression.json
@@ -5,7 +5,7 @@
   "is_featured": false,
   "assignable": true,
   "curriculum_type": null,
-  "marketing_initiative": "hoc",
+  "marketing_initiative": "HOC",
   "grade_levels": null,
-  "header": null
+  "header": "Labs and Skills"
 }


### PR DESCRIPTION
Sets new fields on common courses, following what's in [this sheet](https://docs.google.com/spreadsheets/d/1Aqy79cP6l_T-l5pbp1wZFtwa1f6Cdpustd9Gm1VWlBE/edit#gid=0) and in the [figma](https://www.figma.com/file/fe70qoiGWnV78j9MKfAEdo/Teacher-Experience-UX%2FUI-Improvements?node-id=1549%3A18311&t=7JQuWgOE3UWMn3iL-0).

A few course offerings that are listed in the dropdown for the majority of users (so, not PL and not pilots) were missed. I create [a sheet](https://docs.google.com/spreadsheets/d/1nLvoWAToWfY9iHOBJAJqRc3bFmwdG9_rFFUIw-DWGEA/edit?usp=sharing) to track those and we can fix them manually next week.