### PR TITLE
Music: simple2 timeline exploration

### DIFF
--- a/apps/src/music/blockly/blocks/simple2.js
+++ b/apps/src/music/blockly/blocks/simple2.js
@@ -17,6 +17,8 @@ export class GeneratorHelpersSimple2 {
   static getFunctionImplementation(functionName, functionCode) {
     const actualFunctionName = this.getSafeFunctionName(functionName);
     return `function ${actualFunctionName}() {
+      var __currentFunctionName = '${functionName}';
+      var __currentFunctionInvocation = Math.random() * 100000;
       ProgramSequencer.playSequential();
       ${functionCode}
       ProgramSequencer.endSequential();
@@ -34,6 +36,7 @@ export class GeneratorHelpersSimple2 {
   ) {
     return `
     var __insideWhenRun = true;
+    var __currentFunctionName = 'when_run';
     ProgramSequencer.init();
     ProgramSequencer.playTogether();
     ${functionCallsCode}
@@ -73,6 +76,7 @@ export const whenRunSimple2 = {
   generator: () =>
     `
       var __insideWhenRun = true;
+      var __currentFunctionName = 'when_run';
       ProgramSequencer.init();
       ProgramSequencer.playSequential();
     `
@@ -131,7 +135,9 @@ export const playSoundAtCurrentLocationSimple2 = {
       MusicPlayer.playSoundAtMeasureById(
         "${block.getFieldValue(FIELD_SOUNDS_NAME)}",
         ProgramSequencer.getCurrentMeasure(),
-        __insideWhenRun
+        __insideWhenRun,
+        __currentFunctionName,
+        __currentFunctionInvocation
       );
       ProgramSequencer.updateMeasureForPlayByLength(
         MusicPlayer.getLengthForId(

--- a/apps/src/music/blockly/blocks/simple2.js
+++ b/apps/src/music/blockly/blocks/simple2.js
@@ -37,6 +37,7 @@ export class GeneratorHelpersSimple2 {
     return `
     var __insideWhenRun = true;
     var __currentFunctionName = 'when_run';
+    var __currentFunctionInvocation = Math.random() * 100000;
     ProgramSequencer.init();
     ProgramSequencer.playTogether();
     ${functionCallsCode}
@@ -77,6 +78,7 @@ export const whenRunSimple2 = {
     `
       var __insideWhenRun = true;
       var __currentFunctionName = 'when_run';
+      var __currentFunctionInvocation = Math.random() * 100000;
       ProgramSequencer.init();
       ProgramSequencer.playSequential();
     `

--- a/apps/src/music/blockly/blocks/simple2.js
+++ b/apps/src/music/blockly/blocks/simple2.js
@@ -17,8 +17,10 @@ export class GeneratorHelpersSimple2 {
   static getFunctionImplementation(functionName, functionCode) {
     const actualFunctionName = this.getSafeFunctionName(functionName);
     return `function ${actualFunctionName}() {
-      var __currentFunctionName = '${functionName}';
-      var __currentFunctionInvocation = Math.random() * 100000;
+      var __currentFunction = {
+        name: '${functionName}',
+        uniqueInvocationId: MusicPlayer.getUniqueInvocationId()
+      };
       ProgramSequencer.playSequential();
       ${functionCode}
       ProgramSequencer.endSequential();
@@ -36,8 +38,10 @@ export class GeneratorHelpersSimple2 {
   ) {
     return `
     var __insideWhenRun = true;
-    var __currentFunctionName = 'when_run';
-    var __currentFunctionInvocation = Math.random() * 100000;
+    var __currentFunction = {
+      name: 'when_run',
+      uniqueInvocationId: MusicPlayer.getUniqueInvocationId()
+    };
     ProgramSequencer.init();
     ProgramSequencer.playTogether();
     ${functionCallsCode}
@@ -77,8 +81,10 @@ export const whenRunSimple2 = {
   generator: () =>
     `
       var __insideWhenRun = true;
-      var __currentFunctionName = 'when_run';
-      var __currentFunctionInvocation = Math.random() * 100000;
+      var __currentFunction = {
+        name: 'when_run',
+        uniqueInvocationId: MusicPlayer.getUniqueInvocationId()
+      };
       ProgramSequencer.init();
       ProgramSequencer.playSequential();
     `
@@ -138,8 +144,8 @@ export const playSoundAtCurrentLocationSimple2 = {
         "${block.getFieldValue(FIELD_SOUNDS_NAME)}",
         ProgramSequencer.getCurrentMeasure(),
         __insideWhenRun,
-        __currentFunctionName,
-        __currentFunctionInvocation
+        null,
+        __currentFunction
       );
       ProgramSequencer.updateMeasureForPlayByLength(
         MusicPlayer.getLengthForId(

--- a/apps/src/music/player/MusicPlayer.js
+++ b/apps/src/music/player/MusicPlayer.js
@@ -28,6 +28,7 @@ export default class MusicPlayer {
     this.groupPrefix = 'all';
     this.isInitialized = false;
     this.tracksMetadata = {};
+    this.uniqueInvocationIdUpto = 0;
   }
 
   initialize(library) {
@@ -49,13 +50,7 @@ export default class MusicPlayer {
     LoadSoundFromBuffer(id, buffer);
   }
 
-  playSoundAtMeasureById(
-    id,
-    measure,
-    insideWhenRun,
-    trackId,
-    functionInstance
-  ) {
+  playSoundAtMeasureById(id, measure, insideWhenRun, trackId, functionContext) {
     if (!this.isInitialized) {
       console.log('MusicPlayer not initialized');
       return;
@@ -75,7 +70,7 @@ export default class MusicPlayer {
       insideWhenRun,
       when: measure,
       trackId,
-      functionInstance
+      functionContext
     };
 
     this.soundEvents.push(soundEvent);
@@ -345,5 +340,12 @@ export default class MusicPlayer {
     const sound = folder.sounds.find(sound => sound.src === src);
 
     return sound;
+  }
+
+  // Called by interpreted code in the simple2 model, this returns
+  // a unique value that is used to differentiate each invocation of
+  // a function, so that the timeline renderer can group relevant events.
+  getUniqueInvocationId() {
+    return this.uniqueInvocationIdUpto++;
   }
 }

--- a/apps/src/music/player/MusicPlayer.js
+++ b/apps/src/music/player/MusicPlayer.js
@@ -49,7 +49,13 @@ export default class MusicPlayer {
     LoadSoundFromBuffer(id, buffer);
   }
 
-  playSoundAtMeasureById(id, measure, insideWhenRun, trackId) {
+  playSoundAtMeasureById(
+    id,
+    measure,
+    insideWhenRun,
+    trackId,
+    functionInstance
+  ) {
     if (!this.isInitialized) {
       console.log('MusicPlayer not initialized');
       return;
@@ -68,7 +74,8 @@ export default class MusicPlayer {
       id,
       insideWhenRun,
       when: measure,
-      trackId
+      trackId,
+      functionInstance
     };
 
     this.soundEvents.push(soundEvent);

--- a/apps/src/music/utils/UniqueSounds.js
+++ b/apps/src/music/utils/UniqueSounds.js
@@ -16,11 +16,11 @@ export default class UniqueSounds {
   // all other sounds means that the new sound will replace the old one in
   // the same row.
 
-  getUniqueSounds(songDataEvents) {
+  getUniqueSounds(songDataEvents, preservePositions = true) {
     // First, generate a list of all current unique sounds.
     const currentUniqueSounds = [];
     for (const songEvent of songDataEvents) {
-      const id = songEvent.id;
+      const id = songEvent.trackId + ' ' + songEvent.id;
       if (currentUniqueSounds.indexOf(id) === -1) {
         currentUniqueSounds.push(id);
       }
@@ -31,7 +31,7 @@ export default class UniqueSounds {
 
     // If we have a previous output from this function, then we'll attempt
     // to keep its sounds in the same rows as they were before.
-    if (this.previousUniqueSounds) {
+    if (preservePositions && this.previousUniqueSounds) {
       // This is where we will store the output sounds.  It can be a sparse
       // array since it will maintain existing sound positions if they
       // were already positioned previously.

--- a/apps/src/music/utils/UniqueSounds.js
+++ b/apps/src/music/utils/UniqueSounds.js
@@ -16,11 +16,11 @@ export default class UniqueSounds {
   // all other sounds means that the new sound will replace the old one in
   // the same row.
 
-  getUniqueSounds(songDataEvents, preservePositions = true) {
+  getUniqueSounds(songDataEvents) {
     // First, generate a list of all current unique sounds.
     const currentUniqueSounds = [];
     for (const songEvent of songDataEvents) {
-      const id = songEvent.trackId + ' ' + songEvent.id;
+      const id = songEvent.id;
       if (currentUniqueSounds.indexOf(id) === -1) {
         currentUniqueSounds.push(id);
       }
@@ -31,7 +31,7 @@ export default class UniqueSounds {
 
     // If we have a previous output from this function, then we'll attempt
     // to keep its sounds in the same rows as they were before.
-    if (preservePositions && this.previousUniqueSounds) {
+    if (this.previousUniqueSounds) {
       // This is where we will store the output sounds.  It can be a sparse
       // array since it will maintain existing sound positions if they
       // were already positioned previously.

--- a/apps/src/music/views/Timeline.jsx
+++ b/apps/src/music/views/Timeline.jsx
@@ -3,8 +3,9 @@ import React from 'react';
 import moduleStyles from './timeline.module.scss';
 import classNames from 'classnames';
 import TimelineSampleEvents from './TimelineSampleEvents';
-import {getBlockMode} from '../appConfig';
 import TimelineTrackEvents from './TimelineTrackEvents';
+import TimelineSimple2Events from './TimelineSimple2Events';
+import {getBlockMode} from '../appConfig';
 import {BlockMode} from '../constants';
 
 const barWidth = 60;
@@ -72,6 +73,8 @@ const Timeline = ({isPlaying, currentPlayheadPosition}) => {
         <div className={moduleStyles.soundsArea}>
           {getBlockMode() === BlockMode.TRACKS ? (
             <TimelineTrackEvents {...timelineElementProps} />
+          ) : getBlockMode() === BlockMode.SIMPLE2 ? (
+            <TimelineSimple2Events {...timelineElementProps} />
           ) : (
             <TimelineSampleEvents {...timelineElementProps} />
           )}

--- a/apps/src/music/views/TimelineSimple2Events.jsx
+++ b/apps/src/music/views/TimelineSimple2Events.jsx
@@ -89,16 +89,16 @@ const TimelineSimple2Events = ({
           <div
             style={{
               position: 'absolute',
-              backgroundColor: 'rgba(38 129 153 / 0.7)',
+              backgroundColor: 'rgba(115 115 115 / 0.7)',
               borderRadius: 8,
               left: (uniqueFunction.positionLeft - 1) * barWidth,
               width:
                 (uniqueFunction.positionRight - uniqueFunction.positionLeft) *
                   barWidth -
                 4,
-              top: 20 + uniqueFunction.positionTop - 1,
+              top: 20 + uniqueFunction.positionTop,
               height:
-                uniqueFunction.positionBottom - uniqueFunction.positionTop - 2
+                uniqueFunction.positionBottom - uniqueFunction.positionTop - 3
             }}
           >
             &nbsp;

--- a/apps/src/music/views/TimelineSimple2Events.jsx
+++ b/apps/src/music/views/TimelineSimple2Events.jsx
@@ -1,0 +1,134 @@
+import PropTypes from 'prop-types';
+import React, {useRef, useContext} from 'react';
+import UniqueSounds from '../utils/UniqueSounds';
+import {PlayerUtilsContext} from '../context';
+import TimelineElement from './TimelineElement';
+
+/**
+ * Renders timeline events, organized by unique track ID & unique sample ID.
+ */
+const TimelineSimple2Events = ({
+  currentPlayheadPosition,
+  barWidth,
+  eventVerticalSpace,
+  getEventHeight
+}) => {
+  const playerUtils = useContext(PlayerUtilsContext);
+  const soundEvents = playerUtils.getSoundEvents();
+
+  const uniqueSoundsRef = useRef(new UniqueSounds());
+  // Let's cache the value of getUniqueSounds() so that the various helpers
+  // we call during render don't need to recalculate it.  This also ensures
+  // that we recalculate unique sounds, even when there are no entries to
+  // render.
+  const currentUniqueSounds = uniqueSoundsRef.current.getUniqueSounds(
+    soundEvents,
+    false
+  );
+
+  const getVerticalOffsetForEventId = id => {
+    return (
+      getUniqueIndexForEventId(id) * getEventHeight(currentUniqueSounds.length)
+    );
+  };
+
+  const getUniqueIndexForEventId = id => {
+    return currentUniqueSounds.indexOf(id);
+  };
+
+  // As we encounter a function name, record its boundaries.
+  const uniqueFunctionExtents = [];
+
+  // As we encounter a function name, record its boundaries.
+  for (const soundEvent of soundEvents) {
+    const id = soundEvent.id;
+    const trackId = soundEvent.trackId;
+    const length = playerUtils.getLengthForId(id);
+    const positionLeft = soundEvent.when;
+    const positionRight = positionLeft + length;
+    const positionTop = getVerticalOffsetForEventId(trackId + ' ' + id);
+    const positionBottom =
+      positionTop + getEventHeight(currentUniqueSounds.length);
+
+    const uniqueFunctionIndex = uniqueFunctionExtents.findIndex(
+      x => x.trackId === trackId + soundEvent.functionInstance
+    );
+    if (uniqueFunctionIndex === -1) {
+      uniqueFunctionExtents.push({
+        trackId: trackId + soundEvent.functionInstance,
+        minPosition: positionLeft,
+        maxPosition: positionRight,
+        positionTop: positionTop,
+        positionBottom: positionBottom
+      });
+    } else {
+      const item = uniqueFunctionExtents[uniqueFunctionIndex];
+      uniqueFunctionExtents[uniqueFunctionIndex] = {
+        trackId: item.trackId,
+        minPosition: Math.min(item.minPosition, positionLeft),
+        maxPosition: Math.max(item.maxPosition, positionRight),
+        positionTop: Math.min(item.positionTop, positionTop),
+        positionBottom: Math.max(item.positionBottom, positionBottom)
+      };
+    }
+  }
+
+  console.log('uniqueFunctionExtents', uniqueFunctionExtents);
+
+  return (
+    <div style={{position: 'relative'}}>
+      <div style={{position: 'absolute'}}>
+        {uniqueFunctionExtents.map((uniqueFunction, index) => (
+          <div
+            style={{
+              position: 'absolute',
+              backgroundColor: 'rgba(38 129 153 / 0.7)', // 'rgba(80 153 24 / 0.7)',
+              borderRadius: 8,
+              left: (uniqueFunction.minPosition - 1) * barWidth,
+              width:
+                (uniqueFunction.maxPosition - uniqueFunction.minPosition) *
+                  barWidth -
+                4,
+              top: 20 + uniqueFunction.positionTop - 1,
+              height:
+                uniqueFunction.positionBottom - uniqueFunction.positionTop - 2
+            }}
+          >
+            &nbsp;
+          </div>
+        ))}
+      </div>
+      <div style={{position: 'absolute'}}>
+        {soundEvents.map((eventData, index) => (
+          <TimelineElement
+            key={index}
+            soundId={eventData.id}
+            barWidth={barWidth}
+            height={
+              getEventHeight(currentUniqueSounds.length) - eventVerticalSpace
+            }
+            top={
+              20 +
+              getVerticalOffsetForEventId(
+                eventData.trackId + ' ' + eventData.id
+              )
+            }
+            left={barWidth * (eventData.when - 1)}
+            when={eventData.when}
+            trackId={eventData.trackId}
+            currentPlayheadPosition={currentPlayheadPosition}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+TimelineSimple2Events.propTypes = {
+  currentPlayheadPosition: PropTypes.number.isRequired,
+  barWidth: PropTypes.number.isRequired,
+  eventVerticalSpace: PropTypes.number.isRequired,
+  getEventHeight: PropTypes.func.isRequired
+};
+
+export default TimelineSimple2Events;

--- a/apps/src/music/views/TimelineSimple2Events.jsx
+++ b/apps/src/music/views/TimelineSimple2Events.jsx
@@ -105,7 +105,9 @@ const TimelineSimple2Events = ({
             soundId={eventData.id}
             barWidth={barWidth}
             height={
-              getEventHeight(currentUniqueSounds.length) - eventVerticalSpace
+              getEventHeight(currentUniqueSounds.length) -
+              eventVerticalSpace -
+              1
             }
             top={
               20 +


### PR DESCRIPTION
This adds an initial implementation of a new timeline view for the `simple2` model that explores an idea around showing sounds grouped by the function that plays them.  It places sounds in a unique row for the combination of the function that generated the sound and the sound ID.  The bounding rectangles are for the set of sounds directly played by the body of a unique execution of that function.  

We don't currently do any accounting for nesting of function calls.  The bounding rectangles can also overlap each other.  It also doesn't currently have the "stickiness" that was earlier implemented for the regular timeline in https://github.com/code-dot-org/code-dot-org/pull/49426.

This is just a quick exploration, and perhaps the beginning of more iteration; at any rate, we can see what we learn from it.

<img width="1033" alt="Screenshot 2023-02-16 at 3 17 19 PM" src="https://user-images.githubusercontent.com/2205926/219509693-e88dbe54-9b52-42c8-901d-73d34b2a708b.png">
