### PR TITLE
SL-503: Fix data table suggestions in App Lab text mode

### DIFF
--- a/apps/src/dropletUtils.js
+++ b/apps/src/dropletUtils.js
@@ -1147,7 +1147,9 @@ export function setParamAtIndex(index, value, block) {
 
 /**
  * Take a string like "'param1', 'param2'" and an index and return
- * the param at the given index without extra quotes, commas or spaces.
+ * the param at the given index without extra quotes, commas or spaces
+ * Note: The sanitization here is too aggressive for some parameters and
+ * is the cause of at least one bug: https://codedotorg.atlassian.net/browse/SL-580
  */
 function formatParamString(index, params) {
   // Use encodeURIComponent to encode everything except commas outside
@@ -1181,7 +1183,9 @@ function getParamFromCodeAtIndex(index, methodName, code) {
   // each parameter
 
   const paramsRegex = `^${methodName}\\(((?:(?:\\([^\\)]*\\))|(?:"[^"]*")|(?:\'[^\']*\')|[^)]*)*)\\)?\\s*$`;
+  console.log('paramsRegex', paramsRegex);
   const matchParams = new RegExp(paramsRegex).exec(code);
+  console.log('matchParams', matchParams);
   if (matchParams) {
     return formatParamString(index, matchParams[1]);
   }

--- a/apps/src/dropletUtils.js
+++ b/apps/src/dropletUtils.js
@@ -1183,9 +1183,7 @@ function getParamFromCodeAtIndex(index, methodName, code) {
   // each parameter
 
   const paramsRegex = `^${methodName}\\(((?:(?:\\([^\\)]*\\))|(?:"[^"]*")|(?:\'[^\']*\')|[^)]*)*)\\)?\\s*$`;
-  console.log('paramsRegex', paramsRegex);
   const matchParams = new RegExp(paramsRegex).exec(code);
-  console.log('matchParams', matchParams);
   if (matchParams) {
     return formatParamString(index, matchParams[1]);
   }

--- a/apps/src/storage/getColumnDropdown.js
+++ b/apps/src/storage/getColumnDropdown.js
@@ -42,7 +42,7 @@ function getTableNameFromColumnSocket(socket, editor) {
   const paramValue = getFirstParam('getColumn', socket.parent, editor);
 
   // The socket value (ex. the table name) has an extra set of double quotes in Droplet mode but not in text mode
-  // N.B. formatParamString is what removes the double quotes before we get here in text mode
+  // Note: formatParamString is what removes the double quotes before we get here in text mode
   return stripEncapsulatingDoubleQuotes(paramValue);
 }
 

--- a/apps/src/storage/getColumnDropdown.js
+++ b/apps/src/storage/getColumnDropdown.js
@@ -39,10 +39,12 @@ export function getTables() {
 
 function getTableNameFromColumnSocket(socket, editor) {
   const paramValue = getFirstParam('getColumn', socket.parent, editor);
-  // The socket value has an extra set of double quotes. Trim off the first
-  // and last characters to remove, but don't use utils.stripQuotes because
-  // there may be other quotes in the table name (for example, apostrophes)
-  return paramValue.substring(1, paramValue.length - 1);
+
+  // The socket value (ex. the table name) has an extra set of double quotes in Droplet mode (but not in text mode)
+  // The following call to .replace() trims double-quotes only if they exist as the first and last characters in the string
+  // N.B. In text mode, the call stack goes getFirstParam->getParamAtIndex->getParamFromCodeAtIndex->formatParamString
+  // formatParamString is what removes the double quotes before we get here in text mode
+  return paramValue.replace(/^"(.*)"$/, '$1');
 }
 
 export function getColumns() {

--- a/apps/src/storage/getColumnDropdown.js
+++ b/apps/src/storage/getColumnDropdown.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import msg from '@cdo/locale';
-import {getFirstParam} from '../dropletUtils';
 import GetColumnParamPicker, {ParamType} from './GetColumnParamPicker';
+import {getFirstParam} from '../dropletUtils';
+import {stripEncapsulatingDoubleQuotes} from '../utils';
 
 function openModal(type, callback, table) {
   const modalDiv = document.createElement('div');
@@ -40,11 +41,9 @@ export function getTables() {
 function getTableNameFromColumnSocket(socket, editor) {
   const paramValue = getFirstParam('getColumn', socket.parent, editor);
 
-  // The socket value (ex. the table name) has an extra set of double quotes in Droplet mode (but not in text mode)
-  // The following call to .replace() trims double-quotes only if they exist as the first and last characters in the string
-  // N.B. In text mode, the call stack goes getFirstParam->getParamAtIndex->getParamFromCodeAtIndex->formatParamString
-  // formatParamString is what removes the double quotes before we get here in text mode
-  return paramValue.replace(/^"(.*)"$/, '$1');
+  // The socket value (ex. the table name) has an extra set of double quotes in Droplet mode but not in text mode
+  // N.B. formatParamString is what removes the double quotes before we get here in text mode
+  return stripEncapsulatingDoubleQuotes(paramValue);
 }
 
 export function getColumns() {

--- a/apps/src/utils.js
+++ b/apps/src/utils.js
@@ -157,6 +157,16 @@ export function stripQuotes(inputString) {
 }
 
 /**
+ * Removes double quotes surrounding a string, if they exist
+ * If they don't exist, just return the string
+ * Does not touch quotes that don't match the pattern "..."
+ * @param {string} inputString
+ * @returns {string} inputString with double quotes in first and last position removed, if they exist
+ */
+export const stripEncapsulatingDoubleQuotes = inputString =>
+  inputString.replace(/^"(.*)"$/, '$1');
+
+/**
  * Defines an inheritance relationship between parent class and this class.
  */
 Function.prototype.inherits = function(parent) {

--- a/apps/test/unit/utilsTest.js
+++ b/apps/test/unit/utilsTest.js
@@ -781,6 +781,9 @@ describe('utils modules', () => {
       result = stripEncapsulatingDoubleQuotes('"blah"');
       expect(result).to.equal('blah');
 
+      result = stripEncapsulatingDoubleQuotes('""blah""');
+      expect(result).to.equal('"blah"');
+
       result = stripEncapsulatingDoubleQuotes('" "');
       expect(result).to.equal(' ');
     });

--- a/apps/test/unit/utilsTest.js
+++ b/apps/test/unit/utilsTest.js
@@ -7,6 +7,7 @@ const {
   shallowCopy,
   cloneWithoutFunctions,
   stripQuotes,
+  stripEncapsulatingDoubleQuotes,
   wrapNumberValidatorsForLevelBuilder,
   escapeHtml,
   escapeText,
@@ -770,6 +771,31 @@ describe('utils modules', () => {
       expect(id1).to.equal(id2);
       expect(id2).to.not.equal(id3);
       expect(id3).to.equal(id4);
+    });
+  });
+
+  describe('stripEncapsulatingDoubleQuotes', () => {
+    let result;
+
+    it('removes double quotes at the first and last character position', () => {
+      result = stripEncapsulatingDoubleQuotes('"blah"');
+      expect(result).to.equal('blah');
+
+      result = stripEncapsulatingDoubleQuotes('" "');
+      expect(result).to.equal(' ');
+    });
+
+    it('does not modify a string without encapsulating double quotes', () => {
+      result = stripEncapsulatingDoubleQuotes('blah');
+      expect(result).to.equal('blah');
+    });
+
+    it('does not remove a single double quote', () => {
+      result = stripEncapsulatingDoubleQuotes('"blah ');
+      expect(result).to.equal('"blah ');
+
+      result = stripEncapsulatingDoubleQuotes('blah"');
+      expect(result).to.equal('blah"');
     });
   });
 });


### PR DESCRIPTION
The following PR fixes the bug described in https://codedotorg.atlassian.net/browse/SL-503. 

## Links

Jira ticket: https://codedotorg.atlassian.net/browse/SL-503

## Testing story

New sanitization logic was added to a function called `stripEncapsulatingDoubleQuotes` in `src/utils.js`. Unit tests were added for this function. 

The tests in `apps/test/unit/storage/getColumnsDropdownTest.js` were not modified because 1) there is a 2-hour timebox on this task and 2) the existing tests are testing a lot more than they should be; namely, the highly nested code paths used for getting param values in both block and text modes that are mostly unrelated to my change.

I also tested that the new logic works manually by testing the choosing of a column name in both block and text mode (video below). 


https://user-images.githubusercontent.com/26844240/219503469-eace7367-d956-4249-8fb8-cd11116b676c.mov

## Follow-up work

Researching this task revealed a more nuanced bug with the `formatParamString` function that I captured here: https://codedotorg.atlassian.net/browse/SL-580

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
