### PR TITLE
Update YouTube embed links to prevent tracking

### DIFF
--- a/pegasus/sites.v3/code.org/public/about/2014.md.erb
+++ b/pegasus/sites.v3/code.org/public/about/2014.md.erb
@@ -131,7 +131,7 @@ This chart is *not* based on audited financials, but it's a pretty good approxim
 
 **Code.org's work covered by CBS This Morning:**
 
-<iframe width="375" height="246" src="//www.youtube.com/embed/sUXfjzzHO5g?controls=2" frameborder="0" allowfullscreen></iframe>
+<iframe width="375" height="246" src="//www.youtube-nocookie.com/embed/sUXfjzzHO5g?controls=2" frameborder="0" allowfullscreen></iframe>
 
 [/col-50]
 
@@ -139,7 +139,7 @@ This chart is *not* based on audited financials, but it's a pretty good approxim
 
 **President Obama does the Hour of Code:**
 
-<iframe width="375" height="210" src="//www.youtube.com/embed/AI_dayIQWV4" frameborder="0" allowfullscreen></iframe>
+<iframe width="375" height="210" src="//www.youtube-nocookie.com/embed/AI_dayIQWV4" frameborder="0" allowfullscreen></iframe>
 Hour of Code has won the support of both [Republicans and Democrats](https://www.youtube.com/watch?v=Vgn_YbSmHnw), and [many celebrities](https://www.youtube.com/watch?v=h5_SsNSaJJI&list=PLzdnOPI1iJNciTeOk1ziB4pIpdPwevgv_)
 
 <br/><br/>

--- a/pegasus/sites.v3/code.org/public/about/2015.md.erb
+++ b/pegasus/sites.v3/code.org/public/about/2015.md.erb
@@ -21,7 +21,7 @@ Code.org 2015 Annual Report
 
 [/h0]
 
-# First, the state of K-12 computer science 
+# First, the state of K-12 computer science
 
 January 12, 2016 -  It’s been two and a half years since Code.org hired our first salaried employee. We’ve been humbled to watch the landscape change in K-12 computer science (CS) over that time. This teacher-powered movement has reached hundreds of thousands of classrooms and millions of students. We’ve never been more confident in our ability to realize our vision - that **every student in every school should have the opportunity to learn computer science.**
 
@@ -163,12 +163,12 @@ During the week we were inundated with powerful stories from all corners of the 
 * Volunteers in war-torn regions hosted coding activities in Nigeria, Libya, Iraq, Palestine, and Afghanistan.
 * The national education ministries of Russia and Italy asked *every* school to participate.
 
-<center> <iframe style="max-width: 100%" width="789" height="443" src="https://www.youtube.com/embed/Ofze6CWUCx8" frameborder="0" allowfullscreen></iframe> </center>
+<center> <iframe style="max-width: 100%" width="789" height="443" src="https://www.youtube-nocookie.com/embed/Ofze6CWUCx8" frameborder="0" allowfullscreen></iframe> </center>
 <br>
-After the Hour of Code, we asked participating organizers how it went and the [results are fantastic for our field](/about/evaluation/hourofcode). 
+After the Hour of Code, we asked participating organizers how it went and the [results are fantastic for our field](/about/evaluation/hourofcode).
 
 * **98%** had a good or great experience.
-* **85%** of those new to computer science said the Hour of Code increased their interest in teaching computer science. 
+* **85%** of those new to computer science said the Hour of Code increased their interest in teaching computer science.
 * **49%** said they plan to continue teaching computer science beyond one hour.
 * **18%** said they began teaching computer science after a previous Hour of Code campaign.
 * **87%** said their students did more than just one hour of coding.
@@ -344,7 +344,7 @@ The information above is based on audited financials and was updated on May 2016
 
 <br/>
 <br/>
-The table below shows the total cost breakdown of our headline achievements since founding. 
+The table below shows the total cost breakdown of our headline achievements since founding.
 <br/>
 
 | **Areas of effort / Achievements in 2013 - 2015**                                                                                                                 | Fully-loaded cost (including admin) |

--- a/pegasus/sites.v3/code.org/public/about/2018.md.erb
+++ b/pegasus/sites.v3/code.org/public/about/2018.md.erb
@@ -4,7 +4,7 @@ nav: about_nav
 theme: responsive
 ---
 
-<p align="center"><iframe style="max-width: 100%" width="560" height="315" src="https://www.youtube.com/embed/pYKXqEpy1Mg" frameborder="0" allowfullscreen></iframe></p>
+<p align="center"><iframe style="max-width: 100%" width="560" height="315" src="https://www.youtube-nocookie.com/embed/pYKXqEpy1Mg" frameborder="0" allowfullscreen></iframe></p>
 
 # Code.org 2018 Annual Report
 
@@ -370,11 +370,11 @@ In 2018, we began a more robust investment in international partnerships. Attend
 
 We hosted Hour of Code events with [Argentina President Mauricio Macri](https://twitter.com/codeorg/status/1047246639100964864) and with [Chile President Sebastián Piñera](https://twitter.com/hadip/status/1014470516554559489), and released an inspirational video for Latam audiences, featuring regional presidents, business leaders, and celebrities:
 
-<p align="center"><iframe style="max-width: 100%" width="560" height="315" src="https://www.youtube.com/embed/EGgdCryC8Uo" frameborder="0" allowfullscreen></iframe></p>
+<p align="center"><iframe style="max-width: 100%" width="560" height="315" src="https://www.youtube-nocookie.com/embed/EGgdCryC8Uo" frameborder="0" allowfullscreen></iframe></p>
 
 Last but not least, Code.org was invited to [organize a student-coding event](https://www.youtube.com/watch?v=_IrGZqaoNIU) at the G20 summit for the Ministers of Education, and our founder Hadi Partovi spoke to the Ministers about the importance of integrating computer science into the global school day curriculum:
 
-<p align="center"><iframe style="max-width: 100%" width="560" height="315" src="https://www.youtube.com/embed/ljqysBIvbL0" frameborder="0" allowfullscreen></iframe></p>
+<p align="center"><iframe style="max-width: 100%" width="560" height="315" src="https://www.youtube-nocookie.com/embed/ljqysBIvbL0" frameborder="0" allowfullscreen></iframe></p>
 
 [solid-block-header]
 

--- a/pegasus/sites.v3/code.org/public/about/2019.md.erb
+++ b/pegasus/sites.v3/code.org/public/about/2019.md.erb
@@ -4,7 +4,7 @@ nav: about_nav
 theme: responsive
 ---
 
-<p align="center"><iframe style="max-width: 100%" width="560" height="315" src="https://www.youtube.com/embed/79uXmtWxkT0" frameborder="0" allowfullscreen></iframe></p>
+<p align="center"><iframe style="max-width: 100%" width="560" height="315" src="https://www.youtube-nocookie.com/embed/79uXmtWxkT0" frameborder="0" allowfullscreen></iframe></p>
 
 # Code.org 2019 Annual Report
 
@@ -350,7 +350,7 @@ Inspired by the United Nations’ Sustainable Development Goals, this year’s H
 
 This led to Code.org’s newest activity, [AI for Oceans](/oceans). Created to show the potential of Artificial Intelligence, AI for Oceans is the Hour of Code’s first machine learning activity. By teaching students about AI, training data, and bias while also exploring ethical issues and ways AI can be used in the world, we’re proud to bring another example to classrooms of how CS is about much more than coding.
 
-<p align="center"><iframe style="max-width: 100%" width="560" height="315" src="https://www.youtube.com/embed/Ayxrf65Rs84" frameborder="0" allowfullscreen></iframe></p>
+<p align="center"><iframe style="max-width: 100%" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Ayxrf65Rs84" frameborder="0" allowfullscreen></iframe></p>
 
 Together with the CS Teachers Association and the Computer Science Alliance, we were honored to kick off [CS Education Week](https://csedweek.org/kickoff2019) in December with 400 Native American students from the Santa Fe Indian School in New Mexico. The event featured a student project fair and a #CSforGood panel that spoke to students about the importance of ethical responsibility in computer science.
 
@@ -392,7 +392,7 @@ While many of these countries are acting independently of Code.org, most have dr
 
 In 2019, we continued to strengthen our investment in international partnerships, with notable events across the globe. In February, President Cyril Ramaphosa [pledged to overhaul](https://businesstech.co.za/news/government/298140/6-new-subjects-you-can-expect-to-be-introduced-at-south-african-schools/) South Africa’s education sector in part by including new technology subjects and specialisations including the internet of things, robotics, and artificial intelligence. Later in the year, Code.org President, Alice Steinglass, [attended an Hour of Code with Stevo Pendarovski](https://twitter.com/AliceSteinglass/status/1195086779881148416), the President of North Macedonia. Microsoft also organized a unique opportunity for [two young girls to teach the Prime Minister of Malaysia](https://twitter.com/MicrosoftASIA/status/1204303545819750400), Mahathir Mohamad, how to code using Code.org.
 
-<p align="center"><iframe style="max-width: 100%" width="560" height="315" src="https://www.youtube.com/embed/f2-QYjKEKF4" frameborder="0" allowfullscreen></iframe></p>
+<p align="center"><iframe style="max-width: 100%" width="560" height="315" src="https://www.youtube-nocookie.com/embed/f2-QYjKEKF4" frameborder="0" allowfullscreen></iframe></p>
 
 Last but not least, Pope Francis joined 3 young women to [contribute a line of code](https://app.myperfit.com/apiv2/shares/scholasr/campaigns/37be93ae02f5ceb69f890bf799433cb5102f0435108e8178439a6b3a394e35c1/227/contents/230/preview) to an app, became the first Pope to program a computer, and called on students globally to learn computer science and use their creativity to improve the world.
 

--- a/pegasus/sites.v3/code.org/public/about/evaluation/index.md
+++ b/pegasus/sites.v3/code.org/public/about/evaluation/index.md
@@ -9,7 +9,7 @@ theme: responsive
 
 Code.org® is a nonprofit dedicated to expanding access to computer science in schools and increasing participation by young women and students from other underrepresented groups. Our vision is that every student in every school has the opportunity to learn computer science.
 
-Code.org partners with [Outlier Research & Evaluation at the University of Chicago](http://outlier.uchicago.edu/), a third-party evaluator, to understand our impact and progress towards meeting our mission. In the spirit of transparency and in an effort to share best practices with the field, we are pleased to share the results of our evaluation work with the general public.  
+Code.org partners with [Outlier Research & Evaluation at the University of Chicago](http://outlier.uchicago.edu/), a third-party evaluator, to understand our impact and progress towards meeting our mission. In the spirit of transparency and in an effort to share best practices with the field, we are pleased to share the results of our evaluation work with the general public.
 
 ## Available reports
 
@@ -25,5 +25,5 @@ Code.org partners with [Outlier Research & Evaluation at the University of Chica
 ## Learn More About Our Approach
 In this recorded session, you’ll hear from [Pat Yongpradit](http://twitter.com/mryongpradit), Chief Academic Officer at [Code.org](https://code.org) and [Heather King](http://outlier.uchicago.edu/outlier/team/), program manager at [Outlier](http://outlier.uchicago.edu/), about the results of our programs over the course of the 2014-15 school year. What did teachers take away from professional development? What did students learn? What did we learn from our district partnerships? Learn from our successes and challenges as we discuss how we might work together as a CS education community to increase access to CS education for all.
 
-<iframe style="max-width: 100%" width="420" height="315" src="https://www.youtube.com/embed/jJfZMgvm4SU" frameborder="0" allowfullscreen></iframe>
+<iframe style="max-width: 100%" width="420" height="315" src="https://www.youtube-nocookie.com/embed/jJfZMgvm4SU" frameborder="0" allowfullscreen></iframe>
 

--- a/pegasus/sites.v3/code.org/public/about/evaluation/summary.md
+++ b/pegasus/sites.v3/code.org/public/about/evaluation/summary.md
@@ -129,4 +129,4 @@ Internally, through participant surveys and data science projects, we will conti
 ## Learn More About Our Approach
 In this recorded session, you’ll hear from [Pat Yongpradit](http://twitter.com/mryongpradit), Chief Academic Officer at [Code.org](https://code.org) and [Heather King](http://outlier.uchicago.edu/outlier/team/), program manager at [Outlier](http://outlier.uchicago.edu/), about the results of our programs over the course of the 2014-15 school year. What did teachers take away from professional development? What did students learn? What did we learn from our district partnerships? Learn from our successes and challenges as we discuss how we might work together as a CS education community to increase access to CS education for all.
 
-<iframe style="max-width: 100%;" width="420" height="315" src="https://www.youtube.com/embed/jJfZMgvm4SU" frameborder="0" allowfullscreen></iframe>
+<iframe style="max-width: 100%;" width="420" height="315" src="https://www.youtube-nocookie.com/embed/jJfZMgvm4SU" frameborder="0" allowfullscreen></iframe>

--- a/pegasus/sites.v3/code.org/public/about/news.md.erb
+++ b/pegasus/sites.v3/code.org/public/about/news.md.erb
@@ -7,7 +7,7 @@ theme: responsive
 
 [col-50]
 
-<iframe width="375" height="246" src="https://www.youtube.com/embed/zxcBZg7jYlc" frameborder="0" allowfullscreen></iframe>
+<iframe width="375" height="246" src="https://www.youtube-nocookie.com/embed/zxcBZg7jYlc" frameborder="0" allowfullscreen></iframe>
 
 **Nasdaq interviews Code.org founder Hadi Partovi**
 
@@ -15,7 +15,7 @@ theme: responsive
 
 [col-50]
 
-<iframe width="375" height="246" src="https://www.youtube.com/embed/1iwq-uZNOSg" frameborder="0" allowfullscreen></iframe>
+<iframe width="375" height="246" src="https://www.youtube-nocookie.com/embed/1iwq-uZNOSg" frameborder="0" allowfullscreen></iframe>
 
 **Code.org's work covered by CBS This Morning**
 
@@ -25,7 +25,7 @@ theme: responsive
 
 [col-50]
 
-<iframe width="375" height="246" src="https://www.youtube.com/embed/AI_dayIQWV4" frameborder="0" allowfullscreen></iframe>
+<iframe width="375" height="246" src="https://www.youtube-nocookie.com/embed/AI_dayIQWV4" frameborder="0" allowfullscreen></iframe>
 
 **President Obama does the Hour of Code**
 
@@ -33,7 +33,7 @@ theme: responsive
 
 [col-50]
 
-<iframe width="375" height="246" src="https://www.youtube.com/embed/W5QGo_Yb_Pc?list=PLzdnOPI1iJNfygSF8gKBUq7fT4Y61_h2I" frameborder="0" allowfullscreen></iframe>
+<iframe width="375" height="246" src="https://www.youtube-nocookie.com/embed/W5QGo_Yb_Pc?list=PLzdnOPI1iJNfygSF8gKBUq7fT4Y61_h2I" frameborder="0" allowfullscreen></iframe>
 
 **The Hour of Code has won the support of both Republicans and Democrats**
 

--- a/pegasus/sites.v3/code.org/public/coldplay.md.partial
+++ b/pegasus/sites.v3/code.org/public/coldplay.md.partial
@@ -12,17 +12,17 @@ style_min: true
 
 **This promotion has now ended, and the winners have been notified. Congratulations to all winners, especially our classroom winner, Mrs. Lopez’s 2nd grade class from PS 22 in Graniteville, Staten Island, New York City:**
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/yf9oS3nv5mI" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/yf9oS3nv5mI" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 # Join the Coldplay Dance Party
 
-Coldplay and Code.org believe in the power of computer science education for every student, in every classroom around the world. That's why we're teaming up to inspire students everywhere to code and dance - let's celebrate the magic of computer science and music! 
+Coldplay and Code.org believe in the power of computer science education for every student, in every classroom around the world. That's why we're teaming up to inspire students everywhere to code and dance - let's celebrate the magic of computer science and music!
 
 Join the party by using Code.org's Dance Party activity to code your own choreography to Coldplay's "Higher Power." Get creative with classic moves, and have fun with new album-inspired visuals and dancer formations!
 
 Post your creations for Coldplay and Code.org to see, and we'll share the best ones on social media. Plus, if you participate by June 10, 2022, you'll get a chance to win tickets to see Coldplay on tour, or a chance for your classroom to video chat with the band.
 
-We can't wait to see and share what you create! 
+We can't wait to see and share what you create!
 
 [col-66-center]
 
@@ -54,18 +54,18 @@ In every city on the [tour](https://www.coldplay.com/tour/) we will pick two stu
 
 ## How will Code.org pick who gets to see Coldplay?
 
-We'll be looking first and foremost for creativity and fun - code a "Higher Power" dance that really wows, and ideally pair it up with some actual dancing. For example, check out this [unfinished choreography made by a former Code.org engineer] (https://studio.code.org/projects/dance/S_vcQiglulAGJ0tkN4cv2g) - feel free to remix, change, and complete it. For extra fun, record a video of yourself and/or friends dancing to your creation! 
+We'll be looking first and foremost for creativity and fun - code a "Higher Power" dance that really wows, and ideally pair it up with some actual dancing. For example, check out this [unfinished choreography made by a former Code.org engineer] (https://studio.code.org/projects/dance/S_vcQiglulAGJ0tkN4cv2g) - feel free to remix, change, and complete it. For extra fun, record a video of yourself and/or friends dancing to your creation!
 
 <blockquote class="tiktok-embed" cite="https://www.tiktok.com/@ale.camposss/video/7071055666772708614" data-video-id="7071055666772708614" style="max-width: 605px;min-width: 325px;" > <section> <a target="_blank" title="@ale.camposss" href="https://www.tiktok.com/@ale.camposss">@ale.camposss</a> This is my <a title="higherpower" target="_blank" href="https://www.tiktok.com/tag/higherpower">#HigherPower</a> Dance Party creation! My concert city is Monterrey México @codeorg &#38; @coldplay 💖! I really tried my best😂💫 <a title="codeplay" target="_blank" href="https://www.tiktok.com/tag/codeplay">#codeplay</a> <a target="_blank" title="♬ Higher Power - Coldplay" href="https://www.tiktok.com/music/Higher-Power-6956843326319151106">♬ Higher Power - Coldplay</a> </section> </blockquote> <script async src="https://www.tiktok.com/embed.js"></script>
 
-Grab attention with entries that get lots of likes, comments, or re-shares on social media - across Instagram, TikTok, Twitter, or Facebook.  And Coldplay and Code.org will share, favorite, or comment on especially awesome posts. 
+Grab attention with entries that get lots of likes, comments, or re-shares on social media - across Instagram, TikTok, Twitter, or Facebook.  And Coldplay and Code.org will share, favorite, or comment on especially awesome posts.
 
 Code.org will select winners from the posted Dance Party projects on social media and submitted [via the entry form](https://docs.google.com/forms/d/e/1FAIpQLScEEkMIZfMiXtceBndz0cRbPVzLxbR2XcwmxY7qqSH6nP_0cA/viewform?usp=sf_link).
 
 
 And of course, if you want to get selected, make sure to:
 
-1. Follow the instructions above on how to post, to make sure we have everything we need. 
+1. Follow the instructions above on how to post, to make sure we have everything we need.
 2. Do it early, because we need to give the tickets out well before the shows. In Costa Rica, the Dominican Republic, Mexico, and the United States, individuals needed to post or or submit your creations by March 4, 2022, to be eligible for tickets. The deadline for individuals in Europe and South America is June 10, 2022. The deadline for classrooms entering to win the class chat is also June 10,2022.
 
 You can post multiple projects across Facebook, Twitter, Instagram, and Tiktok to impress us with your creativity.
@@ -106,14 +106,14 @@ Email coldplay@code.org.
 ## Terms and conditions
 This educational campaign ("Dance Party Challenge") is meant to celebrate creativity and education, combining computer science, music, and dance. The primary purpose of the campaign is to promote and celebrate education, and prizes will be awarded to selected participants based on the quality of their project submissions.
 
-The Dance Party Challenge is open to participants globally. Tickets to see Coldplay in concert will only be available as prizes for participants who validly submit their projects before the deadlines specified below. 
+The Dance Party Challenge is open to participants globally. Tickets to see Coldplay in concert will only be available as prizes for participants who validly submit their projects before the deadlines specified below.
 
 The Dance Party Challenge is managed solely by Code.org, a USA-based 501c3 nonprofit whose registered office is at 1501 4th Ave, Seattle, WA 98101, USA. These terms and conditions do not constitute an agreement with Coldplay or band management.
 
 The Dance Party Challenge is open to anyone except employees of Code.org and their close relatives and anyone otherwise connected with the organization or judging of the Dance Party Challenge.
 
-There is no entry fee and no purchase necessary to enter the Dance Party Challenge. 
-By entering the Dance Party Challenge, an entrant is indicating his/her agreement to be bound by these terms and conditions, as well as the terms of service and privacy policy of Code.org. 
+There is no entry fee and no purchase necessary to enter the Dance Party Challenge.
+By entering the Dance Party Challenge, an entrant is indicating his/her agreement to be bound by these terms and conditions, as well as the terms of service and privacy policy of Code.org.
 
 Details about the Dance Party Challenge and how to participate are available at https://code.org/coldplay. Participants can enter the Dance Party Challenge via form submission at https://code.org/coldplay, as well as by posting publicly using the hashtag #codeplay on Facebook, Twitter, Instagram, or Tiktok. Post on social media at your own discretion, subject to the terms of use of each respective platform, in accordance with all applicable data privacy laws, and only with the permission of anybody featured in the post.
 
@@ -121,7 +121,7 @@ To be eligible to win tickets to see Coldplay in concert, project submissions in
 
 Code.org bears no responsibility for entries not received for whatever reason.
 
-Code.org reserves the right to cancel or amend the Dance Party Challenge and these terms and conditions in its sole discretion without notice, including in the event of a catastrophe, war, civil or military disturbance, act of God or any actual or anticipated breach of any applicable law or regulation or any other event outside of Code.org's control - including changes to global or regional health and safety measures in response to the COVID-19 pandemic. Any changes to the Dance Party Challenge will be shared on http://code.org/coldplay by Code.org. Code.org is not responsible for rescheduled or canceled concerts. 
+Code.org reserves the right to cancel or amend the Dance Party Challenge and these terms and conditions in its sole discretion without notice, including in the event of a catastrophe, war, civil or military disturbance, act of God or any actual or anticipated breach of any applicable law or regulation or any other event outside of Code.org's control - including changes to global or regional health and safety measures in response to the COVID-19 pandemic. Any changes to the Dance Party Challenge will be shared on http://code.org/coldplay by Code.org. Code.org is not responsible for rescheduled or canceled concerts.
 
 Code.org is not responsible for inaccurate prize details supplied to any entrant by any third party connected with this Dance Party Challenge.
 
@@ -133,11 +133,11 @@ The prize is as stated and no cash or other alternatives will be offered. The pr
 
 In most countries, use of social media is not permitted for underage individuals. Participants are solely responsible for complying with applicable laws regarding social media use and for complying with the rules of each social media platform. Do not post videos or photos of students without the permission of a parent or guardian.
 
-Code.org will judge, in its sole discretion, the Dance Party Challenge and select the ticket winners from each city, as well as the winning classrooms for the class chat, based on the quality of each submission and the skills demonstrated by the participant(s). 
+Code.org will judge, in its sole discretion, the Dance Party Challenge and select the ticket winners from each city, as well as the winning classrooms for the class chat, based on the quality of each submission and the skills demonstrated by the participant(s).
 
-Code.org's decision as to those eligible to take part and selection of winners in its sole discretion is final. 
+Code.org's decision as to those eligible to take part and selection of winners in its sole discretion is final.
 
-The winners will be notified by email and/or Direct Message on social media, depending on the method of entry. The winners will only ever be contacted by an employee of Code.org. If any winner cannot be contacted or does not claim the prize within 1 day of notification, Code.org reserves the right to withdraw the prize and pick a replacement winner. 
+The winners will be notified by email and/or Direct Message on social media, depending on the method of entry. The winners will only ever be contacted by an employee of Code.org. If any winner cannot be contacted or does not claim the prize within 1 day of notification, Code.org reserves the right to withdraw the prize and pick a replacement winner.
 
 Code.org will notify winners on how to collect or redeem prizes. For concert attendance, each winner will receive two tickets, so that students under the age of 18 attend with an adult chaperone.
 
@@ -145,9 +145,9 @@ The Dance Party Challenge and these terms and conditions will be governed by the
 
 Each concert ticket winner agrees to the use of his/her Dance Party creation, and social media post in any publicity material by Code.org or Coldplay. Any personal data relating to the winner or any other entrants will be used solely for purposes of administering the Dance Party Challenge in accordance with applicable data protection legislation.
 
-The winners' names will be available 28 days after closing date by emailing the following address: coldplay@code.org 
+The winners' names will be available 28 days after closing date by emailing the following address: coldplay@code.org
 
-This promotion is in no way sponsored, endorsed or administered by, or associated with, Facebook, Twitter, Instagram, Tiktok, or any social network. Other than public social media posts, any information you provide will be provided solely to Code.org and not to any other party. The information provided will be used in conjunction with the Code.org Privacy Policy found at https://code.org/privacy. 
+This promotion is in no way sponsored, endorsed or administered by, or associated with, Facebook, Twitter, Instagram, Tiktok, or any social network. Other than public social media posts, any information you provide will be provided solely to Code.org and not to any other party. The information provided will be used in conjunction with the Code.org Privacy Policy found at https://code.org/privacy.
 
 Code.org shall have the right, at its sole discretion and at any time, to change or modify these terms and conditions, such change shall be effective immediately upon posting to this webpage.
 

--- a/pegasus/sites.v3/code.org/public/curriculum/csp/docs/learningresources.md
+++ b/pegasus/sites.v3/code.org/public/curriculum/csp/docs/learningresources.md
@@ -5,7 +5,7 @@ video_player: true
 
 # CS Principles - Learning JavaScript Resources
 
-The following table is intended to outline the main programming topics for Unit 3, so that teachers may familiarize themselves with the material and feel more comfortable running the lessons in the unit. 
+The following table is intended to outline the main programming topics for Unit 3, so that teachers may familiarize themselves with the material and feel more comfortable running the lessons in the unit.
 
 <style>
 .rotate {
@@ -49,7 +49,7 @@ filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=3);
       <td style="border:1px solid #999999;">
         <a href="https://code.org/curriculum/cspunit3/1/Teacher">U3L01 - The Need for Programming Languages</a>
       </td>
-      <td style="border:1px solid #999999;">You Should Learn to Program: Christian Genco at TEDxSMU<iframe width="100%" src="https://www.youtube.com/embed/xfBWk4nw440" frameborder="0" allowfullscreen></iframe></td>
+      <td style="border:1px solid #999999;">You Should Learn to Program: Christian Genco at TEDxSMU<iframe width="100%" src="https://www.youtube-nocookie.com/embed/xfBWk4nw440" frameborder="0" allowfullscreen></iframe></td>
       <td style="border:1px solid #999999;"></td>
     </tr>
     <tr>
@@ -57,14 +57,14 @@ filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=3);
       <td style="border:1px solid #999999;">
         <a href="https://code.org/curriculum/cspunit3/2/Teacher">U3L02 - Using Simple Commands</a>
       </td>
-      <td style="border:1px solid #999999;">Turtle Programming<iframe width="100%" src="https://www.youtube.com/embed/i2KHYUhtOlM" frameborder="0" allowfullscreen></iframe></td>
+      <td style="border:1px solid #999999;">Turtle Programming<iframe width="100%" src="https://www.youtube-nocookie.com/embed/i2KHYUhtOlM" frameborder="0" allowfullscreen></iframe></td>
       <td style="border:1px solid #999999;"></td>
     </tr>
     <tr>
       <td style="border:1px solid #999999;">
         <a href="https://code.org/curriculum/cspunit3/3/Teacher">U3L03 - Creating Functions</a>
       </td>
-      <td style="border:1px solid #999999;">Defining and Calling Functions<iframe width="100%" src="https://www.youtube.com/embed/yPWQfa4CHbw" frameborder="0" allowfullscreen></iframe></td>
+      <td style="border:1px solid #999999;">Defining and Calling Functions<iframe width="100%" src="https://www.youtube-nocookie.com/embed/yPWQfa4CHbw" frameborder="0" allowfullscreen></iframe></td>
       <td style="border:1px solid #999999;">
         <ul>
           <li><a href="https://code.org/applab/docs/functionParams_none">App Lab Docs: Define a function</a></li>
@@ -91,7 +91,7 @@ filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=3);
       <td style="border:1px solid #999999;">
         <a href="https://code.org/curriculum/cspunit3/6/Teacher">U3L06 - Creating Functions with Parameters</a>
       </td>
-      <td style="border:1px solid #999999;">Functions with Parameters<iframe width="100%" src="https://www.youtube.com/embed/k7Ji1E97-V0" frameborder="0" allowfullscreen></iframe></td>
+      <td style="border:1px solid #999999;">Functions with Parameters<iframe width="100%" src="https://www.youtube-nocookie.com/embed/k7Ji1E97-V0" frameborder="0" allowfullscreen></iframe></td>
       <td style="border:1px solid #999999;">
         <ul>
           <li><a href="http://www.w3schools.com/js/js_functions.asp">W3Schools: JS Functions</a></li>
@@ -102,7 +102,7 @@ filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=3);
       <td style="border:1px solid #999999;">
         <a href="https://code.org/curriculum/cspunit3/7/Teacher">U3L07 - Looping and Random Numbers</a>
       </td>
-      <td style="border:1px solid #999999;">Using Loops<iframe width="100%" src="https://www.youtube.com/embed/G8hfAk4PfOM" frameborder="0" allowfullscreen></iframe></td>
+      <td style="border:1px solid #999999;">Using Loops<iframe width="100%" src="https://www.youtube-nocookie.com/embed/G8hfAk4PfOM" frameborder="0" allowfullscreen></iframe></td>
       <td style="border:1px solid #999999;">
         <ul>
           <li><a href="http://www.w3schools.com/js/js_loop_for.asp">W3Schools: JS For Loop</a></li>
@@ -143,7 +143,7 @@ filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=3);
       <td style="border:1px solid #999999;">
         <a href="https://code.org/curriculum/cspunit3/12/Teacher">U3L12 - Introducing Design Mode</a>
       </td>
-      <td style="border:1px solid #999999;">Intro to Design Mode in App Lab<iframe width="100%" src="https://www.youtube.com/embed/-EoTeD4mSNU" frameborder="0" allowfullscreen></iframe></td>
+      <td style="border:1px solid #999999;">Intro to Design Mode in App Lab<iframe width="100%" src="https://www.youtube-nocookie.com/embed/-EoTeD4mSNU" frameborder="0" allowfullscreen></iframe></td>
       <td style="border:1px solid #999999;"></td>
     </tr>
     <tr>
@@ -158,7 +158,7 @@ filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=3);
       <td style="border:1px solid #999999;">
         <a href="https://code.org/curriculum/cspunit3/14/Teacher">U3L14 - Controlling Memory with Variables</a>
       </td>
-      <td style="border:1px solid #999999;">Intro to Variables - Part 1<iframe width="100%" src="https://www.youtube.com/embed/G41G_PEWFjE" frameborder="0" allowfullscreen></iframe><br><br>Intro to Variables - Part 2<iframe width="100%" src="https://www.youtube.com/embed/ijjVDBPwA1o" frameborder="0" allowfullscreen></iframe></td>
+      <td style="border:1px solid #999999;">Intro to Variables - Part 1<iframe width="100%" src="https://www.youtube-nocookie.com/embed/G41G_PEWFjE" frameborder="0" allowfullscreen></iframe><br><br>Intro to Variables - Part 2<iframe width="100%" src="https://www.youtube-nocookie.com/embed/ijjVDBPwA1o" frameborder="0" allowfullscreen></iframe></td>
       <td style="border:1px solid #999999;">
         <ul>
           <li><a href="http://www.w3schools.com/js/js_variables.asp">W3Schools: JS Variables</a></li>
@@ -199,7 +199,7 @@ filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=3);
       <td style="border:1px solid #999999;">
         <a href="https://code.org/curriculum/cspunit3/18/Teacher">U3L18 - Understanding Program Flow and Logic</a>
       </td>
-      <td style="border:1px solid #999999;">Conditionals - Part 1: Boolean Expressions<iframe width="100%" src="https://www.youtube.com/embed/y3rCKJNOwpA" frameborder="0" allowfullscreen></iframe><br><br>Conditionals - Part 2: If/Else Statements<iframe width="100%" src="https://www.youtube.com/embed/UDi7xgIIW8E" frameborder="0" allowfullscreen></iframe></td>
+      <td style="border:1px solid #999999;">Conditionals - Part 1: Boolean Expressions<iframe width="100%" src="https://www.youtube-nocookie.com/embed/y3rCKJNOwpA" frameborder="0" allowfullscreen></iframe><br><br>Conditionals - Part 2: If/Else Statements<iframe width="100%" src="https://www.youtube-nocookie.com/embed/UDi7xgIIW8E" frameborder="0" allowfullscreen></iframe></td>
       <td style="border:1px solid #999999;">
         <ul>
           <li><a href="http://www.w3schools.com/js/js_if_else.asp">W3Schools: JS If/Else Statements</a></li>
@@ -217,7 +217,7 @@ filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=3);
       <td style="border:1px solid #999999;">
         <a href="https://code.org/curriculum/cspunit3/20/Teacher">U3L20 - Compound Conditional Logic</a>
       </td>
-      <td style="border:1px solid #999999;">Conditionals - Part 3: AND & OR Operators<iframe width="100%" src="https://www.youtube.com/embed/kyFdniI-ZZs" frameborder="0" allowfullscreen></iframe></td>
+      <td style="border:1px solid #999999;">Conditionals - Part 3: AND & OR Operators<iframe width="100%" src="https://www.youtube-nocookie.com/embed/kyFdniI-ZZs" frameborder="0" allowfullscreen></iframe></td>
       <td style="border:1px solid #999999;"></td>
     </tr>
     <tr>
@@ -250,7 +250,7 @@ filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=3);
       <td style="border:1px solid #999999;">
         <a href="https://code.org/curriculum/cspunit3/24/Teacher">U3L24 - Introduction to Arrays</a>
       </td>
-      <td style="border:1px solid #999999;">Introduction to Lists<iframe width="100%" src="https://www.youtube.com/embed/KFy7u3Rhozs" frameborder="0" allowfullscreen></iframe></td>
+      <td style="border:1px solid #999999;">Introduction to Lists<iframe width="100%" src="https://www.youtube-nocookie.com/embed/KFy7u3Rhozs" frameborder="0" allowfullscreen></iframe></td>
       <td style="border:1px solid #999999;">
         <ul>
           <li><a href="http://www.w3schools.com/js/js_arrays.asp">W3Schools: JS Arrays</a></li>
@@ -269,7 +269,7 @@ filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=3);
       <td style="border:1px solid #999999;">
         <a href="https://code.org/curriculum/cspunit3/26/Teacher">U3L26 - Processing Arrays</a>
       </td>
-      <td style="border:1px solid #999999;">Processing Lists<iframe width="100%" src="https://www.youtube.com/embed/RQ6GJt9f2vg" frameborder="0" allowfullscreen></iframe></td>
+      <td style="border:1px solid #999999;">Processing Lists<iframe width="100%" src="https://www.youtube-nocookie.com/embed/RQ6GJt9f2vg" frameborder="0" allowfullscreen></iframe></td>
       <td style="border:1px solid #999999;"></td>
     </tr>
     <tr>

--- a/pegasus/sites.v3/code.org/public/curriculum/csp/docs/postap.md
+++ b/pegasus/sites.v3/code.org/public/curriculum/csp/docs/postap.md
@@ -55,8 +55,8 @@ For more information about how to teach this material, please refer to this <a h
       </td>
       <td>
         <ul>
-          <li>Intro to Databases - Part 1 - Creating and Storing Records<iframe width="100%" src="https://www.youtube.com/embed/d8ByCh-BouQ" frameborder="0" allowfullscreen></iframe></li>
-          <li>Intro to Databases - Part 2 - Data Viewer<iframe width="100%" src="https://www.youtube.com/embed/RZlHfbtO2C4" frameborder="0" allowfullscreen></iframe></li>
+          <li>Intro to Databases - Part 1 - Creating and Storing Records<iframe width="100%" src="https://www.youtube-nocookie.com/embed/d8ByCh-BouQ" frameborder="0" allowfullscreen></iframe></li>
+          <li>Intro to Databases - Part 2 - Data Viewer<iframe width="100%" src="https://www.youtube-nocookie.com/embed/RZlHfbtO2C4" frameborder="0" allowfullscreen></iframe></li>
           <li>
             <a href="https://code.org/applab/docs/tabledatastorage" target="_blank">App Lab Docs: Table Data Storage Overview</a>
           </li>
@@ -125,7 +125,7 @@ For more information about how to teach this material, please refer to this <a h
         Stage 6 - Importing and Exporting Data<br><br>
         <a href="https://studio.code.org/s/cspunit6/lessons/6/levels/1" target="_blank">Code Studio</a>
       </td>
-      <td>       
+      <td>
         In this stage, students learn how to “<strong>Remix</strong>” projects and that an app’s data does not transfer when it is remixed. Students learn how to use the <strong>import</strong> and <strong>export</strong> tools in the Data Viewer to transfer data between apps.
       </td>
       <td>

--- a/pegasus/sites.v3/code.org/public/diversity-old.md.erb
+++ b/pegasus/sites.v3/code.org/public/diversity-old.md.erb
@@ -171,9 +171,9 @@ In addition to the Hour of Code, Code.org regularly produces new materials and p
 
 <br>
 
-<center><iframe style="max-width: 100%" width="560" height="315" src="https://www.youtube.com/embed/mFPg96gdPkc" frameborder="0" allowfullscreen></iframe></center>
+<center><iframe style="max-width: 100%" width="560" height="315" src="https://www.youtube-nocookie.com/embed/mFPg96gdPkc" frameborder="0" allowfullscreen></iframe></center>
 <br>
-<center><iframe style="max-width: 100%" width="560" height="315" src="https://www.youtube.com/embed/uhcA6K8rWp0" frameborder="0" allowfullscreen></iframe></center>
+<center><iframe style="max-width: 100%" width="560" height="315" src="https://www.youtube-nocookie.com/embed/uhcA6K8rWp0" frameborder="0" allowfullscreen></iframe></center>
 <br>
 
 The sum of all these efforts — the curriculum design, the professional learning program, the Code.org Advocacy Coalition, the Hour of Code, and countless smaller efforts and initiatives — is how Code.org is holistically addressing the historical problems with diversity and equity in K-12 computer science.

--- a/pegasus/sites.v3/code.org/public/diversity.md.erb
+++ b/pegasus/sites.v3/code.org/public/diversity.md.erb
@@ -183,9 +183,9 @@ In addition to the Hour of Code, Code.org regularly produces new materials and p
 
 <br>
 
-<center><iframe style="max-width: 100%" width="560" height="315" src="https://www.youtube.com/embed/mFPg96gdPkc" frameborder="0" allowfullscreen></iframe></center>
+<center><iframe style="max-width: 100%" width="560" height="315" src="https://www.youtube-nocookie.com/embed/mFPg96gdPkc" frameborder="0" allowfullscreen></iframe></center>
 <br>
-<center><iframe style="max-width: 100%" width="560" height="315" src="https://www.youtube.com/embed/uhcA6K8rWp0" frameborder="0" allowfullscreen></iframe></center>
+<center><iframe style="max-width: 100%" width="560" height="315" src="https://www.youtube-nocookie.com/embed/uhcA6K8rWp0" frameborder="0" allowfullscreen></iframe></center>
 <br>
 
 The sum of all these efforts — the curriculum design, the professional learning program, the Code.org Advocacy Coalition, the Hour of Code, and countless smaller efforts and initiatives — is how Code.org is holistically addressing the historical problems with diversity and equity in K-12 computer science.

--- a/pegasus/sites.v3/code.org/public/educate/algebra.md.erb
+++ b/pegasus/sites.v3/code.org/public/educate/algebra.md.erb
@@ -144,7 +144,7 @@ None of the lessons from the original version of CS in Algebra have been removed
 
 <div class="col-50" style="float: left; padding: 10px;">
   <h3>1. Why is Algebra so Hard?</h3>
-  <iframe allowfullscreen="" frameborder="0" height="195" src="https://www.youtube.com/embed/5MbL4jxHTvY?iv_load_policy=3&amp;rel=0&amp;autohide=1&amp;showinfo=0" width="350"></iframe>
+  <iframe allowfullscreen="" frameborder="0" height="195" src="https://www.youtube-nocookie.com/embed/5MbL4jxHTvY?iv_load_policy=3&amp;rel=0&amp;autohide=1&amp;showinfo=0" width="350"></iframe>
   <p>
     <a href="https://www.dropbox.com/s/2sh8tvt4vorkr1s/Math-10-Why%20Is_algerbra_So_Hard-06162014.mp4">
       Download the video
@@ -154,7 +154,7 @@ None of the lessons from the original version of CS in Algebra have been removed
 
 <div class="col-50" style="float: left; padding: 10px;">
   <h3>2. Modeling and Coordinates</h3>
-  <iframe allowfullscreen="" frameborder="0" height="195" src="https://www.youtube.com/embed/KSt_3ovWfjk?iv_load_policy=3&amp;rel=0&amp;autohide=1&amp;showinfo=0" width="350"></iframe>
+  <iframe allowfullscreen="" frameborder="0" height="195" src="https://www.youtube-nocookie.com/embed/KSt_3ovWfjk?iv_load_policy=3&amp;rel=0&amp;autohide=1&amp;showinfo=0" width="350"></iframe>
   <p>
     <a href="https://www.dropbox.com/s/wl4fb15ihjwkr2d/Math-1-Modeling_Coordinates_06162014.mp4">
       Download the video
@@ -166,7 +166,7 @@ None of the lessons from the original version of CS in Algebra have been removed
 
 <div class="col-50" style="float: left; padding: 10px;">
   <h3>3. Order of Operations</h3>
-  <iframe allowfullscreen="" frameborder="0" height="195" src="https://www.youtube.com/embed/AMFaPKHp3Mg?iv_load_policy=3&amp;rel=0&amp;autohide=1&amp;showinfo=0" width="350"></iframe>
+  <iframe allowfullscreen="" frameborder="0" height="195" src="https://www.youtube-nocookie.com/embed/AMFaPKHp3Mg?iv_load_policy=3&amp;rel=0&amp;autohide=1&amp;showinfo=0" width="350"></iframe>
   <p>
     <a href="https://www.dropbox.com/s/2ux7oadsyekjl6v/Math-2-Order_Of_Operation_06232014_1.mp4">
       Download the video
@@ -176,7 +176,7 @@ None of the lessons from the original version of CS in Algebra have been removed
 
 <div class="col-50" style="float: left; padding: 10px;">
   <h3>4. Domain and Range</h3>
-  <iframe allowfullscreen="" frameborder="0" height="195" src="https://www.youtube.com/embed/88WhYoMxrGw?iv_load_policy=3&amp;rel=0&amp;autohide=1&amp;showinfo=0" width="350"></iframe>
+  <iframe allowfullscreen="" frameborder="0" height="195" src="https://www.youtube-nocookie.com/embed/88WhYoMxrGw?iv_load_policy=3&amp;rel=0&amp;autohide=1&amp;showinfo=0" width="350"></iframe>
   <p>
     <a href="https://www.dropbox.com/s/zf4d2emzaf4cb9k/Math-3_Domain%20and%20Range_06112014.mp4">
       Download the video

--- a/pegasus/sites.v3/code.org/public/educate/algebra/videos.md
+++ b/pegasus/sites.v3/code.org/public/educate/algebra/videos.md
@@ -15,7 +15,7 @@ The videos introduce teachers to the curriculum materials and tools,  data model
 
 <div style="float:left; padding:10px; width:50%">
   <h3>1. Why is Algebra so Hard?</h3>
-  <iframe allowfullscreen="" frameborder="0" height="195" src="https://www.youtube.com/embed/5MbL4jxHTvY?iv_load_policy=3&amp;rel=0&amp;autohide=1&amp;showinfo=0" width="350"></iframe>
+  <iframe allowfullscreen="" frameborder="0" height="195" src="https://www.youtube-nocookie.com/embed/5MbL4jxHTvY?iv_load_policy=3&amp;rel=0&amp;autohide=1&amp;showinfo=0" width="350"></iframe>
   <p>
     <a href="https://videos.code.org/cs-in-algebra/why-is-algebra-so-hard.mp4">
       Download the video
@@ -25,7 +25,7 @@ The videos introduce teachers to the curriculum materials and tools,  data model
 
 <div style="float:left; padding:10px; width:50%">
   <h3>2. Modeling and Coordinates</h3>
-  <iframe allowfullscreen="" frameborder="0" height="195" src="https://www.youtube.com/embed/KSt_3ovWfjk?iv_load_policy=3&amp;rel=0&amp;autohide=1&amp;showinfo=0" width="350"></iframe>
+  <iframe allowfullscreen="" frameborder="0" height="195" src="https://www.youtube-nocookie.com/embed/KSt_3ovWfjk?iv_load_policy=3&amp;rel=0&amp;autohide=1&amp;showinfo=0" width="350"></iframe>
   <p>
     <a href="https://videos.code.org/cs-in-algebra/modeling-coordinates.mp4">
       Download the video
@@ -37,7 +37,7 @@ The videos introduce teachers to the curriculum materials and tools,  data model
 
 <div style="float:left; padding:10px; width:50%">
   <h3>3. Order of Operations</h3>
-  <iframe allowfullscreen="" frameborder="0" height="195" src="https://www.youtube.com/embed/AMFaPKHp3Mg?iv_load_policy=3&amp;rel=0&amp;autohide=1&amp;showinfo=0" width="350"></iframe>
+  <iframe allowfullscreen="" frameborder="0" height="195" src="https://www.youtube-nocookie.com/embed/AMFaPKHp3Mg?iv_load_policy=3&amp;rel=0&amp;autohide=1&amp;showinfo=0" width="350"></iframe>
   <p>
     <a href="https://videos.code.org/cs-in-algebra/order-of-operations.mp4">
       Download the video
@@ -47,7 +47,7 @@ The videos introduce teachers to the curriculum materials and tools,  data model
 
 <div style="float:left; padding:10px; width:50%">
   <h3>4. Domain and Range</h3>
-  <iframe allowfullscreen="" frameborder="0" height="195" src="https://www.youtube.com/embed/88WhYoMxrGw?iv_load_policy=3&amp;rel=0&amp;autohide=1&amp;showinfo=0" width="350"></iframe>
+  <iframe allowfullscreen="" frameborder="0" height="195" src="https://www.youtube-nocookie.com/embed/88WhYoMxrGw?iv_load_policy=3&amp;rel=0&amp;autohide=1&amp;showinfo=0" width="350"></iframe>
   <p>
     <a href="https://videos.code.org/cs-in-algebra/domain-and-range.mp4">
       Download the video
@@ -59,7 +59,7 @@ The videos introduce teachers to the curriculum materials and tools,  data model
 
 <div style="float:left; padding:10px; width:50%">
   <h3>5. Defining Values</h3>
-  <iframe allowfullscreen="" frameborder="0" height="195" src="https://www.youtube.com/embed/xRUoQO1AdVs?iv_load_policy=3&amp;rel=0&amp;autohide=1&amp;showinfo=0" width="350"></iframe>
+  <iframe allowfullscreen="" frameborder="0" height="195" src="https://www.youtube-nocookie.com/embed/xRUoQO1AdVs?iv_load_policy=3&amp;rel=0&amp;autohide=1&amp;showinfo=0" width="350"></iframe>
   <p>
     <a href="https://videos.code.org/cs-in-algebra/defining-values.mp4">
       Download the video
@@ -69,7 +69,7 @@ The videos introduce teachers to the curriculum materials and tools,  data model
 
 <div style="float:left; padding:10px; width:50%">
   <h3>6. Using the Design Recipe to Solve Word Problems</h3>
-  <iframe allowfullscreen="" frameborder="0" height="195" src="https://www.youtube.com/embed/ZWdLNtPu6PQ?iv_load_policy=3&amp;rel=0&amp;autohide=1&amp;showinfo=0" width="350"></iframe>
+  <iframe allowfullscreen="" frameborder="0" height="195" src="https://www.youtube-nocookie.com/embed/ZWdLNtPu6PQ?iv_load_policy=3&amp;rel=0&amp;autohide=1&amp;showinfo=0" width="350"></iframe>
   <p>
     <a href="https://videos.code.org/cs-in-algebra/word-problems-part1.mp4">
       Download the video
@@ -81,7 +81,7 @@ The videos introduce teachers to the curriculum materials and tools,  data model
 
 <div style="float:left; padding:10px; width:50%">
   <h3>7. Using the Design Recipe to Help Students</h3>
-  <iframe allowfullscreen="" frameborder="0" height="195" src="https://www.youtube.com/embed/SL2zLs2P-mU?iv_load_policy=3&amp;rel=0&amp;autohide=1&amp;showinfo=0" width="350"></iframe>
+  <iframe allowfullscreen="" frameborder="0" height="195" src="https://www.youtube-nocookie.com/embed/SL2zLs2P-mU?iv_load_policy=3&amp;rel=0&amp;autohide=1&amp;showinfo=0" width="350"></iframe>
   <p>
     <a href="https://videos.code.org/cs-in-algebra/word-problems-part2.mp4">
       Download the video
@@ -91,7 +91,7 @@ The videos introduce teachers to the curriculum materials and tools,  data model
 
 <div style="float:left; padding:10px; width:50%">
   <h3>8. Boolean Logic and Inequalities in the Plane</h3>
-  <iframe allowfullscreen="" frameborder="0" height="195" src="https://www.youtube.com/embed/OMQO66wWqjk?iv_load_policy=3&amp;rel=0&amp;autohide=1&amp;showinfo=0" width="350"></iframe>
+  <iframe allowfullscreen="" frameborder="0" height="195" src="https://www.youtube-nocookie.com/embed/OMQO66wWqjk?iv_load_policy=3&amp;rel=0&amp;autohide=1&amp;showinfo=0" width="350"></iframe>
   <p>
     <a href="https://videos.code.org/cs-in-algebra/boolean-logic.mp4">
       Download the video
@@ -103,7 +103,7 @@ The videos introduce teachers to the curriculum materials and tools,  data model
 
 <div style="float:left; padding:10px; width:50%">
   <h3>9. Piecewise Functions</h3>
-  <iframe allowfullscreen="" frameborder="0" height="195" src="https://www.youtube.com/embed/joF6lOgCN14?iv_load_policy=3&amp;rel=0&amp;autohide=1&amp;showinfo=0" width="350"></iframe>
+  <iframe allowfullscreen="" frameborder="0" height="195" src="https://www.youtube-nocookie.com/embed/joF6lOgCN14?iv_load_policy=3&amp;rel=0&amp;autohide=1&amp;showinfo=0" width="350"></iframe>
   <p>
     <a href="https://videos.code.org/cs-in-algebra/piecewise-functions.mp4">
       Download the video
@@ -113,7 +113,7 @@ The videos introduce teachers to the curriculum materials and tools,  data model
 
 <div style="float:left; padding:10px; width:50%">
   <h3>10. The Pythagorean Theorem</h3>
-  <iframe allowfullscreen="" frameborder="0" height="195" src="https://www.youtube.com/embed/Bbq0oCmvSmA?iv_load_policy=3&amp;rel=0&amp;autohide=1&amp;showinfo=0" width="350"></iframe>
+  <iframe allowfullscreen="" frameborder="0" height="195" src="https://www.youtube-nocookie.com/embed/Bbq0oCmvSmA?iv_load_policy=3&amp;rel=0&amp;autohide=1&amp;showinfo=0" width="350"></iframe>
   <p>
     <a href="https://videos.code.org/cs-in-algebra/pythagorean-theorem.mp4">
       Download the video

--- a/pegasus/sites.v3/code.org/public/educate/science/index.md
+++ b/pegasus/sites.v3/code.org/public/educate/science/index.md
@@ -14,7 +14,7 @@ Code.org has partnered with the award-winning Project GUTS (Growing Up Thinking 
 
 <div class="col-50" style="float:left; padding:10px;">
   <h3>Curriculum Overview</h3>
-  <iframe allowfullscreen="" frameborder="0" height="195" src="https://www.youtube.com/embed/iDSluSl9I3o?iv_load_policy=3&amp;rel=0&amp;autohide=1&amp;showinfo=0" width="350"></iframe>
+  <iframe allowfullscreen="" frameborder="0" height="195" src="https://www.youtube-nocookie.com/embed/iDSluSl9I3o?iv_load_policy=3&amp;rel=0&amp;autohide=1&amp;showinfo=0" width="350"></iframe>
   <p>
     <a href="https://www.dropbox.com/s/zuzx5m5e5q4r5kj/Welcome%20and%20Curriculum%20overview-SCI_PD-1.mp4">
       Download the video
@@ -24,7 +24,7 @@ Code.org has partnered with the award-winning Project GUTS (Growing Up Thinking 
 
 <div class="col-50" style="float:left; padding:10px;">
   <h3>Introduction to StarLogo Nova</h3>
-  <iframe allowfullscreen="" frameborder="0" height="195" src="https://www.youtube.com/embed/QrXe-nCV1xM?iv_load_policy=3&amp;rel=0&amp;autohide=1&amp;showinfo=0" width="350"></iframe>
+  <iframe allowfullscreen="" frameborder="0" height="195" src="https://www.youtube-nocookie.com/embed/QrXe-nCV1xM?iv_load_policy=3&amp;rel=0&amp;autohide=1&amp;showinfo=0" width="350"></iframe>
   <p>
     <a href="https://www.dropbox.com/s/ehnnc2a3ftyelds/MS-SCI-PD-Intro-to-Starlogo-Nova-9-2015.mp4">
       Download the video
@@ -36,7 +36,7 @@ Code.org has partnered with the award-winning Project GUTS (Growing Up Thinking 
 
 <div class="col-50" style="float:left; padding:10px;">
   <h3>Computational Thinking and the NRC Framework</h3>
-  <iframe allowfullscreen="" frameborder="0" height="195" src="https://www.youtube.com/embed/kP8C6qoUgxs?iv_load_policy=3&amp;rel=0&amp;autohide=1&amp;showinfo=0" width="350"></iframe>
+  <iframe allowfullscreen="" frameborder="0" height="195" src="https://www.youtube-nocookie.com/embed/kP8C6qoUgxs?iv_load_policy=3&amp;rel=0&amp;autohide=1&amp;showinfo=0" width="350"></iframe>
   <p>
     <a href="https://www.dropbox.com/s/h62bfwe0lrkw3nt/Computational%20Thinking%20and%20NRC%20Framework%20-%20SCI%20PD%208_1.mp4">
       Download the video
@@ -46,7 +46,7 @@ Code.org has partnered with the award-winning Project GUTS (Growing Up Thinking 
 
 <div class="col-50" style="float:left; padding:10px;">
   <h3>What is Computational Science?</h3>
-  <iframe allowfullscreen="" frameborder="0" height="195" src="https://www.youtube.com/embed/C-9vMx0O3d8?iv_load_policy=3&amp;rel=0&amp;autohide=1&amp;showinfo=0" width="350"></iframe>
+  <iframe allowfullscreen="" frameborder="0" height="195" src="https://www.youtube-nocookie.com/embed/C-9vMx0O3d8?iv_load_policy=3&amp;rel=0&amp;autohide=1&amp;showinfo=0" width="350"></iframe>
   <p>
     <a href="https://www.dropbox.com/s/7fgk2owc65tb2ef/What%20is%20Computational%20Science%20-%20SCI%20PD%203_1.mp4">
       Download the video
@@ -62,20 +62,20 @@ Code.org has partnered with the award-winning Project GUTS (Growing Up Thinking 
 
 The Middle School Science Curriculum includes four modules; each consists of five or six lessons that augment the educational outcomes of traditional science instruction to include computational thinking within engaging activities of modeling and simulation.
 
-### Module 1: Introduction to Computer Modeling and Simulation 
-The Introductory module presents basic concepts in modeling complex systems through hands-on activities and participatory simulations. A series of highly-engaging design-and-build activities guide students through developing their first computer model in StarLogo Nova, a modeling and simulation environment developed at Massachusetts Institute of Technology. 
+### Module 1: Introduction to Computer Modeling and Simulation
+The Introductory module presents basic concepts in modeling complex systems through hands-on activities and participatory simulations. A series of highly-engaging design-and-build activities guide students through developing their first computer model in StarLogo Nova, a modeling and simulation environment developed at Massachusetts Institute of Technology.
 [Download Module 1](science/files/CS_in_Science_Module_1.pdf)
 
 ### Module 2: Water as a Shared Resource
 In this Earth Science module students will investigate the importance of ground water and the impacts of water usage on aquifer levels as well as explore how to model important parts of the water cycle including evaporation and infiltration of water into different types of soils to recharge the aquifers. [Download Module 2](science/files/CS_in_Science_Module_2.pdf)
 
-### Module 3: Ecosystems as Complex Systems  
+### Module 3: Ecosystems as Complex Systems
 The Life Science module begins with an exploration of a simple predator-prey model to consider who eats whom and what happens when one population grows faster than another. After learning more about ecosystem dynamics, producers and consumers, and interdependent relationships within an ecosystem, students develop their own model of a local ecosystem. [Download Module 3](science/files/CS_in_Science_Module_3.pdf)
 
 ### Module 4: Chemical Reactions
 The Chemical Reactions module explores the conditions under which chemical reactions occur, the evidence of a chemical reaction, limiting reactants versus reactants in excess, and the conditions under which chemical reactions stop. The chemical reaction simulated is that of silver nitrate and copper.  [Download Module 4](science/files/CS_in_Science_Module_4.pdf)
 
-### Download the required curriculum support documents 
+### Download the required curriculum support documents
 
 - [CS in Science Common Forms](science/files/CS_in_Science_Common_Forms.pdf)
 - [CS in Science Guides](science/files/CS_in_Science_Guides.pdf)
@@ -86,7 +86,7 @@ The Chemical Reactions module explores the conditions under which chemical react
 
 ## Crosswalks
 ### Crosswalks between CSTA K-12 Computer Science Standards and the Next Generation Science Standards
-Crosswalks between the *National Research Council’s Framework for K-12 Science Education* and *CSTA K-12 Computer Science Standards*; and between Achieve’s *Next Generation Science Standards* and the *CSTA K-12 Computer Science Standards* illustrate the commonalities that serve as the basis for a set of learning outcomes addressed in the “Computer Science in Science” modules. 
+Crosswalks between the *National Research Council’s Framework for K-12 Science Education* and *CSTA K-12 Computer Science Standards*; and between Achieve’s *Next Generation Science Standards* and the *CSTA K-12 Computer Science Standards* illustrate the commonalities that serve as the basis for a set of learning outcomes addressed in the “Computer Science in Science” modules.
 
 [Download the Crosswalk documents.](science/files/Crosswalk_documents.pdf)
 

--- a/pegasus/sites.v3/code.org/public/educate/science/videos.md
+++ b/pegasus/sites.v3/code.org/public/educate/science/videos.md
@@ -5,7 +5,7 @@ theme: responsive
 ---
 # Middle School CS in Science Videos
 
-Code.org has partnered with the award-winning Project GUTS (Growing Up Thinking Scientifically) to deliver a middle school science program, [CS in Science](/educate/science), consisting of four instructional modules and professional development for the introduction of computer science concepts into science classrooms within the context of modeling and simulation. 
+Code.org has partnered with the award-winning Project GUTS (Growing Up Thinking Scientifically) to deliver a middle school science program, [CS in Science](/educate/science), consisting of four instructional modules and professional development for the introduction of computer science concepts into science classrooms within the context of modeling and simulation.
 
 The videos were created as part of the CS in Science Professional Development Program. The ten videos are intended for teachers to build their background knowledge to get  started in the computer modeling and simulation and to use the four modules in the [CS in Science Curriculum](/educate/science).
 
@@ -15,7 +15,7 @@ The videos introduce teachers to the curriculum materials and tools, agent-based
 
 <div class="col-50" style="float:left; padding:10px;">
   <h3>Curriculum Overview</h3>
-  <iframe allowfullscreen="" frameborder="0" height="195" src="https://www.youtube.com/embed/iDSluSl9I3o?iv_load_policy=3&amp;rel=0&amp;autohide=1&amp;showinfo=0" width="350"></iframe>
+  <iframe allowfullscreen="" frameborder="0" height="195" src="https://www.youtube-nocookie.com/embed/iDSluSl9I3o?iv_load_policy=3&amp;rel=0&amp;autohide=1&amp;showinfo=0" width="350"></iframe>
   <p>
     <a href="https://www.dropbox.com/s/zuzx5m5e5q4r5kj/Welcome%20and%20Curriculum%20overview-SCI_PD-1.mp4">
       Download the video
@@ -25,7 +25,7 @@ The videos introduce teachers to the curriculum materials and tools, agent-based
 
 <div class="col-50" style="float:left; padding:10px;">
   <h3>Professional Development Overview</h3>
-  <iframe allowfullscreen="" frameborder="0" height="195" src="https://www.youtube.com/embed/t29Ann5323w?iv_load_policy=3&amp;rel=0&amp;autohide=1&amp;showinfo=0" width="350"></iframe>
+  <iframe allowfullscreen="" frameborder="0" height="195" src="https://www.youtube-nocookie.com/embed/t29Ann5323w?iv_load_policy=3&amp;rel=0&amp;autohide=1&amp;showinfo=0" width="350"></iframe>
   <p>
     <a href="https://www.dropbox.com/s/x45182j6izy1b73/Professional%20Development%20Overview%20-%20SCI%20PD%201B_1.mp4">
       Download the video
@@ -35,7 +35,7 @@ The videos introduce teachers to the curriculum materials and tools, agent-based
 
 <div class="col-50" style="float:left; padding:10px;">
   <h3>Intro to Complex Adaptive Systems</h3>
-  <iframe allowfullscreen="" frameborder="0" height="195" src="https://www.youtube.com/embed/R4lov0SaFpI?iv_load_policy=3&amp;rel=0&amp;autohide=1&amp;showinfo=0" width="350"></iframe>
+  <iframe allowfullscreen="" frameborder="0" height="195" src="https://www.youtube-nocookie.com/embed/R4lov0SaFpI?iv_load_policy=3&amp;rel=0&amp;autohide=1&amp;showinfo=0" width="350"></iframe>
   <p>
     <a href="https://www.dropbox.com/s/zr0aeof80m4u4s8/Introduction%20to%20Complex%20Adaptive%20Systems%20-%20SCI%20PD%202_1.mp4">
       Download the video
@@ -45,7 +45,7 @@ The videos introduce teachers to the curriculum materials and tools, agent-based
 
 <div class="col-50" style="float:left; padding:10px;">
   <h3>What is Computational Science?</h3>
-  <iframe allowfullscreen="" frameborder="0" height="195" src="https://www.youtube.com/embed/C-9vMx0O3d8?iv_load_policy=3&amp;rel=0&amp;autohide=1&amp;showinfo=0" width="350"></iframe>
+  <iframe allowfullscreen="" frameborder="0" height="195" src="https://www.youtube-nocookie.com/embed/C-9vMx0O3d8?iv_load_policy=3&amp;rel=0&amp;autohide=1&amp;showinfo=0" width="350"></iframe>
   <p>
     <a href="https://www.dropbox.com/s/7fgk2owc65tb2ef/What%20is%20Computational%20Science%20-%20SCI%20PD%203_1.mp4">
       Download the video
@@ -55,7 +55,7 @@ The videos introduce teachers to the curriculum materials and tools, agent-based
 
 <div class="col-50" style="float:left; padding:10px;">
   <h3>Agent-based Modeling of Complex Adaptive Systems</h3>
-  <iframe allowfullscreen="" frameborder="0" height="195" src="https://www.youtube.com/embed/W7_kU2IWuXU?iv_load_policy=3&amp;rel=0&amp;autohide=1&amp;showinfo=0" width="350"></iframe>
+  <iframe allowfullscreen="" frameborder="0" height="195" src="https://www.youtube-nocookie.com/embed/W7_kU2IWuXU?iv_load_policy=3&amp;rel=0&amp;autohide=1&amp;showinfo=0" width="350"></iframe>
   <p>
     <a href="https://www.dropbox.com/s/1zf54f407l4e5ha/Agent%20Based%20Modeling%20of%20CASs%20-%20SCI%20PD%204_1.mp4">
       Download the video
@@ -65,7 +65,7 @@ The videos introduce teachers to the curriculum materials and tools, agent-based
 
 <div class="col-50" style="float:left; padding:10px;">
   <h3>Using Computer Models in Scientific Inquiry</h3>
-  <iframe allowfullscreen="" frameborder="0" height="195" src="https://www.youtube.com/embed/aycgUIfl9DQ?iv_load_policy=3&amp;rel=0&amp;autohide=1&amp;showinfo=0" width="350"></iframe>
+  <iframe allowfullscreen="" frameborder="0" height="195" src="https://www.youtube-nocookie.com/embed/aycgUIfl9DQ?iv_load_policy=3&amp;rel=0&amp;autohide=1&amp;showinfo=0" width="350"></iframe>
   <p>
     <a href="https://www.dropbox.com/s/6ymzjjtft4eccsh/Using%20computer%20models%20in%20scientific%20inquiry%20-%20SCI%20PD%205_1.mp4">
       Download the video
@@ -75,7 +75,7 @@ The videos introduce teachers to the curriculum materials and tools, agent-based
 
 <div class="col-50" style="float:left; padding:10px;">
   <h3>Models in the Classroom</h3>
-  <iframe allowfullscreen="" frameborder="0" height="195" src="https://www.youtube.com/embed/eiMascD1h2A?iv_load_policy=3&amp;rel=0&amp;autohide=1&amp;showinfo=0" width="350"></iframe>
+  <iframe allowfullscreen="" frameborder="0" height="195" src="https://www.youtube-nocookie.com/embed/eiMascD1h2A?iv_load_policy=3&amp;rel=0&amp;autohide=1&amp;showinfo=0" width="350"></iframe>
   <p>
     <a href="https://www.dropbox.com/s/3q0zecatu6xyo31/Models%20in%20the%20Classroom%20-%20SCI%20PD%206_1.mp4">
       Download the video
@@ -85,7 +85,7 @@ The videos introduce teachers to the curriculum materials and tools, agent-based
 
 <div class="col-50" style="float:left; padding:10px;">
   <h3>Dispositions and Classroom Culture</h3>
-  <iframe allowfullscreen="" frameborder="0" height="195" src="https://www.youtube.com/embed/bR_pGotQ3wY?iv_load_policy=3&amp;rel=0&amp;autohide=1&amp;showinfo=0" width="350"></iframe>
+  <iframe allowfullscreen="" frameborder="0" height="195" src="https://www.youtube-nocookie.com/embed/bR_pGotQ3wY?iv_load_policy=3&amp;rel=0&amp;autohide=1&amp;showinfo=0" width="350"></iframe>
   <p>
     <a href="https://www.dropbox.com/s/hhjnhtyv4kujz5q/Dispositions%20and%20Classroom%20Culture%20-%20SCI%20PD%207_1.mp4">
       Download the video
@@ -95,7 +95,7 @@ The videos introduce teachers to the curriculum materials and tools, agent-based
 
 <div class="col-50" style="float:left; padding:10px;">
   <h3>Computational Thinking and the NRC Framework</h3>
-  <iframe allowfullscreen="" frameborder="0" height="195" src="https://www.youtube.com/embed/kP8C6qoUgxs?iv_load_policy=3&amp;rel=0&amp;autohide=1&amp;showinfo=0" width="350"></iframe>
+  <iframe allowfullscreen="" frameborder="0" height="195" src="https://www.youtube-nocookie.com/embed/kP8C6qoUgxs?iv_load_policy=3&amp;rel=0&amp;autohide=1&amp;showinfo=0" width="350"></iframe>
   <p>
     <a href="https://www.dropbox.com/s/h62bfwe0lrkw3nt/Computational%20Thinking%20and%20NRC%20Framework%20-%20SCI%20PD%208_1.mp4">
       Download the video
@@ -105,7 +105,7 @@ The videos introduce teachers to the curriculum materials and tools, agent-based
 
 <div class="col-50" style="float:left; padding:10px;">
   <h3>Introduction to StarLogo Nova</h3>
-  <iframe allowfullscreen="" frameborder="0" height="195" src="https://www.youtube.com/embed/QrXe-nCV1xM?iv_load_policy=3&amp;rel=0&amp;autohide=1&amp;showinfo=0" width="350"></iframe>
+  <iframe allowfullscreen="" frameborder="0" height="195" src="https://www.youtube-nocookie.com/embed/QrXe-nCV1xM?iv_load_policy=3&amp;rel=0&amp;autohide=1&amp;showinfo=0" width="350"></iframe>
   <p>
     <a href="https://www.dropbox.com/s/ehnnc2a3ftyelds/MS-SCI-PD-Intro-to-Starlogo-Nova-9-2015.mp4">
       Download the video

--- a/pegasus/sites.v3/code.org/public/engagement/index.md
+++ b/pegasus/sites.v3/code.org/public/engagement/index.md
@@ -7,9 +7,9 @@ rightbar: blank
 ---
 
 
-<iframe width="750" height="493" src="https://www.youtube.com/embed/jdUkMM3fbfE" frameborder="0" allowfullscreen></iframe>
+<iframe width="750" height="493" src="https://www.youtube-nocookie.com/embed/jdUkMM3fbfE" frameborder="0" allowfullscreen></iframe>
 
-Vista Equity Group hosts an Hour of Code with the Boys and Girls Club 
+Vista Equity Group hosts an Hour of Code with the Boys and Girls Club
 
 # Employee Engagement Opportunities
 

--- a/pegasus/sites.v3/code.org/public/girls.md
+++ b/pegasus/sites.v3/code.org/public/girls.md
@@ -12,7 +12,7 @@ In U.S. high schools, the Advanced Placement exam in Computer Science has histor
 <p>
 While things are starting to move in the right direction, we have a long way to go to reach a balanced population in computer science. Code.org focuses on K-12 learning because data shows that experiences in K-12 directly impact students’ future in computer science. <strong>Among young women, those who try AP Computer Science in high school are 10 times more likely to major in computer science.</strong>
 <p><br>
-<center><iframe width="560" height="315" src="https://www.youtube.com/embed/mFPg96gdPkc" frameborder="0" allowfullscreen></iframe><br></center><Br>
+<center><iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/mFPg96gdPkc" frameborder="0" allowfullscreen></iframe><br></center><Br>
 
 <h1>How You Can Help</h1>
 
@@ -148,25 +148,25 @@ Take a look at some <a href="https://code.org/careers-in-tech">great examples</a
 
 [col-50]
 
-<center><iframe width="368" height="207" src="https://www.youtube.com/embed/FBTWICxTG08" title="YouTube video player" frameborder="0" allowfullscreen></iframe><br><br>
+<center><iframe width="368" height="207" src="https://www.youtube-nocookie.com/embed/FBTWICxTG08" title="YouTube video player" frameborder="0" allowfullscreen></iframe><br><br>
 
 [/col-50]
 
 [col-50]
 
-<center><iframe width="368" height="207" src="https://www.youtube.com/embed/2uXTNK9W-gQ" title="YouTube video player" frameborder="0" allowfullscreen></iframe><br><br>
+<center><iframe width="368" height="207" src="https://www.youtube-nocookie.com/embed/2uXTNK9W-gQ" title="YouTube video player" frameborder="0" allowfullscreen></iframe><br><br>
 
 [/col-50]
 
 [col-50]
 
-<center><iframe width="368" height="207" src="https://www.youtube.com/embed/t0-Z_LfGwUM" frameborder="0" allowfullscreen></iframe><br><br>
+<center><iframe width="368" height="207" src="https://www.youtube-nocookie.com/embed/t0-Z_LfGwUM" frameborder="0" allowfullscreen></iframe><br><br>
 
 [/col-50]
 
 [col-50]
 
-<center><iframe width="368" height="207" src="https://www.youtube.com/embed/RfbbDgx6l1g" frameborder="0" allowfullscreen></iframe><br><br>
+<center><iframe width="368" height="207" src="https://www.youtube-nocookie.com/embed/RfbbDgx6l1g" frameborder="0" allowfullscreen></iframe><br><br>
 
 [/col-50]
 

--- a/pegasus/sites.v3/code.org/public/international/about.es-mx.md
+++ b/pegasus/sites.v3/code.org/public/international/about.es-mx.md
@@ -15,20 +15,20 @@ Code.org® es una organización sin fines de lucro dedicada a ampliar el acceso 
 [col-40]
 
 <div style="background-color:#7665a0;height:190px;padding:25px;display:flex;justify-content:center;flex-direction:column">
-  
+
   <font size="4" color="#FFFFFF"><b>Los cursos de Code.org son utilizados por decenas de millones de estudiantes y por un millón de profesores en todo el mundo.</b></font>
- 
+
 </div>
 
 [/col-40]
 
 <div style="clear:both"></div>
 
-## Historia 
+## Historia
 
 En 2013, Code.org fue lanzado por los hermanos gemelos Hadi y Ali Partovi con un [video que promueve la informática](https://www.youtube.com/watch?v=nKIu9yen5nc). Este video se convirtió en el número 1 en YouTube por un día y 15,000 escuelas nos pidieron ayuda. Desde entonces, nos hemos expandido de un equipo de voluntarios para desarrollar una organización completa que apoya un movimiento mundial. Creemos que una educación de informática de calidad debe estar disponible para todos los niños, no solo para unos pocos afortunados.
 <br>
-<iframe width="560" height="315" src="https://www.youtube.com/embed/nKIu9yen5nc" frameborder="0" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/nKIu9yen5nc" frameborder="0" allowfullscreen></iframe>
 
 ## Lo que hacemos
 
@@ -40,6 +40,6 @@ Más del 40% del tráfico de nuestro sitio web proviene de fuera de los Estados 
 
 <img alt="Code.org International Partners" src="/images/international/international_partners.jpg" width="100%">
 
-## Traducción 
+## Traducción
 
-¿Quieres tener un impacto directo en los estudiantes de tu país? ¡Ayúdenos a hacer que el contenido de Code.org esté disponible en su idioma nativo! Si se ofrece como voluntario para ayudar a traducir nuestros tutoriales y lecciones, se unirá a una comunidad de más de 7,000 traductores que ayudan a brindar educación en informática a estudiantes de todo el mundo. Echa un vistazo a nuestra [guía de traducción](/translate) para obtener más información. 
+¿Quieres tener un impacto directo en los estudiantes de tu país? ¡Ayúdenos a hacer que el contenido de Code.org esté disponible en su idioma nativo! Si se ofrece como voluntario para ayudar a traducir nuestros tutoriales y lecciones, se unirá a una comunidad de más de 7,000 traductores que ayudan a brindar educación en informática a estudiantes de todo el mundo. Echa un vistazo a nuestra [guía de traducción](/translate) para obtener más información.

--- a/pegasus/sites.v3/code.org/public/international/about.md.partial
+++ b/pegasus/sites.v3/code.org/public/international/about.md.partial
@@ -15,34 +15,34 @@ Code.org® is a nonprofit dedicated to expanding access to computer science in s
 [col-40]
 
 <div style="background-color:#7665a0;height:190px;padding:25px;display:flex;justify-content:center;flex-direction:column">
-  
+
   <font size="4" color="#FFFFFF"><b>Code.org courses are used by tens of millions of students and by one million teachers all around the world.</b></font>
- 
+
 </div>
 
 [/col-40]
 
 <div style="clear:both"></div>
 
-## History 
+## History
 
 In 2013, Code.org was launched by twin brothers Hadi and Ali Partovi with a [video promoting computer science](https://www.youtube.com/watch?v=nKIu9yen5nc). This video became #1 on YouTube for a day, and 15,000 schools reached out to us for help. Since then, we've expanded from a bootstrapped staff of volunteers to build a full organization supporting a worldwide movement. We believe that a quality computer science education should be available to every child, not just a lucky few.
 <br>
-<iframe width="560" height="315" src="https://www.youtube.com/embed/nKIu9yen5nc" frameborder="0" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/nKIu9yen5nc" frameborder="0" allowfullscreen></iframe>
 
 ## What We Do
 
 We do work across the education spectrum: designing [our own courses](https://studio.code.org/courses) or partnering with others, training teachers, partnering with large school districts, helping change government policies, expanding internationally via partnerships, and marketing to break stereotypes. Our work builds on decades of effort, by countless organizations and individuals who have helped establish, fund, and spread computer science education. We're grateful for the tireless work of the broader computer science education community, and we thank all the partners and individuals who have expanded our impact over the years.
 
-## Code.org's International Reach 
+## Code.org's International Reach
 
 Over 40% of our website traffic comes from outside of the United States and that number continues to climb. In order to expand global access to computer science, our team works closely with [more than 100 international partners](/about/partners), helping them to promote the Hour of Code, advocate for policy change, and train teachers. We are making computer science part of the international education discourse by partnering with ministries of education from around the world and working with international organizations like the Organisation for Economic Co-operation and Development and the United Nations Educational, Scientific and Cultural Organization.
 
 <img alt="Code.org International Partners" src="/images/international/international_partners.jpg" width="100%">
 
-## Translation 
+## Translation
 
-Want to have a direct impact on students in your country? Help us make Code.org content available in their native language! If you volunteer to help translate our tutorials and lessons, you'll be joining a community of more than 7,000 translators who help bring computer science education to students around the world. Take a look at our [translation guide](/translate) for more information. 
+Want to have a direct impact on students in your country? Help us make Code.org content available in their native language! If you volunteer to help translate our tutorials and lessons, you'll be joining a community of more than 7,000 translators who help bring computer science education to students around the world. Take a look at our [translation guide](/translate) for more information.
 
 ## Our commitment to free curriculum and open source technology
 

--- a/pegasus/sites.v3/code.org/views/hourofcode_content.md
+++ b/pegasus/sites.v3/code.org/views/hourofcode_content.md
@@ -4,19 +4,19 @@ On Monday, October 14, 2013, Code.org announced the “Hour of Code," a campaign
 
 ## Live stream of the announcement
 
-<iframe style="max-width: 100%" width="560" height="315" src="//www.youtube.com/embed/ruJeDKDbr9k" frameborder="0" allowfullscreen></iframe>
+<iframe style="max-width: 100%" width="560" height="315" src="//www.youtube-nocookie.com/embed/ruJeDKDbr9k" frameborder="0" allowfullscreen></iframe>
 
 
-## CODE.ORG INTRODUCES “HOUR OF CODE” CAMPAIGN TO INSPIRE TEN MILLION STUDENTS TO LEARN TO CODE 
+## CODE.ORG INTRODUCES “HOUR OF CODE” CAMPAIGN TO INSPIRE TEN MILLION STUDENTS TO LEARN TO CODE
 *Microsoft, Google, Apple, Amazon, Bill Gates, Mark Zuckerberg, Jack Dorsey Among Those Joining Campaign*
 
 **SAN FRANCISCO and SEATTLE – October 14, 2013 –** Code.org, the non-profit dedicated to promoting computer science education, today announced a nationwide campaign calling on every K-12 student in America to join an "Hour of Code." The initiative asks schools, teachers and parents across the country to help introduce more than 10 million students of all ages to computer programming during Computer Science Education Week, December 9-15, 2013. The organization also announced the support of multiple organizations and individuals, including Google, Microsoft, Amazon, Apple, Bill Gates, Mark Zuckerberg, Reid Hoffman and Jack Dorsey.
- 
+
 “Thanks to the amazing support of new partners and donors, the Hour of Code campaign will launch our long-term mission to give every student the opportunity to learn computer science,” said Hadi Partovi, co-founder and CEO, Code.org. “This isn’t just about the tremendous job opportunities in software – every 21st century child can benefit from learning this foundational field.”
 
 #### Hour of Code - A tutorial featuring technology leaders
 The Hour of Code campaign aims to demystify computer science for students across the country by taking them through introductory tutorials that can be completed online, on a smartphone, or even unplugged. Code.org will offer online tutorials authored by numerous educational groups and is challenging teachers, parents and even employers to encourage students of all ages to engage during Computer Science Education Week.
- 
+
 Code.org’s own tutorial has been created in collaboration with engineers from Microsoft, Google, Twitter and Facebook. Designed as a game that teaches basic coding principles, it will feature guest lectures by technologists including Bill Gates and Mark Zuckerberg and artwork from popular games such as Rovio's "Angry Birds" and PopCap Games’ "Plants vs. Zombies."
 
 #### Prizes for every participating educator
@@ -29,16 +29,16 @@ Classrooms across the country will have a chance to win a variety of prizes for 
 
 #### New donors and partners
 Code.org is announcing its founding donors, including organizations such as Amazon, Microsoft, Google, JPMorgan Chase & Co., LinkedIn, salesforce.com and Omidyar Network, as well as over a dozen technology leaders including Bill Gates, Mark Zuckerberg and Priscilla Chan, Reid Hoffman, Jack Dorsey, Drew Houston, Ron Conway and John Doerr.
- 
+
 In addition to its donors, Code.org has partnered with numerous companies to support the campaign, including Apple, Dropbox, Yahoo, Electronic Arts and Zynga. Additionally, many education organizations will promote the Hour of Code to tens of millions of students and teachers nationwide, including Boys & Girls Clubs of America, the College Board’s Advanced Placement Program, Khan Academy, DonorsChoose.org and many others. The full list of partners and donors can be found here: [code.org/hourofcode](http://code.org/hourofcode).
 
 #### Get involved
 To reach 10 million students, Code.org is encouraging all schools, corporations and individuals to take action. See [hourofcode.com](http://hourofcode.com) for details on how anyone can recruit teachers, schools, employers and community organizations to help.
 
-#### About Code.org 
+#### About Code.org
 Code.org is a non-profit dedicated to growing computer science education by making it available in more schools, and increasing partcipation by women and underrepresented students of color. Our vision is that every student in every school should have the opportunity to learn computer programming. We believe computer science should be part of the core curriculum in education, alongside other science, technology, engineering, and mathematics (STEM) courses, such as biology, physics, chemistry and algebra. For more information, please visit: [www.code.org](http://code.org).
- 
+
 #### About Computer Science Education Week
 Computer Science Education Week is an annual celebration in recognition of the birthday of computing pioneer Admiral Grace Hopper (December 9, 1906). It was established by ACM and CSTA, along with founding partners Anita Borg Institute, ACM, College Board, CRA, IEEE-CS, CSTA, Google, Microsoft, NCTM, NCWIT, NSTA, and SAS. For more information, please visit: [http://csedweek.org/](http://csedweek.org).
- 
+
 


### PR DESCRIPTION
A Onetrust update has prevented some embedded YouTube videos (using iframes) on our site from showing up. Using this url fixes it: `www.youtube-nocookie.com` and prevents tracking. 

**Asana task:** https://app.asana.com/0/1202773141567416/1203989627827644/f