### PR TITLE
Music: fix simple2 triggers

### DIFF
--- a/apps/src/music/blockly/blocks/simple2.js
+++ b/apps/src/music/blockly/blocks/simple2.js
@@ -106,8 +106,12 @@ export const triggeredAtSimple2 = {
     tooltip: 'at trigger',
     extensions: [DYNAMIC_TRIGGER_EXTENSION]
   },
-  generator: () =>
+  generator: block =>
     ` var __insideWhenRun = false;
+      var __currentFunction = {
+        name: '${block.getFieldValue(TRIGGER_FIELD)}',
+        uniqueInvocationId: MusicPlayer.getUniqueInvocationId()
+      };
       ProgramSequencer.playSequentialWithMeasure(
         Math.ceil(
           MusicPlayer.getCurrentPlayheadPosition()

--- a/apps/src/music/views/TimelineSimple2Events.jsx
+++ b/apps/src/music/views/TimelineSimple2Events.jsx
@@ -87,6 +87,7 @@ const TimelineSimple2Events = ({
       <div style={{position: 'absolute'}}>
         {uniqueFunctionExtents.map((uniqueFunction, index) => (
           <div
+            key={index}
             style={{
               position: 'absolute',
               backgroundColor: 'rgba(115 115 115 / 0.7)',


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/50331.  

Fixes `simple2` triggers so that they work again.  Also fixes a React warning.
