### PR TITLE
Fix noisy exception in legacy files api

### DIFF
--- a/dashboard/legacy/middleware/files_api.rb
+++ b/dashboard/legacy/middleware/files_api.rb
@@ -644,7 +644,11 @@ class FilesApi < Sinatra::Base
     content_type :json
 
     filename.downcase! if endpoint == 'files'
-    get_bucket_impl(endpoint).new.list_versions(encrypted_channel_id, filename, with_comments: request.GET['with_comments']).to_json
+    begin
+      get_bucket_impl(endpoint).new.list_versions(encrypted_channel_id, filename, with_comments: request.GET['with_comments']).to_json
+    rescue ArgumentError, OpenSSL::Cipher::CipherError
+      bad_request
+    end
   end
 
   #


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Handle common exceptions and return a 400, rather than raising an exception that clogs up Honeybadger.

Before:
![image](https://user-images.githubusercontent.com/1382374/220410962-f383a9af-42b3-4689-8203-096740ace64c.png)

After:
![image](https://user-images.githubusercontent.com/1382374/220411024-cfe9a3e2-7762-4680-b0d1-ce703fb42d4c.png)


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

* Honeybadger: https://app.honeybadger.io/projects/3240/faults/87958227
* Slack: https://codedotorg.slack.com/archives/C045UAX4WKH/p1676677379160799

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Manual testing, see screenshots above.