### PR TITLE
Fix marketing initiative field on CourseOfferingEditor

### DIFF
--- a/apps/src/lib/levelbuilder/CourseOfferingEditor.jsx
+++ b/apps/src/lib/levelbuilder/CourseOfferingEditor.jsx
@@ -201,7 +201,7 @@ export default function CourseOfferingEditor(props) {
       <label>
         Marketing Initiative
         <select
-          value={courseOffering.marketingInitiative}
+          value={courseOffering.marketing_initiative}
           style={styles.dropdown}
           onChange={e =>
             updateCourseOffering('marketing_initiative', e.target.value)


### PR DESCRIPTION
Fixes the "marketing initiative" field on the CourseOfferingEditor to show the current value.