### PR TITLE
Remove ability to answer for a different year in /yourschool survey

### DIFF
--- a/apps/src/templates/census2017/CensusForm.jsx
+++ b/apps/src/templates/census2017/CensusForm.jsx
@@ -49,7 +49,6 @@ class CensusForm extends Component {
       otherTopicsDesc: '',
       schoolName: prefillData['schoolName'] || '',
       schoolYear: this.props.initialSchoolYear,
-      showSchoolYearDropdown: false,
       submission: {
         name: prefillData['userName'] || '',
         email: prefillData['userEmail'] || '',
@@ -76,16 +75,6 @@ class CensusForm extends Component {
       }
     };
   }
-
-  showSchoolYearDropdown = () => {
-    this.setState({showSchoolYearDropdown: true});
-  };
-
-  handleSchoolYearChange = event => {
-    this.setState({
-      schoolYear: event ? event.value : this.props.initialSchoolYear
-    });
-  };
 
   handleChange = (field, event) => {
     this.setState(
@@ -412,46 +401,11 @@ class CensusForm extends Component {
               </label>
             </div>
           )}
-          {!this.state.showSchoolYearDropdown && (
-            <div>
-              <div style={styles.question}>
-                Please answer the questions below about the{' '}
-                {this.props.initialSchoolYear}-
-                {this.props.initialSchoolYear + 1} school year. (
-                <a onClick={this.showSchoolYearDropdown}>
-                  Answer for a different school year.
-                </a>
-                )
-              </div>
-              <input
-                type="hidden"
-                id="school_year"
-                name="school_year"
-                value={this.props.initialSchoolYear}
-              />
-            </div>
-          )}
-          {this.state.showSchoolYearDropdown && (
-            <label style={styles.dropdownBox}>
-              <span style={styles.question}>Choose a school year:</span>
-              <select
-                name="school_year"
-                value={this.state.schoolYear}
-                onChange={this.handleSchoolYearChange}
-                style={styles.dropdown}
-              >
-                {[
-                  this.props.initialSchoolYear - 1,
-                  this.props.initialSchoolYear,
-                  this.props.initialSchoolYear + 1
-                ].map(schoolYear => (
-                  <option value={schoolYear} key={schoolYear}>
-                    {schoolYear} - {schoolYear + 1}
-                  </option>
-                ))}
-              </select>
-            </label>
-          )}
+          <div style={styles.question}>
+            Please answer the questions below about the{' '}
+            {this.props.initialSchoolYear}-{this.props.initialSchoolYear + 1}{' '}
+            school year.
+          </div>
           <div style={styles.question}>
             How much{' '}
             <span style={{fontWeight: 'bold'}}>

--- a/dashboard/app/controllers/api/v1/census/census_controller.rb
+++ b/dashboard/app/controllers/api/v1/census/census_controller.rb
@@ -4,7 +4,6 @@ class Api::V1::Census::CensusController < ApplicationController
   skip_before_action :verify_authenticity_token
 
   CENSUS_FIELDS = [
-    :school_year,
     :submitter_email_address,
     :submitter_name,
     :submitter_role,

--- a/dashboard/app/controllers/api/v1/census/census_controller.rb
+++ b/dashboard/app/controllers/api/v1/census/census_controller.rb
@@ -1,5 +1,6 @@
 class Api::V1::Census::CensusController < ApplicationController
   include SchoolInfoDeduplicator
+  require 'census_helper'
   skip_before_action :verify_authenticity_token
 
   CENSUS_FIELDS = [
@@ -104,6 +105,7 @@ class Api::V1::Census::CensusController < ApplicationController
       census_params[field] = census_params[field].strip_utf8mb4 unless census_params[field].nil?
     end
 
+    census_params[:school_year] = current_census_year
     census_params[:school_infos] = [school_info]
 
     case params[:form_version]

--- a/dashboard/test/controllers/api/v1/census/census_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/census/census_controller_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'census_helper'
 
 class Api::V1::Census::CensusControllerTest < ActionController::TestCase
   test 'census submission with bad version fails' do
@@ -47,6 +48,45 @@ class Api::V1::Census::CensusControllerTest < ActionController::TestCase
     assert_response 201
     response = JSON.parse(@response.body)
     refute response['census_submission_id'].nil?, "census_submission_id expected in response: #{response}"
+  end
+
+  test 'HoC census submission uses current_census_year' do
+    post :create,
+      params: {
+        form_version: 'CensusHoc2017v3',
+        nces_school_s: '60000113717',
+        submitter_email_address: "fake@email.address",
+        submitter_name: "Somebody",
+        opt_in: true
+      }
+    assert_response 201
+    response = JSON.parse(@response.body)
+    submission_id = response['census_submission_id']
+    submission = Census::CensusSubmission.find(submission_id)
+    refute submission.nil?
+    assert_equal current_census_year, submission.school_year
+  end
+
+  test 'yourschool census submission uses current_census_year' do
+    post :create,
+      params: {
+        form_version: 'CensusYourSchool2017v4',
+        nces_school_s: '60000113717',
+        submitter_email_address: "fake@email.address",
+        submitter_name: "Somebody",
+        submitter_role: 'OTHER',
+        how_many_do_hoc: 'NONE',
+        how_many_after_school: 'NONE',
+        how_many_10_hours: 'NONE',
+        how_many_20_hours: 'NONE',
+        opt_in: true
+      }
+    assert_response 201, @response.body.to_s
+    response = JSON.parse(@response.body)
+    submission_id = response['census_submission_id']
+    submission = Census::CensusSubmission.find(submission_id)
+    refute submission.nil?
+    assert_equal current_census_year, submission.school_year
   end
 
   test 'yourschool census submission with good school succeeds' do

--- a/dashboard/test/controllers/api/v1/census/census_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/census/census_controller_test.rb
@@ -24,7 +24,6 @@ class Api::V1::Census::CensusControllerTest < ActionController::TestCase
       params: {
         form_version: 'CensusHoc2017v3',
         nces_school_s: '60000113717',
-        school_year: 2017,
         submitter_email_address: "fake@email.address",
         submitter_name: "Somebody",
         opt_in: true
@@ -39,7 +38,6 @@ class Api::V1::Census::CensusControllerTest < ActionController::TestCase
       params: {
         form_version: 'CensusHoc2017v3',
         nces_school_s: '-1',
-        school_year: 2017,
         country_s: "US",
         school_name_s:  "Brooklyn Heights",
         submitter_email_address: "fake@email.address",
@@ -56,7 +54,6 @@ class Api::V1::Census::CensusControllerTest < ActionController::TestCase
       params: {
         form_version: 'CensusYourSchool2017v4',
         nces_school_s: '60000113717',
-        school_year: 2017,
         submitter_email_address: "fake@email.address",
         submitter_name: "Somebody",
         submitter_role: 'OTHER',
@@ -76,7 +73,6 @@ class Api::V1::Census::CensusControllerTest < ActionController::TestCase
       params: {
         form_version: 'CensusYourSchool2017v4',
         nces_school_s: '-1',
-        school_year: 2017,
         country_s: "US",
         school_name_s: "Philly High",
         submitter_email_address: "fake@email.address",
@@ -98,7 +94,6 @@ class Api::V1::Census::CensusControllerTest < ActionController::TestCase
       params: {
         form_version: 'CensusYourSchool2017v4',
         nces_school_s: '-1',
-        school_year: 2017,
         country_s: "US",
         school_name_s: "Rushmore",
         submitter_email_address: "rushmore@email.address",
@@ -115,7 +110,6 @@ class Api::V1::Census::CensusControllerTest < ActionController::TestCase
       params: {
         form_version: 'CensusYourSchool2017v4',
         nces_school_s: '-1',
-        school_year: 2017,
         country_s: "US",
         school_name_s: "Rushmore",
         submitter_email_address: "rushmore@email.address",
@@ -137,7 +131,6 @@ class Api::V1::Census::CensusControllerTest < ActionController::TestCase
       params: {
         form_version: 'CensusYourSchool2017v4',
         nces_school_s: '-1',
-        school_year: 2017,
         country_s: "US",
         submitter_email_address: "fake@email.address",
         submitter_name: "Somebody",
@@ -158,7 +151,6 @@ class Api::V1::Census::CensusControllerTest < ActionController::TestCase
       params: {
         form_version: 'CensusTeacherBannerV1',
         nces_school_s: '60000113717',
-        school_year: 2017,
         submitter_email_address: "fake@email.address",
         submitter_name: "Somebody",
         submitter_role: 'TEACHER',
@@ -175,7 +167,6 @@ class Api::V1::Census::CensusControllerTest < ActionController::TestCase
       params: {
         form_version: 'CensusYourSchool2017v4',
         nces_school_s: '60000113717',
-        school_year: 2017,
         submitter_email_address: "fake\u{1F600}@email.address",
         submitter_name: "Somebody\u{1F600}",
         submitter_role: 'OTHER',

--- a/lib/census_helper.rb
+++ b/lib/census_helper.rb
@@ -2,5 +2,5 @@ def current_census_year
   today = Date.today
   month = today.month
   year = today.year
-  (month > 7) ? year : (year - 1)
+  (month > 6) ? year : (year - 1)
 end


### PR DESCRIPTION
On [https://code.org/yourschool](https://code.org/yourschool), you can currently click “Answer for a different school year” in the survey, but we now only want to allow people to report for the year we are currently collecting going forward. So, this PR removes that feature of being able to answer for a different school year.

Since the census can now only be submitted for the current census year, I've updated the controller to now just set the `school_year` to the `current_census_year` instead of taking input for the year.

Lastly, I've updated `census_helper.rb` to match other definitions of current_census_year such that the year is defined as July 1st - June 30th of the following year (rather than August 1st - July 31st of the following year).

### Current look
With the selectable text, "Answer for a different school year":
![Previous_change_year](https://user-images.githubusercontent.com/56283563/220466714-5adb056a-9b0e-496d-95b1-4aa1fce579af.JPG)

After clicking the selected text, year dropdown appears:
![Previous_change_year_dropdown](https://user-images.githubusercontent.com/56283563/220466726-bae6b34f-1416-46fe-b8e5-46fd83bd4a44.JPG)

### New look
![Now_no_change_year](https://user-images.githubusercontent.com/56283563/220466700-e34fff24-97e1-4200-ba66-626fbff6e665.JPG)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?modal=detail&selectedIssue=ACQ-399&assignee=60d62161f65054006980bd71)

## Testing story
Local testing and updating unit tests.

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
