### PR TITLE
Don't require levelbuilder mode or permissions for quick_assign_course_offerings

### DIFF
--- a/dashboard/app/controllers/course_offerings_controller.rb
+++ b/dashboard/app/controllers/course_offerings_controller.rb
@@ -1,7 +1,7 @@
 class CourseOfferingsController < ApplicationController
-  load_and_authorize_resource
+  load_and_authorize_resource except: [:quick_assign_course_offerings]
 
-  before_action :require_levelbuilder_mode
+  before_action :require_levelbuilder_mode, except: [:quick_assign_course_offerings]
   before_action :authenticate_user!
 
   def edit
@@ -23,6 +23,8 @@ class CourseOfferingsController < ApplicationController
   end
 
   def quick_assign_course_offerings
+    return head :forbidden unless current_user
+
     offerings = {}
 
     offerings[:elementary] = {


### PR DESCRIPTION
Fix quick_assign_course_offerings so that it doesn't require levelbuilder mode, doesn't require levelbuilder permissions, but still requires the user to be signed in (copied from [this requirement](https://github.com/code-dot-org/code-dot-org/blob/2bc1e8fb6d29745a4980d92397067656420fb432/dashboard/app/controllers/api/v1/sections_controller.rb#L187) from `valid_course_offerings`).

I tested that I could access this route in levelbuilder mode, as an admin, but not signed out. I didn't add any unit tests here but I will add them in my next PR that updates this route.