### PR TITLE
Remove sentence on Access Report page

### DIFF
--- a/pegasus/sites.v3/code.org/public/yourschool/accessreport.md
+++ b/pegasus/sites.v3/code.org/public/yourschool/accessreport.md
@@ -64,7 +64,7 @@ An overview of each tab is as follows:
 	vizElement.parentNode.insertBefore(scriptElement, vizElement);                
 </script>
 
-Preliminary data for the current school year can be viewed on our [interactive map](https://code.org/yourschool). Learn more about our [data sources](https://code.org/yourschool/about). Underlying data was contributed by various organizations, including the Computer Science Teachers Association (CSTA), University of Texas at Austin, the College Board, Technology Education and Literacy in Schools (TEALS), Project Lead the Way, BootUp PD, and many state education agencies. 
+Learn more about our [data sources](https://code.org/yourschool/about). Underlying data was contributed by various organizations, including the Computer Science Teachers Association (CSTA), University of Texas at Austin, the College Board, Technology Education and Literacy in Schools (TEALS), Project Lead the Way, BootUp PD, and many state education agencies. 
 
 Suggested citation: 
 Code.org. (2022). *Computer science access report data*. Retrieved from code.org/yourschool/accessreport. 


### PR DESCRIPTION
Removes sentence on [https://code.org/yourschool/accessreport](https://code.org/yourschool/accessreport) about preliminary data on the /yourschool map.

## Current
![AR_with_sentence](https://user-images.githubusercontent.com/56283563/220467874-598c0454-2580-48aa-a6d5-f4232c007625.JPG)

## New
![AR_no_sentence](https://user-images.githubusercontent.com/56283563/220467885-d2977592-893f-47fd-b081-29bd644ba599.JPG)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?modal=detail&selectedIssue=ACQ-397&assignee=60d62161f65054006980bd71)

## Testing story
Local testing and drone build.

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
