### PR TITLE
Fix Violations of and Reenable `Style/RedundantSort`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -530,11 +530,6 @@ Style/RedundantRegexpEscape:
 Style/RedundantSelfAssignment:
   Enabled: false
 
-# Offense count: 8
-# This cop supports unsafe auto-correction (--auto-correct-all).
-Style/RedundantSort:
-  Enabled: false
-
 # Offense count: 118
 # This cop supports safe auto-correction (--auto-correct).
 # Configuration parameters: EnforcedStyle, AllowInnerSlashes.

--- a/bin/oneoff/backfill_data/school_info_id
+++ b/bin/oneoff/backfill_data/school_info_id
@@ -38,12 +38,12 @@ user_ids.each do |user_id|
   # if the user has pd_enrollments whose school_info_id is associated with
   # a school_id, update the user with the most recent of those pd_enrollments' school_info_id
   if enrollments_with_school_id.any?
-    enrollment = enrollments_with_school_id.sort_by(&:updated_at).last
+    enrollment = enrollments_with_school_id.max_by(&:updated_at)
     user.update_column(:school_info_id, enrollment.school_info_id)
   # if user doesn't have a school_info_id at all, update with most recent
   # enrollment school_info_id even though it doesn't have school_id
   elsif user.school_info_id.nil?
-    enrollment = enrollments.sort_by(&:updated_at).last
+    enrollment = enrollments.max_by(&:updated_at)
     user.update_column(:school_info_id, enrollment.school_info_id)
   end
   # if the user has a school_info_id not associated with a school_id, and

--- a/dashboard/app/models/teacher_score.rb
+++ b/dashboard/app/models/teacher_score.rb
@@ -86,7 +86,7 @@ class TeacherScore < ApplicationRecord
       student_user_levels = user_levels.select {|u_l| u_l.user_id == student_id}
       student_level_score = {}
       student_user_levels.each do |u_l|
-        teacher_score = teacher_scores.select {|t_s| t_s.user_level_id == u_l.id}.sort_by(&:created_at).last&.score
+        teacher_score = teacher_scores.select {|t_s| t_s.user_level_id == u_l.id}.max_by(&:created_at)&.score
         if teacher_score
           student_level_score[u_l.level_id] = teacher_score
         end

--- a/dashboard/app/models/unit_group.rb
+++ b/dashboard/app/models/unit_group.rb
@@ -483,7 +483,7 @@ class UnitGroup < ApplicationRecord
     all_courses.select do |course|
       course.family_name == family_name &&
         course.published_state == Curriculum::SharedCourseConstants::PUBLISHED_STATE.stable
-    end.sort_by(&:version_year).last
+    end.max_by(&:version_year)
   end
 
   # @param family_name [String] The family name for a course family.
@@ -496,7 +496,7 @@ class UnitGroup < ApplicationRecord
     all_courses.select do |course|
       assigned_course_ids.include?(course.id) &&
         course.family_name == family_name
-    end.sort_by(&:version_year).last
+    end.max_by(&:version_year)
   end
 
   # @param user [User]

--- a/dashboard/lib/queries/user_school_info.rb
+++ b/dashboard/lib/queries/user_school_info.rb
@@ -4,7 +4,6 @@ class Queries::UserSchoolInfo
       user_school_infos.
       includes(:school_info).
       select {|usi| usi.school_info.complete?}.
-      sort_by(&:created_at).
-      last
+      max_by(&:created_at)
   end
 end

--- a/dashboard/scripts/archive/sync_dash
+++ b/dashboard/scripts/archive/sync_dash
@@ -30,7 +30,7 @@ servers = ["1b", "1c", "1d"].map {|i| "production-#{i}"}
 servers.each do |m|
   `mkdir -p #{DIR}#{m}/log`
   `rsync -avz -e "#{SSH}" #{m}.code.org:/home/ubuntu/website-ci/dashboard/log/*.gz #{DIR}#{m}/log`
-  recent_log = Dir.glob("#{DIR}/#{m}/log/milestone*.gz").sort.last
+  recent_log = Dir.glob("#{DIR}/#{m}/log/milestone*.gz").max
   current_log = "#{DIR}/#{m}/log/milestone.log"
 
   append = ''

--- a/lib/cdo/rack/locale.rb
+++ b/lib/cdo/rack/locale.rb
@@ -34,9 +34,9 @@ module Rack
         l.split(';q=')
       end
 
-      lang = languages_and_qvalues.sort_by do |(_locale, qvalue)|
+      lang = languages_and_qvalues.max_by do |(_locale, qvalue)|
         qvalue.to_f
-      end.last.first
+      end.first
 
       lang == '*' ? nil : lang
     end


### PR DESCRIPTION
Fix applied automatically with `bundle exec rubocop --auto-correct-all --only Style/RedundantSort`

> Identifies instances of sorting and then taking only the first or last element. The same behavior can be accomplished without a relatively expensive sort by using `Enumerable#min` instead of sorting and taking the first element and `Enumerable#max` instead of sorting and taking the last element. Similarly, `Enumerable#min_by` and `Enumerable#max_by` can replace `Enumerable#sort_by` calls after which only the first or last element is used.

Note that this change is not guaranteed to always work *exactly* the same:

> This cop is unsafe, because `sort…last` and `max` may not return the same element in all cases.
>
> In an enumerable where there are multiple elements where `a <⇒ b == 0`, or where the transformation done by the `sort_by` block has the same result, `sort.last` and `max` (or `sort_by.last` and `max_by`) will return different elements. `sort.last` will return the last element but `max` will return the first element.
>
> For example:
>
>     words = %w(dog horse mouse)
>     words.sort_by { |word| word.length }.last   #=> 'mouse'
>     words.max_by { |word| word.length }         #=> 'horse'

For each change in this PR, I believe we in either are a situation in which we do not expect there to be multiple elements which could be sorted into the "last" position or one in which we don't care which of them we get.


<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

- https://docs.rubocop.org/rubocop/cops_style.html#styleredundantsort
- https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/RedundantSort

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
