### PR TITLE
Save partner even if rp is already set

### DIFF
--- a/dashboard/app/controllers/test_controller.rb
+++ b/dashboard/app/controllers/test_controller.rb
@@ -229,7 +229,8 @@ class TestController < ApplicationController
       csa_how_offer: 'As an AP course',
       csa_phone_screen: 'Yes',
       csa_already_know: 'Yes',
-      replace_existing: 'No, this course will be added to the schedule in addition to an existing computer science course'
+      replace_existing: 'No, this course will be added to the schedule in addition to an existing computer science course',
+      pay_fee: 'Yes, my school/district would be able to pay the full program fee.'
     }
   end
 
@@ -254,13 +255,12 @@ class TestController < ApplicationController
     form_data = teacher_form_data.merge(
       first_name: teacher_name,
       last_name: 'Test',
+      regional_partner_id: regional_partner.id,
       program: Pd::Application::TeacherApplication::PROGRAMS[:csp]
     ).to_json
     application = Pd::Application::TeacherApplication.create!(
       user: teacher,
       form_data: form_data,
-      regional_partner_id: regional_partner.id,
-      course: 'csp',
       status: 'unreviewed'
     )
 

--- a/dashboard/app/models/pd/application/teacher_application.rb
+++ b/dashboard/app/models/pd/application/teacher_application.rb
@@ -82,7 +82,7 @@ module Pd::Application
     validates :course, presence: true, inclusion: {in: VALID_COURSES}, unless: -> {status == 'incomplete'}
     validate :workshop_present_if_required_for_status, if: -> {status_changed?}
 
-    before_save :save_partner, if: -> {form_data_changed? && !deleted?}
+    before_save :save_partner, if: -> {!deleted? && (form_data_changed? || regional_partner_id.nil?)}
     before_save :update_user_school_info!, if: -> {form_data_changed?}
     before_save :log_status, if: -> {status_changed? || form_data_changed?}
 

--- a/dashboard/app/models/pd/application/teacher_application.rb
+++ b/dashboard/app/models/pd/application/teacher_application.rb
@@ -82,7 +82,7 @@ module Pd::Application
     validates :course, presence: true, inclusion: {in: VALID_COURSES}, unless: -> {status == 'incomplete'}
     validate :workshop_present_if_required_for_status, if: -> {status_changed?}
 
-    before_save :save_partner, if: -> {form_data_changed? && regional_partner_id.nil? && !deleted?}
+    before_save :save_partner, if: -> {form_data_changed? && !deleted?}
     before_save :update_user_school_info!, if: -> {form_data_changed?}
     before_save :log_status, if: -> {status_changed? || form_data_changed?}
 

--- a/dashboard/app/models/pd/application/teacher_application.rb
+++ b/dashboard/app/models/pd/application/teacher_application.rb
@@ -82,7 +82,7 @@ module Pd::Application
     validates :course, presence: true, inclusion: {in: VALID_COURSES}, unless: -> {status == 'incomplete'}
     validate :workshop_present_if_required_for_status, if: -> {status_changed?}
 
-    before_save :save_partner, if: -> {!deleted? && (form_data_changed? || regional_partner_id.nil?)}
+    before_save :save_partner, if: -> {!deleted? && form_data_changed?}
     before_save :update_user_school_info!, if: -> {form_data_changed?}
     before_save :log_status, if: -> {status_changed? || form_data_changed?}
 

--- a/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
@@ -18,7 +18,7 @@ module Api::V1::Pd::Application
       partner = @program_manager.regional_partners.first
       partner.update!(applications_principal_approval: RegionalPartner::ALL_REQUIRE_APPROVAL)
       @hash_with_admin_approval = build TEACHER_APPLICATION_HASH_FACTORY, regional_partner_id: partner.id
-      @application = create TEACHER_APPLICATION_FACTORY, regional_partner: partner
+      @application = create TEACHER_APPLICATION_FACTORY, form_data_hash: @hash_with_admin_approval
 
       @program_manager_without_admin_approval = create :program_manager
       partner_without_admin_approval = @program_manager_without_admin_approval.regional_partners.first

--- a/dashboard/test/controllers/api/v1/pd/applications_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/applications_controller_test.rb
@@ -17,9 +17,15 @@ module Api::V1::Pd
         cohort_capacity_csd: 25,
         cohort_capacity_csp: 50
 
+      @hash_with_rp = build TEACHER_APPLICATION_HASH_FACTORY, regional_partner_id: @regional_partner.id
       @csd_teacher_application = create TEACHER_APPLICATION_FACTORY, course: 'csd'
-      @csd_teacher_application_with_partner = create TEACHER_APPLICATION_FACTORY, course: 'csd', regional_partner: @regional_partner
-      @csd_incomplete_application_with_partner = create TEACHER_APPLICATION_FACTORY, course: 'csd', regional_partner: @regional_partner, status: 'incomplete'
+      @csd_teacher_application_with_partner = create TEACHER_APPLICATION_FACTORY,
+          course: 'csd',
+          form_data_hash: @hash_with_rp
+      @csd_incomplete_application_with_partner = create TEACHER_APPLICATION_FACTORY,
+          course: 'csd',
+          form_data_hash: @hash_with_rp,
+          status: 'incomplete'
       @csp_teacher_application = create TEACHER_APPLICATION_FACTORY, course: 'csp'
 
       @test_show_params = {
@@ -484,7 +490,7 @@ module Api::V1::Pd
         application = create(
           TEACHER_APPLICATION_FACTORY,
           course: 'csp',
-          regional_partner: @regional_partner,
+          form_data_hash: @hash_with_rp,
           user: @serializing_teacher,
           pd_workshop_id: workshop.id
         )
@@ -529,7 +535,7 @@ module Api::V1::Pd
         application = create(
           TEACHER_APPLICATION_FACTORY,
           course: 'csp',
-          regional_partner: @regional_partner,
+          form_data_hash: @hash_with_rp,
           user: @serializing_teacher,
         )
 
@@ -577,7 +583,7 @@ module Api::V1::Pd
         application = create(
           TEACHER_APPLICATION_FACTORY,
           course: 'csp',
-          regional_partner: @regional_partner,
+          form_data_hash: @hash_with_rp,
           user: @serializing_teacher,
           pd_workshop_id: workshop.id
         )
@@ -623,8 +629,8 @@ module Api::V1::Pd
         application = create(
           TEACHER_APPLICATION_FACTORY,
           course: 'csp',
-          regional_partner: @regional_partner,
-          user: @serializing_teacher,
+          form_data_hash: @hash_with_rp,
+          user: @serializing_teacher
         )
 
         application.update_form_data_hash({first_name: 'Minerva', last_name: 'McGonagall'})

--- a/dashboard/test/controllers/api/v1/pd/applications_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/applications_controller_test.rb
@@ -17,14 +17,12 @@ module Api::V1::Pd
         cohort_capacity_csd: 25,
         cohort_capacity_csp: 50
 
-      @hash_with_rp = build TEACHER_APPLICATION_HASH_FACTORY, regional_partner_id: @regional_partner.id
+      @hash_csd_with_rp = build TEACHER_APPLICATION_HASH_FACTORY, :csd, regional_partner_id: @regional_partner.id
       @csd_teacher_application = create TEACHER_APPLICATION_FACTORY, course: 'csd'
       @csd_teacher_application_with_partner = create TEACHER_APPLICATION_FACTORY,
-          course: 'csd',
-          form_data_hash: @hash_with_rp
+          form_data_hash: @hash_csd_with_rp
       @csd_incomplete_application_with_partner = create TEACHER_APPLICATION_FACTORY,
-          course: 'csd',
-          form_data_hash: @hash_with_rp,
+          form_data_hash: @hash_csd_with_rp,
           status: 'incomplete'
       @csp_teacher_application = create TEACHER_APPLICATION_FACTORY, course: 'csp'
 
@@ -490,7 +488,7 @@ module Api::V1::Pd
         application = create(
           TEACHER_APPLICATION_FACTORY,
           course: 'csp',
-          form_data_hash: @hash_with_rp,
+          form_data_hash: @hash_csd_with_rp,
           user: @serializing_teacher,
           pd_workshop_id: workshop.id
         )
@@ -501,7 +499,7 @@ module Api::V1::Pd
         application.save!
 
         sign_in @workshop_organizer
-        get :cohort_view, params: {role: 'csp_teachers'}
+        get :cohort_view, params: {role: 'csd_teachers'}
         assert_response :success
 
         assert_equal(
@@ -534,8 +532,7 @@ module Api::V1::Pd
       Timecop.freeze(time) do
         application = create(
           TEACHER_APPLICATION_FACTORY,
-          course: 'csp',
-          form_data_hash: @hash_with_rp,
+          form_data_hash: @hash_csd_with_rp,
           user: @serializing_teacher,
         )
 
@@ -545,7 +542,7 @@ module Api::V1::Pd
         application.save!
 
         sign_in @workshop_organizer
-        get :cohort_view, params: {role: 'csp_teachers'}
+        get :cohort_view, params: {role: 'csd_teachers'}
         assert_response :success
 
         assert_equal(
@@ -582,8 +579,7 @@ module Api::V1::Pd
 
         application = create(
           TEACHER_APPLICATION_FACTORY,
-          course: 'csp',
-          form_data_hash: @hash_with_rp,
+          form_data_hash: @hash_csd_with_rp,
           user: @serializing_teacher,
           pd_workshop_id: workshop.id
         )
@@ -595,7 +591,7 @@ module Api::V1::Pd
         application.save!
 
         sign_in @program_manager
-        get :cohort_view, params: {role: 'csp_teachers'}
+        get :cohort_view, params: {role: 'csd_teachers'}
         assert_response :success
 
         assert_equal(
@@ -628,8 +624,7 @@ module Api::V1::Pd
       Timecop.freeze(time) do
         application = create(
           TEACHER_APPLICATION_FACTORY,
-          course: 'csp',
-          form_data_hash: @hash_with_rp,
+          form_data_hash: @hash_csd_with_rp,
           user: @serializing_teacher
         )
 
@@ -639,7 +634,7 @@ module Api::V1::Pd
         application.save!
 
         sign_in @program_manager
-        get :cohort_view, params: {role: 'csp_teachers'}
+        get :cohort_view, params: {role: 'csd_teachers'}
         assert_response :success
 
         assert_equal(

--- a/dashboard/test/models/pd/application/teacher_application_test.rb
+++ b/dashboard/test/models/pd/application/teacher_application_test.rb
@@ -47,6 +47,22 @@ module Pd::Application
       assert_equal 'Albus Dumbledore', application_without_principal_title.principal_greeting
     end
 
+    test 'updating form data re-calculates regional partner' do
+      partner_1 = create :regional_partner
+      partner_2 = create :regional_partner
+      hash_with_partner_1 = build TEACHER_APPLICATION_HASH_FACTORY, regional_partner_id: partner_1.id
+      hash_with_partner_2 = build TEACHER_APPLICATION_HASH_FACTORY, regional_partner_id: partner_2.id
+      application = create :pd_teacher_application
+
+      assert_nil application.regional_partner_id
+
+      application.update(form_data_hash: hash_with_partner_1)
+      assert_equal application.reload.regional_partner_id, partner_1.id
+
+      application.update(form_data_hash: hash_with_partner_2)
+      assert_equal application.reload.regional_partner_id, partner_2.id
+    end
+
     test 'meets criteria says an application meets criteria when all YES_NO fields are marked yes' do
       teacher_application = build :pd_teacher_application, course: 'csd',
                                   response_scores: {
@@ -544,7 +560,7 @@ module Pd::Application
         principal_free_lunch_percent: 50,
         principal_underrepresented_minority_percent: 50
 
-      application = create :pd_teacher_application, regional_partner: (create :regional_partner), form_data_hash: application_hash
+      application = create :pd_teacher_application, form_data_hash: application_hash
       application.auto_score!
 
       assert_equal(
@@ -583,7 +599,7 @@ module Pd::Application
         principal_free_lunch_percent: 50,
         principal_underrepresented_minority_percent: 50
 
-      application = create :pd_teacher_application, regional_partner: (create :regional_partner), form_data_hash: application_hash
+      application = create :pd_teacher_application, form_data_hash: application_hash
       application.auto_score!
 
       assert_equal(
@@ -624,7 +640,7 @@ module Pd::Application
         principal_free_lunch_percent: 50,
         principal_underrepresented_minority_percent: 50
 
-      application = create :pd_teacher_application, regional_partner: (create :regional_partner), form_data_hash: application_hash
+      application = create :pd_teacher_application, form_data_hash: application_hash
       application.auto_score!
 
       assert_equal(
@@ -660,7 +676,7 @@ module Pd::Application
         committed: options[:committed].first,
         race: [options[:race].second]
 
-      application = create :pd_teacher_application, regional_partner: (create :regional_partner), form_data_hash: application_hash
+      application = create :pd_teacher_application, form_data_hash: application_hash
       application.auto_score!
 
       assert_equal(
@@ -693,7 +709,7 @@ module Pd::Application
         principal_free_lunch_percent: 49,
         principal_underrepresented_minority_percent: 49
 
-      application = create :pd_teacher_application, regional_partner: nil, form_data_hash: application_hash
+      application = create :pd_teacher_application, form_data_hash: application_hash
       application.auto_score!
 
       assert_equal(
@@ -732,7 +748,7 @@ module Pd::Application
         principal_free_lunch_percent: 49,
         principal_underrepresented_minority_percent: 49
 
-      application = create :pd_teacher_application, regional_partner: nil, form_data_hash: application_hash
+      application = create :pd_teacher_application, form_data_hash: application_hash
       application.auto_score!
 
       assert_equal(
@@ -773,7 +789,7 @@ module Pd::Application
         principal_free_lunch_percent: 49,
         principal_underrepresented_minority_percent: 49
 
-      application = create :pd_teacher_application, regional_partner: nil, form_data_hash: application_hash
+      application = create :pd_teacher_application, form_data_hash: application_hash
       application.auto_score!
 
       assert_equal(
@@ -839,20 +855,21 @@ module Pd::Application
     end
 
     test 'scholarship criteria uses regional partner set fields when specified' do
-      regional_partner = build :regional_partner,
+      regional_partner = create :regional_partner,
         frl_guardrail_percent: REGIONAL_PARTNER_DEFAULT_GUARDRAILS[:frl_not_rural] + 2,
         urg_guardrail_percent: REGIONAL_PARTNER_DEFAULT_GUARDRAILS[:urg] - 2
 
       # Does not meet Free and Reduced Lunch criteria but does meet Underrepresented Group criteria
       principal_options = Pd::Application::PrincipalApprovalApplication.options
-      application_hash = build :pd_teacher_application_hash,
+      application_hash = build TEACHER_APPLICATION_HASH_FACTORY,
         principal_approval: principal_options[:do_you_approve].first,
         principal_schedule_confirmed: principal_options[:committed_to_master_schedule].first,
         principal_wont_replace_existing_course: principal_options[:replace_course].first,
         principal_free_lunch_percent: REGIONAL_PARTNER_DEFAULT_GUARDRAILS[:frl_not_rural] + 1,
-        principal_underrepresented_minority_percent: REGIONAL_PARTNER_DEFAULT_GUARDRAILS[:urg] - 1
+        principal_underrepresented_minority_percent: REGIONAL_PARTNER_DEFAULT_GUARDRAILS[:urg] - 1,
+        regional_partner_id: regional_partner.id
 
-      application = create :pd_teacher_application, regional_partner: regional_partner, form_data_hash: application_hash
+      application = create :pd_teacher_application, form_data_hash: application_hash
       application.auto_score!
 
       # Regional partner defined guardrails: FRL = (default + 2)%, URG = (default - 2)%
@@ -861,7 +878,7 @@ module Pd::Application
     end
 
     test 'scholarship criteria uses default guardrails when regional partner does not specify' do
-      regional_partner = build :regional_partner
+      regional_partner = create :regional_partner
 
       # Meets Free and Reduced Lunch criteria but not Underrepresented Group criteria
       principal_options = Pd::Application::PrincipalApprovalApplication.options
@@ -870,9 +887,10 @@ module Pd::Application
         principal_schedule_confirmed: principal_options[:committed_to_master_schedule].first,
         principal_wont_replace_existing_course: principal_options[:replace_course].first,
         principal_free_lunch_percent: REGIONAL_PARTNER_DEFAULT_GUARDRAILS[:frl_not_rural],
-        principal_underrepresented_minority_percent: REGIONAL_PARTNER_DEFAULT_GUARDRAILS[:urg] - 1
+        principal_underrepresented_minority_percent: REGIONAL_PARTNER_DEFAULT_GUARDRAILS[:urg] - 1,
+        regional_partner_id: regional_partner.id
 
-      application = create :pd_teacher_application, regional_partner: regional_partner, form_data_hash: application_hash
+      application = create :pd_teacher_application, form_data_hash: application_hash
       application.auto_score!
 
       # Regional partner did not set guardrails, default to 50% for both (40% for FRL for rural schools)
@@ -890,7 +908,7 @@ module Pd::Application
         principal_free_lunch_percent: REGIONAL_PARTNER_DEFAULT_GUARDRAILS[:frl_not_rural],
         principal_underrepresented_minority_percent: REGIONAL_PARTNER_DEFAULT_GUARDRAILS[:urg] - 1
 
-      application = create :pd_teacher_application, regional_partner: nil, form_data_hash: application_hash
+      application = create :pd_teacher_application, form_data_hash: application_hash
       application.auto_score!
 
       # No partner guardrails default to 50% for both (40% for FRL for rural schools)
@@ -900,10 +918,11 @@ module Pd::Application
 
     test 'require assigned workshop for registration-related statuses when emails sent by system' do
       workshop_required_statuses = TeacherApplication::WORKSHOP_REQUIRED_STATUSES
-      partner = build :regional_partner, applications_decision_emails: RegionalPartner::SENT_BY_SYSTEM
+      partner = create :regional_partner, applications_decision_emails: RegionalPartner::SENT_BY_SYSTEM
       workshop = create :workshop
+      hash_with_partner = build TEACHER_APPLICATION_HASH_FACTORY, regional_partner_id: partner.id
       application = create :pd_teacher_application, {
-        regional_partner: partner
+        form_data_hash: hash_with_partner
       }
 
       workshop_required_statuses.each do |status|
@@ -921,9 +940,10 @@ module Pd::Application
 
     test 'do not require assigned workshop for registration-related statuses if emails sent by partner' do
       statuses = TeacherApplication::WORKSHOP_REQUIRED_STATUSES
-      partner = build :regional_partner, applications_decision_emails: RegionalPartner::SENT_BY_PARTNER
+      partner = create :regional_partner, applications_decision_emails: RegionalPartner::SENT_BY_PARTNER
+      form_data_with_partner = build TEACHER_APPLICATION_HASH_FACTORY, regional_partner_id: partner.id
       application = create :pd_teacher_application, {
-        regional_partner: partner
+        form_data_hash: form_data_with_partner
       }
 
       statuses.each do |status|
@@ -934,9 +954,10 @@ module Pd::Application
 
     test 'do not require workshop for non-registration-related statuses' do
       statuses = TeacherApplication.statuses - TeacherApplication::WORKSHOP_REQUIRED_STATUSES
-      partner = build :regional_partner, applications_decision_emails: RegionalPartner::SENT_BY_PARTNER
+      partner = create :regional_partner, applications_decision_emails: RegionalPartner::SENT_BY_PARTNER
+      form_data_with_partner = build TEACHER_APPLICATION_HASH_FACTORY, regional_partner_id: partner.id
       application = create :pd_teacher_application, {
-        regional_partner: partner
+        form_data_hash: form_data_with_partner
       }
 
       statuses.each do |status|


### PR DESCRIPTION
We've only been updating an applicant's regional partner from their form data if their current regional partner is nil: https://github.com/code-dot-org/code-dot-org/blob/7b597a5fda39fdf27ed4ebdb7dbe85b3500ee60f/dashboard/app/models/pd/application/teacher_application.rb#L85

This is a problem now that an applicant can save their application and update it later with a new program, state, school, or zip –– all of which could change the RP. Now, the save happens any time the form data changes.

Many tests needed to be updated, as adding regional_partner as part of creating a new record will still trigger `save_partner` via the form data –– and if the form data doesn't have that regional partner, the partner will be nil. The updates to the existing tests better reflect how the RP is actually getting set.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

I added a unit test to document new behavior.

I also tested manually: https://user-images.githubusercontent.com/9142121/224820380-10403d6b-725d-4fc0-bb7c-93e08300643a.mov

Note the extreme lag in the request to update the RP info. I haven't noticed this lag in production, but if there happens to be a problem with this request, we're out of luck –– they can still submit with the wrong RP. See follow-up work for more info.

I also manually tested that we can still manually update the RP from the application detail view.

## Deployment strategy

## Follow-up work

We've been saving the partner from the applicant's form data for the past two years. If there's a problem with getting the partner from the backend, this can get dicey:

We get the original regional partner data from the front-end via this fetch that happens
https://github.com/code-dot-org/code-dot-org/blob/7b597a5fda39fdf27ed4ebdb7dbe85b3500ee60f/apps/src/code-studio/pd/components/useRegionalPartner.jsx#L82-L97
If no fetch happens, the default value for partner is `null`:
https://github.com/code-dot-org/code-dot-org/blob/7b597a5fda39fdf27ed4ebdb7dbe85b3500ee60f/apps/src/code-studio/pd/components/useRegionalPartner.jsx#L59
If the fetch errors, we have no indication that the partner saved in the form data is wrong:
https://github.com/code-dot-org/code-dot-org/blob/7b597a5fda39fdf27ed4ebdb7dbe85b3500ee60f/apps/src/code-studio/pd/components/useRegionalPartner.jsx#L98-L107

I've tracked this at https://codedotorg.atlassian.net/browse/ACQ-479 –– probably easiest would be to not allow a user to submit if there's a problem with the fetch, but perhaps most consistent would be to calculate the RP again on save, not saving the ID to the form data.

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
