### PR TITLE
Add helper methods for grade bands of course offerings

### DIFF
--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -246,14 +246,14 @@ class CourseOffering < ApplicationRecord
   end
 
   def elementary_school_level?
-    !ELEMENTARY_SCHOOL_GRADES.intersection(grade_levels_list).empty?
+    grade_levels_list.any? {|g| ELEMENTARY_SCHOOL_GRADES.include?(g)}
   end
 
   def middle_school_level?
-    !MIDDLE_SCHOOL_GRADES.intersection(grade_levels_list).empty?
+    grade_levels_list.any? {|g| MIDDLE_SCHOOL_GRADES.include?(g)}
   end
 
   def high_school_level?
-    !HIGH_SCHOOL_GRADES.intersection(grade_levels_list).empty?
+    grade_levels_list.any? {|g| HIGH_SCHOOL_GRADES.include?(g)}
   end
 end

--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -35,6 +35,10 @@ class CourseOffering < ApplicationRecord
     with: KEY_RE,
     message: "must contain only lowercase alphabetic characters, numbers, and dashes; got \"%{value}\"."
 
+  ELEMENTARY_SCHOOL_GRADES = %w[K 1 2 3 4 5].freeze
+  MIDDLE_SCHOOL_GRADES = %w[6 7 8].freeze
+  HIGH_SCHOOL_GRADES = %w[9 10 11 12].freeze
+
   # Seeding method for creating / updating / deleting a CourseOffering and CourseVersion for the given
   # potential content root, i.e. a Unit or UnitGroup.
   #
@@ -234,5 +238,22 @@ class CourseOffering < ApplicationRecord
 
   def csd?
     key == 'csd'
+  end
+
+  def grade_levels_list
+    return [] if grade_levels.nil?
+    grade_levels.strip.split(',')
+  end
+
+  def elementary_school_level?
+    !ELEMENTARY_SCHOOL_GRADES.intersection(grade_levels_list).empty?
+  end
+
+  def middle_school_level?
+    !MIDDLE_SCHOOL_GRADES.intersection(grade_levels_list).empty?
+  end
+
+  def high_school_level?
+    !HIGH_SCHOOL_GRADES.intersection(grade_levels_list).empty?
   end
 end

--- a/dashboard/test/models/course_offering_test.rb
+++ b/dashboard/test/models/course_offering_test.rb
@@ -463,6 +463,60 @@ class CourseOfferingTest < ActiveSupport::TestCase
     end
   end
 
+  test "elementary_school_level?" do
+    course1 = create :course_offering, grade_levels: 'K,1'
+    course2 = create :course_offering, grade_levels: 'K,1,2,3,4,5'
+    course3 = create :course_offering, grade_levels: '5,6,7'
+    course4 = create :course_offering, grade_levels: '6,7,8'
+    course5 = create :course_offering, grade_levels: '8,9,10'
+    course6 = create :course_offering, grade_levels: '9,10,11,12'
+    course7 = create :course_offering, grade_levels: '11,12'
+
+    assert course1.elementary_school_level?
+    assert course2.elementary_school_level?
+    assert course3.elementary_school_level?
+    refute course4.elementary_school_level?
+    refute course5.elementary_school_level?
+    refute course6.elementary_school_level?
+    refute course7.elementary_school_level?
+  end
+
+  test "middle_school_level?" do
+    course1 = create :course_offering, grade_levels: 'K,1'
+    course2 = create :course_offering, grade_levels: 'K,1,2,3,4,5'
+    course3 = create :course_offering, grade_levels: '5,6,7'
+    course4 = create :course_offering, grade_levels: '6,7,8'
+    course5 = create :course_offering, grade_levels: '8,9,10'
+    course6 = create :course_offering, grade_levels: '9,10,11,12'
+    course7 = create :course_offering, grade_levels: '11,12'
+
+    refute course1.middle_school_level?
+    refute course2.middle_school_level?
+    assert course3.middle_school_level?
+    assert course4.middle_school_level?
+    assert course5.middle_school_level?
+    refute course6.middle_school_level?
+    refute course7.middle_school_level?
+  end
+
+  test "high_school_level?" do
+    course1 = create :course_offering, grade_levels: 'K,1'
+    course2 = create :course_offering, grade_levels: 'K,1,2,3,4,5'
+    course3 = create :course_offering, grade_levels: '5,6,7'
+    course4 = create :course_offering, grade_levels: '6,7,8'
+    course5 = create :course_offering, grade_levels: '8,9,10'
+    course6 = create :course_offering, grade_levels: '9,10,11,12'
+    course7 = create :course_offering, grade_levels: '11,12'
+
+    refute course1.high_school_level?
+    refute course2.high_school_level?
+    refute course3.high_school_level?
+    refute course4.high_school_level?
+    assert course5.high_school_level?
+    assert course6.high_school_level?
+    assert course7.high_school_level?
+  end
+
   def course_offering_with_versions(num_versions, content_root_trait=:with_unit_group)
     create :course_offering do |offering|
       create_list :course_version, num_versions, content_root_trait, course_offering: offering


### PR DESCRIPTION
Create some helper methods to decide which grade bands a course offering is in. This is one step for [TEACH-250](https://codedotorg.atlassian.net/browse/TEACH-250) that could be easily broken off with tests.