### PR TITLE
Update Some `rbenv-installer` Links

### DIFF
--- a/docker/dev_setup.sh
+++ b/docker/dev_setup.sh
@@ -7,7 +7,7 @@
 set -xe
 
 eval "$(rbenv init -)"
-curl -fsSL https://github.com/rbenv/rbenv-installer/raw/master/bin/rbenv-doctor | bash
+curl -fsSL https://github.com/rbenv/rbenv-installer/raw/main/bin/rbenv-doctor | bash
 
 bundle install --verbose
 

--- a/docker/ui_tests.sh
+++ b/docker/ui_tests.sh
@@ -24,7 +24,7 @@ export CIRCLE_ARTIFACTS=/home/circleci/artifacts
 mkdir $CIRCLE_ARTIFACTS
 
 # rbenv-doctor https://github.com/rbenv/rbenv-installer#readme
-curl -fsSL https://github.com/rbenv/rbenv-installer/raw/master/bin/rbenv-doctor | bash
+curl -fsSL https://github.com/rbenv/rbenv-installer/raw/main/bin/rbenv-doctor | bash
 
 bundle install --verbose
 


### PR DESCRIPTION
Looks like the `rbenv-installer` repo changed their default branch from `master` to `main`, causing these hardcoded links of ours to stop working.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

Old link (404s): https://github.com/rbenv/rbenv-installer/raw/master/bin/rbenv-doctor
New link: https://github.com/rbenv/rbenv-installer/raw/main/bin/rbenv-doctor

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

Tested locally with `docker-compose`

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
