### PR TITLE
make assessment_opportunities translatable

### DIFF
--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -454,7 +454,7 @@ class Lesson < ApplicationRecord
       standards: standards.map(&:summarize_for_lesson_show),
       opportunityStandards: opportunity_standards.map(&:summarize_for_lesson_show),
       is_instructor: script.can_be_instructor?(user),
-      assessmentOpportunities: Services::MarkdownPreprocessor.process(assessment_opportunities),
+      assessmentOpportunities: render_property(:assessment_opportunities),
       lessonPlanPdfUrl: lesson_plan_pdf_url,
       courseVersionStandardsUrl: course_version_standards_url,
       isVerifiedInstructor: user&.verified_instructor?,

--- a/dashboard/lib/services/i18n/curriculum_sync_utils/serializers.rb
+++ b/dashboard/lib/services/i18n/curriculum_sync_utils/serializers.rb
@@ -137,6 +137,7 @@ module Services::I18n::CurriculumSyncUtils
     class LessonCrowdinSerializer < CrowdinSerializer
       attributes(
         :name,
+        :assessment_opportunities,
         :overview,
         :preparation,
         :purpose,

--- a/dashboard/test/models/lesson_test.rb
+++ b/dashboard/test/models/lesson_test.rb
@@ -435,6 +435,7 @@ class LessonTest < ActiveSupport::TestCase
     lesson.expects(:get_localized_property).with(:overview)
     lesson.expects(:get_localized_property).with(:purpose)
     lesson.expects(:get_localized_property).with(:preparation)
+    lesson.expects(:get_localized_property).with(:assessment_opportunities)
 
     lesson.summarize_for_lesson_show(create(:user), false)
   end


### PR DESCRIPTION
Lesson plans are useful resources for teachers and students.
Lessons are stored in what we call `script_json` files. Each lesson includes multiple sections like in the following example:
```
{    "key": "Intro to Problem Solving",
      "name": "Intro to Problem Solving",
      "absolute_position": 2,
      "lockable": false,
      "has_lesson_plan": true,
      "relative_position": 1,
      "properties": {    "assessment_opportunities": "...",
                                   "creative_commons_license": "...",
                                   "overview": "...",
                                   "preparation": "...",
                                   "purpose": "...",
                                   "student_overview": "..."    },
      "seeding_key": {    "lesson.key": "Intro to Problem Solving",
                                       "lesson_group.key": "csd1_1",
                                       "script.name": "csd1-2022"    }
}
```
In the current state, the i18n serializer does not include `assessment_opportunities` as part of the `LessonCrowdinSerializer` but it does include other properties of lessons.

In addition, the lesson model uses the `MarkdownPreprocessor` on the assessment_opportunities markdown without localizing the property first, like it does with other properties.

This PR adds assessment_opportunities to the i18n serializer and uses the `render_property` function on assessment_opportunities property, which localizes the property before processing the markdown content.

## Links

- jira ticket: [P20-36](https://codedotorg.atlassian.net/browse/P20-36)


## Testing story
I ran the full sync on the testing project:
- Checked that assessment_opportunities appear in Crowdin
- Added translations for some assesment_opportunities
- Checked that synced out distributed translated content to the dashboard locales.

Screenshots of before and after attached:
![Screenshot 2023-02-22 at 17 56 05](https://user-images.githubusercontent.com/66776217/220795533-f3b361fa-a946-4dab-a8fd-5afa238939dd.png)

I also updated the existing lesson model test to capture the new behavior.

## Follow-up work

No related follow up work

## Privacy

No data collection involved

## Security

No sensitive security issues

## PR Checklist:

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
