### PR TITLE
Improve query counts for CourseOffering.assignable_course_offerings

### DIFF
--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -89,9 +89,7 @@ class CourseOffering < ApplicationRecord
   end
 
   def any_versions_launched?
-    Rails.cache.fetch("#{cache_key}/any_versions_launched", force: !CourseOffering.should_cache?) do
-      course_versions.any?(&:launched?)
-    end
+    course_versions.any?(&:launched?)
   end
 
   def any_versions_in_development?

--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -107,7 +107,6 @@ class CourseOffering < ApplicationRecord
   def self.all_course_offerings
     if should_cache?
       @@course_offerings ||= CourseOffering.all.includes(course_versions: :content_root)
-      @@course_offerings
     else
       CourseOffering.all.includes(course_versions: :content_root)
     end

--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -106,9 +106,17 @@ class CourseOffering < ApplicationRecord
     course_versions.any? {|cv| cv.content_root.is_a?(Unit) && cv.has_editor_experiment?(user)}
   end
 
+  def self.all_course_offerings
+    if should_cache?
+      @@course_offerings ||= CourseOffering.all.includes(course_versions: :content_root)
+      @@course_offerings
+    else
+      CourseOffering.all.includes(course_versions: :content_root)
+    end
+  end
+
   def self.assignable_course_offerings(user)
-    course_offerings = CourseOffering.all.includes(course_versions: :content_root)
-    course_offerings.select {|co| co.can_be_assigned?(user)}
+    all_course_offerings.select {|co| co.can_be_assigned?(user)}
   end
 
   def self.assignable_course_offerings_info(user, locale_code = 'en-us')

--- a/dashboard/test/controllers/api/v1/sections_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/sections_controller_test.rb
@@ -1299,15 +1299,6 @@ class Api::V1::SectionsControllerTest < ActionController::TestCase
     assert_nil @section.code_review_expires_at
   end
 
-  test 'num queries for valid_course_offerings for a teacher with no extra permissions' do
-    sign_in @teacher
-    Unit.stubs(:should_cache?).returns(true)
-
-    assert_cached_queries(0) do
-      get :valid_course_offerings
-    end
-  end
-
   private
 
   def set_up_code_review_groups

--- a/dashboard/test/controllers/api/v1/sections_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/sections_controller_test.rb
@@ -1303,7 +1303,7 @@ class Api::V1::SectionsControllerTest < ActionController::TestCase
     sign_in @teacher
     Unit.stubs(:should_cache?).returns(true)
 
-    assert_cached_queries(73) do
+    assert_cached_queries(0) do
       get :valid_course_offerings
     end
   end

--- a/dashboard/test/controllers/api/v1/sections_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/sections_controller_test.rb
@@ -1299,6 +1299,15 @@ class Api::V1::SectionsControllerTest < ActionController::TestCase
     assert_nil @section.code_review_expires_at
   end
 
+  test 'num queries for valid_course_offerings for a teacher with no extra permissions' do
+    sign_in @teacher
+    Unit.stubs(:should_cache?).returns(true)
+
+    assert_cached_queries(73) do
+      get :valid_course_offerings
+    end
+  end
+
   private
 
   def set_up_code_review_groups

--- a/dashboard/test/models/course_offering_test.rb
+++ b/dashboard/test/models/course_offering_test.rb
@@ -437,6 +437,20 @@ class CourseOfferingTest < ActiveSupport::TestCase
     assert_equal facilitator_to_teacher_course_versions[@unit_facilitator_to_teacher.course_version.id][:units].keys, [@unit_facilitator_to_teacher.id]
   end
 
+  test 'query count for assignable_course_offerings' do
+    Unit.stubs(:should_cache?).returns true
+
+    assert_cached_queries(0) do
+      CourseOffering.assignable_course_offerings_info(@teacher)
+    end
+
+    assert_cached_queries(0) do
+      CourseOffering.assignable_course_offerings_info(@facilitator)
+    end
+
+    Unit.clear_cache
+  end
+
   test "can serialize and seed course offerings" do
     course_offering = create :course_offering, key: 'course-offering-1', grade_levels: 'K,1,2', curriculum_type: 'Course', marketing_initiative: 'HOC', header: 'Popular Media'
     serialization = course_offering.serialize


### PR DESCRIPTION
This is being done as part of the work to gather the quick assign course offerings. In general, our call to get the course offerings for a user is slow and makes a lot of queries to the database. This PR follows the same approach as https://github.com/code-dot-org/code-dot-org/pull/45432. The `course_offerings` table is currently seeded during the deploy and does not get updated on production, so we can use a class variable to store all instances. On environments where we do update this table (eg levelbuilder), we need to continue querying the database each time


I wasn't sure of a good way of testing performance improvements other than query count, so I used query count a proxy. I used a query counter gem locally for both `valid_course_offerings` -- the API used on the homepage currently -- and `quick_assign_course_offerings` -- the API used on the new section setup page. These are the number of uncached queries after querying the endpoint a few times.

|    | staging | this PR |
| - |---------|-------|
| valid_course_offerings | 1478 | 71 |
| quick_assign_course_offerings | 1340 | 46 |
