### PR TITLE
Show resend email button

### DIFF
--- a/apps/script/generateSharedConstants.rb
+++ b/apps/script/generateSharedConstants.rb
@@ -157,7 +157,17 @@ def main
 
   generate_shared_js_file(
     generate_multiple_constants(
-      %w(PRINCIPAL_APPROVAL_STATE YEAR SECTION_HEADERS PAGE_LABELS VALID_SCORES LABEL_OVERRIDES TEXT_FIELDS MULTI_ANSWER_QUESTION_FIELDS SCOREABLE_QUESTIONS),
+      %w(
+        PRINCIPAL_APPROVAL_STATE
+        SEND_ADMIN_APPROVAL_EMAIL_STATUSES
+        YEAR SECTION_HEADERS
+        PAGE_LABELS
+        VALID_SCORES
+        LABEL_OVERRIDES
+        TEXT_FIELDS
+        MULTI_ANSWER_QUESTION_FIELDS
+        SCOREABLE_QUESTIONS
+      ),
       source_module: Pd::TeacherApplicationConstants,
       transform_keys: true
     ),

--- a/apps/src/code-studio/pd/application_dashboard/detail_view_contents.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/detail_view_contents.jsx
@@ -878,7 +878,6 @@ export class DetailViewContents extends React.Component {
                 }
                 onChange={this.handlePrincipalApprovalChange}
                 showChangeRequirementButton={true}
-                showSendEmailButton={false}
                 applicationStatus={this.props.applicationData.status}
                 approvalRequired={this.state.principalApprovalIsRequired}
               />
@@ -900,7 +899,6 @@ export class DetailViewContents extends React.Component {
           )}
           <PrincipalApprovalButtons
             applicationId={this.props.applicationId}
-            showSendEmailButton={false}
             showChangeRequirementButton={true}
             onChange={this.handlePrincipalApprovalChange}
             applicationStatus={this.props.applicationData.status}

--- a/apps/src/code-studio/pd/application_dashboard/principal_approval_buttons.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/principal_approval_buttons.jsx
@@ -24,7 +24,11 @@ export default class PrincipalApprovalButtons extends React.Component {
   constructor(props) {
     super(props);
 
-    const appStatusesForSendingEmail = ['unreviewed', 'pending', 'waitlisted'];
+    const appStatusesForSendingEmail = [
+      'awaiting_admin_approval',
+      'pending',
+      'waitlisted'
+    ];
 
     this.state = {
       sendEmailRequest: null,

--- a/apps/src/code-studio/pd/application_dashboard/principal_approval_buttons.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/principal_approval_buttons.jsx
@@ -1,9 +1,10 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import Spinner from '../components/spinner.jsx';
-import ConfirmationDialog from '../components/confirmation_dialog';
 import $ from 'jquery';
 import {Button} from 'react-bootstrap';
+import Spinner from '../components/spinner.jsx';
+import ConfirmationDialog from '../components/confirmation_dialog';
+import {SendAdminApprovalEmailStatuses} from '@cdo/apps/generated/pd/teacherApplicationConstants';
 
 export default class PrincipalApprovalButtons extends React.Component {
   static propTypes = {
@@ -13,7 +14,6 @@ export default class PrincipalApprovalButtons extends React.Component {
       PropTypes.string,
       PropTypes.number
     ]).isRequired,
-    showSendEmailButton: PropTypes.bool,
     showResendEmailButton: PropTypes.bool,
     showChangeRequirementButton: PropTypes.bool,
     onChange: PropTypes.func.isRequired,
@@ -24,14 +24,12 @@ export default class PrincipalApprovalButtons extends React.Component {
   constructor(props) {
     super(props);
 
-    const appStatusesForSendingEmail = ['awaiting_admin_approval'];
-
     this.state = {
       sendEmailRequest: null,
       notRequiredRequest: null,
-      showSendEmailButton:
-        appStatusesForSendingEmail.includes(this.props.applicationStatus) &&
-        (this.props.showSendEmailButton || this.props.showResendEmailButton),
+      showResendEmailButton:
+        SendAdminApprovalEmailStatuses.includes(this.props.applicationStatus) &&
+        this.props.showResendEmailButton,
       showChangeRequirementButton: this.props.showChangeRequirementButton,
       showResendEmailConfirmation: false,
       approvalRequired: this.props.approvalRequired
@@ -57,7 +55,7 @@ export default class PrincipalApprovalButtons extends React.Component {
       this.props.onChange(this.props.applicationId, data.principal_approval);
       this.setState({
         sendEmailRequest: null,
-        showSendEmailButton: false
+        showResendEmailButton: false
       });
     });
 
@@ -101,17 +99,13 @@ export default class PrincipalApprovalButtons extends React.Component {
     this.setState({changeRequirementRequest});
   };
 
-  renderSendEmailButton() {
+  renderResendEmailButton() {
     if (this.state.sendEmailRequest) {
       return <Spinner size="small" />;
     }
 
-    const buttonOnClick = this.props.showResendEmailButton
-      ? this.handleResendEmailClick
-      : this.handleSendEmailClick;
-    const buttonText = this.props.showResendEmailButton
-      ? 'Resend request'
-      : 'Send email';
+    const buttonOnClick = this.handleResendEmailClick;
+    const buttonText = 'Resend request';
 
     return (
       <div>
@@ -163,7 +157,7 @@ export default class PrincipalApprovalButtons extends React.Component {
         <div style={styles.element}>
           {this.state.approvalRequired ? 'Is Required' : 'Not Required'}
         </div>
-        {this.state.showSendEmailButton && this.renderSendEmailButton()}
+        {this.state.showResendEmailButton && this.renderResendEmailButton()}
         {this.state.showChangeRequirementButton &&
           this.renderChangeRequirementButton()}
       </div>

--- a/apps/src/code-studio/pd/application_dashboard/principal_approval_buttons.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/principal_approval_buttons.jsx
@@ -24,11 +24,7 @@ export default class PrincipalApprovalButtons extends React.Component {
   constructor(props) {
     super(props);
 
-    const appStatusesForSendingEmail = [
-      'awaiting_admin_approval',
-      'pending',
-      'waitlisted'
-    ];
+    const appStatusesForSendingEmail = ['awaiting_admin_approval'];
 
     this.state = {
       sendEmailRequest: null,

--- a/apps/src/code-studio/pd/application_dashboard/quick_view_table.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/quick_view_table.jsx
@@ -295,7 +295,6 @@ export class QuickViewTable extends React.Component {
       <PrincipalApprovalButtons
         applicationId={props.rowData.id}
         applicationStatus={props.rowData.status}
-        showSendEmailButton={false}
         showResendEmailButton={
           isRequired && props.rowData.allow_sending_principal_email
         }

--- a/apps/test/unit/code-studio/pd/application_dashboard/detail_view_contentsTest.js
+++ b/apps/test/unit/code-studio/pd/application_dashboard/detail_view_contentsTest.js
@@ -328,6 +328,45 @@ describe('DetailViewContents', () => {
         'Make not required'
       );
     });
+    it(`Shows button to resend admin email if status is awaiting_admin_approval and it is allowed to be resent`, () => {
+      const detailView = mountDetailView({
+        applicationData: {
+          ...DEFAULT_APPLICATION_DATA,
+          principal_approval_state: PrincipalApprovalState.inProgress,
+          allow_sending_principal_email: true,
+          status: 'awaiting_admin_approval'
+        }
+      });
+      expect(detailView.find('PrincipalApprovalButtons').text()).to.contain(
+        'Resend request'
+      );
+    });
+    it(`Does not show button to resend admin email if status is awaiting_admin_approval but is not allowed to be resent`, () => {
+      const detailView = mountDetailView({
+        applicationData: {
+          ...DEFAULT_APPLICATION_DATA,
+          principal_approval_state: PrincipalApprovalState.inProgress,
+          allow_sending_principal_email: false,
+          status: 'awaiting_admin_approval'
+        }
+      });
+      expect(detailView.find('PrincipalApprovalButtons').text()).not.to.contain(
+        'Resend request'
+      );
+    });
+    it(`Does not show button to resend admin email if is allowed to be resent but status is pending`, () => {
+      const detailView = mountDetailView({
+        applicationData: {
+          ...DEFAULT_APPLICATION_DATA,
+          principal_approval_state: PrincipalApprovalState.inProgress,
+          allow_sending_principal_email: true,
+          status: 'pending'
+        }
+      });
+      expect(detailView.find('PrincipalApprovalButtons').text()).not.to.contain(
+        'Resend request'
+      );
+    });
   });
 
   describe('Regional Partner View', () => {

--- a/dashboard/app/models/pd/application/teacher_application.rb
+++ b/dashboard/app/models/pd/application/teacher_application.rb
@@ -752,14 +752,14 @@ module Pd::Application
 
       # Do we allow manually sending/resending the principal email?
 
-      # Only if this teacher application is currently awaiting_admin_approval, pending, or pending_space_availability.
-      return false unless awaiting_admin_approval? || pending? || pending_space_availability?
-
       # Only if the principal approval is required.
       return false if principal_approval_not_required
 
       # Only if we haven't gotten a principal response yet.
       return false if response
+
+      # Only if this teacher application has a status that allows it
+      return false unless SEND_ADMIN_APPROVAL_EMAIL_STATUSES.include?(status)
 
       # Only if it's been more than 5 days since we last created an email for the principal.
       return false if last_principal_approval_email_created_at && last_principal_approval_email_created_at > 5.days.ago
@@ -772,9 +772,8 @@ module Pd::Application
 
       # Do we allow the cron job to send a reminder email to the teacher?
 
-      # Only if this teacher application is currently awaiting_admin_approval or pending.
-      # (Unlike allow_sending_principal_email?, don't allow for pending_space_availability.)
-      return false unless awaiting_admin_approval? || pending?
+      # Only if this teacher application has a status that allows it
+      return false unless SEND_ADMIN_APPROVAL_EMAIL_STATUSES.include?(status)
 
       # Only if we haven't already sent one.
       return false if reminder_emails.any?

--- a/dashboard/test/models/pd/application/teacher_application_test.rb
+++ b/dashboard/test/models/pd/application/teacher_application_test.rb
@@ -1026,27 +1026,27 @@ module Pd::Application
     private
 
     test 'test allow_sending_principal_email?' do
-      # If we are unreviewed, we cannot send.
-      application = create :pd_teacher_application
-      application.update!(status: 'unreviewed')
-      refute application.allow_sending_principal_email?
-
       # If we are awaiting_admin_approval, we can send.
       application = create :pd_teacher_application
       application.update!(status: 'awaiting_admin_approval')
       assert application.allow_sending_principal_email?
 
-      # If we are pending, we can send.
+      # If we are unreviewed, we can't send.
+      application = create :pd_teacher_application
+      application.update!(status: 'unreviewed')
+      refute application.allow_sending_principal_email?
+
+      # If we are pending, we can't send.
       application = create :pd_teacher_application
       application.update!(status: 'pending')
-      assert application.allow_sending_principal_email?
+      refute application.allow_sending_principal_email?
 
-      # If we are pending_space_availability, we can send.
+      # If we are pending_space_availability, we can't send.
       application = create :pd_teacher_application
       application.update!(status: 'pending_space_availability')
-      assert application.allow_sending_principal_email?
+      refute application.allow_sending_principal_email?
 
-      # If we're no longer unreviewed/pending/pending_space_availability, we can't send.
+      # If we're accepted, we can't send.
       application = create :pd_teacher_application
       application.update!(status: 'accepted')
       refute application.allow_sending_principal_email?
@@ -1077,23 +1077,23 @@ module Pd::Application
     end
 
     test 'test allow_sending_admin_approval_teacher_reminder_email?' do
-      # If we are unreviewed, we cannot send.
-      application = create :pd_teacher_application
-      application.update!(status: 'unreviewed')
-      create :pd_application_email, application: application, email_type: 'admin_approval', created_at: 6.days.ago
-      refute application.allow_sending_admin_approval_teacher_reminder_email?
-
       # If we are awaiting_admin_approval, we can send.
       application = create :pd_teacher_application
       application.update!(status: 'awaiting_admin_approval')
       create :pd_application_email, application: application, email_type: 'admin_approval', created_at: 6.days.ago
       assert application.allow_sending_admin_approval_teacher_reminder_email?
 
-      # If we are pending, we can send.
+      # If we are unreviewed, we cannot send.
+      application = create :pd_teacher_application
+      application.update!(status: 'unreviewed')
+      create :pd_application_email, application: application, email_type: 'admin_approval', created_at: 6.days.ago
+      refute application.allow_sending_admin_approval_teacher_reminder_email?
+
+      # If we are pending, we cannot send.
       application = create :pd_teacher_application
       application.update!(status: 'pending')
       create :pd_application_email, application: application, email_type: 'admin_approval', created_at: 6.days.ago
-      assert application.allow_sending_admin_approval_teacher_reminder_email?
+      refute application.allow_sending_admin_approval_teacher_reminder_email?
 
       # If we are pending_space_availability, we can't send.
       application = create :pd_teacher_application

--- a/lib/cdo/shared_constants/pd/teacher_application_constants.rb
+++ b/lib/cdo/shared_constants/pd/teacher_application_constants.rb
@@ -13,6 +13,8 @@ module Pd
       complete: 'Complete - '
     }
 
+    SEND_ADMIN_APPROVAL_EMAIL_STATUSES = %w(awaiting_admin_approval).freeze
+
     YEAR = SharedApplicationConstants::APPLICATION_CURRENT_YEAR
 
     REGIONAL_PARTNER_DEFAULT_GUARDRAILS = {


### PR DESCRIPTION
Shows the re-send email button for teacher applications when their status is "Awaiting Admin Approval."

Shows Resend button for Awaiting Admin Approval status:
<img width="1197" alt="Screenshot 2023-03-06 at 10 53 08 AM" src="https://user-images.githubusercontent.com/9142121/223771595-7dfb1cca-bacd-4b66-bd24-2c7e5cb9eec2.png">

Does not show Resend button for different status:
<img width="1429" alt="image" src="https://user-images.githubusercontent.com/9142121/223773658-b911ab3f-e1f9-4835-b6fe-fce53ba08d18.png">

There was also logic to show a "Send Email" button –– I removed that logic because we no longer send admin emails unless the status is "Awaiting Admin Approval" in which case we send the email right away:
https://github.com/code-dot-org/code-dot-org/blob/5f3a6f1289646458b3d814a902d6323bb509e952/dashboard/app/controllers/api/v1/pd/application/teacher_applications_controller.rb#L57-L61

So the only button we use now is "Resend Request," shown in screenshot above.


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

I added unit tests and tested manually.

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

Manual testing reveals that the text describing when the last email was sent does not update once the Resend button request goes through.

Successfully sent, but text not updated:
<img width="1428" alt="Screenshot 2023-03-08 at 11 26 18 AM" src="https://user-images.githubusercontent.com/9142121/223772959-39e2f93b-bf1f-48f7-9bb1-bd64e54cf915.png">

On refresh, text is updated:
<img width="1430" alt="Screenshot 2023-03-08 at 11 26 35 AM" src="https://user-images.githubusercontent.com/9142121/223773106-520393c4-db49-4d25-b6dd-5525bbd0cd92.png">

I added an item for that in our backlog: https://codedotorg.atlassian.net/browse/ACQ-469

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
