### PR TITLE
Increase Reliabiliy of CloudFront Cache Invalidation

### DIFF
--- a/lib/cdo/aws/cloudfront.rb
+++ b/lib/cdo/aws/cloudfront.rb
@@ -22,7 +22,7 @@ module AWS
     ).freeze
     # Use the same HTTP Cache configuration as cdo-varnish
     HTTP_CACHE = HttpCache.config(rack_env)
-    CACHE_INVALIDATION_MAX_RETRIES = 5
+    CACHE_INVALIDATION_MAX_RETRIES = 10
 
     # CloudFront distribution config (`pegasus` and `dashboard`):
     # - `aliases`: whitelist of domains this distribution will use (`*`-wildcards are allowed, e.g. `*.example.com`).

--- a/lib/cdo/http_cache.rb
+++ b/lib/cdo/http_cache.rb
@@ -167,8 +167,6 @@ class HttpCache
             # TODO: Collapse these paths into /private to simplify Pegasus caching config.
             %w(
               /amazon-future-engineer*
-              /create-company-profile*
-              /edit-company-profile*
               /review-hociyskvuwa*
               /manage-professional-development-workshops*
               /professional-development-workshop-surveys*


### PR DESCRIPTION
We've been having some issues with `Aws::CloudFront::Errors::ServiceUnavailable: CloudFront encountered an internal error. Please try again.` errors when trying to flush CloudFront caches during a build. This PR represents a couple of attempts to ameliorate this issue.

First, we increase retries from 5 to 10. The default number of retries is 3, so our increase to 5 is relatively minor change. This is a more ambitious one.

Second, we remove some no-longer-used behaviors. Specifically, the "company profile" paths removed in https://github.com/code-dot-org/code-dot-org/pull/47035 which used to provide ways for companies we've partnered with to create and maintain basic profiles for some Hour of Code marketing work. We expect this to help because we have quite a few behaviors here that have to get invalidated every time, and reducing that number should make this process a bit easier on AWS's resources.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
