### PR TITLE
Music: repeat in simple2 becomes sequential

### DIFF
--- a/apps/src/music/blockly/blockTypes.js
+++ b/apps/src/music/blockly/blockTypes.js
@@ -14,6 +14,7 @@ export const BlockTypes = {
     'play_rest_at_current_location_simple2',
   PLAY_SOUNDS_TOGETHER: 'play_sounds_together',
   PLAY_SOUNDS_SEQUENTIAL: 'play_sounds_sequential',
+  REPEAT_SIMPLE2: 'repeat_simple2',
   NEW_TRACK_AT_START: 'new_track_at_start',
   NEW_TRACK_AT_MEASURE: 'new_track_at_measure',
   NEW_TRACK_ON_TRIGGER: 'new_track_on_trigger',

--- a/apps/src/music/blockly/blocks/simple2.js
+++ b/apps/src/music/blockly/blocks/simple2.js
@@ -239,3 +239,71 @@ export const playSoundsSequential = {
       ProgramSequencer.endSequential();
       `
 };
+
+export const repeatSimple2 = {
+  definition: {
+    type: BlockTypes.REPEAT_SIMPLE2,
+    message0: 'repeat %1 times',
+    args0: [
+      {
+        type: 'input_value',
+        name: 'times'
+      }
+    ],
+    message1: 'do %1',
+    args1: [
+      {
+        type: 'input_statement',
+        name: 'code'
+      }
+    ],
+    inputsInline: true,
+    previousStatement: null,
+    nextStatement: null,
+    style: 'loop_blocks',
+    tooltip: 'repeat',
+    helpUrl: ''
+  },
+  generator: block => {
+    const repeats =
+      Blockly.JavaScript.valueToCode(
+        block,
+        'times',
+        Blockly.JavaScript.ORDER_ASSIGNMENT
+      ) || 0;
+
+    let branch = Blockly.JavaScript.statementToCode(block, 'code');
+    branch = Blockly.JavaScript.addLoopTrap(branch, block);
+    let code = '';
+    const loopVar = Blockly.JavaScript.nameDB_.getDistinctName(
+      'count',
+      Blockly.Names.NameType.VARIABLE
+    );
+    let endVar = repeats;
+    if (!repeats.match(/^\w+$/) && !Blockly.utils.string.isNumber(repeats)) {
+      endVar = Blockly.JavaScript.nameDB_.getDistinctName(
+        'repeat_end',
+        Blockly.Names.NameType.VARIABLE
+      );
+      code += 'var ' + endVar + ' = ' + repeats + ';\n';
+    }
+    code +=
+      'for (var ' +
+      loopVar +
+      ' = 0; ' +
+      loopVar +
+      ' < ' +
+      endVar +
+      '; ' +
+      loopVar +
+      '++) {\n' +
+      branch +
+      '}\n';
+
+    return `
+      ProgramSequencer.playSequential();
+      ${code}
+      ProgramSequencer.endSequential();
+      `;
+  }
+};

--- a/apps/src/music/blockly/musicBlocks.js
+++ b/apps/src/music/blockly/musicBlocks.js
@@ -17,7 +17,8 @@ import {
   playSoundAtCurrentLocationSimple2,
   playRestAtCurrentLocationSimple2,
   playSoundsTogether,
-  playSoundsSequential
+  playSoundsSequential,
+  repeatSimple2
 } from './blocks/simple2';
 
 // All blocks
@@ -34,6 +35,7 @@ const blockList = [
   playRestAtCurrentLocationSimple2,
   playSoundsTogether,
   playSoundsSequential,
+  repeatSimple2,
   forLoop,
   newTrackAtStart,
   newTrackAtMeasure,

--- a/apps/src/music/blockly/toolbox.js
+++ b/apps/src/music/blockly/toolbox.js
@@ -59,6 +59,20 @@ const toolboxBlocks = {
     kind: 'block',
     type: BlockTypes.PLAY_SOUNDS_SEQUENTIAL
   },
+  [BlockTypes.REPEAT_SIMPLE2]: {
+    kind: 'block',
+    type: BlockTypes.REPEAT_SIMPLE2,
+    inputs: {
+      times: {
+        shadow: {
+          type: 'math_number',
+          fields: {
+            NUM: 1
+          }
+        }
+      }
+    }
+  },
   [BlockTypes.PLAY_SOUND_IN_TRACK]: {
     kind: 'block',
     type: BlockTypes.PLAY_SOUND_IN_TRACK,
@@ -330,7 +344,7 @@ export function getToolbox() {
             BlockTypes.TRIGGERED_AT_SIMPLE2,
             BlockTypes.PLAY_SOUNDS_TOGETHER,
             BlockTypes.PLAY_SOUNDS_SEQUENTIAL,
-            'controls_repeat_ext'
+            BlockTypes.REPEAT_SIMPLE2
           ]
         },
         {includeFunctions: true}


### PR DESCRIPTION
The `repeat` block in the `simple2` model now plays its contents sequentially.

<img width="551" alt="Screenshot 2023-02-23 at 2 05 40 PM" src="https://user-images.githubusercontent.com/2205926/221042706-f8d87fa6-2f4c-4dc5-ae88-b891fd89d3cf.png">
