### PR TITLE
[Micro:Bit] Turn off external LEDs when program is reset

### DIFF
--- a/apps/src/lib/kits/maker/boards/microBit/ExternalLed.js
+++ b/apps/src/lib/kits/maker/boards/microBit/ExternalLed.js
@@ -19,4 +19,18 @@ export default class ExternalLed {
   toggle() {
     return this.isOn ? this.off() : this.on();
   }
+
+  blink(delay) {
+    setInterval(this._toggle, delay);
+  }
+
+  _toggle() {
+    if (this.isOn) {
+      this.isOn = false;
+      this.board.setDigitalOutput(this.pin, 0);
+    } else {
+      this.isOn = true;
+      this.board.setDigitalOutput(this.pin, 1);
+    }
+  }
 }

--- a/apps/src/lib/kits/maker/boards/microBit/ExternalLed.js
+++ b/apps/src/lib/kits/maker/boards/microBit/ExternalLed.js
@@ -19,18 +19,4 @@ export default class ExternalLed {
   toggle() {
     return this.isOn ? this.off() : this.on();
   }
-
-  blink(delay) {
-    setInterval(this._toggle, delay);
-  }
-
-  _toggle() {
-    if (this.isOn) {
-      this.isOn = false;
-      this.board.setDigitalOutput(this.pin, 0);
-    } else {
-      this.isOn = true;
-      this.board.setDigitalOutput(this.pin, 1);
-    }
-  }
 }

--- a/apps/src/lib/kits/maker/boards/microBit/MicroBitBoard.js
+++ b/apps/src/lib/kits/maker/boards/microBit/MicroBitBoard.js
@@ -301,16 +301,7 @@ export default class MicroBitBoard extends EventEmitter {
    * Disconnect and clean up the board controller and all components.
    */
   destroy() {
-    this.dynamicComponents_.forEach(component => {
-      // For now, these are _always_ Leds.  Complain if they're not.
-      if (component instanceof ExternalLed) {
-        component.off();
-      } else if (component instanceof ExternalButton) {
-        // No special cleanup required for button
-      } else {
-        throw new Error('Added an unsupported component to dynamic components');
-      }
-    });
+    this.resetDynamicComponents();
     this.dynamicComponents_.length = 0;
 
     if (this.prewiredComponents_) {
@@ -350,7 +341,22 @@ export default class MicroBitBoard extends EventEmitter {
     });
   }
 
+  resetDynamicComponents() {
+    this.dynamicComponents_.forEach(component => {
+      // For now, these are _always_ Leds.  Complain if they're not.
+      if (component instanceof ExternalLed) {
+        // Make sure the LED is turned off.
+        component.off();
+      } else if (component instanceof ExternalButton) {
+        // No special cleanup is required for ExternalButton.
+      } else {
+        throw new Error('Added an unsupported component to dynamic components');
+      }
+    });
+    this.dynamicComponents_.length = 0;
+  }
   reset() {
+    this.resetDynamicComponents();
     cleanupMicroBitComponents(
       this.prewiredComponents_,
       this.dynamicComponents_,

--- a/apps/test/unit/lib/kits/maker/boards/circuitPlayground/CircuitPlaygroundBoardTest.js
+++ b/apps/test/unit/lib/kits/maker/boards/circuitPlayground/CircuitPlaygroundBoardTest.js
@@ -487,10 +487,9 @@ describe('CircuitPlaygroundBoard', () => {
         expect(led1.stop).not.to.have.been.called;
         expect(led2.stop).not.to.have.been.called;
 
-        return board.destroy().then(() => {
-          expect(led1.stop).to.have.been.calledOnce;
-          expect(led2.stop).to.have.been.calledOnce;
-        });
+        board.reset();
+        expect(led1.stop).to.have.been.calledOnce;
+        expect(led2.stop).to.have.been.calledOnce;
       });
     });
   });

--- a/apps/test/unit/lib/kits/maker/boards/microBit/MicroBitBoardTest.js
+++ b/apps/test/unit/lib/kits/maker/boards/microBit/MicroBitBoardTest.js
@@ -369,6 +369,20 @@ describe('MicroBitBoard', () => {
         expect(ledScreenSpy).to.have.been.calledOnce;
       });
     });
+
+    it('turns off any created Leds', () => {
+      return board.connect().then(() => {
+        const led1 = board.createLed(0);
+        const led2 = board.createLed(1);
+        sinon.spy(led1, 'off');
+        sinon.spy(led2, 'off');
+        expect(led1.off).not.to.have.been.called;
+        expect(led2.off).not.to.have.been.called;
+        board.reset();
+        expect(led1.off).to.have.been.calledOnce;
+        expect(led2.off).to.have.been.calledOnce;
+      });
+    });
   });
 
   describe(`destroy()`, () => {


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR ensures that when connected to a micro:bit and an App Lab program is reset, any external LEDs connected to the micro:bit are turned off. This [past PR](https://github.com/code-dot-org/code-dot-org/pull/45945) does this for the Circuit Playground.

Currently, when a micro:bit is connected with an external LED and a program is run that turns the LED on, the LED stays on even after the user resets the program.

In `MicroBitBoard.js` I created a `resetDynamicComponents` function which turns external LEDs off. This function is called in both `reset` and `destroy` within the same file.

Before update:

https://user-images.githubusercontent.com/107423305/221090880-1f714a70-c3c4-4c3b-a18b-77735bc18d04.mp4


After update:

https://user-images.githubusercontent.com/107423305/221090890-a245e945-1657-4038-a288-2f9811bdb8aa.mp4



## Links
[jira](https://codedotorg.atlassian.net/browse/SL-570)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
I tested locally and added a unit test in `MicroBitBoardTest.js` that checks to make sure LEDs are turned off after `reset` is called.
I also updated a unit test in `CircuitPlaygroundBoardTest.js` that tests if after `reset` is called, any created Leds are turned off. A call to `destroy` is made, and then the Leds are checked. However, `destroy` is not called when `reset` is called [in `CircuitPlaygroundBoardTest.js`](https://github.com/code-dot-org/code-dot-org/blob/86e72655091f986ffdbc72e850840e3bd7c3ab61/apps/src/lib/kits/maker/boards/circuitPlayground/CircuitPlaygroundBoard.js#L284), so I updated to a call to `reset`.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
