### PR TITLE
Dyanamically fetch courses for quick assign

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -98,8 +98,8 @@ group :development, :test do
   gem 'timecop'
 
   # For UI testing.
-  gem 'cucumber'
-  gem 'eyes_selenium', '3.18.4'
+  gem 'cucumber', require: false
+  gem 'eyes_selenium', '3.18.4', require: false
   gem 'minitest', '~> 5.15'
   gem 'minitest-around'
   gem 'minitest-reporters', '~> 1.2.0.beta3'

--- a/Gemfile
+++ b/Gemfile
@@ -98,8 +98,8 @@ group :development, :test do
   gem 'timecop'
 
   # For UI testing.
-  gem 'cucumber', require: false
-  gem 'eyes_selenium', '3.18.4', require: false
+  gem 'cucumber'
+  gem 'eyes_selenium', '3.18.4'
   gem 'minitest', '~> 5.15'
   gem 'minitest-around'
   gem 'minitest-reporters', '~> 1.2.0.beta3'

--- a/apps/src/templates/Dialog.story.jsx
+++ b/apps/src/templates/Dialog.story.jsx
@@ -102,7 +102,7 @@ export const NoTitleOnlyConfirm = () => (
 
 export const FullWidth = () => (
   <ExampleDialogButton>
-    <Dialog fullWidth={true}>
+    <Dialog fullWidth={true} hideCloseButton={false} uncloseable={false}>
       <Icon src="https://studio.code.org/blockly/media/skins/flappy/static_avatar.png" />
       <Title>Puzzle 3 of 10</Title>
       <Body>

--- a/apps/src/templates/Dialog.story.jsx
+++ b/apps/src/templates/Dialog.story.jsx
@@ -102,7 +102,7 @@ export const NoTitleOnlyConfirm = () => (
 
 export const FullWidth = () => (
   <ExampleDialogButton>
-    <Dialog fullWidth={true} hideCloseButton={false} uncloseable={false}>
+    <Dialog fullWidth={true}>
       <Icon src="https://studio.code.org/blockly/media/skins/flappy/static_avatar.png" />
       <Title>Puzzle 3 of 10</Title>
       <Body>

--- a/dashboard/app/controllers/course_offerings_controller.rb
+++ b/dashboard/app/controllers/course_offerings_controller.rb
@@ -28,12 +28,9 @@ class CourseOfferingsController < ApplicationController
     offerings = {}
 
     assignable_offerings = CourseOffering.assignable_course_offerings(current_user)
-    puts assignable_offerings.length
-
     assignable_elementary_offerings = assignable_offerings.filter(&:elementary_school_level?)
     assignable_middle_offerings = assignable_offerings.filter(&:middle_school_level?)
     assignable_high_offerings = assignable_offerings.filter(&:high_school_level?)
-    puts assignable_elementary_offerings.length
 
     offerings[:elementary] = group_offerings_for_quick_assign(assignable_elementary_offerings)
     offerings[:middle] = group_offerings_for_quick_assign(assignable_middle_offerings)
@@ -56,6 +53,13 @@ class CourseOfferingsController < ApplicationController
       data[co.curriculum_type] ||= {}
       data[co.curriculum_type][co.header] ||= []
       data[co.curriculum_type][co.header].append(co.summarize_for_quick_assign(current_user, request.locale))
+    end
+
+    data.keys.each do |curriculum_type|
+      data[curriculum_type].keys.each do |header|
+        data[curriculum_type][header].sort_by! {|co| co[:display_name]}
+      end
+      data[curriculum_type] = data[curriculum_type].sort.to_h
     end
 
     data

--- a/dashboard/app/controllers/course_offerings_controller.rb
+++ b/dashboard/app/controllers/course_offerings_controller.rb
@@ -25,7 +25,7 @@ class CourseOfferingsController < ApplicationController
   def quick_assign_course_offerings
     return head :forbidden unless current_user
 
-    offerings = CourseOffering.quick_assign_course_offerings(current_user, request.locale)
+    offerings = QuickAssignHelper.course_offerings(current_user, request.locale)
     render :ok, json: offerings.to_json
   end
 

--- a/dashboard/app/controllers/course_offerings_controller.rb
+++ b/dashboard/app/controllers/course_offerings_controller.rb
@@ -25,17 +25,7 @@ class CourseOfferingsController < ApplicationController
   def quick_assign_course_offerings
     return head :forbidden unless current_user
 
-    offerings = {}
-
-    assignable_offerings = CourseOffering.assignable_course_offerings(current_user)
-    assignable_elementary_offerings = assignable_offerings.filter(&:elementary_school_level?)
-    assignable_middle_offerings = assignable_offerings.filter(&:middle_school_level?)
-    assignable_high_offerings = assignable_offerings.filter(&:high_school_level?)
-
-    offerings[:elementary] = group_offerings_for_quick_assign(assignable_elementary_offerings)
-    offerings[:middle] = group_offerings_for_quick_assign(assignable_middle_offerings)
-    offerings[:high] = group_offerings_for_quick_assign(assignable_high_offerings)
-
+    offerings = CourseOffering.quick_assign_course_offerings(current_user, request.locale)
     render :ok, json: offerings.to_json
   end
 
@@ -43,25 +33,5 @@ class CourseOfferingsController < ApplicationController
 
   def course_offering_params
     params.permit(:display_name, :is_featured, :category, :assignable, :grade_levels, :curriculum_type, :header, :marketing_initiative).to_h
-  end
-
-  def group_offerings_for_quick_assign(course_offerings)
-    data = {}
-    course_offerings.each do |co|
-      next if co.header.blank? || co.curriculum_type.blank?
-
-      data[co.curriculum_type] ||= {}
-      data[co.curriculum_type][co.header] ||= []
-      data[co.curriculum_type][co.header].append(co.summarize_for_quick_assign(current_user, request.locale))
-    end
-
-    data.keys.each do |curriculum_type|
-      data[curriculum_type].keys.each do |header|
-        data[curriculum_type][header].sort_by! {|co| co[:display_name]}
-      end
-      data[curriculum_type] = data[curriculum_type].sort.to_h
-    end
-
-    data
   end
 end

--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -35,15 +35,9 @@ class CourseOffering < ApplicationRecord
     with: KEY_RE,
     message: "must contain only lowercase alphabetic characters, numbers, and dashes; got \"%{value}\"."
 
-<<<<<<< HEAD
   ELEMENTARY_SCHOOL_GRADES = %w[K 1 2 3 4 5].freeze
   MIDDLE_SCHOOL_GRADES = %w[6 7 8].freeze
   HIGH_SCHOOL_GRADES = %w[9 10 11 12].freeze
-=======
-  ES_GRADES = %w[K 1 2 3 4 5].freeze
-  MS_GRADES = %w[6 7 8].freeze
-  HS_GRADES = %w[9 10 11 12].freeze
->>>>>>> Dynamically fetch the course offerings for quick assign
 
   # Seeding method for creating / updating / deleting a CourseOffering and CourseVersion for the given
   # potential content root, i.e. a Unit or UnitGroup.

--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -262,39 +262,4 @@ class CourseOffering < ApplicationRecord
   def high_school_level?
     grade_levels_list.any? {|g| HIGH_SCHOOL_GRADES.include?(g)}
   end
-
-  def self.quick_assign_course_offerings(user, locale)
-    offerings = {}
-
-    assignable_offerings = CourseOffering.assignable_course_offerings(user)
-    assignable_elementary_offerings = assignable_offerings.filter(&:elementary_school_level?)
-    assignable_middle_offerings = assignable_offerings.filter(&:middle_school_level?)
-    assignable_high_offerings = assignable_offerings.filter(&:high_school_level?)
-
-    offerings[:elementary] = group_offerings_for_quick_assign(assignable_elementary_offerings, user, locale)
-    offerings[:middle] = group_offerings_for_quick_assign(assignable_middle_offerings, user, locale)
-    offerings[:high] = group_offerings_for_quick_assign(assignable_high_offerings, user, locale)
-
-    offerings
-  end
-
-  def self.group_offerings_for_quick_assign(course_offerings, user, locale)
-    data = {}
-    course_offerings.each do |co|
-      next if co.header.blank? || co.curriculum_type.blank?
-
-      data[co.curriculum_type] ||= {}
-      data[co.curriculum_type][co.header] ||= []
-      data[co.curriculum_type][co.header].append(co.summarize_for_quick_assign(user, locale))
-    end
-
-    data.keys.each do |curriculum_type|
-      data[curriculum_type].keys.each do |header|
-        data[curriculum_type][header].sort_by! {|co| co[:display_name]}
-      end
-      data[curriculum_type] = data[curriculum_type].sort.to_h
-    end
-
-    data
-  end
 end

--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -262,4 +262,39 @@ class CourseOffering < ApplicationRecord
   def high_school_level?
     grade_levels_list.any? {|g| HIGH_SCHOOL_GRADES.include?(g)}
   end
+
+  def self.quick_assign_course_offerings(user, locale)
+    offerings = {}
+
+    assignable_offerings = CourseOffering.assignable_course_offerings(user)
+    assignable_elementary_offerings = assignable_offerings.filter(&:elementary_school_level?)
+    assignable_middle_offerings = assignable_offerings.filter(&:middle_school_level?)
+    assignable_high_offerings = assignable_offerings.filter(&:high_school_level?)
+
+    offerings[:elementary] = group_offerings_for_quick_assign(assignable_elementary_offerings, user, locale)
+    offerings[:middle] = group_offerings_for_quick_assign(assignable_middle_offerings, user, locale)
+    offerings[:high] = group_offerings_for_quick_assign(assignable_high_offerings, user, locale)
+
+    offerings
+  end
+
+  def self.group_offerings_for_quick_assign(course_offerings, user, locale)
+    data = {}
+    course_offerings.each do |co|
+      next if co.header.blank? || co.curriculum_type.blank?
+
+      data[co.curriculum_type] ||= {}
+      data[co.curriculum_type][co.header] ||= []
+      data[co.curriculum_type][co.header].append(co.summarize_for_quick_assign(user, locale))
+    end
+
+    data.keys.each do |curriculum_type|
+      data[curriculum_type].keys.each do |header|
+        data[curriculum_type][header].sort_by! {|co| co[:display_name]}
+      end
+      data[curriculum_type] = data[curriculum_type].sort.to_h
+    end
+
+    data
+  end
 end

--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -35,9 +35,15 @@ class CourseOffering < ApplicationRecord
     with: KEY_RE,
     message: "must contain only lowercase alphabetic characters, numbers, and dashes; got \"%{value}\"."
 
+<<<<<<< HEAD
   ELEMENTARY_SCHOOL_GRADES = %w[K 1 2 3 4 5].freeze
   MIDDLE_SCHOOL_GRADES = %w[6 7 8].freeze
   HIGH_SCHOOL_GRADES = %w[9 10 11 12].freeze
+=======
+  ES_GRADES = %w[K 1 2 3 4 5].freeze
+  MS_GRADES = %w[6 7 8].freeze
+  HS_GRADES = %w[9 10 11 12].freeze
+>>>>>>> Dynamically fetch the course offerings for quick assign
 
   # Seeding method for creating / updating / deleting a CourseOffering and CourseVersion for the given
   # potential content root, i.e. a Unit or UnitGroup.

--- a/dashboard/lib/quick_assign_helper.rb
+++ b/dashboard/lib/quick_assign_helper.rb
@@ -1,0 +1,36 @@
+module QuickAssignHelper
+  def self.course_offerings(user, locale)
+    offerings = {}
+
+    assignable_offerings = CourseOffering.assignable_course_offerings(user)
+    assignable_elementary_offerings = assignable_offerings.filter(&:elementary_school_level?)
+    assignable_middle_offerings = assignable_offerings.filter(&:middle_school_level?)
+    assignable_high_offerings = assignable_offerings.filter(&:high_school_level?)
+
+    offerings[:elementary] = group_offerings(assignable_elementary_offerings, user, locale)
+    offerings[:middle] = group_offerings(assignable_middle_offerings, user, locale)
+    offerings[:high] = group_offerings(assignable_high_offerings, user, locale)
+
+    offerings
+  end
+
+  def self.group_offerings(course_offerings, user, locale)
+    data = {}
+    course_offerings.each do |co|
+      next if co.header.blank? || co.curriculum_type.blank?
+
+      data[co.curriculum_type] ||= {}
+      data[co.curriculum_type][co.header] ||= []
+      data[co.curriculum_type][co.header].append(co.summarize_for_quick_assign(user, locale))
+    end
+
+    data.keys.each do |curriculum_type|
+      data[curriculum_type].keys.each do |header|
+        data[curriculum_type][header].sort_by! {|co| co[:display_name]}
+      end
+      data[curriculum_type] = data[curriculum_type].sort.to_h
+    end
+
+    data
+  end
+end

--- a/dashboard/lib/quick_assign_helper.rb
+++ b/dashboard/lib/quick_assign_helper.rb
@@ -14,6 +14,11 @@ module QuickAssignHelper
     offerings
   end
 
+  # We want to organize the course offerings in a very specific format.
+  # In particular, we want to group by curriculum_type then header within each curriculum_type.
+  # The headers within each curriculum_type will be sorted alphabetically.
+  # The offerings within a header will be sorted alphabetically by display_name.
+  # Any course_offerings that do not have a curriculum_type and a header will be ignored.
   def self.group_offerings(course_offerings, user, locale)
     data = {}
     course_offerings.each do |co|
@@ -24,6 +29,7 @@ module QuickAssignHelper
       data[co.curriculum_type][co.header].append(co.summarize_for_quick_assign(user, locale))
     end
 
+    # Sort the headers and the course offerings
     data.keys.each do |curriculum_type|
       data[curriculum_type].keys.each do |header|
         data[curriculum_type][header].sort_by! {|co| co[:display_name]}

--- a/dashboard/test/controllers/course_offerings_controller_test.rb
+++ b/dashboard/test/controllers/course_offerings_controller_test.rb
@@ -53,13 +53,16 @@ class CourseOfferingsControllerTest < ActionController::TestCase
   end
 
   test 'quick_assign_course_offerings returns offerings for elementary, middle, and high' do
-    elementary_course = create :course_offering, grade_levels: 'K,1,2,3,4,5', curriculum_type: 'Course', header: 'Test'
-    middle_course = create :course_offering, grade_levels: '6,7,8', curriculum_type: 'Course', header: 'Test'
-    high_course = create :course_offering, grade_levels: '9,10,11,12', curriculum_type: 'Course', header: 'Test'
+    user = create :user
+    sign_in user
+
+    create :course_offering, grade_levels: 'K,1,2,3,4,5', curriculum_type: 'Course', header: 'Test'
+    create :course_offering, grade_levels: '6,7,8', curriculum_type: 'Course', header: 'Test'
+    create :course_offering, grade_levels: '9,10,11,12', curriculum_type: 'Course', header: 'Test'
 
     get :quick_assign_course_offerings
 
-    quick_assign_block = JSON.parse(@response.body)
+    quick_assign_blob = JSON.parse(@response.body)
 
     puts quick_assign_blob.inspect
   end

--- a/dashboard/test/controllers/course_offerings_controller_test.rb
+++ b/dashboard/test/controllers/course_offerings_controller_test.rb
@@ -51,4 +51,16 @@ class CourseOfferingsControllerTest < ActionController::TestCase
     assert_equal 'full_course', course_offering.category
     assert_equal false, course_offering.is_featured
   end
+
+  test 'quick_assign_course_offerings returns offerings for elementary, middle, and high' do
+    elementary_course = create :course_offering, grade_levels: 'K,1,2,3,4,5', curriculum_type: 'Course', header: 'Test'
+    middle_course = create :course_offering, grade_levels: '6,7,8', curriculum_type: 'Course', header: 'Test'
+    high_course = create :course_offering, grade_levels: '9,10,11,12', curriculum_type: 'Course', header: 'Test'
+
+    get :quick_assign_course_offerings
+
+    quick_assign_block = JSON.parse(@response.body)
+
+    puts quick_assign_blob.inspect
+  end
 end

--- a/dashboard/test/controllers/course_offerings_controller_test.rb
+++ b/dashboard/test/controllers/course_offerings_controller_test.rb
@@ -51,19 +51,4 @@ class CourseOfferingsControllerTest < ActionController::TestCase
     assert_equal 'full_course', course_offering.category
     assert_equal false, course_offering.is_featured
   end
-
-  test 'quick_assign_course_offerings returns offerings for elementary, middle, and high' do
-    user = create :user
-    sign_in user
-
-    create :course_offering, grade_levels: 'K,1,2,3,4,5', curriculum_type: 'Course', header: 'Test'
-    create :course_offering, grade_levels: '6,7,8', curriculum_type: 'Course', header: 'Test'
-    create :course_offering, grade_levels: '9,10,11,12', curriculum_type: 'Course', header: 'Test'
-
-    get :quick_assign_course_offerings
-
-    quick_assign_blob = JSON.parse(@response.body)
-
-    puts quick_assign_blob.inspect
-  end
 end

--- a/dashboard/test/lib/quick_assign_helper.rb
+++ b/dashboard/test/lib/quick_assign_helper.rb
@@ -42,7 +42,8 @@ class QuickAssignHelperTest < ActionController::TestCase
     course_offering1 = create :course_offering, curriculum_type: 'Course', header: 'Header 1'
     course_offering2 = create :course_offering, curriculum_type: 'Course', header: 'Header 2'
     course_offering3 = create :course_offering, curriculum_type: 'Standalone Unit', header: 'Header 1'
-    course_offering4 = create :course_offering, curriculum_type: 'Standalone Unit', header: 'Header 2', display_name: 'A'
+    # course_offering4 and course_offering5 should be grouped together, with course_offering5 being first in the resulting list.
+    course_offering4 = create :course_offering, curriculum_type: 'Standalone Unit', header: 'Header 2', display_name: 'Z'
     course_offering5 = create :course_offering, curriculum_type: 'Standalone Unit', header: 'Header 2', display_name: 'B'
 
     teacher = create :teacher
@@ -55,7 +56,7 @@ class QuickAssignHelperTest < ActionController::TestCase
     assert_equal 1, grouped_offerings['Standalone Unit']['Header 1'].length
     assert_equal course_offering3.id, grouped_offerings['Standalone Unit']['Header 1'][0][:id]
     assert_equal 2, grouped_offerings['Standalone Unit']['Header 2'].length
-    assert_equal course_offering4.id, grouped_offerings['Standalone Unit']['Header 2'][0][:id]
-    assert_equal course_offering5.id, grouped_offerings['Standalone Unit']['Header 2'][1][:id]
+    assert_equal course_offering5.id, grouped_offerings['Standalone Unit']['Header 2'][0][:id]
+    assert_equal course_offering4.id, grouped_offerings['Standalone Unit']['Header 2'][1][:id]
   end
 end

--- a/dashboard/test/lib/quick_assign_helper.rb
+++ b/dashboard/test/lib/quick_assign_helper.rb
@@ -1,0 +1,61 @@
+require 'test_helper'
+
+class QuickAssignHelperTest < ActionController::TestCase
+  test 'returns course offerings by grade level' do
+    elementary_course_version = create :course_version
+    elementary_course_version.content_root.update!(published_state: 'stable')
+    elementary_course_version.course_offering.update!(grade_levels: 'K,1,2', curriculum_type: 'Course', header: 'Test')
+
+    middle_course_version = create :course_version
+    middle_course_version.content_root.update!(published_state: 'stable')
+    middle_course_version.course_offering.update!(grade_levels: '7,8', curriculum_type: 'Course', header: 'Test')
+
+    high_course_version = create :course_version
+    high_course_version.content_root.update!(published_state: 'stable')
+    high_course_version.course_offering.update!(grade_levels: '11', curriculum_type: 'Course', header: 'Test')
+
+    teacher = create :teacher
+    course_offerings = QuickAssignHelper.course_offerings(teacher, I18n.default_locale)
+
+    refute course_offerings[:elementary].blank?
+    refute course_offerings[:middle].blank?
+    refute course_offerings[:high].blank?
+  end
+
+  test 'only returns assignable course offerings' do
+    assignable_course_version = create :course_version
+    assignable_course_version.content_root.update!(published_state: 'stable')
+    assignable_course_version.course_offering.update!(grade_levels: 'K,1,2', curriculum_type: 'Course', header: 'Test')
+
+    unassignable_course_version = create :course_version
+    unassignable_course_version.content_root.update!(published_state: 'stable')
+    unassignable_course_version.course_offering.update!(grade_levels: 'K,1,2', curriculum_type: 'Course', header: 'Test', assignable: false)
+
+    teacher = create :teacher
+    course_offerings = QuickAssignHelper.course_offerings(teacher, I18n.default_locale)
+
+    refute course_offerings[:elementary].blank?
+    assert_equal 1, course_offerings[:elementary]['Course']['Test'].length
+  end
+
+  test 'offerings are grouped by curriculum type and header' do
+    course_offering1 = create :course_offering, curriculum_type: 'Course', header: 'Header 1'
+    course_offering2 = create :course_offering, curriculum_type: 'Course', header: 'Header 2'
+    course_offering3 = create :course_offering, curriculum_type: 'Standalone Unit', header: 'Header 1'
+    course_offering4 = create :course_offering, curriculum_type: 'Standalone Unit', header: 'Header 2', display_name: 'A'
+    course_offering5 = create :course_offering, curriculum_type: 'Standalone Unit', header: 'Header 2', display_name: 'B'
+
+    teacher = create :teacher
+    grouped_offerings = QuickAssignHelper.group_offerings([course_offering1, course_offering2, course_offering3, course_offering4, course_offering5], teacher, I18n.default_locale)
+
+    assert_equal 1, grouped_offerings['Course']['Header 1'].length
+    assert_equal course_offering1.id, grouped_offerings['Course']['Header 1'][0][:id]
+    assert_equal 1, grouped_offerings['Course']['Header 2'].length
+    assert_equal course_offering2.id, grouped_offerings['Course']['Header 2'][0][:id]
+    assert_equal 1, grouped_offerings['Standalone Unit']['Header 1'].length
+    assert_equal course_offering3.id, grouped_offerings['Standalone Unit']['Header 1'][0][:id]
+    assert_equal 2, grouped_offerings['Standalone Unit']['Header 2'].length
+    assert_equal course_offering4.id, grouped_offerings['Standalone Unit']['Header 2'][0][:id]
+    assert_equal course_offering5.id, grouped_offerings['Standalone Unit']['Header 2'][1][:id]
+  end
+end


### PR DESCRIPTION
This PR removes the hardcoded data for the quick assign component and instead returns the full set of courses to show. The structure is unchanged from the hardcoded data. I created a [gist](https://gist.github.com/bethanyaconnor/3e8a004f6c9805c669efa168269f9506) with the output I get locally.

I'll add HoC and PL courses in followup PRs.