### PR TITLE
Add Time Capsule subtype of Poetry

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1720,6 +1720,7 @@
   "projectTypeSports": "Sports",
   "projectTypeStory": "Story",
   "projectTypeThebadguys": "The Bad Guys",
+  "projectTypeTimeCapsule": "Time Capsule",
   "projectTypeWeblab": "Web Lab",
   "projectTypeApplabViewMore": "View more App Lab projects",
   "projectTypeGamelabViewMore": "View more Game Lab projects",

--- a/apps/i18n/poetry/en_us.json
+++ b/apps/i18n/poetry/en_us.json
@@ -43,6 +43,8 @@
   "noEffects": "You're missing some code. Add a background or text effect block under `when run`.",
   "noTextEffect": "Try adding a text color block under `when run`.",
   "oneTextEffect": "Great work! You added one text effect. Try adding another.",
+  "patLines": "I love to ride my skateboard all around\nWith my Walkman blasting, I don't hear a sound\nI just learned how to do a sweet new trick\nIt's called the kickflip and it's really sick\n\nSomething happening right now is Yo MTV Raps\nWatching Salt-N-Pepa and LL Cool J, mad snaps\nSlap bracelets are something cool\nAnd neon colors, they totally rule.",
+  "patTitle": "1990 - My Poem 1",
   "poLines": "The birds have vanished into the sky,\nAnd now the last cloud drains away.\nWe sit together, the mountain and me,\nUntil only the mountain remains.",
   "poTitle": "Mountain",
   "poem": "Poem:",

--- a/apps/i18n/poetry/en_us.json
+++ b/apps/i18n/poetry/en_us.json
@@ -43,8 +43,6 @@
   "noEffects": "You're missing some code. Add a background or text effect block under `when run`.",
   "noTextEffect": "Try adding a text color block under `when run`.",
   "oneTextEffect": "Great work! You added one text effect. Try adding another.",
-  "patLines": "I love to ride my skateboard all around\nWith my Walkman blasting, I don't hear a sound\nI just learned how to do a sweet new trick\nIt's called the kickflip and it's really sick\n\nSomething happening right now is Yo MTV Raps\nWatching Salt-N-Pepa and LL Cool J, mad snaps\nSlap bracelets are something cool\nAnd neon colors, they totally rule.",
-  "patTitle": "1990 - My Poem 1",
   "poLines": "The birds have vanished into the sky,\nAnd now the last cloud drains away.\nWe sit together, the mountain and me,\nUntil only the mountain remains.",
   "poTitle": "Mountain",
   "poem": "Poem:",

--- a/apps/src/p5lab/poetry/PoemSelector.jsx
+++ b/apps/src/p5lab/poetry/PoemSelector.jsx
@@ -12,8 +12,8 @@ import project from '@cdo/apps/code-studio/initApp/project';
 import {setPoem} from '../redux/poetry';
 import msg from '@cdo/poetry/locale';
 import {APP_WIDTH} from '../constants';
-import {POEMS, PoetryStandaloneApp} from './constants';
-import {getPoem} from './poem';
+import {PoetryStandaloneApp} from './constants';
+import {getPoem, getPoems} from './poem';
 import * as utils from '@cdo/apps/utils';
 
 const poemShape = PropTypes.shape({
@@ -139,7 +139,7 @@ PoemEditor.defaultProps = {
 function PoemSelector(props) {
   const [isOpen, setIsOpen] = useState(false);
 
-  if (appOptions.level.standaloneAppName !== PoetryStandaloneApp.PoetryHoc) {
+  if (appOptions.level.standaloneAppName === PoetryStandaloneApp.Poetry) {
     return null;
   }
 
@@ -178,7 +178,7 @@ function PoemSelector(props) {
   };
 
   const getPoemOptions = () => {
-    const options = Object.keys(POEMS)
+    const options = Object.keys(getPoems())
       .map(poemKey => getPoem(poemKey))
       .filter(poem => !poem.locales || poem.locales.includes(appOptions.locale))
       .sort((a, b) => (a.title > b.title ? 1 : -1))

--- a/apps/src/p5lab/poetry/constants.js
+++ b/apps/src/p5lab/poetry/constants.js
@@ -285,5 +285,20 @@ export const POEMS = {
 };
 
 export const TIME_CAPSULE_POEMS = {
-  pat: {author: 'Pat Y.'}
+  pat: {
+    locales: ['en_us'],
+    author: 'Pat Y.',
+    title: '1990 - My Poem 1',
+    linesSplit: [
+      'I love to ride my skateboard all around',
+      "With my Walkman blasting, I don't hear a sound",
+      'I just learned how to do a sweet new trick',
+      "It's called the kickflip and it's really sick",
+      '\n',
+      'Something happening right now is Yo MTV Raps',
+      'Watching Salt-N-Pepa and LL Cool J, mad snaps',
+      'Slap bracelets are something cool',
+      'And neon colors, they totally rule.'
+    ]
+  }
 };

--- a/apps/src/p5lab/poetry/constants.js
+++ b/apps/src/p5lab/poetry/constants.js
@@ -1,6 +1,7 @@
 export const PoetryStandaloneApp = {
   Poetry: 'poetry',
-  PoetryHoc: 'poetry_hoc'
+  PoetryHoc: 'poetry_hoc',
+  TimeCapsule: 'time_capsule'
 };
 
 export const PALETTES = {
@@ -281,4 +282,8 @@ export const POEMS = {
       "com'esuli pensieri, nel vespero migrar."
     ]
   }
+};
+
+export const TIME_CAPSULE_POEMS = {
+  pat: {author: 'Pat Y.'}
 };

--- a/apps/src/p5lab/poetry/poem.js
+++ b/apps/src/p5lab/poetry/poem.js
@@ -3,7 +3,7 @@ import msg from '@cdo/poetry/locale';
 import {POEMS, PoetryStandaloneApp, TIME_CAPSULE_POEMS} from './constants';
 
 export function getPoem(key) {
-  const poemList = getPoems(appOptions.level.standaloneAppName);
+  const poemList = getPoems();
   if (!key || !poemList[key]) {
     return undefined;
   }

--- a/apps/src/p5lab/poetry/poem.js
+++ b/apps/src/p5lab/poetry/poem.js
@@ -1,15 +1,28 @@
+/* global appOptions */
 import msg from '@cdo/poetry/locale';
-import {POEMS} from './constants';
+import {POEMS, PoetryStandaloneApp, TIME_CAPSULE_POEMS} from './constants';
 
 export function getPoem(key) {
-  if (!key || !POEMS[key]) {
+  const poemList = getPoems(appOptions.level.standaloneAppName);
+  if (!key || !poemList[key]) {
     return undefined;
   }
   return {
     key: key,
-    locales: POEMS[key].locales,
-    author: POEMS[key].author,
-    title: POEMS[key].title || msg[`${key}Title`](),
-    lines: POEMS[key].linesSplit || msg[`${key}Lines`]().split('\n')
+    locales: poemList[key].locales,
+    author: poemList[key].author,
+    title: poemList[key].title || msg[`${key}Title`](),
+    lines: poemList[key].linesSplit || msg[`${key}Lines`]().split('\n')
   };
+}
+
+export function getPoems() {
+  switch (appOptions.level.standaloneAppName) {
+    case PoetryStandaloneApp.PoetryHoc:
+      return POEMS;
+    case PoetryStandaloneApp.TimeCapsule:
+      return TIME_CAPSULE_POEMS;
+    default:
+      return {};
+  }
 }

--- a/apps/src/templates/projects/projectTypeMap.js
+++ b/apps/src/templates/projects/projectTypeMap.js
@@ -37,7 +37,8 @@ export const PROJECT_TYPE_MAP = {
   poetry_hoc: i18n.projectTypePoetry(),
   thebadguys: i18n.projectTypeThebadguys(),
   science: i18n.projectTypeScience(),
-  story: i18n.projectTypeStory()
+  story: i18n.projectTypeStory(),
+  time_capsule: i18n.projectTypeTimeCapsule()
 };
 
 export const FEATURED_PROJECT_TYPE_MAP = {

--- a/dashboard/app/controllers/projects_controller.rb
+++ b/dashboard/app/controllers/projects_controller.rb
@@ -162,6 +162,9 @@ class ProjectsController < ApplicationController
     science: {
       name: 'New Science Project'
     },
+    time_capsule: {
+      name: 'New Time Capsule Project'
+    }
   }.with_indifferent_access.freeze
 
   @@project_level_cache = {}

--- a/dashboard/app/models/levels/poetry.rb
+++ b/dashboard/app/models/levels/poetry.rb
@@ -33,7 +33,7 @@ class Poetry < GamelabJr
   )
 
   def check_default_poem
-    self.default_poem = nil unless standalone_app_name == 'poetry_hoc'
+    self.default_poem = nil unless Poetry.subtypes_with_poems.include?(standalone_app_name)
   end
 
   # Poetry levels use the same shared_functions as GamelabJr
@@ -42,7 +42,11 @@ class Poetry < GamelabJr
   end
 
   def self.standalone_app_names
-    [['Poetry', 'poetry'], ['Poetry HOC', 'poetry_hoc']]
+    [['Poetry', 'poetry'], ['Poetry HOC', 'poetry_hoc'],  ['Time Capsule', 'time_capsule']]
+  end
+
+  def self.subtypes_with_poems
+    %w(poetry_hoc time_capsule)
   end
 
   def self.skins
@@ -81,6 +85,17 @@ class Poetry < GamelabJr
   end
 
   # Used by levelbuilders to set a default poem on a Poetry level.
+  def self.poems_for_subtype(subtype)
+    case subtype
+    when 'poetry_hoc'
+      hoc_poems
+    when 'time_capsule'
+      time_capsule_poems
+    else
+      []
+    end
+  end
+
   def self.hoc_poems
     [
       ['', ''],
@@ -106,6 +121,13 @@ class Poetry < GamelabJr
       ['An Afternoon Nap', 'lomeli1'],
       ['An Ode to Imagery', 'lomeli2'],
       ['Nothing Gold Can Stay', 'frost']
+    ]
+  end
+
+  def self.time_capsule_poems
+    [
+      ['', ''],
+      ['1990 - My Poem 1', 'pat'],
     ]
   end
 end

--- a/dashboard/app/views/levels/editors/fields/_poetry_fields.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_poetry_fields.html.haml
@@ -4,7 +4,7 @@
 #poetry_fields
   .field
     = f.label :standalone_app_name, 'Level Subtype'
-    %p Poetry HOC levels have a poem dropdown above the playspace and auto-animate the poem.
+    %p Poetry HOC and Time Capsule levels have a poem dropdown above the playspace and auto-animate the poem.
     - if local_assigns[:warning]
       %p= "WARNING: #{warning}"
     = f.select :standalone_app_name, options_for_select(@level.class.standalone_app_names, @level.standalone_app_name), {}, onchange: 'toggleFields(this.value);'
@@ -16,7 +16,7 @@
 :javascript
   function toggleFields(val) {
     const defaultPoem = document.getElementById('defaultPoem');
-    if (val.toLowerCase() === 'poetry_hoc') {
+    if (val.toLowerCase() !== 'poetry') {
       defaultPoem.classList.remove('collapse');
     } else {
       defaultPoem.classList.add('collapse');

--- a/dashboard/app/views/levels/editors/fields/_poetry_fields.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_poetry_fields.html.haml
@@ -9,9 +9,9 @@
       %p= "WARNING: #{warning}"
     = f.select :standalone_app_name, options_for_select(@level.class.standalone_app_names, @level.standalone_app_name), {}, onchange: 'toggleFields(this.value);'
 
-  #defaultPoem{class: ('collapse' if @level.standalone_app_name != 'poetry_hoc')}
+  #defaultPoem{class: ('collapse' if @level.standalone_app_name == 'poetry')}
     = f.label :default_poem, 'Default Poem'
-    = f.select :default_poem, options_for_select(@level.class.hoc_poems, @level.default_poem)
+    = f.select :default_poem, options_for_select(@level.class.poems_for_subtype(@level.standalone_app_name), @level.default_poem)
 
 :javascript
   function toggleFields(val) {

--- a/dashboard/config/scripts/levels/New Time Capsule Project.level
+++ b/dashboard/config/scripts/levels/New Time Capsule Project.level
@@ -19,6 +19,7 @@
     "submittable": "false",
     "never_autoplay_video": "false",
     "disable_param_editing": "true",
+    "is_project_level": true,
     "hide_share_and_remix": "false",
     "disable_if_else_editing": "false",
     "include_shared_functions": "false",

--- a/dashboard/config/scripts/levels/New Time Capsule Project.level
+++ b/dashboard/config/scripts/levels/New Time Capsule Project.level
@@ -1,0 +1,136 @@
+<Poetry>
+  <config><![CDATA[{
+  "properties": {
+    "encrypted": "false",
+    "skin": "gamelab",
+    "block_pools": [
+      "GamelabJr",
+      "Poetry"
+    ],
+    "helper_libraries": [
+      "NativeSpriteLab"
+    ],
+    "use_default_sprites": "true",
+    "hide_animation_mode": "false",
+    "show_type_hints": true,
+    "use_modal_function_editor": "true",
+    "embed": "false",
+    "instructions_important": "false",
+    "submittable": "false",
+    "never_autoplay_video": "false",
+    "disable_param_editing": "true",
+    "hide_share_and_remix": "false",
+    "disable_if_else_editing": "false",
+    "include_shared_functions": "false",
+    "free_play": "true",
+    "validation_enabled": "false",
+    "show_debug_watch": "false",
+    "expand_debugger": "false",
+    "debugger_disabled": "false",
+    "start_in_animation_tab": "false",
+    "all_animations_single_frame": "false",
+    "hide_pause_button": "false",
+    "standalone_app_name": "time_capsule",
+    "preload_asset_list": null,
+    "encrypted_examples": [
+
+    ]
+  },
+  "game_id": 69,
+  "published": true,
+  "created_at": "2023-02-24T06:28:51.000Z",
+  "level_num": "custom",
+  "user_id": 1,
+  "audit_log": "[{\"changed_at\":\"2023-02-23T14:28:51.371-08:00\",\"changed\":[\"cloned from \\\"New Poetry HOC Project\\\"\"],\"cloned_from\":\"New Poetry HOC Project\"},{\"changed_at\":\"2023-02-23 14:31:58 -0800\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"standalone_app_name\",\"preload_asset_list\"],\"changed_by_id\":6959,\"changed_by_email\":\"molly+levelbuilder@code.org\"},{\"changed_at\":\"2023-02-23 14:50:59 -0800\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"default_poem\",\"preload_asset_list\",\"encrypted_examples\"],\"changed_by_id\":6959,\"changed_by_email\":\"molly+levelbuilder@code.org\"},{\"changed_at\":\"2023-02-23 15:27:31 -0800\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"preload_asset_list\",\"encrypted_examples\"],\"changed_by_id\":6959,\"changed_by_email\":\"molly+levelbuilder@code.org\"},{\"changed_at\":\"2023-02-23 15:27:54 -0800\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"preload_asset_list\",\"encrypted_examples\",\"default_poem\"],\"changed_by_id\":6959,\"changed_by_email\":\"molly+levelbuilder@code.org\"},{\"changed_at\":\"2023-02-23 15:28:29 -0800\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"preload_asset_list\",\"encrypted_examples\"],\"changed_by_id\":6959,\"changed_by_email\":\"molly+levelbuilder@code.org\"},{\"changed_at\":\"2023-02-23 15:51:33 -0800\",\"changed\":[\"start_blocks\",\"toolbox_blocks\",\"preload_asset_list\",\"encrypted_examples\",\"default_poem\"],\"changed_by_id\":6959,\"changed_by_email\":\"molly+levelbuilder@code.org\"}]",
+  "level_concept_difficulty": {
+  }
+}]]></config>
+  <blocks>
+    <start_blocks>
+      <xml>
+        <block type="when_run" deletable="false" movable="false"/>
+      </xml>
+    </start_blocks>
+    <toolbox_blocks>
+      <xml xmlns="https://developers.google.com/blockly/xml">
+        <block type="Poetry_whenLineShows" id="2">
+          <title name="N">0</title>
+        </block>
+        <block type="Poetry_makeNewSpriteAnon" id="3">
+          <title name="ANIMATION_NAME">"night_cloud"</title>
+          <title name="LOCATION">{"x":200,"y":225}</title>
+        </block>
+        <block type="Poetry_setSize" id="4">
+          <title name="SPRITE">"night_cloud"</title>
+          <title name="VAL">50</title>
+        </block>
+        <block type="Poetry_startBehavior" id="5">
+          <title name="ANIMATION_NAME">"night_cloud"</title>
+          <title name="BEHAVIOR">growing</title>
+        </block>
+        <block type="Poetry_stopBehavior" id="6">
+          <title name="ANIMATION_NAME">"night_cloud"</title>
+          <title name="BEHAVIOR">fluttering</title>
+        </block>
+        <block type="Poetry_destroy" id="7">
+          <title name="ANIMATION_NAME">"night_cloud"</title>
+        </block>
+        <block type="Poetry_makeBurst" id="8">
+          <title name="EFFECT">"pop"</title>
+          <title name="NUM">10</title>
+          <title name="ANIMATION_NAME">"firework_blue"</title>
+        </block>
+        <block type="Poetry_makeNumSprites" id="9">
+          <title name="NUM">3</title>
+          <title name="ANIMATION_NAME">"night_cloud"</title>
+        </block>
+        <block type="Poetry_setForegroundEffect" id="10">
+          <title name="EFFECT">"rain"</title>
+        </block>
+        <block type="Poetry_playMusic" id="11">
+          <title name="SOUND">"sound://category_loops/vibrant_game_harping_down_forever_loop_2_accent.mp3"</title>
+        </block>
+        <block type="Poetry_playSound" id="12">
+          <title name="SOUND">"sound://category_digital/boing_2.mp3"</title>
+        </block>
+        <block type="Poetry_setFont" id="13">
+          <title name="FONT">"Arial"</title>
+        </block>
+        <block type="Poetry_setFontColor" id="14">
+          <value name="FILL">
+            <block type="colour_picker" id="15">
+              <title name="COLOUR">#ffcc00</title>
+            </block>
+          </value>
+        </block>
+        <block type="Poetry_setTextEffect" id="16">
+          <title name="EFFECT">"fade"</title>
+        </block>
+        <block type="Poetry_addTextHighlight" id="17">
+          <value name="COLOR">
+            <block type="colour_picker" id="18">
+              <title name="COLOUR">#ffff99</title>
+            </block>
+          </value>
+        </block>
+        <block type="Poetry_setBackground" id="19">
+          <value name="COLOR">
+            <block type="colour_picker" id="20">
+              <title name="COLOUR">#cc0000</title>
+            </block>
+          </value>
+        </block>
+        <block type="Poetry_setBackgroundEffect" id="21">
+          <title name="EFFECT">"blooming"</title>
+          <title name="PALETTE">"spring"</title>
+        </block>
+        <block type="gamelab_setBackgroundImageAs" id="22">
+          <title name="IMG">"blue_watercolor"</title>
+        </block>
+        <block type="Poetry_addFrame" id="23">
+          <title name="BRUSH">"zigzag"</title>
+        </block>
+      </xml>
+    </toolbox_blocks>
+  </blocks>
+</Poetry>


### PR DESCRIPTION
It's a requirement for CSC to have a Time Capsule subtype of Poetry that has its own set of poems in the poem dropdown. This PR does the following:
- Create the new subtype, along with a new standalone level for that subtype
- Update our dropdown logic to hide if the subtype is `poetry`, as both `poetry_hoc` and `time_capsule` now have a dropdown (there are only 3 subtypes).
- Update the poem dropdown logic to select the list based on the subtype, instead of always showing the `poetry_hoc` poems.
- Add a single poem to the Time Capsule dropdown. I will do a follow-up PR with the rest of the poems.

## Links

- jira ticket: [SL-559](https://codedotorg.atlassian.net/browse/SL-559)

## Testing story
Tested locally that the new subtype works as expected, and the other subtypes are not affected.

## Follow-up work
- Curriculum can edit the standalone level to fit their needs. Right now it is basically a clone of the `poetry_hoc` standalone level.
- Add the rest of the poems. I am splitting out that work to keep this PR smaller.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
