### PR TITLE
adding courses.yml to the sync in

### DIFF
--- a/bin/i18n-codeorg/in.sh
+++ b/bin/i18n-codeorg/in.sh
@@ -27,6 +27,7 @@ cp_in $orig_dir/restricted.en.yml $loc_dir/restricted.yml
 cp_in $orig_dir/scripts.en.yml $loc_dir/scripts.yml
 cp_in $orig_dir/slides.en.yml $loc_dir/slides.yml
 cp_in $orig_dir/unplugged.en.yml $loc_dir/unplugged.yml
+cp_in $orig_dir/courses.en.yml $loc_dir/courses.yml
 
 ### Apps
 


### PR DESCRIPTION
The course overview is a small description available to teachers, students and non-signed-in users for each of the courses we offer.

The content of those overviews is stored in the file `dashboard/config/locales/courses.en.yml`.
Content is already translatable in the `unit_group.rb` model. However the last time `courses.en.yml` was synced was in 2019, when a refactoring of the sync was made in [PR #28769](https://github.com/code-dot-org/code-dot-org/pull/28769). 

The refactoring  switch form a pattern-based sync-in to a file-by-file sync-in for the `*.yml` dashboard files in the `in.sh` script.
This file-by-file sync-in did not include `courses.en.yml` which resulted into any content added to the files after was not synced-in and therefore never reached the i18n pipeline.

This PR adds `courses.en.yml` to the sync-in.

## Links

- jira ticket: [P20-37](https://codedotorg.atlassian.net/browse/P20-37)

## Testing story
I ran the full sync in the testing project:
- Checked that `courses.yml` was updated to Crowdin.
- Translated some strings to test.
- Checked that translated content was synced down successfully.

Before and after picture attached for tested link: http://localhost-studio.code.org:3000/courses/csd-2022?lang=es-MX

![Screenshot 2023-02-24 at 15 18 51](https://user-images.githubusercontent.com/66776217/221298900-3ddeff78-d60c-421c-a0de-dc573de27b36.png)
