### PR TITLE
SL-528: Parse start_html using ::HTML to preserve expanded tags and fix App Lab rendering

### DIFF
--- a/dashboard/app/models/levels/blockly.rb
+++ b/dashboard/app/models/levels/blockly.rb
@@ -449,10 +449,10 @@ class Blockly < Level
 
   def localized_start_html(start_html)
     return unless start_html
-    start_html_xml = Nokogiri::XML(start_html, &:noblanks)
+    start_html_doc = Nokogiri::HTML(start_html, &:noblanks)
 
     # match any element that contains text
-    start_html_xml.xpath('//*[text()[normalize-space()]]').each do |element|
+    start_html_doc.xpath('//*[text()[normalize-space()]]').each do |element|
       localized_text = I18n.t(
         element.text,
         scope: [:data, :start_html, name],
@@ -462,12 +462,8 @@ class Blockly < Level
       element.content = localized_text if localized_text
     end
 
-    # NO_EMPTY_TAGS used because <element /> blocks fail to render correctly but
-    # <element></element> works, see: https://codedotorg.atlassian.net/browse/SL-528.
-    # TODO: Should we add UTF-8 encoding? We have it here: https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/models/levels/blockly.rb#L520.
-    start_html_xml.serialize(
-      save_with: XML_OPTIONS | Nokogiri::XML::Node::SaveOptions::NO_EMPTY_TAGS
-    ).strip
+    # returning the children of body removes extra <html><body> tags added by parsing with ::HTML
+    start_html_doc.xpath("//body").children.to_html(encoding: 'UTF-8')
   end
 
   def localized_authored_hints

--- a/dashboard/app/models/levels/blockly.rb
+++ b/dashboard/app/models/levels/blockly.rb
@@ -462,7 +462,10 @@ class Blockly < Level
       element.content = localized_text if localized_text
     end
 
-    start_html_xml.serialize(save_with: XML_OPTIONS).strip
+    start_html_xml.serialize(
+      save_with: XML_OPTIONS | Nokogiri::XML::Node::SaveOptions::NO_EMPTY_TAGS,
+      encoding: 'UTF-8'
+    ).strip
   end
 
   def localized_authored_hints

--- a/dashboard/app/models/levels/blockly.rb
+++ b/dashboard/app/models/levels/blockly.rb
@@ -463,7 +463,7 @@ class Blockly < Level
     end
 
     # returning the children of body removes extra <html><body> tags added by parsing with ::HTML
-    start_html_doc.xpath("//body").children.to_html(encoding: 'UTF-8')
+    start_html_doc.xpath("//body").children.to_html(encoding: 'UTF-8', save_with: 0)
   end
 
   def localized_authored_hints

--- a/dashboard/app/models/levels/blockly.rb
+++ b/dashboard/app/models/levels/blockly.rb
@@ -463,7 +463,12 @@ class Blockly < Level
     end
 
     # returning the children of body removes extra <html><body> tags added by parsing with ::HTML
-    start_html_doc.xpath("//body").children.to_html(encoding: 'UTF-8', save_with: 0)
+    # the save_with option prevents the to_html method from pretty printing and adding newlines
+    # see: https://github.com/premailer/premailer/issues/345
+    start_html_doc.xpath("//body").children.to_html(
+      encoding: 'UTF-8',
+      save_with: Nokogiri::XML::Node::SaveOptions::DEFAULT_HTML ^ Nokogiri::XML::Node::SaveOptions::FORMAT
+    )
   end
 
   def localized_authored_hints

--- a/dashboard/app/models/levels/blockly.rb
+++ b/dashboard/app/models/levels/blockly.rb
@@ -463,8 +463,7 @@ class Blockly < Level
     end
 
     start_html_xml.serialize(
-      save_with: XML_OPTIONS | Nokogiri::XML::Node::SaveOptions::NO_EMPTY_TAGS,
-      encoding: 'UTF-8'
+      save_with: XML_OPTIONS | Nokogiri::XML::Node::SaveOptions::NO_EMPTY_TAGS
     ).strip
   end
 

--- a/dashboard/app/models/levels/blockly.rb
+++ b/dashboard/app/models/levels/blockly.rb
@@ -462,6 +462,9 @@ class Blockly < Level
       element.content = localized_text if localized_text
     end
 
+    # NO_EMPTY_TAGS used because <element /> blocks fail to render correctly but
+    # <element></element> works, see: https://codedotorg.atlassian.net/browse/SL-528.
+    # TODO: Should we add UTF-8 encoding? We have it here: https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/models/levels/blockly.rb#L520.
     start_html_xml.serialize(
       save_with: XML_OPTIONS | Nokogiri::XML::Node::SaveOptions::NO_EMPTY_TAGS
     ).strip

--- a/dashboard/test/models/levels/blockly_test.rb
+++ b/dashboard/test/models/levels/blockly_test.rb
@@ -1246,4 +1246,18 @@ class BlocklyTest < ActiveSupport::TestCase
     parsed_xml = Nokogiri::XML(localized_block_xml, &:noblanks)
     assert_equal parsed_xml.at_xpath('//block[@type="studio_ask"]/*[@name="VAR"]').content, localized_variable_str
   end
+
+  test 'keeps tags expanded when localizing start_html' do
+    level = create(
+      :level,
+      :blockly,
+      name: 'test localized_start_html',
+    )
+    start_html = '<div><button id="leftBottomButton" style="padding: 0px; margin: 0px; border-style: solid; background-color: rgb(68, 44, 46); border-radius: 20px; border-width: 0px; border-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-family: Verdana, Geneva, sans-serif; font-size: 15px; position: absolute; left: 10px; top: 250px; background-size: contain; background-position: 50% 50%; background-repeat: no-repeat; width: 45px; height: 190px;" data-canonical-image-url="icon://fa-long-arrow-left" data-icon-color="#ffffff"></button><label style="margin: 0px; padding: 2px; line-height: 1; overflow: hidden; overflow-wrap: break-word; max-width: 320px; border-style: solid; background-color: rgb(254, 234, 230); border-width: 0px; border-color: rgb(255, 255, 255); color: rgb(68, 44, 46); font-family: Arial, Helvetica, sans-serif; position: absolute; left: 0px; top: 4.44089e-16px; border-radius: 4px; height: 40px; width: 320px; font-size: 36px; text-rendering: optimizespeed;" id="appName"> &nbsp;Outfit Picker</label></div>'
+    localized_start_html = level.localized_start_html(start_html)
+
+    # Output should use <button></button> instead of <button />
+    expected_output = '<div><button id="leftBottomButton" style="padding: 0px; margin: 0px; border-style: solid; background-color: rgb(68, 44, 46); border-radius: 20px; border-width: 0px; border-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-family: Verdana, Geneva, sans-serif; font-size: 15px; position: absolute; left: 10px; top: 250px; background-size: contain; background-position: 50% 50%; background-repeat: no-repeat; width: 45px; height: 190px;" data-canonical-image-url="icon://fa-long-arrow-left" data-icon-color="#ffffff"></button><label style="margin: 0px; padding: 2px; line-height: 1; overflow: hidden; overflow-wrap: break-word; max-width: 320px; border-style: solid; background-color: rgb(254, 234, 230); border-width: 0px; border-color: rgb(255, 255, 255); color: rgb(68, 44, 46); font-family: Arial, Helvetica, sans-serif; position: absolute; left: 0px; top: 4.44089e-16px; border-radius: 4px; height: 40px; width: 320px; font-size: 36px; text-rendering: optimizespeed;" id="appName"> Outfit Picker</label></div>'
+    assert_equal expected_output, localized_start_html
+  end
 end

--- a/dashboard/test/models/levels/blockly_test.rb
+++ b/dashboard/test/models/levels/blockly_test.rb
@@ -1253,11 +1253,11 @@ class BlocklyTest < ActiveSupport::TestCase
       :blockly,
       name: 'test localized_start_html',
     )
-    start_html = '<div><button id="leftBottomButton"></button><label >Outfit Picker</label></div>'
+    start_html = '<div><button id="leftBottomButton"></button><label>Outfit Picker</label></div>'
     localized_start_html = level.localized_start_html(start_html)
 
     # Output should use <button></button> instead of <button />
-    expected_output = '<div><button id="leftBottomButton"></button><label >Outfit Picker</label></div>'
+    expected_output = '<div><button id="leftBottomButton"></button><label>Outfit Picker</label></div>'
     assert_equal expected_output, localized_start_html
   end
 end

--- a/dashboard/test/models/levels/blockly_test.rb
+++ b/dashboard/test/models/levels/blockly_test.rb
@@ -1253,11 +1253,11 @@ class BlocklyTest < ActiveSupport::TestCase
       :blockly,
       name: 'test localized_start_html',
     )
-    start_html = '<div><button id="leftBottomButton" style="padding: 0px; margin: 0px; border-style: solid; background-color: rgb(68, 44, 46); border-radius: 20px; border-width: 0px; border-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-family: Verdana, Geneva, sans-serif; font-size: 15px; position: absolute; left: 10px; top: 250px; background-size: contain; background-position: 50% 50%; background-repeat: no-repeat; width: 45px; height: 190px;" data-canonical-image-url="icon://fa-long-arrow-left" data-icon-color="#ffffff"></button><label style="margin: 0px; padding: 2px; line-height: 1; overflow: hidden; overflow-wrap: break-word; max-width: 320px; border-style: solid; background-color: rgb(254, 234, 230); border-width: 0px; border-color: rgb(255, 255, 255); color: rgb(68, 44, 46); font-family: Arial, Helvetica, sans-serif; position: absolute; left: 0px; top: 4.44089e-16px; border-radius: 4px; height: 40px; width: 320px; font-size: 36px; text-rendering: optimizespeed;" id="appName"> &nbsp;Outfit Picker</label></div>'
+    start_html = '<div><button id="leftBottomButton"></button><label >Outfit Picker</label></div>'
     localized_start_html = level.localized_start_html(start_html)
 
     # Output should use <button></button> instead of <button />
-    expected_output = '<div><button id="leftBottomButton" style="padding: 0px; margin: 0px; border-style: solid; background-color: rgb(68, 44, 46); border-radius: 20px; border-width: 0px; border-color: rgb(255, 255, 255); color: rgb(255, 255, 255); font-family: Verdana, Geneva, sans-serif; font-size: 15px; position: absolute; left: 10px; top: 250px; background-size: contain; background-position: 50% 50%; background-repeat: no-repeat; width: 45px; height: 190px;" data-canonical-image-url="icon://fa-long-arrow-left" data-icon-color="#ffffff"></button><label style="margin: 0px; padding: 2px; line-height: 1; overflow: hidden; overflow-wrap: break-word; max-width: 320px; border-style: solid; background-color: rgb(254, 234, 230); border-width: 0px; border-color: rgb(255, 255, 255); color: rgb(68, 44, 46); font-family: Arial, Helvetica, sans-serif; position: absolute; left: 0px; top: 4.44089e-16px; border-radius: 4px; height: 40px; width: 320px; font-size: 36px; text-rendering: optimizespeed;" id="appName"> Outfit Picker</label></div>'
+    expected_output = '<div><button id="leftBottomButton"></button><label >Outfit Picker</label></div>'
     assert_equal expected_output, localized_start_html
   end
 end


### PR DESCRIPTION
The following PR fixes several instances in which folks are seeing App Lab levels with jumbled/misplaced UI elements on sample applications (see screenshots below). The issue is that the call to `Nokogiri::XML` turns expanded tags in our HTML (ex. `<button ...></button>`) to self-enclosing tags (ex. `<button ... />`), and for some reason, this "breaks" the element rendering. 

It turns out the config option that fixes this issue is [already in place](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/models/levels/blockly.rb#L520) at another point in our code. Still, I did not discover that the `Nokogiri::XML::Node::SaveOptions::NO_EMPTY_TAGS` config value was used elsewhere until I finished my investigation.

I diagnosed by looking at the diff in the HTML at every step in the `localized_start_html`. The `start_html` that serves as the argument to this function renders correctly, but as soon as we call `start_html_xml = Nokogiri::XML(start_html, &:noblanks)`, the `start_html_xml` reproduces the bug in an HTML renderer. Since Nokogiri can perform its operations on the self-enclosing tags, we don't need to expand the tags until before we return them from `localized_start_html`. This is good because the config option we need to pass to expand all HTML tags is a valid argument to `start_html_xml.serialize` but cannot be passed to `Nokogiri::XML` to keep them from getting collapsed in the first place.

**NOTE:** This config option will expand _all_ tags, including any that were self-closing in our `start_html`. Theoretically, expanding tags meant to be self-enclosing could also cause issues, but expanding all tags seems to solve most of our problems (see screenshots below). 

For posterity/documentation, https://github.com/sparklemotion/nokogiri/issues/2324 describes a similar issue, but in the opposite direction (self-closing tags being converted to expanded tags), and is the issue that eventually led me to my fix. 

I do not know _why_ using self-enclosing tags instead of expanded tags would cause the issue, but given the volume of tickets we're receiving, it seems worth getting a fix out while we continue the investigation. 

## Links

Jira tickets:
https://codedotorg.atlassian.net/browse/SL-528
https://codedotorg.atlassian.net/browse/P20-43

Zendesk tickets:
https://codeorg.zendesk.com/agent/tickets/427471
https://codeorg.zendesk.com/agent/tickets/424893
https://codeorg.zendesk.com/agent/tickets/430408

## Testing story

**Before** 
Note: These screenshots were generated by resetting version history while the page is in Danish on studio.code.org. I have reproduced this with other languages, including Spanish and French.

https://studio.code.org/s/csp5-2022/lessons/2/levels/1
<img width="321" alt="Screen Shot 2023-02-27 at 12 10 26 PM" src="https://user-images.githubusercontent.com/26844240/221676254-fbe76f69-562c-48ae-ab3c-af3df68a644f.png">

https://studio.code.org/s/csp5-2022/lessons/10/levels/1
<img width="320" alt="Screen Shot 2023-02-27 at 12 25 20 PM" src="https://user-images.githubusercontent.com/26844240/221677624-1209550b-982d-48d0-85fb-aa80af5717c4.png">

https://studio.code.org/s/csp7-2022/lessons/4/levels/2
<img width="315" alt="Screen Shot 2023-02-27 at 12 20 15 PM" src="https://user-images.githubusercontent.com/26844240/221676200-2ba70432-8374-4398-9d2b-00b090522756.png">

https://studio.code.org/s/csp7-2022/lessons/3/levels/6
<img width="313" alt="Screen Shot 2023-02-27 at 12 43 59 PM" src="https://user-images.githubusercontent.com/26844240/221681377-9e8a83b1-7ee2-4c8f-93d3-c95ead5ce663.png">

**After**
Note: These screenshots were generated by resetting version history while the page is in Danish on localhost-studio.code.org:3000. I have reproduced this with other languages, including Spanish and French.

http://localhost-studio.code.org:3000/s/csp5-2022/lessons/2/levels/1
<img width="196" alt="Screen Shot 2023-02-27 at 12 28 06 PM" src="https://user-images.githubusercontent.com/26844240/221678169-6ff77f1f-d4e4-48ab-81fa-932af1fc7f4c.png">

http://localhost-studio.code.org:3000/s/csp5-2022/lessons/10/levels/1
<img width="200" alt="Screen Shot 2023-02-27 at 12 29 14 PM" src="https://user-images.githubusercontent.com/26844240/221678378-9417a8f3-a770-4fd1-b334-762ffe6c133c.png">

http://localhost-studio.code.org:3000/s/csp7-2022/lessons/4/levels/2
<img width="194" alt="Screen Shot 2023-02-27 at 12 30 54 PM" src="https://user-images.githubusercontent.com/26844240/221678707-66d27ccb-9ee5-4759-9557-4533e65acf18.png">

http://localhost-studio.code.org:3000/s/csp7-2022/lessons/3/levels/6
<img width="193" alt="Screen Shot 2023-02-27 at 12 45 05 PM" src="https://user-images.githubusercontent.com/26844240/221681551-da67b747-f36e-4d54-9281-d2feed21acfa.png">
The screenshot above is not totally fixed because of another bug with how Nokogiri handles spaces, but it is much better than the original! I will file a follow-up ticket and link here. 


<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
