### PR TITLE
[Google Blockly] Use blockRendering class for ThrasosPathObject

### DIFF
--- a/apps/src/blockly/addons/cdoPathObjectThrasos.js
+++ b/apps/src/blockly/addons/cdoPathObjectThrasos.js
@@ -1,6 +1,7 @@
 import GoogleBlockly from 'blockly/core';
 
-export default class CdoPathObject extends GoogleBlockly.geras.PathObject {
+export default class CdoPathObject extends GoogleBlockly.blockRendering
+  .PathObject {
   // The built-in function also adds a cross-hatch fill pattern to disabled blocks, which we don't want.
   // Overrriding the function here so we can just set the class but not add the fill pattern.
   updateDisabled_(disabled) {


### PR DESCRIPTION
Alternative to:
- https://github.com/code-dot-org/code-dot-org/pull/50466

Thrasos uses the `BaseRenderer` path object, but our `CdoThrasosPathObject` is extending from the geras one. If we instead extend from `Blockly.blockRendering.PathObject`, we get the expected block renderering and don't lose our overrides either.

![image](https://user-images.githubusercontent.com/43474485/221647286-bf8954c9-4fbc-4beb-8b7c-8e74f42fa610.png)


Geras has its own PathObject class that has a lot of customizations:
https://developers.google.com/blockly/reference/js/blockly.geras_namespace.pathobject_class.md 
For Thrasos, we should be extending the base class instead of the highly customized Geras one.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
