### PR TITLE
Set `PreferredName` for `Naming/RescuedExceptionsVariableName`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -53,6 +53,9 @@ Layout/SpaceInsideBlockBraces:
 Layout/SpaceInsideHashLiteralBraces:
   EnforcedStyle: no_space
 
+Naming/RescuedExceptionsVariableName:
+  PreferredName: exception
+
 Style/EmptyElse:
   EnforcedStyle: empty
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,20 +31,11 @@ CustomCops/OnlyAllowedCharacters:
   Include:
     - '**/*_mailer.rb'
 
-Layout/ParameterAlignment:
-  EnforcedStyle: with_fixed_indentation
-
 Layout/DotPosition:
   EnforcedStyle: trailing
 
-Style/EmptyElse:
-  EnforcedStyle: empty
-
 Layout/EmptyLineBetweenDefs:
   AllowAdjacentOneLineDefs: true
-
-Style/EmptyMethod:
-  EnforcedStyle: expanded
 
 Layout/FirstParameterIndentation:
   EnforcedStyle: consistent
@@ -52,11 +43,8 @@ Layout/FirstParameterIndentation:
 Layout/MultilineMethodCallBraceLayout:
   EnforcedStyle: new_line
 
-Style/NumericLiterals:
-  MinDigits: 7
-
-Style/Semicolon:
-  AllowAsExpressionSeparator: true
+Layout/ParameterAlignment:
+  EnforcedStyle: with_fixed_indentation
 
 Layout/SpaceInsideBlockBraces:
   EnforcedStyle: no_space
@@ -64,6 +52,18 @@ Layout/SpaceInsideBlockBraces:
 
 Layout/SpaceInsideHashLiteralBraces:
   EnforcedStyle: no_space
+
+Style/EmptyElse:
+  EnforcedStyle: empty
+
+Style/EmptyMethod:
+  EnforcedStyle: expanded
+
+Style/NumericLiterals:
+  MinDigits: 7
+
+Style/Semicolon:
+  AllowAsExpressionSeparator: true
 
 Style/WordArray:
   MinSize: 5

--- a/aws/ci_build
+++ b/aws/ci_build
@@ -55,8 +55,8 @@ def upload_log_and_get_link(key, body, metadata)
         {metadata: metadata}
       )
   " <a href='#{log_url}'>☁ Log on S3</a>"
-rescue Exception => e
-  ChatClient.log "Uploading log to S3 failed: #{e}"
+rescue Exception => exception
+  ChatClient.log "Uploading log to S3 failed: #{exception}"
   return ''
 end
 
@@ -93,8 +93,8 @@ def build
       end
 
       result
-    rescue => e
-      CDO.backtrace e
+    rescue => exception
+      CDO.backtrace exception
     end
 
     FileUtils.rm STARTED if File.file?(STARTED)
@@ -109,8 +109,8 @@ def main
   status = 0
   log = RakeUtils.capture do
     status = build
-  rescue => e
-    status = "Error: #{e.message}\n#{CDO.backtrace e}"
+  rescue => exception
+    status = "Error: #{exception.message}\n#{CDO.backtrace exception}"
   end
   return status if status == 0 && log.empty?
 
@@ -272,9 +272,9 @@ def emit_deploy_metric(deployment_stage, successful)
       }]
     }
   )
-rescue => e
+rescue => exception
   ChatClient.log 'Unable to emit metrics', color: 'red'
-  ChatClient.log "/quote #{e}", color: 'gray', message_format: 'text'
+  ChatClient.log "/quote #{exception}", color: 'gray', message_format: 'text'
 end
 
 main

--- a/aws/cloudformation/access_logs.rb
+++ b/aws/cloudformation/access_logs.rb
@@ -45,12 +45,12 @@ def handler(event:, context:)
         result: 'Ok',
         data: Base64.encode64(output.to_h.to_json)
       }
-    rescue => e
-      puts "Error: #{e.full_message}"
+    rescue => exception
+      puts "Error: #{exception.full_message}"
       {
         recordId: record['recordId'],
         result: 'ProcessingFailed',
-        data: Base64.encode64({error: e.full_message}.to_json)
+        data: Base64.encode64({error: exception.full_message}.to_json)
       }
     end
   }

--- a/aws/cloudformation/fast_snapshot_restore.rb
+++ b/aws/cloudformation/fast_snapshot_restore.rb
@@ -19,8 +19,8 @@ def handler(event:, context:)
     raise 'Unsupported type'
   end
   CfnResponse.send(event, context, 'SUCCESS', physical_resource_id: physical_resource_id)
-rescue => e
-  CfnResponse.send(event, context, 'FAILURE', message: e.message)
+rescue => exception
+  CfnResponse.send(event, context, 'FAILURE', message: exception.message)
 end
 
 EC2 = Aws::EC2::Client.new
@@ -56,6 +56,6 @@ def delete(properties)
     availability_zones: azs,
     source_snapshot_ids: snapshots
   )
-rescue => e
-  puts "Ignoring error on delete: #{e}"
+rescue => exception
+  puts "Ignoring error on delete: #{exception}"
 end

--- a/aws/lambda/ssm_session_slack/ssm_session_slack.rb
+++ b/aws/lambda/ssm_session_slack/ssm_session_slack.rb
@@ -43,8 +43,8 @@ def handler(event:, context:)
       user_id = slack.users_lookupByEmail(email: session_name)&.user&.id
       username = user_id ? "<@#{user_id}>" : session_name
     end
-  rescue => e
-    puts e # Log Slack exceptions
+  rescue => exception
+    puts exception # Log Slack exceptions
   end
 
   instance_id = detail.dig('requestParameters', 'target')
@@ -61,8 +61,8 @@ def handler(event:, context:)
       logical_id = tags['aws:cloudformation:logical-id']
       instance_name = "#{stack_name}:#{logical_id}" if stack_name && logical_id
     end
-  rescue => e
-    puts e # Log EC2 exceptions
+  rescue => exception
+    puts exception # Log EC2 exceptions
   end
 
   ip = detail['sourceIPAddress']
@@ -70,8 +70,8 @@ def handler(event:, context:)
     if (loc = Geocoder.search(ip).first)
       ip += " (#{loc.address})"
     end
-  rescue => e
-    puts e # Log geocoder exceptions
+  rescue => exception
+    puts exception # Log geocoder exceptions
   end
 
   message = {

--- a/bin/animation_assets/for_each_library_animation.rb
+++ b/bin/animation_assets/for_each_library_animation.rb
@@ -43,8 +43,8 @@ class AnimationIterator
     progress_bar.finish
 
   # Report any issues while talking to S3 and suggest most likely steps for fixing it.
-  rescue Aws::Errors::ServiceError => e
-    warn e.inspect
+  rescue Aws::Errors::ServiceError => exception
+    warn exception.inspect
     warn <<-EOS.unindent
 
       #{bold 'There was an error talking to S3.'}  Make sure you have credentials set using one of:

--- a/bin/animation_assets/manifest_builder.rb
+++ b/bin/animation_assets/manifest_builder.rb
@@ -88,8 +88,8 @@ class ManifestBuilder
     end
 
   # Report any issues while talking to S3 and suggest most likely steps for fixing it.
-  rescue Aws::Errors::ServiceError => e
-    warn e.inspect
+  rescue Aws::Errors::ServiceError => exception
+    warn exception.inspect
     warn <<-EOS.unindent
 
       #{bold 'There was an error talking to S3.'}  Make sure you have credentials set using one of:
@@ -142,10 +142,10 @@ class ManifestBuilder
         objects['json'].get(response_target: json_destination)
         verbose "Writing #{png_destination}"
         objects['png'].get(response_target: png_destination)
-      rescue Aws::Errors::ServiceError => e
+      rescue Aws::Errors::ServiceError => exception
         next <<~WARN
           There was an error retrieving #{name}.json and #{name}.png from S3:
-          #{e}
+          #{exception}
           The animation has been skipped.
         WARN
       end
@@ -163,8 +163,8 @@ class ManifestBuilder
     EOS
 
   # Report any issues while talking to S3 and suggest most likely steps for fixing it.
-  rescue Aws::Errors::ServiceError => e
-    warn e.inspect
+  rescue Aws::Errors::ServiceError => exception
+    warn exception.inspect
     warn <<-EOS.unindent
 
       #{bold 'There was an error talking to S3.'}  Make sure you have credentials set using one of:
@@ -321,16 +321,16 @@ class ManifestBuilder
       begin
         json_response = objects['json'].get
         metadata = JSON.parse(json_response.body.read)
-      rescue Aws::Errors::ServiceError => e
+      rescue Aws::Errors::ServiceError => exception
         next <<~WARN
           There was an error retrieving #{name}.json from S3:
-          #{e}
+          #{exception}
           The animation has been skipped.
         WARN
-      rescue JSON::JSONError => e
+      rescue JSON::JSONError => exception
         next <<~WARN
           There was an error parsing #{name}.json:
-          #{e}
+          #{exception}
           The animation has been skipped.
         WARN
       end
@@ -353,10 +353,10 @@ class ManifestBuilder
       # consistently reference the version they originally imported.
       begin
         metadata['version'] = objects['png'].object.version_id
-      rescue Aws::Errors::ServiceError => e
+      rescue Aws::Errors::ServiceError => exception
         next <<~WARN
           There was an error retrieving the version_id for #{name}.png from S3:
-          #{e}
+          #{exception}
           The animation has been skipped.
         WARN
       end

--- a/bin/circle/merge-eyes-baselines
+++ b/bin/circle/merge-eyes-baselines
@@ -18,8 +18,8 @@ begin
   else
     puts 'Latest commit does not appear to be a merge commit, not performing any baseline copying.'
   end
-rescue => e
-  puts "Eyes baseline not merged: #{e.message}"
+rescue => exception
+  puts "Eyes baseline not merged: #{exception.message}"
 end
 
 exit(0)

--- a/bin/cron/applab_datasets/spotify
+++ b/bin/cron/applab_datasets/spotify
@@ -57,9 +57,9 @@ def get_token
     }
     auth_response = JSON.parse(RestClient.post(TOKEN_URL, form, headers))
     $token = auth_response['access_token']
-  rescue RestClient::Exception => e
+  rescue RestClient::Exception => exception
     Honeybadger.notify_cronjob_error(
-      e,
+      exception,
       error_message: "Failed to retrieve OAuth token from Spotify for use in App Lab Datasets.",
       context: {
         tenant_id: client_id,
@@ -76,9 +76,9 @@ def get_playlist_data(chart_type, playlist_id)
   begin
     url = "#{BASE_URL}/playlists/#{playlist_id}?#{field_query}"
     response = RestClient.get(url, {authorization: "Bearer #{$token}"})
-  rescue RestClient::Exception => e
+  rescue RestClient::Exception => exception
     Honeybadger.notify_cronjob_error(
-      e,
+      exception,
       error_message: "Failed to retrieve playlist data from Spotify for use in App Lab Datasets.",
       context: {
         playlist_id: playlist_id,

--- a/bin/cron/commit_content
+++ b/bin/cron/commit_content
@@ -79,8 +79,8 @@ def main
   ChatClient.log(content_committer.commit_happening_string)
   content_committer.commit_content
   ChatClient.log(content_committer.commit_happened_string)
-rescue Exception => e
-  ChatClient.message(rack_env.to_s, "<@#{DevelopersTopic.dotd}> EXCEPTION: #{e.message}", color: 'red')
+rescue Exception => exception
+  ChatClient.message(rack_env.to_s, "<@#{DevelopersTopic.dotd}> EXCEPTION: #{exception.message}", color: 'red')
   content_committer.set_slack_failed
 end
 

--- a/bin/cron/create_rollup_tables
+++ b/bin/cron/create_rollup_tables
@@ -170,9 +170,9 @@ def main
         #{batch.map {|row| contained_levels_row(row)}.join(",\n")}
       SQL
     end
-  rescue => e
+  rescue => exception
     Honeybadger.notify(
-      e,
+      exception,
       error_message: "Error when writing contained_levels"
     )
   end
@@ -193,9 +193,9 @@ def main
         #{batch.map {|row| contained_level_answers_row(row)}.join(",\n")}
       SQL
     end
-  rescue => e
+  rescue => exception
     Honeybadger.notify(
-      e,
+      exception,
       error_message: "Error when writing contained_level_answers"
     )
   end
@@ -215,9 +215,9 @@ def main
         #{batch.map {|row| level_sources_multi_types_row(row)}.join(",\n")}
       SQL
     end
-  rescue => e
+  rescue => exception
     Honeybadger.notify(
-      e,
+      exception,
       error_message: "Error when writing level_sources_multi_type"
     )
   end
@@ -311,10 +311,10 @@ def insert_pd_applications_status_logs_rows(rows)
       VALUES
       #{rows.map {|row| pd_applications_status_logs_row(row)}.join(",\n")}
     SQL
-  rescue => e
-    puts e
+  rescue => exception
+    puts exception
     Honeybadger.notify(
-      e,
+      exception,
       error_message: "Error when writing pd_applications_status_logs"
     )
   end

--- a/bin/cron/delete_twilio_data
+++ b/bin/cron/delete_twilio_data
@@ -41,10 +41,10 @@ def main
     end
 
     message.delete
-  rescue Twilio::REST::RestError => e
+  rescue Twilio::REST::RestError => exception
     # Sanitize the exception message so that we don't expose secrets.
-    e.message.gsub! CDO.twilio_sid, 'CDO.twilio_sid'
-    Honeybadger.notify(e)
+    exception.message.gsub! CDO.twilio_sid, 'CDO.twilio_sid'
+    Honeybadger.notify(exception)
     next
   end
 end

--- a/bin/cron/deliver_poste_messages
+++ b/bin/cron/deliver_poste_messages
@@ -65,23 +65,23 @@ def main
 
       begin
         deliverer.send delivery
-      rescue Net::SMTPSyntaxError, Net::SMTPFatalError => e
+      rescue Net::SMTPSyntaxError, Net::SMTPFatalError => exception
         Honeybadger.notify(
-          e,
-          error_message: "Unable to deliver #{delivery[:id]} to '#{delivery[:contact_email]}' because '#{e.message.to_s.strip}'"
+          exception,
+          error_message: "Unable to deliver #{delivery[:id]} to '#{delivery[:contact_email]}' because '#{exception.message.to_s.strip}'"
         )
         deliverer.reset_connection
         sent_at = 0
-      rescue AbortEmailError => e
+      rescue AbortEmailError => exception
         Honeybadger.notify(
-          e,
-          error_message: "Abandoning delivery of #{delivery[:id]} because '#{e.message.to_s.strip}'"
+          exception,
+          error_message: "Abandoning delivery of #{delivery[:id]} because '#{exception.message.to_s.strip}'"
         )
         sent_at = 0
-      rescue => e
+      rescue => exception
         Honeybadger.notify(
-          e,
-          error_message: "Unable to deliver #{delivery[:id]} to '#{delivery[:contact_email]}' because '#{e.message.to_s.strip}'"
+          exception,
+          error_message: "Unable to deliver #{delivery[:id]} to '#{delivery[:contact_email]}' because '#{exception.message.to_s.strip}'"
         )
         raise
       end

--- a/bin/cron/deploy_to_levelbuilder
+++ b/bin/cron/deploy_to_levelbuilder
@@ -91,10 +91,10 @@ def main
     branch_name: branch_name,
     base_branch: 'origin/levelbuilder'
   )
-rescue Exception => e
+rescue Exception => exception
   ChatClient.message(
     'levelbuilder',
-    "<@#{DevelopersTopic.dotd}> EXCEPTION: #{e.message}",
+    "<@#{DevelopersTopic.dotd}> EXCEPTION: #{exception.message}",
     color: 'red'
   )
   DevelopersTopic.set_dtl TOPIC_DTL_FAILED

--- a/bin/cron/deploy_to_test
+++ b/bin/cron/deploy_to_test
@@ -38,10 +38,10 @@ def main
     color: 'green'
   )
   Metrics.write_metric('dtt_start', GitHub.sha('test'), Metrics::AUTOMATIC)
-rescue Exception => e
+rescue Exception => exception
   ChatClient.message(
     'infra-test',
-    "EXCEPTION: #{e.message}\n```\n#{e.class}\n#{e.backtrace}\n```",
+    "EXCEPTION: #{exception.message}\n```\n#{exception.class}\n#{exception.backtrace}\n```",
     color: 'red'
   )
   DevelopersTopic.set_dtt TOPIC_DTT_FAILED

--- a/bin/cron/export_mysql_database_to_redshift
+++ b/bin/cron/export_mysql_database_to_redshift
@@ -58,9 +58,9 @@ def main
     RedshiftImport.complete_table_import(Cdo::DMS.redshift_schemas_imported_from_database)
     ChatClient.message 'data', "Completed weekly export from Aurora MySQL database to Redshift."
   end
-rescue StandardError => e
-  ChatClient.message 'data', "Error during export from Aurora MySQL database to Redshift #{e}", color: 'red'
-  raise e
+rescue StandardError => exception
+  ChatClient.message 'data', "Error during export from Aurora MySQL database to Redshift #{exception}", color: 'red'
+  raise exception
 ensure
   Cdo::RDS.delete_cluster(RedshiftImport::CLONE_CLUSTER_ID)
 end

--- a/bin/cron/merge_lb_to_staging
+++ b/bin/cron/merge_lb_to_staging
@@ -63,10 +63,10 @@ def main
     "robo-DTS created and merged <a href=\"#{GitHub.url(pr_number)}\">PR#{pr_number}</a>",
     color: 'green'
   )
-rescue Exception => e
+rescue Exception => exception
   ChatClient.message(
     'staging',
-    "<!here> EXCEPTION: #{e.message}",
+    "<!here> EXCEPTION: #{exception.message}",
     color: 'red'
   )
   DevelopersTopic.set_dts 'no (robo-DTS failed (Levelbuilder > Staging))'

--- a/bin/cron/process_forms
+++ b/bin/cron/process_forms
@@ -32,9 +32,9 @@ def send_receipts(kind, form)
 
   begin
     recipient = Poste2.create_recipient(form[:email], name: form[:name], ip_address: form[:updated_ip])
-  rescue ArgumentError => e
-    raise e unless /Invalid email address/.match?(e.message)
-    ChatClient.log "Unable to send receipt for form #{form[:id]} because #{e.message}."
+  rescue ArgumentError => exception
+    raise exception unless /Invalid email address/.match?(exception.message)
+    ChatClient.log "Unable to send receipt for form #{form[:id]} because #{exception.message}."
     return 0
   end
   receipts.each do |template|
@@ -71,17 +71,17 @@ def process_batch_of_forms
       elsif kind.respond_to?(:process)
         processed_data = kind.process(JSON.parse(form[:data]))
       end
-    rescue AbortFormError => e
-      ChatClient.log "Unable to process form #{form[:id]} because #{e.message}."
+    rescue AbortFormError => exception
+      ChatClient.log "Unable to process form #{form[:id]} because #{exception.message}."
       DB[:forms].where(id: form[:id]).update(
         processed_at: DATE_FOR_ERRORS,
         indexed_at: DATE_FOR_ERRORS,
         notified_at: DATE_FOR_ERRORS
       )
       next
-    rescue Exception => e
-      ChatClient.log "Unable to process form #{form[:id]} because #{e.message}."
-      raise e
+    rescue Exception => exception
+      ChatClient.log "Unable to process form #{form[:id]} because #{exception.message}."
+      raise exception
     end
 
     DB[:forms].where(id: form[:id]).update(processed_data: processed_data.to_json, processed_at: DateTime.now)

--- a/bin/cron/push_latest_aurora_backup_to_secondary_account
+++ b/bin/cron/push_latest_aurora_backup_to_secondary_account
@@ -25,9 +25,9 @@ def main
   copied_snapshot_on_backup = AuroraBackup.backup_latest_snapshot(rds_client, rds_client_backup, backup_account_id, CDO.db_cluster_id)
 
   ChatClient.message 'cron-daily', "Completed cross account RDS backup: #{copied_snapshot_on_backup.snapshot_id}"
-rescue => e
-  ChatClient.message 'cron-daily', e.message, color: 'red'
-  raise e
+rescue => exception
+  ChatClient.message 'cron-daily', exception.message, color: 'red'
+  raise exception
 end
 
 main

--- a/bin/cron/restart_high_memory_frontend_services
+++ b/bin/cron/restart_high_memory_frontend_services
@@ -72,8 +72,8 @@ def main
       ChatClient.message 'infra-production', capture(restart_command, raise_on_non_zero_exit: false)
     end
     ChatClient.message 'infra-production', 'Done finding and restarting front end services with high memory utilization'
-  rescue StandardError => e
-    ChatClient.message 'infra-production', "Error finding/restarting frond end services with high memory utilization - #{e}"
+  rescue StandardError => exception
+    ChatClient.message 'infra-production', "Error finding/restarting frond end services with high memory utilization - #{exception}"
   end
 end
 

--- a/bin/cronjob
+++ b/bin/cronjob
@@ -69,8 +69,8 @@ def main
 
   honeybadger_notify command, exitstatus, stdout, stderr
   email_notify command, exitstatus, result, ARGV[1]
-rescue => e
-  Honeybadger.notify_cronjob_error e
+rescue => exception
+  Honeybadger.notify_cronjob_error exception
   raise
 end
 

--- a/bin/curriculum/migrate_unit.rb
+++ b/bin/curriculum/migrate_unit.rb
@@ -76,8 +76,8 @@ def main(options)
     models = ['Lesson', 'Activity']
     script.lessons.each do |lesson|
       LessonImportHelper.update_lesson(lesson, models)
-    rescue => e
-      raise e, "Error migrating unit #{script.name.dump} lesson #{lesson.name.dump}: #{e}", e.backtrace
+    rescue => exception
+      raise exception, "Error migrating unit #{script.name.dump} lesson #{lesson.name.dump}: #{exception}", exception.backtrace
     end
 
     has_lesson_plans = script.lessons.any?(&:has_lesson_plan)

--- a/bin/i18n/sync-all.rb
+++ b/bin/i18n/sync-all.rb
@@ -153,9 +153,9 @@ class I18nSync
       raise "Tried to return to staging branch from unknown branch #{GitUtils.current_branch.inspect}"
     end
     `git checkout staging` if should_i "switch to staging branch"
-  rescue => e
-    puts "return_to_staging_branch failed from the error: #{e}"
-    raise e
+  rescue => exception
+    puts "return_to_staging_branch failed from the error: #{exception}"
+    raise exception
   end
 end
 

--- a/bin/i18n/sync-down.rb
+++ b/bin/i18n/sync-down.rb
@@ -51,9 +51,9 @@ def sync_down
     end
 
     puts "Sync down completed successfully"
-  rescue => e
-    puts "Sync down failed from the error: #{e}"
-    raise e
+  rescue => exception
+    puts "Sync down failed from the error: #{exception}"
+    raise exception
   end
 end
 

--- a/bin/i18n/sync-in.rb
+++ b/bin/i18n/sync-in.rb
@@ -36,9 +36,9 @@ def sync_in
   redact_labs_content
   localize_markdown_content
   puts "Sync in completed successfully"
-rescue => e
-  puts "Sync in failed from the error: #{e}"
-  raise e
+rescue => exception
+  puts "Sync in failed from the error: #{exception}"
+  raise exception
 end
 
 # Takes strings describing and naming Framework, StandardCategory, and Standard

--- a/bin/i18n/sync-out.rb
+++ b/bin/i18n/sync-out.rb
@@ -36,9 +36,9 @@ def sync_out(upload_manifests=false)
   end
   clean_up_sync_out(CROWDIN_PROJECTS)
   puts "Sync out completed successfully"
-rescue => e
-  puts "Sync out failed from the error: #{e}"
-  raise e
+rescue => exception
+  puts "Sync out failed from the error: #{exception}"
+  raise exception
 end
 
 # Cleans up any files the sync-out is responsible for managing. When this function is done running,
@@ -585,15 +585,15 @@ def restore_markdown_headers
     end
     begin
       source_header, _source_content, _source_line = Documents.new.helpers.parse_yaml_header(source_path)
-    rescue Exception => e
+    rescue Exception => exception
       puts "Error parsing yaml header in source_path=#{source_path} for path=#{path}"
-      raise e
+      raise exception
     end
     begin
       header, content, _line = Documents.new.helpers.parse_yaml_header(path)
-    rescue Exception => e
+    rescue Exception => exception
       puts "Error parsing yaml header path=#{path}"
-      raise e
+      raise exception
     end
     I18nScriptUtils.sanitize_header!(header)
     restored_header = source_header.merge(header)

--- a/bin/i18n/sync-up.rb
+++ b/bin/i18n/sync-up.rb
@@ -28,9 +28,9 @@ def sync_up
     end
 
     puts "Sync up completed successfully"
-  rescue => e
-    puts "Sync up failed from the error: #{e}"
-    raise e
+  rescue => exception
+    puts "Sync up failed from the error: #{exception}"
+    raise exception
   end
 end
 

--- a/bin/i18n/translation_monitor/crowdin_validator.rb
+++ b/bin/i18n/translation_monitor/crowdin_validator.rb
@@ -90,9 +90,9 @@ class CrowdinValidator
             puts "Wrote history to file #{history_file}"
           end
         end
-      rescue Exception => e
-        puts "Error: #{e.message}"
-        puts e.backtrace
+      rescue Exception => exception
+        puts "Error: #{exception.message}"
+        puts exception.backtrace
       end
     end
   end

--- a/bin/oneoff/backfill_data/backfill_script_announcement_keys.rb
+++ b/bin/oneoff/backfill_data/backfill_script_announcement_keys.rb
@@ -19,9 +19,9 @@ def backfill_script_announcement_keys
     end
     begin
       script.save!
-    rescue Exception => e
+    rescue Exception => exception
       puts "Skipping #{script.id} - #{script.name} because of error:"
-      puts e.message
+      puts exception.message
       next
     end
 

--- a/bin/oneoff/backfill_data/backfill_script_ids_in_teacher_feedbacks.rb
+++ b/bin/oneoff/backfill_data/backfill_script_ids_in_teacher_feedbacks.rb
@@ -40,8 +40,8 @@ def update_script_ids
         # case we want the script to stop so that we can investigate.
         script_id = teacher_feedback.script_level.script_id
         teacher_feedback.update!(script_id: script_id)
-      rescue => e
-        puts "Error updating teacher feedback id #{teacher_feedback.id}: #{e}"
+      rescue => exception
+        puts "Error updating teacher feedback id #{teacher_feedback.id}: #{exception}"
       end
 
       raise ActiveRecord::Rollback unless $options[:actually_update]

--- a/bin/oneoff/backfill_data/backfill_script_ids_in_teacher_feedbacks_2.rb
+++ b/bin/oneoff/backfill_data/backfill_script_ids_in_teacher_feedbacks_2.rb
@@ -43,8 +43,8 @@ def update_script_ids
             script = stable_scripts.first
             teacher_feedback.update!(script_id: script.id)
           end
-        rescue => e
-          puts "Error updating teacher feedback id #{teacher_feedback.id}: #{e}"
+        rescue => exception
+          puts "Error updating teacher feedback id #{teacher_feedback.id}: #{exception}"
         end
         raise ActiveRecord::Rollback unless $options[:actually_update]
       end

--- a/bin/oneoff/backfill_data/destroy_sections_and_followers
+++ b/bin/oneoff/backfill_data/destroy_sections_and_followers
@@ -38,9 +38,9 @@ begin
     end
     count += 1
   end
-rescue Exception => e
+rescue Exception => exception
   puts "PROCESSED: #{count} records."
-  raise e
+  raise exception
 ensure
   ActiveRecord::Base.record_timestamps = true
 end

--- a/bin/oneoff/backfill_data/form_geos
+++ b/bin/oneoff/backfill_data/form_geos
@@ -44,7 +44,7 @@ begin
 
     start_index += batch_size
   end
-rescue Exception => e
+rescue Exception => exception
   puts "PROCESSING: #{log_message}"
-  raise e
+  raise exception
 end

--- a/bin/oneoff/backfill_data/user_proficiencies
+++ b/bin/oneoff/backfill_data/user_proficiencies
@@ -376,9 +376,9 @@ def update_database
       end
       slice_count += 1
     end
-  rescue Exception => e
+  rescue Exception => exception
     puts "EXCEPTION: PROCESSING #{slice_count}..."
-    raise e
+    raise exception
   end
   puts "UPDATED DB."
 end

--- a/bin/oneoff/backfill_data/user_school_infos_backfill
+++ b/bin/oneoff/backfill_data/user_school_infos_backfill
@@ -16,9 +16,9 @@ User.where.not(school_info: nil).where(user_type: "teacher").find_in_batches(bat
         start_date: user.created_at,
         last_confirmation_date: user.last_seen_school_info_interstitial.nil? ? user.created_at : user.last_seen_school_info_interstitial
       )
-    rescue StandardError => e
+    rescue StandardError => exception
       puts "Error: teacher with user id #{user.id} with school id #{user.school_info_id}"
-      exceptions.push(e)
+      exceptions.push(exception)
     end
     if exceptions.any?
       puts exceptions

--- a/bin/oneoff/backfill_data/user_scripts_for_sections
+++ b/bin/oneoff/backfill_data/user_scripts_for_sections
@@ -74,7 +74,7 @@ begin
       end
     end
   end
-rescue Exception => e
+rescue Exception => exception
   puts "EXCEPTION: #{user_id_script_id}..."
-  raise e
+  raise exception
 end

--- a/bin/oneoff/backfill_data/user_scripts_for_user_levels
+++ b/bin/oneoff/backfill_data/user_scripts_for_user_levels
@@ -195,8 +195,8 @@ begin
 
     slice_count += 1
   end
-rescue Exception => e
+rescue Exception => exception
   puts "EXCEPTION: #{user_id_script_id}..."
-  raise e
+  raise exception
 end
 puts 'FINISHED DB WRITES.'

--- a/bin/oneoff/backfill_parent-child_relationships.rb
+++ b/bin/oneoff/backfill_parent-child_relationships.rb
@@ -9,8 +9,8 @@ def main
     if level.contained_level_names.present?
       begin
         level.setup_contained_levels
-      rescue => e
-        puts e
+      rescue => exception
+        puts exception
       end
     end
 
@@ -20,8 +20,8 @@ def main
     if level.project_template_level_name.present?
       begin
         level.setup_project_template_level
-      rescue => e
-        puts e
+      rescue => exception
+        puts exception
       end
     end
     # rubocop:enable Style/Next

--- a/bin/oneoff/backfill_pegasus_forms_sans_solr.rb
+++ b/bin/oneoff/backfill_pegasus_forms_sans_solr.rb
@@ -51,13 +51,13 @@ def process_existing_batch_of_forms
           update_count += 1
         end
       end
-    rescue AbortFormError => e
-      warn "Unable to process form #{form[:id]} because #{e.message}."
+    rescue AbortFormError => exception
+      warn "Unable to process form #{form[:id]} because #{exception.message}."
       error_count += 1
       next
-    rescue Exception => e
-      warn "Unable to process form #{form[:id]} because #{e.message}."
-      raise e
+    rescue Exception => exception
+      warn "Unable to process form #{form[:id]} because #{exception.message}."
+      raise exception
     end
   end
 

--- a/bin/oneoff/block_deletion.rb
+++ b/bin/oneoff/block_deletion.rb
@@ -73,7 +73,7 @@ Block.all.each do |shared_block|
       remove_block(level, name)
       similar_blocks << block
     end
-  rescue => e
-    puts "Failed on #{level.name}, #{e}"
+  rescue => exception
+    puts "Failed on #{level.name}, #{exception}"
   end
 end

--- a/bin/oneoff/data_fix/assign_missing_names
+++ b/bin/oneoff/data_fix/assign_missing_names
@@ -70,6 +70,6 @@ nameless_ids.each do |user_id|
   user.save!
 
   puts "success"
-rescue => e
-  puts "error - #{e}"
+rescue => exception
+  puts "error - #{exception}"
 end

--- a/bin/oneoff/data_fix/fix_invalid_users
+++ b/bin/oneoff/data_fix/fix_invalid_users
@@ -69,9 +69,9 @@ User.where(username: nil).
 
       raise ActiveRecord::Rollback unless options[:actually_update]
     end
-  rescue => e
+  rescue => exception
     generate_username_errors += 1
-    CDO.log.error e
+    CDO.log.error exception
   end
 end
 
@@ -88,9 +88,9 @@ User.where(provider: nil).
 
       raise ActiveRecord::Rollback unless options[:actually_update]
     end
-  rescue => e
+  rescue => exception
     destroy_user_errors += 1
-    CDO.log.error e
+    CDO.log.error exception
   end
 end
 

--- a/bin/oneoff/data_fix/level_group_data
+++ b/bin/oneoff/data_fix/level_group_data
@@ -205,9 +205,9 @@ def main
         end
       end
     end
-  rescue Exception => e
+  rescue Exception => exception
     puts "EXCEPTION ON USER_LEVEL_ID: #{e_user_level_id}."
-    raise e
+    raise exception
   end
 end
 

--- a/bin/oneoff/data_fix/missing_emails
+++ b/bin/oneoff/data_fix/missing_emails
@@ -40,13 +40,13 @@ File.foreach('/tmp/teacher_emails.csv').with_index do |line, line_num|
     # the account to a teacher account, populating the plaintext email address.
     puts "UPDATING: #{user.id} (#{email})..."
     user.update!(user_type: User::TYPE_TEACHER, email: email)
-  rescue Exception => e
+  rescue Exception => exception
     # Since exceptions may happen naturally, we simply log the relevant
     # information to the console and give the executing user a chance to abort
     # the script.
     puts "EXCEPTION:"
     puts "  USER: #{user}"
-    puts "  MESSAGE: #{e.message}"
+    puts "  MESSAGE: #{exception.message}"
     sleep(10)
   end
 end

--- a/bin/oneoff/data_fix/non_us_users_with_race
+++ b/bin/oneoff/data_fix/non_us_users_with_race
@@ -37,10 +37,10 @@ File.foreach('/tmp/non_us_ids_with_races.csv').with_index do |line, line_num|
     begin
       puts "UPDATING: #{user.id} (deleting races: #{user.races})..."
       user.update!(races: nil) # this will delete the races property altogether in the JSON, not just clear it
-    rescue Exception => e
+    rescue Exception => exception
       puts "EXCEPTION:"
       puts "  USER: #{user}"
-      puts "  MESSAGE: #{e.message}"
+      puts "  MESSAGE: #{exception.message}"
       sleep(10)
     end
   rescue ActiveRecord::RecordNotFound

--- a/bin/oneoff/data_fix/time_spent_milliseconds_to_seconds
+++ b/bin/oneoff/data_fix/time_spent_milliseconds_to_seconds
@@ -28,8 +28,8 @@ UserLevel.find_each(start: 93_221_000, finish: 2_811_329_000, batch_size: 5000).
     # update without validation, callbacks, or changes to updated_at
     user_level.update_columns(time_spent: new_time_spent)
   end
-rescue Exception => e
-  puts "Error with user_level #{user_level.id}. Skipping and continuing. Error message: #{e.message}"
+rescue Exception => exception
+  puts "Error with user_level #{user_level.id}. Skipping and continuing. Error message: #{exception.message}"
 end
 
 puts "Finished!"

--- a/bin/oneoff/diff_email_previews
+++ b/bin/oneoff/diff_email_previews
@@ -150,10 +150,10 @@ def download_workshop_emails(output_folder)
     # However it has DateTime field that changes, so we exclude it from the comparison.
     # If we really want to compare headers, we will have to update diff command to ignore DateTime regex.
     # IO.copy_stream(open(base + preview), "#{output_folder}/#{preview}.html")
-  rescue => e
+  rescue => exception
     puts "\nFailed to download #{preview}"
-    puts "Error class: #{e.class.name}"
-    puts "Error msg: #{e.message}"
+    puts "Error class: #{exception.class.name}"
+    puts "Error msg: #{exception.message}"
   end
   puts
 end
@@ -168,9 +168,9 @@ def compare_workshop_emails(folder1, folder2)
   system(shell_command)
 
   puts "Comparision result saved to diffresult.txt"
-rescue => e
-  puts "Error class: #{e.class.name}"
-  puts "Error message: #{e.message}"
+rescue => exception
+  puts "Error class: #{exception.class.name}"
+  puts "Error message: #{exception.message}"
 end
 
 def main

--- a/bin/oneoff/find_unseeded_level_concept_difficulty.rb
+++ b/bin/oneoff/find_unseeded_level_concept_difficulty.rb
@@ -52,10 +52,10 @@ def find_mismatched_levels
     else
       matching_levels += 1
     end
-  rescue Exception => e
+  rescue Exception => exception
     # print filename for better debugging
-    new_e = Exception.new("in level: #{path}: #{e.message}")
-    new_e.set_backtrace(e.backtrace)
+    new_e = Exception.new("in level: #{path}: #{exception.message}")
+    new_e.set_backtrace(exception.backtrace)
     raise new_e
   end
 

--- a/bin/oneoff/move_census_data.rb
+++ b/bin/oneoff/move_census_data.rb
@@ -459,9 +459,9 @@ DB[:forms].where(kind: @census_form_kinds).each do |form|
     puts "Skipping form #{form_id} becasue it has already been migrated to census submission #{previous_migrations[0].census_submission_id}" if @verbose
     skips += 1
   end
-rescue Exception => e
-  puts "Error processing form id #{form[:id]}: #{e.message}"
-  puts e.backtrace if @verbose
+rescue Exception => exception
+  puts "Error processing form id #{form[:id]}: #{exception.message}"
+  puts exception.backtrace if @verbose
   failures += 1
 end
 

--- a/bin/oneoff/remove_controls_for_counter_mutations.rb
+++ b/bin/oneoff/remove_controls_for_counter_mutations.rb
@@ -44,10 +44,10 @@ def remove_controls_for_counter_mutations
     raw_level_data = xml.root.to_s
     File.write(path, raw_level_data)
     updated_levels += 1
-  rescue Exception => e
+  rescue Exception => exception
     # print filename for better debugging
-    new_e = Exception.new("in level: #{path}: #{e.message}")
-    new_e.set_backtrace(e.backtrace)
+    new_e = Exception.new("in level: #{path}: #{exception.message}")
+    new_e.set_backtrace(exception.backtrace)
     raise new_e
   end
 

--- a/bin/oneoff/remove_password_for_code_studio_admin.rb
+++ b/bin/oneoff/remove_password_for_code_studio_admin.rb
@@ -69,6 +69,6 @@ ADMIN_IDS.each do |admin_id|
     raise ActiveRecord::Rollback.new, "Intentional rollback" if DRY_RUN
     puts "Admin password updated - #{admin_id}"
   end
-rescue StandardError => e
-  puts "Error, admin password is not updated - #{admin_id} / #{e}"
+rescue StandardError => exception
+  puts "Error, admin password is not updated - #{admin_id} / #{exception}"
 end

--- a/bin/oneoff/rescore_taught_in_past
+++ b/bin/oneoff/rescore_taught_in_past
@@ -26,8 +26,8 @@ ActiveRecord::Base.transaction do
         rescored_applications << update_string
       end
     end
-  rescue => e
-    puts "Failure on application #{application.id}:\n#{e.message}\n#{application&.errors&.messages}"
+  rescue => exception
+    puts "Failure on application #{application.id}:\n#{exception.message}\n#{application&.errors&.messages}"
     raise
   end
 

--- a/bin/oneoff/send_facilitator_decision_emails
+++ b/bin/oneoff/send_facilitator_decision_emails
@@ -15,8 +15,8 @@ ActiveRecord::Base.transaction do
         applications_emailed << "id: #{application.id}, status: #{application.status}"
       end
     end
-  rescue => e
-    puts "Failure on application #{application.id}:\n#{e.message}\n#{application&.errors&.messages}"
+  rescue => exception
+    puts "Failure on application #{application.id}:\n#{exception.message}\n#{application&.errors&.messages}"
     raise
   end
 

--- a/bin/oneoff/set_2022_ayw_email_settings.rb
+++ b/bin/oneoff/set_2022_ayw_email_settings.rb
@@ -8,7 +8,7 @@ Pd::Workshop.where("subject LIKE '%Academic Year Workshop%'").select {|w| w.crea
       workshop.update!(suppress_email: false)
       puts "Successfully updated workshop id #{workshop.id}"
     end
-  rescue => e
-    puts "Error updating workshop id #{workshop.id}: #{e}"
+  rescue => exception
+    puts "Error updating workshop id #{workshop.id}: #{exception}"
   end
 end

--- a/bin/oneoff/update_behavior_blocks_ids.rb
+++ b/bin/oneoff/update_behavior_blocks_ids.rb
@@ -70,10 +70,10 @@ def update_behavior_blocks_ids
     raw_level_data = xml.root.to_s
     File.write(path, raw_level_data)
     updated_levels += 1
-  rescue Exception => e
+  rescue Exception => exception
     # print filename for better debugging
-    new_e = Exception.new("in level: #{path}: #{e.message}")
-    new_e.set_backtrace(e.backtrace)
+    new_e = Exception.new("in level: #{path}: #{exception.message}")
+    new_e.set_backtrace(exception.backtrace)
     raise new_e
   end
 

--- a/bin/oneoff/update_behavior_blocks_ids2.rb
+++ b/bin/oneoff/update_behavior_blocks_ids2.rb
@@ -70,10 +70,10 @@ def update_behavior_blocks_ids
     raw_level_data = xml.root.to_s
     File.write(path, raw_level_data)
     updated_levels += 1
-  rescue Exception => e
+  rescue Exception => exception
     # print filename for better debugging
-    new_e = Exception.new("in level: #{path}: #{e.message}")
-    new_e.set_backtrace(e.backtrace)
+    new_e = Exception.new("in level: #{path}: #{exception.message}")
+    new_e.set_backtrace(exception.backtrace)
     raise new_e
   end
 

--- a/bin/oneoff/update_behavior_blocks_ids3.rb
+++ b/bin/oneoff/update_behavior_blocks_ids3.rb
@@ -89,10 +89,10 @@ def update_behavior_blocks_ids
     raw_level_data = xml.root.to_s
     File.write(path, raw_level_data)
     updated_levels += 1
-  rescue Exception => e
+  rescue Exception => exception
     # print filename for better debugging
-    new_e = Exception.new("in level: #{path}: #{e.message}")
-    new_e.set_backtrace(e.backtrace)
+    new_e = Exception.new("in level: #{path}: #{exception.message}")
+    new_e.set_backtrace(exception.backtrace)
     raise new_e
   end
 

--- a/bin/oneoff/update_behavior_blocks_ids4.rb
+++ b/bin/oneoff/update_behavior_blocks_ids4.rb
@@ -87,10 +87,10 @@ def update_behavior_blocks_ids
     raw_level_data = xml.root.to_s
     File.write(path, raw_level_data)
     updated_levels += 1
-  rescue Exception => e
+  rescue Exception => exception
     # print filename for better debugging
-    new_e = Exception.new("in level: #{path}: #{e.message}")
-    new_e.set_backtrace(e.backtrace)
+    new_e = Exception.new("in level: #{path}: #{exception.message}")
+    new_e.set_backtrace(exception.backtrace)
     raise new_e
   end
 

--- a/bin/oneoff/wipe_data/fnd-929_remove_old_code_studio_account_permissions
+++ b/bin/oneoff/wipe_data/fnd-929_remove_old_code_studio_account_permissions
@@ -121,6 +121,6 @@ USERS_TO_REVOKE.each do |user_id|
 
     puts "User ID successfully revoked - #{user_id}"
   end
-rescue StandardError => e
-  puts "Error revoking User ID - #{user_id} / #{e}"
+rescue StandardError => exception
+  puts "Error revoking User ID - #{user_id} / #{exception}"
 end

--- a/bin/oneoff/wipe_data/opt_out_petition_emails_under_16
+++ b/bin/oneoff/wipe_data/opt_out_petition_emails_under_16
@@ -43,8 +43,8 @@ def main
         ip_address: EmailPreferenceHelper::CODE_DOT_ORG,
         form_kind: '0'
       )
-    rescue StandardError => e
-      CDO.log.info "Skipping email address - #{petition[:email]} - #{e}."
+    rescue StandardError => exception
+      CDO.log.info "Skipping email address - #{petition[:email]} - #{exception}."
     end
   CDO.log.info "Finished Opt Out of Petition Emails Under 16"
 end

--- a/bin/oneoff/wipe_data/remove_unused_levelbuilder_users
+++ b/bin/oneoff/wipe_data/remove_unused_levelbuilder_users
@@ -92,6 +92,6 @@ USERS_TO_DELETE.each do |user_id|
 
     puts "User ID successfully destroyed - #{user_id}"
   end
-rescue StandardError => e
-  puts "Error destroying User ID - #{user_id} / #{e}"
+rescue StandardError => exception
+  puts "Error destroying User ID - #{user_id} / #{exception}"
 end

--- a/bin/oneoff/wipe_data/remove_unused_production_users
+++ b/bin/oneoff/wipe_data/remove_unused_production_users
@@ -60,6 +60,6 @@ USERS_TO_DELETE.each do |user_id|
 
     puts "User ID successfully destroyed - #{user_id}"
   end
-rescue StandardError => e
-  puts "Error destroying User ID - #{user_id} / #{e}"
+rescue StandardError => exception
+  puts "Error destroying User ID - #{user_id} / #{exception}"
 end

--- a/bin/oneoff/wipe_data_for_clever_district.rb
+++ b/bin/oneoff/wipe_data_for_clever_district.rb
@@ -24,6 +24,6 @@ begin
     found_students += 1
   end
   puts "Cleared data for #{found_students} students"
-rescue Clever::ApiError => e
-  puts "Exception: #{e}"
+rescue Clever::ApiError => exception
+  puts "Exception: #{exception}"
 end

--- a/dashboard/app/controllers/activities_controller.rb
+++ b/dashboard/app/controllers/activities_controller.rb
@@ -54,11 +54,11 @@ class ActivitiesController < ApplicationController
       if @level.game.sharing_filtered?
         begin
           share_failure = ShareFiltering.find_share_failure(params[:program], locale)
-        rescue OpenURI::HTTPError, IO::EAGAINWaitReadable => e
+        rescue OpenURI::HTTPError, IO::EAGAINWaitReadable => exception
           # If WebPurify or Geocoder fail, the program will be allowed, and we
           # retain the share_filtering_error to log it alongside the level_source
           # ID below.
-          share_filtering_error = e
+          share_filtering_error = exception
         end
       end
 

--- a/dashboard/app/controllers/admin_search_controller.rb
+++ b/dashboard/app/controllers/admin_search_controller.rb
@@ -86,8 +86,8 @@ class AdminSearchController < ApplicationController
         display_name: pilot_params[:display_name],
         allow_joining_via_url: pilot_params[:allow_joining_via_url]
       )
-    rescue StandardError => e
-      return render status: :bad_request, json: {error: e.message}
+    rescue StandardError => exception
+      return render status: :bad_request, json: {error: exception.message}
     end
 
     redirect_to :pilots

--- a/dashboard/app/controllers/admin_users_controller.rb
+++ b/dashboard/app/controllers/admin_users_controller.rb
@@ -284,8 +284,8 @@ class AdminUsersController < ApplicationController
 
     flash[:alert] = "MERGED: #{params[:studio_person_a_id]} and #{params[:studio_person_b_id]}"
     redirect_to studio_person_form_path
-  rescue ArgumentError => e
-    flash[:alert] = "MERGE FAILED: #{e.message}"
+  rescue ArgumentError => exception
+    flash[:alert] = "MERGE FAILED: #{exception.message}"
     redirect_to studio_person_form_path
   end
 
@@ -297,8 +297,8 @@ class AdminUsersController < ApplicationController
 
     flash[:alert] = "SPLIT: #{params[:studio_person_id]}"
     redirect_to studio_person_form_path
-  rescue ArgumentError => e
-    flash[:alert] = "SPLIT FAILED: #{e.message}"
+  rescue ArgumentError => exception
+    flash[:alert] = "SPLIT FAILED: #{exception.message}"
     redirect_to studio_person_form_path
   end
 
@@ -310,8 +310,8 @@ class AdminUsersController < ApplicationController
 
     flash[:alert] = "ADDED: #{params[:email]} to #{params[:studio_person_id]}"
     redirect_to studio_person_form_path
-  rescue ArgumentError => e
-    flash[:alert] = "ADD EMAIL FAILED: #{e.message}"
+  rescue ArgumentError => exception
+    flash[:alert] = "ADD EMAIL FAILED: #{exception.message}"
     redirect_to studio_person_form_path
   end
 

--- a/dashboard/app/controllers/api/v1/amazon_future_engineer_controller.rb
+++ b/dashboard/app/controllers/api/v1/amazon_future_engineer_controller.rb
@@ -67,9 +67,9 @@ class Api::V1::AmazonFutureEngineerController < ApplicationController
         privacy_permission: to_bool(afe_params['consentCSTA'])
       )
     end
-  rescue Services::AFEEnrollment::Error, Services::CSTAEnrollment::Error => e
-    Honeybadger.notify e
-    render json: e.to_s, status: :bad_request
+  rescue Services::AFEEnrollment::Error, Services::CSTAEnrollment::Error => exception
+    Honeybadger.notify exception
+    render json: exception.to_s, status: :bad_request
   end
 
   private

--- a/dashboard/app/controllers/api/v1/foorm_simple_survey_submissions_controller.rb
+++ b/dashboard/app/controllers/api/v1/foorm_simple_survey_submissions_controller.rb
@@ -8,8 +8,8 @@ class Api::V1::FoormSimpleSurveySubmissionsController < ApplicationController
     )
     begin
       submission.save_with_foorm_submission(answers.to_json, params[:form_name], params[:form_version])
-    rescue ActiveRecord::ActiveRecordError => e
-      render json: {error: e.message}, status: :bad_request
+    rescue ActiveRecord::ActiveRecordError => exception
+      render json: {error: exception.message}, status: :bad_request
       return
     end
 

--- a/dashboard/app/controllers/api/v1/ml_models_controller.rb
+++ b/dashboard/app/controllers/api/v1/ml_models_controller.rb
@@ -29,8 +29,8 @@ class Api::V1::MlModelsController < Api::V1::JSONApiController
         request.locale,
         PROFANITY_FILTER_REPLACE_TEXT_LIST
       )
-    rescue OpenURI::HTTPError => e
-      share_filtering_error = e
+    rescue OpenURI::HTTPError => exception
+      share_filtering_error = exception
     end
     if share_filtering_error
       FirehoseClient.instance.put_record(

--- a/dashboard/app/controllers/api/v1/pd/foorm/forms_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/foorm/forms_controller.rb
@@ -7,8 +7,8 @@ class Api::V1::Pd::Foorm::FormsController < ApplicationController
     begin
       filled_in_form = Foorm::Form.fill_in_library_items(form_questions)
       render json: filled_in_form
-    rescue => e
-      render status: :internal_server_error, json: {error: e.message}
+    rescue => exception
+      render status: :internal_server_error, json: {error: exception.message}
     end
   end
 

--- a/dashboard/app/controllers/api/v1/pd/workshop_enrollments_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshop_enrollments_controller.rb
@@ -72,8 +72,8 @@ class Api::V1::Pd::WorkshopEnrollmentsController < ApplicationController
         }
       rescue ActiveRecord::ValueTooLong
         render_unsuccessful RESPONSE_MESSAGES[:ERROR], {error_message: 'a response is too long'}
-      rescue ActiveRecord::RecordInvalid => e
-        render_unsuccessful RESPONSE_MESSAGES[:ERROR], {error_message: e.message}
+      rescue ActiveRecord::RecordInvalid => exception
+        render_unsuccessful RESPONSE_MESSAGES[:ERROR], {error_message: exception.message}
       end
     end
   end

--- a/dashboard/app/controllers/api/v1/pd/workshop_survey_foorm_submissions_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshop_survey_foorm_submissions_controller.rb
@@ -36,8 +36,8 @@ class Api::V1::Pd::WorkshopSurveyFoormSubmissionsController < ApplicationControl
     )
     begin
       survey_submission.save_with_foorm_submission(answers.to_json, params[:form_name], params[:form_version])
-    rescue ActiveRecord::ActiveRecordError => e
-      render json: {error: e.message}, status: :bad_request
+    rescue ActiveRecord::ActiveRecordError => exception
+      render json: {error: exception.message}, status: :bad_request
       return
     end
 
@@ -77,9 +77,9 @@ class Api::V1::Pd::WorkshopSurveyFoormSubmissionsController < ApplicationControl
         survey_submission.save_with_foorm_submission(data.to_json, params[:form_name], params[:form_version])
         submission_ids << survey_submission.foorm_submission_id
         survey_submission_ids << survey_submission.id
-      rescue ActiveRecord::ActiveRecordError => e
+      rescue ActiveRecord::ActiveRecordError => exception
         save_success = true
-        error = e.message
+        error = exception.message
       end
     end
     {

--- a/dashboard/app/controllers/api/v1/pd/workshop_survey_report_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshop_survey_report_controller.rb
@@ -91,15 +91,15 @@ module Api::V1::Pd
       return create_generic_survey_report if [COURSE_CSP, COURSE_CSD, COURSE_CSA].include?(@workshop.course)
 
       raise 'Action generic_survey_report should not be used for this workshop'
-    rescue => e
-      notify_error e
+    rescue => exception
+      notify_error exception
     end
 
     # GET /api/v1/pd/workshops/experiment_survey_report/:id/
     def experiment_survey_report
       render json: {experiment: true}
-    rescue => e
-      notify_error e
+    rescue => exception
+      notify_error exception
     end
 
     private

--- a/dashboard/app/controllers/api/v1/pd/workshops_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshops_controller.rb
@@ -67,8 +67,8 @@ class Api::V1::Pd::WorkshopsController < ::ApplicationController
         send_as_csv_attachment workshops.map {|w| Api::V1::Pd::WorkshopDownloadSerializer.new(w).attributes}, 'workshops.csv'
       end
     end
-  rescue ArgumentError => e
-    render json: {error: e.message}, status: :bad_request
+  rescue ArgumentError => exception
+    render json: {error: exception.message}, status: :bad_request
   end
 
   # GET /api/v1/pd/workshops/upcoming_teachercons
@@ -104,8 +104,8 @@ class Api::V1::Pd::WorkshopsController < ::ApplicationController
     end
 
     render json: workshops, each_serializer: Api::V1::Pd::WorkshopSerializer
-  rescue ArgumentError => e
-    render json: {error: e.message}, status: :bad_request
+  rescue ArgumentError => exception
+    render json: {error: exception.message}, status: :bad_request
   end
 
   def to_geojson(workshops)

--- a/dashboard/app/controllers/api/v1/projects/personal_projects_controller.rb
+++ b/dashboard/app/controllers/api/v1/projects/personal_projects_controller.rb
@@ -4,7 +4,7 @@ class Api::V1::Projects::PersonalProjectsController < ApplicationController
     prevent_caching
     return head :forbidden unless current_user
     render json: ProjectsList.fetch_personal_projects(current_user.id)
-  rescue ArgumentError => e
-    render json: {error: e.message}, status: :bad_request
+  rescue ArgumentError => exception
+    render json: {error: exception.message}, status: :bad_request
   end
 end

--- a/dashboard/app/controllers/api/v1/projects/public_gallery_controller.rb
+++ b/dashboard/app/controllers/api/v1/projects/public_gallery_controller.rb
@@ -10,7 +10,7 @@ class Api::V1::Projects::PublicGalleryController < ApplicationController
       limit: params[:limit],
       published_before: params[:published_before],
     )
-  rescue ArgumentError => e
-    render json: {error: e.message}, status: :bad_request
+  rescue ArgumentError => exception
+    render json: {error: exception.message}, status: :bad_request
   end
 end

--- a/dashboard/app/controllers/api/v1/sections_students_controller.rb
+++ b/dashboard/app/controllers/api/v1/sections_students_controller.rb
@@ -94,8 +94,8 @@ class Api::V1::SectionsStudentsController < Api::V1::JSONApiController
         )
         @section.add_student(new_student, current_user)
         new_students.push(new_student.summarize)
-      rescue ActiveRecord::RecordInvalid => e
-        errors << e.message
+      rescue ActiveRecord::RecordInvalid => exception
+        errors << exception.message
       end
       raise ActiveRecord::Rollback if errors.any?
     end

--- a/dashboard/app/controllers/api_controller.rb
+++ b/dashboard/app/controllers/api_controller.rb
@@ -11,8 +11,8 @@ class ApiController < ApplicationController
       auth = {authorization: "Bearer #{tokens[:oauth_token]}"}
       response = RestClient.get("https://api.clever.com/#{endpoint}", auth)
       yield JSON.parse(response)['data']
-    rescue RestClient::ExceptionWithResponse => e
-      render status: e.response.code, json: {error: e.response.body}
+    rescue RestClient::ExceptionWithResponse => exception
+      render status: exception.response.code, json: {error: exception.response.body}
     end
   end
 
@@ -50,9 +50,9 @@ class ApiController < ApplicationController
         subdomain: subdomain,
       }
       render json: response
-    rescue RestClient::Exception => e
+    rescue RestClient::Exception => exception
       Honeybadger.notify(
-        e,
+        exception,
         error_message: "Failed to retrieve OAuth token from Azure for use with the Immersive Reader API.",
         context: {
           client_id: tenant_id,
@@ -61,9 +61,9 @@ class ApiController < ApplicationController
         }
       )
       render status: :failed_dependency, json: {error: 'Unable to get token from Azure.'}
-    rescue JSON::JSONError => e
+    rescue JSON::JSONError => exception
       Honeybadger.notify(
-        e,
+        exception,
         error_message: "Failed to parse response from Azure when trying to get OAuth token for use with the Immersive Reader API.",
         context: {
           client_id: tenant_id,
@@ -128,8 +128,8 @@ class ApiController < ApplicationController
 
     begin
       yield service
-    rescue Google::Apis::ClientError, Google::Apis::AuthorizationError => e
-      render status: :forbidden, json: {error: e}
+    rescue Google::Apis::ClientError, Google::Apis::AuthorizationError => exception
+      render status: :forbidden, json: {error: exception}
     end
   end
 

--- a/dashboard/app/controllers/blocks_controller.rb
+++ b/dashboard/app/controllers/blocks_controller.rb
@@ -31,10 +31,10 @@ class BlocksController < ApplicationController
       edit_block_path(pool: @block.pool, id: @block.name),
       notice: 'Block saved',
     )
-  rescue => e
+  rescue => exception
     redirect_back(
       fallback_location: @block.name ? edit_block_path(id: @block.name) : new_block_path,
-      alert: "Error saving block: #{e}",
+      alert: "Error saving block: #{exception}",
     )
   end
 

--- a/dashboard/app/controllers/concerns/azure_text_to_speech.rb
+++ b/dashboard/app/controllers/concerns/azure_text_to_speech.rb
@@ -26,8 +26,8 @@ module AzureTextToSpeech
 
       token_http_request.request(token_request)&.body
     end
-  rescue => e
-    Honeybadger.notify(e, error_message: 'Request for authentication token from Azure Speech Service failed')
+  rescue => exception
+    Honeybadger.notify(exception, error_message: 'Request for authentication token from Azure Speech Service failed')
     nil
   end
 
@@ -60,8 +60,8 @@ module AzureTextToSpeech
     return yield(nil) if request.body.nil_or_empty?
 
     yield(http_request.request(request)&.body)
-  rescue => e
-    Honeybadger.notify(e, error_message: 'Request for speech from Azure Speech Service failed')
+  rescue => exception
+    Honeybadger.notify(exception, error_message: 'Request for speech from Azure Speech Service failed')
     yield(nil)
   end
 
@@ -96,8 +96,8 @@ module AzureTextToSpeech
       # Only keep voices that contain 2+ genders and a locale
       voice_dictionary.reject {|_, opt| opt.length < 3}
     end
-  rescue => e
-    Honeybadger.notify(e, error_message: 'Request for list of voices from Azure Speech Service failed')
+  rescue => exception
+    Honeybadger.notify(exception, error_message: 'Request for list of voices from Azure Speech Service failed')
     nil
   end
 

--- a/dashboard/app/controllers/course_offerings_controller.rb
+++ b/dashboard/app/controllers/course_offerings_controller.rb
@@ -18,8 +18,8 @@ class CourseOfferingsController < ApplicationController
     end
 
     render json: @course_offering.summarize_for_edit
-  rescue ActiveRecord::RecordNotFound, ActiveRecord::RecordInvalid => e
-    render(status: :not_acceptable, plain: e.message)
+  rescue ActiveRecord::RecordNotFound, ActiveRecord::RecordInvalid => exception
+    render(status: :not_acceptable, plain: exception.message)
   end
 
   def quick_assign_course_offerings

--- a/dashboard/app/controllers/foorm/simple_survey_forms_controller.rb
+++ b/dashboard/app/controllers/foorm/simple_survey_forms_controller.rb
@@ -28,8 +28,8 @@ module Foorm
           survey_data: survey_data
         )
       # Admin only page, so return any errors in plain text.
-      rescue StandardError => e
-        return render status: :bad_request, json: {error: e.message}
+      rescue StandardError => exception
+        return render status: :bad_request, json: {error: exception.message}
       end
 
       render 'index'

--- a/dashboard/app/controllers/lessons_controller.rb
+++ b/dashboard/app/controllers/lessons_controller.rb
@@ -140,8 +140,8 @@ class LessonsController < ApplicationController
     end
 
     render json: @lesson.summarize_for_lesson_edit
-  rescue ActiveRecord::RecordNotFound, ActiveRecord::RecordInvalid => e
-    render(status: :not_acceptable, plain: e.message)
+  rescue ActiveRecord::RecordNotFound, ActiveRecord::RecordInvalid => exception
+    render(status: :not_acceptable, plain: exception.message)
   end
 
   def clone
@@ -154,8 +154,8 @@ class LessonsController < ApplicationController
       copied_lesson = @lesson.copy_to_unit(destination_script, new_level_suffix)
       render(status: :ok, json: {editLessonUrl: edit_lesson_path(id: copied_lesson.id), editScriptUrl: edit_script_path(copied_lesson.script)})
     end
-  rescue => e
-    render(json: {error: e.message}.to_json, status: :not_acceptable)
+  rescue => exception
+    render(json: {error: exception.message}.to_json, status: :not_acceptable)
   end
 
   # Return true if request is one that can be publicly cached.

--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -299,8 +299,8 @@ class LevelsController < ApplicationController
       log_save_error(@level)
       render json: @level.errors, status: :unprocessable_entity
     end
-  rescue ArgumentError, ActiveRecord::RecordInvalid => e
-    render status: :not_acceptable, plain: e.message
+  rescue ArgumentError, ActiveRecord::RecordInvalid => exception
+    render status: :not_acceptable, plain: exception.message
   end
 
   # POST /levels/:id/update_start_code
@@ -364,10 +364,10 @@ class LevelsController < ApplicationController
 
     begin
       @level = type_class.create_from_level_builder(params, create_level_params)
-    rescue ArgumentError => e
-      render(status: :not_acceptable, plain: e.message) && return
-    rescue ActiveRecord::RecordInvalid => e
-      render(status: :not_acceptable, plain: e) && return
+    rescue ArgumentError => exception
+      render(status: :not_acceptable, plain: exception.message) && return
+    rescue ActiveRecord::RecordInvalid => exception
+      render(status: :not_acceptable, plain: exception) && return
     end
     if params[:do_not_redirect]
       render json: @level
@@ -444,10 +444,10 @@ class LevelsController < ApplicationController
     else
       render json: {redirect: edit_level_url(@new_level)}
     end
-  rescue ArgumentError => e
-    render(status: :not_acceptable, plain: e.message)
-  rescue ActiveRecord::RecordInvalid => e
-    render(status: :not_acceptable, plain: e)
+  rescue ArgumentError => exception
+    render(status: :not_acceptable, plain: exception.message)
+  rescue ActiveRecord::RecordInvalid => exception
+    render(status: :not_acceptable, plain: exception)
   end
 
   # GET /levels/:id/embed_level

--- a/dashboard/app/controllers/omniauth_callbacks_controller.rb
+++ b/dashboard/app/controllers/omniauth_callbacks_controller.rb
@@ -462,7 +462,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
           oauth_refresh_token: auth_hash.credentials&.refresh_token
         )
       end
-    rescue => e
+    rescue => exception
       error_class = lookup_user.migrated? ?
         'Failed to create AuthenticationOption during silent takeover' :
         'Failed to update User during silent takeover'
@@ -470,7 +470,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
       # This can happen if the account being taken over is already invalid
       Honeybadger.notify(
         error_class: error_class,
-        error_message: e.message,
+        error_message: exception.message,
         context: {
           user_id: lookup_user.id,
           tags: 'accounts'

--- a/dashboard/app/controllers/programming_classes_controller.rb
+++ b/dashboard/app/controllers/programming_classes_controller.rb
@@ -71,8 +71,8 @@ class ProgrammingClassesController < ApplicationController
       @programming_class.save! if @programming_class.changed?
       @programming_class.write_serialization
       render json: @programming_class.summarize_for_edit.to_json
-    rescue ActiveRecord::RecordInvalid => e
-      render(status: :not_acceptable, plain: e.message)
+    rescue ActiveRecord::RecordInvalid => exception
+      render(status: :not_acceptable, plain: exception.message)
     end
   end
 

--- a/dashboard/app/controllers/programming_environments_controller.rb
+++ b/dashboard/app/controllers/programming_environments_controller.rb
@@ -48,8 +48,8 @@ class ProgrammingEnvironmentsController < ApplicationController
       @programming_environment.save! if @programming_environment.changed?
       @programming_environment.write_serialization
       render json: @programming_environment.summarize_for_edit.to_json
-    rescue ActiveRecord::RecordInvalid => e
-      render(status: :not_acceptable, plain: e.message)
+    rescue ActiveRecord::RecordInvalid => exception
+      render(status: :not_acceptable, plain: exception.message)
     end
   end
 
@@ -70,8 +70,8 @@ class ProgrammingEnvironmentsController < ApplicationController
   def destroy
     @programming_environment.destroy!
     render(status: :ok, plain: "Destroyed #{@programming_environment.name}")
-  rescue => e
-    render(status: :not_acceptable, plain: e.message)
+  rescue => exception
+    render(status: :not_acceptable, plain: exception.message)
   end
 
   def get_summary_by_name

--- a/dashboard/app/controllers/programming_expressions_controller.rb
+++ b/dashboard/app/controllers/programming_expressions_controller.rb
@@ -85,8 +85,8 @@ class ProgrammingExpressionsController < ApplicationController
       programming_expression.save! if programming_expression.changed?
       programming_expression.write_serialization
       render json: programming_expression.summarize_for_edit.to_json
-    rescue ActiveRecord::RecordInvalid => e
-      render(status: :not_acceptable, plain: e.message)
+    rescue ActiveRecord::RecordInvalid => exception
+      render(status: :not_acceptable, plain: exception.message)
     end
   end
 
@@ -125,8 +125,8 @@ class ProgrammingExpressionsController < ApplicationController
     begin
       new_exp = @programming_expression.clone_to_programming_environment(params[:destinationProgrammingEnvironmentName], params[:destinationCategoryKey])
       render(status: :ok, json: {editUrl: edit_programming_expression_path(new_exp)})
-    rescue => e
-      render(json: {error: e.message}.to_json, status: :not_acceptable)
+    rescue => exception
+      render(json: {error: exception.message}.to_json, status: :not_acceptable)
     end
   end
 

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -250,8 +250,8 @@ class ScriptsController < ApplicationController
     begin
       Unit.rake
       redirect_to scripts_path, notice: 'Updated.'
-    rescue StandardError => e
-      @errors << e.to_s
+    rescue StandardError => exception
+      @errors << exception.to_s
       render action: 'index'
     end
   end

--- a/dashboard/app/controllers/sms_controller.rb
+++ b/dashboard/app/controllers/sms_controller.rb
@@ -39,8 +39,8 @@ class SmsController < ApplicationController
       body: body
     )
     head :ok
-  rescue Twilio::REST::RestError => e
-    case e.message
+  rescue Twilio::REST::RestError => exception
+    case exception.message
     when /The message From\/To pair violates a blacklist rule./
       # recipient unsubscribed from twilio, pretend it succeeded
       head :ok

--- a/dashboard/app/controllers/videos_controller.rb
+++ b/dashboard/app/controllers/videos_controller.rb
@@ -19,8 +19,8 @@ class VideosController < ApplicationController
       begin
         require 'cdo/video/youtube'
         Youtube.process @video.key
-      rescue Exception => e
-        render(layout: false, plain: "Error processing video: #{e}. Contact an engineer for support.", status: :internal_server_error) && return
+      rescue Exception => exception
+        render(layout: false, plain: "Error processing video: #{exception}. Contact an engineer for support.", status: :internal_server_error) && return
       end
     end
     video_info = @video.summarize(params.key?(:autoplay))

--- a/dashboard/app/controllers/vocabularies_controller.rb
+++ b/dashboard/app/controllers/vocabularies_controller.rb
@@ -26,8 +26,8 @@ class VocabulariesController < ApplicationController
       vocabulary.save!
       vocabulary.serialize_scripts
       render json: vocabulary.summarize_for_lesson_edit
-    rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid => e
-      render status: :bad_request, json: {error: e.message.to_json}
+    rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid => exception
+      render status: :bad_request, json: {error: exception.message.to_json}
     end
   end
 

--- a/dashboard/app/controllers/xhr_proxy_controller.rb
+++ b/dashboard/app/controllers/xhr_proxy_controller.rb
@@ -134,8 +134,8 @@ class XhrProxyController < ApplicationController
 
     begin
       owner_storage_id, _ = storage_decrypt_channel_id(channel_id)
-    rescue ArgumentError, OpenSSL::Cipher::CipherError => e
-      render_error_response 403, "Invalid token: '#{channel_id}' for url: '#{url}' exception: #{e.message}"
+    rescue ArgumentError, OpenSSL::Cipher::CipherError => exception
+      render_error_response 403, "Invalid token: '#{channel_id}' for url: '#{url}' exception: #{exception.message}"
       return
     end
 

--- a/dashboard/app/helpers/javalab_files_helper.rb
+++ b/dashboard/app/helpers/javalab_files_helper.rb
@@ -10,9 +10,9 @@ module JavalabFilesHelper
       http.request(upload_request)
     end
     return response
-  rescue StandardError => e
+  rescue StandardError => exception
     event_details = {
-      error_details: e.to_json
+      error_details: exception.to_json
     }
     NewRelic::Agent.record_custom_event("JavabuilderHttpConnectionError", event_details) if CDO.newrelic_logging
     nil

--- a/dashboard/app/helpers/proxy_helper.rb
+++ b/dashboard/app/helpers/proxy_helper.rb
@@ -79,8 +79,8 @@ module ProxyHelper
     end
   rescue URI::InvalidURIError
     render_error_response 400, "Invalid URI #{location}"
-  rescue SocketError, Net::OpenTimeout, Net::ReadTimeout, Errno::ECONNRESET, Errno::ECONNREFUSED, Errno::ENETUNREACH => e
-    render_error_response 400, "Network error #{e.class} #{e.message}"
+  rescue SocketError, Net::OpenTimeout, Net::ReadTimeout, Errno::ECONNRESET, Errno::ECONNREFUSED, Errno::ENETUNREACH => exception
+    render_error_response 400, "Network error #{exception.class} #{exception.message}"
   rescue OpenSSL::SSL::SSLError
     render_error_response 400, "Remote host SSL certificate error"
   rescue EOFError
@@ -127,8 +127,8 @@ module ProxyHelper
     end
   rescue URI::InvalidURIError
     return 400, "Invalid URI #{location}"
-  rescue SocketError, Net::OpenTimeout, Net::ReadTimeout, Errno::ECONNRESET => e
-    return 400, "Network error #{e.class} #{e.message}"
+  rescue SocketError, Net::OpenTimeout, Net::ReadTimeout, Errno::ECONNRESET => exception
+    return 400, "Network error #{exception.class} #{exception.message}"
   end
 
   def dashboard_ip_address

--- a/dashboard/app/helpers/users_helper.rb
+++ b/dashboard/app/helpers/users_helper.rb
@@ -50,7 +50,7 @@ module UsersHelper
 
     log_account_takeover_to_firehose(**firehose_params)
     true
-  rescue => e
+  rescue => exception
     # TODO: Remove this block https://codedotorg.atlassian.net/browse/FND-1927
     if source_user && destination_user
       firehose_params = {
@@ -58,7 +58,7 @@ module UsersHelper
         destination_user: destination_user,
         type: takeover_type,
         provider: provider,
-        error: "Type: #{e.class} Message: #{e.message}"
+        error: "Type: #{exception.class} Message: #{exception.message}"
       }
       log_self_takeover_investigation_to_firehose(firehose_params)
     end

--- a/dashboard/app/models/concerns/pd/jot_form_backed_form.rb
+++ b/dashboard/app/models/concerns/pd/jot_form_backed_form.rb
@@ -150,9 +150,9 @@ module Pd
 
                 last_processed_submission_id = submission_id
                 imported += 1 if res == IMPORTED
-              rescue => e
+              rescue => exception
                 # Store message and first line of backtrace for context
-                errors_per_form[form_id][submission_id] = "#{e.message}, #{e.backtrace.first}"
+                errors_per_form[form_id][submission_id] = "#{exception.message}, #{exception.backtrace.first}"
                 batch_error_count += 1
                 all_sync_results[form_id][ERROR] ||= 0
                 all_sync_results[form_id][ERROR] += 1
@@ -297,9 +297,9 @@ module Pd
           end
 
           count += 1
-        rescue => e
+        rescue => exception
           # Store message and first line of backtrace for context
-          errors[placeholder.submission_id] = "#{e.message}, #{e.backtrace.first}"
+          errors[placeholder.submission_id] = "#{exception.message}, #{exception.backtrace.first}"
         end
 
         CDO.log.info "#{count} placeholders filled."
@@ -428,8 +428,8 @@ module Pd
       @form_data_hash ||= {}
       @form_data_hash[show_hidden_questions ? 'all' : 'visible'] ||= begin
         questions.process_answers(answers_hash, show_hidden_questions: show_hidden_questions)
-      rescue => e
-        raise e, "Error processing answers for submission id #{submission_id}, form #{form_id}: #{e}", e.backtrace
+      rescue => exception
+        raise exception, "Error processing answers for submission id #{submission_id}, form #{form_id}: #{exception}", exception.backtrace
       end
     end
 

--- a/dashboard/app/models/experiments/experiment.rb
+++ b/dashboard/app/models/experiments/experiment.rb
@@ -62,9 +62,9 @@ class Experiment < ApplicationRecord
         (experiment.script_id.nil? || experiment.script_id == script.try(:id)) &&
         (experiment_name.nil? || experiment.name == experiment_name)
     end
-  rescue => e
+  rescue => exception
     Honeybadger.notify(
-      e,
+      exception,
       error_message: 'Error getting experiments',
       context: {
         user_id: user&.id

--- a/dashboard/app/models/foorm/form.rb
+++ b/dashboard/app/models/foorm/form.rb
@@ -137,8 +137,8 @@ class Foorm::Form < ApplicationRecord
     errors = []
     begin
       filled_questions = Foorm::Form.fill_in_library_items(questions)
-    rescue StandardError => e
-      errors.append(e.message)
+    rescue StandardError => exception
+      errors.append(exception.message)
       return errors
     end
     filled_questions.deep_symbolize_keys!
@@ -147,8 +147,8 @@ class Foorm::Form < ApplicationRecord
       page[:elements]&.each do |element_data|
         # validate_element will throw an exception if the element is invalid
         Foorm::Form.validate_element(element_data, element_names)
-      rescue StandardError => e
-        errors.append(e.message)
+      rescue StandardError => exception
+        errors.append(exception.message)
       end
     end
     errors

--- a/dashboard/app/models/foorm/library_question.rb
+++ b/dashboard/app/models/foorm/library_question.rb
@@ -52,8 +52,8 @@ class Foorm::LibraryQuestion < ApplicationRecord
     end
 
     Foorm::Form.validate_element(JSON.parse(question).deep_symbolize_keys, Set.new)
-  rescue StandardError => e
-    errors.add(:question, e.message)
+  rescue StandardError => exception
+    errors.add(:question, exception.message)
   end
 
   def write_to_file

--- a/dashboard/app/models/levels/applab.rb
+++ b/dashboard/app/models/levels/applab.rb
@@ -106,8 +106,8 @@ class Applab < Blockly
       self.code_functions = JSON.parse(code_functions)
     end
     true
-  rescue JSON::ParserError => e
-    errors.add(:code_functions, "#{e.class.name}: #{e.message}")
+  rescue JSON::ParserError => exception
+    errors.add(:code_functions, "#{exception.class.name}: #{exception.message}")
     return false
   end
 
@@ -117,8 +117,8 @@ class Applab < Blockly
       properties[property_field] = JSON.parse value
     end
     true
-  rescue JSON::ParserError => e
-    errors.add(property_field, "#{e.class.name}: #{e.message}")
+  rescue JSON::ParserError => exception
+    errors.add(property_field, "#{exception.class.name}: #{exception.message}")
     return false
   end
 

--- a/dashboard/app/models/levels/gamelab.rb
+++ b/dashboard/app/models/levels/gamelab.rb
@@ -88,8 +88,8 @@ class Gamelab < Blockly
     if code_functions.present? && code_functions.is_a?(String)
       self.code_functions = JSON.parse(code_functions)
     end
-  rescue JSON::ParserError => e
-    errors.add(:code_functions, "#{e.class.name}: #{e.message}")
+  rescue JSON::ParserError => exception
+    errors.add(:code_functions, "#{exception.class.name}: #{exception.message}")
     return false
   end
 

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -680,8 +680,8 @@ class Level < ApplicationRecord
       level.save!
 
       level
-    rescue Exception => e
-      raise e, "Failed to clone Level #{name.inspect} as #{new_name.inspect}. Message:\n#{e.message}", e.backtrace
+    rescue Exception => exception
+      raise exception, "Failed to clone Level #{name.inspect} as #{new_name.inspect}. Message:\n#{exception.message}", exception.backtrace
     end
   end
 

--- a/dashboard/app/models/levels/level_group.rb
+++ b/dashboard/app/models/levels/level_group.rb
@@ -181,8 +181,8 @@ class LevelGroup < DSLDefined
       level.clone_sublevels_with_suffix(get_levels_and_texts_by_page, suffix)
       level.rewrite_dsl_file(LevelGroupDSL.serialize(level))
       level
-    rescue Exception => e
-      raise e, "Failed to clone LevelGroup #{name.inspect} as #{new_name.inspect}. Message:\n#{e.message}", e.backtrace
+    rescue Exception => exception
+      raise exception, "Failed to clone LevelGroup #{name.inspect} as #{new_name.inspect}. Message:\n#{exception.message}", exception.backtrace
     end
   end
 

--- a/dashboard/app/models/pd/application/email.rb
+++ b/dashboard/app/models/pd/application/email.rb
@@ -37,8 +37,8 @@ module Pd::Application
       errors = {}
       unsent.find_each do |email|
         email.send!
-      rescue => e
-        errors[email.id] = "#{e.message}, #{e.backtrace.first}"
+      rescue => exception
+        errors[email.id] = "#{exception.message}, #{exception.backtrace.first}"
       end
 
       if errors.any?

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -446,23 +446,23 @@ class Pd::Workshop < ApplicationRecord
       workshop.enrollments.each do |enrollment|
         email = Pd::WorkshopMailer.teacher_enrollment_reminder(enrollment, days_before: days)
         email.deliver_now
-      rescue => e
-        errors << "teacher enrollment #{enrollment.id} - #{e.message}"
+      rescue => exception
+        errors << "teacher enrollment #{enrollment.id} - #{exception.message}"
       end
 
       workshop.facilitators.each do |facilitator|
         next if facilitator == workshop.organizer
         begin
           Pd::WorkshopMailer.facilitator_enrollment_reminder(facilitator, workshop).deliver_now
-        rescue => e
-          errors << "facilitator #{facilitator.id} - #{e.message}"
+        rescue => exception
+          errors << "facilitator #{facilitator.id} - #{exception.message}"
         end
       end
 
       begin
         Pd::WorkshopMailer.organizer_enrollment_reminder(workshop).deliver_now
-      rescue => e
-        errors << "organizer workshop #{workshop.id} - #{e.message}"
+      rescue => exception
+        errors << "organizer workshop #{workshop.id} - #{exception.message}"
       end
 
       # send pre-workshop email for CSA, CSD, CSP facilitators 10 days before the workshop only
@@ -471,8 +471,8 @@ class Pd::Workshop < ApplicationRecord
         next unless facilitator.email
         begin
           Pd::WorkshopMailer.facilitator_pre_workshop(facilitator, workshop).deliver_now
-        rescue => e
-          errors << "pre email for facilitator #{facilitator.id} - #{e.message}"
+        rescue => exception
+          errors << "pre email for facilitator #{facilitator.id} - #{exception.message}"
         end
       end
     end
@@ -485,8 +485,8 @@ class Pd::Workshop < ApplicationRecord
     errors = []
     should_have_ended.each do |workshop|
       Pd::WorkshopMailer.organizer_should_close_reminder(workshop).deliver_now
-    rescue => e
-      errors << "organizer should close workshop #{workshop.id} - #{e.message}"
+    rescue => exception
+      errors << "organizer should close workshop #{workshop.id} - #{exception.message}"
     end
     raise "Failed to send reminders: #{errors.join(', ')}" unless errors.empty?
   end
@@ -505,9 +505,9 @@ class Pd::Workshop < ApplicationRecord
 
         email = Pd::WorkshopMailer.teacher_follow_up(enrollment)
         email.deliver_now
-      rescue => e
-        errors << "teacher enrollment #{enrollment.id} - #{e.message}"
-        Honeybadger.notify(e,
+      rescue => exception
+        errors << "teacher enrollment #{enrollment.id} - #{exception.message}"
+        Honeybadger.notify(exception,
           error_message: 'Failed to send follow up email to teacher',
           context: {pd_enrollment_id: enrollment.id}
         )
@@ -583,9 +583,9 @@ class Pd::Workshop < ApplicationRecord
             result = Geocoder.search(location_address).try(:first)
           end
         end
-      rescue StandardError => e
+      rescue StandardError => exception
         # Log geocoding errors to honeybadger but don't fail
-        Honeybadger.notify(e,
+        Honeybadger.notify(exception,
           error_message: 'Error geocoding workshop location_address',
           context: {
             pd_workshop_id: id,

--- a/dashboard/app/models/regional_partner.rb
+++ b/dashboard/app/models/regional_partner.rb
@@ -207,9 +207,9 @@ class RegionalPartner < ApplicationRecord
               state = Geocoder.search(zip_code, params: {country: 'us'})&.first&.state_code
             end
           end
-        rescue StandardError => e
+        rescue StandardError => exception
           # Log geocoding errors to honeybadger but don't fail
-          Honeybadger.notify(e,
+          Honeybadger.notify(exception,
             error_message: 'Error geocoding regional partner workshop zip_code',
             context: {
               zip_code: zip_code

--- a/dashboard/app/models/unit.rb
+++ b/dashboard/app/models/unit.rb
@@ -514,8 +514,8 @@ class Unit < ApplicationRecord
     @@level_cache[level.id] = level if level && should_cache?
     @@level_cache[level.name] = level if level && should_cache?
     level
-  rescue => e
-    raise e, "Error finding level #{level_identifier}: #{e}"
+  rescue => exception
+    raise exception, "Error finding level #{level_identifier}: #{exception}"
   end
 
   def cached
@@ -1243,10 +1243,10 @@ class Unit < ApplicationRecord
 
         copied_unit
       end
-    rescue => e
+    rescue => exception
       filepath_to_delete = Unit.script_json_filepath(new_name)
       File.delete(filepath_to_delete) if File.exist?(filepath_to_delete)
-      raise e, "Error: #{e.message}"
+      raise exception, "Error: #{exception.message}"
     end
   end
 
@@ -1345,8 +1345,8 @@ class Unit < ApplicationRecord
       if Rails.application.config.levelbuilder_mode
         Unit.merge_and_write_i18n(i18n, unit_name, metadata_i18n, log_event_type: 'write_script')
       end
-    rescue StandardError => e
-      errors.add(:base, e.to_s)
+    rescue StandardError => exception
+      errors.add(:base, exception.to_s)
       return false
     end
     update_teacher_resources(general_params[:resourceIds])
@@ -1359,8 +1359,8 @@ class Unit < ApplicationRecord
         unit.write_script_json
       end
       true
-    rescue StandardError => e
-      errors.add(:base, e.to_s)
+    rescue StandardError => exception
+      errors.add(:base, exception.to_s)
       return false
     end
   end

--- a/dashboard/app/models/unit_group.rb
+++ b/dashboard/app/models/unit_group.rb
@@ -142,10 +142,10 @@ class UnitGroup < ApplicationRecord
 
     unit_group.save!
     unit_group
-  rescue Exception => e
+  rescue Exception => exception
     # print filename for better debugging
-    new_e = Exception.new("in course: #{hash['name']}: #{e.message}")
-    new_e.set_backtrace(e.backtrace)
+    new_e = Exception.new("in course: #{hash['name']}: #{exception.message}")
+    new_e.set_backtrace(exception.backtrace)
     raise new_e
   end
 

--- a/dashboard/bin/rails
+++ b/dashboard/bin/rails
@@ -1,8 +1,8 @@
 #!/usr/bin/env ruby
 begin
   load File.expand_path('../spring', __FILE__)
-rescue LoadError => e
-  raise unless e.message.include?('spring')
+rescue LoadError => exception
+  raise unless exception.message.include?('spring')
 end
 APP_PATH = File.expand_path('../../config/application',  __FILE__)
 require_relative '../config/boot'

--- a/dashboard/bin/rake
+++ b/dashboard/bin/rake
@@ -1,8 +1,8 @@
 #!/usr/bin/env ruby
 begin
   load File.expand_path('../spring', __FILE__)
-rescue LoadError => e
-  raise unless e.message.include?('spring')
+rescue LoadError => exception
+  raise unless exception.message.include?('spring')
 end
 require_relative '../config/boot'
 require 'rake'

--- a/dashboard/bin/sync_jotforms
+++ b/dashboard/bin/sync_jotforms
@@ -17,9 +17,9 @@ def sync_submissions
   JOT_FORM_CLASSES.each do |survey_class|
     survey_class.all_form_ids.each do |form_id|
       survey_class.sync_from_jotform form_id
-    rescue => e
+    rescue => exception
       # One form fails to sync doesn't stop other forms from syncing
-      Honeybadger.notify e
+      Honeybadger.notify exception
     end
   end
 end
@@ -27,9 +27,9 @@ end
 def sync_questions
   Pd::SurveyQuestion.all.each do |survey|
     survey.sync_from_jotform
-  rescue => e
+  rescue => exception
     # One form fails to sync doesn't stop other forms from syncing
-    Honeybadger.notify e
+    Honeybadger.notify exception
   end
 end
 

--- a/dashboard/bin/testunit
+++ b/dashboard/bin/testunit
@@ -1,8 +1,8 @@
 #!/usr/bin/env ruby
 begin
   load File.expand_path('../spring', __FILE__)
-rescue LoadError => e
-  raise unless e.message.include?('spring')
+rescue LoadError => exception
+  raise unless exception.message.include?('spring')
 end
 require 'bundler/setup'
 load Gem.bin_path('testunit', 'testunit')

--- a/dashboard/config/initializers/mysql_check_index_used.rb
+++ b/dashboard/config/initializers/mysql_check_index_used.rb
@@ -39,8 +39,8 @@ module MysqlCheckIndexUsed
         end
       end
     end
-  rescue => e
-    raise translate_exception_class(e, sql, [])
+  rescue => exception
+    raise translate_exception_class(exception, sql, [])
   end
 end
 

--- a/dashboard/db/migrate/20150423215834_create_channel_tokens.rb
+++ b/dashboard/db/migrate/20150423215834_create_channel_tokens.rb
@@ -25,9 +25,9 @@ class CreateChannelTokens < ActiveRecord::Migration[4.2]
       next unless user && user[:user_id]
       begin
         ChannelToken.create!(channel: channel, user_id: user[:user_id], level_id: big_game_template)
-      rescue => e
+      rescue => exception
         puts "Failed to import channel '#{channel}' with ID '#{row[:id]}' and user '#{user[:user_id]}'"
-        puts e.backtrace.join("\n")
+        puts exception.backtrace.join("\n")
       end
     end
   end

--- a/dashboard/db/migrate/20160614000000_add_processed_location_to_pd_workshops.rb
+++ b/dashboard/db/migrate/20160614000000_add_processed_location_to_pd_workshops.rb
@@ -6,9 +6,9 @@ class AddProcessedLocationToPdWorkshops < ActiveRecord::Migration[4.2]
     Pd::Workshop.find_each do |workshop|
       workshop.processed_location = Pd::Workshop.process_location(workshop.location_address)
       workshop.save!
-    rescue RuntimeError => e
+    rescue RuntimeError => exception
       # Log the error but don't fail the migration if something goes wrong.
-      CDO.logger.error "Error processing location for pd_workshop #{workshop.id}: #{e.message}"
+      CDO.logger.error "Error processing location for pd_workshop #{workshop.id}: #{exception.message}"
     end
   end
 

--- a/dashboard/legacy/middleware/channels_api.rb
+++ b/dashboard/legacy/middleware/channels_api.rb
@@ -173,12 +173,12 @@ class ChannelsApi < Sinatra::Base
 
     begin
       value = Projects.new(get_storage_id).update(id, value, request.ip, locale: request.locale, project_type: project_type)
-    rescue ArgumentError, OpenSSL::Cipher::CipherError, ProfanityPrivacyError => e
-      if e.class == ProfanityPrivacyError
+    rescue ArgumentError, OpenSSL::Cipher::CipherError, ProfanityPrivacyError => exception
+      if exception.class == ProfanityPrivacyError
         dont_cache
         status 422
         content_type :json
-        return {nameFailure: e.flagged_text}.to_json
+        return {nameFailure: exception.flagged_text}.to_json
       else
         bad_request
       end

--- a/dashboard/legacy/middleware/files_api.rb
+++ b/dashboard/legacy/middleware/files_api.rb
@@ -415,8 +415,8 @@ class FilesApi < Sinatra::Base
     if endpoint == 'libraries' && file_type != '.java'
       begin
         share_failure = ShareFiltering.find_failure(body, request.locale)
-      rescue OpenURI::HTTPError => e
-        return file_too_large(endpoint) if e.message == "414 Request-URI Too Large"
+      rescue OpenURI::HTTPError => exception
+        return file_too_large(endpoint) if exception.message == "414 Request-URI Too Large"
       end
       # TODO(JillianK): we are temporarily ignoring address share failures because our address detection is very broken.
       # Once we have a better geocoding solution in H1, we should start filtering for addresses again.

--- a/dashboard/legacy/middleware/helpers/bucket_helper.rb
+++ b/dashboard/legacy/middleware/helpers/bucket_helper.rb
@@ -401,9 +401,9 @@ class BucketHelper
         version_restored = true
       rescue Aws::S3::Errors::NoSuchVersion
         # Do nothing - we'll attempt the fallback below.
-      rescue Aws::S3::Errors::InvalidArgument => e
+      rescue Aws::S3::Errors::InvalidArgument => exception
         # On invalid version, try the fallback - otherwise reraise.
-        raise unless invalid_version_id?(e)
+        raise unless invalid_version_id?(exception)
       end
     end
 

--- a/dashboard/legacy/middleware/helpers/profanity_privacy_helper.rb
+++ b/dashboard/legacy/middleware/helpers/profanity_privacy_helper.rb
@@ -31,7 +31,7 @@ end
 def title_profanity_privacy_violation(name, locale)
   share_failure = begin
     ShareFiltering.find_name_failure(name, locale)
-  rescue OpenURI::HTTPError, IO::EAGAINWaitReadable => e
+  rescue OpenURI::HTTPError, IO::EAGAINWaitReadable => exception
     # If WebPurify or Geocoder are unavailable, default to viewable, but log error
     FirehoseClient.instance.put_record(
       :analysis,
@@ -39,7 +39,7 @@ def title_profanity_privacy_violation(name, locale)
         study: 'share_filtering',
         study_group: 'v0',
         event: 'share_filtering_error',
-        data_string: "#{e.class.name}: #{e}",
+        data_string: "#{exception.class.name}: #{exception}",
         data_json: {
           name: name,
           locale: locale

--- a/dashboard/lib/certificate_image.rb
+++ b/dashboard/lib/certificate_image.rb
@@ -84,10 +84,10 @@ class CertificateImage
       # Free the memory in order to avoid memory leaks (images are stored in /tmp
       # until destroyed)
       text_overlay.destroy!
-    rescue Magick::ImageMagickError => e
+    rescue Magick::ImageMagickError => exception
       # We want to know what kinds of text we are failing to render.
       Honeybadger.notify(
-        e,
+        exception,
         context: {
           text: text,
         }

--- a/dashboard/lib/contact_rollups_v2.rb
+++ b/dashboard/lib/contact_rollups_v2.rb
@@ -169,8 +169,8 @@ class ContactRollupsV2
         ContactRollupsPardotMemory.download_pardot_ids
       end
     end
-  rescue StandardError => e
-    @log_collector.record_exception e
+  rescue StandardError => exception
+    @log_collector.record_exception exception
   ensure
     @log_collector.record_metrics(
       {SyncNewContactsDuration: Time.now - start_time}

--- a/dashboard/lib/expired_deleted_account_purger.rb
+++ b/dashboard/lib/expired_deleted_account_purger.rb
@@ -69,14 +69,14 @@ class ExpiredDeletedAccountPurger
     expired_soft_deleted_accounts.each do |account|
       account_purger.purge_data_for_account account
       @num_accounts_purged += 1
-    rescue StandardError => e
-      QueuedAccountPurge.create(user: account, reason_for_review: e.message) unless @dry_run
+    rescue StandardError => exception
+      QueuedAccountPurge.create(user: account, reason_for_review: exception.message) unless @dry_run
       @num_accounts_queued += 1
     end
 
     QueuedAccountPurge.clean_up_resolved_records!
-  rescue StandardError => e
-    yell e.message
+  rescue StandardError => exception
+    yell exception.message
     raise
   ensure
     report_results

--- a/dashboard/lib/level_loader.rb
+++ b/dashboard/lib/level_loader.rb
@@ -127,10 +127,10 @@ class LevelLoader
     else
       nil
     end
-  rescue Exception => e
+  rescue Exception => exception
     # print filename for better debugging
-    new_e = Exception.new("in level: #{level_path}: #{e.message}")
-    new_e.set_backtrace(e.backtrace)
+    new_e = Exception.new("in level: #{level_path}: #{exception.message}")
+    new_e.set_backtrace(exception.backtrace)
     raise new_e
   end
 

--- a/dashboard/lib/pd/jot_form/form_questions.rb
+++ b/dashboard/lib/pd/jot_form/form_questions.rb
@@ -96,8 +96,8 @@ module Pd
 
           form_data = begin
             question.process_answer(answer_data)
-          rescue => e
-            raise e, "Error processing answer #{question_id}: #{e.message}", e.backtrace
+          rescue => exception
+            raise exception, "Error processing answer #{question_id}: #{exception.message}", exception.backtrace
           end
 
           {

--- a/dashboard/lib/pd/survey_pipeline/generic_mapper.rb
+++ b/dashboard/lib/pd/survey_pipeline/generic_mapper.rb
@@ -77,8 +77,8 @@ module Pd::SurveyPipeline
             next if reducer_result.blank?
 
             summaries << group_key.merge({reducer: reducer.name, reducer_result: reducer_result})
-          rescue => e
-            errors << e.message
+          rescue => exception
+            errors << exception.message
           end
         end
       end

--- a/dashboard/lib/services/curriculum_pdfs/resources.rb
+++ b/dashboard/lib/services/curriculum_pdfs/resources.rb
@@ -74,9 +74,9 @@ module Services
           # I'm adding some explicit logging.
           begin
             PDF.merge_local_pdfs(destination, *pdfs)
-          rescue Exception => e
+          rescue Exception => exception
             ChatClient.log(
-              "Error when trying to merge resource PDFs for #{script.name}: #{e}",
+              "Error when trying to merge resource PDFs for #{script.name}: #{exception}",
               color: 'red'
             )
             ChatClient.log(
@@ -91,7 +91,7 @@ module Services
               "temporary directory contents: #{Dir.entries(pdfs_dir).inspect}",
               color: 'red'
             )
-            raise e
+            raise exception
           end
           FileUtils.remove_entry_secure(pdfs_dir)
 
@@ -179,15 +179,15 @@ module Services
             IO.copy_stream(URI.parse(url)&.open, path)
             return path
           end
-        rescue Google::Apis::ClientError, Google::Apis::ServerError, GoogleDrive::Error => e
+        rescue Google::Apis::ClientError, Google::Apis::ServerError, GoogleDrive::Error => exception
           ChatClient.log(
-            "Google error when trying to fetch PDF from #{url.inspect} to #{path.inspect}: #{e}",
+            "Google error when trying to fetch PDF from #{url.inspect} to #{path.inspect}: #{exception}",
             color: 'yellow'
           )
           return nil
-        rescue URI::InvalidURIError, OpenURI::HTTPError => e
+        rescue URI::InvalidURIError, OpenURI::HTTPError => exception
           ChatClient.log(
-            "URI error when trying to fetch PDF from #{url.inspect} to #{path.inspect}: #{e}",
+            "URI error when trying to fetch PDF from #{url.inspect} to #{path.inspect}: #{exception}",
             color: 'yellow'
           )
           return nil

--- a/dashboard/lib/tasks/seed.rake
+++ b/dashboard/lib/tasks/seed.rake
@@ -156,8 +156,8 @@ namespace :seed do
       custom_scripts = script_files.select {|script| File.mtime(script) > scripts_seeded_mtime}
       custom_scripts.each do |filepath|
         Services::ScriptSeed.seed_from_json_file(filepath)
-      rescue => e
-        raise e, "Error parsing script file #{filepath}: #{e}"
+      rescue => exception
+        raise exception, "Error parsing script file #{filepath}: #{exception}"
       end
     rescue
       rm SEEDED # if we failed somewhere in the process, we may have seeded some Scripts, but not all that we were supposed to.

--- a/dashboard/scripts/archive/block_docs_to_i18n
+++ b/dashboard/scripts/archive/block_docs_to_i18n
@@ -51,10 +51,10 @@ def parse_function_docs(doc_files)
 
   doc_files.each do |doc_filename|
     functions << parse_function_doc(doc_filename)
-  rescue Exception => e
+  rescue Exception => exception
     puts "Error processing file #{doc_filename}:"
-    puts e.message
-    puts e.backtrace.inspect
+    puts exception.message
+    puts exception.backtrace.inspect
   end
   functions
 end

--- a/dashboard/scripts/archive/move_all_images_to_s3
+++ b/dashboard/scripts/archive/move_all_images_to_s3
@@ -32,9 +32,9 @@ LevelSourceImage.where('image != "S3"').find_in_batches do |batch|
       end
     rescue Magick::ImageMagickError
       invalid_image += 1
-    rescue Exception => e
-      p e.message
-      p e.backtrace
+    rescue Exception => exception
+      p exception.message
+      p exception.backtrace
       errors += 1
     end
   end

--- a/dashboard/scripts/smoke
+++ b/dashboard/scripts/smoke
@@ -72,14 +72,14 @@ def run_tests(options = {})
         location_uri = URI.join(response["Location"])
         raise "Redirect error. Expecting #{test[:redirect]}, got #{location_uri.path}- #{" - #{test[:failure_message]}" if test[:failure_message]}" if location_uri.path != test[:redirect]
       end
-    rescue Exception => e
-      exit 1 if /Interrupt/.match?(e.inspect)
+    rescue Exception => exception
+      exit 1 if /Interrupt/.match?(exception.inspect)
       if options[:quiet]
-        puts "#{url} ... #{e}"
+        puts "#{url} ... #{exception}"
       else
-        puts e.to_s
+        puts exception.to_s
       end
-      puts "#{url} ... #{e}"
+      puts "#{url} ... #{exception}"
       next
     end
 

--- a/dashboard/test/lib/level_loader_test.rb
+++ b/dashboard/test/lib/level_loader_test.rb
@@ -89,7 +89,7 @@ class LevelLoaderTest < ActiveSupport::TestCase
 
   test 'debugging info for exceptions in load_custom_level' do
     LevelLoader.send(:load_custom_level, 'xxxxx', {})
-  rescue Exception => e
-    assert_includes e.message, "in level"
+  rescue Exception => exception
+    assert_includes exception.message, "in level"
   end
 end

--- a/dashboard/test/mailers/previews/traverse_mail_previews_test.rb
+++ b/dashboard/test/mailers/previews/traverse_mail_previews_test.rb
@@ -16,8 +16,8 @@ class TraverseMailPreviewsTest < ActiveSupport::TestCase
         # Call each method on each mailer preview class. For now its enough to make sure
         # that the mailer preview can successfully run
         klass.new.send(method.to_sym)
-      rescue Exception => e
-        puts e
+      rescue Exception => exception
+        puts exception
         failed_runs << "#{klass}: #{method}"
       end
 

--- a/dashboard/test/models/school_test.rb
+++ b/dashboard/test/models/school_test.rb
@@ -30,8 +30,8 @@ class SchoolTest < ActiveSupport::TestCase
 
     begin
       School.merge_from_csv(School.get_seed_filename(true), is_dry_run: true)
-    rescue => e
-      assert_includes e.message, 'This was a dry run'
+    rescue => exception
+      assert_includes exception.message, 'This was a dry run'
       assert_equal 0, School.count
     end
   end
@@ -56,8 +56,8 @@ class SchoolTest < ActiveSupport::TestCase
 
     begin
       School.merge_from_csv(School.get_seed_filename(true), is_dry_run: true, &parse_row)
-    rescue => e
-      assert_includes e.message, 'This was a dry run'
+    rescue => exception
+      assert_includes exception.message, 'This was a dry run'
       assert_equal before_count, School.count
     end
   end

--- a/dashboard/test/test_helper.rb
+++ b/dashboard/test/test_helper.rb
@@ -319,9 +319,9 @@ class ActiveSupport::TestCase
   def assert_raises_matching(matcher)
     assert_raises do
       yield
-    rescue => e
-      assert_match matcher, e.message
-      raise e
+    rescue => exception
+      assert_match matcher, exception.message
+      raise exception
     end
   end
 

--- a/dashboard/test/ui/features/step_definitions/eyes_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/eyes_steps.rb
@@ -41,8 +41,8 @@ And(/^I close my eyes$/) do
   fail_on_mismatch = !CDO.ignore_eyes_mismatches
   begin
     @eyes.close(fail_on_mismatch)
-  rescue Applitools::TestFailedError => e
-    puts "<span style=\"color: red;\">#{EYES_ERROR_PREFIX} #{Rinku.auto_link(e.to_s)}</span>"
+  rescue Applitools::TestFailedError => exception
+    puts "<span style=\"color: red;\">#{EYES_ERROR_PREFIX} #{Rinku.auto_link(exception.to_s)}</span>"
   end
 end
 

--- a/dashboard/test/ui/features/step_definitions/pd.rb
+++ b/dashboard/test/ui/features/step_definitions/pd.rb
@@ -420,10 +420,10 @@ def create_fake_survey_questions(workshop)
       }
     ].to_json
   )
-rescue => e
+rescue => exception
   puts "Unable to create SurveyQuestions. If you are running this locally, please make
     sure that you have overridden jotform_forms in your locals.yml"
-  raise e
+  raise exception
 end
 
 def create_fake_daily_survey_results(workshop)

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -7,11 +7,11 @@ MODULE_PROGRESS_COLOR_MAP = {not_started: 'rgb(255, 255, 255)', in_progress: 'rg
 def wait_until(timeout = DEFAULT_WAIT_TIMEOUT)
   Selenium::WebDriver::Wait.new(timeout: timeout).until do
     yield
-  rescue Selenium::WebDriver::Error::UnknownError => e
-    puts "Unknown error: #{e}"
+  rescue Selenium::WebDriver::Error::UnknownError => exception
+    puts "Unknown error: #{exception}"
     false
-  rescue Selenium::WebDriver::Error::WebDriverError => e
-    raise unless e.message.include?('no such element')
+  rescue Selenium::WebDriver::Error::WebDriverError => exception
+    raise unless exception.message.include?('no such element')
     false
   rescue Selenium::WebDriver::Error::StaleElementReferenceError
     false
@@ -25,17 +25,17 @@ end
 def element_stale?(element)
   element.enabled?
   false
-rescue Selenium::WebDriver::Error::JavascriptError => e
-  e.message.starts_with? 'Element does not exist in cache'
-rescue Selenium::WebDriver::Error::UnknownError => e
-  puts "Unknown error: #{e}"
+rescue Selenium::WebDriver::Error::JavascriptError => exception
+  exception.message.starts_with? 'Element does not exist in cache'
+rescue Selenium::WebDriver::Error::UnknownError => exception
+  puts "Unknown error: #{exception}"
   true
 rescue Selenium::WebDriver::Error::StaleElementReferenceError
   true
-rescue Selenium::WebDriver::Error::WebDriverError => e
-  return true if e.message.include?('stale element reference') ||
-    e.message.include?('no such element')
-  puts "Unknown error: #{e}"
+rescue Selenium::WebDriver::Error::WebDriverError => exception
+  return true if exception.message.include?('stale element reference') ||
+    exception.message.include?('no such element')
+  puts "Unknown error: #{exception}"
   true
 end
 

--- a/dashboard/test/ui/features/support/browser_helpers.rb
+++ b/dashboard/test/ui/features/support/browser_helpers.rb
@@ -117,8 +117,8 @@ module BrowserHelpers
       JS
       )
     end
-  rescue => e
-    puts "DEBUG: Unable to install js error recorder; #{e}"
+  rescue => exception
+    puts "DEBUG: Unable to install js error recorder; #{exception}"
   end
 
   def check_window_for_js_errors(check_reason_description)
@@ -132,13 +132,13 @@ module BrowserHelpers
         end
       end
     end
-  rescue => e
+  rescue => exception
     # We're not currently failing any tests based on JS errors showing up, so
     # this is just a debugging tool.
     # We're getting intermittent timing errors that have to do with SauceLabs
     # going away before we can check for JS errors.
     # We don't want that to cause test runs to fail, so ignore exceptions for now.
-    puts "DEBUG: Unable to check window for JS errors; #{e}"
+    puts "DEBUG: Unable to check window for JS errors; #{exception}"
   end
 
   def wait

--- a/dashboard/test/ui/features/support/connect.rb
+++ b/dashboard/test/ui/features/support/connect.rb
@@ -132,16 +132,16 @@ def log_result(result)
     body: {"passed" => result}.to_json,
     headers: {'Content-Type' => 'application/json'}
   )
-rescue => e
-  puts "Error logging result: #{e}"
+rescue => exception
+  puts "Error logging result: #{exception}"
 end
 
 # Quit current browser session.
 def quit_browser
   with_read_timeout(5.seconds) do
     $browser&.quit
-  rescue => e
-    puts "Error quitting browser session: #{e}"
+  rescue => exception
+    puts "Error quitting browser session: #{exception}"
   end
   $browser = @browser = nil
 end
@@ -154,8 +154,8 @@ After do |scenario|
     # clear session state
     with_read_timeout(10) do
       steps 'Then I sign out' if $browser
-    rescue => e
-      puts "Session reset error: #{e}"
+    rescue => exception
+      puts "Session reset error: #{exception}"
     end
   else
     log_result scenario.passed?
@@ -167,8 +167,8 @@ def context(str)
   unless ENV['TEST_LOCAL'] == 'true'
     $browser&.execute_script("sauce:context=#{str}")
   end
-rescue => e
-  puts "Context error: #{e}"
+rescue => exception
+  puts "Context error: #{exception}"
 end
 
 failed = false

--- a/dashboard/test/ui/features/support/hooks.rb
+++ b/dashboard/test/ui/features/support/hooks.rb
@@ -26,7 +26,7 @@ end
 
 Around do |_, block|
   block.call
-rescue Selenium::WebDriver::Error::TimeOutError => e
+rescue Selenium::WebDriver::Error::TimeOutError => exception
   check_window_for_js_errors('after timeout')
-  raise e
+  raise exception
 end

--- a/dashboard/test/ui/runner.rb
+++ b/dashboard/test/ui/runner.rb
@@ -64,8 +64,8 @@ def main(options)
 
   run_results = Parallel.map(browser_feature_generator, parallel_config(options.parallel_limit)) do |browser, feature|
     run_feature browser, feature, options
-  rescue => e
-    ChatClient.log "Exception: #{e.message}", color: 'red'
+  rescue => exception
+    ChatClient.log "Exception: #{exception.message}", color: 'red'
     raise
   end
 
@@ -287,8 +287,8 @@ def upload_log_and_get_public_link(filename, metadata)
   return '' unless $options.html
   log_url = LOG_UPLOADER.upload_file(filename, {metadata: metadata})
   " <a href='#{log_url}'>☁ Log on S3</a>"
-rescue Exception => e
-  ChatClient.log "Uploading log to S3 failed: #{e}"
+rescue Exception => exception
+  ChatClient.log "Uploading log to S3 failed: #{exception}"
   return ''
 end
 
@@ -473,8 +473,8 @@ end
 def flakiness_for_test(test_run_identifier)
   return nil if $stop_calculating_flakiness
   TestFlakiness.summary_for(:test_flakiness, test_run_identifier)
-rescue Exception => e
-  puts "Error calculating flakiness: #{e.full_message}. Will stop calculating test flakiness for this run."
+rescue Exception => exception
+  puts "Error calculating flakiness: #{exception.full_message}. Will stop calculating test flakiness for this run."
   $stop_calculating_flakiness = true
   nil
 end
@@ -483,8 +483,8 @@ end
 def estimate_for_test(test_run_identifier)
   return nil if $stop_calculating_flakiness
   TestFlakiness.summary_for(:test_estimate, test_run_identifier)
-rescue Exception => e
-  puts "Error calculating estimate: #{e.full_message}. Will stop calculating test flakiness for this run."
+rescue Exception => exception
+  puts "Error calculating estimate: #{exception.full_message}. Will stop calculating test flakiness for this run."
   $stop_calculating_flakiness = true
   nil
 end

--- a/dashboard/test/ui/utils/selenium_browser.rb
+++ b/dashboard/test/ui/utils/selenium_browser.rb
@@ -37,11 +37,11 @@ module SeleniumBrowser
     # Replaces 'unexpected response' message with the actual parsed error from the JSON response, if provided.
     def create_response(code, body, content_type)
       super
-    rescue Selenium::WebDriver::Error::WebDriverError => e
-      if (msg = e.message.match(/unexpected response, code=(?<code>\d+).*\n(?<error>.*)/))
+    rescue Selenium::WebDriver::Error::WebDriverError => exception
+      if (msg = exception.message.match(/unexpected response, code=(?<code>\d+).*\n(?<error>.*)/))
         error = msg[:error]
         error = JSON.parse(error)['value']['error'] rescue error
-        e.message.replace("Error #{msg[:code]}: #{error}")
+        exception.message.replace("Error #{msg[:code]}: #{error}")
       end
       raise
     end

--- a/lib/cdo/analytics/milestone_parser.rb
+++ b/lib/cdo/analytics/milestone_parser.rb
@@ -140,9 +140,9 @@ class MilestoneParser
     FileUtils.rm path
     debug "Count: #{count}"
     response
-  rescue => e
-    debug "Error counting #{log.key}: #{e.message}"
-    {'count' => 0, 'error' => e.message}
+  rescue => exception
+    debug "Error counting #{log.key}: #{exception.message}"
+    {'count' => 0, 'error' => exception.message}
   end
 
   def stub_fetch(key, path, bytes)

--- a/lib/cdo/aws/cloud_formation.rb
+++ b/lib/cdo/aws/cloud_formation.rb
@@ -250,9 +250,9 @@ module AWS
       begin
         result = cfn.method("#{method}_stack").call(stack_options)
         @stack_id ||= result.stack_id if result.respond_to?(:stack_id)
-      rescue Aws::CloudFormation::Errors::ValidationError => e
-        if e.message == 'No updates are to be performed.'
-          log.info e.message
+      rescue Aws::CloudFormation::Errors::ValidationError => exception
+        if exception.message == 'No updates are to be performed.'
+          log.info exception.message
           return
         else
           raise
@@ -270,8 +270,8 @@ module AWS
           cfn.describe_stacks(stack_name: stack_name).stacks.first.tap do |stack|
             @stack_id = stack.stack_id
           end
-        rescue Aws::CloudFormation::Errors::ValidationError => e
-          raise e unless e.message == "Stack with id #{stack_name} does not exist"
+        rescue Aws::CloudFormation::Errors::ValidationError => exception
+          raise exception unless exception.message == "Stack with id #{stack_name} does not exist"
           false
         end
       @stack_resource && !%w(REVIEW_IN_PROGRESS DELETE_COMPLETE).include?(@stack_resource.stack_status)

--- a/lib/cdo/aws/dms.rb
+++ b/lib/cdo/aws/dms.rb
@@ -181,9 +181,9 @@ module Cdo
         end
 
         CDO.log.info "DMS Task Completed Successfully: #{@arn}"
-      rescue StandardError => e
-        CDO.log.info "Error executing DMS Replication Task #{@arn} - #{e}"
-        raise e
+      rescue StandardError => exception
+        CDO.log.info "Error executing DMS Replication Task #{@arn} - #{exception}"
+        raise exception
       end
 
       # Check periodically until replication task has completed and then validate that it was successful.

--- a/lib/cdo/aws/metrics.rb
+++ b/lib/cdo/aws/metrics.rb
@@ -47,8 +47,8 @@ module Cdo
           namespace: @namespace,
           metric_data: events
         )
-      rescue => e
-        Honeybadger.notify(e)
+      rescue => exception
+        Honeybadger.notify(exception)
       end
 
       def size(events)

--- a/lib/cdo/aws/rds.rb
+++ b/lib/cdo/aws/rds.rb
@@ -71,8 +71,8 @@ module Cdo
           {db_instance_identifier: clone_instance_id},
           {max_attempts: max_attempts, delay: delay}
         )
-      rescue Aws::Waiters::Errors::WaiterFailed => e
-        CDO.log.info "Error waiting for cluster clone instance to become available. #{e}"
+      rescue Aws::Waiters::Errors::WaiterFailed => exception
+        CDO.log.info "Error waiting for cluster clone instance to become available. #{exception}"
       end
       CDO.log.info "Done creating database cluster - #{clone_cluster_id}"
     end
@@ -114,8 +114,8 @@ module Cdo
             db_cluster_parameter_group_name: existing_cluster.db_cluster_parameter_group
           )
         end
-      rescue Aws::RDS::Errors::DBClusterNotFoundFault => e
-        CDO.log.info "Cluster #{cluster_id} does not exist. #{e}.  No need to delete it."
+      rescue Aws::RDS::Errors::DBClusterNotFoundFault => exception
+        CDO.log.info "Cluster #{cluster_id} does not exist. #{exception}.  No need to delete it."
       end
     end
 
@@ -132,9 +132,9 @@ module Cdo
             db_clusters.
             first.
             status
-        rescue Aws::RDS::Errors::DBClusterNotFoundFault => e
+        rescue Aws::RDS::Errors::DBClusterNotFoundFault => exception
           cluster_state = 'deleted'
-          CDO.log.info "Database Cluster #{db_cluster_id} has been deleted. #{e}"
+          CDO.log.info "Database Cluster #{db_cluster_id} has been deleted. #{exception}"
         end
         attempts += 1
         sleep delay

--- a/lib/cdo/aws/s3_packaging.rb
+++ b/lib/cdo/aws/s3_packaging.rb
@@ -44,8 +44,8 @@ class S3Packaging
     rescue Aws::S3::Errors::NoSuchKey
       @logger.info "Package does not exist on S3. If you have made local changes to #{@package_name}, you need to set build_#{@package_name.underscore} and use_my_#{@package_name.underscore} to true in locals.yml"
       return false
-    rescue Exception => e
-      @logger.info "update_from_s3 failed: #{e.message}"
+    rescue Exception => exception
+      @logger.info "update_from_s3 failed: #{exception.message}"
       return false
     end
     return true
@@ -120,10 +120,10 @@ class S3Packaging
         }
       end.compact
     )
-  rescue => e
+  rescue => exception
     # Just log and continue
     warn 'Failed to log bundle size with error:'
-    warn e
+    warn exception
     warn 'Proceeding with build...'
   end
 

--- a/lib/cdo/buffer.rb
+++ b/lib/cdo/buffer.rb
@@ -154,8 +154,8 @@ module Cdo
     def flush_batch
       @last_flush = now
       flush(take_batch.map(&:object))
-    rescue => e
-      Honeybadger.notify(e)
+    rescue => exception
+      Honeybadger.notify(exception)
     end
 
     # Take a single batch of objects from the buffer.

--- a/lib/cdo/contact_rollups/v2/pardot.rb
+++ b/lib/cdo/contact_rollups/v2/pardot.rb
@@ -259,11 +259,11 @@ class PardotV2
     # @see http://developer.pardot.com/kb/api-version-4/prospects/#using-prospects
     post_with_auth_retry "#{PROSPECT_DELETION_URL}/#{pardot_id}"
     true
-  rescue StandardError => e
+  rescue StandardError => exception
     # If the input pardot_id does not exist, Pardot will response with
     # HTTP code 400 and error code 3 "Invalid prospect ID" in the body.
-    return false if /Pardot request failed with HTTP 400/.match?(e.message)
-    raise e
+    return false if /Pardot request failed with HTTP 400/.match?(exception.message)
+    raise exception
   end
 
   # Finds prospects using email address and extract their Pardot ids.
@@ -272,11 +272,11 @@ class PardotV2
   def self.retrieve_pardot_ids_by_email(email)
     doc = post_with_auth_retry "#{PROSPECT_READ_URL}/#{URI.encode_www_form_component(email)}"
     doc.xpath('//prospect/id').map(&:text)
-  rescue StandardError => e
+  rescue StandardError => exception
     # If the input email does not exist, Pardot will response with
     # HTTP code 400, and error code 4 "Invalid prospect email address" in the body.
-    return [] if /Pardot request failed with HTTP 400/.match?(e.message)
-    raise e
+    return [] if /Pardot request failed with HTTP 400/.match?(exception.message)
+    raise exception
   end
 
   # Converts contact keys and values to Pardot prospect keys and values.

--- a/lib/cdo/contact_rollups/v2/pardot_helpers.rb
+++ b/lib/cdo/contact_rollups/v2/pardot_helpers.rb
@@ -25,12 +25,12 @@ module PardotHelpers
     begin
       tries += 1
       yield
-    rescue *retriable_errors => e
+    rescue *retriable_errors => exception
       if tries < max_tries
         sleep([2**tries, max_sleep_seconds].min)
         retry
       end
-      raise e
+      raise exception
     end
   end
 

--- a/lib/cdo/crowdin/legacy_utils.rb
+++ b/lib/cdo/crowdin/legacy_utils.rb
@@ -109,9 +109,9 @@ module Crowdin
       File.open(dest, "w:#{response.body.encoding}") do |destfile|
         destfile.write(response.body)
       end
-    rescue Net::ReadTimeout, Net::OpenTimeout, AWSError => e
+    rescue Net::ReadTimeout, Net::OpenTimeout, AWSError => exception
       # Only attempting retries on request errors. Surfacing errors during write.
-      warn "download_file(#{dest})#{response.present? ? " error code: #{response.code}" : ''} error: #{e}"
+      warn "download_file(#{dest})#{response.present? ? " error code: #{response.code}" : ''} error: #{exception}"
       raise if attempts <= 1
       download_file(download_url, dest, attempts: attempts - 1)
     end

--- a/lib/cdo/crowdin/project.rb
+++ b/lib/cdo/crowdin/project.rb
@@ -61,14 +61,14 @@ module Crowdin
       raise CrowdinServiceUnavailableError if response.code == 503
 
       response
-    rescue Net::ReadTimeout, Net::OpenTimeout, CrowdinRateLimitError, CrowdinInternalServerError, CrowdinServiceUnavailableError => e
+    rescue Net::ReadTimeout, Net::OpenTimeout, CrowdinRateLimitError, CrowdinInternalServerError, CrowdinServiceUnavailableError => exception
       # Handle a timeout by simply retrying. We default to three attempts before
       # giving up; if this doesn't work out, other things we could consider:
       #
       #   - increasing the default number of attempts
       #   - increasing the number of attempts for certain high-failure-rate calls
       #   - increasing the timeout, either globally or for this specific call
-      warn "Crowdin.export_file(#{file_id}) error: #{e}"
+      warn "Crowdin.export_file(#{file_id}) error: #{exception}"
       sleep(3) if response&.code == 429
       raise if attempts <= 1
       export_file(file_id, language, etag: etag, attempts: attempts - 1)

--- a/lib/cdo/data/google_sheet_to_csv.rb
+++ b/lib/cdo/data/google_sheet_to_csv.rb
@@ -25,8 +25,8 @@ class GSheetToCsv
       mtime = @file.mtime
       ctime = File.mtime(@csv_path) if File.file?(@csv_path)
       return mtime.to_s == ctime.to_s
-    rescue GoogleDrive::Error => e
-      ChatClient.log "<p>Error getting modified time for <b>#{@gsheet_path}<b> from Google Drive.</p><pre><code>#{e.message}</code></pre>", color: 'yellow'
+    rescue GoogleDrive::Error => exception
+      ChatClient.log "<p>Error getting modified time for <b>#{@gsheet_path}<b> from Google Drive.</p><pre><code>#{exception.message}</code></pre>", color: 'yellow'
       true # Assume the current thing is up to date.
     end
   end
@@ -47,9 +47,9 @@ class GSheetToCsv
 
     begin
       buf = @file.spreadsheet_csv
-    rescue GoogleDrive::Error => e
-      puts "Error on file: #{@gsheet_path}, #{e}"
-      throw e
+    rescue GoogleDrive::Error => exception
+      puts "Error on file: #{@gsheet_path}, #{exception}"
+      throw exception
     end
     CSV.open(@csv_path, 'wb') do |csv|
       columns = nil

--- a/lib/cdo/data/logging/rake_task_event_logger.rb
+++ b/lib/cdo/data/logging/rake_task_event_logger.rb
@@ -59,9 +59,9 @@ class RakeTaskEventLogger
           }.to_json
         }
       )
-    rescue => e
+    rescue => exception
       Honeybadger.notify(
-        e,
+        exception,
         error_message: "Failed to log rake task information",
         context: {
           event: event

--- a/lib/cdo/data/logging/timed_task_with_logging.rb
+++ b/lib/cdo/data/logging/timed_task_with_logging.rb
@@ -9,8 +9,8 @@ module CustomRake
       logger.start_task_logging
       begin
         puts "Finished #{name} (#{distance_of_time_in_words(Benchmark.realtime {super}.to_f)})"
-      rescue => e
-        logger.exception_task_logging(e)
+      rescue => exception
+        logger.exception_task_logging(exception)
         raise
       end
       logger.end_task_logging

--- a/lib/cdo/google/drive.rb
+++ b/lib/cdo/google/drive.rb
@@ -50,8 +50,8 @@ module Google
       file = @session.file_by_title(path_to_title_array(path))
       return nil if file.nil?
       Google::Drive::File.new(@session, file)
-    rescue GoogleDrive::Error => e
-      ChatClient.log "<p>Error syncing <b>#{path}<b> from Google Drive.</p><pre><code>#{e.message}</code></pre>", color: 'yellow'
+    rescue GoogleDrive::Error => exception
+      ChatClient.log "<p>Error syncing <b>#{path}<b> from Google Drive.</p><pre><code>#{exception.message}</code></pre>", color: 'yellow'
       return nil
     end
 

--- a/lib/cdo/image_moderation.rb
+++ b/lib/cdo/image_moderation.rb
@@ -14,11 +14,11 @@ module ImageModeration
       endpoint: CDO.azure_content_moderation_endpoint,
       api_key: CDO.azure_content_moderation_key
     ).rate_image(image_data, content_type, image_url)
-  rescue AzureContentModerator::AzureError => e
+  rescue AzureContentModerator::AzureError => exception
     # If something goes wrong with the image moderation service our fallback
     # behavior is to allow everything through, but we also want to notify
     # Honeybadger so that we can figure out exactly what is going wrong.
-    Honeybadger.notify(e)
+    Honeybadger.notify(exception)
 
     # Log to firehose as well, to have longer-lived data
     FirehoseClient.instance.put_record(
@@ -27,7 +27,7 @@ module ImageModeration
         study: 'azure-content-moderation',
         study_group: 'v1',
         event: 'moderation-error',
-        data_string: e
+        data_string: exception
       }
     )
     :unknown

--- a/lib/cdo/lighthouse.rb
+++ b/lib/cdo/lighthouse.rb
@@ -58,7 +58,7 @@ module Lighthouse
     ChatClient.log "#{url} Page Speed: <a href='#{html_url}'>#{perf}</a>"
     Cdo::Metrics.put 'Website/PageSpeed', perf,
       Environment: CDO.rack_env, URL: url.to_s
-  rescue => e
-    ChatClient.log "Page speed report failed: #{e}"
+  rescue => exception
+    ChatClient.log "Page speed report failed: #{exception}"
   end
 end

--- a/lib/cdo/log_collector.rb
+++ b/lib/cdo/log_collector.rb
@@ -32,12 +32,12 @@ class LogCollector
       "Action '#{action_name}' completed without error in"\
       " #{self.class.get_friendly_time(Time.now - start_time)}."
     )
-  rescue StandardError => e
+  rescue StandardError => exception
     error(
       "Action '#{action_name}' exited with error in"\
       " #{self.class.get_friendly_time(Time.now - start_time)}."
     )
-    record_exception(e)
+    record_exception(exception)
   end
   alias_method :time_and_continue, :time
 

--- a/lib/cdo/optimizer.rb
+++ b/lib/cdo/optimizer.rb
@@ -93,9 +93,9 @@ module Cdo
         cache.write(cache_key, false)
         IMAGE_OPTIM.optimize_image_data(data) || data
       end
-    rescue => e
+    rescue => exception
       # Log error and return original content.
-      Honeybadger.notify(e,
+      Honeybadger.notify(exception,
         context: {
           key: cache_key
         }

--- a/lib/cdo/pegasus/actionview_sinatra.rb
+++ b/lib/cdo/pegasus/actionview_sinatra.rb
@@ -56,10 +56,10 @@ module ActionViewSinatra
       # save locals hash for access by the locals method
       @locals = locals
       super(options, locals)
-    rescue ActionView::Template::Error => e
+    rescue ActionView::Template::Error => exception
       # allow templates to throw a Sinatra::NotFound error to trigger a 404
-      raise e.cause if e.cause.is_a?(Sinatra::NotFound)
-      raise e
+      raise exception.cause if exception.cause.is_a?(Sinatra::NotFound)
+      raise exception
     end
 
     # Our templates currently use a bunch of sinatra methods like resolve_static, redirect, etc.

--- a/lib/cdo/poste.rb
+++ b/lib/cdo/poste.rb
@@ -30,8 +30,8 @@ module Poste
   # @return [Integer, nil] decrypted id, or nil if it could not be decrypted.
   def self.decrypt_id(encrypted)
     decrypt(encrypted).to_i
-  rescue OpenSSL::Cipher::CipherError, ArgumentError => e
-    CDO.log.warn "Unable to decrypt poste id: #{encrypted}. Error: #{e.message}"
+  rescue OpenSSL::Cipher::CipherError, ArgumentError => exception
+    CDO.log.warn "Unable to decrypt poste id: #{encrypted}. Error: #{exception.message}"
     nil
   end
 

--- a/lib/cdo/redshift_import.rb
+++ b/lib/cdo/redshift_import.rb
@@ -142,8 +142,8 @@ class RedshiftImport
       ALTER TABLE #{current_table_name} RENAME TO #{new_table_name};
     SQL
     redshift_client.exec(query)
-  rescue PG::UndefinedTable => e
-    CDO.log.info "Unable to rename table #{schema}.#{current_table_name} because it does not exist. #{e}"
+  rescue PG::UndefinedTable => exception
+    CDO.log.info "Unable to rename table #{schema}.#{current_table_name} because it does not exist. #{exception}"
   end
 
   # Get name and columns of primary key constraint for a specific table, if constraint exists.

--- a/lib/cdo/secrets.rb
+++ b/lib/cdo/secrets.rb
@@ -65,8 +65,8 @@ module Cdo
       @values[key] ||= begin
         client.then do |client|
           parse_json(get_secret_value(client, key))
-        rescue => e
-          e.message << " Key: #{key}"
+        rescue => exception
+          exception.message << " Key: #{key}"
           raise
         end
       end
@@ -139,8 +139,8 @@ module Cdo
         secret_id: key,
         version_stage: CURRENT
       ).secret_string
-    rescue NOT_FOUND => e
-      e.set_backtrace []
+    rescue NOT_FOUND => exception
+      exception.set_backtrace []
       raise
     end
 

--- a/lib/cdo/shared_cache.rb
+++ b/lib/cdo/shared_cache.rb
@@ -19,8 +19,8 @@ module Cdo
         if CDO.memcached_endpoint
           begin
             memcached_hosts = Dalli::ElastiCache.new(CDO.memcached_endpoint).servers
-          rescue => e # Notify if Auto Discovery fails.
-            Honeybadger.notify(e)
+          rescue => exception # Notify if Auto Discovery fails.
+            Honeybadger.notify(exception)
           end
         end
         return nil unless memcached_hosts.present?

--- a/lib/cdo/slack.rb
+++ b/lib/cdo/slack.rb
@@ -254,10 +254,10 @@ class Slack
         Honeybadger.notify_cronjob_error opts
         response = false
       end
-    rescue Exception => e
+    rescue Exception => exception
       opts = {
         error_class: "Slack integration [error]",
-        error_message: e,
+        error_message: exception,
         context: {url: url, payload: payload}
       }
       Honeybadger.notify_cronjob_error opts

--- a/lib/dynamic_config/adapters/dynamodb_adapter.rb
+++ b/lib/dynamic_config/adapters/dynamodb_adapter.rb
@@ -22,8 +22,8 @@ class DynamoDBAdapter
     return nil if resp.item.nil?
     begin
       value = Oj.load(resp.item['data-value'])
-    rescue => e
-      Honeybadger.notify(e)
+    rescue => exception
+      Honeybadger.notify(exception)
       value = nil
     end
     value
@@ -61,8 +61,8 @@ class DynamoDBAdapter
         key = item['data-key']
         begin
           value = Oj.load(item['data-value'])
-        rescue => e
-          Honeybadger.notify(e)
+        rescue => exception
+          Honeybadger.notify(exception)
           value = nil
         end
         result[key] = value

--- a/lib/dynamic_config/adapters/json_file_adapter.rb
+++ b/lib/dynamic_config/adapters/json_file_adapter.rb
@@ -24,8 +24,8 @@ class JSONFileDatastoreAdapter
     load_from_file
     begin
       return Oj.load(@hash[key])
-    rescue => e
-      Honeybadger.notify(e)
+    rescue => exception
+      Honeybadger.notify(exception)
     end
     nil
   end
@@ -37,8 +37,8 @@ class JSONFileDatastoreAdapter
     @hash.each do |k, v|
       begin
         value = Oj.load(v)
-      rescue => e
-        Honeybadger.notify(e)
+      rescue => exception
+        Honeybadger.notify(exception)
         nil
       end
       ret[k] = value

--- a/lib/dynamic_config/adapters/memory_adapter.rb
+++ b/lib/dynamic_config/adapters/memory_adapter.rb
@@ -14,8 +14,8 @@ class MemoryAdapter
 
   def get(key)
     Oj.load(@hash[key])
-  rescue => e
-    Honeybadger.notify(e)
+  rescue => exception
+    Honeybadger.notify(exception)
     nil
   end
 

--- a/lib/dynamic_config/datastore_cache.rb
+++ b/lib/dynamic_config/datastore_cache.rb
@@ -32,9 +32,9 @@ class DatastoreCache
   def notify_change_listeners
     @listeners.each do |listener|
       listener.on_change
-    rescue => e
-      Rails.logger.warn("Error calling listener: #{e.message}")
-      Honeybadger.notify(e)
+    rescue => exception
+      Rails.logger.warn("Error calling listener: #{exception.message}")
+      Honeybadger.notify(exception)
     end
   end
 
@@ -86,9 +86,9 @@ class DatastoreCache
         updated = true if value != old_value
       end
       notify_change_listeners if updated
-    rescue => e
+    rescue => exception
       retry unless (tries -= 1).zero?
-      Honeybadger.notify(e)
+      Honeybadger.notify(exception)
     end
   end
 

--- a/lib/pdf/collate.rb
+++ b/lib/pdf/collate.rb
@@ -48,9 +48,9 @@ module PDF
       next filename unless string_is_url(filename)
       begin
         local_file = Tempfile.from_url(filename)
-      rescue Exception => e
+      rescue Exception => exception
         puts "Error downloading PDF file #{filename} for output file #{output_file}. Aborting"
-        puts "Error message: #{e}"
+        puts "Error message: #{exception}"
         raise
       end
       temp_file_handles << local_file

--- a/lib/rake/build.rake
+++ b/lib/rake/build.rake
@@ -132,9 +132,9 @@ namespace :build do
         ChatClient.log 'Updating <b>pegasus</b> database...'
         begin
           RakeUtils.rake_stream_output 'pegasus:setup_db', (rack_env?(:test) ? '--trace' : nil)
-        rescue => e
-          ChatClient.log "/quote #{e.message}\n#{CDO.backtrace e}", message_format: 'text'
-          raise e
+        rescue => exception
+          ChatClient.log "/quote #{exception.message}\n#{CDO.backtrace exception}", message_format: 'text'
+          raise exception
         end
       end
 

--- a/lib/rake/ci.rake
+++ b/lib/rake/ci.rake
@@ -79,9 +79,9 @@ namespace :ci do
   timed_task_with_logging :publish_github_release do
     RakeUtils.system "bin/create-release --force"
     ChatClient.log '<a href="https://github.com/code-dot-org/code-dot-org/releases/latest">New release created</a>'
-  rescue RuntimeError => e
+  rescue RuntimeError => exception
     ChatClient.log 'Failed to create a new release.', color: 'red'
-    ChatClient.log "/quote #{e.message}\n#{CDO.backtrace e}", message_format: 'text', color: 'red'
+    ChatClient.log "/quote #{exception.message}\n#{CDO.backtrace exception}", message_format: 'text', color: 'red'
   end
 
   desc 'flush Content Distribution Network (CDN) caches'

--- a/pegasus/rake/generate_pdfs.rake
+++ b/pegasus/rake/generate_pdfs.rake
@@ -36,9 +36,9 @@ def generate_pdf_file(base_url, pdf_conversion_info, fetchfile_for_pdf)
 
   begin
     PDF.generate_from_url(url, pdf_conversion_info.output_pdf_path, verbose: true)
-  rescue Exception => e
+  rescue Exception => exception
     ChatClient.log "PDF generation failure for #{url}"
-    ChatClient.log "/quote #{e.message}\n#{CDO.backtrace e}", message_format: 'text'
+    ChatClient.log "/quote #{exception.message}\n#{CDO.backtrace exception}", message_format: 'text'
     raise
   end
 

--- a/pegasus/router.rb
+++ b/pegasus/router.rb
@@ -348,9 +348,9 @@ class Documents < Sinatra::Base
       remaining_content = match.post_match
       line = content.lines.count - remaining_content.lines.count + 1
       [header, remaining_content, line]
-    rescue => e
+    rescue => exception
       # Append rendered header to error message.
-      e.message << "\n#{match[:yaml]}" if match[:yaml]
+      exception.message << "\n#{match[:yaml]}" if match[:yaml]
       raise
     end
 
@@ -377,10 +377,10 @@ class Documents < Sinatra::Base
 
       response.headers['X-Pegasus-Version'] = '3'
       render_(content, path, line)
-    rescue => e
+    rescue => exception
       # Add document path to backtrace if not already included.
-      if path && [e.message, *e.backtrace].none? {|location| location.include?(path)}
-        e.set_backtrace e.backtrace.unshift(path)
+      if path && [exception.message, *exception.backtrace].none? {|location| location.include?(path)}
+        exception.set_backtrace exception.backtrace.unshift(path)
       end
       raise
     end
@@ -543,9 +543,9 @@ class Documents < Sinatra::Base
 
     def render_template(path, locals={})
       render_(File.read(path), path, 0, locals)
-    rescue => e
-      Honeybadger.context({path: path, e: e})
-      raise "Error rendering #{path}: #{e}"
+    rescue => exception
+      Honeybadger.context({path: path, e: exception})
+      raise "Error rendering #{path}: #{exception}"
     end
 
     def render_(body, path=nil, line=0, locals={})

--- a/pegasus/routes/form_routes.rb
+++ b/pegasus/routes/form_routes.rb
@@ -23,8 +23,8 @@ post '/forms/:kind' do |kind|
       data.delete "volunteer_id_i"
     end
     data.to_json
-  rescue FormError => e
-    halt 400, {'Content-Type' => 'text/json'}, e.errors.to_json
+  rescue FormError => exception
+    halt 400, {'Content-Type' => 'text/json'}, exception.errors.to_json
   rescue Sequel::UniqueConstraintViolation
     halt 409
   rescue NameError
@@ -50,8 +50,8 @@ post "/forms/:kind/:secret" do |kind, secret|
     cache_control :private, :must_revalidate, max_age: 0
     forbidden! unless form = update_form(kind, secret, params)
     form[:data]
-  rescue FormError => e
-    halt 400, {'Content-Type' => 'text/json'}, e.errors.to_json
+  rescue FormError => exception
+    halt 400, {'Content-Type' => 'text/json'}, exception.errors.to_json
   end
 end
 
@@ -64,7 +64,7 @@ post '/forms/:parent_kind/:parent_id/children/:kind' do |parent_kind, parent_id,
   begin
     content_type :json
     insert_or_upsert_form(kind, params, parent_id: parent_form[:id])[:data].to_json
-  rescue FormError => e
-    form_error! e
+  rescue FormError => exception
+    form_error! exception
   end
 end

--- a/pegasus/routes/v2_forms_routes.rb
+++ b/pegasus/routes/v2_forms_routes.rb
@@ -11,8 +11,8 @@ post '/v2/forms/:kind' do |kind|
   begin
     form = insert_or_upsert_form(kind, payload)
     redirect "/v2/forms/#{kind}/#{form[:secret]}", 201
-  rescue FormError => e
-    form_error! e
+  rescue FormError => exception
+    form_error! exception
   end
 end
 
@@ -53,8 +53,8 @@ patch '/v2/forms/:kind/:secret' do |kind, secret|
     content_type :json
     forbidden! unless form = update_form(kind, secret, payload)
     JSON.parse(form[:data]).merge(secret: secret).to_json
-  rescue FormError => e
-    form_error! e
+  rescue FormError => exception
+    form_error! exception
   end
 end
 post '/v2/forms/:kind/:secret/update' do |kind, secret|
@@ -121,7 +121,7 @@ post '/v2/forms/:parent_kind/:parent_id/children/:kind' do |parent_kind, parent_
   begin
     form = insert_or_upsert_form(kind, payload, parent_id: parent_form[:id])
     redirect "/v2/forms/#{kind}/#{form[:secret]}", 201
-  rescue FormError => e
-    form_error! e
+  rescue FormError => exception
+    form_error! exception
   end
 end

--- a/pegasus/sites/virtual/collate_pdfs.rake
+++ b/pegasus/sites/virtual/collate_pdfs.rake
@@ -40,9 +40,9 @@ all_output_files = []
 
 Dir.glob(pegasus_dir('sites/**/*.collate')).each do |collate_file|
   all_output_files << collate_to_pdf_to_fetch_file(collate_file)
-rescue Exception => e
+rescue Exception => exception
   ChatClient.log "PDF generation failure for #{collate_file}"
-  ChatClient.log "/quote #{e.message}\n#{CDO.backtrace e}", message_format: 'text'
+  ChatClient.log "/quote #{exception.message}\n#{CDO.backtrace exception}", message_format: 'text'
   raise
 end
 

--- a/pegasus/sites/virtual/generate_curriculum_pdfs.rake
+++ b/pegasus/sites/virtual/generate_curriculum_pdfs.rake
@@ -38,9 +38,9 @@ all_outfiles = []
 
     begin
       PDF.generate_from_url(url, pdf_conversion_info.output_pdf_path, verbose: true)
-    rescue Exception => e
+    rescue Exception => exception
       ChatClient.log "PDF generation failure for #{url}"
-      ChatClient.log "/quote #{e.message}\n#{CDO.backtrace e}", message_format: 'text'
+      ChatClient.log "/quote #{exception.message}\n#{CDO.backtrace exception}", message_format: 'text'
       raise
     end
 

--- a/pegasus/src/curriculum_router.rb
+++ b/pegasus/src/curriculum_router.rb
@@ -364,8 +364,8 @@ module Pegasus
         content_type :json
         cache_control :private, :must_revalidate, max_age: 0
         kind.submit(request, params).to_json
-      rescue FormError => e
-        halt 400, {'Content-Type' => 'text/json'}, e.errors.to_json
+      rescue FormError => exception
+        halt 400, {'Content-Type' => 'text/json'}, exception.errors.to_json
       end
     end
   end

--- a/pegasus/test/test_email_preference_helpers.rb
+++ b/pegasus/test/test_email_preference_helpers.rb
@@ -31,8 +31,8 @@ class EmailPreferenceHelperTest < SequelTestCase
       source: EmailPreferenceHelper::ACCOUNT_SIGN_UP,
       form_kind: nil
     )
-  rescue StandardError => e
-    assert_equal 'Email does not appear to be a valid e-mail address', e.message
+  rescue StandardError => exception
+    assert_equal 'Email does not appear to be a valid e-mail address', exception.message
     assert_nil Dashboard.db[:email_preferences].where(email: 'amidala@naboo').first
   else
     fail "Expected an email validation error."
@@ -46,8 +46,8 @@ class EmailPreferenceHelperTest < SequelTestCase
       source: EmailPreferenceHelper::ACCOUNT_SIGN_UP,
       form_kind: nil
     )
-  rescue StandardError => e
-    assert_equal 'Opt In is required', e.message
+  rescue StandardError => exception
+    assert_equal 'Opt In is required', exception.message
     assert_nil Dashboard.db[:email_preferences].where(email: 'test_without_opt_in@example.net').first
   else
     fail "Expected an Opt In validation error."
@@ -61,8 +61,8 @@ class EmailPreferenceHelperTest < SequelTestCase
       source: 'Where have all the cowboys gone?',
       form_kind: nil
     )
-  rescue StandardError => e
-    assert_equal 'Source is not included in the list', e.message
+  rescue StandardError => exception
+    assert_equal 'Source is not included in the list', exception.message
     assert_nil Dashboard.db[:email_preferences].where(email: 'test_invalid_source@example.net').first
   else
     fail 'Expected a source validation error.'
@@ -76,8 +76,8 @@ class EmailPreferenceHelperTest < SequelTestCase
       source: EmailPreferenceHelper::ACCOUNT_SIGN_UP,
       form_kind: nil
     )
-  rescue StandardError => e
-    assert_equal 'IP Address is required', e.message
+  rescue StandardError => exception
+    assert_equal 'IP Address is required', exception.message
     assert_nil Dashboard.db[:email_preferences].where(email: 'test_without_ip_address@example.net').first
   else
     fail 'Expected an IP Address error.'

--- a/pegasus/test/test_i18n_hoc_routes.rb
+++ b/pegasus/test/test_i18n_hoc_routes.rb
@@ -35,14 +35,14 @@ class I18nHocRoutesTest < Minitest::Test
   def assert_successful_get(path)
     resp = get(path)
     assert_equal 200, resp.status, path
-  rescue Psych::SyntaxError => e
-    flunk "Caught Psych::SyntaxError when parsing YML for #{path}: #{e}. It's likely that a .yml translation file for this language received a formatting error."
-  rescue SyntaxError => e
-    flunk "Caught SyntaxError for #{path}: #{e}. It's likely that a translation incorrectly edited some templating syntax."
-  rescue NameError => e
-    flunk "Caught NameError for #{path}: #{e}. It's likely that a translation translated a template method name."
-  rescue RuntimeError => e
-    flunk "Caught RuntimeError for #{path}: #{e}. It's likely that a translation modified a .md header to introduce an invalid value"
+  rescue Psych::SyntaxError => exception
+    flunk "Caught Psych::SyntaxError when parsing YML for #{path}: #{exception}. It's likely that a .yml translation file for this language received a formatting error."
+  rescue SyntaxError => exception
+    flunk "Caught SyntaxError for #{path}: #{exception}. It's likely that a translation incorrectly edited some templating syntax."
+  rescue NameError => exception
+    flunk "Caught NameError for #{path}: #{exception}. It's likely that a translation translated a template method name."
+  rescue RuntimeError => exception
+    flunk "Caught RuntimeError for #{path}: #{exception}. It's likely that a translation modified a .md header to introduce an invalid value"
   end
 
   def load_hoc_subpages

--- a/pegasus/test/test_pegasus_documents.rb
+++ b/pegasus/test/test_pegasus_documents.rb
@@ -105,11 +105,11 @@ class PegasusTest < Minitest::Test
           queries = capture_queries(DB, DASHBOARD_DB) {get(uri)}
           break if queries.empty? || (attempts -= 1).zero?
         end
-      rescue Exception => e
+      rescue Exception => exception
         # Filter backtrace from current location.
-        index = e.backtrace.index(caller(2..2).first)
-        e.set_backtrace(e.backtrace[0..index - 1])
-        next "[#{url}] Render failed:\n#{e}\n#{e.backtrace.join("\n")}"
+        index = exception.backtrace.index(caller(2..2).first)
+        exception.set_backtrace(exception.backtrace[0..index - 1])
+        next "[#{url}] Render failed:\n#{exception}\n#{exception.backtrace.join("\n")}"
       end
       response = last_response
       status = response.status

--- a/tools/scripts/rebuildSoundLibraryManifest.rb
+++ b/tools/scripts/rebuildSoundLibraryManifest.rb
@@ -103,8 +103,8 @@ class ManifestBuilder
     EOS
 
   # Report any issues while talking to S3 and suggest most likely steps for fixing it.
-  rescue Aws::Errors::ServiceError => e
-    warn e.inspect
+  rescue Aws::Errors::ServiceError => exception
+    warn exception.inspect
     warn <<-EOS.unindent
 
       #{bold 'There was an error talking to S3.'}  Make sure you have credentials set using one of:
@@ -157,10 +157,10 @@ class ManifestBuilder
         objects['json'].get(response_target: json_destination)
         verbose "Writing #{mp3_destination}"
         objects['mp3'].get(response_target: mp3_destination)
-      rescue Aws::Errors::ServiceError => e
+      rescue Aws::Errors::ServiceError => exception
         next <<~WARN
           There was an error retrieving #{name}.json and #{name}.mp3 from S3:
-          #{e}
+          #{exception}
           The sound has been skipped.
         WARN
       end
@@ -178,8 +178,8 @@ class ManifestBuilder
     EOS
 
   # Report any issues while talking to S3 and suggest most likely steps for fixing it.
-  rescue Aws::Errors::ServiceError => e
-    warn e.inspect
+  rescue Aws::Errors::ServiceError => exception
+    warn exception.inspect
     warn <<-EOS.unindent
 
       #{bold 'There was an error talking to S3.'}  Make sure you have credentials set using one of:
@@ -294,16 +294,16 @@ class ManifestBuilder
         end
         metadata['aliases'] = aliases.map {|a| (a.start_with? "category_") ? (a.delete_prefix "category_") : a}
         metadata['categories'] = categories
-      rescue Aws::Errors::ServiceError => e
+      rescue Aws::Errors::ServiceError => exception
         next <<~WARN
           There was an error retrieving #{name}.json from S3:
-          #{e}
+          #{exception}
           The sound has been skipped.
         WARN
-      rescue JSON::JSONError => e
+      rescue JSON::JSONError => exception
         next <<~WARN
           There was an error parsing #{name}.json:
-          #{e}
+          #{exception}
           The sound has been skipped.
         WARN
       end


### PR DESCRIPTION
Proposed modification to https://github.com/code-dot-org/code-dot-org/pull/50405. Because the default variable name is undesirably compact, add an override to use the more-explicit `exception`.

> This cop makes sure that rescued exceptions variables are named as expected.
>
> The `PreferredName` config option takes a `String`. It represents the required name of the variable. Its default is `e`.

Fix applied automaticaly with `bundle exec rubocop --auto-correct-all --only Naming/RescuedExceptionsVariableName`.

Also alphabetized the existing overrides, while I was in there.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- https://www.rubydoc.info/gems/rubocop/0.75.0/RuboCop/Cop/Naming/RescuedExceptionsVariableName
- https://docs.rubocop.org/rubocop/cops_naming.html#namingrescuedexceptionsvariablename

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
