### PR TITLE
Fix time capsule default poem dropdown on levelbuilder

### DIFF
--- a/dashboard/app/views/levels/editors/fields/_poetry_fields.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_poetry_fields.html.haml
@@ -9,16 +9,26 @@
       %p= "WARNING: #{warning}"
     = f.select :standalone_app_name, options_for_select(@level.class.standalone_app_names, @level.standalone_app_name), {}, onchange: 'toggleFields(this.value);'
 
-  #defaultPoem{class: ('collapse' if @level.standalone_app_name == 'poetry')}
+  #defaultPoemHoc{class: ('collapse' if @level.standalone_app_name != 'poetry_hoc')}
     = f.label :default_poem, 'Default Poem'
-    = f.select :default_poem, options_for_select(@level.class.poems_for_subtype(@level.standalone_app_name), @level.default_poem)
+    = f.select :default_poem, options_for_select(@level.class.hoc_poems, @level.default_poem)
+
+  #defaultPoemTimeCapsule{class: ('collapse' if @level.standalone_app_name != 'time_capsule')}
+    = f.label :default_poem, 'Default Poem'
+    = f.select :default_poem, options_for_select(@level.class.time_capsule_poems, @level.default_poem)
 
 :javascript
   function toggleFields(val) {
-    const defaultPoem = document.getElementById('defaultPoem');
-    if (val.toLowerCase() !== 'poetry') {
-      defaultPoem.classList.remove('collapse');
-    } else {
-      defaultPoem.classList.add('collapse');
+    const defaultPoemHoc = document.getElementById('defaultPoemHoc');
+    const defaultPoemTimeCapsule = document.getElementById('defaultPoemTimeCapsule');
+    if (val.toLowerCase() === 'poetry') {
+      defaultPoemHoc.classList.add('collapse');
+      defaultPoemTimeCapsule.classList.add('collapse');
+    } else if (val.toLowerCase() === 'poetry_hoc') {
+      defaultPoemTimeCapsule.classList.add('collapse');
+      defaultPoemHoc.classList.remove('collapse');
+    } else if (val.toLowerCase() === 'time_capsule') {
+      defaultPoemTimeCapsule.classList.remove('collapse');
+      defaultPoemHoc.classList.add('collapse');
     }
   }


### PR DESCRIPTION
In my previous [PR](https://github.com/code-dot-org/code-dot-org/pull/50445) to add the Time Capsule subtype I did not notice that when you change the subtype, the poem list does not change until you save because we are basing the poem list off of the list saved on the level. To fix this I split out the lists into two separate dropdowns that we show/hide based on the chosen subtype. If there's a cleaner way to do this in haml let me know!

## Testing story
Tested locally

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
