### PR TITLE
Add HoC courses to the set of course offerings to show in the quick assign component

### DIFF
--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -240,6 +240,10 @@ class CourseOffering < ApplicationRecord
     key == 'csd'
   end
 
+  def hoc?
+    category == 'hoc' || marketing_initiative == Curriculum::SharedCourseConstants::COURSE_OFFERING_MARKETING_INITIATIVES.hoc
+  end
+
   def grade_levels_list
     return [] if grade_levels.nil?
     grade_levels.strip.split(',')

--- a/dashboard/app/models/course_version.rb
+++ b/dashboard/app/models/course_version.rb
@@ -214,6 +214,6 @@ class CourseVersion < ApplicationRecord
   end
 
   def hoc?
-    course_offering&.category == 'hoc'
+    !!course_offering&.hoc?
   end
 end

--- a/dashboard/lib/quick_assign_helper.rb
+++ b/dashboard/lib/quick_assign_helper.rb
@@ -8,10 +8,10 @@ module QuickAssignHelper
     assignable_high_offerings = assignable_offerings.filter(&:high_school_level?)
     assignable_hoc_offerings = assignable_offerings.filter(&:hoc?)
 
-    offerings[:elementary] = group_offerings(assignable_elementary_offerings, user, locale)
-    offerings[:middle] = group_offerings(assignable_middle_offerings, user, locale)
-    offerings[:high] = group_offerings(assignable_high_offerings, user, locale)
-    offerings[:hoc] = group_hoc_offerings(assignable_hoc_offerings, user, locale)
+    offerings[:elementary] = group_grade_level_offerings(assignable_elementary_offerings, user, locale)
+    offerings[:middle] = group_grade_level_offerings(assignable_middle_offerings, user, locale)
+    offerings[:high] = group_grade_level_offerings(assignable_high_offerings, user, locale)
+    offerings[:hoc] = group_hoc_and_pl_offerings(assignable_hoc_offerings, user, locale)
 
     offerings
   end
@@ -21,7 +21,7 @@ module QuickAssignHelper
   # The headers within each curriculum_type will be sorted alphabetically.
   # The offerings within a header will be sorted alphabetically by display_name.
   # Any course_offerings that do not have a curriculum_type and a header will be ignored.
-  def self.group_offerings(course_offerings, user, locale)
+  def self.group_grade_level_offerings(course_offerings, user, locale)
     data = {}
     course_offerings.each do |co|
       next if co.header.blank? || co.curriculum_type.blank?
@@ -42,7 +42,13 @@ module QuickAssignHelper
     data
   end
 
-  def self.group_hoc_offerings(course_offerings, user, locale)
+  def self.compare_headers(h1, h2)
+    return -1 if h1 == Curriculum::SharedCourseConstants::COURSE_OFFERING_HEADERS.favorites
+    return 1 if h2 == Curriculum::SharedCourseConstants::COURSE_OFFERING_HEADERS.favorites
+    h1 <=> h2
+  end
+
+  def self.group_hoc_and_pl_offerings(course_offerings, user, locale)
     data = {}
     course_offerings.each do |co|
       next if co.header.blank?
@@ -54,7 +60,6 @@ module QuickAssignHelper
     data.keys.each do |header|
       data[header].sort_by! {|co| co[:display_name]}
     end
-    data = data.sort.to_h
-    data
+    data.sort {|(h1, _), (h2, _)| compare_headers(h1, h2)}.to_h
   end
 end

--- a/dashboard/lib/quick_assign_helper.rb
+++ b/dashboard/lib/quick_assign_helper.rb
@@ -6,10 +6,12 @@ module QuickAssignHelper
     assignable_elementary_offerings = assignable_offerings.filter(&:elementary_school_level?)
     assignable_middle_offerings = assignable_offerings.filter(&:middle_school_level?)
     assignable_high_offerings = assignable_offerings.filter(&:high_school_level?)
+    assignable_hoc_offerings = assignable_offerings.filter(&:hoc?)
 
     offerings[:elementary] = group_offerings(assignable_elementary_offerings, user, locale)
     offerings[:middle] = group_offerings(assignable_middle_offerings, user, locale)
     offerings[:high] = group_offerings(assignable_high_offerings, user, locale)
+    offerings[:hoc] = group_hoc_offerings(assignable_hoc_offerings, user, locale)
 
     offerings
   end
@@ -37,6 +39,22 @@ module QuickAssignHelper
       data[curriculum_type] = data[curriculum_type].sort.to_h
     end
 
+    data
+  end
+
+  def self.group_hoc_offerings(course_offerings, user, locale)
+    data = {}
+    course_offerings.each do |co|
+      next if co.header.blank?
+
+      data[co.header] ||= []
+      data[co.header].append(co.summarize_for_quick_assign(user, locale))
+    end
+
+    data.keys.each do |header|
+      data[header].sort_by! {|co| co[:display_name]}
+    end
+    data = data.sort.to_h
     data
   end
 end

--- a/dashboard/lib/quick_assign_helper.rb
+++ b/dashboard/lib/quick_assign_helper.rb
@@ -52,7 +52,7 @@ module QuickAssignHelper
   # We want to organize the course offerings by their headers then sort those headers
   # according to the logic in compare_headers above
   # The offerings within a header will be sorted alphabetically by display_name.
-  # Any course_offerings that do not a header will be ignored.
+  # Any course_offerings that do not have a header will be ignored.
   def self.group_hoc_and_pl_offerings(course_offerings, user, locale)
     data = {}
     course_offerings.each do |co|

--- a/dashboard/lib/quick_assign_helper.rb
+++ b/dashboard/lib/quick_assign_helper.rb
@@ -42,12 +42,17 @@ module QuickAssignHelper
     data
   end
 
+  # Helper function to compare headers so that "Favorites" is always first in the list
   def self.compare_headers(h1, h2)
     return -1 if h1 == Curriculum::SharedCourseConstants::COURSE_OFFERING_HEADERS.favorites
     return 1 if h2 == Curriculum::SharedCourseConstants::COURSE_OFFERING_HEADERS.favorites
     h1 <=> h2
   end
 
+  # We want to organize the course offerings by their headers then sort those headers
+  # according to the logic in compare_headers above
+  # The offerings within a header will be sorted alphabetically by display_name.
+  # Any course_offerings that do not a header will be ignored.
   def self.group_hoc_and_pl_offerings(course_offerings, user, locale)
     data = {}
     course_offerings.each do |co|

--- a/dashboard/test/lib/quick_assign_helper.rb
+++ b/dashboard/test/lib/quick_assign_helper.rb
@@ -22,6 +22,24 @@ class QuickAssignHelperTest < ActionController::TestCase
     refute course_offerings[:high].blank?
   end
 
+  test 'returns HoC course offerings' do
+    elementary_course_version = create :course_version
+    elementary_course_version.content_root.update!(published_state: 'stable')
+    elementary_course_version.course_offering.update!(grade_levels: 'K,1,2', curriculum_type: 'Course', header: 'Test')
+
+    hoc_course_version = create :course_version
+    hoc_course_version.content_root.update!(published_state: 'stable')
+    hoc_course_version.course_offering.update!(marketing_initiative: 'HOC', header: 'HoC Test')
+
+    teacher = create :teacher
+    course_offerings = QuickAssignHelper.course_offerings(teacher, I18n.default_locale)
+
+    refute course_offerings[:elementary].blank?
+    assert course_offerings[:middle].blank?
+    assert course_offerings[:high].blank?
+    refute course_offerings[:hoc].blank?
+  end
+
   test 'only returns assignable course offerings' do
     assignable_course_version = create :course_version
     assignable_course_version.content_root.update!(published_state: 'stable')
@@ -38,25 +56,47 @@ class QuickAssignHelperTest < ActionController::TestCase
     assert_equal 1, course_offerings[:elementary]['Course']['Test'].length
   end
 
-  test 'offerings are grouped by curriculum type and header' do
-    course_offering1 = create :course_offering, curriculum_type: 'Course', header: 'Header 1'
-    course_offering2 = create :course_offering, curriculum_type: 'Course', header: 'Header 2'
+  test 'grade level offerings are grouped by curriculum type and header' do
+    course_offering1 = create :course_offering, curriculum_type: 'Course', header: 'Header 2'
+    course_offering2 = create :course_offering, curriculum_type: 'Course', header: 'Header 1'
     course_offering3 = create :course_offering, curriculum_type: 'Standalone Unit', header: 'Header 1'
     # course_offering4 and course_offering5 should be grouped together, with course_offering5 being first in the resulting list.
     course_offering4 = create :course_offering, curriculum_type: 'Standalone Unit', header: 'Header 2', display_name: 'Z'
     course_offering5 = create :course_offering, curriculum_type: 'Standalone Unit', header: 'Header 2', display_name: 'B'
 
     teacher = create :teacher
-    grouped_offerings = QuickAssignHelper.group_offerings([course_offering1, course_offering2, course_offering3, course_offering4, course_offering5], teacher, I18n.default_locale)
+    grouped_offerings = QuickAssignHelper.group_grade_level_offerings([course_offering1, course_offering2, course_offering3, course_offering4, course_offering5], teacher, I18n.default_locale)
 
-    assert_equal 1, grouped_offerings['Course']['Header 1'].length
-    assert_equal course_offering1.id, grouped_offerings['Course']['Header 1'][0][:id]
     assert_equal 1, grouped_offerings['Course']['Header 2'].length
+    assert_equal course_offering1.id, grouped_offerings['Course']['Header 1'][0][:id]
+    assert_equal 1, grouped_offerings['Course']['Header 1'].length
     assert_equal course_offering2.id, grouped_offerings['Course']['Header 2'][0][:id]
     assert_equal 1, grouped_offerings['Standalone Unit']['Header 1'].length
     assert_equal course_offering3.id, grouped_offerings['Standalone Unit']['Header 1'][0][:id]
     assert_equal 2, grouped_offerings['Standalone Unit']['Header 2'].length
     assert_equal course_offering5.id, grouped_offerings['Standalone Unit']['Header 2'][0][:id]
     assert_equal course_offering4.id, grouped_offerings['Standalone Unit']['Header 2'][1][:id]
+
+    assert_equal ['Header 1', 'Header 2'], grouped_offerings['Course'].keys
+  end
+
+  test 'HoC course offerings are grouped by header' do
+    course_offering1 = create :course_offering, marketing_initiative: 'HOC', header: 'A Header'
+    course_offering2 = create :course_offering, marketing_initiative: 'HOC', header: 'B Header', display_name: 'Z'
+    course_offering3 = create :course_offering, marketing_initiative: 'HOC', header: 'B Header', display_name: 'A'
+    favorite_course_offering = create :course_offering, marketing_initiative: 'HOC', header: 'Favorites'
+
+    teacher = create :teacher
+    grouped_offerings = QuickAssignHelper.group_hoc_and_pl_offerings([course_offering1, course_offering2, course_offering3, favorite_course_offering], teacher, I18n.default_locale)
+
+    assert_equal 1, grouped_offerings['A Header'].length
+    assert_equal course_offering1.id, grouped_offerings['A Header'][0][:id]
+    assert_equal 2, grouped_offerings['B Header'].length
+    assert_equal course_offering3.id, grouped_offerings['B Header'][0][:id]
+    assert_equal course_offering2.id, grouped_offerings['B Header'][1][:id]
+    assert_equal 1, grouped_offerings['Favorites'].length
+    assert_equal favorite_course_offering.id, grouped_offerings['Favorites'][0][:id]
+
+    assert_equal ['Favorites', 'A Header', 'B Header'], grouped_offerings.keys
   end
 end


### PR DESCRIPTION
Adds HoC courses to the response from `/course_offerings/quick_assign_course_offerings`. This object looks a little different from the grade level objects, so I created a separate function to group them, which I plan to reuse for the PL offerings (coming soon!).

Preview of what the new data looks like (not including the grade level data): https://gist.github.com/bethanyaconnor/6676ca6416ab1a9422d564ac2644008d