### PR TITLE
Fix Amplitude events not showing up

### DIFF
--- a/pegasus/sites.v3/code.org/views/analytics_event_log_helper.haml
+++ b/pegasus/sites.v3/code.org/views/analytics_event_log_helper.haml
@@ -1,3 +1,4 @@
+%script{data: {'amplitude-api-key': CDO.safe_amplitude_api_key}}
 %script{src: webpack_asset_path('js/code.org/views/analytics_event_log_helper.js')}
 
 #analytics-event-log-helper{"data-event-name" => event_name}


### PR DESCRIPTION
Currently, the following Amplitude events are not receiving data:
- 6-12 Teacher Application Started
- Administrator Page Visited
- AI Page Visited
- Physical Computing Page Visited
- CSA Curriculum Page Visited
- CSC Curriculum Page Visited
- CSD Curriculum Page Visited
- CSF Curriculum Page Visited
- CSP Curriculum Page Visited
- Elementary School Curriculum Page Visited
- Middle School Curriculum Page Visited
- High School Curriculum Page Visited
- Elementary School Professional Learning Page Visited
- Middle And High School Professional Learning Page Visited
- Pick Your Professional Learning Page Visited
- Regional Partner Landing Page Visited

Except for the '6-12 Teacher Application Started' (which will be fixed in a separate PR), all of these events use the `analytics_event_log_helper.haml` helper file to connect to `AnalyticsReporter.js` which sends the data (as laid out in [the PR where these events were merged](https://github.com/code-dot-org/code-dot-org/pull/49901)). On each of the pages with these Amplitude events, there is a console error:

![Error](https://user-images.githubusercontent.com/56283563/221980006-2db627df-7a4f-4bc0-be89-f521ba4b378e.PNG)

The events that are working all have access to `application.html.haml` in the `dashboard` directory where the `amplitude-api-key` is obtained, while the events that are not working are in the `pegasus` directory and don't have such access. The change in this PR will have the analytics helper file in the pegasus directory obtain the api key. With this change, the errors no longer show up and there is a successful response status for the call to Amplitude:

![No_error](https://user-images.githubusercontent.com/56283563/221980042-f89adde7-8c1b-4548-9f4f-00ab6f2314a9.PNG)
![Success_Ajax](https://user-images.githubusercontent.com/56283563/221980073-d06ac153-10cb-42e2-924d-a6687fbdb1be.PNG)

Then, using the staging api key (as per [this thread](https://codedotorg.slack.com/archives/C049E9P6QQ1/p1677618755906789)), I was able to test if visiting one of the pages (e.g. code.org/administrators) triggered the corresponding event in the [Amplitude staging environment](https://data.amplitude.com/code-org/Code.org%20Tracking%20Plan/events/main/latest) and it did:

![Administrator staging](https://user-images.githubusercontent.com/56283563/221990220-f2e16309-fb91-438f-80e2-cc86044e6d2e.PNG)
(it switched from "Planned" (meaning ready but without data) to "Live" (meaning it had received data))

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/browse/ACQ-415?atlOrigin=eyJpIjoiMzFhNmJmMTMzM2M0NDQyNzljNWMzZGRiMzZiMmU2ZWIiLCJwIjoiaiJ9)

## Testing story
Local testing.

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
