### PR TITLE
Add num_attempts_allowed to match and free_response level types 

### DIFF
--- a/dashboard/app/models/levels/free_response.rb
+++ b/dashboard/app/models/levels/free_response.rb
@@ -36,6 +36,7 @@ class FreeResponse < Level
     submittable
     peer_reviewable
     optional
+    num_attempts_allowed
   )
 
   before_validation do

--- a/dashboard/app/models/levels/match.rb
+++ b/dashboard/app/models/levels/match.rb
@@ -36,6 +36,7 @@ class Match < DSLDefined
       description 'description here'
       question 'Question'
       answer 'Answer 1'
+      num_attempts_allowed nil
     RUBY
   end
 

--- a/dashboard/app/models/levels/match.rb
+++ b/dashboard/app/models/levels/match.rb
@@ -25,6 +25,10 @@
 #
 
 class Match < DSLDefined
+  serialized_attrs %w(
+    num_attempts_allowed
+  )
+
   def dsl_default
     <<~RUBY
       name '#{DEFAULT_LEVEL_NAME}'

--- a/dashboard/app/models/levels/multi.rb
+++ b/dashboard/app/models/levels/multi.rb
@@ -35,6 +35,7 @@ class Multi < Match
       question 'Question'
       wrong 'wrong answer'
       right 'right answer'
+      num_attempts_allowed nil
     RUBY
   end
 

--- a/dashboard/app/views/levels/editors/fields/_free_response_fields.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_free_response_fields.html.haml
@@ -19,6 +19,10 @@
     %p Optional solution markdown to display to teachers.
     = f.text_area :solution, rows: 3, class: "input-block-level"
   .field
+    = f.label :num_attempts_allowed, "Number of Attempts Allowed"
+    %p Number of attempts students are allowed. Default is one for contained levels and infinite for standalone levels. It will not apply for levels in level groups.
+    = f.number_field :num_attempts_allowed
+  .field
     = render partial: 'levels/editors/fields/checkboxes', locals: {f: f, field_name: :peer_reviewable, description: "Is peer reviewable"}
     %p
       If checked, students that submit a solution for grading can have their


### PR DESCRIPTION
Adds a field called `num_attempts_allowed` to `FreeResponse` and `Match` levels. `Multi` is a subclass of `Match` so it will also inherit this field.

I updated the `FreeResponse` editor to allow for editing this field. I tested this manually, though I don't know a way of adding tests for this file.
![Screen Shot 2023-02-28 at 12 11 22 PM](https://user-images.githubusercontent.com/46464143/222209982-c1afed57-4d72-42e2-8e9b-c03b98aaa31b.png)


Updating the editor for `Match` levels was tougher. Because `Match` is a `DSLDefined` level (also I thought until yesterday that `FreeResponse` levels were also `DSLDefined` woops), the editor is not user friendly. I could not figure out a way to make a friendly input for this field in the editor, so I added it to the default DSL. For existing levels, editors will need to add `num_attempts_allowed <num>` to the DSL editor.

This field isn't being used yet -- it's just being added early so that curriculum writers can set this field now.
 