### PR TITLE
Expand timeline to length of song

### DIFF
--- a/apps/src/music/context.ts
+++ b/apps/src/music/context.ts
@@ -6,7 +6,7 @@ export const AnalyticsContext = React.createContext(null);
 
 type PlayerUtils = Pick<
   MusicPlayer,
-  'getPlaybackEvents' | 'getTracksMetadata' | 'getLengthForId' | 'getTypeForId'
+  'getPlaybackEvents' | 'getTracksMetadata' | 'getLengthForId' | 'getTypeForId' | 'getLastMeasure'
 >;
 
 /** Provides access to commonly used MusicPlayer APIs (without exposing the entire player) */
@@ -16,5 +16,6 @@ export const PlayerUtilsContext: React.Context<
   getPlaybackEvents: () => [],
   getTracksMetadata: () => ({}),
   getLengthForId: () => 0,
-  getTypeForId: () => null
+  getTypeForId: () => null,
+  getLastMeasure: () => 0
 });

--- a/apps/src/music/player/MusicPlayer.ts
+++ b/apps/src/music/player/MusicPlayer.ts
@@ -51,7 +51,7 @@ export default class MusicPlayer {
   private bpm: number;
   private playbackEvents: PlaybackEvent[];
   private lastTriggeredMeasure: number;
-  private lastScheduledMeasure: number;
+  private lastWhenRunMeasure: number;
   private tracksMetadata: {[trackId: string]: TrackMetadata};
   private uniqueInvocationIdUpto: number;
   private samplePlayer: SamplePlayer;
@@ -65,7 +65,7 @@ export default class MusicPlayer {
     this.samplePlayer = new SamplePlayer();
     this.library = {groups: []};
     this.lastTriggeredMeasure = 0;
-    this.lastScheduledMeasure = 0;
+    this.lastWhenRunMeasure = 0;
   }
 
   /**
@@ -117,9 +117,9 @@ export default class MusicPlayer {
 
     const endingMeasure = measure + soundData.length - 1;
     if (insideWhenRun) {
-      this.lastScheduledMeasure = Math.max(
+      this.lastWhenRunMeasure = Math.max(
         endingMeasure,
-        this.lastScheduledMeasure
+        this.lastWhenRunMeasure
       );
     } else {
       this.lastTriggeredMeasure = Math.max(
@@ -198,7 +198,7 @@ export default class MusicPlayer {
 
     // If playing, stop all non-triggered samples that have not yet been played.
     this.samplePlayer.stopAllSamplesStillToPlay();
-    this.lastScheduledMeasure = 0;
+    this.lastWhenRunMeasure = 0;
   }
 
   getPlaybackEvents(): PlaybackEvent[] {
@@ -206,7 +206,7 @@ export default class MusicPlayer {
   }
 
   getLastMeasure(): number {
-    return Math.max(this.lastScheduledMeasure, this.lastTriggeredMeasure);
+    return Math.max(this.lastWhenRunMeasure, this.lastTriggeredMeasure);
   }
 
   // Returns the current playhead position, in floating point for an exact position,

--- a/apps/src/music/player/SamplePlayer.ts
+++ b/apps/src/music/player/SamplePlayer.ts
@@ -144,6 +144,9 @@ export default class SamplePlayer {
     soundApi.StopSound(PREVIEW_GROUP);
   }
 
+  /**
+   * Stops all non-triggered samples that have not yet been played.
+   */
   stopAllSamplesStillToPlay() {
     if (!this.isPlaying) {
       return;

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -197,16 +197,6 @@ class UnconnectedMusicView extends React.Component {
 
     const codeChanged = this.compileSong();
     if (codeChanged) {
-      // Stop all when_run sounds that are still to play, because if they
-      // are still valid after the when_run code is re-executed, they
-      // will be scheduled again.
-      this.stopAllSoundsStillToPlay();
-
-      // Also clear all when_run sounds from the events list, because it
-      // will be recreated in its entirely when the when_run code is
-      // re-executed.
-      this.player.clearWhenRunEvents();
-
       this.executeCompiledSong();
 
       this.analyticsReporter.onBlocksUpdated(
@@ -255,6 +245,10 @@ class UnconnectedMusicView extends React.Component {
   };
 
   executeCompiledSong = () => {
+    // Clear the events list of when_run sounds, because it will be
+    // populated next.
+    this.player.clearWhenRunEvents();
+
     this.musicBlocklyWorkspace.executeCompiledSong({
       MusicPlayer: this.player,
       ProgramSequencer: this.programSequencer,
@@ -267,10 +261,6 @@ class UnconnectedMusicView extends React.Component {
 
     const codeChanged = this.compileSong();
     if (codeChanged) {
-      // Clear the events list of when_run sounds, because it will be
-      // populated next.
-      this.player.clearWhenRunEvents();
-
       this.executeCompiledSong();
     }
 
@@ -281,17 +271,8 @@ class UnconnectedMusicView extends React.Component {
 
   stopSong = () => {
     this.player.stopSong();
-
-    // Clear the events list, and hence the visual timeline, of any
-    // user-triggered sounds.
-    this.player.clearTriggeredEvents();
-
     this.setState({isPlaying: false, currentPlayheadPosition: 0});
     this.triggerCount = 0;
-  };
-
-  stopAllSoundsStillToPlay = () => {
-    this.player.stopAllSoundsStillToPlay();
   };
 
   handleKeyUp = event => {
@@ -393,7 +374,8 @@ class UnconnectedMusicView extends React.Component {
             getPlaybackEvents: () => this.player.getPlaybackEvents(),
             getTracksMetadata: () => this.player.getTracksMetadata(),
             getLengthForId: id => this.player.getLengthForId(id),
-            getTypeForId: id => this.player.getTypeForId(id)
+            getTypeForId: id => this.player.getTypeForId(id),
+            getLastMeasure: () => this.player.getLastMeasure()
           }}
         >
           <div id="music-lab-container" className={moduleStyles.container}>

--- a/apps/src/music/views/Timeline.jsx
+++ b/apps/src/music/views/Timeline.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, {useContext} from 'react';
 import moduleStyles from './timeline.module.scss';
 import classNames from 'classnames';
 import TimelineSampleEvents from './TimelineSampleEvents';
@@ -7,9 +7,10 @@ import TimelineTrackEvents from './TimelineTrackEvents';
 import TimelineSimple2Events from './TimelineSimple2Events';
 import {getBlockMode} from '../appConfig';
 import {BlockMode} from '../constants';
+import {PlayerUtilsContext} from '../context';
 
 const barWidth = 60;
-const numMeasures = 30;
+const minNumMeasures = 30;
 // Leave some vertical space between each event block.
 const eventVerticalSpace = 2;
 
@@ -17,6 +18,12 @@ const eventVerticalSpace = 2;
  * Renders the music playback timeline.
  */
 const Timeline = ({isPlaying, currentPlayheadPosition}) => {
+  const playerUtils = useContext(PlayerUtilsContext);
+  const measuresToDisplay = Math.max(
+    minNumMeasures,
+    playerUtils.getLastMeasure()
+  );
+
   const getEventHeight = (numUniqueRows, availableHeight = 110) => {
     // While we might not actually have this many rows to show,
     // we will limit each row's height to the size that would allow
@@ -46,8 +53,11 @@ const Timeline = ({isPlaying, currentPlayheadPosition}) => {
     getEventHeight
   };
 
-  // Generate an array containing measure numbers from 1..numMeasures.
-  const arrayOfMeasures = Array.from({length: numMeasures}, (_, i) => i + 1);
+  // Generate an array containing measure numbers from 1..measuresToDisplay.
+  const arrayOfMeasures = Array.from(
+    {length: measuresToDisplay},
+    (_, i) => i + 1
+  );
 
   return (
     <div id="timeline" className={moduleStyles.wrapper}>


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Auto-expands the timeline length to the max length of the song. Renders a minimum of 30 measures.

<img width="1512" alt="Screenshot 2023-02-28 at 3 22 16 PM" src="https://user-images.githubusercontent.com/85528507/222006880-38b5fc1f-1ad7-4a29-86b8-75202f16bf19.png">

Also simplified some of the player APIs used in MusicView - for example, we always clear run events before compilation, so I moved those two calls together. Also we clear triggered events only on stop, so I just moved that into `stopSong()`.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
