### PR TITLE
Populating QuickAssign table w headers and selectable offerings

### DIFF
--- a/apps/src/templates/sectionsRefresh/CurriculumQuickAssign.jsx
+++ b/apps/src/templates/sectionsRefresh/CurriculumQuickAssign.jsx
@@ -13,7 +13,7 @@ export const MARKETING_AUDIENCE = {
   PL: 'pl'
 };
 
-export default function CurriculumQuickAssign(updateSection) {
+export default function CurriculumQuickAssign({updateSection}) {
   const [courseOfferings, setCourseOfferings] = useState(null);
   const [decideLater, setDecideLater] = useState(false);
   const [marketingAudience, setMarketingAudience] = useState(null);
@@ -120,7 +120,7 @@ export default function CurriculumQuickAssign(updateSection) {
         <QuickAssignTable
           marketingAudience={marketingAudience}
           courseOfferings={courseOfferings}
-          updateSection={() => updateSection}
+          updateCourse={course => updateSection('course', course)}
         />
       )}
     </div>

--- a/apps/src/templates/sectionsRefresh/CurriculumQuickAssign.jsx
+++ b/apps/src/templates/sectionsRefresh/CurriculumQuickAssign.jsx
@@ -1,4 +1,5 @@
 import React, {useState, useEffect} from 'react';
+import PropTypes from 'prop-types';
 import i18n from '@cdo/locale';
 import Button from '@cdo/apps/templates/Button';
 import moduleStyles from './sections-refresh.module.scss';
@@ -12,7 +13,7 @@ export const MARKETING_AUDIENCE = {
   PL: 'pl'
 };
 
-export default function CurriculumQuickAssign() {
+export default function CurriculumQuickAssign(updateSection) {
   const [courseOfferings, setCourseOfferings] = useState(null);
   const [decideLater, setDecideLater] = useState(false);
   const [marketingAudience, setMarketingAudience] = useState(null);
@@ -119,11 +120,16 @@ export default function CurriculumQuickAssign() {
         <QuickAssignTable
           marketingAudience={marketingAudience}
           courseOfferings={courseOfferings}
+          updateSection={() => updateSection}
         />
       )}
     </div>
   );
 }
+
+CurriculumQuickAssign.propTypes = {
+  updateSection: PropTypes.func.isRequired
+};
 
 const styles = {
   buttonStyle: {

--- a/apps/src/templates/sectionsRefresh/CurriculumQuickAssign.jsx
+++ b/apps/src/templates/sectionsRefresh/CurriculumQuickAssign.jsx
@@ -28,9 +28,11 @@ export default function CurriculumQuickAssign({updateSection}) {
   /*
   When toggling 'decide later', clear out marketing audience or assign one to make
   the table appear again automatically.
+  Additionally, erase any previously selected course assignment.
   */
   const toggleDecideLater = () => {
     setDecideLater(!decideLater);
+    updateSection('course', '');
     if (marketingAudience !== '') {
       setMarketingAudience('');
     } else {
@@ -56,7 +58,7 @@ export default function CurriculumQuickAssign({updateSection}) {
         <div className={moduleStyles.buttonsInRow}>
           <Button
             id={'uitest-elementary-button'}
-            style={styles.buttonStyle}
+            className={moduleStyles.buttonStyle}
             text={i18n.courseBlocksGradeBandsElementary()}
             size={Button.ButtonSize.large}
             icon={
@@ -70,7 +72,7 @@ export default function CurriculumQuickAssign({updateSection}) {
           />
           <Button
             id={'uitest-middle-button'}
-            style={styles.buttonStyle}
+            className={moduleStyles.buttonStyle}
             text={i18n.courseBlocksGradeBandsMiddle()}
             size={Button.ButtonSize.large}
             icon={
@@ -82,7 +84,7 @@ export default function CurriculumQuickAssign({updateSection}) {
           />
           <Button
             id={'uitest-high-button'}
-            style={styles.buttonStyle}
+            className={moduleStyles.buttonStyle}
             text={i18n.courseBlocksGradeBandsHigh()}
             size={Button.ButtonSize.large}
             icon={
@@ -94,7 +96,7 @@ export default function CurriculumQuickAssign({updateSection}) {
           />
           <Button
             id={'uitest-hoc-button'}
-            style={styles.buttonStyle}
+            className={moduleStyles.buttonStyle}
             text={i18n.courseOfferingHOC()}
             size={Button.ButtonSize.large}
             icon={
@@ -106,12 +108,12 @@ export default function CurriculumQuickAssign({updateSection}) {
           />
           <input
             checked={decideLater}
-            style={styles.inputStyle}
+            className={moduleStyles.input}
             type="checkbox"
             id="decide-later"
             onChange={toggleDecideLater}
           />
-          <label style={styles.decideLaterStyle} htmlFor="decide-later">
+          <label className={moduleStyles.decideLater} htmlFor="decide-later">
             {i18n.decideLater()}
           </label>
         </div>
@@ -129,20 +131,4 @@ export default function CurriculumQuickAssign({updateSection}) {
 
 CurriculumQuickAssign.propTypes = {
   updateSection: PropTypes.func.isRequired
-};
-
-const styles = {
-  buttonStyle: {
-    backgroundColor: 'white',
-    padding: 10,
-    color: 'inherit',
-    border: 'none',
-    fontSize: 14
-  },
-  inputStyle: {
-    margin: '0px 5px 0px 200px'
-  },
-  decideLaterStyle: {
-    marginTop: '5px'
-  }
 };

--- a/apps/src/templates/sectionsRefresh/CurriculumQuickAssign.jsx
+++ b/apps/src/templates/sectionsRefresh/CurriculumQuickAssign.jsx
@@ -13,7 +13,7 @@ export const MARKETING_AUDIENCE = {
   PL: 'pl'
 };
 
-export default function CurriculumQuickAssign({updateSection}) {
+export default function CurriculumQuickAssign({updateSection, sectionCourse}) {
   const [courseOfferings, setCourseOfferings] = useState(null);
   const [decideLater, setDecideLater] = useState(false);
   const [marketingAudience, setMarketingAudience] = useState(null);
@@ -32,7 +32,7 @@ export default function CurriculumQuickAssign({updateSection}) {
   */
   const toggleDecideLater = () => {
     setDecideLater(!decideLater);
-    updateSection('course', '');
+    updateSection('course', {});
     if (marketingAudience !== '') {
       setMarketingAudience('');
     } else {
@@ -123,6 +123,7 @@ export default function CurriculumQuickAssign({updateSection}) {
           marketingAudience={marketingAudience}
           courseOfferings={courseOfferings}
           updateCourse={course => updateSection('course', course)}
+          sectionCourse={sectionCourse}
         />
       )}
     </div>
@@ -130,5 +131,6 @@ export default function CurriculumQuickAssign({updateSection}) {
 }
 
 CurriculumQuickAssign.propTypes = {
-  updateSection: PropTypes.func.isRequired
+  updateSection: PropTypes.func.isRequired,
+  sectionCourse: PropTypes.object
 };

--- a/apps/src/templates/sectionsRefresh/QuickAssignTable.jsx
+++ b/apps/src/templates/sectionsRefresh/QuickAssignTable.jsx
@@ -4,6 +4,11 @@ import moduleStyles from './sections-refresh.module.scss';
 import i18n from '@cdo/locale';
 import {CourseOfferingCurriculumTypes as curriculumTypes} from '@cdo/apps/generated/curriculum/sharedCourseConstants';
 
+/*
+Represents the (collection of) tables in Curriculum Quick Assign.
+They display side by side as if they were columns, but leaving them
+as independent tables makes styling them simpler.
+*/
 export default function QuickAssignTable({
   marketingAudience,
   courseOfferings,
@@ -36,6 +41,11 @@ export default function QuickAssignTable({
     );
   };
 
+  /*
+  Responsible for rendering the category headers and calling the next
+  function to render the course offerings. This 'key=' uses the header as
+  a unique identifier, not to be confused with a JSON key (above).
+  */
   const renderRows = courseData => {
     const headers = Object.keys(courseData);
     return headers.map(header => (
@@ -48,6 +58,10 @@ export default function QuickAssignTable({
     ));
   };
 
+  /*
+  Redners all the radio type inputs within each table. Only one can be
+  selected at a time. Selecting one immediately calls updateCourse.
+  */
   const renderOfferings = courseValues => {
     const values = courseValues.map(cv => cv.display_name);
     return values.map(display_name => (

--- a/apps/src/templates/sectionsRefresh/QuickAssignTable.jsx
+++ b/apps/src/templates/sectionsRefresh/QuickAssignTable.jsx
@@ -1,10 +1,16 @@
-import React from 'react';
+import React, {useState} from 'react';
 import PropTypes from 'prop-types';
 import moduleStyles from './sections-refresh.module.scss';
 import i18n from '@cdo/locale';
 import {CourseOfferingCurriculumTypes as curriculumTypes} from '@cdo/apps/generated/curriculum/sharedCourseConstants';
+import {Radio} from 'react-bootstrap';
 
-export default function QuickAssignTable({marketingAudience, courseOfferings}) {
+export default function QuickAssignTable({
+  marketingAudience,
+  courseOfferings,
+  updateSection
+}) {
+  const [assignedCourse, setAssignedCourse] = useState('');
   // Key is type of curriculum e.g. 'Course' or 'Module', which is the singular
   // version of the title we want for the column
   const renderTable = (key, title) => {
@@ -17,13 +23,41 @@ export default function QuickAssignTable({marketingAudience, courseOfferings}) {
             </td>
           </tr>
         </thead>
-        <tbody>
-          {JSON.stringify(
-            Object.values(courseOfferings[marketingAudience][key])
-          )}
+        <tbody className={moduleStyles.tableBody}>
+          {renderRows(courseOfferings[marketingAudience][key])}
         </tbody>
       </table>
     );
+  };
+
+  const renderRows = courseData => {
+    const headers = Object.keys(courseData);
+    return headers.map(header => (
+      <tr>
+        <td className={moduleStyles.courseHeaders}>
+          {header}
+          {renderOfferings(Object.values(courseData[header]))}
+        </td>
+      </tr>
+    ));
+  };
+
+  const renderOfferings = courseValues => {
+    const values = courseValues.map(cv => cv.display_name);
+    return values.map(display_name => (
+      <Radio
+        className={moduleStyles.radio}
+        name={display_name}
+        value={display_name}
+        checked={assignedCourse === display_name}
+        onChange={e => {
+          updateSection('course', e.target.value);
+          setAssignedCourse(display_name);
+        }}
+      >
+        {display_name}
+      </Radio>
+    ));
   };
 
   return (
@@ -40,5 +74,6 @@ export default function QuickAssignTable({marketingAudience, courseOfferings}) {
 
 QuickAssignTable.propTypes = {
   courseOfferings: PropTypes.object.isRequired,
-  marketingAudience: PropTypes.string.isRequired
+  marketingAudience: PropTypes.string.isRequired,
+  updateSection: PropTypes.func.isRequired
 };

--- a/apps/src/templates/sectionsRefresh/QuickAssignTable.jsx
+++ b/apps/src/templates/sectionsRefresh/QuickAssignTable.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import moduleStyles from './sections-refresh.module.scss';
 import i18n from '@cdo/locale';
 import {CourseOfferingCurriculumTypes as curriculumTypes} from '@cdo/apps/generated/curriculum/sharedCourseConstants';
-import {Radio} from 'react-bootstrap';
 
 export default function QuickAssignTable({
   marketingAudience,
@@ -40,7 +39,7 @@ export default function QuickAssignTable({
   const renderRows = courseData => {
     const headers = Object.keys(courseData);
     return headers.map(header => (
-      <tr>
+      <tr key={header}>
         <td className={moduleStyles.courseHeaders}>
           {header}
           {renderOfferings(Object.values(courseData[header]))}
@@ -52,22 +51,27 @@ export default function QuickAssignTable({
   const renderOfferings = courseValues => {
     const values = courseValues.map(cv => cv.display_name);
     return values.map(display_name => (
-      <Radio
-        className={moduleStyles.radio}
-        name={display_name}
-        value={display_name}
-        checked={assignedCourse === display_name}
-        onChange={() => {
-          setAssignedCourse(display_name);
-        }}
-      >
-        {display_name}
-      </Radio>
+      <div className={moduleStyles.flexDisplay} key={display_name}>
+        <input
+          id={display_name}
+          className={moduleStyles.radio}
+          type="radio"
+          name={display_name}
+          value={display_name}
+          checked={assignedCourse === display_name}
+          onChange={() => {
+            setAssignedCourse(display_name);
+          }}
+        />
+        <label className={moduleStyles.label} htmlFor={display_name}>
+          {display_name}
+        </label>
+      </div>
     ));
   };
 
   return (
-    <div className={moduleStyles.multiTables}>
+    <div className={moduleStyles.flexDisplay}>
       {!!courseOfferings[marketingAudience][curriculumTypes.course] &&
         renderTable(curriculumTypes.course, i18n.courses())}
       {!!courseOfferings[marketingAudience][curriculumTypes.module] &&

--- a/apps/src/templates/sectionsRefresh/QuickAssignTable.jsx
+++ b/apps/src/templates/sectionsRefresh/QuickAssignTable.jsx
@@ -1,4 +1,4 @@
-import React, {useState, useEffect} from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import moduleStyles from './sections-refresh.module.scss';
 import i18n from '@cdo/locale';
@@ -12,16 +12,9 @@ as independent tables makes styling them simpler.
 export default function QuickAssignTable({
   marketingAudience,
   courseOfferings,
-  updateCourse
+  updateCourse,
+  sectionCourse
 }) {
-  const [assignedCourse, setAssignedCourse] = useState('');
-
-  useEffect(() => {
-    if (assignedCourse) {
-      updateCourse(assignedCourse);
-    }
-  }, [assignedCourse]);
-
   // Key is type of curriculum e.g. 'Course' or 'Module', which is the singular
   // version of the title we want for the column
   const renderTable = (key, title) => {
@@ -72,9 +65,9 @@ export default function QuickAssignTable({
           type="radio"
           name={display_name}
           value={display_name}
-          checked={assignedCourse === display_name}
+          checked={sectionCourse?.displayName === display_name}
           onChange={() => {
-            setAssignedCourse(display_name);
+            updateCourse({displayName: display_name});
           }}
         />
         <label className={moduleStyles.label} htmlFor={display_name}>
@@ -99,5 +92,6 @@ export default function QuickAssignTable({
 QuickAssignTable.propTypes = {
   courseOfferings: PropTypes.object.isRequired,
   marketingAudience: PropTypes.string.isRequired,
-  updateCourse: PropTypes.func.isRequired
+  updateCourse: PropTypes.func.isRequired,
+  sectionCourse: PropTypes.object
 };

--- a/apps/src/templates/sectionsRefresh/QuickAssignTable.jsx
+++ b/apps/src/templates/sectionsRefresh/QuickAssignTable.jsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, {useState, useEffect} from 'react';
 import PropTypes from 'prop-types';
 import moduleStyles from './sections-refresh.module.scss';
 import i18n from '@cdo/locale';
@@ -8,9 +8,16 @@ import {Radio} from 'react-bootstrap';
 export default function QuickAssignTable({
   marketingAudience,
   courseOfferings,
-  updateSection
+  updateCourse
 }) {
   const [assignedCourse, setAssignedCourse] = useState('');
+
+  useEffect(() => {
+    if (assignedCourse) {
+      updateCourse(assignedCourse);
+    }
+  }, [assignedCourse]);
+
   // Key is type of curriculum e.g. 'Course' or 'Module', which is the singular
   // version of the title we want for the column
   const renderTable = (key, title) => {
@@ -50,8 +57,7 @@ export default function QuickAssignTable({
         name={display_name}
         value={display_name}
         checked={assignedCourse === display_name}
-        onChange={e => {
-          updateSection('course', e.target.value);
+        onChange={() => {
           setAssignedCourse(display_name);
         }}
       >
@@ -75,5 +81,5 @@ export default function QuickAssignTable({
 QuickAssignTable.propTypes = {
   courseOfferings: PropTypes.object.isRequired,
   marketingAudience: PropTypes.string.isRequired,
-  updateSection: PropTypes.func.isRequired
+  updateCourse: PropTypes.func.isRequired
 };

--- a/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
+++ b/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
@@ -47,6 +47,7 @@ export default function SectionsSetUpContainer() {
       />
       <CurriculumQuickAssign
         updateSection={(key, val) => updateSection(0, key, val)}
+        sectionCourse={sections[0].course}
       />
       <div className={moduleStyles.buttonsContainer}>
         <Button

--- a/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
+++ b/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
@@ -45,7 +45,9 @@ export default function SectionsSetUpContainer() {
         section={sections[0]}
         updateSection={(key, val) => updateSection(0, key, val)}
       />
-      <CurriculumQuickAssign />
+      <CurriculumQuickAssign
+        updateSection={(key, val) => updateSection(0, key, val)}
+      />
       <div className={moduleStyles.buttonsContainer}>
         <Button
           icon="plus"

--- a/apps/src/templates/sectionsRefresh/sections-refresh.module.scss
+++ b/apps/src/templates/sectionsRefresh/sections-refresh.module.scss
@@ -22,8 +22,28 @@
   align-items: center;
 }
 
-.multiTables {
+.buttonsInRow .buttonStyle {
+  background-color: $white;
+  padding: 10px;
+  color: inherit;
+  border: none;
+  font-size: 14px;
+}
+
+.buttonsInRow .buttonStyle:hover {
+  color: $brand_primary_default;
+}
+
+.flexDisplay {
   display: flex;
+}
+
+.buttonsInRow .input {
+  margin: 0 5px 0 200px;
+}
+
+.buttonsInRow .decideLater {
+  margin-top: 5px;
 }
 
 .table {
@@ -56,8 +76,12 @@
   left: 10px;
 }
 
-.radio {
+.flexDisplay .radio {
   min-height: 40px;
-  display: grid;
-  align-content: center;
+  margin: 0 0 0 0;
+}
+
+.label {
+  margin: 10px 0 0 5px;
+  text-align: center;
 }

--- a/apps/src/templates/sectionsRefresh/sections-refresh.module.scss
+++ b/apps/src/templates/sectionsRefresh/sections-refresh.module.scss
@@ -42,3 +42,22 @@
   font-size: 24px;
   padding: 12px;
 }
+
+.tableBody {
+  padding: 10px;
+  display: grid;
+}
+
+.courseHeaders {
+  font-weight: 350;
+  font-size: 20px;
+  line-height: 24px;
+  position: relative;
+  left: 10px;
+}
+
+.radio {
+  min-height: 40px;
+  display: grid;
+  align-content: center;
+}

--- a/apps/test/unit/templates/sectionsRefresh/CurriculumQuickAssignTest.jsx
+++ b/apps/test/unit/templates/sectionsRefresh/CurriculumQuickAssignTest.jsx
@@ -6,7 +6,9 @@ import CurriculumQuickAssign from '@cdo/apps/templates/sectionsRefresh/Curriculu
 
 describe('CurriculumQuickAssign', () => {
   it('renders headers and the top row of buttons', () => {
-    const wrapper = shallow(<CurriculumQuickAssign updateSection={() => {}} />);
+    const wrapper = shallow(
+      <CurriculumQuickAssign updateSection={() => {}} sectionCourse={{}} />
+    );
 
     expect(wrapper.find('h3').length).to.equal(1);
     expect(wrapper.find('h5').length).to.equal(1);
@@ -24,7 +26,9 @@ describe('CurriculumQuickAssign', () => {
   });
 
   it('updates caret direction when clicked', () => {
-    const wrapper = shallow(<CurriculumQuickAssign updateSection={() => {}} />);
+    const wrapper = shallow(
+      <CurriculumQuickAssign updateSection={() => {}} sectionCourse={{}} />
+    );
 
     expect(
       wrapper
@@ -45,7 +49,9 @@ describe('CurriculumQuickAssign', () => {
   });
 
   it('clears decide later when marketing audience selected', () => {
-    const wrapper = mount(<CurriculumQuickAssign updateSection={() => {}} />);
+    const wrapper = mount(
+      <CurriculumQuickAssign updateSection={() => {}} sectionCourse={{}} />
+    );
 
     expect(wrapper.find('input').props().checked).to.equal(false);
     wrapper.find('input').simulate('change');

--- a/apps/test/unit/templates/sectionsRefresh/CurriculumQuickAssignTest.jsx
+++ b/apps/test/unit/templates/sectionsRefresh/CurriculumQuickAssignTest.jsx
@@ -6,7 +6,7 @@ import CurriculumQuickAssign from '@cdo/apps/templates/sectionsRefresh/Curriculu
 
 describe('CurriculumQuickAssign', () => {
   it('renders headers and the top row of buttons', () => {
-    const wrapper = shallow(<CurriculumQuickAssign />);
+    const wrapper = shallow(<CurriculumQuickAssign updateSection={() => {}} />);
 
     expect(wrapper.find('h3').length).to.equal(1);
     expect(wrapper.find('h5').length).to.equal(1);
@@ -24,7 +24,7 @@ describe('CurriculumQuickAssign', () => {
   });
 
   it('updates caret direction when clicked', () => {
-    const wrapper = shallow(<CurriculumQuickAssign />);
+    const wrapper = shallow(<CurriculumQuickAssign updateSection={() => {}} />);
 
     expect(
       wrapper
@@ -45,7 +45,7 @@ describe('CurriculumQuickAssign', () => {
   });
 
   it('clears decide later when marketing audience selected', () => {
-    const wrapper = mount(<CurriculumQuickAssign />);
+    const wrapper = mount(<CurriculumQuickAssign updateSection={() => {}} />);
 
     expect(wrapper.find('input').props().checked).to.equal(false);
     wrapper.find('input').simulate('change');

--- a/apps/test/unit/templates/sectionsRefresh/QuickAssignTableTest.jsx
+++ b/apps/test/unit/templates/sectionsRefresh/QuickAssignTableTest.jsx
@@ -17,6 +17,7 @@ describe('QuickAssignTable', () => {
         marketingAudience={MARKETING_AUDIENCE.ELEMENTARY}
         courseOfferings={elementarySchoolCourseOffering}
         updateCourse={() => {}}
+        sectionCourse={{}}
       />
     );
 
@@ -30,6 +31,7 @@ describe('QuickAssignTable', () => {
         marketingAudience={MARKETING_AUDIENCE.HIGH}
         courseOfferings={highSchoolCourseOfferings}
         updateCourse={() => {}}
+        sectionCourse={{}}
       />
     );
     expect(wrapper.find('table').length).to.equal(2);
@@ -44,6 +46,7 @@ describe('QuickAssignTable', () => {
         marketingAudience={MARKETING_AUDIENCE.HIGH}
         courseOfferings={highSchoolCourseOfferings}
         updateCourse={updateSpy}
+        sectionCourse={{}}
       />
     );
 
@@ -53,5 +56,24 @@ describe('QuickAssignTable', () => {
       target: {value: 'Computer Science A', checked: true}
     });
     expect(updateSpy).to.have.been.called;
+  });
+
+  it('automatically checks correct radio button if course is already assigned', () => {
+    const wrapper = mount(
+      <QuickAssignTable
+        marketingAudience={MARKETING_AUDIENCE.HIGH}
+        courseOfferings={highSchoolCourseOfferings}
+        updateCourse={() => {}}
+        sectionCourse={{displayName: 'Computer Science A'}}
+      />
+    );
+
+    const radio = wrapper.find("input[value='Computer Science A']");
+    expect(radio.props().checked).to.be.true;
+    // and verify that the next door radio is checked=false
+    expect(
+      wrapper.find("input[value='Computer Science Discoveries']").props()
+        .checked
+    ).to.be.false;
   });
 });

--- a/apps/test/unit/templates/sectionsRefresh/QuickAssignTableTest.jsx
+++ b/apps/test/unit/templates/sectionsRefresh/QuickAssignTableTest.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import {shallow} from 'enzyme';
+import {shallow, mount} from 'enzyme';
+import sinon from 'sinon';
 import {expect} from '../../../util/reconfiguredChai';
 import QuickAssignTable from '@cdo/apps/templates/sectionsRefresh/QuickAssignTable';
 import {MARKETING_AUDIENCE} from '@cdo/apps/templates/sectionsRefresh/CurriculumQuickAssign';
@@ -34,5 +35,23 @@ describe('QuickAssignTable', () => {
     expect(wrapper.find('table').length).to.equal(2);
     expect(wrapper.contains(i18n.courses())).to.be.true;
     expect(wrapper.contains(i18n.standaloneUnits())).to.be.true;
+  });
+
+  it('calls updateSection when a radio button is pressed', () => {
+    const updateSpy = sinon.spy();
+    const wrapper = mount(
+      <QuickAssignTable
+        marketingAudience={MARKETING_AUDIENCE.HIGH}
+        courseOfferings={highSchoolCourseOfferings}
+        updateCourse={updateSpy}
+      />
+    );
+
+    const radio = wrapper.find("input[value='Computer Science A']");
+    expect(updateSpy).not.to.have.been.called;
+    radio.simulate('change', {
+      target: {value: 'Computer Science A', checked: true}
+    });
+    expect(updateSpy).to.have.been.called;
   });
 });

--- a/apps/test/unit/templates/sectionsRefresh/QuickAssignTableTest.jsx
+++ b/apps/test/unit/templates/sectionsRefresh/QuickAssignTableTest.jsx
@@ -15,6 +15,7 @@ describe('QuickAssignTable', () => {
       <QuickAssignTable
         marketingAudience={MARKETING_AUDIENCE.ELEMENTARY}
         courseOfferings={elementarySchoolCourseOffering}
+        updateCourse={() => {}}
       />
     );
 
@@ -27,6 +28,7 @@ describe('QuickAssignTable', () => {
       <QuickAssignTable
         marketingAudience={MARKETING_AUDIENCE.HIGH}
         courseOfferings={highSchoolCourseOfferings}
+        updateCourse={() => {}}
       />
     );
     expect(wrapper.find('table').length).to.equal(2);


### PR DESCRIPTION
This PR populates the quick assign table with the course offerings headers and courses. Each piece of curriculum is given its own radio button that is then saved in the 'assigned course' state. I used a useEffect and a state value to keep track of what course the user currently has assigned instead of calling updateSection directly from the change event. This allows the radio values to be computed using that state, and keeps the onChange from doing two things at once. After all- the state should always reflect what updateSection is called with.

This pr also fixes some things from the last pr:
- moves all styling from CurriculumQuickAssign into a stylesheet (I learned you can just make a nested/more specific className and it will override the other styles)
- Fixes decideLater button so it now clears out any previous class assignment

Before:
<img width="1103" alt="Screen Shot 2023-02-23 at 1 42 25 PM" src="https://user-images.githubusercontent.com/37230822/222039201-53ab25f9-3ba1-4cdd-b306-2735df56482b.png">

After:
<img width="1190" alt="Screenshot 2023-02-28 at 7 31 56 PM" src="https://user-images.githubusercontent.com/37230822/222039163-d1bbb590-2502-4573-b8f0-adb5b02cb324.png">



## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/TEACH-264
- https://codedotorg.atlassian.net/browse/TEACH-265

## Testing story

Adds a test to ensure clicking a radio button actually updates the course assignment via updateSection

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
