### PR TITLE
Changed styling of toggle so toggle comes first

### DIFF
--- a/apps/src/code-studio/components/ToggleSwitch.jsx
+++ b/apps/src/code-studio/components/ToggleSwitch.jsx
@@ -27,10 +27,10 @@ class ToggleSwitch extends React.Component {
         style={styles.button}
         className="button-active-no-border toggle-input"
       >
-        <div style={styles.label}>{label}</div>
         <div className="toggle-display">
           <i className={'fa fa-toggle-on'} style={iconStyle} />
         </div>
+        <div style={styles.label}>{label}</div>
       </button>
     );
   }
@@ -67,7 +67,7 @@ const styles = {
     width: '32px'
   },
   label: {
-    marginRight: 5,
+    marginLeft: 5,
     padding: 0
   }
 };


### PR DESCRIPTION
This moves the toggle button from the right of the label to the left of the label.  

**This is what it used to look like:**
<img width="342" alt="image" src="https://user-images.githubusercontent.com/24883357/222146114-1e0e297e-8e0a-41e6-8c11-9582f1e6d3b3.png">



**This is what it looks like now:**
<img width="332" alt="image" src="https://user-images.githubusercontent.com/24883357/222145585-4fea5570-5515-4ebe-b0ae-db57d92f0d3c.png">

Re-positioning the text will make this more re-usable in newer components

## Testing story

I visually checked this but didn't add or modify any other tests.
