### PR TITLE
Generate s3 console links for expiring logs

### DIFF
--- a/aws/ci_build
+++ b/aws/ci_build
@@ -54,7 +54,8 @@ def upload_log_and_get_link(key, body, metadata)
         body,
         {metadata: metadata}
       )
-  " <a href='#{log_url}'>☁ Log on S3</a>"
+  permalink = AWS::S3.get_console_link_from_presigned(log_url)
+  " <a href='#{log_url}'>☁ Log on S3</a> (<a href='#{permalink}'>permalink</a>)"
 rescue Exception => msg
   ChatClient.log "Uploading log to S3 failed: #{msg}"
   return ''

--- a/lib/cdo/aws/s3.rb
+++ b/lib/cdo/aws/s3.rb
@@ -292,6 +292,25 @@ module AWS
       Aws::S3::Presigner.new(client: create_client).presigned_url(method, params)
     end
 
+    # Returns a link to the S3 web console for a given presigned S3 URL.
+    # This is useful for finding a file once the presigned URL has expired.
+    # The user will need to authenticate when using the link.
+    # @param [String] a presigned S3 URL
+    # @return [String] a direct link to the file in the S3 console
+    # @raise [Exception] if the provided link isn't a presigned S3 URL
+    def self.get_console_link_from_presigned(presigned_url)
+      presidned_regex = /^https\:\/\/([a-z0-9][a-z0-9-]{1,61}[a-z0-9])\.s3\.amazonaws.com\/(.*)\?.*$/
+      unless presigned_url.match(presidned_regex)
+        raise ArgumentError.new("expected presigned S3 URL like 'https://bucket-name.s3.amazonaws.com/prefix/filename?with=any&query=params'")
+      end
+
+      captured = presidned_regex.match(presigned_url)
+      bucket = captured[1]
+      prefix = captured[2]
+
+      return "https://s3.console.aws.amazon.com/s3/object/#{bucket}?prefix=#{prefix}"
+    end
+
     class LogUploader
       # A LogUploader is constructed with some preconfigured settings that will
       # apply to all log uploads - presumably you may be uploading many similar

--- a/lib/cdo/aws/s3.rb
+++ b/lib/cdo/aws/s3.rb
@@ -299,12 +299,12 @@ module AWS
     # @return [String] a direct link to the file in the S3 console
     # @raise [Exception] if the provided link isn't a presigned S3 URL
     def self.get_console_link_from_presigned(presigned_url)
-      presidned_regex = /^https\:\/\/([a-z0-9][a-z0-9-]{1,61}[a-z0-9])\.s3\.amazonaws.com\/(.*)\?.*$/
-      unless presigned_url.match(presidned_regex)
+      presigned_regex = /^https\:\/\/([a-z0-9][a-z0-9-]{1,61}[a-z0-9])\.s3\.amazonaws.com\/(.*)\?.*$/
+      unless presigned_url.match(presigned_regex)
         raise ArgumentError.new("expected presigned S3 URL like 'https://bucket-name.s3.amazonaws.com/prefix/filename?with=any&query=params'")
       end
 
-      captured = presidned_regex.match(presigned_url)
+      captured = presigned_regex.match(presigned_url)
       bucket = captured[1]
       prefix = captured[2]
 

--- a/lib/test/cdo/aws/s3.rb
+++ b/lib/test/cdo/aws/s3.rb
@@ -51,4 +51,16 @@ class CdoAwsS3Test < Minitest::Test
 
     AWS::S3.s3.unstub(:delete_object)
   end
+
+  def test_get_console_link_from_presigned_rejects_unexpected_input
+    assert_raises(ArgumentError) {AWS::S3.get_console_link_from_presigned("")}
+    assert_raises(ArgumentError) {AWS::S3.get_console_link_from_presigned("https://example.com//test/20230222T200104%2B0000")}
+    assert_raises(ArgumentError) {AWS::S3.get_console_link_from_presigned("https://some-bucket.s3.amazonaws.com")}
+  end
+
+  def test_get_console_link_from_presigned_returns_transformed_url
+    presigned_url = "https://cdo-build-logs.s3.amazonaws.com/test/20230222T200104%2B0000?versionId=AjeSMS0Eq2pkvljW7ohD2J6qMFMx_ykU&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAW5P5EEELIETSUTKS%2F20230222%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230222T204400Z&X-Amz-Expires=259200&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEEQaCXVzLWVhc3QtMSJGMEQCICuSp6dZ0WJeZ3K%2FEoM7yuEO32NgaByJP%2BiD05%2F%2BK2z%2FAiAOMioA0x2aO7J9gori13wBPCRjNn2QBWVFTOjHEgzfZSrWBAjd%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F8BEAAaDDQ3NTY2MTYwNzE5MCIMvVTdvqm2IsQmRZrpKqoEPcSC8vnFXU7DtHoHQZ3vDD83MgR1biwz9QvHEbZS3H1fia2%2FZfLPXELz%2BxVWO23NViPn%2B7XV2%2FKbZNdIFAiMvvuzpfdF2R31%2FmgfXcZP6W2NwUUNqrszxgtxM12V3%2BK%2BkBzcoDQshQPXtPeAKdP1EQuDNwL43oLrFrLZ6xK2n85TxGog5F6f0ZEN2IXZRASVtT41nN0GRWgVnhWqlJJWYigtS8eKN7S56cRI5x2264HKTuoHqb2%2BugTInqvM3sKScpRMcEoxbYe98CFa9N11s%2B8LWYxpkVAk2Qb8jEJ6fbN9FIaPK2FmhDdpsljHKfnl15i8wReuRL3v4ajZtok%2BjIkjtZIDNP6MTpEXm%2BwemjNmJzdpLAlYwud%2FUdClHL95GkBe%2FMyZKlicrjRwiSIPJnHSBBJpgSn9p%2FPWvBZgAs7H3C54lfKGLT5TiIodRgn1XrZg83EXmiMomxHloS9s38mVr5QhdyR742xZcfQQ%2BVMcEVxVntVz7xQdwCeWSL1ZV41s9b2fk9HpE9lTPjHvpxtTSoPTGOW8%2Bv2Yees7%2F%2FMyqrmuvY%2Fy0V%2FGE7NRDA5OXdEPXAm6QUmPWNyG%2BKVzE0FnonkpxfLK4KDCd7jcOZSDd3%2BBa%2Fy3%2F9qnppbuvXU3usv4m9vltmw8GDuHv5T3QivksxkuiVjjJ51qgfdEEOIn6o0jRDjhKo12w7Ce4zATW%2BeLR10hZlWZTomGvoYvLWiUCsWnubTO%2BfgwpeTZnwY6qgFp9%2F6%2B%2BVA%2F4dRfQyn%2FqmH%2BJzwYDj4SzTeTVdJ%2FN8FtRj%2BHBet09EBX7zgdBmmebRnSkqOWm0NuXf9cb9aSBAkclmluSP%2Bmk0by%2BJrYvVJSV6Iwv6yCG2de15XbkfQm46eb3c8EqJpI4CGTfyTwrZB7LednvfTVJrpW9iPcI97LmfIez7MlV1nMBANHRdxOiIm4jrwUkryN7EfBC4y9%2BsOQH5zXFlIiZ8vh%2BA%3D%3D&X-Amz-SignedHeaders=host&X-Amz-Signature=3117b23c8bda56230d2dc8c3fd3452b5b5576a2507dcd881fe40ec3bcd77ce70"
+    expected_url = "https://s3.console.aws.amazon.com/s3/object/cdo-build-logs?prefix=test/20230222T200104%2B0000"
+    assert_equal(expected_url, AWS::S3.get_console_link_from_presigned(presigned_url))
+  end
 end


### PR DESCRIPTION
The presigned link is super convenient for immediate access, but after 72 hours the link is expired and you have to parse the url and hunt for the log file in S3.

![image](https://user-images.githubusercontent.com/7014619/222219019-cd05e954-3d79-4101-8987-607484f70808.png)

![image](https://user-images.githubusercontent.com/7014619/222219202-361f0fd3-5075-4b07-ad33-e5e8f5231bde.png)


This change adds a permalink to the S3 console. You will have to already be logged in, but this saves steps and mental overhead.

## Testing story

## Deployment strategy

## Follow-up work

Similar functionality is used elsewhere, somewhat inconsistently. We may wish to include this in these other locations:
* https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/lib/contact_rollups_v2.rb#L273
* https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/lib/expired_deleted_account_purger.rb#L221
* https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/test/ui/runner.rb#L289

## Security

No new information is exposed in these links, and using them requires AWS Authentication.

## PR Checklist:

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
