### PR TITLE
Ensure the '6-12 Teacher Application Visited' event is showing up on Amplitude

### DIFF
--- a/apps/src/code-studio/pd/application/teacher/TeacherApplication.jsx
+++ b/apps/src/code-studio/pd/application/teacher/TeacherApplication.jsx
@@ -18,6 +18,7 @@ import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 
 const submitButtonText = 'Complete and Send';
 const sessionStorageKey = 'TeacherApplication';
+const hasLoggedTeacherAppStart = 'hasLoggedTeacherAppStart';
 const pageComponents = [
   ChooseYourProgram,
   FindYourRegion,
@@ -66,7 +67,10 @@ const TeacherApplication = props => {
   };
 
   const onInitialize = () => {
-    analyticsReporter.sendEvent(EVENTS.TEACHER_APP_STARTED_EVENT);
+    if (!sessionStorage.getItem(hasLoggedTeacherAppStart)) {
+      sessionStorage.setItem(hasLoggedTeacherAppStart, true);
+      analyticsReporter.sendEvent(EVENTS.TEACHER_APP_VISITED_EVENT);
+    }
     sendFirehoseEvent(userId, 'started-teacher-application');
   };
 

--- a/apps/src/code-studio/pd/application/teacher/TeacherApplication.jsx
+++ b/apps/src/code-studio/pd/application/teacher/TeacherApplication.jsx
@@ -66,6 +66,7 @@ const TeacherApplication = props => {
   };
 
   const onInitialize = () => {
+    analyticsReporter.sendEvent(EVENTS.TEACHER_APP_STARTED_EVENT);
     sendFirehoseEvent(userId, 'started-teacher-application');
   };
 

--- a/apps/src/lib/util/AnalyticsConstants.js
+++ b/apps/src/lib/util/AnalyticsConstants.js
@@ -25,7 +25,7 @@ const EVENTS = {
   WORKSHOP_ENROLLMENT_COMPLETED_EVENT: 'Workshop Enrollment Completed',
 
   // PD Application flow
-  TEACHER_APP_STARTED_EVENT: '6-12 Teacher Application Started',
+  TEACHER_APP_VISITED_EVENT: '6-12 Teacher Application Visited',
   PAGE_CHANGED_EVENT: 'Page Changed',
   PROGRAM_PICKED_EVENT: 'Professional Learning Program Picked',
   SCHOOL_ID_CHANGED_EVENT: 'School ID Changed',

--- a/apps/src/templates/RegionalPartnerSearch.jsx
+++ b/apps/src/templates/RegionalPartnerSearch.jsx
@@ -14,8 +14,6 @@ import {currentLocation} from '@cdo/apps/utils';
 import PropTypes from 'prop-types';
 import queryString from 'query-string';
 import $ from 'jquery';
-import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
-import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 
 const WorkshopCard = props => {
   return (
@@ -594,10 +592,6 @@ const StartApplicationButton = ({
     ? "Apply on partner's site"
     : 'Start application';
 
-  const logStartApplication = () => {
-    analyticsReporter.sendEvent(EVENTS.TEACHER_APP_STARTED_EVENT);
-  };
-
   let notificationHeading, notificationText;
   if (priorityDeadlineDate) {
     notificationHeading = `Priority deadline for your region is ${priorityDeadlineDate}`;
@@ -610,11 +604,7 @@ const StartApplicationButton = ({
 
   const button = (
     <a className={className} id={id} target={target} href={link}>
-      <button
-        type="button"
-        style={styles.bigButton}
-        onClick={logStartApplication}
-      >
+      <button type="button" style={styles.bigButton}>
         {buttonText}
       </button>
     </a>


### PR DESCRIPTION
Currently, the '6-12 Teacher Application Started` Amplitude event isn't receiving data because it is fired when the user clicks the 'Start Application' but that redirects the user to the application before the event can be triggered.

To fix this, I first moved the event to [where the equivalent firehose event is](https://github.com/code-dot-org/code-dot-org/pull/50527/files#diff-1b22856eea87372e3ad3b60fbe5fa0f3651059c0f4053768a843374b623bee3aR74), however that triggered every time the application was opened (including refreshing the page).

So, after discussion with Dani, we decided to use sessionStorage (similar to a strategy used [here](https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/templates/studioHomepages/TeacherHomepage.jsx#L160) by teacher tools) to limit when the event fires to just when the application is first opened or if the user returns in a later session and to rebrand the event as '6-12 Teacher Application Visited' (rather than '6-12 Teacher Application Started'). This way, we know the first instance of that event for a user is when they start it, and any future instance of it is a time when they stopped working on it then came back later to continue working on it.

### Event fires when application is started
![App_Visited_First](https://user-images.githubusercontent.com/56283563/222535191-03e48743-4ff0-4db9-b523-242abb605b3e.JPG)

### Event fires when user comes back to the application in a new session
![App_Visited_Return](https://user-images.githubusercontent.com/56283563/222535201-abb2b437-a76f-4c60-9af4-17e7f76fb245.JPG)

### Event does not fire on refreshing the page
https://user-images.githubusercontent.com/56283563/222535125-1304537d-9cc0-48ac-bd4e-6cb904011372.mp4

### Event successfully logs on Amplitude
This is confirmed by the event successfully switching from "Planned" to "Live" in the staging environment:
![Now_marked_Live](https://user-images.githubusercontent.com/56283563/222536371-7f14f0e7-de2a-448a-8a9a-629ce639a551.JPG)
(I used the staging API key as per [this slack thread](https://codedotorg.slack.com/archives/C049E9P6QQ1/p1677619808161269?thread_ts=1677618755.906789&cid=C049E9P6QQ1))

## Links
Jira task: [here](https://codedotorg.atlassian.net/browse/ACQ-439?atlOrigin=eyJpIjoiYWJiYWMwYWZhMWU0NGRhYTk1MTg4MjJmNDk2YTM2MDQiLCJwIjoiaiJ9)
Amplitude event: [here](https://data.amplitude.com/code-org/Code.org%20Tracking%20Plan/events/main/latest/6-12%20Teacher%20Application%20Visited)

## Testing story
Local testing and logging to Amplitude.

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
