### PR TITLE
Remove the 'Homepage Visited' Amplitude event

### DIFF
--- a/pegasus/helpers/analytics_constants.rb
+++ b/pegasus/helpers/analytics_constants.rb
@@ -3,7 +3,6 @@
 # apps directory)
 module AnalyticsConstants
   EVENTS = [
-    HOMEPAGE_VISITED_EVENT = 'Homepage Visited'.freeze,
     ADMIN_PAGE_VISITED_EVENT = 'Administrator Page Visited'.freeze,
     AI_PAGE_VISIT_EVENT = 'AI Page Visited'.freeze,
     CSA_CURRICULUM_PAGE_VISITED_EVENT = 'CSA Curriculum Page Visited'.freeze,

--- a/pegasus/sites.v3/code.org/public/index.haml
+++ b/pegasus/sites.v3/code.org/public/index.haml
@@ -36,6 +36,5 @@ style_min: true
   = view :homepage_sections
   = view :homepage_gallery
   = view :homepage_supporters
-  = view :analytics_event_log_helper, event_name: AnalyticsConstants::HOMEPAGE_VISITED_EVENT
 
 = view :homepage_video


### PR DESCRIPTION
Removes the 'Homepage Visited' Amplitude event (for visiting [code.org](code.org)) due to its high volume. It would consume a lot of what we are allotted by our plan with Amplitude. To save on resources and focus on other events, this event is being removed.

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/browse/ACQ-438?atlOrigin=eyJpIjoiYzhjZTFjNjI0NGQxNGRiYWE5YzVhZTQyN2Y2YjFmMWUiLCJwIjoiaiJ9)

## Testing story
Local testing that no event is firing.

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
