### PR TITLE
Music Lab: add additional telemetry

### DIFF
--- a/apps/src/music/context.ts
+++ b/apps/src/music/context.ts
@@ -1,8 +1,9 @@
 import React from 'react';
+import AnalyticsReporter from './analytics/AnalyticsReporter';
 import MusicPlayer from './player/MusicPlayer';
 
 /** Provides access to the Analytics reporter object */
-export const AnalyticsContext = React.createContext(null);
+export const AnalyticsContext: React.Context<AnalyticsReporter | null> = React.createContext<AnalyticsReporter | null>(null);
 
 type PlayerUtils = Pick<
   MusicPlayer,

--- a/apps/tsconfig.json
+++ b/apps/tsconfig.json
@@ -14,7 +14,8 @@
     /* Language and Environment */
     "target": "es5" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
     "lib": [
-      "ES2019"
+      "ES2019",
+      "DOM"
     ] /* Specify a set of bundled library declaration files that describe the target runtime environment. */,
     // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
     // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Add additional telemetry to Music Lab, namely tracking which feature-related blocks were used in a project (loops, play together/sequential, functions, etc). Also converted AnalyticsReporter to typescript since it was a relatively straightforward conversion.

## Links

https://codedotorg.atlassian.net/browse/SL-572

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
