### PR TITLE
Reset selected poem on version reset

### DIFF
--- a/apps/src/p5lab/P5Lab.js
+++ b/apps/src/p5lab/P5Lab.js
@@ -288,6 +288,8 @@ export default class P5Lab {
       // If we reset a puzzle, it no longer has any custom uploads.
       // Therefore we can set restricted share mode to false.
       project.sourceHandler.setInRestrictedShareMode(false);
+      // If we reset a puzzle, we should reset the selected poem on that project.
+      project.sourceHandler.setSelectedPoem(null);
       this.studioApp_.resetButtonClick();
     }.bind(this);
 


### PR DESCRIPTION
When we reset version history in Poetry we were not resetting to the default selected poem on the level. This is confusing behavior, and we should reset to the default poem on the level.

## Links

- jira ticket: [SL-621](https://codedotorg.atlassian.net/browse/SL-621)


## Testing story
Tested locally that this works for both poetry and non-poetry levels.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
