### PR TITLE
Add 'Administrator Interest Form Submitted' Amplitude event

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -784,6 +784,8 @@ describe('entry tests', () => {
       './src/sites/code.org/pages/public/yourschool.js',
     'code.org/public/yourschool/thankyou':
       './src/sites/code.org/pages/public/yourschool/thankyou.js',
+    'code.org/public/administrators':
+      './src/sites/code.org/pages/public/administrators.js',
     'code.org/views/regional_partner_search':
       './src/sites/code.org/pages/views/regional_partner_search.js',
     'code.org/views/share_privacy':

--- a/apps/src/lib/util/AnalyticsConstants.js
+++ b/apps/src/lib/util/AnalyticsConstants.js
@@ -38,6 +38,7 @@ const EVENTS = {
 
   // Marketing site pages
   TEACH_PAGE_VISITED_EVENT: 'Teach Page Visited',
+  ADMIN_INTEREST_FORM_SUBMIT_EVENT: 'Administrator Interest Form Submitted',
 
   // Sections
   CURRICULUM_ASSIGNED: 'Section Curriculum Assigned',

--- a/apps/src/sites/code.org/pages/public/administrators.js
+++ b/apps/src/sites/code.org/pages/public/administrators.js
@@ -1,0 +1,11 @@
+import $ from 'jquery';
+import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
+import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
+
+$(document).ready(() => {
+  document
+    .getElementById('admin_interest_form')
+    .addEventListener('submit', () => {
+      analyticsReporter.sendEvent(EVENTS.ADMIN_INTEREST_FORM_SUBMIT_EVENT);
+    });
+});

--- a/pegasus/sites.v3/code.org/public/administrators.haml
+++ b/pegasus/sites.v3/code.org/public/administrators.haml
@@ -3,6 +3,8 @@ title: Code.org District Partner Program
 theme: responsive_full_width
 ---
 
+%script{data: {'amplitude-api-key': CDO.safe_amplitude_api_key}}
+%script{src: webpack_asset_path('js/code.org/public/administrators.js')}
 %link{href: 'shared/css/design-system-pegasus.css', rel: 'stylesheet'}
 
 -# Import FontAwesome Pro

--- a/pegasus/sites.v3/code.org/views/admins_email_signup_form.html
+++ b/pegasus/sites.v3/code.org/views/admins_email_signup_form.html
@@ -1,7 +1,7 @@
 <script src="https://www.google.com/recaptcha/api.js"></script>
 <script src="/js/admins_email_signup_form.js"></script>
 
-<form action="https://webto.salesforce.com/servlet/servlet.WebToLead?encoding=UTF-8" method="POST">
+<form id="admin_interest_form" action="https://webto.salesforce.com/servlet/servlet.WebToLead?encoding=UTF-8" method="POST">
   <input type=hidden name='captcha_settings' value='{"keyname":"fixed","fallback":"true","orgId":"00Dj0000001sjyo","ts":""}'>
   <input type=hidden name="oid" value="00Dj0000001sjyo">
   <input type=hidden name="retURL" value="http://code.org/salesforce-form-thanks">


### PR DESCRIPTION
Adds ['Administrator Interest Form Submitted' Amplitude event](https://data.amplitude.com/code-org/Code.org%20Tracking%20Plan/events/main/latest/Administrator%20Interest%20Form%20Submitted) for when a user fills out the interest form on [code.org/administrators](https://code.org/administrators).

The event logs when the form successfully submits:
![Interest_Form_Submitted_Console](https://user-images.githubusercontent.com/56283563/222294634-0ff6ea18-650d-44e9-8368-42db7d9dbd71.PNG)

This is confirmed by the event successfully switching from "Planned" to "Live" in the staging environment:
![Switched_Planned_To_Live](https://user-images.githubusercontent.com/56283563/222295220-63a02c1c-1f0e-470f-991a-9d99a8fc6770.PNG)
(I used the staging API key as per [this slack thread](https://codedotorg.slack.com/archives/C049E9P6QQ1/p1677619808161269?thread_ts=1677618755.906789&cid=C049E9P6QQ1))

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/browse/ACQ-408?atlOrigin=eyJpIjoiMzBiZGIyZGQzOTg3NGQzNTgzZjVkZTIzN2IzZTQzOGMiLCJwIjoiaiJ9)
Amplitude event: [here](https://data.amplitude.com/code-org/Code.org%20Tracking%20Plan/events/main/latest/Administrator%20Interest%20Form%20Submitted)

## Testing story
Local testing and drone build.

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
