### PR TITLE
Add hostnames to startWebRequest

### DIFF
--- a/dashboard/app/controllers/xhr_proxy_controller.rb
+++ b/dashboard/app/controllers/xhr_proxy_controller.rb
@@ -46,6 +46,7 @@ class XhrProxyController < ApplicationController
     api.nookipedia.com
     api.opencagedata.com
     api.open-notify.org
+    api.open-meteo.com
     api.openrouteservice.org
     api.openweathermap.org
     api.pegelalarm.at
@@ -66,6 +67,7 @@ class XhrProxyController < ApplicationController
     api.wolframalpha.com
     api.zippopotam.us
     bible-api.com
+    bnefoodtrucks.com.au
     ch.tetr.io
     code.org
     covidtracking.com


### PR DESCRIPTION
Adds `api.open-meteo.com` and `bnefoodtrucks.com.au` to the list of allowed APIs for `startWebRequest`.

## Links

Zendesk tickets:
https://codeorg.zendesk.com/agent/tickets/432139
https://codeorg.zendesk.com/agent/tickets/432344

## Testing story

Both tested manually in App Lab using `startWebRequest` (see screenshot for one below).

<img width="1498" alt="Screen Shot 2023-03-01 at 2 41 01 PM" src="https://user-images.githubusercontent.com/26844240/222282035-9a97a7e8-38c5-4891-af49-fb4f15f290bf.png">


<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
