### PR TITLE
Fix default poem selector in levelbuilder

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -717,6 +717,8 @@ describe('entry tests', () => {
       './src/sites/studio/pages/levels/editors/fields/_droplet.js',
     'levels/editors/fields/_grid':
       './src/sites/studio/pages/levels/editors/fields/_grid.js',
+    'levels/editors/fields/_poetry_fields':
+      './src/sites/studio/pages/levels/editors/fields/_poetry_fields.js',
     'levels/editors/fields/_preload_assets':
       './src/sites/studio/pages/levels/editors/fields/_preload_assets.js',
     'levels/editors/fields/_special_level_types':

--- a/apps/src/sites/studio/pages/levels/editors/fields/_poetry_fields.js
+++ b/apps/src/sites/studio/pages/levels/editors/fields/_poetry_fields.js
@@ -1,0 +1,39 @@
+import $ from 'jquery';
+
+$(document).ready(initPage);
+
+function initPage() {
+  const script = document.querySelector('script[data-poems]');
+  const poems = JSON.parse(script.dataset.poems);
+  const hocOptions = poems.poetry_hoc.map(
+    option => new Option(option[0], option[1])
+  );
+  const timeCapsuleOptions = poems.time_capsule.map(
+    option => new Option(option[0], option[1])
+  );
+
+  function updatePoemSelection() {
+    const defaultPoem = $('#defaultPoem');
+    var selectionValue = $('#level_standalone_app_name')
+      .val()
+      .toLowerCase();
+    const defaultPoemSelect = $('#level_default_poem');
+    if (selectionValue === 'poetry') {
+      defaultPoem.addClass('collapse');
+    } else {
+      defaultPoem.removeClass('collapse');
+      // reset dropdown options
+      defaultPoemSelect.empty();
+      let poems = hocOptions;
+      if (selectionValue === 'time_capsule') {
+        poems = timeCapsuleOptions;
+      }
+      poems.forEach(poem => {
+        defaultPoemSelect.append(poem);
+      });
+    }
+    // always unset selected poem
+    defaultPoemSelect.val([]);
+  }
+  $('.poem-subtype-dropdown').on('change', updatePoemSelection);
+}

--- a/dashboard/app/views/levels/editors/fields/_poetry_fields.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_poetry_fields.html.haml
@@ -1,3 +1,10 @@
+- content_for :body_scripts do
+  - poems = {}
+  - poetry_poems = @level.class.poems_for_subtype('poetry_hoc')
+  - time_capsule_poems =  @level.class.poems_for_subtype('time_capsule')
+  - script_data = { poems: {poetry_hoc: poetry_poems, time_capsule: time_capsule_poems}.to_json }
+  %script{src: webpack_asset_path('js/levels/editors/fields/_poetry_fields.js'), data: script_data}
+
 %h1.control-legend{data: {toggle: "collapse", target: "#poetry_fields"}}
   Poetry Fields
 
@@ -7,28 +14,8 @@
     %p Poetry HOC and Time Capsule levels have a poem dropdown above the playspace and auto-animate the poem.
     - if local_assigns[:warning]
       %p= "WARNING: #{warning}"
-    = f.select :standalone_app_name, options_for_select(@level.class.standalone_app_names, @level.standalone_app_name), {}, onchange: 'toggleFields(this.value);'
+    = f.select :standalone_app_name, options_for_select(@level.class.standalone_app_names, @level.standalone_app_name), {}, {class: 'poem-subtype-dropdown'}
 
-  #defaultPoemHoc{class: ('collapse' if @level.standalone_app_name != 'poetry_hoc')}
+  #defaultPoem{class: ('collapse' if @level.standalone_app_name == 'poetry')}
     = f.label :default_poem, 'Default Poem'
-    = f.select :default_poem, options_for_select(@level.class.hoc_poems, @level.default_poem)
-
-  #defaultPoemTimeCapsule{class: ('collapse' if @level.standalone_app_name != 'time_capsule')}
-    = f.label :default_poem, 'Default Poem'
-    = f.select :default_poem, options_for_select(@level.class.time_capsule_poems, @level.default_poem)
-
-:javascript
-  function toggleFields(val) {
-    const defaultPoemHoc = document.getElementById('defaultPoemHoc');
-    const defaultPoemTimeCapsule = document.getElementById('defaultPoemTimeCapsule');
-    if (val.toLowerCase() === 'poetry') {
-      defaultPoemHoc.classList.add('collapse');
-      defaultPoemTimeCapsule.classList.add('collapse');
-    } else if (val.toLowerCase() === 'poetry_hoc') {
-      defaultPoemTimeCapsule.classList.add('collapse');
-      defaultPoemHoc.classList.remove('collapse');
-    } else if (val.toLowerCase() === 'time_capsule') {
-      defaultPoemTimeCapsule.classList.remove('collapse');
-      defaultPoemHoc.classList.add('collapse');
-    }
-  }
+    = f.select :default_poem, options_for_select(@level.class.poems_for_subtype(@level.standalone_app_name), @level.default_poem)


### PR DESCRIPTION
My [previous PR](https://github.com/code-dot-org/code-dot-org/pull/50485) to dynamically change the poem dropdown based on level subtype was buggy. Because I had two dropdowns acting on the same field, only the value from the second dropdown (time capsule) would be used, which meant you couldn't save a default poem on poetry_hoc anymore. I updated it to use the same dropdown and dynamically change the options with javascript instead.

## Testing story
Tested locally--you can now correctly set a default poem on time capsule and poetry_hoc subtypes, and the default poem on a poetry level will always be null (as expected).


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
