### PR TITLE
Change version year of self-paced-pl-csp-2021 to 2021

### DIFF
--- a/dashboard/config/courses/self-paced-pl-csp-2021.course
+++ b/dashboard/config/courses/self-paced-pl-csp-2021.course
@@ -13,7 +13,7 @@
   "properties": {
     "family_name": "self-paced-pl-csp-2021",
     "has_numbered_units": true,
-    "version_year": "unversioned"
+    "version_year": "2021"
   },
   "resources": [
 

--- a/dashboard/config/locales/courses.en.yml
+++ b/dashboard/config/locales/courses.en.yml
@@ -166,7 +166,7 @@ en:
             ### Pick your content
 
             ##### The content of these professional learning modules is organized in the suggested progression for teachers new to both Code.org and CS Principles. However, you can engage with the content in the order that best meets your needs. We recommend all teachers start with the short welcome unit to learn more about these professional learning modules before getting started.
-          version_title: ''
+          version_title: "'21-'22"
         csa-pilot-facilitator:
           title: CSA Pilot Facilitators
           description_short: ''
@@ -227,7 +227,7 @@ en:
           description_short: ''
           description_student: ''
           description_teacher: ''
-          version_title: ''
+          version_title: "'22-'23"
         csd-2022:
           title: Computer Science Discoveries ('22-'23)
           description_short: An introductory computer science course that empowers students to create authentic artifacts


### PR DESCRIPTION
I tested this locally and had no problems. This course doesn't use resources, vocab, or concept maps -- the features that are closely tied to a course version -- so I believe this is safe.

I also updated the `version_title` of `self-paced-pl-csp-2021` and `self-paced-pl-csa-2022`. The latter doesn't need any other changes -- I just noticed that it also had the blank version dropdown with a new version in development.

Slack thread for more context: https://codedotorg.slack.com/archives/C045UAX4WKH/p1677705399243539

Before (the '22-'23 version should be recommended):
![Screen Shot 2023-03-02 at 1 13 53 PM](https://user-images.githubusercontent.com/46464143/222516415-8f919bf3-340f-410a-a2e0-3005a9888a6f.png)


After (ignore the checkmark moving -- I was on a different version than the screenshot above):
![Screen Shot 2023-03-02 at 1 13 21 PM](https://user-images.githubusercontent.com/46464143/222516475-7b4224b3-30ba-4294-9634-4d5379d4a707.png)

