### PR TITLE
Sprite Lab: Fix restricted mode publish edge case

### DIFF
--- a/dashboard/legacy/middleware/helpers/source_bucket.rb
+++ b/dashboard/legacy/middleware/helpers/source_bucket.rb
@@ -59,6 +59,13 @@ class SourceBucket < BucketHelper
       end
     end
 
+    if psj.in_restricted_share_mode?
+      project = Project.find_by_channel_id(encrypted_channel_id)
+      unless project.published_at.nil?
+        Projects.new(owner_id).unpublish(encrypted_channel_id)
+      end
+    end
+
     # Write the updated main.json file back to S3 as the latest version
     response = s3.put_object(bucket: @bucket, key: key, body: psj.to_json)
 


### PR DESCRIPTION
This edge case is related to student upload in sprite lab.
Repro steps:
- Create a new Sprite Lab project as a student and upload some images.
- Use Version History to go back to a point before uploads were enabled.
- Make some changes to the project (optional), run the program and then publish the project. The project should now be published as expected.
- Use Version History to go back to a point where uploads are enabled. **The project is still published.**

The fix for this is we will check for restricted share mode when going back to a previous version. If the project has it and is published, we will silently unpublish the project. If the student tries to check the publish status, we already show a message that projects with uploads can't be published.

## Links

- jira ticket: [SL-614](https://codedotorg.atlassian.net/browse/SL-614)


## Testing story
Tested locally

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
