### PR TITLE
Assign and unassign section buttons a11y, realigning hidden and visible

### DIFF
--- a/apps/src/code-studio/components/progress/bulk-lesson-visibility-toggle.module.scss
+++ b/apps/src/code-studio/components/progress/bulk-lesson-visibility-toggle.module.scss
@@ -1,7 +1,7 @@
 .container {
   // Align the top of the buttons with the top of the SectionAssigner dropdown
   // to its left.
-  padding-top: 33px;
+  padding-top: 38px;
 }
 
 .infoTipIcon {

--- a/apps/src/templates/AssignButton.jsx
+++ b/apps/src/templates/AssignButton.jsx
@@ -99,7 +99,7 @@ class AssignButton extends React.Component {
       <div>
         <div style={buttonMarginStyle}>
           <Button
-            __useDeprecatedTag
+            style={styles.boxShadow}
             color={Button.ButtonColor.orange}
             text={i18n.assignToSection()}
             icon="plus"
@@ -130,6 +130,9 @@ const styles = {
     marginRight: 10,
     display: 'flex',
     alignItems: 'center'
+  },
+  boxShadow: {
+    boxShadow: 'inset 0 2px 0 0 rgb(255 255 255 / 63%)'
   }
 };
 

--- a/apps/src/templates/UnassignSectionButton.jsx
+++ b/apps/src/templates/UnassignSectionButton.jsx
@@ -98,7 +98,7 @@ function UnassignSectionButton({
       className={'uitest-unassign-button'}
     >
       <Button
-        __useDeprecatedTag
+        style={styles.boxShadow}
         color={Button.ButtonColor.green}
         text={text}
         icon={icon}
@@ -139,6 +139,9 @@ const styles = {
     marginRight: 10,
     display: 'flex',
     alignItems: 'center'
+  },
+  boxShadow: {
+    boxShadow: 'inset 0 2px 0 0 rgb(255 255 255 / 40%)'
   }
 };
 


### PR DESCRIPTION
I removed the useDeprecatedTags from both these buttons (unassign in green and assign in orange). Because they are beside a 'go to unit' button that is actually a link (and can't be converted yet) I chose to add back in the box shadow on both buttons to keep the styling consistent. 

Additionally, once Kaitie removed the useDeprecatedTag from the assign to multiple sections button, it shifted the row of buttons. This pr also shifts the hide and show buttons to the right accordingly to realign them vertically. 

Before:
<img width="1084" alt="Screenshot 2023-03-02 at 6 22 25 PM" src="https://user-images.githubusercontent.com/37230822/222615645-f957e7f0-d0e4-4919-9cfc-d5d304f7a2fa.png">

After:
<img width="1114" alt="Screenshot 2023-03-02 at 6 22 18 PM" src="https://user-images.githubusercontent.com/37230822/222615674-050a0e11-5d2e-41e8-95d5-d6e18b4aa5f9.png">


Before:
<img width="899" alt="Screenshot 2023-03-02 at 5 52 30 PM" src="https://user-images.githubusercontent.com/37230822/222613074-2d8ee408-04ee-43df-822e-b70170063912.png">

After:
<img width="949" alt="Screenshot 2023-03-02 at 6 02 13 PM" src="https://user-images.githubusercontent.com/37230822/222613091-2fcec39d-7f97-4371-b9b5-1661a86bee33.png">

## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/A11Y-127
- https://codedotorg.atlassian.net/browse/A11Y-120
- https://codedotorg.atlassian.net/browse/TEACH-312

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
