### PR TITLE
Add experiment flag to go from the AddSectionDialog to the new section setup page

### DIFF
--- a/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
+++ b/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
@@ -4,6 +4,7 @@ import SingleSectionSetUp from './SingleSectionSetUp';
 import CurriculumQuickAssign from './CurriculumQuickAssign';
 import Button from '@cdo/apps/templates/Button';
 import moduleStyles from './sections-refresh.module.scss';
+import {queryParams} from '@cdo/apps/code-studio/utils';
 
 const FORM_ID = 'sections-set-up-container';
 const SECTIONS_API = '/api/v1/sections';
@@ -43,12 +44,12 @@ const saveSection = (e, section) => {
 
   const csrfToken = document.querySelector('meta[name="csrf-token"]')
     .attributes['content'].value;
+  const loginType = queryParams('loginType');
+  const participantType = queryParams('participantType');
 
-  // TODO: remove this once login_type and participant_type are hooked up to
-  // the form.
   const section_data = {
-    login_type: 'word',
-    participant_type: 'student',
+    login_type: loginType,
+    participant_type: participantType,
     ...section
   };
 

--- a/apps/src/templates/teacherDashboard/AddSectionDialog.jsx
+++ b/apps/src/templates/teacherDashboard/AddSectionDialog.jsx
@@ -17,6 +17,21 @@ import {
 } from './teacherSectionsRedux';
 import ParticipantTypePicker from './ParticipantTypePicker';
 import Spinner from '@cdo/apps/code-studio/pd/components/spinner';
+import {navigateToHref} from '@cdo/apps/utils';
+import {SectionLoginType} from '@cdo/apps/util/sharedConstants';
+import experiments from '@cdo/apps/util/experiments';
+
+const redirectToNewSectionPage = (participantType, loginType) => {
+  if (
+    experiments.isEnabled('sectionSetupRefresh') &&
+    !!participantType &&
+    !!loginType
+  ) {
+    navigateToHref(
+      `/sections/new?participantType=${participantType}&loginType=${loginType}`
+    );
+  }
+};
 
 /**
  * UI for a teacher to add a new class section.  For editing a section see
@@ -47,6 +62,26 @@ const AddSectionDialog = ({
   const {loginType, participantType} = section || {};
   const title = i18n.newSectionUpdated();
 
+  const onParticipantTypeSelection = participantType => {
+    if (participantType !== 'student') {
+      redirectToNewSectionPage(participantType, SectionLoginType.email);
+    }
+    setParticipantType(participantType);
+  };
+
+  const onLoginTypeSelection = loginType => {
+    if (
+      [
+        SectionLoginType.picture,
+        SectionLoginType.word,
+        SectionLoginType.email
+      ].includes(loginType)
+    ) {
+      redirectToNewSectionPage(participantType, loginType);
+    }
+    setLoginType(loginType);
+  };
+
   const getDialogContent = () => {
     if (!asyncLoadComplete) {
       return <Spinner size="large" style={{padding: 50}} />;
@@ -59,7 +94,7 @@ const AddSectionDialog = ({
       return (
         <ParticipantTypePicker
           title={title}
-          setParticipantType={setParticipantType}
+          setParticipantType={onParticipantTypeSelection}
           handleCancel={handleCancel}
           availableParticipantTypes={availableParticipantTypes}
         />
@@ -71,7 +106,7 @@ const AddSectionDialog = ({
           title={title}
           handleImportOpen={beginImportRosterFlow}
           setRosterProvider={setRosterProvider}
-          setLoginType={setLoginType}
+          setLoginType={onLoginTypeSelection}
           handleCancel={handleCancel}
         />
       );
@@ -79,17 +114,25 @@ const AddSectionDialog = ({
     return <EditSectionForm title={title} isNewSection={true} />;
   };
 
-  return (
-    <BaseDialog
-      useUpdatedStyles
-      fixedWidth={1010}
-      isOpen={isOpen}
-      overflow="hidden"
-      uncloseable
-    >
-      <PadAndCenter>{getDialogContent()}</PadAndCenter>
-    </BaseDialog>
-  );
+  if (
+    participantType &&
+    loginType &&
+    experiments.isEnabled('sectionSetupRefresh')
+  ) {
+    return null;
+  } else {
+    return (
+      <BaseDialog
+        useUpdatedStyles
+        fixedWidth={1010}
+        isOpen={isOpen}
+        overflow="hidden"
+        uncloseable
+      >
+        <PadAndCenter>{getDialogContent()}</PadAndCenter>
+      </BaseDialog>
+    );
+  }
 };
 
 AddSectionDialog.propTypes = {

--- a/apps/src/templates/teacherDashboard/AddSectionDialog.jsx
+++ b/apps/src/templates/teacherDashboard/AddSectionDialog.jsx
@@ -21,6 +21,8 @@ import {navigateToHref} from '@cdo/apps/utils';
 import {SectionLoginType} from '@cdo/apps/util/sharedConstants';
 import experiments from '@cdo/apps/util/experiments';
 
+// Checks if experiment is enabled and navigates to the new section setup page
+// if both params are non-null.
 const redirectToNewSectionPage = (participantType, loginType) => {
   if (
     experiments.isEnabled('sectionSetupRefresh') &&
@@ -70,6 +72,7 @@ const AddSectionDialog = ({
   };
 
   const onLoginTypeSelection = loginType => {
+    // Oauth section types should use the roster dialog, not the section setup page
     if (
       [
         SectionLoginType.picture,

--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -38,6 +38,7 @@ experiments.OPT_IN_EMAIL_REG_PARTNER = 'optInEmailRegPartner';
 // Experiment for showing a backgrounds tab and enabling student upload
 // for Sprite Lab animations
 experiments.BACKGROUNDS_AND_UPLOAD = 'backgroundsTab';
+experiments.SECTION_SETUP_REFRESH = 'sectionSetupRefresh';
 
 /**
  * This was a gamified version of the finish dialog, built in 2018,

--- a/apps/test/unit/templates/sectionsRefresh/SectionsSetUpContainerTest.jsx
+++ b/apps/test/unit/templates/sectionsRefresh/SectionsSetUpContainerTest.jsx
@@ -3,6 +3,7 @@ import {shallow} from 'enzyme';
 import {expect} from '../../../util/reconfiguredChai';
 import SectionsSetUpContainer from '@cdo/apps/templates/sectionsRefresh/SectionsSetUpContainer';
 import sinon from 'sinon';
+import * as utils from '@cdo/apps/code-studio/utils';
 
 describe('SectionsSetUpContainer', () => {
   it('renders an initial set up section form', () => {
@@ -79,6 +80,40 @@ describe('SectionsSetUpContainer', () => {
       .simulate('click', {preventDefault: () => {}});
 
     expect(fetchSpy).to.have.been.called.once;
+
+    sinon.restore();
+  });
+
+  it('passes participantType and loginTyp to ajax request when save is clicked', () => {
+    sinon
+      .stub(document, 'querySelector')
+      .withArgs('#sections-set-up-container')
+      .returns({
+        checkValidity: () => true
+      })
+      .withArgs('meta[name="csrf-token"]')
+      .returns({
+        attributes: {content: {value: null}}
+      });
+    sinon
+      .stub(utils, 'queryParams')
+      .withArgs('loginType')
+      .returns('word')
+      .withArgs('participantType')
+      .returns('student');
+    const fetchSpy = sinon.spy(window, 'fetch');
+
+    const wrapper = shallow(<SectionsSetUpContainer />);
+
+    wrapper
+      .find('Button')
+      .at(1)
+      .simulate('click', {preventDefault: () => {}});
+
+    expect(fetchSpy).to.have.been.called.once;
+    const fetchBody = JSON.parse(fetchSpy.getCall(0).args[1].body);
+    expect(fetchBody.login_type).to.equal('word');
+    expect(fetchBody.participant_type).to.equal('student');
 
     sinon.restore();
   });

--- a/apps/test/unit/templates/teacherDashboard/AddSectionDialogTest.jsx
+++ b/apps/test/unit/templates/teacherDashboard/AddSectionDialogTest.jsx
@@ -4,6 +4,8 @@ import sinon from 'sinon';
 import {expect} from '../../../util/reconfiguredChai';
 import {UnconnectedAddSectionDialog as AddSectionDialog} from '@cdo/apps/templates/teacherDashboard/AddSectionDialog';
 import _ from 'lodash';
+import * as utils from '@cdo/apps/utils';
+import experiments from '@cdo/apps/util/experiments';
 
 describe('AddSectionDialog', () => {
   let defaultProps,
@@ -98,5 +100,76 @@ describe('AddSectionDialog', () => {
     expect(wrapper.find('LoginTypePicker').length).to.equal(0);
     expect(wrapper.find('ParticipantTypePicker').length).to.equal(0);
     expect(wrapper.find('Connect(EditSectionForm)').length).to.equal(1);
+  });
+
+  describe('with sectionSetupRefresh experiment', () => {
+    let navigateToHrefSpy;
+
+    beforeEach(() => {
+      navigateToHrefSpy = sinon.spy(utils, 'navigateToHref');
+      sinon
+        .stub(experiments, 'isEnabled')
+        .withArgs('sectionSetupRefresh')
+        .returns(true);
+    });
+
+    afterEach(() => {
+      experiments.isEnabled.restore();
+      navigateToHrefSpy.restore();
+    });
+
+    it('redirects to new section setup when selecting non-student participant type', () => {
+      const newSection = _.cloneDeep(defaultProps.section);
+      const wrapper = shallow(
+        <AddSectionDialog
+          {...defaultProps}
+          section={newSection}
+          availableParticipantTypes={['student', 'teacher', 'facilitator']}
+        />
+      );
+
+      wrapper.find('ParticipantTypePicker').invoke('setParticipantType')(
+        'teacher'
+      );
+      expect(navigateToHrefSpy).to.be.called.once;
+      expect(navigateToHrefSpy.getCall(0).args[0]).to.equal(
+        '/sections/new?participantType=teacher&loginType=email'
+      );
+    });
+
+    it('redirects to new section setup when selecting non-oauth login type', () => {
+      const sectionWithParticipantType = _.cloneDeep(defaultProps.section);
+      sectionWithParticipantType.participantType = 'student';
+      const wrapper = shallow(
+        <AddSectionDialog
+          {...defaultProps}
+          section={sectionWithParticipantType}
+          availableParticipantTypes={['student', 'teacher', 'facilitator']}
+        />
+      );
+
+      wrapper.find('Connect(LoginTypePicker)').invoke('setLoginType')('word');
+      expect(navigateToHrefSpy).to.be.called.once;
+      expect(navigateToHrefSpy.getCall(0).args[0]).to.equal(
+        '/sections/new?participantType=student&loginType=word'
+      );
+    });
+
+    it('does not redirect to new section setup when selection oauth login type', () => {
+      const sectionWithParticipantType = _.cloneDeep(defaultProps.section);
+      sectionWithParticipantType.participantType = 'student';
+      const wrapper = shallow(
+        <AddSectionDialog
+          {...defaultProps}
+          section={sectionWithParticipantType}
+          availableParticipantTypes={['student', 'teacher', 'facilitator']}
+        />
+      );
+
+      wrapper.find('Connect(LoginTypePicker)').invoke('setLoginType')(
+        'google_classroom'
+      );
+      expect(navigateToHrefSpy).to.have.not.been.called;
+    });
   });
 });

--- a/dashboard/app/controllers/sections_controller.rb
+++ b/dashboard/app/controllers/sections_controller.rb
@@ -3,7 +3,9 @@ class SectionsController < ApplicationController
   before_action :load_section_by_code, only: [:log_in, :show]
 
   def new
-    return head :forbidden unless current_user&.admin
+    # return head :forbidden unless current_user&.admin
+
+    redirect_to '/home' unless params[:loginType] && params[:participantType]
   end
 
   def show

--- a/dashboard/app/controllers/sections_controller.rb
+++ b/dashboard/app/controllers/sections_controller.rb
@@ -3,7 +3,7 @@ class SectionsController < ApplicationController
   before_action :load_section_by_code, only: [:log_in, :show]
 
   def new
-    # return head :forbidden unless current_user&.admin
+    return head :forbidden unless current_user&.admin
 
     redirect_to '/home' unless params[:loginType] && params[:participantType]
   end

--- a/dashboard/test/controllers/sections_controller_test.rb
+++ b/dashboard/test/controllers/sections_controller_test.rb
@@ -201,6 +201,9 @@ class SectionsControllerTest < ActionController::TestCase
   test_user_gets_response_for :new, params: {loginType: 'picture', participantType: 'student'}, user: :admin, response: :success
 
   test "new redirects to home if loginType and participantType are not present" do
+    user = create :admin
+    sign_in user
+
     get :new
     assert_redirected_to '/home'
 

--- a/dashboard/test/controllers/sections_controller_test.rb
+++ b/dashboard/test/controllers/sections_controller_test.rb
@@ -195,8 +195,8 @@ class SectionsControllerTest < ActionController::TestCase
     assert_redirected_to section_path(id: @picture_section.code)
   end
 
-  test_user_gets_response_for :new, user: nil, response: :forbidden
-  test_user_gets_response_for :new, user: :teacher, response: :forbidden
-  test_user_gets_response_for :new, user: :student, response: :forbidden
-  test_user_gets_response_for :new, user: :admin, response: :success
+  test_user_gets_response_for :new, params: {loginType: 'picture', participantType: 'student'}, user: nil, response: :forbidden
+  test_user_gets_response_for :new, params: {loginType: 'picture', participantType: 'student'}, user: :teacher, response: :forbidden
+  test_user_gets_response_for :new, params: {loginType: 'picture', participantType: 'student'}, user: :student, response: :forbidden
+  test_user_gets_response_for :new, params: {loginType: 'picture', participantType: 'student'}, user: :admin, response: :success
 end

--- a/dashboard/test/controllers/sections_controller_test.rb
+++ b/dashboard/test/controllers/sections_controller_test.rb
@@ -199,4 +199,18 @@ class SectionsControllerTest < ActionController::TestCase
   test_user_gets_response_for :new, params: {loginType: 'picture', participantType: 'student'}, user: :teacher, response: :forbidden
   test_user_gets_response_for :new, params: {loginType: 'picture', participantType: 'student'}, user: :student, response: :forbidden
   test_user_gets_response_for :new, params: {loginType: 'picture', participantType: 'student'}, user: :admin, response: :success
+
+  test "new redirects to home if loginType and participantType are not present" do
+    get :new
+    assert_redirected_to '/home'
+
+    get :new, params: {participantType: 'student'}
+    assert_redirected_to '/home'
+
+    get :new, params: {loginType: 'word'}
+    assert_redirected_to '/home'
+
+    get :new, params: {loginType: 'word', participantType: 'student'}
+    assert_response :success
+  end
 end


### PR DESCRIPTION
Adds a new experiment flag, `sectionSetupRefresh`, then will take users from the dialogs on the homepage to the new section setup page with the loginType and participantType passed in as URL params. Also passes those fields to the create call and bounces the user back to the homepage if they're not set.

One slightly weird thing here is that a non-admin can use this experiment flag but they still can't access the section setup page. We might want to remove the admin restriction soon so we can start testing!

ParticipantTypePicker then LoginTypePicker:

https://user-images.githubusercontent.com/46464143/223152766-6fcfc777-80cc-453d-a8ae-816f2dc6ce6a.mov

ParticipantTypePicker with non-student selection:

https://user-images.githubusercontent.com/46464143/223152778-97470230-3999-41e1-856d-ccdc3576b0bc.mov

LoginTypePicker with oauth loginType goes to the roster dialog:

https://user-images.githubusercontent.com/46464143/223152780-4050972b-5cbf-4a36-942b-810a2731a913.mov

