### PR TITLE
Add allow_multiple_attempts setting to Match and FreeResponse levels

### DIFF
--- a/dashboard/app/models/levels/free_response.rb
+++ b/dashboard/app/models/levels/free_response.rb
@@ -36,6 +36,7 @@ class FreeResponse < Level
     submittable
     peer_reviewable
     optional
+    allow_multiple_attempts
   )
 
   before_validation do

--- a/dashboard/app/models/levels/match.rb
+++ b/dashboard/app/models/levels/match.rb
@@ -25,6 +25,10 @@
 #
 
 class Match < DSLDefined
+  serialized_attrs %w(
+    allow_multiple_attempts
+  )
+
   def dsl_default
     <<~RUBY
       name '#{DEFAULT_LEVEL_NAME}'
@@ -32,6 +36,7 @@ class Match < DSLDefined
       description 'description here'
       question 'Question'
       answer 'Answer 1'
+      allow_multiple_attempts nil
     RUBY
   end
 

--- a/dashboard/app/models/levels/multi.rb
+++ b/dashboard/app/models/levels/multi.rb
@@ -35,6 +35,7 @@ class Multi < Match
       question 'Question'
       wrong 'wrong answer'
       right 'right answer'
+      allow_multiple_attempts nil
     RUBY
   end
 

--- a/dashboard/app/views/levels/editors/fields/_free_response_fields.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_free_response_fields.html.haml
@@ -29,3 +29,6 @@
   .field
     = render partial: 'levels/editors/fields/checkboxes', locals: {f: f, field_name: :optional, description: "Optional"}
     %p If checked, an assessment page will still be considered complete even if this question is left blank.
+  .field
+    = render partial: 'levels/editors/fields/checkboxes', locals: {f: f, field_name: :allow_multiple_attempts, description: "Allow multiple attempts"}
+    %p Whether or not a user can submit multiple answers. Default is no for contained levels and yes for standalone levels. It will not apply for levels in level groups.


### PR DESCRIPTION
Adds a field called `allow_multiple_attempts` to `FreeResponse` and `Match` levels. `Multi` is a subclass of `Match` so it will also inherit this field.

I updated the `FreeResponse` editor to allow for editing this field. I tested this manually, though I don't know a way of adding tests for this file.
![Screen Shot 2023-03-03 at 10 47 23 AM](https://user-images.githubusercontent.com/46464143/222765172-ab67dcbe-2329-438c-b737-faf89c765668.png)



Updating the editor for `Match` levels was tougher. Because `Match` is a `DSLDefined` level (also I thought until this week that `FreeResponse` levels were also `DSLDefined` woops), the editor is not user friendly. I could not figure out a way to make a friendly input for this field in the editor, so I added it to the default DSL. For existing levels, editors will need to add `allow_multiple_attempts true` to the DSL editor.

![Screen Shot 2023-03-03 at 10 49 29 AM](https://user-images.githubusercontent.com/46464143/222765214-0f565aba-3b65-41f1-8cdf-e8fdc330f5a8.png)


This field isn't being used yet -- it's just being added early so that curriculum writers can set this field now.
 