### PR TITLE
Fix 2 missing Amplitude marketing events

### DIFF
--- a/pegasus/sites.v3/code.org/public/educate/professional-learning/middle-high.haml
+++ b/pegasus/sites.v3/code.org/public/educate/professional-learning/middle-high.haml
@@ -9,6 +9,8 @@ theme: responsive_full_width
 -# Import FontAwesome Pro
 %script{src: "https://kit.fontawesome.com/ea2d9d4413.js", crossorigin: "anonymous"}
 
+= view :analytics_event_log_helper, event_name: AnalyticsConstants::MIDDLE_AND_HIGH_SCHOOL_PL_PAGE_VISITED_EVENT
+
 %section.hero-banner-basic{style: "background: #FFDFA1"}
   .wrapper
     .text-wrapper

--- a/pegasus/sites.v3/code.org/public/educate/professional-learning/program-information.md.erb
+++ b/pegasus/sites.v3/code.org/public/educate/professional-learning/program-information.md.erb
@@ -11,9 +11,9 @@ theme: responsive
 
 Look up details of the Professional Learning Program in your region by submitting your zip code below.
 
+<%= view :analytics_event_log_helper, event_name: AnalyticsConstants::RP_LANDING_PAGE_VISITED_EVENT %>
 <%= view :regional_partner_search, source_page_id: "program-information" %>
 
 <br/>
 <br/>
 
-<%= view :analytics_event_log_helper, event_name: AnalyticsConstants::RP_LANDING_PAGE_VISITED_EVENT %>


### PR DESCRIPTION
Currently, there are 2 marketing page Amplitude events still not receiving data:
- Middle And High School Professional Learning Page Visited
- Regional Partner Landing Page Visited

## Middle And High School Professional Learning Page Visited
For this event, the file it was previously in (`/professional-learning/middle-high.md.erb`) [was redesigned](https://github.com/code-dot-org/code-dot-org/pull/50021) into `middle-high.haml` and in this transition the line of code logging the Amplitude event was lost. This PR just puts that line back in in the new file.

### Correctly logs on page visit
![Logged_middle_high](https://user-images.githubusercontent.com/56283563/222806519-7308c316-2d01-4ae3-9acc-f9b2a8a8eb3f.JPG)

### Amplitude site successfully updated from "Planned" to "Live" in the staging environment when testing
![Middle_High_Page_Works](https://user-images.githubusercontent.com/56283563/222805264-3cd83fef-d6cd-4052-ad89-b6367532cf4e.JPG)

## Regional Partner Landing Page Visited
This page was running into an issue where the API key was missing which is strange since that issue was just resolved in [this PR](https://github.com/code-dot-org/code-dot-org/pull/50496).
![RP_Page_Missing_Key](https://user-images.githubusercontent.com/56283563/222807380-a657e87d-7817-458f-91ad-696a2252ea4b.JPG)

But, I remembered there were some issues in development with the placing of the `analytics_event_log_helper` element in a marketing page where sometimes its location in the file changed whether it worked or not. So, I moved it higher in the `program-information.md.erb` file above the RP search bar, and now it works!

### Still logs correctly locally on page visit
![Log_locally_RP](https://user-images.githubusercontent.com/56283563/222807999-8fc1d8bd-86c5-4857-b821-a85f827ee8cd.JPG)

### Amplitude site successfully updated from "Planned" to "Live" in the staging environment when testing (plus, no more error for a missing API key when logging directly to Amplitude)
![RP_Page_Works](https://user-images.githubusercontent.com/56283563/222807647-54bb0be9-9000-4d77-8af2-07921b45dec1.JPG)
![No_errors](https://user-images.githubusercontent.com/56283563/222807989-12ee90ad-95c8-4930-bd80-5910dd6c9f57.JPG)

## Links
'Middle And High School Professional Learning Page Visited' Amplitude event: [here](https://data.amplitude.com/code-org/Code.org%20Tracking%20Plan/events/main/latest/Middle%20And%20High%20School%20Professional%20Learning%20Page%20Visited)
'Regional Partner Landing Page Visited' Amplitude event: [here](https://data.amplitude.com/code-org/Code.org%20Tracking%20Plan/events/main/latest/Regional%20Partner%20Landing%20Page%20Visited)

## Testing story
Local testing and checking that Amplitude is now receiving the events.

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
