### PR TITLE
Update `oj` Gem to 3.14.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -271,7 +271,7 @@ gem 'daemons'
 gem 'httparty'
 gem 'net-scp'
 gem 'net-ssh'
-gem 'oj'
+gem 'oj', '~> 3.10'
 
 gem 'rest-client', '~> 2.0.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -616,7 +616,7 @@ GEM
       sawyer (~> 0.9)
     oily_png (1.2.0)
       chunky_png (~> 1.3.1)
-    oj (3.3.10)
+    oj (3.14.2)
     omniauth (1.9.0)
       hashie (>= 3.4.6, < 3.7.0)
       rack (>= 1.6.2, < 3)
@@ -1032,7 +1032,7 @@ DEPENDENCIES
   newrelic_rpm (~> 6.14.0)
   nokogiri (>= 1.10.0)
   octokit
-  oj
+  oj (~> 3.10)
   omniauth-clever (~> 2.0.0)!
   omniauth-facebook (~> 4.0.0)
   omniauth-google-oauth2 (~> 0.6.0)


### PR DESCRIPTION
Specifically to pick up support for Ruby 2.7, added in 3.10: https://github.com/ohler55/oj/blob/develop/CHANGELOG.md#3101---2020-01-14

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
