### PR TITLE
PL Launch 2023 - Update banner copy

### DIFF
--- a/apps/src/templates/ProfessionalLearningSkinnyBanner.jsx
+++ b/apps/src/templates/ProfessionalLearningSkinnyBanner.jsx
@@ -7,7 +7,7 @@ import bgTablet from './images/superhero-banner-half-blue.png';
 export default function ProfessionalLearningSkinnyBanner() {
   const headerText = 'Help students become superheroes!';
   const text =
-    'Join our Middle School and High School Professional Learning Programs.';
+    'Join our highly supportive Professional Learning Program for middle and high school educators.';
 
   return (
     <aside className="professional-learning-banner">

--- a/apps/src/templates/ProfessionalLearningSkinnyBanner.jsx
+++ b/apps/src/templates/ProfessionalLearningSkinnyBanner.jsx
@@ -7,7 +7,7 @@ import bgTablet from './images/superhero-banner-half-blue.png';
 export default function ProfessionalLearningSkinnyBanner() {
   const headerText = 'Help students become superheroes!';
   const text =
-    'Our Professional Learning program helps you teach computer science!';
+    'Join our Middle School and High School Professional Learning Programs.';
 
   return (
     <aside className="professional-learning-banner">

--- a/apps/src/templates/professionalLearningSkinnyBanner.scss
+++ b/apps/src/templates/professionalLearningSkinnyBanner.scss
@@ -48,10 +48,11 @@ $width-sm: 640px; // Mobile
     justify-content: space-between;
     align-items: center;
     flex-wrap: wrap;
-    padding: 0.5em 2em;
+    padding: 0.5em 2em 0.5em 1.25em;
 
     @media screen and (max-width: $width-md) {
       justify-content: right;
+      padding: 0.5em 1.5em;
     }
 
     @media screen and (max-width: $width-sm) {

--- a/apps/src/templates/studioHomepages/MarketingAnnouncementBanner.jsx
+++ b/apps/src/templates/studioHomepages/MarketingAnnouncementBanner.jsx
@@ -130,13 +130,14 @@ const MarketingAnnouncementBanner = ({announcement, marginBottom}) => {
 
 const styles = {
   container: {
-    position: 'relative'
+    position: 'relative',
+    marginTop: '16px'
   },
   dismissButtonStyle: {
     position: 'absolute',
     top: '6px',
     right: '10px',
-    color: color.white,
+    color: color.neutral_dark60,
     fontSize: '22px',
     fontWeight: 'bold'
   }

--- a/pegasus/sites.v3/code.org/announcements.json
+++ b/pegasus/sites.v3/code.org/announcements.json
@@ -1,8 +1,9 @@
 {
   "pages": {
     "/projects": "coldplay",
-    "/certificates": "hoc-more"
-  },  
+    "/certificates": "hoc-more",
+    "/home": "superhero"
+  },
   "banners": {
     "csleadersprize": {
       "image": "/images/marketing/csleadersprize-dash.png",
@@ -31,9 +32,9 @@
     "superhero": {
       "image": "/images/marketing/superhero_teacherdash.png",
       "title": "Help your students become superheroes!",
-      "body": "Add to your teaching toolbox with Code.org’s Professional Learning Program. More than 90% of attendees would recommend our program to another teacher!",
+      "body": "Join our highly supportive Professional Learning Program for middle and high school educators.",
       "buttonText": "Learn More",
-      "buttonUrl": "https://code.org/educate/professional-learning/",
+      "buttonUrl": "https://code.org/educate/professional-learning/middle-high",
       "buttonId": "superhero-pl-details"
     },
     "csjourneys": {

--- a/pegasus/sites.v3/code.org/homepage.json
+++ b/pegasus/sites.v3/code.org/homepage.json
@@ -96,7 +96,7 @@
         {
           "type": "cta_button_solid_yellow",
           "text": "front_join_us_learn_more",
-          "url": "/educate/professional-learning"
+          "url": "/educate/professional-learning/middle-high"
         }
       ]
     }

--- a/pegasus/sites.v3/code.org/public/educate/curriculum/high-school.md.erb
+++ b/pegasus/sites.v3/code.org/public/educate/curriculum/high-school.md.erb
@@ -6,7 +6,7 @@ theme: responsive
 
 <link href="/css/afe-promo-box.css" rel="stylesheet">
 
-<%= view :professional_learning_marketing_banner, audience_text: 'you', link_address: '/educate/professional-learning/middle-high', button_label: 'Learn more' %>
+<%= view :professional_learning_marketing_banner, link_address: '/educate/professional-learning/middle-high', button_label: 'Learn more' %>
 
 [solid-block-header]
 

--- a/pegasus/sites.v3/code.org/public/educate/curriculum/middle-school.md.erb
+++ b/pegasus/sites.v3/code.org/public/educate/curriculum/middle-school.md.erb
@@ -6,7 +6,7 @@ theme: responsive
 
 <link href="/css/afe-promo-box.css" rel="stylesheet">
 
-<%= view :professional_learning_marketing_banner, audience_text: 'you', link_address: '/educate/professional-learning/middle-high', button_label: 'Learn more' %>
+<%= view :professional_learning_marketing_banner, link_address: '/educate/professional-learning/middle-high', button_label: 'Learn more' %>
 
 [solid-block-header]
 

--- a/pegasus/sites.v3/code.org/public/yourschool.haml
+++ b/pegasus/sites.v3/code.org/public/yourschool.haml
@@ -6,7 +6,7 @@ social:
   "og:description": "Expand computer science at your school or district. Join the thousands of schools who have already incorporated high quality computer science education into their curriculum and provide opportunities for the students in your local area."
 ---
 
-=view :professional_learning_marketing_banner, audience_text: 'you', link_address: '/educate/professional-learning/middle-high', button_label: 'Learn more'
+=view :professional_learning_marketing_banner, link_address: '/educate/professional-learning/middle-high', button_label: 'Learn more'
 
 %link{:rel=>'stylesheet', :type=>'text/css', :href=>'/css/yourschool.css'}
 

--- a/pegasus/sites.v3/code.org/views/professional_learning_marketing_banner.haml
+++ b/pegasus/sites.v3/code.org/views/professional_learning_marketing_banner.haml
@@ -2,7 +2,7 @@
 - if request.locale == "en-US" && display_professional_learning_banners
   = inline_css 'professional_learning_marketing_banner.css'
   - header_text = 'Help students become superheroes!'
-  - text = "Our Professional Learning program helps #{audience_text} teach computer science!"
+  - text = "Join our Middle School and High School Professional Learning Programs."
   - homepage ||= false
   - if homepage
     - large_image = "/images/homepage/superhero-banner-gold.png"

--- a/pegasus/sites.v3/code.org/views/professional_learning_marketing_banner.haml
+++ b/pegasus/sites.v3/code.org/views/professional_learning_marketing_banner.haml
@@ -2,7 +2,7 @@
 - if request.locale == "en-US" && display_professional_learning_banners
   = inline_css 'professional_learning_marketing_banner.css'
   - header_text = 'Help students become superheroes!'
-  - text = "Join our Middle School and High School Professional Learning Programs."
+  - text = "Join our highly supportive Professional Learning Program for middle and high school educators."
   - homepage ||= false
   - if homepage
     - large_image = "/images/homepage/superhero-banner-gold.png"

--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -98,7 +98,7 @@
   social_maker_desc: "Code.org physical computing and maker resources for grades 6-12."
 
   pl_superhero_title: "Help students become superheroes!"
-  pl_superhero_desc: "Our Professional Learning program helps you teach computer science!"
+  pl_superhero_desc: "Join our Middle School and High School Professional Learning Programs."
 
   hoc_live: 'Hour of Code Live'
   hoc_live_sign_up_title: 'Sign up for Hour of Code Live'

--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -98,7 +98,7 @@
   social_maker_desc: "Code.org physical computing and maker resources for grades 6-12."
 
   pl_superhero_title: "Help students become superheroes!"
-  pl_superhero_desc: "Join our Middle School and High School Professional Learning Programs."
+  pl_superhero_desc: "Join our highly supportive Professional Learning Program for middle and high school educators."
 
   hoc_live: 'Hour of Code Live'
   hoc_live_sign_up_title: 'Sign up for Hour of Code Live'

--- a/shared/css/professional_learning_marketing_banner.scss
+++ b/shared/css/professional_learning_marketing_banner.scss
@@ -99,12 +99,13 @@ $dark_blue_background_colour: #0d4172;
 
     .text-wrapper {
       width: 50%;
-      left: 30px;
+      left: 20px;
 
       .header {
         color: black;
         position: relative;
         font-size: 18px;
+        margin-bottom: 8px;
       }
 
       .text {
@@ -112,6 +113,7 @@ $dark_blue_background_colour: #0d4172;
         position: relative;
         font-size: 14px;
         width: calc(100% - 150px);
+        line-height: 1.3;
       }
     }
 
@@ -167,7 +169,7 @@ $dark_blue_background_colour: #0d4172;
 
     .text-wrapper {
       right: 12px;
-      width: 50%;
+      width: 52%;
       float: right;
 
       .header {
@@ -230,9 +232,7 @@ $dark_blue_background_colour: #0d4172;
 
       .text {
         text-align: center;
-        margin-left: 5px;
-        margin-right: 5px;
-        font-size: 13px;
+        line-height: 1.3;
       }
 
       button {


### PR DESCRIPTION
Updates to the PL homepage hero and skinny banners:
- New copy that focuses on middle and high school professional learning
- Change the button link to https://code.org/educate/professional-learning/middle-high

Updated on the following pages:
- https://code.org
- https://code.org/yourschool
- https://code.org/educate/curriculum/high-school
- https://code.org/educate/curriculum/middle-school
- https://code.org/teach (redirects to https://studio.code.org/courses?view=teacher)
- http://studio.code.org/home (logged in teacher account)

**Related PRs:**
- https://github.com/code-dot-org/code-dot-org/pull/49588
- https://github.com/code-dot-org/code-dot-org/pull/49556

**Asana task:** https://app.asana.com/0/0/1204109793558521

----

### Homepage banner
<img width="1290" alt="Screenshot 2023-03-08 at 9 55 32 AM" src="https://user-images.githubusercontent.com/9256643/223793373-4d07bc79-5948-4055-b2d9-d90093ab9207.png">

### Skinny banner
<img width="887" alt="Screenshot 2023-03-08 at 9 56 04 AM" src="https://user-images.githubusercontent.com/9256643/223793413-90eaf907-efc8-47fb-a086-6e527ad70647.png">

### Teacher dashboard (logged in) banner
<img width="1332" alt="Screenshot 2023-03-08 at 10 24 43 AM" src="https://user-images.githubusercontent.com/9256643/223801391-5d29eee0-4b5f-4fa2-b006-a70871bce270.png">


