### PR TITLE
Auto-animate time capsule poems

### DIFF
--- a/apps/src/p5lab/poetry/PoetryLibrary.js
+++ b/apps/src/p5lab/poetry/PoetryLibrary.js
@@ -36,12 +36,13 @@ export default class PoetryLibrary extends CoreLibrary {
       },
       isVisible: true,
       textEffects: [],
-      // By default, start the poem animation when the program starts (frame 1)
+      // For any subtype besides poetry (time capsule or poetry hoc),
+      // start the poem animation when the program starts (frame 1)
       // The animation can be restarted with the animatePoem() block, which
       // updates this value.
       // This value is used as an offset when calculating which lines to show.
       animationStartFrame:
-        appOptions.level.standaloneAppName === 'poetry_hoc' ? 1 : null,
+        appOptions.level.standaloneAppName === 'poetry' ? null : 1,
       backgroundMusic: undefined
     };
     this.backgroundEffect = () => this.p5.background('white');


### PR DESCRIPTION
This was a missed requirement in creating the time capsule subtype of poetry. We want these poems to auto-animate similar to poetry_hoc levels.

https://user-images.githubusercontent.com/33666587/223207630-9624b33f-2933-40ec-ba65-70f634dfb9e5.mp4


## Links

- [slack thread](https://codedotorg.slack.com/archives/C03DBDN67B7/p1677875300488459)

## Testing story
Tested that time capsule levels auto-animate now, poetry_hoc levels still auto-animate, and poetry levels do not auto-animate.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
