### PR TITLE
Always show upload warning in the Animation Picker

### DIFF
--- a/apps/src/code-studio/assets/SelectStartAnimations.jsx
+++ b/apps/src/code-studio/assets/SelectStartAnimations.jsx
@@ -103,7 +103,6 @@ export default class SelectStartAnimations extends React.Component {
               animation library):
             </h3>
             <AnimationPickerBody
-              is13Plus
               onDrawYourOwnClick={() =>
                 console.log('Not supported at this time')
               }
@@ -124,7 +123,6 @@ export default class SelectStartAnimations extends React.Component {
         <div style={styles.pageBreak}>
           <h3>Library Animations:</h3>
           <AnimationPickerBody
-            is13Plus
             onDrawYourOwnClick={() => console.log('Not supported at this time')}
             onPickLibraryAnimation={this.addAnimationToList}
             onAnimationSelectionComplete={() => {}}

--- a/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
@@ -57,7 +57,6 @@ class AnimationPicker extends React.Component {
     visible: PropTypes.bool.isRequired,
     uploadInProgress: PropTypes.bool.isRequired,
     uploadError: PropTypes.string,
-    is13Plus: PropTypes.bool,
     selectedAnimations: PropTypes.arrayOf(AnimationProps).isRequired,
     onClose: PropTypes.func.isRequired,
     onPickNewAnimation: PropTypes.func.isRequired,
@@ -110,7 +109,6 @@ class AnimationPicker extends React.Component {
     return (
       <div>
         <AnimationPickerBody
-          is13Plus={this.props.is13Plus}
           onDrawYourOwnClick={this.props.onPickNewAnimation}
           onPickLibraryAnimation={this.props.onPickLibraryAnimation}
           onUploadClick={this.onUploadClick}
@@ -200,7 +198,6 @@ export default connect(
     visible: state.animationPicker.visible,
     uploadInProgress: state.animationPicker.uploadInProgress,
     uploadError: state.animationPicker.uploadError,
-    is13Plus: state.pageConstants.is13Plus,
     playAnimations: !state.pageConstants.allAnimationsSingleFrame,
     selectedAnimations: Object.values(state.animationPicker.selectedAnimations)
   }),

--- a/apps/src/p5lab/AnimationPicker/AnimationPickerBody.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPickerBody.jsx
@@ -231,6 +231,10 @@ export default class AnimationPickerBody extends React.Component {
     // Display second "Done" button. Useful for mobile, where the original "done" button might not be on screen when
     // animation picker is loaded. 600 pixels is minimum height of the animation picker.
     const shouldDisplaySecondDoneButton = isMobileDevice();
+    const showingUploadButton =
+      !hideUploadOption &&
+      ((!searching && (!inCategory || isBackgroundsTab)) ||
+        results.length === 0);
     return (
       <div style={{marginBottom: 10}}>
         {shouldDisplaySecondDoneButton && (
@@ -243,7 +247,7 @@ export default class AnimationPickerBody extends React.Component {
         <h1 style={dialogStyles.title}>
           {msg.animationPicker_title({assetType})}
         </h1>
-        {!hideUploadOption && (
+        {showingUploadButton && (
           <WarningLabel>{msg.animationPicker_warning()}</WarningLabel>
         )}
         <SearchBar

--- a/apps/src/p5lab/AnimationPicker/AnimationPickerBody.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPickerBody.jsx
@@ -231,10 +231,15 @@ export default class AnimationPickerBody extends React.Component {
     // Display second "Done" button. Useful for mobile, where the original "done" button might not be on screen when
     // animation picker is loaded. 600 pixels is minimum height of the animation picker.
     const shouldDisplaySecondDoneButton = isMobileDevice();
-    const showingUploadButton =
-      !hideUploadOption &&
-      ((!searching && (!inCategory || isBackgroundsTab)) ||
-        results.length === 0);
+    // We show the draw your own and upload buttons if the user is either:
+    // Not currently searching and not in a category, unless that category is backgrounds
+    // OR they are searching but there were no results
+    const showDrawAndUploadButtons =
+      (!searching && (!inCategory || isBackgroundsTab)) || results.length === 0;
+    // We are showing the upload button if it should be visible per the previous boolean and
+    // hideUploadOption is not set to true.
+    const showingUploadButton = !hideUploadOption && showDrawAndUploadButtons;
+
     return (
       <div style={{marginBottom: 10}}>
         {shouldDisplaySecondDoneButton && (
@@ -283,8 +288,7 @@ export default class AnimationPickerBody extends React.Component {
                 {msg.animationPicker_noResultsFound()}
               </div>
             )}
-            {((!searching && (!inCategory || isBackgroundsTab)) ||
-              results.length === 0) && (
+            {showDrawAndUploadButtons && (
               <div>
                 <AnimationPickerListItem
                   label={msg.animationPicker_drawYourOwn()}

--- a/apps/src/p5lab/AnimationPicker/AnimationPickerBody.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPickerBody.jsx
@@ -25,7 +25,6 @@ const MAX_SEARCH_RESULTS = 40;
 
 export default class AnimationPickerBody extends React.Component {
   static propTypes = {
-    is13Plus: PropTypes.bool,
     onDrawYourOwnClick: PropTypes.func.isRequired,
     onPickLibraryAnimation: PropTypes.func.isRequired,
     onUploadClick: PropTypes.func.isRequired,
@@ -218,7 +217,6 @@ export default class AnimationPickerBody extends React.Component {
     const {searchQuery, categoryQuery, results} = this.state;
     const {
       hideUploadOption,
-      is13Plus,
       onDrawYourOwnClick,
       onUploadClick,
       onAnimationSelectionComplete,
@@ -245,7 +243,7 @@ export default class AnimationPickerBody extends React.Component {
         <h1 style={dialogStyles.title}>
           {msg.animationPicker_title({assetType})}
         </h1>
-        {!is13Plus && !hideUploadOption && (
+        {!hideUploadOption && (
           <WarningLabel>{msg.animationPicker_warning()}</WarningLabel>
         )}
         <SearchBar

--- a/apps/test/unit/p5lab/AnimationPicker/AnimationPickerBodyTest.js
+++ b/apps/test/unit/p5lab/AnimationPicker/AnimationPickerBodyTest.js
@@ -37,9 +37,9 @@ describe('AnimationPickerBody', function() {
   };
 
   describe('upload warning', function() {
-    it('shows an upload warning if the user is under 13', function() {
+    it('shows an upload warning if the upload button is visible', function() {
       const body = shallow(
-        <AnimationPickerBody {...defaultProps} is13Plus={false} />
+        <AnimationPickerBody {...defaultProps} hideUploadOption={false} />
       );
       const warnings = body.find(WarningLabel);
       expect(warnings).to.have.length(1);
@@ -48,20 +48,9 @@ describe('AnimationPickerBody', function() {
       );
     });
 
-    it('shows an upload warning if the user age is not known', function() {
+    it('does not show an upload warning if upload button is hidden', function() {
       const body = shallow(
-        <AnimationPickerBody {...defaultProps} is13Plus={undefined} />
-      );
-      const warnings = body.find(WarningLabel);
-      expect(warnings).to.have.length(1);
-      expect(warnings.children().text()).to.equal(
-        msg.animationPicker_warning()
-      );
-    });
-
-    it('does not show an upload warning if the user is 13 or older', function() {
-      const body = shallow(
-        <AnimationPickerBody {...defaultProps} is13Plus={true} />
+        <AnimationPickerBody {...defaultProps} hideUploadOption={false} />
       );
       const warnings = body.find(WarningLabel);
       expect(warnings).to.have.length(0);

--- a/apps/test/unit/p5lab/AnimationPicker/AnimationPickerBodyTest.js
+++ b/apps/test/unit/p5lab/AnimationPicker/AnimationPickerBodyTest.js
@@ -50,7 +50,7 @@ describe('AnimationPickerBody', function() {
 
     it('does not show an upload warning if upload button is hidden', function() {
       const body = shallow(
-        <AnimationPickerBody {...defaultProps} hideUploadOption={false} />
+        <AnimationPickerBody {...defaultProps} hideUploadOption={true} />
       );
       const warnings = body.find(WarningLabel);
       expect(warnings).to.have.length(0);
@@ -103,7 +103,7 @@ describe('AnimationPickerBody', function() {
       expect(uploadButton.length).to.equal(1);
     });
 
-    it('does not show uplaod button if hideUploadButton', function() {
+    it('does not show upload button if hideUploadButton', function() {
       const body = shallow(
         <AnimationPickerBody {...defaultProps} hideUploadOption={true} />
       );


### PR DESCRIPTION
We previously would only show a warning about not uploading personal information in the Animation Picker if the user was under 13. We decided this is a worthwhile warning to show all users, so now it will be visible if the upload button is enabled on any version of the Animation Picker (costumes, backgrounds, animations).

<img width="838" alt="Screenshot 2023-03-06 at 1 21 25 PM" src="https://user-images.githubusercontent.com/33666587/223235211-f41be3a3-86f7-4457-8c63-523b05798ee2.png">


## Links
- jira ticket: [SL-618](https://codedotorg.atlassian.net/browse/SL-618)

## Testing story
Tested locally and updated unit tests. Now all users see the warning

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
