### PR TITLE
fix CORS headers on localhost

### DIFF
--- a/config.yml.erb
+++ b/config.yml.erb
@@ -325,7 +325,7 @@ app_servers: {}
 rack_mini_profiler_enabled:
 https_development:
 default_scheme: '<%=(env == 'development') || ci ? 'http:' : 'https:'%>'
-allowed_iframe_ancestors: http://*.disney.com http://*.diznee.net cuantrix.mx <%=pegasus_hostname%> <%=dashboard_hostname%> curriculum.code.org codecurricula.com
+allowed_iframe_ancestors: http://*.disney.com http://*.diznee.net cuantrix.mx <%=pegasus_host%> <%=dashboard_host%> curriculum.code.org codecurricula.com
 skip_locales:
 secret_pictures_csv:
 no_https_store:

--- a/config.yml.erb
+++ b/config.yml.erb
@@ -325,7 +325,7 @@ app_servers: {}
 rack_mini_profiler_enabled:
 https_development:
 default_scheme: '<%=(env == 'development') || ci ? 'http:' : 'https:'%>'
-allowed_iframe_ancestors: http://*.disney.com http://*.diznee.net cuantrix.mx <%=pegasus_host%> <%=dashboard_host%> curriculum.code.org codecurricula.com
+allowed_iframe_ancestors: http://*.disney.com http://*.diznee.net cuantrix.mx <%=pegasus_site_host%> <%=dashboard_site_host%> curriculum.code.org codecurricula.com
 skip_locales:
 secret_pictures_csv:
 no_https_store:

--- a/lib/cdo.rb
+++ b/lib/cdo.rb
@@ -110,6 +110,14 @@ module Cdo
       host
     end
 
+    def dashboard_host
+      site_host('studio.code.org')
+    end
+
+    def pegasus_host
+      site_host('code.org')
+    end
+
     def site_url(domain, path = '', scheme = '')
       path = '/' + path unless path.empty? || path[0] == '/'
       "#{scheme}//#{site_host(domain)}#{path}"

--- a/lib/cdo.rb
+++ b/lib/cdo.rb
@@ -110,11 +110,11 @@ module Cdo
       host
     end
 
-    def dashboard_host
+    def dashboard_site_host
       site_host('studio.code.org')
     end
 
-    def pegasus_host
+    def pegasus_site_host
       site_host('code.org')
     end
 


### PR DESCRIPTION
* Depends on https://github.com/code-dot-org/code-dot-org/pull/50611. Fixes a scenario where we cannot see certain pegasus pages working properly on localhost.

### before

<img width="1444" alt="Screenshot 2023-03-06 at 9 55 52 PM" src="https://user-images.githubusercontent.com/8001765/223333451-4267208f-93a6-4b01-82b8-4fb79d87d6d3.png">

### after

<img width="1437" alt="Screenshot 2023-03-06 at 9 57 53 PM" src="https://user-images.githubusercontent.com/8001765/223333473-c702879c-9b18-45b0-946d-196d15feac38.png">

## Testing story

* Manual verification shown in screenshots
* quick check to make sure nothing will change in production:
    ```
    [production] dashboard > CDO.canonical_hostname('studio.code.org')
    => "studio.code.org"
    [production] dashboard > CDO.site_host('studio.code.org')
    => "studio.code.org"
    [production] dashboard > CDO.canonical_hostname('code.org')
    => "code.org"
    [production] dashboard > CDO.site_host('code.org')
    => "code.org"
    ```