### PR TITLE
[CDO Blockly] Grid dropdown should not have white background

### DIFF
--- a/apps/style/common.scss
+++ b/apps/style/common.scss
@@ -1205,7 +1205,7 @@ $workspace-header-button-margin: ($workspace-headers-height - $workspace-header-
     border-color: rgb(84 84 84) !important;
   }
   &.blocklyGridDropdownMenu {
-    background-color: white !important;
+    background-color: white;
     padding-top: 5px !important;
 
     .goog-menuitem {

--- a/apps/style/common.scss
+++ b/apps/style/common.scss
@@ -1201,9 +1201,7 @@ $workspace-header-button-margin: ($workspace-headers-height - $workspace-header-
   .goog-menuitem-hover {
     background-color: rgb(255 255 255 / 0.35);
   }
-  &:not(.blocklyGridDropdownMenu) {
-    border-color: rgb(84 84 84) !important;
-  }
+  border-color: rgb(84 84 84) !important;
   &.blocklyGridDropdownMenu {
     background-color: white;
     padding-top: 5px !important;


### PR DESCRIPTION
## Problem 
A user reported that with clickable white images are not usable as the grid dropdown background is always white.
![image (94)](https://user-images.githubusercontent.com/43474485/223726283-ec9ba896-d619-4ccb-bc50-1c3cd9f119e3.png)
This bug is affecting all CDO Blockly labs that use this field type (e.g. Play Lab, Sprite Lab).

Judging from some of our static resources (instruction GIFs, YouTube videos) this appears to be a regression:
<img width="620" alt="image" src="https://user-images.githubusercontent.com/43474485/223727350-c8bee0e9-22ae-44a4-b2e7-38ba649b777e.png">
<img width="1049" alt="image" src="https://user-images.githubusercontent.com/43474485/223727532-bada406d-3401-4959-8d50-052df654a1fe.png">

By adjusting some style rules for classes that aren't used anywhere else, we can get back to how it used to look. _Note that horizontal arrangement of the dropdown items is an unrelated recent but desired change._
<img width="1054" alt="image" src="https://user-images.githubusercontent.com/43474485/223727183-3df05a51-bdbf-4a42-bf4f-42b13763cd06.png">


I also confirmed with the curriculum team that this is acceptable change/revert.

## Links

[SL-638: [CDO Blockly] Rectangular drop down has white background](https://codedotorg.atlassian.net/browse/SL-638)

Slack thread: [Slack message from Hannah Nees in #student-learning](https://codedotorg.slack.com/archives/C03DBDN67B7/p1678210280005509) 

Zendesk: https://codeorg.zendesk.com/agent/tickets/433561

Example level: https://studio.code.org/s/coursea-2022/lessons/12/levels/6



## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
