### PR TITLE
[Project Beats] Change keyboard shortcuts

### DIFF
--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -293,10 +293,13 @@ class UnconnectedMusicView extends React.Component {
       return;
     }
 
-    if (event.key === 't') {
+    // When assigning new keyboard shortcuts, be aware that the following
+    // keys are used for Blockly keyboard navigation: A, D, I, S, T, W, X
+    // https://developers.google.com/blockly/guides/configure/web/keyboard-nav
+    if (event.key === 'v') {
       this.setState({timelineAtTop: !this.state.timelineAtTop});
     }
-    if (event.key === 'i') {
+    if (event.key === 'b') {
       this.toggleInstructions(true);
     }
     if (event.key === 'n') {


### PR DESCRIPTION
## Context 
Project Beats (aka Music Lab) current has three keyboard shortcuts that toggle various panels. Two of these shortcuts are also used by our new keyboard navigation plugin for Google Blockly labs, currently available in Project Beats. These conflicts create confusing behavior when this accessible mode is enabled.

This video demonstrates both conflicts:
* Pressing **I** is used to insert (ie. move) a block, but also toggles the instructions panel on and off.
* Pressing **T** opens the toolbox, but also toggles the position of the Project Beats timeline.


https://user-images.githubusercontent.com/43474485/223733743-9e08d3fd-83ab-4be1-a080-9795ae2e21f1.mp4



@breville and @sanchitmalhotra126 shared that the shortcuts for Project Beats are seldom used, so finding alternatives make sense.

This video shows the expected behavior of keyboard navigation with adjusted keyboard shortcuts for Project Beats:

https://user-images.githubusercontent.com/43474485/223733725-42a4248d-d785-46f7-8ae1-6c0f629e673c.mp4

The new shortcuts for Project Beats are:
* **V** - Toggle timeline vertical position
* **B** - Toggle instructions
* **N** - Cycle panel arrangements

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
