### PR TITLE
[Project Beats] Add accessible music lab themes to Google Blockly wrapper

### DIFF
--- a/apps/src/blockly/constants.js
+++ b/apps/src/blockly/constants.js
@@ -11,11 +11,15 @@ export const MenuOptionStates = {
 export const Themes = {
   MODERN: 'modern',
   DARK: 'dark',
-  MUSICLAB_DARK: 'musiclabdark',
-  HIGH_CONTRAST: 'highContrast',
+  HIGH_CONTRAST: 'highcontrast',
   PROTANOPIA: 'protanopia',
   DEUTERANOPIA: 'deuteranopia',
-  TRITANOPIA: 'tritanopia'
+  TRITANOPIA: 'tritanopia',
+  MUSICLAB_DARK: 'musiclabdark',
+  MUSICLAB_HIGH_CONTRAST: 'musiclabhighcontrast',
+  MUSICLAB_PROTANOPIA: 'musiclabprotanopia',
+  MUSICLAB_DEUTERANOPIA: 'musiclabdeuteranopia',
+  MUSICLAB_TRITANOPIA: 'musiclabtritanopia'
 };
 
 // Used for custom field type ClampedNumber(,)

--- a/apps/src/blockly/googleBlocklyWrapper.js
+++ b/apps/src/blockly/googleBlocklyWrapper.js
@@ -24,13 +24,21 @@ import CdoRendererThrasos from './addons/cdoRendererThrasos';
 import CdoRendererZelos from './addons/cdoRendererZelos';
 import CdoTheme from './themes/cdoTheme';
 import CdoDarkTheme from './themes/cdoDark';
-import CdoHighContrastTheme from './themes/cdoHighContrast';
+import {
+  CdoHighContrastTheme,
+  MusicLabHighContrastTheme
+} from './themes/cdoHighContrast';
 import {
   CdoProtanopiaTheme,
   CdoDeuteranopiaTheme,
   CdoTritanopiaTheme
 } from './themes/cdoAccessibleThemes';
-import MusicLabTheme from './themes/musicLabDark';
+import {
+  MusicLabProtanopiaTheme,
+  MusicLabDeuteranopiaTheme,
+  MusicLabTritanopiaTheme
+} from './themes/musicLabAccessibleThemes';
+import MusicLabDarkTheme from './themes/musicLabDark';
 import initializeTouch from './addons/cdoTouch';
 import CdoTrashcan from './addons/cdoTrashcan';
 import * as cdoUtils from './addons/cdoUtils';
@@ -302,7 +310,11 @@ function initializeBlocklyWrapper(blocklyInstance) {
     [Themes.PROTANOPIA]: CdoProtanopiaTheme,
     [Themes.DEUTERANOPIA]: CdoDeuteranopiaTheme,
     [Themes.TRITANOPIA]: CdoTritanopiaTheme,
-    [Themes.MUSICLAB_DARK]: MusicLabTheme
+    [Themes.MUSICLAB_DARK]: MusicLabDarkTheme,
+    [Themes.MUSICLAB_HIGH_CONTRAST]: MusicLabHighContrastTheme,
+    [Themes.MUSICLAB_PROTANOPIA]: MusicLabProtanopiaTheme,
+    [Themes.MUSICLAB_DEUTERANOPIA]: MusicLabDeuteranopiaTheme,
+    [Themes.MUSICLAB_TRITANOPIA]: MusicLabTritanopiaTheme
   };
   blocklyWrapper.JavaScript = javascriptGenerator;
   blocklyWrapper.navigationController = new NavigationController();

--- a/apps/src/blockly/themes/cdoHighContrast.js
+++ b/apps/src/blockly/themes/cdoHighContrast.js
@@ -65,15 +65,38 @@ const cdoHighContrastBlockStyles = {
   ...cdoCustomHighContrastStyles
 };
 
-export default GoogleBlockly.Theme.defineTheme('cdohighcontrast', {
-  base: HighContrastTheme,
-  blockStyles: cdoHighContrastBlockStyles,
-  categoryStyles: {},
-  componentStyles: {
-    toolboxBackgroundColour: '#DDDDDD'
-  },
-  fontStyle: {
-    family: '"Gotham 4r", sans-serif'
-  },
-  startHats: null
-});
+const CdoHighContrastTheme = GoogleBlockly.Theme.defineTheme(
+  'cdohighcontrast',
+  {
+    base: HighContrastTheme,
+    blockStyles: cdoHighContrastBlockStyles,
+    categoryStyles: {},
+    componentStyles: {
+      toolboxBackgroundColour: '#DDDDDD'
+    },
+    fontStyle: {
+      family: '"Gotham 4r", sans-serif'
+    },
+    startHats: null
+  }
+);
+
+export default CdoHighContrastTheme;
+export const MusicLabHighContrastTheme = GoogleBlockly.Theme.defineTheme(
+  'musiclabhighcontrast',
+  {
+    base: CdoHighContrastTheme,
+    blockStyles: cdoHighContrastBlockStyles,
+    componentStyles: {
+      toolboxBackgroundColour: '#424242', // gray-800
+      // The flyout background is especially dark so that workspace blocks
+      // underneath the flyout (which is semi-transparent) are obscured enough
+      // to make the blocks in the flyout easy to see.
+      flyoutBackgroundColour: '#121212',
+      workspaceBackgroundColour: '#212121' // gray-900
+    },
+    fontStyle: {
+      family: '"Gotham 4r", sans-serif'
+    }
+  }
+);

--- a/apps/src/blockly/themes/musicLabAccessibleThemes.js
+++ b/apps/src/blockly/themes/musicLabAccessibleThemes.js
@@ -1,0 +1,31 @@
+import GoogleBlockly from 'blockly/core';
+import {
+  deuteranopiaBlockStyles,
+  protanopiaBlockStyles,
+  tritanopiaBlockStyles
+} from './cdoAccessibleStyles';
+import MusicLabDark from './musicLabDark';
+
+export const MusicLabProtanopiaTheme = GoogleBlockly.Theme.defineTheme(
+  'musiclabprotanopia',
+  {
+    base: MusicLabDark,
+    blockStyles: protanopiaBlockStyles
+  }
+);
+
+export const MusicLabDeuteranopiaTheme = GoogleBlockly.Theme.defineTheme(
+  'musiclabdeuteranopia',
+  {
+    base: MusicLabDark,
+    blockStyles: deuteranopiaBlockStyles
+  }
+);
+
+export const MusicLabTritanopiaTheme = GoogleBlockly.Theme.defineTheme(
+  'musiclabtritanopia',
+  {
+    base: MusicLabDark,
+    blockStyles: tritanopiaBlockStyles
+  }
+);


### PR DESCRIPTION
We now have a set of accessible themes for our Google Blockly labs. Because of Music Lab's "dark mode first" presentation, the themes used in Dance et al are not compatible. 

<details><summary>

[**Show me what that would look like any way.**]

</summary>

<img width="659" alt="image" src="https://user-images.githubusercontent.com/43474485/223772098-f754f345-d866-4c89-91eb-c7b463bedda0.png">


</details>

One way around this is to create a set of new themes specifically for Project Beats that include the custom `componentStyles` that differentiate the default Music Lab theme from the CDO default theme. 

This PR does not make these new themes selectable by users but does add them to the wrapper so they can be tested out. To use, enter the following commands into the browser console:

`Blockly.getMainWorkspace().setTheme(Blockly.themes.musiclabprotanopia)`:
<img width="617" alt="image" src="https://user-images.githubusercontent.com/43474485/223771652-8c4c20f9-3789-4801-b56d-131de8ab7e2b.png">

`Blockly.getMainWorkspace().setTheme(Blockly.themes.musiclabdeuteranopia)`:
<img width="594" alt="image" src="https://user-images.githubusercontent.com/43474485/223771733-e9b5fd3b-bc51-4322-9c0d-b834328ad993.png">

`Blockly.getMainWorkspace().setTheme(Blockly.themes.musiclabtritanopia)`:
<img width="635" alt="image" src="https://user-images.githubusercontent.com/43474485/223771835-4d8556ab-bed5-489e-b3db-9442cd52fe0b.png">

`Blockly.getMainWorkspace().setTheme(Blockly.themes.musiclabhighcontrast)`:
_Note that we may not want to ever enable high contrast mode with a black background as this defeats the purpose. (Blocks should stand out from the workspace background)_
<img width="660" alt="image" src="https://user-images.githubusercontent.com/43474485/223771330-fca0de20-b209-41c6-b9fc-4e805105426c.png">


## Follow-up work

In order to make these available to users, we will want to add context menu options for theme. We will need to add logic so that labs will only be able to access either the "cdo" or "musiclab" themes, but not both. 
https://codedotorg.atlassian.net/browse/SL-646

(Alternatively, we could move Project Beats gradually to a world where the theme doesn't require its own unique component styles.)


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
