### PR TITLE
Add CS leaders prize to scholarship status

### DIFF
--- a/lib/cdo/shared_constants/pd/scholarship_info_constants.rb
+++ b/lib/cdo/shared_constants/pd/scholarship_info_constants.rb
@@ -3,6 +3,7 @@ module Pd
     SCHOLARSHIP_STATUSES = [
       NO = 'no'.freeze,
       YES_CDO = 'yes_code_dot_org'.freeze,
+      YES_CS_LEADERS = 'yes_cs_leaders'.freeze,
       YES_OTHER = 'yes_other'.freeze
     ].freeze
 
@@ -16,6 +17,7 @@ module Pd
     SCHOLARSHIP_DROPDOWN_OPTIONS = [
       {value: NO, label: "No, paid teacher"},
       {value: YES_CDO, label: "Yes, Code.org scholarship"},
+      {value: YES_CS_LEADERS, label: "Yes, CS Leaders Prize"},
       {value: YES_OTHER, label: "Yes, other funding (non code.org)"}
     ].freeze
 


### PR DESCRIPTION
Adds the "CS Leaders Prize" as an option for scholarship.

Tested manually:

<img width="974" alt="Screenshot 2023-03-08 at 1 18 32 PM" src="https://user-images.githubusercontent.com/9142121/223819092-4a760cc9-6241-4f1f-b628-de06f025cb46.png">

On backend, when I check the status, I see
```
[development] dashboard > Pd::ScholarshipInfo.all.pluck(:scholarship_status)
   (1.6ms)  SELECT `pd_scholarship_infos`.`scholarship_status` FROM `pd_scholarship_infos`
=> ["yes_cs_leaders", "yes_cs_leaders"]
```

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
