### PR TITLE
Music: initial modal video

### DIFF
--- a/apps/src/music/analytics/AnalyticsReporter.ts
+++ b/apps/src/music/analytics/AnalyticsReporter.ts
@@ -136,14 +136,15 @@ export default class AnalyticsReporter {
   }
 
   onVideoClosed(id: string, duration: number) {
+    const logMessage = `Video closed. Id: ${id}. Duration: ${duration}}`;
+
     if (!this.sessionInProgress) {
-      this.log('No session in progress');
+      this.log(`No session in progress.  (${logMessage}`);
       return;
+    } else {
+      this.log(logMessage);
     }
 
-    this.log(
-      `Video closed. Id: ${id}.  Duration: ${duration}}`
-    );
     track('Video closed', {id, duration}).promise;
   }
 

--- a/apps/src/music/analytics/AnalyticsReporter.ts
+++ b/apps/src/music/analytics/AnalyticsReporter.ts
@@ -135,6 +135,18 @@ export default class AnalyticsReporter {
     track('Button clicked', {buttonName, ...properties}).promise;
   }
 
+  onVideoClosed(id: string, duration: number) {
+    if (!this.sessionInProgress) {
+      this.log('No session in progress');
+      return;
+    }
+
+    this.log(
+      `Video closed. Id: ${id}.  Duration: ${duration}}`
+    );
+    track('Video closed', {id, duration}).promise;
+  }
+
   onInstructionsVisited(page: number) {
     if (!this.sessionInProgress) {
       this.log('No session in progress');

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -384,6 +384,9 @@ class UnconnectedMusicView extends React.Component {
     const instructionsPosition =
       instructionPositionOrder[this.state.instructionsPosIndex];
 
+    const showVideo =
+      AppConfig.getValue('show-video') === 'true' && this.state.showingVideo;
+
     return (
       <AnalyticsContext.Provider value={this.analyticsReporter}>
         <PlayerUtilsContext.Provider
@@ -401,7 +404,7 @@ class UnconnectedMusicView extends React.Component {
                 instructionsPosition === InstructionsPositions.TOP &&
                 this.renderInstructions(InstructionsPositions.TOP)}
 
-              {this.state.showingVideo && (
+              {showVideo && (
                 <Video id="initial-modal-0" onClose={this.onVideoClosed} />
               )}
 

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -84,8 +84,7 @@ class UnconnectedMusicView extends React.Component {
       timelineAtTop: false,
       showInstructions: false,
       instructionsPosIndex,
-      showingVideo: true,
-      sessionStartTime: Date.now()
+      showingVideo: true
     };
   }
 
@@ -329,9 +328,6 @@ class UnconnectedMusicView extends React.Component {
 
   onVideoClosed = () => {
     this.setState({showingVideo: false});
-
-    const videoDuration = (Date.now() - this.state.sessionStartTime) / 1000;
-    this.analyticsReporter.onVideoClosed('initial-modal-0', videoDuration);
   };
 
   renderInstructions(position) {
@@ -406,7 +402,7 @@ class UnconnectedMusicView extends React.Component {
                 this.renderInstructions(InstructionsPositions.TOP)}
 
               {this.state.showingVideo && (
-                <Video onClose={this.onVideoClosed} />
+                <Video id="initial-modal-0" onClose={this.onVideoClosed} />
               )}
 
               {this.state.timelineAtTop &&

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -20,6 +20,7 @@ import Globals from '../globals';
 import MusicBlocklyWorkspace from '../blockly/MusicBlocklyWorkspace';
 import AppConfig, {getBlockMode} from '../appConfig';
 import SoundUploader from '../utils/SoundUploader';
+import Video from './Video';
 
 const baseUrl = 'https://curriculum.code.org/media/musiclab/';
 
@@ -82,7 +83,9 @@ class UnconnectedMusicView extends React.Component {
       updateNumber: 0,
       timelineAtTop: false,
       showInstructions: false,
-      instructionsPosIndex
+      instructionsPosIndex,
+      showingVideo: true,
+      sessionStartTime: Date.now()
     };
   }
 
@@ -324,6 +327,13 @@ class UnconnectedMusicView extends React.Component {
     );
   };
 
+  onVideoClosed = () => {
+    this.setState({showingVideo: false});
+
+    const videoDuration = (Date.now() - this.state.sessionStartTime) / 1000;
+    this.analyticsReporter.onVideoClosed('initial-modal-0', videoDuration);
+  };
+
   renderInstructions(position) {
     return (
       <div
@@ -394,6 +404,10 @@ class UnconnectedMusicView extends React.Component {
               {this.state.showInstructions &&
                 instructionsPosition === InstructionsPositions.TOP &&
                 this.renderInstructions(InstructionsPositions.TOP)}
+
+              {this.state.showingVideo && (
+                <Video onClose={this.onVideoClosed} />
+              )}
 
               {this.state.timelineAtTop &&
                 this.renderTimelineArea(

--- a/apps/src/music/views/Video.jsx
+++ b/apps/src/music/views/Video.jsx
@@ -1,7 +1,14 @@
 import PropTypes from 'prop-types';
-import React, {useLayoutEffect, useState} from 'react';
+import React, {
+  useRef,
+  useContext,
+  useLayoutEffect,
+  useEffect,
+  useState
+} from 'react';
 import styles from './video.module.scss';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
+import {AnalyticsContext} from '../context';
 
 function useWindowSize() {
   const [size, setSize] = useState([0, 0]);
@@ -19,7 +26,14 @@ function useWindowSize() {
 /**
  * Renders a simple modal video player.
  */
-const Video = ({onClose}) => {
+const Video = ({id, onClose}) => {
+  const startTime = useRef(null);
+  const analyticsReporter = useContext(AnalyticsContext);
+
+  useEffect(() => {
+    startTime.current = Date.now();
+  }, []);
+
   let [targetWidth, targetHeight] = useWindowSize();
   targetWidth -= 80;
   targetHeight -= 100;
@@ -32,6 +46,13 @@ const Video = ({onClose}) => {
     width = targetWidth;
     height = (9 / 16) * width;
   }
+
+  const onCloseClicked = () => {
+    onClose();
+
+    const videoDuration = (Date.now() - startTime.current) / 1000;
+    analyticsReporter.onVideoClosed(id, videoDuration);
+  };
 
   return (
     <div id="video-container" className={styles.container}>
@@ -50,7 +71,7 @@ const Video = ({onClose}) => {
         <div className={styles.closeContainer}>
           <FontAwesome
             icon={'times'}
-            onClick={onClose}
+            onClick={onCloseClicked}
             className={styles.closeIcon}
           />
         </div>
@@ -60,6 +81,7 @@ const Video = ({onClose}) => {
 };
 
 Video.propTypes = {
+  id: PropTypes.string.isRequired,
   onClose: PropTypes.func.isRequired
 };
 

--- a/apps/src/music/views/Video.jsx
+++ b/apps/src/music/views/Video.jsx
@@ -1,0 +1,69 @@
+import PropTypes from 'prop-types';
+import React, {useLayoutEffect, useState} from 'react';
+import styles from './video.module.scss';
+import FontAwesome from '@cdo/apps/templates/FontAwesome';
+
+function useWindowSize() {
+  const [size, setSize] = useState([0, 0]);
+  useLayoutEffect(() => {
+    function updateSize() {
+      setSize([window.innerWidth, window.innerHeight]);
+    }
+    window.addEventListener('resize', updateSize);
+    updateSize();
+    return () => window.removeEventListener('resize', updateSize);
+  }, []);
+  return size;
+}
+
+/**
+ * Renders a video player.
+ */
+const Video = ({onClose}) => {
+  //const targetWidth = window.innerWidth - 20;
+  //const targetHeight = window.innerHeight - 100;
+
+  let [targetWidth, targetHeight] = useWindowSize();
+  targetWidth -= 80;
+  targetHeight -= 100;
+
+  let width, height;
+  if (targetWidth / targetHeight > 16 / 9) {
+    height = targetHeight;
+    width = (16 / 9) * height;
+  } else {
+    width = targetWidth;
+    height = (9 / 16) * width;
+  }
+
+  return (
+    <div id="video-container" className={styles.container}>
+      <div className={styles.inner} style={{width, height}}>
+        <div className={styles.video}>
+          <iframe
+            width="100%"
+            height="100%"
+            style={{border: 'none'}}
+            src="https://www.youtube.com/embed/qYZF6oIZtfc"
+            title="YouTube video player"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowFullScreen
+          />
+        </div>
+        <div className={styles.closeContainer}>
+          <FontAwesome
+            icon={'times'}
+            onClick={onClose}
+            className={styles.closeIcon}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+Video.propTypes = {
+  onClose: PropTypes.func.isRequired
+};
+
+export default Video;

--- a/apps/src/music/views/Video.jsx
+++ b/apps/src/music/views/Video.jsx
@@ -68,12 +68,8 @@ const Video = ({id, onClose}) => {
             allowFullScreen
           />
         </div>
-        <div className={styles.closeContainer}>
-          <FontAwesome
-            icon={'times'}
-            onClick={onCloseClicked}
-            className={styles.closeIcon}
-          />
+        <div className={styles.closeContainer} onClick={onCloseClicked}>
+          <FontAwesome icon={'times'} className={styles.closeIcon} />
         </div>
       </div>
     </div>

--- a/apps/src/music/views/Video.jsx
+++ b/apps/src/music/views/Video.jsx
@@ -17,12 +17,9 @@ function useWindowSize() {
 }
 
 /**
- * Renders a video player.
+ * Renders a simple modal video player.
  */
 const Video = ({onClose}) => {
-  //const targetWidth = window.innerWidth - 20;
-  //const targetHeight = window.innerHeight - 100;
-
   let [targetWidth, targetHeight] = useWindowSize();
   targetWidth -= 80;
   targetHeight -= 100;

--- a/apps/src/music/views/Video.jsx
+++ b/apps/src/music/views/Video.jsx
@@ -41,8 +41,8 @@ const Video = ({onClose}) => {
             width="100%"
             height="100%"
             style={{border: 'none'}}
-            src="https://www.youtube.com/embed/qYZF6oIZtfc"
-            title="YouTube video player"
+            src="https://www.youtube-nocookie.com/embed/qYZF6oIZtfc"
+            title=""
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
             allowFullScreen
           />

--- a/apps/src/music/views/video.module.scss
+++ b/apps/src/music/views/video.module.scss
@@ -1,0 +1,48 @@
+@import "./theme/tokens-dark";
+@import "color.scss";
+@import "./music-view.module.scss";
+
+.container {
+  background-color: rgba(0 0 0 / 0.5);
+  position: absolute;
+  z-index: 75;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.inner {
+  margin: 0 auto;
+  width: calc(100% - 40px);
+  height: calc(100% - 40px);
+
+  position: relative;
+}
+
+.video {
+  border-radius: 15px;
+  overflow: hidden;
+  width: 100%;
+  height: 100%;
+}
+
+.closeContainer {
+  position: absolute;
+  right: -20px;
+  top: -15px;
+  width: 40px;
+  height: 40px;
+  background-color: black;
+  color: white;
+  border-radius: 50%;
+  border: solid 1px white;
+  z-index: 20;
+  cursor: pointer;
+}
+
+.closeIcon {
+  position: absolute;
+  font-size: 35px;
+  left: 6px;
+  top: 1px;
+}

--- a/apps/src/musicMenu/MusicMenu.jsx
+++ b/apps/src/musicMenu/MusicMenu.jsx
@@ -54,6 +54,14 @@ const optionsList = [
       {value: 'false', description: "Don't show instructions."},
       {value: 'true', description: 'Show instructions.'}
     ]
+  },
+  {
+    name: 'show-video',
+    type: 'radio',
+    values: [
+      {value: 'false', description: "Don't show video."},
+      {value: 'true', description: 'Show video.'}
+    ]
   }
 ];
 


### PR DESCRIPTION
This shows an initial modal video.  Final URL to be determined.  It's only a YouTube video, with no fallback player, and closing must be done by pressing the X icon.  When it's closed, we report an analytic with how long it took until it was closed.  The video modal dynamically resizes to fit the window while maintaining its aspect ratio.

While the video URL is just a placeholder, the `?show-video=true` URL parameter needs to be added to see it.  Once we have the real video, we can reuse the URL parameter so that `?show-video=false` hides the video, which should be helpful for development.

<img width="1512" alt="Screenshot 2023-03-08 at 10 59 59 AM" src="https://user-images.githubusercontent.com/2205926/223810032-e17724ef-322b-417e-b73a-ad5ced4c6e98.png">
