### PR TITLE
Music: fix trigger

### DIFF
--- a/apps/src/music/blockly/blocks/simple2.js
+++ b/apps/src/music/blockly/blocks/simple2.js
@@ -125,6 +125,7 @@ export const triggeredAtSimple2 = {
         name: '${block.getFieldValue(TRIGGER_FIELD)}',
         uniqueInvocationId: MusicPlayer.getUniqueInvocationId()
       };
+      var __effects = {};
       ProgramSequencer.playSequentialWithMeasure(
         Math.ceil(
           MusicPlayer.getCurrentPlayheadPosition()


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/50356.  Missed one spot where we set up the new effects variable, which caused triggered code to not run.
