### PR TITLE
Only log 'Course Overview Page Visited' Amplitude event for teachers

### DIFF
--- a/apps/src/lib/util/AnalyticsConstants.js
+++ b/apps/src/lib/util/AnalyticsConstants.js
@@ -12,7 +12,8 @@ const EVENTS = {
   TEACHER_LOGIN_EVENT: 'Teacher Login',
 
   // Course/Unit info
-  COURSE_OVERVIEW_PAGE_VISITED_EVENT: 'Course Overview Page Visited',
+  COURSE_OVERVIEW_PAGE_VISITED_BY_TEACHER_EVENT:
+    'Course Overview Page Visited By Teacher',
   UNIT_OVERVIEW_PAGE_VISITED_BY_TEACHER_EVENT:
     'Unit Overview Page Visited By Teacher',
   TRY_NOW_BUTTON_CLICK_EVENT: 'Try Now Button Clicked',

--- a/apps/src/sites/studio/pages/courses/show.js
+++ b/apps/src/sites/studio/pages/courses/show.js
@@ -102,6 +102,7 @@ function showCourseOverview() {
         redirectToCourseUrl={scriptData.redirect_to_course_url}
         showAssignButton={courseSummary.show_assign_button}
         userId={userId}
+        userType={scriptData.user_type}
         participantAudience={courseSummary.participant_audience}
       />
     </Provider>,

--- a/apps/src/templates/courseOverview/CourseOverview.js
+++ b/apps/src/templates/courseOverview/CourseOverview.js
@@ -62,6 +62,7 @@ class CourseOverview extends Component {
     redirectToCourseUrl: PropTypes.string,
     showAssignButton: PropTypes.bool,
     userId: PropTypes.number,
+    userType: PropTypes.string,
     participantAudience: PropTypes.string,
     // Redux
     announcements: PropTypes.arrayOf(announcementShape),
@@ -75,9 +76,14 @@ class CourseOverview extends Component {
       props.redirectToCourseUrl && props.redirectToCourseUrl.length > 0;
     this.state = {showRedirectDialog};
 
-    analyticsReporter.sendEvent(EVENTS.COURSE_OVERVIEW_PAGE_VISITED_EVENT, {
-      'unit group name': props.name
-    });
+    if (props.userType === 'teacher') {
+      analyticsReporter.sendEvent(
+        EVENTS.COURSE_OVERVIEW_PAGE_VISITED_BY_TEACHER_EVENT,
+        {
+          'unit group name': props.name
+        }
+      );
+    }
   }
 
   onChangeVersion = versionId => {

--- a/dashboard/app/views/courses/show.html.haml
+++ b/dashboard/app/views/courses/show.html.haml
@@ -14,6 +14,7 @@
 - data[:show_redirect_warning] = redirect_warning
 - data[:redirect_to_course_url] = unit_group.redirect_to_course_url(@current_user)
 - data[:user_id] = @current_user.try(:id)
+- data[:user_type] = @current_user.try(:user_type)
 
 - content_for(:head) do
   %script{ src: webpack_asset_path('js/courses/show.js'), data: {courses_show: data.to_json}}


### PR DESCRIPTION
The sheer volume of "Course Overview Page Visited" events in Amplitude is consuming a large portion of what we are allotted by our plan with Amplitude. To save on resources, this PR only logs that event when a teacher views the page.

## View as student (doesn't show "Course Overview Page Visited" event)
![Doesnt_Show_For_Student](https://user-images.githubusercontent.com/56283563/223825726-fe46811f-b5fa-4a18-9d94-05ab53b2bc6b.PNG)

## View as teacher (shows "Course Overview Page Visited" event)
Logs locally:
![Works_For_Teacher](https://user-images.githubusercontent.com/56283563/223825697-e567d015-4748-4036-8150-da7a3883e2c9.PNG)

Correctly turns "Planning" to "Live" on Amplitude site:
![Works_For_Teacher_Amplitude](https://user-images.githubusercontent.com/56283563/223825709-d830ed2d-cfcb-4216-a966-248bc8cfb861.PNG)

## Links
Jira task: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?modal=detail&selectedIssue=ACQ-468&assignee=60d62161f65054006980bd71)
Amplitude event: [here](https://data.amplitude.com/code-org/Code.org%20Tracking%20Plan/events/main/latest/Course%20Overview%20Page%20Visited%20By%20Teacher)

## Testing story
Local testing.

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
