### PR TITLE
Refactor platform storybooks

### DIFF
--- a/apps/src/templates/FallbackPlayerCaptionDialogLink.story.jsx
+++ b/apps/src/templates/FallbackPlayerCaptionDialogLink.story.jsx
@@ -1,21 +1,17 @@
 import React from 'react';
 import FallbackPlayerCaptionDialogLink from './FallbackPlayerCaptionDialogLink';
 
-export default storybook => {
-  return storybook
-    .storiesOf('Dialogs/FallbackPlayerCaptionDialogLink', module)
-    .addStoryTable([
-      {
-        name: 'below standalone video player',
-        description:
-          "Link shown below standalone level's fallback video player, which pops a dialog explaining that captions are available on YouTube.",
-        story: () => <FallbackPlayerCaptionDialogLink />
-      },
-      {
-        name: 'in header of dialog video player',
-        description:
-          "Link shown below standalone level's fallback video player, which pops a dialog explaining that captions are available on YouTube.",
-        story: () => <FallbackPlayerCaptionDialogLink inDialog={true} />
-      }
-    ]);
+export default {
+  title: 'FallbackPlayerCaptionDialogLink',
+  component: FallbackPlayerCaptionDialogLink
+};
+
+const Template = args => <FallbackPlayerCaptionDialogLink {...args} />;
+
+export const BelowStandaloneVideoPlayer = Template.bind({});
+BelowStandaloneVideoPlayer.args = {};
+
+export const InHeaderOfDialogVideoPlayer = Template.bind({});
+InHeaderOfDialogVideoPlayer.args = {
+  inDialog: true
 };

--- a/apps/src/templates/GDPRDialog.story.jsx
+++ b/apps/src/templates/GDPRDialog.story.jsx
@@ -10,9 +10,6 @@ const Template = args => <GDPRDialog {...args} />;
 
 export const Simple = Template.bind({});
 Simple.args = {
-  name: 'GDPR Dialog',
-  description:
-    'Dialog shown to users in the EU to prompt them to accept the data transfer agreement',
   isDialogOpen: true,
   currentUserId: 12345
 };

--- a/apps/src/templates/ReCaptchaDialog.story.jsx
+++ b/apps/src/templates/ReCaptchaDialog.story.jsx
@@ -1,23 +1,25 @@
 import React from 'react';
 import ReCaptchaDialog from './ReCaptchaDialog';
 
+export default {
+  title: 'ReCaptchaDialog',
+  component: ReCaptchaDialog
+};
+
 //Using Google's publicly available test key:
 //https://developers.google.com/recaptcha/docs/faq#id-like-to-run-automated-tests-with-recaptcha.-what-should-i-do
-export default storybook => {
-  return storybook.storiesOf('Dialogs/ReCaptchaDialog', module).addStoryTable([
-    {
-      name: 'Dialog open',
-      description:
-        'Dialog forces user to cancel or complete captcha before submitting',
-      story: () => (
-        <ReCaptchaDialog
-          siteKey="6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI"
-          handleSubmit={() => {}}
-          handleCancel={() => {}}
-          submitText="Join section"
-          isOpen={true}
-        />
-      )
-    }
-  ]);
+const DEFAULT_PROPS = {
+  handleSubmit: () => {},
+  handleCancel: () => {},
+  isOpen: true,
+  submitText: 'Join section',
+  siteKey: '6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI'
+};
+const Template = args => <ReCaptchaDialog {...DEFAULT_PROPS} {...args} />;
+
+export const DialogOpen = Template.bind({});
+DialogOpen.args = {
+  name: 'Dialog open',
+  description:
+    'Dialog forces user to cancel or complete captcha before submitting'
 };

--- a/apps/src/templates/ReCaptchaDialog.story.jsx
+++ b/apps/src/templates/ReCaptchaDialog.story.jsx
@@ -18,8 +18,4 @@ const DEFAULT_PROPS = {
 const Template = args => <ReCaptchaDialog {...DEFAULT_PROPS} {...args} />;
 
 export const DialogOpen = Template.bind({});
-DialogOpen.args = {
-  name: 'Dialog open',
-  description:
-    'Dialog forces user to cancel or complete captcha before submitting'
-};
+DialogOpen.args = {};

--- a/apps/src/templates/SchoolInfoInputs.story.js
+++ b/apps/src/templates/SchoolInfoInputs.story.js
@@ -2,84 +2,85 @@ import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import SchoolInfoInputs from './SchoolInfoInputs';
 
-export default storybook => {
-  class SchoolInfoInputsWrapper extends Component {
-    static propTypes = {
-      showErrors: PropTypes.bool,
-      showRequiredIndicator: PropTypes.bool
-    };
+class SchoolInfoInputsWrapper extends Component {
+  static propTypes = {
+    showErrors: PropTypes.bool,
+    showRequiredIndicator: PropTypes.bool
+  };
 
-    state = {
-      country: '',
-      schoolType: '',
-      ncesSchoolId: '',
-      schoolName: '',
-      schoolCity: '',
-      schoolState: '',
-      schoolZip: ''
-    };
+  state = {
+    country: '',
+    schoolType: '',
+    ncesSchoolId: '',
+    schoolName: '',
+    schoolCity: '',
+    schoolState: '',
+    schoolZip: ''
+  };
 
-    onCountryChange(_, event) {
-      const newCountry = event ? event.value : '';
-      this.setState({country: newCountry});
-    }
-
-    onSchoolTypeChange(event) {
-      const newType = event ? event.target.value : '';
-      this.setState({schoolType: newType});
-    }
-
-    onSchoolChange(_, event) {
-      const newSchool = event ? event.value : '';
-      this.setState({ncesSchoolId: newSchool});
-    }
-
-    onSchoolNotFoundChange(field, event) {
-      let newValue = event ? event.target.value : '';
-      this.setState({
-        [field]: newValue
-      });
-    }
-
-    render() {
-      return (
-        <div>
-          <SchoolInfoInputs
-            useLocationSearch={false}
-            onCountryChange={this.onCountryChange.bind(this)}
-            onSchoolTypeChange={this.onSchoolTypeChange.bind(this)}
-            onSchoolChange={this.onSchoolChange.bind(this)}
-            onSchoolNotFoundChange={this.onSchoolNotFoundChange.bind(this)}
-            country={this.state.country}
-            schoolType={this.state.schoolType}
-            ncesSchoolId={this.state.ncesSchoolId}
-            schoolName={this.state.schoolName}
-            schoolCity={this.state.schoolCity}
-            schoolState={this.state.schoolState}
-            schoolZip={this.state.schoolZip}
-            showErrors={this.props.showErrors}
-            showRequiredIndicator={this.props.showRequiredIndicator}
-          />
-        </div>
-      );
-    }
+  onCountryChange(_, event) {
+    const newCountry = event ? event.value : '';
+    this.setState({country: newCountry});
   }
 
-  return storybook.storiesOf('SchoolInfoInputs', module).addStoryTable([
-    {
-      name: 'Inputs for school info (not required)',
-      description: `Gets school info data.`,
-      story: () => <SchoolInfoInputsWrapper />
-    },
-    {
-      name: 'Inputs for school info (required)',
-      description: `Gets school info data.`,
-      story: () => (
-        <SchoolInfoInputsWrapper
-          showErrors={true}
-          showRequiredIndicator={true}
+  onSchoolTypeChange(event) {
+    const newType = event ? event.target.value : '';
+    this.setState({schoolType: newType});
+  }
+
+  onSchoolChange(_, event) {
+    const newSchool = event ? event.value : '';
+    this.setState({ncesSchoolId: newSchool});
+  }
+
+  onSchoolNotFoundChange(field, event) {
+    let newValue = event ? event.target.value : '';
+    this.setState({
+      [field]: newValue
+    });
+  }
+
+  render() {
+    return (
+      <div>
+        <SchoolInfoInputs
+          useLocationSearch={false}
+          onCountryChange={this.onCountryChange.bind(this)}
+          onSchoolTypeChange={this.onSchoolTypeChange.bind(this)}
+          onSchoolChange={this.onSchoolChange.bind(this)}
+          onSchoolNotFoundChange={this.onSchoolNotFoundChange.bind(this)}
+          country={this.state.country}
+          schoolType={this.state.schoolType}
+          ncesSchoolId={this.state.ncesSchoolId}
+          schoolName={this.state.schoolName}
+          schoolCity={this.state.schoolCity}
+          schoolState={this.state.schoolState}
+          schoolZip={this.state.schoolZip}
+          showErrors={this.props.showErrors}
+          showRequiredIndicator={this.props.showRequiredIndicator}
         />
-      )
-    }
-  ]);
+      </div>
+    );
+  }
+}
+
+export default {
+  title: 'SchoolInfoInputs',
+  component: SchoolInfoInputs
+};
+
+const Template = args => <SchoolInfoInputsWrapper {...args} />;
+
+export const SchoolInfoRequired = Template.bind({});
+SchoolInfoRequired.args = {
+  name: 'Inputs for school info (required)',
+  description: `Gets school info data.`,
+  showErrors: true,
+  showRequiredIndicator: true
+};
+
+export const SchoolInfoNotRequired = Template.bind({});
+SchoolInfoNotRequired.args = {
+  name: 'Inputs for school info (not required)',
+  description: `Gets school info data.`
 };

--- a/apps/src/templates/SchoolInfoInputs.story.js
+++ b/apps/src/templates/SchoolInfoInputs.story.js
@@ -73,14 +73,9 @@ const Template = args => <SchoolInfoInputsWrapper {...args} />;
 
 export const SchoolInfoRequired = Template.bind({});
 SchoolInfoRequired.args = {
-  name: 'Inputs for school info (required)',
-  description: `Gets school info data.`,
   showErrors: true,
   showRequiredIndicator: true
 };
 
 export const SchoolInfoNotRequired = Template.bind({});
-SchoolInfoNotRequired.args = {
-  name: 'Inputs for school info (not required)',
-  description: `Gets school info data.`
-};
+SchoolInfoNotRequired.args = {};

--- a/apps/src/templates/certificates/petition/PetitionCallToAction.story.js
+++ b/apps/src/templates/certificates/petition/PetitionCallToAction.story.js
@@ -1,10 +1,14 @@
 import React from 'react';
 import PetitionCallToAction from '@cdo/apps/templates/certificates/petition/PetitionCallToAction';
 
-export default storybook => {
-  return storybook
-    .storiesOf('Congrats/PetitionCallToAction', module)
-    .add('Default', () => (
-      <PetitionCallToAction gaPagePath={'congrats/coursetest-2050'} />
-    ));
+export default {
+  title: 'PetitionCallToAction',
+  component: PetitionCallToAction
+};
+
+const Template = args => <PetitionCallToAction {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  gaPagePath: 'congrats/coursetest-2050'
 };


### PR DESCRIPTION
Migrated the following React Storybooks to follow the new pattern:
* [ReCaptchaDialog.story.jsx](https://github.com/code-dot-org/code-dot-org/commit/4d94ae13ded2f415cdca201af731eece144122b6)
* [SchoolInfoInputs.story.js](https://github.com/code-dot-org/code-dot-org/commit/3cbb723fe9fdb5221a2c0c190fdba7eb970e728c)
* [PetitionCallToAction.story.js](https://github.com/code-dot-org/code-dot-org/commit/820aad4dd8a99d4b0fb47d49cc689d0e299617c7)
* [FallbackPlayerCaptionDialogLink.story.jsx](https://github.com/code-dot-org/code-dot-org/commit/f0ff21ff4cbb1a66002658d5ab96bfe538b1b1c7)

Also fixed some previous migrations by removing the `name` and `description` attributes. These shouldn't be added to the new pattern.

## Testing story
Manually tested using `yarn storybook` in the `apps` directory.
