### PR TITLE
Install ruby to `/usr/local`

### DIFF
--- a/cookbooks/cdo-ruby/recipes/ruby-build.rb
+++ b/cookbooks/cdo-ruby/recipes/ruby-build.rb
@@ -40,6 +40,6 @@ execute 'install ruby-build' do
 end
 
 execute 'install ruby with ruby build' do
-  command "ruby-build #{node['cdo-ruby']['version']}"
+  command "ruby-build #{node['cdo-ruby']['version']} /usr/local"
   not_if "which ruby && ruby --version | grep --quiet '^ruby #{node['cdo-ruby']['version']}'"
 end

--- a/cookbooks/cdo-ruby/recipes/ruby-build.rb
+++ b/cookbooks/cdo-ruby/recipes/ruby-build.rb
@@ -40,9 +40,9 @@ execute 'install ruby-build' do
 end
 
 execute 'install ruby with ruby build' do
-  # Target /usr/local; it might make sense to install ruby itself to /usr, but
-  # the directory we target here is also the one RubyGems will target for its
-  # own installation and local is more appropriate for that content.
+  # Target /usr/local; it might make sense to install ruby itself to /usr as
+  # our old apt approach did, but the directory we target here is also the one
+  # RubyGems will target, and local is more appropriate for that installation
   command "ruby-build #{node['cdo-ruby']['version']} /usr/local"
   not_if "which ruby && ruby --version | grep --quiet '^ruby #{node['cdo-ruby']['version']}'"
 end

--- a/cookbooks/cdo-ruby/recipes/ruby-build.rb
+++ b/cookbooks/cdo-ruby/recipes/ruby-build.rb
@@ -40,7 +40,6 @@ execute 'install ruby-build' do
 end
 
 execute 'install ruby with ruby build' do
-  # target /usr for consistency; that's where our old apt approach targeted
-  command "ruby-build #{node['cdo-ruby']['version']} /usr"
+  command "ruby-build #{node['cdo-ruby']['version']}"
   not_if "which ruby && ruby --version | grep --quiet '^ruby #{node['cdo-ruby']['version']}'"
 end

--- a/cookbooks/cdo-ruby/recipes/ruby-build.rb
+++ b/cookbooks/cdo-ruby/recipes/ruby-build.rb
@@ -40,6 +40,9 @@ execute 'install ruby-build' do
 end
 
 execute 'install ruby with ruby build' do
+  # Target /usr/local; it might make sense to install ruby itself to /usr, but
+  # the directory we target here is also the one RubyGems will target for its
+  # own installation and local is more appropriate for that content.
   command "ruby-build #{node['cdo-ruby']['version']} /usr/local"
   not_if "which ruby && ruby --version | grep --quiet '^ruby #{node['cdo-ruby']['version']}'"
 end

--- a/cookbooks/cdo-ruby/recipes/rubygems.rb
+++ b/cookbooks/cdo-ruby/recipes/rubygems.rb
@@ -1,4 +1,15 @@
-cookbook_file '/etc/gemrc' do
+# Clean up configuration file for our old, apt-installed rubygems if it's still
+# around. TODO: remove this block once all environments have been cleaned up
+file '/etc/gemrc' do
+  action :delete
+  only_if {File.exist? '/etc/gemrc'}
+end
+
+directory '/usr/local/etc' do
+  recursive true
+end
+
+cookbook_file '/usr/local/etc/gemrc' do
   action :create_if_missing
   source 'gemrc'
   mode '0644'

--- a/cookbooks/cdo-ruby/test/integration/default/serverspec/ruby_spec.rb
+++ b/cookbooks/cdo-ruby/test/integration/default/serverspec/ruby_spec.rb
@@ -1,6 +1,6 @@
 require_relative '../../../kitchen/data/helper_spec'
 
-file_exist '/usr/bin/ruby'
+file_exist '/usr/local/bin/ruby'
 cmd 'ruby -v', 'ruby 2.7'
 cmd 'gem -v', '3.3.22'
 cmd 'bundler -v', '2.3.22'


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/49864, to resolve some issues with our persistent managed servers since then.

Specifically, our old apt approach did install the ruby executable itself to `/usr/bin/ruby`, but then configured RubyGems to target `/usr/local/` for all other content, most notably the executables and libraries installed by gems. When we switched to `ruby-build`, we targeted `/usr` so the executable would be overwritten, but I did not realize that RubyGems would then target that same directory for all other content. This has a couple of implications, the most significant being that because `/usr/local` has a higher priority than `/usr` when loading executables or libraries, all of our new ruby-build-installed Ruby executables were being ignored in favor of our old apt-installed ones.

I haven't been able to figure out how the apt install configured these things separately, so to ensure our new Ruby functionality gets used, we update our `ruby-build` logic to target the higher-priority `/usr/local`. This will result in our new install overwriting the old install, but does mean that several build artifacts will linger in `/usr` on our persistent managed servers. I'm not sure of a good way to clean these up, but neither can I see a situation in which them being around will cause us actual problems beyond just being a bit messy.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Testing story

Tested on an adhoc; specifically, I manually recreated our full build history on an adhoc: I installed ruby with apt and installed all our ruby dependencies with that version, then uninstalled ruby with apt and installed ruby to `/usr` with `ruby-build` and installed all our dependencies with that. I then reinstalled ruby to `/usr/local` with `ruby-build`, and verified that that final install takes priority over the old ones.

## Follow-up work

After this has been deployed to all persistent managed servers, we can remove the manual symlinks `ruby2.7 -> ruby` and `libruby2.7.so.2.7 -> libruby.so.2.7` we've created.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
