### PR TITLE
Updating regional partners DB to include new 'inactive' field

### DIFF
--- a/dashboard/app/models/regional_partner.rb
+++ b/dashboard/app/models/regional_partner.rb
@@ -18,6 +18,7 @@
 #  updated_at         :datetime         not null
 #  deleted_at         :datetime
 #  properties         :text(65535)
+#  inactive           :boolean
 #
 
 require 'state_abbr'

--- a/dashboard/app/serializers/regional_partner_serializer.rb
+++ b/dashboard/app/serializers/regional_partner_serializer.rb
@@ -18,6 +18,7 @@
 #  updated_at         :datetime         not null
 #  deleted_at         :datetime
 #  properties         :text(65535)
+#  inactive           :boolean
 #
 
 class RegionalPartnerSerializer < ActiveModel::Serializer

--- a/dashboard/db/migrate/20230308220632_add_inactive_field_to_regional_partner.rb
+++ b/dashboard/db/migrate/20230308220632_add_inactive_field_to_regional_partner.rb
@@ -1,0 +1,5 @@
+class AddInactiveFieldToRegionalPartner < ActiveRecord::Migration[6.0]
+  def change
+    add_column :regional_partners, :inactive, :boolean
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,9 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_02_14_123814) do
+ActiveRecord::Schema.define(version: 2023_03_08_220632) do
 
-  create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
     t.integer "level_id"
     t.string "action"
@@ -28,7 +28,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["user_id", "level_id"], name: "index_activities_on_user_id_and_level_id"
   end
 
-  create_table "activity_sections", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "activity_sections", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "lesson_activity_id", null: false
     t.string "key", null: false
     t.integer "position", null: false
@@ -39,7 +39,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["lesson_activity_id"], name: "index_activity_sections_on_lesson_activity_id"
   end
 
-  create_table "ap_cs_offerings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "ap_cs_offerings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "school_code", limit: 6, null: false
     t.string "course", limit: 3, null: false
     t.integer "school_year", limit: 2, null: false
@@ -48,7 +48,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["school_code", "school_year", "course"], name: "index_ap_cs_offerings_on_school_code_and_school_year_and_course", unique: true
   end
 
-  create_table "ap_school_codes", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "ap_school_codes", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "school_year"
     t.string "school_code", limit: 6, null: false
     t.string "school_id", limit: 12, null: false
@@ -58,7 +58,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["school_id"], name: "fk_rails_08d2269647"
   end
 
-  create_table "assessment_activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "assessment_activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "level_id", null: false
     t.integer "script_id", null: false
@@ -70,7 +70,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["user_id", "level_id", "script_id"], name: "index_assessment_activities_on_user_and_level_and_script"
   end
 
-  create_table "authentication_options", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "authentication_options", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "hashed_email", default: "", null: false
     t.string "credential_type", null: false
@@ -86,7 +86,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["user_id", "deleted_at"], name: "index_authentication_options_on_user_id_and_deleted_at"
   end
 
-  create_table "authored_hint_view_requests", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "authored_hint_view_requests", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "script_id"
     t.integer "level_id"
@@ -112,7 +112,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["user_id", "script_id", "level_id", "hint_id"], name: "index_authored_hint_view_requests_on_all_related_ids"
   end
 
-  create_table "backpacks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "backpacks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "storage_app_id", null: false
     t.datetime "created_at", null: false
@@ -121,7 +121,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["user_id"], name: "index_backpacks_on_user_id", unique: true
   end
 
-  create_table "blocks", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "blocks", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "pool", default: "", null: false
     t.string "category"
@@ -134,7 +134,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["pool", "name"], name: "index_blocks_on_pool_and_name", unique: true
   end
 
-  create_table "callouts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "callouts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "element_id", limit: 1024, null: false
     t.string "localization_key", limit: 1024, null: false
     t.datetime "created_at"
@@ -145,7 +145,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.string "callout_text"
   end
 
-  create_table "census_inaccuracy_investigations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "census_inaccuracy_investigations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.text "notes", null: false
     t.integer "census_submission_id", null: false
@@ -157,7 +157,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["user_id"], name: "fk_rails_9c9f685588"
   end
 
-  create_table "census_overrides", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "census_overrides", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "school_id", limit: 12, null: false
     t.integer "school_year", limit: 2, null: false
     t.string "teaches_cs", limit: 2, null: false
@@ -166,7 +166,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["school_id"], name: "fk_rails_06131f8f87"
   end
 
-  create_table "census_state_course_codes", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "census_state_course_codes", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "state"
     t.string "course"
     t.datetime "created_at", null: false
@@ -174,7 +174,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["state", "course"], name: "index_census_state_course_codes_on_state_and_course", unique: true
   end
 
-  create_table "census_submission_form_maps", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "census_submission_form_maps", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "census_submission_id", null: false
     t.integer "form_id", null: false
     t.datetime "created_at", null: false
@@ -183,7 +183,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["form_id"], name: "index_census_submission_form_maps_on_form_id"
   end
 
-  create_table "census_submissions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "census_submissions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "type", null: false
     t.string "submitter_email_address"
     t.string "submitter_name"
@@ -217,7 +217,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["school_year", "id"], name: "index_census_submissions_on_school_year_and_id"
   end
 
-  create_table "census_submissions_school_infos", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "census_submissions_school_infos", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "census_submission_id", null: false
     t.integer "school_info_id", null: false
     t.datetime "created_at", null: false
@@ -226,7 +226,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["school_info_id", "census_submission_id"], name: "school_info_id_census_submission", unique: true
   end
 
-  create_table "census_summaries", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "census_summaries", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "school_id", limit: 12, null: false
     t.integer "school_year", limit: 2, null: false
     t.string "teaches_cs", limit: 2
@@ -236,7 +236,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["school_id", "school_year"], name: "index_census_summaries_on_school_id_and_school_year", unique: true
   end
 
-  create_table "channel_tokens", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "channel_tokens", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "storage_app_id", null: false
     t.integer "level_id", null: false
     t.datetime "created_at"
@@ -249,7 +249,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["storage_id"], name: "index_channel_tokens_on_storage_id"
   end
 
-  create_table "circuit_playground_discount_applications", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "circuit_playground_discount_applications", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "unit_6_intention"
     t.boolean "full_discount"
@@ -265,7 +265,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["user_id"], name: "index_circuit_playground_discount_applications_on_user_id", unique: true
   end
 
-  create_table "circuit_playground_discount_codes", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "circuit_playground_discount_codes", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "code", null: false
     t.boolean "full_discount", null: false
     t.datetime "expiration", null: false
@@ -286,7 +286,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["code_review_id"], name: "index_code_review_comments_on_code_review_id"
   end
 
-  create_table "code_review_group_members", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "code_review_group_members", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "code_review_group_id", null: false
     t.bigint "follower_id", null: false
     t.datetime "created_at", null: false
@@ -295,7 +295,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["follower_id"], name: "index_code_review_group_members_on_follower_id"
   end
 
-  create_table "code_review_groups", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "code_review_groups", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "section_id", null: false
     t.string "name"
     t.datetime "created_at", null: false
@@ -303,7 +303,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["section_id"], name: "index_code_review_groups_on_section_id"
   end
 
-  create_table "code_review_requests", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "code_review_requests", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "script_id", null: false
     t.integer "level_id", null: false
@@ -316,7 +316,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["user_id", "script_id", "level_id", "closed_at", "deleted_at"], name: "index_code_review_requests_unique", unique: true
   end
 
-  create_table "code_reviews", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "code_reviews", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "project_id", null: false
     t.integer "script_id", null: false
@@ -328,14 +328,14 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.datetime "deleted_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.virtual "active", type: :boolean, as: "if(isnull(`deleted_at`),TRUE,NULL)"
-    t.virtual "open", type: :boolean, as: "if(isnull(`closed_at`),TRUE,NULL)"
+    t.virtual "active", type: :boolean, as: "if((`deleted_at` is null),true,NULL)"
+    t.virtual "open", type: :boolean, as: "if((`closed_at` is null),true,NULL)"
     t.index ["project_id", "deleted_at"], name: "index_code_reviews_on_project_id_and_deleted_at"
     t.index ["user_id", "project_id", "open", "active"], name: "index_code_reviews_unique", unique: true
     t.index ["user_id", "script_id", "project_level_id", "closed_at", "deleted_at"], name: "index_code_reviews_for_peer_lookup"
   end
 
-  create_table "concepts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "concepts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -343,14 +343,14 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["video_key"], name: "index_concepts_on_video_key"
   end
 
-  create_table "concepts_levels", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "concepts_levels", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "concept_id"
     t.integer "level_id"
     t.index ["concept_id"], name: "index_concepts_levels_on_concept_id"
     t.index ["level_id"], name: "index_concepts_levels_on_level_id"
   end
 
-  create_table "contact_rollups_final", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "contact_rollups_final", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "email", null: false
     t.json "data", null: false
     t.datetime "created_at", null: false
@@ -358,7 +358,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["email"], name: "index_contact_rollups_final_on_email", unique: true
   end
 
-  create_table "contact_rollups_pardot_memory", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "contact_rollups_pardot_memory", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "email", null: false
     t.integer "pardot_id"
     t.datetime "pardot_id_updated_at"
@@ -374,7 +374,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["pardot_id"], name: "index_contact_rollups_pardot_memory_on_pardot_id", unique: true
   end
 
-  create_table "contact_rollups_processed", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "contact_rollups_processed", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "email", null: false
     t.json "data", null: false
     t.datetime "created_at", null: false
@@ -382,7 +382,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["email"], name: "index_contact_rollups_processed_on_email", unique: true
   end
 
-  create_table "contact_rollups_raw", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "contact_rollups_raw", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "email", null: false
     t.string "sources", null: false
     t.json "data"
@@ -391,7 +391,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "contained_level_answers", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "contained_level_answers", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "level_id", null: false
@@ -401,7 +401,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["level_id"], name: "index_contained_level_answers_on_level_id"
   end
 
-  create_table "contained_levels", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "contained_levels", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "level_group_level_id", null: false
@@ -414,7 +414,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["level_group_level_id"], name: "index_contained_levels_on_level_group_level_id"
   end
 
-  create_table "course_offerings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "course_offerings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "key", null: false
     t.string "display_name", null: false
     t.datetime "created_at", null: false
@@ -429,7 +429,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["key"], name: "index_course_offerings_on_key", unique: true
   end
 
-  create_table "course_scripts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "course_scripts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "course_id", null: false
     t.integer "script_id", null: false
     t.integer "position", null: false
@@ -440,7 +440,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["script_id"], name: "index_course_scripts_on_script_id"
   end
 
-  create_table "course_versions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "course_versions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "key", null: false
     t.string "display_name", null: false
     t.text "properties"
@@ -455,7 +455,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["course_offering_id"], name: "index_course_versions_on_course_offering_id"
   end
 
-  create_table "courses", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "courses", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.text "properties"
     t.datetime "created_at", null: false
@@ -463,7 +463,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["name"], name: "index_courses_on_name"
   end
 
-  create_table "data_docs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "data_docs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "key", null: false
     t.string "name"
     t.text "content"
@@ -473,14 +473,14 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["name"], name: "index_data_docs_on_name"
   end
 
-  create_table "donor_schools", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "donor_schools", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.string "nces_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "donors", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "donors", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.string "url"
     t.string "show"
@@ -492,7 +492,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "email_preferences", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "email_preferences", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "email", null: false
     t.boolean "opt_in", null: false
     t.string "ip_address", null: false
@@ -503,7 +503,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["email"], name: "index_email_preferences_on_email", unique: true
   end
 
-  create_table "experiments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "experiments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "name", null: false
@@ -525,7 +525,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["start_at"], name: "index_experiments_on_start_at"
   end
 
-  create_table "featured_projects", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "featured_projects", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "storage_app_id"
     t.datetime "featured_at"
     t.datetime "unfeatured_at"
@@ -534,7 +534,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["topic"], name: "index_featured_projects_on_topic"
   end
 
-  create_table "followers", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "followers", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "student_user_id", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -544,7 +544,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["student_user_id"], name: "index_followers_on_student_user_id"
   end
 
-  create_table "foorm_forms", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "foorm_forms", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.integer "version", null: false
     t.text "questions", null: false
@@ -554,7 +554,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["name", "version"], name: "index_foorm_forms_on_name_and_version", unique: true
   end
 
-  create_table "foorm_libraries", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "foorm_libraries", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.integer "version", null: false
     t.boolean "published", null: false
@@ -563,7 +563,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["name", "version"], name: "index_foorm_libraries_on_multiple_fields", unique: true
   end
 
-  create_table "foorm_library_questions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "foorm_library_questions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "library_name", null: false
     t.integer "library_version", null: false
     t.string "question_name", null: false
@@ -574,7 +574,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["library_name", "library_version", "question_name"], name: "index_foorm_library_questions_on_multiple_fields", unique: true
   end
 
-  create_table "foorm_simple_survey_forms", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "foorm_simple_survey_forms", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "path", null: false
     t.string "kind"
     t.string "form_name", null: false
@@ -585,7 +585,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["path"], name: "index_foorm_simple_survey_forms_on_path"
   end
 
-  create_table "foorm_simple_survey_submissions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "foorm_simple_survey_submissions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "foorm_submission_id", null: false
     t.integer "user_id"
     t.bigint "simple_survey_form_id"
@@ -604,7 +604,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "frameworks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "frameworks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "shortcode", null: false
     t.string "name", null: false
     t.text "properties"
@@ -613,7 +613,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["shortcode"], name: "index_frameworks_on_shortcode", unique: true
   end
 
-  create_table "games", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "games", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -622,7 +622,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["intro_video_id"], name: "index_games_on_intro_video_id"
   end
 
-  create_table "hint_view_requests", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "hint_view_requests", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
     t.integer "script_id"
     t.integer "level_id"
@@ -634,7 +634,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["user_id"], name: "index_hint_view_requests_on_user_id"
   end
 
-  create_table "ib_cs_offerings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "ib_cs_offerings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "school_code", limit: 6, null: false
     t.string "level", limit: 2, null: false
     t.integer "school_year", limit: 2, null: false
@@ -643,7 +643,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["school_code", "school_year", "level"], name: "index_ib_cs_offerings_on_school_code_and_school_year_and_level", unique: true
   end
 
-  create_table "ib_school_codes", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "ib_school_codes", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "school_code", limit: 6, null: false
     t.string "school_id", limit: 12, null: false
     t.datetime "created_at", null: false
@@ -652,7 +652,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["school_id"], name: "index_ib_school_codes_on_school_id", unique: true
   end
 
-  create_table "lesson_activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "lesson_activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "lesson_id", null: false
     t.string "key", null: false
     t.integer "position", null: false
@@ -663,7 +663,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["lesson_id"], name: "index_lesson_activities_on_lesson_id"
   end
 
-  create_table "lesson_groups", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "lesson_groups", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "key", null: false
     t.integer "script_id", null: false
     t.boolean "user_facing", default: true, null: false
@@ -674,35 +674,35 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["script_id", "key"], name: "index_lesson_groups_on_script_id_and_key", unique: true
   end
 
-  create_table "lessons_opportunity_standards", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "lessons_opportunity_standards", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "lesson_id", null: false
     t.bigint "standard_id", null: false
     t.index ["lesson_id", "standard_id"], name: "index_lessons_opportunity_standards_on_lesson_id_and_standard_id", unique: true
     t.index ["standard_id", "lesson_id"], name: "index_lessons_opportunity_standards_on_standard_id_and_lesson_id"
   end
 
-  create_table "lessons_programming_expressions", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "lessons_programming_expressions", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "lesson_id", null: false
     t.bigint "programming_expression_id", null: false
     t.index ["lesson_id", "programming_expression_id"], name: "lesson_programming_expression", unique: true
     t.index ["programming_expression_id", "lesson_id"], name: "programming_expression_lesson"
   end
 
-  create_table "lessons_resources", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "lessons_resources", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "lesson_id", null: false
     t.integer "resource_id", null: false
     t.index ["lesson_id", "resource_id"], name: "index_lessons_resources_on_lesson_id_and_resource_id", unique: true
     t.index ["resource_id", "lesson_id"], name: "index_lessons_resources_on_resource_id_and_lesson_id"
   end
 
-  create_table "lessons_vocabularies", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "lessons_vocabularies", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "lesson_id", null: false
     t.bigint "vocabulary_id", null: false
     t.index ["lesson_id", "vocabulary_id"], name: "index_lessons_vocabularies_on_lesson_id_and_vocabulary_id", unique: true
     t.index ["vocabulary_id", "lesson_id"], name: "index_lessons_vocabularies_on_vocabulary_id_and_lesson_id"
   end
 
-  create_table "level_concept_difficulties", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "level_concept_difficulties", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "level_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -719,7 +719,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["level_id"], name: "index_level_concept_difficulties_on_level_id"
   end
 
-  create_table "level_source_images", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "level_source_images", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "level_source_id", unsigned: true
     t.binary "image", size: :medium
     t.datetime "created_at"
@@ -727,7 +727,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["level_source_id"], name: "index_level_source_images_on_level_source_id"
   end
 
-  create_table "level_sources", id: :bigint, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "level_sources", id: :bigint, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "level_id"
     t.string "md5", limit: 32, null: false
     t.string "data", limit: 20000, null: false
@@ -737,7 +737,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["level_id", "md5"], name: "index_level_sources_on_level_id_and_md5"
   end
 
-  create_table "level_sources_multi_types", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "level_sources_multi_types", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "level_source_id", null: false, unsigned: true
     t.integer "level_id", null: false
     t.text "data"
@@ -747,7 +747,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["level_source_id"], name: "index_level_sources_multi_types_on_level_source_id"
   end
 
-  create_table "levels", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "levels", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "game_id"
     t.string "name", null: false
     t.datetime "created_at"
@@ -766,7 +766,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["name"], name: "index_levels_on_name"
   end
 
-  create_table "levels_script_levels", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "levels_script_levels", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "level_id", null: false
     t.integer "script_level_id", null: false
     t.index ["level_id"], name: "index_levels_script_levels_on_level_id"
@@ -774,14 +774,14 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["script_level_id"], name: "index_levels_script_levels_on_script_level_id"
   end
 
-  create_table "libraries", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "libraries", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.text "content"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "metrics", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "metrics", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.date "computed_on", null: false
@@ -794,7 +794,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.float "value", null: false
   end
 
-  create_table "objectives", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "objectives", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.text "properties"
     t.integer "lesson_id"
     t.datetime "created_at", null: false
@@ -804,7 +804,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["lesson_id"], name: "index_objectives_on_lesson_id"
   end
 
-  create_table "other_curriculum_offerings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "other_curriculum_offerings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "curriculum_provider_name", null: false
     t.string "school_id", limit: 12, null: false
     t.string "course", null: false
@@ -815,7 +815,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["school_id"], name: "fk_rails_5682e60354"
   end
 
-  create_table "paired_user_levels", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "paired_user_levels", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "driver_user_level_id", unsigned: true
     t.bigint "navigator_user_level_id", unsigned: true
     t.datetime "created_at", null: false
@@ -824,7 +824,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["navigator_user_level_id"], name: "index_paired_user_levels_on_navigator_user_level_id"
   end
 
-  create_table "parent_levels_child_levels", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "parent_levels_child_levels", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "parent_level_id", null: false
     t.integer "child_level_id", null: false
     t.integer "position"
@@ -833,7 +833,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["parent_level_id"], name: "index_parent_levels_child_levels_on_parent_level_id"
   end
 
-  create_table "pd_accepted_programs", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_accepted_programs", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "workshop_name", null: false
@@ -842,7 +842,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.integer "teacher_application_id"
   end
 
-  create_table "pd_application_emails", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_application_emails", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "pd_application_id", null: false
     t.string "application_status", null: false
     t.string "email_type", null: false
@@ -852,14 +852,14 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["pd_application_id"], name: "index_pd_application_emails_on_pd_application_id"
   end
 
-  create_table "pd_application_tags", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_application_tags", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_pd_application_tags_on_name", unique: true
   end
 
-  create_table "pd_application_tags_applications", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_application_tags_applications", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "pd_application_id", null: false
     t.integer "pd_application_tag_id", null: false
     t.datetime "created_at", null: false
@@ -868,7 +868,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["pd_application_tag_id"], name: "index_pd_application_tags_applications_on_pd_application_tag_id"
   end
 
-  create_table "pd_applications", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_applications", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
     t.string "type", null: false
     t.string "application_year", null: false
@@ -898,14 +898,14 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["user_id"], name: "index_pd_applications_on_user_id"
   end
 
-  create_table "pd_applications_status_logs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_applications_status_logs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "pd_application_id", null: false
     t.string "status", null: false
     t.datetime "timestamp", null: false
     t.integer "position", null: false
   end
 
-  create_table "pd_attendances", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_attendances", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "pd_session_id", null: false
     t.integer "teacher_id"
     t.datetime "created_at"
@@ -919,14 +919,14 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["teacher_id"], name: "index_pd_attendances_on_teacher_id"
   end
 
-  create_table "pd_course_facilitators", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_course_facilitators", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "facilitator_id", null: false
     t.string "course", null: false
     t.index ["course"], name: "index_pd_course_facilitators_on_course"
     t.index ["facilitator_id", "course"], name: "index_pd_course_facilitators_on_facilitator_id_and_course", unique: true
   end
 
-  create_table "pd_district_payment_terms", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_district_payment_terms", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "school_district_id"
     t.string "course", null: false
     t.string "rate_type", null: false
@@ -934,7 +934,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["school_district_id", "course"], name: "index_pd_district_payment_terms_school_district_course"
   end
 
-  create_table "pd_enrollment_notifications", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_enrollment_notifications", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "pd_enrollment_id", null: false
@@ -942,7 +942,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["pd_enrollment_id"], name: "index_pd_enrollment_notifications_on_pd_enrollment_id"
   end
 
-  create_table "pd_enrollments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_enrollments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "pd_workshop_id", null: false
     t.string "name"
     t.string "first_name"
@@ -964,7 +964,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["pd_workshop_id"], name: "index_pd_enrollments_on_pd_workshop_id"
   end
 
-  create_table "pd_facilitator_program_registrations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_facilitator_program_registrations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.text "form_data"
     t.datetime "created_at", null: false
@@ -973,7 +973,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["user_id", "teachercon"], name: "index_pd_fac_prog_reg_on_user_id_and_teachercon", unique: true
   end
 
-  create_table "pd_facilitator_teachercon_attendances", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_facilitator_teachercon_attendances", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.date "tc1_arrive"
     t.date "tc1_depart"
@@ -993,7 +993,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["user_id"], name: "index_pd_facilitator_teachercon_attendances_on_user_id"
   end
 
-  create_table "pd_fit_weekend1819_registrations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_fit_weekend1819_registrations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "pd_application_id"
     t.text "form_data"
     t.datetime "created_at", null: false
@@ -1001,7 +1001,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["pd_application_id"], name: "index_pd_fit_weekend1819_registrations_on_pd_application_id"
   end
 
-  create_table "pd_fit_weekend_registrations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_fit_weekend_registrations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "pd_application_id"
     t.string "registration_year", null: false
     t.text "form_data"
@@ -1011,7 +1011,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["registration_year"], name: "index_pd_fit_weekend_registrations_on_registration_year"
   end
 
-  create_table "pd_international_opt_ins", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_international_opt_ins", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.text "form_data", null: false
     t.datetime "created_at", null: false
@@ -1019,7 +1019,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["user_id"], name: "index_pd_international_opt_ins_on_user_id"
   end
 
-  create_table "pd_legacy_survey_summaries", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_legacy_survey_summaries", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "facilitator_id"
     t.string "course"
     t.string "subject"
@@ -1028,7 +1028,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "pd_misc_surveys", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_misc_surveys", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "form_id", null: false
     t.bigint "submission_id", null: false
     t.text "answers"
@@ -1040,7 +1040,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["user_id"], name: "index_pd_misc_surveys_on_user_id"
   end
 
-  create_table "pd_payment_terms", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_payment_terms", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "regional_partner_id", null: false
     t.date "start_date", null: false
     t.date "end_date"
@@ -1052,7 +1052,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["regional_partner_id"], name: "index_pd_payment_terms_on_regional_partner_id"
   end
 
-  create_table "pd_post_course_surveys", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_post_course_surveys", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "form_id", null: false
     t.bigint "submission_id", null: false
     t.text "answers"
@@ -1067,7 +1067,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["user_id"], name: "index_pd_post_course_surveys_on_user_id"
   end
 
-  create_table "pd_pre_workshop_surveys", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_pre_workshop_surveys", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "pd_enrollment_id", null: false
     t.text "form_data", null: false
     t.datetime "created_at", null: false
@@ -1075,7 +1075,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["pd_enrollment_id"], name: "index_pd_pre_workshop_surveys_on_pd_enrollment_id", unique: true
   end
 
-  create_table "pd_regional_partner_cohorts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_regional_partner_cohorts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "regional_partner_id"
     t.integer "role", comment: "teacher or facilitator"
     t.string "year", comment: "free-form text year range, YYYY-YYYY, e.g. 2016-2017"
@@ -1089,14 +1089,14 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["summer_workshop_id"], name: "index_pd_regional_partner_cohorts_on_summer_workshop_id"
   end
 
-  create_table "pd_regional_partner_cohorts_users", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_regional_partner_cohorts_users", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "pd_regional_partner_cohort_id", null: false
     t.integer "user_id", null: false
     t.index ["pd_regional_partner_cohort_id"], name: "index_pd_regional_partner_cohorts_users_on_cohort_id"
     t.index ["user_id"], name: "index_pd_regional_partner_cohorts_users_on_user_id"
   end
 
-  create_table "pd_regional_partner_contacts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_regional_partner_contacts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
     t.integer "regional_partner_id"
     t.text "form_data"
@@ -1106,7 +1106,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["user_id"], name: "index_pd_regional_partner_contacts_on_user_id"
   end
 
-  create_table "pd_regional_partner_mappings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_regional_partner_mappings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "regional_partner_id", null: false
     t.string "state"
     t.string "zip_code"
@@ -1117,7 +1117,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["regional_partner_id"], name: "index_pd_regional_partner_mappings_on_regional_partner_id"
   end
 
-  create_table "pd_regional_partner_mini_contacts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_regional_partner_mini_contacts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
     t.integer "regional_partner_id"
     t.text "form_data"
@@ -1127,7 +1127,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["user_id"], name: "index_pd_regional_partner_mini_contacts_on_user_id"
   end
 
-  create_table "pd_regional_partner_program_registrations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_regional_partner_program_registrations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.text "form_data"
     t.integer "teachercon", null: false
@@ -1136,7 +1136,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["user_id", "teachercon"], name: "index_pd_reg_part_prog_reg_on_user_id_and_teachercon"
   end
 
-  create_table "pd_scholarship_infos", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_scholarship_infos", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "application_year", null: false
     t.string "scholarship_status", null: false
@@ -1151,7 +1151,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["user_id"], name: "index_pd_scholarship_infos_on_user_id"
   end
 
-  create_table "pd_sessions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_sessions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "pd_workshop_id"
     t.datetime "start", null: false
     t.datetime "end", null: false
@@ -1163,7 +1163,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["pd_workshop_id"], name: "index_pd_sessions_on_pd_workshop_id"
   end
 
-  create_table "pd_survey_questions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_survey_questions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "form_id"
     t.text "questions", null: false, comment: "JSON Question data for this JotForm form."
     t.datetime "created_at", null: false
@@ -1172,7 +1172,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["form_id"], name: "index_pd_survey_questions_on_form_id", unique: true
   end
 
-  create_table "pd_teacher_applications", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_teacher_applications", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "user_id", null: false
@@ -1186,7 +1186,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["user_id"], name: "index_pd_teacher_applications_on_user_id", unique: true
   end
 
-  create_table "pd_teachercon1819_registrations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_teachercon1819_registrations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "pd_application_id"
     t.text "form_data"
     t.datetime "created_at", null: false
@@ -1198,7 +1198,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["user_id"], name: "index_pd_teachercon1819_registrations_on_user_id"
   end
 
-  create_table "pd_teachercon_surveys", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_teachercon_surveys", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "pd_enrollment_id", null: false
     t.text "form_data", null: false
     t.datetime "created_at", null: false
@@ -1206,7 +1206,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["pd_enrollment_id"], name: "index_pd_teachercon_surveys_on_pd_enrollment_id", unique: true
   end
 
-  create_table "pd_workshop_daily_surveys", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_workshop_daily_surveys", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "form_id", null: false
     t.bigint "submission_id", null: false
     t.integer "user_id", null: false
@@ -1224,7 +1224,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["user_id"], name: "index_pd_workshop_daily_surveys_on_user_id"
   end
 
-  create_table "pd_workshop_facilitator_daily_surveys", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_workshop_facilitator_daily_surveys", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "form_id", null: false
     t.bigint "submission_id", null: false
     t.integer "user_id", null: false
@@ -1244,7 +1244,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["user_id"], name: "index_pd_workshop_facilitator_daily_surveys_on_user_id"
   end
 
-  create_table "pd_workshop_survey_foorm_submissions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_workshop_survey_foorm_submissions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "foorm_submission_id", null: false
     t.integer "user_id", null: false
     t.integer "pd_session_id"
@@ -1260,7 +1260,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["user_id"], name: "index_pd_workshop_survey_foorm_submissions_on_user_id"
   end
 
-  create_table "pd_workshop_surveys", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_workshop_surveys", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "pd_enrollment_id", null: false
     t.text "form_data", null: false
     t.datetime "created_at", null: false
@@ -1269,7 +1269,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["pd_enrollment_id"], name: "index_pd_workshop_surveys_on_pd_enrollment_id", unique: true
   end
 
-  create_table "pd_workshops", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_workshops", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "organizer_id", null: false
     t.string "location_name"
     t.string "location_address"
@@ -1294,14 +1294,14 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["regional_partner_id"], name: "index_pd_workshops_on_regional_partner_id"
   end
 
-  create_table "pd_workshops_facilitators", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_workshops_facilitators", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "pd_workshop_id", null: false
     t.integer "user_id", null: false
     t.index ["pd_workshop_id"], name: "index_pd_workshops_facilitators_on_pd_workshop_id"
     t.index ["user_id"], name: "index_pd_workshops_facilitators_on_user_id"
   end
 
-  create_table "peer_reviews", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "peer_reviews", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "submitter_id"
     t.integer "reviewer_id"
     t.boolean "from_instructor", default: false, null: false
@@ -1320,7 +1320,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["submitter_id"], name: "index_peer_reviews_on_submitter_id"
   end
 
-  create_table "pilots", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pilots", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "display_name", null: false
     t.boolean "allow_joining_via_url", null: false
@@ -1329,7 +1329,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["name"], name: "index_pilots_on_name", unique: true
   end
 
-  create_table "plc_course_units", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "plc_course_units", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "plc_course_id"
     t.string "unit_name"
     t.text "unit_description"
@@ -1342,14 +1342,14 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["script_id"], name: "index_plc_course_units_on_script_id"
   end
 
-  create_table "plc_courses", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "plc_courses", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "course_id"
     t.index ["course_id"], name: "fk_rails_d5fc777f73"
   end
 
-  create_table "plc_enrollment_module_assignments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "plc_enrollment_module_assignments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "plc_enrollment_unit_assignment_id"
     t.integer "plc_learning_module_id"
     t.datetime "created_at", null: false
@@ -1360,7 +1360,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["user_id"], name: "index_plc_enrollment_module_assignments_on_user_id"
   end
 
-  create_table "plc_enrollment_unit_assignments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "plc_enrollment_unit_assignments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "plc_user_course_enrollment_id"
     t.integer "plc_course_unit_id"
     t.string "status"
@@ -1372,7 +1372,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["user_id"], name: "index_plc_enrollment_unit_assignments_on_user_id"
   end
 
-  create_table "plc_learning_modules", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "plc_learning_modules", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -1383,7 +1383,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["stage_id"], name: "index_plc_learning_modules_on_stage_id"
   end
 
-  create_table "plc_user_course_enrollments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "plc_user_course_enrollments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "status"
     t.integer "plc_course_id"
     t.integer "user_id"
@@ -1393,7 +1393,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["user_id", "plc_course_id"], name: "index_plc_user_course_enrollments_on_user_id_and_plc_course_id", unique: true
   end
 
-  create_table "programming_classes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "programming_classes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "programming_environment_id"
     t.integer "programming_environment_category_id"
     t.string "key"
@@ -1410,7 +1410,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["key", "programming_environment_id"], name: "index_programming_classes_on_key_and_programming_environment_id", unique: true
   end
 
-  create_table "programming_environment_categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "programming_environment_categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "programming_environment_id", null: false
     t.string "key", null: false
     t.string "name"
@@ -1422,7 +1422,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["programming_environment_id"], name: "index_programming_environment_categories_on_environment_id"
   end
 
-  create_table "programming_environments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "programming_environments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.text "properties"
     t.datetime "created_at", null: false
@@ -1431,7 +1431,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["name"], name: "index_programming_environments_on_name", unique: true
   end
 
-  create_table "programming_expressions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "programming_expressions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "category"
     t.text "properties"
@@ -1446,7 +1446,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["programming_environment_id"], name: "index_programming_expressions_on_programming_environment_id"
   end
 
-  create_table "programming_methods", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "programming_methods", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "programming_class_id"
     t.string "key"
     t.integer "position"
@@ -1474,7 +1474,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["storage_app_id"], name: "index_project_commits_on_storage_app_id"
   end
 
-  create_table "projects", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+  create_table "projects", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "storage_id"
     t.text "value", size: :medium
     t.datetime "updated_at", null: false
@@ -1494,7 +1494,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["storage_id"], name: "storage_apps_storage_id_index"
   end
 
-  create_table "puzzle_ratings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "puzzle_ratings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
     t.integer "script_id"
     t.integer "level_id"
@@ -1505,7 +1505,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["user_id", "script_id", "level_id"], name: "index_puzzle_ratings_on_user_id_and_script_id_and_level_id", unique: true
   end
 
-  create_table "queued_account_purges", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "queued_account_purges", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.text "reason_for_review"
     t.datetime "created_at", null: false
@@ -1513,7 +1513,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["user_id"], name: "index_queued_account_purges_on_user_id", unique: true
   end
 
-  create_table "reference_guides", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "reference_guides", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "key", null: false
     t.bigint "course_version_id", null: false
     t.string "parent_reference_guide_key"
@@ -1526,14 +1526,14 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["course_version_id", "parent_reference_guide_key"], name: "index_reference_guides_on_course_version_id_and_parent_key"
   end
 
-  create_table "regional_partner_program_managers", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "regional_partner_program_managers", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "program_manager_id", null: false
     t.integer "regional_partner_id", null: false
     t.index ["program_manager_id"], name: "index_regional_partner_program_managers_on_program_manager_id"
     t.index ["regional_partner_id"], name: "index_regional_partner_program_managers_on_regional_partner_id"
   end
 
-  create_table "regional_partners", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "regional_partners", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.integer "group"
     t.boolean "urban"
@@ -1549,9 +1549,10 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.datetime "updated_at", null: false
     t.datetime "deleted_at"
     t.text "properties"
+    t.boolean "inactive"
   end
 
-  create_table "regional_partners_school_districts", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "regional_partners_school_districts", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "regional_partner_id", null: false
     t.integer "school_district_id", null: false
     t.string "course", comment: "Course for a given workshop"
@@ -1560,7 +1561,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["school_district_id"], name: "index_regional_partners_school_districts_on_school_district_id"
   end
 
-  create_table "resources", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "resources", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.string "url", null: false
     t.string "key", null: false
@@ -1572,7 +1573,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["name", "url"], name: "index_resources_on_name_and_url", type: :fulltext
   end
 
-  create_table "school_districts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "school_districts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "city", null: false
     t.string "state", null: false
@@ -1584,7 +1585,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["state"], name: "index_school_districts_on_state"
   end
 
-  create_table "school_infos", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "school_infos", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "country"
     t.string "school_type"
     t.integer "zip"
@@ -1603,7 +1604,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["school_id"], name: "index_school_infos_on_school_id"
   end
 
-  create_table "school_stats_by_years", primary_key: ["school_id", "school_year"], options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "school_stats_by_years", primary_key: ["school_id", "school_year"], options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "school_id", limit: 12, null: false, comment: "NCES public school ID"
     t.string "school_year", limit: 9, null: false, comment: "School Year"
     t.string "grades_offered_lo", limit: 2, comment: "Grades Offered - Lowest"
@@ -1640,7 +1641,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["school_id"], name: "index_school_stats_by_years_on_school_id"
   end
 
-  create_table "schools", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "schools", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "id", limit: 12, null: false, comment: "NCES public school ID"
     t.integer "school_district_id"
     t.string "name", null: false
@@ -1666,7 +1667,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["zip"], name: "index_schools_on_zip"
   end
 
-  create_table "script_levels", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "script_levels", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "script_id", null: false
     t.integer "chapter"
     t.datetime "created_at"
@@ -1686,7 +1687,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["stage_id"], name: "index_script_levels_on_stage_id"
   end
 
-  create_table "scripts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "scripts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -1710,21 +1711,21 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["wrapup_video_id"], name: "index_scripts_on_wrapup_video_id"
   end
 
-  create_table "scripts_resources", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "scripts_resources", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "script_id"
     t.integer "resource_id"
     t.index ["resource_id", "script_id"], name: "index_scripts_resources_on_resource_id_and_script_id"
     t.index ["script_id", "resource_id"], name: "index_scripts_resources_on_script_id_and_resource_id", unique: true
   end
 
-  create_table "scripts_student_resources", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "scripts_student_resources", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "script_id"
     t.integer "resource_id"
     t.index ["resource_id", "script_id"], name: "index_scripts_student_resources_on_resource_id_and_script_id"
     t.index ["script_id", "resource_id"], name: "index_scripts_student_resources_on_script_id_and_resource_id", unique: true
   end
 
-  create_table "secret_pictures", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "secret_pictures", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "path", null: false
     t.datetime "created_at"
@@ -1733,28 +1734,28 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["path"], name: "index_secret_pictures_on_path", unique: true
   end
 
-  create_table "secret_words", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "secret_words", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "word", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["word"], name: "index_secret_words_on_word", unique: true
   end
 
-  create_table "section_hidden_scripts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "section_hidden_scripts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "section_id", null: false
     t.integer "script_id", null: false
     t.index ["script_id"], name: "index_section_hidden_scripts_on_script_id"
     t.index ["section_id"], name: "index_section_hidden_scripts_on_section_id"
   end
 
-  create_table "section_hidden_stages", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "section_hidden_stages", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "section_id", null: false
     t.integer "stage_id", null: false
     t.index ["section_id"], name: "index_section_hidden_stages_on_section_id"
     t.index ["stage_id"], name: "index_section_hidden_stages_on_stage_id"
   end
 
-  create_table "sections", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "sections", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "name"
     t.datetime "created_at"
@@ -1780,13 +1781,13 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["user_id"], name: "index_sections_on_user_id"
   end
 
-  create_table "seed_info", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "seed_info", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "table", null: false
     t.datetime "mtime"
     t.index ["table"], name: "index_seed_info_on_table"
   end
 
-  create_table "seeded_s3_objects", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "seeded_s3_objects", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "bucket"
     t.string "key"
     t.string "etag"
@@ -1795,7 +1796,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["bucket", "key", "etag"], name: "index_seeded_s3_objects_on_bucket_and_key_and_etag"
   end
 
-  create_table "shared_blockly_functions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "shared_blockly_functions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "level_type"
     t.integer "block_type", default: 0, null: false
@@ -1805,7 +1806,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.text "stack"
   end
 
-  create_table "sign_ins", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "sign_ins", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.datetime "sign_in_at", null: false
     t.integer "sign_in_count", null: false
@@ -1813,7 +1814,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["user_id"], name: "index_sign_ins_on_user_id"
   end
 
-  create_table "stages", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "stages", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.integer "absolute_position"
     t.integer "script_id", null: false
@@ -1829,7 +1830,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["script_id", "key"], name: "index_stages_on_script_id_and_key", unique: true
   end
 
-  create_table "stages_standards", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "stages_standards", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "stage_id", null: false
     t.integer "standard_id", null: false
     t.datetime "created_at", null: false
@@ -1838,7 +1839,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["standard_id"], name: "index_stages_standards_on_standard_id"
   end
 
-  create_table "standard_categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "standard_categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "shortcode", null: false
     t.integer "framework_id", null: false
     t.integer "parent_category_id"
@@ -1850,7 +1851,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["parent_category_id"], name: "index_standard_categories_on_parent_category_id"
   end
 
-  create_table "standards", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "standards", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.text "description"
     t.bigint "category_id"
     t.integer "framework_id"
@@ -1860,7 +1861,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["framework_id", "shortcode"], name: "index_standards_on_framework_id_and_shortcode"
   end
 
-  create_table "state_cs_offerings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "state_cs_offerings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "state_school_id", null: false
     t.string "course", null: false
     t.integer "school_year", limit: 2, null: false
@@ -1869,13 +1870,13 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["state_school_id", "school_year", "course"], name: "index_state_cs_offerings_on_id_and_year_and_course", unique: true
   end
 
-  create_table "studio_people", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "studio_people", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "emails"
   end
 
-  create_table "survey_results", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "survey_results", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
     t.string "kind"
     t.text "properties"
@@ -1885,7 +1886,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["user_id"], name: "index_survey_results_on_user_id"
   end
 
-  create_table "teacher_feedbacks", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "teacher_feedbacks", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.text "comment"
     t.integer "student_id"
     t.integer "level_id", null: false
@@ -1905,7 +1906,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["teacher_id"], name: "index_teacher_feedbacks_on_teacher_id"
   end
 
-  create_table "teacher_profiles", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "teacher_profiles", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "studio_person_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -1919,7 +1920,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["studio_person_id"], name: "index_teacher_profiles_on_studio_person_id"
   end
 
-  create_table "teacher_scores", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "teacher_scores", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "user_level_id", unsigned: true
     t.integer "teacher_id"
     t.integer "score"
@@ -1928,7 +1929,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["user_level_id"], name: "index_teacher_scores_on_user_level_id"
   end
 
-  create_table "unit_groups", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "unit_groups", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.text "properties"
     t.datetime "created_at", null: false
@@ -1944,21 +1945,21 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["published_state"], name: "index_unit_groups_on_published_state"
   end
 
-  create_table "unit_groups_resources", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "unit_groups_resources", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "unit_group_id"
     t.integer "resource_id"
     t.index ["resource_id", "unit_group_id"], name: "index_unit_groups_resources_on_resource_id_and_unit_group_id"
     t.index ["unit_group_id", "resource_id"], name: "index_unit_groups_resources_on_unit_group_id_and_resource_id", unique: true
   end
 
-  create_table "unit_groups_student_resources", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "unit_groups_student_resources", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "unit_group_id"
     t.integer "resource_id"
     t.index ["resource_id", "unit_group_id"], name: "index_ug_student_resources_on_resource_id_and_unit_group_id"
     t.index ["unit_group_id", "resource_id"], name: "index_ug_student_resources_on_unit_group_id_and_resource_id", unique: true
   end
 
-  create_table "user_geos", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "user_geos", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -1974,7 +1975,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["user_id"], name: "index_user_geos_on_user_id"
   end
 
-  create_table "user_levels", id: :bigint, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "user_levels", id: :bigint, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "level_id", null: false
     t.integer "attempts", default: 0, null: false
@@ -1992,7 +1993,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["user_id", "script_id", "level_id", "deleted_at"], name: "index_user_levels_unique", unique: true
   end
 
-  create_table "user_ml_models", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "user_ml_models", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
     t.string "model_id"
     t.string "name"
@@ -2005,7 +2006,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["user_id"], name: "index_user_ml_models_on_user_id"
   end
 
-  create_table "user_module_task_assignments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "user_module_task_assignments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_enrollment_module_assignment_id"
     t.integer "professional_learning_task_id"
     t.string "status"
@@ -2013,7 +2014,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["user_enrollment_module_assignment_id"], name: "task_assignment_to_module_assignment_index"
   end
 
-  create_table "user_permissions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "user_permissions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "permission", null: false
     t.datetime "created_at"
@@ -2021,7 +2022,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["user_id", "permission"], name: "index_user_permissions_on_user_id_and_permission", unique: true
   end
 
-  create_table "user_proficiencies", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "user_proficiencies", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -2080,13 +2081,13 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["user_id"], name: "index_user_proficiencies_on_user_id", unique: true
   end
 
-  create_table "user_project_storage_ids", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "user_project_storage_ids", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
     t.integer "user_id"
     t.index ["user_id"], name: "user_id", unique: true
     t.index ["user_id"], name: "user_storage_ids_user_id_index"
   end
 
-  create_table "user_school_infos", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "user_school_infos", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.datetime "start_date", null: false
     t.datetime "end_date"
@@ -2097,7 +2098,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["user_id"], name: "index_user_school_infos_on_user_id"
   end
 
-  create_table "user_scripts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "user_scripts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "script_id", null: false
     t.datetime "started_at"
@@ -2112,7 +2113,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["user_id", "script_id", "deleted_at"], name: "index_user_scripts_on_user_id_and_script_id_and_deleted_at", unique: true
   end
 
-  create_table "users", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "users", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "studio_person_id"
     t.string "email", default: "", null: false
     t.string "parent_email"
@@ -2176,7 +2177,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["username", "deleted_at"], name: "index_users_on_username_and_deleted_at", unique: true
   end
 
-  create_table "videos", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "videos", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "key"
     t.string "youtube_code"
     t.datetime "created_at"
@@ -2186,7 +2187,7 @@ ActiveRecord::Schema.define(version: 2023_02_14_123814) do
     t.index ["key", "locale"], name: "index_videos_on_key_and_locale", unique: true
   end
 
-  create_table "vocabularies", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "vocabularies", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "key", null: false
     t.string "word", null: false
     t.text "definition", null: false

--- a/dashboard/test/models/regional_partner_test.rb
+++ b/dashboard/test/models/regional_partner_test.rb
@@ -19,7 +19,8 @@ class RegionalPartnerTest < ActiveSupport::TestCase
         city: 'Seattle',
         state: 'WA',
         zip_code: '98101',
-        phone_number: '555-111-2222'
+        phone_number: '555-111-2222',
+        inactive: true
     end
   end
 


### PR DESCRIPTION
This is the first part of a two part change to add a new field on the [Regional Partner edit page](https://studio.code.org/regional_partners/1/edit) that is a checkbox which is “Is Active Regional Partner”. 

## Links

- jira ticket: https://codedotorg.atlassian.net/browse/ACQ-251?atlOrigin=eyJpIjoiODZlZjQ3NWNkNThjNDNkN2E1ZmMzMzZmNzk0NWMzZGMiLCJwIjoiaiJ9


## Testing story

Included updates in existing basic test for model to ensure the new field can be set.

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy
Change include a DB migration file. Will commit the change to leverage this new field only after this change is rolled out to production and baked for a few days.

## Follow-up work

Second part of this work would be to use the new field in regional partners edit page

- [x ] Tests provide adequate coverage
- [x ] Privacy and Security impacts have been assessed
- [x ] Code is well-commented
- [x ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [x ] User impact is well-understood and desirable
- [x ] Pull Request is labeled appropriately
- [x ] Follow-up work items (including potential tech debt) are tracked and linked
