### PR TITLE
Pulls in PL Course Offerings to new table, updates styling, tests

### DIFF
--- a/apps/src/templates/sectionsRefresh/CurriculumQuickAssign.jsx
+++ b/apps/src/templates/sectionsRefresh/CurriculumQuickAssign.jsx
@@ -20,6 +20,8 @@ export default function CurriculumQuickAssign({updateSection, sectionCourse}) {
   const [decideLater, setDecideLater] = useState(false);
   const [marketingAudience, setMarketingAudience] = useState(null);
 
+  const showPlOfferings = queryParams('participantType') === 'teacher';
+
   // Retrieve course offerings on mount and convert to JSON
   useEffect(() => {
     const participantType = queryParams('participantType');
@@ -72,10 +74,10 @@ export default function CurriculumQuickAssign({updateSection, sectionCourse}) {
           onChange={toggleDecideLater}
         />
         <h3>{i18n.assignACurriculum()}</h3>
-        <h5>{i18n.useDropdownMessage()}</h5>
+        <h4>{i18n.useDropdownMessage()}</h4>
       </div>
       <CurriculumQuickAssignTopRow
-        showPlOfferings={false}
+        showPlOfferings={showPlOfferings}
         marketingAudience={marketingAudience}
         updateMarketingAudience={updateMarketingAudience}
       />

--- a/apps/src/templates/sectionsRefresh/CurriculumQuickAssign.jsx
+++ b/apps/src/templates/sectionsRefresh/CurriculumQuickAssign.jsx
@@ -20,7 +20,7 @@ export default function CurriculumQuickAssign({updateSection, sectionCourse}) {
   const [decideLater, setDecideLater] = useState(false);
   const [marketingAudience, setMarketingAudience] = useState(null);
 
-  const showPlOfferings = queryParams('participantType') === 'teacher';
+  const showPlOfferings = queryParams('participantType') !== 'student';
 
   // Retrieve course offerings on mount and convert to JSON
   useEffect(() => {

--- a/apps/src/templates/sectionsRefresh/CurriculumQuickAssign.jsx
+++ b/apps/src/templates/sectionsRefresh/CurriculumQuickAssign.jsx
@@ -56,7 +56,8 @@ export default function CurriculumQuickAssign({updateSection, sectionCourse}) {
   // To distinguish between types of tables: HOC & PL vs Grade Bands
   const isPlOrHoc = () => {
     return (
-      marketingAudience === (MARKETING_AUDIENCE.HOC || MARKETING_AUDIENCE.PL)
+      marketingAudience === MARKETING_AUDIENCE.HOC ||
+      marketingAudience === MARKETING_AUDIENCE.PL
     );
   };
 
@@ -74,7 +75,7 @@ export default function CurriculumQuickAssign({updateSection, sectionCourse}) {
           onChange={toggleDecideLater}
         />
         <h3>{i18n.assignACurriculum()}</h3>
-        <h4>{i18n.useDropdownMessage()}</h4>
+        <h5>{i18n.useDropdownMessage()}</h5>
       </div>
       <CurriculumQuickAssignTopRow
         showPlOfferings={showPlOfferings}

--- a/apps/src/templates/sectionsRefresh/CurriculumQuickAssignTopRow.jsx
+++ b/apps/src/templates/sectionsRefresh/CurriculumQuickAssignTopRow.jsx
@@ -68,7 +68,7 @@ export default function CurriculumQuickAssignTopRow({
         <Button
           id={'uitest-hoc-button'}
           className={moduleStyles.buttonStyle}
-          text={i18n.courseOfferingHOC()}
+          text={i18n.teacherCourseHoc()}
           size={Button.ButtonSize.large}
           icon={
             marketingAudience === MARKETING_AUDIENCE.HOC

--- a/apps/src/templates/sectionsRefresh/QuickAssignTableHocPl.jsx
+++ b/apps/src/templates/sectionsRefresh/QuickAssignTableHocPl.jsx
@@ -77,10 +77,10 @@ export default function QuickAssignTableHocPl({
   return (
     <div>
       {marketingAudience === MARKETING_AUDIENCE.HOC && (
-        <div>{allTables(i18n.courseOfferingHOC())}</div>
+        <div>{allTables(i18n.teacherCourseHoc())}</div>
       )}
       {marketingAudience === MARKETING_AUDIENCE.PL && (
-        <div>{allTables(i18n.ProfessionalLearning())}</div>
+        <div>{allTables(i18n.professionalLearning())}</div>
       )}
     </div>
   );

--- a/apps/src/templates/sectionsRefresh/sections-refresh.module.scss
+++ b/apps/src/templates/sectionsRefresh/sections-refresh.module.scss
@@ -88,5 +88,4 @@
 
 .label {
   margin: 10px 0 0 5px;
-  text-align: center;
 }

--- a/apps/src/templates/sectionsRefresh/sections-refresh.module.scss
+++ b/apps/src/templates/sectionsRefresh/sections-refresh.module.scss
@@ -87,5 +87,5 @@
 }
 
 .label {
-  margin: 10px 0 0 5px;
+  margin: 10px 10px 0 5px;
 }

--- a/apps/test/unit/templates/sectionsRefresh/CurriculumQuickAssignTest.jsx
+++ b/apps/test/unit/templates/sectionsRefresh/CurriculumQuickAssignTest.jsx
@@ -11,7 +11,7 @@ describe('CurriculumQuickAssign', () => {
     );
 
     expect(wrapper.find('h3').length).to.equal(1);
-    expect(wrapper.find('h5').length).to.equal(1);
+    expect(wrapper.find('h4').length).to.equal(1);
     expect(wrapper.find('Button').length).to.equal(4);
     expect(
       wrapper

--- a/apps/test/unit/templates/sectionsRefresh/CurriculumQuickAssignTest.jsx
+++ b/apps/test/unit/templates/sectionsRefresh/CurriculumQuickAssignTest.jsx
@@ -11,7 +11,7 @@ describe('CurriculumQuickAssign', () => {
     );
 
     expect(wrapper.find('h3').length).to.equal(1);
-    expect(wrapper.find('h4').length).to.equal(1);
+    expect(wrapper.find('h5').length).to.equal(1);
     expect(wrapper.find('Button').length).to.equal(4);
     expect(
       wrapper

--- a/apps/test/unit/templates/sectionsRefresh/CurriculumQuickAssignTest.jsx
+++ b/apps/test/unit/templates/sectionsRefresh/CurriculumQuickAssignTest.jsx
@@ -12,7 +12,8 @@ describe('CurriculumQuickAssign', () => {
 
     expect(wrapper.find('h3').length).to.equal(1);
     expect(wrapper.find('h5').length).to.equal(1);
-    expect(wrapper.find('Button').length).to.equal(4);
+    // We haven't specified participantType = student, so all 5 buttons appear
+    expect(wrapper.find('Button').length).to.equal(5);
     expect(
       wrapper
         .find('Button')

--- a/apps/test/unit/templates/sectionsRefresh/QuickAssignTableHocPlTest.jsx
+++ b/apps/test/unit/templates/sectionsRefresh/QuickAssignTableHocPlTest.jsx
@@ -3,7 +3,7 @@ import {shallow} from 'enzyme';
 import {expect} from '../../../util/reconfiguredChai';
 import QuickAssignTableHocPl from '@cdo/apps/templates/sectionsRefresh/QuickAssignTableHocPl';
 import {MARKETING_AUDIENCE} from '@cdo/apps/templates/sectionsRefresh/CurriculumQuickAssign';
-import {hocCourseOfferings} from './CourseOfferingsTestData';
+import {hocCourseOfferings, plCourseOfferings} from './CourseOfferingsTestData';
 import i18n from '@cdo/locale';
 
 describe('QuickAssignTable', () => {
@@ -50,6 +50,45 @@ describe('QuickAssignTable', () => {
         .find('table')
         .at(1)
         .contains('Sports')
+    ).to.be.true;
+  });
+
+  it('renders Professional Learning as the first and only table/column header', () => {
+    const wrapper = shallow(
+      <QuickAssignTableHocPl
+        marketingAudience={MARKETING_AUDIENCE.PL}
+        courseOfferings={plCourseOfferings}
+        updateCourse={() => {}}
+        sectionCourse={{}}
+      />
+    );
+    expect(wrapper.find('table').length).to.equal(3);
+    expect(wrapper.contains(i18n.professionalLearning())).to.be.true;
+  });
+
+  it('renders one header in each of the first two columns', () => {
+    const wrapper = shallow(
+      <QuickAssignTableHocPl
+        marketingAudience={MARKETING_AUDIENCE.PL}
+        courseOfferings={plCourseOfferings}
+        updateCourse={() => {}}
+        sectionCourse={{}}
+      />
+    );
+    expect(wrapper.find('table').length).to.equal(3);
+    // First header displays in table 0
+    expect(
+      wrapper
+        .find('table')
+        .at(0)
+        .contains('6–12 Virtual Academic Year Workshops')
+    ).to.be.true;
+    // Second header displays in table 1
+    expect(
+      wrapper
+        .find('table')
+        .at(1)
+        .contains('Self-Paced')
     ).to.be.true;
   });
 });


### PR DESCRIPTION
This PR adds the PL functionality by querying the url param for participant type. 
<img width="1124" alt="Screenshot 2023-03-09 at 11 07 12 AM" src="https://user-images.githubusercontent.com/37230822/224129364-3ac0fc30-ed97-4032-a39a-51a30c13f6c6.png">


It also updates the styling of the labels so that the course offerings are left aligned and there is a right margin to keep appropriate space on the right edge of the table.
<img width="1104" alt="Screenshot 2023-03-08 at 5 45 56 PM" src="https://user-images.githubusercontent.com/37230822/223894098-b8ffb5be-ddf1-4550-b502-18a15049fe64.png">


## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/TEACH-295
- https://codedotorg.atlassian.net/browse/TEACH-317

## Testing story

I added tests to the hocPl component to verify that the table renders as expected.

I will plan to add more tests for this area once I do the followup work to ensure only users with a facilitator permission can see this table

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
