### PR TITLE
adding dashboard/config/courses/*.course to sync-in

### DIFF
--- a/bin/i18n/sync-in.rb
+++ b/bin/i18n/sync-in.rb
@@ -568,7 +568,7 @@ def localize_course_resources
   # Currently, csd is the only fully translatable course that has resources in this directory
   translatable_courses = %w(csd)
   resources = {}
-  Dir.glob(File.join('dashboard', 'config', 'courses', '*.course')).sort.each do |file|
+  Dir.glob(File.join('dashboard', 'config', 'courses', '*.course')).each do |file|
     course_json = JSON.parse(File.read(file))
     course_properties = course_json['properties']
     next unless translatable_courses.include?(course_properties['family_name'])


### PR DESCRIPTION
This PR tackles a series of Jira tickets regarding CSD translatability bugs.

Currently the [landing page](https://studio.code.org/courses/csd-2022) for the CSD course have a couple items that are not translated.
This elements are translatable but the content has not been added to the sync.
In PR [#50450](https://github.com/code-dot-org/code-dot-org/pull/50450) `dashboard/config/locales/courses.en.yml` was added to the sync.
However some content of teacher resources dropdown menu was not translated yet.
<img width="459" alt="image" src="https://user-images.githubusercontent.com/66776217/223878373-d102e185-2f91-4690-89bb-1987512ac0d7.png">

The explanation for this partial translatability bug resides in resources being synced from `scrip_json` files. These files store content from Units, such as `csd1-2022.script_json`. In addition, resources for the whole course are stored in the `dashboard/config/courses` directory. These `*.course` files are not synced, therefore the only resources that appear translated are those shared between whole course and individual units.

This PR adds to the sync-in CSD resources stored in `*.course` files. Morover, it stores the added resources ussing the same key structure as Unit resources, that way, the existing i18n functions will be able to find this resources without any further changes.

## Links

- jira ticket: [P20-37](https://codedotorg.atlassian.net/browse/P20-37)
- jira ticket: [P20-38](https://codedotorg.atlassian.net/browse/P20-38)
- jira ticket: [P20-45](https://codedotorg.atlassian.net/browse/P20-45)

## Testing story

I ran the full sync:
- Checked that resources were correctly added to `courses.yml`
- Checked on crowding that resources were uploaded and created custom translations in the testing Crowdin project.
- Checked that content was correctly distributed

<img width="1728" alt="Screenshot 2023-03-08 at 13 12 37" src="https://user-images.githubusercontent.com/66776217/223888691-5968c427-975d-4d9d-98e8-64c1cc15f6a2.png">


## Deployment strategy
Changes made by this PR will be effective after the next i18n sync.

## Follow-up work

Some resources are not available for localization intentionally.

This PR maintains yml files as localization files. These files should be transitioned into json files as part of tech-debt reduction work.

## Security

As always, allowing translators to modify links is a potential risk.


## PR Checklist:



- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
