### PR TITLE
[Google Blockly] fix export

### DIFF
--- a/apps/src/blockly/themes/cdoHighContrast.js
+++ b/apps/src/blockly/themes/cdoHighContrast.js
@@ -65,7 +65,7 @@ const cdoHighContrastBlockStyles = {
   ...cdoCustomHighContrastStyles
 };
 
-const CdoHighContrastTheme = GoogleBlockly.Theme.defineTheme(
+export const CdoHighContrastTheme = GoogleBlockly.Theme.defineTheme(
   'cdohighcontrast',
   {
     base: HighContrastTheme,
@@ -81,7 +81,6 @@ const CdoHighContrastTheme = GoogleBlockly.Theme.defineTheme(
   }
 );
 
-export default CdoHighContrastTheme;
 export const MusicLabHighContrastTheme = GoogleBlockly.Theme.defineTheme(
   'musiclabhighcontrast',
   {


### PR DESCRIPTION
Fixes an export for a recently merged change. Now that there are multiple themes being exported, neither are being imported as the default in the wrapper.

Relates to:
- https://github.com/code-dot-org/code-dot-org/pull/50646