### PR TITLE
Music: fix pattern playback timing

### DIFF
--- a/apps/src/music/player/MusicPlayer.ts
+++ b/apps/src/music/player/MusicPlayer.ts
@@ -487,7 +487,7 @@ export default class MusicPlayer {
         const resultEvent = {
           sampleId: `${kit}/${event.src}`,
           offsetSeconds: this.convertPlayheadPositionToSeconds(
-            patternEvent.when + event.tick / 16
+            patternEvent.when + (event.tick-1) / 16
           ),
           triggered: patternEvent.triggered,
           effects: patternEvent.effects


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/50364.  When converting the entries in a pattern to samples, the code needs to compensate for the fact that the events inside a pattern have 1-based ticks.  (Why 1-based? Mainly to be consistent with measure timings in our playback events, which are also 1-based.)  Before this fix, drum sounds were being played a 1/16 note too late.
