### PR TITLE
Updating regional partners DB to include new 'isactive' field

### DIFF
--- a/dashboard/app/models/regional_partner.rb
+++ b/dashboard/app/models/regional_partner.rb
@@ -18,6 +18,7 @@
 #  updated_at         :datetime         not null
 #  deleted_at         :datetime
 #  properties         :text(65535)
+#  is_active          :boolean
 #
 
 require 'state_abbr'

--- a/dashboard/app/serializers/regional_partner_serializer.rb
+++ b/dashboard/app/serializers/regional_partner_serializer.rb
@@ -18,6 +18,7 @@
 #  updated_at         :datetime         not null
 #  deleted_at         :datetime
 #  properties         :text(65535)
+#  is_active          :boolean
 #
 
 class RegionalPartnerSerializer < ActiveModel::Serializer

--- a/dashboard/db/migrate/20230309041659_add_isactive_field_to_regional_partner.rb
+++ b/dashboard/db/migrate/20230309041659_add_isactive_field_to_regional_partner.rb
@@ -1,0 +1,5 @@
+class AddIsactiveFieldToRegionalPartner < ActiveRecord::Migration[6.0]
+  def change
+    add_column :regional_partners, :is_active, :boolean
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -328,8 +328,8 @@ ActiveRecord::Schema.define(version: 2023_03_09_041659) do
     t.datetime "deleted_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.virtual "active", type: :boolean, as: "if((`deleted_at` is null),true,NULL)"
-    t.virtual "open", type: :boolean, as: "if((`closed_at` is null),true,NULL)"
+    t.virtual "active", type: :boolean, as: "if(isnull(`deleted_at`),TRUE,NULL)"
+    t.virtual "open", type: :boolean, as: "if(isnull(`closed_at`),TRUE,NULL)"
     t.index ["project_id", "deleted_at"], name: "index_code_reviews_on_project_id_and_deleted_at"
     t.index ["user_id", "project_id", "open", "active"], name: "index_code_reviews_unique", unique: true
     t.index ["user_id", "script_id", "project_level_id", "closed_at", "deleted_at"], name: "index_code_reviews_for_peer_lookup"

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_03_03_220302) do
+ActiveRecord::Schema.define(version: 2023_03_09_041659) do
 
   create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -328,8 +328,8 @@ ActiveRecord::Schema.define(version: 2023_03_03_220302) do
     t.datetime "deleted_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.virtual "active", type: :boolean, as: "if(isnull(`deleted_at`),TRUE,NULL)"
-    t.virtual "open", type: :boolean, as: "if(isnull(`closed_at`),TRUE,NULL)"
+    t.virtual "active", type: :boolean, as: "if((`deleted_at` is null),true,NULL)"
+    t.virtual "open", type: :boolean, as: "if((`closed_at` is null),true,NULL)"
     t.index ["project_id", "deleted_at"], name: "index_code_reviews_on_project_id_and_deleted_at"
     t.index ["user_id", "project_id", "open", "active"], name: "index_code_reviews_unique", unique: true
     t.index ["user_id", "script_id", "project_level_id", "closed_at", "deleted_at"], name: "index_code_reviews_for_peer_lookup"
@@ -1553,6 +1553,7 @@ ActiveRecord::Schema.define(version: 2023_03_03_220302) do
     t.datetime "updated_at", null: false
     t.datetime "deleted_at"
     t.text "properties"
+    t.boolean "is_active"
   end
 
   create_table "regional_partners_school_districts", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|

--- a/dashboard/test/models/regional_partner_test.rb
+++ b/dashboard/test/models/regional_partner_test.rb
@@ -19,7 +19,8 @@ class RegionalPartnerTest < ActiveSupport::TestCase
         city: 'Seattle',
         state: 'WA',
         zip_code: '98101',
-        phone_number: '555-111-2222'
+        phone_number: '555-111-2222',
+        is_active: true
     end
   end
 


### PR DESCRIPTION
This is the first part of a two part change to add a new field on the [Regional Partner edit page](https://studio.code.org/regional_partners/1/edit) that is a checkbox which is “Is Active Regional Partner”. 

## Links

- jira ticket: https://codedotorg.atlassian.net/browse/ACQ-251?atlOrigin=eyJpIjoiODZlZjQ3NWNkNThjNDNkN2E1ZmMzMzZmNzk0NWMzZGMiLCJwIjoiaiJ9


## Testing story

Included updates in existing basic test for model to ensure the new field can be set.

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy
Change includes a DB migration file. Will commit the change to leverage this new field only after this change is rolled out to production and baked for a few days.

## Follow-up work

- Once the change is rolled out to production, will be doing a backfill of the data to set the data for the new field to true
- Once that is in place, will make the new change to use the new field in regional partners edit page

- [x] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
