### PR TITLE
Sprite Lab Upload: Hide lower close button if there are two modals

### DIFF
--- a/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
@@ -133,7 +133,6 @@ class AnimationPicker extends React.Component {
         <StylizedBaseDialog
           title={msg.animationPicker_leaveSelectionTitle()}
           isOpen={this.state.exitingDialog}
-          uncloseable={this.props.uploadInProgress}
           backdropStyle={{
             top: -15,
             right: -15,

--- a/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
@@ -66,7 +66,8 @@ class AnimationPicker extends React.Component {
     onUploadDone: PropTypes.func.isRequired,
     onUploadError: PropTypes.func.isRequired,
     playAnimations: PropTypes.bool.isRequired,
-    onAnimationSelectionComplete: PropTypes.func.isRequired
+    onAnimationSelectionComplete: PropTypes.func.isRequired,
+    uploadWarningShowing: PropTypes.bool.isRequired
   };
 
   state = {
@@ -106,7 +107,6 @@ class AnimationPicker extends React.Component {
     }
 
     const contextName = this.contextSpecificName();
-    console.log(`upload in progress? ${this.props.uploadInProgress}`);
 
     return (
       <div>
@@ -133,7 +133,9 @@ class AnimationPicker extends React.Component {
         <StylizedBaseDialog
           title={msg.animationPicker_leaveSelectionTitle()}
           isOpen={this.state.exitingDialog}
-          uncloseable={this.props.uploadInProgress}
+          uncloseable={
+            this.props.uploadInProgress || this.props.uploadWarningShowing
+          }
           backdropStyle={{
             top: -15,
             right: -15,
@@ -161,17 +163,17 @@ class AnimationPicker extends React.Component {
   }
 
   render() {
-    console.log(`upload in progress? ${this.props.uploadInProgress}`);
     if (!this.props.visible) {
       return null;
     }
-    console.log('it is visible');
 
     return (
       <BaseDialog
         isOpen
         handleClose={this.onClose}
-        uncloseable={this.props.uploadInProgress}
+        uncloseable={
+          this.props.uploadInProgress || this.props.uploadWarningShowing
+        }
         fullWidth={true}
         style={styles.dialog}
       >
@@ -206,7 +208,8 @@ export default connect(
     uploadError: state.animationPicker.uploadError,
     is13Plus: state.pageConstants.is13Plus,
     playAnimations: !state.pageConstants.allAnimationsSingleFrame,
-    selectedAnimations: Object.values(state.animationPicker.selectedAnimations)
+    selectedAnimations: Object.values(state.animationPicker.selectedAnimations),
+    uploadWarningShowing: state.animationPicker.uploadWarningShowing
   }),
   dispatch => ({
     onClose() {

--- a/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
@@ -106,6 +106,7 @@ class AnimationPicker extends React.Component {
     }
 
     const contextName = this.contextSpecificName();
+    console.log(`upload in progress? ${this.props.uploadInProgress}`);
 
     return (
       <div>
@@ -132,6 +133,7 @@ class AnimationPicker extends React.Component {
         <StylizedBaseDialog
           title={msg.animationPicker_leaveSelectionTitle()}
           isOpen={this.state.exitingDialog}
+          uncloseable={this.props.uploadInProgress}
           backdropStyle={{
             top: -15,
             right: -15,
@@ -159,9 +161,11 @@ class AnimationPicker extends React.Component {
   }
 
   render() {
+    console.log(`upload in progress? ${this.props.uploadInProgress}`);
     if (!this.props.visible) {
       return null;
     }
+    console.log('it is visible');
 
     return (
       <BaseDialog

--- a/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
@@ -133,9 +133,7 @@ class AnimationPicker extends React.Component {
         <StylizedBaseDialog
           title={msg.animationPicker_leaveSelectionTitle()}
           isOpen={this.state.exitingDialog}
-          uncloseable={
-            this.props.uploadInProgress || this.props.uploadWarningShowing
-          }
+          uncloseable={this.props.uploadInProgress}
           backdropStyle={{
             top: -15,
             right: -15,

--- a/apps/src/p5lab/AnimationPicker/AnimationUploadButton.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationUploadButton.jsx
@@ -49,7 +49,7 @@ export function UnconnectedAnimationUploadButton({
         onClick={
           showRestrictedUploadWarning
             ? project.isPublished()
-              ? () => setIsPublishedWarningModalOpen(true)
+              ? showPublishedWarning
               : showUploadModal
             : onUploadClick
         }
@@ -61,6 +61,16 @@ export function UnconnectedAnimationUploadButton({
   function showUploadModal() {
     setIsUploadModalOpen(true);
     showingUploadWarning();
+  }
+
+  function showPublishedWarning() {
+    setIsPublishedWarningModalOpen(true);
+    showingUploadWarning();
+  }
+
+  function closePublishedWarning() {
+    setIsPublishedWarningModalOpen(false);
+    exitedUploadWarning();
   }
 
   // Warning dialog that says if you upload, you can no longer share and remix,
@@ -120,7 +130,7 @@ export function UnconnectedAnimationUploadButton({
     return (
       <BaseDialog
         isOpen={isPublishedWarningModalOpen}
-        handleClose={() => setIsPublishedWarningModalOpen(false)}
+        handleClose={closePublishedWarning}
       >
         <div>
           <h1 className={styles.modalHeader}>
@@ -132,7 +142,7 @@ export function UnconnectedAnimationUploadButton({
           <button
             className={classNames(styles.modalButton, styles.confirmButton)}
             type="button"
-            onClick={() => setIsPublishedWarningModalOpen(false)}
+            onClick={closePublishedWarning}
           >
             {msg.dialogOK()}
           </button>

--- a/apps/src/p5lab/AnimationPicker/AnimationUploadButton.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationUploadButton.jsx
@@ -58,21 +58,6 @@ export function UnconnectedAnimationUploadButton({
     );
   }
 
-  function showUploadModal() {
-    setIsUploadModalOpen(true);
-    showingUploadWarning();
-  }
-
-  function showPublishedWarning() {
-    setIsPublishedWarningModalOpen(true);
-    showingUploadWarning();
-  }
-
-  function closePublishedWarning() {
-    setIsPublishedWarningModalOpen(false);
-    exitedUploadWarning();
-  }
-
   // Warning dialog that says if you upload, you can no longer share and remix,
   // and you confirm you will not upload PII.
   function renderUploadModal() {
@@ -157,6 +142,22 @@ export function UnconnectedAnimationUploadButton({
     // redux setting, for use in share/remix
     refreshInRestrictedShareMode();
     onUploadClick();
+    exitedUploadWarning();
+  }
+
+  function showUploadModal() {
+    setIsUploadModalOpen(true);
+    showingUploadWarning();
+  }
+
+  function showPublishedWarning() {
+    setIsPublishedWarningModalOpen(true);
+    showingUploadWarning();
+  }
+
+  function closePublishedWarning() {
+    setIsPublishedWarningModalOpen(false);
+    exitedUploadWarning();
   }
 
   function cancelUpload() {

--- a/apps/src/p5lab/AnimationPicker/AnimationUploadButton.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationUploadButton.jsx
@@ -8,6 +8,10 @@ import classNames from 'classnames';
 import styles from './animation-upload-button.module.scss';
 import {connect} from 'react-redux';
 import {refreshInRestrictedShareMode} from '@cdo/apps/code-studio/projectRedux.js';
+import {
+  exitedUploadWarning,
+  showingUploadWarning
+} from '../redux/animationPicker.js';
 
 /**
  * Render the animation upload button. If the project should restrict uploads
@@ -44,12 +48,17 @@ export function UnconnectedAnimationUploadButton({
           showRestrictedUploadWarning
             ? project.isPublished()
               ? () => setIsPublishedWarningModalOpen(true)
-              : () => setIsUploadModalOpen(true)
+              : showUploadModal
             : onUploadClick
         }
         isBackgroundsTab={isBackgroundsTab}
       />
     );
+  }
+
+  function showUploadModal() {
+    setIsUploadModalOpen(true);
+    showingUploadWarning();
   }
 
   // Warning dialog that says if you upload, you can no longer share and remix,
@@ -145,6 +154,7 @@ export function UnconnectedAnimationUploadButton({
     setRestrictedShareConfirmed(false);
     setNoPIIConfirmed(false);
     setIsUploadModalOpen(false);
+    exitedUploadWarning();
   }
 
   return (

--- a/apps/src/p5lab/AnimationPicker/AnimationUploadButton.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationUploadButton.jsx
@@ -25,7 +25,9 @@ export function UnconnectedAnimationUploadButton({
   shouldRestrictAnimationUpload,
   isBackgroundsTab,
   inRestrictedShareMode,
-  refreshInRestrictedShareMode
+  refreshInRestrictedShareMode,
+  showingUploadWarning,
+  exitedUploadWarning
 }) {
   const [isUploadModalOpen, setIsUploadModalOpen] = useState(false);
   const [
@@ -65,10 +67,7 @@ export function UnconnectedAnimationUploadButton({
   // and you confirm you will not upload PII.
   function renderUploadModal() {
     return (
-      <BaseDialog
-        isOpen={isUploadModalOpen}
-        handleClose={() => setIsUploadModalOpen(false)}
-      >
+      <BaseDialog isOpen={isUploadModalOpen} handleClose={cancelUpload}>
         <div>
           <h1 className={styles.modalHeader}>
             {msg.animationPicker_restrictedShareRulesHeader()}
@@ -172,7 +171,9 @@ UnconnectedAnimationUploadButton.propTypes = {
   isBackgroundsTab: PropTypes.bool.isRequired,
   // populated from redux
   inRestrictedShareMode: PropTypes.bool.isRequired,
-  refreshInRestrictedShareMode: PropTypes.func.isRequired
+  refreshInRestrictedShareMode: PropTypes.func.isRequired,
+  showingUploadWarning: PropTypes.func.isRequired,
+  exitedUploadWarning: PropTypes.func.isRequired
 };
 
 export default connect(
@@ -181,6 +182,8 @@ export default connect(
   }),
   dispatch => ({
     refreshInRestrictedShareMode: inRestrictedShareMode =>
-      dispatch(refreshInRestrictedShareMode(inRestrictedShareMode))
+      dispatch(refreshInRestrictedShareMode(inRestrictedShareMode)),
+    showingUploadWarning: () => dispatch(showingUploadWarning()),
+    exitedUploadWarning: () => dispatch(exitedUploadWarning())
   })
 )(UnconnectedAnimationUploadButton);

--- a/apps/src/p5lab/redux/animationPicker.js
+++ b/apps/src/p5lab/redux/animationPicker.js
@@ -28,6 +28,8 @@ const BEGIN_UPLOAD = 'AnimationPicker/BEGIN_UPLOAD';
 const HANDLE_UPLOAD_ERROR = 'AnimationPicker/HANDLE_UPLOAD_ERROR';
 const SELECT_ANIMATION = 'AnimationPicker/SELECT_ANIMATION';
 const REMOVE_ANIMATION = 'AnimationPicker/REMOVE_ANIMATION';
+const SHOWING_UPLOAD_WARNING = 'AnimationPicker/SHOWING_UPLOAD_WARNING';
+const EXITED_UPLOAD_WARNING = 'AnimationPicker/EXITED_UPLOAD_WARNING';
 
 // Default state, which we reset to any time we hide the animation picker.
 const initialState = {
@@ -68,6 +70,16 @@ export default function reducer(state, action) {
   }
   if (action.type === HIDE) {
     return initialState;
+  }
+  if (action.type === SHOWING_UPLOAD_WARNING) {
+    return _.assign({}, state, {
+      uploadInProgress: true
+    });
+  }
+  if (action.type === EXITED_UPLOAD_WARNING) {
+    return _.assign({}, state, {
+      uploadInProgress: false
+    });
   }
   if (action.type === BEGIN_UPLOAD) {
     return _.assign({}, state, {
@@ -139,6 +151,29 @@ export function beginUpload(filename) {
   return {
     type: BEGIN_UPLOAD,
     filename: filename
+  };
+}
+
+/**
+ * We are showing the pre-upload warning. Mark the upload as in progress.
+ * @returns  {{type: string}}
+ */
+export function showingUploadWarning() {
+  console.log('in showingUploadWarning');
+  return {
+    type: SHOWING_UPLOAD_WARNING
+  };
+}
+
+/**
+ * The user exited the upload warning without approving upload. Don't mark the upload
+ * as in-progress anymore.
+ * @returns  {{type: string}}
+ */
+export function exitedUploadWarning() {
+  console.log('in exitedUploadWarning');
+  return {
+    type: EXITED_UPLOAD_WARNING
   };
 }
 

--- a/apps/src/p5lab/redux/animationPicker.js
+++ b/apps/src/p5lab/redux/animationPicker.js
@@ -158,7 +158,7 @@ export function beginUpload(filename) {
 }
 
 /**
- * We are showing the pre-upload warning. Mark the upload as in progress.
+ * We are showing the pre-upload warning.
  * @returns  {{type: string}}
  */
 export function showingUploadWarning() {
@@ -168,8 +168,7 @@ export function showingUploadWarning() {
 }
 
 /**
- * The user exited the upload warning without approving upload. Don't mark the upload
- * as in-progress anymore.
+ * The user exited the upload warning.
  * @returns  {{type: string}}
  */
 export function exitedUploadWarning() {

--- a/apps/src/p5lab/redux/animationPicker.js
+++ b/apps/src/p5lab/redux/animationPicker.js
@@ -41,7 +41,8 @@ const initialState = {
   isSpriteLab: false,
   isBackground: false,
   // List of animations selected to be added through multiselect
-  selectedAnimations: {}
+  selectedAnimations: {},
+  uploadWarningShowing: false
 };
 
 export default function reducer(state, action) {
@@ -72,14 +73,16 @@ export default function reducer(state, action) {
     return initialState;
   }
   if (action.type === SHOWING_UPLOAD_WARNING) {
-    return _.assign({}, state, {
-      uploadInProgress: true
-    });
+    return {
+      ...state,
+      uploadWarningShowing: true
+    };
   }
   if (action.type === EXITED_UPLOAD_WARNING) {
-    return _.assign({}, state, {
-      uploadInProgress: false
-    });
+    return {
+      ...state,
+      uploadWarningShowing: false
+    };
   }
   if (action.type === BEGIN_UPLOAD) {
     return _.assign({}, state, {
@@ -159,7 +162,6 @@ export function beginUpload(filename) {
  * @returns  {{type: string}}
  */
 export function showingUploadWarning() {
-  console.log('in showingUploadWarning');
   return {
     type: SHOWING_UPLOAD_WARNING
   };
@@ -171,7 +173,6 @@ export function showingUploadWarning() {
  * @returns  {{type: string}}
  */
 export function exitedUploadWarning() {
-  console.log('in exitedUploadWarning');
   return {
     type: EXITED_UPLOAD_WARNING
   };

--- a/apps/src/templates/BaseDialog.jsx
+++ b/apps/src/templates/BaseDialog.jsx
@@ -79,7 +79,6 @@ export default class BaseDialog extends React.Component {
   }
 
   render() {
-    console.log(`uncloseable? ${this.props.uncloseable}`);
     if (!this.props.isOpen && !this.props.hideBackdrop) {
       return <div />;
     }

--- a/apps/src/templates/BaseDialog.jsx
+++ b/apps/src/templates/BaseDialog.jsx
@@ -79,6 +79,7 @@ export default class BaseDialog extends React.Component {
   }
 
   render() {
+    console.log(`uncloseable? ${this.props.uncloseable}`);
     if (!this.props.isOpen && !this.props.hideBackdrop) {
       return <div />;
     }

--- a/apps/test/unit/p5lab/AnimationPicker/AnimationUploadButtonTest.js
+++ b/apps/test/unit/p5lab/AnimationPicker/AnimationUploadButtonTest.js
@@ -16,6 +16,8 @@ describe('AnimationUploadButton', function() {
         isBackgroundsTab={false}
         refreshInRestrictedShareMode={emptyFunction}
         inRestrictedShareMode={false}
+        showingUploadWarning={emptyFunction}
+        exitedUploadWarning={emptyFunction}
       />
     );
     const uploadButton = body.find(AnimationPickerListItem).at(0);
@@ -32,6 +34,8 @@ describe('AnimationUploadButton', function() {
         isBackgroundsTab={false}
         refreshInRestrictedShareMode={emptyFunction}
         inRestrictedShareMode={true}
+        showingUploadWarning={emptyFunction}
+        exitedUploadWarning={emptyFunction}
       />
     );
     const uploadButton = body.find(AnimationPickerListItem).at(0);
@@ -48,6 +52,8 @@ describe('AnimationUploadButton', function() {
         isBackgroundsTab={false}
         refreshInRestrictedShareMode={emptyFunction}
         inRestrictedShareMode={false}
+        showingUploadWarning={emptyFunction}
+        exitedUploadWarning={emptyFunction}
       />
     );
     const uploadButton = body.find(AnimationPickerListItem).at(0);
@@ -64,6 +70,8 @@ describe('AnimationUploadButton', function() {
         isBackgroundsTab={false}
         refreshInRestrictedShareMode={emptyFunction}
         inRestrictedShareMode={false}
+        showingUploadWarning={emptyFunction}
+        exitedUploadWarning={emptyFunction}
       />
     );
     const uploadButton = body.find(AnimationPickerListItem).at(0);

--- a/apps/test/unit/p5lab/redux/animationPickerTest.js
+++ b/apps/test/unit/p5lab/redux/animationPickerTest.js
@@ -40,7 +40,8 @@ describe('animationPicker', function() {
       uploadError: null,
       isSpriteLab: false,
       isBackground: false,
-      selectedAnimations: {}
+      selectedAnimations: {},
+      uploadWarningShowing: false
     };
 
     it('has expected default state', function() {


### PR DESCRIPTION
With the new sprite lab student upload feature, we show two different modals over the costume picker modal. This PR hides the close button on the lower modal if there is a modal above it, to avoid confusion and duplicate close buttons.

### Before
The same behavior was present for the upload checkbox modal, pictured in "after"
![Screenshot 2023-03-09 at 2 06 45 PM](https://user-images.githubusercontent.com/33666587/224175255-858363c4-791c-48a6-9b48-a059e36b302c.png)

### After
![Screenshot 2023-03-09 at 2 16 03 PM](https://user-images.githubusercontent.com/33666587/224175219-01fecfec-1e7e-419e-86c4-bdbb66db3381.png)

![Screenshot 2023-03-09 at 1 44 49 PM](https://user-images.githubusercontent.com/33666587/224175276-e6ad06e9-bb4b-4a9d-bac4-4ffed93da707.png)


## Links

- jira tickets: [SL-616](https://codedotorg.atlassian.net/browse/SL-616)

## Testing story
Tested locally.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
