### PR TITLE
Remove `cdo-ruby::old_version` Chef Attribute

### DIFF
--- a/cookbooks/cdo-ruby/README.md
+++ b/cookbooks/cdo-ruby/README.md
@@ -11,7 +11,6 @@ This cookbook uses [`ruby-build`](https://github.com/rbenv/ruby-build#readme) in
 ## Attributes
 
 - `node['cdo-ruby']['version']`: Ruby version. See `ruby-build --definitions` for available options
-- `node['cdo-ruby']['old_version']`: Old version of Ruby to be uninstalled. Optional, and soon to be deprecated.
 - `node['cdo-ruby']['rubygems_version']`: Updates the version of [RubyGems](https://rubygems.org/) installed.
 - `node['cdo-ruby']['bundler_version']`: Updates the version of [Bundler](http://bundler.io/) installed.
 - `node['cdo-ruby']['rake_version']`: Updates the version of [Rake](https://ruby.github.io/rake/) installed.

--- a/cookbooks/cdo-ruby/attributes/default.rb
+++ b/cookbooks/cdo-ruby/attributes/default.rb
@@ -1,6 +1,5 @@
 default['cdo-ruby'] = {
   version: '2.7.5',
-  old_version: '2.7',
   rubygems_version: '3.3.22',
   bundler_version: '2.3.22',
   rake_version: '13.0.1'

--- a/cookbooks/cdo-ruby/recipes/ruby-build.rb
+++ b/cookbooks/cdo-ruby/recipes/ruby-build.rb
@@ -4,22 +4,6 @@
 #   https://www.ruby-lang.org/en/documentation/installation/#ruby-build
 #   https://github.com/rbenv/ruby-build#readme
 
-# Remove old Ruby version packages if present.
-# TODO: remove this (and the old_version attribute) once all existing servers
-# have been updated
-if (old = node['cdo-ruby']['old_version'])
-  include_recipe 'apt'
-  %W[
-    ruby#{old}-dev
-    ruby#{old}
-  ].each do |pkg|
-    apt_package pkg do
-      action :purge
-      notifies :run, 'execute[apt-get autoremove]', :immediately
-    end
-  end
-end
-
 # Arbitrarily use the latest version of ruby build at time this code was
 # written; this probably doesn't matter, but we need to pick something.
 RUBY_BUILD_VERSION = '20221225'.freeze


### PR DESCRIPTION
Now that we've removed the apt ruby packages from all persistent managed servers, we no longer need this attribute.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
