### PR TITLE
Music: fix pattern editing

### DIFF
--- a/apps/src/music/views/PatternPanel.jsx
+++ b/apps/src/music/views/PatternPanel.jsx
@@ -21,7 +21,7 @@ const PatternPanel = ({library, initValue, onChange}) => {
 
   // Make a copy of the value object so that we don't overwrite Blockly's
   // data.
-  const currentValue = {...initValue};
+  const currentValue = JSON.parse(JSON.stringify(initValue));
 
   const group = library.groups[0];
   const currentFolder = findFolder(currentValue.kit);


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/50364.  This fixes an issue in which making changes in the pattern editor was overwriting the default value being passed through, leading to edits in one block's pattern editor showing up in other blocks' pattern editors.

I almost got this right, duplicating the initial value object, which did avoid this issue from happening with the pattern kit dropdown, but the spread operator didn't do a deep copy of the nested data, so the pattern events weren't copied.
