### PR TITLE
Music: repeat gets number field

### DIFF
--- a/apps/src/music/blockly/blocks/simple2.js
+++ b/apps/src/music/blockly/blocks/simple2.js
@@ -356,8 +356,11 @@ export const repeatSimple2 = {
     message0: 'repeat %1 times',
     args0: [
       {
-        type: 'input_value',
-        name: 'times'
+        type: 'field_number',
+        name: 'times',
+        value: 1,
+        min: 0,
+        max: 100
       }
     ],
     message1: 'do %1',
@@ -375,12 +378,7 @@ export const repeatSimple2 = {
     helpUrl: ''
   },
   generator: block => {
-    const repeats =
-      Blockly.JavaScript.valueToCode(
-        block,
-        'times',
-        Blockly.JavaScript.ORDER_ASSIGNMENT
-      ) || 0;
+    const repeats = block.getFieldValue('times');
 
     let branch = Blockly.JavaScript.statementToCode(block, 'code');
     branch = Blockly.JavaScript.addLoopTrap(branch, block);
@@ -390,13 +388,11 @@ export const repeatSimple2 = {
       Blockly.Names.NameType.VARIABLE
     );
     let endVar = repeats;
-    if (!repeats.match(/^\w+$/) && !Blockly.utils.string.isNumber(repeats)) {
-      endVar = Blockly.JavaScript.nameDB_.getDistinctName(
-        'repeat_end',
-        Blockly.Names.NameType.VARIABLE
-      );
-      code += 'var ' + endVar + ' = ' + repeats + ';\n';
-    }
+    endVar = Blockly.JavaScript.nameDB_.getDistinctName(
+      'repeat_end',
+      Blockly.Names.NameType.VARIABLE
+    );
+    code += 'var ' + endVar + ' = ' + repeats + ';\n';
     code +=
       'for (var ' +
       loopVar +

--- a/apps/src/music/blockly/toolbox.js
+++ b/apps/src/music/blockly/toolbox.js
@@ -88,15 +88,8 @@ const toolboxBlocks = {
   [BlockTypes.REPEAT_SIMPLE2]: {
     kind: 'block',
     type: BlockTypes.REPEAT_SIMPLE2,
-    inputs: {
-      times: {
-        shadow: {
-          type: 'math_number',
-          fields: {
-            NUM: 1
-          }
-        }
-      }
+    fields: {
+      times: 1
     }
   },
   [BlockTypes.PLAY_SOUND_IN_TRACK]: {


### PR DESCRIPTION
This is a proposal to change the `repeat` block's value from a shadow block to a number field.

Using a number field makes the block look more like others in this lab so far.

### before

<img width="178" alt="Screenshot 2023-03-10 at 10 52 20 AM" src="https://user-images.githubusercontent.com/2205926/224401753-dadb4293-e811-4650-b20b-10fd40283986.png">

### after

<img width="150" alt="Screenshot 2023-03-10 at 10 52 31 AM" src="https://user-images.githubusercontent.com/2205926/224401665-88f5319e-9ffc-4565-ad09-d6ab093426d7.png">


