### PR TITLE
Add jquery wait step to script_overview test

### DIFF
--- a/dashboard/test/ui/features/teacher_tools/script_overview.feature
+++ b/dashboard/test/ui/features/teacher_tools/script_overview.feature
@@ -61,6 +61,7 @@ Feature: Unit overview page
     # On last level of the lesson
     And I am on "http://studio.code.org/s/csp3-2019/lessons/3/levels/1"
     And I click selector ".submitButton"
+    And I wait for jquery to load
     And I wait until element ".uitest-end-of-lesson-header:contains(You finished Lesson 3!)" is visible
     And I reload the page
     And  element ".uitest-end-of-lesson-header:contains(You finished Lesson 3!)" is not visible


### PR DESCRIPTION
This test was very flaky this morning, failing because jquery had not loaded. This is a speculative fix to avoid that issue.


## Links
- [slack thread](https://codedotorg.slack.com/archives/C045UAX4WKH/p1678471188055309)

## Testing story
I couldn't reproduce the failure locally, but the test still passes when this step is added.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
