### PR TITLE
remove unnecessary permission filter

### DIFF
--- a/aws/cloudformation/iam.yml.erb
+++ b/aws/cloudformation/iam.yml.erb
@@ -381,9 +381,6 @@ Resources:
                     "assets_development/*",
                     "animations_development/*",
                     "files_development/*"
-                ],
-                "s3:delimiter": [
-                    "/"
                 ]
               }
           - Sid: AllowNeededS3ActionsInCertainBucketFolders


### PR DESCRIPTION
Contractors are unable to access project versions, i think it may be due to this unnecessary permission.

## Links

## Testing story

Will test manually, then update this PR as appropriate.

## Deployment strategy

## Follow-up work

## Privacy

## Security <!-- comment here -->

## Caching

## PR Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
