### PR TITLE
Modify S3 Log File Uploader

### DIFF
--- a/dashboard/test/ui/runner.rb
+++ b/dashboard/test/ui/runner.rb
@@ -285,7 +285,9 @@ end
 # @return [String] a public hyperlink to the uploaded log, or empty string.
 def upload_log_and_get_public_link(filename, metadata)
   return '' unless $options.html
-  log_url = LOG_UPLOADER.upload_file(filename, {metadata: metadata})
+  # Assume all log files are Cucumber reports in html format.
+  # TODO: Set content type dynamically based on filename extension.
+  log_url = LOG_UPLOADER.upload_file(filename, {content_type: 'text/html', metadata: metadata})
   " <a href='#{log_url}'>☁ Log on S3</a>"
 rescue Exception => msg
   ChatClient.log "Uploading log to S3 failed: #{msg}"

--- a/lib/cdo/aws/s3.rb
+++ b/lib/cdo/aws/s3.rb
@@ -318,13 +318,13 @@ module AWS
       def upload_log(name, body, options={})
         key = "#{@prefix}/#{name}"
 
+        options[:content_type] ||= 'text/plain'
         options[:acl] = 'public-read' if @make_public
         result = AWS::S3.create_client.put_object(
           options.merge(
             bucket: @bucket,
             key: key,
-            body: body,
-            content_type: 'text/plain'
+            body: body
           )
         )
         if @make_public


### PR DESCRIPTION
My previous change to set the content type of log files uploaded to S3 by our build systems (#50575  missed the fact that Cucumber logs are typically [generated in an HTML format](https://github.com/code-dot-org/code-dot-org/blob/1003ddc2281b4bed5a1d4473c2e4104bafc476f8/dashboard/test/ui/runner.rb#LL177C5-L177C5).

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
