### PR TITLE
Music: show lengths in sounds panel

### DIFF
--- a/apps/src/music/views/SoundsPanel.jsx
+++ b/apps/src/music/views/SoundsPanel.jsx
@@ -23,6 +23,14 @@ const getIconClassName = type => {
   return styles['icon-' + type];
 };
 
+const getLengthRepresentation = length => {
+  const lengthToSymbol = {
+    0.5: '\u00bd',
+    0.25: '\u00bc'
+  };
+  return lengthToSymbol[length] || length;
+};
+
 const SoundsPanelRow = ({
   currentValue,
   playingPreview,
@@ -51,19 +59,24 @@ const SoundsPanelRow = ({
       </div>
       <div className={styles.soundRowMiddle}>{sound.name}</div>
       <div className={styles.soundRowRight}>
-        <FontAwesome
-          icon={'play-circle'}
-          className={classNames(
-            styles.preview,
-            isPlayingPreview && styles.previewPlaying
-          )}
-          onClick={e => {
-            if (!isPlayingPreview) {
-              onPreview(folder.path + '/' + sound.src);
-            }
-            e.stopPropagation();
-          }}
-        />
+        <div className={styles.length}>
+          {getLengthRepresentation(sound.length)}
+        </div>
+        <div className={styles.previewContainer}>
+          <FontAwesome
+            icon={'play-circle'}
+            className={classNames(
+              styles.preview,
+              isPlayingPreview && styles.previewPlaying
+            )}
+            onClick={e => {
+              if (!isPlayingPreview) {
+                onPreview(folder.path + '/' + sound.src);
+              }
+              e.stopPropagation();
+            }}
+          />
+        </div>
       </div>
     </div>
   );

--- a/apps/src/music/views/soundsPanel.module.scss
+++ b/apps/src/music/views/soundsPanel.module.scss
@@ -60,15 +60,28 @@
 }
 
 .soundRowMiddle {
-  width: calc(100% - 23px - 30px);
+  width: calc(100% - 23px - 55px);
   float: left;
 }
 
 .soundRowRight {
   float: right;
-  width: 15px;
+  width: 40px;
   margin-right: 15px;
-  font-size: 16px;
+
+  .length {
+    display: inline-block;
+    font-size: 13px;
+    width: 15px;
+    margin-right: 10px;
+    color: $gray-400;
+    text-align: right;
+  }
+
+  .previewContainer {
+    display: inline-block;
+    font-size: 16px;
+  }
 }
 
 .preview {


### PR DESCRIPTION
With this change, we show lengths in the sounds panel.  For fractional values, we can use [vulgar fractions](https://en.wikipedia.org/wiki/Fraction#Simple,_common,_or_vulgar_fractions), and adding more is easy if necessary.  

<img width="391" alt="Screenshot 2023-03-10 at 4 52 31 PM" src="https://user-images.githubusercontent.com/2205926/224455276-84109932-46f6-48c0-8115-b7e0002ec4ad.png">
