### PR TITLE
Music: add link to documentation

### DIFF
--- a/apps/src/music/analytics/AnalyticsReporter.ts
+++ b/apps/src/music/analytics/AnalyticsReporter.ts
@@ -124,14 +124,18 @@ export default class AnalyticsReporter {
   }
 
   onButtonClicked(buttonName: string, properties: object) {
+    const logMessage = `Button clicked. Payload: ${JSON.stringify({
+      buttonName,
+      ...properties
+    })}`;
+
     if (!this.sessionInProgress) {
-      this.log('No session in progress');
+      this.log(`No session in progress.  (${logMessage})`);
       return;
+    } else {
+      this.log(logMessage);
     }
 
-    this.log(
-      `Button clicked. Payload: ${JSON.stringify({buttonName, ...properties})}`
-    );
     track('Button clicked', {buttonName, ...properties}).promise;
   }
 
@@ -139,7 +143,7 @@ export default class AnalyticsReporter {
     const logMessage = `Video closed. Id: ${id}. Duration: ${duration}}`;
 
     if (!this.sessionInProgress) {
-      this.log(`No session in progress.  (${logMessage}`);
+      this.log(`No session in progress.  (${logMessage})`);
       return;
     } else {
       this.log(logMessage);

--- a/apps/src/music/views/Controls.jsx
+++ b/apps/src/music/views/Controls.jsx
@@ -7,7 +7,7 @@ import moduleStyles from './controls.module.scss';
 import BeatPad from './BeatPad';
 import {AnalyticsContext} from '../context';
 
-const documentationUrl = 'https://studio.code.org/docs/ide/projectbeats';
+const documentationUrl = '/docs/ide/projectbeats';
 
 /**
  * Renders the playback controls bar, including the play/pause button, show/hide beat pad button,
@@ -69,7 +69,7 @@ const Controls = ({
     'question-circle-o',
     () => {
       analyticsReporter.onButtonClicked('documentation-link');
-      window.open(documentationUrl, '_blank');
+      window.open(documentationUrl, '_blank', 'noopener,noreferrer');
     }
   );
   const beatPadIconSection = renderIconButton('th', () => {

--- a/apps/src/music/views/Controls.jsx
+++ b/apps/src/music/views/Controls.jsx
@@ -98,6 +98,9 @@ const Controls = ({
         <a href={documentationUrl} target="_blank" rel="noopener noreferrer">
           <FontAwesome
             icon={'question-circle-o'}
+            onClick={() => {
+              analyticsReporter.onButtonClicked('documentation-link');
+            }}
             className={classNames(
               moduleStyles.iconButton,
               moduleStyles.iconButtonLink

--- a/apps/src/music/views/Controls.jsx
+++ b/apps/src/music/views/Controls.jsx
@@ -7,6 +7,8 @@ import moduleStyles from './controls.module.scss';
 import BeatPad from './BeatPad';
 import {AnalyticsContext} from '../context';
 
+const documentationUrl = 'https://studio.code.org/docs/ide/projectbeats';
+
 /**
  * Renders the playback controls bar, including the play/pause button, show/hide beat pad button,
  * and show/hide instructions button.
@@ -63,6 +65,13 @@ const Controls = ({
     </div>
   );
 
+  const documentationLinkIconSection = renderIconButton(
+    'question-circle-o',
+    () => {
+      analyticsReporter.onButtonClicked('documentation-link');
+      window.open(documentationUrl, '_blank');
+    }
+  );
   const beatPadIconSection = renderIconButton('th', () => {
     analyticsReporter.onButtonClicked('show-hide-beatpad', {
       showing: !isShowingBeatPad
@@ -90,6 +99,7 @@ const Controls = ({
           className={moduleStyles.iconButton}
         />
       </div>
+      {documentationLinkIconSection}
       {rightIcon}
     </div>
   );

--- a/apps/src/music/views/Controls.jsx
+++ b/apps/src/music/views/Controls.jsx
@@ -65,13 +65,6 @@ const Controls = ({
     </div>
   );
 
-  const documentationLinkIconSection = renderIconButton(
-    'question-circle-o',
-    () => {
-      analyticsReporter.onButtonClicked('documentation-link');
-      window.open(documentationUrl, '_blank', 'noopener,noreferrer');
-    }
-  );
   const beatPadIconSection = renderIconButton('th', () => {
     analyticsReporter.onButtonClicked('show-hide-beatpad', {
       showing: !isShowingBeatPad
@@ -99,7 +92,19 @@ const Controls = ({
           className={moduleStyles.iconButton}
         />
       </div>
-      {documentationLinkIconSection}
+      <div
+        className={classNames(moduleStyles.controlButtons, moduleStyles.side)}
+      >
+        <a href={documentationUrl} target="_blank" rel="noopener noreferrer">
+          <FontAwesome
+            icon={'question-circle-o'}
+            className={classNames(
+              moduleStyles.iconButton,
+              moduleStyles.iconButtonLink
+            )}
+          />
+        </a>
+      </div>
       {rightIcon}
     </div>
   );

--- a/apps/src/music/views/controls.module.scss
+++ b/apps/src/music/views/controls.module.scss
@@ -34,6 +34,10 @@
 .iconButton {
   cursor: pointer;
   font-size: 30px;
+
+  &Link {
+    color: white;
+  }
 }
 
 .startOverButton {


### PR DESCRIPTION
This adds a link to documentation, which will be opened in a separate browser tab when clicked.  It's the `?` in a circle.

<img width="976" alt="Screenshot 2023-03-10 at 5 19 59 PM" src="https://user-images.githubusercontent.com/2205926/224457289-7c557993-d5fd-4e44-b1a5-fe03b3cf210a.png">
