### PR TITLE
Music: adjust timeline widths

### DIFF
--- a/apps/src/music/views/TimelineElement.jsx
+++ b/apps/src/music/views/TimelineElement.jsx
@@ -60,7 +60,7 @@ const TimelineElement = ({
         isSkipSound && moduleStyles.timelineElementSkipSound
       )}
       style={{
-        width: barWidth * length - 4,
+        width: barWidth * length,
         height,
         top,
         left

--- a/apps/src/music/views/TimelineSimple2Events.jsx
+++ b/apps/src/music/views/TimelineSimple2Events.jsx
@@ -99,8 +99,7 @@ const TimelineSimple2Events = ({
               left: (uniqueFunction.positionLeft - 1) * barWidth,
               width:
                 (uniqueFunction.positionRight - uniqueFunction.positionLeft) *
-                  barWidth -
-                4,
+                barWidth,
               top: 20 + uniqueFunction.positionTop,
               height:
                 uniqueFunction.positionBottom - uniqueFunction.positionTop - 3


### PR DESCRIPTION
This adjusts the timeline element widths to render perfectly again; they had regressed at some point in recent weeks.  

Now, for example, a measure-long element will end exactly before the next measure is drawn.

### before

<img width="176" alt="Screenshot 2023-03-13 at 1 06 32 PM" src="https://user-images.githubusercontent.com/2205926/224821925-d43f6aac-a762-49f8-b5f4-c17882dd42f4.png">

### after

<img width="173" alt="Screenshot 2023-03-13 at 1 06 39 PM" src="https://user-images.githubusercontent.com/2205926/224821957-d0d462c0-6009-4b83-a732-2f9d71d34644.png">

Also makes the same fix for the the function boundary rectangle in the `simple2` model:
<img width="111" alt="Screenshot 2023-03-13 at 1 12 08 PM" src="https://user-images.githubusercontent.com/2205926/224821976-10e9ef74-a579-444d-a307-42e2aaed78fe.png">

