### PR TITLE
Music: use fraction in rest dropdown

### DIFF
--- a/apps/src/music/blockly/fields.js
+++ b/apps/src/music/blockly/fields.js
@@ -31,7 +31,7 @@ export const fieldRestDurationDefinition = {
   type: 'field_dropdown',
   name: FIELD_REST_DURATION_NAME,
   options: [
-    ['1/2 beat', '0.125'],
+    ['\u00bd beat', '0.125'],
     ['1 beat', '0.25'],
     ['2 beats', '0.5'],
     ['1 measure', '1'],


### PR DESCRIPTION
A proposal to use `½` instead of `1/2` in the rest dropdown.

<img width="206" alt="Screenshot 2023-03-13 at 1 26 49 PM" src="https://user-images.githubusercontent.com/2205926/224824946-95587f30-52ba-48e0-8b53-0df29e2a3039.png">
