### PR TITLE
Remove Unused `ruby_dep` Dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,12 +70,6 @@ gem 'rack-cache'
 
 group :development, :test do
   gem 'rerun'
-
-  # Ref: https://github.com/e2/ruby_dep/issues/24
-  # https://github.com/e2/ruby_dep/issues/25
-  # https://github.com/e2/ruby_dep/issues/30
-  gem 'ruby_dep', '~> 1.3.1'
-
   gem 'shotgun'
   gem 'thin'
   # Use debugger

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -783,7 +783,6 @@ GEM
     ruby-progressbar (1.11.0)
     ruby-rc4 (0.1.5)
     ruby2_keywords (0.0.5)
-    ruby_dep (1.3.1)
     ruby_parser (3.18.1)
       sexp_processor (~> 4.16)
     rubyzip (1.2.2)
@@ -1056,7 +1055,6 @@ DEPENDENCIES
   rubocop-rails-accessibility
   ruby-prof
   ruby-progressbar
-  ruby_dep (~> 1.3.1)
   sass-rails (~> 6.0.0)
   sassc-rails!
   scenic


### PR DESCRIPTION
In https://github.com/code-dot-org/code-dot-org/pull/20894, we added an explicit dependency on `ruby_dep` so we could specify the version that gets installed by the `listen` gem (a dependency of `rerun`), which at the time depended on it. The `listen` gem has since been updated and no longer has this dependency, so we no longer need it at all!

Also, it's preventing a potential upgrade to Ruby 3.0:

```
Bundler found conflicting requirements for the Ruby version:
  In Gemfile:
    ruby_dep (~> 1.3.1) was resolved to 1.3.1, which depends on
      Ruby (>= 2.0.0, ~> 2.0)

  Current Ruby version:
    Ruby (= 3.0.5)
```

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
