### PR TITLE
rename one WorkshopEnrollment to WorkshopEnroll

### DIFF
--- a/apps/src/code-studio/pd/workshop_enrollment/workshop_enroll.jsx
+++ b/apps/src/code-studio/pd/workshop_enrollment/workshop_enroll.jsx
@@ -21,7 +21,7 @@ const SUBMISSION_STATUSES = {
   UNKNOWN_ERROR: 'error'
 };
 
-export default class WorkshopEnrollment extends React.Component {
+export default class WorkshopEnroll extends React.Component {
   static propTypes = {
     workshop: WorkshopPropType,
     session_dates: PropTypes.arrayOf(PropTypes.string),

--- a/apps/src/sites/studio/pages/pd/workshop_enrollment/new.js
+++ b/apps/src/sites/studio/pages/pd/workshop_enrollment/new.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import WorkshopEnrollment from '@cdo/apps/code-studio/pd/workshop_enrollment/workshop_enrollment';
+import WorkshopEnroll from '@cdo/apps/code-studio/pd/workshop_enrollment/workshop_enroll';
 import getScriptData from '@cdo/apps/util/getScriptData';
 
 document.addEventListener('DOMContentLoaded', function() {
   ReactDOM.render(
-    <WorkshopEnrollment {...getScriptData('props')} />,
+    <WorkshopEnroll {...getScriptData('props')} />,
     document.getElementById('enrollment-container')
   );
 });


### PR DESCRIPTION
Today there are two react components named `WorkshopEnrollment`:

1. view / edit workshop page
![Screenshot 2023-03-14 at 7 52 23 AM](https://user-images.githubusercontent.com/8001765/225041281-2e56800e-d5bc-4cc1-a933-a972acdc6ac7.png)

2. page to actually enroll in a workshop
![Screenshot 2023-03-14 at 7 54 40 AM](https://user-images.githubusercontent.com/8001765/225041339-9f5aebbd-535a-41e7-a365-5e60656b66d5.png)

This makes it unnecessarily difficult to navigate the codebase. This PR helps resolve the ambiguity by renaming (2) to `WorkshopEnroll`. This was easy to change so I am open to other names too.

## Testing story

There is no existing test coverage so I tested this manually. UI tests which require enrollment [skip this step](https://github.com/code-dot-org/code-dot-org/blob/489a15c4a0f7cd4a266b255a73eece192d5589e6/dashboard/test/ui/features/step_definitions/steps.rb#L982-L983) to save time, which is generally the right strategy except that there should still be one UI test covering the skipped step. adding a follow-up to add UI test coverage here: https://codedotorg.atlassian.net/browse/ACQ-481
