### PR TITLE
restoring deleted projectbeats code docs files and allowing new filenames to seed

### DIFF
--- a/dashboard/app/models/programming_expression.rb
+++ b/dashboard/app/models/programming_expression.rb
@@ -131,7 +131,7 @@ class ProgrammingExpression < ApplicationRecord
 
   def self.seed_all
     removed_records = all.pluck(:id)
-    Dir.glob(Rails.root.join("config/programming_expressions/{applab,gamelab,weblab,spritelab}/*.json")).each do |path|
+    Dir.glob(Rails.root.join("config/programming_expressions/**/*.json")).each do |path|
       removed_records -= [ProgrammingExpression.seed_record(path)]
     end
     where(id: removed_records).destroy_all

--- a/dashboard/config/programming_expressions/projectbeats/create_function.json
+++ b/dashboard/config/programming_expressions/projectbeats/create_function.json
@@ -1,0 +1,17 @@
+{
+  "key": "create_function",
+  "name": "Create Function",
+  "category": "Functions",
+  "category_key": "functions",
+  "content": "Functions are blocks that represent a set of blocks to be played, in order to group together parts of a song. Functions can be used to represent a section of a song, like the chorus or verse, or a specific instrument's part in a song. \n\nFor example, the following code creates a new function block called \"my beat\":\n\n![](https://images.code.org/b7839df79fd44089bd82fa205a73d925-Screenshot 2023-03-09 at 10.54.31 AM.png)\n\nOnce this code is added to the workspace, the new function is accessible in the \"Functions\" section of the toolbox:\n\n![](https://images.code.org/1f8f59e7a794c448aff1a1abd0d6f843-Screenshot 2023-03-09 at 10.56.11 AM.png)\n\nThis \"my beat\" block can be used anywhere in the project to play these four sounds as a group.",
+  "image_url": "https://images.code.org/12cdf5bbc6655c7cbde77f0e3bb2381e-Screenshot 2023-03-09 at 10.50.22 AM.png",
+  "palette_params": [
+    {
+      "name": "name",
+      "required": true,
+      "description": "The name of the function to create."
+    }
+  ],
+  "short_description": "Creates a new block, or \"function\" that represents a sequence of sounds.",
+  "tips": "The effect block only works in functions so that you can choose which sounds you want effects on. Make sure you make a function before you use the effect block!"
+}

--- a/dashboard/config/programming_expressions/projectbeats/play_pattern.json
+++ b/dashboard/config/programming_expressions/projectbeats/play_pattern.json
@@ -1,0 +1,21 @@
+{
+  "key": "play_pattern",
+  "name": "Play Pattern",
+  "category": "Play",
+  "category_key": "play",
+  "content": "This block lets you make custom beats using collections of sounds. Each row of bubbles in the grid represents a specific sound, and each column represents a moment within a measure to play that sound. To play a sound on a beat, toggle the bubble in the lighter colored columns. To play more complex rhythms, try toggling the other bubbles!",
+  "image_url": "https://images.code.org/45bf45bf41daa5b82a5d860543c57908-Screenshot 2023-03-09 at 9.53.15 AM.png",
+  "palette_params": [
+    {
+      "name": "sound pack",
+      "required": true,
+      "description": "This defines the set of sounds to play, e.g. 'glitch' or 'machine'. Each set is different, so play around to hear the different sounds!"
+    },
+    {
+      "name": "pattern",
+      "required": true,
+      "description": "The pattern to play. Select bubbles to play sounds at specific times. Multiple sounds can be played at any time."
+    }
+  ],
+  "short_description": "Play a sequence of sounds to make a beat."
+}

--- a/dashboard/config/programming_expressions/projectbeats/play_random.json
+++ b/dashboard/config/programming_expressions/projectbeats/play_random.json
@@ -1,0 +1,9 @@
+{
+  "key": "play_random",
+  "name": "Play Random",
+  "category": "Control",
+  "category_key": "control",
+  "content": "Each time this block is reached, one of the blocks inside it will be played at random. Use this block to add some variation into compositions.",
+  "image_url": "https://images.code.org/4191f32bf2cc829674c8180af5269910-Screenshot 2023-03-09 at 10.06.23 AM.png",
+  "short_description": "Plays one of the sounds at random."
+}

--- a/dashboard/config/programming_expressions/projectbeats/play_sample.json
+++ b/dashboard/config/programming_expressions/projectbeats/play_sample.json
@@ -1,0 +1,16 @@
+{
+  "key": "play_sample",
+  "name": "Play",
+  "category": "Play",
+  "category_key": "play",
+  "content": "Putting several of these blocks together will play the sounds one after another. If you want to play samples simultaneously, put the blocks in the [`play together`(#94E4FF)](/docs/ide/projectbeats/expressions/play_together) block.",
+  "image_url": "https://images.code.org/eddfb0d2592e9b433ac9813abbf23e15-Screenshot 2023-03-09 at 9.58.34 AM.png",
+  "palette_params": [
+    {
+      "name": "sample",
+      "required": true,
+      "description": "Click on this parameter to choose the sample to play in the library. Samples are mostly two measures long, although some are shorter, like cymbal crashes, claps, and others."
+    }
+  ],
+  "short_description": "Plays a sound, like a beat or a melody, for its full length. Sounds played by this block are called \"samples\"."
+}

--- a/dashboard/config/programming_expressions/projectbeats/play_sequential.json
+++ b/dashboard/config/programming_expressions/projectbeats/play_sequential.json
@@ -1,0 +1,9 @@
+{
+  "key": "play_sequential",
+  "name": "Play Sequential",
+  "category": "Control",
+  "category_key": "control",
+  "content": "When using the [`play together`(#94E4FF)](/docs/ide/projectbeats/expressions/play_together), sometimes there are times where you want to play some sounds in sequence. This block lets you play sounds in sequence regardless as to whether the blocks are in a [`play together`(#94E4FF)](/docs/ide/projectbeats/expressions/play_together) block.",
+  "image_url": "https://images.code.org/330de73e642a0eb1c6d4a9d2718dcec5-Screenshot 2023-03-09 at 10.17.48 AM.png",
+  "short_description": "When in a \"play together\" block, play a set of sounds sequentially."
+}

--- a/dashboard/config/programming_expressions/projectbeats/play_together.json
+++ b/dashboard/config/programming_expressions/projectbeats/play_together.json
@@ -1,0 +1,9 @@
+{
+  "key": "play_together",
+  "name": "Play Together",
+  "category": "Control",
+  "category_key": "control",
+  "content": "All sounds placed within this block will play at the same time, allowing multiple instruments to play at once. ",
+  "image_url": "https://images.code.org/ce95df07a251b8141ac8a62b8f86fbce-Screenshot 2023-03-09 at 10.24.10 AM.png",
+  "short_description": "Plays multiple sounds at the same time"
+}

--- a/dashboard/config/programming_expressions/projectbeats/rest.json
+++ b/dashboard/config/programming_expressions/projectbeats/rest.json
@@ -1,0 +1,16 @@
+{
+  "key": "rest",
+  "name": "Rest",
+  "category": "Play",
+  "category_key": "play",
+  "content": "Waits for the specified amount of time before playing the next sound.",
+  "image_url": "https://images.code.org/f2e418449a07b9a21ecd2e3529fe0965-Screenshot 2023-03-09 at 10.00.42 AM.png",
+  "palette_params": [
+    {
+      "name": "length",
+      "required": true,
+      "description": "The length of time to wait. A beat is one fourth of a measure."
+    }
+  ],
+  "short_description": "Wait for a time before playing the next sample."
+}

--- a/dashboard/config/programming_expressions/projectbeats/set_effect.json
+++ b/dashboard/config/programming_expressions/projectbeats/set_effect.json
@@ -1,0 +1,22 @@
+{
+  "key": "set_effect",
+  "name": "Set Effect",
+  "category": "Effects",
+  "category_key": "effects",
+  "content": "This block applies effects to all sounds played in a function. Currently there are three effects:\n- Volume: Changes the loudness of the function\n- Filter: Changes the tone of the function, making the sounds muted or muffled.\n- Delay: Adds an echo to the sounds",
+  "image_url": "https://images.code.org/bf1e7c67a86e17be4d5686e596e6999f-Screenshot 2023-03-09 at 10.33.32 AM.png",
+  "palette_params": [
+    {
+      "name": "effect",
+      "required": true,
+      "description": "The effect to apply to the function.\n\n- Volume: Changes the loudness of the function\n- Filter: Changes the tone of the function, making the sounds muted or muffled.\n- Delay: Adds an echo to the sounds"
+    },
+    {
+      "name": "amount",
+      "required": true,
+      "description": "The amount of the effect. The options are:\n- normal: Set the effect to its default. For filter and delay, this means the effect is off. For volume, this means the function should be played at a full volume.\n- medium: For volume, this reduces the loudness slightly. For filter, this adds a small amount of the effect. For delay, this adds a noticeable echo.\n- low: For volume, this plays the function's sounds quietly. For filter, this muffles the sound, e.g. only plays the 'low' parts of the sounds. For delay, this adds a small amount of echo."
+    }
+  ],
+  "short_description": "Change the volume (loudness) or sound of a function",
+  "tips": "You can change the amounts of effects to make your track more interesting over time. For instance, it's common to use the 'filter' effect to have a beat or bass line grow or build before a big change in a song."
+}

--- a/dashboard/config/programming_expressions/projectbeats/trigger.json
+++ b/dashboard/config/programming_expressions/projectbeats/trigger.json
@@ -1,0 +1,16 @@
+{
+  "key": "trigger",
+  "name": "Trigger",
+  "category": "Control",
+  "category_key": "control",
+  "content": "\nCode connected to this block will play at the next measure when the associated button is pressed on the beat pad. This lets you play parts live as the track is playing. You can also press the \"1\" through \"6\" keys on your keyboard to trigger these buttons.\n\n![the beat pad](https://images.code.org/4b81addccd320e43970b8590ff3aa572-Screenshot 2023-03-09 at 10.29.23 AM.png)",
+  "image_url": "https://images.code.org/4c83d91809dadd41d1ea5452edea8ddd-Screenshot 2023-03-09 at 10.29.09 AM.png",
+  "palette_params": [
+    {
+      "name": "button",
+      "required": true,
+      "description": "The number of the button that, when pressed, will run this code"
+    }
+  ],
+  "short_description": "Play sounds when a button on the beat pad is pressed."
+}


### PR DESCRIPTION
This Pr fixes a seeding bug for programming_expressions. Nine new programming expressions docs were spontaneously deleted. This was not a user error, nor was it an issue with the cyclical nature of our deploy (the rest of the content scoop and deploy to production succeeded without a hitch).

Before, the seed_all function called to look for any new files in these specific folder names: {applab,gamelab,weblab,spritelab}. This meant that new environments were not pulled in (projectbeats being one of them). Now, the programming expression matches the patterns that existed already in programming_class and programming_environment.

Once I updated this and started adding back in the json files, the seeding worked locally! See below:
<img width="1106" alt="Screenshot 2023-03-14 at 3 28 59 PM" src="https://user-images.githubusercontent.com/37230822/225156888-9f053db0-396f-470e-8215-eec6a06ceb64.png">

This list of folders seemed very intentional at the time- [see PR here](https://github.com/code-dot-org/code-dot-org/pull/39274). Requesting review from Dani to see if this specificity is still necessary. A more conservative approach would be to add javalab and projectbeats to this list. However, I imagine we'd then run into the same issue again.

Investigation notes doc and slack threads here:
https://docs.google.com/document/d/1EV_1_X5RP8kQi2A8HT-duiHR6iiCyuE9mQ_GcHOCxeQ/edit
https://codedotorg.slack.com/archives/C0T0PNTM3/p1678478257127849


## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/TEACH-336

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
