### PR TITLE
Upgrade `FactoryGirl` to `FactoryBot`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -117,7 +117,7 @@ group :development, :test do
 end
 
 # Needed for unit testing, and also for /rails/mailers email previews.
-gem 'factory_girl_rails', group: [:development, :staging, :test, :adhoc]
+gem 'factory_girl_rails', '>= 4.8.2', group: [:development, :staging, :test, :adhoc]
 
 # For pegasus PDF generation.
 gem 'open_uri_redirections', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -117,7 +117,7 @@ group :development, :test do
 end
 
 # Needed for unit testing, and also for /rails/mailers email previews.
-gem 'factory_girl_rails', '>= 4.8.2', group: [:development, :staging, :test, :adhoc]
+gem 'factory_bot_rails', '~> 4.8.2', group: [:development, :staging, :test, :adhoc]
 
 # For pegasus PDF generation.
 gem 'open_uri_redirections', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -388,10 +388,10 @@ GEM
       nokogiri
       selenium-webdriver
       state_machine
-    factory_girl (4.9.0)
+    factory_bot (4.8.2)
       activesupport (>= 3.0.0)
-    factory_girl_rails (4.9.0)
-      factory_girl (~> 4.9.0)
+    factory_bot_rails (4.8.2)
+      factory_bot (~> 4.8.2)
       railties (>= 3.0.0)
     fakeredis (0.6.0)
       redis (~> 3.2)
@@ -962,7 +962,7 @@ DEPENDENCIES
   dotiw
   execjs
   eyes_selenium (= 3.18.4)
-  factory_girl_rails (>= 4.8.2)
+  factory_bot_rails (~> 4.8.2)
   fakeredis
   firebase
   firebase_token_generator

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -388,10 +388,10 @@ GEM
       nokogiri
       selenium-webdriver
       state_machine
-    factory_girl (4.7.0)
+    factory_girl (4.9.0)
       activesupport (>= 3.0.0)
-    factory_girl_rails (4.7.0)
-      factory_girl (~> 4.7.0)
+    factory_girl_rails (4.9.0)
+      factory_girl (~> 4.9.0)
       railties (>= 3.0.0)
     fakeredis (0.6.0)
       redis (~> 3.2)
@@ -962,7 +962,7 @@ DEPENDENCIES
   dotiw
   execjs
   eyes_selenium (= 3.18.4)
-  factory_girl_rails
+  factory_girl_rails (>= 4.8.2)
   fakeredis
   firebase
   firebase_token_generator

--- a/dashboard/app/controllers/test_controller.rb
+++ b/dashboard/app/controllers/test_controller.rb
@@ -192,7 +192,7 @@ class TestController < ApplicationController
   end
 
   # Use the same data from pd_teacher_application_hash_common
-  # We can't use the factory directly because FactoryGirl is not available on prod
+  # We can't use the factory directly because FactoryBot is not available on prod
   def teacher_form_data
     {
       school: School.first.id,

--- a/dashboard/lib/mega_section.rb
+++ b/dashboard/lib/mega_section.rb
@@ -1,4 +1,4 @@
-include FactoryGirl::Syntax::Methods
+include FactoryBot::Syntax::Methods
 
 class MegaSection
   SAMPLE_TEACHER_EMAIL = 'mega_section_teacher@code.org'.freeze

--- a/dashboard/lib/sample_data.rb
+++ b/dashboard/lib/sample_data.rb
@@ -1,4 +1,4 @@
-include FactoryGirl::Syntax::Methods
+include FactoryBot::Syntax::Methods
 
 class SampleData
   SAMPLE_TEACHER_EMAIL = 'testteacher@code.org'.freeze

--- a/dashboard/test/controllers/projects_controller_test.rb
+++ b/dashboard/test/controllers/projects_controller_test.rb
@@ -25,7 +25,7 @@ class ProjectsControllerTest < ActionController::TestCase
     # them specific content.
     ProjectsController::STANDALONE_PROJECTS.each do |type, config|
       next if Level.exists?(name: config[:name])
-      factory = FactoryGirl.factories.registered?(type) ? type : :level
+      factory = FactoryBot.factories.registered?(type) ? type : :level
       create(factory, name: config[:name])
     end
 

--- a/dashboard/test/factories/README.md
+++ b/dashboard/test/factories/README.md
@@ -1,4 +1,4 @@
-This directory contains definitions for [FactoryGirl](https://github.com/thoughtbot/factory_girl).
+This directory contains definitions for [FactoryBot](https://github.com/thoughtbot/factory_bot).
 
 Our pattern is to put factories for non-namespaced models in `factories.rb` and factories for
 namespaced models in a file named for the namespace, e.g., `pd_factories.rb` or `plc_factories.rb`.

--- a/dashboard/test/factories/census_factories.rb
+++ b/dashboard/test/factories/census_factories.rb
@@ -1,6 +1,6 @@
-FactoryGirl.allow_class_lookup = false
+FactoryBot.allow_class_lookup = false
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :census_submission_school_info, parent: :school_info_us do
     transient do
       school_year 2017

--- a/dashboard/test/factories/curriculum_factories.rb
+++ b/dashboard/test/factories/curriculum_factories.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :reference_guide do
     association :course_version
 

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -1,8 +1,8 @@
 require 'cdo/activity_constants'
 
-FactoryGirl.allow_class_lookup = false
+FactoryBot.allow_class_lookup = false
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :course_offering do
     sequence(:key, 'a') {|c| "bogus-course-offering-#{c}"}
     sequence(:display_name, 'a') {|c| "bogus-course-offering-#{c}"}

--- a/dashboard/test/factories/foorm_factories.rb
+++ b/dashboard/test/factories/foorm_factories.rb
@@ -1,6 +1,6 @@
-FactoryGirl.allow_class_lookup = false
+FactoryBot.allow_class_lookup = false
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :foorm_form, class: 'Foorm::Form' do
     sequence(:name) {|n| "FormName#{n}"}
     version 0

--- a/dashboard/test/factories/pd_factories.rb
+++ b/dashboard/test/factories/pd_factories.rb
@@ -1,6 +1,6 @@
-FactoryGirl.allow_class_lookup = false
+FactoryBot.allow_class_lookup = false
 
-FactoryGirl.define do
+FactoryBot.define do
   # example zip: 35010
   factory :regional_partner_alabama, parent: :regional_partner_with_summer_workshops do
     mappings {[create(:pd_regional_partner_mapping, state: "AL")]}

--- a/dashboard/test/factories/plc_factories.rb
+++ b/dashboard/test/factories/plc_factories.rb
@@ -1,6 +1,6 @@
-FactoryGirl.allow_class_lookup = false
+FactoryBot.allow_class_lookup = false
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :plc_enrollment_unit_assignment, class: 'Plc::EnrollmentUnitAssignment' do
     plc_user_course_enrollment nil
     plc_course_unit nil

--- a/dashboard/test/factories/queued_account_purges.rb
+++ b/dashboard/test/factories/queued_account_purges.rb
@@ -13,7 +13,7 @@
 #  index_queued_account_purges_on_user_id  (user_id) UNIQUE
 #
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :queued_account_purge do
     user
     reason_for_review "Fake reason."

--- a/dashboard/test/factories/workshop_factories.rb
+++ b/dashboard/test/factories/workshop_factories.rb
@@ -12,7 +12,7 @@ end
 #
 # Factories for different types of PD workshops
 #
-FactoryGirl.define do
+FactoryBot.define do
   factory :workshop, class: 'Pd::Workshop', aliases: [:pd_workshop] do
     transient do
       num_sessions 1

--- a/dashboard/test/integration/remix_test.rb
+++ b/dashboard/test/integration/remix_test.rb
@@ -218,8 +218,8 @@ class RemixTest < ActionDispatch::IntegrationTest
   end
 
   private def stub_project_level(type)
-    factory = FactoryGirl.factories.registered?(type) ? type : :level
-    level = FactoryGirl.create(factory)
+    factory = FactoryBot.factories.registered?(type) ? type : :level
+    level = FactoryBot.create(factory)
     ProjectsController.any_instance.stubs(:get_from_cache).returns(level)
   end
 

--- a/dashboard/test/mailers/previews/parent_mailer_preview.rb
+++ b/dashboard/test/mailers/previews/parent_mailer_preview.rb
@@ -1,6 +1,6 @@
 # This can be viewed on non-production environments at /rails/mailers/parent_mailer
 class ParentMailerPreview < ActionMailer::Preview
-  include FactoryGirl::Syntax::Methods
+  include FactoryBot::Syntax::Methods
 
   def parent_email_added_to_student_account_preview
     student = build :student

--- a/dashboard/test/mailers/previews/pd_regional_partner_mini_contact_mailer_preview.rb
+++ b/dashboard/test/mailers/previews/pd_regional_partner_mini_contact_mailer_preview.rb
@@ -1,6 +1,6 @@
 # This can be viewed on non-production environments at /rails/mailers/pd_regional_partner_mini_contact_mailer
 class PdRegionalPartnerMiniContactMailerPreview < ActionMailer::Preview
-  include FactoryGirl::Syntax::Methods
+  include FactoryBot::Syntax::Methods
 
   def contact_receipt_with_partner
     rp = build :regional_partner

--- a/dashboard/test/mailers/previews/pd_teacher_application_mailer_preview.rb
+++ b/dashboard/test/mailers/previews/pd_teacher_application_mailer_preview.rb
@@ -1,6 +1,6 @@
 # This can be viewed on non-production environments at /rails/mailers/pd_teacher_application_mailer
 class PdTeacherApplicationMailerPreview < ActionMailer::Preview
-  include FactoryGirl::Syntax::Methods
+  include FactoryBot::Syntax::Methods
   include Pd::Application::ActiveApplicationModels
 
   %w(

--- a/dashboard/test/mailers/previews/pd_workshop_mailer_preview.rb
+++ b/dashboard/test/mailers/previews/pd_workshop_mailer_preview.rb
@@ -1,6 +1,6 @@
 # This can be viewed on non-production environments at /rails/mailers/pd_workshop_mailer
 class PdWorkshopMailerPreview < ActionMailer::Preview
-  include FactoryGirl::Syntax::Methods
+  include FactoryBot::Syntax::Methods
 
   DEFAULT_COURSE = Pd::Workshop::COURSE_ECS
   DEFAULT_SUBJECT = Pd::Workshop::SUBJECT_ECS_PHASE_2

--- a/dashboard/test/mailers/previews/teacher_mailer_preview.rb
+++ b/dashboard/test/mailers/previews/teacher_mailer_preview.rb
@@ -1,6 +1,6 @@
 # This can be viewed on non-production environments at /rails/mailers/teacher_mailer
 class TeacherMailerPreview < ActionMailer::Preview
-  include FactoryGirl::Syntax::Methods
+  include FactoryBot::Syntax::Methods
 
   def new_teacher_email_es_mx_preview
     teacher = build :teacher, email: 'teacher@gmail.com'

--- a/dashboard/test/mailers/previews/traverse_mail_previews_test.rb
+++ b/dashboard/test/mailers/previews/traverse_mail_previews_test.rb
@@ -8,7 +8,7 @@ class TraverseMailPreviewsTest < ActiveSupport::TestCase
     end
 
     classes.each do |klass|
-      methods =  klass.instance_methods - FactoryGirl::Syntax::Methods.methods - FactoryGirl::Syntax::Methods.instance_methods
+      methods =  klass.instance_methods - FactoryBot::Syntax::Methods.methods - FactoryBot::Syntax::Methods.instance_methods
 
       failed_runs = []
 

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -435,7 +435,7 @@ class UserTest < ActiveSupport::TestCase
   end
 
   def cannot_create_user_with_email(*args)
-    assert_fails_email_uniqueness_validation FactoryGirl.build(*args)
+    assert_fails_email_uniqueness_validation FactoryBot.build(*args)
   end
 
   test "cannot update multi-auth user with duplicate of multi-auth user's email" do
@@ -476,7 +476,7 @@ class UserTest < ActiveSupport::TestCase
 
   def cannot_give_user_additional_email(type, email)
     user = create type
-    user.authentication_options << FactoryGirl.build(:google_authentication_option, user: user, email: email)
+    user.authentication_options << FactoryBot.build(:google_authentication_option, user: user, email: email)
     refute user.save
     assert_fails_email_uniqueness_validation user
   end

--- a/dashboard/test/test_helper.rb
+++ b/dashboard/test/test_helper.rb
@@ -124,7 +124,7 @@ class ActiveSupport::TestCase
   end
 
   # Add more helper methods to be used by all tests here...
-  include FactoryGirl::Syntax::Methods
+  include FactoryBot::Syntax::Methods
   include ActiveSupport::Testing::SetupAllAndTeardownAll
   include ActiveSupport::Testing::TransactionalTestCase
   include CaptureQueries
@@ -444,7 +444,7 @@ class ActionController::TestCase
   # @param method [Symbol, String] http method with which to perform the action (default :get)
   # @param response [Symbol, String, Number] expected response (default :success)
   # @param user [Symbol, String, Proc] user to log in, or nil to test as a not-logged-in user (default: nil)
-  #   It can be a factory name to be passed to FactoryGirl.create,
+  #   It can be a factory name to be passed to FactoryBot.create,
   #   or a proc that runs in the context of the test case and returns a user.
   # @param params [Hash, Proc] params to pass to the action. It can be a direct hash,
   #   or a proc that generates a hash at runtime in the context of the test case.
@@ -499,7 +499,7 @@ class ActionController::TestCase
       params = instance_exec(&params) if params.is_a? Proc
 
       if user
-        # user can be a symbol or string for FactoryGirl creation,
+        # user can be a symbol or string for FactoryBot creation,
         # or a proc that returns a user object at runtime
         actual_user = user.is_a?(Proc) ? instance_exec(&user) : create(user)
         sign_in actual_user

--- a/dashboard/test/ui/features/step_definitions/pd.rb
+++ b/dashboard/test/ui/features/step_definitions/pd.rb
@@ -34,7 +34,7 @@ Given /^I am a program manager named "([^"]*)" for regional partner "([^"]*)"$/ 
   regional_partner = RegionalPartner.find_or_create_by(name: partner_name, group: 1)
 
   email, password = generate_user(pm_name)
-  FactoryGirl.create(:program_manager, name: pm_name, email: email, password: password, regional_partner: regional_partner)
+  FactoryBot.create(:program_manager, name: pm_name, email: email, password: password, regional_partner: regional_partner)
 
   steps %Q{
     And I sign in as "#{pm_name}"
@@ -74,8 +74,8 @@ Given /^there is a facilitator named "([^"]+)" for course "([^"]+)"$/ do |name, 
 
   email, password = generate_user(name)
 
-  FactoryGirl.create(:pd_course_facilitator, course: course, facilitator:
-    FactoryGirl.create(:facilitator, name: name, email: email, password: password)
+  FactoryBot.create(:pd_course_facilitator, course: course, facilitator:
+    FactoryBot.create(:facilitator, name: name, email: email, password: password)
   )
 end
 
@@ -130,7 +130,7 @@ Given(/^I am a teacher who has just followed a workshop certificate link$/) do
     And I create a workshop for course "CS Principles" attended by "#{test_teacher_name}" with 3 facilitators and end it
   }
 
-  enrollment = FactoryGirl.create(
+  enrollment = FactoryBot.create(
     :pd_enrollment,
     :with_attendance,
     :from_user,
@@ -247,7 +247,7 @@ end
 And(/^I am viewing a workshop with fake survey results$/) do
   require_rails_env
 
-  workshop = FactoryGirl.create :summer_workshop,
+  workshop = FactoryBot.create :summer_workshop,
     :ended,
     num_sessions: 5,
     enrolled_and_attending_users: 10,
@@ -481,7 +481,7 @@ def create_enrollment(workshop, name=nil)
   first_name = name.nil? ? "First - #{SecureRandom.hex}" : name
   last_name = name.nil? ? "Last - #{SecureRandom.hex}" : "Last"
   user = Retryable.retryable(on: [ActiveRecord::RecordInvalid], tries: 5) do
-    FactoryGirl.create :teacher
+    FactoryBot.create :teacher
   end
   Pd::Enrollment.create!(
     first_name: first_name,
@@ -521,7 +521,7 @@ And(/^I create a workshop for course "([^"]*)" ([a-z]+) by "([^"]*)" with (\d+) 
     end
 
   workshop = Retryable.retryable(on: [ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid], tries: 5) do
-    FactoryGirl.create(:workshop, :funded,
+    FactoryBot.create(:workshop, :funded,
       on_map: true,
       course: course,
       organizer_id: organizer.id,


### PR DESCRIPTION
This gem was renamed, and the name we're using is no longer receiving updates.

Mostly just following the documentation at https://github.com/thoughtbot/factory_bot/blob/v4.9.0/UPGRADE_FROM_FACTORY_GIRL.md:

```bash
git grep --name-only FactoryGirl | xargs sed -i "s/FactoryGirl/FactoryBot/"
git grep --name-only factory_girl | xargs sed -i "s/factory_girl/factory_bot/"
```

Also update from 4.7.0 to 4.8.2 while we're at it; no significant changes between those versions, and the Girl to Bot transition should be entirely seamless.

## Links

- [Project Naming History](https://github.com/thoughtbot/factory_bot/blob/main/NAME.md#factory-bot)

## Follow-up work

After this, we probably want to continue to update the version we target; at least to [v4.11.1](https://github.com/thoughtbot/factory_bot/releases/tag/v4.11.1), possibly all the way to v6.x