### PR TITLE
[Google Blockly] Fix - Themes for read-only workspaces

### DIFF
--- a/apps/src/blockly/addons/cdoUtils.js
+++ b/apps/src/blockly/addons/cdoUtils.js
@@ -99,6 +99,6 @@ export function getField(type) {
  * @returns {?Blockly.Field}
  */
 // Users can change their active theme using the context menu. Use this setting, if present.
-export function chooseTheme(themeOption) {
+export function getUserTheme(themeOption) {
   return Blockly.themes[localStorage.blocklyTheme] || themeOption || cdoTheme;
 }

--- a/apps/src/blockly/addons/cdoUtils.js
+++ b/apps/src/blockly/addons/cdoUtils.js
@@ -1,4 +1,5 @@
 import {ToolboxType, CLAMPED_NUMBER_REGEX} from '../constants';
+import cdoTheme from '../themes/cdoTheme';
 
 export function setHSV(block, h, s, v) {
   block.setColour(Blockly.utils.colour.hsvToHex(h, s, v * 255));
@@ -90,4 +91,14 @@ export function getField(type) {
     field = new Blockly.FieldTextInput();
   }
   return field;
+}
+
+/**
+ * Returns a theme object, based on the presence of an option in the browser's localStorage.
+ * @param {string} type
+ * @returns {?Blockly.Field}
+ */
+// Users can change their active theme using the context menu. Use this setting, if present.
+export function chooseTheme(themeOption) {
+  return Blockly.themes[localStorage.blocklyTheme] || themeOption || cdoTheme;
 }

--- a/apps/src/blockly/googleBlocklyWrapper.js
+++ b/apps/src/blockly/googleBlocklyWrapper.js
@@ -65,6 +65,11 @@ const BLOCK_PADDING = 7; // Calculated from difference between block height and 
 const INFINITE_LOOP_TRAP =
   '  executionInfo.checkTimeout(); if (executionInfo.isTerminated()){return;}\n';
 
+// Users can change their active theme using the context menu. Use this setting, if present.
+function chooseTheme(themeOption) {
+  return Blockly.themes[localStorage.blocklyTheme] || themeOption || CdoTheme;
+}
+
 /**
  * Wrapper class for https://github.com/google/blockly
  * This wrapper will facilitate migrating from CDO Blockly to Google Blockly
@@ -500,9 +505,10 @@ function initializeBlocklyWrapper(blocklyInstance) {
     },
 
     createReadOnlyBlockSpace: (container, xml, options) => {
+      const theme = chooseTheme(options.theme);
       const workspace = new Blockly.WorkspaceSvg({
         readOnly: true,
-        theme: options.theme || CdoTheme,
+        theme: theme,
         plugins: {},
         RTL: options.rtl
       });
@@ -513,7 +519,7 @@ function initializeBlocklyWrapper(blocklyInstance) {
           'xmlns:html': 'http://www.w3.org/1999/xhtml',
           'xmlns:xlink': 'http://www.w3.org/1999/xlink',
           version: '1.1',
-          class: 'geras-renderer modern-theme readOnlyBlockSpace'
+          class: 'geras-renderer modern-theme readOnlyBlockSpace injectionDiv'
         },
         null
       );
@@ -548,6 +554,7 @@ function initializeBlocklyWrapper(blocklyInstance) {
         'style',
         `transform: translate(0px, ${notchHeight + BLOCK_PADDING}px)`
       );
+      workspace.setTheme(theme);
       return workspace;
     }
   };
@@ -555,7 +562,7 @@ function initializeBlocklyWrapper(blocklyInstance) {
   blocklyWrapper.inject = function(container, opt_options, opt_audioPlayer) {
     const options = {
       ...opt_options,
-      theme: opt_options.theme || CdoTheme,
+      theme: chooseTheme(opt_options.theme),
       trashcan: false, // Don't use default trashcan.
       move: {
         wheel: true,
@@ -572,11 +579,6 @@ function initializeBlocklyWrapper(blocklyInstance) {
       renderer: opt_options.renderer || 'cdo_renderer',
       comments: false
     };
-    // Users can change their active theme using the context menu. Use this setting, if present.
-    // Music Lab doesn't look good without its custom theme, so we prevent others from being used.
-    if (localStorage.blocklyTheme) {
-      options.theme = this.themes[localStorage.blocklyTheme] || options.theme;
-    }
     // CDO Blockly takes assetUrl as an inject option, and it's used throughout
     // apps, so we should also set it here.
     blocklyWrapper.assetUrl = opt_options.assetUrl || (path => `./${path}`);

--- a/apps/src/blockly/googleBlocklyWrapper.js
+++ b/apps/src/blockly/googleBlocklyWrapper.js
@@ -65,11 +65,6 @@ const BLOCK_PADDING = 7; // Calculated from difference between block height and 
 const INFINITE_LOOP_TRAP =
   '  executionInfo.checkTimeout(); if (executionInfo.isTerminated()){return;}\n';
 
-// Users can change their active theme using the context menu. Use this setting, if present.
-function chooseTheme(themeOption) {
-  return Blockly.themes[localStorage.blocklyTheme] || themeOption || CdoTheme;
-}
-
 /**
  * Wrapper class for https://github.com/google/blockly
  * This wrapper will facilitate migrating from CDO Blockly to Google Blockly
@@ -505,7 +500,7 @@ function initializeBlocklyWrapper(blocklyInstance) {
     },
 
     createReadOnlyBlockSpace: (container, xml, options) => {
-      const theme = chooseTheme(options.theme);
+      const theme = cdoUtils.chooseTheme(options.theme);
       const workspace = new Blockly.WorkspaceSvg({
         readOnly: true,
         theme: theme,
@@ -562,7 +557,7 @@ function initializeBlocklyWrapper(blocklyInstance) {
   blocklyWrapper.inject = function(container, opt_options, opt_audioPlayer) {
     const options = {
       ...opt_options,
-      theme: chooseTheme(opt_options.theme),
+      theme: cdoUtils.chooseTheme(opt_options.theme),
       trashcan: false, // Don't use default trashcan.
       move: {
         wheel: true,

--- a/apps/src/blockly/googleBlocklyWrapper.js
+++ b/apps/src/blockly/googleBlocklyWrapper.js
@@ -500,7 +500,7 @@ function initializeBlocklyWrapper(blocklyInstance) {
     },
 
     createReadOnlyBlockSpace: (container, xml, options) => {
-      const theme = cdoUtils.chooseTheme(options.theme);
+      const theme = cdoUtils.getUserTheme(options.theme);
       const workspace = new Blockly.WorkspaceSvg({
         readOnly: true,
         theme: theme,
@@ -557,7 +557,7 @@ function initializeBlocklyWrapper(blocklyInstance) {
   blocklyWrapper.inject = function(container, opt_options, opt_audioPlayer) {
     const options = {
       ...opt_options,
-      theme: cdoUtils.chooseTheme(opt_options.theme),
+      theme: cdoUtils.getUserTheme(opt_options.theme),
       trashcan: false, // Don't use default trashcan.
       move: {
         wheel: true,

--- a/apps/src/blockly/themes/cdoDark.js
+++ b/apps/src/blockly/themes/cdoDark.js
@@ -6,5 +6,8 @@ import {Themes} from '../constants.js';
 // https://github.com/google/blockly-samples/blob/master/plugins/theme-dark/src/index.js
 export default GoogleBlockly.Theme.defineTheme(Themes.DARK, {
   base: DarkTheme,
-  blockStyles: cdoBlockStyles
+  blockStyles: cdoBlockStyles,
+  fontStyle: {
+    family: '"Gotham 4r", sans-serif'
+  }
 });


### PR DESCRIPTION
## Problem
AmyBW reported an issue where blocks in read-only workspaces were being rendered incorrectly. This is currently impacting all Google Blockly lab levels with blocks embedded in hints/instructions as well as our internal block pools tool on levelbuilder. [[Slack thread](https://codedotorg.slack.com/archives/C03DBDN67B7/p1678479415540099)]

![Screen Shot 2023-03-10 at 12 15 32 PM](https://user-images.githubusercontent.com/43474485/225330265-7473e82d-a39a-4d27-9380-cbca6c488bb7.png)

## Explanation
Typically, when we create a Blockly workspace, we call Blockly's `inject` method, but we skip this step for read-only workspaces. Blockly does support calling `new WorkspaceSvg() directly but we need to make sure it's doing everything correctly.

Attempting to manually set the theme in the dev console produced an error: 
<img width="504" alt="image" src="https://user-images.githubusercontent.com/43474485/225331776-4d70271e-3f50-4587-a850-fc1f32b08c86.png">

`setTheme` calls `workspace.getInjectionDiv` which calls every element's `parentNode.getAttribute('class')` looking for `injectionDiv`:
https://github.com/google/blockly/blob/17064a1c396d392736b10fcd21493d262d98e27c/core/workspace_svg.ts#L702
Our read-only workspaces had no element with that class so Blockly couldn't determine the parent div. Additionally, because we were skipping the inject call it seems like we weren't properly applying the new theme to all elements.

## Solution

`injectionDiv` needs to be added to the list of classes in the svg we create for the workspace to fix this. We also need to add a call to `setTheme` before return the new workspace.

**Fixed:**
![image](https://user-images.githubusercontent.com/43474485/225334949-cb58b279-d58f-4ae8-a7dc-e2b4a2743036.png)

While we're at it, we can also refactor how the default theme is chosen for both standard and read-only workspaces. Because we want alignment in how the theme is chosen, this logic can be moved to a helper function. This allows newly created read-only workspaces to use the theme currently indicated by the browser's localStorage, as set by the workspace context menu.

**Read-workspaces rendering with the high contrast theme on page reload:**
<img width="827" alt="image" src="https://user-images.githubusercontent.com/43474485/225337271-d6a11f5f-7620-4ad1-9b0b-532354d17c12.png">
<img width="594" alt="image" src="https://user-images.githubusercontent.com/43474485/225337392-f7e0bfba-7171-44f5-b3da-7ccbe6bce627.png">
 
While not related to the scope of this task, I also snuck in a fix to the CdoDark theme after @breville pointed out that it was missing the Gotham font specification.

## Follow-up work

Dynamically switching themes with the context menu only affects the main workspace (ie. the workspace within the scope of the context menu). We can update the logic in `contextMenu.js` to affect each of `Blockly.Workspace.getAll()` instead of just `scope.workspace`. This will make it so that switching themes will affect every workspace on screen at once. (https://codedotorg.atlassian.net/browse/SL-649 - Assigned to @bencodeorg)

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
