### PR TITLE
Do not send app mailers without an RP

### DIFF
--- a/dashboard/app/models/pd/application/teacher_application.rb
+++ b/dashboard/app/models/pd/application/teacher_application.rb
@@ -361,7 +361,7 @@ module Pd::Application
     end
 
     def should_send_decision_email?
-      if regional_partner.nil? || regional_partner&.applications_decision_emails == RegionalPartner::SENT_BY_PARTNER
+      if regional_partner.nil? || regional_partner.applications_decision_emails == RegionalPartner::SENT_BY_PARTNER
         false
       else
         AUTO_EMAIL_STATUSES.include?(status)

--- a/dashboard/app/models/pd/application/teacher_application.rb
+++ b/dashboard/app/models/pd/application/teacher_application.rb
@@ -136,7 +136,7 @@ module Pd::Application
     end
 
     def set_status_from_admin_approval
-      # Do not modify status is application is not incomplete.
+      # Do not modify status if application is incomplete.
       return if status == 'incomplete'
 
       # Do not modify status if admin approval status has not changed.

--- a/dashboard/app/models/pd/application/teacher_application.rb
+++ b/dashboard/app/models/pd/application/teacher_application.rb
@@ -136,17 +136,14 @@ module Pd::Application
     end
 
     def set_status_from_admin_approval
-      # Do not modify status if application is incomplete.
       return if status == 'incomplete'
+      return if principal_approval_state&.include?(PRINCIPAL_APPROVAL_STATE[:complete])
 
       # Do not modify status if admin approval status has not changed.
       # Since principal_approval_not_required is a serialized attribute, we cannot use the Dirty
       # API easily –– instead, use the Dirty API to look at the properties attribute.
       return if properties_change.include?(nil)
       return unless properties_change.map(&:keys)&.flatten&.include?('principal_approval_not_required')
-
-      # Do not modify status if the principal approval has already been completed.
-      return if principal_approval_state&.include?(PRINCIPAL_APPROVAL_STATE[:complete])
 
       if !principal_approval_not_required && status != 'awaiting_admin_approval'
         self.status = 'awaiting_admin_approval'

--- a/dashboard/app/models/pd/application/teacher_application.rb
+++ b/dashboard/app/models/pd/application/teacher_application.rb
@@ -364,7 +364,7 @@ module Pd::Application
     end
 
     def should_send_decision_email?
-      if regional_partner&.applications_decision_emails == RegionalPartner::SENT_BY_PARTNER
+      if regional_partner.nil? || regional_partner&.applications_decision_emails == RegionalPartner::SENT_BY_PARTNER
         false
       else
         AUTO_EMAIL_STATUSES.include?(status)

--- a/dashboard/test/lib/services/registration_reminder_test.rb
+++ b/dashboard/test/lib/services/registration_reminder_test.rb
@@ -9,13 +9,15 @@ class Services::RegistrationReminderTest < ActiveSupport::TestCase
     #
     Timecop.freeze do
       # Initial creation: No reminders
-      application = create :pd_teacher_application
+      application_hash = build :pd_teacher_application_hash, regional_partner_id: create(:regional_partner).id
+      application = create :pd_teacher_application, form_data_hash: application_hash
       Services::RegistrationReminder.queue_registration_reminders!
       assert_empty application.emails.where(email_type: 'registration_reminder')
 
-      # Fake sending first accepted email
+      # Fake sending first accepted email by updating the status to accepted and setting sent_at field
       Timecop.travel 1.day
-      create :pd_application_email, application: application, email_type: 'accepted', sent_at: DateTime.now
+      application.update!(status: 'accepted')
+      application.emails.where(email_type: 'accepted').last.mark_sent!
       Services::RegistrationReminder.queue_registration_reminders!
       assert_empty application.emails.where(email_type: 'registration_reminder')
 
@@ -99,6 +101,18 @@ class Services::RegistrationReminderTest < ActiveSupport::TestCase
     application = create :pd_teacher_application, created_at: DateTime.new(2019, 9, 30)
     create :pd_application_email, application: application, email_type: 'accepted', sent_at: 1.week.ago
     assert_equal 0, Services::RegistrationReminder.applications_needing_first_reminder.count
+  end
+
+  test 'applications_needing_first_reminder omits applications without an RP since the accepted email does not get sent' do
+    Timecop.freeze do
+      application = create :pd_teacher_application
+      application.update!(status: 'accepted')
+      assert_empty application.emails.where(email_type: 'accepted')
+
+      Timecop.travel 7.days
+      Services::RegistrationReminder.queue_registration_reminders!
+      assert_equal 0, Services::RegistrationReminder.applications_needing_first_reminder.count
+    end
   end
 
   test 'applications_needing_first_reminder includes eligible applications' do

--- a/dashboard/test/models/pd/application/teacher_application_test.rb
+++ b/dashboard/test/models/pd/application/teacher_application_test.rb
@@ -434,16 +434,26 @@ module Pd::Application
       assert_equal 3, application.status_log.count
     end
 
-    test 'setting an auto-email status queues up an email' do
-      application = create :pd_teacher_application
+    test 'setting an auto-email status queues up an email if associated with an RP' do
+      application_hash = build :pd_teacher_application_hash, regional_partner_id: create(:regional_partner).id
+      application = create :pd_teacher_application, form_data_hash: application_hash
       assert_empty application.emails
 
       application.expects(:queue_email).with('accepted')
       application.update!(status: 'accepted')
     end
 
-    test 'setting an non auto-email status does not queue up a status email' do
+    test 'setting an auto-email status does not queue up an email if no RP' do
       application = create :pd_teacher_application
+      assert_empty application.emails
+
+      application.expects(:queue_email).never
+      application.update!(status: 'accepted')
+    end
+
+    test 'setting a non auto-email status does not queue up a status email even if associated with an RP' do
+      application_hash = build :pd_teacher_application_hash, regional_partner_id: create(:regional_partner).id
+      application = create :pd_teacher_application, form_data_hash: application_hash
       assert_empty application.emails
 
       application.expects(:queue_email).never
@@ -510,17 +520,15 @@ module Pd::Application
     end
 
     test 'should_send_decision_email?' do
-      application = build :pd_teacher_application, status: :pending
+      partner = create :regional_partner, applications_decision_emails: RegionalPartner::SENT_BY_SYSTEM
+      application_hash = build :pd_teacher_application_hash, regional_partner_id: partner.id
+      application = create :pd_teacher_application, form_data_hash: application_hash
 
       # no auto-email status: no email
       refute application.should_send_decision_email?
 
-      # auto-email status with no partner: yes email
+      # auto-email status with partner emails sent_by_system: yes email
       application.status = :accepted
-      assert application.should_send_decision_email?
-
-      # auto-email status, partner with sent_by_system: yes email
-      application.regional_partner = build(:regional_partner, applications_decision_emails: RegionalPartner::SENT_BY_SYSTEM)
       assert application.should_send_decision_email?
 
       # auto-email status, partner with sent_by_partner: no email


### PR DESCRIPTION
For applicants *not* linked to a regional partner, removes the auto-email for accepted applications, declined applications, and applications needing a registration reminder.

The "registration reminder" service relies on an accepted email being sent to trigger the reminder. Instead of changing the logic of the SQL joins, I added a test and updated a test for documentation. This is a bit wonky, as it does depend on the logic behind the *model* sending emails, but I think this ensures (a) the test will break if the model behavior changes, and (b) avoids adding more complex joins to an already-complex SQL statement. Happy for more discussion here though!

## Links

https://codedotorg.atlassian.net/browse/ACQ-442

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
