### PR TITLE
Adding 'Is Active' check box to regional partners edit, view and index pages

### DIFF
--- a/dashboard/app/controllers/regional_partners_controller.rb
+++ b/dashboard/app/controllers/regional_partners_controller.rb
@@ -149,6 +149,7 @@ class RegionalPartnersController < ApplicationController
   def regional_partner_params
     params.require(:regional_partner).permit(
       :name,
+      :is_active,
       :group,
       :urban,
       :cohort_capacity_csd,

--- a/dashboard/app/controllers/test_controller.rb
+++ b/dashboard/app/controllers/test_controller.rb
@@ -236,7 +236,7 @@ class TestController < ApplicationController
 
   def create_teacher_application
     return unless (user = current_user)
-    regional_partner = RegionalPartner.create!(name: "regional-partner#{Time.now.to_i}-#{rand(1_000_000)}")
+    regional_partner = RegionalPartner.create!(name: "regional-partner#{Time.now.to_i}-#{rand(1_000_000)}", is_active: true)
 
     RegionalPartnerProgramManager.create!(program_manager_id: user.id, regional_partner_id: regional_partner.id)
 

--- a/dashboard/app/models/regional_partner.rb
+++ b/dashboard/app/models/regional_partner.rb
@@ -139,7 +139,7 @@ class RegionalPartner < ApplicationRecord
   validates_inclusion_of :applications_decision_emails, in: APPLICATION_DECISION_EMAILS, if: -> {applications_decision_emails.present?}
   validates :csd_cost, numericality: {greater_than: 0}, if: -> {csd_cost.present?}
   validates :csp_cost, numericality: {greater_than: 0}, if: -> {csp_cost.present?}
-  validates :is_active, inclusion: [true, false]
+  validates_presence_of :is_active
 
   # assign a program manager to a regional partner
   def program_manager=(program_manager_id)

--- a/dashboard/app/models/regional_partner.rb
+++ b/dashboard/app/models/regional_partner.rb
@@ -139,6 +139,7 @@ class RegionalPartner < ApplicationRecord
   validates_inclusion_of :applications_decision_emails, in: APPLICATION_DECISION_EMAILS, if: -> {applications_decision_emails.present?}
   validates :csd_cost, numericality: {greater_than: 0}, if: -> {csd_cost.present?}
   validates :csp_cost, numericality: {greater_than: 0}, if: -> {csp_cost.present?}
+  validates :is_active, inclusion: [true, false]
 
   # assign a program manager to a regional partner
   def program_manager=(program_manager_id)

--- a/dashboard/app/views/regional_partners/_form.html.haml
+++ b/dashboard/app/views/regional_partners/_form.html.haml
@@ -8,9 +8,9 @@
   .field
     = f.label :name
     = f.text_field :name
-  .field
-    = f.label nil, "Active"
+  .field.checkbox
     = f.check_box :is_active
+    = f.label :is_active
   %h2 Regional Manager Information
   .field
     = f.label :contact_name

--- a/dashboard/app/views/regional_partners/_form.html.haml
+++ b/dashboard/app/views/regional_partners/_form.html.haml
@@ -8,6 +8,9 @@
   .field
     = f.label :name
     = f.text_field :name
+  .field
+    = f.label nil, "Active"
+    = f.check_box :is_active
   %h2 Regional Manager Information
   .field
     = f.label :contact_name

--- a/dashboard/app/views/regional_partners/index.html.haml
+++ b/dashboard/app/views/regional_partners/index.html.haml
@@ -48,4 +48,4 @@
           %td= regional_partner.contact_email_with_backup
           - if can? :update, regional_partner
             %td= link_to t('crud.edit'), edit_regional_partner_path(regional_partner)
-            %td= link_to t('crud.show'), @regional_partner
+            %td= link_to t('crud.show'), regional_partner

--- a/dashboard/app/views/regional_partners/index.html.haml
+++ b/dashboard/app/views/regional_partners/index.html.haml
@@ -32,6 +32,7 @@
     %thead
       %th ID
       %th Name
+      %th Active
       %th Contact
       %th Edit
       %th Show
@@ -40,6 +41,10 @@
         %tr
           %td= link_to regional_partner.id, regional_partner
           %td= regional_partner.name
+          - if regional_partner.is_active
+            %td= 'Yes'
+          - else
+            %td= 'No'
           %td= regional_partner.contact_email_with_backup
           - if can? :update, regional_partner
             %td= link_to t('crud.edit'), edit_regional_partner_path(regional_partner)

--- a/dashboard/app/views/regional_partners/show.html.haml
+++ b/dashboard/app/views/regional_partners/show.html.haml
@@ -24,7 +24,7 @@
   %strong Active:
   - if @regional_partner.is_active
     = 'Yes'
-  -else
+  - else
     = 'No'
 %p
   %strong Contact Email:

--- a/dashboard/app/views/regional_partners/show.html.haml
+++ b/dashboard/app/views/regional_partners/show.html.haml
@@ -21,6 +21,12 @@
   %strong Name:
   = @regional_partner.name
 %p
+  %strong Active:
+  - if @regional_partner.is_active
+    = 'Yes'
+  -else
+    = 'No'
+%p
   %strong Contact Email:
   = @regional_partner.contact_email
 %p

--- a/dashboard/db/migrate/20230313222451_backfill_regional_partner_is_active.rb
+++ b/dashboard/db/migrate/20230313222451_backfill_regional_partner_is_active.rb
@@ -1,0 +1,6 @@
+class BackfillRegionalPartnerIsActive < ActiveRecord::Migration[6.0]
+  def change
+    RegionalPartner.reset_column_information
+    RegionalPartner.update_all(is_active: true)
+  end
+end

--- a/dashboard/db/migrate/20230313222451_backfill_regional_partner_is_active.rb
+++ b/dashboard/db/migrate/20230313222451_backfill_regional_partner_is_active.rb
@@ -1,6 +1,9 @@
 class BackfillRegionalPartnerIsActive < ActiveRecord::Migration[6.0]
-  def change
+  def up
     RegionalPartner.reset_column_information
     RegionalPartner.update_all(is_active: true)
+  end
+
+  def down
   end
 end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_03_09_041659) do
+ActiveRecord::Schema.define(version: 2023_03_13_222451) do
 
   create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"

--- a/dashboard/test/controllers/regional_partners_controller_test.rb
+++ b/dashboard/test/controllers/regional_partners_controller_test.rb
@@ -47,7 +47,7 @@ class RegionalPartnersControllerTest < ActionController::TestCase
   test 'create regional partner creates regional partner' do
     sign_in @workshop_admin
     assert_creates RegionalPartner do
-      post :create, params: {regional_partner: {name: "Test Regional Partner"}}
+      post :create, params: {regional_partner: {name: "Test Regional Partner", is_active: true}}
     end
     regional_partner = RegionalPartner.last
     assert_redirected_to regional_partner
@@ -61,6 +61,7 @@ class RegionalPartnersControllerTest < ActionController::TestCase
     end
     assert_template :new
     assert_select '#error_explanation > ul > li', text: 'Phone number is invalid'
+    assert_select '#error_explanation > ul > li', text: 'Is active is not included in the list'
   end
 
   test 'update regional partner updates regional partner' do

--- a/dashboard/test/controllers/regional_partners_controller_test.rb
+++ b/dashboard/test/controllers/regional_partners_controller_test.rb
@@ -61,7 +61,7 @@ class RegionalPartnersControllerTest < ActionController::TestCase
     end
     assert_template :new
     assert_select '#error_explanation > ul > li', text: 'Phone number is invalid'
-    assert_select '#error_explanation > ul > li', text: 'Is active is not included in the list'
+    assert_select '#error_explanation > ul > li', text: 'Is active is required'
   end
 
   test 'update regional partner updates regional partner' do

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -1466,6 +1466,7 @@ FactoryBot.define do
     group 1
     pl_programs_offered ['CSD', 'CSP']
     applications_principal_approval RegionalPartner::ALL_REQUIRE_APPROVAL
+    is_active true
   end
 
   factory :regional_partner_with_mappings, parent: :regional_partner do

--- a/dashboard/test/models/regional_partner_test.rb
+++ b/dashboard/test/models/regional_partner_test.rb
@@ -39,7 +39,7 @@ class RegionalPartnerTest < ActiveSupport::TestCase
   test "create regional partner with programs offered cleans empties" do
     regional_partner = RegionalPartner.new
     assert_creates RegionalPartner do
-      regional_partner.update(name: "valid regional partner", pl_programs_offered: ['', 'Fish'])
+      regional_partner.update(name: "valid regional partner", pl_programs_offered: ['', 'Fish'], is_active: true)
     end
     assert regional_partner.valid?
     assert_includes regional_partner.pl_programs_offered, "Fish"

--- a/dashboard/test/models/regional_partner_test.rb
+++ b/dashboard/test/models/regional_partner_test.rb
@@ -27,12 +27,13 @@ class RegionalPartnerTest < ActiveSupport::TestCase
   test "create regional partner with invalid attributes does not create" do
     regional_partner = RegionalPartner.new
     assert_does_not_create RegionalPartner do
-      regional_partner.update(name: "", group: "fish", phone_number: 'fish')
+      regional_partner.update(name: "", group: "fish", phone_number: 'fish', is_active: nil)
     end
     refute regional_partner.valid?
     assert_includes regional_partner.errors.full_messages, "Name is too short (minimum is 1 character)"
     assert_includes regional_partner.errors.full_messages, "Group is not a number"
     assert_includes regional_partner.errors.full_messages, "Phone number is invalid"
+    assert_includes regional_partner.errors.full_messages, "Is active is not included in the list"
   end
 
   test "create regional partner with programs offered cleans empties" do

--- a/dashboard/test/models/regional_partner_test.rb
+++ b/dashboard/test/models/regional_partner_test.rb
@@ -33,7 +33,7 @@ class RegionalPartnerTest < ActiveSupport::TestCase
     assert_includes regional_partner.errors.full_messages, "Name is too short (minimum is 1 character)"
     assert_includes regional_partner.errors.full_messages, "Group is not a number"
     assert_includes regional_partner.errors.full_messages, "Phone number is invalid"
-    assert_includes regional_partner.errors.full_messages, "Is active is not included in the list"
+    assert_includes regional_partner.errors.full_messages, "Is active is required"
   end
 
   test "create regional partner with programs offered cleans empties" do

--- a/dashboard/test/ui/features/step_definitions/pd.rb
+++ b/dashboard/test/ui/features/step_definitions/pd.rb
@@ -20,7 +20,7 @@ end
 Given /^I am a CSF facilitator named "([^"]*)" for regional partner "([^"]*)"$/ do |facilitator_name, partner_name|
   require_rails_env
 
-  RegionalPartner.find_or_create_by(name: partner_name, group: 1)
+  RegionalPartner.find_or_create_by(name: partner_name, group: 1, is_active: true)
 
   steps %Q{
     And there is a facilitator named "#{facilitator_name}" for course "#{Pd::Workshop::COURSE_CSF}"
@@ -31,7 +31,7 @@ end
 Given /^I am a program manager named "([^"]*)" for regional partner "([^"]*)"$/ do |pm_name, partner_name|
   require_rails_env
 
-  regional_partner = RegionalPartner.find_or_create_by(name: partner_name, group: 1)
+  regional_partner = RegionalPartner.find_or_create_by(name: partner_name, group: 1, is_active: true)
 
   email, password = generate_user(pm_name)
   FactoryBot.create(:program_manager, name: pm_name, email: email, password: password, regional_partner: regional_partner)


### PR DESCRIPTION
 - Rails migration to backfill the new "is_active" column for regional partners to true.
 - Adding validation in model to make it a required field
 - UI changes to show the new field in edit, show and index pages
 - Fixed a broken link to show in the index page

Edit page updates with new "Is active" field
![image](https://user-images.githubusercontent.com/124813947/225384281-28dfa431-d3d6-4c10-aef9-d444cd9f57cd.png)

List page updates with new "Is active" field
![image](https://user-images.githubusercontent.com/124813947/225384853-95210b88-c9b7-48eb-a535-b55fb3339d64.png)

View page updates with new "Is active" field
![image](https://user-images.githubusercontent.com/124813947/225384924-ded74054-5c8d-4ca3-a988-d28cdafeaee1.png)

## Links

JIRA ticket: https://codedotorg.atlassian.net/browse/ACQ-251?atlOrigin=eyJpIjoiNTE3NWMzMzM1YWUwNDEyOGIzZWQ5NzM2YzU0NGU3MmMiLCJwIjoiaiJ9

Change that added the migration to include the new field in DB: https://github.com/code-dot-org/code-dot-org/pull/50680 

## Testing story

Includes tests that cover controller and model changes.

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

This change involves a back fill for all regional partners. The total number of regional partners is about 100 in production and less than 10 in staging. Hence, this shouldn't be a long blocking operation.

## Follow-up work

None

## Privacy

No

## Security

N/A

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [ ] New features are translatable or updates will not break translations
  **A new field was added in the UI, but the page is mainly for internal/partner use and doesn't have any translations at this time**
- [ ] Relevant documentation has been added or updated
  **N/A**
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
