### PR TITLE
Project Beats: Rename 'do something' to 'my function' for music lab specifically

### DIFF
--- a/apps/src/music/blockly/MusicBlocklyWorkspace.js
+++ b/apps/src/music/blockly/MusicBlocklyWorkspace.js
@@ -89,7 +89,7 @@ export default class MusicBlocklyWorkspace {
     delete Blockly.Blocks.procedures_ifreturn;
 
     // Rename the new function placeholder text for Music Lab specifically.
-    Blockly.Msg['PROCEDURES_DEFNORETURN_PROCEDURE'] = 'make new block';
+    Blockly.Msg['PROCEDURES_DEFNORETURN_PROCEDURE'] = 'my function';
 
     Blockly.setInfiniteLoopTrap();
 

--- a/apps/src/music/blockly/MusicBlocklyWorkspace.js
+++ b/apps/src/music/blockly/MusicBlocklyWorkspace.js
@@ -88,6 +88,9 @@ export default class MusicBlocklyWorkspace {
     delete Blockly.Blocks.procedures_defreturn;
     delete Blockly.Blocks.procedures_ifreturn;
 
+    // Rename the new function placeholder text for Music Lab specifically.
+    Blockly.Msg['PROCEDURES_DEFNORETURN_PROCEDURE'] = 'make new block';
+
     Blockly.setInfiniteLoopTrap();
 
     this.resizeBlockly();


### PR DESCRIPTION
Renames the default new function text from 'do something' to 'my function' for Music Lab specifically. See [slack](https://codedotorg.slack.com/archives/C04TH8400AU/p1678907438333899) for more discussion. We are keeping this rename scoped to just Music Lab for now to avoid renaming the same text in other labs.

<img width="307" alt="Screenshot 2023-03-17 at 12 29 59 PM" src="https://user-images.githubusercontent.com/85528507/226001588-1d9e145a-0103-4af9-9dff-001ec611a18f.png">

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

https://codedotorg.atlassian.net/browse/SL-601

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Tested locally on Music Lab and other blockly labs - confirmed that the function text is changed for music lab, but not for other labs.
