### PR TITLE
[Google Blockly] Add util to get student code (Save sources in JSON, pt 1)

### DIFF
--- a/apps/src/appMain.js
+++ b/apps/src/appMain.js
@@ -15,8 +15,7 @@ import defaultSkinModule from './skins.js';
 
 window.__TestInterface = {
   loadBlocks: (...args) => studioApp().loadBlocks(...args),
-  getBlockXML: () =>
-    Blockly.Xml.domToText(Blockly.Xml.blockSpaceToDom(Blockly.mainBlockSpace)),
+  getBlockXML: () => Blockly.cdoUtils.getCode(Blockly.mainBlockSpace),
   arrangeBlockPosition: (...args) => studioApp().arrangeBlockPosition(...args),
   getDropletContents: () => studioApp().editor.getValue(),
   getDroplet: () => studioApp().editor,

--- a/apps/src/blockly/addons/cdoUtils.js
+++ b/apps/src/blockly/addons/cdoUtils.js
@@ -104,5 +104,7 @@ export function getUserTheme(themeOption) {
 }
 
 export function getCode(workspace) {
-  return JSON.stringify(Blockly.serialization.workspaces.save(workspace));
+  return Blockly.Xml.domToText(Blockly.Xml.blockSpaceToDom(workspace));
+  // After supporting JSON block sources, change to:
+  // return JSON.stringify(Blockly.serialization.workspaces.save(workspace));
 }

--- a/apps/src/blockly/addons/cdoUtils.js
+++ b/apps/src/blockly/addons/cdoUtils.js
@@ -102,3 +102,7 @@ export function getField(type) {
 export function getUserTheme(themeOption) {
   return Blockly.themes[localStorage.blocklyTheme] || themeOption || cdoTheme;
 }
+
+export function getCode(workspace) {
+  return JSON.stringify(Blockly.serialization.workspaces.save(workspace));
+}

--- a/apps/src/blockly/cdoBlocklyWrapper.js
+++ b/apps/src/blockly/cdoBlocklyWrapper.js
@@ -271,6 +271,9 @@ function initializeBlocklyWrapper(blocklyInstance) {
     },
     getField: function(type) {
       return new Blockly.FieldTextInput('', getFieldInputChangeHandler(type));
+    },
+    getCode: function(workspace) {
+      return Blockly.Xml.domToText(Blockly.Xml.blockSpaceToDom(workspace));
     }
   };
   return blocklyWrapper;

--- a/apps/src/bounce/bounce.js
+++ b/apps/src/bounce/bounce.js
@@ -1185,8 +1185,7 @@ Bounce.onPuzzleComplete = function() {
       : TestResults.TOO_FEW_BLOCKS_FAIL;
   }
 
-  var xml = Blockly.Xml.blockSpaceToDom(Blockly.mainBlockSpace);
-  var textBlocks = Blockly.Xml.domToText(xml);
+  var textBlocks = Blockly.cdoUtils.getCode(Blockly.mainBlockSpace);
 
   Bounce.waitingForReport = true;
 

--- a/apps/src/calc/calc.js
+++ b/apps/src/calc/calc.js
@@ -713,8 +713,7 @@ Calc.evaluateResults_ = function(targetSet, userSet) {
 Calc.execute = function() {
   Calc.generateResults_();
 
-  var xml = Blockly.Xml.blockSpaceToDom(Blockly.mainBlockSpace);
-  var textBlocks = Blockly.Xml.domToText(xml);
+  var textBlocks = Blockly.cdoUtils.getCode(Blockly.mainBlockSpace);
 
   var reportData = {
     app: 'calc',

--- a/apps/src/code-studio/initApp/loadApp.js
+++ b/apps/src/code-studio/initApp/loadApp.js
@@ -115,8 +115,7 @@ export function setupApp(appOptions) {
       // in the contained level case, unless we're editing blocks.
       if (appOptions.level.edit_blocks || !appOptions.hasContainedLevels) {
         if (appOptions.hasContainedLevels) {
-          var xml = Blockly.Xml.blockSpaceToDom(Blockly.mainBlockSpace);
-          report.program = Blockly.Xml.domToText(xml);
+          report.program = Blockly.cdoUtils.getCode(Blockly.mainBlockSpace);
         }
         report.callback = appOptions.report.callback;
       }
@@ -479,9 +478,7 @@ const sourceHandler = {
         // If we're readOnly, source hasn't changed at all
         source = Blockly.cdoUtils.isWorkspaceReadOnly(Blockly.mainBlockSpace)
           ? currentLevelSource
-          : Blockly.Xml.domToText(
-              Blockly.Xml.blockSpaceToDom(Blockly.mainBlockSpace)
-            );
+          : Blockly.cdoUtils.getCode(Blockly.mainBlockSpace);
         resolve(source);
       } else if (appOptions.getCode) {
         source = appOptions.getCode();
@@ -542,7 +539,7 @@ export function getAppOptions() {
  * Loads the "appOptions" object from the dom and augments it with additional
  * information needed by apps to run.
  *
- * This should only be called once per page load, with appoptions specified as a
+ * This should only be called once per page load, with appOptions specified as a
  * data attribute on the script tag.
  *
  * @return {Promise.<AppOptionsConfig>} a Promise object which resolves to the fully populated appOptions

--- a/apps/src/craft/agent/craft.js
+++ b/apps/src/craft/agent/craft.js
@@ -847,9 +847,7 @@ export default class Craft {
       testResult: testResultType,
       image: encodedImage,
       program: encodeURIComponent(
-        Blockly.Xml.domToText(
-          Blockly.Xml.blockSpaceToDom(Blockly.mainBlockSpace)
-        )
+        Blockly.cdoUtils.getCode(Blockly.mainBlockSpace)
       ),
       // typically delay feedback until response back
       // for things like e.g. crowdsourced hints & hint blocks

--- a/apps/src/craft/aquatic/craft.js
+++ b/apps/src/craft/aquatic/craft.js
@@ -658,7 +658,7 @@ Craft.reportResult = function(success) {
     testResult: testResultType,
     image: encodedImage,
     program: encodeURIComponent(
-      Blockly.Xml.domToText(Blockly.Xml.blockSpaceToDom(Blockly.mainBlockSpace))
+      Blockly.cdoUtils.getCode(Blockly.mainBlockSpace)
     ),
     // typically delay feedback until response back
     // for things like e.g. crowdsourced hints & hint blocks

--- a/apps/src/craft/designer/craft.js
+++ b/apps/src/craft/designer/craft.js
@@ -987,7 +987,7 @@ Craft.reportResult = function(success) {
     testResult: testResultType,
     image: encodedImage,
     program: encodeURIComponent(
-      Blockly.Xml.domToText(Blockly.Xml.blockSpaceToDom(Blockly.mainBlockSpace))
+      Blockly.cdoUtils.getCode(Blockly.mainBlockSpace)
     ),
     // typically delay feedback until response back
     // for things like e.g. crowdsourced hints & hint blocks

--- a/apps/src/craft/simple/craft.js
+++ b/apps/src/craft/simple/craft.js
@@ -930,7 +930,7 @@ Craft.reportResult = function(success) {
     testResult: testResultType,
     image: encodedImage,
     program: encodeURIComponent(
-      Blockly.Xml.domToText(Blockly.Xml.blockSpaceToDom(Blockly.mainBlockSpace))
+      Blockly.cdoUtils.getCode(Blockly.mainBlockSpace)
     ),
     // typically delay feedback until response back
     // for things like e.g. crowdsourced hints & hint blocks

--- a/apps/src/dance/Dance.js
+++ b/apps/src/dance/Dance.js
@@ -475,9 +475,10 @@ Dance.prototype.onPuzzleComplete = function(result, message) {
   // If we know they succeeded, mark `levelComplete` true.
   const levelComplete = result;
 
-  // We're using blockly, report the program as xml.
-  var xml = Blockly.Xml.blockSpaceToDom(Blockly.mainBlockSpace);
-  let program = encodeURIComponent(Blockly.Xml.domToText(xml));
+  // We're using blockly, report the program as JSON.
+  let program = encodeURIComponent(
+    Blockly.cdoUtils.getCode(Blockly.mainBlockSpace)
+  );
 
   if (this.testResults >= TestResults.FREE_PLAY) {
     this.studioApp_.playAudio('win');

--- a/apps/src/eval/eval.js
+++ b/apps/src/eval/eval.js
@@ -496,8 +496,7 @@ Eval.execute = function() {
     }
   }
 
-  var xml = Blockly.Xml.blockSpaceToDom(Blockly.mainBlockSpace);
-  var textBlocks = Blockly.Xml.domToText(xml);
+  var textBlocks = Blockly.cdoUtils.getCode(Blockly.mainBlockSpace);
 
   var reportData = {
     app: 'eval',

--- a/apps/src/flappy/flappy.js
+++ b/apps/src/flappy/flappy.js
@@ -888,8 +888,7 @@ Flappy.onPuzzleComplete = function() {
 };
 
 function sendReport() {
-  const xml = Blockly.Xml.blockSpaceToDom(Blockly.mainBlockSpace);
-  const textBlocks = Blockly.Xml.domToText(xml);
+  const textBlocks = Blockly.cdoUtils.getCode(Blockly.mainBlockSpace);
 
   Flappy.waitingForReport = true;
 

--- a/apps/src/jigsaw/jigsaw.js
+++ b/apps/src/jigsaw/jigsaw.js
@@ -264,8 +264,7 @@ Jigsaw.onPuzzleComplete = function() {
     studioApp().playAudio('failure');
   }
 
-  var xml = Blockly.Xml.blockSpaceToDom(Blockly.mainBlockSpace);
-  var textBlocks = Blockly.Xml.domToText(xml);
+  var textBlocks = Blockly.cdoUtils.getCode(Blockly.mainBlockSpace);
 
   Jigsaw.waitingForReport = true;
 

--- a/apps/src/maze/maze.js
+++ b/apps/src/maze/maze.js
@@ -474,8 +474,7 @@ module.exports = class Maze {
 
       program = studioApp().editor.getValue();
     } else {
-      var xml = Blockly.Xml.blockSpaceToDom(Blockly.mainBlockSpace);
-      program = Blockly.Xml.domToText(xml);
+      program = Blockly.cdoUtils.getCode(Blockly.mainBlockSpace);
     }
 
     this.waitingForReport = true;

--- a/apps/src/p5lab/P5Lab.js
+++ b/apps/src/p5lab/P5Lab.js
@@ -906,27 +906,34 @@ export default class P5Lab {
       program = encodeURIComponent(this.studioApp_.getCode());
       this.message = null;
     } else {
-      // We're using blockly, report the program as xml
-      var xml = Blockly.Xml.blockSpaceToDom(Blockly.mainBlockSpace);
+      let textBlocks;
+      if (Blockly.version === 'Google') {
+        // We're using Google Blockly, report the program as JSON
+        textBlocks = Blockly.cdoUtils.getCode(Blockly.mainBlockSpace);
+      } else {
+        // We're using CDO Blockly, report the program as xml
+        var xml = Blockly.Xml.blockSpaceToDom(Blockly.mainBlockSpace);
 
-      // When SharedFunctions (aka shared behavior_definitions) are enabled, they
-      // are always appended to startBlocks on page load.
-      // See StudioApp -> setStartBlocks_
-      // Because of this, we need to remove the SharedFunctions when we are in
-      // toolbox edit mode. Otherwise, they end up in a student's toolbox.
-      if (this.level.edit_blocks === TOOLBOX_EDIT_MODE) {
-        var allBlocks = Array.from(xml.querySelectorAll('xml > block'));
-        var toRemove = allBlocks.filter(element => {
-          return (
-            element.getAttribute('type') === 'behavior_definition' &&
-            element.getAttribute('usercreated') !== 'true'
-          );
-        });
-        toRemove.forEach(element => {
-          xml.removeChild(element);
-        });
+        // When SharedFunctions (aka shared behavior_definitions) are enabled, they
+        // are always appended to startBlocks on page load.
+        // See StudioApp -> setStartBlocks_
+        // Because of this, we need to remove the SharedFunctions when we are in
+        // toolbox edit mode. Otherwise, they end up in a student's toolbox.
+        if (this.level.edit_blocks === TOOLBOX_EDIT_MODE) {
+          var allBlocks = Array.from(xml.querySelectorAll('xml > block'));
+          var toRemove = allBlocks.filter(element => {
+            return (
+              element.getAttribute('type') === 'behavior_definition' &&
+              element.getAttribute('usercreated') !== 'true'
+            );
+          });
+          toRemove.forEach(element => {
+            xml.removeChild(element);
+          });
+        }
+        textBlocks = Blockly.Xml.domToText(xml);
       }
-      program = encodeURIComponent(Blockly.Xml.domToText(xml));
+      program = encodeURIComponent(textBlocks);
     }
 
     if (this.testResults >= TestResults.FREE_PLAY) {

--- a/apps/src/sites/studio/pages/shared_blockly_functions/edit.js
+++ b/apps/src/sites/studio/pages/shared_blockly_functions/edit.js
@@ -101,9 +101,7 @@ document
         '#functionDescriptionText'
       ).value;
       if (stack) {
-        getInput('stack').value = Blockly.Xml.domToText(
-          Blockly.Xml.blockToDom(stack)
-        );
+        getInput('stack').value = Blockly.cdoUtils.getCode(stack);
       }
     } catch (error) {
       alert(`Error saving:\n\n${error}`);

--- a/apps/src/studio/studio.js
+++ b/apps/src/studio/studio.js
@@ -3806,8 +3806,7 @@ Studio.sendPuzzleReport = function(onComplete = Studio.onReportComplete) {
 
     program = studioApp().getCode();
   } else {
-    var xml = Blockly.Xml.blockSpaceToDom(Blockly.mainBlockSpace);
-    program = Blockly.Xml.domToText(xml);
+    program = Blockly.cdoUtils.getCode(Blockly.mainBlockSpace);
   }
 
   Studio.waitingForReport = true;

--- a/apps/src/turtle/artist.js
+++ b/apps/src/turtle/artist.js
@@ -1575,8 +1575,7 @@ Artist.prototype.checkAnswer = function() {
 
 Artist.prototype.getUserCode = function() {
   if (this.studioApp_.isUsingBlockly()) {
-    var xml = Blockly.Xml.blockSpaceToDom(Blockly.mainBlockSpace);
-    return Blockly.Xml.domToText(xml);
+    return Blockly.cdoUtils.getCode(Blockly.mainBlockSpace);
   } else if (this.level.editCode) {
     // If we want to "normalize" the JavaScript to avoid proliferation of nearly
     // identical versions of the code on the service, we could do either of these:

--- a/apps/test/integration/feedbackTests.js
+++ b/apps/test/integration/feedbackTests.js
@@ -33,9 +33,7 @@ describe('checkForEmptyContainerBlockFailure_', function() {
 
     // make sure we loaded correctly. text wont match exactly, but make sure if
     // we had xml, we loaded something
-    var loaded = Blockly.Xml.domToText(
-      Blockly.Xml.blockSpaceToDom(Blockly.mainBlockSpace)
-    );
+    var loaded = Blockly.cdoUtils.getCode(Blockly.mainBlockSpace);
     assert(
       !args.blockXml || loaded,
       'either we didnt have  input xml' + 'or we did, and we loaded something'
@@ -309,9 +307,7 @@ describe('getUserBlocks_', function() {
 
     // make sure we loaded correctly. text wont match exactly, but make sure if
     // we had xml, we loaded something
-    var loaded = Blockly.Xml.domToText(
-      Blockly.Xml.blockSpaceToDom(Blockly.mainBlockSpace)
-    );
+    var loaded = Blockly.cdoUtils.getCode(Blockly.mainBlockSpace);
     assert(loaded, "we didn't correctly load our test blocks");
 
     var userBlocks = studioApp.feedback_.getUserBlocks_();
@@ -421,9 +417,7 @@ describe('getMissingBlocks_ tests', function() {
 
     // make sure we loaded correctly. text wont match exactly, but make sure if
     // we had xml, we loaded something
-    var loaded = Blockly.Xml.domToText(
-      Blockly.Xml.blockSpaceToDom(Blockly.mainBlockSpace)
-    );
+    var loaded = Blockly.cdoUtils.getCode(Blockly.mainBlockSpace);
     assert(
       !options.userBlockXml || loaded,
       'either we didnt have  input xml' + 'or we did, and we loaded something'

--- a/apps/test/integration/levelTests.js
+++ b/apps/test/integration/levelTests.js
@@ -3,7 +3,7 @@
  * Tests collections are specified in .js files in the solutions directory.
  * To extract the xml for a test from a workspace, run the following code in
  * your console:
- * Blockly.Xml.domToText(Blockly.Xml.blockSpaceToDom(Blockly.mainBlockSpace));
+ * Blockly.cdoUtils.getCode(Blockly.mainBlockSpace);
  */
 
 // todo - should we also have tests around which blocks to show as part of the


### PR DESCRIPTION
## Context
We have always saved student Blockly code as an XML string. While XML is still supported in Google Blockly, JSON is the preferred format and will allow us to eventually store function definitions off of the main workspace.
To accomplish this, we can create helper functions in each Blockly wrapper that will handle saving and loading student code in whichever manner is appropriate. We can change the format of this source without breaking existing projects.

## Strategy
We will not perform a bulk update on existing projects as the XML sources should continue to work. Instead, we will changes things so that the next time a Google Blockly project is opened we convert it to JSON.
1. Replace all* instances where student code is saved with a new helper that matches in both wrappers. (This PR)
2. Replace where student code is loaded (in StudioApp.js) with a new util helper that matches in both wrappers.
3. Update both util helpers in the Google Blockly space to start working with JSON, potentially behind an experiment flag.

_*Note about `P5Lab.js`:_ Sprite Lab includes a concept of shared functions that are merged into a student's sources through XML manipulation. This lab breaks the pattern set by the util function as it is the only case where we don't directly follow `blockSpaceToDom` with `domToText`. Because Sprite Lab uses CDO Blockly, it seems reasonable to add a special check here for our Blockly version and allow it to work as it always has. Because we are aiming to migrate Sprite Lab this year, we will want to update this logic soon so that it can work through JSON manipulation. (This is actually probably less complex than XML parsing/manipulation.) It's also worth noting that while Poetry is a Google Blockly instance of P5Lab it never uses shared functions.

Once we've tested this sufficiently, we can make this a permanent change. Because CDO Blockly does not support loading blocks from a JSON config, this change would make it so that Google Blockly projects would break if we for some reason forced the lab to use old CDO Blockly.

## Links

Jira - https://codedotorg.atlassian.net/browse/SL-640

## Testing story

I will be manually testing a variety of projects/labs to make sure that existing projects do not break and that new projects can still be created based on the given start sources. To increase our confidence in this change, we can consider strategies such as making this opt-in with an experiment flag, or doing a bug bash using an adhoc.

## Deployment strategy

Described above.

## Follow-up work

Described above.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
