### PR TITLE
fix issues with test video on IT page

### DIFF
--- a/pegasus/sites.v3/code.org/public/educate/it.md.erb
+++ b/pegasus/sites.v3/code.org/public/educate/it.md.erb
@@ -101,7 +101,7 @@ We use [YouTube](https://www.youtube.com) to embed videos into Code.org and our 
 
 Before you start Code.org's online courses, test playback for the video below to make sure you're good to go.
 
-<iframe style="margin: 10px 0;" width="350" height="155" src="<%= "#{CDO.studio_url('/videos/embed/artist_intro', CDO.default_scheme)}?width=350&height=195" %>" frameborder="0" allowfullscreen data-ot-ignore></iframe>
+<%= view :video_with_fallback, video_code: 'ws8rmHcqXeM', download_path: "//videos.code.org/new/5-artist-intro.mp4" %>
 
 This is the player used throughout the curriculum. It will try to show the video through YouTube and, if YouTube is blocked, show the Code.org hosted video using our "fallback" player instead.
 

--- a/pegasus/sites.v3/code.org/views/index_video_reveal.haml
+++ b/pegasus/sites.v3/code.org/views/index_video_reveal.haml
@@ -4,11 +4,7 @@
   }
 
 %div{style: "text-align:right; overflow:hidden"}
-  %div{style: "width:100%; height: 100%; margin: 0 auto;"}
-    .videodiv{style: "position:relative;"}
-      %img{style: "display:block; width:100%; height:auto", src: "/images/16x9.png"}/
-      -# either youtube or fallback video player inserted here
-      .insert_video_player{:data=>{:video_code=>video_code, :download_path=>download_path}}
+  =view :video_with_fallback, video_code: video_code, download_path: download_path
 
   %div{style: "float:left"}
     =view :share_buttons, facebook: facebook, twitter: twitter

--- a/pegasus/sites.v3/code.org/views/video_with_fallback.haml
+++ b/pegasus/sites.v3/code.org/views/video_with_fallback.haml
@@ -1,0 +1,5 @@
+%div{style: "width:100%; height: 100%; margin: 0 auto;"}
+  .videodiv{style: "position:relative;"}
+    %img{style: "display:block; width:100%; height:auto", src: "/images/16x9.png"}/
+    -# either youtube or fallback video player inserted here
+    .insert_video_player{:data=>{:video_code=>video_code, :download_path=>download_path}}

--- a/pegasus/sites.v3/code.org/views/video_with_fallback.haml
+++ b/pegasus/sites.v3/code.org/views/video_with_fallback.haml
@@ -1,4 +1,4 @@
-%div{style: "width:100%; height: 100%; margin: 0 auto;"}
+%figure{style: "width:100%; height: 100%; margin: 0 auto;"}
   .videodiv{style: "position:relative;"}
     %img{style: "display:block; width:100%; height:auto", src: "/images/16x9.png"}/
     -# either youtube or fallback video player inserted here


### PR DESCRIPTION
Finishes https://codedotorg.atlassian.net/browse/ACQ-472. Previously (https://github.com/code-dot-org/code-dot-org/pull/50611) I wasn't aware of any alternate pegasus-friendly way to display the video, until Brendan tipped me off in https://github.com/code-dot-org/code-dot-org/pull/50349#issuecomment-1464803447. That exact solution didn't work, because of the existing issue on the /educate/resources/videos page (see below), but I was able to dig to the bottom of that codepath to find a simpler way to load a video with fallback player on pegasus.

It's worth noting that this approach depends on some code which is loaded into every pegasus page which turns any 
 `.insert_video_player` element into a playable video: 
- https://github.com/code-dot-org/code-dot-org/blob/b3e9c75155f1b19611aae8a15db2effacbaaa6ea/apps/src/sites/code.org/pages/views/theme_common_head_after.js#L26
- https://github.com/code-dot-org/code-dot-org/blob/3d2fefef4800ca34c0a60a1b2731f869f020a2cb/apps/src/util/loadVideos.js#L42

In addition to preventing youtube.com access, this PR also improves how the video looks on the page:

## Screenshots

### before
![Screenshot 2023-03-15 at 4 24 47 PM](https://user-images.githubusercontent.com/8001765/225465814-c8c66b9b-2544-406c-ad0c-6d712f31dd76.png)

### after
![Screenshot 2023-03-15 at 4 24 23 PM](https://user-images.githubusercontent.com/8001765/225465823-8c489c34-3af9-42a9-8858-ce136e83e088.png)


## Testing story

manually verified as follows:
* load http://localhost-studio.code.org:3000/educate/it 
  * video plays properly, including after pressing play, pause, play
  * chrome network tab shows video comes from youtube-nocookie.com
  * no requests being made to youtube.com
* using chrome network tab, block youtube-nocookie.com domain and reload the page
  * video plays properly, including after pressing play, pause, play
  * no requests to youtube.com or youtube-nocookie.com

## Follow-up work
- https://github.com/code-dot-org/code-dot-org/pull/50797
- https://github.com/code-dot-org/code-dot-org/pull/50791
- fix issue with videos going blank on https://code.org/educate/resources/videos : https://codedotorg.atlassian.net/browse/ACQ-484