### PR TITLE
Warn teachers on Spritelab image import

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -127,6 +127,7 @@
   "animationPicker_uploadImage": "Upload image",
   "animationPicker_uploading": "Uploading...",
   "animationPicker_warning": "Warning: Do not upload anything that contains personal information.",
+  "animationPicker_warnNoPublishShare": "Note: projects with images uploaded by students cannot be published or remixed.",
   "animationSearchPlaceholder": "Search for images...",
   "announcements": "Announcements",
   "announcementHeadingBackToSchool": "Get set up for the new school year",

--- a/apps/src/code-studio/initApp/loadApp.js
+++ b/apps/src/code-studio/initApp/loadApp.js
@@ -473,7 +473,6 @@ const sourceHandler = {
   setTeacherHasConfirmedUploadWarning(teacherHasConfirmedUploadWarning) {
     getAppOptions().level.teacherHasConfirmedUploadWarning = teacherHasConfirmedUploadWarning;
   },
-  // maybe rename to get
   teacherHasConfirmedUploadWarning() {
     return getAppOptions().level.teacherHasConfirmedUploadWarning;
   },

--- a/apps/src/code-studio/initApp/loadApp.js
+++ b/apps/src/code-studio/initApp/loadApp.js
@@ -470,6 +470,13 @@ const sourceHandler = {
   inRestrictedShareMode() {
     return getAppOptions().level.inRestrictedShareMode;
   },
+  setTeacherHasConfirmedUploadWarning(teacherHasConfirmedUploadWarning) {
+    getAppOptions().level.teacherHasConfirmedUploadWarning = teacherHasConfirmedUploadWarning;
+  },
+  // maybe rename to get
+  teacherHasConfirmedUploadWarning() {
+    return getAppOptions().level.teacherHasConfirmedUploadWarning;
+  },
   // returns a Promise to the level source
   getLevelSource(currentLevelSource) {
     return new Promise((resolve, reject) => {

--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -720,9 +720,6 @@ var projects = (module.exports = {
         sourceHandler.setTeacherHasConfirmedUploadWarning(
           currentSources.teacherHasConfirmedUploadWarning
         );
-        // ensure restrictedShareMode is set correctly in redux
-        // so we hide publish and remix correctly.
-        // update
         getStore().dispatch(refreshTeacherHasConfirmedUploadWarning());
       }
 

--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -33,7 +33,8 @@ import {getStore} from '../../redux';
 import {
   workspaceAlertTypes,
   displayWorkspaceAlert,
-  refreshInRestrictedShareMode
+  refreshInRestrictedShareMode,
+  refreshTeacherHasConfirmedUploadWarning
 } from '../projectRedux';
 
 // Name of the packed source file
@@ -117,7 +118,8 @@ var currentSources = {
   animations: null,
   selectedSong: null,
   selectedPoem: null,
-  inRestrictedShareMode: false
+  inRestrictedShareMode: false,
+  teacherHasConfirmedUploadWarning: false
 };
 
 /**
@@ -143,7 +145,8 @@ function unpackSources(data) {
     selectedSong: data.selectedSong,
     selectedPoem: data.selectedPoem,
     libraries: data.libraries,
-    inRestrictedShareMode: data.inRestrictedShareMode
+    inRestrictedShareMode: data.inRestrictedShareMode,
+    teacherHasConfirmedUploadWarning: data.teacherHasConfirmedUploadWarning
   };
 }
 
@@ -708,9 +711,19 @@ var projects = (module.exports = {
         sourceHandler.setInRestrictedShareMode(
           currentSources.inRestrictedShareMode
         );
-        // ensure restrictdShareMode is set correctly in redux
+        // ensure restrictedShareMode is set correctly in redux
         // so we hide publish and remix correctly.
         getStore().dispatch(refreshInRestrictedShareMode());
+      }
+
+      if (currentSources.teacherHasConfirmedUploadWarning !== undefined) {
+        sourceHandler.setTeacherHasConfirmedUploadWarning(
+          currentSources.teacherHasConfirmedUploadWarning
+        );
+        // ensure restrictedShareMode is set correctly in redux
+        // so we hide publish and remix correctly.
+        // update
+        getStore().dispatch(refreshTeacherHasConfirmedUploadWarning());
       }
 
       if (isEditing) {
@@ -967,7 +980,7 @@ var projects = (module.exports = {
   },
   /**
    * Saves the project only if the sources {source, html, animations,
-   * makerAPIsEnabled, selectedSong, selectedPoem, inRestrictedShareMode} have changed.
+   * makerAPIsEnabled, selectedSong, selectedPoem, inRestrictedShareMode, teacherHasConfirmedUploadWarning} have changed.
    * @returns {Promise} A promise containing the project data if the project
    * was saved, otherwise returns a promise which resolves with no arguments.
    */
@@ -1225,6 +1238,17 @@ var projects = (module.exports = {
     return this.sourceHandler.inRestrictedShareMode();
   },
 
+  setTeacherHasConfirmedUploadWarning(hasConfirmedUploadWarning) {
+    this.sourceHandler.setTeacherHasConfirmedUploadWarning(
+      hasConfirmedUploadWarning
+    );
+    return this.save();
+  },
+
+  teacherHasConfirmedUploadWarning() {
+    return this.sourceHandler.teacherHasConfirmedUploadWarning();
+  },
+
   /**
    * Saves the project to the Channels API. Calls `callback` on success if a
    * callback function was provided.
@@ -1302,6 +1326,7 @@ var projects = (module.exports = {
           const selectedPoem = this.sourceHandler.getSelectedPoem();
           const libraries = this.sourceHandler.getLibrariesList();
           const inRestrictedShareMode = this.sourceHandler.inRestrictedShareMode();
+          const teacherHasConfirmedUploadWarning = this.sourceHandler.teacherHasConfirmedUploadWarning();
           callback({
             source,
             html,
@@ -1310,7 +1335,8 @@ var projects = (module.exports = {
             selectedSong,
             selectedPoem,
             libraries,
-            inRestrictedShareMode
+            inRestrictedShareMode,
+            teacherHasConfirmedUploadWarning
           });
         })
         .catch(error => callback({error}))

--- a/apps/src/code-studio/projectRedux.js
+++ b/apps/src/code-studio/projectRedux.js
@@ -11,6 +11,8 @@ const SET_NAME_FAILURE = 'project/SET_NAME_FAILURE';
 const UNSET_NAME_FAILURE = 'project/UNSET_NAME_FAILURE';
 const REFRESH_IN_RESTRICTED_SHARE_MODE =
   'project/REFRESH_IN_RESTRICTED_SHARE_MODE';
+const REFRESH_TEACHER_HAS_CONFIRMED_UPLOAD_WARNING =
+  'project/REFRESH_TEACHER_HAS_CONFIRMED_UPLOAD_WARNING';
 
 export const projectUpdatedStatuses = {
   default: 'default',
@@ -33,7 +35,8 @@ const initialState = {
   projectNameFailure: undefined,
   showTryAgainDialog: false,
   showWorkspaceAlert: {type: '', message: '', displayBottom: undefined},
-  inRestrictedShareMode: false
+  inRestrictedShareMode: false,
+  teacherHasConfirmedUploadWarning: false
 };
 
 export default (state = initialState, action) => {
@@ -97,6 +100,12 @@ export default (state = initialState, action) => {
     return {
       ...state,
       inRestrictedShareMode: dashboard.project.inRestrictedShareMode()
+    };
+  }
+  if (action.type === REFRESH_TEACHER_HAS_CONFIRMED_UPLOAD_WARNING) {
+    return {
+      ...state,
+      teacherHasConfirmedUploadWarning: dashboard.project.teacherHasConfirmedUploadWarning()
     };
   }
 
@@ -170,5 +179,11 @@ export const unsetNameFailure = () => ({
 export function refreshInRestrictedShareMode() {
   return {
     type: REFRESH_IN_RESTRICTED_SHARE_MODE
+  };
+}
+
+export function refreshTeacherHasConfirmedUploadWarning() {
+  return {
+    type: REFRESH_TEACHER_HAS_CONFIRMED_UPLOAD_WARNING
   };
 }

--- a/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
@@ -51,7 +51,7 @@ class AnimationPicker extends React.Component {
     hideBackgrounds: PropTypes.bool.isRequired,
     hideCostumes: PropTypes.bool.isRequired,
     pickerType: PropTypes.oneOf(Object.values(PICKER_TYPE)).isRequired,
-    shouldRestrictAnimationUpload: PropTypes.bool.isRequired,
+    shouldWarnOnAnimationUpload: PropTypes.bool.isRequired,
 
     // Provided via Redux
     visible: PropTypes.bool.isRequired,
@@ -124,9 +124,7 @@ class AnimationPicker extends React.Component {
           hideCostumes={this.props.hideCostumes}
           selectedAnimations={this.props.selectedAnimations}
           pickerType={this.props.pickerType}
-          shouldRestrictAnimationUpload={
-            this.props.shouldRestrictAnimationUpload
-          }
+          shouldWarnOnAnimationUpload={this.props.shouldWarnOnAnimationUpload}
         />
         <StylizedBaseDialog
           title={msg.animationPicker_leaveSelectionTitle()}

--- a/apps/src/p5lab/AnimationPicker/AnimationPickerBody.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPickerBody.jsx
@@ -39,7 +39,7 @@ export default class AnimationPickerBody extends React.Component {
     hideCostumes: PropTypes.bool.isRequired,
     selectedAnimations: PropTypes.arrayOf(AnimationProps).isRequired,
     pickerType: PropTypes.string.isRequired,
-    shouldRestrictAnimationUpload: PropTypes.bool.isRequired
+    shouldWarnOnAnimationUpload: PropTypes.bool.isRequired
   };
 
   state = {
@@ -220,7 +220,7 @@ export default class AnimationPickerBody extends React.Component {
       onDrawYourOwnClick,
       onUploadClick,
       onAnimationSelectionComplete,
-      shouldRestrictAnimationUpload
+      shouldWarnOnAnimationUpload
     } = this.props;
 
     const searching = searchQuery !== '';
@@ -299,9 +299,7 @@ export default class AnimationPickerBody extends React.Component {
                 {!hideUploadOption && (
                   <AnimationUploadButton
                     onUploadClick={onUploadClick}
-                    shouldRestrictAnimationUpload={
-                      shouldRestrictAnimationUpload
-                    }
+                    shouldWarnOnAnimationUpload={shouldWarnOnAnimationUpload}
                     isBackgroundsTab={isBackgroundsTab}
                   />
                 )}

--- a/apps/src/p5lab/AnimationPicker/AnimationUploadButton.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationUploadButton.jsx
@@ -20,7 +20,7 @@ import {
  * Render the animation upload button. If the project should warn on upload
  * (which occurs for Sprite Lab projects), and the project has not already seen
  * the warning (see details on warnings by user type below), we show a warning modal
- * before allowing uploads. If the project should restrict uploads and is already
+ * before allowing uploads. For students, if the project should restrict uploads and is already
  * published, we will not allow uploads until the project is un-published.
  */
 export function UnconnectedAnimationUploadButton({

--- a/apps/src/p5lab/AnimationTab/AnimationTab.jsx
+++ b/apps/src/p5lab/AnimationTab/AnimationTab.jsx
@@ -23,7 +23,7 @@ class AnimationTab extends React.Component {
     libraryManifest: PropTypes.object.isRequired,
     // TODO: When we remove the backgrounds_and_upload experiment we can get rid of hideUploadOption
     hideUploadOption: PropTypes.bool.isRequired,
-    shouldRestrictAnimationUpload: PropTypes.bool.isRequired,
+    shouldWarnOnAnimationUpload: PropTypes.bool.isRequired,
     hideAnimationNames: PropTypes.bool.isRequired,
     hideBackgrounds: PropTypes.bool.isRequired,
     hideCostumes: PropTypes.bool.isRequired,
@@ -55,7 +55,7 @@ class AnimationTab extends React.Component {
       libraryManifest,
       onColumnWidthsChange,
       pickerType,
-      shouldRestrictAnimationUpload
+      shouldWarnOnAnimationUpload
     } = this.props;
     let hidePiskelStyle = {visibility: 'visible'};
     if (currentAnimation) {
@@ -101,7 +101,7 @@ class AnimationTab extends React.Component {
             hideCostumes={hideCostumes}
             pickerType={pickerType}
             defaultQuery={defaultQuery}
-            shouldRestrictAnimationUpload={shouldRestrictAnimationUpload}
+            shouldWarnOnAnimationUpload={shouldWarnOnAnimationUpload}
           />
         )}
       </div>

--- a/apps/src/p5lab/P5LabView.jsx
+++ b/apps/src/p5lab/P5LabView.jsx
@@ -104,10 +104,24 @@ class P5LabView extends React.Component {
     return this.props.isBlockly;
   }
 
-  // Teachers and users of non-blockly labs should always be allowed to upload animations
-  // with no restrictions. Otherwise, if users upload animations we will disable publish and remix.
+  // NOTE: this can be simplified to return this.props.blockly once we've removed the backgrounds_and_upload experiment
+  // Users of non-blockly labs should always be allowed to upload animations
+  // with no restrictions. Teachers in blockly labs (ie, sprite lab) can upload with a warning.
+  // If students upload animations we will disable publish and remix.
   shouldWarnOnAnimationUpload() {
-    return this.props.isBlockly;
+    if (!this.props.isBlockly) {
+      return false;
+    }
+
+    // hide warning modal for teachers until we've enabled this experiment for everyone
+    if (
+      this.props.currentUserType === 'teacher' &&
+      !experiments.isEnabled(experiments.BACKGROUNDS_AND_UPLOAD)
+    ) {
+      return false;
+    }
+
+    return true;
   }
 
   renderCodeMode() {

--- a/apps/src/p5lab/P5LabView.jsx
+++ b/apps/src/p5lab/P5LabView.jsx
@@ -106,11 +106,7 @@ class P5LabView extends React.Component {
 
   // Teachers and users of non-blockly labs should always be allowed to upload animations
   // with no restrictions. Otherwise, if users upload animations we will disable publish and remix.
-  shouldRestrictAnimationUpload() {
-    if (this.props.currentUserType === 'teacher') {
-      return false;
-    }
-
+  shouldWarnOnAnimationUpload() {
     return this.props.isBlockly;
   }
 
@@ -170,7 +166,7 @@ class P5LabView extends React.Component {
               channelId={channelId}
               libraryManifest={this.state.libraryManifest}
               hideUploadOption={this.shouldHideAnimationUpload()}
-              shouldRestrictAnimationUpload={this.shouldRestrictAnimationUpload()}
+              shouldWarnOnAnimationUpload={this.shouldWarnOnAnimationUpload()}
               hideAnimationNames={this.props.isBlockly}
               navigable={navigable}
               defaultQuery={this.props.isBackground ? defaultQuery : undefined}
@@ -219,7 +215,7 @@ class P5LabView extends React.Component {
         defaultQuery={defaultQuery}
         libraryManifest={this.state.libraryManifest}
         hideUploadOption={this.shouldHideAnimationUpload()}
-        shouldRestrictAnimationUpload={this.shouldRestrictAnimationUpload()}
+        shouldWarnOnAnimationUpload={this.shouldWarnOnAnimationUpload()}
         hideAnimationNames={this.props.isBlockly}
         hideBackgrounds={this.props.isBlockly && !isBackgroundMode}
         hideCostumes={isBackgroundMode}

--- a/apps/src/p5lab/P5LabView.jsx
+++ b/apps/src/p5lab/P5LabView.jsx
@@ -113,7 +113,6 @@ class P5LabView extends React.Component {
       return false;
     }
 
-    // hide warning modal for teachers until we've enabled this experiment for everyone
     if (
       this.props.currentUserType === 'teacher' &&
       !experiments.isEnabled(experiments.BACKGROUNDS_AND_UPLOAD)

--- a/apps/src/sites/studio/pages/levels/_pixelation.js
+++ b/apps/src/sites/studio/pages/levels/_pixelation.js
@@ -480,9 +480,11 @@ function initProjects() {
         options.projectData = levelSource;
       },
       setInRestrictedShareMode: function(_) {},
+      setTeacherHasConfirmedUploadWarning: function (_) {},
       inRestrictedShareMode: function() {
         return undefined;
       },
+      teacherHasConfirmedUploadWarning: function () {return undefined;},
       getLevelSource: function() {
         return {
           // This method is expected to return a Promise. Since this file does not go through our

--- a/apps/test/unit/code-studio/initApp/projectTest.js
+++ b/apps/test/unit/code-studio/initApp/projectTest.js
@@ -1248,6 +1248,8 @@ function createStubSourceHandler() {
     setInitialLibrariesList: sinon.stub(),
     getLibrariesList: sinon.stub(),
     setInRestrictedShareMode: sinon.stub(),
-    inRestrictedShareMode: sinon.stub()
+    inRestrictedShareMode: sinon.stub(),
+    setTeacherHasConfirmedUploadWarning: sinon.stub(),
+    teacherHasConfirmedUploadWarning: sinon.stub()
   };
 }

--- a/apps/test/unit/p5lab/AnimationPicker/AnimationPickerBodyTest.js
+++ b/apps/test/unit/p5lab/AnimationPicker/AnimationPickerBodyTest.js
@@ -33,7 +33,7 @@ describe('AnimationPickerBody', function() {
     selectedAnimations: [],
     onAnimationSelectionComplete: emptyFunction,
     pickerType: PICKER_TYPE.gamelab,
-    shouldRestrictAnimationUpload: false
+    shouldWarnOnAnimationUpload: false
   };
 
   describe('upload warning', function() {

--- a/apps/test/unit/p5lab/AnimationPicker/AnimationUploadButtonTest.js
+++ b/apps/test/unit/p5lab/AnimationPicker/AnimationUploadButtonTest.js
@@ -7,84 +7,121 @@ import AnimationPickerListItem from '../../../../src/p5lab/AnimationPicker/Anima
 
 const emptyFunction = () => {};
 
+const defaultProps = {
+  onUploadClick: emptyFunction,
+  shouldWarnOnAnimationUpload: true,
+  isBackgroundsTab: false,
+  refreshInRestrictedShareMode: emptyFunction,
+  inRestrictedShareMode: false,
+  refreshTeacherHasConfirmedUploadWarning: emptyFunction,
+  teacherHasConfirmedUploadWarning: false,
+  showingUploadWarning: emptyFunction,
+  exitedUploadWarning: emptyFunction,
+  currentUserType: 'student'
+};
+
 describe('AnimationUploadButton', function() {
-  it('shows warning if should restrict and is not already in restricted mode', () => {
-    const body = shallow(
-      <AnimationUploadButton
-        onUploadClick={emptyFunction}
-        shouldRestrictAnimationUpload={true}
-        isBackgroundsTab={false}
-        refreshInRestrictedShareMode={emptyFunction}
-        inRestrictedShareMode={false}
-        showingUploadWarning={emptyFunction}
-        exitedUploadWarning={emptyFunction}
-      />
-    );
-    const uploadButton = body.find(AnimationPickerListItem).at(0);
-    uploadButton.simulate('click');
-    const warningModal = body.find(BaseDialog).at(0);
-    expect(warningModal.props().isOpen).to.be.true;
+  describe('student scenarios', () => {
+    it('shows warning if should restrict and is not already in restricted mode', () => {
+      const body = shallow(<AnimationUploadButton {...defaultProps} />);
+      const uploadButton = body.find(AnimationPickerListItem).at(0);
+      uploadButton.simulate('click');
+      const warningModal = body.find(BaseDialog).at(0);
+      expect(warningModal.props().isOpen).to.be.true;
+    });
+
+    it('does not show warning if should restrict and is already in restricted mode', () => {
+      const combinedProps = {
+        ...defaultProps,
+        inRestrictedShareMode: true
+      };
+
+      const body = shallow(<AnimationUploadButton {...combinedProps} />);
+      const uploadButton = body.find(AnimationPickerListItem).at(0);
+      uploadButton.simulate('click');
+      const warningModal = body.find(BaseDialog);
+      expect(warningModal.at(0).props().isOpen).to.be.false;
+    });
+
+    it('does not show warning if should not restrict', () => {
+      const combinedProps = {
+        ...defaultProps,
+        shouldWarnOnAnimationUpload: false
+      };
+
+      const body = shallow(<AnimationUploadButton {...combinedProps} />);
+      const uploadButton = body.find(AnimationPickerListItem).at(0);
+      uploadButton.simulate('click');
+      const warningModal = body.find(BaseDialog);
+      expect(warningModal.at(0).props().isOpen).to.be.false;
+    });
+
+    it('warning message requires both checkboxes to be checked to go forward', () => {
+      const body = shallow(<AnimationUploadButton {...defaultProps} />);
+      const uploadButton = body.find(AnimationPickerListItem).at(0);
+      uploadButton.simulate('click');
+      const warningModal = body.find(BaseDialog).at(0);
+      let confirmButton = warningModal.find('button').at(1);
+      expect(confirmButton.props().disabled).to.be.true;
+      const checkboxes = warningModal.find('input');
+      checkboxes.at(0).simulate('change', {target: {checked: true}});
+      checkboxes.at(1).simulate('change', {target: {checked: true}});
+      confirmButton = body.find('button').at(1);
+      expect(confirmButton.props().disabled).to.be.false;
+    });
   });
 
-  it('does not show warning if should restrict and is already in restricted mode', () => {
-    const body = shallow(
-      <AnimationUploadButton
-        onUploadClick={emptyFunction}
-        shouldRestrictAnimationUpload={true}
-        isBackgroundsTab={false}
-        refreshInRestrictedShareMode={emptyFunction}
-        inRestrictedShareMode={true}
-        showingUploadWarning={emptyFunction}
-        exitedUploadWarning={emptyFunction}
-      />
-    );
-    const uploadButton = body.find(AnimationPickerListItem).at(0);
-    uploadButton.simulate('click');
-    const warningModal = body.find(BaseDialog);
-    expect(warningModal.at(0).props().isOpen).to.be.false;
-  });
+  describe('teacher scenarios', () => {
+    const defaultPropsTeacher = {
+      ...defaultProps,
+      currentUserType: 'teacher'
+    };
 
-  it('does not show warning if should not restrict', () => {
-    const body = shallow(
-      <AnimationUploadButton
-        onUploadClick={emptyFunction}
-        shouldRestrictAnimationUpload={false}
-        isBackgroundsTab={false}
-        refreshInRestrictedShareMode={emptyFunction}
-        inRestrictedShareMode={false}
-        showingUploadWarning={emptyFunction}
-        exitedUploadWarning={emptyFunction}
-      />
-    );
-    const uploadButton = body.find(AnimationPickerListItem).at(0);
-    uploadButton.simulate('click');
-    const warningModal = body.find(BaseDialog);
-    expect(warningModal.at(0).props().isOpen).to.be.false;
-  });
+    it('shows warning if should restrict and is not already in restricted mode', () => {
+      const body = shallow(<AnimationUploadButton {...defaultPropsTeacher} />);
+      const uploadButton = body.find(AnimationPickerListItem).at(0);
+      uploadButton.simulate('click');
+      const warningModal = body.find(BaseDialog).at(0);
+      expect(warningModal.props().isOpen).to.be.true;
+    });
 
-  it('warning message requires both checkboxes to be checked to go forward', () => {
-    const body = shallow(
-      <AnimationUploadButton
-        onUploadClick={emptyFunction}
-        shouldRestrictAnimationUpload={true}
-        isBackgroundsTab={false}
-        refreshInRestrictedShareMode={emptyFunction}
-        inRestrictedShareMode={false}
-        showingUploadWarning={emptyFunction}
-        exitedUploadWarning={emptyFunction}
-      />
-    );
-    const uploadButton = body.find(AnimationPickerListItem).at(0);
-    uploadButton.simulate('click');
-    const warningModal = body.find(BaseDialog).at(0);
-    const buttons = warningModal.find('button');
-    console.log(`found ${buttons.length} buttons`);
-    let confirmButton = warningModal.find('button').at(1);
-    expect(confirmButton.props().disabled).to.be.true;
-    const checkboxes = warningModal.find('input');
-    checkboxes.at(0).simulate('change', {target: {checked: true}});
-    checkboxes.at(1).simulate('change', {target: {checked: true}});
-    confirmButton = body.find('button').at(1);
-    expect(confirmButton.props().disabled).to.be.false;
+    it('does not show warning if should restrict and is already in restricted mode', () => {
+      const combinedProps = {
+        ...defaultPropsTeacher,
+        teacherHasConfirmedUploadWarning: true
+      };
+
+      const body = shallow(<AnimationUploadButton {...combinedProps} />);
+      const uploadButton = body.find(AnimationPickerListItem).at(0);
+      uploadButton.simulate('click');
+      const warningModal = body.find(BaseDialog);
+      expect(warningModal.at(0).props().isOpen).to.be.false;
+    });
+
+    it('does not show warning if should not restrict', () => {
+      const combinedProps = {
+        ...defaultPropsTeacher,
+        shouldWarnOnAnimationUpload: false
+      };
+
+      const body = shallow(<AnimationUploadButton {...combinedProps} />);
+      const uploadButton = body.find(AnimationPickerListItem).at(0);
+      uploadButton.simulate('click');
+      const warningModal = body.find(BaseDialog);
+      expect(warningModal.at(0).props().isOpen).to.be.false;
+    });
+
+    it('warning message requires PII checkbox to be checked to go forward', () => {
+      const body = shallow(<AnimationUploadButton {...defaultPropsTeacher} />);
+      const uploadButton = body.find(AnimationPickerListItem).at(0);
+      uploadButton.simulate('click');
+      const warningModal = body.find(BaseDialog).at(0);
+      let confirmButton = warningModal.find('button').at(1);
+      expect(confirmButton.props().disabled).to.be.true;
+      const checkboxes = warningModal.find('input');
+      checkboxes.at(0).simulate('change', {target: {checked: true}});
+      confirmButton = body.find('button').at(1);
+      expect(confirmButton.props().disabled).to.be.false;
+    });
   });
 });


### PR DESCRIPTION
Add a warning that shows up the first time a teacher tries to upload an image in a Sprite Lab project. This warning is similar to that seen by students (implemented [here](https://github.com/code-dot-org/code-dot-org/pull/50269)), but does not restrict sharing/remixing as we do for students.

![image](https://user-images.githubusercontent.com/25372625/225703945-0a6b676a-b52d-464c-a420-c86b8cdd4fbe.png)

For now, this warning only shows up if you have the BACKGROUNDS_AND_UPLOAD [experiment flag](https://github.com/code-dot-org/code-dot-org/pull/50310/files#diff-1b812462009f740ac2d7308869034061e47ea3a8bc66c42e815d46801aea4b66R40), `backgroundsTab`, enabled and are in a Blockly lab (ie, Spritelab).

## Links

- jira ticket: [SL-617](https://codedotorg.atlassian.net/browse/SL-617)

## Testing story

Tested manually for both student and teacher scenarios that, with the experiment enabled, teachers see this warning once when they upload an image for the first time (via the "costumes" or "animations" tabs), and do not see it on subsequent uploads. Also confirmed warning was not shown on page refresh (ie, reloading project from JSON). Added unit tests to cover new UI scenarios.
