### PR TITLE
Update broken support article link in welcome emails

### DIFF
--- a/dashboard/app/views/teacher_mailer/new_teacher_email.html.haml
+++ b/dashboard/app/views/teacher_mailer/new_teacher_email.html.haml
@@ -41,7 +41,7 @@
   Still have questions?
 %p
   Check out our
-  %a{href:"https://support.code.org/hc/en-us/categories/13985259602061-Teachers"}Getting Started guide
+  %a{href:"https://support.code.org/hc/en-us/categories/13985259602061-Teachers"}Getting Started articles
   or reach out to
   %a{href:"mailto:support@code.org"}support@code.org.
 

--- a/dashboard/app/views/teacher_mailer/new_teacher_email.html.haml
+++ b/dashboard/app/views/teacher_mailer/new_teacher_email.html.haml
@@ -41,7 +41,7 @@
   Still have questions?
 %p
   Check out our
-  %a{href:"https://support.code.org/hc/en-us/sections/115000120211-Getting-started-on-Code-org"}Getting Started guide
+  %a{href:"https://support.code.org/hc/en-us/categories/13985259602061-Teachers"}Getting Started guide
   or reach out to
   %a{href:"mailto:support@code.org"}support@code.org.
 

--- a/dashboard/app/views/teacher_mailer/new_teacher_email_es-MX.html.haml
+++ b/dashboard/app/views/teacher_mailer/new_teacher_email_es-MX.html.haml
@@ -32,7 +32,7 @@
   ¿Todavía tienes preguntas?
 %p
   Consulta nuestra
-  %a{href: "https://support.code.org/hc/en-us/sections/115000120211-Getting-started-on-Code-org"} guía de introducción
+  %a{href: "https://support.code.org/hc/en-us/categories/13985259602061-Teachers"} guía de introducción
   o comunícate con
   %a{href: "mailto:support@code.org"} support@code.org.
 

--- a/dashboard/app/views/teacher_mailer/new_teacher_email_es-MX.html.haml
+++ b/dashboard/app/views/teacher_mailer/new_teacher_email_es-MX.html.haml
@@ -31,8 +31,8 @@
 %h3
   ¿Todavía tienes preguntas?
 %p
-  Consulta nuestra
-  %a{href: "https://support.code.org/hc/es/categories/13985259602061-Teachers"} guía de introducción
+  Consulta nuestros
+  %a{href: "https://support.code.org/hc/es/categories/13985259602061-Teachers"} artículos de introducción
   o comunícate con
   %a{href: "mailto:support@code.org"} support@code.org.
 

--- a/dashboard/app/views/teacher_mailer/new_teacher_email_es-MX.html.haml
+++ b/dashboard/app/views/teacher_mailer/new_teacher_email_es-MX.html.haml
@@ -32,7 +32,7 @@
   ¿Todavía tienes preguntas?
 %p
   Consulta nuestra
-  %a{href: "https://support.code.org/hc/en-us/categories/13985259602061-Teachers"} guía de introducción
+  %a{href: "https://support.code.org/hc/es/categories/13985259602061-Teachers"} guía de introducción
   o comunícate con
   %a{href: "mailto:support@code.org"} support@code.org.
 


### PR DESCRIPTION
Customer Success team recently re-grouped a bunch of support articles, changing some URLs in the process. Our welcome email references a "getting started" support page which we noticed was going to a dead end in Zendesk. Hannah N notified me and provided me the new URL of the support article.

I checked the other transactional emails for the presence of this link; it's not present anywhere else.

This PR updates both the English and Spanish versions of our welcome email.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
