### PR TITLE
Project Beats: remove missing notes from local manifest

### DIFF
--- a/apps/static/music/music-library.json
+++ b/apps/static/music/music-library.json
@@ -574,11 +574,6 @@
               "name": "Pluck B5",
               "src": "pluck-83",
               "note": 83
-            },
-            {
-              "name": "Pluck C6",
-              "src": "pluck-84",
-              "note": 84
             }
           ]
         },
@@ -766,11 +761,6 @@
               "name": "Rhodes B5",
               "src": "rhodes-83",
               "note": 83
-            },
-            {
-              "name": "Rhodes C6",
-              "src": "rhodes-84",
-              "note": 84
             }
           ]
         },
@@ -958,11 +948,6 @@
               "name": "Synth B5",
               "src": "synth-83",
               "note": 83
-            },
-            {
-              "name": "Synth C6",
-              "src": "synth-84",
-              "note": 84
             }
           ]
         },


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Quick fixes to the local manifest JSON file - removing notes for files we don't have (these aren't displayed in the chord UI anyway).