### PR TITLE
[Google Blockly] Support JSON with loading blocks and Flappy/Bounce block arrangements (Save sources in JSON, pt 2)

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -1228,7 +1228,7 @@ StudioApp.prototype.showNextHint = function() {
 /**
  * Initialize Blockly for a readonly iframe.  Called on page load. No sounds.
  * XML argument may be generated from the console with:
- * Blockly.cdoUtils.getCode(Blockly.mainBlockSpace).slice(5, -6)
+ * Blockly.Xml.domToText(Blockly.Xml.blockSpaceToDom(Blockly.mainBlockSpace)).slice(5, -6)
  */
 StudioApp.prototype.initReadonly = function(options) {
   Blockly.inject(document.getElementById('codeWorkspace'), {
@@ -1250,32 +1250,12 @@ StudioApp.prototype.loadBlocks = function(blocks) {
       JSON.parse(blocks),
       Blockly.mainBlockSpace
     );
-    // Delete this log when we remove experiments.BLOCKLY_JSON
-    console.log('JSON used to load blocks');
+    console.log('Successfully parsed JSON to load blocks.');
+    console.log(JSON.parse(blocks));
   } catch (error) {
+    // Blocks will typically be saved as XML, unless saved with experiments.BLOCKLY_JSON
     var xml = parseXmlElement(blocks);
     Blockly.Xml.domToBlockSpace(Blockly.mainBlockSpace, xml);
-  }
-};
-
-/**
- * Applies the specified arrangement to top startBlocks. If any
- * individual blocks have x or y properties set in the XML, those values
- * take priority. If no arrangement for a particular block type is
- * specified, blocks are automatically positioned by Blockly.
- *
- * Note that, currently, only bounce and flappy use arrangements.
- *
- * @param {string} startBlocks String representation of start blocks xml.
- * @param {Object.<Object>} arrangement A map from block type to position.
- * @return {string} String representation of start blocks xml, including
- *    block position.
- */
-StudioApp.prototype.arrangeBlockPosition = function(startBlocks, arrangement) {
-  try {
-    return Blockly.cdoUtils.arrangeBlocksJson(startBlocks, arrangement);
-  } catch (error) {
-    return Blockly.cdoUtils.arrangeBlocksXml(startBlocks, arrangement);
   }
 };
 
@@ -2716,7 +2696,10 @@ StudioApp.prototype.setStartBlocks_ = function(config, loadLastAttempt) {
       config.level.sharedFunctions
     );
   }
-  startBlocks = this.arrangeBlockPosition(startBlocks, config.blockArrangement);
+  startBlocks = Blockly.cdoUtils.arrangeBlockPosition(
+    startBlocks,
+    config.blockArrangement
+  );
   try {
     this.loadBlocks(startBlocks);
   } catch (e) {

--- a/apps/src/appMain.js
+++ b/apps/src/appMain.js
@@ -16,7 +16,8 @@ import defaultSkinModule from './skins.js';
 window.__TestInterface = {
   loadBlocks: (...args) => studioApp().loadBlocks(...args),
   getBlockXML: () => Blockly.cdoUtils.getCode(Blockly.mainBlockSpace),
-  arrangeBlockPosition: (...args) => studioApp().arrangeBlockPosition(...args),
+  arrangeBlockPosition: (...args) =>
+    Blockly.cdoUtils.arrangeBlockPosition(...args),
   getDropletContents: () => studioApp().editor.getValue(),
   getDroplet: () => studioApp().editor,
   // Set to true to ignore onBeforeUnload events

--- a/apps/src/blockly/addons/cdoUtils.js
+++ b/apps/src/blockly/addons/cdoUtils.js
@@ -116,37 +116,35 @@ export function getCode(workspace) {
 }
 
 export function arrangeBlocksJson(startBlocksJson, arrangement) {
-  var code = JSON.parse(startBlocksJson);
-  var block;
-  for (var i = 0; i < code.blocks.blocks.length; i++) {
-    block = code.blocks.blocks[i];
-    if (arrangement[block.type]) {
-      if (arrangement[block.type].x && block.x) {
-        block.x = arrangement[block.type].x;
+  const code = JSON.parse(startBlocksJson);
+  code.blocks.blocks.forEach(block => {
+    // look to see if we have a predefined arrangement for this type
+    const type = block.type;
+    if (arrangement[type]) {
+      if (arrangement[type].x && !block.x) {
+        block.x = arrangement[type].x;
       }
-      if (arrangement[block.type].y && block.y) {
-        block.y = arrangement[block.type].y;
+      if (arrangement[type].y && !block.y) {
+        block.y = arrangement[type].y;
       }
     }
-  }
+  });
   return JSON.stringify(code);
 }
 
 export function arrangeBlocksXml(startBlocksXml, arrangement) {
-  var type, xmlChild;
+  if (!arrangement) {
+    return;
+  }
 
-  var xml = parseXmlElement(startBlocksXml);
+  const xml = parseXmlElement(startBlocksXml);
+  const xmlChildNodes = xml.childNodes || [];
 
-  var xmlChildNodes = xml.childNodes || [];
-  arrangement = arrangement || {};
-
-  for (var j = 0; j < xmlChildNodes.length; j++) {
-    xmlChild = xmlChildNodes[j];
-
+  xmlChildNodes.forEach(xmlChild => {
     // Only look at element nodes
     if (xmlChild.nodeType === 1) {
       // look to see if we have a predefined arrangement for this type
-      type = xmlChild.getAttribute('type');
+      const type = xmlChild.getAttribute('type');
       if (arrangement[type]) {
         if (arrangement[type].x && !xmlChild.hasAttribute('x')) {
           xmlChild.setAttribute('x', arrangement[type].x);
@@ -156,6 +154,6 @@ export function arrangeBlocksXml(startBlocksXml, arrangement) {
         }
       }
     }
-  }
+  });
   return Blockly.Xml.domToText(xml);
 }

--- a/apps/src/blockly/addons/cdoUtils.js
+++ b/apps/src/blockly/addons/cdoUtils.js
@@ -115,7 +115,35 @@ export function getCode(workspace) {
   }
 }
 
-export function arrangeBlocksJson(startBlocksJson, arrangement) {
+/**
+ * Applies the specified arrangement to top startBlocks. If any
+ * individual blocks have x or y properties set in the XML, those values
+ * take priority. If no arrangement for a particular block type is
+ * specified, blocks are automatically positioned by Blockly.
+ *
+ * Note that, currently, only bounce and flappy use arrangements.
+ *
+ * @param {string} startBlocks String representation of start blocks xml.
+ * @param {Object.<Object>} arrangement A map from block type to position.
+ * @return {string} String representation of start blocks xml or JSON,
+ * including block position.
+ */
+export function arrangeBlockPosition(blockText, arrangement) {
+  if (!arrangement) {
+    return;
+  }
+  try {
+    const arrangedBlocks = arrangeBlocksJson(blockText, arrangement);
+    console.log('Successfully parsed JSON to arrange blocks.');
+    console.log(JSON.parse(blockText));
+    return arrangedBlocks;
+  } catch (error) {
+    // Blocks will typically be saved as XML, unless saved with experiments.BLOCKLY_JSON
+    return arrangeBlocksXml(blockText, arrangement);
+  }
+}
+
+function arrangeBlocksJson(startBlocksJson, arrangement) {
   const code = JSON.parse(startBlocksJson);
   code.blocks.blocks.forEach(block => {
     // look to see if we have a predefined arrangement for this type
@@ -127,12 +155,13 @@ export function arrangeBlocksJson(startBlocksJson, arrangement) {
       if (arrangement[type].y && !block.y) {
         block.y = arrangement[type].y;
       }
+      console.log(`Applied arrangement for block of type ${block.type}`);
     }
   });
   return JSON.stringify(code);
 }
 
-export function arrangeBlocksXml(startBlocksXml, arrangement) {
+function arrangeBlocksXml(startBlocksXml, arrangement) {
   if (!arrangement) {
     return;
   }

--- a/apps/src/blockly/cdoBlocklyWrapper.js
+++ b/apps/src/blockly/cdoBlocklyWrapper.js
@@ -275,7 +275,7 @@ function initializeBlocklyWrapper(blocklyInstance) {
     getCode: function(workspace) {
       return Blockly.Xml.domToText(Blockly.Xml.blockSpaceToDom(workspace));
     },
-    arrangeBlocksXml: function(blocks, arrangement) {
+    arrangeBlocksPosition: function(blocks, arrangement) {
       // Arrangements are only used in Flappy and Bounce
       return blocks;
     }

--- a/apps/src/blockly/cdoBlocklyWrapper.js
+++ b/apps/src/blockly/cdoBlocklyWrapper.js
@@ -274,6 +274,10 @@ function initializeBlocklyWrapper(blocklyInstance) {
     },
     getCode: function(workspace) {
       return Blockly.Xml.domToText(Blockly.Xml.blockSpaceToDom(workspace));
+    },
+    arrangeBlocksXml: function(blocks, arrangement) {
+      // Arrangements are only used in Flappy and Bounce
+      return blocks;
     }
   };
   return blocklyWrapper;

--- a/apps/src/p5lab/P5Lab.js
+++ b/apps/src/p5lab/P5Lab.js
@@ -908,10 +908,12 @@ export default class P5Lab {
     } else {
       let textBlocks;
       if (Blockly.version === 'Google') {
-        // We're using Google Blockly, report the program as JSON
+        // Google Blockly labs don't have shared functions yet, so we can use
+        // util directly.
         textBlocks = Blockly.cdoUtils.getCode(Blockly.mainBlockSpace);
       } else {
-        // We're using CDO Blockly, report the program as xml
+        // We're using CDO Blockly, report the program as xml with any shared
+        // functions added in.
         var xml = Blockly.Xml.blockSpaceToDom(Blockly.mainBlockSpace);
 
         // When SharedFunctions (aka shared behavior_definitions) are enabled, they

--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -39,6 +39,8 @@ experiments.OPT_IN_EMAIL_REG_PARTNER = 'optInEmailRegPartner';
 // for Sprite Lab animations
 experiments.BACKGROUNDS_AND_UPLOAD = 'backgroundsTab';
 experiments.SECTION_SETUP_REFRESH = 'sectionSetupRefresh';
+// Experiment for saving Google Blockly lab code as JSON instead of XML
+experiments.BLOCKLY_JSON = 'blocklyJson';
 
 /**
  * This was a gamified version of the finish dialog, built in 2018,


### PR DESCRIPTION
## Context
We have always saved student Blockly code as an XML string. While XML is still supported in Google Blockly, JSON is the preferred format and will allow us to eventually store function definitions off of the main workspace.
To accomplish this, we can create helper functions in each Blockly wrapper that will handle saving and loading student code in whichever manner is appropriate. We can change the format of this source without breaking existing projects.

## Strategy
We will not perform a bulk update on existing projects as the XML sources should continue to work. Instead, we will changes things so that the next time a Google Blockly project is opened we convert it to JSON. This overall strategy was established by a previous PR:
1. Replace all* instances where student code is saved with a new helper that matches in both wrappers:
 --  https://github.com/code-dot-org/code-dot-org/pull/50786
3. Replace where student code is loaded (in StudioApp.js) with a new util helper that matches in both wrappers. (This PR)
4. Update both util helpers in the Google Blockly space to start working with JSON, behind an experiment flag. (This PR)

In StudioApp.js, we find a general flow for adding the blocks to the workspace:
[`setStartBlocks`](https://github.com/code-dot-org/code-dot-org/blob/mike/load-blocks-from-json-experiment/apps/src/StudioApp.js#L2699-L2736) - This pulls down the source for the blocks, usually in XML. It then calls:
  -- [`arrangeBlockPosition`](https://github.com/code-dot-org/code-dot-org/pull/50813/files#diff-dd5a7531bc734452cd21d4bd0ab327de7fb4a8a763a29864898ae369fb081e90L1265-L1291) - Rewrites the x/y position of some blocks (only used by Flappy/Bounce - Google Blockly labs)
  -- [`loadBlocks`](https://github.com/code-dot-org/code-dot-org/pull/50813/files#diff-dd5a7531bc734452cd21d4bd0ab327de7fb4a8a763a29864898ae369fb081e90L1247-L1250) - Actually loads the blocks onto the workspace.

### Update how we load blocks

We are moving to a place where the `startBlocks` parameter of `setStartBlocks_` could be either stringified JSON or XML for a Blockly lab. We don't need to actually modify anything here, but it may be worth looking through `setStartBlocks_`, linked above, to understand how it works.

As we will be supporting JSON or XML, `arrangeBlockPosition` must work in either case. A `try...catch` is employed to first attempt modification assuming `startBlocks` is JSON. The catch handles any error by assuming that `startBlocks` must then be XML. Either way, we return an updated source of truth of the blocks. Two new util functions are created for this purpose. `arrangeBlockPosition` isn't really needed for any CDO Blockly labs, so the CDO version that was added to that corresponding wrapping can just return its first argument immediately.

`loadBlocks` must also be updated to support JSON. We can employ a similar `try...catch` structure to first attempt loading the blocks from JSON and fall back to XML if that doesn't work. The existing method for loading blocks from XML works with both Blockly versions. This is also the only place we seem to load blocks, so nothing here is moved out to a util. 

### Allow saving as JSON via experiment
It was relatively light touch to also add an experiment flag that tells our Google Blockly labs to start saving code changes as JSON. This would allow testing the new flow on production on an opt-in basis. Production is the best environment for testing this as adhocs and localhost don't have the same volume of projects on different accounts.

This video demonstrates a potential flow for testing that we are now supporting both JSON and XML, using Bounce:

https://user-images.githubusercontent.com/43474485/225768429-2e81408a-acc3-4752-a195-8091ff314ec4.mp4

Video beats:
- 0:00 - A block is added to a new bounce project.
- 0:02 - Project saved as XML when Run button pressed.
- 0:08 - Project refreshed to show changes persist
- 0:14 - Experiment flag added to url
- 0:17 - Project reloads, still loading blocks from previous XML. Console immediately shows the same blocks as JSON
- 0:24 - Project saved as JSON and output to the console
- 0:47 - Changes persist on further reload. Console indicates "JSON used to load blocks"
- 1:03 - Experiment flag removed
- 1:09 - Project reloads. Source is still JSON, which is used to load blocks. (This is expected. We don't want projects to break just because the experiment is disabled.)
- 1:16 - A final change is made to the project, which is saved in XML.
- 1:24 - The project reloads a final time. This time the source is back in XML.

In summary, this video demonstrates that the new utils enable us to load an XML project, convert it to JSON, and, if need be, convert it back. At all steps along the way, the blocks are loaded as expected.

I also tested this flow in a CDO Blockly lab (Artist). No matter the state of the experiment flag, XML is still always used for loading and saving blocks in CDO Blockly labs.

## Links

Jira - https://codedotorg.atlassian.net/browse/SL-640

## Follow-up work

Add tests. For example, we should test that loading a set of XML blocks with Google Blockly and then saving it yields an expected JSON output. We could also test that loading blocks from either type of source leads to the correct set of blocks being created. 

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
