### PR TITLE
Music: show new video

### DIFF
--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -388,7 +388,7 @@ class UnconnectedMusicView extends React.Component {
       instructionPositionOrder[this.state.instructionsPosIndex];
 
     const showVideo =
-      AppConfig.getValue('show-video') === 'true' && this.state.showingVideo;
+      AppConfig.getValue('show-video') !== 'false' && this.state.showingVideo;
 
     return (
       <AnalyticsContext.Provider value={this.analyticsReporter}>

--- a/apps/src/music/views/Video.jsx
+++ b/apps/src/music/views/Video.jsx
@@ -62,7 +62,7 @@ const Video = ({id, onClose}) => {
             width="100%"
             height="100%"
             style={{border: 'none'}}
-            src="https://www.youtube-nocookie.com/embed/qYZF6oIZtfc"
+            src="https://www.youtube-nocookie.com/embed/ab2SBrfkKXU"
             title=""
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
             allowFullScreen


### PR DESCRIPTION
This shows the new video, unless the `show-video=false` URL parameter is specified, using the player added in https://github.com/code-dot-org/code-dot-org/pull/50652.
