### PR TITLE
Project Beats: convert MusicLibrary into class

### DIFF
--- a/apps/src/music/blockly/blocks/simple2.js
+++ b/apps/src/music/blockly/blocks/simple2.js
@@ -161,7 +161,7 @@ export const playSoundAtCurrentLocationSimple2 = {
         __effects
       );
       ProgramSequencer.updateMeasureForPlayByLength(
-        MusicPlayer.getLengthForId(
+        MusicLibrary.getLengthForId(
           "${block.getFieldValue(FIELD_SOUNDS_NAME)}"
         )
       );

--- a/apps/src/music/player/MusicLibrary.ts
+++ b/apps/src/music/player/MusicLibrary.ts
@@ -1,5 +1,35 @@
-export default interface MusicLibrary {
+export default class MusicLibrary {
   groups: FolderGroup[];
+
+  constructor(libraryJson: any) {
+    if (!libraryJson.groups || libraryJson.groups.length === 0) {
+      throw new Error(`Invalid library JSON: ${libraryJson}`);
+    }
+
+    this.groups = libraryJson.groups;
+  }
+
+  getLengthForId(id: string): number | null {
+    return this.getSoundForId(id)?.length || null;
+  }
+
+  getSoundForId(id: string): SoundData | null {
+    const splitId = id.split('/');
+    const path = splitId[0];
+    const src = splitId[1];
+
+    const folder = this.getFolderForPath(path);
+
+    if (folder) {
+      return folder.sounds.find(sound => sound.src === src) || null;
+    }
+
+    return null;
+  }
+
+  getFolderForPath(path: string): SoundFolder | null {
+    return this.groups[0].folders.find(folder => folder.path === path) || null;
+  }
 }
 
 export type SoundType = 'beat' | 'bass' | 'lead' | 'fx';

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -21,6 +21,7 @@ import MusicBlocklyWorkspace from '../blockly/MusicBlocklyWorkspace';
 import AppConfig, {getBlockMode} from '../appConfig';
 import SoundUploader from '../utils/SoundUploader';
 import Video from './Video';
+import MusicLibrary from '../player/MusicLibrary';
 
 const baseUrl = 'https://curriculum.code.org/media/musiclab/';
 
@@ -105,7 +106,8 @@ class UnconnectedMusicView extends React.Component {
 
     document.body.addEventListener('keyup', this.handleKeyUp);
 
-    this.loadLibrary().then(library => {
+    this.loadLibrary().then(libraryJson => {
+      const library = new MusicLibrary(libraryJson);
       this.musicBlocklyWorkspace.init(
         document.getElementById('blockly-div'),
         this.onBlockSpaceChange,
@@ -116,6 +118,7 @@ class UnconnectedMusicView extends React.Component {
 
       Globals.setLibrary(library);
       Globals.setPlayer(this.player);
+      this.library = library;
     });
 
     // Only attempt to load instructions if configured to.
@@ -255,7 +258,8 @@ class UnconnectedMusicView extends React.Component {
       MusicPlayer: this.player,
       ProgramSequencer: this.programSequencer,
       RandomSkipManager: this.randomSkipManager,
-      getTriggerCount: () => this.triggerCount
+      getTriggerCount: () => this.triggerCount,
+      MusicLibrary: this.library
     });
   };
 

--- a/apps/src/music/views/PatternPanel.jsx
+++ b/apps/src/music/views/PatternPanel.jsx
@@ -12,19 +12,12 @@ const arrayOfTicks = Array.from({length: 16}, (_, i) => i + 1);
  */
 
 const PatternPanel = ({library, initValue, onChange}) => {
-  const findFolder = path => {
-    const folder = library.groups[0].folders.find(
-      folder => folder.path === path
-    );
-    return folder;
-  };
-
   // Make a copy of the value object so that we don't overwrite Blockly's
   // data.
   const currentValue = JSON.parse(JSON.stringify(initValue));
 
   const group = library.groups[0];
-  const currentFolder = findFolder(currentValue.kit);
+  const currentFolder = library.getFolderForPath(currentValue.kit);
 
   const toggleEvent = (sound, tick) => {
     const index = currentValue.events.findIndex(
@@ -50,7 +43,7 @@ const PatternPanel = ({library, initValue, onChange}) => {
 
   const handleFolderChange = event => {
     const value = event.target.value;
-    const folder = findFolder(value);
+    const folder = library.getFolderForPath(value);
     currentValue.kit = folder.path;
     onChange(currentValue);
   };


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

One more quick refactor/pre-factor. This converts MusicLibrary from an interface into a class so it can own library-related lookup functions like getLengthForId, etc. Moving these out of MusicPlayer will be useful later on as we start to pull out more logic out of MusicPlayer and into other components.

## Testing story

Tested locally. No user-facing changes.