### PR TITLE
Set up Curriculum Catalog page

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -585,6 +585,8 @@ describe('entry tests', () => {
     'courses/resources': './src/sites/studio/pages/courses/resources.js',
     'courses/code': './src/sites/studio/pages/courses/code.js',
     'courses/standards': './src/sites/studio/pages/courses/standards.js',
+    'curriculum_catalog/index':
+      './src/sites/studio/pages/curriculum_catalog/index.js',
     'data_docs/index': './src/sites/studio/pages/data_docs/index.js',
     'data_docs/show': './src/sites/studio/pages/data_docs/show.js',
     'incubator/index': './src/sites/studio/pages/incubator/index.js',

--- a/apps/src/sites/studio/pages/curriculum_catalog/index.js
+++ b/apps/src/sites/studio/pages/curriculum_catalog/index.js
@@ -13,7 +13,7 @@ $(document).ready(function() {
       <>
         <h1>Curriculum Catalog!</h1>
         {curriculaData.map(curriculum => (
-          <li key={curriculum.key}>{curriculum.key}</li>
+          <li key={curriculum.key}>{curriculum.display_name}</li>
         ))}
       </>
     </Provider>,

--- a/apps/src/sites/studio/pages/curriculum_catalog/index.js
+++ b/apps/src/sites/studio/pages/curriculum_catalog/index.js
@@ -1,0 +1,22 @@
+import $ from 'jquery';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import {Provider} from 'react-redux';
+import {getStore} from '@cdo/apps/redux';
+
+$(document).ready(function() {
+  const script = document.querySelector('script[data-curricula]');
+  const curriculaData = JSON.parse(script.dataset.curricula);
+
+  ReactDOM.render(
+    <Provider store={getStore()}>
+      <>
+        <h1>Curriculum Catalog!</h1>
+        {curriculaData.map(curriculum => (
+          <li key={curriculum.key}>{curriculum.key}</li>
+        ))}
+      </>
+    </Provider>,
+    document.getElementById('curriculum-catalog-container')
+  );
+});

--- a/dashboard/app/controllers/curriculum_catalog_controller.rb
+++ b/dashboard/app/controllers/curriculum_catalog_controller.rb
@@ -1,0 +1,6 @@
+class CurriculumCatalogController < ApplicationController
+  # GET /catalog
+  def index
+    @curricula_data = CourseOffering.all.order(:key).map(&:serialize)
+  end
+end

--- a/dashboard/app/controllers/curriculum_catalog_controller.rb
+++ b/dashboard/app/controllers/curriculum_catalog_controller.rb
@@ -1,6 +1,6 @@
 class CurriculumCatalogController < ApplicationController
   # GET /catalog
   def index
-    @curricula_data = CourseOffering.all.order(:key).map(&:serialize)
+    @curricula_data = CourseOffering.all.order(:display_name).map(&:serialize)
   end
 end

--- a/dashboard/app/views/curriculum_catalog/index.html.haml
+++ b/dashboard/app/views/curriculum_catalog/index.html.haml
@@ -1,0 +1,2 @@
+%script{src: webpack_asset_path('js/curriculum_catalog/index.js'), data: {curricula: @curricula_data.to_json}}
+#curriculum-catalog-container

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -106,6 +106,8 @@ Dashboard::Application.routes.draw do
     get 'docs/*path', to: 'curriculum_proxy#get_doc'
     get 'curriculum/*path', to: 'curriculum_proxy#get_curriculum'
 
+    get '/catalog', to: 'curriculum_catalog#index'
+
     # User-facing section routes
     resources :sections, only: [:show, :new] do
       member do


### PR DESCRIPTION
This PR both sets up the new curriculum catalog page at studio.code.org/catalog and imports the course offering data into it. To show the data is making it into the page successfully, I added a placeholder list that shows each course offering sorted by course name (as specified in [this ticket](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?modal=detail&selectedIssue=ACQ-445&assignee=60d62161f65054006980bd71)).

![List_of_course_catalog_curricula](https://user-images.githubusercontent.com/56283563/225939700-e9c9030b-c8d4-459c-8555-0ad128e7f107.PNG)

To view locally, go to [http://localhost-studio.code.org:3000/catalog](http://localhost-studio.code.org:3000/catalog).

## Links
Jira tickets: [set up page](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?modal=detail&selectedIssue=ACQ-444&assignee=60d62161f65054006980bd71) and [import data](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?modal=detail&selectedIssue=ACQ-445&assignee=60d62161f65054006980bd71)

## Testing story
Local testing.

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
