### PR TITLE
SL-639: Fix image access for App Lab assets from 'https://images.code.org...'

### DIFF
--- a/apps/src/assetManagement/assetPrefix.js
+++ b/apps/src/assetManagement/assetPrefix.js
@@ -55,7 +55,7 @@ export function fixPath(filename) {
   // Rewrite urls to pass through our media proxy. Unless of course we are in an
   // exported app, in which case our media proxy won't be good for anything
   // anyway.
-  if (ABSOLUTE_REGEXP.test(filename) && !window.location.protocol !== 'file:') {
+  if (ABSOLUTE_REGEXP.test(filename) && window.location.protocol !== 'file:') {
     if (
       ABSOLUTE_CDO_CURRICULUM_REGEXP.test(filename) ||
       ABSOLUTE_CDO_IMAGES_REGEXP.test(filename)

--- a/apps/src/assetManagement/assetPrefix.js
+++ b/apps/src/assetManagement/assetPrefix.js
@@ -4,10 +4,10 @@ import {getStore} from '@cdo/apps/redux';
 // For proxying non-https assets
 const MEDIA_PROXY = '//' + location.host + '/media?u=';
 
-// Starts with http or https
+// starts with http or https
 export const ABSOLUTE_REGEXP = new RegExp('^https?://', 'i');
 
-// Absolute URL to curriculum.code.org (which doesn't require media proxy)
+// absolute URL to curriculum.code.org (which doesn't require media proxy)
 const ABSOLUTE_CDO_CURRICULUM_REGEXP = new RegExp(
   '^https://curriculum.code.org/',
   'i'

--- a/apps/src/assetManagement/assetPrefix.js
+++ b/apps/src/assetManagement/assetPrefix.js
@@ -4,14 +4,15 @@ import {getStore} from '@cdo/apps/redux';
 // For proxying non-https assets
 const MEDIA_PROXY = '//' + location.host + '/media?u=';
 
-// starts with http or https
+// Starts with http or https
 export const ABSOLUTE_REGEXP = new RegExp('^https?://', 'i');
 
-// absolute URL to curriculum.code.org (which doesn't require media proxy)
+// Absolute URL to curriculum.code.org (which doesn't require media proxy)
 const ABSOLUTE_CDO_CURRICULUM_REGEXP = new RegExp(
   '^https://curriculum.code.org/',
   'i'
 );
+const ABSOLUTE_CDO_IMAGES_REGEXP = new RegExp('^https://images.code.org/', 'i');
 
 export const DATA_URL_PREFIX_REGEX = new RegExp('^data:image');
 
@@ -54,8 +55,11 @@ export function fixPath(filename) {
   // Rewrite urls to pass through our media proxy. Unless of course we are in an
   // exported app, in which case our media proxy won't be good for anything
   // anyway.
-  if (ABSOLUTE_REGEXP.test(filename) && window.location.protocol !== 'file:') {
-    if (ABSOLUTE_CDO_CURRICULUM_REGEXP.test(filename)) {
+  if (ABSOLUTE_REGEXP.test(filename) && !window.location.protocol !== 'file:') {
+    if (
+      ABSOLUTE_CDO_CURRICULUM_REGEXP.test(filename) ||
+      ABSOLUTE_CDO_IMAGES_REGEXP.test(filename)
+    ) {
       // We know that files served from this location will respond with the
       // access-control-allow-origin: * header, meaning no CORS issue & no need
       // for the media proxy.

--- a/apps/test/unit/assetManagement/assetPrefixTest.js
+++ b/apps/test/unit/assetManagement/assetPrefixTest.js
@@ -75,10 +75,8 @@ describe('apps/src/assetManagement/assetPrefix.js', () => {
     });
 
     it('should not prepend assetPathPrefix or channelId when the filename is relative and channelId is not set', () => {
-      const dataTableAsset =
-        '//images.code.org/00dabb18b629e99ae0a77c5db2b3d0f9-Flag_of_Alabama.svg.png';
-      const result = fixPath(dataTableAsset);
-      expect(result).to.equal(dataTableAsset);
+      const result = fixPath('//images.code.org/test-image.png');
+      expect(result).to.equal('//images.code.org/test-image.png');
     });
   });
 });

--- a/apps/test/unit/assetManagement/assetPrefixTest.js
+++ b/apps/test/unit/assetManagement/assetPrefixTest.js
@@ -1,0 +1,77 @@
+import sinon from 'sinon';
+import * as redux from '@cdo/apps/redux';
+import {init, fixPath} from '@cdo/apps/assetManagement/assetPrefix';
+import {expect} from '../../util/reconfiguredChai';
+
+describe('apps/src/assetManagement/assetPrefix.js', () => {
+  describe('fixPath', () => {
+    let reduxStub, result;
+
+    beforeEach(() => {
+      reduxStub = sinon.stub(redux, 'getStore').returns({
+        getState: () => ({
+          level: {
+            name: 'test-level'
+          }
+        })
+      });
+    });
+
+    afterEach(() => {
+      reduxStub.restore();
+    });
+
+    it('should route an absolute URL through the MEDIA_PROXY', () => {
+      result = fixPath('http://example.com/test%20image.png');
+      expect(result).to.equal(
+        `//${
+          location.host
+        }/media?u=http%3A%2F%2Fexample.com%2Ftest%2520image.png`
+      );
+
+      result = fixPath('https://example.com/test%20image.png');
+      expect(result).to.equal(
+        `//${
+          location.host
+        }/media?u=https%3A%2F%2Fexample.com%2Ftest%2520image.png`
+      );
+    });
+
+    it('should not route known absolute URLs through the MEDIA_PROXY', () => {
+      result = fixPath('https://curriculum.code.org/test-image.png');
+      expect(result).to.equal('https://curriculum.code.org/test-image.png');
+
+      result = fixPath('https://images.code.org/test-image.png');
+      expect(result).to.equal('https://images.code.org/test-image.png');
+    });
+
+    it('should return the default image when the filename is empty', () => {
+      result = fixPath();
+      expect(result).to.equal('/blockly/media/1x1.gif');
+
+      result = fixPath('');
+      expect(result).to.equal('/blockly/media/1x1.gif');
+
+      result = fixPath(null);
+      expect(result).to.equal('/blockly/media/1x1.gif');
+    });
+
+    it('should replace sound:// prefix with soundPathPrefix', () => {
+      const result = fixPath('sound://test-sound.wav');
+      expect(result).to.equal('/api/v1/sound-library/test-sound.wav');
+    });
+
+    it('should replace starter:// prefix with starterAssetPathPrefix', () => {
+      const result = fixPath('image://test-starter-image.png');
+      expect(result).to.equal(
+        '/level_starter_assets/test-level/test-starter-image.png'
+      );
+    });
+
+    it('should prepend assetPathPrefix and channelId when the filename is relative', () => {
+      init({channel: 'test-channel'});
+      const result = fixPath('image.png');
+      expect(result).to.equal(`/v3/assets/test-channel/image.png`);
+    });
+  });
+});

--- a/apps/test/unit/assetManagement/assetPrefixTest.js
+++ b/apps/test/unit/assetManagement/assetPrefixTest.js
@@ -73,5 +73,12 @@ describe('apps/src/assetManagement/assetPrefix.js', () => {
       const result = fixPath('image.png');
       expect(result).to.equal(`/v3/assets/test-channel/image.png`);
     });
+
+    it('should not prepend assetPathPrefix or channelId when the filename is relative and channelId is not set', () => {
+      const dataTableAsset =
+        '//images.code.org/00dabb18b629e99ae0a77c5db2b3d0f9-Flag_of_Alabama.svg.png';
+      const result = fixPath(dataTableAsset);
+      expect(result).to.equal(dataTableAsset);
+    });
   });
 });


### PR DESCRIPTION
Images from `https://images.code.org` were being routed (incorrectly) through our media proxy and failing to render in App Lab. The logic for this lives in the `apps/src/assetManagement/assetPrefix.js` `fixPath` function. I noticed that assets from https://curriculum.code.org are already set up to bypass the media proxy. The comment says: 

```
// We know that files served from this location will respond with the
// access-control-allow-origin: * header, meaning no CORS issue & no need
// for the media proxy.
```

Adding a second check so assets from https://images.code.org also bypass the media proxy appears to solve the problem.

I also wrote unit tests for the `fixPath` function because there appear to be no tests for this file. Several conditions are mentioned in the `fixPath` function, so testing them helped me understand what it's doing. If anyone has context, it's also worth giving the tests a look!

## Links

Jira link: https://codedotorg.atlassian.net/browse/SL-639
Example of what this PR fixes: https://studio.code.org/projects/applab/splXUVTT12tcZxW_hHFOub_LtcdPg3MSs417MdA2Ous

## Testing story

I added tests and verified that the sample project included in the ticket is fixed by this code change.

Before:

<img width="1188" alt="Screen Shot 2023-03-20 at 3 38 15 PM" src="https://user-images.githubusercontent.com/26844240/226481222-eaaa5600-fb37-40a9-b73c-4be84a2cc3c7.png">

After:

<img width="1187" alt="Screen Shot 2023-03-20 at 3 29 20 PM" src="https://user-images.githubusercontent.com/26844240/226481239-0bc26fcd-8a8d-485c-9494-347b2d2207b8.png">

Note: I changed the flag from the sample project in the ticket from Alabama to Alaska because the fact that Alabama's flag has a red "X" on it confused me at first/made me think the image wasn't rendering :) 

I also checked that this doesn't seem to be interfering with WebLab assets on a level that has images loaded from `images.code.org` (see https://studio.code.org/s/csd2-2022/lessons/11/levels/7/sublevel/1). In production, we are not routing existing WebLab requests for assets from `images.code.org` through the media proxy but seem to be requesting images from `images.code.org` that (maybe sequentially?) kick off requests for the same assets from `downloads.computinginthecore.org`.

## Deployment strategy

The ticket notes that we need to contact @dancodedotorg after deploy, but this is so we can standardize on student-facing URLS always having `https://` in front. Both formats will continue to work/there is no switchover. 

## Follow-up work

- [x] Should I ask if there are any other domains we should proactively include here to bypass the media proxy?

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
