### PR TITLE
Simplify `Cache-Control` Header

### DIFF
--- a/dashboard/app/controllers/application_controller.rb
+++ b/dashboard/app/controllers/application_controller.rb
@@ -93,12 +93,12 @@ class ApplicationController < ActionController::Base
 
   def prevent_caching
     # Rails has some logic to normalize the cache-control header that varies
-    # from version to version. Ideally, we would include 'no-cache' here but
-    # that causes Rails (starting in 5.2, still true as of 6.0) to remove
-    # 'must-revalidate' which causes issues on older mobile Safari browsers.
+    # from version to version. Ideally, we would include 'no-cache, max-age=0,
+    # must-revalidate' here, but when `no-store` is present it will clear out
+    # all the others.
     # See Rails logic at
-    # https://github.com/rails/rails/blob/v6.0.4.4/actionpack/lib/action_dispatch/http/cache.rb#L184
-    response.headers["Cache-Control"] = "no-store, max-age=0, must-revalidate"
+    # https://github.com/rails/rails/blob/v6.1.4.7/actionpack/lib/action_dispatch/http/cache.rb#L185
+    response.headers["Cache-Control"] = "no-store"
     response.headers["Pragma"] = "no-cache"
     response.headers["Expires"] = "Fri, 01 Jan 1990 00:00:00 GMT"
   end

--- a/dashboard/test/test_helper.rb
+++ b/dashboard/test/test_helper.rb
@@ -334,11 +334,7 @@ class ActiveSupport::TestCase
   end
 
   def assert_caching_disabled(cache_control_header)
-    expected_directives = [
-      'no-store',
-      'max-age=0',
-      'must-revalidate'
-    ]
+    expected_directives = ['no-store']
     assert_cache_control_match expected_directives, cache_control_header
   end
 


### PR DESCRIPTION
In preparation for an eventual upgrade to Rails 6.1, in which additional logic was added to the existing Cache-Control header normalization logic which special-cases the `no-store` header: https://github.com/rails/rails/pull/39461

We previously wanted to ensure that `must-revalidate` was present to prevent issues with older Safari mobile browsers (see https://github.com/code-dot-org/code-dot-org/pull/43776 for context), but our belief at this point is that those old versions are no longer relevant.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

This logic was originally added in https://github.com/code-dot-org/code-dot-org/pull/3724

## Testing story

Open to suggestions on the best way to test this. In particular, I'm not sure how to test broad browser compatibility. We know that this might cause issues with older mobile safari browsers, but aren't sure _how_ old you have to go for this to become and issue and we have very limited ability to access older versions.

## Caching

In general, the danger here is that even though `no-store` is the recommended way to avoid caching content, older browsers might have implemented that incorrectly and require workarounds like `max-age` or `must-revalidate` to achieve the functionality that's supposed to be offered by `no-store`. I'm not sure how to identify those possible violations, however, or even what we would do if we did, given that the new Rails logic is quite strict about not mixing other directives with `no-store`.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
