### PR TITLE
Update many links on code.org/apply to not open in new tab

### DIFF
--- a/pegasus/sites.v3/code.org/public/educate/professional-learning/middle-high.haml
+++ b/pegasus/sites.v3/code.org/public/educate/professional-learning/middle-high.haml
@@ -30,7 +30,7 @@ theme: responsive_full_width
         %li Explore the curriculum and learning tools
         %li Experience the course as a teacher and a learner
         %li Collaborate with fellow teachers
-      %a{href: "/educate/professional-learning/program-information", class: "link-button", rel: "noopener noreferrer"} Apply now
+      %a{href: "/educate/professional-learning/program-information", class: "link-button"} Apply now
     %div.col-50{style: "float: right"}
       %figure.video-responsive{style: "margin-top: 5px; max-width: unset"}
         %div
@@ -63,8 +63,7 @@ theme: responsive_full_width
           %li No computer science experience required
           %li Based in United States
           %li Teaching 25+ hours of course to a class in next school year
-        %a{href: "/educate/professional-learning/program-information" , class: "link-button", rel: "noopener noreferrer"} Apply now
-        %a{href: "/educate/professional-learning/program-information", class: "link-button secondary", rel: "noopener noreferrer"} Learn more
+        %a{href: "/educate/professional-learning/program-information", class: "link-button"} Learn more
       .action-block.action-block--one-col
         %p.overline Beginner
         %h3 CS Principles
@@ -77,8 +76,7 @@ theme: responsive_full_width
           %li Based in United States
           %li Teaching 100+ hours of course to a class in next school year
           %li Teach AP or non-AP course
-        %a{href: "/educate/professional-learning/program-information", class: "link-button", rel: "noopener noreferrer"} Apply now
-        %a{href: "/educate/professional-learning/program-information", class: "link-button secondary", rel: "noopener noreferrer"} Learn more
+        %a{href: "/educate/professional-learning/program-information", class: "link-button"} Learn more
       .action-block.action-block--one-col
         %p.overline Intermediate
         %h3 AP® CSA
@@ -91,8 +89,7 @@ theme: responsive_full_width
           %li Based in United States
           %li Teaching 140+ hours of course to a class  in next school year
           %li Teach AP or non-AP course
-        %a{href: "/educate/professional-learning/program-information", class: "link-button", rel: "noopener noreferrer"} Apply now
-        %a{href: "/educate/professional-learning/program-information", class: "link-button secondary", rel: "noopener noreferrer"} Learn more
+        %a{href: "/educate/professional-learning/program-information", class: "link-button"} Learn more
   .clear
 
 = view :section_divider_line
@@ -111,7 +108,7 @@ theme: responsive_full_width
       %li{style: "width: 32%"}
         %h3 Community Support
         %p Collaborate with your regional cohort of teachers and get the support of a nationwide online teacher community
-    %a{href: "/educate/professional-learning/program-information", rel: "noopener noreferrer"} Find out more about the program specifics in your region.
+    %a{href: "/educate/professional-learning/program-information"} Find out more about the program specifics in your region.
 
 %section.bg-neutral-light
   .wrapper
@@ -138,7 +135,7 @@ theme: responsive_full_width
         %h4 Enroll
         %p Sign up for the summer workshop in your region and get ready to start the yearlong program!
     %div.centered
-      %a{href: "/educate/professional-learning/program-information", class: "link-button", rel: "noopener noreferrer"} Apply now
+      %a{href: "/educate/professional-learning/program-information", class: "link-button"} Apply now
 
 %section
   .wrapper
@@ -148,7 +145,7 @@ theme: responsive_full_width
       .text-wrapper.col-50
         %p <strong>The cost of the program varies by region.</strong>
         %p You may be eligible for a scholarship to cover the cost of your program.
-        %a{href: "/educate/professional-learning/program-information", class: "link-button", rel: "noopener noreferrer"} Learn more about the program in your region
+        %a{href: "/educate/professional-learning/program-information", class: "link-button"} Learn more about the program in your region
   .clear
 
 = view :section_divider_line
@@ -161,15 +158,15 @@ theme: responsive_full_width
       .action-block.action-block--one-col.secondary
         %h3 Self-Paced Learning
         %p{style: "height: 80px"} Learn at your own pace using our online learning modules. You can start whenever is convenient for you and the courses are free.
-        %a{href: "/educate/professional-development-online", class: "link-button secondary", rel: "noopener noreferrer"} Learn more
+        %a{href: "/educate/professional-development-online", class: "link-button secondary"} Learn more
       .action-block.action-block--one-col.secondary
         %h3 Elementary Workshops
         %p{style: "height: 80px"} Do you teach Kindergarten through 5th grade? Check out the link below to learn more about our K5 workshops.
-        %a{href: "/professional-development-workshops", class: "link-button secondary", rel: "noopener noreferrer"} Learn more
+        %a{href: "/professional-development-workshops", class: "link-button secondary"} Learn more
       .action-block.action-block--one-col.secondary
         %h3 Outside the United States
         %p{style: "height: 80px"} If you are an international teacher interested in professional learning. Learn more about what is offered in your area.
-        %a{href: "https://support.code.org/hc/en-us/articles/115003865532-I-teach-outside-of-the-US-Are-there-resources-to-help-me-teach-computer-science-", class: "link-button secondary", rel: "noopener noreferrer"} Learn more
+        %a{href: "https://support.code.org/hc/en-us/articles/115003865532-I-teach-outside-of-the-US-Are-there-resources-to-help-me-teach-computer-science-", class: "link-button secondary"} Learn more
 
 = view :section_divider_line
 

--- a/pegasus/sites.v3/code.org/public/educate/professional-learning/middle-high.haml
+++ b/pegasus/sites.v3/code.org/public/educate/professional-learning/middle-high.haml
@@ -30,7 +30,7 @@ theme: responsive_full_width
         %li Explore the curriculum and learning tools
         %li Experience the course as a teacher and a learner
         %li Collaborate with fellow teachers
-      %a{href: "/educate/professional-learning/program-information", class: "link-button", target: "_blank", rel: "noopener noreferrer"} Apply now
+      %a{href: "/educate/professional-learning/program-information", class: "link-button", rel: "noopener noreferrer"} Apply now
     %div.col-50{style: "float: right"}
       %figure.video-responsive{style: "margin-top: 5px; max-width: unset"}
         %div
@@ -63,8 +63,8 @@ theme: responsive_full_width
           %li No computer science experience required
           %li Based in United States
           %li Teaching 25+ hours of course to a class in next school year
-        %a{href: "/educate/professional-learning/program-information" , class: "link-button", target: "_blank", rel: "noopener noreferrer"} Apply now
-        %a{href: "/educate/professional-learning/program-information", class: "link-button secondary", target: "_blank", rel: "noopener noreferrer"} Learn more
+        %a{href: "/educate/professional-learning/program-information" , class: "link-button", rel: "noopener noreferrer"} Apply now
+        %a{href: "/educate/professional-learning/program-information", class: "link-button secondary", rel: "noopener noreferrer"} Learn more
       .action-block.action-block--one-col
         %p.overline Beginner
         %h3 CS Principles
@@ -77,8 +77,8 @@ theme: responsive_full_width
           %li Based in United States
           %li Teaching 100+ hours of course to a class in next school year
           %li Teach AP or non-AP course
-        %a{href: "/educate/professional-learning/program-information", class: "link-button", target: "_blank", rel: "noopener noreferrer"} Apply now
-        %a{href: "/educate/professional-learning/program-information", class: "link-button secondary", target: "_blank", rel: "noopener noreferrer"} Learn more
+        %a{href: "/educate/professional-learning/program-information", class: "link-button", rel: "noopener noreferrer"} Apply now
+        %a{href: "/educate/professional-learning/program-information", class: "link-button secondary", rel: "noopener noreferrer"} Learn more
       .action-block.action-block--one-col
         %p.overline Intermediate
         %h3 AP® CSA
@@ -91,8 +91,8 @@ theme: responsive_full_width
           %li Based in United States
           %li Teaching 140+ hours of course to a class  in next school year
           %li Teach AP or non-AP course
-        %a{href: "/educate/professional-learning/program-information", class: "link-button", target: "_blank", rel: "noopener noreferrer"} Apply now
-        %a{href: "/educate/professional-learning/program-information", class: "link-button secondary", target: "_blank", rel: "noopener noreferrer"} Learn more
+        %a{href: "/educate/professional-learning/program-information", class: "link-button", rel: "noopener noreferrer"} Apply now
+        %a{href: "/educate/professional-learning/program-information", class: "link-button secondary", rel: "noopener noreferrer"} Learn more
   .clear
 
 = view :section_divider_line
@@ -111,7 +111,7 @@ theme: responsive_full_width
       %li{style: "width: 32%"}
         %h3 Community Support
         %p Collaborate with your regional cohort of teachers and get the support of a nationwide online teacher community
-    %a{href: "/educate/professional-learning/program-information", target: "_blank", rel: "noopener noreferrer"} Find out more about the program specifics in your region.
+    %a{href: "/educate/professional-learning/program-information", rel: "noopener noreferrer"} Find out more about the program specifics in your region.
 
 %section.bg-neutral-light
   .wrapper
@@ -138,7 +138,7 @@ theme: responsive_full_width
         %h4 Enroll
         %p Sign up for the summer workshop in your region and get ready to start the yearlong program!
     %div.centered
-      %a{href: "/educate/professional-learning/program-information", class: "link-button", target: "_blank", rel: "noopener noreferrer"} Apply now
+      %a{href: "/educate/professional-learning/program-information", class: "link-button", rel: "noopener noreferrer"} Apply now
 
 %section
   .wrapper
@@ -148,7 +148,7 @@ theme: responsive_full_width
       .text-wrapper.col-50
         %p <strong>The cost of the program varies by region.</strong>
         %p You may be eligible for a scholarship to cover the cost of your program.
-        %a{href: "/educate/professional-learning/program-information", class: "link-button", target: "_blank", rel: "noopener noreferrer"} Learn more about the program in your region
+        %a{href: "/educate/professional-learning/program-information", class: "link-button", rel: "noopener noreferrer"} Learn more about the program in your region
   .clear
 
 = view :section_divider_line
@@ -161,15 +161,15 @@ theme: responsive_full_width
       .action-block.action-block--one-col.secondary
         %h3 Self-Paced Learning
         %p{style: "height: 80px"} Learn at your own pace using our online learning modules. You can start whenever is convenient for you and the courses are free.
-        %a{href: "/educate/professional-development-online", class: "link-button secondary", target: "_blank", rel: "noopener noreferrer"} Learn more
+        %a{href: "/educate/professional-development-online", class: "link-button secondary", rel: "noopener noreferrer"} Learn more
       .action-block.action-block--one-col.secondary
         %h3 Elementary Workshops
         %p{style: "height: 80px"} Do you teach Kindergarten through 5th grade? Check out the link below to learn more about our K5 workshops.
-        %a{href: "/professional-development-workshops", class: "link-button secondary", target: "_blank", rel: "noopener noreferrer"} Learn more
+        %a{href: "/professional-development-workshops", class: "link-button secondary", rel: "noopener noreferrer"} Learn more
       .action-block.action-block--one-col.secondary
         %h3 Outside the United States
         %p{style: "height: 80px"} If you are an international teacher interested in professional learning. Learn more about what is offered in your area.
-        %a{href: "https://support.code.org/hc/en-us/articles/115003865532-I-teach-outside-of-the-US-Are-there-resources-to-help-me-teach-computer-science-", class: "link-button secondary", target: "_blank", rel: "noopener noreferrer"} Learn more
+        %a{href: "https://support.code.org/hc/en-us/articles/115003865532-I-teach-outside-of-the-US-Are-there-resources-to-help-me-teach-computer-science-", class: "link-button secondary", rel: "noopener noreferrer"} Learn more
 
 = view :section_divider_line
 


### PR DESCRIPTION
We don't want all the links to open in a new window. Just ones that are outside the funnels we are hoping for people to move through.
