### PR TITLE
Music: always start playback

### DIFF
--- a/apps/src/music/player/SamplePlayer.ts
+++ b/apps/src/music/player/SamplePlayer.ts
@@ -68,6 +68,8 @@ export default class SamplePlayer {
     this.isPlaying = true;
 
     this.playSamples(sampleEventList);
+
+    soundApi.StartPlayback();
   }
 
   previewSample(sampleId: string, onStop: () => any) {

--- a/apps/src/music/player/sound.js
+++ b/apps/src/music/player/sound.js
@@ -48,6 +48,10 @@ function LoadSounds(desiredSounds) {
   }
 }
 
+export function StartPlayback() {
+  audioSystem.StartPlayback();
+}
+
 // play a sound.
 // an optional groupTag puts the sound in a group with a limited set of instances.
 export function PlaySound(

--- a/apps/src/music/player/soundSub.js
+++ b/apps/src/music/player/soundSub.js
@@ -127,6 +127,10 @@ WebAudio.prototype.PlaySoundByBuffer = function(
 
   source.start(when); // play the source now
 
+  if (['suspended', 'interrupted'].includes(source.context.state)) {
+    source.context.resume();
+  }
+
   return source;
 };
 

--- a/apps/src/music/player/soundSub.js
+++ b/apps/src/music/player/soundSub.js
@@ -97,6 +97,12 @@ WebAudio.prototype.LoadSoundFromBuffer = function(buffer, callback) {
   }
 };
 
+WebAudio.prototype.StartPlayback = function() {
+  if (['suspended', 'interrupted'].includes(audioContext.state)) {
+    audioContext.resume();
+  }
+};
+
 WebAudio.prototype.PlaySoundByBuffer = function(
   audioBuffer,
   id,
@@ -120,10 +126,6 @@ WebAudio.prototype.PlaySoundByBuffer = function(
   source.loop = loop;
 
   source.start(when); // play the source now
-
-  if (['suspended', 'interrupted'].includes(source.context.state)) {
-    source.context.resume();
-  }
 
   return source;
 };


### PR DESCRIPTION
Before this change, playing an empty song would make the playhead appear but not move until a sound was scheduled.  With this change, the playhead will always begin moving, even if there are no sound events.

The reason is that browsers typically initialize the Web Audio `AudioContext` with a state of `"suspended"`, and in some cases only allow `resume()` to be called within the call stack of a user interaction.  As it happens, we play the song when the user presses the play button, and now we will resume a suspended context in that case.  

Previously, we were only resuming when a sound was being scheduled, [here](https://github.com/code-dot-org/code-dot-org/blob/c925d0538358930df160552cf1627dabf3f0eb9b/apps/src/music/player/soundSub.js#L124-L126).  We'll leave intact in case it helps with browsers that might suspend the AudioContext when the web page loses visibility.  Then, if the user taps the beat pad to schedule more sounds, for example, we will be within the call stack of the user interaction, and should be able to resume playing.
