### PR TITLE
Restrict helpful_links page to levelbuilder only

### DIFF
--- a/dashboard/app/controllers/helpful_links_controller.rb
+++ b/dashboard/app/controllers/helpful_links_controller.rb
@@ -1,2 +1,3 @@
 class HelpfulLinksController < ApplicationController
+  before_action :require_levelbuilder_mode
 end


### PR DESCRIPTION
See [slack comment](https://codedotorg.slack.com/archives/C045UAX4WKH/p1678924056370849?thread_ts=1678816613.467649&cid=C045UAX4WKH). Restricts this page to only appear on levelbuilder; any links off of this page are unaffected.