### PR TITLE
Remove Unused `petit` Gem Dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -215,7 +215,6 @@ gem 'sequel'
 gem 'user_agent_parser'
 
 gem 'paranoia', '~> 2.5.0'
-gem 'petit', github: 'code-dot-org/petit'  # For URL shortening
 
 # JSON model serializer for REST APIs.
 gem 'active_model_serializers', '~> 0.10.13'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,4 @@
 GIT
-  remote: https://github.com/code-dot-org/petit.git
-  revision: bbe411d61d3f78fff59d9fa79d21c14b1c635750
-  specs:
-    petit (0.3.0)
-      activesupport
-      aws-sdk-dynamodb (~> 1)
-      jsonapi-serializers
-      rack-parser
-      rake
-      sinatra
-      unicorn
-
-GIT
   remote: https://github.com/code-dot-org/redis-slave-read.git
   revision: cfe1bd0f5cf65eee5b52560139cab133f22cb880
   ref: cfe1bd0f5cf65eee5b52560139cab133f22cb880
@@ -522,8 +509,6 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     jsonapi-renderer (0.2.2)
-    jsonapi-serializers (1.0.0)
-      activesupport
     jumphash (0.1.0)
     jwt (2.5.0)
     kaminari (0.17.0)
@@ -673,8 +658,6 @@ GEM
     rack-openid (1.3.1)
       rack (>= 1.1.0)
       ruby-openid (>= 2.1.8)
-    rack-parser (0.7.0)
-      rack
     rack-protection (2.1.0)
       rack
     rack-ssl-enforcer (0.2.9)
@@ -1023,7 +1006,6 @@ DEPENDENCIES
   parallel_tests
   paranoia (~> 2.5.0)
   pdf-reader
-  petit!
   pg
   phantomjs (~> 1.9.7.1)
   pry


### PR DESCRIPTION
Originally added in https://github.com/code-dot-org/code-dot-org/pull/17132 to enable us to build a url-shortening service. As far as I can tell, we never got around to building that service and currently don't have any functionality we provide which uses this gem. Removing it in preparation for entirely removing our dependency on `unicorn`, which this gem is entangled with.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

- https://github.com/code-dot-org/code-dot-org/pull/17132
- https://github.com/code-dot-org/code-dot-org/pull/17102
- https://github.com/code-dot-org/petit

## Testing story

Searched slack, github, and the repository itself for any other references to this gem or the functionality we intended to build on top of it. Found nothing

## Follow-up work

We could consider eliminating our fork at https://github.com/code-dot-org/petit

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
