### PR TITLE
Add initial curriculum catalog card

### DIFF
--- a/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
@@ -7,13 +7,15 @@ import '../../../style/code-studio/curriculum_catalog_card.scss';
 
 const CurriculumCatalogCard = ({
   assignButtonDescription,
+  assignButtonText,
   courseName,
   duration,
   gradeOrAgeRange,
   imageAltText,
   imageName,
   topic,
-  quickViewButtonDescription
+  quickViewButtonDescription,
+  quickViewButtonText
 }) => (
   <div className="curriculumCatalogCardContainer">
     <img src={cardImageNamesToSrc[imageName]} alt={imageAltText} />
@@ -32,20 +34,22 @@ const CurriculumCatalogCard = ({
       <div className="buttonsContainer">
         {/* each button should be same fixed size */}
         <Button
+          className="leftButton"
           color={Button.ButtonColor.neutralDark}
           type="button"
           onClick={() => {}}
           aria-label={quickViewButtonDescription}
         >
-          Quick View
+          {quickViewButtonText}
         </Button>
         <Button
+          className="rightButton"
           color={Button.ButtonColor.brandSecondaryDefault}
           type="button"
           onClick={() => {}}
           aria-label={assignButtonDescription}
         >
-          Assign
+          {assignButtonText}
         </Button>
       </div>
     </div>
@@ -60,6 +64,8 @@ CurriculumCatalogCard.propTypes = {
   gradeOrAgeRange: PropTypes.string.isRequired,
   imageName: PropTypes.string.isRequired,
   topic: PropTypes.string.isRequired,
+  quickViewButtonText: PropTypes.string.isRequired,
+  assignButtonText: PropTypes.string.isRequired,
 
   // for screenreaders
   imageAltText: PropTypes.string,

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
@@ -4,6 +4,7 @@ import FontAwesome from '@cdo/apps/templates/FontAwesome';
 import Button from '@cdo/apps/templates/Button';
 import {cardImageNamesToSrc} from '@cdo/apps/templates/curriculumCatalog/cardImageNamesToSrc';
 import '../../../../shared/css/phase1-design-system.scss';
+import '../../../style/code-studio/curriculum_catalog_card.scss';
 
 const CurriculumCatalogCard = ({
   assignButtonDescription,
@@ -15,41 +16,39 @@ const CurriculumCatalogCard = ({
   topic,
   quickViewButtonDescription
 }) => (
-  <div className="curriculumCatalogContainer">
+  <div className="curriculumCatalogCardContainer">
     <img src={cardImageNamesToSrc[imageName]} alt={imageAltText} />
-    {/*topic should have color $brand_primary_default */}
-    <p className="overline">{topic}</p>
-    <h4>{courseName}</h4>
-    {/* display: flex for divs with icons*/}
-    <div className="gradeOrAge">
-      {/* add right padding to icons */}
-      <FontAwesome icon={'user'} className={'fa-solid'} />
-      <div>{gradeOrAgeRange}</div>
-    </div>
-    <div className="duration">
-      {/*TODO [MEG]: Update this to be clock fa-solid when we update FontAwesome */}
-      <FontAwesome icon={'clock-o'} />
-      <div>{duration}</div>
-    </div>
-    {/* display: flex; justify-content: space-between for buttons*/}
-    <div className="quickViewAndAssignButtonContainer">
-      {/* each button should be same fixed size */}
-      <Button
-        color={Button.ButtonColor.neutralDark}
-        type="button"
-        onClick={() => {}}
-        aria-label={quickViewButtonDescription}
-      >
-        Quick View
-      </Button>
-      <Button
-        color={Button.ButtonColor.brandSecondaryDefault}
-        type="button"
-        onClick={() => {}}
-        aria-label={assignButtonDescription}
-      >
-        Assign
-      </Button>
+    <div className="infoContainer">
+      <p className="overline">{topic}</p>
+      <h4>{courseName}</h4>
+      <div className={'iconWithDescription'}>
+        <FontAwesome icon={'user'} className={'fa-solid'} />
+        <p className={'iconDescription'}>{gradeOrAgeRange}</p>
+      </div>
+      <div className={'iconWithDescription'}>
+        {/*TODO [MEG]: Update this to be clock fa-solid when we update FontAwesome */}
+        <FontAwesome icon={'clock-o'} />
+        <p className={'iconDescription'}>{duration}</p>
+      </div>
+      <div className="buttonsContainer">
+        {/* each button should be same fixed size */}
+        <Button
+          color={Button.ButtonColor.neutralDark}
+          type="button"
+          onClick={() => {}}
+          aria-label={quickViewButtonDescription}
+        >
+          Quick View
+        </Button>
+        <Button
+          color={Button.ButtonColor.brandSecondaryDefault}
+          type="button"
+          onClick={() => {}}
+          aria-label={assignButtonDescription}
+        >
+          Assign
+        </Button>
+      </div>
     </div>
   </div>
 );
@@ -70,7 +69,7 @@ CurriculumCatalogCard.propTypes = {
 };
 
 CurriculumCatalogCard.defaultProps = {
-  imageAltText: '' // for decorative images.
+  imageAltText: '' // for decorative images
 };
 
 export default CurriculumCatalogCard;

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import FontAwesome from '@cdo/apps/templates/FontAwesome';
+import Button from '@cdo/apps/templates/Button';
+import {cardImageNamesToSrc} from '@cdo/apps/templates/curriculumCatalog/cardImageNamesToSrc';
+import '../../../../shared/css/phase1-design-system.scss';
+
+const CurriculumCatalogCard = ({
+  assignButtonDescription,
+  courseName,
+  duration,
+  gradeOrAgeRange,
+  imageAltText,
+  imageName,
+  topic,
+  quickViewButtonDescription
+}) => (
+  <div className="curriculumCatalogContainer">
+    <img src={cardImageNamesToSrc[imageName]} alt={imageAltText} />
+    {/*topic should have color $brand_primary_default */}
+    <p className="overline">{topic}</p>
+    <h4>{courseName}</h4>
+    {/* display: flex for divs with icons*/}
+    <div className="gradeOrAge">
+      {/* add right padding to icons */}
+      <FontAwesome icon={'user'} className={'fa-solid'} />
+      <div>{gradeOrAgeRange}</div>
+    </div>
+    <div className="duration">
+      {/*TODO [MEG]: Update this to be clock fa-solid when we update FontAwesome */}
+      <FontAwesome icon={'clock-o'} />
+      <div>{duration}</div>
+    </div>
+    {/* display: flex; justify-content: space-between for buttons*/}
+    <div className="quickViewAndAssignButtonContainer">
+      {/* each button should be same fixed size */}
+      <Button
+        color={Button.ButtonColor.neutralDark}
+        type="button"
+        onClick={() => {}}
+        aria-label={quickViewButtonDescription}
+      >
+        Quick View
+      </Button>
+      <Button
+        color={Button.ButtonColor.brandSecondaryDefault}
+        type="button"
+        onClick={() => {}}
+        aria-label={assignButtonDescription}
+      >
+        Assign
+      </Button>
+    </div>
+  </div>
+);
+
+// TODO [MEG]: use better PropType validation
+// look at translatedCourseOfferingCsTopics and translatedCourseOfferingSchoolSubjects
+CurriculumCatalogCard.propTypes = {
+  courseName: PropTypes.string.isRequired,
+  duration: PropTypes.string.isRequired,
+  gradeOrAgeRange: PropTypes.string.isRequired,
+  imageName: PropTypes.string.isRequired,
+  topic: PropTypes.string.isRequired,
+
+  // for screenreaders
+  imageAltText: PropTypes.string,
+  quickViewButtonDescription: PropTypes.string.isRequired,
+  assignButtonDescription: PropTypes.string.isRequired
+};
+
+CurriculumCatalogCard.defaultProps = {
+  imageAltText: '' // for decorative images.
+};
+
+export default CurriculumCatalogCard;

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
@@ -34,7 +34,6 @@ const CurriculumCatalogCard = ({
       <div className="buttonsContainer">
         {/* each button should be same fixed size */}
         <Button
-          className="leftButton"
           color={Button.ButtonColor.neutralDark}
           type="button"
           onClick={() => {}}
@@ -43,7 +42,6 @@ const CurriculumCatalogCard = ({
           {quickViewButtonText}
         </Button>
         <Button
-          className="rightButton"
           color={Button.ButtonColor.brandSecondaryDefault}
           type="button"
           onClick={() => {}}

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
@@ -2,8 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
 import Button from '@cdo/apps/templates/Button';
-import {cardImageNamesToSrc} from '@cdo/apps/templates/curriculumCatalog/cardImageNamesToSrc';
 import '../../../style/code-studio/curriculum_catalog_card.scss';
+
+// TODO [MEG]: remove this placeholder and require() syntax once images are pulled
+const tempImage = require('@cdo/static/resource_cards/anotherhoc.png');
 
 const CurriculumCatalogCard = ({
   assignButtonDescription,
@@ -12,13 +14,13 @@ const CurriculumCatalogCard = ({
   duration,
   gradeOrAgeRange,
   imageAltText,
-  imageName,
+  imageSrc,
   topic,
   quickViewButtonDescription,
   quickViewButtonText
 }) => (
   <div className="curriculumCatalogCardContainer">
-    <img src={cardImageNamesToSrc[imageName]} alt={imageAltText} />
+    <img src={imageSrc} alt={imageAltText} />
     <div className="curriculumInfoContainer">
       <p className="overline">{topic}</p>
       <h4>{courseName}</h4>
@@ -60,7 +62,7 @@ CurriculumCatalogCard.propTypes = {
   courseName: PropTypes.string.isRequired,
   duration: PropTypes.string.isRequired,
   gradeOrAgeRange: PropTypes.string.isRequired,
-  imageName: PropTypes.string.isRequired,
+  imageSrc: PropTypes.string.isRequired,
   topic: PropTypes.string.isRequired,
   quickViewButtonText: PropTypes.string.isRequired,
   assignButtonText: PropTypes.string.isRequired,
@@ -72,7 +74,8 @@ CurriculumCatalogCard.propTypes = {
 };
 
 CurriculumCatalogCard.defaultProps = {
-  imageAltText: '' // for decorative images
+  imageAltText: '', // for decorative images
+  imageSrc: tempImage // TODO [MEG]: remove this default once images are pulled
 };
 
 export default CurriculumCatalogCard;

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
 import Button from '@cdo/apps/templates/Button';
 import {cardImageNamesToSrc} from '@cdo/apps/templates/curriculumCatalog/cardImageNamesToSrc';
-import '../../../../shared/css/phase1-design-system.scss';
 import '../../../style/code-studio/curriculum_catalog_card.scss';
 
 const CurriculumCatalogCard = ({
@@ -18,7 +17,7 @@ const CurriculumCatalogCard = ({
 }) => (
   <div className="curriculumCatalogCardContainer">
     <img src={cardImageNamesToSrc[imageName]} alt={imageAltText} />
-    <div className="infoContainer">
+    <div className="curriculumInfoContainer">
       <p className="overline">{topic}</p>
       <h4>{courseName}</h4>
       <div className={'iconWithDescription'}>

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.story.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.story.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import CurriculumCatalogCard from '@cdo/apps/templates/curriculumCatalog/CurriculumCatalogCard';
+
+export default {
+  title: 'CurriculumCatalogCard',
+  component: CurriculumCatalogCard
+};
+
+const Template = args => <CurriculumCatalogCard {...args} />;
+
+export const BaseCard = Template.bind({});
+BaseCard.args = {
+  courseName: 'Express Course',
+  duration: 'Quarter',
+  gradeOrAgeRange: 'Grades 4-12',
+  imageName: 'another-hoc',
+  topic: 'Programming',
+
+  // for screenreaders
+  quickViewButtonDescription: 'View more details about the Express Course',
+  assignButtonDescription: 'Assign the Express Course'
+};
+BaseCard.storyName = 'CurriculumCatalogCard – Base';

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.story.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.story.jsx
@@ -8,16 +8,20 @@ export default {
 
 const Template = args => <CurriculumCatalogCard {...args} />;
 
-export const BaseCard = Template.bind({});
-BaseCard.args = {
+const defaultArgs = {
   courseName: 'Express Course',
   duration: 'Quarter',
   gradeOrAgeRange: 'Grades 4-12',
   imageName: 'another-hoc',
   topic: 'Programming',
+  quickViewButtonText: 'Quick View',
+  assignButtonText: 'Assign',
 
   // for screenreaders
   quickViewButtonDescription: 'View more details about the Express Course',
   assignButtonDescription: 'Assign the Express Course'
 };
+
+export const BaseCard = Template.bind({});
+BaseCard.args = defaultArgs;
 BaseCard.storyName = 'CurriculumCatalogCard – Base';

--- a/apps/src/templates/curriculumCatalog/cardImageNamesToSrc.js
+++ b/apps/src/templates/curriculumCatalog/cardImageNamesToSrc.js
@@ -1,0 +1,3 @@
+export const cardImageNamesToSrc = {
+  'another-hoc': require('@cdo/static/resource_cards/anotherhoc.png')
+};

--- a/apps/src/templates/curriculumCatalog/cardImageNamesToSrc.js
+++ b/apps/src/templates/curriculumCatalog/cardImageNamesToSrc.js
@@ -1,3 +1,0 @@
-export const cardImageNamesToSrc = {
-  'another-hoc': require('@cdo/static/resource_cards/anotherhoc.png')
-};

--- a/apps/style/code-studio/curriculum_catalog_card.scss
+++ b/apps/style/code-studio/curriculum_catalog_card.scss
@@ -57,6 +57,8 @@ $border-radius: 4px;
       button {
         height: 40px;
         margin: 0;
+        // TODO [MEG] Adjust to accommodate different string
+        // sizes, look at gap https://css-tricks.com/almanac/properties/g/gap/
         width: 132px; // calculated: (totalContainerWidth - 2*padding - minimumSpaceBetweenButtons) / 2
         font-size: 1em;
       }

--- a/apps/style/code-studio/curriculum_catalog_card.scss
+++ b/apps/style/code-studio/curriculum_catalog_card.scss
@@ -28,6 +28,10 @@ $border-radius: 4px;
     .overline {
       color: $brand_primary_default;
       margin-bottom: 0.5em;
+      font-size: 0.75em;
+      font-family: $gotham-bold;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
     }
 
     h4 {

--- a/apps/style/code-studio/curriculum_catalog_card.scss
+++ b/apps/style/code-studio/curriculum_catalog_card.scss
@@ -1,59 +1,64 @@
 @import "phase1-design-system";
 
+$border-radius: 4px;
+
 .curriculumCatalogCardContainer {
   display: flex;
   flex-flow: column;
   background-color: $neutral_light;
-  border-color: $neutral_dark20;
-  border-radius: 4px;
+  border-radius: $border-radius;
   height: 384px;
   width: 309px;
 
   img {
     height: 140px;
     object-fit: cover;
-    border-radius: 4px 4px 0 0;
+    border-radius: $border-radius $border-radius 0 0;
   }
 
   .curriculumInfoContainer {
-    margin: 20px 16px;
-    height: 100%;
     display: flex;
     flex-flow: column;
+    height: 100%;
+    border: 1px solid $neutral_dark20;
+    border-top: 0;
+    border-radius: 0 0 $border-radius $border-radius;
+    padding: 1.25em 1em;
 
     .overline {
       color: $brand_primary_default;
-      margin: 0 0 8px 0;
+      margin-bottom: 0.5em;
     }
 
     h4 {
-      margin-bottom: 12px;
+      margin-bottom: 0.75em;
       color: $neutral_dark;
     }
 
     .iconWithDescription {
       display: flex;
-      font-size: 14px;
       color: $neutral_dark80;
-      margin: 0 0 8px 0;
+      margin: 0 0 0.5em 0;
       align-items: center;
 
       .iconDescription {
-        margin: 0 0 0 8px;
+        font-size: 0.875em;
+        margin: 0 0 0 0.5em;
         color: $neutral_dark;
       }
     }
 
     .buttonsContainer {
       display: flex;
+      flex-wrap: wrap;
       justify-content: space-between;
       margin-top: auto;
 
       button {
         height: 40px;
         margin: 0;
-        min-width: 132px; // calculated: (totalContainerWidth - 2*padding - minimumSpaceBetweenButtons) / 2
-        font-size: 16px;
+        width: 132px; // calculated: (totalContainerWidth - 2*padding - minimumSpaceBetweenButtons) / 2
+        font-size: 1em;
       }
     }
   }

--- a/apps/style/code-studio/curriculum_catalog_card.scss
+++ b/apps/style/code-studio/curriculum_catalog_card.scss
@@ -23,7 +23,7 @@
 
     .overline {
       color: $brand_primary_default;
-      margin-bottom: 8px;
+      margin: 0 0 8px 0;
     }
 
     h4 {
@@ -35,9 +35,11 @@
       display: flex;
       font-size: 14px;
       color: $neutral_dark80;
+      margin: 0 0 8px 0;
+      align-items: center;
 
       .iconDescription {
-        margin-left: 8px;
+        margin: 0 0 0 8px;
         color: $neutral_dark;
       }
     }

--- a/apps/style/code-studio/curriculum_catalog_card.scss
+++ b/apps/style/code-studio/curriculum_catalog_card.scss
@@ -1,0 +1,58 @@
+@import "color";
+@import "font";
+
+.curriculumCatalogCardContainer {
+  display: flex;
+  flex-flow: column;
+  background-color: $neutral_white;
+  stroke: $neutral_dark20;
+  stroke-width: 1px;
+  border-radius: 4px;
+  height: 384px;
+  width: 309px;
+
+  img {
+    height: 140px;
+    object-fit: cover;
+  }
+
+  .infoContainer {
+    margin: 20px 16px;
+    height: 100%;
+    display: flex;
+    flex-flow: column;
+
+    .overline {
+      color: $brand_primary_default;
+      margin-bottom: 8px;
+    }
+
+    h4 {
+      margin-bottom: 12px;
+      color: $neutral_dark;
+    }
+
+    .iconWithDescription {
+      display: flex;
+
+      .iconDescription {
+        margin-left: 8px;
+        font-size: 14px;
+        color: $neutral_dark80;
+      }
+    }
+
+    .buttonsContainer {
+      display: flex;
+      justify-content: space-between;
+      margin-top: auto;
+
+      button {
+        height: 40px;
+        margin: 0;
+        width: 132px; // calculated: (totalContainerWidth - 2*padding - minimumSpaceBetweenButtons) / 2
+        font-size: 16px;
+      }
+    }
+  }
+}

--- a/apps/style/code-studio/curriculum_catalog_card.scss
+++ b/apps/style/code-studio/curriculum_catalog_card.scss
@@ -1,12 +1,10 @@
-@import "color";
-@import "font";
+@import "phase1-design-system";
 
 .curriculumCatalogCardContainer {
   display: flex;
   flex-flow: column;
-  background-color: $neutral_white;
-  stroke: $neutral_dark20;
-  stroke-width: 1px;
+  background-color: $neutral_light;
+  border-color: $neutral_dark20;
   border-radius: 4px;
   height: 384px;
   width: 309px;
@@ -14,9 +12,10 @@
   img {
     height: 140px;
     object-fit: cover;
+    border-radius: 4px 4px 0 0;
   }
 
-  .infoContainer {
+  .curriculumInfoContainer {
     margin: 20px 16px;
     height: 100%;
     display: flex;
@@ -34,11 +33,12 @@
 
     .iconWithDescription {
       display: flex;
+      font-size: 14px;
+      color: $neutral_dark80;
 
       .iconDescription {
         margin-left: 8px;
-        font-size: 14px;
-        color: $neutral_dark80;
+        color: $neutral_dark;
       }
     }
 
@@ -50,7 +50,7 @@
       button {
         height: 40px;
         margin: 0;
-        width: 132px; // calculated: (totalContainerWidth - 2*padding - minimumSpaceBetweenButtons) / 2
+        min-width: 132px; // calculated: (totalContainerWidth - 2*padding - minimumSpaceBetweenButtons) / 2
         font-size: 16px;
       }
     }

--- a/shared/css/phase1-design-system.scss
+++ b/shared/css/phase1-design-system.scss
@@ -76,6 +76,13 @@ a {
 
 p {
   color: $neutral_dark;
+
+  &.overline {
+    font-size: .75em;
+    font-family: $gotham-bold;
+    text-transform: uppercase;
+    letter-spacing: .5px;
+  }
 }
 
 #signin {

--- a/shared/css/phase1-design-system.scss
+++ b/shared/css/phase1-design-system.scss
@@ -76,13 +76,6 @@ a {
 
 p {
   color: $neutral_dark;
-
-  &.overline {
-    font-size: .75em;
-    font-family: $gotham-bold;
-    text-transform: uppercase;
-    letter-spacing: .5px;
-  }
 }
 
 #signin {


### PR DESCRIPTION
Adds initial curriculum catalog card.
<img width="408" alt="Screenshot 2023-03-20 at 7 50 19 PM" src="https://user-images.githubusercontent.com/9142121/226490298-38b93187-8b19-4381-895a-042fa804bcd7.png">

There are four follow-up tasks for the card (these are not split into separate Jira work items, but rather updated as part of this task https://codedotorg.atlassian.net/browse/ACQ-426):
1) Add unit tests –– I'm hoping to try using React Testing Library for this, as I think it will be helpful as we start testing more complex components that involve hooks and other functions to decide what to render.
2) Add better prop validation, including translatable strings. This work involves adding a map for the translated strings and adding the initial strings into our Crowdin pipeline.
3) Modify styling to accommodate (a) updates detailed [here](https://docs.google.com/document/d/1UID-xzCF5gxOHihcYiYuZwpotCpGXGPTzqX1UyS37-I/edit?disco=AAAArT6a29w), (b) longer text, which might come up in other languages and with longer course titles, and (b) accessibility concerns –– I'm seeing the color contrast of the topic is not meeting guidelines, but it might be solved with the updates detailed in (a).
4) Add the images from the Course Offering model –– this could be part of task (2), as it's part of ensuring we have good validation on both the front-end and the back-end.

## Links

Figma design spec: https://www.figma.com/file/w5R6KSZF01FAysZor6j4sa/Curriculum-Catalog?node-id=953-28390&t=jTwfq9obdB0ou10I-0 

## Testing story

For now, I only tested this manually in Storybook, using the console to check for dimensions specified in [Figma](https://www.figma.com/file/w5R6KSZF01FAysZor6j4sa/Curriculum-Catalog?node-id=953-28390&t=chu8rnx0qAJwbEa7-0). Instructions:
(1) Run `dashboard-server` locally
(2) Run storybook locally (`cd apps`; `yarn storybook`)
(3) In a new tab, open http://localhost:9001/iframe.html?args=&id=curriculumcatalogcard--base-card&viewMode=story

E.g. to make sure the icon color is correct:
<img width="960" alt="image" src="https://user-images.githubusercontent.com/9142121/226595382-a7113846-2749-4002-998b-0104fef16d97.png">

I also checked for tab navigability and what it sounds like on a screenreader.

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
