### PR TITLE
Adding cloudwatch metrics for rake tasks (debugging is there)

### DIFF
--- a/lib/cdo/data/logging/rake_task_event_logger.rb
+++ b/lib/cdo/data/logging/rake_task_event_logger.rb
@@ -108,7 +108,7 @@ class RakeTaskEventLogger
       ChatClient.log "END rake task information --------\n", color: 'green'
       puts "Metric flushed ---------------------------e-d-----e3-2--"
     rescue => exception
-      ChatClient.log "SOMETHIGN WENT WRONG --------\n", color: 'green'
+      ChatClient.log "SOMETHIGN WENT WRONG ?--------\n", color: 'green'
       Honeybadger.notify(
         exception,
         error_message: "Failed to log rake task information in cloudwatch",

--- a/lib/cdo/data/logging/rake_task_event_logger.rb
+++ b/lib/cdo/data/logging/rake_task_event_logger.rb
@@ -34,7 +34,6 @@ class RakeTaskEventLogger
   end
 
   def exception_task_logging(exception)
-    ChatClient.log exception
     @end_time = Time.new
     duration_ms = ((@end_time - @start_time).to_f * 1000).to_i
     event = 'exception'.freeze

--- a/lib/cdo/data/logging/rake_task_event_logger.rb
+++ b/lib/cdo/data/logging/rake_task_event_logger.rb
@@ -108,6 +108,7 @@ class RakeTaskEventLogger
       ChatClient.log "END rake task information --------\n", color: 'green'
       puts "Metric flushed ---------------------------e-d-----e3-2--"
     rescue => exception
+      ChatClient.log "SOMETHIGN WENT WRONG --------\n", color: 'green'
       Honeybadger.notify(
         exception,
         error_message: "Failed to log rake task information in cloudwatch",

--- a/lib/cdo/data/logging/rake_task_event_logger.rb
+++ b/lib/cdo/data/logging/rake_task_event_logger.rb
@@ -100,15 +100,7 @@ class RakeTaskEventLogger
                     is_continuous_integration_run: ENV['CI'] ? 'true' : 'false'}
       Cdo::Metrics.put(metric_name, metric_value, dimensions)
       Cdo::Metrics.flush!
-      ChatClient.log "\nBEGIN rake task information --------", color: 'green'
-      ChatClient.log @rake_task.name, color: 'green'
-      ChatClient.log task_chain, color: 'green'
-      ChatClient.log @@depth.to_s, color: 'green'
-      ChatClient.log task_chain.split(',').count.to_s, color: 'green'
-      ChatClient.log "END rake task information --------\n", color: 'green'
-      puts "Metric flushed ---------------------------e-d-----e3-2--"
     rescue => exception
-      ChatClient.log "SOMETHIGN WENT WRONG ?--------\n", color: 'green'
       Honeybadger.notify(
         exception,
         error_message: "Failed to log rake task information in cloudwatch",

--- a/lib/cdo/data/logging/timed_task_with_logging.rb
+++ b/lib/cdo/data/logging/timed_task_with_logging.rb
@@ -8,8 +8,11 @@ module CustomRake
       logger = RakeTaskEventLogger.new(self)
       logger.start_task_logging
       begin
+        RakeTaskEventLogger.increase_depth
         puts "Finished #{name} (#{distance_of_time_in_words(Benchmark.realtime {super}.to_f)})"
+        RakeTaskEventLogger.decrease_depth
       rescue => exception
+        RakeTaskEventLogger.decrease_depth
         logger.exception_task_logging(exception)
         raise
       end


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This enables tracking metrics for rake task in a high level.
We want to be able to start tracking how long this tasks take to know which one need optimization and taking more resources.

More dimensions will be added to the data:
- User submitting metric for instance

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
