### PR TITLE
require teacher application when enrolling in certain workshops

### DIFF
--- a/dashboard/app/controllers/pd/workshop_enrollment_controller.rb
+++ b/dashboard/app/controllers/pd/workshop_enrollment_controller.rb
@@ -32,6 +32,8 @@ class Pd::WorkshopEnrollmentController < ApplicationController
       }
     elsif !current_user
       render :logged_out
+    elsif missing_application?
+      render :missing_application
     elsif current_user.teacher? && current_user.email.blank?
       render '/pd/application/teacher_application/no_teacher_email'
     else
@@ -208,5 +210,9 @@ class Pd::WorkshopEnrollmentController < ApplicationController
       :school_name,
       :full_address,
     )
+  end
+
+  private def missing_application?
+    @workshop.require_application? && !current_user.pd_applications.where(type: 'TeacherApplication').any?
   end
 end

--- a/dashboard/app/controllers/pd/workshop_enrollment_controller.rb
+++ b/dashboard/app/controllers/pd/workshop_enrollment_controller.rb
@@ -213,6 +213,11 @@ class Pd::WorkshopEnrollmentController < ApplicationController
   end
 
   private def missing_application?
-    @workshop.require_application? && !current_user.pd_applications.where(type: 'TeacherApplication').any?
+    @workshop.require_application? && !has_current_application?
+  end
+
+  private def has_current_application?
+    year = Pd::SharedApplicationConstants::APPLICATION_CURRENT_YEAR
+    Pd::Application::TeacherApplication.where(user: current_user, application_year: year).any?
   end
 end

--- a/dashboard/app/controllers/pd/workshop_enrollment_controller.rb
+++ b/dashboard/app/controllers/pd/workshop_enrollment_controller.rb
@@ -217,7 +217,10 @@ class Pd::WorkshopEnrollmentController < ApplicationController
   end
 
   private def has_current_application?
-    year = Pd::SharedApplicationConstants::APPLICATION_CURRENT_YEAR
-    Pd::Application::TeacherApplication.where(user: current_user, application_year: year).any?
+    Pd::Application::TeacherApplication.where(
+      user: current_user,
+      application_year: Pd::SharedApplicationConstants::APPLICATION_CURRENT_YEAR,
+      status: 'accepted'
+      ).any?
   end
 end

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -133,7 +133,7 @@ class Pd::Workshop < ApplicationRecord
     courses = [COURSE_CSP, COURSE_CSD, COURSE_CSA]
     subjects = ACADEMIC_YEAR_SUBJECTS.concat([SUBJECT_SUMMER_WORKSHOP])
     courses.include?(course) && subjects.include?(subject) &&
-      (regional_partner.nil? || regional_partner.link_to_partner_application.blank?)
+      regional_partner && regional_partner.link_to_partner_application.blank?
   end
 
   def self.organized_by(organizer)

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -130,10 +130,10 @@ class Pd::Workshop < ApplicationRecord
 
   # Whether enrollment in this workshop requires an application
   def require_application?
-    return false if regional_partner&.link_to_partner_application.blank?
     courses = [COURSE_CSP, COURSE_CSD, COURSE_CSA]
     subjects = ACADEMIC_YEAR_SUBJECTS.concat([SUBJECT_SUMMER_WORKSHOP])
-    courses.include?(course) && subjects.include?(subject)
+    courses.include?(course) && subjects.include?(subject) &&
+      regional_partner&.link_to_partner_application.present?
   end
 
   def self.organized_by(organizer)

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -128,6 +128,13 @@ class Pd::Workshop < ApplicationRecord
     end
   end
 
+  # Whether enrollment in this workshop requires an application
+  def require_application?
+    courses = [COURSE_CSP, COURSE_CSD, COURSE_CSA]
+    subjects = ACADEMIC_YEAR_SUBJECTS.concat([SUBJECT_SUMMER_WORKSHOP])
+    courses.include?(course) && subjects.include?(subject)
+  end
+
   def self.organized_by(organizer)
     where(organizer_id: organizer.id)
   end

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -130,6 +130,7 @@ class Pd::Workshop < ApplicationRecord
 
   # Whether enrollment in this workshop requires an application
   def require_application?
+    return false if regional_partner&.link_to_partner_application.blank?
     courses = [COURSE_CSP, COURSE_CSD, COURSE_CSA]
     subjects = ACADEMIC_YEAR_SUBJECTS.concat([SUBJECT_SUMMER_WORKSHOP])
     courses.include?(course) && subjects.include?(subject)

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -133,7 +133,7 @@ class Pd::Workshop < ApplicationRecord
     courses = [COURSE_CSP, COURSE_CSD, COURSE_CSA]
     subjects = ACADEMIC_YEAR_SUBJECTS.concat([SUBJECT_SUMMER_WORKSHOP])
     courses.include?(course) && subjects.include?(subject) &&
-      regional_partner&.link_to_partner_application.present?
+      (regional_partner.nil? || regional_partner.link_to_partner_application.blank?)
   end
 
   def self.organized_by(organizer)

--- a/dashboard/app/views/pd/workshop_enrollment/missing_application.html.haml
+++ b/dashboard/app/views/pd/workshop_enrollment/missing_application.html.haml
@@ -1,0 +1,6 @@
+- content_for(:head) do
+  = stylesheet_link_tag 'css/pd', media: 'all'
+  %script{src: webpack_asset_path('js/pd/workshop_enrollment/new.js'), data: @script_data}
+
+#enrollment-container
+  -# populated by React

--- a/dashboard/app/views/pd/workshop_enrollment/missing_application.html.haml
+++ b/dashboard/app/views/pd/workshop_enrollment/missing_application.html.haml
@@ -5,4 +5,5 @@
   You must have a completed application in order to enroll in this workshop. If
   you have completed your application on a different account please sign in to
   that account and then try enrolling again. If you have any questions please
-  reach out to support@code.org.
+  reach out to
+  = mail_to('support@code.org') + '.'

--- a/dashboard/app/views/pd/workshop_enrollment/missing_application.html.haml
+++ b/dashboard/app/views/pd/workshop_enrollment/missing_application.html.haml
@@ -1,6 +1,8 @@
-- content_for(:head) do
-  = stylesheet_link_tag 'css/pd', media: 'all'
-  %script{src: webpack_asset_path('js/pd/workshop_enrollment/new.js'), data: @script_data}
+%h1
+  Teacher Application Is Required
 
-#enrollment-container
-  -# populated by React
+%p
+  You must have a completed application in order to enroll in this workshop. If
+  you have completed your application on a different account please sign in to
+  that account and then try enrolling again. If you have any questions please
+  reach out to support@code.org.

--- a/dashboard/app/views/pd/workshop_enrollment/missing_application.html.haml
+++ b/dashboard/app/views/pd/workshop_enrollment/missing_application.html.haml
@@ -2,7 +2,7 @@
   Teacher Application Is Required
 
 %p
-  You must have a completed application in order to enroll in this workshop. If
+  You must have an accepted application in order to enroll in this workshop. If
   you have completed your application on a different account please sign in to
   that account and then try enrolling again. If you have any questions please
   reach out to

--- a/dashboard/test/controllers/pd/workshop_enrollment_controller_test.rb
+++ b/dashboard/test/controllers/pd/workshop_enrollment_controller_test.rb
@@ -81,11 +81,43 @@ class Pd::WorkshopEnrollmentControllerTest < ::ActionController::TestCase
     # see Pd::Workshop#require_application? for the logic that determines whether a workshop requires an application
     rp = create :regional_partner
     workshop = create :summer_workshop, regional_partner: rp
+    assert workshop.require_application?
 
     sign_in teacher
     get :new, params: {workshop_id: workshop.id}
     assert_response :success
     assert_template :missing_application
+  end
+
+  test 'teacher with old application gets missing application view' do
+    teacher = create :teacher
+
+    rp = create :regional_partner
+    workshop = create :summer_workshop, regional_partner: rp
+    assert workshop.require_application?
+
+    old_year = Pd::SharedApplicationConstants::YEAR_18_19
+    create :pd_teacher_application, user: teacher, application_year: old_year
+
+    sign_in teacher
+    get :new, params: {workshop_id: workshop.id}
+    assert_response :success
+    assert_template :missing_application
+  end
+
+  test 'teacher with required application gets new view' do
+    teacher = create :teacher
+
+    rp = create :regional_partner
+    workshop = create :summer_workshop, regional_partner: rp
+    assert workshop.require_application?
+
+    create :pd_teacher_application, user: teacher
+
+    sign_in teacher
+    get :new, params: {workshop_id: workshop.id}
+    assert_response :success
+    assert_template :new
   end
 
   # TODO: remove this test when workshop_organizer is deprecated

--- a/dashboard/test/controllers/pd/workshop_enrollment_controller_test.rb
+++ b/dashboard/test/controllers/pd/workshop_enrollment_controller_test.rb
@@ -75,6 +75,19 @@ class Pd::WorkshopEnrollmentControllerTest < ::ActionController::TestCase
     assert_template :new
   end
 
+  test 'teacher with missing application gets missing application view' do
+    teacher = create :teacher
+
+    # see Pd::Workshop#require_application? for the logic that determines whether a workshop requires an application
+    rp = create :regional_partner
+    workshop = create :summer_workshop, regional_partner: rp
+
+    sign_in teacher
+    get :new, params: {workshop_id: workshop.id}
+    assert_response :success
+    assert_template :missing_application
+  end
+
   # TODO: remove this test when workshop_organizer is deprecated
   test 'workshop organizers can see enrollment form' do
     # Note - organizers can see the form, but cannot enroll in their own workshops.

--- a/dashboard/test/controllers/pd/workshop_enrollment_controller_test.rb
+++ b/dashboard/test/controllers/pd/workshop_enrollment_controller_test.rb
@@ -91,13 +91,26 @@ class Pd::WorkshopEnrollmentControllerTest < ::ActionController::TestCase
 
   test 'teacher with old application gets missing application view' do
     teacher = create :teacher
+    old_year = Pd::SharedApplicationConstants::YEAR_18_19
+    create :pd_teacher_application, user: teacher, application_year: old_year
 
     rp = create :regional_partner
     workshop = create :summer_workshop, regional_partner: rp
     assert workshop.require_application?
 
-    old_year = Pd::SharedApplicationConstants::YEAR_18_19
-    create :pd_teacher_application, user: teacher, application_year: old_year
+    sign_in teacher
+    get :new, params: {workshop_id: workshop.id}
+    assert_response :success
+    assert_template :missing_application
+  end
+
+  test 'teacher with incomplete application gets missing application view' do
+    teacher = create :teacher
+    create :pd_teacher_application, user: teacher, status: 'incomplete'
+
+    rp = create :regional_partner
+    workshop = create :summer_workshop, regional_partner: rp
+    assert workshop.require_application?
 
     sign_in teacher
     get :new, params: {workshop_id: workshop.id}
@@ -107,12 +120,11 @@ class Pd::WorkshopEnrollmentControllerTest < ::ActionController::TestCase
 
   test 'teacher with required application gets new view' do
     teacher = create :teacher
+    create :pd_teacher_application, user: teacher, status: 'accepted'
 
     rp = create :regional_partner
     workshop = create :summer_workshop, regional_partner: rp
     assert workshop.require_application?
-
-    create :pd_teacher_application, user: teacher
 
     sign_in teacher
     get :new, params: {workshop_id: workshop.id}

--- a/dashboard/test/factories/workshop_factories.rb
+++ b/dashboard/test/factories/workshop_factories.rb
@@ -259,6 +259,21 @@ FactoryBot.define do
         capacity 35          # Average capacity
       end
       factory(:csd_summer_workshop) {csd}
+
+      trait :csd_virtual do
+        course Pd::Workshop::COURSE_CSD
+        subject Pd::Workshop::SUBJECT_VIRTUAL_KICKOFF
+        virtual true
+        capacity 35          # Average capacity
+      end
+      factory(:csd_virtual_workshop) {csd_virtual}
+
+      trait :csa do
+        course Pd::Workshop::COURSE_CSA
+        subject Pd::Workshop::SUBJECT_CSA_SUMMER_WORKSHOP
+        capacity 35          # Average capacity
+      end
+      factory(:csa_summer_workshop) {csa}
     end
 
     factory :facilitator_workshop do

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -1489,6 +1489,26 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     assert workshop.valid?
   end
 
+  test 'CSA summer workshops must require teacher application' do
+    workshop = create :pd_workshop, course: COURSE_CSA, subject: SUBJECT_SUMMER_WORKSHOP
+    assert workshop.require_application?
+  end
+
+  test 'CSP academic year workshop must require teacher application' do
+    workshop = create :pd_workshop, course: COURSE_CSP, subject: SUBJECT_CSP_WORKSHOP_1
+    assert workshop.require_application?
+  end
+
+  test 'CSF workshop must not require teacher application' do
+    workshop = create :pd_workshop, course: COURSE_CSF, subject: SUBJECT_CSF_101
+    refute workshop.require_application?
+  end
+
+  test 'virtual CSD workshop must not require teacher application' do
+    workshop = create :pd_workshop, course: COURSE_CSD, subject: SUBJECT_VIRTUAL_KICKOFF, virtual: true
+    refute workshop.require_application?
+  end
+
   private
 
   def session_on_day(day_offset)

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -1491,34 +1491,39 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     assert workshop.valid?
   end
 
-  test 'CSA summer workshops must require teacher application' do
-    workshop = create :pd_workshop, course: COURSE_CSA, subject: SUBJECT_SUMMER_WORKSHOP, regional_partner: @regional_partner
+  test 'CSP summer workshop must require teacher application' do
+    workshop = create :csp_summer_workshop, regional_partner: @regional_partner
     assert workshop.require_application?
   end
 
-  test 'CSP academic year workshop must require teacher application' do
-    workshop = create :pd_workshop, course: COURSE_CSP, subject: SUBJECT_CSP_WORKSHOP_1, regional_partner: @regional_partner
+  test 'CSD academic year workshop must require teacher application' do
+    workshop = create :csd_academic_year_workshop, regional_partner: @regional_partner
+    assert workshop.require_application?
+  end
+
+  test 'CSA summer workshop must require teacher application' do
+    workshop = create :csa_summer_workshop, regional_partner: @regional_partner
     assert workshop.require_application?
   end
 
   test 'CSF workshop must not require teacher application' do
-    workshop = create :pd_workshop, course: COURSE_CSF, subject: SUBJECT_CSF_101, regional_partner: @regional_partner
+    workshop = create :csf_workshop, regional_partner: @regional_partner
     refute workshop.require_application?
   end
 
   test 'virtual CSD workshop must not require teacher application' do
-    workshop = create :pd_workshop, course: COURSE_CSD, subject: SUBJECT_VIRTUAL_KICKOFF, virtual: true, regional_partner: @regional_partner
+    workshop = create :csd_virtual_workshop, regional_partner: @regional_partner
     refute workshop.require_application?
   end
 
-  test 'CSA summer workshop without regional partner must not require teacher application' do
-    workshop = create :pd_workshop, course: COURSE_CSA, subject: SUBJECT_SUMMER_WORKSHOP
+  test 'workshop without regional partner must not require teacher application' do
+    workshop = create :csp_summer_workshop
     refute workshop.require_application?
   end
 
   test 'regional partner with partner application must not require teacher application' do
     rp = create :regional_partner, link_to_partner_application: 'https://example.com'
-    workshop = create :pd_workshop, course: COURSE_CSP, subject: SUBJECT_CSP_WORKSHOP_1, regional_partner: rp
+    workshop = create :csp_summer_workshop, regional_partner: rp
     refute workshop.require_application?
   end
 

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -1490,22 +1490,37 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
   end
 
   test 'CSA summer workshops must require teacher application' do
-    workshop = create :pd_workshop, course: COURSE_CSA, subject: SUBJECT_SUMMER_WORKSHOP
+    rp = create :regional_partner, link_to_partner_application: 'https://example.com'
+    workshop = create :pd_workshop, course: COURSE_CSA, subject: SUBJECT_SUMMER_WORKSHOP, regional_partner: rp
     assert workshop.require_application?
   end
 
   test 'CSP academic year workshop must require teacher application' do
-    workshop = create :pd_workshop, course: COURSE_CSP, subject: SUBJECT_CSP_WORKSHOP_1
+    rp = create :regional_partner, link_to_partner_application: 'https://example.com'
+    workshop = create :pd_workshop, course: COURSE_CSP, subject: SUBJECT_CSP_WORKSHOP_1, regional_partner: rp
     assert workshop.require_application?
   end
 
   test 'CSF workshop must not require teacher application' do
-    workshop = create :pd_workshop, course: COURSE_CSF, subject: SUBJECT_CSF_101
+    rp = create :regional_partner, link_to_partner_application: 'https://example.com'
+    workshop = create :pd_workshop, course: COURSE_CSF, subject: SUBJECT_CSF_101, regional_partner: rp
     refute workshop.require_application?
   end
 
   test 'virtual CSD workshop must not require teacher application' do
-    workshop = create :pd_workshop, course: COURSE_CSD, subject: SUBJECT_VIRTUAL_KICKOFF, virtual: true
+    rp = create :regional_partner, link_to_partner_application: 'https://example.com'
+    workshop = create :pd_workshop, course: COURSE_CSD, subject: SUBJECT_VIRTUAL_KICKOFF, virtual: true, regional_partner: rp
+    refute workshop.require_application?
+  end
+
+  test 'CSA summer workshop without regional partner must not require teacher application' do
+    workshop = create :pd_workshop, course: COURSE_CSA, subject: SUBJECT_SUMMER_WORKSHOP
+    refute workshop.require_application?
+  end
+
+  test 'regional partner without link must not require teacher application' do
+    rp = create :regional_partner, link_to_partner_application: nil
+    workshop = create :pd_workshop, course: COURSE_CSP, subject: SUBJECT_CSP_WORKSHOP_1, regional_partner: rp
     refute workshop.require_application?
   end
 

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -14,6 +14,8 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
 
     @workshop_organizer = create(:workshop_organizer)
     @organizer_workshop = create(:workshop, organizer: @workshop_organizer)
+
+    @regional_partner = create(:regional_partner)
   end
   setup do
     @workshop.reload
@@ -1490,26 +1492,22 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
   end
 
   test 'CSA summer workshops must require teacher application' do
-    rp = create :regional_partner, link_to_partner_application: 'https://example.com'
-    workshop = create :pd_workshop, course: COURSE_CSA, subject: SUBJECT_SUMMER_WORKSHOP, regional_partner: rp
+    workshop = create :pd_workshop, course: COURSE_CSA, subject: SUBJECT_SUMMER_WORKSHOP, regional_partner: @regional_partner
     assert workshop.require_application?
   end
 
   test 'CSP academic year workshop must require teacher application' do
-    rp = create :regional_partner, link_to_partner_application: 'https://example.com'
-    workshop = create :pd_workshop, course: COURSE_CSP, subject: SUBJECT_CSP_WORKSHOP_1, regional_partner: rp
+    workshop = create :pd_workshop, course: COURSE_CSP, subject: SUBJECT_CSP_WORKSHOP_1, regional_partner: @regional_partner
     assert workshop.require_application?
   end
 
   test 'CSF workshop must not require teacher application' do
-    rp = create :regional_partner, link_to_partner_application: 'https://example.com'
-    workshop = create :pd_workshop, course: COURSE_CSF, subject: SUBJECT_CSF_101, regional_partner: rp
+    workshop = create :pd_workshop, course: COURSE_CSF, subject: SUBJECT_CSF_101, regional_partner: @regional_partner
     refute workshop.require_application?
   end
 
   test 'virtual CSD workshop must not require teacher application' do
-    rp = create :regional_partner, link_to_partner_application: 'https://example.com'
-    workshop = create :pd_workshop, course: COURSE_CSD, subject: SUBJECT_VIRTUAL_KICKOFF, virtual: true, regional_partner: rp
+    workshop = create :pd_workshop, course: COURSE_CSD, subject: SUBJECT_VIRTUAL_KICKOFF, virtual: true, regional_partner: @regional_partner
     refute workshop.require_application?
   end
 
@@ -1518,8 +1516,8 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     refute workshop.require_application?
   end
 
-  test 'regional partner without link must not require teacher application' do
-    rp = create :regional_partner, link_to_partner_application: nil
+  test 'regional partner with partner application must not require teacher application' do
+    rp = create :regional_partner, link_to_partner_application: 'https://example.com'
     workshop = create :pd_workshop, course: COURSE_CSP, subject: SUBJECT_CSP_WORKSHOP_1, regional_partner: rp
     refute workshop.require_application?
   end

--- a/lib/cdo/shared_constants/pd/shared_workshop_constants.rb
+++ b/lib/cdo/shared_constants/pd/shared_workshop_constants.rb
@@ -28,12 +28,14 @@ module Pd
     SUBJECT_TEACHER_CON = 'Code.org TeacherCon'.freeze
 
     # Academic Year Workshop subjects shared between CSA, CSD, and CSP
-    SUBJECT_WORKSHOP_1 = 'Academic Year Workshop 1'.freeze
-    SUBJECT_WORKSHOP_2 = 'Academic Year Workshop 2'.freeze
-    SUBJECT_WORKSHOP_3 = 'Academic Year Workshop 3'.freeze
-    SUBJECT_WORKSHOP_4 = 'Academic Year Workshop 4'.freeze
-    SUBJECT_WORKSHOP_1_2 = 'Academic Year Workshop 1 + 2'.freeze
-    SUBJECT_WORKSHOP_3_4 = 'Academic Year Workshop 3 + 4'.freeze
+    ACADEMIC_YEAR_SUBJECTS = [
+      SUBJECT_WORKSHOP_1 = 'Academic Year Workshop 1'.freeze,
+      SUBJECT_WORKSHOP_2 = 'Academic Year Workshop 2'.freeze,
+      SUBJECT_WORKSHOP_3 = 'Academic Year Workshop 3'.freeze,
+      SUBJECT_WORKSHOP_4 = 'Academic Year Workshop 4'.freeze,
+      SUBJECT_WORKSHOP_1_2 = 'Academic Year Workshop 1 + 2'.freeze,
+      SUBJECT_WORKSHOP_3_4 = 'Academic Year Workshop 3 + 4'.freeze
+    ]
 
     # Note: the original intent of this constant is to put subjects
     # in here that will be used explicitly in JS code.


### PR DESCRIPTION
Finishes https://codedotorg.atlassian.net/browse/ACQ-473. In addition to the stated requirements, also verifies that the application is for the current application year, but does not verify that the course name on the application matches the course associated with the workshop.

upon following the enrollment link, a teacher without an accepted application for the current year will see the following:

![Screenshot 2023-03-21 at 9 27 06 AM](https://user-images.githubusercontent.com/8001765/226675950-ad2321af-29fe-42aa-9856-1da99d8d6e56.png)

## Testing story

new unit tests covering new behavior. existing test coverage on enrollments controller covers existing behavior. adding UI tests for the enrollment page is covered by https://codedotorg.atlassian.net/browse/ACQ-481 .