### PR TITLE
Music: update colors

### DIFF
--- a/apps/src/music/views/Timeline.jsx
+++ b/apps/src/music/views/Timeline.jsx
@@ -77,7 +77,15 @@ const Timeline = ({isPlaying, currentPlayheadPosition}) => {
                       moduleStyles.barLineCurrent
                   )}
                 />
-                <div className={moduleStyles.barNumber}>{measure}</div>
+                <div
+                  className={classNames(
+                    moduleStyles.barNumber,
+                    measure === Math.floor(currentPlayheadPosition) &&
+                      moduleStyles.barNumberCurrent
+                  )}
+                >
+                  {measure}
+                </div>
               </div>
             );
           })}

--- a/apps/src/music/views/TimelineSimple2Events.jsx
+++ b/apps/src/music/views/TimelineSimple2Events.jsx
@@ -89,7 +89,7 @@ const TimelineSimple2Events = ({
             key={index}
             style={{
               position: 'absolute',
-              backgroundColor: 'rgba(115 115 115 / 0.7)',
+              backgroundColor: 'rgba(255 255 255 / 0.12)',
               borderRadius: 8,
               left: (uniqueFunction.positionLeft - 1) * barWidth,
               width:

--- a/apps/src/music/views/beatpad.module.scss
+++ b/apps/src/music/views/beatpad.module.scss
@@ -4,7 +4,7 @@
 
 .container {
   background-color: $neutral_dark80;
-  color: $neutral_light;
+  color: $neutral_white;
   display: flex;
   flex-direction: column;
   border: $neutral_dark80 solid;
@@ -49,7 +49,7 @@ $hover-opacity: 0.5;
 @mixin enabled-trigger($color) {
   cursor: pointer;
   border-color: $color;
-  color: $neutral_light;
+  color: $neutral_white;
   &:hover {
     background-color: rgba($color, $hover-opacity);
   }
@@ -58,8 +58,8 @@ $hover-opacity: 0.5;
     background-color: $color;
     border-width: 2px;
     color: $neutral_dark90;
-    border-color: $neutral_light;
-    box-shadow: 0 0 5px $neutral_light;
+    border-color: $neutral_white;
+    box-shadow: 0 0 5px $neutral_white;
   }
 }
 

--- a/apps/src/music/views/beatpad.module.scss
+++ b/apps/src/music/views/beatpad.module.scss
@@ -1,5 +1,5 @@
-@import "./theme/tokens-dark";
 @import "color.scss";
+@import "./theme/tokens-dark";
 @import "./music-view.module.scss";
 
 .container {

--- a/apps/src/music/views/beatpad.module.scss
+++ b/apps/src/music/views/beatpad.module.scss
@@ -3,11 +3,11 @@
 @import "./music-view.module.scss";
 
 .container {
-  background-color: $gray-800;
-  color: $gray;
+  background-color: $neutral_dark80;
+  color: $neutral_light;
   display: flex;
   flex-direction: column;
-  border: $gray-800 solid;
+  border: $neutral_dark80 solid;
   border-radius: $default-border-radius;
 }
 
@@ -32,7 +32,7 @@
   flex: 1;
   display: flex;
   flex-direction: column;
-  background-color: $gray-900;
+  background-color: $neutral_dark90;
   padding: 10px;
 }
 
@@ -49,7 +49,7 @@ $hover-opacity: 0.5;
 @mixin enabled-trigger($color) {
   cursor: pointer;
   border-color: $color;
-  color: $gray;
+  color: $neutral_light;
   &:hover {
     background-color: rgba($color, $hover-opacity);
   }
@@ -57,9 +57,9 @@ $hover-opacity: 0.5;
   &:active {
     background-color: $color;
     border-width: 2px;
-    color: $gray-900;
-    border-color: $gray;
-    box-shadow: 0 0 5px $gray;
+    color: $neutral_dark90;
+    border-color: $neutral_light;
+    box-shadow: 0 0 5px $neutral_light;
   }
 }
 
@@ -68,8 +68,8 @@ $hover-opacity: 0.5;
   border-radius: 8px;
   border-width: 2px 2px 4px 2px;
   border-style: solid;
-  color: $gray-700;
-  background-color: $gray-900;
+  color: $neutral_dark70;
+  background-color: $neutral_dark90;
   text-align: center;
   max-width: 40px;
   height: 40px;

--- a/apps/src/music/views/chordPanel.module.scss
+++ b/apps/src/music/views/chordPanel.module.scss
@@ -1,11 +1,11 @@
-@import "./theme/tokens-dark.scss";
+@import "color.scss";
 
 .chordPanelContainer {
   display: flex;
   flex-direction: column;
-  background-color: $gray-500;
+  background-color: $neutral_dark50;
   align-items: center;
-  border: 2px solid $gray-100;
+  border: 2px solid $neutral_dark10;
   border-radius: 4px;
   padding: 5px;
 
@@ -33,11 +33,11 @@
       }
 
       &Disabled {
-        color: $gray-400;
+        color: $neutral_dark40;
         cursor: not-allowed;
 
         &:hover {
-          color: $gray-400;
+          color: $neutral_dark40;
         }
       }
     }
@@ -78,11 +78,11 @@
       }
 
       &.disabled {
-        background-color: $gray-600;
+        background-color: $neutral_dark60;
         cursor: not-allowed;
 
         &:hover {
-          background-color: $gray-600;
+          background-color: $neutral_dark60;
         }
       }
 
@@ -94,7 +94,7 @@
       .noteLabel {
         text-align: center;
         margin-top: 120px;
-        color: $gray-800;
+        color: $neutral_dark80;
         font-size: 12px;
         user-select: none;
       }

--- a/apps/src/music/views/controls.module.scss
+++ b/apps/src/music/views/controls.module.scss
@@ -5,7 +5,7 @@
 .controlsContainer {
   display: flex;
   justify-content: center;
-  background-color: $gray-800;
+  background-color: $neutral_dark80;
   z-index: 70;
   border-radius: $default-border-radius;
   margin: $default-spacing 0;

--- a/apps/src/music/views/instructions.module.scss
+++ b/apps/src/music/views/instructions.module.scss
@@ -1,8 +1,8 @@
-@import "./theme/tokens-dark";
+@import "color.scss";
 @import "./music-view.module.scss";
 
 .instructions {
-  background-color: $gray-900;
+  background-color: $neutral_dark90;
   width: 100%;
   height: 100%;
   border-radius: $default-border-radius;
@@ -102,7 +102,7 @@
     .progressText {
       font-size: 12px;
       margin: 0 10px;
-      color: $gray-400;
+      color: $neutral_dark40;
     }
 
     .button {

--- a/apps/src/music/views/music-view.module.scss
+++ b/apps/src/music/views/music-view.module.scss
@@ -1,5 +1,3 @@
-@import "./theme/tokens-dark";
-
 // Constants
 $timeline-area-height: 200px;
 $default-border-radius: 4px;

--- a/apps/src/music/views/patternPanel.module.scss
+++ b/apps/src/music/views/patternPanel.module.scss
@@ -1,5 +1,4 @@
 @import "color.scss";
-@import "./theme/tokens-dark";
 
 .patternPanel {
   font-size: 13px;

--- a/apps/src/music/views/soundsPanel.module.scss
+++ b/apps/src/music/views/soundsPanel.module.scss
@@ -1,12 +1,11 @@
 @import "color.scss";
-@import "./theme/tokens-dark";
 
 .soundsPanel {
   user-select: none;
 }
 
 .folder {
-  background-color: $gray-900;
+  background-color: $neutral_dark90;
   overflow: hidden;
   border-radius: 4px;
   padding: 6px;
@@ -22,7 +21,7 @@
   font-size: 18px;
   padding: 6px 0;
   margin-bottom: 6px;
-  border-bottom: solid 1px $gray-800;
+  border-bottom: solid 1px $neutral_dark80;
   margin-right: 12px;
 }
 
@@ -30,10 +29,10 @@
   overflow: hidden;
   padding: 4px 0;
   &:hover {
-    background-color: $gray-800;
+    background-color: $neutral_dark80;
   }
   &Selected {
-    background-color: $gray-700;
+    background-color: $neutral_dark70;
   }
 }
 
@@ -74,7 +73,7 @@
     font-size: 13px;
     width: 15px;
     margin-right: 10px;
-    color: $gray-400;
+    color: $neutral_dark40;
     text-align: right;
   }
 
@@ -85,10 +84,10 @@
 }
 
 .preview {
-  color: $gray-300;
+  color: $neutral_dark30;
 
   &Playing {
-    color: $gray-600;
+    color: $neutral_dark60;
     cursor: default;
   }
 }

--- a/apps/src/music/views/theme/tokens-dark.scss
+++ b/apps/src/music/views/theme/tokens-dark.scss
@@ -5,18 +5,6 @@ $teal: #66dbe8;
 $purple: #dcb6fd;
 $strawberry: #feabab;
 
-// Neutrals
-$gray: #fafafa;
-$gray-100: #f5f5f5;
-$gray-200: #eee;
-$gray-300: #e0e0e0;
-$gray-400: #bdbdbd;
-$gray-500: #9e9e9e;
-$gray-600: #757575;
-$gray-700: #616161;
-$gray-800: #424242;
-$gray-900: #212121;
-
 // Semantic
 $green: #a8d6a8;
 $red: #f3a297;

--- a/apps/src/music/views/timeline.module.scss
+++ b/apps/src/music/views/timeline.module.scss
@@ -48,7 +48,7 @@ $full-width: 900px;
         padding-left: 6px;
 
         &Current {
-          color: $neutral_light;
+          color: $neutral_white;
         }
       }
     }

--- a/apps/src/music/views/timeline.module.scss
+++ b/apps/src/music/views/timeline.module.scss
@@ -1,9 +1,9 @@
-@import "./theme/tokens-dark";
+@import "color.scss";
 
 $full-width: 900px;
 
 .wrapper {
-  background-color: $gray-900;
+  background-color: $neutral_dark90;
   width: 100%;
   height: 100%;
   border-radius: 4px;
@@ -36,18 +36,20 @@ $full-width: 900px;
         position: absolute;
         top: 20px;
         bottom: 0;
-        border-left: 2px $gray-800 solid;
-        color: $gray-600;
+        border-left: 2px $neutral_dark50 solid;
 
         &Current {
-          border-left-color: $gray-600;
-          color: $gray-300;
+          border-left-color: $neutral_dark20;
         }
       }
 
       .barNumber {
-        color: white;
+        color: $neutral_dark20;
         padding-left: 6px;
+
+        &Current {
+          color: $neutral_light;
+        }
       }
     }
 
@@ -134,7 +136,7 @@ $full-width: 900px;
       top: 0;
       width: 1px;
       height: 100%;
-      border-left: 3px $yellow solid;
+      border-left: 3px yellow solid;
     }
   }
 }

--- a/apps/src/music/views/topbuttons.module.scss
+++ b/apps/src/music/views/topbuttons.module.scss
@@ -1,4 +1,4 @@
-@import "./theme/tokens-dark";
+@import "color.scss";
 @import "./music-view.module.scss";
 
 .buttonRow {
@@ -8,18 +8,18 @@
   max-width: 130px;
 
   .button {
-    background-color: $gray-900;
-    color: $gray;
+    background-color: $neutral_dark90;
+    color: $neutral_light;
     font-size: 13px;
     padding: 5px 10px;
     border-radius: 10px;
-    border: solid 1px $gray-200;
+    border: solid 1px $neutral_dark20;
     cursor: pointer;
     transition: background-color 0.1s ease;
     position: relative;
 
     &:hover {
-      background-color: $gray-800;
+      background-color: $neutral_dark80;
     }
   }
 }
@@ -29,7 +29,7 @@
   top: 90px;
   right: 0;
   width: 150px;
-  background-color: $gray-800;
+  background-color: $neutral_dark80;
   border-radius: $default-border-radius;
   padding: 5px;
   opacity: 0;

--- a/apps/src/music/views/topbuttons.module.scss
+++ b/apps/src/music/views/topbuttons.module.scss
@@ -9,7 +9,7 @@
 
   .button {
     background-color: $neutral_dark90;
-    color: $neutral_light;
+    color: $neutral_white;
     font-size: 13px;
     padding: 5px 10px;
     border-radius: 10px;

--- a/apps/src/music/views/video.module.scss
+++ b/apps/src/music/views/video.module.scss
@@ -2,6 +2,11 @@
 @import "color.scss";
 @import "./music-view.module.scss";
 
+@keyframes fadein {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
 .container {
   background-color: rgba(0 0 0 / 0.5);
   position: absolute;
@@ -9,6 +14,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  animation: fadein 1s;
 }
 
 .inner {
@@ -26,6 +32,7 @@
   height: 100%;
   border: solid 2px white;
   box-sizing: border-box;
+  background-color: black;
 }
 
 .closeContainer {

--- a/apps/src/music/views/video.module.scss
+++ b/apps/src/music/views/video.module.scss
@@ -1,4 +1,3 @@
-@import "./theme/tokens-dark";
 @import "color.scss";
 @import "./music-view.module.scss";
 


### PR DESCRIPTION
This just updates some of the Music Lab colors to match the new Blockly dark mode shades of gray from https://github.com/code-dot-org/code-dot-org/pull/50827.

<img width="1511" alt="Screenshot 2023-03-20 at 6 48 00 PM" src="https://user-images.githubusercontent.com/2205926/226501320-e0362892-f877-4bea-8a1b-94975d2c7d14.png">
