### PR TITLE
add check for empty files

### DIFF
--- a/bin/i18n/sync-out.rb
+++ b/bin/i18n/sync-out.rb
@@ -352,7 +352,7 @@ def postprocess_course_resources(locale, courses_source)
   courses_yaml = YAML.load_file(courses_source)
   lang_code = PegasusLanguages.get_code_by_locale(locale)
   return if courses_yaml[lang_code].nil?
-  if courses_yaml[lang_code]['data']['resources']
+  if courses_yaml[lang_code]['data']['resources'] # no processing of empty files
     courses_resources = courses_yaml[lang_code]['data']['resources']
     courses_resources.each do |_key, resource|
       next if resource['url'].blank?

--- a/bin/i18n/sync-out.rb
+++ b/bin/i18n/sync-out.rb
@@ -351,6 +351,7 @@ end
 def postprocess_course_resources(locale, courses_source)
   courses_yaml = YAML.load_file(courses_source)
   lang_code = PegasusLanguages.get_code_by_locale(locale)
+  return if courses_yaml[lang_code].nil?
   if courses_yaml[lang_code]['data']['resources']
     courses_resources = courses_yaml[lang_code]['data']['resources']
     courses_resources.each do |_key, resource|

--- a/bin/i18n/sync-out.rb
+++ b/bin/i18n/sync-out.rb
@@ -351,8 +351,8 @@ end
 def postprocess_course_resources(locale, courses_source)
   courses_yaml = YAML.load_file(courses_source)
   lang_code = PegasusLanguages.get_code_by_locale(locale)
-  return if courses_yaml[lang_code].nil?
-  if courses_yaml[lang_code]['data']['resources'] # no processing of empty files
+  return if courses_yaml[lang_code].nil? # no processing of empty files
+  if courses_yaml[lang_code]['data']['resources']
     courses_resources = courses_yaml[lang_code]['data']['resources']
     courses_resources.each do |_key, resource|
       next if resource['url'].blank?


### PR DESCRIPTION
When post-processing `course.yml` files, the `postprocess_course_resources` method introduced in [this PR](https://github.com/code-dot-org/code-dot-org/pull/50666) fails when it encounters an empty file.
`postprocess_course_resources': NoMethodError: undefined method []' for nil:NilClass`

This PR add a line that stops the method when a `course.yml` file is empty.

## PR Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
