### PR TITLE
Add a Temporary DCDO Flag for Unicorn-Specific Middleware

### DIFF
--- a/dashboard/config.ru
+++ b/dashboard/config.ru
@@ -17,8 +17,15 @@ unless rack_env?(:development)
     }
 end
 
-require 'gctools/oobgc/unicorn_middleware'
-use GC::OOB::UnicornMiddleware
+# Temporarily wrap this unicorn-specific middleware in a DCDO flag so we can
+# evaluate whether or not this still has a performance impact now that we're no
+# longer using unicorn.
+# TODO: either remove the flag or this entire block, depending on the results
+unless DCDO.get('oobgc_unicorn_middleware_disabled', false)
+  require 'gctools/oobgc/unicorn_middleware'
+  use GC::OOB::UnicornMiddleware
+end
+
 use Rack::ContentLength
 require 'rack/ssl-enforcer'
 use Rack::SslEnforcer,


### PR DESCRIPTION
So we can evaluate whether or not we still benefit from it without needing a new build.

## Links

See thread at https://codedotorg.slack.com/archives/C03CK49G9/p1679344334036199 for more context

## Testing story

Tested locally with a `puts` statement to verify that this block can successfully be turned on and off.

## Follow-up work

Once this is in production, we should at some point prior to a daily peak flip this flag and restart the web application services so we can check the effects on frontend memory usage.