### PR TITLE
Music: highlight playing blocks

### DIFF
--- a/apps/src/music/blockly/MusicBlocklyWorkspace.js
+++ b/apps/src/music/blockly/MusicBlocklyWorkspace.js
@@ -292,11 +292,15 @@ export default class MusicBlocklyWorkspace {
     return this.workspace.getAllBlocks();
   }
 
-  updateHighlightedBlocks(playing, notPlaying) {
-    notPlaying.forEach(blockId => {
+  updateHighlightedBlocks(playingBlockIds, notPlayingBlockIds) {
+    // Some blocks might appear in both lists, such as when a
+    // block is in a loop and only one instance is actively playing.
+    // For that reason, we clear the highlights for the not playing list
+    // first, and then highlight for the playing list second.
+    notPlayingBlockIds.forEach(blockId => {
       Blockly.mainBlockSpace.highlightBlock(blockId, false);
     });
-    playing.forEach(blockId => {
+    playingBlockIds.forEach(blockId => {
       Blockly.mainBlockSpace.highlightBlock(blockId, true);
     });
   }

--- a/apps/src/music/blockly/MusicBlocklyWorkspace.js
+++ b/apps/src/music/blockly/MusicBlocklyWorkspace.js
@@ -292,14 +292,12 @@ export default class MusicBlocklyWorkspace {
     return this.workspace.getAllBlocks();
   }
 
-  updateHighlightedBlocks(playingBlockIds, notPlayingBlockIds) {
-    // Some blocks might appear in both lists, such as when a
-    // block is in a loop and only one instance is actively playing.
-    // For that reason, we clear the highlights for the not playing list
-    // first, and then highlight for the playing list second.
-    notPlayingBlockIds.forEach(blockId => {
-      Blockly.mainBlockSpace.highlightBlock(blockId, false);
+  updateHighlightedBlocks(playingBlockIds) {
+    // Clear all highlights.
+    Blockly.mainBlockSpace.getAllBlocks().forEach(block => {
+      Blockly.mainBlockSpace.highlightBlock(block.id, false);
     });
+    // Highlight playing blocks.
     playingBlockIds.forEach(blockId => {
       Blockly.mainBlockSpace.highlightBlock(blockId, true);
     });

--- a/apps/src/music/blockly/MusicBlocklyWorkspace.js
+++ b/apps/src/music/blockly/MusicBlocklyWorkspace.js
@@ -292,6 +292,15 @@ export default class MusicBlocklyWorkspace {
     return this.workspace.getAllBlocks();
   }
 
+  updateHighlightedBlocks(playing, notPlaying) {
+    notPlaying.forEach(blockId => {
+      Blockly.mainBlockSpace.highlightBlock(blockId, false);
+    });
+    playing.forEach(blockId => {
+      Blockly.mainBlockSpace.highlightBlock(blockId, true);
+    });
+  }
+
   getLocalStorageKeyName() {
     // Save code for each block mode in a different local storage item.
     // This way, switching block modes will load appropriate user code.

--- a/apps/src/music/blockly/blocks/simple2.js
+++ b/apps/src/music/blockly/blocks/simple2.js
@@ -158,7 +158,8 @@ export const playSoundAtCurrentLocationSimple2 = {
         null,
         __currentFunction,
         RandomSkipManager.getSkipContext(),
-        __effects
+        __effects,
+        "${block.id}"
       );
       ProgramSequencer.updateMeasureForPlayByLength(
         MusicLibrary.getLengthForId(

--- a/apps/src/music/blockly/blocks/simple2.js
+++ b/apps/src/music/blockly/blocks/simple2.js
@@ -190,7 +190,8 @@ export const playPatternAtCurrentLocationSimple2 = {
         null,
         __currentFunction,
         RandomSkipManager.getSkipContext(),
-        __effects
+        __effects,
+        "${block.id}"
       );
       ProgramSequencer.updateMeasureForPlayByLength(
         ${DEFAULT_PATTERN_LENGTH}
@@ -219,7 +220,8 @@ export const playChordAtCurrentLocationSimple2 = {
         null,
         __currentFunction,
         RandomSkipManager.getSkipContext(),
-        __effects
+        __effects,
+        "${block.id}"
       );
       ProgramSequencer.updateMeasureForPlayByLength(
         ${DEFAULT_CHORD_LENGTH}

--- a/apps/src/music/player/MusicPlayer.ts
+++ b/apps/src/music/player/MusicPlayer.ts
@@ -365,6 +365,7 @@ export default class MusicPlayer {
         insideWhenRun,
         trackId
       );
+
       maxSoundLength = Math.max(
         maxSoundLength,
         this.library.getSoundForId(soundId)?.length || 0
@@ -408,32 +409,33 @@ export default class MusicPlayer {
     return this.uniqueInvocationIdUpto++;
   }
 
-  getCurrentlyPlayingsounds():Object {
-    const playbackEvents = this.getPlaybackEvents();
+  // Returns an object containing two arrays.  One has the block IDs of all
+  // blocks currently playing, while the other is for those not currently
+  // playing.
+  getCurrentlyPlayingBlockIds(): {
+    playingBlockIds: string[];
+    notPlayingBlockIds: string[];
+  } {
     const currentPlayheadPosition = this.getCurrentPlayheadPosition();
+    const playbackEvents = this.getPlaybackEvents();
 
-    const playingSounds :string[]= [];
-    const notPlayingSounds :string[]= [];
+    const playingBlockIds: string[] = [];
+    const notPlayingBlockIds: string[] = [];
 
-    playbackEvents.forEach((playbackEvent:PlaybackEvent) => {
-      const currentlyPlaying = currentPlayheadPosition !== 0 &&
-      currentPlayheadPosition >= playbackEvent.when &&
-      currentPlayheadPosition < playbackEvent.when + playbackEvent.length;
+    playbackEvents.forEach((playbackEvent: PlaybackEvent) => {
+      const currentlyPlaying =
+        currentPlayheadPosition !== 0 &&
+        currentPlayheadPosition >= playbackEvent.when &&
+        currentPlayheadPosition < playbackEvent.when + playbackEvent.length;
 
       if (currentlyPlaying) {
-        playingSounds.push(playbackEvent.blockId || "");
+        playingBlockIds.push(playbackEvent.blockId || '');
       } else {
-        notPlayingSounds.push(playbackEvent.blockId || "");
+        notPlayingBlockIds.push(playbackEvent.blockId || '');
       }
     });
 
-    return {playingSounds, notPlayingSounds};
-    /*
-    return this.playbackEvents.filter(eventData =>
-      currentPlayheadPosition !== 0 &&
-      currentPlayheadPosition >= eventData.when &&
-      currentPlayheadPosition < eventData.when + eventData.length);
-      */
+    return {playingBlockIds, notPlayingBlockIds};
   }
 
   /**

--- a/apps/src/music/player/MusicPlayer.ts
+++ b/apps/src/music/player/MusicPlayer.ts
@@ -79,7 +79,8 @@ export default class MusicPlayer {
     trackId?: string,
     functionContext?: FunctionContext,
     skipContext?: SkipContext,
-    effects?: Effects
+    effects?: Effects,
+    blockId?: string
   ) {
     if (!this.samplePlayer.initialized() || this.library === null) {
       console.log('MusicPlayer not initialized');
@@ -114,7 +115,8 @@ export default class MusicPlayer {
       skipContext,
       effects,
       length: soundData.length,
-      soundType: soundData.type
+      soundType: soundData.type,
+      blockId
     };
 
     this.playbackEvents.push(soundEvent);
@@ -404,6 +406,34 @@ export default class MusicPlayer {
   // a function, so that the timeline renderer can group relevant events.
   getUniqueInvocationId() {
     return this.uniqueInvocationIdUpto++;
+  }
+
+  getCurrentlyPlayingsounds():Object {
+    const playbackEvents = this.getPlaybackEvents();
+    const currentPlayheadPosition = this.getCurrentPlayheadPosition();
+
+    const playingSounds :string[]= [];
+    const notPlayingSounds :string[]= [];
+
+    playbackEvents.forEach((playbackEvent:PlaybackEvent) => {
+      const currentlyPlaying = currentPlayheadPosition !== 0 &&
+      currentPlayheadPosition >= playbackEvent.when &&
+      currentPlayheadPosition < playbackEvent.when + playbackEvent.length;
+
+      if (currentlyPlaying) {
+        playingSounds.push(playbackEvent.blockId || "");
+      } else {
+        notPlayingSounds.push(playbackEvent.blockId || "");
+      }
+    });
+
+    return {playingSounds, notPlayingSounds};
+    /*
+    return this.playbackEvents.filter(eventData =>
+      currentPlayheadPosition !== 0 &&
+      currentPlayheadPosition >= eventData.when &&
+      currentPlayheadPosition < eventData.when + eventData.length);
+      */
   }
 
   /**

--- a/apps/src/music/player/MusicPlayer.ts
+++ b/apps/src/music/player/MusicPlayer.ts
@@ -133,7 +133,8 @@ export default class MusicPlayer {
     trackId?: string,
     functionContext?: FunctionContext,
     skipContext?: SkipContext,
-    effects?: Effects
+    effects?: Effects,
+    blockId?: string
   ) {
     if (!this.samplePlayer.initialized()) {
       console.log('MusicPlayer not initialized');
@@ -153,7 +154,8 @@ export default class MusicPlayer {
       functionContext,
       skipContext,
       effects,
-      length: constants.DEFAULT_PATTERN_LENGTH
+      length: constants.DEFAULT_PATTERN_LENGTH,
+      blockId
     };
 
     this.playbackEvents.push(patternEvent);
@@ -170,7 +172,8 @@ export default class MusicPlayer {
     trackId?: string,
     functionContext?: FunctionContext,
     skipContext?: SkipContext,
-    effects?: Effects
+    effects?: Effects,
+    blockId?: string
   ) {
     if (!this.samplePlayer.initialized()) {
       console.log('MusicPlayer not initialized');
@@ -190,7 +193,8 @@ export default class MusicPlayer {
       functionContext,
       skipContext,
       effects,
-      length: constants.DEFAULT_CHORD_LENGTH
+      length: constants.DEFAULT_CHORD_LENGTH,
+      blockId
     };
 
     this.playbackEvents.push(chordEvent);

--- a/apps/src/music/player/MusicPlayer.ts
+++ b/apps/src/music/player/MusicPlayer.ts
@@ -416,15 +416,11 @@ export default class MusicPlayer {
   // Returns an object containing two arrays.  One has the block IDs of all
   // blocks currently playing, while the other is for those not currently
   // playing.
-  getCurrentlyPlayingBlockIds(): {
-    playingBlockIds: string[];
-    notPlayingBlockIds: string[];
-  } {
+  getCurrentlyPlayingBlockIds(): string[] {
     const currentPlayheadPosition = this.getCurrentPlayheadPosition();
     const playbackEvents = this.getPlaybackEvents();
 
     const playingBlockIds: string[] = [];
-    const notPlayingBlockIds: string[] = [];
 
     playbackEvents.forEach((playbackEvent: PlaybackEvent) => {
       const currentlyPlaying =
@@ -434,12 +430,10 @@ export default class MusicPlayer {
 
       if (currentlyPlaying) {
         playingBlockIds.push(playbackEvent.blockId || '');
-      } else {
-        notPlayingBlockIds.push(playbackEvent.blockId || '');
       }
     });
 
-    return {playingBlockIds, notPlayingBlockIds};
+    return playingBlockIds;
   }
 
   /**

--- a/apps/src/music/player/interfaces/PlaybackEvent.ts
+++ b/apps/src/music/player/interfaces/PlaybackEvent.ts
@@ -19,4 +19,6 @@ export interface PlaybackEvent {
   effects?: Effects;
   /** length of the event in measures */
   length: number;
+  /** The ID of the block that created this event */
+  blockId?: string;
 }

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -158,15 +158,8 @@ class UnconnectedMusicView extends React.Component {
   };
 
   updateHighlightedBlocks = () => {
-    const {
-      playingBlockIds,
-      notPlayingBlockIds
-    } = this.player.getCurrentlyPlayingBlockIds();
-
-    this.musicBlocklyWorkspace.updateHighlightedBlocks(
-      playingBlockIds,
-      notPlayingBlockIds
-    );
+    const playingBlockIds = this.player.getCurrentlyPlayingBlockIds();
+    this.musicBlocklyWorkspace.updateHighlightedBlocks(playingBlockIds);
   };
 
   loadLibrary = async () => {

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -152,6 +152,16 @@ class UnconnectedMusicView extends React.Component {
       this.setState({
         currentPlayheadPosition: this.player.getCurrentPlayheadPosition()
       });
+
+      const {
+        playingSounds,
+        notPlayingSounds
+      } = this.player.getCurrentlyPlayingsounds();
+
+      this.musicBlocklyWorkspace.updateHighlightedBlocks(
+        playingSounds,
+        notPlayingSounds
+      );
     }
   };
 

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -153,16 +153,20 @@ class UnconnectedMusicView extends React.Component {
         currentPlayheadPosition: this.player.getCurrentPlayheadPosition()
       });
 
-      const {
-        playingSounds,
-        notPlayingSounds
-      } = this.player.getCurrentlyPlayingsounds();
-
-      this.musicBlocklyWorkspace.updateHighlightedBlocks(
-        playingSounds,
-        notPlayingSounds
-      );
+      this.updateHighlightedBlocks();
     }
+  };
+
+  updateHighlightedBlocks = () => {
+    const {
+      playingBlockIds,
+      notPlayingBlockIds
+    } = this.player.getCurrentlyPlayingBlockIds();
+
+    this.musicBlocklyWorkspace.updateHighlightedBlocks(
+      playingBlockIds,
+      notPlayingBlockIds
+    );
   };
 
   loadLibrary = async () => {
@@ -241,6 +245,7 @@ class UnconnectedMusicView extends React.Component {
       this.analyticsReporter.onButtonClicked('play');
     } else {
       this.stopSong();
+      this.updateHighlightedBlocks();
     }
   };
 


### PR DESCRIPTION
With this change, we highlight the Blockly blocks that are currently playing.  It works for sound, pattern, and chord blocks.  The highlights are removed when playback is stopped.


https://user-images.githubusercontent.com/2205926/226821512-1f80b75e-2860-4d65-a8ec-0c6b48616360.mov

