### PR TITLE
Wait for bubble choice level to fully load during UI test

### DIFF
--- a/dashboard/test/ui/features/teacher_tools/level_types/bubble_choice.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_types/bubble_choice.feature
@@ -10,6 +10,8 @@ Feature: BubbleChoice
     And I click selector ".submitButton"
 
     # Make sure you are taken back to the BubbleChoice activity page with progress
+    And I wait until current URL contains "/lessons/40/levels/1"
+    And I wait for the page to fully load
     And I wait until element ".uitest-bubble-choice:eq(0)" is visible
     And element ".uitest-bubble-choice:eq(0) .progress-bubble:first" is visible
     And check that the url contains "/s/allthethings/lessons/40/levels/1"

--- a/dashboard/test/ui/features/teacher_tools/level_types/bubble_choice.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_types/bubble_choice.feature
@@ -11,6 +11,7 @@ Feature: BubbleChoice
 
     # Make sure you are taken back to the BubbleChoice activity page with progress
     And I wait until current URL contains "/lessons/40/levels/1"
+    And I wait for jquery to load
     And I wait until element ".uitest-bubble-choice:eq(0)" is visible
     And element ".uitest-bubble-choice:eq(0) .progress-bubble:first" is visible
     And check that the url contains "/s/allthethings/lessons/40/levels/1"

--- a/dashboard/test/ui/features/teacher_tools/level_types/bubble_choice.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_types/bubble_choice.feature
@@ -11,7 +11,6 @@ Feature: BubbleChoice
 
     # Make sure you are taken back to the BubbleChoice activity page with progress
     And I wait until current URL contains "/lessons/40/levels/1"
-    And I wait for the page to fully load
     And I wait until element ".uitest-bubble-choice:eq(0)" is visible
     And element ".uitest-bubble-choice:eq(0) .progress-bubble:first" is visible
     And check that the url contains "/s/allthethings/lessons/40/levels/1"


### PR DESCRIPTION
The `Firefox_teacher_tools_level_types_bubble_choice_Viewing BubbleChoice progress` test has been super flaky recently. This morning it actually took 15 tries to pass:
![image](https://user-images.githubusercontent.com/43474485/226910933-775fd660-517c-4443-bf18-838d4240dac6.png)

When failing, the result is JavaScript error with the message `"ReferenceError: $ is not defined"`, suggesting that the page is not being given time to fully load. I manually confirmed the expected behavior covered by the test by visiting https://test-studio.code.org/s/allthethings/lessons/40/levels/1 and entering 
`$(".uitest-bubble-choice:eq(0)").is(':visible') && $(".uitest-bubble-choice:eq(0)").css('visibility') !== 'hidden';` in the console. (output was `true`)

This PR would add a couple steps to wait until we are on the expected page and then wait for the page to fully load to make sure the jQuery JavaScript is included.

I am DOTD today 3/22 - If this passes on drone and merges this morning I can follow-up to see if it succeeds in making the test less flaky on test.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
