### PR TITLE
Clarify free response allow_multiple_attempts field

### DIFF
--- a/dashboard/app/views/levels/editors/fields/_free_response_fields.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_free_response_fields.html.haml
@@ -31,4 +31,4 @@
     %p If checked, an assessment page will still be considered complete even if this question is left blank.
   .field
     = render partial: 'levels/editors/fields/checkboxes', locals: {f: f, field_name: :allow_multiple_attempts, description: "Allow multiple attempts"}
-    %p Whether or not a user can submit multiple answers. Default is no for contained levels and yes for standalone levels. It will not apply for levels in level groups.
+    %p Whether or not a user can submit multiple answers. It will not apply for levels in level groups.


### PR DESCRIPTION
Most FreeResponse levels won't have `allow_multiple_attempts` set as they were created before this field. When I wrote the description for this field, I was thinking of that scenario. But anytime these levels are edited, this field will be set to true or false.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
