### PR TITLE
Change allow_multiple_attempts editor to a dropdown to allow for nil values

### DIFF
--- a/dashboard/app/views/levels/editors/fields/_free_response_fields.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_free_response_fields.html.haml
@@ -30,5 +30,6 @@
     = render partial: 'levels/editors/fields/checkboxes', locals: {f: f, field_name: :optional, description: "Optional"}
     %p If checked, an assessment page will still be considered complete even if this question is left blank.
   .field
-    = render partial: 'levels/editors/fields/checkboxes', locals: {f: f, field_name: :allow_multiple_attempts, description: "Allow multiple attempts"}
+    = f.label :allow_multiple_attempts
     %p Whether or not a user can submit multiple answers. Default is no for contained levels and yes for standalone levels. It will not apply for levels in level groups.
+    = f.select :allow_multiple_attempts, options_for_select(['true', 'false'], @level.allow_multiple_attempts), {include_blank: true}


### PR DESCRIPTION
Most levels will have a nil value for this field. `nil`, `true`, and `false` all have subtly different behaviors:
- `true` means that multiple attempts are _always_ allowed
- `false` means that multiple attempts are _never_ allowed
- `nil` means that multiple attempts are allowed on standalone levels but not on contained levels

For most levels, the `nil` behavior is frankly not needed. However, this field will default to `false` and I worry about someone fixing a typo in an old level and accidentally changing the behavior of the level. Therefore, I decided to change this to a dropdown to avoid that issue. 

![Screen Shot 2023-03-23 at 11 59 57 AM](https://user-images.githubusercontent.com/46464143/227262874-07b39070-956f-4c4a-a040-0b9f5cf9490c.png)
