### PR TITLE
Update `rake` Gem to v12

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -243,7 +243,7 @@ group :development, :staging, :levelbuilder do
   gem 'rubocop-performance', require: false
   gem 'rubocop-rails', require: false
   gem 'rubocop-rails-accessibility', require: false
-  gem 'scss_lint', require: false
+  gem 'scss_lint', '~> 0.51.0', require: false
 end
 
 # Reduce volume of production logs

--- a/Gemfile
+++ b/Gemfile
@@ -243,7 +243,7 @@ group :development, :staging, :levelbuilder do
   gem 'rubocop-performance', require: false
   gem 'rubocop-rails', require: false
   gem 'rubocop-rails-accessibility', require: false
-  gem 'scss_lint', '~> 0.51.0', require: false
+  gem 'scss_lint', require: false
 end
 
 # Reduce volume of production logs

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -697,7 +697,7 @@ GEM
       thor (>= 0.20.3, < 2.0)
     rainbow (3.0.0)
     raindrops (0.20.0)
-    rake (11.3.0)
+    rake (12.3.3)
     rambling-trie (2.2.1)
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
@@ -783,8 +783,8 @@ GEM
     scenic-mysql_adapter (1.0.1)
       mysql2
       scenic (>= 1.4.0)
-    scss_lint (0.49.0)
-      rake (>= 0.9, < 12)
+    scss_lint (0.51.0)
+      rake (>= 0.9, < 13)
       sass (~> 3.4.20)
     selenium-webdriver (3.141.0)
       childprocess (~> 0.5)
@@ -1041,7 +1041,7 @@ DEPENDENCIES
   sassc-rails!
   scenic
   scenic-mysql_adapter
-  scss_lint
+  scss_lint (~> 0.51.0)
   selenium-webdriver (= 3.141.0)
   sequel
   shotgun

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -783,7 +783,7 @@ GEM
     scenic-mysql_adapter (1.0.1)
       mysql2
       scenic (>= 1.4.0)
-    scss_lint (0.51.0)
+    scss_lint (0.55.0)
       rake (>= 0.9, < 13)
       sass (~> 3.4.20)
     selenium-webdriver (3.141.0)
@@ -1041,7 +1041,7 @@ DEPENDENCIES
   sassc-rails!
   scenic
   scenic-mysql_adapter
-  scss_lint (~> 0.51.0)
+  scss_lint
   selenium-webdriver (= 3.141.0)
   sequel
   shotgun


### PR DESCRIPTION
Specifically to pick up https://github.com/ruby/rake/pull/211, which is required for Rails 6.1 support; without it, we get `undefined method ``with_application' for Rake:Module (NoMethodError)` when trying to run any rails script.

Specifically, I implemented this by running `bundle update rake scss_lint --conservative`; `scss_lint` to pick up the change "Relax gem dependency constraints to allow rake 12.x", and `--conservative` to avoid also updating the `sass` gem, just to keep this changeset scoped.

## Links

- https://github.com/sds/scss-lint/blob/master/CHANGELOG.md#0510
- https://github.com/ruby/rake/releases/tag/v12.2.0

## Testing story

Tested locally that this resolves for me the problems with running rake tasks on Rails 6.1

Relying on existing tests to verify that this does not otherwise result in any change to functionality.