### PR TITLE
Update `where.not` Calls with Multiple Predicates

### DIFF
--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -456,7 +456,9 @@ class ScriptLevelsController < ApplicationController
     end
 
     if @level.try(:peer_reviewable?)
-      @peer_reviews = PeerReview.where(level: @level, submitter: current_user).where.not(data: nil, reviewer: nil)
+      @peer_reviews = PeerReview.where(
+        level: @level, submitter: current_user
+      ).where.not(data: nil).where.not(reviewer: nil)
     end
 
     @callback = milestone_script_level_url(

--- a/dashboard/app/models/peer_review.rb
+++ b/dashboard/app/models/peer_review.rb
@@ -216,9 +216,10 @@ class PeerReview < ApplicationRecord
 
   def self.get_potential_reviews(script, user)
     where(
-      script: script,
+      script: script
     ).where.not(
-      submitter: user,
+      submitter: user
+    ).where.not(
       level_source_id: PeerReview.where(reviewer: user, script: script).pluck(:level_source_id)
     )
   end


### PR DESCRIPTION
In preparation for an upgrade to Rails 6.1, in which this has been changed from `NAND` to `NOR`. Chaining is now the recommended way to implement a logical `NAND`, and works the same in both versions.

## Links

- https://guides.rubyonrails.org/6_1_release_notes.html#active-record-notable-changes

## Testing story

Fortunately, I only found two instances in our codebase of multi-predicate `where.not` calls, both related to `PeerReview`. The instance in the model definition itself is covered by [this existing test](https://github.com/code-dot-org/code-dot-org/blob/299c39a55be552bcc125aa841d5f9de8539d550c/dashboard/test/models/peer_review_test.rb#L165-L186), and I added a new test to cover the instance in `ScriptLevelsController`.