### PR TITLE
Update `factory_bot` to 4.11.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -111,7 +111,7 @@ group :development, :test do
 end
 
 # Needed for unit testing, and also for /rails/mailers email previews.
-gem 'factory_bot_rails', '~> 4.8.2', group: [:development, :staging, :test, :adhoc]
+gem 'factory_bot_rails', '~> 4.11', group: [:development, :staging, :test, :adhoc]
 
 # For pegasus PDF generation.
 gem 'open_uri_redirections', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -375,10 +375,10 @@ GEM
       nokogiri
       selenium-webdriver
       state_machine
-    factory_bot (4.8.2)
+    factory_bot (4.11.1)
       activesupport (>= 3.0.0)
-    factory_bot_rails (4.8.2)
-      factory_bot (~> 4.8.2)
+    factory_bot_rails (4.11.1)
+      factory_bot (~> 4.11.1)
       railties (>= 3.0.0)
     fakeredis (0.6.0)
       redis (~> 3.2)
@@ -944,7 +944,7 @@ DEPENDENCIES
   dotiw
   execjs
   eyes_selenium (= 3.18.4)
-  factory_bot_rails (~> 4.8.2)
+  factory_bot_rails (~> 4.11)
   fakeredis
   firebase
   firebase_token_generator


### PR DESCRIPTION
The latest 4.x version, now that we can do so; follow-up to https://github.com/code-dot-org/code-dot-org/pull/50768

No major changes between 4.8 and 4.11, just picking up some bugfixes and getting us ready to eventually upgrade all the way to `>= 6.2.0` to pick up support for Ruby 3.0

## Links

- https://github.com/thoughtbot/factory_bot/releases/tag/v4.11.0
- https://github.com/thoughtbot/factory_bot/releases/tag/v4.11.1 

## Testing story

Relying on existing tests to verify that this test library continues to operate as expected.