### PR TITLE
Fixing regional partner presence validation error when set to inactive

### DIFF
--- a/dashboard/app/models/regional_partner.rb
+++ b/dashboard/app/models/regional_partner.rb
@@ -139,7 +139,7 @@ class RegionalPartner < ApplicationRecord
   validates_inclusion_of :applications_decision_emails, in: APPLICATION_DECISION_EMAILS, if: -> {applications_decision_emails.present?}
   validates :csd_cost, numericality: {greater_than: 0}, if: -> {csd_cost.present?}
   validates :csp_cost, numericality: {greater_than: 0}, if: -> {csp_cost.present?}
-  validates_presence_of :is_active
+  validates :is_active, inclusion: {in: [true, false], message: "is required"}
 
   # assign a program manager to a regional partner
   def program_manager=(program_manager_id)

--- a/dashboard/test/controllers/regional_partners_controller_test.rb
+++ b/dashboard/test/controllers/regional_partners_controller_test.rb
@@ -52,6 +52,7 @@ class RegionalPartnersControllerTest < ActionController::TestCase
     regional_partner = RegionalPartner.last
     assert_redirected_to regional_partner
     assert_equal "Test Regional Partner", regional_partner.name
+    assert_equal true, regional_partner.is_active
   end
 
   test 'create regional partner with invalid fields does not create regional partner' do
@@ -68,6 +69,12 @@ class RegionalPartnersControllerTest < ActionController::TestCase
     sign_in @workshop_admin
     patch :update, params: {id: @regional_partner.id, regional_partner: {name: 'Updated Name'}}
     assert_equal @regional_partner.reload.name, 'Updated Name'
+  end
+
+  test 'update regional partner active status updates regional partner' do
+    sign_in @workshop_admin
+    patch :update, params: {id: @regional_partner.id, regional_partner: {is_active: false}}
+    assert_equal @regional_partner.reload.is_active, false
   end
 
   # TODO: remove this test when workshop_organizer is deprecated


### PR DESCRIPTION
Context: As part of [this](https://github.com/code-dot-org/code-dot-org/pull/50779) PR, a new Boolean field was introduced to track if a regional partner was active. 

Issue: When a regional partner was either updated or created with Is_Active to false, the save was failing saying the required field was not set

Root cause: The model validation to ensure the field was set was done using validates_presense_of method on Active record, which behind the scenes calls the base Object.blank? method and is successful if the call returns true. But, this method returns a false if the object is either empty, false or white space. As a result when the field was set to false, it was still considered empty.

Fix: Change the presence validation to use inclusion instead as recommended

https://apidock.com/rails/ActiveModel/Validations/ClassMethods/validates_presence_of
https://apidock.com/rails/Object/blank%3F

## Testing story

- Included new unit test and confirmed it was failing before the fix
- Manually tried setting and creating an inactive regional partner

## PR Checklist:

- [x] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
