### PR TITLE
Project Beats: move current playhead position to redux

### DIFF
--- a/apps/src/music/redux/musicRedux.ts
+++ b/apps/src/music/redux/musicRedux.ts
@@ -8,10 +8,12 @@ const registerReducers = require('@cdo/apps/redux').registerReducers;
 
 interface MusicState {
   isPlaying: boolean;
+  currentPlayheadPosition: number;
 }
 
 const initialState: MusicState = {
-  isPlaying: false
+  isPlaying: false,
+  currentPlayheadPosition: 0
 };
 
 const musicSlice = createSlice({
@@ -20,6 +22,9 @@ const musicSlice = createSlice({
   reducers: {
     setIsPlaying: (state, action: PayloadAction<boolean>) => {
       state.isPlaying = action.payload;
+    },
+    setCurrentPlayheadPosition: (state, action: PayloadAction<number>) => {
+      state.currentPlayheadPosition = action.payload;
     }
   }
 });
@@ -30,4 +35,4 @@ const musicSlice = createSlice({
 // to be connected to this state.
 registerReducers({music: musicSlice.reducer});
 
-export const {setIsPlaying} = musicSlice.actions;
+export const {setIsPlaying, setCurrentPlayheadPosition} = musicSlice.actions;

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -24,7 +24,7 @@ import ProgressManager from '../progress/ProgressManager';
 import MusicValidator from '../progress/MusicValidator';
 import Video from './Video';
 import MusicLibrary from '../player/MusicLibrary';
-import {setIsPlaying} from '../redux/musicRedux';
+import {setIsPlaying, setCurrentPlayheadPosition} from '../redux/musicRedux';
 
 const baseUrl = 'https://curriculum.code.org/media/musiclab/';
 
@@ -54,7 +54,8 @@ class UnconnectedMusicView extends React.Component {
     userType: PropTypes.string,
     signInState: PropTypes.oneOf(Object.values(SignInState)),
     isPlaying: PropTypes.bool,
-    setIsPlaying: PropTypes.func
+    setIsPlaying: PropTypes.func,
+    setCurrentPlayheadPosition: PropTypes.func
   };
 
   constructor(props) {
@@ -84,7 +85,6 @@ class UnconnectedMusicView extends React.Component {
     }
 
     this.state = {
-      currentPlayheadPosition: 0,
       updateNumber: 0,
       timelineAtTop: false,
       showInstructions: false,
@@ -175,9 +175,9 @@ class UnconnectedMusicView extends React.Component {
 
   updateTimer = () => {
     if (this.props.isPlaying) {
-      this.setState({
-        currentPlayheadPosition: this.player.getCurrentPlayheadPosition()
-      });
+      this.props.setCurrentPlayheadPosition(
+        this.player.getCurrentPlayheadPosition()
+      );
 
       this.updateHighlightedBlocks();
 
@@ -360,8 +360,8 @@ class UnconnectedMusicView extends React.Component {
     this.player.playSong();
 
     this.props.setIsPlaying(true);
+    this.props.setCurrentPlayheadPosition(1);
     this.setState({
-      currentPlayheadPosition: 1,
       selectedBlockId: undefined
     });
 
@@ -375,7 +375,7 @@ class UnconnectedMusicView extends React.Component {
     this.executeCompiledSong();
 
     this.props.setIsPlaying(false);
-    this.setState({currentPlayheadPosition: 0});
+    this.props.setCurrentPlayheadPosition(0);
     this.triggerCount = 0;
   };
 
@@ -503,7 +503,6 @@ class UnconnectedMusicView extends React.Component {
           instructionsOnRight={instructionsOnRight}
         />
         <Timeline
-          currentPlayheadPosition={this.state.currentPlayheadPosition}
           selectedBlockId={this.state.selectedBlockId}
           onBlockSelected={this.onBlockSelected}
         />
@@ -582,7 +581,9 @@ const MusicView = connect(
     isPlaying: state.music.isPlaying
   }),
   dispatch => ({
-    setIsPlaying: isPlaying => dispatch(setIsPlaying(isPlaying))
+    setIsPlaying: isPlaying => dispatch(setIsPlaying(isPlaying)),
+    setCurrentPlayheadPosition: currentPlayheadPosition =>
+      dispatch(setCurrentPlayheadPosition(currentPlayheadPosition))
   })
 )(UnconnectedMusicView);
 

--- a/apps/src/music/views/Timeline.jsx
+++ b/apps/src/music/views/Timeline.jsx
@@ -18,12 +18,11 @@ const eventVerticalSpace = 2;
 /**
  * Renders the music playback timeline.
  */
-const Timeline = ({
-  currentPlayheadPosition,
-  selectedBlockId,
-  onBlockSelected
-}) => {
+const Timeline = ({selectedBlockId, onBlockSelected}) => {
   const isPlaying = useSelector(state => state.music.isPlaying);
+  const currentPlayheadPosition = useSelector(
+    state => state.music.currentPlayheadPosition
+  );
   const playerUtils = useContext(PlayerUtilsContext);
   const measuresToDisplay = Math.max(
     minNumMeasures,
@@ -53,7 +52,6 @@ const Timeline = ({
     : null;
 
   const timelineElementProps = {
-    currentPlayheadPosition,
     selectedBlockId,
     onBlockSelected,
     barWidth,
@@ -129,10 +127,8 @@ const Timeline = ({
 };
 
 Timeline.propTypes = {
-  currentPlayheadPosition: PropTypes.number.isRequired,
   selectedBlockId: PropTypes.string,
-  onBlockSelected: PropTypes.func,
-  sounds: PropTypes.array
+  onBlockSelected: PropTypes.func
 };
 
 export default Timeline;

--- a/apps/src/music/views/TimelineElement.jsx
+++ b/apps/src/music/views/TimelineElement.jsx
@@ -25,11 +25,13 @@ const TimelineElement = ({
   left,
   when,
   skipContext,
-  currentPlayheadPosition,
   selectedBlockId,
   onBlockSelected
 }) => {
   const isPlaying = useSelector(state => state.music.isPlaying);
+  const currentPlayheadPosition = useSelector(
+    state => state.music.currentPlayheadPosition
+  );
   const isInsideRandom = skipContext?.insideRandom;
   const isSkipSound = isPlaying && skipContext?.skipSound;
 
@@ -82,7 +84,6 @@ TimelineElement.propTypes = {
   left: PropTypes.number,
   when: PropTypes.number.isRequired,
   skipContext: PropTypes.object,
-  currentPlayheadPosition: PropTypes.number.isRequired,
   selectedBlockId: PropTypes.string,
   onBlockSelected: PropTypes.func
 };

--- a/apps/src/music/views/TimelineSampleEvents.jsx
+++ b/apps/src/music/views/TimelineSampleEvents.jsx
@@ -8,7 +8,6 @@ import TimelineElement from './TimelineElement';
  * Renders timeline events, organized by unique sample ID.
  */
 const TimelineSampleEvents = ({
-  currentPlayheadPosition,
   barWidth,
   eventVerticalSpace,
   getEventHeight
@@ -48,7 +47,6 @@ const TimelineSampleEvents = ({
           top={20 + getVerticalOffsetForEventId(eventData.id)}
           left={barWidth * (eventData.when - 1)}
           when={eventData.when}
-          currentPlayheadPosition={currentPlayheadPosition}
         />
       ))}
     </>
@@ -56,7 +54,6 @@ const TimelineSampleEvents = ({
 };
 
 TimelineSampleEvents.propTypes = {
-  currentPlayheadPosition: PropTypes.number.isRequired,
   barWidth: PropTypes.number.isRequired,
   eventVerticalSpace: PropTypes.number.isRequired,
   getEventHeight: PropTypes.func.isRequired

--- a/apps/src/music/views/TimelineSimple2Events.jsx
+++ b/apps/src/music/views/TimelineSimple2Events.jsx
@@ -7,7 +7,6 @@ import TimelineElement from './TimelineElement';
  * Renders timeline events for the simple2 model.
  */
 const TimelineSimple2Events = ({
-  currentPlayheadPosition,
   selectedBlockId,
   onBlockSelected,
   barWidth,
@@ -126,7 +125,6 @@ const TimelineSimple2Events = ({
             left={barWidth * (eventData.when - 1)}
             when={eventData.when}
             skipContext={eventData.skipContext}
-            currentPlayheadPosition={currentPlayheadPosition}
             selectedBlockId={selectedBlockId}
             onBlockSelected={onBlockSelected}
           />
@@ -137,7 +135,6 @@ const TimelineSimple2Events = ({
 };
 
 TimelineSimple2Events.propTypes = {
-  currentPlayheadPosition: PropTypes.number.isRequired,
   selectedBlockId: PropTypes.string,
   onBlockSelected: PropTypes.func,
   barWidth: PropTypes.number.isRequired,

--- a/apps/src/music/views/TimelineTrackEvents.jsx
+++ b/apps/src/music/views/TimelineTrackEvents.jsx
@@ -5,7 +5,6 @@ import moduleStyles from './timeline.module.scss';
 import TimelineElement from './TimelineElement';
 
 const TimelineTrackEvents = ({
-  currentPlayheadPosition,
   barWidth,
   eventVerticalSpace,
   getEventHeight
@@ -85,7 +84,6 @@ const TimelineTrackEvents = ({
                         height={singleElementHeight}
                         top={index * singleElementHeight}
                         when={eventData.when}
-                        currentPlayheadPosition={currentPlayheadPosition}
                       />
                     )
                   )}
@@ -100,7 +98,6 @@ const TimelineTrackEvents = ({
 };
 
 TimelineTrackEvents.propTypes = {
-  currentPlayheadPosition: PropTypes.number.isRequired,
   barWidth: PropTypes.number.isRequired,
   eventVerticalSpace: PropTypes.number.isRequired,
   getEventHeight: PropTypes.func.isRequired


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Another quick redux refactor. Moves current playhead position out of MusicView state and into redux so MusicView doesn't need to keep track of it (only update it).
