### PR TITLE
DB level not null validation for is_active field in regional partners

### DIFF
--- a/dashboard/app/models/regional_partner.rb
+++ b/dashboard/app/models/regional_partner.rb
@@ -18,7 +18,7 @@
 #  updated_at         :datetime         not null
 #  deleted_at         :datetime
 #  properties         :text(65535)
-#  is_active          :boolean
+#  is_active          :boolean          not null
 #
 
 require 'state_abbr'

--- a/dashboard/app/serializers/regional_partner_serializer.rb
+++ b/dashboard/app/serializers/regional_partner_serializer.rb
@@ -18,7 +18,7 @@
 #  updated_at         :datetime         not null
 #  deleted_at         :datetime
 #  properties         :text(65535)
-#  is_active          :boolean
+#  is_active          :boolean          not null
 #
 
 class RegionalPartnerSerializer < ActiveModel::Serializer

--- a/dashboard/db/migrate/20230323175726_add_not_null_validation_to_is_active_field_regional_partner.rb
+++ b/dashboard/db/migrate/20230323175726_add_not_null_validation_to_is_active_field_regional_partner.rb
@@ -1,0 +1,8 @@
+class AddNotNullValidationToIsActiveFieldRegionalPartner < ActiveRecord::Migration[6.0]
+  def up
+    change_column_null :regional_partners, :is_active, false, true
+  end
+
+  def down
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_03_13_222451) do
+ActiveRecord::Schema.define(version: 2023_03_23_175726) do
 
   create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"


### PR DESCRIPTION
Adding a new DB level validation for the new is_active field in regional partners table.

JIRA https://codedotorg.atlassian.net/browse/ACQ-489?atlOrigin=eyJpIjoiMjhmM2Q4NzU1NDMzNDMzYTgwZDlmNjUzNzkxZGEzOGQiLCJwIjoiaiJ9

## Testing story
Tested manually by adding a few entries with nil (by explicitly disabling validation at model) 

1. Running migration was successful and updated those entries with true
2. Once the migration completed, creating new entries failed with the expected error

## PR Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
