### PR TITLE
Validate styles on block edit pages

### DIFF
--- a/apps/src/block_utils.js
+++ b/apps/src/block_utils.js
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+import {styleTypes} from './blockly/themes/cdoBlockStyles.mjs';
 import xml from './xml';
 
 const ATTRIBUTES_TO_CLEAN = ['uservisible', 'deletable', 'movable'];
@@ -977,6 +978,23 @@ exports.createJsWrapperBlockCreator = function(
     if (inline === undefined) {
       inline = true;
     }
+
+    if (style && !styleTypes.includes(style)) {
+      // Attempt to guess the intended styles based on the first three letters.
+      const bestGuess =
+        styleTypes[
+          styleTypes.findIndex(type =>
+            type.startsWith(style.toLowerCase().slice(0, 3))
+          )
+        ];
+      throw new Error(
+        `"${style}" is not a valid style for ${name || func}. ` +
+          (bestGuess
+            ? `Did you mean "${bestGuess}"?`
+            : `Choose one of [${styleTypes.sort().join(', ')}]`)
+      );
+    }
+
     args = args || [];
     if (args.filter(arg => arg.statement).length > 1 && inline) {
       console.warn('blocks with multiple statement inputs cannot be inlined');

--- a/apps/src/blockly/themes/cdoBlockStyles.mjs
+++ b/apps/src/blockly/themes/cdoBlockStyles.mjs
@@ -68,7 +68,11 @@ const labBlockStyles = {
 // The order of the properties in this object is intentional
 // as it gives priority to our most-used block styles when
 // remapping to nearest colors for our accessible themes.
-export default {
+const cdoBlockStyles = {
   ...commonBlockStyles,
   ...labBlockStyles
 };
+
+export default cdoBlockStyles;
+
+export const styleTypes = Object.keys(cdoBlockStyles);

--- a/dashboard/config/blocks/GamelabJr/gamelab_checkTouching.json
+++ b/dashboard/config/blocks/GamelabJr/gamelab_checkTouching.json
@@ -6,7 +6,7 @@
       1,
       0.74
     ],
-    "style": "eventBlocks",
+    "style": "event_blocks",
     "func": "checkTouching",
     "blockText": "{CONDITION} {SPRITE1} touches {SPRITE2}",
     "miniToolboxBlocks": [


### PR DESCRIPTION
## Context
As part of the prep work to migrate Sprite Lab to Google Blockly, we will want to make sure all Sprite Lab blocks have style properties with valid values. If present, these styles will be used when rendering blocks instead of hard-coded HSV color values. This is critical to making our themes work as expected. The syntax for styles is also simpler, more maintainable, and easier to validate. We recently added styles to all the blocks that are defined in our levelbuilder block pools:
https://github.com/code-dot-org/code-dot-org/pull/50871 https://github.com/code-dot-org/code-dot-org/pull/50872 https://github.com/code-dot-org/code-dot-org/pull/50873 https://github.com/code-dot-org/code-dot-org/pull/50874
This data is not validated before being saved which means that blocks could potentially be created or modified without having a valid style listed. 

## Proposal
For block arguments with custom inputs, we validate the properties by comparing against a list of valid input types:
![image](https://user-images.githubusercontent.com/43474485/227576986-be98b1f2-8174-463c-b811-a89f7b269689.png)
https://github.com/code-dot-org/code-dot-org/blob/mike/validate-styles-on-block-edit-pages/apps/src/block_utils.js#L1003-L1010

If we export a list of styles from our default theme palette, we can adapt the logic above to validate block styles.
Now, if a levelbuilder enters an unexpected style, they are alerted in realtime so that they can fix it before saving:

![image](https://user-images.githubusercontent.com/43474485/227577825-45a98e41-34fb-4226-ac83-89247a8940e3.png)

Styles are a new convention and the list shown above is admittedly pretty long and hard to parse. In anticipation of some common mistakes, we can use the first few letters entered to suggest a "best guess" of the style the levelbuilder was looking for:

![image](https://user-images.githubusercontent.com/43474485/227578539-864e4717-cb27-4485-8e9d-5b6ae90f1a16.png)
![image](https://user-images.githubusercontent.com/43474485/227578893-805c7ac8-6114-4cce-bab5-f14b440dc3fb.png)
![image](https://user-images.githubusercontent.com/43474485/227578968-95686b4f-cedb-4f19-ac17-c24c78866a12.png)
If the first few letters aren't a good enough clue we can still provide the full list:
![image](https://user-images.githubusercontent.com/43474485/227579281-34affd46-d7da-4161-8685-35748921acf5.png)

Going forwards, we expect a convention where all or most blocks have styles. Adding this validation takes away some of the guesswork. 

Like the best features, this change was immediately useful to me as it quickly revealed that I had actually shipped one invalid block styles in the PR linked in the top section:
![image](https://user-images.githubusercontent.com/43474485/227579622-e64fccc8-2d69-4bbb-983c-4d243c74beeb.png)

(Fortunately, the `checkTouching` block is only usable today in CDO Blockly - which doesn't support these styles - so there's no chance that this bug impacted any user's experience.)

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
