### PR TITLE
Filter for applicable course offerings in Curriculum Catalog

### DIFF
--- a/dashboard/app/controllers/curriculum_catalog_controller.rb
+++ b/dashboard/app/controllers/curriculum_catalog_controller.rb
@@ -1,14 +1,6 @@
 class CurriculumCatalogController < ApplicationController
   # GET /catalog
   def index
-    @curricula_data = assignable_published_for_students_course_offerings.sort_by(&:display_name).map(&:serialize)
-  end
-
-  # We only want course offerings that are:
-  # - Assignable (course offering 'assignable' setting is true)
-  # - Published (associated unit group or unit 'published_state' setting is 'preview' or 'stable')
-  # - For students (associated unit group or unit 'participant_audience' setting is student)
-  private def assignable_published_for_students_course_offerings
-    CourseOffering.all.select {|co| co.assignable? && co.any_version_is_in_published_state? && co.get_participant_audience == 'student'}
+    @curricula_data = CourseOffering.assignable_published_for_students_course_offerings.sort_by(&:display_name).map(&:serialize)
   end
 end

--- a/dashboard/app/controllers/curriculum_catalog_controller.rb
+++ b/dashboard/app/controllers/curriculum_catalog_controller.rb
@@ -1,6 +1,14 @@
 class CurriculumCatalogController < ApplicationController
   # GET /catalog
   def index
-    @curricula_data = CourseOffering.all.order(:display_name).map(&:serialize)
+    @curricula_data = assignable_published_for_students_course_offerings.sort_by(&:display_name).map(&:serialize)
+  end
+
+  # We only want course offerings that are:
+  # - Assignable (course offering 'assignable' setting is true)
+  # - Published (associated unit group or unit 'published_state' setting is 'preview' or 'stable')
+  # - For students (associated unit group or unit 'participant_audience' setting is student)
+  private def assignable_published_for_students_course_offerings
+    CourseOffering.all.select {|co| co.assignable? && co.any_version_is_in_published_state? && co.get_participant_audience == 'student'}
   end
 end

--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -108,6 +108,12 @@ class CourseOffering < ApplicationRecord
     course_versions.any? {|cv| cv.content_root.is_a?(Unit) && cv.has_editor_experiment?(user)}
   end
 
+  # Checks if any course version has a published_state of 'preview' or 'stable'
+  def any_version_is_in_published_state?
+    published_states = ['preview', 'stable']
+    course_versions.any? {|cv| published_states.include?(cv.published_state)}
+  end
+
   def self.all_course_offerings
     if should_cache?
       @@course_offerings ||= CourseOffering.all.includes(course_versions: :content_root)

--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -122,6 +122,14 @@ class CourseOffering < ApplicationRecord
     end
   end
 
+  # We only want course offerings that are:
+  # - Assignable (course offering 'assignable' setting is true)
+  # - Published (associated unit group or unit 'published_state' setting is 'preview' or 'stable')
+  # - For students (associated unit group or unit 'participant_audience' setting is student)
+  def self.assignable_published_for_students_course_offerings
+    all_course_offerings.select {|co| co.assignable? && co.any_version_is_in_published_state? && co.get_participant_audience == 'student'}
+  end
+
   def self.assignable_course_offerings(user)
     all_course_offerings.select {|co| co.can_be_assigned?(user)}
   end

--- a/dashboard/test/models/course_offering_test.rb
+++ b/dashboard/test/models/course_offering_test.rb
@@ -310,18 +310,18 @@ class CourseOfferingTest < ActiveSupport::TestCase
   end
 
   test 'any_version_is_in_published_state? is true if one of the course versions have a published_state of preview or stable' do
-    unit1 = create(:script, name: 'unit1', family_name: 'family-11', version_year: '1991', is_course: true, published_state: 'beta')
+    unit1 = create(:script, name: 'unit1', family_name: 'family-12', version_year: '1991', is_course: true, published_state: 'beta')
     CourseOffering.add_course_offering(unit1)
-    unit2 = create(:script, name: 'unit2', family_name: 'family-11', version_year: '1992', is_course: true, published_state: 'preview')
+    unit2 = create(:script, name: 'unit2', family_name: 'family-12', version_year: '1992', is_course: true, published_state: 'preview')
     CourseOffering.add_course_offering(unit2)
 
     assert unit1.course_version.course_offering.any_version_is_in_published_state?
   end
 
   test 'any_version_is_in_published_state? is true if all of the course versions have a published_state of preview or stable' do
-    unit1 = create(:script, name: 'unit1', family_name: 'family-12', version_year: '1991', is_course: true, published_state: 'stable')
+    unit1 = create(:script, name: 'unit1', family_name: 'family-13', version_year: '1991', is_course: true, published_state: 'stable')
     CourseOffering.add_course_offering(unit1)
-    unit2 = create(:script, name: 'unit2', family_name: 'family-12', version_year: '1992', is_course: true, published_state: 'preview')
+    unit2 = create(:script, name: 'unit2', family_name: 'family-13', version_year: '1992', is_course: true, published_state: 'preview')
     CourseOffering.add_course_offering(unit2)
 
     assert unit1.course_version.course_offering.any_version_is_in_published_state?
@@ -331,32 +331,35 @@ class CourseOfferingTest < ActiveSupport::TestCase
     # Course offering that doesn't satisfy any of the conditions
     none_unit = create(:script, name: 'unit1', family_name: 'none', version_year: '1991', is_course: true, published_state: 'in_development', instructor_audience: 'universal_instructor', participant_audience: 'teacher')
     none_co = CourseOffering.add_course_offering(none_unit)
-    none_co.assignable = false
-    none_co.save!
+    none_co.update!(assignable: false)
+
     # Course offering that only satisfies the 'assignable' condition
     assignable_unit = create(:script, name: 'unit2', family_name: 'assignable', version_year: '1992', is_course: true, published_state: 'in_development', instructor_audience: 'universal_instructor', participant_audience: 'teacher')
     assignable_co = CourseOffering.add_course_offering(assignable_unit)
+
     # Course offering that only satisfies the 'published' condition
     published_unit = create(:script, name: 'unit3', family_name: 'published', version_year: '1993', is_course: true, published_state: 'stable', instructor_audience: 'universal_instructor', participant_audience: 'teacher')
     published_co = CourseOffering.add_course_offering(published_unit)
-    published_co.assignable = false
-    published_co.save!
+    published_co.update!(assignable: false)
+
     # Course offering that only satisfies the 'for student' condition
     for_student_unit = create(:script, name: 'unit4', family_name: 'for-student', version_year: '1994', is_course: true, published_state: 'in_development', instructor_audience: 'universal_instructor', participant_audience: 'student')
     for_student_co = CourseOffering.add_course_offering(for_student_unit)
-    for_student_co.assignable = false
-    for_student_co.save!
+    for_student_co.update!(assignable: false)
+
     # Course offering that only satisfies the 'assignable' and 'published' condition
     assignable_published_unit = create(:script, name: 'unit5', family_name: 'assignable-published', version_year: '1995', is_course: true, published_state: 'stable', instructor_audience: 'universal_instructor', participant_audience: 'teacher')
     assignable_published_co = CourseOffering.add_course_offering(assignable_published_unit)
+
     # Course offering that only satisfies the 'assignable' and 'for student' condition
     assignable_for_student_unit = create(:script, name: 'unit6', family_name: 'assignable-for-student', version_year: '1996', is_course: true, published_state: 'in_development', instructor_audience: 'universal_instructor', participant_audience: 'student')
     assignable_for_student_co = CourseOffering.add_course_offering(assignable_for_student_unit)
+
     # Course offering that only satisfies the 'published' and 'for student' condition
     published_for_student_unit = create(:script, name: 'unit7', family_name: 'published-for-student', version_year: '1997', is_course: true, published_state: 'stable', instructor_audience: 'universal_instructor', participant_audience: 'student')
     published_for_student_co = CourseOffering.add_course_offering(published_for_student_unit)
-    published_for_student_co.assignable = false
-    published_for_student_co.save!
+    published_for_student_co.update!(assignable: false)
+
     # Course offering that satisfies all 3 conditions
     all_unit = create(:script, name: 'unit8', family_name: 'all', version_year: '1998', is_course: true, published_state: 'stable', instructor_audience: 'universal_instructor', participant_audience: 'student')
     all_co = CourseOffering.add_course_offering(all_unit)

--- a/dashboard/test/models/course_offering_test.rb
+++ b/dashboard/test/models/course_offering_test.rb
@@ -300,6 +300,79 @@ class CourseOfferingTest < ActiveSupport::TestCase
     refute unit1.course_version.course_offering.any_versions_in_development?
   end
 
+  test 'any_version_is_in_published_state? is false if none of the course versions have a published_state of preview or stable' do
+    unit1 = create(:script, name: 'unit1', family_name: 'family-10', version_year: '1991', is_course: true, published_state: 'beta')
+    CourseOffering.add_course_offering(unit1)
+    unit2 = create(:script, name: 'unit2', family_name: 'family-10', version_year: '1992', is_course: true, published_state: 'beta')
+    CourseOffering.add_course_offering(unit2)
+
+    refute unit1.course_version.course_offering.any_version_is_in_published_state?
+  end
+
+  test 'any_version_is_in_published_state? is true if one of the course versions have a published_state of preview or stable' do
+    unit1 = create(:script, name: 'unit1', family_name: 'family-11', version_year: '1991', is_course: true, published_state: 'beta')
+    CourseOffering.add_course_offering(unit1)
+    unit2 = create(:script, name: 'unit2', family_name: 'family-11', version_year: '1992', is_course: true, published_state: 'preview')
+    CourseOffering.add_course_offering(unit2)
+
+    assert unit1.course_version.course_offering.any_version_is_in_published_state?
+  end
+
+  test 'any_version_is_in_published_state? is true if all of the course versions have a published_state of preview or stable' do
+    unit1 = create(:script, name: 'unit1', family_name: 'family-12', version_year: '1991', is_course: true, published_state: 'stable')
+    CourseOffering.add_course_offering(unit1)
+    unit2 = create(:script, name: 'unit2', family_name: 'family-12', version_year: '1992', is_course: true, published_state: 'preview')
+    CourseOffering.add_course_offering(unit2)
+
+    assert unit1.course_version.course_offering.any_version_is_in_published_state?
+  end
+
+  test 'assignable_published_for_students_course_offerings filters only for assignable, published, and for student course offerings' do
+    # Course offering that doesn't satisfy any of the conditions
+    none_unit = create(:script, name: 'unit1', family_name: 'none', version_year: '1991', is_course: true, published_state: 'in_development', instructor_audience: 'universal_instructor', participant_audience: 'teacher')
+    none_co = CourseOffering.add_course_offering(none_unit)
+    none_co.assignable = false
+    none_co.save!
+    # Course offering that only satisfies the 'assignable' condition
+    assignable_unit = create(:script, name: 'unit2', family_name: 'assignable', version_year: '1992', is_course: true, published_state: 'in_development', instructor_audience: 'universal_instructor', participant_audience: 'teacher')
+    assignable_co = CourseOffering.add_course_offering(assignable_unit)
+    # Course offering that only satisfies the 'published' condition
+    published_unit = create(:script, name: 'unit3', family_name: 'published', version_year: '1993', is_course: true, published_state: 'stable', instructor_audience: 'universal_instructor', participant_audience: 'teacher')
+    published_co = CourseOffering.add_course_offering(published_unit)
+    published_co.assignable = false
+    published_co.save!
+    # Course offering that only satisfies the 'for student' condition
+    for_student_unit = create(:script, name: 'unit4', family_name: 'for-student', version_year: '1994', is_course: true, published_state: 'in_development', instructor_audience: 'universal_instructor', participant_audience: 'student')
+    for_student_co = CourseOffering.add_course_offering(for_student_unit)
+    for_student_co.assignable = false
+    for_student_co.save!
+    # Course offering that only satisfies the 'assignable' and 'published' condition
+    assignable_published_unit = create(:script, name: 'unit5', family_name: 'assignable-published', version_year: '1995', is_course: true, published_state: 'stable', instructor_audience: 'universal_instructor', participant_audience: 'teacher')
+    assignable_published_co = CourseOffering.add_course_offering(assignable_published_unit)
+    # Course offering that only satisfies the 'assignable' and 'for student' condition
+    assignable_for_student_unit = create(:script, name: 'unit6', family_name: 'assignable-for-student', version_year: '1996', is_course: true, published_state: 'in_development', instructor_audience: 'universal_instructor', participant_audience: 'student')
+    assignable_for_student_co = CourseOffering.add_course_offering(assignable_for_student_unit)
+    # Course offering that only satisfies the 'published' and 'for student' condition
+    published_for_student_unit = create(:script, name: 'unit7', family_name: 'published-for-student', version_year: '1997', is_course: true, published_state: 'stable', instructor_audience: 'universal_instructor', participant_audience: 'student')
+    published_for_student_co = CourseOffering.add_course_offering(published_for_student_unit)
+    published_for_student_co.assignable = false
+    published_for_student_co.save!
+    # Course offering that satisfies all 3 conditions
+    all_unit = create(:script, name: 'unit8', family_name: 'all', version_year: '1998', is_course: true, published_state: 'stable', instructor_audience: 'universal_instructor', participant_audience: 'student')
+    all_co = CourseOffering.add_course_offering(all_unit)
+
+    filtered_course_offerings = CourseOffering.assignable_published_for_students_course_offerings
+
+    refute filtered_course_offerings.include?(none_co)
+    refute filtered_course_offerings.include?(assignable_co)
+    refute filtered_course_offerings.include?(published_co)
+    refute filtered_course_offerings.include?(for_student_co)
+    refute filtered_course_offerings.include?(assignable_published_co)
+    refute filtered_course_offerings.include?(assignable_for_student_co)
+    refute filtered_course_offerings.include?(published_for_student_co)
+    assert filtered_course_offerings.include?(all_co)
+  end
+
   test 'can_be_assigned? is false if its an unassignable course' do
     unassignable_course_offering = create :course_offering
     refute unassignable_course_offering.can_be_assigned?(@student)


### PR DESCRIPTION
Only show applicable course offerings on the [Curriculum Catalog page](studio.code.org/catalog). Applicable courses are ones that are all of the following:
- Assignable (course offering 'assignable' setting is true)
- Published (associated unit group or unit 'published_state' setting is 'preview' or 'stable')
- For students (associated unit group or unit 'participant_audience' setting is student)

After filtering, the Curriculum Catalog page now only shows 74 course offerings (as opposed to the previous 400+):
![page1](https://user-images.githubusercontent.com/56283563/227663218-276885ad-4cde-4e7e-a18a-10ea7d1ae161.JPG)
![page2](https://user-images.githubusercontent.com/56283563/227663222-9ad36c8b-dcac-4101-811f-8d6de5a810b3.JPG)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?modal=detail&selectedIssue=ACQ-487&assignee=60d62161f65054006980bd71)

## Testing story
Local testing and adding unit tests.

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
