### PR TITLE
Project Beats: move selected block ID to Redux

### DIFF
--- a/apps/src/music/redux/musicRedux.ts
+++ b/apps/src/music/redux/musicRedux.ts
@@ -9,11 +9,13 @@ const registerReducers = require('@cdo/apps/redux').registerReducers;
 interface MusicState {
   isPlaying: boolean;
   currentPlayheadPosition: number;
+  selectedBlockId: string | undefined;
 }
 
 const initialState: MusicState = {
   isPlaying: false,
-  currentPlayheadPosition: 0
+  currentPlayheadPosition: 0,
+  selectedBlockId: undefined
 };
 
 const musicSlice = createSlice({
@@ -25,6 +27,26 @@ const musicSlice = createSlice({
     },
     setCurrentPlayheadPosition: (state, action: PayloadAction<number>) => {
       state.currentPlayheadPosition = action.payload;
+    },
+    // If the user selects a block ID by clicking a timeline element, then
+    // set the selected block ID.
+    // If the user selects the currently-selected block ID, then unselect it.
+    // If undefined is provided, we'll unselect all blocks.
+    // During playback, we are dynamically highlighting blocks which overrides
+    // the selection, so just do nothing here.
+    selectBlockId: (state, action: PayloadAction<string>) => {
+      if (state.isPlaying) {
+        return;
+      }
+
+      if (state.selectedBlockId === action.payload) {
+        state.selectedBlockId = undefined;
+      } else {
+        state.selectedBlockId = action.payload;
+      }
+    },
+    clearSelectedBlockId: state => {
+      state.selectedBlockId = undefined;
     }
   }
 });
@@ -35,4 +57,9 @@ const musicSlice = createSlice({
 // to be connected to this state.
 registerReducers({music: musicSlice.reducer});
 
-export const {setIsPlaying, setCurrentPlayheadPosition} = musicSlice.actions;
+export const {
+  setIsPlaying,
+  setCurrentPlayheadPosition,
+  selectBlockId,
+  clearSelectedBlockId
+} = musicSlice.actions;

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -27,7 +27,8 @@ import MusicLibrary from '../player/MusicLibrary';
 import {
   setIsPlaying,
   setCurrentPlayheadPosition,
-  clearSelectedBlockId
+  clearSelectedBlockId,
+  selectBlockId
 } from '../redux/musicRedux';
 
 const baseUrl = 'https://curriculum.code.org/media/musiclab/';
@@ -178,7 +179,10 @@ class UnconnectedMusicView extends React.Component {
       );
     }
 
-    if (prevProps.selectedBlockId !== this.props.selectedBlockId) {
+    if (
+      prevProps.selectedBlockId !== this.props.selectedBlockId &&
+      !this.props.isPlaying
+    ) {
       this.musicBlocklyWorkspace.selectBlock(this.props.selectedBlockId);
     }
   }
@@ -304,7 +308,10 @@ class UnconnectedMusicView extends React.Component {
     }
 
     if (e.type === Blockly.Events.SELECTED) {
-      if (!this.props.isPlaying) {
+      if (
+        !this.props.isPlaying &&
+        e.newElementId !== this.props.selectedBlockId
+      ) {
         this.props.selectBlockId(e.newElementId);
       }
     }
@@ -572,6 +579,7 @@ const MusicView = connect(
     setIsPlaying: isPlaying => dispatch(setIsPlaying(isPlaying)),
     setCurrentPlayheadPosition: currentPlayheadPosition =>
       dispatch(setCurrentPlayheadPosition(currentPlayheadPosition)),
+    selectBlockId: blockId => dispatch(selectBlockId(blockId)),
     clearSelectedBlockId: () => dispatch(clearSelectedBlockId())
   })
 )(UnconnectedMusicView);

--- a/apps/src/music/views/Timeline.jsx
+++ b/apps/src/music/views/Timeline.jsx
@@ -1,4 +1,3 @@
-import PropTypes from 'prop-types';
 import React, {useContext} from 'react';
 import moduleStyles from './timeline.module.scss';
 import classNames from 'classnames';
@@ -8,7 +7,8 @@ import TimelineSimple2Events from './TimelineSimple2Events';
 import {getBlockMode} from '../appConfig';
 import {BlockMode} from '../constants';
 import {PlayerUtilsContext} from '../context';
-import {useSelector} from 'react-redux';
+import {useDispatch, useSelector} from 'react-redux';
+import {clearSelectedBlockId} from '../redux/musicRedux';
 
 const barWidth = 60;
 const minNumMeasures = 30;
@@ -18,8 +18,9 @@ const eventVerticalSpace = 2;
 /**
  * Renders the music playback timeline.
  */
-const Timeline = ({selectedBlockId, onBlockSelected}) => {
+const Timeline = () => {
   const isPlaying = useSelector(state => state.music.isPlaying);
+  const dispatch = useDispatch();
   const currentPlayheadPosition = useSelector(
     state => state.music.currentPlayheadPosition
   );
@@ -52,8 +53,6 @@ const Timeline = ({selectedBlockId, onBlockSelected}) => {
     : null;
 
   const timelineElementProps = {
-    selectedBlockId,
-    onBlockSelected,
     barWidth,
     eventVerticalSpace,
     getEventHeight
@@ -70,7 +69,7 @@ const Timeline = ({selectedBlockId, onBlockSelected}) => {
       <div
         id="timeline-container"
         className={moduleStyles.container}
-        onClick={() => onBlockSelected(undefined)}
+        onClick={() => dispatch(clearSelectedBlockId())}
       >
         <div className={moduleStyles.fullWidthOverlay}>
           {arrayOfMeasures.map((measure, index) => {
@@ -126,9 +125,6 @@ const Timeline = ({selectedBlockId, onBlockSelected}) => {
   );
 };
 
-Timeline.propTypes = {
-  selectedBlockId: PropTypes.string,
-  onBlockSelected: PropTypes.func
-};
+Timeline.propTypes = {};
 
 export default Timeline;

--- a/apps/src/music/views/TimelineElement.jsx
+++ b/apps/src/music/views/TimelineElement.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 import moduleStyles from './timeline.module.scss';
-import {useSelector} from 'react-redux';
+import {useDispatch, useSelector} from 'react-redux';
 
 // TODO: Unify type constants and colors with those SoundPanel.jsx
 const typeToColorClass = {
@@ -24,11 +24,11 @@ const TimelineElement = ({
   top,
   left,
   when,
-  skipContext,
-  selectedBlockId,
-  onBlockSelected
+  skipContext
 }) => {
   const isPlaying = useSelector(state => state.music.isPlaying);
+  const selectedBlockId = useSelector(state => state.music.selectedBlockId);
+  const dispatch = useDispatch();
   const currentPlayheadPosition = useSelector(
     state => state.music.currentPlayheadPosition
   );
@@ -56,7 +56,7 @@ const TimelineElement = ({
         isInsideRandom && moduleStyles.timelineElementInsideRandom,
         isSkipSound && moduleStyles.timelineElementSkipSound,
         isBlockSelected && moduleStyles.timelineElementBlockSelected,
-        onBlockSelected && !isPlaying && moduleStyles.timelineElementClickable
+        !isPlaying && moduleStyles.timelineElementClickable
       )}
       style={{
         width: barWidth * eventData.length,
@@ -65,9 +65,7 @@ const TimelineElement = ({
         left
       }}
       onClick={event => {
-        if (onBlockSelected && !isPlaying) {
-          onBlockSelected(eventData.blockId);
-        }
+        dispatch(selectedBlockId(eventData.blockId));
         event.stopPropagation();
       }}
     >
@@ -83,9 +81,7 @@ TimelineElement.propTypes = {
   top: PropTypes.number.isRequired,
   left: PropTypes.number,
   when: PropTypes.number.isRequired,
-  skipContext: PropTypes.object,
-  selectedBlockId: PropTypes.string,
-  onBlockSelected: PropTypes.func
+  skipContext: PropTypes.object
 };
 
 export default TimelineElement;

--- a/apps/src/music/views/TimelineElement.jsx
+++ b/apps/src/music/views/TimelineElement.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import classNames from 'classnames';
 import moduleStyles from './timeline.module.scss';
 import {useDispatch, useSelector} from 'react-redux';
+import {selectBlockId} from '../redux/musicRedux';
 
 // TODO: Unify type constants and colors with those SoundPanel.jsx
 const typeToColorClass = {
@@ -65,7 +66,7 @@ const TimelineElement = ({
         left
       }}
       onClick={event => {
-        dispatch(selectedBlockId(eventData.blockId));
+        dispatch(selectBlockId(eventData.blockId));
         event.stopPropagation();
       }}
     >

--- a/apps/src/music/views/TimelineSimple2Events.jsx
+++ b/apps/src/music/views/TimelineSimple2Events.jsx
@@ -7,8 +7,6 @@ import TimelineElement from './TimelineElement';
  * Renders timeline events for the simple2 model.
  */
 const TimelineSimple2Events = ({
-  selectedBlockId,
-  onBlockSelected,
   barWidth,
   eventVerticalSpace,
   getEventHeight
@@ -125,8 +123,6 @@ const TimelineSimple2Events = ({
             left={barWidth * (eventData.when - 1)}
             when={eventData.when}
             skipContext={eventData.skipContext}
-            selectedBlockId={selectedBlockId}
-            onBlockSelected={onBlockSelected}
           />
         ))}
       </div>
@@ -135,8 +131,6 @@ const TimelineSimple2Events = ({
 };
 
 TimelineSimple2Events.propTypes = {
-  selectedBlockId: PropTypes.string,
-  onBlockSelected: PropTypes.func,
   barWidth: PropTypes.number.isRequired,
   eventVerticalSpace: PropTypes.number.isRequired,
   getEventHeight: PropTypes.func.isRequired


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Another redux migration. Just trying to chip away at the amount of state MusicView needs to keep track of.

## Testing story

Tested locally. No user-facing changes.
