### PR TITLE
Sharing: links sent by SMS get ?sms=true

### DIFF
--- a/dashboard/app/controllers/sms_controller.rb
+++ b/dashboard/app/controllers/sms_controller.rb
@@ -20,7 +20,8 @@ class SmsController < ApplicationController
   end
 
   private def send_sms_link(link, phone)
-    body = "Check this out on Code Studio: #{link} (reply STOP to stop receiving this)"
+    decorated_link = link + '?sms=true'
+    body = "Check this out on Code Studio: #{decorated_link} (reply STOP to stop receiving this)"
     send_sms(body, phone)
   end
 

--- a/dashboard/test/controllers/sms_controller_test.rb
+++ b/dashboard/test/controllers/sms_controller_test.rb
@@ -13,7 +13,7 @@ class SmsControllerTest < ActionController::TestCase
     expected_twilio_options = {
       messaging_service_sid: 'fake_messaging_service_sid',
       to: 'xxxxxx',
-      body: "Check this out on Code Studio: http://test.host/c/#{level_source.id} (reply STOP to stop receiving this)"
+      body: "Check this out on Code Studio: http://test.host/c/#{level_source.id}?sms=true (reply STOP to stop receiving this)"
     }
 
     twilio_messages_mock = stub(:messages)
@@ -34,7 +34,7 @@ class SmsControllerTest < ActionController::TestCase
     expected_twilio_options = {
       messaging_service_sid: 'fake_messaging_service_sid',
       to: 'xxxxxx',
-      body: "Check this out on Code Studio: #{project_share_url} (reply STOP to stop receiving this)"
+      body: "Check this out on Code Studio: #{project_share_url}?sms=true (reply STOP to stop receiving this)"
     }
 
     twilio_messages_mock = stub(:messages)


### PR DESCRIPTION
To help understand whether links shared "by phone" are being used, this adds `?sms=true` to the end of each URL shared via SMS.

I double-checked logs of ~2400 SMS messages and didn't see any URLs that have `?` in them already, so this seems safe to append.