### PR TITLE
Add the PL skinny bannner to /csd /csp and /csa

### DIFF
--- a/pegasus/sites.v3/code.org/public/educate/csa.md.erb
+++ b/pegasus/sites.v3/code.org/public/educate/csa.md.erb
@@ -7,6 +7,8 @@ style_min: true
 
 <link href="/css/csa.css" rel="stylesheet">
 
+<%= view :professional_learning_marketing_banner, link_address: '/educate/professional-learning/middle-high', button_label: 'Learn more' %>
+
 <%=view :solid_block_header, :title=>"AP® Computer Science A" %>
 
 <section class="top">

--- a/pegasus/sites.v3/code.org/public/educate/csd.md.erb
+++ b/pegasus/sites.v3/code.org/public/educate/csd.md.erb
@@ -4,6 +4,8 @@ video_player: true
 theme: responsive
 ---
 
+<%= view :professional_learning_marketing_banner, link_address: '/educate/professional-learning/middle-high', button_label: 'Learn more' %>
+
 <%=view :solid_block_header, :title=>"Computer Science Discoveries" %>
 
 <link href="/shared/css/course-blocks.css", type="text/css", rel="stylesheet"></link>

--- a/pegasus/sites.v3/code.org/public/educate/csp.md.erb
+++ b/pegasus/sites.v3/code.org/public/educate/csp.md.erb
@@ -5,6 +5,8 @@ theme: responsive
 style_min: true
 ---
 
+<%= view :professional_learning_marketing_banner, link_address: '/educate/professional-learning/middle-high', button_label: 'Learn more' %>
+
 <%=view :solid_block_header, :title=>"Computer Science Principles" %>
 
 <link href="/shared/css/course-blocks.css", type="text/css", rel="stylesheet"></link>


### PR DESCRIPTION
Adds the PL skinny banner to code.org/educate/csd, code.org/educate/csp, and code.org/educate/csa.

### CSD
<img width="1144" alt="Screenshot 2023-03-27 at 7 51 55 AM" src="https://user-images.githubusercontent.com/208083/227934045-b8e2b9f7-ef39-4a20-8d94-49812874e1d5.png">


### CSP

<img width="1146" alt="Screenshot 2023-03-27 at 7 52 08 AM" src="https://user-images.githubusercontent.com/208083/227934059-af18ab45-5312-4551-b67f-c09f7615b131.png">

### CSA

<img width="1145" alt="Screenshot 2023-03-27 at 7 52 32 AM" src="https://user-images.githubusercontent.com/208083/227934054-01fc8e9a-5c53-421c-b5ab-15df46fb3c99.png">
