### PR TITLE
Script to backfill allow_multiple_attempts

### DIFF
--- a/bin/curriculum/backfill-allow-multiple-attempts.rb
+++ b/bin/curriculum/backfill-allow-multiple-attempts.rb
@@ -1,0 +1,72 @@
+#!/usr/bin/env ruby
+
+require_relative '../../deployment'
+raise unless [:development, :adhoc, :levelbuilder].include? rack_env
+
+# Wait until after initial error checking before loading the rails environment.
+def require_rails_env
+  puts "loading rails environment..."
+  start_time = Time.now
+  require_relative '../../dashboard/config/environment'
+  puts "rails environment loaded in #{(Time.now - start_time).to_i} seconds."
+end
+
+require_rails_env
+
+def level_is_standalone?(level)
+  level.script_levels.count > 0
+end
+
+def level_is_contained?(level)
+  level.levels_parent_levels.count {|l| l.kind == 'contained'} > 0
+end
+
+def find_union(standalone_levels, contained_levels)
+  standalone_level_names = standalone_levels.map(&:name)
+  contained_levels.filter {|l| standalone_level_names.include?(l.name)}.uniq
+end
+
+def backfill_free_response_levels
+  standalone_free_response_levels = FreeResponse.all.filter {|l| level_is_standalone?(l)}
+  contained_free_response_levels = FreeResponse.all.filter {|l| level_is_contained?(l)}
+  free_response_levels_to_flag = find_union(standalone_free_response_levels, contained_free_response_levels)
+  standalone_free_response_levels -= free_response_levels_to_flag
+  puts "Free Response levels to manually check:"
+  free_response_levels_to_flag.each {|l| puts l.name}
+
+  standalone_free_response_levels.each do |level|
+    level.allow_multiple_attempts = "true"
+    level.save!
+  end
+
+  FreeResponse.all.filter {|l| l.allow_multiple_attempts.nil?}.each do |level|
+    level.allow_multiple_attempts = "false"
+    level.save!
+  end
+end
+
+def backfill_match_levels
+  standalone_match_levels = Match.all.filter {|l| level_is_standalone?(l)}
+  contained_match_levels = Match.all.filter {|l| level_is_contained?(l)}
+  match_levels_to_flag = find_union(standalone_match_levels, contained_match_levels)
+  standalone_match_levels -= match_levels_to_flag
+  puts "Match levels to manually check:"
+  match_levels_to_flag.each {|l| puts l.name}
+
+  standalone_match_levels.each do |level|
+    level.allow_multiple_attempts = "true"
+    level.save!
+  end
+
+  Match.all.filter {|l| l.allow_multiple_attempts.nil?}.each do |level|
+    level.allow_multiple_attempts = "false"
+    level.save!
+  end
+end
+
+def main
+  backfill_free_response_levels
+  backfill_match_levels
+end
+
+main

--- a/bin/curriculum/backfill-allow-multiple-attempts.rb
+++ b/bin/curriculum/backfill-allow-multiple-attempts.rb
@@ -30,17 +30,17 @@ def backfill_free_response_levels
   standalone_free_response_levels = FreeResponse.all.filter {|l| level_is_standalone?(l)}
   contained_free_response_levels = FreeResponse.all.filter {|l| level_is_contained?(l)}
   free_response_levels_to_flag = find_union(standalone_free_response_levels, contained_free_response_levels)
-  standalone_free_response_levels -= free_response_levels_to_flag
+  contained_free_response_levels -= free_response_levels_to_flag
   puts "Free Response levels to manually check:"
   free_response_levels_to_flag.each {|l| puts l.name}
 
-  standalone_free_response_levels.each do |level|
-    level.allow_multiple_attempts = "true"
+  contained_free_response_levels.each do |level|
+    level.allow_multiple_attempts = "false"
     level.save!
   end
 
   FreeResponse.all.filter {|l| l.allow_multiple_attempts.nil?}.each do |level|
-    level.allow_multiple_attempts = "false"
+    level.allow_multiple_attempts = "true"
     level.save!
   end
 end
@@ -49,17 +49,17 @@ def backfill_match_levels
   standalone_match_levels = Match.all.filter {|l| level_is_standalone?(l)}
   contained_match_levels = Match.all.filter {|l| level_is_contained?(l)}
   match_levels_to_flag = find_union(standalone_match_levels, contained_match_levels)
-  standalone_match_levels -= match_levels_to_flag
+  contained_match_levels -= match_levels_to_flag
   puts "Match levels to manually check:"
   match_levels_to_flag.each {|l| puts l.name}
 
-  standalone_match_levels.each do |level|
-    level.allow_multiple_attempts = "true"
+  contained_match_levels.each do |level|
+    level.allow_multiple_attempts = "false"
     level.save!
   end
 
   Match.all.filter {|l| l.allow_multiple_attempts.nil?}.each do |level|
-    level.allow_multiple_attempts = "false"
+    level.allow_multiple_attempts = "true"
     level.save!
   end
 end

--- a/dashboard/app/dsl/match_dsl.rb
+++ b/dashboard/app/dsl/match_dsl.rb
@@ -17,6 +17,10 @@ class MatchDSL < ContentDSL
 
   def layout(text) @hash[:layout] = text end
 
+  def allow_multiple_attempts(bool)
+    @hash[:allow_multiple_attempts] = bool.to_s.to_bool
+  end
+
   # @override
   def self.i18n_fields
     super + %w(

--- a/dashboard/app/dsl/match_dsl.rb
+++ b/dashboard/app/dsl/match_dsl.rb
@@ -18,7 +18,7 @@ class MatchDSL < ContentDSL
   def layout(text) @hash[:layout] = text end
 
   def allow_multiple_attempts(bool)
-    @hash[:allow_multiple_attempts] = bool.to_s.to_bool
+    @hash[:allow_multiple_attempts] = ActiveModel::Type::Boolean.new.cast(bool)
   end
 
   # @override

--- a/dashboard/app/models/levels/dsl_defined.rb
+++ b/dashboard/app/models/levels/dsl_defined.rb
@@ -149,7 +149,7 @@ class DSLDefined < Level
 
   def existing_filename
     # Find a file in config/scripts/**/*.[class]* containing the string "name '[name]'"
-    grep_string = "grep -lir \"name '#{name}'\" --include=*.#{self.class.to_s.underscore}* config/scripts --color=never"
+    grep_string = "grep -lir \"name '#{name}'\" --include=*.#{self.class.to_s.underscore}* #{Rails.root}/config/scripts --color=never"
     `#{grep_string}`.chomp
   end
 

--- a/dashboard/config/scripts/sp_vpl_21_mod2_progress_c4u.multi
+++ b/dashboard/config/scripts/sp_vpl_21_mod2_progress_c4u.multi
@@ -6,7 +6,7 @@ wrong 'Level 3'
 wrong 'Level 4'
 wrong 'Level 8'
 right 'Level 9'
-
+allow_multiple_attempts true
 
 markdown <<MARKDOWN
 ![Image showing two student progressions. Student A has completed all ten levels, while Student B has not completed levels 5, 6, 7, and 9.](https://images.code.org/c92e6cd9ee2669a069e72e67b919af2e-image-1625773034493.36.58 PM.png)

--- a/dashboard/config/scripts/test_contained_multi.multi
+++ b/dashboard/config/scripts/test_contained_multi.multi
@@ -6,6 +6,7 @@ wrong '0', feedback: 'No, that is 1 - 1.'
 wrong '1', feedback: 'No, that is 1 * 1.'
 right '2', feedback: 'Yes, you are a genius!'
 wrong '4', feedback: 'No, that is not even close.'
+allow_multiple_attempts false
 
 markdown <<MARKDOWN
 Test **markdown** _here_

--- a/dashboard/test/controllers/levels_controller_test.rb
+++ b/dashboard/test/controllers/levels_controller_test.rb
@@ -700,7 +700,7 @@ class LevelsControllerTest < ActionController::TestCase
   end
 
   test "should load file contents when editing a dsl defined level" do
-    level_path = 'config/scripts/test_demo_level.external'
+    level_path = "#{Rails.root}/config/scripts/test_demo_level.external"
     contents = File.read(level_path)
     data, _ = External.parse(contents, level_path)
     External.setup data
@@ -713,7 +713,7 @@ class LevelsControllerTest < ActionController::TestCase
   end
 
   test "should load encrypted file contents when editing a dsl defined level with the wrong encryption key" do
-    level_path = 'config/scripts/test_external_markdown.external'
+    level_path = "#{Rails.root}/config/scripts/test_external_markdown.external"
     contents = File.read(level_path)
     data, _ = External.parse(contents, level_path)
     External.setup data


### PR DESCRIPTION
This PR adds a script to backfill all Match and FreeResponse levels (and their descendants, including Multi levels) to have a value for `allow_multiple_attempts`. I will run this script on the levelbuilder machine after this PR is deployed there. This update touches every Match and FreeResponse level, so it would've been a very difficult PR to review. Plus, there were some changes in the level files that were due to local differences.

The core logic here is:
- standalone levels in a course should have `allow_multiple_attempts` set to true
- Contained levels should have `allow_multiple_attempts` set to false
- standalone levels within a BubbleChoice level should have `allow_multiple_attempts` set to true
- levels within LevelGroups will ignore this field 

As a result, I simply go through each contained level and set this field to false and default every other level to true. There are two levels that were flagged; I have included those levels in this PR:
- `Test Contained Multi` is used as a contained level in allthethings and a standalone level in allthehiddenthings. We don't seem to use the latter so I set `allow_multiple_attempts` to false
- `SP-VPL-21-mod2-progress-c4u` is used as a standalone level in several script and is a contained level in a level called "dan-jess-delete-later", which itself is not in any units. Therefore, I set `allow_multiple_attempts` to true.

FreeResponse levels are [written on save](https://github.com/code-dot-org/code-dot-org/blob/80e66f2642704fe1a2c1b57a198bc1a8c6b9bb15/dashboard/app/models/levels/level.rb#L58) but the DSL levels have much more complex logic. I ended up needing to append the field manually then run it through `assign_attributes`, which is overridden [here](https://github.com/code-dot-org/code-dot-org/blob/80e66f2642704fe1a2c1b57a198bc1a8c6b9bb15/dashboard/app/models/levels/dsl_defined.rb#L204).

## Rollout plan

I will run this script on levelbuilder one weekday morning. Ideally, I can run it early enough that no curriculum writers will be working yet and I can get all of these changes into a single PR. Then, if we hear of any issues, that PR can be rolled back cleanly.

There are a handful of levels that fail to update locally for me. These levels don't seem to be editable in general but I'll take a closer look when I run this script on levelbuilder. Locally, this script took 14 minutes to run for me and I expect a similar length run on the levelbuilder machine.
