### PR TITLE
Deliver pd emails immediately rather than queueing first

### DIFF
--- a/dashboard/bin/scheduled_pd_application_emails
+++ b/dashboard/bin/scheduled_pd_application_emails
@@ -4,7 +4,7 @@ abort 'Script already running' unless only_one_running?(__FILE__)
 
 require_relative '../config/environment'
 
-def queue_pd_reminder_emails
+def send_pd_reminder_emails
   # For each teacher application, queue up one reminder email if their admin
   # hasn't yet responded.
   Pd::Application::TeacherApplication.where(
@@ -17,15 +17,11 @@ def queue_pd_reminder_emails
 
   # Queue reminder emails for teachers that have been accepted but have not yet
   # registered for a workshop.
-  Services::RegistrationReminder.queue_registration_reminders!
+  Services::RegistrationReminder.send_registration_reminders!
 
   # Queue reminder emails for teachers who have started an application but
   # have not completed it
-  Services::CompleteApplicationReminder.queue_complete_application_reminders!
+  Services::CompleteApplicationReminder.send_complete_application_reminders!
 end
 
-# First, add PD reminder emails to the queue.
-queue_pd_reminder_emails
-
-# Second, send all queued emails.
-Pd::Application::Email.send_all_queued_emails
+send_pd_reminder_emails

--- a/dashboard/lib/services/complete_application_reminder.rb
+++ b/dashboard/lib/services/complete_application_reminder.rb
@@ -5,13 +5,13 @@ class Services::CompleteApplicationReminder
     #
     # We send reminders to complete an application 7 days after an applicant has last saved their application,
     # another one 14 days after an applicant has last saved their application.
-    def queue_complete_application_reminders!
+    def send_complete_application_reminders!
       applications_needing_initial_reminder.each do |application|
-        application.queue_email 'complete_application_initial_reminder'
+        application.queue_email 'complete_application_initial_reminder', deliver_now: true
       end
 
       applications_needing_final_reminder.each do |application|
-        application.queue_email 'complete_application_final_reminder'
+        application.queue_email 'complete_application_final_reminder', deliver_now: true
       end
     end
 

--- a/dashboard/lib/services/registration_reminder.rb
+++ b/dashboard/lib/services/registration_reminder.rb
@@ -2,19 +2,19 @@ class Services::RegistrationReminder
   # Don't send reminders for applications created prior to this date
   REMINDER_START_DATE = Date.new(2019, 10, 1)
 
-  # This method queues enrollment reminder emails for any applications that are eligible for a
+  # This method sends enrollment reminder emails for any applications that are eligible for a
   # reminder.  It is designed to be called repeatedly (e.g. from a cronjob).
   #
   # This is an enrollment reminder email for any teacher that has been accepted, but has not
   # registered in a workshop. This form will automatically be sent 2 weeks after the first
   # registration email was sent. If the teacher is still not registered after another 1 week,
   # a second (and last) email will be sent.
-  def self.queue_registration_reminders!
+  def self.send_registration_reminders!
     (
       applications_needing_first_reminder |
       applications_needing_second_reminder
     ).each do |application|
-      application.queue_email 'registration_reminder'
+      application.queue_email 'registration_reminder', deliver_now: true
     end
   end
 

--- a/dashboard/test/lib/services/complete_application_reminder_test.rb
+++ b/dashboard/test/lib/services/complete_application_reminder_test.rb
@@ -1,7 +1,11 @@
 require 'test_helper'
 
 class Services::CompleteApplicationReminderTest < ActiveSupport::TestCase
-  test 'queue_registration_reminders!' do
+  setup do
+    Pd::Application::TeacherApplication.any_instance.stubs(:deliver_email)
+  end
+
+  test 'send_complete_application_reminders!' do
     # The expected behavior of this method is to find applications needing incomplete reminder
     # emails and queue up the emails to be sent at the appropriate times.  It runs on a cronjob.
     # Here, we walk through the typical flow for an application and verify that emails are queued
@@ -10,58 +14,48 @@ class Services::CompleteApplicationReminderTest < ActiveSupport::TestCase
     Timecop.freeze do
       # Initial creation: No reminders
       application = create :pd_teacher_application, status: 'incomplete'
-      Services::CompleteApplicationReminder.queue_complete_application_reminders!
+      Services::CompleteApplicationReminder.send_complete_application_reminders!
       assert_empty application.emails.where(email_type: 'complete_application_initial_reminder')
       assert_empty application.emails.where(email_type: 'complete_application_final_reminder')
 
       # First email is due in 7 days. At 6 days, no email yet:
       Timecop.travel 6.days
-      Services::CompleteApplicationReminder.queue_complete_application_reminders!
+      Services::CompleteApplicationReminder.send_complete_application_reminders!
       assert_empty application.emails.where(email_type: 'complete_application_initial_reminder')
 
       # At 7 days, email is sent on schedule:
       Timecop.travel 1.day
-      Services::CompleteApplicationReminder.queue_complete_application_reminders!
+      Services::CompleteApplicationReminder.send_complete_application_reminders!
       assert_equal 1, application.emails.where(email_type: 'complete_application_initial_reminder').count
 
       # Immediate re-run does not create another reminder
-      Services::CompleteApplicationReminder.queue_complete_application_reminders!
+      Services::CompleteApplicationReminder.send_complete_application_reminders!
       assert_equal 1, application.emails.where(email_type: 'complete_application_initial_reminder').count
-
-      # Fake sending the email from the queue
-      application.emails.
-        where(email_type: 'complete_application_initial_reminder', sent_at: nil).
-        update(sent_at: DateTime.now)
 
       # Next email is due in 7 more days.  At 6 days, only the one reminder has been sent:
       Timecop.travel 6.days
-      Services::CompleteApplicationReminder.queue_complete_application_reminders!
+      Services::CompleteApplicationReminder.send_complete_application_reminders!
       assert_equal 1, application.emails.where(email_type: 'complete_application_initial_reminder').count
 
       # At 7 days, the second reminder is sent on schedule and the first reminder is not sent again:
       Timecop.travel 1.day
-      Services::CompleteApplicationReminder.queue_complete_application_reminders!
+      Services::CompleteApplicationReminder.send_complete_application_reminders!
       assert_equal 1, application.emails.where(email_type: 'complete_application_final_reminder').count
       assert_equal 1, application.emails.where(email_type: 'complete_application_initial_reminder').count
 
       # Immediate re-run does not create another reminder
-      Services::CompleteApplicationReminder.queue_complete_application_reminders!
+      Services::CompleteApplicationReminder.send_complete_application_reminders!
       assert_equal 1, application.emails.where(email_type: 'complete_application_final_reminder').count
-
-      # Fake sending the email from the queue
-      application.emails.
-        where(email_type: 'complete_application_final_reminder', sent_at: nil).
-        update(sent_at: DateTime.now)
 
       # That's the last one - no more reminders are sent
       Timecop.travel 30.days
-      Services::CompleteApplicationReminder.queue_complete_application_reminders!
+      Services::CompleteApplicationReminder.send_complete_application_reminders!
       assert_equal 1, application.emails.where(email_type: 'complete_application_final_reminder').count
       assert_equal 1, application.emails.where(email_type: 'complete_application_initial_reminder').count
     end
   end
 
-  test 'queue_registration_reminders! takes into account user updates' do
+  test 'send_complete_application_reminders! takes into account user updates' do
     # Here, we walk through a flow for an application where a teacher is frequently
     # updating and saving their application and verify that emails are queued
     # at the appropriate moments.
@@ -69,62 +63,51 @@ class Services::CompleteApplicationReminderTest < ActiveSupport::TestCase
     Timecop.freeze do
       # Initial creation: No reminders
       application = create :pd_teacher_application, status: 'incomplete'
-      Services::CompleteApplicationReminder.queue_complete_application_reminders!
+      Services::CompleteApplicationReminder.send_complete_application_reminders!
       assert_empty application.emails.where(email_type: 'complete_application_initial_reminder')
       assert_empty application.emails.where(email_type: 'complete_application_final_reminder')
 
       # 6 days later, a user updates their application and saves again, and no reminder is sent
       Timecop.travel 6.days
       application.update!(form_data: application.form_data_hash.merge(firstName: 'Simon').to_json)
-      application.reload
-      Services::CompleteApplicationReminder.queue_complete_application_reminders!
+      Services::CompleteApplicationReminder.send_complete_application_reminders!
       assert_empty application.emails.where(email_type: 'complete_application_initial_reminder')
 
       # 7 days from creation, no reminder is sent because of the update
       Timecop.travel 1.day
-      Services::CompleteApplicationReminder.queue_complete_application_reminders!
+      Services::CompleteApplicationReminder.send_complete_application_reminders!
       assert_empty application.emails.where(email_type: 'complete_application_initial_reminder')
 
       # 7 days after the update, email is sent on schedule:
       Timecop.travel 6.days
-      Services::CompleteApplicationReminder.queue_complete_application_reminders!
+      Services::CompleteApplicationReminder.send_complete_application_reminders!
       assert_equal 1, application.emails.where(email_type: 'complete_application_initial_reminder').count
 
       # Immediate re-run does not create another reminder
-      Services::CompleteApplicationReminder.queue_complete_application_reminders!
+      Services::CompleteApplicationReminder.send_complete_application_reminders!
       assert_equal 1, application.emails.where(email_type: 'complete_application_initial_reminder').count
-
-      # Fake sending the email from the queue
-      application.emails.
-        where(email_type: 'complete_application_initial_reminder', sent_at: nil).
-        update(sent_at: DateTime.now)
 
       # 3 days later, a user updates their application, and no new reminder is sent
       Timecop.travel 3.days
       application.update!(form_data: application.form_data_hash.merge(firstName: 'Garfunkel').to_json)
-      Services::CompleteApplicationReminder.queue_complete_application_reminders!
+      Services::CompleteApplicationReminder.send_complete_application_reminders!
       assert_equal 1, application.emails.where(email_type: 'complete_application_initial_reminder').count
 
       # 7 days after original email was sent, no reminder is sent because of the update
       Timecop.travel 4.days
-      Services::CompleteApplicationReminder.queue_complete_application_reminders!
+      Services::CompleteApplicationReminder.send_complete_application_reminders!
       assert_equal 1, application.emails.where(email_type: 'complete_application_initial_reminder').count
       assert_empty application.emails.where(email_type: 'complete_application_final_reminder')
 
       # 14 days after last update, a second reminder is sent
       Timecop.travel 10.days
-      Services::CompleteApplicationReminder.queue_complete_application_reminders!
+      Services::CompleteApplicationReminder.send_complete_application_reminders!
       assert_equal 1, application.emails.where(email_type: 'complete_application_initial_reminder').count
       assert_equal 1, application.emails.where(email_type: 'complete_application_final_reminder').count
 
-      # Fake sending the email from the queue
-      application.emails.
-        where(email_type: 'complete_application_final_reminder', sent_at: nil).
-        update(sent_at: DateTime.now)
-
       # That's the last one - no more reminders are sent
       Timecop.travel 30.days
-      Services::CompleteApplicationReminder.queue_complete_application_reminders!
+      Services::CompleteApplicationReminder.send_complete_application_reminders!
       assert_equal 1, application.emails.where(email_type: 'complete_application_initial_reminder').count
       assert_equal 1, application.emails.where(email_type: 'complete_application_final_reminder').count
     end


### PR DESCRIPTION
Rather than sending emails from the cron job, this moves the sending of emails into the method that is called by the cron job –– this allows us to avoid "fake-sending" emails to test the method's behavior and moves all the actions into one place.

I looked at other cron jobs, and it looks like only this one has the pattern of sending mailers from the cron job itself.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Updated existing unit tests

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
