### PR TITLE
Project Beats: move progress state to redux

### DIFF
--- a/apps/src/music/progress/ProgressManager.ts
+++ b/apps/src/music/progress/ProgressManager.ts
@@ -32,11 +32,17 @@ interface Progression {
 }
 
 // The current progress state.
-interface ProgressState {
+export interface ProgressState {
   step: number;
   satisfied: boolean;
   message: string | null;
 }
+
+export const initialProgressState: ProgressState = {
+  step: 0,
+  satisfied: false,
+  message: null
+};
 
 export default class ProgressManager {
   private progression: Progression;
@@ -52,18 +58,14 @@ export default class ProgressManager {
     this.progression = progression;
     this.validator = validator;
     this.onProgressChange = onProgressChange;
-    this.currentProgressState = {
-      step: 0,
-      satisfied: false,
-      message: null
-    };
+    this.currentProgressState = initialProgressState;
   }
 
-  getProgression() {
+  getProgression(): Progression {
     return this.progression;
   }
 
-  getCurrentState() {
+  getCurrentState(): ProgressState {
     return this.currentProgressState;
   }
 

--- a/apps/src/music/redux/musicRedux.ts
+++ b/apps/src/music/redux/musicRedux.ts
@@ -28,6 +28,10 @@ interface MusicState {
   showInstructions: boolean;
   instructionsPosition: InstructionsPosition;
   isBeatPadShowing: boolean;
+  // TODO: Currently Music Lab is the only Lab that uses
+  // this progres system, but in the future, we may want to
+  // move this into a more generic, high-level, lab-agnostic
+  // reducer.
   currentProgressState: ProgressState;
 }
 

--- a/apps/src/music/redux/musicRedux.ts
+++ b/apps/src/music/redux/musicRedux.ts
@@ -1,4 +1,5 @@
 import {createSlice, PayloadAction} from '@reduxjs/toolkit';
+import {initialProgressState, ProgressState} from '../progress/ProgressManager';
 
 const registerReducers = require('@cdo/apps/redux').registerReducers;
 
@@ -27,6 +28,7 @@ interface MusicState {
   showInstructions: boolean;
   instructionsPosition: InstructionsPosition;
   isBeatPadShowing: boolean;
+  currentProgressState: ProgressState;
 }
 
 const initialState: MusicState = {
@@ -36,7 +38,8 @@ const initialState: MusicState = {
   timelineAtTop: false,
   showInstructions: false,
   instructionsPosition: InstructionsPosition.LEFT,
-  isBeatPadShowing: false
+  isBeatPadShowing: false,
+  currentProgressState: {...initialProgressState}
 };
 
 const musicSlice = createSlice({
@@ -99,6 +102,9 @@ const musicSlice = createSlice({
     },
     toggleBeatPad: state => {
       state.isBeatPadShowing = !state.isBeatPadShowing;
+    },
+    setCurrentProgressState: (state, action: PayloadAction<ProgressState>) => {
+      state.currentProgressState = {...action.payload};
     }
   }
 });
@@ -121,5 +127,6 @@ export const {
   advanceInstructionsPosition,
   showBeatPad,
   hideBeatPad,
-  toggleBeatPad
+  toggleBeatPad,
+  setCurrentProgressState
 } = musicSlice.actions;

--- a/apps/src/music/views/Instructions.jsx
+++ b/apps/src/music/views/Instructions.jsx
@@ -3,20 +3,15 @@ import React, {useContext, useEffect, useState} from 'react';
 import classNames from 'classnames';
 import moduleStyles from './instructions.module.scss';
 import {AnalyticsContext} from '../context';
+import {useSelector} from 'react-redux';
 
 /**
  * Renders the Music Lab instructions component.
  */
-const Instructions = ({
-  progression,
-  currentPanel,
-  message,
-  onNextPanel,
-  baseUrl,
-  vertical,
-  right
-}) => {
+const Instructions = ({progression, onNextPanel, baseUrl, vertical, right}) => {
   const [showBigImage, setShowBigImage] = useState(false);
+  const progressState = useSelector(state => state.music.currentProgressState);
+  const currentPanel = progressState.step;
 
   const getNextPanel = () => {
     return currentPanel + 1 < progression.steps.length
@@ -51,7 +46,7 @@ const Instructions = ({
       {progression && (
         <InstructionsPanel
           panel={progression.steps[currentPanel]}
-          message={message}
+          message={progressState.message}
           vertical={vertical}
           baseUrl={baseUrl}
           path={progression.path}
@@ -63,7 +58,7 @@ const Instructions = ({
       <div className={moduleStyles.bottom}>
         <div className={moduleStyles.progressText}>{progressText}</div>
         <div>
-          {onNextPanel && (
+          {progressState.satisfied && (
             <button
               type="button"
               onClick={() => onNextPanel()}

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -30,7 +30,8 @@ import {
   selectBlockId,
   setShowInstructions,
   setInstructionsPosition,
-  InstructionsPositions
+  InstructionsPositions,
+  setCurrentProgressState
 } from '../redux/musicRedux';
 import KeyHandler from './KeyHandler';
 
@@ -59,7 +60,8 @@ class UnconnectedMusicView extends React.Component {
     showInstructions: PropTypes.bool,
     instructionsPosition: PropTypes.string,
     setShowInstructions: PropTypes.func,
-    setInstructionsPosition: PropTypes.func
+    setInstructionsPosition: PropTypes.func,
+    setCurrentProgressState: PropTypes.func
   };
 
   constructor(props) {
@@ -129,7 +131,7 @@ class UnconnectedMusicView extends React.Component {
         this.progressManager = new ProgressManager(
           progression,
           musicValidator,
-          this.onProgresschange
+          this.onProgressChange
         );
         this.props.setShowInstructions(!!progression);
         this.setAllowedSoundsForProgress();
@@ -183,10 +185,8 @@ class UnconnectedMusicView extends React.Component {
     }
   };
 
-  onProgresschange = () => {
-    // This is a way to tell React to re-render the scene, notably
-    // the instructions.
-    this.setState({updateNumber: this.state.updateNumber + 1});
+  onProgressChange = () => {
+    this.props.setCurrentProgressState(this.progressManager.getCurrentState());
   };
 
   getIsPlaying = () => {
@@ -390,13 +390,6 @@ class UnconnectedMusicView extends React.Component {
     // maximum possible content size, requiring no dynamic
     // resizing or user scrolling.  We did this for the dynamic
     // instructions in AI Lab.
-    const progression = this.progressManager.getProgression();
-
-    const progressState = this.progressManager.getCurrentState();
-    const currentPanel = progressState.step;
-    const message = progressState.message;
-    const satisfied = progressState.satisfied;
-
     return (
       <div
         className={classNames(
@@ -411,10 +404,8 @@ class UnconnectedMusicView extends React.Component {
         )}
       >
         <Instructions
-          progression={progression}
-          currentPanel={currentPanel}
-          message={message}
-          onNextPanel={satisfied ? this.onNextPanel : null}
+          progression={this.progressManager.getProgression()}
+          onNextPanel={this.onNextPanel}
           baseUrl={baseUrl}
           vertical={position !== InstructionsPositions.TOP}
           right={position === InstructionsPositions.RIGHT}
@@ -531,7 +522,9 @@ const MusicView = connect(
     setShowInstructions: showInstructions =>
       dispatch(setShowInstructions(showInstructions)),
     setInstructionsPosition: instructionsPosition =>
-      dispatch(setInstructionsPosition(instructionsPosition))
+      dispatch(setInstructionsPosition(instructionsPosition)),
+    setCurrentProgressState: progressState =>
+      dispatch(setCurrentProgressState(progressState))
   })
 )(UnconnectedMusicView);
 


### PR DESCRIPTION
Moves the progress state into redux. This change was mostly motivated by wanting to reduce (and eventually remove) the usages of `updateNumber` in MusicView's state. We needed to use that mechanism to force components to re-render, but by moving pieces of state that they listen to into redux, we don't need to manually force changes for the same updates.

## Testing story

Tested locally with progress on. No user-facing changes.