### PR TITLE
Split Java Lab Redux store (part 1, console)

### DIFF
--- a/apps/src/javalab/Javalab.js
+++ b/apps/src/javalab/Javalab.js
@@ -9,22 +9,24 @@ import javalab, {
   setAllSourcesAndFileMetadata,
   setAllValidation,
   setDisplayTheme,
-  appendOutputLog,
   setIsStartMode,
   setLevelName,
-  appendNewlineToConsoleLog,
   setIsRunning,
   setIsTesting,
-  openPhotoPrompter,
-  closePhotoPrompter,
   setBackpackEnabled,
-  appendMarkdownLog,
   setIsReadOnlyWorkspace,
   setHasOpenCodeReview,
   setValidationPassed,
   setHasRunOrTestedCode,
   setIsJavabuilderConnecting
 } from './javalabRedux';
+import javalabConsole, {
+  appendOutputLog,
+  appendNewlineToConsoleLog,
+  appendMarkdownLog,
+  closePhotoPrompter,
+  openPhotoPrompter
+} from './redux/consoleRedux';
 import {TestResults} from '@cdo/apps/constants';
 import project from '@cdo/apps/code-studio/initApp/project';
 import JavabuilderConnection from './JavabuilderConnection';
@@ -191,7 +193,7 @@ Javalab.prototype.init = function(config) {
     isSubmitted: !!config.level.submitted
   });
 
-  registerReducers({javalab});
+  registerReducers({javalab, javalabConsole});
   // If we're in editBlock mode (for editing start_sources) we set up the save button to save
   // the project file information into start_sources on the level.
   if (this.isStartMode) {

--- a/apps/src/javalab/JavalabConsole.jsx
+++ b/apps/src/javalab/JavalabConsole.jsx
@@ -8,7 +8,7 @@ import {
   appendInputLog,
   clearConsoleLogs,
   closePhotoPrompter
-} from './javalabRedux';
+} from './redux/consoleRedux';
 import {DisplayTheme} from './DisplayTheme';
 import CommandHistory from '@cdo/apps/lib/tools/jsdebugger/CommandHistory';
 import PaneHeader, {
@@ -277,10 +277,10 @@ class JavalabConsole extends React.Component {
 
 export default connect(
   state => ({
-    consoleLogs: state.javalab.consoleLogs,
+    consoleLogs: state.javalabConsole.consoleLogs,
     displayTheme: state.javalab.displayTheme,
-    isPhotoPrompterOpen: state.javalab.isPhotoPrompterOpen,
-    photoPrompterPromptText: state.javalab.photoPrompterPromptText,
+    isPhotoPrompterOpen: state.javalabConsole.isPhotoPrompterOpen,
+    photoPrompterPromptText: state.javalabConsole.photoPrompterPromptText,
     shouldJumpToInput: state.javalab.isRunning || state.javalab.isTesting,
     editorFontSize: state.javalab.editorFontSize
   }),

--- a/apps/src/javalab/JavalabView.jsx
+++ b/apps/src/javalab/JavalabView.jsx
@@ -5,12 +5,8 @@ import color from '@cdo/apps/util/color';
 import JavalabConsole from './JavalabConsole';
 import JavalabEditor from './JavalabEditor';
 import JavalabPanels from './JavalabPanels';
-import {
-  appendOutputLog,
-  setDisplayTheme,
-  setIsRunning,
-  setIsTesting
-} from './javalabRedux';
+import {setDisplayTheme, setIsRunning, setIsTesting} from './javalabRedux';
+import {appendOutputLog} from './redux/consoleRedux';
 import {DisplayTheme} from './DisplayTheme';
 import StudioAppWrapper from '@cdo/apps/templates/StudioAppWrapper';
 import TopInstructions, {

--- a/apps/src/javalab/javalabRedux.js
+++ b/apps/src/javalab/javalabRedux.js
@@ -12,8 +12,6 @@ import {
   updateAllSourceFileOrders
 } from './JavalabFileHelper';
 
-const APPEND_CONSOLE_LOG = 'javalab/APPEND_CONSOLE_LOG';
-const CLEAR_CONSOLE_LOGS = 'javalab/CLEAR_CONSOLE_LOGS';
 const RENAME_FILE = 'javalab/RENAME_FILE';
 const SET_SOURCE = 'javalab/SET_SOURCE';
 const SOURCE_VISIBILITY_UPDATED = 'javalab/SOURCE_VISIBILITY_UPDATED';
@@ -38,8 +36,6 @@ const SET_BACKPACK_ENABLED = 'javalab/SET_BACKPACK_ENABLED';
 const SET_IS_START_MODE = 'javalab/SET_IS_START_MODE';
 const SET_LEVEL_NAME = 'javalab/SET_LEVEL_NAME';
 const TOGGLE_VISUALIZATION_COLLAPSED = 'javalab/TOGGLE_VISUALIZATION_COLLAPSED';
-const OPEN_PHOTO_PROMPTER = 'javalab/OPEN_PHOTO_PROMPTER';
-const CLOSE_PHOTO_PROMPTER = 'javalab/CLOSE_PHOTO_PROMPTER';
 const SET_IS_READONLY_WORKSPACE = 'javalab/SET_IS_READONLY_WORKSPACE';
 const SET_HAS_OPEN_CODE_REVIEW = 'javalab/SET_HAS_OPEN_CODE_REVIEW';
 const SET_COMMIT_SAVE_STATUS = 'javalab/SET_COMMIT_SAVE_STATUS';
@@ -67,7 +63,6 @@ const initialSources = {
 // Exported for test
 export const initialState = {
   ...fileMetadataForEditor(initialSources),
-  consoleLogs: [],
   sources: initialSources,
   displayTheme: DisplayTheme.LIGHT,
   validation: {},
@@ -84,8 +79,6 @@ export const initialState = {
   isStartMode: false,
   levelName: undefined,
   isVisualizationCollapsed: false,
-  isPhotoPrompterOpen: false,
-  photoPrompterPromptText: '',
   isReadOnlyWorkspace: false,
   hasOpenCodeReview: false,
   isCommitSaveInProgress: false,
@@ -100,31 +93,6 @@ export const initialState = {
   canIncreaseFontSize: DEFAULT_FONT_SIZE_PX < MAX_FONT_SIZE_PX,
   canDecreaseFontSize: DEFAULT_FONT_SIZE_PX > MIN_FONT_SIZE_PX
 };
-
-// Action Creators
-export const appendInputLog = input => ({
-  type: APPEND_CONSOLE_LOG,
-  log: {type: 'input', text: input}
-});
-
-export const appendOutputLog = output => ({
-  type: APPEND_CONSOLE_LOG,
-  log: {type: 'output', text: output}
-});
-
-export const appendNewlineToConsoleLog = () => ({
-  type: APPEND_CONSOLE_LOG,
-  log: {type: 'newline'}
-});
-
-export const appendMarkdownLog = log => ({
-  type: APPEND_CONSOLE_LOG,
-  log: {type: 'markdown', text: log}
-});
-
-export const clearConsoleLogs = () => ({
-  type: CLEAR_CONSOLE_LOGS
-});
 
 export const setAllValidation = validation => ({
   type: SET_ALL_VALIDATION,
@@ -231,15 +199,6 @@ export const setIsStartMode = isStartMode => ({
 export const setLevelName = levelName => ({
   type: SET_LEVEL_NAME,
   levelName
-});
-
-export const openPhotoPrompter = promptText => ({
-  type: OPEN_PHOTO_PROMPTER,
-  promptText
-});
-
-export const closePhotoPrompter = () => ({
-  type: CLOSE_PHOTO_PROMPTER
 });
 
 export const openEditorDialog = dialogName => ({
@@ -419,18 +378,6 @@ export const setHasRunOrTestedCode = hasRunOrTestedCode => ({
 
 // Reducer
 export default function reducer(state = initialState, action) {
-  if (action.type === APPEND_CONSOLE_LOG) {
-    return {
-      ...state,
-      consoleLogs: [...state.consoleLogs, action.log]
-    };
-  }
-  if (action.type === CLEAR_CONSOLE_LOGS) {
-    return {
-      ...state,
-      consoleLogs: []
-    };
-  }
   if (action.type === SET_SOURCE) {
     let newSources = {...state.sources};
     newSources[action.filename] = {
@@ -615,20 +562,6 @@ export default function reducer(state = initialState, action) {
     return {
       ...state,
       isVisualizationCollapsed: !state.isVisualizationCollapsed
-    };
-  }
-  if (action.type === OPEN_PHOTO_PROMPTER) {
-    return {
-      ...state,
-      isPhotoPrompterOpen: true,
-      photoPrompterPromptText: action.promptText
-    };
-  }
-  if (action.type === CLOSE_PHOTO_PROMPTER) {
-    return {
-      ...state,
-      isPhotoPrompterOpen: false,
-      photoPrompterPromptText: ''
     };
   }
   if (action.type === SET_IS_READONLY_WORKSPACE) {

--- a/apps/src/javalab/redux/consoleRedux.js
+++ b/apps/src/javalab/redux/consoleRedux.js
@@ -1,0 +1,77 @@
+// Redux store for state that relates to the Java Lab console.
+
+const APPEND_CONSOLE_LOG = 'javalab/APPEND_CONSOLE_LOG';
+const CLEAR_CONSOLE_LOGS = 'javalab/CLEAR_CONSOLE_LOGS';
+const OPEN_PHOTO_PROMPTER = 'javalab/OPEN_PHOTO_PROMPTER';
+const CLOSE_PHOTO_PROMPTER = 'javalab/CLOSE_PHOTO_PROMPTER';
+
+const initialState = {
+  consoleLogs: [],
+  isPhotoPrompterOpen: false,
+  photoPrompterPromptText: ''
+};
+
+// Action Creators
+export const appendInputLog = input => ({
+  type: APPEND_CONSOLE_LOG,
+  log: {type: 'input', text: input}
+});
+
+export const appendOutputLog = output => ({
+  type: APPEND_CONSOLE_LOG,
+  log: {type: 'output', text: output}
+});
+
+export const appendNewlineToConsoleLog = () => ({
+  type: APPEND_CONSOLE_LOG,
+  log: {type: 'newline'}
+});
+
+export const appendMarkdownLog = log => ({
+  type: APPEND_CONSOLE_LOG,
+  log: {type: 'markdown', text: log}
+});
+
+export const clearConsoleLogs = () => ({
+  type: CLEAR_CONSOLE_LOGS
+});
+
+export const openPhotoPrompter = promptText => ({
+  type: OPEN_PHOTO_PROMPTER,
+  promptText
+});
+
+export const closePhotoPrompter = () => ({
+  type: CLOSE_PHOTO_PROMPTER
+});
+
+// Reducer
+export default function reducer(state = initialState, action) {
+  if (action.type === APPEND_CONSOLE_LOG) {
+    return {
+      ...state,
+      consoleLogs: [...state.consoleLogs, action.log]
+    };
+  }
+  if (action.type === CLEAR_CONSOLE_LOGS) {
+    return {
+      ...state,
+      consoleLogs: []
+    };
+  }
+  if (action.type === OPEN_PHOTO_PROMPTER) {
+    return {
+      ...state,
+      isPhotoPrompterOpen: true,
+      photoPrompterPromptText: action.promptText
+    };
+  }
+  if (action.type === CLOSE_PHOTO_PROMPTER) {
+    return {
+      ...state,
+      isPhotoPrompterOpen: false,
+      photoPrompterPromptText: ''
+    };
+  }
+  return state;
+}

--- a/apps/test/unit/javalab/JavalabConsoleTest.js
+++ b/apps/test/unit/javalab/JavalabConsoleTest.js
@@ -9,11 +9,12 @@ import {
   stubRedux,
   restoreRedux
 } from '@cdo/apps/redux';
-import javalab, {
-  setDisplayTheme,
-  closePhotoPrompter,
-  openPhotoPrompter
-} from '@cdo/apps/javalab/javalabRedux';
+import javalab, {setDisplayTheme} from '@cdo/apps/javalab/javalabRedux';
+import javalabConsole, {
+  openPhotoPrompter,
+  closePhotoPrompter
+} from '@cdo/apps/javalab/redux/consoleRedux';
+
 import {DisplayTheme} from '@cdo/apps/javalab/DisplayTheme';
 import sinon from 'sinon';
 import PhotoSelectionView from '@cdo/apps/javalab/components/PhotoSelectionView';
@@ -23,7 +24,7 @@ describe('Java Lab Console Test', () => {
 
   beforeEach(() => {
     stubRedux();
-    registerReducers({javalab});
+    registerReducers({javalab, javalabConsole});
     store = getStore();
   });
 


### PR DESCRIPTION
Part 1 of splitting up the Java Lab Redux store.
I am planning to migrate this store to redux-toolkit, but it is too big right now. Testing the migration would be much easier if it were split into smaller pieces. Therefore, I am first going to split the store into a few slices of state, then will migrate each slice. This split just has the console related state: the console logs and the photo prompter state. The other state slices I am planning on are (let me know if these make sense):
- editor (all the sources/file naming state)
- view (all the different height/width/display state)
- generic Java Lab (everything else)

## Links

- jira ticket: [SL-724](https://codedotorg.atlassian.net/browse/SL-724)


## Testing story
Tested locally that the console logs and photo prompter still work as expected.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
