### PR TITLE
Prevent saving unknown blocks on block editing pages

### DIFF
--- a/apps/src/sites/studio/pages/blocks/edit.js
+++ b/apps/src/sites/studio/pages/blocks/edit.js
@@ -18,7 +18,7 @@ const INVALID_COLOR = '#d00';
 
 let poolField, nameField, helperEditor, configEditor, validationDiv;
 let hasLintingErrors = false;
-let canRenderBlock = false;
+let isValidBlockConfig = false;
 
 $(document).ready(() => {
   registerReducers({animationList: animationList});
@@ -91,13 +91,15 @@ function onUpdateLinting(_, errors) {
 }
 
 const setSubmitButtonState = () => {
-  const submitButton = document.querySelector('#block_submit');
-  const disabled = hasLintingErrors || !canRenderBlock;
-  if (disabled) {
-    submitButton.setAttribute('disabled', 'disabled');
-  } else {
-    submitButton.removeAttribute('disabled');
-  }
+  const disabled = hasLintingErrors || !isValidBlockConfig;
+  ['#block_clone', '#block_submit'].forEach(buttonId => {
+    const button = document.querySelector(buttonId);
+    if (disabled) {
+      button.setAttribute('disabled', 'disabled');
+    } else {
+      button.removeAttribute('disabled');
+    }
+  });
 };
 
 function validateBlockConfig(editor) {
@@ -107,9 +109,11 @@ function validateBlockConfig(editor) {
     }
     updateBlockPreview();
     validateBlockRenders();
+    isValidBlockConfig = true;
     validationDiv.text('Config and helper code appear valid.');
     validationDiv.css('color', VALID_COLOR);
   } catch (err) {
+    isValidBlockConfig = false;
     validationDiv.text(err.toString());
     validationDiv.css('color', INVALID_COLOR);
   }
@@ -123,10 +127,7 @@ function validateBlockRenders() {
       .getAllBlocks()
       .some(block => block.getFieldValue('NAME')?.includes('unknown block'))
   ) {
-    canRenderBlock = false;
     throw 'Unable to render block with given configuration.';
-  } else {
-    canRenderBlock = true;
   }
 }
 

--- a/apps/src/sites/studio/pages/blocks/edit.js
+++ b/apps/src/sites/studio/pages/blocks/edit.js
@@ -12,6 +12,7 @@ import animationList, {
 } from '@cdo/apps/p5lab/redux/animationList';
 import {getDefaultListMetadata} from '@cdo/apps/assetManagement/animationLibraryApi';
 import {getStore, registerReducers} from '@cdo/apps/redux';
+import {BlocklyVersion} from '@cdo/apps/constants';
 
 const VALID_COLOR = 'black';
 const INVALID_COLOR = '#d00';
@@ -119,15 +120,15 @@ function validateBlockConfig(editor) {
   }
 }
 
-// Validation only relevant for blocks rendered via google blockly
-// "unknown block" is only implemented in google blockly
+// Only apply this validation to pools being rendered in Google Blockly,
+// as those are the pools where we have UI tests and want to prevent
+// levelbuilder changes from causing them to fail
 function validateBlockRenders() {
   if (
-    Blockly.mainBlockSpace
-      .getAllBlocks()
-      .some(block => block.getFieldValue('NAME')?.includes('unknown block'))
+    Blockly.version === BlocklyVersion.GOOGLE &&
+    Blockly.mainBlockSpace.getAllBlocks().some(block => !!block.unknownBlock)
   ) {
-    throw 'Unable to render block with given configuration.';
+    throw 'Blockly is unable to render a block with the given configuration.';
   }
 }
 

--- a/dashboard/app/views/blocks/edit.html.haml
+++ b/dashboard/app/views/blocks/edit.html.haml
@@ -25,7 +25,7 @@
       %div
         = f.submit class: 'btn', id: 'block_submit'
       %br
-        = f.submit class: 'btn btn-info', value: 'Save as Clone', data: {'disable-with': 'Cloning...'}
+        = f.submit class: 'btn btn-info', id: 'block_clone', value: 'Save as Clone', data: {'disable-with': 'Cloning...'}
 
     - unless @block.new_record?
       = form_for(@block,


### PR DESCRIPTION
When editing a custom block in a Google Blockly-based block pool, disable submit button and show an error message if we cannot render the block. This check is in place to prevent a new UI test covering custom blocks from breaking due to a content change, and should be merged before the [UI test change is merged](https://github.com/code-dot-org/code-dot-org/pull/50963).

<img width="849" alt="image" src="https://user-images.githubusercontent.com/25372625/229191371-a8875766-d53d-48ad-a44d-9453b4ee6fbf.png">

This change should not really affect when editing block pools still on CDO Blockly (eg, "GamelabJr" aka Sprite Lab) -- I did make it so you can't clone blocks with bad JSON across all block types. LMK if that is potentially disruptive to levelbuilder workflows.

## Links

- jira ticket: [SL-474](https://codedotorg.atlassian.net/browse/SL-474)

## Testing story

Tested manually editing blocks in CDO ("GamelabJr" aka Sprite Lab pool) and Google Blockly (Dancelab pool). Saw the error message seen above when pasting in config that generates an "unknown block", and continued to see linting error messages where appropriate. Saw Update/Clone buttons reenabled when valid config was added.