### PR TITLE
Music: fix loading sounds for alternate library

### DIFF
--- a/apps/src/music/constants.ts
+++ b/apps/src/music/constants.ts
@@ -51,7 +51,7 @@ export const BlockMode = {
   TRACKS: 'Tracks'
 };
 
-export const DEFAULT_SOUND = 'dance/groovy_beat';
+export const DEFAULT_SOUND = 'beats/groovy_beat';
 
 // For reference, events look like this:
 // events: [{src: 'sound_1', tick: 3}]

--- a/apps/src/music/player/SamplePlayer.ts
+++ b/apps/src/music/player/SamplePlayer.ts
@@ -19,7 +19,6 @@ interface PlayingSample {
 
 const MAIN_AUDIO_GROUP = 'mainaudio';
 const PREVIEW_GROUP = 'preview';
-const GROUP_PREFIX = 'all';
 
 /**
  * Handles playback of individual samples.
@@ -29,12 +28,14 @@ export default class SamplePlayer {
   private isPlaying: boolean;
   private startPlayingAudioTime: number;
   private isInitialized: boolean;
+  private groupPath: string;
 
   constructor() {
     this.playingSamples = [];
     this.isPlaying = false;
     this.startPlayingAudioTime = -1;
     this.isInitialized = false;
+    this.groupPath = '';
   }
 
   initialize(library: MusicLibrary) {
@@ -48,6 +49,8 @@ export default class SamplePlayer {
       })
       .flat(2);
     soundApi.InitSound(soundList);
+
+    this.groupPath = library.groups[0].path;
 
     this.isInitialized = true;
   }
@@ -80,7 +83,12 @@ export default class SamplePlayer {
 
     this.cancelPreviews();
 
-    soundApi.PlaySound(GROUP_PREFIX + '/' + sampleId, PREVIEW_GROUP, 0, onStop);
+    soundApi.PlaySound(
+      this.groupPath + '/' + sampleId,
+      PREVIEW_GROUP,
+      0,
+      onStop
+    );
   }
 
   previewSamples(events: SampleEvent[], onStop: () => any) {
@@ -94,7 +102,7 @@ export default class SamplePlayer {
     let counter = 0;
     events.forEach(event => {
       soundApi.PlaySound(
-        GROUP_PREFIX + '/' + event.sampleId,
+        this.groupPath + '/' + event.sampleId,
         PREVIEW_GROUP,
         soundApi.GetCurrentAudioTime() + event.offsetSeconds,
         () => {
@@ -149,7 +157,7 @@ export default class SamplePlayer {
 
       if (eventStart >= currentAudioTime - delayCompensation) {
         const uniqueId = soundApi.PlaySound(
-          GROUP_PREFIX + '/' + sampleEvent.sampleId,
+          this.groupPath + '/' + sampleEvent.sampleId,
           MAIN_AUDIO_GROUP,
           eventStart,
           null,

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -231,7 +231,7 @@ class UnconnectedMusicView extends React.Component {
       const libraryParameter = AppConfig.getValue('library');
       const libraryFilename = libraryParameter
         ? `music-library-${libraryParameter}.json`
-        : 'music-library.json';
+        : 'music-library-by-type.json';
       const response = await fetch(baseUrl + libraryFilename);
       const library = await response.json();
       return library;


### PR DESCRIPTION
This fixes loading sounds for an alternate library that has its sounds in a base directory other than `all/`, by using the library's first group's `path` rather than the hardcoded `"all"`.

This change also changes the default library, temporarily, from `music-library.json` to `music-library-by-type.json`.

To work with this new library, it also changes the default sound used in the toolbox.  Longer term, we should use a value from the current library, but we'll need to take care to do this right, since the library is loaded asynchronously.  