### PR TITLE
[WebLab/GameLab] Correctly use pressedLabel if PaneButton isPressed

### DIFF
--- a/apps/src/templates/PaneHeader.jsx
+++ b/apps/src/templates/PaneHeader.jsx
@@ -200,7 +200,7 @@ export const PaneButton = Radium(function(props) {
       <span className={moduleStyles.headerButtonSpan}>
         {hiddenImage}
         {renderIcon()}
-        <span style={styles.noPadding}>{label}</span>
+        <span style={styles.noPadding}>{buttonLabel}</span>
       </span>
     </Tag>
   );


### PR DESCRIPTION
## Problem
A user [reported](https://codeorg.zendesk.com/agent/tickets/436918) that Web Lab's Inspector button label does not toggle to reflect its on/off status. The button functions as expected but the text remains off even when the Inspector seems to be On. This is easily repro'd by clicking the button labeled "Inspector: On" in any Web Lab level on production. While unreported by users, investigation into the issue revealed that the same buggy behavior is present in the JSDebugger for Game Lab.

![2023-03-28 09-03-23 2023-03-28 09_03_58](https://user-images.githubusercontent.com/43474485/228246496-ab59bf72-c4af-43a8-bc1f-1803a519f641.gif) ![2023-03-28 09-04-22 2023-03-28 09_08_15](https://user-images.githubusercontent.com/43474485/228246512-8da24053-550f-4ef6-8d82-42881bf71869.gif)

## Investigation
`<PaneButton/>` component have three relevant properties here: `isPressed`, `label`, and `pressedLabel`. The first property listed is a boolean that should determine which string should be used for the button. Five months ago, we performed a refactor of this space which I believe inadvertently broke this logic. 

https://github.com/code-dot-org/code-dot-org/pull/48974/files#diff-0a8789c36ce4024192db45ed67b90f686db316d4ff7505c30e78cc8d1a8f575cL168-L172

Before this change, a `label` constant was set based on the three property which was then used for the text of the actual button span. (`label` was not necessarily equivalent to `props.label`.) https://github.com/code-dot-org/code-dot-org/pull/48974/files#diff-0a8789c36ce4024192db45ed67b90f686db316d4ff7505c30e78cc8d1a8f575cL172

After this change, local constants were created for each of the props listed. A new constant `buttonLabel` was created based on the same logic as before, but this constant was only used to determine `iconClassNames` a couple lines below. `label` was still used for the text of the actual button span, but now this was coming directly from `props.label`. The regression made it impossible for `props.pressedLabel` to ever get used as intended. https://github.com/code-dot-org/code-dot-org/pull/48974/files#diff-0a8789c36ce4024192db45ed67b90f686db316d4ff7505c30e78cc8d1a8f575cR93-R115

## Solution
We can just use the new `buttonLabel` in place of `label`. This fixes both the Web Lab and Game Lab use cases. `PaneButton` components are created in a variety of labs, including (at least) Java Lab and App Lab. However, only the JsDebugger and WebLabView components actually set a value to the `isPressed` and `pressedLabel` properties. In all other cases, `buttonLabel` should continue to be set to `props.label` and no new regressions should be found.

![2023-03-28 09-25-22 2023-03-28 09_25_44](https://user-images.githubusercontent.com/43474485/228251916-90f14953-10f7-4dfc-a571-b41123a49ce3.gif) ![2023-03-28 09-25-59 2023-03-28 09_26_23](https://user-images.githubusercontent.com/43474485/228251931-802bf3c5-6fd4-48e6-997a-b47858c55739.gif)



## Links

ZenDesk report: https://codeorg.zendesk.com/agent/tickets/436918

## Testing/Follow-up

This is intended to be a quick fix, but we can also consider adding a test to make sure that the button text changes in the way that is expected: https://codedotorg.atlassian.net/browse/SL-732


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
