### PR TITLE
Add new CSA pre-work email

### DIFF
--- a/dashboard/app/mailers/pd/workshop_mailer.rb
+++ b/dashboard/app/mailers/pd/workshop_mailer.rb
@@ -126,6 +126,18 @@ class Pd::WorkshopMailer < ActionMailer::Base
       reply_to: reply_to
   end
 
+  def teacher_pre_workshop_csa(enrollment)
+    @enrollment = enrollment
+    @workshop = enrollment.workshop
+    @cancel_url = url_for controller: 'pd/workshop_enrollment', action: :cancel, code: enrollment.code
+
+    mail content_type: 'text/html',
+      from: from_teacher,
+      subject: 'Preparing for your Computer Science A summer workshop',
+      to: email_address(@enrollment.full_name, @enrollment.email),
+      reply_to: email_address(@workshop.organizer.name, @workshop.organizer.email)
+  end
+
   def facilitator_enrollment_reminder(user, workshop)
     @user = user
     @workshop = workshop

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -525,11 +525,27 @@ class Pd::Workshop < ApplicationRecord
     raise "Failed to send follow up: #{errors.join(', ')}" unless errors.empty?
   end
 
+  def self.send_teacher_pre_work_csa
+    # Collect errors, but do not stop batch. Rethrow all errors below.
+    errors = []
+    scheduled_start_in_days(20).each do |workshop|
+      workshop.enrollments.each do |enrollment|
+        Pd::WorkshopMailer.teacher_pre_workshop_csa(enrollment).deliver_now
+      rescue => exception
+        errors << "teacher enrollment #{enrollment.id} - #{exception.message}"
+      end
+    rescue => exception
+      errors << "teacher workshop #{workshop.id} - #{exception.message}"
+    end
+    raise "Failed to send CSA pre-work: #{errors.join(', ')}" unless errors.empty?
+  end
+
   def self.send_automated_emails
     send_reminder_for_upcoming_in_days(3)
     send_reminder_for_upcoming_in_days(10)
     send_reminder_to_close
     send_follow_up_after_days(30)
+    send_teacher_pre_work_csa if course == COURSE_CSA
   end
 
   # Updates enrollments with resolved users.

--- a/dashboard/app/views/pd/workshop_mailer/teacher_pre_workshop_csa.html.haml
+++ b/dashboard/app/views/pd/workshop_mailer/teacher_pre_workshop_csa.html.haml
@@ -1,0 +1,46 @@
+:css
+  body {
+    font-family: Gotham, sans-serif;
+  }
+
+%p
+  Hi
+  = @enrollment.first_name + ','
+
+%p
+  Thanks for enrolling in
+  = "#{@workshop.organizer.name}'#{@workshop.organizer.name.ends_with?('s') ? '' : 's'} "
+  5-day Summer workshop on the Code.org
+  = @workshop.course
+  curriculum.
+
+%h3
+  Preparing for the workshop
+
+%p
+  To ensure the best experience possible for your workshop,
+  we encourage you to engage in the self-paced pre-work that
+  was specifically designed for CSA. The pre-work includes:
+%ul
+  %li
+    Orientation to Code.org and CSA
+  %li
+    Navigating Code.org's tools
+  %li
+    Support with text-based programming
+  %li
+    Creating and using objects in Java
+
+%p
+  While the CSA pre-work is optional, we strongly recommend
+  that you participate to get the most from your professional
+  development experience. Head to
+  =link_to('studio.code.org/courses/self-paced-pl-csa', 'https://studio.code.org/courses/self-paced-pl-csa')
+  to get started with the pre-work course today!
+
+= render partial: 'how_to_cancel'
+
+%p
+  Thank you,
+  %br
+  = @workshop.organizer.name

--- a/dashboard/test/mailers/previews/pd_workshop_mailer_preview.rb
+++ b/dashboard/test/mailers/previews/pd_workshop_mailer_preview.rb
@@ -83,6 +83,10 @@ class PdWorkshopMailerPreview < ActionMailer::Preview
       options: {days_before: 10}
   end
 
+  def teacher_pre_workshop_csa
+    mail :teacher_pre_workshop_csa, Pd::Workshop::COURSE_CSA
+  end
+
   def teacher_enrollment_reminder__csp_for_returning_teachers_10_day
     mail :teacher_enrollment_reminder, Pd::Workshop::COURSE_CSP, Pd::Workshop::SUBJECT_CSP_FOR_RETURNING_TEACHERS,
       options: {days_before: 10}

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -862,6 +862,18 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     Pd::Workshop.send_reminder_for_upcoming_in_days(3)
   end
 
+  test 'CSA teacher pre-work 20 days out' do
+    mock_mail = stub
+    mock_mail.stubs(:deliver_now).returns(nil)
+
+    workshop = create :csa_summer_workshop, num_facilitators: 2
+    create_list :pd_enrollment, 3, workshop: workshop
+    Pd::Workshop.expects(:scheduled_start_in_days).returns([workshop])
+
+    Pd::WorkshopMailer.expects(:teacher_pre_workshop_csa).returns(mock_mail).times(3)
+    Pd::Workshop.send_teacher_pre_work_csa
+  end
+
   test 'workshop starting date picks the day of the first session' do
     workshop = create :workshop, sessions: [
       session1 = create(:pd_session, start: Date.today + 15.days),


### PR DESCRIPTION
Creates the new 'CSA Teacher Pre-work - In Person and Virtual - 20 days out' workshop email as per the first item on [this spec](https://docs.google.com/document/d/1GiWJcTYnSWfQQpTED-0qbUEiocb5D3F8KXYUVjDsS3w/edit#heading=h.ffqn6lxzlxqr):
![CSA_summer_workshop_email](https://user-images.githubusercontent.com/56283563/228376764-bbb5ff1a-4f60-4479-b8d3-857f85639142.JPG)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?modal=detail&selectedIssue=ACQ-452&assignee=60d62161f65054006980bd71)
Spec: [here](https://docs.google.com/document/d/1GiWJcTYnSWfQQpTED-0qbUEiocb5D3F8KXYUVjDsS3w/edit#heading=h.ffqn6lxzlxqr)

## Testing story
Local testing and adding unit test.

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
