### PR TITLE
Project Beats: preview functionality & UI updates in pattern/chord fields

### DIFF
--- a/apps/src/music/blockly/FieldChord.ts
+++ b/apps/src/music/blockly/FieldChord.ts
@@ -12,6 +12,8 @@ const MAX_DISPLAY_NOTES = 3;
 interface FieldChordOptions {
   getLibrary: () => MusicLibrary;
   previewChord: (value: ChordEventValue) => void;
+  previewNote: (note: number, instrument: string, onStop?: () => void) => void;
+  cancelPreviews: () => void;
   currentValue: ChordEventValue;
 }
 
@@ -114,6 +116,8 @@ export default class FieldChord extends Field {
         library: this.options.getLibrary(),
         initValue: this.getValue(),
         previewChord: this.options.previewChord,
+        previewNote: this.options.previewNote,
+        cancelPreviews: this.options.cancelPreviews,
         onChange: value => this.setValue(value)
       }),
       this.newDiv

--- a/apps/src/music/blockly/FieldPattern.js
+++ b/apps/src/music/blockly/FieldPattern.js
@@ -89,6 +89,10 @@ class FieldPattern extends GoogleBlockly.Field {
       <PatternPanel
         library={this.options.getLibrary()}
         initValue={this.getValue()}
+        bpm={this.options.getBPM()}
+        previewSound={this.options.previewSound}
+        previewPattern={this.options.previewPattern}
+        cancelPreviews={this.options.cancelPreviews}
         onChange={value => {
           this.setValue(value);
         }}

--- a/apps/src/music/blockly/fields.js
+++ b/apps/src/music/blockly/fields.js
@@ -25,7 +25,17 @@ export const fieldSoundsDefinition = {
 export const fieldPatternDefinition = {
   type: FIELD_PATTERN_TYPE,
   name: FIELD_PATTERN_NAME,
+  getBPM: () => Globals.getPlayer().getBPM(),
   getLibrary: Globals.getLibrary,
+  previewSound: (id, onStop) => {
+    Globals.getPlayer().previewSound(id, onStop);
+  },
+  previewPattern: (patternValue, onStop) => {
+    Globals.getPlayer().previewPattern(patternValue, onStop);
+  },
+  cancelPreviews: () => {
+    Globals.getPlayer().cancelPreviews();
+  },
   currentValue: DEFAULT_PATTERN
 };
 
@@ -35,6 +45,12 @@ export const fieldChordDefinition = {
   getLibrary: Globals.getLibrary,
   previewChord: (chordValue, onStop) => {
     Globals.getPlayer().previewChord(chordValue, onStop);
+  },
+  previewNote: (note, instrument, onStop) => {
+    Globals.getPlayer().previewNote(note, instrument, onStop);
+  },
+  cancelPreviews: () => {
+    Globals.getPlayer().cancelPreviews();
   },
   currentValue: DEFAULT_CHORD
 };

--- a/apps/src/music/player/SamplePlayer.ts
+++ b/apps/src/music/player/SamplePlayer.ts
@@ -75,7 +75,7 @@ export default class SamplePlayer {
     soundApi.StartPlayback();
   }
 
-  previewSample(sampleId: string, onStop: () => any) {
+  previewSample(sampleId: string, onStop?: () => any) {
     if (!this.isInitialized) {
       console.warn('Sample player not initialized.');
       return;
@@ -91,7 +91,7 @@ export default class SamplePlayer {
     );
   }
 
-  previewSamples(events: SampleEvent[], onStop: () => any) {
+  previewSamples(events: SampleEvent[], onStop?: () => any) {
     if (!this.isInitialized) {
       console.warn('Sample player not initialized.');
       return;
@@ -100,17 +100,21 @@ export default class SamplePlayer {
     this.cancelPreviews();
 
     let counter = 0;
-    events.forEach(event => {
-      soundApi.PlaySound(
-        this.groupPath + '/' + event.sampleId,
-        PREVIEW_GROUP,
-        soundApi.GetCurrentAudioTime() + event.offsetSeconds,
-        () => {
+    const onStopWrapper = onStop
+      ? () => {
           counter++;
           if (counter === events.length) {
             onStop();
           }
         }
+      : undefined;
+
+    events.forEach(event => {
+      soundApi.PlaySound(
+        this.groupPath + '/' + event.sampleId,
+        PREVIEW_GROUP,
+        soundApi.GetCurrentAudioTime() + event.offsetSeconds,
+        onStopWrapper
       );
     });
   }

--- a/apps/src/music/views/ChordPanel.tsx
+++ b/apps/src/music/views/ChordPanel.tsx
@@ -1,4 +1,4 @@
-import React, {useState, useEffect, useRef} from 'react';
+import React, {useState, useEffect, useCallback} from 'react';
 import {getNoteName, isBlackKey} from '../utils/Notes';
 import MusicLibrary from '../player/MusicLibrary';
 import {ChordEventValue, PlayStyle} from '../player/interfaces/ChordEvent';
@@ -46,16 +46,19 @@ const ChordPanel: React.FunctionComponent<ChordPanelProps> = ({
     .filter(folder => folder.type === 'instrument')
     .map(folder => [folder.name, folder.path]);
 
-  const onPressKey = (note: number) => {
-    const newSelectedNotes = [...selectedNotes];
-    if (newSelectedNotes.includes(note)) {
-      newSelectedNotes.splice(newSelectedNotes.indexOf(note), 1);
-    } else {
-      newSelectedNotes.push(note);
-      previewNote(note, instrument);
-    }
-    setSelectedNotes(newSelectedNotes);
-  };
+  const onPressKey = useCallback(
+    (note: number) => {
+      const newSelectedNotes = [...selectedNotes];
+      if (newSelectedNotes.includes(note)) {
+        newSelectedNotes.splice(newSelectedNotes.indexOf(note), 1);
+      } else {
+        newSelectedNotes.push(note);
+        previewNote(note, instrument);
+      }
+      setSelectedNotes(newSelectedNotes);
+    },
+    [selectedNotes, instrument, setSelectedNotes, previewNote]
+  );
 
   useEffect(() => {
     onChange({
@@ -68,6 +71,18 @@ const ChordPanel: React.FunctionComponent<ChordPanelProps> = ({
   useEffect(() => {
     setIsDisabled(selectedNotes.length >= MAX_NOTES);
   }, [selectedNotes]);
+
+  const playPreview = useCallback(
+    () =>
+      previewChord({
+        notes: selectedNotes,
+        playStyle,
+        instrument
+      }),
+    [previewChord, selectedNotes, playStyle, instrument]
+  );
+
+  const onClear = useCallback(() => setSelectedNotes([]), [setSelectedNotes]);
 
   return (
     <div className={moduleStyles.chordPanelContainer}>
@@ -104,14 +119,8 @@ const ChordPanel: React.FunctionComponent<ChordPanelProps> = ({
       />
       <PreviewControls
         enabled={selectedNotes.length > 0}
-        playPreview={() =>
-          previewChord({
-            notes: selectedNotes,
-            playStyle,
-            instrument
-          })
-        }
-        onClickClear={() => setSelectedNotes([])}
+        playPreview={playPreview}
+        onClickClear={onClear}
         cancelPreviews={cancelPreviews}
       />
     </div>

--- a/apps/src/music/views/PatternPanel.jsx
+++ b/apps/src/music/views/PatternPanel.jsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, {useCallback, useState} from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import styles from './patternPanel.module.scss';
@@ -29,21 +29,24 @@ const PatternPanel = ({
   const currentFolder = library.getFolderForPath(currentValue.kit);
   const [currentPreviewTick, setCurrentPreviewTick] = useState(0);
 
-  const toggleEvent = (sound, tick) => {
-    const index = currentValue.events.findIndex(
-      event => event.src === sound.src && event.tick === tick
-    );
-    if (index !== -1) {
-      // If found, delete.
-      currentValue.events.splice(index, 1);
-    } else {
-      // Not found, so add.
-      currentValue.events.push({src: sound.src, tick});
-      previewSound(`${currentValue.kit}/${sound.src}`);
-    }
+  const toggleEvent = useCallback(
+    (sound, tick) => {
+      const index = currentValue.events.findIndex(
+        event => event.src === sound.src && event.tick === tick
+      );
+      if (index !== -1) {
+        // If found, delete.
+        currentValue.events.splice(index, 1);
+      } else {
+        // Not found, so add.
+        currentValue.events.push({src: sound.src, tick});
+        previewSound(`${currentValue.kit}/${sound.src}`);
+      }
 
-    onChange(currentValue);
-  };
+      onChange(currentValue);
+    },
+    [currentValue]
+  );
 
   const hasEvent = (sound, tick) => {
     const element = currentValue.events.find(
@@ -70,12 +73,12 @@ const PatternPanel = ({
     );
   };
 
-  const onClear = () => {
+  const onClear = useCallback(() => {
     currentValue.events = [];
     onChange(currentValue);
-  };
+  }, [currentValue]);
 
-  const startPreview = () => {
+  const startPreview = useCallback(() => {
     setCurrentPreviewTick(1);
     const intervalId = setInterval(
       () => setCurrentPreviewTick(tick => tick + 1),
@@ -86,7 +89,7 @@ const PatternPanel = ({
       clearInterval(intervalId);
       setCurrentPreviewTick(0);
     });
-  };
+  }, [setCurrentPreviewTick, currentValue]);
 
   return (
     <div className={styles.patternPanel}>

--- a/apps/src/music/views/PreviewControls.tsx
+++ b/apps/src/music/views/PreviewControls.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+
+const classNames = require('classnames');
+const FontAwesome = require('../../templates/FontAwesome');
+const moduleStyles = require('./preview-controls.module.scss').default;
+
+/**
+ * Set of controls for previewing sounds in various custom Music Lab block fields
+ */
+const PreviewControls: React.FunctionComponent<
+  PreviewButtonProps & ClearButtonProps
+> = props => (
+  <div className={moduleStyles.controlsRow}>
+    <PreviewButton {...props} />
+    <ClearButton {...props} />
+  </div>
+);
+
+interface ClearButtonProps {
+  onClickClear: () => void;
+  cancelPreviews: () => void;
+}
+
+const ClearButton: React.FunctionComponent<ClearButtonProps> = ({
+  onClickClear,
+  cancelPreviews
+}) => (
+  <FontAwesome
+    icon={'trash-o'}
+    onClick={() => {
+      cancelPreviews();
+      onClickClear();
+    }}
+    className={moduleStyles.previewButton}
+  />
+);
+
+interface PreviewButtonProps {
+  enabled: boolean;
+  playPreview: () => void;
+}
+
+const PreviewButton: React.FunctionComponent<PreviewButtonProps> = ({
+  enabled,
+  playPreview
+}) => {
+  return (
+    <FontAwesome
+      icon={'volume-up'}
+      onClick={playPreview}
+      className={classNames(
+        moduleStyles.previewButton,
+        !enabled && moduleStyles.previewButtonDisabled
+      )}
+    />
+  );
+};
+
+export default PreviewControls;

--- a/apps/src/music/views/PreviewControls.tsx
+++ b/apps/src/music/views/PreviewControls.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useCallback} from 'react';
 
 const classNames = require('classnames');
 const FontAwesome = require('../../templates/FontAwesome');
@@ -24,16 +24,17 @@ interface ClearButtonProps {
 const ClearButton: React.FunctionComponent<ClearButtonProps> = ({
   onClickClear,
   cancelPreviews
-}) => (
-  <FontAwesome
-    icon={'trash-o'}
-    onClick={() => {
-      cancelPreviews();
-      onClickClear();
-    }}
-    className={moduleStyles.previewButton}
-  />
-);
+}) => {
+  const onClick = useCallback(() => {
+    cancelPreviews();
+    onClickClear();
+  }, [cancelPreviews, onClickClear]);
+  return (
+    <button className={moduleStyles.buttonContainer} onClick={onClick}>
+      <FontAwesome icon={'trash-o'} className={moduleStyles.previewButton} />
+    </button>
+  );
+};
 
 interface PreviewButtonProps {
   enabled: boolean;
@@ -45,14 +46,18 @@ const PreviewButton: React.FunctionComponent<PreviewButtonProps> = ({
   playPreview
 }) => {
   return (
-    <FontAwesome
-      icon={'volume-up'}
-      onClick={playPreview}
-      className={classNames(
-        moduleStyles.previewButton,
-        !enabled && moduleStyles.previewButtonDisabled
-      )}
-    />
+    <button
+      className={moduleStyles.buttonContainer}
+      onClick={enabled ? playPreview : undefined}
+    >
+      <FontAwesome
+        icon={'volume-up'}
+        className={classNames(
+          moduleStyles.previewButton,
+          !enabled && moduleStyles.previewButtonDisabled
+        )}
+      />
+    </button>
   );
 };
 

--- a/apps/src/music/views/chordPanel.module.scss
+++ b/apps/src/music/views/chordPanel.module.scss
@@ -22,31 +22,6 @@
       font-size: 12px;
       margin: 0 30px;
     }
-
-    .previewButton {
-      font-size: 30px;
-      cursor: pointer;
-      transition: color 0.1s ease;
-
-      &:hover {
-        color: $green;
-      }
-
-      &Disabled {
-        color: $neutral_dark40;
-        cursor: not-allowed;
-
-        &:hover {
-          color: $neutral_dark40;
-        }
-      }
-    }
-
-    .clearButton {
-      font-size: 12px;
-      padding: 5px;
-      width: 100%;
-    }
   }
 
   .keybed {
@@ -87,7 +62,7 @@
       }
 
       &.selected {
-        background-color: $green;
+        background-color: $light_teal;
         cursor: pointer;
       }
 
@@ -100,7 +75,7 @@
       }
 
       &:hover {
-        background-color: $green;
+        background-color: $light_teal;
       }
     }
   }

--- a/apps/src/music/views/patternPanel.module.scss
+++ b/apps/src/music/views/patternPanel.module.scss
@@ -5,22 +5,29 @@
 }
 
 .row {
-  height: 24px;
+  display: flex;
+  align-items: center;
+
+  &:hover {
+    background-color: rgba($background_gray, 0.2);
+  }
 }
 
 .name {
   display: inline-block;
   width: 80px;
-  vertical-align: top;
+  vertical-align: middle;
 }
 
 .outerCell {
   display: inline-block;
-  width: 20px;
-  height: 20px;
-  padding-top: 2px;
+  padding: 5px 3px;
   box-sizing: border-box;
   cursor: pointer;
+
+  &Playing {
+    background-color: $light-gray;
+  }
 }
 
 .cell {

--- a/apps/src/music/views/preview-controls.module.scss
+++ b/apps/src/music/views/preview-controls.module.scss
@@ -1,0 +1,35 @@
+@import "color.scss";
+
+.controlsRow {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  width: 100%;
+  margin: 10px 0;
+  justify-content: space-around;
+
+  .previewButton {
+    font-size: 30px;
+    cursor: pointer;
+    transition: color 0.1s ease;
+
+    &:hover {
+      color: $light_teal;
+    }
+
+    &Disabled {
+      color: $neutral_dark40;
+      cursor: not-allowed;
+
+      &:hover {
+        color: $neutral_dark40;
+      }
+    }
+  }
+
+  .clearButton {
+    font-size: 12px;
+    padding: 5px;
+    width: 100%;
+  }
+}

--- a/apps/src/music/views/preview-controls.module.scss
+++ b/apps/src/music/views/preview-controls.module.scss
@@ -1,4 +1,5 @@
 @import "color.scss";
+@import "../../mixins.scss";
 
 .controlsRow {
   display: flex;
@@ -8,22 +9,29 @@
   margin: 10px 0;
   justify-content: space-around;
 
+  .buttonContainer {
+    @include remove-button-styles($color: $background_gray);
+
+    &:hover,
+    &:focus {
+      > .previewButton {
+        color: $light_teal;
+
+        &Disabled {
+          color: $neutral_dark40;
+        }
+      }
+    }
+  }
+
   .previewButton {
     font-size: 30px;
     cursor: pointer;
     transition: color 0.1s ease;
 
-    &:hover {
-      color: $light_teal;
-    }
-
     &Disabled {
       color: $neutral_dark40;
       cursor: not-allowed;
-
-      &:hover {
-        color: $neutral_dark40;
-      }
     }
   }
 


### PR DESCRIPTION
Adds a few improvements to the preview UI and functionality in chord and pattern blocks:
- Pressing a key in the chord block plays the note you selected
- Pressing a cell in the drum pattern panel previews the sample you selected
- Adds preview and clear controls to the pattern panel
- When hovering over a cell in the pattern panel, the row is highlighted to indicate which sound it belongs to
- When previewing the full pattern in the pattern panel, the playing cells highlight (this is a bit experimental and we can remove it if it's too much).

<img width="442" alt="Screenshot 2023-03-28 at 3 52 40 PM" src="https://user-images.githubusercontent.com/85528507/228387285-86d81348-e831-409f-9be1-44fd9bd8f84b.png">

https://user-images.githubusercontent.com/85528507/228387402-940652e1-b752-42e3-8aed-6aba8e41a810.mov

## Testing story

Tested locally.