### PR TITLE
Fix a Few More `Using the last argument as keyword parameters is deprecated` Warnings

### DIFF
--- a/lib/test/cdo/aws/test_metrics.rb
+++ b/lib/test/cdo/aws/test_metrics.rb
@@ -7,7 +7,7 @@ class CdoMetricsTest < Minitest::Test
   end
 
   def test_put
-    Cdo::Metrics.put('App Server/WorkerBoot', 1, Host: 'localhost.code.org')
+    Cdo::Metrics.put('App Server/WorkerBoot', 1, {Host: 'localhost.code.org'})
     Cdo::Metrics.flush!
     refute_empty Cdo::Metrics.client.api_requests
     assert_equal(

--- a/lib/test/cron/test_aurora_backup.rb
+++ b/lib/test/cron/test_aurora_backup.rb
@@ -84,11 +84,10 @@ class AuroraBackupTest < Minitest::Test
       client: snapshot_client
     )
     rds_client = Minitest::Mock.new
-    rds_client.expect :modify_db_cluster_snapshot_attribute, nil, {
+    rds_client.expect :modify_db_cluster_snapshot_attribute, nil,
       attribute_name: 'restore',
       db_cluster_snapshot_identifier: temp_snapshot_name,
       values_to_add: [backup_account_id]
-    }
 
     result = AuroraBackup.share_snapshot_with_account(rds_client, backup_account_id, latest_snapshot, temp_snapshot_name)
     assert_equal result.snapshot_id, temp_snapshot_name

--- a/pegasus/test/fixtures/fake_dashboard.rb
+++ b/pegasus/test/fixtures/fake_dashboard.rb
@@ -236,12 +236,12 @@ module FakeDashboard
 
   # Patch Mysql2Adapter to only create the specified tables when loading the schema.
   module SchemaTableFilter
-    def create_table(name, options = {})
+    def create_table(name, **)
       if (::FakeDashboard::FAKE_DB.keys.map(&:to_s) + [
         ActiveRecord::Base.schema_migrations_table_name,
         ActiveRecord::Base.internal_metadata_table_name,
       ]).include?(name)
-        super(name, options)
+        super
       end
     end
   end
@@ -249,15 +249,15 @@ module FakeDashboard
 
   # Patch Mysql2Adapter to stub create_view when loading the schema.
   module SchemaViewFilter
-    def create_view(name, options = {})
+    def create_view(name, **)
     end
   end
   ActiveRecord::ConnectionAdapters::Mysql2Adapter.prepend SchemaViewFilter
 
   # Patch Mysql2Adapter to create temporary tables instead of persistent ones.
   module TempTableFilter
-    def create_table(name, options = {})
-      super(name, options.merge(temporary: true))
+    def create_table(name, **options)
+      super(name, **options.merge(temporary: true))
     end
 
     # Temporary tables may shadow persistent tables we don't want to drop.


### PR DESCRIPTION
In preparation for an update to Ruby 3.x; see https://github.com/code-dot-org/code-dot-org/pull/49447 for more context.