### PR TITLE
[CSC] Add new shape block for rhombuses

### DIFF
--- a/apps/src/turtle/blocks.js
+++ b/apps/src/turtle/blocks.js
@@ -1550,7 +1550,10 @@ exports.install = function(blockly, blockInstallOptions) {
         'block_id_${this.id}');\n`;
   };
 
-  function createDrawShapeBlock(blockName) {
+  function createDrawShapeBlock(blockName = 'shape', shapeNames) {
+    if (!skin[shapeNames]) {
+      shapeNames = 'shapes';
+    }
     return {
       helpUrl: '',
       init: function() {
@@ -1564,8 +1567,8 @@ exports.install = function(blockly, blockInstallOptions) {
 
         // Generates a list of pairs of the form [[url, name]]
         var values = [];
-        for (var name in skin.shapes) {
-          var url = skin.shapes[name];
+        for (var name in skin[shapeNames]) {
+          var url = skin[shapeNames][name];
           values.push([url, name]);
         }
         dropdown = new blockly.FieldImageDropdown(values, 40, 40);
@@ -1579,12 +1582,12 @@ exports.install = function(blockly, blockInstallOptions) {
 
   // Add size input to the draw shape block (text input & socket)
   function appendToDrawShapeBlock(blockName, block) {
-    if (blockName === 'turtle_shape_with_side_length') {
+    if (blockName.endsWith('_with_side_length')) {
       block.appendDummyInput().appendField(msg.withSideLength());
       block.appendValueInput('SIZE').setCheck(blockly.BlockValueType.NUMBER);
       block.appendDummyInput().appendField(msg.pixels());
       block.setTooltip(msg.drawShapeWithSideLength());
-    } else if (blockName === 'turtle_shape_with_side_length_non_param') {
+    } else if (blockName.endsWith('_with_side_length_non_param')) {
       block.appendDummyInput().appendField(msg.withSideLength());
       block
         .appendDummyInput()
@@ -1605,13 +1608,7 @@ exports.install = function(blockly, blockInstallOptions) {
   blockly.Blocks.shape = createDrawShapeBlock();
 
   generator.shape = function() {
-    return (
-      'Turtle.drawShape("' +
-      this.getFieldValue('VALUE') +
-      '", null, \'block_id_' +
-      this.id +
-      "');\n"
-    );
+    return generateDrawShapeCommand(this.getFieldValue('VALUE'), null, this.id);
   };
 
   blockly.Blocks.turtle_shape_with_side_length = createDrawShapeBlock(
@@ -1624,8 +1621,24 @@ exports.install = function(blockly, blockInstallOptions) {
       'SIZE',
       Blockly.JavaScript.ORDER_NONE
     );
-    return `Turtle.drawShape('${this.getFieldValue('VALUE')}',${size},
-        'block_id_${this.id}');\n`;
+    return generateDrawShapeCommand(this.getFieldValue('VALUE'), size, this.id);
+  };
+
+  blockly.Blocks.rhombus_shape_with_side_length = createDrawShapeBlock(
+    'rhombus_shape_with_side_length',
+    'rhombus45degree'
+  );
+
+  generator.rhombus_shape_with_side_length =
+    generator.turtle_shape_with_side_length;
+
+  generator.turtle_shape_with_side_length = function() {
+    let size = generator.valueToCode(
+      this,
+      'SIZE',
+      Blockly.JavaScript.ORDER_NONE
+    );
+    return generateDrawShapeCommand(this.getFieldValue('VALUE'), size, this.id);
   };
 
   blockly.Blocks.turtle_shape_with_side_length_non_param = createDrawShapeBlock(
@@ -1634,9 +1647,13 @@ exports.install = function(blockly, blockInstallOptions) {
 
   generator.turtle_shape_with_side_length_non_param = function() {
     let size = window.parseFloat(this.getFieldValue('SIZE')) || 0;
-    return `Turtle.drawShape('${this.getFieldValue('VALUE')}',${size},
-        'block_id_${this.id}');\n`;
+    return generateDrawShapeCommand(this.getFieldValue('VALUE'), size, this.id);
   };
+
+  function generateDrawShapeCommand(value, size, id) {
+    return `Turtle.drawShape('${value}',${size},
+        'block_id_${id}');\n`;
+  }
 
   blockly.Blocks.turtle_setArtist = {
     helpUrl: '',

--- a/apps/src/turtle/skins.js
+++ b/apps/src/turtle/skins.js
@@ -1,11 +1,11 @@
-var skinBase = require('../skins');
-var linePatterns = require('./linePatterns');
+const skinBase = require('../skins');
+const linePatterns = require('./linePatterns');
 
 exports.load = function(assetUrl, id) {
-  var skin = skinBase.load(assetUrl, id);
+  const skin = skinBase.load(assetUrl, id);
   skin.linePatterns = linePatterns.load(assetUrl);
 
-  var CONFIGS = {
+  const CONFIGS = {
     anna: {
       // slider speed gets divided by this value
       speedModifier: 10,
@@ -90,9 +90,9 @@ exports.load = function(assetUrl, id) {
    *
    * @return the mapping of names to urls
    */
-  var stickers = function() {
+  const stickers = function() {
     // Playlab characters
-    var playlab = [
+    const playlab = [
       'Alien',
       'Bat',
       'Bird',
@@ -165,63 +165,75 @@ exports.load = function(assetUrl, id) {
 
     return mapping;
   };
+  var rhombus60degree = [
+    'smallRhombusMaroon',
+    'smallRhombusRed',
+    'smallRhombusOrange',
+    'smallRhombusYellow',
+    'smallRhombusGreen',
+    'smallRhombusCyan',
+    'smallRhombusLightBlue',
+    'smallRhombusBlue',
+    'smallRhombusPurple',
+    'smallRhombusMagenta'
+  ];
+  var rhombus45degree = [
+    'smallRhombusMaroon45',
+    'smallRhombusRed45',
+    'smallRhombusOrange45',
+    'smallRhombusYellow45',
+    'smallRhombusGreen45',
+    'smallRhombusCyan45',
+    'smallRhombusLightBlue45',
+    'smallRhombusBlue45',
+    'smallRhombusPurple45',
+    'smallRhombusMagenta45'
+  ];
+  var rhombus30degree = [
+    'smallRhombusMaroon30',
+    'smallRhombusRed30',
+    'smallRhombusOrange30',
+    'smallRhombusYellow30',
+    'smallRhombusGreen30',
+    'smallRhombusCyan30',
+    'smallRhombusLightBlue30',
+    'smallRhombusBlue30',
+    'smallRhombusPurple30',
+    'smallRhombusMagenta30'
+  ];
+  var patternBlocks = [
+    'hexagonYellow',
+    'triangleGreen',
+    'squareOrange',
+    'trapezoidRed'
+  ];
+
+  var allShapes = [
+    ...rhombus60degree,
+    ...rhombus45degree,
+    ...rhombus30degree,
+    ...patternBlocks
+  ];
+
   /**
    * Generates a mapping of geometry sticker names to the urls of their images.
    *
    * @return the mapping of names to urls
    */
-  var shapes = function() {
+  var shapes = function(imageNames) {
     // Pattern Blocks
-    var shapes = [
-      'smallRhombusMaroon',
-      'smallRhombusRed',
-      'smallRhombusOrange',
-      'smallRhombusYellow',
-      'smallRhombusGreen',
-      'smallRhombusCyan',
-      'smallRhombusLightBlue',
-      'smallRhombusBlue',
-      'smallRhombusPurple',
-      'smallRhombusMagenta',
-      'smallRhombusMaroon45',
-      'smallRhombusRed45',
-      'smallRhombusOrange45',
-      'smallRhombusYellow45',
-      'smallRhombusGreen45',
-      'smallRhombusCyan45',
-      'smallRhombusLightBlue45',
-      'smallRhombusBlue45',
-      'smallRhombusPurple45',
-      'smallRhombusMagenta45',
-      'smallRhombusMaroon30',
-      'smallRhombusRed30',
-      'smallRhombusOrange30',
-      'smallRhombusYellow30',
-      'smallRhombusGreen30',
-      'smallRhombusCyan30',
-      'smallRhombusLightBlue30',
-      'smallRhombusBlue30',
-      'smallRhombusPurple30',
-      'smallRhombusMagenta30',
-      'hexagonYellow',
-      'triangleGreen',
-      'squareOrange',
-      'trapezoidRed'
-    ];
 
     var mapping = {};
-    var name;
 
-    for (var i = 0; i < shapes.length; i++) {
-      name = shapes[i];
+    imageNames.forEach(name => {
       mapping[name] = assetUrl('media/common_images/shapes/' + name + '.png');
-    }
-
+    });
     return mapping;
   };
 
   skin.stickers = stickers();
-  skin.shapes = shapes();
+  skin.shapes = shapes(allShapes);
+  skin.rhombus45degree = shapes(rhombus45degree);
 
   var config = CONFIGS[skin.id];
 


### PR DESCRIPTION
The CSC team has requested one new variant of `draw shape` block. Initially created here:
* https://github.com/code-dot-org/code-dot-org/pull/45409

This block should work the same way but feature just the subset of rhombus images indicated below:
![Screen Shot 2023-03-28 at 9 13 55 AM](https://user-images.githubusercontent.com/43474485/228570925-e6485f9e-cfb8-40e4-9209-ce96b75628c3.png)

To accomplish this, I first refactored the shapes list within the skin to make it easier to select a subset. I then defined a new block that uses the subset list to populate the field dropdown. Because we had several blocks that were generating code in much the same way, I created a helper function for this.

**Screenshot of new block working as expected:**
![image](https://user-images.githubusercontent.com/43474485/228571622-9fcfd03f-69b2-4b83-9f6d-510b139ff677.png)

## Links

Jira: https://codedotorg.atlassian.net/browse/SL-708

## Follow-up work

The CSC has expressed interest in adding more images (rhombuses of different colors) to the block dropdown. If this is requested, they will provide the assets and we can simply add them to the skin.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
