### PR TITLE
[Star Wars] remove random actor type option from speed block

### DIFF
--- a/apps/src/studio/blocks.js
+++ b/apps/src/studio/blocks.js
@@ -801,6 +801,7 @@ exports.install = function(blockly, blockInstallOptions) {
 
       this.appendDummyInput().appendField(msg.setItemSpeedSet());
       const itemChoices = [...skin.itemChoices];
+      // Remove "random" option, but preserve it for other blocks.
       if (itemChoices[itemChoices.length - 1][1] === RANDOM_VALUE) {
         itemChoices.pop();
       }

--- a/apps/src/studio/blocks.js
+++ b/apps/src/studio/blocks.js
@@ -800,8 +800,12 @@ exports.install = function(blockly, blockInstallOptions) {
       Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
 
       this.appendDummyInput().appendField(msg.setItemSpeedSet());
+      const itemChoices = [...skin.itemChoices];
+      if (itemChoices[itemChoices.length - 1][1] === RANDOM_VALUE) {
+        itemChoices.pop();
+      }
       this.appendDummyInput().appendField(
-        new blockly.FieldDropdown(skin.itemChoices),
+        new blockly.FieldDropdown(itemChoices),
         'CLASS'
       );
 

--- a/apps/src/studio/blocks.js
+++ b/apps/src/studio/blocks.js
@@ -824,9 +824,16 @@ exports.install = function(blockly, blockInstallOptions) {
   ];
 
   generator.studio_setItemSpeed = function() {
+    var classParam = this.getFieldValue('CLASS');
+    if (classParam === RANDOM_VALUE) {
+      var allValues = skin.itemChoices.slice(0, -1).map(function(item) {
+        return item[1];
+      });
+      classParam = 'Studio.random([' + allValues + '])';
+    }
     return generateSetterCode({
       ctx: this,
-      extraParams: this.getFieldValue('CLASS'),
+      extraParams: classParam,
       name: 'setItemSpeed'
     });
   };

--- a/apps/src/studio/blocks.js
+++ b/apps/src/studio/blocks.js
@@ -800,13 +800,8 @@ exports.install = function(blockly, blockInstallOptions) {
       Blockly.cdoUtils.setHSV(this, 184, 1.0, 0.74);
 
       this.appendDummyInput().appendField(msg.setItemSpeedSet());
-      const itemChoices = [...skin.itemChoices];
-      // Remove "random" option, but preserve it for other blocks.
-      if (itemChoices[itemChoices.length - 1][1] === RANDOM_VALUE) {
-        itemChoices.pop();
-      }
       this.appendDummyInput().appendField(
-        new blockly.FieldDropdown(itemChoices),
+        new blockly.FieldDropdown(skin.itemChoices),
         'CLASS'
       );
 


### PR DESCRIPTION
A user reported that a student's Star Wars game was crashing. @ebeastlake  discovered that this was due to the block `set type random to a slow speed`. 

![image](https://user-images.githubusercontent.com/43474485/228557491-85484ace-19d6-4cd7-8ba4-317c0022fa56.png)
`"CLASS"` field options for `studio_setItemSpeed`, only used in Star Wars:
<img width="349" alt="image" src="https://user-images.githubusercontent.com/43474485/228557871-0aa465bf-3f77-457d-8c6b-71365174390f.png">
These dropdown options come from the Play Lab skin's `itemChoices` list which ends with a "random" option. The random option is still needed for some blocks:
<img width="692" alt="image" src="https://user-images.githubusercontent.com/43474485/228558075-daa0592b-5563-4f37-a7c8-ec2b7c8e3792.png">


When we create this block, we can check whether the random option is at the end of the list and remove it. We want to deep-copy the array first so as to not affect other block fields. 
https://github.com/code-dot-org/code-dot-org/blob/mike/remove-random-option-for-sw-speed-block/apps/src/studio/starwars/skins.js#L715-L725

## Result
The speed block no longer provides a random option in the first field: 
<img width="384" alt="image" src="https://user-images.githubusercontent.com/43474485/228559345-4fcb84c1-a942-491e-bff8-955dcb33f7b8.png">

If block XML dictates that the value is `"random"` (e.g. existing student projects), the field will continue to show "random" and cause the same error until it is changed. 
<img width="346" alt="image" src="https://user-images.githubusercontent.com/43474485/228559743-b2c581d1-7d7e-4fd7-95c5-9c717e869ca6.png">


## Links

ZenDesk report: https://codeorg.zendesk.com/agent/tickets/432951
Jira Issue: https://codedotorg.atlassian.net/browse/SL-635
## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
