### PR TITLE
Remove repeated sentence from CSF emails

### DIFF
--- a/dashboard/app/views/pd/workshop_mailer/teacher_enrollment_reminder.html.haml
+++ b/dashboard/app/views/pd/workshop_mailer/teacher_enrollment_reminder.html.haml
@@ -42,7 +42,6 @@
 - elsif @workshop.subject != Pd::Workshop::COURSE_FACILITATOR
   %p
     - if @workshop.course == Pd::Workshop::COURSE_CSF
-      This is a great step towards bringing computer science to your classroom!
     If you have any questions, reach out to your workshop organizer directly:
     = "#{@organizer.name} at "
     = mail_to @organizer.email, "#{@organizer.email}."

--- a/dashboard/app/views/pd/workshop_mailer/teacher_enrollment_reminder.html.haml
+++ b/dashboard/app/views/pd/workshop_mailer/teacher_enrollment_reminder.html.haml
@@ -41,7 +41,6 @@
   = render partial: 'pre_survey'
 - elsif @workshop.subject != Pd::Workshop::COURSE_FACILITATOR
   %p
-    - if @workshop.course == Pd::Workshop::COURSE_CSF
     If you have any questions, reach out to your workshop organizer directly:
     = "#{@organizer.name} at "
     = mail_to @organizer.email, "#{@organizer.email}."


### PR DESCRIPTION
Removes a sentence which is repeated twice in CSF emails.  You can see the sentence repeated on line 23 of the same file. 

### Before

<img width="1780" alt="Screenshot 2023-03-29 at 2 34 26 PM" src="https://user-images.githubusercontent.com/208083/228635060-8e1144cb-1913-45ec-b200-947e41621681.png">

### After
<img width="1507" alt="Screenshot 2023-03-29 at 3 58 40 PM" src="https://user-images.githubusercontent.com/208083/228653411-81f56b67-ada3-4e03-b1d9-a5e4ce8c4b0c.png">

