### PR TITLE
Remove `karma-webpack` Build Artifacts after Build

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -565,7 +565,7 @@ describe('entry tests', () => {
   };
 
   config.clean = {
-    all: ['build'],
+    build: ['build'],
     // The karma-webpack-backed unit tests generate several hundred megabytes
     // worth of assets in /tmp/ on each run which will accumulate indefinitely
     // on our persistent test server unless we clean them up.

--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -146,10 +146,6 @@ describe('entry tests', () => {
     }
   }
 
-  config.clean = {
-    all: ['build']
-  };
-
   config.copy = {
     src: {
       files: [
@@ -448,9 +444,9 @@ describe('entry tests', () => {
   // so that bundled files will be properly served.
   // this is the source of the following warning, which can be ignored:
   // "All files matched by "/tmp/_karma_webpack_425424/**/*" were excluded or matched by prior matchers."
+  const webpackOutputBasePath = path.join(os.tmpdir(), '_karma_webpack_');
   const webpackOutputPath =
-    path.join(os.tmpdir(), '_karma_webpack_') +
-    Math.floor(Math.random() * 1000000);
+    webpackOutputBasePath + Math.floor(Math.random() * 1000000);
   const webpackOutputPublicPath = '/webpack_output/';
 
   config.karma = {
@@ -565,6 +561,14 @@ describe('entry tests', () => {
       preprocessors: {
         'test/entry-tests.js': ['webpack', 'sourcemap']
       }
+    }
+  };
+
+  config.clean = {
+    all: ['build'],
+    unitTest: {
+      options: {force: true},
+      src: [webpackOutputBasePath + '*']
     }
   };
 
@@ -1408,7 +1412,8 @@ describe('entry tests', () => {
     'newer:messages',
     'exec:convertScssVars',
     'exec:generateSharedConstants',
-    'karma:unit'
+    'karma:unit',
+    'clean:unitTest'
   ]);
 
   grunt.registerTask('storybookTest', ['karma:storybook']);

--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -566,6 +566,9 @@ describe('entry tests', () => {
 
   config.clean = {
     all: ['build'],
+    // The karma-webpack-backed unit tests generate several hundred megabytes
+    // worth of assets in /tmp/ on each run which will accumulate indefinitely
+    // on our persistent test server unless we clean them up.
     unitTest: {
       options: {force: true},
       src: [webpackOutputBasePath + '*']

--- a/cookbooks/cdo-apps/recipes/build.rb
+++ b/cookbooks/cdo-apps/recipes/build.rb
@@ -22,16 +22,3 @@ execute 'build-cdo' do
   # Rebuild when Ruby is upgraded.
   subscribes :run, "apt_package[ruby#{node['cdo-ruby']['version']}]", :delayed if node['cdo-ruby']
 end
-
-# Clean up build artifacts left over on persistent servers after building.
-execute 'clean-build-artifacts' do
-  # Currently, this only removes the build artifacts for the `karma-webpack`
-  # NPM package because they've been accumulating on the test server and eating
-  # up our storage space. This could be expanded in the future to include any
-  # other cleanup we might discover we need.
-  command 'rm -r /tmp/_karma_webpack_*'
-
-  # We don't need to run this every time, just after a build.
-  action :nothing
-  subscribes :run, 'execute[build-cdo]'
-end

--- a/cookbooks/cdo-apps/recipes/build.rb
+++ b/cookbooks/cdo-apps/recipes/build.rb
@@ -22,3 +22,16 @@ execute 'build-cdo' do
   # Rebuild when Ruby is upgraded.
   subscribes :run, "apt_package[ruby#{node['cdo-ruby']['version']}]", :delayed if node['cdo-ruby']
 end
+
+# Clean up build artifacts left over on persistent servers after building.
+execute 'clean-build-artifacts' do
+  # Currently, this only removes the build artifacts for the `karma-webpack`
+  # NPM package because they've been accumulating on the test server and eating
+  # up our storage space. This could be expanded in the future to include any
+  # other cleanup we might discover we need.
+  command 'rm -r /tmp/_karma_webpack_*'
+
+  # We don't need to run this every time, just after a build.
+  action :nothing
+  subscribes :run, 'execute[build-cdo]'
+end


### PR DESCRIPTION
Long-term solution to the `test-DiskUsedWarning` errors we've been getting; there are currently over 80 gigabytes worth of build artifacts at `/tmp/_karma_webpack_*` on the test server, accumulating at a rate of about 180M per DTT.

These build artifacts are new [as of our upgrade to Webpack 5](https://github.com/code-dot-org/code-dot-org/pull/48105/files#diff-27cd61447671698bcd3bdf81385851a09335cd1cbc19f1ea789655aab5f6cc0fR438) and are necessary for the apps unit tests, but should be cleaned up after the tests are finished.

## Links

- https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#alarm:name=test-DiskUsedWarning-19FWUFI4AIBKP
- https://github.com/code-dot-org/code-dot-org/pull/48105

## Testing story

Tested locally and on an adhoc that this cleans up files as desired. Also verified that the cleanup executed successfully in the drone run for this PR.
