### PR TITLE
Music: fix video size

### DIFF
--- a/apps/src/music/views/Video.jsx
+++ b/apps/src/music/views/Video.jsx
@@ -14,7 +14,9 @@ function useWindowSize() {
   const [size, setSize] = useState([0, 0]);
   useLayoutEffect(() => {
     function updateSize() {
-      setSize([window.innerWidth, window.innerHeight]);
+      const width = document.documentElement.clientWidth;
+      const height = document.documentElement.clientHeight;
+      setSize([width, height]);
     }
     window.addEventListener('resize', updateSize);
     updateSize();


### PR DESCRIPTION
In Chrome on iOS, the video was sometimes showing too large.  From some on-device debugging (using `chrome://inspect` to view some custom logging), it seemed that `window.innerHeight` in landscape orientation was often too high (almost as big as the width), causing the video to occupy space beyond what was visible.  

I tried using the technique described [here](https://stackoverflow.com/a/73493610), in which we set a small timeout before using the values, but was still seeing the problem with `window.innerHeight`.  However, switching from `window.innerHeight/Width` to `document.documentElement.clientHeight/Width`, as suggested [here](https://stackoverflow.com/a/54812656), seems to have fixed the issue.