### PR TITLE
[JIMT][SL-710] - remove rmagick check note

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -154,8 +154,6 @@ These steps may need to change over time as 3rd party tools update to have versi
 
 1. Install an assortment of additional packages via `brew install enscript gs imagemagick ruby-build coreutils sqlite parallel tidy-html5`
 
-1. [Check your rmagick version](#rmagick)
-
 1. Install [Node Version Manager](https://github.com/nvm-sh/nvm) and install Node
     1. Install NVM via `brew install nvm`
 
@@ -271,7 +269,6 @@ These steps may need to change over time as 3rd party tools update to have versi
 1. Install OpenSSL:
     1. `brew install openssl`
     1. `export LIBRARY_PATH=$LIBRARY_PATH:/usr/local/opt/openssl/lib/`
-1. [Check rmagick version](#rmagick)
 1. If you want to render personalized certificates locally, see these special instructions regarding [ImageMagick with pango](#imagemagick-with-pango).
 1. Prevent future problems related to the `Too many open files` error:
     1. Add the following to `~/.bash_profile` or your desired shell configuration file:
@@ -486,16 +483,6 @@ Wondering where to start?  See our [contribution guidelines](CONTRIBUTING.md) fo
 
 ---
 ### Bundle Install Tips
-
-#### rmagick
-If rmagick doesn't install, check your version of imagemagick, and downgrade if >= 7
-- `convert --version`
-- `brew install imagemagick@6`
-- `brew unlink imagemagick`
-- `brew link imagemagick@6 --force`
-If you continue to have issues with rmagick, after changing your imagemagick version, you may need to uninstall/reinstall the gem
-- `gem uninstall rmagick`
-- `gem install rmagick -v 2.16.0`
 
 #### Apple Silicon (M1) bundle install steps
 


### PR DESCRIPTION
Itty bitty change - the setup docs were mostly solid, but it looks like the rmagick version in the gemfile.lock was bumped to 4.2.5 from 2.16.0 about 8 months ago, so I don't think we still need the section about downgrading to v6 of imagemagick or manually installing the old rmagick version. Regular install worked for me w/o additional tweaks.

## Links

jira ticket: [SL-710](https://codedotorg.atlassian.net/browse/SL-710)

## Testing story

N/A. Just confirm that we don't need this section in the docs and then nuke it.

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
