### PR TITLE
remove unnecessary condition

### DIFF
--- a/aws/cloudformation/iam.yml.erb
+++ b/aws/cloudformation/iam.yml.erb
@@ -381,9 +381,6 @@ Resources:
                     "assets_development/*",
                     "animations_development/*",
                     "files_development/*"
-                ],
-                "s3:delimiter": [
-                    "/"
                 ]
               }
           - Sid: AllowNeededS3ActionsInCertainBucketFolders


### PR DESCRIPTION
This PR removes a problematic condition on the ListBuckets and ListBucketVersions actions.

## Links

## Testing story

As these permissions are additive, I was able to add a new policy to the contributor with the correct ListBucketVersions policy. With this policy applied, the following command was successful.

Before - reproducing the problem:

```
> aws s3api list-object-versions --bucket cdo-v3-sources --prefix sources_development/1016/1283/main.json

An error occurred (AccessDenied) when calling the ListObjectVersions operation: Access Denied
```

After applying manual policy, the versions are listed.

## Deployment strategy

1. update iam stack with this code
2. delete [manual policy](https://us-east-1.console.aws.amazon.com/iam/home#/roles/Contributor$jsonEditor?policyName=ManualListBucketVersions&step=edit) from Contributor role
3. Confirm that Contributors are still able to run `list-object-versions` commands
4. merge this PR

## Security

Action remains scoped to the appropriate prefixes

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] ~Tests provide adequate coverage~
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [ ] ~New features are translatable or updates will not break translations~
- [x] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
