### PR TITLE
Project Beats: can select greater than 16 notes in chord block

### DIFF
--- a/apps/src/music/views/ChordPanel.tsx
+++ b/apps/src/music/views/ChordPanel.tsx
@@ -189,7 +189,7 @@ const Key: React.FunctionComponent<KeyProps> = ({
         type === 'white' && moduleStyles.whiteKey,
         type === 'black' && moduleStyles.blackKey
       )}
-      onClick={onClick}
+      onClick={isSelected || !isDisabled ? onClick : undefined}
     >
       <p className={moduleStyles.noteLabel}>{text}</p>
     </div>


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Quick bug fix to prevent users from selecting more than 16 notes in a chord block

## Links

https://codedotorg.atlassian.net/browse/SL-751

## Testing story

Tested locally