### PR TITLE
Add an event when the summary page is visited

### DIFF
--- a/apps/src/lib/util/AnalyticsConstants.js
+++ b/apps/src/lib/util/AnalyticsConstants.js
@@ -52,7 +52,7 @@ const EVENTS = {
   FEEDBACK_SUBMITTED: 'Level Feedback Submitted',
   RUBRIC_LEVEL_VIEWED_EVENT: 'Rubric Level Viewed',
   TEACHER_VIEWING_STUDENT_WORK: 'Teacher Viewing Student Work',
-  SUMMARY_PAGE_VISITED: 'Summary Page Visited',
+  SUMMARY_PAGE_LOADED: 'Summary Page Loaded',
 
   // Maker setup
   MAKER_SETUP_PAGE_BOARD_TYPE_EVENT: 'Board Type On Maker Setup Page',

--- a/apps/src/lib/util/AnalyticsConstants.js
+++ b/apps/src/lib/util/AnalyticsConstants.js
@@ -52,6 +52,7 @@ const EVENTS = {
   FEEDBACK_SUBMITTED: 'Level Feedback Submitted',
   RUBRIC_LEVEL_VIEWED_EVENT: 'Rubric Level Viewed',
   TEACHER_VIEWING_STUDENT_WORK: 'Teacher Viewing Student Work',
+  SUMMARY_PAGE_VISITED: 'Summary Page Visited',
 
   // Maker setup
   MAKER_SETUP_PAGE_BOARD_TYPE_EVENT: 'Board Type On Maker Setup Page',

--- a/apps/src/templates/levelSummary/CheckForUnderstanding.jsx
+++ b/apps/src/templates/levelSummary/CheckForUnderstanding.jsx
@@ -36,7 +36,7 @@ const CheckForUnderstanding = ({
 
   useEffect(() => {
     const {level} = scriptData;
-    analyticsReporter.sendEvent(EVENTS.SUMMARY_PAGE_VISITED, {
+    analyticsReporter.sendEvent(EVENTS.SUMMARY_PAGE_LOADED, {
       levelId: level.id,
       levelName: level.properties.name,
       levelType: level.type,

--- a/apps/src/templates/levelSummary/CheckForUnderstanding.jsx
+++ b/apps/src/templates/levelSummary/CheckForUnderstanding.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect} from 'react';
 import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
@@ -6,6 +6,8 @@ import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
 import SectionSelector from '@cdo/apps/code-studio/components/progress/SectionSelector';
 import i18n from '@cdo/locale';
 import styles from './check-for-understanding.module.scss';
+import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
+import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 
 const FREE_RESPONSE = 'FreeResponse';
 
@@ -31,6 +33,16 @@ const CheckForUnderstanding = ({
   const questionMarkdown = scriptData.level.properties.long_instructions;
   const teacherMarkdown = scriptData.teacher_markdown;
   const height = scriptData.level.height || '80';
+
+  useEffect(() => {
+    const {level} = scriptData;
+    analyticsReporter.sendEvent(EVENTS.SUMMARY_PAGE_VISITED, {
+      levelId: level.id,
+      levelName: level.properties.name,
+      levelType: level.type,
+      ...scriptData.reportingData
+    });
+  }, []);
 
   return (
     <div className={styles.summaryContainer}>

--- a/dashboard/app/views/levels/_summary.html.haml
+++ b/dashboard/app/views/levels/_summary.html.haml
@@ -23,11 +23,18 @@
       height: level.respond_to?(:height) ? level.height : nil,
       type: level.type,
       id: level.id,
+      name: level.name
     },
     last_attempt: last_attempt,
     left_align: left_align,
     responses: responses,
     teacher_markdown: teacher_markdown,
+    reportingData: {
+      lessonName: @script_level.lesson.name,
+      lessonId: @script_level.lesson.id,
+      unitName: @script.name,
+      unitId: @script.id
+    }
   }
 
 

--- a/dashboard/app/views/levels/_summary.html.haml
+++ b/dashboard/app/views/levels/_summary.html.haml
@@ -33,7 +33,8 @@
       lessonName: @script_level.lesson.name,
       lessonId: @script_level.lesson.id,
       unitName: @script.name,
-      unitId: @script.id
+      unitId: @script.id,
+      curriculumUmbrella: @script.curriculum_umbrella
     }
   }
 


### PR DESCRIPTION
Fires an Amplitude event when the CFU page is loaded. 

Example event:
```
[AMPLITUDE ANALYTICS EVENT]: Summary Page Loaded. Payload: {"payload":{"levelId":34773,"levelType":"FreeResponse","lessonName":"Decomposition and Design","lessonId":134369,"unitName":"csa1-2022","unitId":13555,"curriculumUmbrella":"CSA"}}
```

## Links

[jira](https://codedotorg.atlassian.net/browse/TEACH-349)

## Testing story

I didn't include a test here because it's a pretty straightforward change and testing useEffect is a little tricky. If folks think a test would be useful here, let me know and I'll take a look.

