### PR TITLE
Adds course offering header strings to en.yml for translation

### DIFF
--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -1271,6 +1271,25 @@ en:
     no_teacher_email:
       body_markdown: 'Your account doesn’t have an email address. Please [visit your account settings](%{user_registration}) to add your email address before completing this form.'
   courses_category: 'Full Courses'
+  course_offering:
+    headers:
+      favorites: 'Favorites',
+      labs_and_skills: 'Labs and Skills',
+      minecraft: 'Minecraft',
+      hello_world: 'Hello World',
+      popular_media: 'Popular Media',
+      sports: 'Sports',
+      express: 'Express',
+      csf: 'CS Fundamentals',
+      csc: 'CS Connections',
+      year_long: 'Year Long',
+      csa_labs: 'CSA Labs',
+      self_paced: 'Self-Paced',
+      teacher_led: 'Teacher-Led',
+      collections: 'Collections',
+      workshops_k5: 'K-5 Workshops',
+      summer_workshops_612: '6-12 Summer Workshops',
+      virtual_academic_year_workshops_612: '6–12 Virtual Academic Year Workshops'
   cookie_banner:
     message: 'By continuing to browse our site or clicking "I agree," you agree to the storing of cookies on your computer or device.'
     more_information: "See Code.org's Privacy Policy."

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -1273,22 +1273,22 @@ en:
   courses_category: 'Full Courses'
   course_offering:
     headers:
-      favorites: 'Favorites',
-      labs_and_skills: 'Labs and Skills',
-      minecraft: 'Minecraft',
-      hello_world: 'Hello World',
-      popular_media: 'Popular Media',
-      sports: 'Sports',
-      express: 'Express',
-      csf: 'CS Fundamentals',
-      csc: 'CS Connections',
-      year_long: 'Year Long',
-      csa_labs: 'CSA Labs',
-      self_paced: 'Self-Paced',
-      teacher_led: 'Teacher-Led',
-      collections: 'Collections',
-      workshops_k5: 'K-5 Workshops',
-      summer_workshops_612: '6-12 Summer Workshops',
+      favorites: 'Favorites'
+      labs_and_skills: 'Labs and Skills'
+      minecraft: 'Minecraft'
+      hello_world: 'Hello World'
+      popular_media: 'Popular Media'
+      sports: 'Sports'
+      express: 'Express'
+      csf: 'CS Fundamentals'
+      csc: 'CS Connections'
+      year_long: 'Year Long'
+      csa_labs: 'CSA Labs'
+      self_paced: 'Self-Paced'
+      teacher_led: 'Teacher-Led'
+      collections: 'Collections'
+      workshops_k5: 'K-5 Workshops'
+      summer_workshops_612: '6-12 Summer Workshops'
       virtual_academic_year_workshops_612: '6–12 Virtual Academic Year Workshops'
   cookie_banner:
     message: 'By continuing to browse our site or clicking "I agree," you agree to the storing of cookies on your computer or device.'


### PR DESCRIPTION
This is part one of the ticket (tagged below) for translating the headers for course offerings. I will have to go back and re-backfill the table, but wanted to get this strings in the pipeline so the translation process can begin. This will serve as the basis for an upcoming PR that incorporates the translations.

These match the existing constants in the shared constants file, as seen here:
<img width="645" alt="Screenshot 2023-03-31 at 10 38 56 AM" src="https://user-images.githubusercontent.com/37230822/229191338-e79f4b56-5403-4573-8bcf-1c1446168c6a.png">

## Links


- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/TEACH-362

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
