### PR TITLE
adding samoan to dashboard locales.yml

### DIFF
--- a/dashboard/config/locales.yml
+++ b/dashboard/config/locales.yml
@@ -394,6 +394,12 @@
   native: "Slovenščina"
   webfonts: false
 
+"sm": "sm-WS"
+"sm-WS":
+  english: "Samoan"
+  native: "Sāmoa"
+  debug: true
+
 "sq": "sq-AL"
 "sq-AL":
   english: "Albanian"


### PR DESCRIPTION
We have a partner working on translations for Samoan, Samoan was added to to [cdo-languages](https://docs.google.com/spreadsheets/d/10dS5PJKRt846ol9f9L3pKh03JfZkN7UIEcwMmiGS4i0/edit#gid=0), and updated in Crowdin Projects.
The next step is updating `dashboard/config/locales.yml ` to include samoan in the dropdown language menu.

- jira ticket: [P20-100](https://codedotorg.atlassian.net/browse/P20-100)
