### PR TITLE
[Micro:bit] Fix contained level with micro:bit enabled

### DIFF
--- a/apps/src/lib/kits/maker/toolkit.js
+++ b/apps/src/lib/kits/maker/toolkit.js
@@ -20,13 +20,13 @@ import {findPortWithViableDevice} from './portScanning';
 import * as redux from './redux';
 import {isChrome, gtChrome33, isCodeOrgBrowser} from './util/browserChecks';
 import MicroBitBoard from './boards/microBit/MicroBitBoard';
-import project from '../../../code-studio/initApp/project';
 import {MB_API} from './boards/microBit/MicroBitConstants';
 import WebSerialPortWrapper from '@cdo/apps/lib/kits/maker/WebSerialPortWrapper';
 import {
   WEB_SERIAL_FILTERS,
   shouldUseWebSerial
 } from '@cdo/apps/lib/kits/maker/util/boardUtils';
+import {getAppOptions} from '@cdo/apps/code-studio/initApp/loadApp';
 
 // Re-export some modules so consumers only need this 'toolkit' module
 export {dropletConfig, configMicrobit, configCircuitPlayground, MakerError};
@@ -164,8 +164,9 @@ function confirmSupportedBrowser() {
  * @returns {Promise.<MakerBoard>}
  */
 function getBoard() {
+  const makerBoardAPI = getAppOptions().level.makerlabEnabled;
   const boardConstructor =
-    project.getMakerAPIs() === MB_API ? MicroBitBoard : CircuitPlaygroundBoard;
+    makerBoardAPI === MB_API ? MicroBitBoard : CircuitPlaygroundBoard;
 
   if (shouldRunWithFakeBoard()) {
     return Promise.resolve(new FakeBoard());

--- a/apps/src/lib/kits/maker/toolkit.js
+++ b/apps/src/lib/kits/maker/toolkit.js
@@ -165,7 +165,6 @@ function confirmSupportedBrowser() {
  */
 function getBoard() {
   const makerBoardAPI = getAppOptions().level?.makerlabEnabled;
-  console.log(makerBoardAPI);
   const boardConstructor =
     makerBoardAPI === MB_API ? MicroBitBoard : CircuitPlaygroundBoard;
 

--- a/apps/src/lib/kits/maker/toolkit.js
+++ b/apps/src/lib/kits/maker/toolkit.js
@@ -164,7 +164,8 @@ function confirmSupportedBrowser() {
  * @returns {Promise.<MakerBoard>}
  */
 function getBoard() {
-  const makerBoardAPI = getAppOptions().level.makerlabEnabled;
+  const makerBoardAPI = getAppOptions().level?.makerlabEnabled;
+  console.log(makerBoardAPI);
   const boardConstructor =
     makerBoardAPI === MB_API ? MicroBitBoard : CircuitPlaygroundBoard;
 


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR fixes a bug on contained levels with micro:bit Maker API enabled.  Examples of contained levels are [this level with micro:bit](https://studio.code.org/s/microbit-2023/lessons/3/levels/2) or [this level with the Circuit Playground](https://studio.code.org/s/devices-2022/lessons/3/levels/2). Within contained levels `project.getMakerAPIs`  returns `null` in `toolkit.js` so that for both micro:bit and CircuitPlayground contained levels, the `boardConstructor` is assigned `CircuitPlaygroundBoard`.

Thus, I call on `getAppOptions()`  to access the `level.makerlabEnabled` property which is set whether the curriculum level is a contained level or not. 

I was curious about why `projects.getMakerAPIs` returns `null` for contained levels. In `project.js`, [in the `init`  function](https://github.com/code-dot-org/code-dot-org/blob/de87cfcfba89ae61e8a0bee295170d6c6ccf22ae/apps/src/code-studio/initApp/project.js#L677), we first check the condition:
```
if (this.isProjectLevel || current)
```
and if `true`, we call on `setMakerAPIsStatusFromLevel`. This function checks if `appOptions.level.makerlabEnabled` is assigned a value and if it is, then `makerAPIsEnabled` in the current source is assigned that same value.
Then we check `this.getMakerAPIs()`, i.e. if the current source has the property `makerAPIsEnabled` . If it does, then we set `appOptions.level.makerlabEnabled` to this value. At this point, `appOptions` and the current source are in sync!

The problem with contained levels is that the App Lab project is read-only so that there is no current source. Thus, the condition `this.isProjectLevel || current` is false which means the source value of `makerAPIsEnabled` remains `null` and out of sync with `appOptions.level.makerlabEnabled`.  Thus, the bug fix is to rely upon the value of `appOptions.level.makerlabEnabled` in `toolkit.js`. 

For stand-alone projects, `appOptions.level.makerlabEnabled` is updated [here](https://github.com/code-dot-org/code-dot-org/blob/de87cfcfba89ae61e8a0bee295170d6c6ccf22ae/apps/src/code-studio/initApp/project.js#L684) as explained above. In `SettingsCog.jsx`, the function `confirmEnableMaker` calls on `project.setMakerEnabled` which sets the property `makerAPIsEnabled`. 

At this point, I am unsure why there are 2 sources of truth to access if a project or curriculum level has Maker Toolkit enabled. It seems from an initial glance that it may be possible to only use `appOptions.level.makerlabEnabled` and remove the`makeAPIsEnabled`property to simplify the code.

## Links
[Slack thread](https://codedotorg.slack.com/archives/C04NG4SUCQ0/p1680546143587599) which includes a link to a ZenDesk ticket which reported this issue.

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
- [jira ticket](https://codedotorg.atlassian.net/browse/SL-766)
<!--
- spec: []()

-->

## Testing story
I tested locally on contained and non-contained levels with both the micro:bit and Circuit Playground. I also check to make sure stand-alone projects with Maker API enabled work as well (both boards).

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work
- Now that we support 2 different boards, refactor `makerlabEnabled` which sounds like it returns a boolean but actually returns a string or a boolean. `makerlabEnabled` currently returns `microbit` if a micro:bit is assigned, but returns`true` or `circuitPlayground` if a Circuit Playground is connected.
- Remove the 2 sources of truth for accessing whether a project has the Maker Toolkit enabled and use only `appOptions.level.makerlabEnabled`.
[jira ticket](https://codedotorg.atlassian.net/browse/SL-768)

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
