### PR TITLE
AiLab: Return filter match

### DIFF
--- a/dashboard/app/controllers/api/v1/ml_models_controller.rb
+++ b/dashboard/app/controllers/api/v1/ml_models_controller.rb
@@ -20,9 +20,9 @@ class Api::V1::MlModelsController < Api::V1::JSONApiController
     model_id = UserMlModel.generate_id
     model_data = params["ml_model"]
     return head :bad_request if model_data.nil? || model_data == ""
+
     # If there's a PII/profanity API error, we rescue the exception and the save
     # will succeed. The saved model will bypass the PII/profanity filters.
-
     begin
       profanity_or_pii = ShareFiltering.find_failure(
         model_data.except(:trainedModel).to_s,

--- a/dashboard/app/controllers/api/v1/ml_models_controller.rb
+++ b/dashboard/app/controllers/api/v1/ml_models_controller.rb
@@ -45,6 +45,17 @@ class Api::V1::MlModelsController < Api::V1::JSONApiController
       )
     end
     if profanity_or_pii
+      FirehoseClient.instance.put_record(
+        :analysis,
+        {
+          study: 'ai-ml',
+          study_group: 'pii-profanity-api',
+          event: 'profanity_or_pii',
+          user_id: current_user&.id,
+          data_json: model_data.except(:trainedModel).to_json,
+          profanity_or_pii_json: profanity_or_pii&.to_json
+        }
+      )
       render json: {id: model_id, status: "piiProfanity", data: profanity_or_pii}
     else
       metadata = model_data.except(:trainedModel, :featureNumberKey)

--- a/dashboard/app/controllers/api/v1/ml_models_controller.rb
+++ b/dashboard/app/controllers/api/v1/ml_models_controller.rb
@@ -45,7 +45,7 @@ class Api::V1::MlModelsController < Api::V1::JSONApiController
       )
     end
     if profanity_or_pii
-      render json: {id: model_id, status: "piiProfanity"}
+      render json: {id: model_id, status: "piiProfanity", data: profanity_or_pii}
     else
       metadata = model_data.except(:trainedModel, :featureNumberKey)
       @user_ml_model = UserMlModel.create(


### PR DESCRIPTION
With this change, we send a filter match back to AI Lab.  It can display some relevant information to assist in debugging, using the change in https://github.com/code-dot-org/ml-playground/pull/299.

Also, prior to this change, we were only logging information about any failure of the filter to run to Firehose, [here](https://github.com/code-dot-org/code-dot-org/blob/845b7d9c0d473b32e789ecd04196330f70c8a088/dashboard/app/controllers/api/v1/ml_models_controller.rb#L35-L46).  With over a quarter of a million models saved, we only hit this 21 times.

With this change, we also now record details of any filter match to the same study, but with an event of `"profanity_or_pii"`.  This should help us understand how often, and why, users are having model saves prevented by the filter.
