### PR TITLE
Music: set the default library

### DIFF
--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -228,7 +228,7 @@ class UnconnectedMusicView extends React.Component {
       const libraryParameter = AppConfig.getValue('library');
       const libraryFilename = libraryParameter
         ? `music-library-${libraryParameter}.json`
-        : 'music-library-by-type.json';
+        : 'music-library.json';
       const response = await fetch(baseUrl + libraryFilename);
       const library = await response.json();
       return library;


### PR DESCRIPTION
This changes the default library back from `music-library-by-type.json` to `music-library.json`, reverting the temporary change made in https://github.com/code-dot-org/code-dot-org/pull/50977.  The file is ready on the server.
