### PR TITLE
Music: timeline support for patterns & chords

### DIFF
--- a/apps/src/music/player/MusicPlayer.ts
+++ b/apps/src/music/player/MusicPlayer.ts
@@ -212,7 +212,8 @@ export default class MusicPlayer {
       when: 1,
       value: chordValue,
       triggered: false,
-      length: constants.DEFAULT_CHORD_LENGTH
+      length: constants.DEFAULT_CHORD_LENGTH,
+      id: 'preview'
     };
     this.samplePlayer.previewSamples(
       this.convertEventToSamples(chordEvent),
@@ -235,7 +236,8 @@ export default class MusicPlayer {
       when: 1,
       value: patternValue,
       triggered: false,
-      length: constants.DEFAULT_PATTERN_LENGTH
+      length: constants.DEFAULT_PATTERN_LENGTH,
+      id: 'preview'
     };
 
     this.samplePlayer.previewSamples(

--- a/apps/src/music/player/MusicPlayer.ts
+++ b/apps/src/music/player/MusicPlayer.ts
@@ -145,7 +145,8 @@ export default class MusicPlayer {
       skipContext,
       effects,
       length: constants.DEFAULT_PATTERN_LENGTH,
-      blockId
+      blockId,
+      id: JSON.stringify(value)
     };
 
     this.addNewEvent(patternEvent);
@@ -184,7 +185,8 @@ export default class MusicPlayer {
       skipContext,
       effects,
       length: constants.DEFAULT_CHORD_LENGTH,
-      blockId
+      blockId,
+      id: JSON.stringify(value)
     };
 
     this.addNewEvent(chordEvent);
@@ -270,7 +272,7 @@ export default class MusicPlayer {
   }
 
   /**
-   * Clear all from the list of playback events, and stop any sounds that have 
+   * Clear all from the list of playback events, and stop any sounds that have
    * not yet been played, if playback is in progress.
    */
   clearAllEvents() {

--- a/apps/src/music/player/interfaces/PlaybackEvent.ts
+++ b/apps/src/music/player/interfaces/PlaybackEvent.ts
@@ -21,4 +21,6 @@ export interface PlaybackEvent {
   length: number;
   /** The ID of the block that created this event */
   blockId?: string;
+  /** A unique ID used to group same sounds together in the timeline */
+  id?: string;
 }

--- a/apps/src/music/player/interfaces/PlaybackEvent.ts
+++ b/apps/src/music/player/interfaces/PlaybackEvent.ts
@@ -22,5 +22,5 @@ export interface PlaybackEvent {
   /** The ID of the block that created this event */
   blockId?: string;
   /** A unique ID used to group same sounds together in the timeline */
-  id?: string;
+  id: string;
 }

--- a/apps/src/music/player/interfaces/SoundEvent.ts
+++ b/apps/src/music/player/interfaces/SoundEvent.ts
@@ -6,6 +6,5 @@ import {PlaybackEvent} from './PlaybackEvent';
  */
 export interface SoundEvent extends PlaybackEvent {
   type: 'sound';
-  id: string;
   soundType: SoundType;
 }

--- a/apps/src/music/views/TimelineElement.jsx
+++ b/apps/src/music/views/TimelineElement.jsx
@@ -11,8 +11,8 @@ const typeToColorClass = {
   bass: moduleStyles.timelineElementBlue,
   lead: moduleStyles.timelineElementGreen,
   fx: moduleStyles.timelineElementYellow,
-  pattern: moduleStyles.timelineElementPink,
-  chord: moduleStyles.timelineElementOrange
+  pattern: moduleStyles.timelineElementPattern,
+  chord: moduleStyles.timelineElementChord
 };
 
 /**

--- a/apps/src/music/views/TimelineSimple2Events.jsx
+++ b/apps/src/music/views/TimelineSimple2Events.jsx
@@ -31,8 +31,8 @@ const TimelineSimple2Events = ({
   // that we recalculate unique sounds, even when there are no entries to
   // render.
   const currentUniqueSounds = [];
-  for (const songEvent of soundEvents) {
-    const id = songEvent.functionContext.name + ' ' + songEvent.id;
+  for (const soundEvent of soundEvents) {
+    const id = soundEvent.functionContext.name + ' ' + soundEvent.id;
     if (currentUniqueSounds.indexOf(id) === -1) {
       currentUniqueSounds.push(id);
     }

--- a/apps/src/music/views/timeline.module.scss
+++ b/apps/src/music/views/timeline.module.scss
@@ -80,16 +80,6 @@
           border-color: brown;
         }
 
-        &Pink {
-          background-color: pink;
-          border-color: slategray;
-        }
-
-        &Orange {
-          background-color: orange;
-          border-color: violet;
-        }
-
         &Pattern {
           background-color: black;
           border-color: white;

--- a/apps/src/music/views/timeline.module.scss
+++ b/apps/src/music/views/timeline.module.scss
@@ -90,6 +90,16 @@
           border-color: violet;
         }
 
+        &Pattern {
+          background-color: black;
+          border-color: white;
+        }
+
+        &Chord {
+          background-color: $light_cyan;
+          border-color: $neutral_dark80;
+        }
+
         &Playing {
           box-shadow: 0 0 10px rgba(255 255 255 / 0.5);
         }


### PR DESCRIPTION
Now, duplicate patterns and chords appear on the same row in the timeline, while different ones appear on different lines.  We create a unique "ID" for this purpose, and for now it's just a JSON serialization of the value.  The styling is also updated to match the editor panels and custom fields.

<img width="616" alt="Screenshot 2023-04-03 at 11 38 54 PM" src="https://user-images.githubusercontent.com/2205926/229709010-638743e2-ee72-4816-9f07-670817e56f89.png">
