### PR TITLE
[CFU] Change entry point design

### DIFF
--- a/apps/src/templates/levelSummary/SummaryEntryPoint.jsx
+++ b/apps/src/templates/levelSummary/SummaryEntryPoint.jsx
@@ -23,12 +23,15 @@ const SummaryEntryPoint = ({scriptData, students}) => {
         color={Button.ButtonColor.neutralDark}
         text={i18n.viewStudentResponses()}
         href={summaryUrl}
+        className={styles.button}
         __useDeprecatedTag
       />
 
+      <div className={styles.responseIcon}>
+        <i className="fa fa-user" />
+      </div>
       <div className={styles.responseCounter}>
         <p>
-          <i className="fa fa-user" />
           <span className={styles.counter}>
             {scriptData.responses.length}/{students.length}{' '}
           </span>

--- a/apps/src/templates/levelSummary/summary-entry-point.module.scss
+++ b/apps/src/templates/levelSummary/summary-entry-point.module.scss
@@ -2,33 +2,76 @@
 
 .summaryEntryPoint {
   padding-bottom: 8px;
+  display: flow-root;
+  // Don't squish things onto multiple lines in small spaces.
+  min-width: max-content;
+  // If the content would otherwise be right at the edge of the available
+  // space, and not long enough to force a horizontal scrollbar (e.g.
+  // JavaLab contained levels), add enough padding to enable the
+  // horizontal scrollbar, so the content doesn't get cut off by the
+  // vertical scrollbar.
+  padding-inline-end: 12px;
 }
 
-.responseCounter {
-  display: inline-block;
-  padding: 0 12px;
+.button {
+  float: left;
+}
+
+[dir="rtl"] .button {
+  float: right;
+}
+
+.responseIcon {
+  float: left;
+  padding: 1px 8px;
 
   height: 30px; // button height;
   line-height: 30px;
+
+  /* stylelint-disable selector-pseudo-class-no-unknown */
+  :global(.fa) {
+    vertical-align: middle;
+    font-size: 30px;
+    color: $brand_primary_default;
+  }
+  /* stylelint-enable selector-pseudo-class-no-unknown */
+}
+
+[dir="rtl"] .responseIcon {
+  float: right;
+}
+
+.responseCounter {
+  float: left;
+  padding: 2px 0;
+
+  height: 34px; // button height;
+  line-height: 34px;
 
   p {
     margin: 0;
   }
 
   span.counter {
-    padding: 0 8px;
+    display: inherit;
     font-weight: bold;
+    font-size: 16px;
+    line-height: 16px;
   }
 
   span.text {
     display: block;
+    font-size: 14px;
+    line-height: 16px;
   }
+}
 
-  /* stylelint-disable selector-pseudo-class-no-unknown */
-  :global(.fa) {
-    vertical-align: middle;
-    font-size: 18px;
-    color: $brand_primary_default;
+[dir="rtl"] .responseCounter {
+  float: right;
+
+  // Since the `X/Y` counter doesn't have anything to get translated, explicitly
+  // set the text direction when in RTL mode.
+  span.counter {
+    direction: rtl;
   }
-  /* stylelint-enable selector-pseudo-class-no-unknown */
 }


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Change the design of the entry point. The 👤 icon is now on its own instead of on the same line as the `X/Y` count, and larger. The text font size, and padding have also changed.

| Before | After |
| ----- | ----- |
| ![image](https://user-images.githubusercontent.com/1382374/229870989-7b8de489-658f-4bf3-94aa-3e78a2ed907b.png) | ![image](https://user-images.githubusercontent.com/1382374/229871299-32171e5c-3ed6-46c9-a7e7-bb596874108f.png) |
| ![image](https://user-images.githubusercontent.com/1382374/229871431-14d2c038-feb4-4ac3-b8b1-6fbea1e5b2b0.png) | ![image](https://user-images.githubusercontent.com/1382374/229871631-0aa078c7-c36d-441d-9dcd-e85e28ae721a.png) |


RTL:

![image](https://user-images.githubusercontent.com/1382374/229900936-29316b63-eea9-4ff1-990f-db71ec992dbe.png)
![image](https://user-images.githubusercontent.com/1382374/229901209-dd496376-42b9-4836-b923-8c37585c5f1d.png)




## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

- Slack decision to change design: https://codedotorg.slack.com/archives/C0462BZKHL6/p1680034699731099
- Design signoff: https://codedotorg.slack.com/archives/C0462BZKHL6/p1680202248075559
