### PR TITLE
[CFU] Add summary entry point on standalone levels

### DIFF
--- a/apps/src/sites/studio/pages/levels/_free_response.js
+++ b/apps/src/sites/studio/pages/levels/_free_response.js
@@ -14,7 +14,7 @@ import {getStore} from '@cdo/apps/redux';
 $(document).ready(() => {
   const scriptData = getScriptData('freeresponse');
 
-  $('#containedLevel0 > #summaryEntryPoint').each(function () {
+  $('#summaryEntryPoint').each(function () {
     const container = this;
     const store = getStore();
 

--- a/apps/src/templates/levelSummary/SummaryEntryPoint.jsx
+++ b/apps/src/templates/levelSummary/SummaryEntryPoint.jsx
@@ -18,7 +18,13 @@ const SummaryEntryPoint = ({scriptData, students}) => {
   const summaryUrl = document.location.pathname + SUMMARY_PATH + params;
 
   return (
-    <div className={styles.summaryEntryPoint}>
+    <div
+      className={
+        styles.summaryEntryPoint +
+        ' ' +
+        (scriptData.is_contained_level ? '' : styles.isStandalone)
+      }
+    >
       <Button
         color={Button.ButtonColor.neutralDark}
         text={i18n.viewStudentResponses()}

--- a/apps/src/templates/levelSummary/summary-entry-point.module.scss
+++ b/apps/src/templates/levelSummary/summary-entry-point.module.scss
@@ -13,6 +13,10 @@
   padding-inline-end: 12px;
 }
 
+.summaryEntryPoint.isStandalone {
+  padding-top: 40px;
+}
+
 .button {
   float: left;
 }

--- a/apps/test/unit/templates/levelSummary/SummaryEntryPointTest.jsx
+++ b/apps/test/unit/templates/levelSummary/SummaryEntryPointTest.jsx
@@ -8,7 +8,8 @@ import styles from '@cdo/apps/templates/levelSummary/summary-entry-point.module.
 import teacherSections from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 
 const JS_DATA = {
-  responses: [{user_id: 0, text: 'student answer'}]
+  responses: [{user_id: 0, text: 'student answer'}],
+  is_contained_level: false
 };
 
 const INITIAL_STATE = {
@@ -45,5 +46,17 @@ describe('SummaryEntryPoint', () => {
     expect(wrapper.find(`.${styles.responseCounter}`).text()).to.eq(
       '1/1 students answered'
     );
+  });
+
+  it('adds standalone class on non-contained levels', () => {
+    const wrapper = setUpWrapper();
+
+    expect(wrapper.find(`.${styles.isStandalone}`).length).to.eq(1);
+  });
+
+  it('does not add standalone class on contained levels', () => {
+    const wrapper = setUpWrapper({}, {is_contained_level: true});
+
+    expect(wrapper.find(`.${styles.isStandalone}`).length).to.eq(0);
   });
 });

--- a/dashboard/app/views/levels/_free_response.html.haml
+++ b/dashboard/app/views/levels/_free_response.html.haml
@@ -1,17 +1,18 @@
 :ruby
+  level ||= @level
+  last_attempt = @last_attempt unless local_assigns.has_key? :last_attempt
+  in_level_group ||= false
+  left_align = local_assigns[:left_align]
+  is_contained_level ||= false
   js_data = {
     responses: @responses&.map do |response|
       {
         user_id: response.user_id,
         text: response.level_source.data,
       }
-    end
+    end,
+    is_contained_level: is_contained_level
   }
-  level ||= @level
-  last_attempt = @last_attempt unless local_assigns.has_key? :last_attempt
-  in_level_group ||= false
-  left_align = local_assigns[:left_align]
-  is_contained_level ||= false
 
 - if level.solution.present? && is_contained_level && Policies::InlineAnswer.visible_for_script_level?(current_user, @script_level)
   %div{id: "containedLevelAnswer0"}
@@ -37,10 +38,9 @@
       }
     );
 
-- if is_contained_level && DCDO.get("show_level_summary_entry_point", false)
-  %div#summaryEntryPoint
-
 .free-response{:class => ('left-aligned' if left_align)}
+  - if DCDO.get("show_level_summary_entry_point", false)
+    %div#summaryEntryPoint
   - title = level.get_property(:title)
   - if title.present? && (!in_level_group || is_contained_level)
     %h1= title


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Add the summary entry point (counter/button) to standalone levels. Contained levels are visually unchanged.

![image](https://user-images.githubusercontent.com/1382374/229872478-3778e4bf-4536-4790-b787-e87cf001a0aa.png)


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->


- spec: [Spec: Summarizing Check for Understanding Levels](https://docs.google.com/document/d/1S3LYEBG9TwEcT2pwB-a9juV4topjd1polHIZ52i8aC8/edit#)
- jira ticket: [TEACH-292](https://codedotorg.atlassian.net/browse/TEACH-292)

