### PR TITLE
[CFU] Refactor summary entry point to use response_count

### DIFF
--- a/apps/src/templates/levelSummary/SummaryEntryPoint.jsx
+++ b/apps/src/templates/levelSummary/SummaryEntryPoint.jsx
@@ -39,7 +39,7 @@ const SummaryEntryPoint = ({scriptData, students}) => {
       <div className={styles.responseCounter}>
         <p>
           <span className={styles.counter}>
-            {scriptData.responses.length}/{students.length}{' '}
+            {scriptData.response_count}/{students.length}{' '}
           </span>
           <span className={styles.text}>{i18n.studentsAnswered()}</span>
         </p>

--- a/apps/test/unit/templates/levelSummary/SummaryEntryPointTest.jsx
+++ b/apps/test/unit/templates/levelSummary/SummaryEntryPointTest.jsx
@@ -8,7 +8,7 @@ import styles from '@cdo/apps/templates/levelSummary/summary-entry-point.module.
 import teacherSections from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 
 const JS_DATA = {
-  responses: [{user_id: 0, text: 'student answer'}],
+  response_count: 1,
   is_contained_level: false
 };
 

--- a/dashboard/app/views/levels/_free_response.html.haml
+++ b/dashboard/app/views/levels/_free_response.html.haml
@@ -5,12 +5,7 @@
   left_align = local_assigns[:left_align]
   is_contained_level ||= false
   js_data = {
-    responses: @responses&.map do |response|
-      {
-        user_id: response.user_id,
-        text: response.level_source.data,
-      }
-    end,
+    response_count: @responses&.count || 0,
     is_contained_level: is_contained_level
   }
 


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Followup to review comment https://github.com/code-dot-org/code-dot-org/pull/50836#discussion_r1145170243, refactoring from passing in `responses` and only using `responses.length`, to passing in `response_count`.

No visual changes. This just optimizes the ActiveRecord query and removes unused data from the DOM.

