### PR TITLE
Music: don't show related videos at end of video

### DIFF
--- a/apps/src/music/views/Video.jsx
+++ b/apps/src/music/views/Video.jsx
@@ -64,7 +64,7 @@ const Video = ({id, onClose}) => {
             width="100%"
             height="100%"
             style={{border: 'none'}}
-            src="https://www.youtube-nocookie.com/embed/ab2SBrfkKXU"
+            src="https://www.youtube-nocookie.com/embed/ab2SBrfkKXU?rel=0"
             title=""
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
             allowFullScreen


### PR DESCRIPTION
With this option, the video should no longer suggest related videos when it finishes.