### PR TITLE
Move javalabRedux to redux folder

### DIFF
--- a/apps/src/javalab/CommitDialog.jsx
+++ b/apps/src/javalab/CommitDialog.jsx
@@ -8,7 +8,7 @@ import StylizedBaseDialog, {
 import {connect} from 'react-redux';
 import _ from 'lodash';
 import CommitDialogBody from './CommitDialogBody';
-import {setCommitSaveStatus} from '@cdo/apps/javalab/javalabRedux';
+import {setCommitSaveStatus} from '@cdo/apps/javalab/redux/javalabRedux';
 import {CompileStatus} from './constants';
 import {BackpackAPIContext} from './BackpackAPIContext';
 

--- a/apps/src/javalab/Javalab.js
+++ b/apps/src/javalab/Javalab.js
@@ -14,7 +14,7 @@ import javalab, {
   setValidationPassed,
   setHasRunOrTestedCode,
   setIsJavabuilderConnecting
-} from './javalabRedux';
+} from './redux/javalabRedux';
 import javalabConsole, {
   appendOutputLog,
   appendNewlineToConsoleLog,

--- a/apps/src/javalab/JavalabView.jsx
+++ b/apps/src/javalab/JavalabView.jsx
@@ -5,7 +5,7 @@ import color from '@cdo/apps/util/color';
 import JavalabConsole from './JavalabConsole';
 import JavalabEditor from './JavalabEditor';
 import JavalabPanels from './JavalabPanels';
-import {setIsRunning, setIsTesting} from './javalabRedux';
+import {setIsRunning, setIsTesting} from './redux/javalabRedux';
 import {appendOutputLog} from './redux/consoleRedux';
 import {setDisplayTheme} from './redux/viewRedux';
 import {DisplayTheme} from './DisplayTheme';

--- a/apps/src/javalab/redux/editorRedux.js
+++ b/apps/src/javalab/redux/editorRedux.js
@@ -1,3 +1,7 @@
+/**
+ * Redux store for editor-specific Java Lab state.
+ */
+
 import {
   fileMetadataForEditor,
   updateAllSourceFileOrders

--- a/apps/src/javalab/redux/javalabRedux.js
+++ b/apps/src/javalab/redux/javalabRedux.js
@@ -1,3 +1,7 @@
+/**
+ * Redux store for generic Java Lab state.
+ */
+
 const SET_IS_RUNNING = 'javalab/SET_IS_RUNNING';
 const SET_IS_TESTING = 'javalab/SET_IS_TESTING';
 const SET_BACKPACK_ENABLED = 'javalab/SET_BACKPACK_ENABLED';

--- a/apps/src/javalab/redux/viewRedux.js
+++ b/apps/src/javalab/redux/viewRedux.js
@@ -1,3 +1,8 @@
+/**
+ * Redux store for state specific to the visuals of Java Lab
+ * (widths/heights/font sizes/etc.)
+ */
+
 import {DisplayTheme} from '@cdo/apps/javalab/DisplayTheme';
 import UserPreferences from '@cdo/apps/lib/util/UserPreferences';
 import {

--- a/apps/src/templates/instructions/CommitsAndReviewTab.jsx
+++ b/apps/src/templates/instructions/CommitsAndReviewTab.jsx
@@ -12,7 +12,7 @@ import Button from '@cdo/apps/templates/Button';
 import {
   setIsReadOnlyWorkspace,
   setHasOpenCodeReview
-} from '@cdo/apps/javalab/javalabRedux';
+} from '@cdo/apps/javalab/redux/javalabRedux';
 import project from '@cdo/apps/code-studio/initApp/project';
 import CodeReviewError from '@cdo/apps/templates/instructions/codeReviewV2/CodeReviewError';
 

--- a/apps/test/unit/javalab/BackpackTest.js
+++ b/apps/test/unit/javalab/BackpackTest.js
@@ -2,7 +2,7 @@ import React from 'react';
 import {expect, assert} from '../../util/reconfiguredChai';
 import {mount} from 'enzyme';
 import {registerReducers, stubRedux, restoreRedux} from '@cdo/apps/redux';
-import javalab from '@cdo/apps/javalab/javalabRedux';
+import javalab from '@cdo/apps/javalab/redux/javalabRedux';
 import BackpackClientApi from '@cdo/apps/code-studio/components/backpack/BackpackClientApi';
 import sinon from 'sinon';
 import {UnconnectedBackpack as Backpack} from '@cdo/apps/javalab/Backpack';

--- a/apps/test/unit/javalab/JavalabConsoleTest.js
+++ b/apps/test/unit/javalab/JavalabConsoleTest.js
@@ -14,7 +14,7 @@ import javalabConsole, {
   openPhotoPrompter,
   closePhotoPrompter
 } from '@cdo/apps/javalab/redux/consoleRedux';
-import javalab from '@cdo/apps/javalab/javalabRedux';
+import javalab from '@cdo/apps/javalab/redux/javalabRedux';
 import {DisplayTheme} from '@cdo/apps/javalab/DisplayTheme';
 import sinon from 'sinon';
 import PhotoSelectionView from '@cdo/apps/javalab/components/PhotoSelectionView';

--- a/apps/test/unit/javalab/JavalabEditorDialogManagerTest.js
+++ b/apps/test/unit/javalab/JavalabEditorDialogManagerTest.js
@@ -23,7 +23,7 @@ import VersionHistoryWithCommitsDialog from '@cdo/apps/templates/VersionHistoryW
 import javalabEditor, {
   setAllSourcesAndFileMetadata
 } from '@cdo/apps/javalab/redux/editorRedux';
-import javalab from '@cdo/apps/javalab/javalabRedux';
+import javalab from '@cdo/apps/javalab/redux/javalabRedux';
 import javalabView from '@cdo/apps/javalab/redux/viewRedux';
 
 describe('JavalabEditorDialogManager', () => {

--- a/apps/test/unit/javalab/JavalabEditorTest.js
+++ b/apps/test/unit/javalab/JavalabEditorTest.js
@@ -16,7 +16,7 @@ import javalab, {
   setIsReadOnlyWorkspace,
   setHasOpenCodeReview,
   setBackpackEnabled
-} from '@cdo/apps/javalab/javalabRedux';
+} from '@cdo/apps/javalab/redux/javalabRedux';
 import javalabEditor, {
   sourceFileOrderUpdated,
   sourceVisibilityUpdated,


### PR DESCRIPTION
This is just a move of `javalabRedux` to the `javalab/redux` folder, and relevant import updates. This is the last part of the pre-work to move Javalab redux to redux-toolkit.

## Links

- jira ticket: [SL-724](https://codedotorg.atlassian.net/browse/SL-724)

## Testing story
Tested locally that accessing the redux store still works, and tests still pass.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
