### PR TITLE
Music: update drum kit friendly names

### DIFF
--- a/apps/src/music/blockly/FieldPattern.js
+++ b/apps/src/music/blockly/FieldPattern.js
@@ -89,7 +89,7 @@ class FieldPattern extends GoogleBlockly.Field {
     this.renderContent();
 
     this.newDiv_.style.color = 'white';
-    this.newDiv_.style.width = '400px';
+    this.newDiv_.style.width = '420px';
     this.newDiv_.style.backgroundColor = 'black';
     this.newDiv_.style.padding = '5px';
 

--- a/apps/src/music/views/patternPanel.module.scss
+++ b/apps/src/music/views/patternPanel.module.scss
@@ -16,7 +16,7 @@
 
 .nameContainer {
   display: inline-block;
-  width: 80px;
+  width: 100px;
   vertical-align: middle;
   padding-left: 3px;
 

--- a/apps/static/music/music-library.json
+++ b/apps/static/music/music-library.json
@@ -957,42 +957,42 @@
           "type": "kit",
           "sounds": [
             {
-              "name": "Glitch 1",
+              "name": "Bass Drum",
               "src": "sound_1",
               "length": 0.0625
             },
             {
-              "name": "Glitch 2",
+              "name": "5nare",
               "src": "sound_2",
               "length": 0.0625
             },
             {
-              "name": "Glitch 3",
+              "name": "Closed Hi-hat",
               "src": "sound_3",
               "length": 0.0625
             },
             {
-              "name": "Glitch 4",
+              "name": "Open Hi-hat",
               "src": "sound_4",
               "length": 0.0625
             },
             {
-              "name": "Glitch 5",
+              "name": "Mid Tom",
               "src": "sound_5",
               "length": 0.0625
             },
             {
-              "name": "Glitch 6",
+              "name": "High Tom",
               "src": "sound_6",
               "length": 0.0625
             },
             {
-              "name": "Glitch 7",
+              "name": "Ride",
               "src": "sound_7",
               "length": 0.0625
             },
             {
-              "name": "Glitch 8",
+              "name": "Cymbal",
               "src": "sound_8",
               "length": 0.0625
             }
@@ -1004,42 +1004,42 @@
           "type": "kit",
           "sounds": [
             {
-              "name": "Machine 1",
+              "name": "Bass Drum",
               "src": "sound_1",
               "length": 0.0625
             },
             {
-              "name": "Machine 2",
+              "name": "Snare",
               "src": "sound_2",
               "length": 0.0625
             },
             {
-              "name": "Machine 3",
+              "name": "Closed Hi-hat",
               "src": "sound_3",
               "length": 0.0625
             },
             {
-              "name": "Machine 4",
+              "name": "Open Hi-hat",
               "src": "sound_4",
               "length": 0.0625
             },
             {
-              "name": "Machine 5",
+              "name": "Mid Tom",
               "src": "sound_5",
               "length": 0.0625
             },
             {
-              "name": "Machine 6",
+              "name": "High Tom",
               "src": "sound_6",
               "length": 0.0625
             },
             {
-              "name": "Machine 7",
+              "name": "Ride",
               "src": "sound_7",
               "length": 0.0625
             },
             {
-              "name": "Machine 8",
+              "name": "Cymbal",
               "src": "sound_8",
               "length": 0.0625
             }


### PR DESCRIPTION
This updates the drum kit friendly names, as well as slightly adjusts the layout so they fit.

We will generally use the same friendly names across all kits, reflecting the way that the same pattern values should work across all all of them, but it's fine to vary the friendly names as appropriate.

<img width="466" alt="Screenshot 2023-04-04 at 7 19 38 PM" src="https://user-images.githubusercontent.com/2205926/229964509-d3115b05-021c-406e-9bd9-bcd1a7500f03.png">
