### PR TITLE
[AiLab] bump ml-playground version to 0.0.45

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -62,7 +62,7 @@
     "@code-dot-org/js-numbers": "0.1.0-cdo.0",
     "@code-dot-org/maze": "2.16.0",
     "@code-dot-org/ml-activities": "0.0.26",
-    "@code-dot-org/ml-playground": "0.0.44",
+    "@code-dot-org/ml-playground": "0.0.45",
     "@code-dot-org/p5.play": "1.3.21-cdo",
     "@code-dot-org/piskel": "0.13.0-cdo.9",
     "@code-dot-org/redactable-markdown": "0.4.0",

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -1409,10 +1409,10 @@
     messageformat "^1.1.0"
     react-typist "^2.0.5"
 
-"@code-dot-org/ml-playground@0.0.44":
-  version "0.0.44"
-  resolved "https://registry.yarnpkg.com/@code-dot-org/ml-playground/-/ml-playground-0.0.44.tgz#39d8bf3b1387744512fe04bf0e529fdb5737645f"
-  integrity sha512-2AhxnUGErm3Vb4x4OU389CqvgxmikAs2vEHw2hyuRaQE6zVzvTM04JKN3hLjAbtShSRxSqZzpNoVeEPrJxMeAA==
+"@code-dot-org/ml-playground@0.0.45":
+  version "0.0.45"
+  resolved "https://registry.yarnpkg.com/@code-dot-org/ml-playground/-/ml-playground-0.0.45.tgz#02368c0cd1fd9bdcaece3b87c042b359ec7215d8"
+  integrity sha512-uI/aTbNmuJ1W8RKaUx5jIBMBivbCg9FSH8ch6QxlS1VTIWKOyz7AWfSC+kekNa7Q41Tcb+m1X2j6/Jj8ukqZVQ==
   dependencies:
     "@fortawesome/fontawesome-svg-core" "^1.2.25"
     "@fortawesome/free-solid-svg-icons" "^5.11.2"


### PR DESCRIPTION
Contains a change to show a filter error, from https://github.com/code-dot-org/ml-playground/pull/299.  
