### PR TITLE
Music: adjust block names

### DIFF
--- a/apps/src/music/blockly/blocks/simple2.js
+++ b/apps/src/music/blockly/blocks/simple2.js
@@ -170,13 +170,13 @@ export const playSoundAtCurrentLocationSimple2 = {
 export const playPatternAtCurrentLocationSimple2 = {
   definition: {
     type: BlockTypes.PLAY_PATTERN_AT_CURRENT_LOCATION_SIMPLE2,
-    message0: 'play pattern %1',
+    message0: 'play drums %1',
     args0: [fieldPatternDefinition],
     inputsInline: true,
     previousStatement: null,
     nextStatement: null,
     style: 'lab_blocks',
-    tooltip: 'play pattern',
+    tooltip: 'play drums',
     helpUrl: ''
   },
   generator: block =>
@@ -200,13 +200,13 @@ export const playPatternAtCurrentLocationSimple2 = {
 export const playChordAtCurrentLocationSimple2 = {
   definition: {
     type: BlockTypes.PLAY_CHORD_AT_CURRENT_LOCATION_SIMPLE2,
-    message0: 'play chord %1',
+    message0: 'play notes %1',
     args0: [fieldChordDefinition],
     inputsInline: true,
     previousStatement: null,
     nextStatement: null,
     style: 'lab_blocks',
-    tooltip: 'play chord',
+    tooltip: 'play notes',
     helpUrl: ''
   },
   generator: block =>

--- a/apps/src/music/views/BeatPad.jsx
+++ b/apps/src/music/views/BeatPad.jsx
@@ -50,7 +50,7 @@ const BeatPad = ({triggers, playTrigger, onClose, isPlaying}) => {
   return (
     <div className={styles.container}>
       <div className={styles.labelContainer}>
-        <p className={styles.label}>{'Beat Pad'}</p>
+        <p className={styles.label}>{'Control'}</p>
         <FontAwesome
           icon={'times'}
           onClick={onClose}


### PR DESCRIPTION
This captures a proposal to rename `play chord` to `play notes` and `play pattern` to `play drums`:

<img width="195" alt="Screenshot 2023-04-04 at 1 31 38 PM" src="https://user-images.githubusercontent.com/2205926/230178961-4d16d254-da97-4500-a3eb-f62506863989.png">

It also includes a change to rename `Beat Pad` to `Control`:

<img width="272" alt="Screenshot 2023-04-04 at 1 31 56 PM" src="https://user-images.githubusercontent.com/2205926/230178991-b72f9b22-5fc6-4315-ac7c-3afe19ac4772.png">

