### PR TITLE
Formatting test duration in status page to hh:mm:ss format for better readability

### DIFF
--- a/dashboard/test/ui/test_status.js
+++ b/dashboard/test/ui/test_status.js
@@ -125,10 +125,14 @@ Test.prototype.updateView = function () {
   // Update row appearance
   row.className = this.status;
   if (succeeded || failed) {
-    var formattedDuration = new Date(this.duration * 1000);
+    var formattedDuration = new Date(this.duration * 1000)
+      .toISOString()
+      .slice(11, 19)
+      .split(":");
+
     statusCell.innerHTML =
       (succeeded ? "Succeeded" : "Failed") +
-      ` in ${formattedDuration.toISOString().slice(11, 19)}` +
+      ` in ${formattedDuration[0]} hr ${formattedDuration[1]} min ${formattedDuration[2]} sec` +
       (this.attempt > 0 ? ` on retry #${this.attempt}` : "");
     logLinkCell.innerHTML = `<a href="${this.publicLogUrl()}">Log on S3</a>`;
   } else {

--- a/dashboard/test/ui/test_status.js
+++ b/dashboard/test/ui/test_status.js
@@ -126,8 +126,8 @@ Test.prototype.updateView = function () {
   row.className = this.status;
   if (succeeded || failed) {
     var formattedDuration = new Date(this.duration * 1000)
-      .toISOString()
-      .slice(11, 19)
+      .toISOString() // Sample formatting - 1970-01-01T00:00:42.000Z
+      .slice(11, 19) // extracts the time from the above string
       .split(":");
 
     statusCell.innerHTML =

--- a/dashboard/test/ui/test_status.js
+++ b/dashboard/test/ui/test_status.js
@@ -72,7 +72,7 @@ function Test(fromRow) {
   this.updateView();
 }
 
-Test.prototype.setLastModified = function(object, lastModified) {
+Test.prototype.setLastModified = function (object, lastModified) {
   // Do no updating if things haven't changed.
   if (this.lastModified_ && lastModified <= this.lastModified_) {
     return Promise.resolve();
@@ -89,7 +89,7 @@ Test.prototype.setLastModified = function(object, lastModified) {
   }
 };
 
-Test.prototype.fetchStatus = function(object) {
+Test.prototype.fetchStatus = function (object) {
   this.isUpdating_ = true;
   this.updateView();
   const ensure = () => {
@@ -98,7 +98,7 @@ Test.prototype.fetchStatus = function(object) {
   };
 
   return Promise.resolve(object)
-    .then(json => {
+    .then((json) => {
       if (json.commit === COMMIT_HASH) {
         this.versionId = json.version_id;
         this.attempt = parseInt(json.attempt, 10);
@@ -107,13 +107,13 @@ Test.prototype.fetchStatus = function(object) {
         this.status = this.success ? STATUS_SUCCEEDED : STATUS_FAILED;
       }
     })
-    .then(ensure, error => {
+    .then(ensure, (error) => {
       ensure();
       throw error;
     });
 };
 
-Test.prototype.updateView = function() {
+Test.prototype.updateView = function () {
   const succeeded = this.status === STATUS_SUCCEEDED;
   const failed = this.status === STATUS_FAILED;
 
@@ -125,9 +125,10 @@ Test.prototype.updateView = function() {
   // Update row appearance
   row.className = this.status;
   if (succeeded || failed) {
+    var formattedDuration = new Date(this.duration * 1000);
     statusCell.innerHTML =
       (succeeded ? "Succeeded" : "Failed") +
-      ` in ${Math.round(this.duration)} seconds` +
+      ` in ${formattedDuration.toISOString().slice(11, 19)}` +
       (this.attempt > 0 ? ` on retry #${this.attempt}` : "");
     logLinkCell.innerHTML = `<a href="${this.publicLogUrl()}">Log on S3</a>`;
   } else {
@@ -143,14 +144,14 @@ Test.prototype.updateView = function() {
   updateProgress && updateProgress();
 };
 
-Test.prototype.s3Key = function() {
+Test.prototype.s3Key = function () {
   const featureRegex = /features\/(.*)\.feature/i;
   const result = featureRegex.exec(this.feature);
   const featureName = result[1].replace(/\//g, "_");
   return `${S3_PREFIX}/${this.browser}_${featureName}${S3_KEY_SUFFIX}`;
 };
 
-Test.prototype.publicLogUrl = function() {
+Test.prototype.publicLogUrl = function () {
   return `https://${S3_BUCKET}.s3.amazonaws.com/${this.s3Key()}?versionId=${
     this.versionId
   }`;
@@ -166,7 +167,7 @@ function keyify(str) {
 // Build a cache of tests for this run.
 var tests = {};
 var rows = document.querySelectorAll("tbody tr");
-rows.forEach(row => {
+rows.forEach((row) => {
   let test = new Test(row);
   tests[test.browser] = tests[test.browser] || {};
   tests[test.browser][keyify(test.feature)] = test;
@@ -210,7 +211,7 @@ function calculateBrowserProgress(browser) {
   return {
     successCount,
     failureCount,
-    pendingCount
+    pendingCount,
   };
 }
 
@@ -288,7 +289,7 @@ function updateProgressNow() {
   renderBrowserProgress("total", {
     successCount,
     failureCount,
-    pendingCount
+    pendingCount,
   });
 
   // Set the tab's status icon according to how complete the test run is
@@ -321,9 +322,9 @@ function refresh() {
   let lastRefreshEpochSeconds = Math.floor(lastRefreshTime.getTime() / 1000);
   let newTime = new Date();
   fetch(`${API_BASEPATH}/${S3_PREFIX}/since/${lastRefreshEpochSeconds}`, {
-    mode: "no-cors"
+    mode: "no-cors",
   })
-    .then(response => {
+    .then((response) => {
       if (response.ok) {
         return response.json();
       }
@@ -331,20 +332,20 @@ function refresh() {
         `While fetching updates, "${response.url}" returned ${response.status}.`
       );
     })
-    .then(json => {
-      return Promise.all(json.map(object => refreshIndividualTest(object)))
+    .then((json) => {
+      return Promise.all(json.map((object) => refreshIndividualTest(object)))
         .then(() => {
           lastRefreshTime = newTime;
           lastRefreshTimeLabel.textContent =
             "Updated " + lastRefreshTime.toTimeString();
         })
-        .catch(error => {
+        .catch((error) => {
           lastRefreshTimeLabel.textContent =
             "Partially updated at " + newTime.toTimeString();
           console.warn(error);
         });
     })
-    .catch(error => console.error(error))
+    .catch((error) => console.error(error))
     .then(ensure, ensure);
 }
 
@@ -398,7 +399,7 @@ function toggleHideSucceeded() {
   let display = hideSucceeded ? "none" : "table-row";
   let rule = _.findLast(
     sheet.rules,
-    rule => rule.selectorText === ".SUCCEEDED"
+    (rule) => rule.selectorText === ".SUCCEEDED"
   );
   if (rule) {
     rule.style.display = display;

--- a/dashboard/test/ui/test_status.js
+++ b/dashboard/test/ui/test_status.js
@@ -125,14 +125,11 @@ Test.prototype.updateView = function () {
   // Update row appearance
   row.className = this.status;
   if (succeeded || failed) {
-    var formattedDuration = new Date(this.duration * 1000)
-      .toISOString() // Sample formatting - 1970-01-01T00:00:42.000Z
-      .slice(11, 19) // extracts the time from the above string
-      .split(":");
+    var formatDurn = new Date(this.duration * 1000);
 
     statusCell.innerHTML =
       (succeeded ? "Succeeded" : "Failed") +
-      ` in ${formattedDuration[0]} hr ${formattedDuration[1]} min ${formattedDuration[2]} sec` +
+      ` in ${formatDurn.getUTCHours()} hr ${formatDurn.getUTCMinutes()} min ${formatDurn.getUTCSeconds()} sec` +
       (this.attempt > 0 ? ` on retry #${this.attempt}` : "");
     logLinkCell.innerHTML = `<a href="${this.publicLogUrl()}">Log on S3</a>`;
   } else {


### PR DESCRIPTION
The current test status page for UI and eyes test shows the duration in seconds, which can take a bit for someone to parse and infer how long the test would run. For better readability, formatting the duration to saying <hh> hrs <mm> mins <ss> seconds.

Additionally fixed lint errors that were blocking commit on this file.

## Links
None - following up as this was suggested as an idea during DOTD shadow

## Testing story

Below are the screen shots for tests that are less than a min, around a min, min and a few seconds and an hour long

16 seconds
![image](https://user-images.githubusercontent.com/124813947/234462437-cbe664e2-1b0b-4c1c-8d8d-855bbcbf0e85.png)

75 seconds
![image](https://user-images.githubusercontent.com/124813947/234462490-27091473-feaa-4685-bf85-3e3d3d8d60db.png)

180 seconds
![image](https://user-images.githubusercontent.com/124813947/234462577-84cb2d6b-95eb-40d1-986b-b72cfdacd2c3.png)

3600 seconds
![image](https://user-images.githubusercontent.com/124813947/234462671-e0123954-3cd4-4f4f-95e4-78897a16a654.png)

7600 seconds
![image](https://user-images.githubusercontent.com/124813947/234462740-c7427a80-8659-477b-9a4a-e60ec9b4dc5c.png)


## Deployment strategy
Will be rolled out with regular DOTD deployments, and automated test/staging deployments

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
