### PR TITLE
[CFU] Hide response counter when no section selected

### DIFF
--- a/apps/src/templates/levelSummary/CheckForUnderstanding.jsx
+++ b/apps/src/templates/levelSummary/CheckForUnderstanding.jsx
@@ -114,19 +114,23 @@ const CheckForUnderstanding = ({
       <div className={styles.studentResponses}>
         <h2>{i18n.studentResponses()}</h2>
 
-        <div
-          className={
-            isRtl ? styles.studentsSubmittedLeft : styles.studentsSubmittedRight
-          }
-        >
-          <p>
-            <i className="fa fa-user" />
-            <span>
-              {scriptData.responses.length}/{students.length}{' '}
-              {i18n.studentsAnswered()}
-            </span>
-          </p>
-        </div>
+        {selectedSection && (
+          <div
+            className={
+              isRtl
+                ? styles.studentsSubmittedLeft
+                : styles.studentsSubmittedRight
+            }
+          >
+            <p>
+              <i className="fa fa-user" />
+              <span>
+                {scriptData.responses.length}/{students.length}{' '}
+                {i18n.studentsAnswered()}
+              </span>
+            </p>
+          </div>
+        )}
 
         <label>
           {i18n.responsesForClassSection()}

--- a/apps/src/templates/levelSummary/SummaryEntryPoint.jsx
+++ b/apps/src/templates/levelSummary/SummaryEntryPoint.jsx
@@ -8,7 +8,7 @@ import styles from './summary-entry-point.module.scss';
 
 const SUMMARY_PATH = '/summary';
 
-const SummaryEntryPoint = ({scriptData, students}) => {
+const SummaryEntryPoint = ({scriptData, students, selectedSection}) => {
   // If viewing the page as Participant, be sure to rewrite the link URL
   // to view as Instructor, so we don't just get redirected back.
   const params = document.location.search.replace(
@@ -33,17 +33,21 @@ const SummaryEntryPoint = ({scriptData, students}) => {
         __useDeprecatedTag
       />
 
-      <div className={styles.responseIcon}>
-        <i className="fa fa-user" />
-      </div>
-      <div className={styles.responseCounter}>
-        <p>
-          <span className={styles.counter}>
-            {scriptData.response_count}/{students.length}{' '}
-          </span>
-          <span className={styles.text}>{i18n.studentsAnswered()}</span>
-        </p>
-      </div>
+      {selectedSection && (
+        <div>
+          <div className={styles.responseIcon}>
+            <i className="fa fa-user" />
+          </div>
+          <div className={styles.responseCounter}>
+            <p>
+              <span className={styles.counter}>
+                {scriptData.response_count}/{students.length}{' '}
+              </span>
+              <span className={styles.text}>{i18n.studentsAnswered()}</span>
+            </p>
+          </div>
+        </div>
+      )}
     </div>
   );
 };
@@ -55,7 +59,11 @@ SummaryEntryPoint.propTypes = {
       id: PropTypes.number.isRequired,
       name: PropTypes.string
     })
-  )
+  ),
+  selectedSection: PropTypes.shape({
+    id: PropTypes.number.isRequired,
+    name: PropTypes.string.isRequired
+  })
 };
 
 export default connect(
@@ -63,6 +71,8 @@ export default connect(
   // remove the teacher panel, or try to use this component on a page without
   // the teacher panel, it will require extra steps to load in the data.
   state => ({
-    students: state.teacherSections.selectedStudents
+    students: state.teacherSections.selectedStudents,
+    selectedSection:
+      state.teacherSections.sections[state.teacherSections.selectedSectionId]
   })
 )(SummaryEntryPoint);

--- a/apps/test/unit/templates/levelSummary/CheckForUnderstandingTest.jsx
+++ b/apps/test/unit/templates/levelSummary/CheckForUnderstandingTest.jsx
@@ -121,4 +121,18 @@ describe('CheckForUnderstanding', () => {
       'test teacher markdown'
     );
   });
+
+  it('does not render response counter/text if no section selected', () => {
+    const wrapper = setUpWrapper({
+      teacherSections: {
+        selectedStudents: [{id: 0}],
+        selectedSectionId: null,
+        sectionIds: [0],
+        sections: [{id: 0, name: 'test section'}]
+      }
+    });
+
+    expect(wrapper.find(`.${styles.studentsSubmittedRight}`).length).to.eq(0);
+    expect(wrapper.find(`.${styles.studentsSubmittedLeft}`).length).to.eq(0);
+  });
 });

--- a/apps/test/unit/templates/levelSummary/SummaryEntryPointTest.jsx
+++ b/apps/test/unit/templates/levelSummary/SummaryEntryPointTest.jsx
@@ -14,7 +14,10 @@ const JS_DATA = {
 
 const INITIAL_STATE = {
   teacherSections: {
-    selectedStudents: [{id: 0}]
+    selectedStudents: [{id: 0}],
+    selectedSectionId: 0,
+    sectionIds: [0],
+    sections: [{id: 0, name: 'test section'}]
   }
 };
 
@@ -58,5 +61,19 @@ describe('SummaryEntryPoint', () => {
     const wrapper = setUpWrapper({}, {is_contained_level: true});
 
     expect(wrapper.find(`.${styles.isStandalone}`).length).to.eq(0);
+  });
+
+  it('does not render response counter/text if no section selected', () => {
+    const wrapper = setUpWrapper({
+      teacherSections: {
+        selectedStudents: [{id: 0}],
+        selectedSectionId: null,
+        sectionIds: [0],
+        sections: [{id: 0, name: 'test section'}]
+      }
+    });
+
+    expect(wrapper.find(`.${styles.responseIcon}`).length).to.eq(0);
+    expect(wrapper.find(`.${styles.responseCounter}`).length).to.eq(0);
   });
 });


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

For the entry point, hide everything but the button when no section is selected. For the summary page, hide the icon/counter/text.

![image](https://user-images.githubusercontent.com/1382374/230208951-c655c4a3-eadb-4080-a774-f07705e74a09.png)
![image](https://user-images.githubusercontent.com/1382374/230209204-3403f160-0b5b-4009-86d6-1c27ccabd675.png)

![image](https://user-images.githubusercontent.com/1382374/230209140-f53003d6-1f5c-4fa1-88d7-716c88154341.png)


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [TEACH-382](https://codedotorg.atlassian.net/browse/TEACH-382)
