### PR TITLE
Move common environment reporting functions to utils

### DIFF
--- a/apps/src/lib/util/AnalyticsReporter.js
+++ b/apps/src/lib/util/AnalyticsReporter.js
@@ -5,21 +5,15 @@ import {
   identify,
   setUserId
 } from '@amplitude/analytics-browser';
-import {currentLocation} from '@cdo/apps/utils';
 import logToCloud from '@cdo/apps/logToCloud';
+import {
+  getEnvironment,
+  isProductionEnvironment,
+  isStagingEnvironment
+} from '../../utils';
 
 // A flag that can be toggled to send events regardless of environment
 const ALWAYS_SEND = false;
-
-const Environments = {
-  production: 'production',
-  levelbuilder: 'levelbuilder',
-  test: 'test',
-  staging: 'staging',
-  adhoc: 'adhoc',
-  development: 'development',
-  unknown: 'unknown'
-};
 
 class AnalyticsReporter {
   constructor() {
@@ -74,10 +68,10 @@ class AnalyticsReporter {
     if (!userId) {
       return userIdString;
     }
-    if (this.isProductionEnvironment()) {
+    if (isProductionEnvironment()) {
       return userIdString.padStart(5, '0');
     } else {
-      const environment = this.getEnvironment();
+      const environment = getEnvironment();
       return `${environment}-${userIdString}`;
     }
   }
@@ -92,46 +86,10 @@ class AnalyticsReporter {
     if (alwaysPut) {
       return true;
     }
-    if (this.isProductionEnvironment() || this.isStagingEnvironment()) {
+    if (isProductionEnvironment() || isStagingEnvironment()) {
       return true;
     }
     return false;
-  }
-
-  /**
-   * Returns the current environment.
-   * @return {string} The current environment, e.g., "staging" or "production".
-   */
-  getEnvironment() {
-    const hostname = currentLocation().hostname;
-    if (hostname.includes('adhoc')) {
-      // As adhoc hostnames may include other keywords, check it first.
-      return Environments.adhoc;
-    }
-    if (hostname.includes('test')) {
-      return Environments.test;
-    }
-    if (hostname.includes('levelbuilder')) {
-      return Environments.levelbuilder;
-    }
-    if (hostname.includes('staging')) {
-      return Environments.staging;
-    }
-    if (hostname.includes('localhost') || hostname.includes('127.0.0.1')) {
-      return Environments.development;
-    }
-    if (hostname === 'code.org' || hostname === 'studio.code.org') {
-      return Environments.production;
-    }
-    return Environments.unknown;
-  }
-
-  isStagingEnvironment() {
-    return this.getEnvironment() === Environments.staging;
-  }
-
-  isProductionEnvironment() {
-    return this.getEnvironment() === Environments.production;
   }
 }
 

--- a/apps/src/lib/util/firehose.js
+++ b/apps/src/lib/util/firehose.js
@@ -6,6 +6,11 @@ import {
   tryGetLocalStorage
 } from '@cdo/apps/utils';
 import {getStore} from '@cdo/apps/redux';
+import {
+  getEnvironment,
+  isDevelopmentEnvironment,
+  isTestEnvironment
+} from '../../utils';
 
 /**
  * A barebones client for posting data to an AWS Firehose stream.
@@ -58,50 +63,6 @@ class FirehoseClient {
   }
 
   /**
-   * Returns the current environment.
-   * @return {string} The current environment, e.g., "staging" or "production".
-   */
-  getEnvironment() {
-    const hostname = window.location.hostname;
-    if (hostname.includes('adhoc')) {
-      // As adhoc hostnames may include other keywords, check it first.
-      return 'adhoc';
-    }
-    if (hostname.includes('test')) {
-      return 'test';
-    }
-    if (hostname.includes('levelbuilder')) {
-      return 'levelbuilder';
-    }
-    if (hostname.includes('staging')) {
-      return 'staging';
-    }
-    if (hostname.includes('localhost')) {
-      return 'development';
-    }
-    if (hostname.includes('code.org')) {
-      return 'production';
-    }
-    return 'unknown';
-  }
-
-  /**
-   * Returns whether the environment appears to be the test environment.
-   * @return {boolean} Whether the hostname includes "test".
-   */
-  isTestEnvironment() {
-    return this.getEnvironment() === 'test';
-  }
-
-  /**
-   * Returns whether the environment appears to be a development environment.
-   * @return {boolean} Whether the hostname includes "localhost".
-   */
-  isDevelopmentEnvironment() {
-    return this.getEnvironment() === 'development';
-  }
-
-  /**
    * Returns whether the request should be sent through to AWS Firehose.
    * @param {boolean} alwaysPut An override to default environment behavior.
    * @return {boolean} Whether the request should be sent through to AWS
@@ -111,7 +72,7 @@ class FirehoseClient {
     if (alwaysPut) {
       return true;
     }
-    if (this.isTestEnvironment() || this.isDevelopmentEnvironment()) {
+    if (isTestEnvironment() || isDevelopmentEnvironment()) {
       return false;
     }
     return true;
@@ -170,7 +131,7 @@ class FirehoseClient {
    */
   addCommonValues(data, includeUserId, useProgressScriptId) {
     data['created_at'] = new Date().toISOString();
-    data['environment'] = this.getEnvironment();
+    data['environment'] = getEnvironment();
     data['uuid'] = this.getAnalyticsUuid();
     data['device'] = JSON.stringify(this.getDeviceInfo());
     data['locale'] = this.getLocale();
@@ -325,7 +286,7 @@ class FirehoseClient {
 // info, contact the infrastructure team.
 /* eslint-disable */
 function createNewFirehose(AWS, Firehose) {
-  var _0xr0t13 = function(message) {
+  var _0xr0t13 = function (message) {
     return message.replace(/[a-z]/gi, letter =>
       String.fromCharCode(
         letter.charCodeAt(0) + (letter.toLowerCase() <= 'm' ? 13 : -13)
@@ -342,15 +303,15 @@ function createNewFirehose(AWS, Firehose) {
     '\x75\x73\x2d\x65\x61\x73\x74\x2d\x31',
     '\x63\x6f\x6e\x66\x69\x67'
   ];
-  (function(_0xb54a92, _0x4e682a) {
-    var _0x44f3e8 = function(_0x35c55a) {
+  (function (_0xb54a92, _0x4e682a) {
+    var _0x44f3e8 = function (_0x35c55a) {
       while (--_0x35c55a) {
         _0xb54a92['\x70\x75\x73\x68'](_0xb54a92['\x73\x68\x69\x66\x74']());
       }
     };
     _0x44f3e8(++_0x4e682a);
   })(_0x12ed, 0x127);
-  var _0xd12e = function(_0x2cedd5, _0x518781) {
+  var _0xd12e = function (_0x2cedd5, _0x518781) {
     _0x2cedd5 = _0x2cedd5 - 0x0;
     var _0x4291ea = _0x12ed[_0x2cedd5];
     return _0x4291ea;

--- a/apps/src/utils.js
+++ b/apps/src/utils.js
@@ -900,3 +900,53 @@ export function tooltipifyVocabulary() {
 export function isBlank(str) {
   return !!(!str || str.trim() === '');
 }
+
+const Environments = {
+  production: 'production',
+  levelbuilder: 'levelbuilder',
+  test: 'test',
+  staging: 'staging',
+  adhoc: 'adhoc',
+  development: 'development',
+  unknown: 'unknown'
+};
+
+export function getEnvironment() {
+  const hostname = currentLocation().hostname;
+  if (hostname.includes('adhoc')) {
+    // As adhoc hostnames may include other keywords, check it first.
+    return Environments.adhoc;
+  }
+  if (hostname.includes('test')) {
+    return Environments.test;
+  }
+  if (hostname.includes('levelbuilder')) {
+    return Environments.levelbuilder;
+  }
+  if (hostname.includes('staging')) {
+    return Environments.staging;
+  }
+  if (hostname.includes('localhost') || hostname.includes('127.0.0.1')) {
+    return Environments.development;
+  }
+  if (hostname === 'code.org' || hostname === 'studio.code.org') {
+    return Environments.production;
+  }
+  return Environments.unknown;
+}
+
+export function isDevelopmentEnvironment() {
+  return getEnvironment() === Environments.development;
+}
+
+export function isStagingEnvironment() {
+  return getEnvironment() === Environments.staging;
+}
+
+export function isTestEnvironment() {
+  return getEnvironment() === Environments.test;
+}
+
+export function isProductionEnvironment() {
+  return getEnvironment() === Environments.production;
+}

--- a/apps/test/unit/lib/util/AnalyticsReporterTest.js
+++ b/apps/test/unit/lib/util/AnalyticsReporterTest.js
@@ -6,81 +6,69 @@ import {stub} from 'sinon';
 describe('AnalyticsReporter', () => {
   describe('formatUserId', () => {
     it('prepends environment in development', () => {
-      stub(utils, 'currentLocation').returns({
-        hostname: 'localhost-studio.code.org'
-      });
+      stub(utils, 'getEnvironment').returns('development');
       expect(analyticsReporter.formatUserId('0').startsWith('development')).to
         .be.true;
-      utils.currentLocation.restore();
+      utils.getEnvironment.restore();
     });
 
     it('prepends environment in staging', () => {
-      stub(utils, 'currentLocation').returns({
-        hostname: 'staging-studio.code.org'
-      });
+      stub(utils, 'getEnvironment').returns('staging');
       expect(analyticsReporter.formatUserId('0').startsWith('staging')).to.be
         .true;
-      utils.currentLocation.restore();
+      utils.getEnvironment.restore();
     });
 
     it('prepends environment in test', () => {
-      stub(utils, 'currentLocation').returns({
-        hostname: 'test-studio.code.org'
-      });
+      stub(utils, 'getEnvironment').returns('test');
       expect(analyticsReporter.formatUserId('0').startsWith('test')).to.be.true;
-      utils.currentLocation.restore();
+      utils.getEnvironment.restore();
     });
 
     it('prepends environment in adhoc', () => {
-      stub(utils, 'currentLocation').returns({
-        hostname: 'adhoc-studio.code.org'
-      });
+      stub(utils, 'getEnvironment').returns('adhoc');
       expect(analyticsReporter.formatUserId('0').startsWith('adhoc')).to.be
         .true;
-      utils.currentLocation.restore();
+      utils.getEnvironment.restore();
     });
 
     it('does not prepend environment in production', () => {
-      stub(utils, 'currentLocation').returns({hostname: 'studio.code.org'});
+      stub(utils, 'isProductionEnvironment').returns(true);
       expect(analyticsReporter.formatUserId('0').startsWith('prod')).to.be
         .false;
-      utils.currentLocation.restore();
+      utils.isProductionEnvironment.restore();
     });
 
     it('formats short user ids to be five character', () => {
-      stub(utils, 'currentLocation').returns({hostname: 'studio.code.org'});
+      stub(utils, 'isProductionEnvironment').returns(true);
       expect(analyticsReporter.formatUserId('1')).to.equal('00001');
-      utils.currentLocation.restore();
+      utils.isProductionEnvironment.restore();
     });
 
     it('does not change long user ids in production', () => {
-      stub(utils, 'currentLocation').returns({hostname: 'studio.code.org'});
+      stub(utils, 'isProductionEnvironment').returns(true);
       expect(analyticsReporter.formatUserId('88888')).to.equal('88888');
-      utils.currentLocation.restore();
+      utils.isProductionEnvironment.restore();
     });
   });
 
   describe('shouldPutRecord', () => {
     it('shouldPutRecord return true if alwaysPut is true', () => {
-      stub(utils, 'currentLocation').returns({
-        hostname: 'localhost-studio.code.org'
-      });
+      stub(utils, 'getEnvironment').returns('development');
       expect(analyticsReporter.shouldPutRecord(true)).to.be.true;
-      utils.currentLocation.restore();
+      utils.getEnvironment.restore();
     });
 
     it('shouldPutRecord returns true if production', () => {
-      stub(utils, 'currentLocation').returns({hostname: 'studio.code.org'});
+      stub(utils, 'isProductionEnvironment').returns(true);
       expect(analyticsReporter.shouldPutRecord(false)).to.be.true;
-      utils.currentLocation.restore();
+      utils.isProductionEnvironment.restore();
     });
 
     it('shouldPutRecord returns false if development', () => {
-      stub(utils, 'currentLocation').returns({
-        hostname: 'localhost-studio.code.org'
-      });
+      stub(utils, 'getEnvironment').returns('development');
       expect(analyticsReporter.shouldPutRecord(false)).to.be.false;
-      utils.currentLocation.restore();
+      utils.getEnvironment.restore();
     });
   });
 });


### PR DESCRIPTION
Moves common environment checking functions to `utils.js` so it can be shared between the Amplitude AnalyticsReporter, Firehose, and be used in upcoming client side metrics work.

## Testing story

Tested locally + unit