### PR TITLE
adding guardrails for non-existent ml playground files

### DIFF
--- a/bin/i18n/sync-out.rb
+++ b/bin/i18n/sync-out.rb
@@ -430,11 +430,13 @@ def distribute_translations(upload_manifests)
       relative_path = loc_file.delete_prefix(locale_dir)
       next unless file_changed?(locale, relative_path)
 
-      external_translations = JSON.parse(File.read(loc_file))
+      external_translations = parse_file(loc_file)
       next if external_translations.empty?
 
       # Merge new translations
-      existing_translations = JSON.parse(File.read(ml_playground_path))
+      existing_translations = File.exist?(ml_playground_path) ?
+                                parse_file(ml_playground_path).dig(locale, "datasets") || {} :
+                                {}
       existing_translations['datasets'] = existing_translations['datasets'] || Hash.new
       existing_translations['datasets'][dataset_id] = external_translations
       sanitize_data_and_write(existing_translations, ml_playground_path)


### PR DESCRIPTION
Sync out fails in the distribution of content with the following error:
`Sync out failed from the error: Errno::ENOENT: No such file or directory @ rb_sysopen - apps/i18n/mlPlayground/sm_ws.json`
This is trigger by adding samoan to the supported languages.

This PR adds guardrails to the sync-out, checking if the ml-playground file, for a locale exists, before reading the file, and returning an empty Hash otherwise.

## Links

- jira ticket: [P20-109](https://codedotorg.atlassian.net/browse/P20-109)

## Testing story

Ran sync in test server and successfully included Samoan for ml-playground strings.
![image](https://user-images.githubusercontent.com/66776217/230398077-cd208f8c-fd49-4a13-a244-974b87330c4a.png)

## Deployment strategy

This PR does not have any effect in the Deployment.
