### PR TITLE
Change small-footer to position:fixed

### DIFF
--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -654,7 +654,7 @@ $small-footer-standard-width: 400px;
 }
 
 .small-footer-base {
-  position: absolute;
+  position: fixed;
   bottom: 0;
   margin: 0 $codeApp-left-margin;
   display: flex;


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

The footer now sticks to the bottom of the screen even when the page is long, instead of scrolling with the page.

Before:
![image](https://user-images.githubusercontent.com/1382374/230420557-cca9bf1c-cdff-4df2-8686-98fdd81c3bde.png)


After:

https://user-images.githubusercontent.com/1382374/230421344-edf614bc-d25f-44d9-b233-8c4c7ddec52d.mp4


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->


- jira ticket: [TEACH-385](https://codedotorg.atlassian.net/browse/TEACH-385)

## Testing

Tested locally on a few different pages, but mostly relying on eyes tests to tell us if this breaks something.