### PR TITLE
Initial front-end metrics implementation

### DIFF
--- a/apps/src/lib/metrics/MetricsApi.ts
+++ b/apps/src/lib/metrics/MetricsApi.ts
@@ -1,0 +1,6 @@
+/**
+ * Interface for interacting with a metrics service API.
+ */
+export default interface MetricsApi {
+  sendLogs: (logs: object[]) => Promise<Response>;
+}

--- a/apps/src/lib/metrics/MetricsReporter.ts
+++ b/apps/src/lib/metrics/MetricsReporter.ts
@@ -1,0 +1,104 @@
+import MetricsApi from './MetricsApi';
+
+const isDevelopmentEnvironment =
+  require('../../utils').isDevelopmentEnvironment;
+
+const CHECK_CAN_REPORT_INTERVAL = 30 * 60 * 1000; // 30 minutes in ms
+const LOCAL_STORAGE_KEY_NAME = 'cdo-metrics-reporter-last-check-time';
+
+type LogLevel = 'INFO' | 'WARNING' | 'SEVERE';
+
+/**
+ * Reports logs and metrics, intended primarily for developer-facing
+ * error reporting, metric reporting, and logging.
+ *
+ * For tracking user interactions and behaviors (product-facing),
+ * see {@link AnalyticsReporter} which reports to Amplitude.
+ *
+ * For legacy client-side reporting see {@link firehose} for AWS
+ * Firehose reporting and {@link logToCloud} for New Relic reporting.
+ */
+class MetricsReporter {
+  private lastCheckCanReportTime: number;
+
+  constructor(private readonly metricsApi: MetricsApi) {
+    this.metricsApi = metricsApi;
+    this.lastCheckCanReportTime =
+      parseInt(localStorage.getItem(LOCAL_STORAGE_KEY_NAME) || '0') || 0;
+  }
+
+  logInfo(message: string | object) {
+    this.log('INFO', message);
+    if (isDevelopmentEnvironment()) {
+      console.log('[MetricsReporter] ' + JSON.stringify(message));
+    }
+  }
+
+  logWarning(message: string | object) {
+    this.log('WARNING', message);
+    if (isDevelopmentEnvironment()) {
+      console.warn('[MetricsReporter] ' + JSON.stringify(message));
+    }
+  }
+
+  logError(message: string | object) {
+    this.log('SEVERE', message);
+    if (isDevelopmentEnvironment()) {
+      console.error('[MetricsReporter] ' + JSON.stringify(message));
+    }
+  }
+
+  private log(level: LogLevel, message: string | object) {
+    const payload = {
+      level,
+      message,
+      deviceInfo: this.getDeviceInfo()
+    };
+
+    if (!this.isReportingEnabled()) {
+      this.fallbackLog(payload);
+      return;
+    }
+
+    this.metricsApi.sendLogs([payload]).then(response => {
+      if (!response.ok) {
+        this.fallbackLog(payload);
+      }
+
+      if (response.status === 401) {
+        // Unauthorized response from server; client logging is likely disabled.
+        // We will check again after a time period of CHECK_CAN_REPORT_INTERVAL
+        this.setReportingDisabled();
+      }
+    });
+  }
+
+  private getDeviceInfo(): object {
+    return {
+      user_agent: window.navigator.userAgent,
+      window_width: window.innerWidth,
+      window_height: window.innerHeight,
+      hostname: window.location.hostname,
+      full_path: window.location.href
+    };
+  }
+
+  private fallbackLog(payload: object) {
+    console.log(
+      'Client-side reporting disabled. Attempted to report: ' +
+        JSON.stringify(payload)
+    );
+  }
+
+  private isReportingEnabled(): boolean {
+    return Date.now() - this.lastCheckCanReportTime > CHECK_CAN_REPORT_INTERVAL;
+  }
+
+  private setReportingDisabled() {
+    this.lastCheckCanReportTime = Date.now();
+    localStorage.setItem(
+      LOCAL_STORAGE_KEY_NAME,
+      this.lastCheckCanReportTime.toString()
+    );
+  }
+}

--- a/apps/src/lib/metrics/MetricsReporter.ts
+++ b/apps/src/lib/metrics/MetricsReporter.ts
@@ -84,10 +84,12 @@ class MetricsReporter {
   }
 
   private fallbackLog(payload: object) {
-    console.log(
-      'Client-side reporting disabled. Attempted to report: ' +
-        JSON.stringify(payload)
-    );
+    if (isDevelopmentEnvironment()) {
+      console.log(
+        'Client-side reporting disabled. Attempted to report: ' +
+          JSON.stringify(payload)
+      );
+    }
   }
 
   private isReportingEnabled(): boolean {

--- a/apps/src/lib/metrics/MetricsReporter.ts
+++ b/apps/src/lib/metrics/MetricsReporter.ts
@@ -3,7 +3,15 @@ import MetricsApi from './MetricsApi';
 const isDevelopmentEnvironment =
   require('../../utils').isDevelopmentEnvironment;
 
-const CHECK_CAN_REPORT_INTERVAL = 30 * 60 * 1000; // 30 minutes in ms
+/**
+ * If we receive an unauthorized response from the server, this may
+ * indicate that browser event reporting has been temporarily disabled.
+ * We will wait for a specific time interval (defined below) before making
+ * a request again, so as to not flood the server with requests.
+ */
+const CHECK_CAN_REPORT_INTERVAL_MINUTES = 30;
+const CHECK_CAN_REPORT_INTERVAL_MS =
+  CHECK_CAN_REPORT_INTERVAL_MINUTES * 60 * 1000;
 const LOCAL_STORAGE_KEY_NAME = 'cdo-metrics-reporter-last-check-time';
 
 type LogLevel = 'INFO' | 'WARNING' | 'SEVERE';
@@ -93,7 +101,9 @@ class MetricsReporter {
   }
 
   private isReportingEnabled(): boolean {
-    return Date.now() - this.lastCheckCanReportTime > CHECK_CAN_REPORT_INTERVAL;
+    return (
+      Date.now() - this.lastCheckCanReportTime > CHECK_CAN_REPORT_INTERVAL_MS
+    );
   }
 
   private setReportingDisabled() {


### PR DESCRIPTION
Initial implementation for a generic front-end metrics reporter. For now, this isn't used anywhere and isn't hooked up to any backend service, but I wanted to get some initial feedback before moving forward. Quick walkthrough of the new classes:

- **MetricsApi.ts**
  - Interface describing an API for communicating with a backend metrics service. This interface allows us to have an abstraction layer between the actual reporter, and the backend service its communicating with. In practice, we'll create an implementation of this interface that communicates with dashboard, once the backend piece is set up.

- **MetricsReporter.ts**
  - Metrics reporting class that can be used anywhere within front-end code. For now, it isn't exported anywhere, but I'm thinking this will be best used a singleton, and exported from this file with whatever implementation of the API we are currently using (e.g. `export default MetricsReporter(new SomethingThatImplementsMetricsApi())`)
  - Currently this only has functions for logging. Next step will be add functions for reporting events and counters.
  - Includes a mechanism for turning off reporting for some period of time (currently set to 30 min) if we get back a 401 unauthorized response from the server. The reason for this is, as we initially implement this as an experiment, we may turn off reporting via DCDO or Gatekeeper, and so this prevents us from spamming the backend if turned off. For an additional gatekeeping, we could also use a front-end DCDO flag, but I wasn't sure if that was necessary. The last check time (in epoch ms) is stored in local storage.

example structure of logs appearing in Cloudwatch (currently reporting to a test log group).

<img width="1184" alt="Screenshot 2023-04-06 at 1 47 57 PM" src="https://user-images.githubusercontent.com/85528507/230456493-12c899b0-5160-4873-b84c-a4ae82527d57.png">

### Background/Context

Some context on why this change is happening. We currently have various reporting solutions on the back-end and the front-end, but none currently meet our needs for robust developer-facing debugging. A quick summary of the services we use **on the front-end specifically**:
- New Relic (logToCloud.js) - for overall site monitoring and error tracking. Currently not very usable due to data ingest issues
- AWS Firehose (firehose.js) - used for a mix developer logging and product facing analytics. Cumbersome to query and visualize in Redshift; and product facing analytics reporting is expected to be replaced by Amplitude/GA
- Google Analytics - used for some product-facing analytics
- Amplitude (AnalyticsReporter.js) - used for some product-facing analytics

Given the issues with New Relic and Firehose, we have been exploring alternatives. The work started by this PR will add a new reporting path that reports client metrics to AWS Cloudwatch, where logs and metrics can be more easily viewed, retained, and visualized. As of the writing of this PR, we are implementing this metrics path as a time-boxed experiment to gather data on its usefulness. As such, we are including mechanisms such as the ability to turn off reporting via experiment flags.

## Testing story

Tested locally. Will add unit tests before shipping or as a follow up, once I get some initial feedback.