### PR TITLE
Show multi answer letters on standalone levels

### DIFF
--- a/dashboard/app/views/levels/_multi_answer.html.haml
+++ b/dashboard/app/views/levels/_multi_answer.html.haml
@@ -2,7 +2,7 @@
 - if Policies::InlineAnswer.visible_for_script_level?(current_user, @script_level)
   - correct_answers = data['answers'].each_with_index.map do |answer, index|
     - next unless answer['correct']
-    - letter = standalone ? nil : Multi.value_to_letter(index)
+    - letter = Multi.value_to_letter(index)
     - {index: index, letter: letter}
   - end.compact
   - unless correct_answers.empty?

--- a/dashboard/app/views/levels/_single_multi.html.haml
+++ b/dashboard/app/views/levels/_single_multi.html.haml
@@ -80,10 +80,9 @@
               .fa{class: checked_class}
             .item-mark{id: "cross_#{i}", style: 'display: none;'}
               .fa{class: cross_class}
-            - unless standalone
-              %label.item-label.item-answer-letter{style: "height: #{height}"}
-                ="#{multi_answer_characters[i]}. "
-                &nbsp;
+            %label.item-label.item-answer-letter{style: "height: #{height}"}
+              ="#{multi_answer_characters[i]}. "
+              &nbsp;
             %label.item-label{style: "height: #{height}"}
               != render_multi_or_match_content(localized_answers[i]['text'])
           - if use_tight_layout && !force_wrap_layout


### PR DESCRIPTION
Pretty straightforward change to resolve [TEACH-391](https://codedotorg.atlassian.net/browse/TEACH-391).

This branch:
![Screen Shot 2023-04-07 at 9 25 46 AM](https://user-images.githubusercontent.com/46464143/230616674-596df10d-ccb7-4aa3-82d2-d90c22abaa0a.png)

Production:
![Screen Shot 2023-04-07 at 9 26 03 AM](https://user-images.githubusercontent.com/46464143/230616715-875a83a8-290f-4329-a00e-89088248ade1.png)

It's possible we see some eyes diffs for this PR. If they are on standalone levels, that is expected.
