### PR TITLE
Remove Unused `binding_of_caller` Gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,7 +78,6 @@ group :development, :test do
   gem 'active_record_query_trace'
   gem 'benchmark-ips'
   gem 'better_errors', '>= 2.7.0'
-  gem 'binding_of_caller'
   gem 'brakeman'
   gem 'haml-rails' # haml (instead of erb) generators
   gem 'ruby-prof'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -280,8 +280,6 @@ GEM
       erubi (>= 1.0.0)
       rack (>= 0.9.0)
     bindata (2.4.10)
-    binding_of_caller (0.8.0)
-      debug_inspector (>= 0.0.1)
     bootstrap-sass (2.3.2.2)
       sass (~> 3.2)
     brakeman (4.5.0)
@@ -925,7 +923,6 @@ DEPENDENCIES
   bcrypt (= 3.1.13)
   benchmark-ips
   better_errors (>= 2.7.0)
-  binding_of_caller
   bootstrap-sass (~> 2.3.2.2)
   brakeman
   cancancan (~> 3.2.0)


### PR DESCRIPTION
This is a development-environment-only gem added [way back prior to even the creation of our monorepo](https://github.com/code-dot-org/dashboard/commit/a17aea759d977bcda05e4872d2f18f654d26bd49) which adds some debug tools [that we don't ever actually use](https://codedotorg.slack.com/archives/C0T0PNTM3/p1680813928352919). The version of the gem we're currently using is also incompatible with Ruby 3.0. We could [update to a version that does support modern Ruby](https://github.com/code-dot-org/code-dot-org/pull/51177), but I'd prefer we just clean it up instead.

## Links

- https://github.com/banister/binding_of_caller/releases/tag/v1.0.0