### PR TITLE
[Google Blockly] use thrasos as default renderer

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -1212,11 +1212,11 @@ StudioApp.prototype.inject = function (div, options) {
     customSimpleDialog: this.feedback_.showSimpleDialog.bind(this.feedback_)
   };
 
-  // Allows Google Blockly labs to use the Zelos or Thrasos renderer instead of the default.
+  // Allows Google Blockly labs to use the Zelos or legacy Geras renderer instead of the default Thrasos.
   if (experiments.isEnabled('zelos')) {
     options.renderer = 'cdo_renderer_zelos';
-  } else if (experiments.isEnabled('thrasos')) {
-    options.renderer = 'cdo_renderer_thrasos';
+  } else if (experiments.isEnabled('geras')) {
+    options.renderer = 'cdo_renderer';
   }
   Blockly.inject(div, utils.extend(defaults, options), Sounds.getSingleton());
 };

--- a/apps/src/blockly/googleBlocklyWrapper.js
+++ b/apps/src/blockly/googleBlocklyWrapper.js
@@ -508,7 +508,8 @@ function initializeBlocklyWrapper(blocklyInstance) {
         readOnly: true,
         theme: theme,
         plugins: {},
-        RTL: options.rtl
+        RTL: options.rtl,
+        renderer: options.renderer || 'cdo_renderer_thrasos'
       });
       const svg = Blockly.utils.dom.createSvgElement(
         'svg',
@@ -517,7 +518,8 @@ function initializeBlocklyWrapper(blocklyInstance) {
           'xmlns:html': 'http://www.w3.org/1999/xhtml',
           'xmlns:xlink': 'http://www.w3.org/1999/xlink',
           version: '1.1',
-          class: 'geras-renderer modern-theme readOnlyBlockSpace injectionDiv'
+          class:
+            'cdo_renderer_thrasos-renderer modern-theme readOnlyBlockSpace injectionDiv'
         },
         null
       );
@@ -574,7 +576,7 @@ function initializeBlocklyWrapper(blocklyInstance) {
         blockDragger: ScrollBlockDragger,
         metricsManager: CdoMetricsManager
       },
-      renderer: opt_options.renderer || 'cdo_renderer',
+      renderer: opt_options.renderer || 'cdo_renderer_thrasos',
       comments: false
     };
     // CDO Blockly takes assetUrl as an inject option, and it's used throughout


### PR DESCRIPTION
Updates our Google Blockly labs to use the thrasos renderer by default, unless overridden with an experiment.

Unblocks:
* https://github.com/code-dot-org/code-dot-org/pull/51066

## About the Thrasos renderer
Thrasos (Greek: "bold") is the name of Blockly's modern replacement for the Geras (Greek: "old") renderer that we use today in most labs. It has a flatter, more modern look, and improved vertical alignment of text on taller blocks. Geras blocks have a 3d look that is accomplished through an extra SVG "highlight". C-shaped blocks also have a more symmetrical shape.

**_Geras:_**
![image](https://user-images.githubusercontent.com/43474485/230491310-0d1517c7-9aac-4f1d-9339-183d2a1de686.png)![image](https://user-images.githubusercontent.com/43474485/230491540-6c947f24-0f98-408f-8c54-caf777a06b71.png)

**_Thrasos:_**
![image](https://user-images.githubusercontent.com/43474485/230491387-800b8064-a45f-4df4-bd77-a6a03ccafdcb.png)![image](https://user-images.githubusercontent.com/43474485/230491583-56a6ea92-ee68-4897-aa5c-b88f5a273a64.png)


Thrasos is the current default renderer for Music Lab and we would like to start using it other labs as well. In addition to the desired modernization and consistency this would bring, it would also simplify some complexity that is currently blocking Sprite Lab migration work (https://github.com/code-dot-org/code-dot-org/pull/51066).

Today, the Blockly team explicitly recommends this renderer for new projects although they still support Geras for projects that already use it as well as the Zelos renderer, which was explicitly designed to mimic Scratch.

This change updates the default renderer for all Google Blockly labs to consistently use Thrasos, including main workspaces created through the standard inject and readOnlyBlockSpaces, which are used in places like instructions. To test our confidence with this change, I made sure all blocks rendered as expected in the Dance and Poetry block pools, and compared various Google Blockly lab projects.

### Side-by-side comparisons

| Geras | Thrasos|
|-|-|
|![flappy geras](https://user-images.githubusercontent.com/43474485/230492023-c8c19817-696a-461b-bf1d-7991d85cbf0d.jpg)|![flappy thrasos](https://user-images.githubusercontent.com/43474485/230492061-db9df473-e6d1-42ac-b2de-f8dde796782f.jpg)|
|![poemart geras](https://user-images.githubusercontent.com/43474485/230492159-e0e08b69-3b41-48f0-9483-238d2a7d3b40.jpg)|![poemart thrasos](https://user-images.githubusercontent.com/43474485/230492179-08395860-8ccc-435f-8876-32c08d23d244.jpg)|
|![highcontrast geras](https://user-images.githubusercontent.com/43474485/230492225-fa3d27c9-ab50-4ea0-be41-77d15540d05c.jpg)|![highcontrast thrasos](https://user-images.githubusercontent.com/43474485/230492247-262aa2d7-ed0a-44a3-97aa-58994644ec26.jpg)|

## Testing story

No functional changes. It's possible that this could contribute to eyes diffs, so we will communicate with the DOTD when this is merged.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
