### PR TITLE
[CFU] Fix entry point styling by removing extra div

### DIFF
--- a/apps/src/templates/levelSummary/SummaryEntryPoint.jsx
+++ b/apps/src/templates/levelSummary/SummaryEntryPoint.jsx
@@ -34,7 +34,7 @@ const SummaryEntryPoint = ({scriptData, students, selectedSection}) => {
       />
 
       {selectedSection && (
-        <div>
+        <>
           <div className={styles.responseIcon}>
             <i className="fa fa-user" />
           </div>
@@ -46,7 +46,7 @@ const SummaryEntryPoint = ({scriptData, students, selectedSection}) => {
               <span className={styles.text}>{i18n.studentsAnswered()}</span>
             </p>
           </div>
-        </div>
+        </>
       )}
     </div>
   );


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Fixes a style regression I introduced in #51151. In small containers, the entry point should force a horizontal scroll bar, instead of wrapping.

Broken:
![image](https://user-images.githubusercontent.com/1382374/230483745-c35da01f-6799-4f9c-9ba5-0915b01b38e2.png)
![image](https://user-images.githubusercontent.com/1382374/230483784-5888ec03-0fa0-494e-954f-6e8a582b3e06.png)


Fixed:

![image](https://user-images.githubusercontent.com/1382374/230483565-cd15f34c-5515-4aa9-809b-998f39d372ea.png)
