### PR TITLE
Change small-footer to position:fixed in some places

### DIFF
--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -716,7 +716,7 @@ $small-footer-standard-width: 400px;
   }
 }
 
-/* Override footer position on StudioApp level pages. */
+/* Override footer position on some pages, but not published project views */
 #page-small-footer .small-footer-base {
   position: fixed;
 }

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -716,6 +716,12 @@ $small-footer-standard-width: 400px;
   }
 }
 
+/* Override footer position on StudioApp level pages. */
+#page-small-footer .small-footer-base {
+  position: fixed;
+}
+
+
 #copyright-scroll-area {
   overflow-y: auto;
   padding: 0.8em;


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Try another fix for #51166, which was reverted in #51183. I'm not sure this is the best fix, since this `page-small-footer` element is used in multiple places that I don't completely understand.

Example Eyes failures:
![image](https://user-images.githubusercontent.com/1382374/230499498-66463524-a900-4f33-a4fe-b0ca7aef7ab8.png)
![image](https://user-images.githubusercontent.com/1382374/230499569-15ea0781-408c-4141-86a0-6790b71e4048.png)



Sticky when viewing a level (or level summary):

![image](https://user-images.githubusercontent.com/1382374/230499428-25957816-7d57-4307-8422-cff3478d882e.png)
![image](https://user-images.githubusercontent.com/1382374/230499378-31b555ef-e800-4f77-93b4-af21137d3a66.png)


Unchanged when viewing a published project:

![image](https://user-images.githubusercontent.com/1382374/230499164-8544d16e-182d-463f-9e04-4d5d6db34b4b.png)
![image](https://user-images.githubusercontent.com/1382374/230499210-7a3ccf4d-a225-4e56-aa14-a3762fdb7e4c.png)


