### PR TITLE
Align cdoFieldImageDropdown columns with field_rectangular_dropdown

### DIFF
--- a/apps/src/blockly/addons/cdoFieldImageDropdown.js
+++ b/apps/src/blockly/addons/cdoFieldImageDropdown.js
@@ -10,10 +10,10 @@ export class CdoFieldImageDropdown extends FieldGridDropdown {
     // assuming that the number of options usually won't change that drastically,
     // so the number of columns can probably stay the same.
     const initialOptions = fixMenuGenerator(menuGenerator, width, height);
-    const numColumns =
-      initialOptions.length <= 7
-        ? 1
-        : Math.floor(Math.sqrt(initialOptions.length));
+    const numColumns = Math.max(
+      4,
+      Math.floor(Math.sqrt(initialOptions.length))
+    );
 
     super(
       () => fixMenuGenerator(menuGenerator, width, height),


### PR DESCRIPTION
We recently updated the blockly repo to calculate the number of columns in a field_rectangular_dropdown (for example, the backgrounds dropdown): https://github.com/code-dot-org/blockly/pull/308/files . This PR aligns the google blockly version of this to use the same calculation.

(Screenshots include the backgrounds tab experiment turned on)
### Before 
<img width="249" alt="Screenshot 2023-04-06 at 3 30 40 PM" src="https://user-images.githubusercontent.com/33666587/230506131-921bcc23-7ca7-45af-9a51-cb6792dee1ba.png">

### After
<img width="273" alt="Screenshot 2023-04-06 at 3 32 32 PM" src="https://user-images.githubusercontent.com/33666587/230506107-eac193b7-6f86-4c7d-a68d-eaceb90b3723.png">

## Links

- jira ticket: [SL-636](https://codedotorg.atlassian.net/browse/SL-636)


## Testing story
Tested locally.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
