### PR TITLE
Adding feature flag for the CPA compliance project

### DIFF
--- a/lib/cdo/cpa.rb
+++ b/lib/cdo/cpa.rb
@@ -15,7 +15,7 @@ CPA_ALL_USER_LOCKOUT = 'cpa_all_user_lockout'
 # cookie 'cpa_experience'.
 # @param schedule [Map] A map of the CPA phases to dates. Example:
 # {
-# 	“new_user_lockout”: “2023-07-01T00:00:00Z”,
+#   “new_user_lockout”: “2023-07-01T00:00:00Z”,
 #   “all_user_lockout”: “2024-07-01T00:00:00Z”
 # }
 # The DateTime strings must be ISO 8601 formatted.

--- a/lib/cdo/cpa.rb
+++ b/lib/cdo/cpa.rb
@@ -1,0 +1,49 @@
+require_relative '../../shared/middleware/helpers/experiments'
+require 'date'
+# Support for the Colorado Privacy Act (CPA) compliance.
+
+CPA_NEW_USER_LOCKOUT = 'cpa_new_user_lockout'
+CPA_ALL_USER_LOCKOUT = 'cpa_all_user_lockout'
+
+# There are three phases for the Colorado Privacy Act:
+# 1. Nothing - nil
+# 2. New User Accounts must be compliant - 'cpa_new_user_lockout'
+# 3. All User Accounts must be compliant - 'cpa_all_user_lockout'
+#
+# @param override [String] configuration overrides if we are manually testing the
+# experiences. This parameter will default to the query string parameter or
+# cookie 'cpa_experience'.
+# @param schedule [Map] A map of the CPA phases to dates. Example:
+# {
+# 	“new_user_lockout”: “2023-07-01T00:00:00Z”,
+#   “all_user_lockout”: “2024-07-01T00:00:00Z”
+# }
+# The DateTime strings must be ISO 8601 formatted.
+# @param current_time [DateTime] The current time, this should only be set for
+# testing purposes.
+# @return [String, nil] A string representing the current phase of the
+# compliance. nil if no phase.
+def cpa_experience(
+  schedule = experiment_value('cpa_schedule'),
+  override = experiment_value('cpa_experience'),
+  current_time = DateTime.now.new_offset(0)
+)
+  # If we detect a configuration override, use that instead.
+  return override if override
+
+  # Verify the schedule is well defined.
+  return nil unless schedule
+  return nil unless schedule[CPA_NEW_USER_LOCKOUT]
+  return nil unless schedule[CPA_ALL_USER_LOCKOUT]
+
+  # Calculate the phase of the CPA compliance schedule.
+  new_user_lockout = DateTime.parse(schedule[CPA_NEW_USER_LOCKOUT])
+  all_user_lockout = DateTime.parse(schedule[CPA_ALL_USER_LOCKOUT])
+  if current_time > all_user_lockout
+    CPA_ALL_USER_LOCKOUT
+  elsif current_time > new_user_lockout
+    CPA_NEW_USER_LOCKOUT
+  else
+    nil
+  end
+end

--- a/lib/cdo/http_cache.rb
+++ b/lib/cdo/http_cache.rb
@@ -40,6 +40,8 @@ class HttpCache
     'offline_pilot',
     # Experiment flag used to debug the onetrust cookie experience.
     'onetrust_cookie_scripts',
+    # Feature flag for the Colorado Privacy Act (CPA)
+    'cpa_experience',
     # Page mode, for A/B experiments and feature-flag rollouts.
     'pm'
   ].freeze

--- a/lib/test/cdo/test_cpa.rb
+++ b/lib/test/cdo/test_cpa.rb
@@ -1,0 +1,48 @@
+require_relative '../test_helper'
+require 'cdo/cpa'
+
+class CPATest < Minitest::Test
+  def test_cpa_experience_no_config
+    assert_nil cpa_experience(nil, nil)
+  end
+
+  def test_cpa_experience_with_override
+    result = cpa_experience(nil, CPA_ALL_USER_LOCKOUT)
+    assert_equal CPA_ALL_USER_LOCKOUT, result
+  end
+
+  def test_cpa_experience_with_invalid_schedule
+    result = cpa_experience({}, nil)
+    assert_nil result
+  end
+
+  def test_cpa_experience_before_new_user_lockout
+    current_time = DateTime.parse('2023-01-01T00:00:00Z')
+    schedule = {
+      CPA_NEW_USER_LOCKOUT => '2023-01-02T00:00:00Z',
+      CPA_ALL_USER_LOCKOUT => '2023-01-03T00:00:00Z'
+    }
+    result = cpa_experience(schedule, nil, current_time)
+    assert_nil result
+  end
+
+  def test_cpa_experience_after_new_user_lockout
+    current_time = DateTime.parse('2023-01-02T00:00:01Z')
+    schedule = {
+      CPA_NEW_USER_LOCKOUT => '2023-01-02T00:00:00Z',
+      CPA_ALL_USER_LOCKOUT => '2023-01-03T00:00:00Z'
+    }
+    result = cpa_experience(schedule, nil, current_time)
+    assert_equal CPA_NEW_USER_LOCKOUT, result
+  end
+
+  def test_cpa_experience_after_all_user_lockout
+    current_time = DateTime.parse('2023-01-03T00:00:01Z')
+    schedule = {
+      CPA_NEW_USER_LOCKOUT => '2023-01-02T00:00:00Z',
+      CPA_ALL_USER_LOCKOUT => '2023-01-03T00:00:00Z'
+    }
+    result = cpa_experience(schedule, nil, current_time)
+    assert_equal CPA_ALL_USER_LOCKOUT, result
+  end
+end


### PR DESCRIPTION
Adds a helper method `cpa_experience` which returns the current phase of our Colorado Privacy Act (CPA) compliance. It also adds support for query string and cookie overrides so we can manually test the different phases before going live.

## Links
* [JIRA](https://codedotorg.atlassian.net/browse/P20-99)

## Testing story
* Unit tests