### PR TITLE
Add non-English styling to Curriculum Catalog Card

### DIFF
--- a/apps/src/templates/button.module.scss
+++ b/apps/src/templates/button.module.scss
@@ -7,6 +7,11 @@ $button-height-large: 40px;
 $button-height-narrow: 40px;
 $button-height-small: 20px;
 
+@mixin focus-outline {
+  outline: $brand_primary_default solid 2px;
+  outline-offset: 2px;
+}
+
 /* stylelint-disable selector-pseudo-class-no-unknown */
 div,
 button,
@@ -220,8 +225,7 @@ a:visited,
     }
 
     &:focus {
-      outline: $brand_primary_default solid 2px;
-      outline-offset: 2px;
+      @include focus-outline;
     }
 
     &:disabled,
@@ -243,8 +247,7 @@ a:visited,
     }
 
     &:focus {
-      outline: $brand_primary_default solid 2px;
-      outline-offset: 2px;
+      @include focus-outline;
     }
 
     &:disabled {

--- a/apps/src/templates/button.module.scss
+++ b/apps/src/templates/button.module.scss
@@ -220,7 +220,8 @@ a:visited,
     }
 
     &:focus {
-      border-color: $brand_primary_default;
+      outline: $brand_primary_default solid 2px;
+      outline-offset: 2px;
     }
 
     &:disabled,
@@ -242,7 +243,8 @@ a:visited,
     }
 
     &:focus {
-      border-color: $brand_primary_default;
+      outline: $brand_primary_default solid 2px;
+      outline-offset: 2px;
     }
 
     &:disabled {

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
@@ -22,7 +22,8 @@ const CurriculumCatalogCard = ({
   imageSrc,
   subjects,
   topics,
-  isTranslated
+  isTranslated,
+  language
 }) => (
   <CustomizableCurriculumCatalogCard
     assignButtonText={i18n.assign()}
@@ -49,6 +50,7 @@ const CurriculumCatalogCard = ({
     imageAltText={imageAltText}
     isTranslated={isTranslated}
     translationIconTitle={i18n.courseInYourLanguage()}
+    isEnglish={language === 'en'}
   />
 );
 
@@ -66,7 +68,8 @@ CurriculumCatalogCard.propTypes = {
   ).isRequired,
   topics: PropTypes.arrayOf(
     PropTypes.oneOf(Object.keys(translatedCourseOfferingCsTopics))
-  ).isRequired
+  ).isRequired,
+  language: PropTypes.string.isRequired
 };
 
 CurriculumCatalogCard.defaultProps = {
@@ -87,7 +90,8 @@ const CustomizableCurriculumCatalogCard = ({
   translationIconTitle,
   subjectsAndTopics,
   quickViewButtonDescription,
-  quickViewButtonText
+  quickViewButtonText,
+  isEnglish
 }) => (
   <div className={style.curriculumCatalogCardContainer}>
     <img src={imageSrc} alt={imageAltText} />
@@ -114,8 +118,13 @@ const CustomizableCurriculumCatalogCard = ({
         <FontAwesome icon="clock-o" />
         <p className={style.iconDescription}>{duration}</p>
       </div>
-      <div className={style.buttonsContainer}>
-        {/* each button should be same fixed size */}
+      <div
+        className={
+          isEnglish
+            ? style.buttonsContainerEnglish
+            : style.buttonsContainerNotEnglish
+        }
+      >
         <Button
           color={Button.ButtonColor.neutralDark}
           type="button"
@@ -145,6 +154,7 @@ CustomizableCurriculumCatalogCard.propTypes = {
   isTranslated: PropTypes.bool,
   translationIconTitle: PropTypes.string.isRequired,
   subjectsAndTopics: PropTypes.arrayOf(PropTypes.string).isRequired,
+  isEnglish: PropTypes.bool,
   quickViewButtonText: PropTypes.string.isRequired,
   assignButtonText: PropTypes.string.isRequired,
 

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
@@ -24,7 +24,7 @@ const CurriculumCatalogCard = ({
   subjects,
   topics,
   isTranslated,
-  language
+  isEnglish
 }) => (
   <CustomizableCurriculumCatalogCard
     assignButtonText={i18n.assign()}
@@ -51,7 +51,7 @@ const CurriculumCatalogCard = ({
     imageAltText={imageAltText}
     isTranslated={isTranslated}
     translationIconTitle={i18n.courseInYourLanguage()}
-    isEnglish={language === 'en'}
+    isEnglish={isEnglish}
   />
 );
 
@@ -70,7 +70,7 @@ CurriculumCatalogCard.propTypes = {
   topics: PropTypes.arrayOf(
     PropTypes.oneOf(Object.keys(translatedCourseOfferingCsTopics))
   ).isRequired,
-  language: PropTypes.string.isRequired
+  isEnglish: PropTypes.bool.isRequired
 };
 
 CurriculumCatalogCard.defaultProps = {
@@ -161,9 +161,9 @@ CustomizableCurriculumCatalogCard.propTypes = {
   gradeRange: PropTypes.string.isRequired,
   imageSrc: PropTypes.string.isRequired,
   isTranslated: PropTypes.bool,
+  isEnglish: PropTypes.bool,
   translationIconTitle: PropTypes.string.isRequired,
   subjectsAndTopics: PropTypes.arrayOf(PropTypes.string).isRequired,
-  isEnglish: PropTypes.bool,
   quickViewButtonText: PropTypes.string.isRequired,
   assignButtonText: PropTypes.string.isRequired,
 

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
 import Button from '@cdo/apps/templates/Button';
 import i18n from '@cdo/locale';
@@ -93,7 +94,14 @@ const CustomizableCurriculumCatalogCard = ({
   quickViewButtonText,
   isEnglish
 }) => (
-  <div className={style.curriculumCatalogCardContainer}>
+  <div
+    className={classNames(
+      style.curriculumCatalogCardContainer,
+      isEnglish
+        ? style.curriculumCatalogCardContainer_english
+        : style.curriculumCatalogCardContainer_notEnglish
+    )}
+  >
     <img src={imageSrc} alt={imageAltText} />
     <div className={style.curriculumInfoContainer}>
       {/*TODO [MEG]: Show all subjects and topics rather than only the first one */}
@@ -111,19 +119,20 @@ const CustomizableCurriculumCatalogCard = ({
       <h4>{courseDisplayName}</h4>
       <div className={style.iconWithDescription}>
         <FontAwesome icon="user" className="fa-solid" />
-        <p className={style.iconDescription}>{gradeRange}</p>
+        <p className={style.iconWithDescriptionText}>{gradeRange}</p>
       </div>
       <div className={style.iconWithDescription}>
         {/*TODO [MEG]: Update this to be clock fa-solid when we update FontAwesome */}
         <FontAwesome icon="clock-o" />
-        <p className={style.iconDescription}>{duration}</p>
+        <p className={style.iconWithDescriptionText}>{duration}</p>
       </div>
       <div
-        className={
+        className={classNames(
+          style.buttonsContainer,
           isEnglish
-            ? style.buttonsContainerEnglish
-            : style.buttonsContainerNotEnglish
-        }
+            ? style.buttonsContainer_english
+            : style.buttonsContainer_notEnglish
+        )}
       >
         <Button
           color={Button.ButtonColor.neutralDark}

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.story.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.story.jsx
@@ -15,9 +15,14 @@ const defaultArgs = {
   oldestGrade: 12,
   subjects: ['english_language_arts'],
   topics: ['cybersecurity'],
-  isTranslated: true
+  isTranslated: true,
+  language: 'en'
 };
 
 export const BaseCard = Template.bind({});
 BaseCard.args = defaultArgs;
 BaseCard.storyName = 'CurriculumCatalogCard – Base';
+
+export const NonEnglishCard = Template.bind({});
+NonEnglishCard.args = {...defaultArgs, language: 'es'};
+NonEnglishCard.storyName = 'CurriculumCatalogCard – Not English Format';

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.story.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.story.jsx
@@ -16,7 +16,7 @@ const defaultArgs = {
   subjects: ['english_language_arts'],
   topics: ['cybersecurity'],
   isTranslated: true,
-  language: 'en'
+  isEnglish: true
 };
 
 export const BaseCard = Template.bind({});
@@ -24,5 +24,5 @@ BaseCard.args = defaultArgs;
 BaseCard.storyName = 'CurriculumCatalogCard – Base';
 
 export const NonEnglishCard = Template.bind({});
-NonEnglishCard.args = {...defaultArgs, language: 'es'};
+NonEnglishCard.args = {...defaultArgs, isEnglish: false};
 NonEnglishCard.storyName = 'CurriculumCatalogCard – Not English Format';

--- a/apps/src/templates/curriculumCatalog/curriculum_catalog_card.module.scss
+++ b/apps/src/templates/curriculumCatalog/curriculum_catalog_card.module.scss
@@ -1,6 +1,7 @@
 @import "phase1-design-system";
 
 $border-radius: 4px;
+$container-width: 309px;
 
 .curriculumCatalogCardContainer {
   display: flex;
@@ -8,7 +9,7 @@ $border-radius: 4px;
   background-color: $neutral_light;
   border-radius: $border-radius;
   height: 384px;
-  width: 309px;
+  width: $container-width;
 
   img {
     height: 140px;
@@ -65,18 +66,33 @@ $border-radius: 4px;
       }
     }
 
-    .buttonsContainer {
+    .buttonsContainerNotEnglish {
+      display: flex;
+      flex-direction: column;
+      flex-wrap: wrap;
+      margin-top: auto;
+      row-gap: 3px;
+
+      button {
+        margin: 0;
+        width: 100%;
+        height: 34px;
+        font-size: 0.9em;
+      }
+    }
+
+    .buttonsContainerEnglish {
       display: flex;
       flex-wrap: wrap;
       justify-content: space-between;
       margin-top: auto;
 
       button {
+        // width calculated to ensure space between buttons is 12px
+        // (totalContainerWidth - 2*padding - minimumSpaceBetweenButtons) / 2
+        width: ($container-width - (2 * 16) - 12) / 2;
         height: 40px;
         margin: 0;
-        // TODO [MEG] Adjust to accommodate different string
-        // sizes, look at gap https://css-tricks.com/almanac/properties/g/gap/
-        width: 132px; // calculated: (totalContainerWidth - 2*padding - minimumSpaceBetweenButtons) / 2
         font-size: 1em;
       }
     }

--- a/apps/src/templates/curriculumCatalog/curriculum_catalog_card.module.scss
+++ b/apps/src/templates/curriculumCatalog/curriculum_catalog_card.module.scss
@@ -42,6 +42,7 @@ $container-width: 309px;
     margin: 0;
 
     &:focus {
+      border-color: inherit;
       outline: $brand_primary_default solid 2px;
       outline-offset: 2px;
     }

--- a/apps/src/templates/curriculumCatalog/curriculum_catalog_card.module.scss
+++ b/apps/src/templates/curriculumCatalog/curriculum_catalog_card.module.scss
@@ -39,6 +39,15 @@ $container-width: 309px;
       color: $neutral_dark80;
     }
 
+    button {
+      margin: 0;
+
+      &:focus {
+        outline: $brand_primary_default solid 2px;
+        outline-offset: 2px;
+      }
+    }
+
     .tagsAndTranslatabilityContainer {
       display: flex;
       justify-content: space-between;
@@ -74,7 +83,6 @@ $container-width: 309px;
       row-gap: 3px;
 
       button {
-        margin: 0;
         width: 100%;
         height: 34px;
         font-size: 0.9em;
@@ -92,7 +100,6 @@ $container-width: 309px;
         // (totalContainerWidth - 2*padding - minimumSpaceBetweenButtons) / 2
         width: ($container-width - (2 * 16) - 12) / 2;
         height: 40px;
-        margin: 0;
         font-size: 1em;
       }
     }

--- a/apps/src/templates/curriculumCatalog/curriculum_catalog_card.module.scss
+++ b/apps/src/templates/curriculumCatalog/curriculum_catalog_card.module.scss
@@ -91,7 +91,7 @@ $container-width: 309px;
 }
 
 .buttonsContainer_notEnglish {
-  flex-direction: column;
+  flex-direction: column-reverse;
   row-gap: 1em;
 
   button {

--- a/apps/src/templates/curriculumCatalog/curriculum_catalog_card.module.scss
+++ b/apps/src/templates/curriculumCatalog/curriculum_catalog_card.module.scss
@@ -40,12 +40,6 @@ $container-width: 309px;
 
   button {
     margin: 0;
-
-    &:focus {
-      border-color: inherit;
-      outline: $brand_primary_default solid 2px;
-      outline-offset: 2px;
-    }
   }
 
   h4 {

--- a/apps/src/templates/curriculumCatalog/curriculum_catalog_card.module.scss
+++ b/apps/src/templates/curriculumCatalog/curriculum_catalog_card.module.scss
@@ -8,7 +8,6 @@ $container-width: 309px;
   flex-flow: column;
   background-color: $neutral_light;
   border-radius: $border-radius;
-  height: 384px;
   width: $container-width;
 
   img {
@@ -16,92 +15,100 @@ $container-width: 309px;
     object-fit: cover;
     border-radius: $border-radius $border-radius 0 0;
   }
+}
 
-  .curriculumInfoContainer {
-    display: flex;
-    flex-flow: column;
-    height: 100%;
-    border: 1px solid $neutral_dark20;
-    border-top: 0;
-    border-radius: 0 0 $border-radius $border-radius;
-    padding: 1.25em 1em;
+.curriculumCatalogCardContainer_english {
+  height: 24em;
+}
 
-    .overline {
-      color: $brand_primary_default;
-      margin-bottom: 0.5em;
-      font-size: 0.75em;
-      font-family: $gotham-bold;
-      text-transform: uppercase;
-      letter-spacing: 0.5px;
+.curriculumCatalogCardContainer_notEnglish {
+  height: 26em;
+}
+
+.curriculumInfoContainer {
+  display: flex;
+  flex-flow: column;
+  height: 100%;
+  border: 1px solid $neutral_dark20;
+  border-top: 0;
+  border-radius: 0 0 $border-radius $border-radius;
+  padding: 1.25em 1em;
+
+  i {
+    color: $neutral_dark80;
+  }
+
+  button {
+    margin: 0;
+
+    &:focus {
+      outline: $brand_primary_default solid 2px;
+      outline-offset: 2px;
     }
+  }
 
-    i {
-      color: $neutral_dark80;
-    }
+  h4 {
+    margin-bottom: 0.75em;
+    color: $neutral_dark;
+  }
+}
 
-    button {
-      margin: 0;
+.tagsAndTranslatabilityContainer {
+  display: flex;
+  justify-content: space-between;
 
-      &:focus {
-        outline: $brand_primary_default solid 2px;
-        outline-offset: 2px;
-      }
-    }
+  i {
+    margin-left: auto;
+    font-size: 1.5em;
+  }
+}
 
-    .tagsAndTranslatabilityContainer {
-      display: flex;
-      justify-content: space-between;
+.iconWithDescription {
+  display: flex;
+  margin: 0 0 0.5em 0;
+  align-items: center;
 
-      i {
-        margin-left: auto;
-        font-size: 1.5em;
-      }
-    }
+  .iconWithDescriptionText {
+    font-size: 0.875em;
+    margin: 0 0 0 0.5em;
+    color: $neutral_dark;
+  }
+}
 
-    h4 {
-      margin-bottom: 0.75em;
-      color: $neutral_dark;
-    }
+.overline {
+  color: $brand_primary_default;
+  margin-bottom: 0.5em;
+  font-size: 0.75em;
+  font-family: $gotham-bold;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
 
-    .iconWithDescription {
-      display: flex;
-      margin: 0 0 0.5em 0;
-      align-items: center;
+.buttonsContainer {
+  display: flex;
+  flex-wrap: wrap;
+  margin-top: auto;
+}
 
-      .iconDescription {
-        font-size: 0.875em;
-        margin: 0 0 0 0.5em;
-        color: $neutral_dark;
-      }
-    }
+.buttonsContainer_notEnglish {
+  flex-direction: column;
+  row-gap: 1em;
 
-    .buttonsContainerNotEnglish {
-      display: flex;
-      flex-direction: column;
-      flex-wrap: wrap;
-      margin-top: auto;
-      row-gap: 3px;
+  button {
+    width: 100%;
+    height: 34px;
+    font-size: 1em;
+  }
+}
 
-      button {
-        width: 100%;
-        height: 34px;
-        font-size: 0.9em;
-      }
-    }
+.buttonsContainer_english {
+  justify-content: space-between;
 
-    .buttonsContainerEnglish {
-      display: flex;
-      flex-wrap: wrap;
-      justify-content: space-between;
-      margin-top: auto;
-
-      button {
-        // width calculated to ensure space between buttons is 12px
-        // (totalContainerWidth - 2*padding - minimumSpaceBetweenButtons) / 2
-        width: ($container-width - (2 * 16) - 12) / 2;
-        height: 40px;
-        font-size: 1em;
-      }
-    }
+  button {
+    // width calculated to ensure space between buttons is 12px
+    // (totalContainerWidth - 2*padding - minimumSpaceBetweenButtons) / 2
+    width: ($container-width - (2 * 16) - 12) / 2;
+    height: 40px;
+    font-size: 1em;
   }
 }

--- a/apps/test/unit/templates/curriculumCatalog/curriculumCatalogCardTest.jsx
+++ b/apps/test/unit/templates/curriculumCatalog/curriculumCatalogCardTest.jsx
@@ -15,7 +15,7 @@ describe('CurriculumCatalogCard', () => {
       oldestGrade: 12,
       subjects: ['math'],
       topics: ['cybersecurity'],
-      language: 'en'
+      isEnglish: true
     };
   });
 

--- a/apps/test/unit/templates/curriculumCatalog/curriculumCatalogTest.jsx
+++ b/apps/test/unit/templates/curriculumCatalog/curriculumCatalogTest.jsx
@@ -14,7 +14,8 @@ describe('CurriculumCatalogCard', () => {
       youngestGrade: 4,
       oldestGrade: 12,
       subjects: ['math'],
-      topics: ['cybersecurity']
+      topics: ['cybersecurity'],
+      language: 'en'
     };
   });
 


### PR DESCRIPTION
Adds non-english styling of the card, which (a) changes the button layout, and (b) makes the card longer to accommodate for the button layout. Molly [has](https://codedotorg.slack.com/archives/C0SUN2SSF/p1681136757119949?thread_ts=1680644392.505969&cid=C0SUN2SSF) [approved](https://codedotorg.slack.com/archives/C0SUN2SSF/p1680877656561739?thread_ts=1680644392.505969&cid=C0SUN2SSF) the design. Also added the correct focus state (see [thread](https://codedotorg.slack.com/archives/C0SUN2SSF/p1680644742383219?thread_ts=1680644392.505969&cid=C0SUN2SSF))

English card:
<img width="298" alt="image" src="https://user-images.githubusercontent.com/9142121/230621107-8b8f2b93-2b43-4c99-8171-3803ae128ba0.png">

Non-English card:
<img width="298" alt="image" src="https://user-images.githubusercontent.com/9142121/230625845-af996450-22e9-4062-965c-b8ed78b9c352.png">

Focus state for button:
![image (1)](https://user-images.githubusercontent.com/9142121/230916133-7984ad1b-152b-4b08-80b0-48fa40f47efd.png)

This work also flattens styles. See initial discussion of flattening styles here https://github.com/code-dot-org/code-dot-org/pull/51099#issuecomment-1496671038, and compare the [non-flattened styles](https://github.com/code-dot-org/code-dot-org/blob/7e4dd023e2518548ed495b3b390b8ffdfb4d893b/apps/src/templates/curriculumCatalog/curriculum_catalog_card.module.scss) to the [flattened styles](https://github.com/code-dot-org/code-dot-org/blob/1a59eabf80b254d11b97c8c103a2d9e27a59e59f/apps/src/templates/curriculumCatalog/curriculum_catalog_card.module.scss) (split view comparison [here](https://github.com/code-dot-org/code-dot-org/pull/51202/commits/1a59eabf80b254d11b97c8c103a2d9e27a59e59f?diff=split&w=0))

## Links

## Testing story

No unit tests added here, as it's only styling modifications. Adding an eyes test to capture the Curriculum Catalog Page (which includes the card) will be part of the work before launching.

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
