### PR TITLE
Add steps to wait until pages load to (hopefully) reduce flakiness

### DIFF
--- a/dashboard/test/ui/features/step_definitions/levelbuilder_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/levelbuilder_steps.rb
@@ -155,6 +155,13 @@ Given(/^I wait for the temp data doc page to load$/) do
   }
 end
 
+Given(/^I wait for the temp data doc edit page to load$/) do
+  steps %{
+    And I wait until I am on "http://studio.code.org/data_docs/#{@temp_data_doc_key}/edit"
+    And I wait until element "#edit-data-doc" is visible
+  }
+end
+
 Given(/^element "([^"]*)" contains the name of the temp data doc$/) do |selector|
   steps %{
      And element "#{selector}" contains text "#{@temp_data_doc_name}"

--- a/dashboard/test/ui/features/teacher_tools/levelbuilder/create_and_delete_data_docs.feature
+++ b/dashboard/test/ui/features/teacher_tools/levelbuilder/create_and_delete_data_docs.feature
@@ -28,7 +28,7 @@ Feature: Creating and deleting data docs
     And element "a" contains the name of the temp data doc
     And the element contains the path to the temp data doc
     And I click the icon to edit the temp data doc
-    And I wait until element "#edit-data-doc" is visible
+    And I wait for the temp data doc edit page to load
     And I press keys "New description of Doc" for element "textarea"
     And I click "button[type='submit']" to load a new page
 

--- a/dashboard/test/ui/features/teacher_tools/script_overview.feature
+++ b/dashboard/test/ui/features/teacher_tools/script_overview.feature
@@ -61,6 +61,7 @@ Feature: Unit overview page
     # On last level of the lesson
     And I am on "http://studio.code.org/s/csp3-2019/lessons/3/levels/1"
     And I click selector ".submitButton"
+    And I wait until I am on "http://studio.code.org/s/csp3-2019"
     And I wait for jquery to load
     And I wait until element ".uitest-end-of-lesson-header:contains(You finished Lesson 3!)" is visible
     And I reload the page
@@ -73,7 +74,6 @@ Feature: Unit overview page
     And I click selector "#uitest-lesson-plan" once I see it
     When I switch tabs
     And I wait until current URL contains "curriculum.code.org/csp-19/unit3/1/"
-    
 
   Scenario: Unit overview new lesson plan
     Given I create an authorized teacher-associated student named "Blake"


### PR DESCRIPTION
Adds steps to wait until pages load to reduce flakiness on a couple of tests that are sitting on our flakiness threshold. See [this Slack message](https://codedotorg.slack.com/archives/C045UAX4WKH/p1680805308628539); unfortunately, I don't have a great idea for the flakiest test in the list.

Failing run for the data docs test: https://app.saucelabs.com/tests/4cb268509f9d48168cb46e7332ce854d#72
Failing run for the end-of-lesson test: https://app.saucelabs.com/tests/ccaa79c2574948af8fe77d816f587c10#21