### PR TITLE
Change summary page small-footer to position:fixed

### DIFF
--- a/dashboard/app/assets/stylesheets/levels/summary.scss
+++ b/dashboard/app/assets/stylesheets/levels/summary.scss
@@ -1,0 +1,4 @@
+/* Override footer position on the summary page only. */
+.small-footer-base {
+  position: fixed;
+}

--- a/dashboard/app/views/levels/_summary.html.haml
+++ b/dashboard/app/views/levels/_summary.html.haml
@@ -43,3 +43,4 @@
 
 - content_for(:head) do
   %script{src: webpack_asset_path('js/levels/_summary.js'), data: {summary: js_data.to_json}}
+  = stylesheet_link_tag 'levels/summary', media: 'all'


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Alternative fix for #51185. Only stickies the footer on the summary view, specifically.

See also this slack thread: https://codedotorg.slack.com/archives/C0T0PNR0D/p1680818195616849

![image](https://user-images.githubusercontent.com/1382374/230637811-425e5acd-be4a-4d16-889b-8e6bdba544cc.png)

