### PR TITLE
Fix UI test flakiness

### DIFF
--- a/dashboard/test/ui/features/star_labs/block_trashing.feature
+++ b/dashboard/test/ui/features/star_labs/block_trashing.feature
@@ -5,6 +5,7 @@ Background:
   Given I am on "http://studio.code.org/s/course2/lessons/19/levels/2"
   And I rotate to landscape
   And I wait for the page to fully load
+  And I dismiss the login reminder
   Then element "#runButton" is visible
   And element "#resetButton" is hidden
   # In this level's initial setup:


### PR DESCRIPTION
In this particular UI test, the login reminder was showing the whole time.  It seemed likely this was causing some flakiness, particularly as the browser viewport seemed to change more than necessary, as seen in the **before** screenshots from a Sauce Labs run.  

After a number of runs with this change, the error has not occurred again, so hopefully it has reduced flakiness.

### before

<img width="579" alt="Screenshot 2023-04-07 at 11 03 59 AM" src="https://user-images.githubusercontent.com/2205926/230658552-8771afac-e137-4e96-b455-1495eabcbf2c.png">

<img width="555" alt="Screenshot 2023-04-07 at 11 04 07 AM" src="https://user-images.githubusercontent.com/2205926/230658333-f140de86-8b04-435a-bae0-d64ede3b660c.png">
