### PR TITLE
Fix UI test navigation flakiness

### DIFF
--- a/dashboard/test/ui/features/star_labs/flappy.feature
+++ b/dashboard/test/ui/features/star_labs/flappy.feature
@@ -4,6 +4,7 @@ Feature: Flappy puzzles can be solved
 
 Scenario: Solving puzzle 1
   Given I am on "http://studio.code.org/flappy/1?noautoplay=true"
+  Then I wait until I am on "http://studio.code.org/flappy/1?noautoplay=true"
   And I rotate to landscape
   And I wait for the page to fully load
   And I drag block "flap" to block "whenClick"
@@ -14,6 +15,7 @@ Scenario: Solving puzzle 1
 
 Scenario: Solving puzzle 2
   Given I am on "http://studio.code.org/flappy/2?noautoplay=true"
+  Then I wait until I am on "http://studio.code.org/flappy/2?noautoplay=true"
   And I rotate to landscape
   And I wait for the page to fully load
   And I drag block "endGame" to block "whenCollideGround"
@@ -25,6 +27,7 @@ Scenario: Solving puzzle 2
 @no_mobile
 Scenario: Failing puzzle 2
   Given I am on "http://studio.code.org/flappy/2?noautoplay=true"
+  Then I wait until I am on "http://studio.code.org/flappy/2?noautoplay=true"
   And I rotate to landscape
   And I wait for the page to fully load
   And I press "runButton"


### PR DESCRIPTION
Taking a look at a failed run of this UI test, we could see something suspicious in the Sauce Labs video.

```
  Given I am on "http://studio.code.org/flappy/2?noautoplay=true"
  And I rotate to landscape
  And I wait for the page to fully load
  And I drag block "endGame" to block "whenCollideGround"
```

While trying to do the final step in this snippet, we were still on the first level bubble, not the second.  The navigation had not completed; in fact, it had barely begun.

<img width="1244" alt="Screenshot 2023-04-07 at 11 48 54 AM" src="https://user-images.githubusercontent.com/2205926/230673138-5def36f0-f691-405d-9578-540506b887d8.png">

I tried making a change to the navigation code [here](https://github.com/code-dot-org/code-dot-org/blob/6dd20591440c8fa55ec7b935cec1ebe62e4882ff/dashboard/test/ui/features/step_definitions/steps.rb#L86) to wait until the `document.readyState` was not `complete`, before then then waiting until it was `complete`  to try to ensure that the navigation had both begun and completed, but it didn't seem robust enough.  

I also tried adding the logic from the `"I wait until I am on"` [step](https://github.com/code-dot-org/code-dot-org/blob/6dd20591440c8fa55ec7b935cec1ebe62e4882ff/dashboard/test/ui/features/step_definitions/steps.rb#L288-L291) to that same location, to make sure we had landed on the right page before continuing, but this didn't account for redirects that can occur during navigation.

So, for now, I just patched up this one test by having it wait until it's definitely on the destination page.
