### PR TITLE
Update enrollment workshop emails

### DIFF
--- a/dashboard/app/views/pd/workshop_mailer/_workshop_logistics.html.haml
+++ b/dashboard/app/views/pd/workshop_mailer/_workshop_logistics.html.haml
@@ -8,7 +8,7 @@
       - @workshop.sessions.each do |session|
         = session.start_date_with_start_and_end_times_us_format
         %br
-  - unless @workshop.location_name.blank? || @workshop.virtual?
+  - unless @workshop.location_name.blank?
     %tr
       %td.heading
         Location:
@@ -31,3 +31,8 @@
           = facilitator.name
           (#{mail_to(facilitator.email)})
           %br
+  - if !@workshop.notes.blank? && @workshop.virtual?
+    %td.heading
+      Notes:
+    %td
+      = @workshop.notes

--- a/dashboard/app/views/pd/workshop_mailer/teacher_enrollment_reminder.html.haml
+++ b/dashboard/app/views/pd/workshop_mailer/teacher_enrollment_reminder.html.haml
@@ -41,6 +41,10 @@
   = render partial: 'pre_survey'
 - elsif @workshop.subject != Pd::Workshop::COURSE_FACILITATOR
   %p
+    - if @is_first_pre_survey_email
+      Please take a moment to review the following logistical details about your workshop.
+    - else
+      If you have not already done so, please review the following logistical details about your workshop.
     If you have any questions, reach out to your workshop organizer directly:
     = "#{@organizer.name} at "
     = mail_to @organizer.email, "#{@organizer.email}."

--- a/dashboard/test/mailers/previews/pd_workshop_mailer_preview.rb
+++ b/dashboard/test/mailers/previews/pd_workshop_mailer_preview.rb
@@ -18,7 +18,8 @@ class PdWorkshopMailerPreview < ActionMailer::Preview
              workshop_params: {
                virtual: true,
                location_name: 'zoom_link',
-               location_address: nil
+               location_address: nil,
+               notes: 'Please join the webinar using zoom_link. The webinar will take place at 8 pm ET/ 5 pm PT.'
              }
       end
 
@@ -31,7 +32,8 @@ class PdWorkshopMailerPreview < ActionMailer::Preview
              workshop_params: {
                virtual: true,
                location_name: 'zoom_link',
-               location_address: nil
+               location_address: nil,
+               notes: 'Please join the webinar using zoom_link. The webinar will take place at 8 pm ET/ 5 pm PT.'
              }
       end
 
@@ -44,7 +46,8 @@ class PdWorkshopMailerPreview < ActionMailer::Preview
              workshop_params: {
                virtual: true,
                location_name: 'zoom_link',
-               location_address: nil
+               location_address: nil,
+               notes: 'Please join the webinar using zoom_link. The webinar will take place at 8 pm ET/ 5 pm PT.'
              }
       end
     end


### PR DESCRIPTION
Within [the spec for adding CSA Capstone emails](https://docs.google.com/document/d/1zHEB469KPc4k9RqmwvNy3GM3_tEYFSreRDajPqhnBDI/edit?pli=1#heading=h.w1s1tlid3g44), there were a few changes that were not specific to just CSA capstone emails so I split those into this PR as it pertains to more emails.

### Changes
- For the workshop "Logistics" section:
   - Show the "Location" field for virtual workshops now (it will have the zoom link)
   - Always include the "Notes" field if it is not empty and it's a virtual workshop (the notes will also include the zoom link)
- For the enrollment reminder email:
   - Have a reminder to review the workshop's logistical details (with slightly different wording depending on whether it's the 10-day-before reminder or the 3-day-before reminder)

### Examples
Location field now shows up for virtual workshops:
![Location_shows_up](https://user-images.githubusercontent.com/56283563/230680428-71612d0e-a84b-4701-94f1-e9d303e609b2.PNG)

"Notes" field now shows up for virtual workshops in the "Logistics" section:
![Notes_show_up](https://user-images.githubusercontent.com/56283563/230680439-9e9e5212-6758-4460-9e4b-a749ee2b6f22.PNG)

"Notes" field still doesn't show up for in-person workshops in the "Logistics" section:
![No_notes](https://user-images.githubusercontent.com/56283563/230680444-ec30ca7f-c927-4f23-ab2f-94844761214a.PNG)

Reminder to review the workshop's logistical details (10-day-reminder):
![10_day](https://user-images.githubusercontent.com/56283563/230680455-114b353c-c027-4014-b147-238582ecd75e.PNG)

Reminder to review the workshop's logistical details (3-day-reminder):
![3_day](https://user-images.githubusercontent.com/56283563/230680464-1d0233cb-dcd3-46fe-a5af-8821962bc005.PNG)

## Links
Spec: [here](https://docs.google.com/document/d/1zHEB469KPc4k9RqmwvNy3GM3_tEYFSreRDajPqhnBDI/edit?pli=1#heading=h.w1s1tlid3g44)

## Testing story
Local testing.

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
