### PR TITLE
remove dig file

### DIFF
--- a/bin/i18n/sync-out.rb
+++ b/bin/i18n/sync-out.rb
@@ -434,9 +434,7 @@ def distribute_translations(upload_manifests)
       next if external_translations.empty?
 
       # Merge new translations
-      existing_translations = File.exist?(ml_playground_path) ?
-                                parse_file(ml_playground_path).dig(locale, "datasets") || {} :
-                                {}
+      existing_translations = File.exist?(ml_playground_path) ? parse_file(ml_playground_path) || {} : {}
       existing_translations['datasets'] = existing_translations['datasets'] || Hash.new
       existing_translations['datasets'][dataset_id] = external_translations
       sanitize_data_and_write(existing_translations, ml_playground_path)


### PR DESCRIPTION
Patching #51164  

Locale.json files in the apps directory are flat files, i.e. Strings are not wrapped with locale like in this example:
```
{
    "es-ES": {
        "data": { ... }
    }
{
```

Therefore, when parsing `mlPlaygroun.json` to merge external strings (from ml-playground repo) with local strings (from code-dot-org repo), the method `dig` does not work and should not be there.

## Testing
Added translations to Spanish in Crowdin.
Ran sync Down and Out
Checked that `apps/i18n/mlPlayground/es_es.json` containes newly added strings and existing ones.