### PR TITLE
add deep rendering tests to workshop form js

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/components/organizer_form_part.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/organizer_form_part.jsx
@@ -1,3 +1,4 @@
+import $ from 'jquery';
 import PropTypes from 'prop-types';
 import React from 'react';
 import {Row, Col} from 'react-bootstrap';

--- a/apps/test/unit/code-studio/pd/workshop_dashboard/components/workshopFormTest.js
+++ b/apps/test/unit/code-studio/pd/workshop_dashboard/components/workshopFormTest.js
@@ -1,11 +1,17 @@
 import React from 'react';
-import {shallow} from 'enzyme';
+import {shallow, mount} from 'enzyme';
 import {assert} from 'chai';
 import {Factory} from 'rosie';
 import {FormControl} from 'react-bootstrap';
-import Permission from '@cdo/apps/code-studio/pd/workshop_dashboard/permission';
+import Permission, {
+  WorkshopAdmin
+} from '@cdo/apps/code-studio/pd/workshop_dashboard/permission';
 import {WorkshopForm} from '@cdo/apps/code-studio/pd/workshop_dashboard/components/workshop_form';
 import '../workshopFactory';
+import {Provider} from 'react-redux';
+import {MemoryRouter} from 'react-router-dom';
+import mapboxReducer from '@cdo/apps/redux/mapbox';
+import {createStore, combineReducers} from 'redux';
 
 describe('WorkshopForm test', () => {
   let fakeWorkshop;
@@ -14,7 +20,7 @@ describe('WorkshopForm test', () => {
     fakeWorkshop = Factory.build('workshop');
   });
 
-  it('renders csf intro workshop', () => {
+  it('renders csf intro workshop ', () => {
     const wrapper = shallow(
       <WorkshopForm
         permission={new Permission()}
@@ -31,16 +37,25 @@ describe('WorkshopForm test', () => {
   });
 
   it('renders csp summer workshop', () => {
+    const store = createStore(
+      combineReducers({
+        mapbox: mapboxReducer
+      })
+    );
+
     const cspSummerWorkshop = Factory.build('csp summer workshop');
-    const wrapper = shallow(
-      <WorkshopForm
-        permission={new Permission()}
-        facilitatorCourses={[]}
-        workshop={cspSummerWorkshop}
-        onSaved={() => {}}
-        readOnly={false}
-      />,
-      {context: {router: {}}}
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter>
+          <WorkshopForm
+            permission={new Permission([WorkshopAdmin])}
+            facilitatorCourses={[]}
+            workshop={cspSummerWorkshop}
+            onSaved={() => {}}
+            readOnly={false}
+          />
+        </MemoryRouter>
+      </Provider>
     );
 
     const someControl = wrapper.find(FormControl);

--- a/apps/test/unit/code-studio/pd/workshop_dashboard/components/workshopFormTest.js
+++ b/apps/test/unit/code-studio/pd/workshop_dashboard/components/workshopFormTest.js
@@ -14,12 +14,29 @@ describe('WorkshopForm test', () => {
     fakeWorkshop = Factory.build('workshop');
   });
 
-  it('renders', () => {
+  it('renders csf intro workshop', () => {
     const wrapper = shallow(
       <WorkshopForm
         permission={new Permission()}
         facilitatorCourses={[]}
         workshop={fakeWorkshop}
+        onSaved={() => {}}
+        readOnly={false}
+      />,
+      {context: {router: {}}}
+    );
+
+    const someControl = wrapper.find(FormControl);
+    assert(someControl.exists());
+  });
+
+  it('renders csp summer workshop', () => {
+    const cspSummerWorkshop = Factory.build('csp summer workshop');
+    const wrapper = shallow(
+      <WorkshopForm
+        permission={new Permission()}
+        facilitatorCourses={[]}
+        workshop={cspSummerWorkshop}
         onSaved={() => {}}
         readOnly={false}
       />,

--- a/apps/test/unit/code-studio/pd/workshop_dashboard/components/workshopFormTest.js
+++ b/apps/test/unit/code-studio/pd/workshop_dashboard/components/workshopFormTest.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {shallow, mount} from 'enzyme';
+import {mount} from 'enzyme';
 import {assert} from 'chai';
 import {Factory} from 'rosie';
 import {FormControl} from 'react-bootstrap';
@@ -14,22 +14,30 @@ import mapboxReducer from '@cdo/apps/redux/mapbox';
 import {createStore, combineReducers} from 'redux';
 
 describe('WorkshopForm test', () => {
-  let fakeWorkshop;
+  let fakeWorkshop, store;
 
   beforeEach(() => {
     fakeWorkshop = Factory.build('workshop');
+    store = createStore(
+      combineReducers({
+        mapbox: mapboxReducer
+      })
+    );
   });
 
-  it('renders csf intro workshop ', () => {
-    const wrapper = shallow(
-      <WorkshopForm
-        permission={new Permission()}
-        facilitatorCourses={[]}
-        workshop={fakeWorkshop}
-        onSaved={() => {}}
-        readOnly={false}
-      />,
-      {context: {router: {}}}
+  it('renders csf intro workshop', () => {
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter>
+          <WorkshopForm
+            permission={new Permission([WorkshopAdmin])}
+            facilitatorCourses={[]}
+            workshop={fakeWorkshop}
+            onSaved={() => {}}
+            readOnly={false}
+          />
+        </MemoryRouter>
+      </Provider>
     );
 
     const someControl = wrapper.find(FormControl);
@@ -37,12 +45,6 @@ describe('WorkshopForm test', () => {
   });
 
   it('renders csp summer workshop', () => {
-    const store = createStore(
-      combineReducers({
-        mapbox: mapboxReducer
-      })
-    );
-
     const cspSummerWorkshop = Factory.build('csp summer workshop');
     const wrapper = mount(
       <Provider store={store}>

--- a/apps/test/unit/code-studio/pd/workshop_dashboard/workshopFactory.js
+++ b/apps/test/unit/code-studio/pd/workshop_dashboard/workshopFactory.js
@@ -24,6 +24,15 @@ Factory.define('workshop')
   .attr('organizer', {name: 'Oscar Organzier', email: 'oscar@code.org'})
   .attr('virtual', false);
 
+Factory.define('csp summer workshop')
+  .extend('workshop')
+  .attr('course', 'CS Principles')
+  .attr('subject', '5-day Summer')
+  .attr('sessions', () => Factory.buildList('session', 5))
+  .attr('account_required_for_attendance?', true)
+  .attr('scholarship_workshop?', true)
+  .attr('location_name', 'physical');
+
 Factory.define('session')
   .sequence('id')
   .attr('code', 'TEST')


### PR DESCRIPTION
Related to https://codedotorg.atlassian.net/browse/ACQ-462. This adds a first enzyme `mount` test for the workshop form. For more background, see [workshop form refactor proposal](https://docs.google.com/document/d/1lFUGI_tK7HaTl8VU-WNMjRpIM4kLmThYWkiCYVeg_yg/edit#heading=h.x20ojf9pks8i).

links
* js factory docs: https://www.npmjs.com/package/rosie 

## Testing story

Improves existing test coverage
