### PR TITLE
Music: fix tests

### DIFF
--- a/dashboard/app/views/levels/show.html.haml
+++ b/dashboard/app/views/levels/show.html.haml
@@ -65,7 +65,7 @@
         = render partial: "levels/#{@level.class.to_s.underscore}"
       - unless @level.is_a?(StandaloneVideo) || @level.properties['hide_reference_area']
         = render partial: 'levels/reference_area'
-    - elsif @game == Game.music
+    - elsif @game.app == Game::MUSIC
       = render partial: 'levels/music'
     - else
       = render partial: 'levels/blockly'

--- a/dashboard/test/integration/db_query_test.rb
+++ b/dashboard/test/integration/db_query_test.rb
@@ -152,7 +152,7 @@ class DBQueryTest < ActionDispatch::IntegrationTest
     student.assign_script(unit)
     sign_in student
 
-    assert_cached_queries(20) do
+    assert_cached_queries(19) do
       get "/s/#{unit.name}/lessons/1/levels/1"
       assert_response :success
     end

--- a/dashboard/test/integration/db_query_test.rb
+++ b/dashboard/test/integration/db_query_test.rb
@@ -152,7 +152,7 @@ class DBQueryTest < ActionDispatch::IntegrationTest
     student.assign_script(unit)
     sign_in student
 
-    assert_cached_queries(19) do
+    assert_cached_queries(20) do
       get "/s/#{unit.name}/lessons/1/levels/1"
       assert_response :success
     end


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/51125.  

Fixes errors in a couple unit tests — `dashboard/test/integration/db_query_test.rb` and `dashboard/test/integration/caching_test.rb` — by avoiding the addition of another database hit in `show.html.haml`.  

These failed in the DTT, but surprisingly not in the Drone run for the PR.  
