### PR TITLE
Set/clarify default for allow_multiple_attempts

### DIFF
--- a/dashboard/app/models/levels/match.rb
+++ b/dashboard/app/models/levels/match.rb
@@ -36,7 +36,7 @@ class Match < DSLDefined
       description 'description here'
       question 'Question'
       answer 'Answer 1'
-      allow_multiple_attempts nil
+      allow_multiple_attempts false
     RUBY
   end
 

--- a/dashboard/app/models/levels/multi.rb
+++ b/dashboard/app/models/levels/multi.rb
@@ -35,7 +35,7 @@ class Multi < Match
       question 'Question'
       wrong 'wrong answer'
       right 'right answer'
-      allow_multiple_attempts nil
+      allow_multiple_attempts false
     RUBY
   end
 

--- a/dashboard/app/views/levels/editors/fields/_free_response_fields.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_free_response_fields.html.haml
@@ -31,4 +31,4 @@
     %p If checked, an assessment page will still be considered complete even if this question is left blank.
   .field
     = render partial: 'levels/editors/fields/checkboxes', locals: {f: f, field_name: :allow_multiple_attempts, description: "Allow multiple attempts"}
-    %p Whether or not a user can submit multiple answers. Default is no for contained levels and yes for standalone levels. It will not apply for levels in level groups.
+    %p Whether or not a user can submit multiple answers. It will not apply for levels in level groups.


### PR DESCRIPTION
Sets a default value for `allow_multiple_attempts` for Match and Multi levels. This value was already false for `FreeResponse` levels so just clarifying the description to match that.