### PR TITLE
Remove curriculum guide from supplies list in email

### DIFF
--- a/dashboard/app/views/pd/workshop_mailer/_supply_list.html.haml
+++ b/dashboard/app/views/pd/workshop_mailer/_supply_list.html.haml
@@ -12,7 +12,3 @@
     for more information regarding compatible operating systems and browsers. We
     do not recommend bringing a tablet as your primary device.
   %li Headphones or earphones.
-  - if @workshop.subject == Pd::Workshop::SUBJECT_CSF_201
-    %li
-      A physical copy of the 2021-2022 CS Fundamentals Curriculum Guide. If you
-      do not have one available, one will be provided for you at the workshop.


### PR DESCRIPTION
Hard copies of curriculum guides will no longer be supplied for workshops so we are removing this from the email. 