### PR TITLE
Show cards on curriculum catalog page

### DIFF
--- a/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
@@ -54,7 +54,8 @@ const CurriculumCatalog = ({curriculaData}) => {
                     oldestGrade={gradeLevelArray[gradeLevelArray.length - 1]}
                     subjects={school_subject?.split(',')}
                     topics={cs_topic?.split(',')}
-                    isTranslated={!!Math.round(Math.random())} // TODO [MEG] actually pass in this data
+                    isTranslated={!!Math.round(Math.random())} // TODO [MEG]: actually pass in this data
+                    isEnglish={true} // TODO [MEG]: use locale
                   />
                 );
               }

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
@@ -8,63 +8,61 @@ import CourseCatalogIllustration01 from '../../../static/curriculum_catalog/cour
 import CurriculumCatalogCard from '@cdo/apps/templates/curriculumCatalog/CurriculumCatalogCard';
 import {translatedCourseOfferingDurations} from '@cdo/apps/templates/teacherDashboard/CourseOfferingHelpers';
 
-const CurriculumCatalog = ({curriculaData}) => {
-  return (
-    <>
-      <div className={style.catalogHeader}>
-        <HeaderBanner
-          headingText={i18n.curriculumCatalogHeaderTitle()}
-          subHeadingText={i18n.curriculumCatalogHeaderSubtitle()}
-          short={false}
-          imageUrl={CourseCatalogIllustration01}
-        />
-      </div>
-      <div className={style.catalogContentContainer}>
-        <div className={style.catalogContent}>
-          {/*TODO [MEG]: calculate and pass in duration and translated from backend, use image in imageSrc */}
-          {curriculaData
-            .filter(curriculum => !!curriculum.grade_levels)
-            .map(
-              ({
-                key,
-                image,
-                display_name,
-                grade_levels,
-                school_subject,
-                cs_topic
-              }) => {
-                // TODO [MEG]: We are currently assuming if there are grade levels, there are at least two
-                // grades and the list is in ascending order.
-                const gradeLevelArray = grade_levels.split(',');
-                const durationPossibilities = Object.keys(
-                  translatedCourseOfferingDurations
-                );
+const CurriculumCatalog = ({curriculaData}) => (
+  <>
+    <div className={style.catalogHeader}>
+      <HeaderBanner
+        headingText={i18n.curriculumCatalogHeaderTitle()}
+        subHeadingText={i18n.curriculumCatalogHeaderSubtitle()}
+        short={false}
+        imageUrl={CourseCatalogIllustration01}
+      />
+    </div>
+    <div className={style.catalogContentContainer}>
+      <div className={style.catalogContent}>
+        {/*TODO [MEG]: calculate and pass in duration and translated from backend, use image in imageSrc */}
+        {curriculaData
+          .filter(curriculum => !!curriculum.grade_levels)
+          .map(
+            ({
+              key,
+              image,
+              display_name,
+              grade_levels,
+              school_subject,
+              cs_topic
+            }) => {
+              // TODO [MEG]: We are currently assuming if there are grade levels, there are at least two
+              // grades and the list is in ascending order.
+              const gradeLevelArray = grade_levels.split(',');
+              const durationPossibilities = Object.keys(
+                translatedCourseOfferingDurations
+              );
 
-                return (
-                  <CurriculumCatalogCard
-                    key={key}
-                    imageSrc={image}
-                    courseDisplayName={display_name}
-                    duration={
-                      durationPossibilities[
-                        Math.floor(Math.random() * durationPossibilities.length)
-                      ]
-                    } // TODO [MEG] actually pass in this data
-                    youngestGrade={gradeLevelArray[0]}
-                    oldestGrade={gradeLevelArray[gradeLevelArray.length - 1]}
-                    subjects={school_subject?.split(',')}
-                    topics={cs_topic?.split(',')}
-                    isTranslated={!!Math.round(Math.random())} // TODO [MEG]: actually pass in this data
-                    isEnglish={true} // TODO [MEG]: use locale
-                  />
-                );
-              }
-            )}
-        </div>
+              return (
+                <CurriculumCatalogCard
+                  key={key}
+                  imageSrc={image}
+                  courseDisplayName={display_name}
+                  duration={
+                    durationPossibilities[
+                      Math.floor(Math.random() * durationPossibilities.length)
+                    ]
+                  } // TODO [MEG] actually pass in this data
+                  youngestGrade={gradeLevelArray[0]}
+                  oldestGrade={gradeLevelArray[gradeLevelArray.length - 1]}
+                  subjects={school_subject?.split(',')}
+                  topics={cs_topic?.split(',')}
+                  isTranslated={!!Math.round(Math.random())} // TODO [MEG]: actually pass in this data
+                  isEnglish={true} // TODO [MEG]: use locale
+                />
+              );
+            }
+          )}
       </div>
-    </>
-  );
-};
+    </div>
+  </>
+);
 
 CurriculumCatalog.propTypes = {
   curriculaData: PropTypes.arrayOf(curriculumDataShape)

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
@@ -23,9 +23,7 @@ const CurriculumCatalog = ({curriculaData}) => {
         <div className={style.catalogContent}>
           {/*TODO [MEG]: calculate and pass in duration and translated from backend, use image in imageSrc */}
           {curriculaData
-            .filter(
-              curriculum => !!curriculum.grade_levels && !!curriculum.image
-            )
+            .filter(curriculum => !!curriculum.grade_levels)
             .map(
               ({
                 key,

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
@@ -6,6 +6,7 @@ import style from '../../../style/code-studio/curriculum_catalog_container.modul
 import HeaderBanner from '../HeaderBanner';
 import CourseCatalogIllustration01 from '../../../static/curriculum_catalog/course-catalog-illustration-01.png';
 import CurriculumCatalogCard from '@cdo/apps/templates/curriculumCatalog/CurriculumCatalogCard';
+import {translatedCourseOfferingDurations} from '@cdo/apps/templates/teacherDashboard/CourseOfferingHelpers';
 
 const CurriculumCatalog = ({curriculaData}) => {
   return (
@@ -20,24 +21,42 @@ const CurriculumCatalog = ({curriculaData}) => {
       </div>
       <div className={style.catalogContentContainer}>
         <div className={style.catalogContent}>
-          {/*TODO [MEG]: calculate and pass in duration from backend, use image in imageSrc */}
+          {/*TODO [MEG]: calculate and pass in duration and translated from backend, use image in imageSrc */}
           {curriculaData
-            .filter(curriculum => !!curriculum.grade_levels)
+            .filter(
+              curriculum => !!curriculum.grade_levels && !!curriculum.image
+            )
             .map(
-              ({key, display_name, grade_levels, school_subject, cs_topic}) => {
+              ({
+                key,
+                image,
+                display_name,
+                grade_levels,
+                school_subject,
+                cs_topic
+              }) => {
                 // TODO [MEG]: We are currently assuming if there are grade levels, there are at least two
                 // grades and the list is in ascending order.
                 const gradeLevelArray = grade_levels.split(',');
+                const durationPossibilities = Object.keys(
+                  translatedCourseOfferingDurations
+                );
 
                 return (
                   <CurriculumCatalogCard
                     key={key}
+                    imageSrc={image}
                     courseDisplayName={display_name}
-                    duration={'quarter'}
+                    duration={
+                      durationPossibilities[
+                        Math.floor(Math.random() * durationPossibilities.length)
+                      ]
+                    } // TODO [MEG] actually pass in this data
                     youngestGrade={gradeLevelArray[0]}
                     oldestGrade={gradeLevelArray[gradeLevelArray.length - 1]}
                     subjects={school_subject?.split(',')}
                     topics={cs_topic?.split(',')}
+                    isTranslated={!!Math.round(Math.random())} // TODO [MEG] actually pass in this data
                   />
                 );
               }

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
@@ -20,30 +20,28 @@ const CurriculumCatalog = ({curriculaData}) => {
       </div>
       <div className={style.catalogContentContainer}>
         <div className={style.catalogContent}>
-          {/*TODO [MEG]: calculate and pass in duration from backend, use image in imageSrc, add validations on backend for presence of grades, subjects, topics */}
-          {curriculaData.map(
-            ({key, display_name, grade_levels, school_subject, cs_topic}) => {
-              const grade_level_array = grade_levels?.split(',');
+          {/*TODO [MEG]: calculate and pass in duration from backend, use image in imageSrc */}
+          {curriculaData
+            .filter(curriculum => !!curriculum.grade_levels)
+            .map(
+              ({key, display_name, grade_levels, school_subject, cs_topic}) => {
+                // TODO [MEG]: We are currently assuming if there are grade levels, there are at least two
+                // grades and the list is in ascending order.
+                const gradeLevelArray = grade_levels.split(',');
 
-              return (
-                <CurriculumCatalogCard
-                  key={key}
-                  courseDisplayName={display_name}
-                  duration={'quarter'}
-                  youngestGrade={
-                    grade_level_array ? grade_level_array[0] : 'none'
-                  }
-                  oldestGrade={
-                    grade_level_array
-                      ? grade_level_array[grade_level_array.length - 1]
-                      : 'none'
-                  }
-                  subjects={school_subject?.split(',')}
-                  topics={cs_topic?.split(',')}
-                />
-              );
-            }
-          )}
+                return (
+                  <CurriculumCatalogCard
+                    key={key}
+                    courseDisplayName={display_name}
+                    duration={'quarter'}
+                    youngestGrade={gradeLevelArray[0]}
+                    oldestGrade={gradeLevelArray[gradeLevelArray.length - 1]}
+                    subjects={school_subject?.split(',')}
+                    topics={cs_topic?.split(',')}
+                  />
+                );
+              }
+            )}
         </div>
       </div>
     </>

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {curriculaDataShape} from './curriculumCatalogShapes';
+import {curriculumDataShape} from './curriculumCatalogShapes';
 import i18n from '@cdo/locale';
 import style from '../../../style/code-studio/curriculum_catalog_container.module.scss';
 import HeaderBanner from '../HeaderBanner';
@@ -66,7 +66,7 @@ const CurriculumCatalog = ({curriculaData}) => {
 };
 
 CurriculumCatalog.propTypes = {
-  curriculaData: PropTypes.arrayOf(curriculaDataShape)
+  curriculaData: PropTypes.arrayOf(curriculumDataShape)
 };
 
 export default CurriculumCatalog;

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
@@ -1,37 +1,57 @@
-import React, {Component} from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import {curriculaDataShape} from './curriculumCatalogShapes';
 import i18n from '@cdo/locale';
 import style from '../../../style/code-studio/curriculum_catalog_container.module.scss';
 import HeaderBanner from '../HeaderBanner';
 import CourseCatalogIllustration01 from '../../../static/curriculum_catalog/course-catalog-illustration-01.png';
+import CurriculumCatalogCard from '@cdo/apps/templates/curriculumCatalog/CurriculumCatalogCard';
 
-class CurriculumCatalog extends Component {
-  static propTypes = {
-    curriculaData: PropTypes.arrayOf(curriculaDataShape)
-  };
+const CurriculumCatalog = ({curriculaData}) => {
+  return (
+    <>
+      <div className={style.catalogHeader}>
+        <HeaderBanner
+          headingText={i18n.curriculumCatalogHeaderTitle()}
+          subHeadingText={i18n.curriculumCatalogHeaderSubtitle()}
+          short={false}
+          imageUrl={CourseCatalogIllustration01}
+        />
+      </div>
+      <div className={style.catalogContentContainer}>
+        <div className={style.catalogContent}>
+          {/*TODO [MEG]: calculate and pass in duration from backend, use image in imageSrc, add validations on backend for presence of grades, subjects, topics */}
+          {curriculaData.map(
+            ({key, display_name, grade_levels, school_subject, cs_topic}) => {
+              const grade_level_array = grade_levels?.split(',');
 
-  render() {
-    return (
-      <>
-        <div className={style.catalogHeader}>
-          <HeaderBanner
-            headingText={i18n.curriculumCatalogHeaderTitle()}
-            subHeadingText={i18n.curriculumCatalogHeaderSubtitle()}
-            short={false}
-            imageUrl={CourseCatalogIllustration01}
-          />
+              return (
+                <CurriculumCatalogCard
+                  key={key}
+                  courseDisplayName={display_name}
+                  duration={'quarter'}
+                  youngestGrade={
+                    grade_level_array ? grade_level_array[0] : 'none'
+                  }
+                  oldestGrade={
+                    grade_level_array
+                      ? grade_level_array[grade_level_array.length - 1]
+                      : 'none'
+                  }
+                  subjects={school_subject?.split(',')}
+                  topics={cs_topic?.split(',')}
+                />
+              );
+            }
+          )}
         </div>
-        <div className={style.catalogContentContainer}>
-          <div className={style.catalogContent}>
-            {this.props.curriculaData.map(curriculum => (
-              <li key={curriculum.key}>{curriculum.display_name}</li>
-            ))}
-          </div>
-        </div>
-      </>
-    );
-  }
-}
+      </div>
+    </>
+  );
+};
+
+CurriculumCatalog.propTypes = {
+  curriculaData: PropTypes.arrayOf(curriculaDataShape)
+};
 
 export default CurriculumCatalog;

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
@@ -20,7 +20,7 @@ const CurriculumCatalog = ({curriculaData}) => (
     </div>
     <div className={style.catalogContentContainer}>
       <div className={style.catalogContent}>
-        {/*TODO [MEG]: calculate and pass in duration and translated from backend, use image in imageSrc */}
+        {/*TODO [MEG]: calculate and pass in duration and translated from backend */}
         {curriculaData
           .filter(curriculum => !!curriculum.grade_levels)
           .map(

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
@@ -59,14 +59,14 @@ CurriculumCatalogCard.propTypes = {
   courseDisplayName: PropTypes.string.isRequired,
   duration: PropTypes.oneOf(Object.keys(translatedCourseOfferingDurations))
     .isRequired,
-  youngestGrade: PropTypes.number,
-  oldestGrade: PropTypes.number,
+  youngestGrade: PropTypes.string.isRequired,
+  oldestGrade: PropTypes.string.isRequired,
   imageAltText: PropTypes.string,
   imageSrc: PropTypes.string.isRequired,
   isTranslated: PropTypes.bool,
   subjects: PropTypes.arrayOf(
     PropTypes.oneOf(Object.keys(translatedCourseOfferingSchoolSubjects))
-  ).isRequired,
+  ),
   topics: PropTypes.arrayOf(
     PropTypes.oneOf(Object.keys(translatedCourseOfferingCsTopics))
   ).isRequired,
@@ -76,7 +76,9 @@ CurriculumCatalogCard.propTypes = {
 CurriculumCatalogCard.defaultProps = {
   imageSrc: tempImage, // TODO [MEG]: remove this default once images are pulled
   imageAltText: '', // for decorative images
-  isTranslated: false
+  isTranslated: false,
+  subjects: [],
+  topics: []
 };
 
 const CustomizableCurriculumCatalogCard = ({

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
@@ -39,10 +39,10 @@ const CurriculumCatalogCard = ({
     })} // TODO [MEG]: Decide on translation strategy for this
     imageSrc={imageSrc}
     subjectsAndTopics={[
-      ...subjects.map(
+      ...subjects?.map(
         subject => translatedCourseOfferingSchoolSubjects[subject]
       ),
-      ...topics.map(topic => translatedCourseOfferingCsTopics[topic])
+      ...topics?.map(topic => translatedCourseOfferingCsTopics[topic])
     ]}
     quickViewButtonDescription={i18n.quickViewDescription({
       course_name: courseDisplayName
@@ -69,7 +69,7 @@ CurriculumCatalogCard.propTypes = {
   ),
   topics: PropTypes.arrayOf(
     PropTypes.oneOf(Object.keys(translatedCourseOfferingCsTopics))
-  ).isRequired,
+  ),
   isEnglish: PropTypes.bool.isRequired
 };
 
@@ -165,7 +165,7 @@ CustomizableCurriculumCatalogCard.propTypes = {
   isTranslated: PropTypes.bool,
   isEnglish: PropTypes.bool,
   translationIconTitle: PropTypes.string.isRequired,
-  subjectsAndTopics: PropTypes.arrayOf(PropTypes.string).isRequired,
+  subjectsAndTopics: PropTypes.arrayOf(PropTypes.string),
   quickViewButtonText: PropTypes.string.isRequired,
   assignButtonText: PropTypes.string.isRequired,
 

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.story.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.story.jsx
@@ -11,8 +11,8 @@ const Template = args => <CurriculumCatalogCard {...args} />;
 const defaultArgs = {
   courseDisplayName: 'AI for Oceans',
   duration: 'quarter',
-  youngestGrade: 4,
-  oldestGrade: 12,
+  youngestGrade: '4',
+  oldestGrade: '12',
   subjects: ['english_language_arts'],
   topics: ['cybersecurity'],
   isTranslated: true,

--- a/apps/src/templates/curriculumCatalog/curriculumCatalogShapes.jsx
+++ b/apps/src/templates/curriculumCatalog/curriculumCatalogShapes.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 
-export const curriculaDataShape = PropTypes.shape({
+export const curriculumDataShape = PropTypes.shape({
   id: PropTypes.string,
   key: PropTypes.string,
   display_name: PropTypes.string.isRequired,
@@ -12,7 +12,7 @@ export const curriculaDataShape = PropTypes.shape({
   grade_levels: PropTypes.string.isRequired,
   header: PropTypes.string,
   image: PropTypes.string,
-  cs_topic: PropTypes.string.isRequired,
-  school_subject: PropTypes.string.isRequired,
+  cs_topic: PropTypes.string,
+  school_subject: PropTypes.string,
   device_compatibility: PropTypes.string
 });

--- a/apps/src/templates/curriculumCatalog/curriculumCatalogShapes.jsx
+++ b/apps/src/templates/curriculumCatalog/curriculumCatalogShapes.jsx
@@ -3,16 +3,16 @@ import PropTypes from 'prop-types';
 export const curriculaDataShape = PropTypes.shape({
   id: PropTypes.string,
   key: PropTypes.string,
-  display_name: PropTypes.string,
+  display_name: PropTypes.string.isRequired,
   category: PropTypes.string,
   is_featured: PropTypes.bool,
   assignable: PropTypes.bool,
   curriculum_type: PropTypes.string,
   marketing_initiative: PropTypes.string,
-  grade_levels: PropTypes.string,
+  grade_levels: PropTypes.string.isRequired,
   header: PropTypes.string,
   image: PropTypes.string,
-  cs_topic: PropTypes.string,
-  school_subject: PropTypes.string,
+  cs_topic: PropTypes.string.isRequired,
+  school_subject: PropTypes.string.isRequired,
   device_compatibility: PropTypes.string
 });

--- a/apps/src/templates/curriculumCatalog/curriculum_catalog_card.module.scss
+++ b/apps/src/templates/curriculumCatalog/curriculum_catalog_card.module.scss
@@ -1,3 +1,4 @@
+@use "sass:math";
 @import "phase1-design-system";
 
 $border-radius: 4px;
@@ -109,7 +110,7 @@ $container-width: 309px;
   button {
     // width calculated to ensure space between buttons is 12px
     // (totalContainerWidth - 2*padding - minimumSpaceBetweenButtons) / 2
-    width: ($container-width - (2 * 16) - 12) / 2;
+    width: math.div($container-width - (2 * 16) - 12, 2);
     height: 40px;
     font-size: 1em;
   }

--- a/apps/src/templates/curriculumCatalog/curriculum_catalog_card.module.scss
+++ b/apps/src/templates/curriculumCatalog/curriculum_catalog_card.module.scss
@@ -60,19 +60,18 @@ $container-width: 309px;
   justify-content: space-between;
 
   i {
-    margin-left: auto;
     font-size: 1.5em;
   }
 }
 
 .iconWithDescription {
   display: flex;
-  margin: 0 0 0.5em 0;
   align-items: center;
+  column-gap: 0.5em;
 
   .iconWithDescriptionText {
     font-size: 0.875em;
-    margin: 0 0 0 0.5em;
+    margin: 0;
     color: $neutral_dark;
   }
 }

--- a/apps/src/templates/curriculumCatalog/curriculum_catalog_card.module.scss
+++ b/apps/src/templates/curriculumCatalog/curriculum_catalog_card.module.scss
@@ -22,7 +22,7 @@ $container-width: 309px;
 }
 
 .curriculumCatalogCardContainer_notEnglish {
-  height: 26em;
+  height: 26.5em;
 }
 
 .curriculumInfoContainer {

--- a/apps/src/templates/curriculumCatalog/curriculum_catalog_card.module.scss
+++ b/apps/src/templates/curriculumCatalog/curriculum_catalog_card.module.scss
@@ -68,6 +68,7 @@ $container-width: 309px;
   display: flex;
   align-items: center;
   column-gap: 0.5em;
+  margin: 0 0 0.5em 0;
 
   .iconWithDescriptionText {
     font-size: 0.875em;

--- a/apps/src/templates/curriculumCatalog/curriculum_catalog_card.module.scss
+++ b/apps/src/templates/curriculumCatalog/curriculum_catalog_card.module.scss
@@ -45,6 +45,13 @@ $container-width: 309px;
   h4 {
     margin-bottom: 0.75em;
     color: $neutral_dark;
+
+    // Shows max two lines before truncating with ellipsis
+    // See https://css-tricks.com/line-clampin/
+    display: -webkit-box;
+    overflow: hidden;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
   }
 }
 

--- a/apps/style/code-studio/curriculum_catalog_container.module.scss
+++ b/apps/style/code-studio/curriculum_catalog_container.module.scss
@@ -1,18 +1,17 @@
 @use "color.scss";
-@import "style-constants";
 
 .catalogHeader {
   background-color: color.$darkest_gray;
 }
 
 .catalogContentContainer {
-  display: flex;
-  justify-content: center;
-  margin-top: 16px;
+  max-width: 60em;
+  margin: 1em auto;
 }
 
 .catalogContent {
-  max-width: $content-width;
-  width: 100%;
-  margin: 0 16px;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1em;
 }

--- a/apps/test/unit/templates/curriculumCatalog/CurriculumCatalogTest.jsx
+++ b/apps/test/unit/templates/curriculumCatalog/CurriculumCatalogTest.jsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import {render, screen} from '@testing-library/react';
+import {Provider} from 'react-redux';
+import {combineReducers, createStore} from 'redux';
+import responsive, {
+  setResponsiveSize,
+  ResponsiveSize
+} from '@cdo/apps/code-studio/responsiveRedux';
+import CurriculumCatalog from '@cdo/apps/templates/curriculumCatalog/CurriculumCatalog';
+
+describe('CurriculumCatalog', () => {
+  const makerCurriculum = {
+    key: 'devices',
+    display_name: 'Creating Apps for Devices',
+    grade_levels: '6,7,8,9,10,11,12',
+    image: 'https://images.code.org/name.png',
+    cs_topic: 'art_and_design,app_design,physical_computing,programming',
+    school_subject: null
+  };
+
+  const countingCurriculum = {
+    key: 'counting-csc',
+    display_name: 'Computer Science Discoveries',
+    grade_levels: '3,4,5',
+    image: 'https://images.code.org/name.png',
+    cs_topic: 'programming',
+    school_subject: 'math'
+  };
+
+  const course1Curriculum = {
+    key: 'course1',
+    display_name: 'Course 1',
+    grade_levels: 'K,1',
+    image: 'https://images.code.org/name.png',
+    cs_topic: 'programming',
+    school_subject: null
+  };
+
+  const allCurricula = [makerCurriculum, countingCurriculum, course1Curriculum];
+  const defaultProps = {curriculaData: allCurricula};
+
+  beforeEach(() => {
+    const store = createStore(combineReducers({responsive}));
+    store.dispatch(setResponsiveSize(ResponsiveSize.lg));
+    render(
+      <Provider store={store}>
+        <CurriculumCatalog {...defaultProps} />
+      </Provider>
+    );
+  });
+
+  it('renders page title', () => {
+    screen.getByRole('heading', {name: 'Curriculum Catalog'});
+  });
+
+  it('renders page subtitle', () => {
+    screen.getByText('Code.org courses, tutorials, and more', {exact: false});
+  });
+
+  it('renders name of each curriculum', () => {
+    allCurricula
+      .map(curriculum => curriculum.display_name)
+      .forEach(courseName => screen.getByRole('heading', {name: courseName}));
+  });
+});

--- a/apps/test/unit/templates/curriculumCatalog/CurriculumCatalogTest.jsx
+++ b/apps/test/unit/templates/curriculumCatalog/CurriculumCatalogTest.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {render, screen} from '@testing-library/react';
 import {Provider} from 'react-redux';
-import {combineReducers, createStore} from 'redux';
+import {configureStore} from '@reduxjs/toolkit';
 import responsive, {
   setResponsiveSize,
   ResponsiveSize
@@ -40,7 +40,7 @@ describe('CurriculumCatalog', () => {
   const defaultProps = {curriculaData: allCurricula};
 
   beforeEach(() => {
-    const store = createStore(combineReducers({responsive}));
+    const store = configureStore({reducer: {responsive}});
     store.dispatch(setResponsiveSize(ResponsiveSize.lg));
     render(
       <Provider store={store}>

--- a/apps/test/unit/templates/curriculumCatalog/curriculumCatalogCardTest.jsx
+++ b/apps/test/unit/templates/curriculumCatalog/curriculumCatalogCardTest.jsx
@@ -11,8 +11,8 @@ describe('CurriculumCatalogCard', () => {
     defaultProps = {
       courseDisplayName: 'AI for Oceans',
       duration: 'quarter',
-      youngestGrade: 4,
-      oldestGrade: 12,
+      youngestGrade: '4',
+      oldestGrade: '12',
       subjects: ['math'],
       topics: ['cybersecurity'],
       isEnglish: true


### PR DESCRIPTION
Puts the curriculum cards onto the Curriculum Catalog page. See it at http://localhost-studio.code.org:3000/catalog

<img width="404" alt="image" src="https://user-images.githubusercontent.com/9142121/231228827-d1b15eaa-b56e-49d7-9a08-8f1c320dda91.png">


Responsive (minus the banner –– see comment):
https://user-images.githubusercontent.com/9142121/231229618-53de77e5-2b7a-4a71-8e15-b7a0cb3265c6.mov


There are several todo's added as comments in the code –– syncing up with Turner and Dani to figure out what's already tracked and what needs a ticket.

A couple of design improvements were part of this work:
1) Truncates the title to be maximum two lines. This is part of the [design spec](https://www.figma.com/file/w5R6KSZF01FAysZor6j4sa/Curriculum-Catalog?node-id=101-9&t=RQcYzLk94iszMTYK-0)
<img width="296" alt="image" src="https://user-images.githubusercontent.com/9142121/231227973-333752c7-544e-411c-954d-17dc55255849.png">

2) Makes the non-English card a little bit longer to accommodate the possible two-line title.
<img width="293" alt="image" src="https://user-images.githubusercontent.com/9142121/231228491-eac881dc-bbb6-4811-b3aa-b3e3d451b0fb.png">

3) Finally manually looked at the RTL version by going into the developers console and manually changing the "direction" tag to `rtl`. Some styling adjustments were made to ensure the RTL looks normal.
<img width="320" alt="image" src="https://user-images.githubusercontent.com/9142121/231252425-ad15ba54-7998-4961-b659-f2b095289a45.png">


## Links

The creator of the React Testing Library suggests [testing the parent component only](https://www.youtube.com/watch?v=0qmPdcV-rN8) (so I'd remove the tests from Curriculum Catalog Card and put them into the Curriculum Catalog). However, by the time we test all the logic for the filtering and the assign and quick view logic, they'd become super large files. I'm keeping it as-is for now (keeping them separate), but open to more conversation about this.

## Testing story

For testing, used React Testing Library. Added [Redux Toolkit](https://redux.js.org/introduction/why-rtk-is-redux-today) to our repo because `createStore` is deprecated:
<img width="871" alt="image" src="https://user-images.githubusercontent.com/9142121/231214248-c8656a79-4231-4359-a088-932cd77ace22.png">

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
