### PR TITLE
Add forwardRef to CommitsAndReviewTab

### DIFF
--- a/apps/src/templates/instructions/CommitsAndReviewTab.jsx
+++ b/apps/src/templates/instructions/CommitsAndReviewTab.jsx
@@ -1,4 +1,10 @@
-import React, {useState, useEffect, useCallback, useMemo} from 'react';
+import React, {
+  useState,
+  useEffect,
+  useCallback,
+  useMemo,
+  forwardRef
+} from 'react';
 import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 import color from '@cdo/apps/util/color';
@@ -18,8 +24,8 @@ import CodeReviewError from '@cdo/apps/templates/instructions/codeReviewV2/CodeR
 
 export const VIEWING_CODE_REVIEW_URL_PARAM = 'viewingCodeReview';
 
-const CommitsAndReviewTab = props => {
-  const {
+const CommitsAndReviewTab = forwardRef(function (
+  {
     channelId,
     serverLevelId,
     serverProjectLevelId,
@@ -34,8 +40,9 @@ const CommitsAndReviewTab = props => {
     setHasOpenCodeReview,
     isCommitSaveInProgress,
     hasCommitSaveError
-  } = props;
-
+  },
+  ref
+) {
   const [isLoadingTimelineData, setIsLoadingTimelineData] = useState(false);
   const [openReviewData, setOpenReviewData] = useState(null);
   const [timelineData, setTimelineData] = useState([]);
@@ -172,7 +179,10 @@ const CommitsAndReviewTab = props => {
   // comments cannot be made on projects in this state.
   if (!channelId) {
     return (
-      <div style={{...styles.reviewsContainer, ...styles.messageText}}>
+      <div
+        ref={ref}
+        style={{...styles.reviewsContainer, ...styles.messageText}}
+      >
         {javalabMsg.noCodeReviewUntilStudentEditsCode()}
       </div>
     );
@@ -180,14 +190,14 @@ const CommitsAndReviewTab = props => {
 
   if (isLoadingTimelineData) {
     return (
-      <div style={styles.loadingContainer}>
+      <div ref={ref} style={styles.loadingContainer}>
         <Spinner size="large" />
       </div>
     );
   }
 
   return (
-    <div style={styles.reviewsContainer}>
+    <div ref={ref} style={styles.reviewsContainer}>
       <div style={styles.header}>
         <div style={styles.navigator}>
           {codeReviewEnabled && !viewAsTeacher && (
@@ -254,7 +264,7 @@ const CommitsAndReviewTab = props => {
       )}
     </div>
   );
-};
+});
 
 export const UnconnectedCommitsAndReviewTab = CommitsAndReviewTab;
 export default connect(
@@ -277,7 +287,9 @@ export default connect(
       dispatch(setIsReadOnlyWorkspace(isReadOnly)),
     setHasOpenCodeReview: hasOpenCodeReview =>
       dispatch(setHasOpenCodeReview(hasOpenCodeReview))
-  })
+  }),
+  null,
+  {forwardRef: true}
 )(CommitsAndReviewTab);
 
 CommitsAndReviewTab.propTypes = {


### PR DESCRIPTION
When doing some testing in Java Lab I noticed we were getting a forwardRef warning around the CommitsAndReviewTab. We started seeing these after the [redux upgrade](https://github.com/code-dot-org/code-dot-org/pull/50691). The fix is to add a forwardRef to this component.

## Testing story
Tested locally that the tab still works as expected. As far as I can tell, this warning warns of potential unexpected behavior, but I haven't been able to produce any weird behavior without the forwardRef.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
