### PR TITLE
Revert "Enable load balancer slow start"

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -244,10 +244,6 @@ Resources:
           Value: lb_cookie
         - Key: stickiness.lb_cookie.duration_seconds
           Value: 30
-        # Linearly increase the HTTP throughput share to new instances to give them time to initialize and load caches.
-        - Key: slow_start.duration_seconds
-          Value: 120
-
 <%   unless frontends -%>
       Targets:
         - {Id: !Ref <%=daemon%>, Port: 80}


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#51105

`You cannot enable both slow start mode and least outstanding requests`
https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-target-groups.html#slow-start-mode