### PR TITLE
Apply Initializer Prepends on Each Code Reload

### DIFF
--- a/dashboard/config/initializers/fast_localization.rb
+++ b/dashboard/config/initializers/fast_localization.rb
@@ -40,4 +40,6 @@ module UpdateCheckerExt
   end
 end
 
-ActiveSupport::FileUpdateChecker.prepend UpdateCheckerExt
+Rails.application.config.to_prepare do
+  ActiveSupport::FileUpdateChecker.prepend UpdateCheckerExt
+end

--- a/dashboard/config/initializers/no_transform_paths.rb
+++ b/dashboard/config/initializers/no_transform_paths.rb
@@ -27,4 +27,7 @@ module Cdo
     end
   end
 end
-ActionDispatch::FileHandler.prepend Cdo::NoTransformPaths
+
+Rails.application.config.to_prepare do
+  ActionDispatch::FileHandler.prepend Cdo::NoTransformPaths
+end

--- a/dashboard/config/initializers/trackable.rb
+++ b/dashboard/config/initializers/trackable.rb
@@ -19,4 +19,6 @@ module OverrideUpdateTrackedFields
   end
 end
 
-User.prepend OverrideUpdateTrackedFields
+Rails.application.config.to_prepare do
+  User.prepend OverrideUpdateTrackedFields
+end


### PR DESCRIPTION
Currently, the extra functionality `prepend`ed onto these classes by initializer logic is only applied once when the application configuration is initially loaded. This works fine in most environments, but in environments in which we want to be able to reload code on the fly (currently only `development`) this means that the modifications are lost after reload.

To fix, we hook the `prepend` call itself into the `to_prepare` event, which explicitly runs once per code reload in environments which support code reloading, and only once during initial load otherwise.

## Links

- https://guides.rubyonrails.org/configuring.html#initialization-events
- https://stackoverflow.com/questions/8895103/how-can-i-keep-my-initializer-configuration-from-being-lost-in-development-mode

## Testing story

Tested locally to confirm that the functionality added by the initializer is applied to the class after reload, and that repeated reloading does not result in either loss of functionality or repeated reapplying of functionality.

Before this change, after creating a new user account in my local development environment, `User.last.sign_ins.count` and `User.last.user_geos.count` both return `0`. With this change, both return `1`.

## Follow-up work

This is required to be able to set `cache_classes = false` in the test environment