### PR TITLE
Fix flaky UI test - Firefox star_labs/applab/shared_apps

### DIFF
--- a/dashboard/test/ui/features/star_labs/applab/scenarios.feature
+++ b/dashboard/test/ui/features/star_labs/applab/scenarios.feature
@@ -49,36 +49,39 @@ Feature: App Lab Scenarios
     And I wait until element "#divApplab > .screen > div#text_area1" is visible
     Then element "div#text_area1" has html "Line 1<div>Line 2</div><div><br></div><div>Line3</div>"
 
-  Scenario: Change event works in text input and text area
+ Scenario: Change event works in text input
     Given I switch to design mode
     And I drag a TEXT_INPUT into the app
-    And I drag a TEXT_AREA into the app
     And I switch to code mode
     And I ensure droplet is in text mode
     And I append text to droplet "onEvent('text_input1', 'change', function(event) {\n"
     And I append text to droplet "  console.log(event.targetId + ': ' + getText('text_input1'));\n"
-    And I append text to droplet "});\n\n"
-    And I append text to droplet "onEvent('text_area1', 'change', function(event) {\n"
-    And I append text to droplet "  console.log(event.targetId + ': ' + getText('text_area1'));\n"
     And I append text to droplet "});"
 
     # in text input, blur produces a change event
     When I press "runButton"
-    And I wait until element "#divApplab > .screen > div#text_area1" is visible
-    And I press keys "123" for element "#text_input1"
+    And I wait until element with id "text_input1" is visible
+    And I press keys "123" for element with id "text_input1"
     And I blur selector "#text_input1"
     Then element "#debug-output" has escaped text "\"text_input1: 123\""
 
     # in a text input, enter produces a change event but then blur does not
-    When I press keys "456\n" for element "#text_input1"
+    When I press keys "456\n" for element with id "text_input1"
     Then element "#debug-output" has escaped text "\"text_input1: 123\"\"text_input1: 123456\""
     And I blur selector "#text_input1"
     Then element "#debug-output" has escaped text "\"text_input1: 123\"\"text_input1: 123456\""
 
+Scenario: Change event works in text area
+    Given I switch to design mode
+    And I drag a TEXT_AREA into the app
+    And I switch to code mode
+    And I ensure droplet is in text mode
+    And I append text to droplet "onEvent('text_area1', 'change', function(event) {\n"
+    And I append text to droplet "  console.log(event.targetId + ': ' + getText('text_area1'));\n"
+    And I append text to droplet "});"
+
     # in a text area, blur produces a change event. sending keystrokes (especially 'enter')
     # to a contentetiable div was too hard to test here due to browser differences.
-    When I press "resetButton"
-    And I wait until element "#runButton" is visible
     And I press "runButton"
     And I wait until element "#divApplab > .screen > div#text_area1" is visible
     And I focus selector "#text_area1"

--- a/dashboard/test/ui/features/star_labs/applab/scenarios.feature
+++ b/dashboard/test/ui/features/star_labs/applab/scenarios.feature
@@ -48,7 +48,7 @@ Feature: App Lab Scenarios
     When I press "runButton"
     And I wait until element "#divApplab > .screen > div#text_area1" is visible
     Then element "div#text_area1" has html "Line 1<div>Line 2</div><div><br></div><div>Line3</div>"
-     
+
   Scenario: Change event works in text input and text area
     Given I switch to design mode
     And I drag a TEXT_INPUT into the app

--- a/dashboard/test/ui/features/star_labs/applab/scenarios.feature
+++ b/dashboard/test/ui/features/star_labs/applab/scenarios.feature
@@ -74,6 +74,7 @@ Feature: App Lab Scenarios
     Then element "#debug-output" has escaped text "\"text_input1: 123\"\"text_input1: 123456\""
     And I blur selector "#text_input1"
     Then element "#debug-output" has escaped text "\"text_input1: 123\"\"text_input1: 123456\""
+
     # in a text area, blur produces a change event. sending keystrokes (especially 'enter')
     # to a contentetiable div was too hard to test here due to browser differences.
     When I press "resetButton"

--- a/dashboard/test/ui/features/star_labs/applab/scenarios.feature
+++ b/dashboard/test/ui/features/star_labs/applab/scenarios.feature
@@ -48,40 +48,36 @@ Feature: App Lab Scenarios
     When I press "runButton"
     And I wait until element "#divApplab > .screen > div#text_area1" is visible
     Then element "div#text_area1" has html "Line 1<div>Line 2</div><div><br></div><div>Line3</div>"
-
-  Scenario: Change event works in text input
+     
+  Scenario: Change event works in text input and text area
     Given I switch to design mode
     And I drag a TEXT_INPUT into the app
+    And I drag a TEXT_AREA into the app
     And I switch to code mode
     And I ensure droplet is in text mode
     And I append text to droplet "onEvent('text_input1', 'change', function(event) {\n"
     And I append text to droplet "  console.log(event.targetId + ': ' + getText('text_input1'));\n"
-    And I append text to droplet "});"
-
-    # in text input, blur produces a change event
-    When I press "runButton"
-    And I wait until element ".screen > input" is visible
-    And I press keys "123" for element ".screen > input"
-    And I blur selector "#text_input1"
-    Then element "#debug-output" has escaped text "\"text_input1: 123\""
-
-    # in a text input, enter produces a change event but then blur does not
-    When I press keys "456\n" for element ".screen > input"
-    Then element "#debug-output" has escaped text "\"text_input1: 123\"\"text_input1: 123456\""
-    And I blur selector "#text_input1"
-    Then element "#debug-output" has escaped text "\"text_input1: 123\"\"text_input1: 123456\""
-
-  Scenario: Change event works in text area
-    Given I switch to design mode
-    And I drag a TEXT_AREA into the app
-    And I switch to code mode
-    And I ensure droplet is in text mode
+    And I append text to droplet "});\n\n"
     And I append text to droplet "onEvent('text_area1', 'change', function(event) {\n"
     And I append text to droplet "  console.log(event.targetId + ': ' + getText('text_area1'));\n"
     And I append text to droplet "});"
 
+    # in text input, blur produces a change event
+    When I press "runButton"
+    And I wait until element "#divApplab > .screen > div#text_area1" is visible
+    And I press keys "123" for element "#text_input1"
+    And I blur selector "#text_input1"
+    Then element "#debug-output" has escaped text "\"text_input1: 123\""
+
+    # in a text input, enter produces a change event but then blur does not
+    When I press keys "456\n" for element "#text_input1"
+    Then element "#debug-output" has escaped text "\"text_input1: 123\"\"text_input1: 123456\""
+    And I blur selector "#text_input1"
+    Then element "#debug-output" has escaped text "\"text_input1: 123\"\"text_input1: 123456\""
     # in a text area, blur produces a change event. sending keystrokes (especially 'enter')
     # to a contentetiable div was too hard to test here due to browser differences.
+    When I press "resetButton"
+    And I wait until element "#runButton" is visible
     And I press "runButton"
     And I wait until element "#divApplab > .screen > div#text_area1" is visible
     And I focus selector "#text_area1"

--- a/dashboard/test/ui/features/star_labs/applab/scenarios.feature
+++ b/dashboard/test/ui/features/star_labs/applab/scenarios.feature
@@ -49,7 +49,7 @@ Feature: App Lab Scenarios
     And I wait until element "#divApplab > .screen > div#text_area1" is visible
     Then element "div#text_area1" has html "Line 1<div>Line 2</div><div><br></div><div>Line3</div>"
 
- Scenario: Change event works in text input
+  Scenario: Change event works in text input
     Given I switch to design mode
     And I drag a TEXT_INPUT into the app
     And I switch to code mode
@@ -60,18 +60,18 @@ Feature: App Lab Scenarios
 
     # in text input, blur produces a change event
     When I press "runButton"
-    And I wait until element with id "text_input1" is visible
-    And I press keys "123" for element with id "text_input1"
+    And I wait until element ".screen > input" is visible
+    And I press keys "123" for element ".screen > input"
     And I blur selector "#text_input1"
     Then element "#debug-output" has escaped text "\"text_input1: 123\""
 
     # in a text input, enter produces a change event but then blur does not
-    When I press keys "456\n" for element with id "text_input1"
+    When I press keys "456\n" for element ".screen > input"
     Then element "#debug-output" has escaped text "\"text_input1: 123\"\"text_input1: 123456\""
     And I blur selector "#text_input1"
     Then element "#debug-output" has escaped text "\"text_input1: 123\"\"text_input1: 123456\""
 
-Scenario: Change event works in text area
+  Scenario: Change event works in text area
     Given I switch to design mode
     And I drag a TEXT_AREA into the app
     And I switch to code mode

--- a/dashboard/test/ui/features/star_labs/applab/shared_apps.feature
+++ b/dashboard/test/ui/features/star_labs/applab/shared_apps.feature
@@ -32,7 +32,7 @@ Feature: App Lab Scenarios
     And I wait until element "#divApplab > .screen > button#testButton1" is visible
     Then element "#testButton1" contains text "Click me"
     When I press "testButton1"
-    Then element "#testButton1" contains text "Clicked"
+    And I wait until element "#testButton1" contains text "Clicked"
 
   Scenario: Can change a dropdown value in shared app
     Given I ensure droplet is in text mode
@@ -85,6 +85,7 @@ Feature: App Lab Scenarios
     When I navigate to the shared version of my project
     And I wait until element ".screen > input" is visible
     And I press keys "GLULX" for element ".screen > input"
+    And I wait for 3 seconds
     Then element ".screen > input" has value "GLULX"
 
   @no_ie

--- a/dashboard/test/ui/features/star_labs/applab/shared_apps.feature
+++ b/dashboard/test/ui/features/star_labs/applab/shared_apps.feature
@@ -79,7 +79,6 @@ Feature: App Lab Scenarios
     Then element "#checkbox1" is checked
     And element "#checkbox2" is checked
 
-  @no_ie
   Scenario: Can type in text input on share page
     Given I switch to design mode
     And I drag a TEXT_INPUT into the app
@@ -88,7 +87,6 @@ Feature: App Lab Scenarios
     And I press keys "GLULX" for element ".screen > input"
     Then element ".screen > input" has value "GLULX"
 
-  @no_ie
   @no_mobile
   Scenario: Can type in textarea on share page
     Given I switch to design mode

--- a/dashboard/test/ui/features/star_labs/applab/shared_apps.feature
+++ b/dashboard/test/ui/features/star_labs/applab/shared_apps.feature
@@ -32,7 +32,8 @@ Feature: App Lab Scenarios
     And I wait until element "#divApplab > .screen > button#testButton1" is visible
     Then element "#testButton1" contains text "Click me"
     When I press "testButton1"
-    And I wait until element "#testButton1" contains text "Clicked"
+    And I wait for 3 seconds
+    Then element "#testButton1" contains text "Clicked"
 
   Scenario: Can change a dropdown value in shared app
     Given I ensure droplet is in text mode

--- a/dashboard/test/ui/features/star_labs/applab/shared_apps.feature
+++ b/dashboard/test/ui/features/star_labs/applab/shared_apps.feature
@@ -84,7 +84,7 @@ Feature: App Lab Scenarios
     And I drag a TEXT_INPUT into the app
     When I navigate to the shared version of my project
     And I wait until element ".screen > input" is visible
-    And I press keys "GLULX" for element ".screen > input" and wait until text appears
+    And I press keys "GLULX" for element ".screen > input" and wait until value changes
     Then element ".screen > input" has value "GLULX"
 
   @no_mobile

--- a/dashboard/test/ui/features/star_labs/applab/shared_apps.feature
+++ b/dashboard/test/ui/features/star_labs/applab/shared_apps.feature
@@ -84,8 +84,8 @@ Feature: App Lab Scenarios
     And I drag a TEXT_INPUT into the app
     When I navigate to the shared version of my project
     And I wait until element ".screen > input" is visible
-    And I press keys "GLULX" for element ".screen > input" and wait until value changes
-    Then element ".screen > input" has value "GLULX"
+    And I press keys "GLULX" for element ".screen > input"
+    And I wait until element ".screen > input" has the value "GLULX"
 
   @no_mobile
   Scenario: Can type in textarea on share page

--- a/dashboard/test/ui/features/star_labs/applab/shared_apps.feature
+++ b/dashboard/test/ui/features/star_labs/applab/shared_apps.feature
@@ -86,7 +86,6 @@ Feature: App Lab Scenarios
     When I navigate to the shared version of my project
     And I wait until element ".screen > input" is visible
     And I press keys "GLULX" for element ".screen > input"
-    And I wait for 3 seconds
     Then element ".screen > input" has value "GLULX"
 
   @no_ie

--- a/dashboard/test/ui/features/star_labs/applab/shared_apps.feature
+++ b/dashboard/test/ui/features/star_labs/applab/shared_apps.feature
@@ -80,6 +80,7 @@ Feature: App Lab Scenarios
     Then element "#checkbox1" is checked
     And element "#checkbox2" is checked
 
+  @no_ie
   Scenario: Can type in text input on share page
     Given I switch to design mode
     And I drag a TEXT_INPUT into the app

--- a/dashboard/test/ui/features/star_labs/applab/shared_apps.feature
+++ b/dashboard/test/ui/features/star_labs/applab/shared_apps.feature
@@ -32,8 +32,7 @@ Feature: App Lab Scenarios
     And I wait until element "#divApplab > .screen > button#testButton1" is visible
     Then element "#testButton1" contains text "Click me"
     When I press "testButton1"
-    And I wait for 3 seconds
-    Then element "#testButton1" contains text "Clicked"
+    And I wait until element "#testButton1" contains text "Clicked"
 
   Scenario: Can change a dropdown value in shared app
     Given I ensure droplet is in text mode

--- a/dashboard/test/ui/features/star_labs/applab/shared_apps.feature
+++ b/dashboard/test/ui/features/star_labs/applab/shared_apps.feature
@@ -84,7 +84,7 @@ Feature: App Lab Scenarios
     And I drag a TEXT_INPUT into the app
     When I navigate to the shared version of my project
     And I wait until element ".screen > input" is visible
-    And I press keys "GLULX" for element ".screen > input"
+    And I press keys "GLULX" for element ".screen > input" and wait until text appears
     Then element ".screen > input" has value "GLULX"
 
   @no_mobile

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -1150,7 +1150,7 @@ And(/^I press keys "([^"]*)" for element "([^"]*)"$/) do |key, selector|
   press_keys(element, key)
 end
 
-And(/^I press keys "([^"]*)" for element "([^"]*)" and wait until text appears$/) do |key, selector|
+And(/^I press keys "([^"]*)" for element "([^"]*)" and wait until value changes$/) do |key, selector|
   element = @browser.find_element(:css, selector)
   press_keys(element, key)
   wait_short_until do

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -1145,13 +1145,11 @@ def convert_keys(keys)
   keys.chars.map {|k| k == "\n" ? :enter : k}
 end
 
-# Known issue: IE does not register the key presses in this step.
-# Add @no_ie tag to your scenario to skip IE when using this step.
 And(/^I press keys "([^"]*)" for element "([^"]*)"$/) do |key, selector|
   element = @browser.find_element(:css, selector)
   press_keys(element, key)
-  is_special_case = key.start_with?(":") || selector == ".ace_text-input"
-  check_key_values = !is_special_case
+  only_alphanumeric_backslash = key.gsub(/[^0-9a-z \\]/i, '') == key
+  check_key_values = only_alphanumeric_backslash && selector != ".ace_text-input"
   if check_key_values
     wait_short_until do
       element_text = element.attribute("value")

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -1150,6 +1150,10 @@ end
 And(/^I press keys "([^"]*)" for element "([^"]*)"$/) do |key, selector|
   element = @browser.find_element(:css, selector)
   press_keys(element, key)
+  wait_short_until do
+    element_text = element.attribute("value")
+    element_text == key
+  end
 end
 
 When /^I press keys "([^"]*)"$/ do |keys|

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -1152,7 +1152,7 @@ And(/^I press keys "([^"]*)" for element "([^"]*)"$/) do |key, selector|
   press_keys(element, key)
   wait_short_until do
     element_text = element.attribute("value")
-    element_text == key
+    element_text.include? key
   end
 end
 

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -1150,13 +1150,11 @@ And(/^I press keys "([^"]*)" for element "([^"]*)"$/) do |key, selector|
   press_keys(element, key)
 end
 
-And(/^I press keys "([^"]*)" for element "([^"]*)" and wait until value changes$/) do |key, selector|
+And(/^I wait until element "([^"]*)" has the value "([^"]*)"$/) do |selector, value|
   element = @browser.find_element(:css, selector)
-  press_keys(element, key)
   wait_short_until do
     element_text = element.attribute("value")
-    input_key = key.delete "\n"
-    element_text.include? input_key
+    element_text.include? value
   end
 end
 

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -1150,10 +1150,14 @@ end
 And(/^I press keys "([^"]*)" for element "([^"]*)"$/) do |key, selector|
   element = @browser.find_element(:css, selector)
   press_keys(element, key)
-  wait_short_until do
-    element_text = element.attribute("value")
-    input_key = key.delete "\n"
-    element_text.include? input_key
+  is_special_case = key.start_with?(":") || selector == ".ace_text-input"
+  check_key_values = !is_special_case
+  if check_key_values
+    wait_short_until do
+      element_text = element.attribute("value")
+      input_key = key.delete "\n"
+      element_text.include? input_key
+    end
   end
 end
 

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -1155,7 +1155,8 @@ And(/^I press keys "([^"]*)" for element "([^"]*)" and wait until text appears$/
   press_keys(element, key)
   wait_short_until do
     element_text = element.attribute("value")
-    element_text.include? key
+    input_key = key.delete "\n"
+    element_text.include? input_key
   end
 end
 

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -1148,14 +1148,14 @@ end
 And(/^I press keys "([^"]*)" for element "([^"]*)"$/) do |key, selector|
   element = @browser.find_element(:css, selector)
   press_keys(element, key)
-  only_alphanumeric_backslash = key.gsub(/[^0-9a-z \\]/i, '') == key
-  check_key_values = only_alphanumeric_backslash && selector != ".ace_text-input"
-  if check_key_values
-    wait_short_until do
-      element_text = element.attribute("value")
-      input_key = key.delete "\n"
-      element_text.include? input_key
-    end
+end
+
+And(/^I press keys "([^"]*)" for element "([^"]*)" and wait until text appears$/) do |key, selector|
+  element = @browser.find_element(:css, selector)
+  press_keys(element, key)
+  wait_short_until do
+    element_text = element.attribute("value")
+    element_text.include? key
   end
 end
 

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -1152,7 +1152,8 @@ And(/^I press keys "([^"]*)" for element "([^"]*)"$/) do |key, selector|
   press_keys(element, key)
   wait_short_until do
     element_text = element.attribute("value")
-    element_text.include? key
+    input_key = key.delete "\n"
+    element_text.include? input_key
   end
 end
 

--- a/dashboard/test/ui/features/teacher_tools/projects/personal_project_gallery.feature
+++ b/dashboard/test/ui/features/teacher_tools/projects/personal_project_gallery.feature
@@ -33,6 +33,7 @@ Scenario: Can Rename a Project
   Then I click selector ".ui-projects-table-dropdown"
   And I press the child number 0 of class ".pop-up-menu-item"
   And I wait until element ".ui-project-rename-input" is visible
+  And I clear the text from element ".ui-project-rename-input"
   And I press keys "New Name" for element ".ui-project-rename-input"
   Then I click selector ".ui-projects-rename-save"
   And I wait until element ".ui-projects-rename-save" is not visible


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR:
- updates the UI tests `shared_apps.feature`and `person_project_gallery.feature`,
- adds a `And I wait until element...has the value...` command in `steps.rb`

My original task was to fix the flaky Firefox star_labs/applab/shared_apps UI test. I examined this consistently flaky UI test's history over the week of April 4-11 in [SauceLabs Insights](https://app.saucelabs.com/analytics/test-history/vdc/inconsistent/test-case?dateFilter=%7B%22type%22%3A%22relative%22%2C%22value%22%3A604800%7D&name=Firefox_star_labs_applab_shared_apps). Out of 70 test runs, there were 11 failures. There were an additional 6 test errors due to a SauceLabs outage on April 6. Discounting these errors,  the failure rate of this UI test is ~17%. 
 Interestingly, the failures occurred at 2 different places in the [UI test](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/test/ui/features/star_labs/applab/shared_apps.feature). 4/11 failures occurred after [line 34](https://github.com/code-dot-org/code-dot-org/blob/ac4da2f22321a086b233d5d0d33d32ee36e0bd5e/dashboard/test/ui/features/star_labs/applab/shared_apps.feature#L34) and 7 occurred after [line 87](https://github.com/code-dot-org/code-dot-org/blob/ac4da2f22321a086b233d5d0d33d32ee36e0bd5e/dashboard/test/ui/features/star_labs/applab/shared_apps.feature#L87).

Taking a look at several of the videos of the failed runs in Sauce Labs, I didn't notice anything unusual about the UI at the 2 failure points.

At line 35, we test that after the 'testButton1' is clicked, the text the button contains changes from 'Click Me' to 'Clicked'. It seems like when the test is checking the contained text after the click, there isn't enough time allowed for the text to change. Thus, I [modify the statement on line 35](https://github.com/code-dot-org/code-dot-org/blob/bad5f72096c905f9af3148b48b4f29d29bc83feb/dashboard/test/ui/features/star_labs/applab/shared_apps.feature#L35) to `And I wait until element "#testButton1" contains text "Clicked"`. 

At line 88, we test that after the keys 'GLULX' are pressed in the input box, the input box text has the value of 'GLULX'. Similar to the situation above, it seems like when the test is checking the value of the input box, there isn't enough time for the value to change. Initially, I added `And I wait for 3 seconds` before checking the value of the input box because because I saw examples of this command in several other UI test files.

However, I discussed with @breville this approach, and he suggested instead to use a command that waited for something specific to have changed (visibility or content). When Sauce Labs is particularly slow, 3 seconds may not be sufficient, but normally, it may be longer than needed.

Although there is a command that waits for an element's contained text to change, there isn't a command that waits until an element's value has changed. 

At first, I modified the `And I press keys...for element...` command and added a `wait_short_until` that waits up to 30 seconds until the element's value string matched the string composed of the keys that were pressed. It evolved quite a bit because there were many different cases to consider - these cases are described more in detail below. Eventually, I added a new command `And I wait until element...has the value...`. This new command can be called in flaky tests for which the subsequent command is checking the value but the value hasn't had time to change yet.

Special cases that were considered:

1. As I mentioned above, the condition I set for the `wait_short_until` was initially the element's value string matching the key string. However, there are cases when the user presses keys for an input box that already contains text. 

This occurs in the `personal_projects_gallery.feature` test. When I watched the Sauce Labs video of a failed test run after my update, I saw that the project title 'Old Name' was in the input box and 'New Name' was appended to the existing title.
 Go to 1:21.

https://user-images.githubusercontent.com/107423305/231602496-a8e3e23d-5603-422e-903b-f81fab656394.mp4

Thus, I added the line `And I clear the text from element ".ui-project-rename-input"` before pressing the keys for 'New Name' in `personal_projects_gallery.feature`.

An example of a UI test for which the text in an input box is intentionally not cleared is in `scenarios.feature`. In the ['Scenario: Change event works in text input and text area'](https://github.com/code-dot-org/code-dot-org/blob/3a2a4a0ef2b7563174653402e38413821e8632c2/dashboard/test/ui/features/star_labs/applab/scenarios.feature#L52), the user enters the keys '123' into the input box, and then '456' without clearing the previous input. Thus, the debug console prints all 6 digits.

2. When `press keys  "456\n"` is executed, the newline character is not included in the value of the element.

3. Special keys are used such as `":enter"` and `":down"` in `droplet.feature` when the keys pressed are for element `".ace_text-input"`. 

4. There are instances when we refer to user-entered data using syntax such as`'#{@temp_user_data}'`. 

Thanks to @breville for pairing with me on this task. It was a really valuable introduction to UI tests and the Ruby language.

## Links
[jira ticket](https://codedotorg.atlassian.net/browse/SL-772)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
I set up locally to run tests remotely on Sauce Labs.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work
While updating this UI test, noticed @no_ie tags still existing in test files even though we no longer run tests on IE. Remove references to tags '@eyes_ie' and '@no_ie'.
[jira ticket](https://codedotorg.atlassian.net/browse/SL-786)
<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
