### PR TITLE
Fixing Markdown by updating course_version call

### DIFF
--- a/dashboard/lib/services/globally_unique_identifiers.rb
+++ b/dashboard/lib/services/globally_unique_identifiers.rb
@@ -76,7 +76,7 @@ module Services
 
       keys = result.named_captures
       course_version = CourseVersion.joins(:course_offering).
-        find_by(key: keys["CourseVersion"], "course_offerings.key": keys["CourseOffering"], content_root_type: ["Unit", "UnitGroup"])
+        where(key: keys["CourseVersion"], "course_offerings.key": keys["CourseOffering"]).last
       return Resource.find_by(key: keys["Resource"], course_version: course_version)
     end
 

--- a/dashboard/lib/services/globally_unique_identifiers.rb
+++ b/dashboard/lib/services/globally_unique_identifiers.rb
@@ -76,7 +76,7 @@ module Services
 
       keys = result.named_captures
       course_version = CourseVersion.joins(:course_offering).
-        find_by(key: keys["CourseVersion"], "course_offerings.key": keys["CourseOffering"])
+        find_by(key: keys["CourseVersion"], "course_offerings.key": keys["CourseOffering"], content_root_type: ["Unit", "UnitGroup"])
       return Resource.find_by(key: keys["Resource"], course_version: course_version)
     end
 

--- a/dashboard/test/lib/services/markdown_preprocessor_test.rb
+++ b/dashboard/test/lib/services/markdown_preprocessor_test.rb
@@ -75,7 +75,7 @@ class Services::MarkdownPreprocessorTest < ActiveSupport::TestCase
     end
 
     # verify that the cache can be skipped
-    assert_queries 3 do
+    assert_queries 4 do
       Services::MarkdownPreprocessor.process(input, cache_options: {force: true})
     end
   end


### PR DESCRIPTION
The resource markdown has been broken for standalone units & newly created resources. These offerings have multiple potential course_version matches, with both content_root_type of 'script' and 'unit' (this happened during the renaming from script -> unit). 

Because 'find' (the existing code) returns the first record of the two matches, this was returning the 'script' cv when we actually want the 'unit' one. However, we don't want a solution that breaks for the older courses, so we need a solution that pulls 'unit' if that cv exists, 'script' otherwise. Using 'where' here instead of 'find' will get both records (if both exist), and  grab the 'last' of the two, which will be the 'unit' cv. 


Context in this slack thread: https://codedotorg.slack.com/archives/C045UAX4WKH/p1677627035829539

## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/TEACH-305

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
