### PR TITLE
Restrict to only English videos on the level video editor

### DIFF
--- a/dashboard/app/views/levels/editors/fields/_video.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_video.html.haml
@@ -1,6 +1,6 @@
 - content_for :body_scripts do
   - video_infos = {}
-  - Video.all.each { |video| video_infos[video.key] = video.summarize(false) }
+  - Video.where(locale: I18n.default_locale).each { |video| video_infos[video.key] = video.summarize(false) }
   - script_data = { editorvideo: { video_infos: video_infos }.to_json }
   %script{src: webpack_asset_path('js/levels/editors/fields/_video.js'), data: script_data}
 


### PR DESCRIPTION
Fix for issue report [in Slack](https://codedotorg.slack.com/archives/C045UAX4WKH/p1681232924960159). I tested locally and could repro before this fix and could not after.

Some background on videos: videos have a `key` which is used to link the video to the level. All videos have an English version (`locale` column = `en-US`) but some videos are localized into different languages. In those cases, they share the same `key` as their English counterpart with the `locale` value equal to the language they're localized into.

In this specific case, we are grouping videos by `key`, which overwrites the English video info with non-English video info sometimes. This isn't causing any major issues, but a 17 comment Slack thread seems like it's confusing enough that we should fix it.