### PR TITLE
Update `sequel` Gem to 5.67.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -210,7 +210,7 @@ gem 'twilio-ruby' # SMS API for send-to-phone feature
 # - /pegasus/sites.v3/hourofcode/public/fonts/
 gem 'font-awesome-rails', '~> 4.7.0.8'
 
-gem 'sequel'
+gem 'sequel', '5.29.0'
 gem 'user_agent_parser'
 
 gem 'paranoia', '~> 2.5.0'

--- a/Gemfile
+++ b/Gemfile
@@ -210,7 +210,7 @@ gem 'twilio-ruby' # SMS API for send-to-phone feature
 # - /pegasus/sites.v3/hourofcode/public/fonts/
 gem 'font-awesome-rails', '~> 4.7.0.8'
 
-gem 'sequel', '5.29.0'
+gem 'sequel', '~> 5.29'
 gem 'user_agent_parser'
 
 gem 'paranoia', '~> 2.5.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -786,7 +786,7 @@ GEM
     selenium-webdriver (3.141.0)
       childprocess (~> 0.5)
       rubyzip (~> 1.2, >= 1.2.2)
-    sequel (5.9.0)
+    sequel (5.29.0)
     sexp_processor (4.16.0)
     shotgun (0.9.1)
       rack (>= 1.0)
@@ -1036,7 +1036,7 @@ DEPENDENCIES
   scenic-mysql_adapter
   scss_lint
   selenium-webdriver (= 3.141.0)
-  sequel
+  sequel (= 5.29.0)
   shotgun
   sinatra (= 2.1.0)
   sort_alphabetical!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -786,7 +786,7 @@ GEM
     selenium-webdriver (3.141.0)
       childprocess (~> 0.5)
       rubyzip (~> 1.2, >= 1.2.2)
-    sequel (5.29.0)
+    sequel (5.67.0)
     sexp_processor (4.16.0)
     shotgun (0.9.1)
       rack (>= 1.0)
@@ -1036,7 +1036,7 @@ DEPENDENCIES
   scenic-mysql_adapter
   scss_lint
   selenium-webdriver (= 3.141.0)
-  sequel (= 5.29.0)
+  sequel (~> 5.29)
   shotgun
   sinatra (= 2.1.0)
   sort_alphabetical!


### PR DESCRIPTION
Target 5.29 to make sure we pick up support for Ruby 3.0, but do so using a pessimistic version constraint so we pick up all other 5.x fixes, too.

We could alternatively [update just to 5.29](https://github.com/code-dot-org/code-dot-org/pull/51274) but I don't see any breaking changes between those versions and I do see a lot of little fixes that would be nice to pick up.

## Links

https://github.com/jeremyevans/sequel/blob/5.67.0/CHANGELOG#L509

## Testing story

Entirely relying on existing tests