### PR TITLE
Update `pry` Gem to 0.14.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -337,7 +337,7 @@ gem 'datapackage'
 
 gem 'ruby-progressbar'
 
-gem 'pry'
+gem 'pry', '~> 0.14.0'
 
 # Google's Compact Language Detector
 gem 'cld'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -297,7 +297,7 @@ GEM
       activesupport (>= 3.0)
     cocaine (0.5.8)
       climate_control (>= 0.0.3, < 1.0)
-    coderay (1.1.1)
+    coderay (1.1.3)
     colorize (0.8.1)
     composite_primary_keys (12.0.10)
       activerecord (~> 6.0.0)
@@ -527,7 +527,7 @@ GEM
     memoist (0.16.2)
     memory_profiler (0.9.10)
     metaclass (0.0.4)
-    method_source (0.9.2)
+    method_source (1.0.0)
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2020.0512)
@@ -628,9 +628,9 @@ GEM
     pg (1.0.0)
     phantomjs (1.9.7.1)
     progress (3.3.1)
-    pry (0.12.2)
-      coderay (~> 1.1.0)
-      method_source (~> 0.9.0)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     public_suffix (5.0.1)
     puma_worker_killer (0.1.0)
       get_process_mem (~> 0.2)
@@ -1000,7 +1000,7 @@ DEPENDENCIES
   pdf-reader
   pg
   phantomjs (~> 1.9.7.1)
-  pry
+  pry (~> 0.14.0)
   puma!
   puma_worker_killer
   pusher (~> 1.3.1)


### PR DESCRIPTION
Specifically target `~> 0.14.0` to pick up support for Ruby 3.0

Breaking changes in 0.13.x were mostly about deleting functionality deprecated in 0.12. The only breaking change in 0.14.x is removal of support for plugin autoloading.

## Links

- https://github.com/pry/pry/blob/master/CHANGELOG.md#v0140-february-8-2021

## Testing story

Verified that attempting to insert a `binding.pry` statement doesn't work as expected in Ruby 3.0 on our current version of `pry`, but does on this one.