### PR TITLE
Refactoring and simplifying CQA table, updating icons

### DIFF
--- a/apps/src/templates/sectionsRefresh/CurriculumQuickAssign.jsx
+++ b/apps/src/templates/sectionsRefresh/CurriculumQuickAssign.jsx
@@ -44,6 +44,7 @@ export default function CurriculumQuickAssign({updateSection, sectionCourse}) {
     updateSection('course', {});
     if (marketingAudience !== '') {
       setMarketingAudience('');
+      setSelectedCourseOffering(null);
     } else {
       setMarketingAudience(MARKETING_AUDIENCE.ELEMENTARY);
     }

--- a/apps/src/templates/sectionsRefresh/CurriculumQuickAssignTopRow.jsx
+++ b/apps/src/templates/sectionsRefresh/CurriculumQuickAssignTopRow.jsx
@@ -17,6 +17,21 @@ export default function CurriculumQuickAssignTopRow({
   marketingAudience,
   updateMarketingAudience
 }) {
+  // Determines which icon to render for each audience
+  const marketingAudienceIcon = audience => {
+    return marketingAudience === audience ? 'caret-down' : 'caret-right';
+  };
+
+  // If the given audience is already selected, deselect it.
+  // Otherwise, set to this audience
+  const determineMarketingAudience = newAudience => {
+    if (newAudience === marketingAudience) {
+      updateMarketingAudience('');
+    } else {
+      updateMarketingAudience(newAudience);
+    }
+  };
+
   return (
     <div className={moduleStyles.buttonRow}>
       <div className={moduleStyles.buttonsInRow}>
@@ -25,14 +40,10 @@ export default function CurriculumQuickAssignTopRow({
           className={moduleStyles.buttonStyle}
           text={i18n.courseBlocksGradeBandsElementary()}
           size={Button.ButtonSize.large}
-          icon={
-            marketingAudience === MARKETING_AUDIENCE.ELEMENTARY
-              ? 'caret-up'
-              : 'caret-down'
-          }
+          icon={marketingAudienceIcon(MARKETING_AUDIENCE.ELEMENTARY)}
           onClick={e => {
             e.preventDefault();
-            updateMarketingAudience(MARKETING_AUDIENCE.ELEMENTARY);
+            determineMarketingAudience(MARKETING_AUDIENCE.ELEMENTARY);
           }}
         />
         <Button
@@ -40,14 +51,10 @@ export default function CurriculumQuickAssignTopRow({
           className={moduleStyles.buttonStyle}
           text={i18n.courseBlocksGradeBandsMiddle()}
           size={Button.ButtonSize.large}
-          icon={
-            marketingAudience === MARKETING_AUDIENCE.MIDDLE
-              ? 'caret-up'
-              : 'caret-down'
-          }
+          icon={marketingAudienceIcon(MARKETING_AUDIENCE.MIDDLE)}
           onClick={e => {
             e.preventDefault();
-            updateMarketingAudience(MARKETING_AUDIENCE.MIDDLE);
+            determineMarketingAudience(MARKETING_AUDIENCE.MIDDLE);
           }}
         />
         <Button
@@ -55,14 +62,10 @@ export default function CurriculumQuickAssignTopRow({
           className={moduleStyles.buttonStyle}
           text={i18n.courseBlocksGradeBandsHigh()}
           size={Button.ButtonSize.large}
-          icon={
-            marketingAudience === MARKETING_AUDIENCE.HIGH
-              ? 'caret-up'
-              : 'caret-down'
-          }
+          icon={marketingAudienceIcon(MARKETING_AUDIENCE.HIGH)}
           onClick={e => {
             e.preventDefault();
-            updateMarketingAudience(MARKETING_AUDIENCE.HIGH);
+            determineMarketingAudience(MARKETING_AUDIENCE.HIGH);
           }}
         />
         <Button
@@ -70,14 +73,10 @@ export default function CurriculumQuickAssignTopRow({
           className={moduleStyles.buttonStyle}
           text={i18n.teacherCourseHoc()}
           size={Button.ButtonSize.large}
-          icon={
-            marketingAudience === MARKETING_AUDIENCE.HOC
-              ? 'caret-up'
-              : 'caret-down'
-          }
+          icon={marketingAudienceIcon(MARKETING_AUDIENCE.HOC)}
           onClick={e => {
             e.preventDefault();
-            updateMarketingAudience(MARKETING_AUDIENCE.HOC);
+            determineMarketingAudience(MARKETING_AUDIENCE.HOC);
           }}
         />
         {showPlOfferings && (
@@ -86,14 +85,10 @@ export default function CurriculumQuickAssignTopRow({
             className={moduleStyles.buttonStyle}
             text={i18n.professionalLearning()}
             size={Button.ButtonSize.large}
-            icon={
-              marketingAudience === MARKETING_AUDIENCE.PL
-                ? 'caret-up'
-                : 'caret-down'
-            }
+            icon={marketingAudienceIcon(MARKETING_AUDIENCE.PL)}
             onClick={e => {
               e.preventDefault();
-              updateMarketingAudience(MARKETING_AUDIENCE.PL);
+              determineMarketingAudience(MARKETING_AUDIENCE.PL);
             }}
           />
         )}

--- a/apps/test/unit/templates/sectionsRefresh/CurriculumQuickAssignTest.jsx
+++ b/apps/test/unit/templates/sectionsRefresh/CurriculumQuickAssignTest.jsx
@@ -28,12 +28,12 @@ describe('CurriculumQuickAssign', () => {
       <CurriculumQuickAssign updateSection={() => {}} sectionCourse={{}} />
     );
 
-    expect(wrapper.find('Button').at(0).props().icon).to.equal('caret-down');
+    expect(wrapper.find('Button').at(0).props().icon).to.equal('caret-right');
     wrapper
       .find('Button')
       .at(0)
       .simulate('click', {preventDefault: () => {}});
-    expect(wrapper.find('Button').at(0).props().icon).to.equal('caret-up');
+    expect(wrapper.find('Button').at(0).props().icon).to.equal('caret-down');
   });
 
   it('clears decide later when marketing audience selected', () => {


### PR DESCRIPTION
This pr covers three updates. I did them together because they're all small and cover the same area. 

1. Makes sure that clicking 'decide later' clears out the selected course offering (which makes the version and unit dropdowns disappear)- a fix!
2. Updates the icons to be right unless selected, then pointing down if selected to match advanced settings
3. Updates the marketing audience selectors to collapse the table if pressed again
4. (3A) Refactors the icon and onClick functions to be shared to avoid repeating code

New icon status:
<img width="1195" alt="Screenshot 2023-04-12 at 1 25 54 PM" src="https://user-images.githubusercontent.com/37230822/231578477-43735a07-90da-4aa0-8b27-44080b99fb9e.png">


## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/TEACH-414
- https://codedotorg.atlassian.net/browse/TEACH-411

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  6.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
