### PR TITLE
Create role for Advocacy Director of Policy

### DIFF
--- a/aws/cloudformation/iam.yml.erb
+++ b/aws/cloudformation/iam.yml.erb
@@ -481,6 +481,43 @@ Resources:
       Value: initial,value
       Description: List of Google IDs of people being granted billing access.
 
+  AdvocacyDirectorOfPolicyRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: AdvocacyDirectorOfPolicy
+      Description: Google-federated AWS Role for the Advocacy Director of Policy.
+      Path: /Advocacy/
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal: {Federated: !Sub "arn:aws:iam::${AWS::AccountId}:saml-provider/Google"}
+            Action: sts:AssumeRoleWithSAML
+            Condition:
+              StringEquals:
+                SAML:aud: https://signin.aws.amazon.com/saml
+      ManagedPolicyArns:
+        - !Ref AdvocacyDirectorOfPolicyS3Policy
+
+  AdvocacyDirectorOfPolicyS3Policy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      ManagedPolicyName: ContributorS3Policy
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action:
+              - s3:ListBucket
+            Resource: arn:aws:s3:::cdo-census
+          - Effect: Allow
+            Action:
+              - s3:PutObject
+              - s3:PutObjectAcl
+              - s3:GetObject
+              - s3:GetObjectAcl
+            Resource: arn:aws:s3:::cdo-census/*
+
   # Used by FirehoseMicroservice Lambda function.
   # TODO move to Data stack
   FirehoseLambdaRole:


### PR DESCRIPTION
This creates a new role and policies. The user needs access to upload files to the cdo-census bucket.

Questions
- As this is a single-human role, it's a weird edge case for Role Based Access Control. Interested in alternative approaches here. Per the slack discussion, these permissions don't make sense for all of Advocacy.

AP CSP Note
- This change would have no impact on AP CSP test takers

## Links

Jira Issue: https://codedotorg.atlassian.net/browse/INF-872

## Testing story

Validate via:

`bundle exec rake stack:iam:validate RAILS_ENV=production`

## Deployment strategy

Deploy via
```
git pull origin staging
bundle exec rake stack:iam:validate RAILS_ENV=production
ADMIN=1 bundle exec rake stack:iam:start RAILS_ENV=production
```

Merge this PR once that is successful.

Then have Accounts add this role to the user in Google, so they can assume it via SAML login.

## Security

Access is scoped to the cdo-census bucket.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
