### PR TITLE
Update FactoryBot Static Attributes to Dynamic

### DIFF
--- a/dashboard/test/factories/census_factories.rb
+++ b/dashboard/test/factories/census_factories.rb
@@ -3,7 +3,7 @@ FactoryBot.allow_class_lookup = false
 FactoryBot.define do
   factory :census_submission_school_info, parent: :school_info_us do
     transient do
-      school_year 2017
+      school_year {2017}
     end
 
     trait :with_teaches_yes_teacher_census_submission do
@@ -32,14 +32,14 @@ FactoryBot.define do
   end
 
   factory :census_school, parent: :school do
-    state 'AK'
+    state {'AK'}
     is_high_school
     transient do
-      school_year 2017
+      school_year {2017}
     end
 
     trait :with_state_not_having_state_data do
-      state "QQ"
+      state {"QQ"}
     end
 
     trait :with_teaches_yes_teacher_census_submission do
@@ -122,87 +122,87 @@ FactoryBot.define do
   end
 
   factory :census_submission, class: Census::CensusSubmission do
-    submitter_email_address "parent@school.edu"
-    school_year 2017
-    how_many_20_hours "none"
-    how_many_10_hours "none"
-    how_many_do_hoc "none"
-    how_many_after_school "none"
-    submitter_role "parent"
-    class_frequency "less_than_one_hour_per_week"
+    submitter_email_address {"parent@school.edu"}
+    school_year {2017}
+    how_many_20_hours {"none"}
+    how_many_10_hours {"none"}
+    how_many_do_hoc {"none"}
+    how_many_after_school {"none"}
+    submitter_role {"parent"}
+    class_frequency {"less_than_one_hour_per_week"}
 
     transient do
-      school_info_count 1
+      school_info_count {1}
     end
 
     school_infos {build_list(:school_info, school_info_count)}
 
     trait :with_bad_how_many do
-      how_many_20_hours "a bunch"
-      how_many_10_hours "not sure"
-      how_many_do_hoc "many"
-      how_many_after_school "all of them"
+      how_many_20_hours {"a bunch"}
+      how_many_10_hours {"not sure"}
+      how_many_do_hoc {"many"}
+      how_many_after_school {"all of them"}
     end
 
     trait :with_bad_role do
-      submitter_role "student"
+      submitter_role {"student"}
     end
 
     trait :with_bad_frequency do
-      class_frequency 'often'
+      class_frequency {'often'}
     end
 
     trait :with_bad_school_year do
-      school_year 1900
+      school_year {1900}
     end
 
     trait :with_long_email do
-      submitter_email_address 'a' * 256
+      submitter_email_address {'a' * 256}
     end
 
     trait :with_long_name do
-      submitter_name 'a' * 256
+      submitter_name {'a' * 256}
     end
 
     trait :with_long_other_description do
-      topic_other_description 'a' * 256
+      topic_other_description {'a' * 256}
     end
 
     trait :as_teacher do
-      submitter_role "teacher"
+      submitter_role {"teacher"}
     end
 
     trait :with_pledge do
-      pledged true
+      pledged {true}
     end
 
     trait :with_topic_booleans do
-      topic_blocks true
-      topic_text true
-      topic_robots true
-      topic_internet true
-      topic_security true
-      topic_data true
-      topic_web_design true
-      topic_game_design true
-      topic_other true
-      topic_do_not_know true
+      topic_blocks {true}
+      topic_text {true}
+      topic_robots {true}
+      topic_internet {true}
+      topic_security {true}
+      topic_data {true}
+      topic_web_design {true}
+      topic_game_design {true}
+      topic_other {true}
+      topic_do_not_know {true}
     end
 
     trait :with_other_description do
-      topic_other_description "Another topic"
+      topic_other_description {"Another topic"}
     end
 
     trait :with_teaches_yes do
-      how_many_20_hours "all"
+      how_many_20_hours {"all"}
       with_topic_booleans
       with_other_description
-      topic_text true
+      topic_text {true}
     end
 
     trait :with_teaches_no do
-      how_many_20_hours "none"
-      how_many_10_hours "none"
+      how_many_20_hours {"none"}
+      how_many_10_hours {"none"}
     end
   end
 
@@ -211,13 +211,13 @@ FactoryBot.define do
 
   factory :census_your_school2017v1, parent: :census_your_school2017v0, class: Census::CensusYourSchool2017v1 do
     trait :requiring_followup do
-      how_many_20_hours "all"
+      how_many_20_hours {"all"}
     end
   end
 
   factory :census_your_school2017v2, parent: :census_your_school2017v1, class: Census::CensusYourSchool2017v2 do
     trait :requiring_other_description do
-      topic_other true
+      topic_other {true}
       requiring_followup
     end
   end
@@ -229,25 +229,25 @@ FactoryBot.define do
   end
 
   factory :census_your_school2017v5, parent: :census_your_school2017v4, class: Census::CensusYourSchool2017v5 do
-    share_with_regional_partners true
+    share_with_regional_partners {true}
   end
 
   factory :census_your_school2017v6, parent: :census_your_school2017v5, class: Census::CensusYourSchool2017v6 do
-    topic_ethical_social true
+    topic_ethical_social {true}
   end
 
   factory :census_your_school2017v7, parent: :census_your_school2017v6, class: Census::CensusYourSchool2017v7 do
     trait :with_inaccuracy_reported do
-      inaccuracy_reported true
+      inaccuracy_reported {true}
     end
 
     trait :with_inaccuracy_comment do
-      inaccuracy_comment "That ain't right!"
+      inaccuracy_comment {"That ain't right!"}
     end
   end
 
   factory :census_hoc2017v1, parent: :census_submission, class: Census::CensusHoc2017v1 do
-    submitter_name "Hoc Submitter"
+    submitter_name {"Hoc Submitter"}
   end
 
   factory :census_hoc2017v2, parent: :census_hoc2017v1, class: Census::CensusHoc2017v2 do
@@ -257,54 +257,54 @@ FactoryBot.define do
   end
 
   factory :census_submission_form_map, class: Census::CensusSubmissionFormMap do
-    census_submission nil
-    form_id nil
+    census_submission {nil}
+    form_id {nil}
 
     trait :with_submission do
       census_submission {build :census_hoc2017v1}
     end
 
     trait :with_form do
-      form_id 1
+      form_id {1}
     end
   end
 
   factory :census_teacher_banner_v1, parent: :census_submission, class: Census::CensusTeacherBannerV1 do
-    submitter_role "TEACHER"
+    submitter_role {"TEACHER"}
   end
 
   factory :census_summary, class: 'Census::CensusSummary' do
     school {build :school}
-    school_year 2017
-    teaches_cs nil
-    audit_data "Fake Audit Data"
+    school_year {2017}
+    teaches_cs {nil}
+    audit_data {"Fake Audit Data"}
 
     trait :with_valid_teaches_cs do
-      teaches_cs "N"
+      teaches_cs {"N"}
     end
 
     trait :with_valid_historic_teaches_cs do
-      teaches_cs "HN"
+      teaches_cs {"HN"}
     end
 
     trait :with_invalid_teaches_cs do
-      teaches_cs "X"
+      teaches_cs {"X"}
     end
 
     trait :with_invalid_school_year do
-      school_year 1900
+      school_year {1900}
     end
 
     trait :without_school_year do
-      school_year nil
+      school_year {nil}
     end
 
     trait :without_school do
-      school nil
+      school {nil}
     end
 
     trait :without_audit_data do
-      audit_data nil
+      audit_data {nil}
     end
   end
 end

--- a/dashboard/test/factories/curriculum_factories.rb
+++ b/dashboard/test/factories/curriculum_factories.rb
@@ -3,8 +3,8 @@ FactoryBot.define do
     association :course_version
 
     sequence(:key) {|n| "bogus-reference-guide-#{n}"}
-    display_name "Sample Reference Guide"
-    content "Some markdown *text*"
+    display_name {"Sample Reference Guide"}
+    content {"Some markdown *text*"}
 
     position do |reference_guide|
       (reference_guide.course_version.reference_guides.maximum(:position) || 0) + 1 if reference_guide.course_version

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
   factory :course_offering do
     sequence(:key, 'a') {|c| "bogus-course-offering-#{c}"}
     sequence(:display_name, 'a') {|c| "bogus-course-offering-#{c}"}
-    assignable true
+    assignable {true}
   end
 
   factory :course_version do
@@ -30,24 +30,24 @@ FactoryBot.define do
   factory :unit_group do
     sequence(:name) {|n| "bogus-course-#{n}"}
     sequence(:family_name) {|n| "bogus-course-#{n}"}
-    version_year "1991"
-    published_state "beta"
-    instruction_type "teacher_led"
-    participant_audience "student"
-    instructor_audience "teacher"
+    version_year {"1991"}
+    published_state {"beta"}
+    instruction_type {"teacher_led"}
+    participant_audience {"student"}
+    instructor_audience {"teacher"}
   end
 
   factory :experiment do
     sequence(:name) {|n| "fancyFeature#{n}"}
 
     factory :user_based_experiment, class: 'UserBasedExperiment' do
-      percentage 50
+      percentage {50}
     end
     factory :teacher_based_experiment, class: 'TeacherBasedExperiment' do
-      min_user_id 0
-      max_user_id 0
-      overflow_max_user_id 0
-      script nil
+      min_user_id {0}
+      max_user_id {0}
+      overflow_max_user_id {0}
+      script {nil}
     end
     factory :single_section_experiment, class: 'SingleSectionExperiment' do
       section
@@ -59,7 +59,7 @@ FactoryBot.define do
   factory :pilot do
     sequence(:name) {|n| "test-pilot-#{n}"}
     sequence(:display_name) {|n| "Test Pilot #{n}"}
-    allow_joining_via_url 0
+    allow_joining_via_url {0}
   end
 
   factory :section_hidden_lesson do
@@ -81,12 +81,12 @@ FactoryBot.define do
   end
 
   factory :user do
-    birthday Time.zone.today - 21.years
+    birthday {Time.zone.today - 21.years}
     email {("#{user_type}_#{SecureRandom.uuid}@code.org")}
-    password "00secret"
-    locale 'en-US'
+    password {"00secret"}
+    locale {'en-US'}
     sequence(:name) {|n| "User#{n} Codeberg"}
-    user_type User::TYPE_STUDENT
+    user_type {User::TYPE_STUDENT}
 
     # Used to test specific interactions for older (unmigrated) users. This
     # trait and associated tests can be removed when the work to migrate all
@@ -97,21 +97,21 @@ FactoryBot.define do
     end
 
     factory :teacher do
-      user_type User::TYPE_TEACHER
-      birthday Date.new(1980, 3, 14)
+      user_type {User::TYPE_TEACHER}
+      birthday {Date.new(1980, 3, 14)}
       factory :admin do
         google_sso_provider
-        password nil
+        password {nil}
         after(:create) {|user| user.update(admin: true)}
       end
       trait :with_school_info do
         school_info
       end
       trait :with_terms_of_service do
-        terms_of_service_version 1
+        terms_of_service_version {1}
       end
       trait :not_first_sign_in do
-        sign_in_count 2
+        sign_in_count {2}
       end
       factory :terms_of_service_teacher do
         with_terms_of_service
@@ -136,7 +136,7 @@ FactoryBot.define do
       end
       factory :facilitator do
         transient do
-          course nil
+          course {nil}
         end
 
         sequence(:name) {|n| "Facilitator Person #{n}"}
@@ -151,7 +151,7 @@ FactoryBot.define do
         end
       end
       factory :workshop_admin do
-        name 'Workshop Admin'
+        name {'Workshop Admin'}
         after(:create) do |user|
           user.permission = UserPermission::WORKSHOP_ADMIN
         end
@@ -196,25 +196,25 @@ FactoryBot.define do
       end
 
       factory :district_contact do
-        name 'District Contact Person'
-        ops_first_name 'District'
-        ops_last_name 'Person'
+        name {'District Contact Person'}
+        ops_first_name {'District'}
+        ops_last_name {'Person'}
       end
 
-      transient {pilot_experiment nil}
+      transient {pilot_experiment {nil}}
       after(:create) do |teacher, evaluator|
         if evaluator.pilot_experiment
           create :single_user_experiment, min_user_id: teacher.id, name: evaluator.pilot_experiment
         end
       end
-      transient {editor_experiment nil}
+      transient {editor_experiment {nil}}
       after(:create) do |teacher, evaluator|
         if evaluator.editor_experiment
           create :single_user_experiment, min_user_id: teacher.id, name: evaluator.editor_experiment
         end
       end
       factory :platformization_partner do
-        editor_experiment 'platformization-partners'
+        editor_experiment {'platformization-partners'}
       end
 
       # We have some teacher records in our system that do not pass validation because they have
@@ -243,11 +243,11 @@ FactoryBot.define do
     end
 
     factory :student do
-      user_type User::TYPE_STUDENT
-      birthday Time.zone.today - 17.years
+      user_type {User::TYPE_STUDENT}
+      birthday {Time.zone.today - 17.years}
 
       factory :young_student do
-        birthday Time.zone.today - 10.years
+        birthday {Time.zone.today - 10.years}
 
         factory :young_student_with_tos_teacher do
           after(:create) do |user|
@@ -265,21 +265,21 @@ FactoryBot.define do
 
         factory :parent_managed_student do
           sequence(:parent_email) {|n| "testparent#{n}@example.com.xx"}
-          email nil
-          hashed_email nil
-          provider nil
+          email {nil}
+          hashed_email {nil}
+          provider {nil}
         end
       end
 
       factory :manual_username_password_student do
-        email nil
-        hashed_email nil
-        provider User::PROVIDER_MANUAL
+        email {nil}
+        hashed_email {nil}
+        provider {User::PROVIDER_MANUAL}
       end
 
       factory :student_in_word_section do
-        encrypted_password nil
-        provider 'sponsored'
+        encrypted_password {nil}
+        provider {'sponsored'}
 
         after(:create) do |user|
           word_section = create(:section, login_type: Section::LOGIN_TYPE_WORD)
@@ -289,13 +289,13 @@ FactoryBot.define do
       end
 
       factory :student_in_picture_section do
-        encrypted_password nil
-        provider 'sponsored'
+        encrypted_password {nil}
+        provider {'sponsored'}
         in_picture_section
       end
 
       factory :old_student do
-        birthday Time.zone.today - 30.years
+        birthday {Time.zone.today - 30.years}
       end
 
       trait :in_picture_section do
@@ -335,8 +335,8 @@ FactoryBot.define do
       end
 
       trait :without_email do
-        email ''
-        hashed_email nil
+        email {''}
+        hashed_email {nil}
       end
     end
 
@@ -351,15 +351,15 @@ FactoryBot.define do
     end
 
     trait :sso_provider do
-      encrypted_password nil
-      provider %w(facebook windowslive clever).sample
+      encrypted_password {nil}
+      provider {%w(facebook windowslive clever).sample}
       sequence(:uid) {|n| n}
     end
 
     trait :sso_provider_with_token do
       sso_provider
-      oauth_token 'fake-oauth-token'
-      oauth_token_expiration 'fake-oauth-token-expiration'
+      oauth_token {'fake-oauth-token'}
+      oauth_token_expiration {'fake-oauth-token-expiration'}
     end
 
     trait :untrusted_email_sso_provider do
@@ -374,48 +374,48 @@ FactoryBot.define do
 
     trait :clever_sso_provider do
       untrusted_email_sso_provider
-      provider 'clever'
+      provider {'clever'}
     end
 
     trait :facebook_sso_provider do
       sso_provider_with_token
-      provider 'facebook'
+      provider {'facebook'}
     end
 
     trait :google_sso_provider do
       sso_provider_with_token
-      provider 'google_oauth2'
-      oauth_refresh_token 'fake-oauth-refresh-token'
+      provider {'google_oauth2'}
+      oauth_refresh_token {'fake-oauth-refresh-token'}
     end
 
     trait :microsoft_v2_sso_provider do
       sso_provider_with_token
-      provider 'microsoft_v2_auth'
+      provider {'microsoft_v2_auth'}
     end
 
     trait :powerschool_sso_provider do
       untrusted_email_sso_provider
-      provider 'powerschool'
+      provider {'powerschool'}
     end
 
     trait :the_school_project_sso_provider do
       sso_provider
-      provider 'the_school_project'
+      provider {'the_school_project'}
     end
 
     trait :twitter_sso_provider do
       sso_provider
-      provider 'twitter'
+      provider {'twitter'}
     end
 
     trait :qwiklabs_sso_provider do
       sso_provider
-      provider 'lti_lti_prod_kids.qwikcamps.com'
+      provider {'lti_lti_prod_kids.qwikcamps.com'}
     end
 
     trait :windowslive_sso_provider do
       sso_provider_with_token
-      provider 'windowslive'
+      provider {'windowslive'}
     end
 
     trait :with_google_authentication_option do
@@ -452,8 +452,8 @@ FactoryBot.define do
 
     trait :with_puzzles do
       transient do
-        num_puzzles 1
-        puzzle_result ActivityConstants::MINIMUM_PASS_RESULT
+        num_puzzles {1}
+        puzzle_result {ActivityConstants::MINIMUM_PASS_RESULT}
       end
       after(:create) do |user, evaluator|
         evaluator.num_puzzles.times do
@@ -485,15 +485,15 @@ FactoryBot.define do
   factory :authentication_option do
     association :user
     sequence(:email) {|n| "testuser#{n}@example.com.xx"}
-    credential_type AuthenticationOption::EMAIL
-    authentication_id SecureRandom.uuid
+    credential_type {AuthenticationOption::EMAIL}
+    authentication_id {SecureRandom.uuid}
 
     factory :google_authentication_option do
-      credential_type AuthenticationOption::GOOGLE
+      credential_type {AuthenticationOption::GOOGLE}
     end
 
     factory :facebook_authentication_option do
-      credential_type AuthenticationOption::FACEBOOK
+      credential_type {AuthenticationOption::FACEBOOK}
     end
   end
 
@@ -505,32 +505,32 @@ FactoryBot.define do
   factory :section do
     sequence(:name) {|n| "Section #{n}"}
     user {create :teacher}
-    login_type 'email'
-    participant_type 'student'
+    login_type {'email'}
+    participant_type {'student'}
 
     initialize_with {Section.new(attributes)}
 
     trait :teacher_participants do
-      participant_type 'teacher'
-      login_type 'email'
-      grades ['pl']
+      participant_type {'teacher'}
+      login_type {'email'}
+      grades {['pl']}
     end
 
     trait :facilitator_participants do
-      participant_type 'facilitator'
-      login_type 'email'
-      grades ['pl']
+      participant_type {'facilitator'}
+      login_type {'email'}
+      grades {['pl']}
     end
   end
 
   factory :game do
     sequence(:name) {|n| "game#{n}.com"}
-    app "maze"
+    app {"maze"}
   end
 
   factory :level, class: Blockly do
     sequence(:name) {|n| "Level_#{n}"}
-    level_num 'custom'
+    level_num {'custom'}
 
     game
 
@@ -563,7 +563,7 @@ FactoryBot.define do
 
     trait :spelling_bee do
       game {create(:game, app: "maze", name: "Maze")}
-      skin 'letters'
+      skin {'letters'}
     end
 
     trait :blockly do
@@ -617,7 +617,7 @@ FactoryBot.define do
 
   factory :odometer, parent: :level, class: Odometer do
     game {Game.odometer}
-    level_num 'custom'
+    level_num {'custom'}
   end
 
   factory :artist, parent: :level, class: Artist do
@@ -625,55 +625,55 @@ FactoryBot.define do
   end
 
   factory :maze, parent: :level, class: :Maze do
-    skin 'birds'
+    skin {'birds'}
   end
 
   factory :applab, parent: :level, class: Applab do
     game {Game.applab}
-    level_num 'custom'
+    level_num {'custom'}
 
     trait :with_autoplay_video do
       video_key {create(:video).key}
     end
 
     trait :with_map_reference do
-      map_reference '/test/alpha.html'
+      map_reference {'/test/alpha.html'}
     end
 
     trait :with_reference_links do
-      reference_links ['/test/abc.html', '/test/def.html']
+      reference_links {['/test/abc.html', '/test/def.html']}
     end
   end
 
   factory :ailab, parent: :level, class: Ailab do
     game {Game.ailab}
-    level_num 'custom'
+    level_num {'custom'}
   end
 
   factory :free_response, parent: :level, class: FreeResponse do
     game {Game.free_response}
-    level_num 'custom'
+    level_num {'custom'}
   end
 
   factory :playlab, parent: :level, class: Studio do
     game {create(:game, app: Game::PLAYLAB)}
-    level_num 'custom'
+    level_num {'custom'}
   end
 
   factory :gamelab, parent: :level, class: Gamelab do
     game {Game.gamelab}
-    level_num 'custom'
+    level_num {'custom'}
   end
 
   factory :weblab, parent: :level, class: Weblab do
     game {Game.weblab}
-    level_num 'custom'
+    level_num {'custom'}
   end
 
   factory :multi, parent: :level, class: Multi do
     game {create(:game, app: "multi")}
     transient do
-      submittable false
+      submittable {false}
     end
     properties do
       {
@@ -704,8 +704,8 @@ FactoryBot.define do
 
   factory :external_link, parent: :level, class: ExternalLink do
     game {Game.external_link}
-    url nil
-    link_title 'title'
+    url {nil}
+    link_title {'title'}
   end
 
   factory :curriculum_reference, parent: :level, class: CurriculumReference do
@@ -714,7 +714,7 @@ FactoryBot.define do
 
   factory :javalab, parent: :level, class: Javalab do
     game {Game.javalab}
-    level_num 'custom'
+    level_num {'custom'}
 
     trait :with_example_solutions do
       after(:create) do |level|
@@ -726,12 +726,12 @@ FactoryBot.define do
 
   factory :spritelab, parent: :level, class: GamelabJr do
     game {Game.spritelab}
-    level_num 'custom'
+    level_num {'custom'}
   end
 
   factory :dance, parent: :level, class: Dancelab do
     game {Game.dance}
-    level_num 'custom'
+    level_num {'custom'}
   end
 
   factory :block do
@@ -739,8 +739,8 @@ FactoryBot.define do
       sequence(:index)
     end
     name {"gamelab_block#{index}"}
-    category 'custom'
-    pool 'fakeLevelType'
+    category {'custom'}
+    pool {'fakeLevelType'}
     config do
       {
         func: "block#{index}",
@@ -755,16 +755,16 @@ FactoryBot.define do
       sequence(:index)
     end
     name {"doing_something#{index}"}
-    level_type 'fakeLevelType'
-    block_type 'function'
-    description 'This does >>something<< interesting!'
-    arguments '{"this sprite": "Sprite"}'
-    stack '<block type="implementationBlock"></block>'
+    level_type {'fakeLevelType'}
+    block_type {'function'}
+    description {'This does >>something<< interesting!'}
+    arguments {'{"this sprite": "Sprite"}'}
+    stack {'<block type="implementationBlock"></block>'}
   end
 
   factory :level_source do
     level
-    data '<xml/>'
+    data {'<xml/>'}
     trait :with_image do
       level {create(:level, game: Game.find_by_app(Game::ARTIST))}
       after :create do |level_source, _|
@@ -786,21 +786,21 @@ FactoryBot.define do
 
   factory :unit, aliases: [:script] do
     sequence(:name) {|n| "bogus-script-#{n}"}
-    published_state "beta"
-    is_migrated true
-    instruction_type "teacher_led"
-    participant_audience "student"
-    instructor_audience "teacher"
+    published_state {"beta"}
+    is_migrated {true}
+    instruction_type {"teacher_led"}
+    participant_audience {"student"}
+    instructor_audience {"teacher"}
 
     trait :is_course do
       sequence(:version_year) {|n| "bogus-version-year-#{n}"}
       sequence(:family_name) {|n| "bogus-family-name-#{n}"}
-      is_course true
+      is_course {true}
     end
 
     trait :with_lessons do
       transient do
-        lessons_count 2
+        lessons_count {2}
       end
 
       after(:create) do |script, evaluator|
@@ -813,8 +813,8 @@ FactoryBot.define do
 
     trait :with_levels do
       transient do
-        lessons_count 1
-        levels_count 2
+        lessons_count {1}
+        levels_count {2}
       end
 
       after(:create) do |script, evaluator|
@@ -886,10 +886,10 @@ FactoryBot.define do
 
   factory :project do
     transient do
-      owner create :user
+      owner {create :user}
     end
 
-    updated_ip '127.0.0.1'
+    updated_ip {'127.0.0.1'}
 
     after(:build) do |project, evaluator|
       project_storage = create :project_storage, user_id: evaluator.owner.id
@@ -905,7 +905,7 @@ FactoryBot.define do
     user
     model_id {SecureRandom.alphanumeric(12)}
     name {"Model name #{Random.rand(111..999)}"}
-    metadata '{ "description": "Model details" }'
+    metadata {'{ "description": "Model details" }'}
   end
 
   factory :script_level do
@@ -914,7 +914,7 @@ FactoryBot.define do
     end
 
     trait :assessment do
-      assessment true
+      assessment {true}
     end
 
     lesson do |script_level|
@@ -985,7 +985,7 @@ FactoryBot.define do
   factory :lesson do
     sequence(:name) {|n| "Bogus Lesson #{n}"}
     sequence(:key) {|n| "Bogus-Lesson-#{n}"}
-    has_lesson_plan false
+    has_lesson_plan {false}
     script do |lesson|
       lesson.lesson_group&.script || create(:script)
     end
@@ -1011,31 +1011,31 @@ FactoryBot.define do
 
   factory :resource do
     association :course_version
-    url 'fake.url'
-    name 'fake name'
+    url {'fake.url'}
+    name {'fake name'}
   end
 
   factory :objective do
     sequence(:key) {|n| "objective-#{n}"}
-    description 'fake description'
+    description {'fake description'}
   end
 
   factory :vocabulary do
     association :course_version
     sequence(:key, 'a') {|char| "vocab_#{char}"}
-    word 'word'
-    definition 'definition'
+    word {'word'}
+    definition {'definition'}
   end
 
   factory :programming_environment do
     sequence(:name) {|n| "programming-environment-#{n}"}
-    published true
+    published {true}
   end
 
   factory :programming_environment_category do
     sequence(:key, 'a') {|n| "programming_environment_category_#{n}"}
     sequence(:name, 'b') {|n| "programming-environment-category-#{n}"}
-    color '#000000'
+    color {'#000000'}
   end
 
   factory :programming_expression do
@@ -1058,7 +1058,7 @@ FactoryBot.define do
 
   factory :callout do
     sequence(:element_id) {|n| "#pageElement#{n}"}
-    localization_key 'drag_blocks'
+    localization_key {'drag_blocks'}
     script_level
   end
 
@@ -1088,7 +1088,7 @@ FactoryBot.define do
   factory :standard_category do
     sequence(:shortcode) {|n| "category-#{n}"}
     sequence(:description) {|n| "fake category description #{n}"}
-    category_type 'fake category type'
+    category_type {'fake category type'}
   end
 
   factory :standard do
@@ -1116,16 +1116,16 @@ FactoryBot.define do
 
   factory :video do
     sequence(:key) {|n| "concept_#{n}"}
-    youtube_code 'Bogus text'
-    download 'https://videos.code.org/test-video.mp4'
+    youtube_code {'Bogus text'}
+    download {'https://videos.code.org/test-video.mp4'}
   end
 
   factory :follower do
     association :student_user, factory: :student
 
     transient do
-      section nil
-      user nil
+      section {nil}
+      user {nil}
     end
 
     after(:build) do |follower, evaluator|
@@ -1148,18 +1148,18 @@ FactoryBot.define do
 
   factory :user_school_info do
     user {create :teacher}
-    start_date DateTime.now
-    last_confirmation_date DateTime.now
+    start_date {DateTime.now}
+    last_confirmation_date {DateTime.now}
     association :school_info
   end
 
   factory :peer_review do
     submitter {create :teacher}
-    from_instructor false
+    from_instructor {false}
     script {create :script}
     level {create :level}
     level_source {create :level_source}
-    data "MyText"
+    data {"MyText"}
     before :create do |peer_review|
       create :user_level, user: peer_review.submitter, level: peer_review.level
     end
@@ -1173,8 +1173,8 @@ FactoryBot.define do
     game {create(:game, app: "level_group")}
     sequence(:name) {|n| "Level_Group_Level_#{n}"}
     transient do
-      title 'title'
-      submittable false
+      title {'title'}
+      submittable {false}
     end
     properties do
       {
@@ -1197,7 +1197,7 @@ FactoryBot.define do
   factory :bubble_choice_level, class: BubbleChoice do
     game {create(:game, app: "bubble_choice")}
     sequence(:name) {|n| "Bubble_Choice_Level_#{n}"}
-    display_name 'display_name'
+    display_name {'display_name'}
     properties do
       {
         display_name: display_name,
@@ -1207,7 +1207,7 @@ FactoryBot.define do
     # Allow passing a list of levels in the create method to automatically set
     # up sublevels
     transient do
-      sublevels []
+      sublevels {[]}
     end
 
     after(:create) do |bubble_choice, evaluator|
@@ -1222,7 +1222,7 @@ FactoryBot.define do
 
   factory :survey_result do
     user {create :teacher}
-    kind 'Diversity2016'
+    kind {'Diversity2016'}
     properties {{diversity_asian: "1", diversity_farm: "3"}}
   end
 
@@ -1243,15 +1243,15 @@ FactoryBot.define do
 
   factory :level_concept_difficulty do
     level {create :level}
-    repeat_loops 2
+    repeat_loops {2}
   end
 
   factory :user_proficiency do
     user {create :student}
-    sequencing_d1_count 1
-    repeat_loops_d2_count 2
-    repeat_loops_d4_count 3
-    conditionals_d5_count 4
+    sequencing_d1_count {1}
+    repeat_loops_d2_count {2}
+    repeat_loops_d4_count {3}
+    conditionals_d5_count {4}
   end
 
   # school info: default to public with district and school
@@ -1262,20 +1262,20 @@ FactoryBot.define do
 
   # this is the only factory used for testing the deprecated data formats (without country).
   factory :school_info_without_country, class: SchoolInfo do
-    school_type SchoolInfo::SCHOOL_TYPE_PUBLIC
-    state 'WA'
+    school_type {SchoolInfo::SCHOOL_TYPE_PUBLIC}
+    state {'WA'}
     association :school_district, strategy: :build
   end
 
   factory :school_info_non_us, class: SchoolInfo do
-    country 'GB'
-    school_type SchoolInfo::SCHOOL_TYPE_PUBLIC
-    full_address '31 West Bank, London, England'
-    school_name 'Grazebrook'
+    country {'GB'}
+    school_type {SchoolInfo::SCHOOL_TYPE_PUBLIC}
+    full_address {'31 West Bank, London, England'}
+    school_name {'Grazebrook'}
   end
 
   factory :school_info_us, class: SchoolInfo do
-    country 'US'
+    country {'US'}
 
     trait :with_district do
       association :school_district, strategy: :build
@@ -1290,17 +1290,17 @@ FactoryBot.define do
   # although some US school types behave identically, we keep their factories separate here
   # because the behavior of each school type may diverge over time.
   factory :school_info_us_private, parent: :school_info_us do
-    school_type SchoolInfo::SCHOOL_TYPE_PRIVATE
-    state 'NJ'
-    zip '08534'
-    school_name 'Princeton Day School'
+    school_type {SchoolInfo::SCHOOL_TYPE_PRIVATE}
+    state {'NJ'}
+    zip {'08534'}
+    school_name {'Princeton Day School'}
   end
 
   factory :school_info_us_other, parent: :school_info_us do
-    school_type SchoolInfo::SCHOOL_TYPE_OTHER
-    state 'NJ'
-    zip '08534'
-    school_name 'Princeton Day School'
+    school_type {SchoolInfo::SCHOOL_TYPE_OTHER}
+    state {'NJ'}
+    zip {'08534'}
+    school_name {'Princeton Day School'}
   end
 
   factory :school_info_with_public_school_only, class: SchoolInfo do
@@ -1316,35 +1316,35 @@ FactoryBot.define do
   end
 
   factory :school_info_us_public, parent: :school_info_us do
-    school_type SchoolInfo::SCHOOL_TYPE_PUBLIC
-    state 'WA'
+    school_type {SchoolInfo::SCHOOL_TYPE_PUBLIC}
+    state {'WA'}
   end
 
   factory :school_info_us_charter, parent: :school_info_us do
-    school_type SchoolInfo::SCHOOL_TYPE_CHARTER
-    state 'WA'
+    school_type {SchoolInfo::SCHOOL_TYPE_CHARTER}
+    state {'WA'}
   end
 
   factory :school_info_us_homeschool, parent: :school_info_us do
-    school_type SchoolInfo::SCHOOL_TYPE_HOMESCHOOL
-    state 'NJ'
-    zip '08534'
+    school_type {SchoolInfo::SCHOOL_TYPE_HOMESCHOOL}
+    state {'NJ'}
+    zip {'08534'}
   end
 
   factory :school_info_us_after_school, parent: :school_info_us do
-    school_type SchoolInfo::SCHOOL_TYPE_AFTER_SCHOOL
-    state 'NJ'
-    zip '08534'
-    school_name 'Princeton Day School'
+    school_type {SchoolInfo::SCHOOL_TYPE_AFTER_SCHOOL}
+    state {'NJ'}
+    zip {'08534'}
+    school_name {'Princeton Day School'}
   end
 
   factory :school_info_non_us_homeschool, parent: :school_info_non_us do
-    school_type SchoolInfo::SCHOOL_TYPE_HOMESCHOOL
-    school_name nil
+    school_type {SchoolInfo::SCHOOL_TYPE_HOMESCHOOL}
+    school_name {nil}
   end
 
   factory :school_info_non_us_after_school, parent: :school_info_non_us do
-    school_type SchoolInfo::SCHOOL_TYPE_AFTER_SCHOOL
+    school_type {SchoolInfo::SCHOOL_TYPE_AFTER_SCHOOL}
   end
 
   # end school info
@@ -1353,49 +1353,49 @@ FactoryBot.define do
     # School district ids are provided
     id {(SchoolDistrict.maximum(:id) || 0) + 1}
 
-    name "A school district"
-    city "Seattle"
-    state "WA"
-    zip "98101"
+    name {"A school district"}
+    city {"Seattle"}
+    state {"WA"}
+    zip {"98101"}
   end
 
   factory :school_stats_by_year do
-    grade_10_offered true
-    school_year "2016-2017"
+    grade_10_offered {true}
+    school_year {"2016-2017"}
     school {build :school}
 
     trait :is_high_school do
-      grade_09_offered true
-      grade_10_offered true
-      grade_11_offered true
-      grade_12_offered true
-      grade_13_offered true
+      grade_09_offered {true}
+      grade_10_offered {true}
+      grade_11_offered {true}
+      grade_12_offered {true}
+      grade_13_offered {true}
     end
 
     trait :is_k8_school do
-      grade_09_offered false
-      grade_10_offered false
-      grade_11_offered false
-      grade_12_offered false
-      grade_13_offered false
+      grade_09_offered {false}
+      grade_10_offered {false}
+      grade_11_offered {false}
+      grade_12_offered {false}
+      grade_13_offered {false}
 
-      grade_kg_offered true
-      grade_01_offered true
-      grade_02_offered true
-      grade_03_offered true
-      grade_04_offered true
-      grade_05_offered true
-      grade_06_offered true
-      grade_07_offered true
-      grade_08_offered true
+      grade_kg_offered {true}
+      grade_01_offered {true}
+      grade_02_offered {true}
+      grade_03_offered {true}
+      grade_04_offered {true}
+      grade_05_offered {true}
+      grade_06_offered {true}
+      grade_07_offered {true}
+      grade_08_offered {true}
     end
 
     # Schools eligible for circuit playground discount codes
     # are schools where over 50% of students are eligible
     # for free and reduced meals.
     trait :is_maker_high_needs_school do
-      frl_eligible_total 51
-      students_total 100
+      frl_eligible_total {51}
+      students_total {100}
     end
   end
 
@@ -1405,11 +1405,11 @@ FactoryBot.define do
   factory :school_common, class: School do
     # school ids are not auto-assigned, so we have to assign one here
     id {((School.maximum(:id) || 0).next).to_s}
-    address_line1 "123 Sample St"
-    address_line2 "attn: Main Office"
-    city "Seattle"
-    state "WA"
-    zip "98122"
+    address_line1 {"123 Sample St"}
+    address_line2 {"attn: Main Office"}
+    city {"Seattle"}
+    state {"WA"}
+    zip {"98122"}
 
     trait :with_district do
       association :school_district, strategy: :build
@@ -1435,43 +1435,43 @@ FactoryBot.define do
   end
 
   factory :public_school, parent: :school_common do
-    school_type SchoolInfo::SCHOOL_TYPE_PUBLIC
-    name "A seattle public school"
+    school_type {SchoolInfo::SCHOOL_TYPE_PUBLIC}
+    name {"A seattle public school"}
     with_district
 
     state_school_id {School.construct_state_school_id(state, school_district.try(:id), id)}
 
     trait :without_state_school_id do
-      state_school_id nil
+      state_school_id {nil}
     end
 
     trait :with_invalid_state_school_id do
-      state_school_id "123456789"
+      state_school_id {"123456789"}
     end
   end
 
   factory :private_school, parent: :school_common do
-    school_type SchoolInfo::SCHOOL_TYPE_PRIVATE
-    name "A seattle private school"
+    school_type {SchoolInfo::SCHOOL_TYPE_PRIVATE}
+    name {"A seattle private school"}
   end
 
   factory :charter_school, parent: :school_common do
-    school_type SchoolInfo::SCHOOL_TYPE_CHARTER
-    name "A seattle charter school"
+    school_type {SchoolInfo::SCHOOL_TYPE_CHARTER}
+    name {"A seattle charter school"}
     with_district
   end
 
   factory :regional_partner do
     sequence(:name) {|n| "Partner#{n}"}
-    group 1
-    pl_programs_offered ['CSD', 'CSP']
-    applications_principal_approval RegionalPartner::ALL_REQUIRE_APPROVAL
-    is_active true
+    group {1}
+    pl_programs_offered {['CSD', 'CSP']}
+    applications_principal_approval {RegionalPartner::ALL_REQUIRE_APPROVAL}
+    is_active {true}
   end
 
   factory :regional_partner_with_mappings, parent: :regional_partner do
     sequence(:name) {|n| "Partner#{n}"}
-    group 1
+    group {1}
     mappings do
       [
         create(
@@ -1485,15 +1485,15 @@ FactoryBot.define do
 
   factory :regional_partner_with_summer_workshops, parent: :regional_partner do
     sequence(:name) {|n| "Partner#{n}"}
-    contact_name "Contact Name"
-    contact_email "contact@code.org"
-    group 1
+    contact_name {"Contact Name"}
+    contact_email {"contact@code.org"}
+    group {1}
     apps_open_date_teacher {(Date.current - 2.days).strftime("%Y-%m-%d")}
     apps_close_date_teacher {(Date.current + 3.days).strftime("%Y-%m-%d")}
-    csd_cost 10
-    csp_cost 12
-    cost_scholarship_information "Additional scholarship information will be here."
-    additional_program_information "Additional program information will be here."
+    csd_cost {10}
+    csp_cost {12}
+    cost_scholarship_information {"Additional scholarship information will be here."}
+    additional_program_information {"Additional program information will be here."}
     pd_workshops do
       [
         create(
@@ -1521,10 +1521,10 @@ FactoryBot.define do
   end
 
   factory :channel_token do
-    transient {storage_user nil}
+    transient {storage_user {nil}}
     # Note: This creates channel_tokens where the channel is NOT an accurately
     # encrypted version of storage_app_id/app_id
-    storage_app_id 1
+    storage_app_id {1}
     association :level
     storage_id {storage_user.try(:id) || 2}
   end
@@ -1535,44 +1535,44 @@ FactoryBot.define do
 
   factory :circuit_playground_discount_code do
     sequence(:code) {|n| "FAKE#{n}_asdf123"}
-    full_discount true
+    full_discount {true}
     expiration {Time.now + 30.days}
   end
 
   factory :seeded_s3_object do
-    bucket "Bucket containing object"
-    key "Object Key"
-    etag "Object etag"
+    bucket {"Bucket containing object"}
+    key {"Object Key"}
+    etag {"Object etag"}
   end
 
   factory :email_preference do
-    email 'test@example.net'
-    opt_in false
-    ip_address '10.0.0.1'
-    source :ACCOUNT_SIGN_UP
+    email {'test@example.net'}
+    opt_in {false}
+    ip_address {'10.0.0.1'}
+    source {:ACCOUNT_SIGN_UP}
   end
 
   factory :user_geo do
-    ip_address '10.0.0.1'
+    ip_address {'10.0.0.1'}
 
     # Space Needle
     trait :seattle do
-      city 'Seattle'
-      state 'Washington'
-      country 'United States'
-      postal_code '98109'
-      latitude 47.620470
-      longitude(-122.349181)
+      city {'Seattle'}
+      state {'Washington'}
+      country {'United States'}
+      postal_code {'98109'}
+      latitude {47.620470}
+      longitude {-122.349181}
     end
 
     # Sydney Opera House
     trait :sydney do
-      city 'Sydney'
-      state 'New South Wales'
-      country 'Australia'
-      postal_code '2000'
-      latitude(-33.859100)
-      longitude 151.200200
+      city {'Sydney'}
+      state {'New South Wales'}
+      country {'Australia'}
+      postal_code {'2000'}
+      latitude {-33.859100}
+      longitude {151.200200}
     end
   end
 
@@ -1590,21 +1590,21 @@ FactoryBot.define do
   end
 
   factory :code_review do
-    user_id 1
-    project_id 1
-    script_id 1
-    level_id 1
-    project_level_id 1
-    project_version "1"
-    storage_id 1
+    user_id {1}
+    project_id {1}
+    script_id {1}
+    level_id {1}
+    project_level_id {1}
+    project_version {"1"}
+    storage_id {1}
   end
 
   factory :code_review_comment do
     association :commenter, factory: :student
     association :code_review
 
-    is_resolved false
-    comment 'a note about the project'
+    is_resolved {false}
+    comment {'a note about the project'}
   end
 
   factory :code_review_group do
@@ -1620,7 +1620,7 @@ FactoryBot.define do
   factory :project_commit do
     sequence(:project_id)
     sequence(:object_version_id)
-    comment 'a commit comment'
+    comment {'a commit comment'}
   end
 
   factory :teacher_score do

--- a/dashboard/test/factories/foorm_factories.rb
+++ b/dashboard/test/factories/foorm_factories.rb
@@ -3,9 +3,10 @@ FactoryBot.allow_class_lookup = false
 FactoryBot.define do
   factory :foorm_form, class: 'Foorm::Form' do
     sequence(:name) {|n| "FormName#{n}"}
-    version 0
-    questions '{
-       "pages":[
+    version {0}
+    questions do
+      '{
+        "pages":[
           {
             "name":"page_1",
             "elements":[
@@ -17,83 +18,88 @@ FactoryBot.define do
             ]
           }
         ]
-    }'
-
-    trait :with_rating_question do
-      questions '{
-        "pages":[
-          {
-            "name":"page_1",
-            "elements":[
-              {
-                "type": "rating",
-                "name": "teacher_comfort",
-                "title": "I feel comfortable collaborating with teachers in my cohort and asking for support.",
-                "rateMax": 7,
-                "minRateDescription": "Strongly Disagree",
-                "maxRateDescription": "Strongly Agree"
-              }
-            ]
-          }
-        ]
       }'
     end
 
+    trait :with_rating_question do
+      questions do
+        '{
+          "pages":[
+            {
+              "name":"page_1",
+              "elements":[
+                {
+                  "type": "rating",
+                  "name": "teacher_comfort",
+                  "title": "I feel comfortable collaborating with teachers in my cohort and asking for support.",
+                  "rateMax": 7,
+                  "minRateDescription": "Strongly Disagree",
+                  "maxRateDescription": "Strongly Agree"
+                }
+              ]
+            }
+          ]
+        }'
+      end
+    end
+
     trait :with_multi_select_question do
-      questions '{
-        "pages":[
-          {
-            "name":"page_1",
-            "elements":[
-              {
-                "type":"checkbox",
-                "name":"not_members_spice_girls",
-                "title":"Which of the following are NOT names of members of the Spice Girls?",
-                "choices":[
-                  {
-                    "value":"sporty",
-                    "text":"Sporty"
-                  },
-                  {
-                    "value":"radical",
-                    "text":"Radical"
-                  },
-                  {
-                    "value":"spicy",
-                    "text":"Spicy"
-                  },
-                  {
-                    "value":"posh",
-                    "text":"Posh"
-                  },
-                  {
-                    "value":"ginger",
-                    "text":"Ginger"
-                  }
-                ]
-              }
-            ]
-          }
-        ]
-      }'
+      questions do
+        '{
+          "pages":[
+            {
+              "name":"page_1",
+              "elements":[
+                {
+                  "type":"checkbox",
+                  "name":"not_members_spice_girls",
+                  "title":"Which of the following are NOT names of members of the Spice Girls?",
+                  "choices":[
+                    {
+                      "value":"sporty",
+                      "text":"Sporty"
+                    },
+                    {
+                      "value":"radical",
+                      "text":"Radical"
+                    },
+                    {
+                      "value":"spicy",
+                      "text":"Spicy"
+                    },
+                    {
+                      "value":"posh",
+                      "text":"Posh"
+                    },
+                    {
+                      "value":"ginger",
+                      "text":"Ginger"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }'
+      end
     end
   end
 
   factory :basic_foorm_submission, class: 'Foorm::Submission' do
-    form_name "surveys/pd/sample"
+    form_name {"surveys/pd/sample"}
     foorm_submission_metadata
-    answers '{}'
+    answers {'{}'}
 
     trait :with_multi_select_answer do
-      answers '{
-        "not_members_spice_girls": ["radical", "spicy"]
-      }'
+      answers do
+        '{not_members_spice_girls": ["radical", "spicy"]}'
+      end
     end
 
     trait :with_rating_answer do
-      answers '{
-        "teacher_comfort": 1
-      }'
+      answers do
+        '{"teacher_comfort": 1}'
+      end
     end
   end
 
@@ -106,7 +112,7 @@ FactoryBot.define do
   factory :day_5_workshop_foorm_submission, class: 'Pd::WorkshopSurveyFoormSubmission' do
     association :pd_workshop, factory: :csd_summer_workshop
     association :user, factory: :teacher
-    day 5
+    day {5}
 
     trait :answers_low do
       association :foorm_submission, factory: [:daily_workshop_day_5_foorm_submission, :answers_low]
@@ -118,62 +124,66 @@ FactoryBot.define do
   end
 
   factory :daily_workshop_day_5_foorm_submission, class: 'Foorm::Submission' do
-    form_name "surveys/pd/summer_workshop_post_survey_test"
+    form_name {"surveys/pd/summer_workshop_post_survey_test"}
     foorm_submission_metadata
-    answers '{}'
+    answers {'{}'}
 
     trait :answers_low do
-      answers '{
-        "overall_success": {
-          "more_prepared": "1",
-          "know_help":"1",
-          "pd_suitable_experience":"1",
-          "connected_community": "1",
-          "would_recommend":"1",
-          "absolute_best_pd":"1"
-        },
-        "teacher_engagement": {
-          "activities_engaging": "1",
-          "participated":"1",
-          "frequently_talk_about":"1",
-          "planning_to_use": "1"
-        },
-        "teaching_in_general_matrix": {
-          "formally_assess_learning": "1",
-          "recruit_strategies":"1",
-          "retain_strategies":"1"
-        },
-       "expertise_rating": 1,
-       "two_things_liked": "things",
-       "permission_promotional": "yes_with_name"
-      }'
+      answers do
+        '{
+          "overall_success": {
+            "more_prepared": "1",
+            "know_help":"1",
+            "pd_suitable_experience":"1",
+            "connected_community": "1",
+            "would_recommend":"1",
+            "absolute_best_pd":"1"
+          },
+          "teacher_engagement": {
+            "activities_engaging": "1",
+            "participated":"1",
+            "frequently_talk_about":"1",
+            "planning_to_use": "1"
+          },
+          "teaching_in_general_matrix": {
+            "formally_assess_learning": "1",
+            "recruit_strategies":"1",
+            "retain_strategies":"1"
+          },
+         "expertise_rating": 1,
+         "two_things_liked": "things",
+         "permission_promotional": "yes_with_name"
+        }'
+      end
     end
 
     trait :answers_high do
-      answers '{
-        "overall_success": {
-          "more_prepared": "7",
-          "know_help":"7",
-          "pd_suitable_experience":"7",
-          "connected_community": "7",
-          "would_recommend":"7",
-          "absolute_best_pd":"7"
-        },
-        "teacher_engagement": {
-          "activities_engaging": "7",
-          "participated":"7",
-          "frequently_talk_about":"7",
-          "planning_to_use": "7"
-        },
-        "teaching_in_general_matrix": {
-          "formally_assess_learning": "7",
-          "recruit_strategies":"7",
-          "retain_strategies":"7"
-        },
-       "expertise_rating": 5,
-       "two_things_liked": "things",
-       "permission_promotional": "yes_with_name"
-      }'
+      answers do
+        '{
+          "overall_success": {
+            "more_prepared": "7",
+            "know_help":"7",
+            "pd_suitable_experience":"7",
+            "connected_community": "7",
+            "would_recommend":"7",
+            "absolute_best_pd":"7"
+          },
+          "teacher_engagement": {
+            "activities_engaging": "7",
+            "participated":"7",
+            "frequently_talk_about":"7",
+            "planning_to_use": "7"
+          },
+          "teaching_in_general_matrix": {
+            "formally_assess_learning": "7",
+            "recruit_strategies":"7",
+            "retain_strategies":"7"
+          },
+         "expertise_rating": 5,
+         "two_things_liked": "things",
+         "permission_promotional": "yes_with_name"
+        }'
+      end
     end
 
     trait :answers_high_with_survey_config_variables do
@@ -200,29 +210,31 @@ FactoryBot.define do
   factory :pd_pre_workshop_foorm_submission, class: 'Pd::WorkshopSurveyFoormSubmission' do
     association :pd_workshop, factory: :csd_summer_workshop
     association :user, factory: :teacher
-    day 0
+    day {0}
 
     association :foorm_submission, factory: :pre_workshop_foorm_submission
   end
 
   # this factory uses the real summer workshop pre survey.
   factory :pre_workshop_foorm_submission, class: 'Foorm::Submission' do
-    form_name "surveys/pd/summer_workshop_pre_survey"
+    form_name {"surveys/pd/summer_workshop_pre_survey"}
     foorm_submission_metadata
 
-    answers '{"workshop_course":"CS Discoveries","workshop_subject":"5-day Summer","regional_partner_name":"Partner1",
-              "is_virtual":"true","num_facilitators":"1","day":"0","is_friday_institute":"false","workshop_agenda":"",
-              "required_course_status":"required","course_length_weeks":"11_15","section_time_minutes":"50_less",
-              "grade_levels_csd":["11","9"],"total_pd_time":"16_35","cs_community":{"someone_to_turn_to":"6",
-              "know_teacher_leaders":"6"},"lead_learner":"4","recruit_responsibility":"2",
-              "highest_level_cs_education":"college_courses","assigned_or_chose_to_teach":"assigned",
-              "gender_identity":"female","racial_ethnic_identity":["white"]}'
+    answers do
+      '{"workshop_course":"CS Discoveries","workshop_subject":"5-day Summer","regional_partner_name":"Partner1",
+      "is_virtual":"true","num_facilitators":"1","day":"0","is_friday_institute":"false","workshop_agenda":"",
+      "required_course_status":"required","course_length_weeks":"11_15","section_time_minutes":"50_less",
+      "grade_levels_csd":["11","9"],"total_pd_time":"16_35","cs_community":{"someone_to_turn_to":"6",
+      "know_teacher_leaders":"6"},"lead_learner":"4","recruit_responsibility":"2",
+      "highest_level_cs_education":"college_courses","assigned_or_chose_to_teach":"assigned",
+      "gender_identity":"female","racial_ethnic_identity":["white"]}'
+    end
   end
 
   factory :day_0_workshop_foorm_submission, class: 'Pd::WorkshopSurveyFoormSubmission' do
     association :pd_workshop, factory: :csd_summer_workshop
     association :user, factory: :teacher
-    day 0
+    day {0}
 
     trait :answers_low do
       association :foorm_submission, factory: [:daily_workshop_day_0_foorm_submission, :answers_low]
@@ -234,53 +246,59 @@ FactoryBot.define do
   end
 
   factory :daily_workshop_day_0_foorm_submission, class: 'Foorm::Submission' do
-    form_name "surveys/pd/summer_workshop_pre_survey_test"
+    form_name {"surveys/pd/summer_workshop_pre_survey_test"}
     foorm_submission_metadata
 
     trait :answers_low do
-      answers '{
-        "course_length_weeks":"5_fewer",
-        "teaching_cs_matrix":{"committed_to_teaching_cs": "1", "like_teaching_cs": "1", "understand_cs": "1", "skills_cs": "1"},
-        "expertise_rating":1,
-        "birth_year": "1990",
-        "racial_ethnic_identity": ["black_aa","white"]
-      }'
+      answers do
+        '{
+          "course_length_weeks":"5_fewer",
+          "teaching_cs_matrix":{"committed_to_teaching_cs": "1", "like_teaching_cs": "1", "understand_cs": "1", "skills_cs": "1"},
+          "expertise_rating":1,
+          "birth_year": "1990",
+          "racial_ethnic_identity": ["black_aa","white"]
+        }'
+      end
     end
 
     trait :answers_high do
-      answers '{
-        "course_length_weeks":"30_more",
-        "teaching_cs_matrix":{"committed_to_teaching_cs": "7", "like_teaching_cs": "7", "understand_cs": "7", "skills_cs": "7"},
-        "expertise_rating":5,
-        "birth_year": "1983",
-        "racial_ethnic_identity": ["black_aa","hispanic_latino"]
-      }'
+      answers do
+        '{
+          "course_length_weeks":"30_more",
+          "teaching_cs_matrix":{"committed_to_teaching_cs": "7", "like_teaching_cs": "7", "understand_cs": "7", "skills_cs": "7"},
+          "expertise_rating":5,
+          "birth_year": "1983",
+          "racial_ethnic_identity": ["black_aa","hispanic_latino"]
+        }'
+      end
     end
   end
 
   factory :foorm_form_with_inconsistent_questions, class: 'Foorm::Form' do
-    name "surveys/pd/sample_survey"
-    version 0
-    created_at "2020-03-26 21:58:28"
-    updated_at "2020-03-26 21:58:28"
-    questions '{
-      "pages": [
-          {
-            "name": "teaching_context",
-            "elements": [
+    name {"surveys/pd/sample_survey"}
+    version {0}
+    created_at {"2020-03-26 21:58:28"}
+    updated_at {"2020-03-26 21:58:28"}
+    questions do
+      '{
+        "pages": [
             {
-              "type": "rating",
-              "title": "Lead Learner. 1. model expertise in how to learn  --- 5. need deep content expertise",
-              "name": "expertise_rating",
-              "indent": 12,
-              "titleLocation": "hidden",
-              "minRate": 2,
-              "minRateDescription": "Strongly aligned with A",
-              "maxRateDescription": "Strongly aligned with B!"
-            }]
-          }
-        ]
-      }'
+              "name": "teaching_context",
+              "elements": [
+              {
+                "type": "rating",
+                "title": "Lead Learner. 1. model expertise in how to learn  --- 5. need deep content expertise",
+                "name": "expertise_rating",
+                "indent": 12,
+                "titleLocation": "hidden",
+                "minRate": 2,
+                "minRateDescription": "Strongly aligned with A",
+                "maxRateDescription": "Strongly aligned with B!"
+              }]
+            }
+          ]
+        }'
+    end
   end
 
   factory :csf_intro_post_workshop_submission, class: 'Pd::WorkshopSurveyFoormSubmission' do
@@ -301,58 +319,62 @@ FactoryBot.define do
   end
 
   factory :facilitator_post_survey_foorm_submission, class: 'Foorm::Submission' do
-    form_name 'surveys/pd/csd_csp_facilitator_post_survey'
+    form_name {'surveys/pd/csd_csp_facilitator_post_survey'}
     foorm_submission_metadata
-    answers '{}'
+    answers {'{}'}
   end
 
   factory :csf_intro_post_foorm_submission, class: 'Foorm::Submission' do
-    form_name "surveys/pd/workshop_csf_intro_post_test"
+    form_name {"surveys/pd/workshop_csf_intro_post_test"}
     foorm_submission_metadata
 
     trait :answers_low do
-      answers '{
-      "overall_success": {
-        "more_prepared": "1",
-        "where_to_go":"1",
-        "suitable_my_level":"1",
-        "feel_community": "1",
-        "would_recommend":"1",
-        "best_pd":"1"
-      },
-      "teacher_engagement": {
-        "engaging": "1",
-        "active":"1",
-        "ideas":"1"
-      },
-      "supported": "lots",
-      "permission": "no"
-    }'
+      answers do
+        '{
+          "overall_success": {
+            "more_prepared": "1",
+            "where_to_go":"1",
+            "suitable_my_level":"1",
+            "feel_community": "1",
+            "would_recommend":"1",
+            "best_pd":"1"
+          },
+          "teacher_engagement": {
+            "engaging": "1",
+            "active":"1",
+            "ideas":"1"
+          },
+          "supported": "lots",
+          "permission": "no"
+        }'
+      end
     end
 
     trait :answers_high do
-      answers '{
-      "overall_success": {
-        "more_prepared": "7",
-        "where_to_go":"7",
-        "suitable_my_level":"7",
-        "feel_community": "7",
-        "would_recommend":"7",
-        "best_pd":"7"
-      },
-      "teacher_engagement": {
-        "engaging": "7",
-        "active":"7",
-        "ideas":"7"
-      },
-      "supported": "lots",
-      "permission": "yes_name"
-    }'
+      answers do
+        '{
+          "overall_success": {
+            "more_prepared": "7",
+            "where_to_go":"7",
+            "suitable_my_level":"7",
+            "feel_community": "7",
+            "would_recommend":"7",
+            "best_pd":"7"
+          },
+          "teacher_engagement": {
+            "engaging": "7",
+            "active":"7",
+            "ideas":"7"
+          },
+          "supported": "lots",
+          "permission": "yes_name"
+        }'
+      end
     end
   end
 
   factory :csf_intro_post_facilitator_workshop_submission, class: 'Pd::WorkshopSurveyFoormSubmission' do
-    facilitator_id 1
+    facilitator_id {1}
     association :pd_workshop, factory: :csf_101_workshop
     association :user, factory: :teacher
 
@@ -366,815 +388,829 @@ FactoryBot.define do
   end
 
   factory :csf_intro_post_facilitator_foorm_submission, class: 'Foorm::Submission' do
-    form_name "surveys/pd/workshop_csf_intro_post_test"
+    form_name {"surveys/pd/workshop_csf_intro_post_test"}
     foorm_submission_metadata
 
     trait :answers_low do
-      answers '{
-      "facilitatorId": 1,
-      "facilitatorName": "Facilitator1",
-      "facilitator_effectiveness":{
-        "demonstrated_knowledge":"1",
-        "built_equitable":"1",
-        "on_track":"1",
-        "productive_discussions":"1",
-        "ways_equitable":"1",
-        "healthy_relationship":"1"
-      },
-      "k5_facilitator_did_well":"things done well"
-    }'
+      answers do
+        '{
+          "facilitatorId": 1,
+          "facilitatorName": "Facilitator1",
+          "facilitator_effectiveness":{
+            "demonstrated_knowledge":"1",
+            "built_equitable":"1",
+            "on_track":"1",
+            "productive_discussions":"1",
+            "ways_equitable":"1",
+            "healthy_relationship":"1"
+          },
+          "k5_facilitator_did_well":"things done well"
+        }'
+      end
     end
 
     trait :answers_high do
-      answers '{
-      "facilitatorId": 1,
-      "facilitatorName": "Facilitator1",
-      "facilitator_effectiveness":{
-        "demonstrated_knowledge":"7",
-        "built_equitable":"7",
-        "on_track":"7",
-        "productive_discussions":"7",
-        "ways_equitable":"7",
-        "healthy_relationship":"7"
-      },
-      "k5_facilitator_did_well":"things done well"
-    }'
+      answers do
+        '{
+          "facilitatorId": 1,
+          "facilitatorName": "Facilitator1",
+          "facilitator_effectiveness":{
+            "demonstrated_knowledge":"7",
+            "built_equitable":"7",
+            "on_track":"7",
+            "productive_discussions":"7",
+            "ways_equitable":"7",
+            "healthy_relationship":"7"
+          },
+          "k5_facilitator_did_well":"things done well"
+        }'
+      end
     end
   end
 
   trait :foorm_submission_metadata do
-    form_version 0
+    form_version {0}
   end
 
   factory :foorm_form_summer_pre_survey, class: 'Foorm::Form' do
-    name 'surveys/pd/summer_workshop_pre_survey_test'
-    version 0
-    created_at '2020-03-25 21:58:28'
-    updated_at '2020-03-26 21:58:28'
-    questions '{
-    "pages": [
-    {
-      "name": "teaching_context",
-      "elements": [
-      {
-        "type": "radiogroup",
-        "name": "course_length_weeks",
-        "title": "For a typical section of {workshop_course} that you will teach, approximately how many WEEKS will the class run?",
-        "choices": [
-        {
-          "value": "5_fewer",
-          "text": "5 or fewer"
-        },
-        {
-          "value": "6_10",
-          "text": "6 - 10"
-        },
-        {
-          "value": "11_15",
-          "text": "11 - 15"
-        },
-        {
-          "value": "16_20",
-          "text": "16 - 20"
-        },
-        {
-          "value": "21_30",
-          "text": "21 - 30"
-        },
-        {
-          "value": "30_more",
-          "text": "30 or more (full year)"
-        }
+    name {'surveys/pd/summer_workshop_pre_survey_test'}
+    version {0}
+    created_at {'2020-03-25 21:58:28'}
+    updated_at {'2020-03-26 21:58:28'}
+    questions do
+      '{
+        "pages": [
+          {
+            "name": "teaching_context",
+            "elements": [
+            {
+              "type": "radiogroup",
+              "name": "course_length_weeks",
+              "title": "For a typical section of {workshop_course} that you will teach, approximately how many WEEKS will the class run?",
+              "choices": [
+              {
+                "value": "5_fewer",
+                "text": "5 or fewer"
+              },
+              {
+                "value": "6_10",
+                "text": "6 - 10"
+              },
+              {
+                "value": "11_15",
+                "text": "11 - 15"
+              },
+              {
+                "value": "16_20",
+                "text": "16 - 20"
+              },
+              {
+                "value": "21_30",
+                "text": "21 - 30"
+              },
+              {
+                "value": "30_more",
+                "text": "30 or more (full year)"
+              }
+              ]
+            }
+            ],
+            "title": "Teaching Context",
+            "description": "First, we have some questions about the context in which you are teaching {workshop_course}."
+          },
+          {
+            "name": "teaching_computer_science",
+            "elements": [
+            {
+              "type": "matrix",
+              "name": "teaching_cs_matrix",
+              "title": "How much do you agree or disagree with the following statements about teaching computer science? ",
+              "columns": [
+              {
+                "value": "1",
+                "text": "Strongly Disagree"
+              },
+              {
+                "value": "2",
+                "text": "Disagree "
+              },
+              {
+                "value": "3",
+                "text": "Slightly Disagree "
+              },
+              {
+                "value": "4",
+                "text": "Neutral "
+              },
+              {
+                "value": "5",
+                "text": "Slightly Agree "
+              },
+              {
+                "value": "6",
+                "text": "Agree "
+              },
+              {
+                "value": "7",
+                "text": "Strongly Agree "
+              }
+              ],
+              "rows": [
+              {
+                "value": "committed_to_teaching_cs",
+                "text": "I am committed to teaching computer science."
+              },
+              {
+                "value": "like_teaching_cs",
+                "text": "I like, or think I will like, teaching computer science."
+              },
+              {
+                "value": "understand_cs",
+                "text": "I understand computer science concepts well enough to be an effective teacher of computer science."
+              },
+              {
+                "value": "skills_cs",
+                "text": "I have the skills necessary to be an effective teacher of computer science. "
+              }
+              ]
+            }
+            ],
+            "title": "Teaching Computer Science"
+          },
+          {
+            "name": "teaching_philosophy",
+            "elements": [
+            {
+              "type": "html",
+              "name": "statement_AB_expertise",
+              "html": "<table style=\"width: 600px; margin-left: auto; margin-right: auto;\" cellpadding=\"5\">\n<tbody>\n                <tr>\n                  <td style=\"padding-top: 10px; text-align: center;\">\n                    <span style=\"font-family: arial, helvetica, sans-serif; font-size: 12pt;\">\n                      <strong>Statement A</strong>\n                    </span>\n                  </td>\n                  <td style=\"padding-top: 10px; text-align: center;\">\n                    <span style=\"font-family: arial, helvetica, sans-serif; font-size: 12pt;\">\n                      <strong>      </strong>\n                    </span>\n                  </td>\n                  <td style=\"padding-top: 10px; text-align: center;\">\n                    <span style=\"font-family: arial, helvetica, sans-serif; font-size: 12pt;\">\n                      <strong>Statement B</strong>\n                    </span>\n                  </td>\n                </tr>\n                <tr>\n                  <td style=\"border: 1px solid black; width: 250px; vertical-align: top; text-align: left;\">\n                    <span style=\"color: black;\">\"I do not need to have deep expertise in computer science in order to successfully teach it. I have expertise in how to learn, and I can model that for my students as we learn the content together.\" </span>\n                  </td>\n                  <td style=\"text-align: center;\">\n                    <em><span style=\"color: #999999;\"> </span></em>\n                  </td>\n                  <td style=\"border: 1px solid black; width: 250px; vertical-align: top; text-align: left;\"> \t\n<span style=\"color: black;\">\"As the teacher, I need to have deep content expertise so that I can properly answer students’ questions and guide instruction appropriately.\"</span>\n                    \n                  </td>\n                </tr>\n              </tbody>\n</table>"
+            },
+            {
+              "type": "rating",
+              "title": "Lead Learner. 1. model expertise in how to learn  --- 5. need deep content expertise",
+              "name": "expertise_rating",
+              "indent": 12,
+              "titleLocation": "hidden",
+              "minRateDescription": "Strongly aligned with A",
+              "maxRateDescription": "Strongly aligned with B"
+            }
+            ],
+            "title": "Teaching Philosophy"
+          },
+          {
+            "name": "wrap_up_submit",
+            "elements": [
+            {
+              "type": "text",
+              "name": "birth_year",
+              "title": "What is your year of birth? ",
+              "description": "Please enter a whole number e.g. 1975. ",
+              "inputType": "number",
+              "placeHolder": "enter a number"
+            },
+            {
+              "type": "checkbox",
+              "name": "racial_ethnic_identity",
+              "title": "What is your racial or ethnic identity? [check all that apply] ",
+              "choices": [
+              {
+                "value": "am_indian_alaska",
+                "text": "American Indian/Alaska Native"
+              },
+              {
+                "value": "asian",
+                "text": "Asian"
+              },
+              {
+                "value": "black_aa",
+                "text": "Black or African American"
+              },
+              {
+                "value": "hispanic_latino",
+                "text": "Hispanic or Latino"
+              },
+              {
+                "value": "native_hawaiin_pi",
+                "text": "Native Hawaiian or other Pacific Islander"
+              },
+              {
+                "value": "white",
+                "text": "White"
+              },
+              {
+                "value": "other",
+                "text": "Other"
+              },
+              {
+                "value": "no_answer",
+                "text": "Prefer not to answer"
+              }
+              ]
+            },
+            {
+              "type": "html",
+              "name": "thank_you",
+              "html": "<h2>Thank you!</h2>\n<p>Thank you so much for taking the time to complete this survey. Your input and feedback is vital for our programs.</p>\n"
+            }
+            ],
+            "title": "Wrap Up and Submit"
+          }
         ]
-      }
-      ],
-      "title": "Teaching Context",
-      "description": "First, we have some questions about the context in which you are teaching {workshop_course}."
-    },
-    {
-      "name": "teaching_computer_science",
-      "elements": [
-      {
-        "type": "matrix",
-        "name": "teaching_cs_matrix",
-        "title": "How much do you agree or disagree with the following statements about teaching computer science? ",
-        "columns": [
-        {
-          "value": "1",
-          "text": "Strongly Disagree"
-        },
-        {
-          "value": "2",
-          "text": "Disagree "
-        },
-        {
-          "value": "3",
-          "text": "Slightly Disagree "
-        },
-        {
-          "value": "4",
-          "text": "Neutral "
-        },
-        {
-          "value": "5",
-          "text": "Slightly Agree "
-        },
-        {
-          "value": "6",
-          "text": "Agree "
-        },
-        {
-          "value": "7",
-          "text": "Strongly Agree "
-        }
-        ],
-        "rows": [
-        {
-          "value": "committed_to_teaching_cs",
-          "text": "I am committed to teaching computer science."
-        },
-        {
-          "value": "like_teaching_cs",
-          "text": "I like, or think I will like, teaching computer science."
-        },
-        {
-          "value": "understand_cs",
-          "text": "I understand computer science concepts well enough to be an effective teacher of computer science."
-        },
-        {
-          "value": "skills_cs",
-          "text": "I have the skills necessary to be an effective teacher of computer science. "
-        }
-        ]
-      }
-      ],
-      "title": "Teaching Computer Science"
-    },
-    {
-      "name": "teaching_philosophy",
-      "elements": [
-      {
-        "type": "html",
-        "name": "statement_AB_expertise",
-        "html": "<table style=\"width: 600px; margin-left: auto; margin-right: auto;\" cellpadding=\"5\">\n<tbody>\n                <tr>\n                  <td style=\"padding-top: 10px; text-align: center;\">\n                    <span style=\"font-family: arial, helvetica, sans-serif; font-size: 12pt;\">\n                      <strong>Statement A</strong>\n                    </span>\n                  </td>\n                  <td style=\"padding-top: 10px; text-align: center;\">\n                    <span style=\"font-family: arial, helvetica, sans-serif; font-size: 12pt;\">\n                      <strong>      </strong>\n                    </span>\n                  </td>\n                  <td style=\"padding-top: 10px; text-align: center;\">\n                    <span style=\"font-family: arial, helvetica, sans-serif; font-size: 12pt;\">\n                      <strong>Statement B</strong>\n                    </span>\n                  </td>\n                </tr>\n                <tr>\n                  <td style=\"border: 1px solid black; width: 250px; vertical-align: top; text-align: left;\">\n                    <span style=\"color: black;\">\"I do not need to have deep expertise in computer science in order to successfully teach it. I have expertise in how to learn, and I can model that for my students as we learn the content together.\" </span>\n                  </td>\n                  <td style=\"text-align: center;\">\n                    <em><span style=\"color: #999999;\"> </span></em>\n                  </td>\n                  <td style=\"border: 1px solid black; width: 250px; vertical-align: top; text-align: left;\"> \t\n<span style=\"color: black;\">\"As the teacher, I need to have deep content expertise so that I can properly answer students’ questions and guide instruction appropriately.\"</span>\n                    \n                  </td>\n                </tr>\n              </tbody>\n</table>"
-      },
-      {
-        "type": "rating",
-        "title": "Lead Learner. 1. model expertise in how to learn  --- 5. need deep content expertise",
-        "name": "expertise_rating",
-        "indent": 12,
-        "titleLocation": "hidden",
-        "minRateDescription": "Strongly aligned with A",
-        "maxRateDescription": "Strongly aligned with B"
-      }
-      ],
-      "title": "Teaching Philosophy"
-    },
-    {
-      "name": "wrap_up_submit",
-      "elements": [
-      {
-        "type": "text",
-        "name": "birth_year",
-        "title": "What is your year of birth? ",
-        "description": "Please enter a whole number e.g. 1975. ",
-        "inputType": "number",
-        "placeHolder": "enter a number"
-      },
-      {
-        "type": "checkbox",
-        "name": "racial_ethnic_identity",
-        "title": "What is your racial or ethnic identity? [check all that apply] ",
-        "choices": [
-        {
-          "value": "am_indian_alaska",
-          "text": "American Indian/Alaska Native"
-        },
-        {
-          "value": "asian",
-          "text": "Asian"
-        },
-        {
-          "value": "black_aa",
-          "text": "Black or African American"
-        },
-        {
-          "value": "hispanic_latino",
-          "text": "Hispanic or Latino"
-        },
-        {
-          "value": "native_hawaiin_pi",
-          "text": "Native Hawaiian or other Pacific Islander"
-        },
-        {
-          "value": "white",
-          "text": "White"
-        },
-        {
-          "value": "other",
-          "text": "Other"
-        },
-        {
-          "value": "no_answer",
-          "text": "Prefer not to answer"
-        }
-        ]
-      },
-      {
-        "type": "html",
-        "name": "thank_you",
-        "html": "<h2>Thank you!</h2>\n<p>Thank you so much for taking the time to complete this survey. Your input and feedback is vital for our programs.</p>\n"
-      }
-      ],
-      "title": "Wrap Up and Submit"
-    }
-    ]
-  }'
+      }'
+    end
   end
 
   factory :foorm_form_summer_post_survey, class: 'Foorm::Form' do
-    name 'surveys/pd/summer_workshop_post_survey_test'
-    version 0
-    created_at '2020-03-25 21:58:28'
-    updated_at '2020-03-26 21:58:28'
-    questions '{
-    "pages": [
-    {
-      "name": "workshop_experience",
-      "title": "Your {workshop_course} Workshop Experience",
-      "elements": [
-      {
-        "type": "matrix",
-        "name": "overall_success",
-        "title": "How much do you agree or disagree with the following statements about the workshop overall?",
-        "columns": [
-        {
-          "value": "1",
-          "text": "Strongly Disagree"
-        },
-        {
-          "value": "2",
-          "text": "Disagree "
-        },
-        {
-          "value": "3",
-          "text": "Slightly Disagree "
-        },
-        {
-          "value": "4",
-          "text": "Neutral "
-        },
-        {
-          "value": "5",
-          "text": "Slightly Agree "
-        },
-        {
-          "value": "6",
-          "text": "Agree "
-        },
-        {
-          "value": "7",
-          "text": "Strongly Agree "
-        }
-        ],
-        "rows": [
-        {
-          "value": "more_prepared",
-          "text": "I am more prepared to teach the material covered in this workshop than before I came."
-        },
-        {
-          "value": "know_help",
-          "text": "I know where to go if I need help preparing to teach this material."
-        },
-        {
-          "value": "pd_suitable_experience",
-          "text": "This professional development was suitable for my level of experience with teaching CS."
-        },
-        {
-          "value": "connected_community",
-          "text": "I feel connected to a community of computer science teachers."
-        },
-        {
-          "value": "would_recommend",
-          "text": "I would recommend this professional development to others."
-        },
-        {
-          "value": "absolute_best_pd",
-          "text": "This was the the absolute best professional development I have ever participated in."
-        }
+    name {'surveys/pd/summer_workshop_post_survey_test'}
+    version {0}
+    created_at {'2020-03-25 21:58:28'}
+    updated_at {'2020-03-26 21:58:28'}
+    questions do
+      '{
+        "pages": [
+          {
+            "name": "workshop_experience",
+            "title": "Your {workshop_course} Workshop Experience",
+            "elements": [
+            {
+              "type": "matrix",
+              "name": "overall_success",
+              "title": "How much do you agree or disagree with the following statements about the workshop overall?",
+              "columns": [
+              {
+                "value": "1",
+                "text": "Strongly Disagree"
+              },
+              {
+                "value": "2",
+                "text": "Disagree "
+              },
+              {
+                "value": "3",
+                "text": "Slightly Disagree "
+              },
+              {
+                "value": "4",
+                "text": "Neutral "
+              },
+              {
+                "value": "5",
+                "text": "Slightly Agree "
+              },
+              {
+                "value": "6",
+                "text": "Agree "
+              },
+              {
+                "value": "7",
+                "text": "Strongly Agree "
+              }
+              ],
+              "rows": [
+              {
+                "value": "more_prepared",
+                "text": "I am more prepared to teach the material covered in this workshop than before I came."
+              },
+              {
+                "value": "know_help",
+                "text": "I know where to go if I need help preparing to teach this material."
+              },
+              {
+                "value": "pd_suitable_experience",
+                "text": "This professional development was suitable for my level of experience with teaching CS."
+              },
+              {
+                "value": "connected_community",
+                "text": "I feel connected to a community of computer science teachers."
+              },
+              {
+                "value": "would_recommend",
+                "text": "I would recommend this professional development to others."
+              },
+              {
+                "value": "absolute_best_pd",
+                "text": "This was the the absolute best professional development I have ever participated in."
+              }
+              ]
+            },
+            {
+              "type": "matrix",
+              "name": "teacher_engagement",
+              "title": "How much do you agree or disagree with the following statements about your level of engagement in the workshop?",
+              "columns": [
+              {
+                "value": "1",
+                "text": "Strongly Disagree"
+              },
+              {
+                "value": "2",
+                "text": "Disagree "
+              },
+              {
+                "value": "3",
+                "text": "Slightly Disagree "
+              },
+              {
+                "value": "4",
+                "text": "Neutral "
+              },
+              {
+                "value": "5",
+                "text": "Slightly Agree "
+              },
+              {
+                "value": "6",
+                "text": "Agree "
+              },
+              {
+                "value": "7",
+                "text": "Strongly Agree "
+              }
+              ],
+              "rows": [
+              {
+                "value": "activities_engaging",
+                "text": "I found the activities we did in this workshop interesting and engaging."
+              },
+              {
+                "value": "participated",
+                "text": "I was highly active and participated a lot in the workshop activities."
+              },
+              {
+                "value": "frequently_talk_about",
+                "text": "When I\'m not in Code.org workshops, I frequently talk about ideas or content from the workshop with others."
+              },
+              {
+                "value": "planning_to_use",
+                "text": "I am definitely planning to make use of ideas and content covered in this workshop in my classroom."
+              }
+              ]
+            },
+            {
+              "type": "comment",
+              "name": "venue_logistics_feedback",
+              "title": "Do you have feedback about the venue and the way logistics were run for the workshop this week? Please be specific and provide suggestions for improvement."
+            }
+            ]
+          },
+          {
+            "name": "teaching_practices",
+            "elements": [
+            {
+              "type": "matrix",
+              "name": "teaching_in_general_matrix",
+              "title": "Teaching computer science in general. Right now... ",
+              "columns": [
+              {
+                "value": "0",
+                "text": "N/A"
+              },
+              {
+                "value": "1",
+                "text": "1"
+              },
+              {
+                "value": "2",
+                "text": "2"
+              },
+              {
+                "value": "3",
+                "text": "3"
+              },
+              {
+                "value": "4",
+                "text": "4"
+              },
+              {
+                "value": "5",
+                "text": "5"
+              },
+              {
+                "value": "6",
+                "text": "6"
+              },
+              {
+                "value": "7",
+                "text": "7"
+              }
+              ],
+              "rows": [
+              {
+                "value": "formally_assess_learning",
+                "text": "I know how to formally assess students’ learning and performance in computer science."
+              },
+              {
+                "value": "recruit_strategies",
+                "text": "I have strategies to recruit students into my computer science class."
+              },
+              {
+                "value": "retain_strategies",
+                "text": "I have strategies to retain students in my computer science class."
+              }
+              ]
+            }
+            ],
+            "title": "Self-assessment of Computer Science Knowledge & Teaching Practices"
+          },
+          {
+            "name": "teaching_philosophy",
+            "elements": [
+            {
+              "type": "html",
+              "name": "statement_AB_expertise",
+              "html": "<table style=\"width: 600px; margin-left: auto; margin-right: auto;\" cellpadding=\"5\">\n<tbody>\n                <tr>\n                  <td style=\"padding-top: 10px; text-align: center;\">\n                    <span style=\"font-family: arial, helvetica, sans-serif; font-size: 12pt;\">\n                      <strong>Statement A</strong>\n                    </span>\n                  </td>\n                  <td style=\"padding-top: 10px; text-align: center;\">\n                    <span style=\"font-family: arial, helvetica, sans-serif; font-size: 12pt;\">\n                      <strong>      </strong>\n                    </span>\n                  </td>\n                  <td style=\"padding-top: 10px; text-align: center;\">\n                    <span style=\"font-family: arial, helvetica, sans-serif; font-size: 12pt;\">\n                      <strong>Statement B</strong>\n                    </span>\n                  </td>\n                </tr>\n                <tr>\n                  <td style=\"border: 1px solid black; width: 250px; vertical-align: top; text-align: left;\">\n                    <span style=\"color: black;\">\"I do not need to have deep expertise in computer science in order to successfully teach it. I have expertise in how to learn, and I can model that for my students as we learn the content together.\" </span>\n                  </td>\n                  <td style=\"text-align: center;\">\n                    <em><span style=\"color: #999999;\"> </span></em>\n                  </td>\n                  <td style=\"border: 1px solid black; width: 250px; vertical-align: top; text-align: left;\"> \t\n<span style=\"color: black;\">\"As the teacher, I need to have deep content expertise so that I can properly answer students’ questions and guide instruction appropriately.\"</span>\n                    \n                  </td>\n                </tr>\n              </tbody>\n</table>"
+            },
+            {
+              "type": "rating",
+              "title": "Lead Learner. 1. model expertise in how to learn  --- 5. need deep content expertise",
+              "name": "expertise_rating",
+              "indent": 12,
+              "titleLocation": "hidden",
+              "minRateDescription": "Strongly aligned with A",
+              "maxRateDescription": "Strongly aligned with B"
+            }
+            ],
+            "title": "Teaching Philosophy"
+          },
+          {
+            "name": "overall_feedback",
+            "elements": [
+            {
+              "type": "comment",
+              "name": "two_things_liked",
+              "title": "What were the one or two things you liked most about the activities you did in this workshop and why?"
+            },
+            {
+              "type": "radiogroup",
+              "name": "permission_promotional",
+              "title": " I give the workshop organizer permission to quote my written feedback from today for use on social media, promotional materials, and other communications. ",
+              "choices": [
+              {
+                "value": "yes_with_name",
+                "text": "Yes, I give the workshop organizer permission to quote me and use my name. "
+              },
+              {
+                "value": "yes_anonymous",
+                "text": "Yes, I give the workshop organizer permission to quote me, but I want to be anonymous."
+              },
+              {
+                "value": "no",
+                "text": "No, I do not give the workshop organizer my permission. "
+              }
+              ]
+            }
+            ],
+            "title": "Overall Workshop Feedback"
+          }
         ]
-      },
-      {
-        "type": "matrix",
-        "name": "teacher_engagement",
-        "title": "How much do you agree or disagree with the following statements about your level of engagement in the workshop?",
-        "columns": [
-        {
-          "value": "1",
-          "text": "Strongly Disagree"
-        },
-        {
-          "value": "2",
-          "text": "Disagree "
-        },
-        {
-          "value": "3",
-          "text": "Slightly Disagree "
-        },
-        {
-          "value": "4",
-          "text": "Neutral "
-        },
-        {
-          "value": "5",
-          "text": "Slightly Agree "
-        },
-        {
-          "value": "6",
-          "text": "Agree "
-        },
-        {
-          "value": "7",
-          "text": "Strongly Agree "
-        }
-        ],
-        "rows": [
-        {
-          "value": "activities_engaging",
-          "text": "I found the activities we did in this workshop interesting and engaging."
-        },
-        {
-          "value": "participated",
-          "text": "I was highly active and participated a lot in the workshop activities."
-        },
-        {
-          "value": "frequently_talk_about",
-          "text": "When I\'m not in Code.org workshops, I frequently talk about ideas or content from the workshop with others."
-        },
-        {
-          "value": "planning_to_use",
-          "text": "I am definitely planning to make use of ideas and content covered in this workshop in my classroom."
-        }
-        ]
-      },
-      {
-        "type": "comment",
-        "name": "venue_logistics_feedback",
-        "title": "Do you have feedback about the venue and the way logistics were run for the workshop this week? Please be specific and provide suggestions for improvement."
-      }
-      ]
-    },
-    {
-      "name": "teaching_practices",
-      "elements": [
-      {
-        "type": "matrix",
-        "name": "teaching_in_general_matrix",
-        "title": "Teaching computer science in general. Right now... ",
-        "columns": [
-        {
-          "value": "0",
-          "text": "N/A"
-        },
-        {
-          "value": "1",
-          "text": "1"
-        },
-        {
-          "value": "2",
-          "text": "2"
-        },
-        {
-          "value": "3",
-          "text": "3"
-        },
-        {
-          "value": "4",
-          "text": "4"
-        },
-        {
-          "value": "5",
-          "text": "5"
-        },
-        {
-          "value": "6",
-          "text": "6"
-        },
-        {
-          "value": "7",
-          "text": "7"
-        }
-        ],
-        "rows": [
-        {
-          "value": "formally_assess_learning",
-          "text": "I know how to formally assess students’ learning and performance in computer science."
-        },
-        {
-          "value": "recruit_strategies",
-          "text": "I have strategies to recruit students into my computer science class."
-        },
-        {
-          "value": "retain_strategies",
-          "text": "I have strategies to retain students in my computer science class."
-        }
-        ]
-      }
-      ],
-      "title": "Self-assessment of Computer Science Knowledge & Teaching Practices"
-    },
-    {
-      "name": "teaching_philosophy",
-      "elements": [
-      {
-        "type": "html",
-        "name": "statement_AB_expertise",
-        "html": "<table style=\"width: 600px; margin-left: auto; margin-right: auto;\" cellpadding=\"5\">\n<tbody>\n                <tr>\n                  <td style=\"padding-top: 10px; text-align: center;\">\n                    <span style=\"font-family: arial, helvetica, sans-serif; font-size: 12pt;\">\n                      <strong>Statement A</strong>\n                    </span>\n                  </td>\n                  <td style=\"padding-top: 10px; text-align: center;\">\n                    <span style=\"font-family: arial, helvetica, sans-serif; font-size: 12pt;\">\n                      <strong>      </strong>\n                    </span>\n                  </td>\n                  <td style=\"padding-top: 10px; text-align: center;\">\n                    <span style=\"font-family: arial, helvetica, sans-serif; font-size: 12pt;\">\n                      <strong>Statement B</strong>\n                    </span>\n                  </td>\n                </tr>\n                <tr>\n                  <td style=\"border: 1px solid black; width: 250px; vertical-align: top; text-align: left;\">\n                    <span style=\"color: black;\">\"I do not need to have deep expertise in computer science in order to successfully teach it. I have expertise in how to learn, and I can model that for my students as we learn the content together.\" </span>\n                  </td>\n                  <td style=\"text-align: center;\">\n                    <em><span style=\"color: #999999;\"> </span></em>\n                  </td>\n                  <td style=\"border: 1px solid black; width: 250px; vertical-align: top; text-align: left;\"> \t\n<span style=\"color: black;\">\"As the teacher, I need to have deep content expertise so that I can properly answer students’ questions and guide instruction appropriately.\"</span>\n                    \n                  </td>\n                </tr>\n              </tbody>\n</table>"
-      },
-      {
-        "type": "rating",
-        "title": "Lead Learner. 1. model expertise in how to learn  --- 5. need deep content expertise",
-        "name": "expertise_rating",
-        "indent": 12,
-        "titleLocation": "hidden",
-        "minRateDescription": "Strongly aligned with A",
-        "maxRateDescription": "Strongly aligned with B"
-      }
-      ],
-      "title": "Teaching Philosophy"
-    },
-    {
-      "name": "overall_feedback",
-      "elements": [
-      {
-        "type": "comment",
-        "name": "two_things_liked",
-        "title": "What were the one or two things you liked most about the activities you did in this workshop and why?"
-      },
-      {
-        "type": "radiogroup",
-        "name": "permission_promotional",
-        "title": " I give the workshop organizer permission to quote my written feedback from today for use on social media, promotional materials, and other communications. ",
-        "choices": [
-        {
-          "value": "yes_with_name",
-          "text": "Yes, I give the workshop organizer permission to quote me and use my name. "
-        },
-        {
-          "value": "yes_anonymous",
-          "text": "Yes, I give the workshop organizer permission to quote me, but I want to be anonymous."
-        },
-        {
-          "value": "no",
-          "text": "No, I do not give the workshop organizer my permission. "
-        }
-        ]
-      }
-      ],
-      "title": "Overall Workshop Feedback"
-    }
-    ]
-  }'
+      }'
+    end
   end
 
   factory :foorm_form_csf_intro_post_survey, class: 'Foorm::Form' do
-    name 'surveys/pd/workshop_csf_intro_post_test'
-    version 0
-    created_at '2020-03-30 21:58:28'
-    updated_at '2020-03-31 21:58:28'
-    questions '{
-    "title": "Satisfaction Survey for Code.org\'s CS Fundamentals 5-day Summer Professional Development Workshop",
-    "pages": [
-    {
-      "name": "page1",
-      "elements": [
-      {
-        "type": "html",
-        "name": "intro_text",
-        "html": "Thanks!"
-      },
-      {
-        "type": "matrix",
-        "name": "overall_success",
-        "title": "How much do you agree or disagree with the following statements about the workshop overall?",
-        "columns": [
-        {
-          "value": "1",
-          "text": "Strongly Disagree"
-        },
-        {
-          "value": "2",
-          "text": "Disagree"
-        },
-        {
-          "value": "3",
-          "text": "Slightly Disagree"
-        },
-        {
-          "value": "4",
-          "text": "Neutral"
-        },
-        {
-          "value": "5",
-          "text": "Slightly Agree"
-        },
-        {
-          "value": "6",
-          "text": "Agree"
-        },
-        {
-          "value": "7",
-          "text": "Strongly Agree"
-        }
-        ],
-        "rows": [
-        {
-          "value": "more_prepared",
-          "text": "I feel more prepared to teach the material covered in this workshop than before I came."
-        },
-        {
-          "value": "where_to_go",
-          "text": "I know where to go if I need help preparing to teach this material."
-        },
-        {
-          "value": "suitable_my_level",
-          "text": "This professional development was suitable for my level of experience with teaching CS."
-        },
-        {
-          "value": "feel_community",
-          "text": "I feel connected to a community of computer science teachers."
-        },
-        {
-          "value": "would_recommend",
-          "text": "I would recommend this professional development to others."
-        },
-        {
-          "value": "best_pd",
-          "text": "This was the absolute best professional development I’ve ever participated in."
-        }
-        ]
-      },
-      {
-        "type": "matrix",
-        "name": "teacher_engagement",
-        "title": "How much do you agree or disagree with the following statements about your level of engagement in the workshop?",
-        "columns": [
-        {
-          "value": "1",
-          "text": "Strongly Disagree"
-        },
-        {
-          "value": "2",
-          "text": "Disagree"
-        },
-        {
-          "value": "3",
-          "text": "Slightly Disagree"
-        },
-        {
-          "value": "4",
-          "text": "Neutral"
-        },
-        {
-          "value": "5",
-          "text": "Slightly Agree"
-        },
-        {
-          "value": "6",
-          "text": "Agree"
-        },
-        {
-          "value": "7",
-          "text": "Strongly Agree"
-        }
-        ],
-        "rows": [
-        {
-          "value": "engaging",
-          "text": "I found the activities we did in this workshop interesting and engaging."
-        },
-        {
-          "value": "active",
-          "text": "I was highly active and participated a lot in the workshop activities."
-        },
-        {
-          "value": "ideas",
-          "text": "I am definitely planning to make use of ideas and content covered in this workshop in my classroom."
-        }
-        ]
-      },
-      {
-        "type": "comment",
-        "name": "supported",
-        "title": "What supported your learning the most today and why?"
-      },{
-       "type": "paneldynamic",
-       "name": "facilitators",
-       "title": "Your facilitators",
-       "templateElements": [
-         {
-           "type": "matrix",
-           "name": "facilitator_effectiveness",
-           "title": "During my workshop, {panel.facilitator_name} did the following:",
-           "columns": [
-             {
-               "value": "1",
-               "text": "Strongly Disagree"
-             },
-             {
-               "value": "2",
-               "text": "Disagree"
-             },
-             {
-               "value": "3",
-               "text": "Slightly Disagree"
-             },
-             {
-               "value": "4",
-               "text": "Neutral"
-             },
-             {
-               "value": "5",
-               "text": "Slightly Agree"
-             },
-             {
-               "value": "6",
-               "text": "Agree"
-             },
-             {
-               "value": "7",
-               "text": "Strongly Agree"
-             }
-           ],
-           "rows": [
-             {
-               "value": "demonstrated_knowledge",
-               "text": "Demonstrated knowledge of the curriculum."
-             },
-             {
-               "value": "built_equitable",
-               "text": "Built and sustained an equitable learning environment in our workshop."
-             },
-             {
-               "value": "on_track",
-               "text": "Kept the workshop and participants on track."
-             },
-             {
-               "value": "productive_discussions",
-               "text": "Supported productive workshop discussions."
-             },
-             {
-               "value": "ways_equitable",
-               "text": "Helped me see ways to create and support an equitable learning environment for my students."
-             },
-             {
-               "value": "healthy_relationship",
-               "text": "Demonstrated a healthy working relationship with their co-facilitator (if applicable)."
-             }
-           ]
-         },
-         {
-           "type": "comment",
-           "name": "k5_facilitator_did_well",
-           "title": "What were two things {panel.facilitator_name} did well?"
-         },
-         {
-           "type": "comment",
-           "name": "k5_facilitator_could_improve",
-           "title": "What were two things {panel.facilitator_name} could do better?"
-         }
-       ],
-       "templateTitle": "Information about: {panel.facilitator_name}",
-       "allowAddPanel": false,
-       "allowRemovePanel": false
-     },{
-       "type": "radiogroup",
-       "name": "permission",
-       "title": "I give the workshop organizer permission to quote my written feedback from today for use on social media, promotional materials, and other communications.",
-       "isRequired": true,
-       "choices": [
-         {
-           "value": "yes_name",
-           "text": "Yes, I give the workshop organizer permission to quote me and use my name."
-         },
-         {
-           "value": "yes_anonymous",
-           "text": "Yes, I give the workshop organizer permission to quote me, but I want to be anonymous."
-         },
-         {
-           "value": "no",
-           "text": "No, I do not give the workshop organizer my permission."
-         }
-       ]
-     }
-   ]
-  }]
-  }'
+    name {'surveys/pd/workshop_csf_intro_post_test'}
+    version {0}
+    created_at {'2020-03-30 21:58:28'}
+    updated_at {'2020-03-31 21:58:28'}
+    questions do
+      '{
+        "title": "Satisfaction Survey for Code.org\'s CS Fundamentals 5-day Summer Professional Development Workshop",
+        "pages": [
+          {
+            "name": "page1",
+            "elements": [
+            {
+              "type": "html",
+              "name": "intro_text",
+              "html": "Thanks!"
+            },
+            {
+              "type": "matrix",
+              "name": "overall_success",
+              "title": "How much do you agree or disagree with the following statements about the workshop overall?",
+              "columns": [
+              {
+                "value": "1",
+                "text": "Strongly Disagree"
+              },
+              {
+                "value": "2",
+                "text": "Disagree"
+              },
+              {
+                "value": "3",
+                "text": "Slightly Disagree"
+              },
+              {
+                "value": "4",
+                "text": "Neutral"
+              },
+              {
+                "value": "5",
+                "text": "Slightly Agree"
+              },
+              {
+                "value": "6",
+                "text": "Agree"
+              },
+              {
+                "value": "7",
+                "text": "Strongly Agree"
+              }
+              ],
+              "rows": [
+              {
+                "value": "more_prepared",
+                "text": "I feel more prepared to teach the material covered in this workshop than before I came."
+              },
+              {
+                "value": "where_to_go",
+                "text": "I know where to go if I need help preparing to teach this material."
+              },
+              {
+                "value": "suitable_my_level",
+                "text": "This professional development was suitable for my level of experience with teaching CS."
+              },
+              {
+                "value": "feel_community",
+                "text": "I feel connected to a community of computer science teachers."
+              },
+              {
+                "value": "would_recommend",
+                "text": "I would recommend this professional development to others."
+              },
+              {
+                "value": "best_pd",
+                "text": "This was the absolute best professional development I’ve ever participated in."
+              }
+              ]
+            },
+            {
+              "type": "matrix",
+              "name": "teacher_engagement",
+              "title": "How much do you agree or disagree with the following statements about your level of engagement in the workshop?",
+              "columns": [
+              {
+                "value": "1",
+                "text": "Strongly Disagree"
+              },
+              {
+                "value": "2",
+                "text": "Disagree"
+              },
+              {
+                "value": "3",
+                "text": "Slightly Disagree"
+              },
+              {
+                "value": "4",
+                "text": "Neutral"
+              },
+              {
+                "value": "5",
+                "text": "Slightly Agree"
+              },
+              {
+                "value": "6",
+                "text": "Agree"
+              },
+              {
+                "value": "7",
+                "text": "Strongly Agree"
+              }
+              ],
+              "rows": [
+              {
+                "value": "engaging",
+                "text": "I found the activities we did in this workshop interesting and engaging."
+              },
+              {
+                "value": "active",
+                "text": "I was highly active and participated a lot in the workshop activities."
+              },
+              {
+                "value": "ideas",
+                "text": "I am definitely planning to make use of ideas and content covered in this workshop in my classroom."
+              }
+              ]
+            },
+            {
+              "type": "comment",
+              "name": "supported",
+              "title": "What supported your learning the most today and why?"
+            },{
+             "type": "paneldynamic",
+             "name": "facilitators",
+             "title": "Your facilitators",
+             "templateElements": [
+               {
+                 "type": "matrix",
+                 "name": "facilitator_effectiveness",
+                 "title": "During my workshop, {panel.facilitator_name} did the following:",
+                 "columns": [
+                   {
+                     "value": "1",
+                     "text": "Strongly Disagree"
+                   },
+                   {
+                     "value": "2",
+                     "text": "Disagree"
+                   },
+                   {
+                     "value": "3",
+                     "text": "Slightly Disagree"
+                   },
+                   {
+                     "value": "4",
+                     "text": "Neutral"
+                   },
+                   {
+                     "value": "5",
+                     "text": "Slightly Agree"
+                   },
+                   {
+                     "value": "6",
+                     "text": "Agree"
+                   },
+                   {
+                     "value": "7",
+                     "text": "Strongly Agree"
+                   }
+                 ],
+                 "rows": [
+                   {
+                     "value": "demonstrated_knowledge",
+                     "text": "Demonstrated knowledge of the curriculum."
+                   },
+                   {
+                     "value": "built_equitable",
+                     "text": "Built and sustained an equitable learning environment in our workshop."
+                   },
+                   {
+                     "value": "on_track",
+                     "text": "Kept the workshop and participants on track."
+                   },
+                   {
+                     "value": "productive_discussions",
+                     "text": "Supported productive workshop discussions."
+                   },
+                   {
+                     "value": "ways_equitable",
+                     "text": "Helped me see ways to create and support an equitable learning environment for my students."
+                   },
+                   {
+                     "value": "healthy_relationship",
+                     "text": "Demonstrated a healthy working relationship with their co-facilitator (if applicable)."
+                   }
+                 ]
+               },
+               {
+                 "type": "comment",
+                 "name": "k5_facilitator_did_well",
+                 "title": "What were two things {panel.facilitator_name} did well?"
+               },
+               {
+                 "type": "comment",
+                 "name": "k5_facilitator_could_improve",
+                 "title": "What were two things {panel.facilitator_name} could do better?"
+               }
+             ],
+             "templateTitle": "Information about: {panel.facilitator_name}",
+             "allowAddPanel": false,
+             "allowRemovePanel": false
+           },{
+             "type": "radiogroup",
+             "name": "permission",
+             "title": "I give the workshop organizer permission to quote my written feedback from today for use on social media, promotional materials, and other communications.",
+             "isRequired": true,
+             "choices": [
+               {
+                 "value": "yes_name",
+                 "text": "Yes, I give the workshop organizer permission to quote me and use my name."
+               },
+               {
+                 "value": "yes_anonymous",
+                 "text": "Yes, I give the workshop organizer permission to quote me, but I want to be anonymous."
+               },
+               {
+                 "value": "no",
+                 "text": "No, I do not give the workshop organizer my permission."
+               }
+             ]
+           }
+         ]
+        }]
+      }'
+    end
   end
 
   factory :foorm_form_summer_daily_survey, class: 'Foorm::Form' do
-    name 'surveys/pd/summer_workshop_daily_survey_test'
-    version 0
-    created_at '2020-03-25 21:58:28'
-    updated_at '2020-03-26 21:58:28'
-    questions '{}'
+    name {'surveys/pd/summer_workshop_daily_survey_test'}
+    version {0}
+    created_at {'2020-03-25 21:58:28'}
+    updated_at {'2020-03-26 21:58:28'}
+    questions {'{}'}
   end
 
   factory :foorm_form_teacher_end_of_year_survey, class: 'Foorm::Form' do
-    name 'surveys/teachers/teacher_end_of_year_survey_test'
-    version 0
-    created_at '2020-03-25 21:58:28'
-    updated_at '2020-03-26 21:58:28'
-    questions '{}'
+    name {'surveys/teachers/teacher_end_of_year_survey_test'}
+    version {0}
+    created_at {'2020-03-25 21:58:28'}
+    updated_at {'2020-03-26 21:58:28'}
+    questions {'{}'}
   end
 
   factory :foorm_form_duplicate_question_survey, class: 'Foorm::Form' do
-    name 'surveys/teachers/duplicate_question_test'
-    version 0
-    created_at '2020-03-25 21:58:28'
-    updated_at '2020-03-26 21:58:28'
-    questions '{
-      "title": "Sample Survey",
-      "pages": [
-      {
-        "name": "page1",
-        "elements": [
+    name {'surveys/teachers/duplicate_question_test'}
+    version {0}
+    created_at {'2020-03-25 21:58:28'}
+    updated_at {'2020-03-26 21:58:28'}
+    questions do
+      '{
+        "title": "Sample Survey",
+        "pages": [
           {
-            "type": "comment",
-            "name": "question1",
-            "title": "sample!"
-          },
-          {
-            "type": "comment",
-            "name": "question1",
-            "title": "another sample!"
+            "name": "page1",
+            "elements": [
+              {
+                "type": "comment",
+                "name": "question1",
+                "title": "sample!"
+              },
+              {
+                "type": "comment",
+                "name": "question1",
+                "title": "another sample!"
+              }
+            ]
           }
         ]
-      }
-    ]
-  }'
+      }'
+    end
   end
 
   factory :foorm_form_duplicate_choice_survey, class: 'Foorm::Form' do
-    name 'surveys/teachers/duplicate_choice_test'
-    version 0
-    created_at '2020-03-25 21:58:28'
-    updated_at '2020-03-26 21:58:28'
-    questions '{
-      "title": "Sample Survey",
-      "pages": [
-      {
-        "name": "page1",
-        "elements": [
+    name {'surveys/teachers/duplicate_choice_test'}
+    version {0}
+    created_at {'2020-03-25 21:58:28'}
+    updated_at {'2020-03-26 21:58:28'}
+    questions do
+      '{
+        "title": "Sample Survey",
+        "pages": [
           {
-            "type": "checkbox",
-            "name": "question1",
-            "title": "sample!",
-           "choices": [
-             {
-               "value": "choice1",
-               "text": "Choice 1."
-             },
-             {
-               "value": "choice1",
-               "text": "Choice 1 again."
-             }
-           ]
-          },
-          {
-            "type": "matrix",
-            "name": "question2",
-            "title": "another sample!",
-             "columns": [
-               {
-                 "value": "1",
-                 "text": "Strongly Disagree"
-               },
-               {
-                 "value": "1",
-                 "text": "Disagree"
-               }
-             ],
-             "rows": [
-               {
-                 "value": "demonstrated_knowledge",
-                 "text": "Demonstrated knowledge of the curriculum."
-               },
-               {
-                 "value": "demonstrated_knowledge",
-                 "text": "Built and sustained an equitable learning environment in our workshop."
-               }
-             ]
+            "name": "page1",
+            "elements": [
+              {
+                "type": "checkbox",
+                "name": "question1",
+                "title": "sample!",
+               "choices": [
+                 {
+                   "value": "choice1",
+                   "text": "Choice 1."
+                 },
+                 {
+                   "value": "choice1",
+                   "text": "Choice 1 again."
+                 }
+               ]
+              },
+              {
+                "type": "matrix",
+                "name": "question2",
+                "title": "another sample!",
+                 "columns": [
+                   {
+                     "value": "1",
+                     "text": "Strongly Disagree"
+                   },
+                   {
+                     "value": "1",
+                     "text": "Disagree"
+                   }
+                 ],
+                 "rows": [
+                   {
+                     "value": "demonstrated_knowledge",
+                     "text": "Demonstrated knowledge of the curriculum."
+                   },
+                   {
+                     "value": "demonstrated_knowledge",
+                     "text": "Built and sustained an equitable learning environment in our workshop."
+                   }
+                 ]
+              }
+            ]
           }
         ]
-      }
-    ]
-  }'
+      }'
+    end
   end
 
   factory :foorm_library_question, class: 'Foorm::LibraryQuestion' do
     sequence(:library_name) {|n| "surveys/pd/library_name#{n}"}
-    library_version 0
+    library_version {0}
     sequence(:question_name) {|n| "what_supported#{n}"}
     sequence(:question) do |n|
       "{
@@ -1187,12 +1223,12 @@ FactoryBot.define do
 
   factory :foorm_library, class: 'Foorm::Library' do
     sequence(:name) {|n| "surveys/pd/library_name#{n}"}
-    version 0
-    published true
+    version {0}
+    published {true}
 
     trait :with_questions do
       transient do
-        number_of_questions 1
+        number_of_questions {1}
       end
 
       after(:create) do |library, evaluator|
@@ -1207,8 +1243,8 @@ FactoryBot.define do
 
   factory :foorm_simple_survey_form, class: 'Foorm::SimpleSurveyForm' do
     sequence(:path) {|n| "test_path_#{n}"}
-    form_name 'A form that does not actually exist'
-    form_version 0
+    form_name {'A form that does not actually exist'}
+    form_version {0}
   end
 
   factory :foorm_simple_survey_submission, class: 'Foorm::SimpleSurveySubmission' do

--- a/dashboard/test/factories/foorm_factories.rb
+++ b/dashboard/test/factories/foorm_factories.rb
@@ -92,7 +92,7 @@ FactoryBot.define do
 
     trait :with_multi_select_answer do
       answers do
-        '{not_members_spice_girls": ["radical", "spicy"]}'
+        '{"not_members_spice_girls": ["radical", "spicy"]}'
       end
     end
 

--- a/dashboard/test/factories/pd_factories.rb
+++ b/dashboard/test/factories/pd_factories.rb
@@ -4,15 +4,15 @@ FactoryBot.define do
   # example zip: 35010
   factory :regional_partner_alabama, parent: :regional_partner_with_summer_workshops do
     mappings {[create(:pd_regional_partner_mapping, state: "AL")]}
-    cost_scholarship_information "Some **important** information about scholarships."
-    additional_program_information "And some _additional_ program information."
+    cost_scholarship_information {"Some **important** information about scholarships."}
+    additional_program_information {"And some _additional_ program information."}
   end
 
   # example zip: 60415
   factory :regional_partner_illinois, parent: :regional_partner_with_summer_workshops do
     # Link to partner-specific site.
-    contact_name "Illinois Contact"
-    link_to_partner_application "https://code.org/specific-link"
+    contact_name {"Illinois Contact"}
+    link_to_partner_application {"https://code.org/specific-link"}
     mappings {[create(:pd_regional_partner_mapping, state: "IL")]}
   end
 
@@ -27,10 +27,10 @@ FactoryBot.define do
   # example zip: 07001
   factory :regional_partner_newjersey, parent: :regional_partner_with_summer_workshops do
     # No contact details, no workshop application dates, and no workshops.
-    contact_name nil
-    contact_email nil
-    apps_open_date_teacher nil
-    apps_close_date_teacher nil
+    contact_name {nil}
+    contact_email {nil}
+    apps_open_date_teacher {nil}
+    apps_close_date_teacher {nil}
     mappings {[create(:pd_regional_partner_mapping, state: "NJ")]}
     pd_workshops {[]}
   end
@@ -52,13 +52,13 @@ FactoryBot.define do
 
   # example zip: 90210
   factory :regional_partner_beverly_hills, parent: :regional_partner_with_summer_workshops do
-    contact_name "Beverly Hills Contact"
+    contact_name {"Beverly Hills Contact"}
     mappings {[create(:pd_regional_partner_mapping, zip_code: "90210", state: nil)]}
   end
 
   factory :pd_session, class: 'Pd::Session' do
     transient do
-      duration_hours 6
+      duration_hours {6}
     end
     association :workshop, factory: :workshop
     start {Date.current + 9.hours}
@@ -71,14 +71,14 @@ FactoryBot.define do
 
   factory :pd_payment_term, class: 'Pd::PaymentTerm' do
     start_date {Date.current}
-    fixed_payment 50
+    fixed_payment {50}
   end
 
   factory :pd_teachercon_survey, class: 'Pd::TeacherconSurvey' do
     association :pd_enrollment, factory: :pd_enrollment, strategy: :create
 
     transient do
-      randomized_survey_answers false
+      randomized_survey_answers {false}
     end
 
     after(:build) do |survey, evaluator|
@@ -233,7 +233,7 @@ FactoryBot.define do
     association :pd_enrollment, factory: :pd_enrollment, strategy: :create
 
     transient do
-      randomized_survey_answers false
+      randomized_survey_answers {false}
     end
 
     after(:build) do |survey, evaluator|
@@ -319,7 +319,7 @@ FactoryBot.define do
   factory :pd_enrollment, class: 'Pd::Enrollment' do
     association :workshop
     sequence(:first_name) {|n| "Participant#{n}"}
-    last_name 'Codeberg'
+    last_name {'Codeberg'}
     email {"participant_#{SecureRandom.hex(10)}@example.com.xx"}
     association :school_info
     code {SecureRandom.hex(10)}
@@ -340,9 +340,9 @@ FactoryBot.define do
   factory :pd_scholarship_info, class: 'Pd::ScholarshipInfo' do
     association :user, factory: :teacher
 
-    course Pd::Workshop::COURSE_KEY_MAP[Pd::Workshop::COURSE_CSP]
-    application_year Pd::SharedApplicationConstants::YEAR_19_20
-    scholarship_status Pd::ScholarshipInfoConstants::YES_CDO
+    course {Pd::Workshop::COURSE_KEY_MAP[Pd::Workshop::COURSE_CSP]}
+    application_year {Pd::SharedApplicationConstants::YEAR_19_20}
+    scholarship_status {Pd::ScholarshipInfoConstants::YES_CDO}
   end
 
   factory :pd_attendance, class: 'Pd::Attendance' do
@@ -359,10 +359,10 @@ FactoryBot.define do
   # or marked attended on either all (true) or a specified list of workshop sessions.
   factory :pd_workshop_participant, parent: :teacher do
     transient do
-      workshop nil
-      enrolled true
-      attended false
-      cdo_scholarship_recipient false
+      workshop {nil}
+      enrolled {true}
+      attended {false}
+      cdo_scholarship_recipient {false}
     end
     after(:create) do |teacher, evaluator|
       raise 'workshop required' unless evaluator.workshop
@@ -393,14 +393,14 @@ FactoryBot.define do
 
   factory :pd_district_payment_term, class: 'Pd::DistrictPaymentTerm' do
     association :school_district
-    course Pd::Workshop::COURSES.first
-    rate_type Pd::DistrictPaymentTerm::RATE_TYPES.first
-    rate 10
+    course {Pd::Workshop::COURSES.first}
+    rate_type {Pd::DistrictPaymentTerm::RATE_TYPES.first}
+    rate {10}
   end
 
   factory :pd_course_facilitator, class: 'Pd::CourseFacilitator' do
     association :facilitator
-    course Pd::Workshop::COURSES.first
+    course {Pd::Workshop::COURSES.first}
   end
 
   factory :pd_pre_workshop_survey, class: 'Pd::PreWorkshopSurvey' do
@@ -408,8 +408,8 @@ FactoryBot.define do
   end
 
   factory :pd_regional_partner_contact, class: 'Pd::RegionalPartnerContact' do
-    user nil
-    regional_partner nil
+    user {nil}
+    regional_partner {nil}
     form_data {build(:pd_regional_partner_contact_hash, :matched).to_json}
   end
 
@@ -445,8 +445,8 @@ FactoryBot.define do
   end
 
   factory :pd_regional_partner_mini_contact, class: 'Pd::RegionalPartnerMiniContact' do
-    user nil
-    regional_partner nil
+    user {nil}
+    regional_partner {nil}
     form_data {build(:pd_regional_partner_mini_contact_hash).to_json}
   end
 
@@ -465,17 +465,17 @@ FactoryBot.define do
   end
 
   factory :pd_international_opt_in, class: 'Pd::InternationalOptIn' do
-    user nil
-    form_data nil
+    user {nil}
+    form_data {nil}
   end
 
   factory :pd_regional_partner_cohort, class: 'Pd::RegionalPartnerCohort' do
-    course Pd::Workshop::COURSE_CSP
+    course {Pd::Workshop::COURSE_CSP}
   end
 
   factory :pd_regional_partner_mapping, class: 'Pd::RegionalPartnerMapping' do
     association :regional_partner
-    state 'WA'
+    state {'WA'}
   end
 
   ruby_to_js_style_keys = ->(k) {k.to_s.camelize(:lower)}
@@ -488,30 +488,30 @@ FactoryBot.define do
   # ------- Teacher ------- #
 
   factory :pd_teacher_application_hash_common, class: 'Hash' do
-    country 'United States'
-    first_name 'Severus'
-    last_name 'Snape'
-    alternate_email 'ilovepotions@gmail.com'
-    phone '5558675309'
-    gender_identity 'Male'
-    race ['Other']
-    street_address '333 Hogwarts Place'
-    city 'Magic City'
-    state 'Washington'
+    country {'United States'}
+    first_name {'Severus'}
+    last_name {'Snape'}
+    alternate_email {'ilovepotions@gmail.com'}
+    phone {'5558675309'}
+    gender_identity {'Male'}
+    race {['Other']}
+    street_address {'333 Hogwarts Place'}
+    city {'Magic City'}
+    state {'Washington'}
     add_attribute :zip_code, '98101'
     association :school
-    principal_role 'Headmaster'
-    principal_first_name 'Albus'
-    principal_last_name 'Dumbledore'
-    principal_title 'Dr.'
-    principal_email 'socks@hogwarts.edu'
-    principal_confirm_email 'socks@hogwarts.edu'
-    principal_phone_number '5555882300'
-    current_role 'Teacher'
-    previous_yearlong_cdo_pd ['CS in Science']
-    committed 'Yes'
-    willing_to_travel 'Up to 50 miles'
-    agree 'Yes'
+    principal_role {'Headmaster'}
+    principal_first_name {'Albus'}
+    principal_last_name {'Dumbledore'}
+    principal_title {'Dr.'}
+    principal_email {'socks@hogwarts.edu'}
+    principal_confirm_email {'socks@hogwarts.edu'}
+    principal_phone_number {'5555882300'}
+    current_role {'Teacher'}
+    previous_yearlong_cdo_pd {['CS in Science']}
+    committed {'Yes'}
+    willing_to_travel {'Up to 50 miles'}
+    agree {'Yes'}
 
     initialize_with do
       attributes.dup.tap do |hash|
@@ -522,49 +522,49 @@ FactoryBot.define do
     end
 
     trait :with_custom_school do
-      school(-1)
-      school_name 'Code.org'
-      school_address '1501 4th Ave'
-      school_city 'Seattle'
-      school_state 'Washington'
-      school_zip_code '98101'
-      school_type 'Public school'
+      school {-1}
+      school_name {'Code.org'}
+      school_address {'1501 4th Ave'}
+      school_city {'Seattle'}
+      school_state {'Washington'}
+      school_zip_code {'98101'}
+      school_type {'Public school'}
     end
 
     trait :with_no_school do
-      school(-1)
+      school {-1}
     end
 
     trait :with_multiple_workshops do
-      able_to_attend_multiple ['December 11-15, 2017 in Indiana, USA']
+      able_to_attend_multiple {['December 11-15, 2017 in Indiana, USA']}
 
       after(:build) do |hash|
         hash.delete 'ableToAttendSingle'
       end
     end
 
-    pay_fee Pd::Application::TeacherApplication.options[:pay_fee].first
-    enough_course_hours Pd::Application::TeacherApplication.options[:enough_course_hours].first
-    completing_on_behalf_of_someone_else 'No'
-    replace_existing 'No, this course will be added to the schedule in addition to an existing computer science course'
+    pay_fee {Pd::Application::TeacherApplication.options[:pay_fee].first}
+    enough_course_hours {Pd::Application::TeacherApplication.options[:enough_course_hours].first}
+    completing_on_behalf_of_someone_else {'No'}
+    replace_existing {'No, this course will be added to the schedule in addition to an existing computer science course'}
 
     trait :csp do
-      program Pd::Application::TeacherApplication::PROGRAMS[:csp]
-      csp_which_grades ['11', '12']
-      csp_how_offer 'As an AP course'
+      program {Pd::Application::TeacherApplication::PROGRAMS[:csp]}
+      csp_which_grades {['11', '12']}
+      csp_how_offer {'As an AP course'}
     end
 
     trait :csd do
-      program Pd::Application::TeacherApplication::PROGRAMS[:csd]
-      csd_which_grades ['6', '7']
+      program {Pd::Application::TeacherApplication::PROGRAMS[:csd]}
+      csd_which_grades {['6', '7']}
     end
 
     trait :csa do
-      program Pd::Application::TeacherApplication::PROGRAMS[:csa]
-      csa_which_grades ['11', '12']
-      csa_how_offer 'As an AP course'
-      csa_already_know 'Yes'
-      csa_phone_screen 'Yes'
+      program {Pd::Application::TeacherApplication::PROGRAMS[:csa]}
+      csa_which_grades {['11', '12']}
+      csa_how_offer {'As an AP course'}
+      csa_already_know {'Yes'}
+      csa_phone_screen {'Yes'}
     end
   end
 
@@ -575,7 +575,7 @@ FactoryBot.define do
 
   factory :pd_teacher_application, class: 'Pd::Application::TeacherApplication' do
     association :user, factory: [:teacher, :with_school_info], strategy: :create
-    course 'csp'
+    course {'csp'}
     transient do
       form_data_hash {build :pd_teacher_application_hash_common, course.to_sym}
     end
@@ -592,50 +592,50 @@ FactoryBot.define do
   # ----- Principal ----- #
 
   factory :pd_principal_approval_application_hash_common, parent: :form_data_hash do
-    title 'Dr.'
-    first_name 'Albus'
-    last_name 'Dumbledore'
-    email 'albus@hogwarts.edu'
-    can_email_you 'Yes'
-    confirm_principal true
+    title {'Dr.'}
+    first_name {'Albus'}
+    last_name {'Dumbledore'}
+    email {'albus@hogwarts.edu'}
+    can_email_you {'Yes'}
+    confirm_principal {true}
 
     trait :approved_no do
-      do_you_approve 'No'
+      do_you_approve {'No'}
     end
 
     trait :replace_course_yes_csp do
-      replace_course 'Yes'
+      replace_course {'Yes'}
     end
 
     trait :replace_course_yes_csd do
-      replace_course 'Yes'
+      replace_course {'Yes'}
     end
 
     trait :approved_yes do
-      do_you_approve 'Yes'
+      do_you_approve {'Yes'}
       with_approval_fields
     end
 
     trait :approved_other do
-      do_you_approve 'Other:'
+      do_you_approve {'Other:'}
       with_approval_fields
     end
 
     trait :with_approval_fields do
-      school 'Hogwarts Academy of Witchcraft and Wizardry'
-      total_student_enrollment 200
-      free_lunch_percent '50'
-      white '16'
-      black '15'
-      hispanic '14'
-      asian '13'
-      pacific_islander '12'
-      american_indian '11'
-      other '10'
-      committed_to_master_schedule Pd::Application::PrincipalApprovalApplication.options[:committed_to_master_schedule][0]
-      replace_course Pd::Application::PrincipalApprovalApplication.options[:replace_course][1]
-      understand_fee 'Yes'
-      pay_fee Pd::Application::PrincipalApprovalApplication.options[:pay_fee][0]
+      school {'Hogwarts Academy of Witchcraft and Wizardry'}
+      total_student_enrollment {200}
+      free_lunch_percent {'50'}
+      white {'16'}
+      black {'15'}
+      hispanic {'14'}
+      asian {'13'}
+      pacific_islander {'12'}
+      american_indian {'11'}
+      other {'10'}
+      committed_to_master_schedule {Pd::Application::PrincipalApprovalApplication.options[:committed_to_master_schedule][0]}
+      replace_course {Pd::Application::PrincipalApprovalApplication.options[:replace_course][1]}
+      understand_fee {'Yes'}
+      pay_fee {Pd::Application::PrincipalApprovalApplication.options[:pay_fee][0]}
     end
   end
 
@@ -646,10 +646,10 @@ FactoryBot.define do
 
   factory :pd_principal_approval_application, class: 'Pd::Application::PrincipalApprovalApplication' do
     association :teacher_application, factory: :pd_teacher_application
-    course 'csp'
+    course {'csp'}
     transient do
-      approved 'Yes'
-      replace_course Pd::Application::PrincipalApprovalApplication.options[:replace_course][1]
+      approved {'Yes'}
+      replace_course {Pd::Application::PrincipalApprovalApplication.options[:replace_course][1]}
       form_data_hash do
         build(
           :pd_principal_approval_application_hash_common,
@@ -665,32 +665,32 @@ FactoryBot.define do
   # ----- FiT Weekend ----- #
 
   factory :pd_workshop_daily_survey, class: 'Pd::WorkshopDailySurvey' do
-    form_id 12345
+    form_id {12345}
     submission_id {(Pd::WorkshopDailySurvey.maximum(:submission_id) || 0) + 1}
     association :pd_workshop
     association :user
-    day 5
+    day {5}
   end
 
   factory :pd_workshop_facilitator_daily_survey, class: 'Pd::WorkshopFacilitatorDailySurvey' do
-    form_id 12345
+    form_id {12345}
     submission_id {(Pd::WorkshopFacilitatorDailySurvey.maximum(:submission_id) || 0) + 1}
     association :pd_session
     pd_workshop {pd_session.workshop}
     association :user
     association :facilitator
-    day 5
+    day {5}
   end
 
   factory :pd_survey_question, class: 'Pd::SurveyQuestion' do
-    form_id 12345
-    questions '{}'
+    form_id {12345}
+    questions {'{}'}
   end
 
   factory :pd_application_email, class: 'Pd::Application::Email' do
     association :application, factory: :pd_teacher_application
-    email_type 'confirmation'
-    application_status 'confirmation'
+    email_type {'confirmation'}
+    application_status {'confirmation'}
     to {application.user.email}
   end
 end

--- a/dashboard/test/factories/plc_factories.rb
+++ b/dashboard/test/factories/plc_factories.rb
@@ -2,37 +2,37 @@ FactoryBot.allow_class_lookup = false
 
 FactoryBot.define do
   factory :plc_enrollment_unit_assignment, class: 'Plc::EnrollmentUnitAssignment' do
-    plc_user_course_enrollment nil
-    plc_course_unit nil
-    status Plc::EnrollmentUnitAssignment::START_BLOCKED
-    user nil
+    plc_user_course_enrollment {nil}
+    plc_course_unit {nil}
+    status {Plc::EnrollmentUnitAssignment::START_BLOCKED}
+    user {nil}
   end
 
   factory :plc_course_unit, class: 'Plc::CourseUnit' do
     plc_course {create(:plc_course)}
     script {create(:script)}
-    unit_name "MyString"
-    unit_description "MyString"
-    unit_order 1
+    unit_name {"MyString"}
+    unit_description {"MyString"}
+    unit_order {1}
   end
 
   factory :plc_enrollment_module_assignment, class: 'Plc::EnrollmentModuleAssignment' do
-    plc_enrollment_unit_assignment nil
-    plc_learning_module nil
-    user nil
+    plc_enrollment_unit_assignment {nil}
+    plc_learning_module {nil}
+    user {nil}
   end
 
   factory :plc_user_course_enrollment, class: 'Plc::UserCourseEnrollment' do
-    status "MyString"
-    plc_course nil
-    user nil
+    status {"MyString"}
+    plc_course {nil}
+    user {nil}
   end
 
   factory :plc_learning_module, class: 'Plc::LearningModule' do
     sequence(:name) {|n| "plc-learning-module-#{n}"}
     plc_course_unit {create(:plc_course_unit)}
     lesson {create(:lesson)}
-    module_type Plc::LearningModule::CONTENT_MODULE
+    module_type {Plc::LearningModule::CONTENT_MODULE}
   end
 
   factory :plc_course, class: 'Plc::Course' do

--- a/dashboard/test/factories/queued_account_purges.rb
+++ b/dashboard/test/factories/queued_account_purges.rb
@@ -16,10 +16,10 @@
 FactoryBot.define do
   factory :queued_account_purge do
     user
-    reason_for_review "Fake reason."
+    reason_for_review {"Fake reason."}
 
     trait :autoretryable do
-      reason_for_review "Net::ReadTimeout"
+      reason_for_review {"Net::ReadTimeout"}
     end
   end
 end

--- a/dashboard/test/factories/workshop_factories.rb
+++ b/dashboard/test/factories/workshop_factories.rb
@@ -15,25 +15,25 @@ end
 FactoryBot.define do
   factory :workshop, class: 'Pd::Workshop', aliases: [:pd_workshop] do
     transient do
-      num_sessions 1
-      num_facilitators 0
+      num_sessions {1}
+      num_facilitators {0}
       sessions_from {Date.current + 9.hours} # Start time of the first session, then one per day after that.
-      each_session_hours 6
-      num_enrollments 0
-      enrolled_and_attending_users 0
-      enrolled_unattending_users 0
-      num_completed_surveys 0
-      randomized_survey_answers false
-      assign_session_code false
+      each_session_hours {6}
+      num_enrollments {0}
+      enrolled_and_attending_users {0}
+      enrolled_unattending_users {0}
+      num_completed_surveys {0}
+      randomized_survey_answers {false}
+      assign_session_code {false}
     end
 
     association :organizer, factory: :workshop_organizer
-    location_name 'Hogwarts School of Witchcraft and Wizardry'
-    course Pd::Workshop::COURSES.first
+    location_name {'Hogwarts School of Witchcraft and Wizardry'}
+    course {Pd::Workshop::COURSES.first}
     subject {Pd::Workshop::SUBJECTS[course].try(&:first)}
-    capacity 10
-    on_map true
-    funded false
+    capacity {10}
+    on_map {true}
+    funded {false}
 
     #
     # Traits
@@ -41,8 +41,8 @@ FactoryBot.define do
 
     # TODO: Change into a sub-factory
     trait :teachercon do
-      course Pd::Workshop::COURSE_CSP
-      subject Pd::Workshop::SUBJECT_CSP_TEACHER_CON
+      course {Pd::Workshop::COURSE_CSP}
+      subject {Pd::Workshop::SUBJECT_CSP_TEACHER_CON}
     end
 
     trait :in_progress do
@@ -55,11 +55,11 @@ FactoryBot.define do
     end
 
     trait :with_codes_assigned do
-      assign_session_code true
+      assign_session_code {true}
     end
 
     trait :funded do
-      funded true
+      funded {true}
       funding_type {course == Pd::Workshop::COURSE_CSF ? Pd::Workshop::FUNDING_TYPE_FACILITATOR : nil}
     end
 
@@ -125,26 +125,26 @@ FactoryBot.define do
       # Make a CSF 101 "Intro" workshop by default
       intro
 
-      course Pd::Workshop::COURSE_CSF
-      capacity 30          # Average capacity
-      on_map true          # About 60% are on the map
+      course {Pd::Workshop::COURSE_CSF}
+      capacity {30}          # Average capacity
+      on_map {true}          # About 60% are on the map
       funded               # About 90% are funded
-      num_sessions 1       # Most have 1 session
-      num_facilitators 1   # Most have 1 facilitator
-      each_session_hours 7 # The most common session length
+      num_sessions {1}       # Most have 1 session
+      num_facilitators {1}   # Most have 1 facilitator
+      each_session_hours {7} # The most common session length
 
       # CSF Intro, also known as CSF 101
       # Our most common workshop type as of August 2019.
       trait :intro do
-        subject Pd::Workshop::SUBJECT_CSF_101
-        location_name 'Walkerville Elementary School'
+        subject {Pd::Workshop::SUBJECT_CSF_101}
+        location_name {'Walkerville Elementary School'}
       end
       factory(:csf_intro_workshop, aliases: [:csf_101_workshop]) {intro}
 
       # CSF Deep Dive, also known as CSF 201
       trait :deep_dive do
-        subject Pd::Workshop::SUBJECT_CSF_201
-        location_name 'Third Street Elementary School'
+        subject {Pd::Workshop::SUBJECT_CSF_201}
+        location_name {'Third Street Elementary School'}
       end
       factory(:csf_deep_dive_workshop, aliases: [:csf_201_workshop]) {deep_dive}
     end
@@ -156,10 +156,10 @@ FactoryBot.define do
       # Make a CSP workshop by default
       csp
 
-      capacity 30          # Average capacity
-      on_map false         # Never on the map
+      capacity {30}          # Average capacity
+      on_map {false}         # Never on the map
       funded               # More than half are funded
-      num_facilitators 2   # Most have 2 facilitators
+      num_facilitators {2}   # Most have 2 facilitators
 
       # Some specific academic year workshops are usually two days instead of one.
       # Add a trait making it easy to specify that we're testing a two-day workshop.
@@ -181,8 +181,8 @@ FactoryBot.define do
 
       # CSP Academic Year Workshops
       trait :csp do
-        course Pd::Workshop::COURSE_CSP
-        location_name 'Bayside High School'
+        course {Pd::Workshop::COURSE_CSP}
+        location_name {'Bayside High School'}
 
         # Possible subjects:
         # Pd::Workshop::SUBJECT_CSP_WORKSHOP_1
@@ -191,14 +191,14 @@ FactoryBot.define do
         # Pd::Workshop::SUBJECT_CSP_WORKSHOP_4
         # Pd::Workshop::SUBJECT_CSP_WORKSHOP_1_2 (2-day)
         # Pd::Workshop::SUBJECT_CSP_WORKSHOP_3_4 (2-day)
-        subject Pd::Workshop::SUBJECT_CSP_WORKSHOP_1
+        subject {Pd::Workshop::SUBJECT_CSP_WORKSHOP_1}
       end
       factory(:csp_academic_year_workshop) {csp}
 
       # CSD Academic Year Workshops
       trait :csd do
-        course Pd::Workshop::COURSE_CSD
-        location_name 'Sunrise Middle School'
+        course {Pd::Workshop::COURSE_CSD}
+        location_name {'Sunrise Middle School'}
 
         # Possible subjects:
         # Pd::Workshop::SUBJECT_CSD_WORKSHOP_1
@@ -207,14 +207,14 @@ FactoryBot.define do
         # Pd::Workshop::SUBJECT_CSD_WORKSHOP_4
         # Pd::Workshop::SUBJECT_CSD_WORKSHOP_1_2 (2-day)
         # Pd::Workshop::SUBJECT_CSD_WORKSHOP_3_4 (2-day)
-        subject Pd::Workshop::SUBJECT_CSD_WORKSHOP_1
+        subject {Pd::Workshop::SUBJECT_CSD_WORKSHOP_1}
       end
       factory(:csd_academic_year_workshop) {csd}
 
       # CSA Academic Year Workshops
       trait :csa do
-        course Pd::Workshop::COURSE_CSA
-        location_name 'Greendale Community College'
+        course {Pd::Workshop::COURSE_CSA}
+        location_name {'Greendale Community College'}
 
         # Possible subjects:
         # Pd::Workshop::SUBJECT_CSA_WORKSHOP_1
@@ -223,7 +223,7 @@ FactoryBot.define do
         # Pd::Workshop::SUBJECT_CSA_WORKSHOP_4
         # Pd::Workshop::SUBJECT_CSA_WORKSHOP_1_2 (2-day)
         # Pd::Workshop::SUBJECT_CSA_WORKSHOP_3_4 (2-day)
-        subject Pd::Workshop::SUBJECT_CSA_WORKSHOP_1
+        subject {Pd::Workshop::SUBJECT_CSA_WORKSHOP_1}
       end
       factory(:csa_academic_year_workshop) {csa}
     end
@@ -233,12 +233,12 @@ FactoryBot.define do
       # CSP local summer workshop by default
       csp
 
-      location_name 'Greendale Community College'
-      on_map false         # Never on the map
-      funded false         # Less than half are funded
-      num_facilitators 2   # Most have 2 facilitators
-      num_sessions 5       # Most have 5 sessions
-      each_session_hours 8 # The most common session length
+      location_name {'Greendale Community College'}
+      on_map {false}         # Never on the map
+      funded {false}         # Less than half are funded
+      num_facilitators {2}   # Most have 2 facilitators
+      num_sessions {5}       # Most have 5 sessions
+      each_session_hours {8} # The most common session length
       # Schedule it for summer of the current application cycle
       sessions_from do
         Date.new(
@@ -247,100 +247,100 @@ FactoryBot.define do
       end
 
       trait :csp do
-        course Pd::Workshop::COURSE_CSP
-        subject Pd::Workshop::SUBJECT_CSP_SUMMER_WORKSHOP
-        capacity 40          # Average capacity
+        course {Pd::Workshop::COURSE_CSP}
+        subject {Pd::Workshop::SUBJECT_CSP_SUMMER_WORKSHOP}
+        capacity {40}          # Average capacity
       end
       factory(:csp_summer_workshop) {csp}
 
       trait :csd do
-        course Pd::Workshop::COURSE_CSD
-        subject Pd::Workshop::SUBJECT_CSD_SUMMER_WORKSHOP
-        capacity 35          # Average capacity
+        course {Pd::Workshop::COURSE_CSD}
+        subject {Pd::Workshop::SUBJECT_CSD_SUMMER_WORKSHOP}
+        capacity {35}          # Average capacity
       end
       factory(:csd_summer_workshop) {csd}
 
       trait :csd_virtual do
-        course Pd::Workshop::COURSE_CSD
-        subject Pd::Workshop::SUBJECT_VIRTUAL_KICKOFF
-        virtual true
-        capacity 35          # Average capacity
+        course {Pd::Workshop::COURSE_CSD}
+        subject {Pd::Workshop::SUBJECT_VIRTUAL_KICKOFF}
+        virtual {true}
+        capacity {35}          # Average capacity
       end
       factory(:csd_virtual_workshop) {csd_virtual}
 
       trait :csa do
-        course Pd::Workshop::COURSE_CSA
-        subject Pd::Workshop::SUBJECT_CSA_SUMMER_WORKSHOP
-        capacity 35          # Average capacity
+        course {Pd::Workshop::COURSE_CSA}
+        subject {Pd::Workshop::SUBJECT_CSA_SUMMER_WORKSHOP}
+        capacity {35}          # Average capacity
       end
       factory(:csa_summer_workshop) {csa}
     end
 
     factory :facilitator_workshop do
-      course Pd::Workshop::COURSE_FACILITATOR
-      subject nil
-      capacity 100         # Typical capacity
-      on_map false         # Never on map
-      funded false         # Never funded
-      num_sessions 2       # Most have 2 sessions
-      num_facilitators 0   # Most have no facilitators
-      each_session_hours 8 # The most common session length
+      course {Pd::Workshop::COURSE_FACILITATOR}
+      subject {nil}
+      capacity {100}         # Typical capacity
+      on_map {false}         # Never on map
+      funded {false}         # Never funded
+      num_sessions {2}       # Most have 2 sessions
+      num_facilitators {0}   # Most have no facilitators
+      each_session_hours {8} # The most common session length
     end
 
     # Facilitator-in-training weekend workshop
     factory :fit_workshop do
-      subject Pd::Workshop::SUBJECT_FIT
-      course Pd::Workshop::COURSE_CSP # CSD is also valid
-      capacity 100         # Typical capacity
-      on_map false         # Never on map
+      subject {Pd::Workshop::SUBJECT_FIT}
+      course {Pd::Workshop::COURSE_CSP} # CSD is also valid
+      capacity {100}         # Typical capacity
+      on_map {false}         # Never on map
       funded               # Sometimes funded (50%)
-      num_sessions 2       # Most have 2 sessions
-      num_facilitators 2   # Most have 2 facilitators
-      each_session_hours 8 # The most common session length
+      num_sessions {2}       # Most have 2 sessions
+      num_facilitators {2}   # Most have 2 facilitators
+      each_session_hours {8} # The most common session length
     end
 
     factory :admin_workshop do
-      course Pd::Workshop::COURSE_ADMIN
-      subject nil
-      capacity 35          # Average capacity
-      on_map false         # Never on map
+      course {Pd::Workshop::COURSE_ADMIN}
+      subject {nil}
+      capacity {35}          # Average capacity
+      on_map {false}         # Never on map
       funded               # More than half are funded
-      num_sessions 1       # Most have 1 session
-      num_facilitators 0   # Most have no facilitators
-      each_session_hours 2 # The most common session length
+      num_sessions {1}       # Most have 1 session
+      num_facilitators {0}   # Most have no facilitators
+      each_session_hours {2} # The most common session length
     end
 
     factory :admin_counselor_workshop do
-      course Pd::Workshop::COURSE_ADMIN_COUNSELOR
-      subject Pd::Workshop::SUBJECT_ADMIN_COUNSELOR_WELCOME
-      capacity 35          # Average capacity
-      on_map false         # Never on map
-      funded false         # Never funded
-      num_sessions 1       # Most have 1 session
-      num_facilitators 1   # Want to work with facilitators
-      each_session_hours 2 # Not sure on session length
+      course {Pd::Workshop::COURSE_ADMIN_COUNSELOR}
+      subject {Pd::Workshop::SUBJECT_ADMIN_COUNSELOR_WELCOME}
+      capacity {35}          # Average capacity
+      on_map {false}         # Never on map
+      funded {false}         # Never funded
+      num_sessions {1}       # Most have 1 session
+      num_facilitators {1}   # Want to work with facilitators
+      each_session_hours {2} # Not sure on session length
     end
 
     factory :counselor_workshop do
-      course Pd::Workshop::COURSE_COUNSELOR
-      subject nil
-      capacity 40          # Average capacity
-      on_map false         # Never on map
+      course {Pd::Workshop::COURSE_COUNSELOR}
+      subject {nil}
+      capacity {40}          # Average capacity
+      on_map {false}         # Never on map
       funded               # All funded
-      num_sessions 1       # Most have 1 session
-      num_facilitators 0   # Most have no facilitators
-      each_session_hours 6 # The most common session length
+      num_sessions {1}       # Most have 1 session
+      num_facilitators {0}   # Most have no facilitators
+      each_session_hours {6} # The most common session length
     end
 
     factory :csp_wfrt do
-      course Pd::Workshop::COURSE_CSP
-      subject Pd::Workshop::SUBJECT_CSP_FOR_RETURNING_TEACHERS
-      capacity 40
-      on_map false
-      funded false
-      num_sessions 1
-      num_facilitators 2
-      each_session_hours 7
+      course {Pd::Workshop::COURSE_CSP}
+      subject {Pd::Workshop::SUBJECT_CSP_FOR_RETURNING_TEACHERS}
+      capacity {40}
+      on_map {false}
+      funded {false}
+      num_sessions {1}
+      num_facilitators {2}
+      each_session_hours {7}
     end
   end
 end


### PR DESCRIPTION
In preparation for an update to FactoryBot 5.x (and beyond), which [deprecated static attributes in favor of dynamic attributes](https://thoughtbot.com/blog/deprecating-static-attributes-in-factory_bot-4-11)

Update applied automatically by temporarily configuring my local environment to enable [the `FactoryBot/AttributeDefinedStatically` lint rule](https://docs.rubocop.org/rubocop-rspec/cops_rspec_factorybot.html#rspecfactorybotattributedefinedstatically):

```diff
diff --git a/.rubocop.yml b/.rubocop.yml
index 041a14ac898..594b15160a3 100644
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,7 @@ inherit_from:
 require:
   - rubocop-performance
   - rubocop-rails
+  - rubocop-rspec
   - rubocop-rails-accessibility
   - './tools/customLinters/rubocop_only_allowed_characters.rb'

@@ -74,6 +75,10 @@ Style/Semicolon:
 Style/WordArray:
   MinSize: 5

+RSpec/FactoryBot/AttributeDefinedStatically:
+  Include:
+    - 'dashboard/test/factories/*.rb'
+
 # END CODE.ORG OVERRIDES

 # BEGIN BLOCKLIST: Below are rules we don't plan to enable in the forseeable
diff --git a/Gemfile b/Gemfile
index 81ed2677555..917649bcb73 100644
--- a/Gemfile
+++ b/Gemfile
@@ -242,6 +242,7 @@ group :development, :staging, :levelbuilder do
   gem 'rubocop-performance', require: false
   gem 'rubocop-rails', require: false
   gem 'rubocop-rails-accessibility', require: false
+  gem 'rubocop-rspec', require: false
   gem 'scss_lint', require: false
 end
```

And then running:

    rubocop --require rubocop-rspec --only RSpec/FactoryBot/AttributeDefinedStatically --auto-correct dashboard/test/factories/*

I then used `rubocop --only Layout/SpaceInsideBlockBraces --auto-correct dashboard/test/factories/*.rb` to automatically fix some white space errors, and manually edited `dashboard/test/factories/foorm_factories.rb` to fix up a few more.

## Links

- https://thoughtbot.com/blog/deprecating-static-attributes-in-factory_bot-4-11
- https://docs.rubocop.org/rubocop-rspec/cops_rspec_factorybot.html#rspecfactorybotattributedefinedstatically

## Testing story

Relying on our existing tests to verify that this update to test configuration syntax does not result in any functional changes.

## Follow-up work

After this, we should be ready to upgrade to FactoryBot 5.x