### PR TITLE
Fix musiclab exhaustive-deps violations

### DIFF
--- a/apps/src/music/views/PatternPanel.jsx
+++ b/apps/src/music/views/PatternPanel.jsx
@@ -45,8 +45,7 @@ const PatternPanel = ({
 
       onChange(currentValue);
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [currentValue]
+    [onChange, previewSound, currentValue]
   );
 
   const hasEvent = (sound, tick) => {
@@ -77,8 +76,7 @@ const PatternPanel = ({
   const onClear = useCallback(() => {
     currentValue.events = [];
     onChange(currentValue);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentValue]);
+  }, [onChange, currentValue]);
 
   const startPreview = useCallback(() => {
     setCurrentPreviewTick(1);
@@ -91,8 +89,7 @@ const PatternPanel = ({
       clearInterval(intervalId);
       setCurrentPreviewTick(0);
     });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [setCurrentPreviewTick, currentValue]);
+  }, [previewPattern, bpm, setCurrentPreviewTick, currentValue]);
 
   return (
     <div className={styles.patternPanel}>


### PR DESCRIPTION
Fix violations related to incomplete dependency lists in React hooks in Music Lab's `PatternPanel` component (used in the "play drums" block).

## Links

- Discussion thread for ESLint rule: [link](https://github.com/facebook/react/issues/14920)
- eslint upgrade PR that produced these violations: [link](https://github.com/code-dot-org/code-dot-org/pull/51059)
- jira ticket: [link](https://codedotorg.atlassian.net/browse/SL-777)

## Testing story

Tested manually before/after making these changes that there was no visible regression in behavior in basic use case.