### PR TITLE
Refactor a scenario in scenarios.feature UI test

### DIFF
--- a/dashboard/test/ui/features/star_labs/applab/scenarios.feature
+++ b/dashboard/test/ui/features/star_labs/applab/scenarios.feature
@@ -60,13 +60,13 @@ Feature: App Lab Scenarios
 
     # in text input, blur produces a change event
     When I press "runButton"
-    And I wait until element "#divApplab > .screen > div#text_input1" is visible
-    And I press keys "123" for element "#text_input1"
+    And I wait until element ".screen > input" is visible
+    And I press keys "123" for element ".screen > input"
     And I blur selector "#text_input1"
     Then element "#debug-output" has escaped text "\"text_input1: 123\""
 
     # in a text input, enter produces a change event but then blur does not
-    When I press keys "456\n" for element "#text_input1"
+    When I press keys "456\n" for element ".screen > input"
     Then element "#debug-output" has escaped text "\"text_input1: 123\"\"text_input1: 123456\""
     And I blur selector "#text_input1"
     Then element "#debug-output" has escaped text "\"text_input1: 123\"\"text_input1: 123456\""

--- a/dashboard/test/ui/features/star_labs/applab/scenarios.feature
+++ b/dashboard/test/ui/features/star_labs/applab/scenarios.feature
@@ -5,6 +5,29 @@ Feature: App Lab Scenarios
     Given I start a new Applab project
     And I wait for the page to fully load
 
+  Scenario:
+    # Project Template Workspace Icon should not appear since this is not a project template backed level
+    Then element ".projectTemplateWorkspaceIcon" is not visible
+
+  Scenario: App Lab Http Image
+    # Create an app with an http image.
+    When I ensure droplet is in text mode
+    And I append text to droplet "image('test123', 'http://example.com')"
+    And I press "runButton"
+    And I wait until element "#divApplab > .screen > img#test123" is visible
+    And element "#divApplab > .screen > img#test123" has attribute "src" equal to "//studio.code.org/media?u=http%3A%2F%2Fexample.com"
+
+  Scenario: App Lab Clear Puzzle and Design Mode
+    # Create an app with a design mode button, then clear the puzzle
+    Given I switch to design mode
+    And I drag a BUTTON into the app
+    And I switch to code mode
+    And Applab HTML has a button
+    And I reset the puzzle to the starting version
+    And I wait to see "#divApplab"
+    And I wait until element "#divApplab" is visible
+    And Applab HTML has no button
+
   Scenario: Can read and set button text
     Given I ensure droplet is in text mode
     And I append text to droplet "button('testButton1', 'Peanut Butter');\n"
@@ -37,13 +60,13 @@ Feature: App Lab Scenarios
 
     # in text input, blur produces a change event
     When I press "runButton"
-    And I wait until element with id "text_input1" is visible
-    And I press keys "123" for element with id "text_input1"
+    And I wait until element "#divApplab > .screen > div#text_input1" is visible
+    And I press keys "123" for element "#text_input1"
     And I blur selector "#text_input1"
     Then element "#debug-output" has escaped text "\"text_input1: 123\""
 
     # in a text input, enter produces a change event but then blur does not
-    When I press keys "456\n" for element with id "text_input1"
+    When I press keys "456\n" for element "#text_input1"
     Then element "#debug-output" has escaped text "\"text_input1: 123\"\"text_input1: 123456\""
     And I blur selector "#text_input1"
     Then element "#debug-output" has escaped text "\"text_input1: 123\"\"text_input1: 123456\""

--- a/dashboard/test/ui/features/star_labs/applab/scenarios.feature
+++ b/dashboard/test/ui/features/star_labs/applab/scenarios.feature
@@ -6,7 +6,7 @@ Feature: App Lab Scenarios
     And I wait for the page to fully load
 
   Scenario:
-    # Project Template Workspace Icon should not appear since this is not a project template backed level
+    # Project Template Workspace Icon should not appear since this is not a project template backed level.
     Then element ".projectTemplateWorkspaceIcon" is not visible
 
   Scenario: App Lab Http Image
@@ -18,7 +18,7 @@ Feature: App Lab Scenarios
     And element "#divApplab > .screen > img#test123" has attribute "src" equal to "//studio.code.org/media?u=http%3A%2F%2Fexample.com"
 
   Scenario: App Lab Clear Puzzle and Design Mode
-    # Create an app with a design mode button, then clear the puzzle
+    # Create an app with a design mode button, then clear the puzzle.
     Given I switch to design mode
     And I drag a BUTTON into the app
     And I switch to code mode
@@ -58,15 +58,15 @@ Feature: App Lab Scenarios
     And I append text to droplet "  console.log(event.targetId + ': ' + getText('text_input1'));\n"
     And I append text to droplet "});"
 
-    # in text input, blur produces a change event
+    # In a text input, blur produces a change event.
     When I press "runButton"
-    And I wait until element ".screen > input" is visible
-    And I press keys "123" for element ".screen > input"
+    And I wait until element "#text_input1" is visible
+    And I press keys "123" for element "#text_input1"
     And I blur selector "#text_input1"
     Then element "#debug-output" has escaped text "\"text_input1: 123\""
 
-    # in a text input, enter produces a change event but then blur does not
-    When I press keys "456\n" for element ".screen > input"
+    # In a text input, enter produces a change event but then blur does not.
+    And I press keys "456\n" for element ".screen > input"
     Then element "#debug-output" has escaped text "\"text_input1: 123\"\"text_input1: 123456\""
     And I blur selector "#text_input1"
     Then element "#debug-output" has escaped text "\"text_input1: 123\"\"text_input1: 123456\""
@@ -80,10 +80,10 @@ Scenario: Change event works in text area
     And I append text to droplet "  console.log(event.targetId + ': ' + getText('text_area1'));\n"
     And I append text to droplet "});"
 
-    # in a text area, blur produces a change event. sending keystrokes (especially 'enter')
-    # to a contentetiable div was too hard to test here due to browser differences.
-    And I press "runButton"
-    And I wait until element "#divApplab > .screen > div#text_area1" is visible
+    # In a text area, blur produces a change event. Sending keystrokes (especially 'enter')
+    # to a contenteditable div was too hard to test here due to browser differences.
+    When I press "runButton"
+    And I wait until element "#text_area1" is visible
     And I focus selector "#text_area1"
     And I set selector "#text_area1" text to "abc"
     And I blur selector "#text_area1"
@@ -99,7 +99,7 @@ Scenario: Change event works in text area
     And I upload the file named "artist_image_1.png"
     And I wait until element ".assetRow td:contains(artist_image_1.png)" is visible
 
-    # Delete asset
+    # Delete asset.
     Then I press the first ".btn-danger" element
     And I press the first ".btn-danger" element
     And I wait until element "#manage-asset-status" contains text "successfully deleted!"

--- a/dashboard/test/ui/features/star_labs/applab/scenarios.feature
+++ b/dashboard/test/ui/features/star_labs/applab/scenarios.feature
@@ -5,29 +5,6 @@ Feature: App Lab Scenarios
     Given I start a new Applab project
     And I wait for the page to fully load
 
-  Scenario:
-    # Project Template Workspace Icon should not appear since this is not a project template backed level
-    Then element ".projectTemplateWorkspaceIcon" is not visible
-
-  Scenario: App Lab Http Image
-    # Create an app with an http image.
-    When I ensure droplet is in text mode
-    And I append text to droplet "image('test123', 'http://example.com')"
-    And I press "runButton"
-    And I wait until element "#divApplab > .screen > img#test123" is visible
-    And element "#divApplab > .screen > img#test123" has attribute "src" equal to "//studio.code.org/media?u=http%3A%2F%2Fexample.com"
-
-  Scenario: App Lab Clear Puzzle and Design Mode
-    # Create an app with a design mode button, then clear the puzzle
-    Given I switch to design mode
-    And I drag a BUTTON into the app
-    And I switch to code mode
-    And Applab HTML has a button
-    And I reset the puzzle to the starting version
-    And I wait to see "#divApplab"
-    And I wait until element "#divApplab" is visible
-    And Applab HTML has no button
-
   Scenario: Can read and set button text
     Given I ensure droplet is in text mode
     And I append text to droplet "button('testButton1', 'Peanut Butter');\n"
@@ -49,36 +26,39 @@ Feature: App Lab Scenarios
     And I wait until element "#divApplab > .screen > div#text_area1" is visible
     Then element "div#text_area1" has html "Line 1<div>Line 2</div><div><br></div><div>Line3</div>"
 
-  Scenario: Change event works in text input and text area
+  Scenario: Change event works in text input
     Given I switch to design mode
     And I drag a TEXT_INPUT into the app
-    And I drag a TEXT_AREA into the app
     And I switch to code mode
     And I ensure droplet is in text mode
     And I append text to droplet "onEvent('text_input1', 'change', function(event) {\n"
     And I append text to droplet "  console.log(event.targetId + ': ' + getText('text_input1'));\n"
-    And I append text to droplet "});\n\n"
-    And I append text to droplet "onEvent('text_area1', 'change', function(event) {\n"
-    And I append text to droplet "  console.log(event.targetId + ': ' + getText('text_area1'));\n"
     And I append text to droplet "});"
 
     # in text input, blur produces a change event
     When I press "runButton"
-    And I wait until element "#divApplab > .screen > div#text_area1" is visible
-    And I press keys "123" for element "#text_input1"
+    And I wait until element with id "text_input1" is visible
+    And I press keys "123" for element with id "text_input1"
     And I blur selector "#text_input1"
     Then element "#debug-output" has escaped text "\"text_input1: 123\""
 
     # in a text input, enter produces a change event but then blur does not
-    When I press keys "456\n" for element "#text_input1"
+    When I press keys "456\n" for element with id "text_input1"
     Then element "#debug-output" has escaped text "\"text_input1: 123\"\"text_input1: 123456\""
     And I blur selector "#text_input1"
     Then element "#debug-output" has escaped text "\"text_input1: 123\"\"text_input1: 123456\""
 
+Scenario: Change event works in text area
+    Given I switch to design mode
+    And I drag a TEXT_AREA into the app
+    And I switch to code mode
+    And I ensure droplet is in text mode
+    And I append text to droplet "onEvent('text_area1', 'change', function(event) {\n"
+    And I append text to droplet "  console.log(event.targetId + ': ' + getText('text_area1'));\n"
+    And I append text to droplet "});"
+
     # in a text area, blur produces a change event. sending keystrokes (especially 'enter')
     # to a contentetiable div was too hard to test here due to browser differences.
-    When I press "resetButton"
-    And I wait until element "#runButton" is visible
     And I press "runButton"
     And I wait until element "#divApplab > .screen > div#text_area1" is visible
     And I focus selector "#text_area1"

--- a/dashboard/test/ui/features/star_labs/applab/scenarios.feature
+++ b/dashboard/test/ui/features/star_labs/applab/scenarios.feature
@@ -66,7 +66,7 @@ Feature: App Lab Scenarios
     Then element "#debug-output" has escaped text "\"text_input1: 123\""
 
     # In a text input, enter produces a change event but then blur does not.
-    And I press keys "456\n" for element ".screen > input"
+    And I press keys "456\n" for element "#text_input1"
     Then element "#debug-output" has escaped text "\"text_input1: 123\"\"text_input1: 123456\""
     And I blur selector "#text_input1"
     Then element "#debug-output" has escaped text "\"text_input1: 123\"\"text_input1: 123456\""


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR refactors one scenario in the UI test `scenarios.feature`.

Currently, the scenario 'Change event works in text input and text area' tests both a text input and a text area for a change event. However, when you view the Sauce Labs video of this test run (see video below) at 0:33, you will see that the user clicks and drags a text input element in Design Mode, but then clicks and drags a text area element on top of the text input so that the input box is no longer visible. At 0:46, keys are pressed in the input box using a command, but a user would normally not be able to type in the input box at this point since the text area is covering it up.

BEFORE UPDATE:


https://user-images.githubusercontent.com/107423305/232097371-4c9b2420-1817-4a6e-9586-c256a393b03f.mp4


I noticed this because I was curious that at [line 67](https://github.com/code-dot-org/code-dot-org/blob/79e0ce080e16e7d9bf9f0f523cb70536ce6d26a6/dashboard/test/ui/features/star_labs/applab/scenarios.feature#L67), the command used is `And I wait until element "#divApplab > .screen > div#text_area1" is visible` even though the scenario is currently testing the input box.

Normally, if the input box is not visible, then the user is unable to type text into the box. Thus, I refactored this scenario into 2 different scenarios (one for text input and one for text area) so that it replicates what would be possible as an actual user experience.

AFTER UPDATE: 

Here is the refactored scenario testing the text input with change event:


https://user-images.githubusercontent.com/107423305/232178543-c731cafc-3136-4a09-b0c9-9f95a3009508.mp4



Here is the refactored scenario testing the text area with change event:



https://user-images.githubusercontent.com/107423305/232178537-cf940275-26d2-47ce-82d1-05d5a477068f.mp4




## Links
This was a follow up to [this PR\(https://github.com/code-dot-org/code-dot-org/pull/51266).

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
I tested locally and verified using Sauce Labs.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
