### PR TITLE
Only show CSA Before Workshop note for Summer Workshop subject

### DIFF
--- a/dashboard/app/views/pd/workshop_mailer/_teacher_enrollment_details.html.haml
+++ b/dashboard/app/views/pd/workshop_mailer/_teacher_enrollment_details.html.haml
@@ -39,10 +39,8 @@
   = render partial: 'virtual_tips'
 - elsif !@workshop.virtual? && @is_reminder
   = render partial: 'supply_list'
-
-%h3
-  Health and wellness precautions
-- if !@workshop.virtual?
+  %h3
+    Health and wellness precautions
   %p
     Our workshops are highly interactive. If you are feeling ill, or show
     any flu-like symptoms such as a fever or cough, please inform your

--- a/dashboard/app/views/pd/workshop_mailer/_teacher_enrollment_details.html.haml
+++ b/dashboard/app/views/pd/workshop_mailer/_teacher_enrollment_details.html.haml
@@ -10,7 +10,7 @@
 
 %h3
   Before the Workshop
-- if @workshop.course == Pd::Workshop::COURSE_CSA
+- if @workshop.course == Pd::Workshop::COURSE_CSA && @workshop.subject == Pd::Workshop::SUBJECT_CSA_SUMMER_WORKSHOP
   %p
     Reminder: For the best professional development experience, we strongly
     encourage you to engage in the pre-work that is specifically designed for

--- a/dashboard/app/views/pd/workshop_mailer/_teacher_enrollment_details.html.haml
+++ b/dashboard/app/views/pd/workshop_mailer/_teacher_enrollment_details.html.haml
@@ -8,19 +8,20 @@
     vertical-align: top;
   }
 
-%h3
-  Before the Workshop
-- if @workshop.course == Pd::Workshop::COURSE_CSA && @workshop.subject == Pd::Workshop::SUBJECT_CSA_SUMMER_WORKSHOP
-  %p
-    Reminder: For the best professional development experience, we strongly
-    encourage you to engage in the pre-work that is specifically designed for
-    CSA. The pre-work can be found at
-    = link_to('studio.code.org/courses/self-paced-pl-csa', 'https://studio.code.org/courses/self-paced-pl-csa') + '.'
-- else
-  %p
-    There is no requirement that you are familiar with the course before you
-    join the workshop - we will walk you through what you need to know in our
-    time together.
+- if @workshop.subject == Pd::Workshop::SUBJECT_SUMMER_WORKSHOP
+  %h3
+    Before the Workshop
+  - if @workshop.course == Pd::Workshop::COURSE_CSA
+    %p
+      Reminder: For the best professional development experience, we strongly
+      encourage you to engage in the pre-work that is specifically designed for
+      CSA. The pre-work can be found at
+      = link_to('studio.code.org/courses/self-paced-pl-csa', 'https://studio.code.org/courses/self-paced-pl-csa') + '.'
+  - else
+    %p
+      There is no requirement that you are familiar with the course before you
+      join the workshop - we will walk you through what you need to know in our
+      time together.
 
 - if @is_reminder && @workshop.course == Pd::Workshop::COURSE_CSD && @workshop.subject == Pd::Workshop::SUBJECT_CSD_WORKSHOP_4
   %h3
@@ -38,8 +39,10 @@
   = render partial: 'virtual_tips'
 - elsif !@workshop.virtual? && @is_reminder
   = render partial: 'supply_list'
-  %h3
-    Health and wellness precautions
+
+%h3
+  Health and wellness precautions
+- if !@workshop.virtual?
   %p
     Our workshops are highly interactive. If you are feeling ill, or show
     any flu-like symptoms such as a fever or cough, please inform your


### PR DESCRIPTION
This PR refactors how we show the "Before the Workshop" section in workshop enrollment receipt and reminder emails to tailor the information better to the specific workshop case. This change affects both the enrollment receipt and enrollment reminder emails but it does not depend on whether a given email is a receipt or reminder email so I arbitrarily chose the receipt emails to demo below.

### Case: CSA summer workshop email (no change expected)
Original:
![old_csa_summer_workshop](https://user-images.githubusercontent.com/56283563/232156512-154b877e-a240-400a-bcd3-c9933da0abfd.JPG)

New:
![new_csa_summer_workshop](https://user-images.githubusercontent.com/56283563/232156670-30028f05-50bb-4a51-9aff-3906a6947d48.JPG)

### Case: CSA not summer workshop (e.g. CSA capstone in this case) email
Original:
![old_csa_non_summer_workshop](https://user-images.githubusercontent.com/56283563/232156651-d020f15e-fea0-487f-94e8-ca75b9ec8d5e.JPG)

New:
![new_csa_non_summer_workshop](https://user-images.githubusercontent.com/56283563/232156690-b489dfb2-78bf-4dc8-a288-5792d7ed374b.JPG)

### Case: Not CSA (e.g. CSD in this case) summer workshop email (no change expected)
Original:
![old_non_csa_summer_workshop](https://user-images.githubusercontent.com/56283563/232156648-44325502-bb35-4388-ba5b-2e1c87f9a9f3.JPG)

New:
![new_non_csa_summer_workshop](https://user-images.githubusercontent.com/56283563/232156712-eed46fec-6731-4310-8db0-510fec0a6020.JPG)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?modal=detail&selectedIssue=ACQ-523&assignee=60d62161f65054006980bd71)

## Testing story
Local testing.

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
