### PR TITLE
Turning on Samoan in production

### DIFF
--- a/dashboard/config/locales.yml
+++ b/dashboard/config/locales.yml
@@ -398,7 +398,6 @@
 "sm-WS":
   english: "Samoan"
   native: "Sāmoa"
-  debug: true
 
 "sq": "sq-AL"
 "sq-AL":

--- a/i18n/locales/sm-WS/hourofcode/activity-guidelines.md
+++ b/i18n/locales/sm-WS/hourofcode/activity-guidelines.md
@@ -1,0 +1,278 @@
+---
+title: Activity Guidelines
+---
+
+<style>
+  ul {
+    margin: 0px 20px 20px 20px;
+  }
+</style>
+
+# Guidelines for creating and submitting tutorials and lessons for Hour of Code™ and Computer Science Education Week
+
+Code.org hosts a variety of Hour of Code™ activities, lessons, and videos on the Code.org and Hour of Code websites. The current list is at [hourofcode.com/learn]({{ urls/learn }}).
+
+Want to submit your own self-guided tutorial, teacher-led lesson, or robotics/maker activity that explains a computer science principle? Join this global movement and help participants around the world get started with an hour of code or go further with multi-lesson, day-long, or week-long activities.
+
+**After reading the guidelines, you can submit your activity through our [Hour of Code™ Activity Submission page](https://forms.gle/eeAt6kVuz3RKg5n18). You can submit an activity at any time, but the deadline for inclusion in any given calendar year is October 1. (For example, any activities received after October 1, 2022, will not be listed for 2022's Hour of Code.)** If you have any questions about your activitiy submission, please reach out to us at support@code.org.
+
+A few tips:
+
+1. **Submit more than one activity**: If you’ve built activities for different levels, different ages, or other categories, we list your activities separately so each teacher can find the right thing for their classroom. Submit each tutorial or activity individually. Given the number of submissions we have seen in recent years, we will have time to review **up to 5 activities** per partner. After that, we will make a best effort to review as many as possible before Hour of Code begins.
+
+2. **Beyond beginner lessons**: In addition to lessons for teachers and students who are learning computer science for the first time, we list learning experiences for computer science-savvy classrooms that want to go a little bit further! Help us by submitting lessons for classes that are already comfortable with the basics.
+
+3. **Subject areas**: Have a great lesson idea that integrates Computer Science into Math? History? Language Arts? Science? Art? Or another subject? We’ve had numerous requests from teachers who want to connect the Hour of Code to their subject area. Teachers can filter for their classroom type (grade band or subject area) so we need your help filling in gaps to offer classroom activities or lesson plans that relate CS to every major subject area for different grade bands. We also continue to have a “Computer Science” category for teachers who are looking for generic CS activities.
+
+<a id="top"></a>
+
+## Index:
+
+- [What to submit](#whatsubmit)
+- [General guidelines for creating an Hour of Code™ activity](#guidelines)
+- [How to Submit](#submit)
+- [How activities will be evaluated](#inclusion)
+- [Suggestions for designing your activity](#design)
+- [Trademark Guidelines](#tm)
+- [Tracking Pixel](#pixel)
+- [Promoting your activity, CSEdWeek, and Hour of Code](#promote)
+
+<a id="whatsubmit"></a>
+
+## What to submit
+
+**Self-guided puzzle or game ([example](https://code.org/dance))**
+
+These activities are designed for students to self-direct through a tutorial. They don’t require much instruction from a teacher or teacher prep work.
+
+**Teacher Facilitated lesson ([example](https://studio.code.org/s/course1/lessons/2/levels/1), [template](https://docs.google.com/document/d/1DhaLNd6uim9rRPkHrglnOvVcgzGc8axKIzv8YI56JGA))**
+
+Now that hundreds of thousands of educators have tried the Hour of Code, many classrooms are ready for more creative activities that teach the basics of computer science. To help more advanced teachers find inspiration, we collect and curate "teacher-led" lessons and activity plans for Hour of Code veterans.
+
+One type of activity that we will feature for experienced teachers are “open sandbox” creation projects. Activities that encourage students to build their own app, game, website or other project. If facilitated properly, more open-ended activities can better showcase the creative nature of computer science.
+
+Some educators may also prefer to host Hour of Code activities that follow a traditional lesson format rather than a guided-puzzle/game experience.
+
+You can start with this [template](https://docs.google.com/document/d/1DhaLNd6uim9rRPkHrglnOvVcgzGc8axKIzv8YI56JGA) for your lesson plan.
+
+**Activities for teachers in other subjects/fields**
+
+We also feature lesson plans designed for different subject areas. For example, a one-hour lesson plan for teaching code in a geometry class. Or a mad-lib exercise for English class. Or a creative quiz-creation activity for history class. These can help recruit teachers in other subject areas to guide an Hour of Code activity that is unique to their field, while demonstrating how CS can influence and enhance many different subject areas.
+
+Examples:
+
+- Mirror Images (an activity for an art teacher)
+- An arduino activity for a physics teacher
+- A history of technology activity for a history teacher
+- And see [this list](https://docs.google.com/document/d/19jQ2VhBUyIn30VFbfdHOVpmlymhNiB0AkEqRxHz3dr0/edit) for more ideas from educators (or add your own to the list to inspire others)
+
+**For students with special needs**
+
+If you create an activity or tutorial that is designed for special needs students, please call that out in the description. In particular, there are very few options for the vision-impaired. If your activity is designed for this audience, please let us know.
+
+[**Back to the top**](#top)
+
+<a id="guidelines"></a>
+
+## General guidelines for creating an Hour of Code activity
+
+The goal of an Hour of Code is to give beginners an accessible first taste of computer science or programming. The tone should be that:
+
+- Anybody can learn computer science - regardless of age, gender, race, or ability/disability. 
+- Computer science is connected to a wide variety of fields and interests. Everybody should learn it!
+- Encourage students to create something unique that can be shared with parents/friends or online. 
+
+The activities should teach a computer science concept such as loops, conditionals, encryption, or how the Internet works. An activity can also teach about how computer science connects to real world occupations, events, or history. For example, teaching UX design to make apps that are meaningful for an audience or cause. We discourage activities that focus on the syntax of programming rather than the concepts. For example, we will list, but not highlight, activities that teach HTML. Similarly, we discourage block programming lessons that focus on setting/changing configuration options rather than learning how to model an algorithm or process.
+
+*Technical requirements:* Because of the wide variety of school and classroom technology setups, the best activities are Web-based or smartphone-friendly, or otherwise unplugged-style activities that teach computer science concepts without the use of a computer (see <http://csunplugged.com/>). Activities that require an app-install, desktop app, or game-console experiences are okay but not ideal. We will not list activities that require sign up or payment. (Robotics activities can require robotics purchase.)
+
+*Student-led (Self-Guided) Format:* The original Hour of Code was built mostly on the success of self-guided tutorials or lessons, optionally facilitated by the teacher. There are plenty of existing options, but if you want to create a new one, these activities should be designed so they can be fun for a student working alone, or in a classroom whose teacher has minimal prep or CS background. They should provide directions for students as opposed to an open-ended hour-long challenge. Ideally, the instructions and tutorials are integrated directly into the programming platform, to avoid switching tabs or windows between the tutorial and the programming platform.
+
+To get a sense of the wide variety of types of tutorials and lesson plans you can create, visit the [Hour of Code Activities page](https://hourofcode.com/us/learn).
+
+[**Back to the top**](#top)
+
+<a id="submit"></a>
+
+## How to submit
+
+Visit the [Hour of Code™ Activity Submission page](https://forms.gle/eeAt6kVuz3RKg5n18) and complete the questions to submit your activity.
+
+What you’ll need:
+
+* Name and email of the primary contact representing the submitted activity
+* Activity Name (cannot include “Hour of Code” in the name)
+* URL link to the activity
+* An activity description (max character count: 400) 
+    * Please include in the description whether it’s mainly student-guided or teacher-facilitated. Additionally, some schools are interested in knowing if Hour of Code activities address Common Core or Next Generation Science Standards. If the activity addresses specific standards, consider including this information.
+* Recommended grade level(s) for intended users. You may refer to the \[Computer Science Teachers’ Association’s K-12 Standards\] (https://k12cs.org/framework-statements-by-grade-band/) for grade-appropriate computer science concepts. Example grade levels include: 
+    * Kindergarten - Grade 1 (ages 4-6)
+    * Grades 2-5 (ages 7-10)
+    * Grades 6-8 (ages 11-13)
+    * Grades 9+ (ages 14+)
+* A list of subject areas your activity covers (in addition to Computer Science). For example, if a math teacher can use your activity to teach about angles or parabolas, list as math. If you have a mad libs activity that teaches verbs/nouns/etc. choose language arts.
+* A list of programming languages your activity teaches. I.e. C/C++, Java, JavaScript, etc. or language independent (for lesson plans that can be taught in multiple languages)
+* A list of supported natural languages. Note: Language-detection is the responsibility of the activity provider; we will redirect all users to the single URL provided.
+* What level of experience should an educator have to use your activity? (e.g. Beginner or Comfortable.) And, what level of experience should the students have? If you’d like to prepare more advanced Hour of Code™ Activities, please include the prior knowledge needed in the description of your activity.
+* The length of your activity 
+    * 1 hour only
+    * 1 hour with follow-on course
+    * 2-6 hours (can be multiple lessons)
+* A list of accessibility accommodations, if your activity has them. These include screen reader compatibility, text-to-speech capabilities, use of high-contrast colors, or any other accommodations made for learners with disabilities.
+
+#### Additional things you’ll need when submitting Lesson Plans
+
+* Link to your lesson plan. This can be a web page, dropbox link, google drive or similar service. 
+* What software and/or hardware the teacher will need to do your lesson plan (Scratch? Robots? Nothing?)
+
+#### Additional things you’ll need when submitting Online Activities
+
+* Name and logo of your organization
+* Whether it is COPPA compliant or not
+* A URL link to teacher notes (optional)
+* A list of tested/compatible platforms: 
+    * Web based: Which platforms have you tested? 
+        * OS - Mac, Win, and other versions
+        * Browsers - IE11, Edge, Firefox, Chrome, Safari
+        * iOS mobile Safari (mobile-optimized)
+        * Android Chrome (mobile-optimized)
+    * Non web-based: specify platform for native code (Mac, Win, iOS, Android, xBox, other)
+    * Unplugged
+* Screenshot or marketing image of the Hour of Code activity. Please send at least one image with 4:3 dimensions. It should be at least 520px by 390px. This image should have NO text on it (other than your logo), in order to make it more accessible for non-English speakers. If an appropriate image is not provided, we may take our own screenshot of your tutorial OR we may choose not to list it. All images must be submitted as a URL link to a .jpg, .jpeg, or .png.
+* In order to more accurately track participation, third party tutorial partners need to include 1-pixel tracking images on the first page of their Hour of Code tutorials. See the [Tracking Pixel](#pixel) section below for more details.
+* Upon finishing your activity, users should be directed to [code.org/api/hour/finish](https://code.org/api/hour/finish) where they will be able to: 
+    * Share on social media that they completed the Hour of Code
+    * Receive a certificate that they completed the Hour of Code
+    * See leaderboards about which countries/cities have the highest participation rates in Hour of Code activities
+    * For users who spend an hour on your activity and don’t complete it, please include a button on your activity that says “I’m finished with my Hour of Code” which links back to [code.org/api/hour/finish](https://code.org/api/hour/finish) as well.
+* (Optional) We may follow-up with an online survey/form link asking for a report of the following activity metrics: 
+    * For online activities (especially smartphone/tablet apps): 
+        * Number of users
+        * How many completed the task
+        * Average time on task
+        * Number of total lines of code written over all users
+        * How many continued on to further learning (measured as any user who finishes the task and goes onto additional tasks at your site)
+    * For offline activities 
+        * Number of downloads of paper version of activity (if applicable)
+
+#### Additional things you’ll need when submitting Robotics
+
+* If you submit a robotics activity, we need to know the cost per student for robotics.
+* To evaluate robotics activities for inclusion on the website, we will need you to send sample kits to reviewers.
+
+[**Back to the top**](#top)
+
+<a id="inclusion"></a>
+
+## How activities will be evaluated
+
+A diverse committee of computer science educators will rank submissions based on qualitative and quantitative criteria. All activities that fit the basic criteria will be listed. Teachers will be able to filter and sort to find the best activities for their classroom.
+
+The rubric for evaluating activities and lesson plans will look for the following criteria on all activities and rank them accordingly:
+
+- High production quality
+- Promote learning by all demographic groups (esp. students underrepresented in CS, like young women, students from marginalized racial and ethnic groups, and students with disabilities)
+- Educational (teaches computer science concepts well)
+- Fun and engaging
+- Encourages students to create something unique they can share (For younger students: with parents and classmates. For olders students: on the Internet)
+
+If the review committee rates the activity a zero in production quality (due to bad bugs or instructions that make it very hard to use), in promoting learning in underrepresented groups (due to racist/sexist material), in educational value (does not teach CS concepts), or fun/engaging (due to being difficult/discouraging for students to work through), the activity will not be listed.
+
+In addition, in order to be listed, all activities must:
+
+- Be appropriate for a public school classroom (no guns, no explicit/mature content, no religious content, etc.)
+- Require no sign up 
+- Require no payment (exception for robotics activities these can require robot/kit purchase)
+
+For self-directed activities for new teachers and students the review committee will be looking for whether:
+
+- Teachers can use the tutorial or activity with no background in computer science
+- Students can be successful with no background in computer science
+- Students can direct themselves through the tutorial without parental or teacher guidance
+
+Teachers and students will be able to search through and filter our list of activities based on filters such as grade, experience level, subject, hardware, etc. By default, we will show lesson plans and activities first that:
+
+- Receive the highest ratings from the review committee
+- Are one hour self-directed activities designed for beginners (students and teachers)
+- Appeal to a wide range of users (across platforms, languages, and ages)
+- Require no installation
+- Are new this year
+
+[**Back to the top**](#top)
+
+<a id="design"></a>
+
+## Suggestions for designing one hour self guided tutorials
+
+You can include the [Hour of Code logo](https://hourofcode.com/us/promote/resources#logo) in your tutorial, but this is not required. If you use the Hour of Code logo, see the trademark guidelines below. <u>Under no circumstances can the Code.org logo and name be used.</u> Both are trademarked, and can’t be co-mingled with a 3rd party brand name without express written permission.
+
+**Make sure that the average student can finish comfortably in an hour.** Consider adding an open-ended activity at the end for students who move more quickly through the lesson. Remember that most kids will be absolute beginners to computer science and coding.
+
+**Include teacher notes.** Most activities should be student-directed, but if an activity is facilitated or managed by a teacher, please include clear and simple directions for the teacher in the form of teacher-notes at a separate URL submitted with your activity. Not only are the students novices, some of the teachers are as well. Include info such as:
+
+- What platforms and browsers does the tutorial work best on?
+- Does it work on smartphones? Tablets?
+- Do you recommend pair programming? 
+- Considerations for use in a classroom? E.g. if there are videos, advise teachers to show the videos on a projected screen for the entire classroom to view together
+
+**Incorporate feedback at the end of the activity.** (E.g. “You finished 10 levels and learned about loops! Great job!”)
+
+**Encourage students to post to social media (where appropriate) when they've finished.** For example “I’ve done an Hour of Code with ________ Have you? #HourOfCode” or “I’ve done an #HourOfCode as a part of #CSEdWeek. Have you? @Scratch.” Use the hashtag **#HourOfCode** (with capital letters H, O, C)
+
+**Create your activity in Spanish or in other languages besides English.**
+
+**Explain or connect the activity to a socially significant context.** Computer programming becomes a superpower when students see how it can change the world for the better!
+
+**Make sure your tutorial can be used in a [Pair Programming](http://www.ncwit.org/resources/pair-programming-box-power-collaborative-learning) paradigm.** This is particularly useful for the Hour of Code because many classrooms do not have 1:1 hardware for all students.
+
+[**Back to the top**](#top)
+
+<a id="tm"></a>
+
+## Trademark Guidelines
+
+Hour of Code® and Hora del Código® are registered trademarks of Code.org. Many of our tutorial partners have used our "Hour of Code" trademarks on their web sites in connection with their Hour of Code activities. We don't want to prevent this usage, but we want to make sure the usage falls within a few limits:
+
+1. Use “Hour of Code” only in connection with non-commercial CS Education activities in the context of the Hour of Code campaign, and for no other purpose.
+2. Any reference to "Hour of Code" should be used in a fashion that doesn't suggest that it's your own brand name, but that it rather references the Hour of Code as a grassroots movement. Good example: "Participate in the Hour of Code ® at ACMECorp.com". Bad example: "Try Hour of Code by ACME Corp".
+3. Use a “®” superscript in the most prominent places you mention "Hour of Code", both on your web site and in app descriptions.
+4. Include language on the page (or in the footer), including links to the Hour of Code, CSEdWeek and Code.org web sites, that discloses both the following: a. Hour of Code® and Hora del Código® are registered trademarks of Code.org; and b. “The '[Hour of Code](http://hourofcode.com/) ® is a nationwide initiative by [Code.org](http://code.org/) to introduce millions of students to one hour of computer science and computer programming.”
+5. Do not use "Hour of Code" in app names.
+6. Do not use “Hour of Code” in connection with any commercial use or purpose (e.g., placing your Hour of Code activity behind a paywall; promoting another paid service as part of your Hour of Code activity; selling Hour of Code merchandise).
+7. Do not use “Hour of Code” in connection with any activity that requires a login or account creation.
+
+[**Back to the top**](#top)
+
+<a id="pixel"></a>
+
+## Tracking Pixel
+
+In order to more accurately track participation we ask every tutorial partner to include a 1-pixel tracking image on the first page of their Hour of Code tutorials. The pixel-image must be on the start page only. Do not include on any interim pages of your tutorial.
+
+This will allow us to count users who do your Hour of Code tutorial. It will lead to more accurate participation counts for your tutorial.
+
+If your tutorial is approved and included on the final tutorial page, Code.org will provide you with a unique tracking pixel for you to integrate into your tutorial. See example below.
+
+NOTE: this isn't important to do for installable apps (iOS/Android apps, or desktop-install apps)
+
+Example tracking pixels for Dance Party:
+
+IMG SRC = <http://code.org/api/hour/begin_dance.png>   
+
+
+[**Back to the top**](#top)
+
+<a id="promote"></a>
+
+## Promoting your activities, CSEdWeek, and Hour of Code
+
+Please promote your activity to your network! Direct them to your Hour of Code page. Your users are much more likely to react to a mailing from you about your activity. Use the international Hour of Code campaign during Computer Science Education Week as an excuse to encourage users to invite others to join in, and help us reach more students!
+
+- Feature Hour of Code and CSEdWeek on your website. Ex: <http://www.tynker.com/hour-of-code>
+- Promote Hour of Code using social media, traditional media, mailing lists, etc, using hashtag #HourOfCode (with capital letters H, O, C)
+- Host a local event or ask your employees to host an event at local schools or community groups.
+- See our [resource kit](https://hourofcode.com/us/promote) for further information.
+
+[**Back to the top**](#top)
+
+{{ signup_button }} <!-- Adding in specific year for 2022 per Eric for later fix on line 18 as site was not auto-udpating to correct year -->

--- a/i18n/locales/sm-WS/hourofcode/advisory-committee.md
+++ b/i18n/locales/sm-WS/hourofcode/advisory-committee.md
@@ -1,0 +1,9 @@
+---
+title: Hour of Code and CSEdWeek Advisory Committee
+---
+
+# Hour of Code and CSEdWeek Advisory Committee
+
+{{ advisory-committee/about_headshots }}
+
+{{ advisory-committee/about_people }}

--- a/i18n/locales/sm-WS/hourofcode/assistive-technology.md
+++ b/i18n/locales/sm-WS/hourofcode/assistive-technology.md
@@ -1,0 +1,48 @@
+---
+title: Completing an Hour of Code with Assistive Technology
+---
+
+<h1>Completing an Hour of Code with Assistive Technology</h1>
+
+<p>Anyone can try an Hour of Code during Computer Science Education Week.</p>
+
+<h2>Using Screen Readers</h2>
+
+<p>The Hour of Code activities page now includes a <a href="https://hourofcode.com/us/learn?platform=screenreader" target="_blank">filter for activities compatible with screen readers</a>.</p>
+
+<p>If you use a screen reader, the <a href="https://quorumlanguage.com/hourofcode/astro1.html" target="_blank">Quorum tutorial for beginners</a> or the <a href="https://quorumlanguage.com/hourofcode/part1.html" target="_blank">Quorum tutorial for comfortable students</a> are great places to start an Hour of Code. Quorum started as an interpreted language originally designed to be accessible through screen readers. It has become a general purpose programming language designed for any user. And, if you want to go beyond an Hour of Code, the team at Quorum has additional tools and curriculum.</p>
+
+<p>If you use a screen reader and are interested in robotics, try the <a href="https://milnel2.github.io/blocks4alliOS/danceCircle1.html" target="_blank">Dash Joins a Dance Circle activity</a> (for grades K-5) or the <a href="https://milnel2.github.io/blocks4alliOS/danceCircle2.html" target="_blank">Dash Joins a Dance Circle with Functions activity</a> (for grades 6-8) from Lauren Milne.</p>
+
+<br />
+
+<div class="row">
+    <div class="col-xs-4">
+        <a href="https://quorumlanguage.com/hourofcode/astro1.html" target="_blank">
+        <img src="https://code.org/images/fill-300x225/tutorials/hoc2017/quorum_astronomy.jpg" alt="Tutorial for beginners">
+        </a>
+    </div>
+    <div class="col-xs-4">
+        <a href="https://quorumlanguage.com/hourofcode/part1.html" target="_blank">
+        <img src="https://code.org/images/fill-300x225/quorum.jpg" alt="Tutorial for comfortable students">
+        </a>
+    </div>
+    <div class="col-xs-4">
+        <a href="https://milnel2.github.io/blocks4alliOS/danceCircle1.html" target="_blank">
+        <img src="https://code.org/images/fill-300x225//tutorials/hoc2021/milne_dash.jpg" alt="Robotics tutorial for beginners">
+        </a>
+        <a href="https://milnel2.github.io/blocks4alliOS/danceCircle1.html" target="_blank">For grades K-5</a>
+        <br>
+        <a href="https://milnel2.github.io/blocks4alliOS/danceCircle2.html" target="_blank">For grades 6-8</a>
+    </div>
+</div>
+
+<div style="clear: both"></div>
+
+<h2>Code.org Tutorials Without Audio</h2>
+
+<p>The <a href="https://studio.code.org/courses" target="_blank">Code.org tutorials</a> can all be used with or without sound. All the videos have captions.</p>
+
+<h2>Pair Programming</h2>
+
+<p>Pair programming is a tool computer scientists use to solve problems as a pair or team. Try working on Hour of Code challenges with a friend or classmate. Don’t forget to <a href="https://www.youtube.com/watch?v=vgkahOzFH2Q" target="_blank">check out this video</a> to learn the best techniques for pair programming.</p>

--- a/i18n/locales/sm-WS/hourofcode/how-to/2019.md
+++ b/i18n/locales/sm-WS/hourofcode/how-to/2019.md
@@ -1,0 +1,154 @@
+---
+title: How-to Guide
+---
+
+{{ signup_button }}
+
+# Ala e fuafua ai lau Hour of Code
+
+### Ia e auai i lenei faamoemoe ma faailoa i isi tamaiti aoga mo le latou uluai itula i mataupu tau komepiuta faasainesi, e ala i laasaga nei.  O le Hour of Code e faigofie ona faafoe - aemaise lava mo e ua faatoa tau amata.  Afai o e manaomia se fesoasoani e mafai ona e alu i le fesootaiga lea o le [local volunteer]({{ urls/volunteer_local }}) e mafai ai ona faafoe ai le Hour of Code mo lau vasega.
+
+### Vaai i le matou participation guide
+
+ pe afai o iai ni fesili.</h3> 
+
+
+
+***
+
+
+
+## 1. Matamata i le video lea e faamatala le faatinoga o le galuega <iframe width="500" height="255" src="//www.youtube.com/embed/SrnvvWDm73k" frameborder="0" allowfullscreen></iframe> 
+
+
+
+## 2. Galuega ma Vasega Faataitai
+
+Matou te saunia ni polokalame eseese e malie ma manaia [ o ni vasega e taiala ai fanau aoga ]({{ urls/learn }}) o soo se tausaga ma poo le a le tulaga o le malamalama'aga. E tele tamaiti aoga e fiafia e faatino toatasi lava e latou vasega faataitai, e ala lea i galuega faatino o loo iai lesona ua fuafua mo faiaoga e fai ma taiala e faatino ai ni talanoaga pe faalautele ai foi le galuega faatino. 
+
+Vaai i galuega faatino ma fuafua mamao lava e oe pe e te filifili se vasega se tasi mo au tamaiti aoga uma, pe tuu i tamaiti e filifili a latou lava polokalame. 
+
+[<img src="/images/fit-700/tutorials.png" />]({{ urls/learn }})
+
+
+
+## 3 Fai sou Polokalame mo le Aso
+
+
+
+### Ia e mafaufau i vaega e te manaomia i tulaga tau o le tekenolosi - e tele ituaiga komepiuta e te filifili i ai
+
+- O le Hour of Code e sili ona lelei le fa'aaogaina pe afai o se komepiuta o fesootai ma le upega tafailagi Ae e le faapea o le a manaomia e tamaiti uma se komepiuta, ma e mafai lava ona fa'aaoga le Hour of Code e aunoa ma se komepiuta.  Mo galuega faatino e taua o le 'unplugged activities' e faigofie ona e vailiili le vaega o le polokalame o le Classroom Technology ma filifili le vaega e taua o le "No computers or devices". 
+- E tatau ona faataitai muamua vasega poo tutorials i komepitua a tamaiti aoga poo isi masini o loo fa'aaoga ina ia mautino ai o loo fesootai lelei ma le ola foi le sound ma le video.  E maualalo le fesootaiga o le upega poo le WiFi?  Ia e fuafua e fa'aali video i le amataga o le vasega, ina ia aua ne'i download taitasi e tamaiti videos taitasi.  Pe taumafai e fa'aaoga le offline tutorials. 
+- Ia saunia ni mea fa'alogo mo lau vasega, pe fai i tamaiti ia aumai a latou mea fa'alogo, pe afai o le vasega o le a e filifili e manaomia le sound. 
+- E le lava ni au komepiuta poo devices?  Fa'aaoga le fesootaiga lea  ina ia mafai ona galulue faatasi ai ni tamaiti se toalua.  A galulue faatasi tamaiti i paga, e mafai ona fesoasoani le tasi i le isi nai lo le lagolago i le faiaoga.  E iloa ma vaaitino foi i latou i galuega tau komepiuta e faigofie ai ona mafai ona fesootai ma galulue faatasi ai. </li> </ul> 
+  
+  <img src="/images/fit-350/group_ipad.jpg" />
+  
+  
+
+### Filifili se aso ma se taimi. 
+
+E toatele tagata i le lalolagi e auai i le faatauaina o le Vaiaso o le Hour of Code (Tesema 9-13) i le taimi e maua ai vasega faataitai ma galuega faatino fou.  Ae e mafai ona e fa'aaoga le Hour of Code i soo se taimi ma se aso i le tausaga. 
+
+
+
+## 4 Faalauiloa le Hour of Code
+
+O lea ua uma ona taoto lau polokalame, ua tatau loa ona faailoa. 
+
+
+
+### Faailoa i lau aoga ma tagata lautele
+
+Faailoa le Hour of Code i isi faiaoga o loo mananao e auai i lenei polokalame O se avanoa taua foi lenei e faailoa ai i le Komiti o Matua a lau aoga poo le faailoa i tusi mo matua, ina ia latou silafia o le a o atu tamaiti e mananao e fa'aaoga galuega faatino ma vasega i o latou fale
+
+
+
+### Ia faailoa i nisi e tagata e ono fesoasoani i lau polokalame e ala lea i le Resitalaina o lau Polokalame
+
+A oo ina resitala lau polokalame [ mo le Hour of Code](/), e lafo atu se imeli e fesoasoani i le faafoeina o se polokalame manuia o lau Hour of Code. O leisi foi lea auala e faailoa ai i ni tagata o loo fia fesoasoani o loo auai lau aoga i le polokalame. O tagata fesoasoani e aoga tele ma e mafai ona o atu e fai ni a latou tautualaga i lau vasega e faatatau i tulaga tau komepiuta faasaienisi  pe fesoasoani i tamaiti aoga i galuega faatino a le Hour of Code. 
+
+
+
+### Ia faafiafia au tamaiti aoga. 
+
+O nisi nei o polokalame e mafai ona e faailoa [ o ata faamalosi 'au ](/promote/resources) e faailoa ai e eseese tagata ma auala e faatino ai mataupu tau komepiuta faasaienisi.  Pe oka foi ni ata faailoa e faaosofia ai le fiafia o lau vasega.  E faaosofia le fiafia o tamaiti aoga e faatino galuega mo mataupu pe afai latou te vaai atu i isi tagata, e pei o latou, o loo fa'amalosia le fa'aaogaina o le polokalame. 
+
+{{ promote_new_posters }}
+
+A fia malamalama i posters, videos, stickers ma isi ala e faailoa ai lau polokalame  mo tagata lautele. </p> 
+
+
+
+## 5 Amata loa ma le malosi lau Hour of Code
+
+A taunuu mai loa lau Hour of Code, e tatau ona e amata ma le malosi lau polokalame e ala i fesoasoani ma meafaigaluega nei. 
+
+E mafai ona e valaaulia [ ni tagata e mafai ona fesoasoani ]({{ urls/volunteer_local }}) e fa'aosofia ma fa'amalosiau i tamaiti aoga e ala i le talanoa i le loloto o avanoa i mataupu tau komepiuta faasaienisi.  E ova ma le afe o tagata fesoasoani i le lalolagi ua sauni e fesoasoani i lau polokalame o le Hour of Code e ala i se asiasiga i lau vasega poo se talanoaga e tuu sao lava i au tamaiti aoga. 
+
+Fa'aali le ata faamalosiau lenei: 
+
+- O le fesootaiga lea Code.org e iai Bill Gates, Mark Zuckerberg ma le tama pasiketipolo lauiloa i le NBA, o Chris Bosh. E iai ata eseese e  1 minute, [ 5 minute](https://www.youtube.com/watch?v=nKIu9yen5nc) ma le  9 minute</li> 
+  
+  - E te maua isi alagaoa mananaia  ma  ata mananaia. </li> </ul> 
+  
+  E leai se afaina pe afai e fou ma o se taimi muamua lea mo oe ma au tamaiti aoga i le mataupu tau komepiuta faasaienisi.  O ni auala nei e mafai ai ona fa'ailoa au galuega faatino i le Hour of Code:
+  
+  - Fa'amatala auala e aafia ai e le tekenolosi o tatou olaga, atoa ai foi ma ni fa'ataitaiga e fiafia ai tamaiti ma teineiti (talanoa i le aoga e fa'asao ai o ola o tagata, ala e fesoasoani ai mo tagata, aoga e fesootai ai ma tagata ma isi autu faapena). 
+- Mo le vasega, lisi ma faamau itu e fa'aaoga ai le polokalame i aso uma o le olaga. 
+- O fautuaga ina ia faatosina ai tamaitai i le mataupu o le computer science[ i le fesootaiga lea]({{ urls/girls }}).
+
+
+
+
+## 6 Fai loa lau polokalame!
+
+Faasino tamaiti aoga i le galuega fa'atino 
+
+- Tusi le fesootaiga mo le vasega faataitai i le laupapa.  Vaai le fesootaiga o le lisi i le [ faamaumauga mo le vasega faataitai ua e filifilia ]({{ urls/learn }}) e lalo atu o le fuainumera o tagata e auai. 
+
+Afai e faigata mo tamaiti aoga e mafai lava ona e tali iai:
+
+- "Ou te le iloa." "Ia ta taumafai fa'atasi e vaai pe faafefea ona fai."
+- "O isi taimi e ese le mea tatou e mananao ai e ese foi le mea e fai e le komepiuta. O faafitauli masani lava na o le tekonolosi."
+- "O le malamalama i le faapolokalameina o galuega tau le komepiuta e pei o la e fa'atoa tau a'o ona amata ona tautala i se gagana fou, e le faapea o le a lelei atoatoa i se taimi vave."
+
+O le a le mea e tupu pe afai e vave uma se tamaitiiti aoga? 
+
+- E mafai ona vaai tamaiti aoga i vasega faataitai uma ma [ e mafai ona fai se isi galuega faatino a le Hour of Code ]({{ urls/learn }}).
+- Poo le fai i tamaiti aoga ua vave uma e fesoasoani i isi tamaiti aoga o loo faigata ona faauma galuega faatino. 
+
+<p style="clear:both">&nbsp;</p>
+
+## 7 Ia faataua le ausia manuia ma le taumafai a au tamaiti aoga. 
+
+[col-33]
+
+<img src="/images/fit-300/boy-certificate.jpg" />
+
+[/col-33]
+
+- [Lolomi ni tusi faailoga ]({{ urls/certificates }})mo tagata na auai i le polokalame ma tamaiti aoga
+- [ Lolomi mea faapipii "Ua uma ona faia le Hour of Code!"]({{ urls/promote_stickers }})mo au tamaiti aoga. 
+- [ Oka ni mitiafu faapitoa ](http://blog.code.org/post/132608499493/hour-of-code-shirts-and-more)mo lau aoga. 
+- Fa'aali ata ma videos o lau Hour of Code i isi ala fesootaiga.  Fa'aaoga le #HourOfCode ma le @codeorg ina ia mafai ona faailoa lau taumafai ua iu manuia!
+
+
+
+----
+
+
+
+## Other Hour of Code resources for educators:
+
+- Asiasi le upega mo Faiaoga [ o le Hour of Code](http://forum.code.org/c/plc/hour-of-code) e maua ai ni fautuaga ma se fesoasoani mai isi foi faiaoga. 
+- Toe iloilo le [Hour of Code Fesili Masani (FAQ)](https://support.code.org/hc/en-us/categories/200147083-Hour-of-Code).
+
+
+
+## What comes after the Hour of Code?
+
+E le faapea o le a gata mataupu tau le Komepitua faasaienisi i lenei poloakalame o le Hour of Code! O la matou taiala e fa'aaoga le upega tafailagi ma e faavavau lava ona leai se totogi,  [ Ia e iloa ma malamalama pe faafefea ona ](/beyond) aumai le CS i lau aoga ma mo au tamaiti aoga. 
+
+{{ signup_button }}

--- a/i18n/locales/sm-WS/hourofcode/how-to/afterschool.md
+++ b/i18n/locales/sm-WS/hourofcode/how-to/afterschool.md
@@ -1,0 +1,92 @@
+---
+title: Taiala o le Hour of Code pe a tuua aoga
+---
+
+{{ signup_button }}
+
+# O ala e aoaoina ai le Hour of Code mo le itula e tasi i vasega poo kalapu i taimi e tuua ai aoga. 
+
+### Join the movement and introduce your students to computer science with these steps.
+
+Computational thinking helps nurture problem-solving skills, logic, and creativity. And technology is transforming every industry on the planet. Students today should learn how to create technology, not just use it. By starting early, they’ll have a foundation for success in any 21st-century career path.
+
+O le faataitai o le Hour of Code e faigofie ma o se auala malie e faailoa i tamaiti aoga le computer science, masalo o se uluai taimi foi lea. Afai o e manaomia se fesoasoani, e mafai ona e maua [ni tagata fesoasoani ]({{ urls/volunteer_local }})e mafai ona fesoasoani i le sekiina o le Hour of Code i au vasega poo kalapu e faia pe a tuua le aoga. 
+
+### An Hour of Code can also be hosted remotely! To get started, check out our [tips for hosting a virtual Hour of Code event](https://hourofcode.com/us/how-to/virtual).
+
+* * *
+
+## 1. Matamata i le video lea e fa'asino atu auala e faatino ai galuega.  <iframe width="500" height="255" src="//www.youtube.com/embed/SrnvvWDm73k" frameborder="0" allowfullscreen></iframe> 
+
+## 2. Filifili se vasega
+
+E eseese ituaiga vasega o iai[e malie, e tasi le itula le umi o vasega]({{ urls/learn }})mo tagata mai soo se tausaga, ua uma ona fausia e a matou paaga eseese[. Faataitai nei loa!]({{ urls/learn }})
+
+**O vasega uma o le Hour of Code**e le tele se taimi e tapenaina e i latou na faia, ma e mafai lava e le tagata e toatasi ona faia - e mafai foi e le fanau ona fai e latou lava galuega e tusa ma lo latou malamalama ma lo latou malosi. 
+
+[![](/images/fit-700/tutorials.png)]({{ urls/learn }})
+
+**E manaomia sau lesona faataitai mo au vasega Hour of Code pe a tuua le aoga? **Vaai le upega lea[ma ni auivi](/files/AfterschoolEducatorLessonPlanOutline.docx)
+
+## Faailoa lau Hour of Code
+
+Fa'ailoa lau Hour of Code[fa'aaoga meafaigaluega nei]({{ urls/promote }})ma fa'amalosia isi e faatu foi ni a latou polokalame. 
+
+## Ia e mafaufau i vaega e te manaomia i tulaga tau o le tekenolosi - e tele ituaiga komepiuta e te filifili i ai
+
+O le Hour of Code e sili ona lelei le fa'aaogaina pe afai o se komepiuta o fesootai ma le upega tafailagi Ae e le faapea o le a manaomia e tamaiti uma se komepiuta, ma e mafai lava ona fa'aaoga le Hour of Code e aunoa ma se komepiuta. 
+
+E tatau ona faataitai muamua vasega poo tutorials i komepitua a tamaiti aoga poo isi masini o loo fa'aaoga ina ia mautino ai o loo fesootai lelei ma le ola foi le sound ma le video. <strong x-id="1">E maualalo ma laiitiiti le fesootaiga? </strong>E tatau ona fa'aali ata poo videos i le amataga o lau vasega, ina ia aua ne'i tatala pe download e le tagata lava ia ana ata. Pe taumafai e fa'aaoga le offline tutorials. 
+
+Ia saunia ni mea fa'alogo mo lau vasega, pe fai i tamaiti ia aumai a latou mea fa'alogo, pe afai o le vasega o le a e filifili e manaomia le sound. 
+
+<strong x-id="1">E le lava ni devices? </strong>Fa'aaoga le polokalame e galulue faatasi ai ni tagata se toalua. A galulue faatasi tamaiti i paga, e mafai ona fesoasoani le tasi i le isi nai lo le lagolago i le faiaoga. E iloa ma vaaitino foi i latou i galuega tau komepiuta e faigofie ai ona mafai ona fesootai ma galulue faatasi ai. </p> 
+
+## Amata lau vasega o le Hour of Code i se ata e fa'aosofia ai le lagona o le fiafia
+
+Amata lau Hour of Code e ala i le fa'amalosia o tagata ma fa'amatala le aoga ma aafiaga o le computer science i aso uma o le olaga.
+
+**Fa'aali le ata faamalosiau lenei: **
+
+- O le video a le Code.org, o loo iai tagata ta'uta'ua e pei o Bill Gates, Mark Zuckerberg, ma le tama pasiketipolo lauiloa i le NBA o Chris Bosh (e iai ata e ) 1 le minute[ 5 minute ](https://www.youtube.com/watch?v=nKIu9yen5nc)ma le [ 9 minute](https://www.youtube.com/watch?v=dU1xS07N-FA) le umi. </li> 
+    
+    - O le ata o le Hour of Code ua fa'asalalu i le lalolagi</li> 
+        
+        - [O le valaau a le Peresitene o Obama i tamaiti aoga ina ia a'o ma malamalama i le computer science](https://www.youtube.com/watch?v=6XvmhE1J9PY).
+        - E maua isi video e fa'amalosiau[i le fesootaiga lea](https://www.youtube.com/playlist?list=PLzdnOPI1iJNfpD8i4Sx7U0y2MccnrNZuP).</ul> 
+        
+        **E leai se afaina pe afai e te fou i le mataupu i le computer science. O nai vaega ia e fesoasoani atu ai ina ia fa'ailoa galuega fa'atino o lau Hour of Code: **
+        
+        - Fa'amatala auala e aafia ai e le tekenolosi o tatou olaga, atoa ai foi ma ni fa'ataitaiga e fiafia ai tamaiti ma teineiti (talanoa i le aoga e fa'asao ai o ola o tagata, ala e fesoasoani ai mo tagata, aoga e fesootai ai ma tagata ma isi autu faapena). 
+        - Lisi uma vaega e fa'aaogaina ai le code i aso uma o le olaga. 
+        - O fautuaga ina ia faatosina ai tamaitai i le mataupu o le computer science[ i le fesootaiga lea]({{ urls/girls }}).
+        
+        **E toe manaomia seisi fesoasoani?**Download le fesootaiga lea[ma lesona faataitai](/files/AfterschoolEducatorLessonPlanOutline.docx).
+        
+        ## 6. Fa'ailo!
+        
+        **Fa'asino tagata i le galuega fa'atino** - Tusi le fesootaiga mo le vasega i le laupapa. Vaai le fesootaiga o le lisi i le [ faamaumauga mo le vasega faataitai ua e filifilia ]({{ urls/learn }}) e lalo atu o le fuainumera o tagata e auai. 
+        
+        **Afai e faigata mo se tasi e mafai ona e tali iai:** - "Ou te le iloa. Let’s figure this out together.” - “Technology doesn’t always work out the way we want.” - “Learning to program is like learning a new language; you won’t be fluent right away.”
+        
+        **O le a le mea e fai pe afai ua vave se tasi?** - ia e fa'amalosi i tagata e toe fai seisi galuega fa'atino a le Hour of Code i le [hourofcode.com/learn]({{ urls/learn }}) - Poo le fai atu iai mo i latou ua vave uma e mafai ona fesoasoani i nisi o loo faigata ona malamalama i galuega.
+        
+        ## 7) Fa'ailoa ma fa'atauaina
+        
+        - [Lolomi ni tusi faailoga ]({{ urls/certificates }})mo tagata na auai i le polokalame ma tamaiti aoga
+        - [Lolomi ni pepa fa'apipii "Ua maea a'u galuega mo le Hour of Code]({{ promote/resources_stickers }}).
+        - [ Oka ni mitiafu faapitoa ](http://blog.code.org/post/132608499493/hour-of-code-shirts-and-more)mo tagata.
+        - Fa'ailoa ma fa'aali ata ma videos o lau Hour of Code i luga o ala fesootaiga. Fa'aaoga le #HourOfCode ma le @codeorg ina ia mafai ona fa'ailoa atu lou ausia foi o se tulaga manuia!
+        
+        ## O isi alagaoa a le Hour of Code mo faiaoga
+        
+        - Vaai le [fesootaiga lea e iai faataitaiga lelei ma le atoatoa](http://www.slideshare.net/TeachCode/hour-of-code-best-practices-for-successful-educators-51273466)mai isi faiaoga a le Hour of Code mai taimi ua tuanai. 
+        - Matamata i le pu'ega o le matou [Taiala mo Faiaoga i le webinar a le Hour of Code](https://youtu.be/EJeMeSW2-Mw).
+        - Asiasi le upega mo Faiaoga [ o le Hour of Code](http://forum.code.org/c/plc/hour-of-code) e maua ai ni fautuaga ma se fesoasoani mai isi foi faiaoga. 
+        - Toe iloilo le [Hour of Code Fesili Masani (FAQ)](https://support.code.org/hc/en-us/categories/200147083-Hour-of-Code).
+        
+        ## What comes after the Hour of Code?
+        
+        O le Hour of Code o le sitepu muamua o lau malaga aoaoina ina ia e malamalama ma iloa atili fa'amatalaga e fa'atatau i le tekonolosi ma lona aoga ma ala e mafai ai ona gaosi ma fa'atino polokalame tau komepiuta. Fesoasoani i tamaiti aoga ina ia fa'aauau pea le aoaoina ma ia fa'amalosi i latou e [ina ia fa'alautele le malamalama i luga o le upega tafailagi](/beyond)!
+        
+        {{ signup_button }}

--- a/i18n/locales/sm-WS/hourofcode/how-to/companies-old.md
+++ b/i18n/locales/sm-WS/hourofcode/how-to/companies-old.md
@@ -1,0 +1,121 @@
+---
+title: How to host an Hour of Code - Companies
+---
+
+{{ signup_button }}
+
+# E faapefea ona aumai lau Hour of Code i lau kamupani
+### Find out how you and your employees can inspire students to try computer science!
+
+***
+
+## Fesootai ma isi vasega ma tagata fesoasoani mo lau Hour of Code
+Code.org e ofoina atu le avanoa ma lau aufaigaluega e [ fesootai ]({{ urls/volunteer }}) ma isi vasega e latalata ane ia oe o loo faia le Hour of Code ma e mafai ona faasoa la latou galuega i itu lelei ma itu faigata ina ia mafai ona faaosofia le fiafia o tamaiti aoga e aoaoina le mataupu tau komepiuta faasaienisi.
+
+[<button>Resitala e avea oe ma se tagata fesoasoani!</button>]({{ urls/volunteer }})
+<br>
+<br>
+
+Mo nisi faamatalaga i ala e faamalosia le aufaigaluega ma fesootai lau aufaigaluega ma vasega, asiasi la matou [taiala mo galuega tau pisinisi]({{ localized_files/hoc_corporate_toolkit }}).
+
+## O isi auala faaopoopo e mafai ai e kamupani ona fesoasoani i le Hour of Code
+
+- Fesili i lau Pule e[lafo se imeli i tagata uma o le kamupani]({{ promote/sample_emails }})ina ia faamamafa le taua o le computer science ma ia faamalosia le aufaigaluega ina ia logo atu le tala i isi tagata.
+- Fai se Happy Hour poo se Itula Fiafia e fa'aali ai le Hour of Code i nisi o loo outou galulue ina ia mafai ona
+
+faataitai i galuega faatino.</li> 
+  
+  - Fai se vasega faapitoa a le Hour of Code ma valaau se vasega a tamaiti aoga poo se faalapotopotoga e faia fua se auaunaga ina ia omai e faataitai le Hour of Code i totonu lava o le ofisa o lou fale faigaluega.  Vaai le How-to guide o loo i lalo, e fesoasoani ia te oe. </ul> 
+
+
+
+
+# Ala e mafai ai ona e faafoe le se vasega faapitoa a le Hour of Code mo ni tamaiti aoga
+
+
+
+## 1. Faalauiloa le Hour of Code
+
+- Fa'ailoa lau [ vasega faapitoa - Hour of Code]({{ urls/promote }})ma faamalosia isi latou te mafai ona faafoeina foi se vasega faapitoa. 
+- Ia fa'amalosia foi isi inisia o polokalame tau komepiuta o lau kamupani e asiasi se vasega e lata ane ina ia mafai ona fesoasoani ma taitai se Hour of Code ma mafai ai foi ona fa'aosofia le lagona fiafia o tamaiti aoga e aoaina le mataupu o le computer science. E mafai ona latou [resitala]({{ urls/volunteer_engineer }})ina ia fesootai ma auai i se vasega. 
+
+
+
+## 2. Matamata i le video lea e faamatala le faatinoga o le galuega <iframe width="500" height="255" src="//www.youtube.com/embed/SrnvvWDm73k" frameborder="0" allowfullscreen></iframe> 
+
+
+
+## 3 Filifili se galuega fa'atino. 
+
+E tele ituaiga polokalame [e malie ma manaia, ma e ta'i itula le uma o galuega fa'atino]({{ urls/learn }})mo tagata i soo se tausaga, na saunia e tagata eseese.  [Faataitai nei]({{ urls/learn }})
+
+**O galuega faatino uma a le Hour of Code**e manaomia muamua sina taimi e tapena ai le tagata, ina ia e malamalama atoa i galuega ma le polokalame, ma e mafai lava ona faatino lava e le tagata e toatasi - e aoga ina ia galue lava le tagata ia i le vave e talafeagai ma le tulaga o lona silafia. 
+
+[<img src="/images/fit-700/tutorials.png" />]({{ urls/learn }})
+
+
+
+## 4 Ia fuafua ma malamalama i ou vaega e manaomia ai sou silafia i tulaga tau i le tekonolosi - o komepiuta o se tasi o vaega ma e mafai ona e filifili i ai pe e te manao ia pe leai. 
+
+O le Hour of Code e sili ona lelei le fa'aaogaina pe afai o se komepiuta o fesootai ma le upega tafailagi Ae **e le**manaomia e tagata uma se komepiuta, ma e mafai ona faatino galuega a le Hour of Code e aunoa ma le fa'aaogaina o se komepiuta. 
+
+**Tapena muamua!**Ia fai muamua vaega nei ae lei amatalia lau vasega:
+
+- Faataitai muamua galuega faatino i komepiuta ma isi foi masini poo devices.  Ia mautinoa o loo ola lelei le polokalame i isi upega o fesootaiga, ma o loo ola foi le sound ma le video.
+- E tatau ona iai ni mea faalogo, pe fai i tagata e tatau ona aumai ni a latou mea faalogo, ona e manaomia ona latou fa'aaoga mea fa'alogo e fa'alogo i musika poo se pese poo isi vaega faapena
+- **E le lava ni devices? **Fa'aaoga le polokalame e galulue faatasi ai ni tagata se toalua.  A galulue faatasi ni tagata se toalua, e mafai ona la fesoasoani i le isi ma le fa'alagolago tele i le o loo fa'afoeina le vasega.  E iloa ma vaaitino foi i latou i galuega tau komepiuta e faigofie ai ona mafai ona fesootai ma galulue faatasi ai. </li> 
+  
+  - **E maualalo ma laiitiiti le fesootaiga? **E tatau ona fa'aali ata poo videos i le amataga o lau vasega, ina ia aua ne'i tatala pe download e le tagata lava ia ana ata. Pe fai foi galuega faatino e le manaomia ai le upega tafailagi. </ul> 
+
+
+
+## 5  Amata lau vasega o le Hour of Code i se ata e fa'aosofia ai le lagona o le fiafia
+
+Amata lau Hour of Code e ala i le fa'amalosia o tagata ma fa'amatala le aoga ma aafiaga o le computer science i aso uma o le olaga. Fa'asoa foi vaega na fa'aosofia ai ma faatupula'ia ai le fiafia ia te oe i le mataupu o le computer science ma lau galuega o loo faia i lau kamupani. 
+
+**Fa'aali le ata faamalosiau lenei: **
+
+- O le video a le Code.org, o loo iai tagata ta'uta'ua e pei o Bill Gates, Mark Zuckerberg, ma le tama pasiketipolo lauiloa i le NBA o Chris Bosh (e iai ata e ) 1 le minute[ 5 minute ](https://www.youtube.com/watch?v=nKIu9yen5nc)ma le [ 9 minute](https://www.youtube.com/watch?v=dU1xS07N-FA) le umi. </li> 
+  
+  - O le ata o le Hour of Code ua fa'asalalu i le lalolagi</li> 
+  
+  - [O le valaau a le Peresitene o Obama i tamaiti aoga ina ia a'o ma malamalama i le computer science](https://www.youtube.com/watch?v=6XvmhE1J9PY).
+- E maua isi video e fa'amalosiau[i le fesootaiga lea](https://www.youtube.com/playlist?list=PLzdnOPI1iJNfpD8i4Sx7U0y2MccnrNZuP).</ul> 
+
+**O ni manatu e fa'ailoa ai galuega fa'atino a lau Hour of Code i tamaiti aoga:**
+
+- Fa'amatala le aoga o le tekonolosi i o tatou olaga, o ni fa'ata'ita'iga mo tama ma teine latou te fiafia i ai - talanoa i le aoga o le tekonolosi i le fa'asaoina o ola, ma le fesoasoani i tagata ma ala ua mafai ai ona feso'ota'i tagata. 
+- Afai o e galuega i se kamupani tau tekonolosi, fa'aali ni fa'ataitaiga malie, ma ni oloa tulaga ese o lo'o gaosi e le tou kamupani
+- Afai e te le o galue mo se kamupani tau tekonolosi, fa'amatala le aoga o le tekonolosi mo lau kamupani, e mafai ai ona fo'ia ni fa'afitauli ma ausia ai se tulaga manuia. 
+- Valaaulia inisia o polokalame tau komepiuta mai lau kamupani e fa'amatala le mafua'aga ua latou filifili ai ma fiafia i le mataupu o le computer science ma ni poloketi o loo latou galulue ai.  
+- O fautuaga ina ia faatosina ai tamaitai i le mataupu o le computer science[ i le fesootaiga lea]({{ urls/girls }}).
+
+
+
+## 6 Fa'ailo!
+
+**Fa'asino tagata i le galuega fa'atino.**
+
+- Tusi i le laupapa le feso'ota'iga poo le link e maua i le galuega fa'atino E maua le fesootaiga poo link i le [vaega o loo iai fa'amaumauga mo le galuega fa'atino ]({{ urls/learn }})ua e filifili, e lalo o le fuainumera o tagata o loo auai i le vasega.
+- Mo tamaiti aoga laiti, e tatau ona uma ona fa'aalu i luga le galuega fa'atino e fa'asao ai le taimi pe teu i le bookmark
+
+**Afai e feagai tagata ma ni tulaga faigata, e mafai lava ona e tali iai fa'apea: **
+
+- "Ou te le iloa." "Ia ta taumafai fa'atasi e vaai pe faafefea ona fai."
+- "O le malamalama i le faapolokalameina o galuega tau le komepiuta e pei o la e fa'atoa tau a'o ona amata ona tautala i se gagana fou, e le faapea o le a lelei atoatoa i se taimi vave."
+
+**O le a le mea e fai pe a vave uma se tasi? **
+
+- E mafai ona fai seisi galuega fa'atino a le Hour of Code i le hourofcode.com/learn.
+- Pe fai iai e fesoasoani i sana uo o loo faigata ia te ia le galuega fa'atino. 
+
+
+
+## 7) Fa'ailoa ma fa'atauaina
+
+- [Lolomi ni tusi faailoga ]({{ urls/certificates }})mo tagata na auai i le polokalame ma tamaiti aoga
+- [Lolomi ni pepa fa'apipii "Ua maea a'u galuega o le Hour of Code]({{ promote/resources_stickers }}).
+- [Oka ni mitiafu fa'apitoa](http://blog.code.org/post/132608499493/hour-of-code-shirts-and-more) mo lau aufaigaluega.
+- Fa'aali ata ma videos o lau Hour of Code i isi ala fesootaiga.  Fa'aaoga le #HourOfCode ma le @codeorg ina ia mafai ona faailoa lau taumafai ua iu manuia!
+
+{{ signup_button }}

--- a/i18n/locales/sm-WS/hourofcode/how-to/companies.md
+++ b/i18n/locales/sm-WS/hourofcode/how-to/companies.md
@@ -1,0 +1,184 @@
+---
+title: Hour of Code How-To Guide for Companies
+---
+
+{{ signup_button }}
+
+# How your company can engage with the Hour of Code
+
+### Find out how you and your employees can inspire students to try computer science!
+
+* * *
+
+Computational thinking helps nurture problem-solving skills, logic, and creativity. And technology is transforming every industry on the planet. Students today should learn how to create technology, not just use it. By starting early, they’ll have a foundation for success in any 21st-century career path.
+
+During the Hour of Code campaign, your company can help raise awareness of the computer science movement. Whether you volunteer as an individual or plan an event for your company, all of your efforts can make a huge impact on the way young women and students from marginalized racial and ethnic groups view computer science and their own potential.
+
+Check out the steps below to get started, and see our [guide for corporate partners](/files/hoc-corporate-toolkit.pdf) for more on how to get your company excited about the Hour of Code.
+
+- [Connect with a local school](#connect-with-a-school)
+- [Encourage employees to volunteer with a classroom](#encourage-employees)
+- [Host your own Hour of Code event](#host-hour-of-code)
+- [Promote the Hour of Code](#promote-hour-of-code)
+- [More ways to support the Hour of Code](#support-hour-of-code)
+
+* * *
+
+<a id="connect-with-a-school"></a>
+
+## Connect with a local school
+
+It's always best to start locally, with schools that you or your employees have a strong connection to, like an alma mater, a child’s school, or a local organization or school that is focused on serving a population that has been historically underrepresented in computer science.
+
+[![](/images/fit-600/Marketing/2018_HoC-392.jpg)]({{ urls/learn }})
+
+From there, you can visit the school’s website to find appropriate contacts to reach out to, like a principal, vice principal, technology or computer science instructors, or even the school’s PTSA. You could also partner with organizations like the Boys & Girls Clubs of America, a YMCA branch, and more to co-host an event.
+
+If you are unable to connect with a school, please [contact us](https://support.code.org/hc/en-us/requests/new) and we’ll connect you with one of our local partners if possible.
+
+* * *
+
+<a id="encourage-employees"></a>
+
+## Encourage employees to volunteer with a classroom
+
+[![](/images/fit-600/Marketing/pexels-andrea-piacquadio-3762940.jpg)]({{ urls/learn }})
+
+One of the most fulfilling ways to participate in the Hour of Code is to volunteer with a local classroom, either in-person or virtually. Best of all, you don’t have to be an engineer in order to volunteer. You can still provide a meaningful experience to students by sharing your own career experience and how CS or technology has impacted your role.
+
+[<button>Sign up to volunteer</button>]({{ urls/volunteer }})
+
+Once a volunteer registers, a teacher can review their profile on our [volunteer map](https://code.org/volunteer/local) - so profiles should be submitted as complete as possible. If you’re a good fit for their classroom, a teacher will contact you through the platform (we will never share your email address with the teacher). You can then coordinate details directly with the teacher around [how to best volunteer with their classroom](https://hourofcode.com/us/how-to/volunteers).
+
+For more guidance on volunteering and sample messaging to get your company excited about the Hour of Code, check out our [guide for corporate partners]({{ localized_files/hoc_corporate_toolkit }}).
+
+* * *
+
+<h4><font color="00adbc"><i>“I LOVED seeing how excited the kids were. One amazing thing was the teachers noticed some of the students who didn’t do as well academically were excelling at thinking like a developer and helping others - giving them a place to feel confident.”</i></font></h4>
+
+-Hour of Code volunteer
+
+* * *
+
+<a id="host-hour-of-code"></a>
+
+## Host your own Hour of Code event
+
+If you want to go the extra mile, your company can also host an Hour of Code event. There is no specific formula for hosting an event so we encourage you to be creative! Given that our staff size is small (but mighty!), Code.org does not have a team dedicated to coordinating Hour of Code events. However, here are some tips to get started.
+
+### 1. Matamata i le video lea e fa'asino atu auala e faatino ai galuega.  <iframe width="500" height="255" src="//www.youtube.com/embed/SrnvvWDm73k" frameborder="0" allowfullscreen></iframe> 
+
+### 2. Determine a date, format, and location for your event
+
+We’ve seen events that are [virtual](https://hourofcode.com/us/how-to/virtual) or in-person, at the company office or held in the community, and for students of all ages! You can also take a look at what other [corporate partners](https://medium.com/@codeorg/amazon-microsoft-google-vista-and-more-rally-to-bring-the-hour-of-code-to-students-worldwide-4641325542cf) and [donors](https://medium.com/@codeorg/how-code-orgs-corporate-supporters-helped-spread-the-love-for-2019-s-hour-of-code-73a3c088f10f) have done in the past for some inspiring ideas.
+
+<br />
+
+#### Sample Agenda:
+
+|Time | Agenda Item | |\---\---\---\---\---\---\---\---\---\---\---\---\---\---\---\---- | \---\---\---\---\----- | |1-5 minutes | Show an [inspirational video](https://hourofcode.com/us/promote/resources#videos)| |5-10 minutes | Introduce yourself and learn more about the students: Where do you work, what do you do, and what do you love most about your job? What or who inspired you? How did you get interested in computer science? Did you have a mentor? Ask the students questions and leave time for Q&A. | |30-60 minutes | Code! If your event is in-person, this is the time to answer questions and guide students through tough puzzles. Try not to give them the solution outright, instead, try asking them questions so they can answer themselves what went wrong, and encourage students to ask each other if they have questions. If you are volunteering virtually, work with the teacher on what the best approach might be. It may make more sense to return at the end of the session to see what progress students have made. | | |1-3 minutes | Thank everyone and share inspirational parting words. Hand out any of your company swag ([stickers](#celebrate) are awesome)! | | <br />
+
+#### Other ideas to add to your event
+
+- Explain ways technology impacts our lives, with examples that students of all backgrounds will care about - talk about technology that’s saving lives, helping people, connecting people.
+- If you are a tech company, demo fun, innovative products your company is working on. If you aren’t a tech company, discuss ways your company uses technology to solve problems and accomplish goals.
+- Valaaulia inisia o polokalame tau komepiuta mai lau kamupani e fa'amatala le mafua'aga ua latou filifili ai ma fiafia i le mataupu o le computer science ma ni poloketi o loo latou galulue ai. 
+
+### 3. Plan your technology needs
+
+[![](/images/fit-600/Marketing/Excel-Charter-SchoolHoC-2015-stills-9.jpg)]({{ urls/learn }})
+
+#### Devices:
+
+O le Hour of Code e sili ona lelei le fa'aaogaina pe afai o se komepiuta o fesootai ma le upega tafailagi Ae e le faapea o le a manaomia e tamaiti uma se komepiuta, ma e mafai lava ona fa'aaoga le Hour of Code e aunoa ma se komepiuta. For unplugged activities, simply filter the Classroom Technology section to show options for “No computers or devices”.
+
+- **Test activities** on computers or devices. Make sure they work properly on browsers with sound and video.
+- **Don't have enough devices?** Use pair programming. A galulue faatasi tamaiti i paga, e mafai ona fesoasoani le tasi i le isi nai lo le lagolago i le faiaoga. E iloa ma vaaitino foi i latou i galuega tau komepiuta e faigofie ai ona mafai ona fesootai ma galulue faatasi ai. 
+- **Provide headphones** for your participants or ask them to bring their own if they’ll be trying tutorials that work best with sounds.
+- **Have low bandwidth**? Plan to show videos at the front of the event, so each participant isn't downloading their own videos. Or try the unplugged / offline activities.
+
+#### Virtual Events:
+
+If your event is going to be virtual, you’ll want to decide on your conference platform (and test it) prior to your event. This may impact the number of students you feel comfortable engaging, so it’s best to determine this prior to inviting a classroom or promoting your event. For ideas on how to run a remote Hour of Code, read our [tips for a virtual Hour of Code event](https://hourofcode.com/us/how-to/virtual).
+
+### 4. Choose an activity
+
+We provide a variety of fun, student-guided tutorials for all age groups and experience levels. It’s popular for students to try self-led tutorials, though you may want to begin the event with an [inspirational video](https://hourofcode.com/us/promote/resources#videos) for everyone to view together.
+
+<a href="https://hourofcode.com/us/learn">Explore the activities</a> and decide ahead of time if you want to choose a single tutorial for all of your guests, or let each child pick their own. **All Hour of Code activities** require minimal prep-time, and are self-guided - allowing participants to work at their own pace and skill-level.
+
+[![](/images/tutorials.png)]({{ urls/learn }})
+
+Once you have a solid roadmap for your event, you can then start inviting students, a school, or the larger community. We recommend starting with a local school you have a relationship with or [browsing our map](https://hourofcode.com/us/map) of Hour of Code events.
+
+<a id="celebrate"></a>
+
+### 5. Celebrate
+
+[![](/images/fit-600/Marketing/2018_HoC-391.jpg)]({{ urls/learn }})
+
+After students or guests have completed their Hour of Code, it’s time to celebrate their success. Here are some ideas for making your event even more fun:
+
+- [Lolomi ni tusi faailoga ]({{ urls/certificates }})mo tagata na auai i le polokalame ma tamaiti aoga
+- [Print "I did an Hour of Code! stickers"]({{ promote/resources_stickers }}) or find other prizes and swag on the [Code.org Amazon Store](https://code.org/shop).
+- Fa'aali ata ma videos o lau Hour of Code i isi ala fesootaiga. Use [#HourOfCode](https://twitter.com/hashtag/hourofcode) and [@codeorg](https://twitter.com/codeorg) so we can highlight your success, too!
+
+* * *
+
+<a id="promote-hour-of-code"></a>
+
+## Promote the Hour of Code
+
+One of the best ways to help is to spread the word and promote the Hour of Code.
+
+[![](/images/fit-600/Marketing/g8TUlHzF.jpeg)]({{ urls/learn }})
+
+### 1. Register Your Event
+
+When you [sign up your Hour of Code event](/#join), you’ll receive helpful email communications with news and tips for hosting a successful Hour of Code. It’s also how you can let local schools or parents know that you’re hosting an event near them.
+
+### 2. Post on Social Media
+
+Help raise awareness of the computer science movement with this sample content to post on social media and share with your employees.
+
+#### Hour of Code general announcement
+
+- Computer science is changing our world. Help students be part of this change starting with one #HourOfCode. https://hourofcode.com/
+- Don’t just use technology—learn how to build it. Help someone start with an #HourOfCode. https://hourofcode.com/
+
+#### Stats
+
+- Did you know only 53% of U.S. schools teach computer science? Give every student the chance to learn one #HourOfCode https://hourofcode.com/
+- In the U.S., only 26% of software professionals are women. Introduce more young women to computer science with #HourOfCode https://hourofcode.com/
+- 67% of computing jobs in the U.S. are not in the tech sector. Help put computer science in the standard curriculum with #HourOfCode https://hourofcode.com/
+
+#### Create your own
+
+- One #HourOfCode can lead to [fill in your story]. https://hourofcode.com/
+- I’m supporting #HourOfCode because [fill in your thoughts]. Join us https://hourofcode.com
+
+#### Engineer-specific
+
+- If your very first line of code changed your life, help students near you write their first #HourOfCode https://code.org/volunteer
+- If you learned to code—what’s your story? Inspire a student near you through their first #HourOfCode https://code.org/volunteer
+
+<a href="https://hourofcode.com/promote/resources#posters">Find more</a> posters, videos, stickers and other ways to promote your event to your community.
+
+* * *
+
+<a id="support-hour-of-code"></a>
+
+## More ways to support the Hour of Code
+
+[![](/images/fit-600/Marketing/girl-strong-coding.png)]({{ urls/learn }})
+
+- Spread awareness by wearing [Code.org swag](https://store.code.org/) (all proceeds go to supporting more students gain access to computer science education).
+- Choose to benefit Code.org when you shop on [AmazonSmile](https://code.org/donate/amazonsmile).
+- Ask your CEO to send a company-wide email emphasizing the importance of computer science and encouraging employees to spread the word.
+- Have some fun with co-workers in a [giving campaign](https://medium.com/@codeorg/how-a-haircut-happy-hour-turned-into-a-fundraiser-for-code-org-1952b197faa2).
+- [Sign this petition](https://code.org/promote) to make sure that every student has the opportunity to learn computer science.
+- [Donate](https://code.org/donate) to Code.org so that we can keep our educational resources free and accessible to all.
+
+For more suggestions on how to support Code.org and the Hour of Code, visit [Code.org/Help](https://code.org/help)
+
+{{ signup_button }}

--- a/i18n/locales/sm-WS/hourofcode/how-to/districts.md
+++ b/i18n/locales/sm-WS/hourofcode/how-to/districts.md
@@ -1,0 +1,42 @@
+---
+title: Hour of Code How-To for Districts
+---
+
+{{ signup_button }}
+
+# How to involve your entire school district
+
+### Every school in your district can take part in the largest learning event in history.
+
+* * *
+
+## Get every school participating, every student learning!
+
+### 1. Recruit local schools
+
+Share [this email]({{ promote/sample_emails }}) and [teacher how to guide]({{ urls/how_to_guide }}), or include a [short blurb]({{ promote/stats_url }}) in newsletters/district communications. <br />
+
+### 2. Provide a sample logistics plan for schools
+
+Share this [sample logistics plan]({{ hoc_logistics_plan }}) with schools to give them ideas of how to organize whole school participation. It’s as easy as doing it in every math class, homeroom period, or rotating throughout the week through the computer lab.
+
+### 3. Share on social media
+
+Post to [Facebook](https://www.facebook.com/sharer/sharer.php?u=http%3A%2F%2Fhourofcode.com%2Fus) or [Twitter](https://twitter.com/intent/tweet?url=http%3A%2F%2Fhourofcode.com&text=I%27m%20participating%20in%20this%20year%27s%20%23HourOfCode%2C%20are%20you%3F%20%40codeorg&original_referer=https%3A%2F%2Fwww.google.com%2Furl%3Fq%3Dhttps%253A%252F%252Ftwitter.com%252Fshare%253Fhashtags%253D%2526amp%253Brelated%253Dcodeorg%2526amp%253Btext%253DI%252527m%252Bparticipating%252Bin%252Bthis%252Byear%252527s%252B%252523HourOfCode%25252C%252Bare%252Byou%25253F%252B%252540codeorg%2526amp%253Burl%253Dhttp%25253A%25252F%25252Fhourofcode.com%26sa%3DD%26sntz%3D1%26usg%3DAFQjCNE1GLTUbKZfMlEh9Aj5w0iswz6PYQ&related=codeorg&hashtags=). Or share one of these inspirational [pictures and quotes]({{ promote/resources_social }}) from world leaders, or [stats]({{ promote/stats_url }}).
+
+### 4. Promote on your district’s homepage
+
+Let visitors know about your participation and Hour of Code events. Link it to [Hour of Code]({{ urls/home }}).
+
+### 5. Host a district Hour of Code event
+
+See our [event how to guide]({{ urls/how_to_events }}) for a sample run of show, media outreach kit, and other supports.
+
+## What comes after the Hour of Code?
+
+The Hour of Code is just the first step on a journey to learn more about how technology works and how to create software applications. To continue this journey:
+
+- Encourage students to continue to [learn online]({{ urls/learn_beyond }}).
+- [Learn more](https://code.org/administrators) about implementing a computer science pathway in your district.
+
+{{ signup_button }}

--- a/i18n/locales/sm-WS/hourofcode/how-to/events.md
+++ b/i18n/locales/sm-WS/hourofcode/how-to/events.md
@@ -1,0 +1,59 @@
+---
+title: Hour of Code Event How-To
+---
+
+{{ signup_button }}
+
+# How to organize an Hour of Code assembly or event
+
+### Get your entire school or community involved in an Hour of Code!
+
+* * *
+
+## 1. Prepare for your event
+
+- Determine a venue, date, and time.
+- Send [a letter](https://hourofcode.com/promote/resources#sample-emails) to your local mayor, member of Congress, governor, or influential business person and invite them to speak. Check out our [how-to toolkit]({{ localized_files/elected_official }}) when hosting an elected official during an Hour of Code for more info.
+- Invite media/press. i.e. local news station, newspaper, education/tech bloggers. See our [press kit]({{ promote/press_kit_url }}) for help.
+
+## 2. During your event
+
+- Kick off your event with one of our [inspirational videos]({{ promote/videos }}).
+- Give an intro overviewing the importance of computer science, using these [stats and infographics]({{ promote/stats_url }}).   
+      
+    
+- **Other event ideas**: 
+    - Invite a local industry leader to discuss his or her work involving computer science.
+    - Invite a local politician and have students teach him or her how to code.
+    - Have a group of students demonstrate an unplugged activity.
+    - Have a group of students teach the principal or a group of teachers how to code.
+    - If your school already teaches computer science, have students demo projects.
+
+## 3. Share how it went
+
+Share pictures of your event on Facebook and Twitter and use the hashtag **#HourOfCode**.
+
+* * *
+
+## Example plan for a school assembly or event
+
+**Event:** School-wide Computer Science Education Week kick-off assembly
+
+**Date:** {{ campaign_date/start_short }} (start of Computer Science Education Week)
+
+**Time:** During the school day. Mid-morning event preferred. Approximately 1 hour.
+
+**Location:** School assembly hall (e.g. theater, gym, cafeteria)
+
+## Run of Show
+
+| Time             | Action                                                                                                                                |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| 10:00 - 10:05 am | Open with one of our [inspirational videos]({{ promote/videos }}).                                                                    |
+| 10:05 - 10:15 am | Principal gives an intro overviewing the importance of computer science. Use these [stats and infographics]({{ promote/stats_url }}). |
+| 10:15 - 10:30 am | Special guest to talk about their background and how technology and computer science plays an important role in their everyday lives. |
+| 10:30 - 10:40 am | Students do an Hour of Code demo for the school. Fun twist: have them teach the principal, politician, or other students!             |
+| 10:40 - 11:00 am | Students demo an unplugged activity and how computer science can be taught without using computers.                                   |
+| 11:00 - 11:05 am | Teacher who helped bring school-wide event gives closing remarks.                                                                     |
+
+{{ signup_button }}

--- a/i18n/locales/sm-WS/hourofcode/how-to/index.md
+++ b/i18n/locales/sm-WS/hourofcode/how-to/index.md
@@ -1,0 +1,172 @@
+---
+title: Hour of Code How-to Guide
+---
+
+{{ signup_button }}
+
+# Ala e fuafua ai lau Hour of Code
+
+### Join the movement and introduce your students to computer science with these steps.
+
+Students today should learn how to create technology, not just use it.
+
+Trying an Hour of Code is a simple and fun way to introduce students to computer science, perhaps for the very first time! Find an activity that fits your setting, whether in-class or after-school, in-person or virtual. Take a look at our [participation guide if you still have questions]({{ localized_files/participation_guide }}) after checking out the steps below:
+
+- [Watch the Hour of Code how-to video](#how-to-video)
+- [Explore activities and tutorials](#explore-activities)
+- [Create your plan for the day](#create-your-plan)
+- [Faalauiloa le Hour of Code](#promote-your-hour)
+- [How to start your Hour of Code strong](#how-to-start)
+- [Get coding](#code)
+- [Celebrate your students' success](#celebrate)
+- [O isi alagaoa a le Hour of Code mo faiaoga](#other-resources)
+
+* * *
+
+<a id="how-to-video"></a>
+
+## 1. Watch the Hour of Code how-to video <iframe width="500" height="255" src="//www.youtube.com/embed/SrnvvWDm73k" frameborder="0" allowfullscreen></iframe> 
+
+* * *
+
+<a id="explore-activities"></a>
+
+## 2. Explore activities and tutorials
+
+Matou te saunia ni polokalame eseese e malie ma manaia [ o ni vasega e taiala ai fanau aoga ]({{ urls/learn }}) o soo se tausaga ma poo le a le tulaga o le malamalama'aga. E tele tamaiti aoga e fiafia e faatino toatasi lava e latou vasega faataitai, e ala lea i galuega faatino o loo iai lesona ua fuafua mo faiaoga e fai ma taiala e faatino ai ni talanoaga pe faalautele ai foi le galuega faatino. 
+
+Vaai i galuega faatino ma fuafua mamao lava e oe pe e te filifili se vasega se tasi mo au tamaiti aoga uma, pe tuu i tamaiti e filifili a latou lava polokalame. 
+
+[![](/images/tutorials.png)]({{ urls/learn }})
+
+* * *
+
+<a id="create-your-plan"></a>
+
+## 3. Create your plan for the day
+
+### Ia e mafaufau i vaega e te manaomia i tulaga tau o le tekenolosi - e tele ituaiga komepiuta e te filifili i ai
+
+- O le Hour of Code e sili ona lelei le fa'aaogaina pe afai o se komepiuta o fesootai ma le upega tafailagi Ae e le faapea o le a manaomia e tamaiti uma se komepiuta, ma e mafai lava ona fa'aaoga le Hour of Code e aunoa ma se komepiuta. Mo galuega faatino e taua o le 'unplugged activities' e faigofie ona e vailiili le vaega o le polokalame o le Classroom Technology ma filifili le vaega e taua o le "No computers or devices". 
+- E tatau ona faataitai muamua vasega poo tutorials i komepitua a tamaiti aoga poo isi masini o loo fa'aaoga ina ia mautino ai o loo fesootai lelei ma le ola foi le sound ma le video. E maualalo le fesootaiga o le upega poo le WiFi? Ia e fuafua e fa'aali video i le amataga o le vasega, ina ia aua ne'i download taitasi e tamaiti videos taitasi. Pe taumafai e fa'aaoga le offline tutorials. 
+- Ia saunia ni mea fa'alogo mo lau vasega, pe fai i tamaiti ia aumai a latou mea fa'alogo, pe afai o le vasega o le a e filifili e manaomia le sound. 
+- E le lava ni au komepiuta poo devices? Fa'aaoga le fesootaiga lea  ina ia mafai ona galulue faatasi ai ni tamaiti se toalua. A galulue faatasi tamaiti i paga, e mafai ona fesoasoani le tasi i le isi nai lo le lagolago i le faiaoga. E iloa ma vaaitino foi i latou i galuega tau komepiuta e faigofie ai ona mafai ona fesootai ma galulue faatasi ai. </li> </ul> 
+    
+    <img src="/images/fit-600/group_ipad.jpg" />
+    
+    ### Filifili se aso ma se taimi. 
+    
+    People around the world join in the Hour of Code celebration during CS Education Week (December 5-11) when the latest tutorials and activities are released. Ae e mafai ona e fa'aaoga le Hour of Code i soo se taimi ma se aso i le tausaga. 
+    
+    * * *
+    
+    
+
+<a id="promote-your-hour"></a>
+
+    
+    ## 4. Promote your Hour of Code
+    
+    O lea ua uma ona taoto lau polokalame, ua tatau loa ona faailoa. 
+    
+    ### Faailoa i lau aoga ma tagata lautele
+    
+    Faailoa le Hour of Code i isi faiaoga o loo mananao e auai i lenei polokalame O se avanoa taua foi lenei e faailoa ai i le Komiti o Matua a lau aoga poo le faailoa i tusi mo matua, ina ia latou silafia o le a o atu tamaiti e mananao e fa'aaoga galuega faatino ma vasega i o latou fale
+    
+    ### Ia faailoa i nisi e tagata e ono fesoasoani i lau polokalame e ala lea i le Resitalaina o lau Polokalame
+    
+    When you [sign up your Hour of Code event](/#join), you’ll receive helpful email communications with news and tips for hosting a successful Hour of Code. O leisi foi lea auala e faailoa ai i ni tagata o loo fia fesoasoani o loo auai lau aoga i le polokalame. O tagata fesoasoani e aoga tele ma e mafai ona o atu e fai ni a latou tautualaga i lau vasega e faatatau i tulaga tau komepiuta faasaienisi pe fesoasoani i tamaiti aoga i galuega faatino a le Hour of Code. 
+    
+    ### Ia faafiafia au tamaiti aoga. 
+    
+    O nisi nei o polokalame e mafai ona e faailoa [ o ata faamalosi 'au ](/promote/resources) e faailoa ai e eseese tagata ma auala e faatino ai mataupu tau komepiuta faasaienisi. Or print inspirational posters for your classroom! E faaosofia le fiafia o tamaiti aoga e faatino galuega mo mataupu pe afai latou te vaai atu i isi tagata, e pei o latou, o loo fa'amalosia le fa'aaogaina o le polokalame. 
+    
+    {{ promote_new_posters }}
+    
+    A fia malamalama i posters, videos, stickers ma isi ala e faailoa ai lau polokalame  mo tagata lautele. </p> 
+    
+    * * *
+    
+    
+
+<a id="how-to-start"></a>
+
+    
+    ## 5. How to start your Hour of Code strong
+    
+    A taunuu mai loa lau Hour of Code, e tatau ona e amata ma le malosi lau polokalame e ala i fesoasoani ma meafaigaluega nei. 
+    
+    E mafai ona e valaaulia [ ni tagata e mafai ona fesoasoani ]({{ urls/volunteer_local }}) e fa'aosofia ma fa'amalosiau i tamaiti aoga e ala i le talanoa i le loloto o avanoa i mataupu tau komepiuta faasaienisi. E ova ma le afe o tagata fesoasoani i le lalolagi ua sauni e fesoasoani i lau polokalame o le Hour of Code e ala i se asiasiga i lau vasega poo se talanoaga e tuu sao lava i au tamaiti aoga. 
+    
+    Fa'aali le ata faamalosiau lenei: 
+    
+    - O le fesootaiga lea Code.org e iai Bill Gates, Mark Zuckerberg ma le tama pasiketipolo lauiloa i le NBA, o Chris Bosh. E iai ata eseese e  1 minute, [ 5 minute](https://www.youtube.com/watch?v=nKIu9yen5nc) ma le  9 minute</li> 
+        
+        - E te maua isi alagaoa mananaia  ma  ata mananaia. </li> </ul> 
+            
+            It’s okay if both you and your students are brand new to computer science. Here are some ideas to introduce your Hour of Code activity:
+            
+            - Fa'amatala auala e aafia ai e le tekenolosi o tatou olaga, atoa ai foi ma ni fa'ataitaiga e fiafia ai tamaiti ma teineiti (talanoa i le aoga e fa'asao ai o ola o tagata, ala e fesoasoani ai mo tagata, aoga e fesootai ai ma tagata ma isi autu faapena). 
+            - Mo le vasega, lisi ma faamau itu e fa'aaoga ai le polokalame i aso uma o le olaga. 
+            - See tips for getting young women interested in computer science [here]({{ urls/girls }}).
+            
+            * * *
+            
+            
+
+<a id="code"></a>
+
+            
+            ## 6. Get coding!
+            
+            Faasino tamaiti aoga i le galuega fa'atino 
+            
+            - Write the tutorial link on a whiteboard. Find the link listed on the [information for your selected tutorial]({{ urls/learn }}).
+            
+            Afai e faigata mo tamaiti aoga e mafai lava ona e tali iai:
+            
+            - “I don’t know. Let’s figure this out together.”
+            - "O isi taimi e ese le mea tatou e mananao ai e ese foi le mea e fai e le komepiuta. O faafitauli masani lava na o le tekonolosi."
+            - "O le malamalama i le faapolokalameina o galuega tau le komepiuta e pei o la e fa'atoa tau a'o ona amata ona tautala i se gagana fou, e le faapea o le a lelei atoatoa i se taimi vave."
+            
+            O le a le mea e tupu pe afai e vave uma se tamaitiiti aoga? 
+            
+            - E mafai ona vaai tamaiti aoga i vasega faataitai uma ma [ e mafai ona fai se isi galuega faatino a le Hour of Code ]({{ urls/learn }}).
+            - Poo le fai i tamaiti aoga ua vave uma e fesoasoani i isi tamaiti aoga o loo faigata ona faauma galuega faatino. 
+            
+            * * *
+            
+            
+
+<a id="celebrate"></a>
+
+            
+            ## 7. Celebrate your students' success
+            
+            [col-33]
+            
+            ![](/images/fit-600/boy-certificate.jpg)
+            
+            [/col-33]
+            
+            - [Lolomi ni tusi faailoga ]({{ urls/certificates }})mo tagata na auai i le polokalame ma tamaiti aoga
+            - [ Lolomi mea faapipii "Ua uma ona faia le Hour of Code!"]({{ urls/promote_stickers }})mo au tamaiti aoga. 
+            - Fa'ailoa ma fa'aali ata ma videos o lau Hour of Code i luga o ala fesootaiga. Fa'aaoga le #HourOfCode ma le @codeorg ina ia mafai ona fa'ailoa atu lou ausia foi o se tulaga manuia!
+            
+            * * *
+            
+            
+
+<a id="other-resources"></a>
+
+            
+            ## Other Hour of Code resources for educators:
+            
+            - Asiasi le upega mo Faiaoga [ o le Hour of Code](http://forum.code.org/c/plc/hour-of-code) e maua ai ni fautuaga ma se fesoasoani mai isi foi faiaoga. 
+            - Toe iloilo le [Hour of Code Fesili Masani (FAQ)](https://support.code.org/hc/en-us/categories/200147083-Hour-of-Code).
+            
+            ### What comes after the Hour of Code?
+            
+            Computer science doesn’t have to end with the Hour of Code! [Learn how](/beyond) to bring CS to your school and students.
+            
+            {{ signup_button }}

--- a/i18n/locales/sm-WS/hourofcode/how-to/parents-new.md
+++ b/i18n/locales/sm-WS/hourofcode/how-to/parents-new.md
@@ -1,0 +1,90 @@
+---
+title: How-to guide for parents
+---
+
+# How to do an Hour of Code with your child
+Trying an Hour of Code is a simple and fun way to introduce your child to computer science, perhaps for the very first time. Not only is computer science foundational to all fields of study, but <a href="https://medium.com/@codeorg/cs-helps-students-outperform-in-school-college-and-workplace-66dd64a69536">recent studies show</a>: children who study computer science perform better in other subjects, excel at problem-solving, and are <font color="00adbc"><b>17% more likely to enroll in college</b></font>.
+
+You can join tens of millions of students worldwide in this global event. Together, we can inspire kids to learn, break stereotypes, and help children discover a newfound interest. Best of all, you already have everything you need to bring the Hour of Code into your home!
+
+[<img src="/images/fit-600/Marketing/mother-helping-her-daughter-use-a-laptop-4260325.jpg" />]({{ urls/learn }})
+
+<h3>What do I need to get started?</h3>
+The Hour of Code is simple to run - even for beginners. You don’t need experience in computer science or teaching in order to facilitate a fun activity for your children that will get them both learning and laughing.
+
+You can try the Hour of Code with a computer, a tablet, a smartphone, or completely unplugged! Here's how to get started.
+
+***
+
+## 1) Explore activities and tutorials.
+
+[<img src="/images/fit-600/tutorials.png" />]({{ urls/learn }})
+
+There are countless <a href="https://hourofcode.com/us/learn">Hour of Code activities</a> available to you if you’re working on a computer with internet access. We encourage you to take a look at some of your options ahead of time so that you can help guide your child towards exercises they’ll enjoy.
+
+All of our activities integrate problem-solving and critical-thinking with fun and creativity, but here are some student favorites:
+
+- For the child who loves to play: <a href="https://code.org/minecraft">Minecraft</a> or <a href="https://code.org/dance">Dance Party</a>
+- For the child who loves Disney: <a href="https://code.org/starwars">Star Wars</a>, <a href="https://studio.code.org/s/frozen/stage/1/puzzle/1">Frozen</a>, or <a href="https://partners.disney.com/hour-of-code?cds&cmp=vanity%7Cnatural%7Cus%7Cmoanahoc%7C">Moana</a>
+- For the child who loves to learn: <a href="https://code.org/oceans">AI for Oceans</a> or <a href="https://scratch.mit.edu/projects/editor/?tutorial=music&utm_source=codeorg">Make Music with Scratch</a>
+
+<h3>Low-tech or no-tech?</h3>
+If you’ll be using limited or no technology, you can filter <a href="https://hourofcode.com/us/learn">Hour of Code activities</a> by selecting “No computers or devices” in the <em>Classroom technology</em> section.
+
+[<img src="/images/fit-500/Marketing/filtering-activities-hoc.jpg" />]({{ urls/learn }})
+
+You can also check out these <a href="https://www.youtube.com/playlist?list=PLzdnOPI1iJNcpfa4LtbaIl35gqir_5XUu">short videos</a> for more ideas on how to facilitate an unplugged activity at home!
+
+## 2) Prepare ahead of time
+Now that you have some tutorials in mind, it may be helpful to try these activities on your device before introducing them to your child.
+
+[<img src="/images/fit-600/Marketing/father-and-children-looking-at-a-laptop-4260749.jpg" />]({{ urls/learn }})
+
+<h3>More than one child at home?</h3>
+Consider providing each of your children with headphones if they’ll be working on separate devices. That way, they’ll be able to play activities with sound without distracting each other.
+
+If you’ll only be using one device, or simply want to make your Hour of Code more interactive, try <a href="https://www.youtube.com/watch?v=vgkahOzFH2Q">pair programming</a>. Pair programming encourages children to work together. When they partner up, they help one another to problem-solve. E iloa ma vaaitino foi i latou i galuega tau komepiuta e faigofie ai ona mafai ona fesootai ma galulue faatasi ai.
+
+<h3>Get the kids excited! </h3>
+This is a great opportunity to add a new type of activity to your child’s day. You can extend the fun beyond one tutorial with these suggestions:
+
+- Show them an <a href="https://www.youtube.com/playlist?list=PLzdnOPI1iJNcadqJAZnbDYShie4gLZQQJ">inspirational video</a> that features one of their favorite role models
+- Inspire them with a video on one of the <a href="https://www.youtube.com/playlist?list=PLzdnOPI1iJNfpD8i4Sx7U0y2MccnrNZuP">many careers</a> that computer science skills can lead to
+- <a href="https://store.code.org/">Order some swag</a>! You can choose from t-shirts, stickers, or even temporary tattoos. Share it with them right away to get them excited, or save it for the end of your Hour of Code as a special prize.
+
+<a href="https://store.code.org/" target="_blank"><img src="/images/fit-500/Marketing/hourofcodestore.jpg"></a>
+
+## 3) Tips for introducing your child to CS
+
+It’s okay if both you and your child are brand new to computer science. Here are some ideas to introduce your Hour of Code activity and get you both thinking about CS:
+
+- Explain ways that technology impacts our lives, with specific examples that may interest your child. For example, you could talk about medicine or connecting people virtually. Also, check out <a href="https://code.org/csforgood">Code.org/CSforGood</a> for suggested discussion questions.
+- Together, list everyday things that use code in order to work properly.
+
+[<img src="/images/fit-600/Marketing/girl-sitting-on-sofa-while-using-tablet-computer-4144035.jpg" />]({{ urls/learn }})
+
+<h3>Have girls at home?</h3>
+<a href="https://code.org/girls">Here are our recommendations</a> to help spark their interest in computer science. **Pro-tip**: You can start just by telling them they’d be great at it!
+
+<h3>Problem-solve together</h3>
+Lastly, when your child comes across difficulties it's okay to respond:
+- "Ou te le iloa." "Ia ta taumafai fa'atasi e vaai pe faafefea ona fai."
+- "O isi taimi e ese le mea tatou e mananao ai e ese foi le mea e fai e le komepiuta. O faafitauli masani lava na o le tekonolosi."
+- "O le malamalama i le faapolokalameina o galuega tau le komepiuta e pei o la e fa'atoa tau a'o ona amata ona tautala i se gagana fou, e le faapea o le a lelei atoatoa i se taimi vave."
+
+Computer science is all about learning how to “debug” situations that didn’t turn out the way we thought they would. Together, you and your child can think of creative ways to solve the problem!
+
+
+## 4) Don’t forget to celebrate!
+
+The Hour of Code is a global event, and your family deserves to celebrate. Here are some ways to make your Hour of Code extra special:
+
+- Print <a href="https://staging.code.org/certificates">Hour of Code Certificates</a> that you award when your child completes their activity
+- <a href="https://staging.hourofcode.com/us/promote/resources#stickers">Print stickers</a> at home or <a href="https://store.code.org/">purchase them online</a>, as an added surprise.
+- Share photos and videos of your at-home Hour of Code on social media. Fa'aaoga le #HourOfCode ma le @codeorg ina ia mafai ona faailoa lau taumafai ua iu manuia!
+
+[<img src="/images/fit-600/Marketing/g8TUlHzF.jpeg" />]({{ urls/learn }})
+
+<h2>What comes after the Hour of Code?</h2>
+
+E le faapea o le a gata mataupu tau le Komepitua faasaienisi i lenei poloakalame o le Hour of Code! While 90% of parents want their child to learn computer science, most schools still don’t teach it. To help, our curriculum is web-based and free to use, forever. <a href="https://code.org/yourschool">Learn how</a> to bring CS to your child’s school today.

--- a/i18n/locales/sm-WS/hourofcode/how-to/parents.md
+++ b/i18n/locales/sm-WS/hourofcode/how-to/parents.md
@@ -1,0 +1,98 @@
+---
+title: Hour of Code How-to Guide for parents
+---
+
+# How to do an Hour of Code with your child
+
+Trying an Hour of Code is a simple and fun way to introduce your child to computer science, perhaps for the very first time. Not only is computer science foundational to all fields of study, but [recent studies show](https://medium.com/@codeorg/cs-helps-students-outperform-in-school-college-and-workplace-66dd64a69536): children who study computer science perform better in other subjects, excel at problem-solving, and are <font color="00adbc"><b>17% more likely to enroll in college</b></font>.
+
+You can join tens of millions of students worldwide in this global event. Together, we can inspire kids to learn, break stereotypes, and help children discover a newfound interest. Best of all, you already have everything you need to bring the Hour of Code into your home!
+
+[![](/images/fit-600/Marketing/mother-helping-her-daughter-use-a-laptop-4260325.jpg)]({{ urls/learn }})
+
+<h3>What do I need to get started?</h3>
+
+The Hour of Code is simple to run - even for beginners. You don’t need experience in computer science or teaching in order to facilitate a fun activity for your children that will get them both learning and laughing.
+
+You can try the Hour of Code with a computer, a tablet, a smartphone, or completely unplugged! Here's how to get started.
+
+[<button>View PDF Guide</button>]({{ localized_files/hourofcode_parent_how_to }})
+
+* * *
+
+## 1) Explore activities and tutorials.
+
+[![](/images/tutorials.png)]({{ urls/learn }})
+
+There are countless [Hour of Code activities](https://hourofcode.com/us/learn) available to you if you’re working on a computer with internet access. We encourage you to take a look at some of your options ahead of time so that you can help guide your child towards exercises they’ll enjoy.
+
+All of our activities integrate problem-solving and critical-thinking with fun and creativity, but here are some student favorites:
+
+- For the child who loves to play: [Minecraft](https://code.org/minecraft) or [Dance Party](https://code.org/dance)
+- For the child who loves Disney: [Star Wars](https://code.org/starwars), [Frozen](https://studio.code.org/s/frozen/lessons/1/levels/1), or [Moana](https://partners.disney.com/hour-of-code?cds&cmp=vanity%7Cnatural%7Cus%7Cmoanahoc%7C)
+- For the child who loves to learn: [AI for Oceans](https://code.org/oceans) or [Make Music with Scratch](https://scratch.mit.edu/projects/editor/?tutorial=music&utm_source=codeorg)
+
+<h3>Low-tech or no-tech?</h3>
+
+If you’ll be using limited or no technology, you can filter [Hour of Code activities](https://hourofcode.com/us/learn) by selecting “No computers or devices” in the *Classroom technology* section.
+
+[![](/images/Marketing/filtering-activities-hoc.jpg)]({{ urls/learn }})
+
+You can also check out these [short videos](https://www.youtube.com/playlist?list=PLzdnOPI1iJNcpfa4LtbaIl35gqir_5XUu) for more ideas on how to facilitate an unplugged activity at home!
+
+## 2) Prepare ahead of time
+
+Now that you have some tutorials in mind, it may be helpful to try these activities on your device before introducing them to your child.
+
+[![](/images/fit-600/Marketing/father-and-children-looking-at-a-laptop-4260749.jpg)]({{ urls/learn }})
+
+<h3>More than one child at home?</h3>
+
+Consider providing each of your children with headphones if they’ll be working on separate devices. That way, they’ll be able to play activities with sound without distracting each other.
+
+If you’ll only be using one device, or simply want to make your Hour of Code more interactive, try [pair programming](https://www.youtube.com/watch?v=vgkahOzFH2Q). Pair programming encourages children to work together. When they partner up, they help one another to problem-solve. E iloa ma vaaitino foi i latou i galuega tau komepiuta e faigofie ai ona mafai ona fesootai ma galulue faatasi ai. 
+
+<h3>Get the kids excited! </h3>
+
+This is a great opportunity to add a new type of activity to your child’s day. You can extend the fun beyond one tutorial with these suggestions:
+
+- Show them an [inspirational video](https://www.youtube.com/playlist?list=PLzdnOPI1iJNcadqJAZnbDYShie4gLZQQJ) that features one of their favorite role models
+- Inspire them with a video on one of the [many careers](https://www.youtube.com/playlist?list=PLzdnOPI1iJNfpD8i4Sx7U0y2MccnrNZuP) that computer science skills can lead to
+- [Order some swag](https://store.code.org/)! You can choose from t-shirts, stickers, or even temporary tattoos. Share it with them right away to get them excited, or save it for the end of your Hour of Code as a special prize.
+
+<a href="https://store.code.org/" target="_blank"><img src="/images/fit-500/Marketing/hourofcodestore.jpg"></a>
+
+## 3) Tips for introducing your child to CS
+
+It’s okay if both you and your child are brand new to computer science. Here are some ideas to introduce your Hour of Code activity and get you both thinking about CS:
+
+- Explain ways that technology impacts our lives, with specific examples that may interest your child. For example, you could talk about medicine or connecting people virtually. Also, check out [Code.org/CSforGood](https://code.org/csforgood) for suggested discussion questions.
+- Together, list everyday things that use code in order to work properly.
+
+[![](/images/fit-600/Marketing/girl-sitting-on-sofa-while-using-tablet-computer-4144035.jpg)]({{ urls/learn }})
+
+<h3>Have young women at home?</h3>
+
+<a href="https://code.org/girls">Here are our recommendations</a> to help spark their interest in computer science. **Pro-tip**: You can start just by telling them they’d be great at it!
+
+<h3>Problem-solve together</h3>
+
+Lastly, when your child comes across difficulties it's okay to respond: - “I don’t know. Let’s figure this out together.” - “Technology doesn’t always work out the way we want.” - “Learning to program is like learning a new language; you won’t be fluent right away.”
+
+Computer science is all about learning how to “debug” situations that didn’t turn out the way we thought they would. Together, you and your child can think of creative ways to solve the problem!
+
+## 4) Don’t forget to celebrate!
+
+The Hour of Code is a global event, and your family deserves to celebrate. Here are some ways to make your Hour of Code extra special:
+
+- Print [Hour of Code Certificates](https://staging.code.org/certificates) that you award when your child completes their activity
+- [Print stickers](https://staging.hourofcode.com/us/promote/resources#stickers) at home or [purchase them online](https://store.code.org/), as an added surprise.
+- Share photos and videos of your at-home Hour of Code on social media. Use [#HourOfCode](https://twitter.com/hashtag/hourofcode) and [@codeorg](https://twitter.com/codeorg) so we can highlight your success, too!
+
+[![](/images/fit-600/Marketing/g8TUlHzF.jpeg)]({{ urls/learn }})
+
+<h2>What comes after the Hour of Code?</h2>
+
+E le faapea o le a gata mataupu tau le Komepitua faasaienisi i lenei poloakalame o le Hour of Code! While 90% of parents want their child to learn computer science, most schools still don’t teach it. To help, our curriculum is web-based and free to use, forever. [Learn how](https://code.org/yourschool) to bring CS to your child’s school today.
+
+[<button>View PDF Guide</button>]({{ localized_files/hourofcode_parent_how_to }})

--- a/i18n/locales/sm-WS/hourofcode/how-to/public-officials.md
+++ b/i18n/locales/sm-WS/hourofcode/how-to/public-officials.md
@@ -1,0 +1,64 @@
+---
+title: How-to guide for public officials
+---
+
+{{ signup_button }}
+
+# How to involve your entire community
+
+### Show your state, district, or city your commitment to computer science
+
+* * *
+
+</br>
+
+## Are you hosting an elected official at your Hour of Code?
+
+[View our toolkit](/files/elected-official.pdf) with all the information you need to make their visit and your event great!
+
+![](/images/fit-800/hoc_govs.png)
+
+From left to right: *Governors from Arkansas, North Carolina, and Arizona participating in an Hour of Code.*
+
+## Get every school participating, every student learning!
+
+### 1. Read our one-pager
+
+See [why computer science education is important]({{ localized_files/hoc_one_pager }}), and how you can help the effort by supporting the Hour of Code.
+
+### 2. Recruit local schools and districts
+
+Use [this email]({{ promote/sample_emails }}) or [this blurb]({{ promote/stats_url }}) as a starting point, and take a look at this [how-to]({{ urls/how_to_guide }}) for schools and districts.
+
+### 3. Host an Hour of Code event
+
+See our [event how-to guide]({{ urls/how_to_events }}) for a sample run of show, [media outreach kit]({{ promote/press_kit_url }}), and other event-planning resources. Hosting an event is a great way to promote the Hour of Code and increase participation.
+
+### 4. Attend an event during Computer Science Education Week ({{ campaign_date/short }})
+
+[Find classrooms and schools]({{ urls/events }}) participating in your district, city, or state.
+
+### 5. Issue a proclamation or resolution
+
+See this [sample resolution]({{ urls/proclamation }}) supportive of Computer Science Education Week and its goals that could be used by state and local legislators.
+
+### 6. Draft an op-ed
+
+Consider publishing an opinion piece in your local paper. See this [sample op-ed]({{ promote/op_ed }}) supporting Computer Science Education Week and its goals.
+
+### 7. Spread the word
+
+[Share the Hour of Code video on Facebook](https://www.facebook.com/sharer/sharer.php?u=http%3A%2F%2Fhourofcode.com%2Fus) and [talk about your support on Twitter](https://twitter.com/intent/tweet?url=http%3A%2F%2Fhourofcode.com&text=I%27m%20participating%20in%20this%20year%27s%20%23HourOfCode%2C%20are%20you%3F%20%40codeorg&original_referer=https%3A%2F%2Fwww.google.com%2Furl%3Fq%3Dhttps%253A%252F%252Ftwitter.com%252Fshare%253Fhashtags%253D%2526amp%253Brelated%253Dcodeorg%2526amp%253Btext%253DI%252527m%252Bparticipating%252Bin%252Bthis%252Byear%252527s%252B%252523HourOfCode%25252C%252Bare%252Byou%25253F%252B%252540codeorg%2526amp%253Burl%253Dhttp%25253A%25252F%25252Fhourofcode.com%26sa%3DD%26sntz%3D1%26usg%3DAFQjCNE1GLTUbKZfMlEh9Aj5w0iswz6PYQ&related=codeorg&hashtags=). Share pictures of events or a video of you and other adults doing the Hour of Code. Use the hashtag **#HourOfCode** so Code.org (@code.org) can see it and promote the support. Or, use these sample tweets:
+
+- *Every student, boy or girl, should have the chance to learn computer science. Join us in starting with one #HourOfCode [https://hourofcode.com]({{ urls/home }})*
+- *Today, we're proud to join the Hour of Code movement. Are you in? #HourOfCode [https://hourofcode.com]({{ urls/home }})*
+
+### 8. Issue a press release
+
+[Use this sample]({{ promote/official_press_release }}) as a guide.
+
+### 9. Connect locally
+
+[Learn more about computer science education in your state]({{ urls/advocacy }}). Sign the petition there and you’ll get updates on Code.org's local, state, and federal advocacy efforts.
+
+{{ signup_button }}

--- a/i18n/locales/sm-WS/hourofcode/how-to/virtual.md
+++ b/i18n/locales/sm-WS/hourofcode/how-to/virtual.md
@@ -1,0 +1,71 @@
+---
+title: Hour of Code How-To Guide for Virtual Events
+---
+
+{{ signup_button }}
+
+# Tips for a virtual Hour of Code event
+
+### You don't have to be in-person to run a successful Hour of Code!
+
+***
+
+While the Hour of Code is traditionally held in classrooms throughout the globe, you don’t need to be in-person to enjoy the fun! You can still host an interactive and inspirational Hour of Code for students remotely using some of these recommendations.  Take a look at our [guide for virtual events]({{ localized_files/participation_guide_virtual }}) if you still have questions.
+
+<br><br>
+
+[<img src="/images/fit-600/Marketing/pexels-andrea-piacquadio-3762940.jpg" />]({{ urls/learn }})
+
+## You may be apart, but you can still start together
+Even if you plan for students to complete their activities independently, we recommend starting your event with a virtual kick-off online to get participants excited. There are several interesting ways you can start your event:
+
+<ul>
+<li><b>Invite a guest speaker</b>: Thousands of volunteers from all backgrounds are waiting to hear from you! Simply use our <a href="https://code.org/volunteer/local">volunteer map</a> to search for them. With a virtual Hour of Code, you’re not limited by distance so if needed, consider searching outside of your zip code for volunteers that are offering to help remotely. Once you’ve connected with a volunteer, you can reference the <a href="http://hourofcode.com/us/how-to/volunteers">Hour of Code Volunteer How-To</a> as a guide for determining potential topics, discussion questions, and more.</li>
+<li><b>Show an inspirational video</b>: Another reliable option to start your event, is showing participants one of our many <a href="http://hourofcode.com/us/promote/resources#videos">inspirational videos</a>. Many videos are less than 5 minutes long and feature inspiration and encouragement from celebrities your students will recognize.</li>
+<li><b>Discuss computer science for good</b>: Turn your Hour of Code event into a deeper understanding of computer science by considering the impact of technology on our everyday lives. Ask students guiding questions and turn the beginning of your event into an interactive discussion. For ideas on how to get the conversation started, check out these <a href="https://code.org/csforgood#prompts">discussion questions</a>.</li>
+</ul>
+
+---
+
+## What to prepare ahead of time
+
+### 1. Determine your video conferencing platform
+Chances are you’re probably familiar with platforms like Cisco Webex, Google Meet, Microsoft Teams, Skype, or Zoom by now. Whichever tool you prefer, we just encourage you to familiarize yourself, test out it’s capabilities, and run through your Hour of Code agenda prior to your event date.
+
+[<img src="/images/fit-600/Marketing/photo-of-boy-video-calling-with-a-woman-4145197.jpg" />]({{ urls/learn }})
+
+### 2. Plan how students will participate
+**Self-led Hour of Code activity**<br> We recommend that after your kickoff, you allow students to leave the video conference to work through their <a href="https://hourofcode.com/us/learn">Hour of Code activities</a> on their own rather than live together. This will allow students to immerse themselves in their own projects and gain a stronger understanding of the CS concepts. It will also minimize the distraction and obstacle of having to have a video conference window open.
+
+It may be helpful for you to determine 1-3 tutorial options for them to choose from ahead of time. This allows you to choose activities that are best suited for their grade level. Plus, if students have questions that require your assistance you’ll be better prepared to help if you’re already familiar with the tutorials they’re working on.
+
+If your class is expected to do their activity immediately after kickoff, you might consider keeping a virtual conference room, chat platform, or other means of communication open so they can reconnect with you with questions as needed.
+
+**Hour of Code activity together online**<br> If you prefer to keep your participants on the same video call for the duration of your event, please note that they’ll need to have two windows open at all times - one for the video conferencing platform, and the other for students to work on their activity.
+
+**With parents**<br> For students that are Grade 4 and below, consider encouraging their parents to host an Hour of Code at home. You can support them with some recommended tutorials as well as this helpful <a href="https://hourofcode.com/us/how-to/parents">How-To for Parents</a>.
+
+[<img src="/images/fit-600/Marketing//happy-father-and-child-browsing-laptop-in-bedroom-4545778.jpg" />](https://hourofcode.com/us/how-to/parents)
+
+### 3 Enlist a volunteer
+You can find a volunteer suited to your needs by visiting our <a href="https://code.org/volunteer/local">volunteer map</a>. Many are available for remote participation and are more than willing to speak about their experience in computer science, how technology impacts their roles, or simply to help you with troubleshooting student questions. Once you find a volunteer, make sure you set up a meeting with them ahead of time to discuss their role for the event, work out technical requirements, and establish the logistics of participating online.
+
+### 4 Celebration supplies
+Take a look below for ideas on celebrating your virtual Hour of Code. Some may require you to prepare ahead of time such as creating completion <a href="https://studio.code.org/certificates/batch">certificates</a> for all of your participants.
+
+---
+
+## Celebrate together
+
+Similar to how you started the event, come together afterwards to celebrate! Here are some ideas for making your virtual celebration interactive and special:
+
+- Allow students to share their completed projects with the rest of the class. If your conferencing platform allows, you can even encourage students to take a screenshot of their projects and set it as their virtual background!
+- Discuss learnings: What have they learned about computer science or technology? What did they do when they ran into a problem, how did they solve it?
+- <a href="https://studio.code.org/certificates/batch">Create and share certificates</a> for your participants
+- Share photos and videos of your virtual Hour of Code on social media. Fa'aaoga le #HourOfCode ma le @codeorg ina ia mafai ona faailoa lau taumafai ua iu manuia!
+
+[<img src="/images/fit-600/Marketing/g8TUlHzF.jpeg" />]({{ urls/learn }})
+
+Lastly, if you didn’t start the event with a <a href="https://code.org/volunteer/local">guest speaker</a>, <a href="https://hourofcode.com/us/promote/resources#">inspirational video</a>, or <a href="https://code.org/csforgood#prompts">discussion questions</a>, this would be another great opportunity to incorporate one of those experiences as well.
+
+{{ signup_button }}

--- a/i18n/locales/sm-WS/hourofcode/how-to/volunteers-old.md
+++ b/i18n/locales/sm-WS/hourofcode/how-to/volunteers-old.md
@@ -1,0 +1,91 @@
+---
+title: How-to guide for Hour of Code volunteers
+---
+
+{{ signup_button }}
+
+# How-to Guide for Volunteers
+### Make a difference in a classroom today!
+
+***
+
+## Why volunteer?
+Check out some testimony from past volunteers:
+
+- “The best part of my experience was that the entire class were women and people of color. It bodes well for the future of our industry to have a chance to reach and excite these kids.”
+- “Especially enjoyed getting to encourage young girls in technology. Felt like I was helping the next generation in my local area.”
+- “I LOVED seeing how excited the kids were. One amazing thing was that the teachers noticed that some of the students who didn’t do as well academically were excelling at thinking like a developer and helping others learn - giving them a place to feel confident.”
+
+## Anyone can volunteer
+### Volunteers and speakers in tech:
+Do you have a connection to CS or tech? If you work in software engineering, at a tech company in any role (non-engineer or engineering), or you’ve taken computer science courses, you can help inspire students! Many students have never met anyone who works in the tech industry and our teachers love being able to connect their classrooms to professionals and university students.
+
+You can be a guest speaker in a classroom, or help a teacher run the activity. Visit a local classroom to inspire students to keep learning computer science.
+<br>
+<br>
+
+<a href="https://code.org/volunteer"><button>Sign up today to be a tech volunteer!</button>
+
+<br>
+<br>
+
+### Anyone passionate about expanding opportunity:
+Do you believe that learning computer science can open doors of opportunity for students? Help out in a local classroom or organize an after school event! You don’t need any background in computer science to host an Hour of Code. And, just offering to help out is often enough to convince your child’s teacher, a friend, or a club to try an hour.
+
+### How do you get started?
+
+1. [Send this email]({{ promote/help_schools }}) to your child’s teacher offering to help them run an Hour of Code.
+2. Offer to host an Hour of Code event after school at a local school. [Use this How-To Guide]({{ urls/how_to_guide }}) to help you plan.
+
+## Recruit your co-workers to volunteer
+Tell your friends and co-workers about the Hour of Code. Thousands of teachers are  looking for volunteers, so ask them to [sign up as a volunteer](https://code.org/volunteer). Ask your employer to get involved. [Send this email]({{ promote/sample_emails }}) to your manager or the CEO to get everyone on board.
+
+## How to prepare
+- [Pick out a video]({{ promote/videos }}) to show to help focus the class and get them excited to do an Hour of Code.
+- Check out the [Hour of Code Volunteer Toolkit](/files/hoc-volunteer-toolkit.pdf) which includes an overview, timeline, preparation material, and marketing material. Everything you need to be ready for your volunteer experience!
+- If you're going to be doing a tutorial during your session, spend 30 minutes trying at least one [Hour of Code tutorial]({{ urls/learn }}).
+- If you're visiting a school, complete any background checks or required paperwork.
+- [Review these tips](https://code.org/files/CSTT_Volunteers.pdf) about how to interact with students.
+- Join the conversation on Facebook, Twitter, Instagram, and Tumblr with #HourOfCode.
+- Connect with the teacher to discuss what you plan to speak about during your session.
+- If you are a virtual volunteer, test A/V and screen sharing capabilities beforehand.
+
+## Day-of Hour of Code Event
+When you're hosting an Hour of Code event, follow the sample agenda below to help guide your day. Before then, make sure you sign into the school and greet the teacher the day of the event. Confirm the agreed schedule for the day and discuss any talking points.
+
+### Sample agenda:
+
+| Time          | Agenda item                                                                                                                                                                                                                                                                                                                                                  |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 1-5 minutes   | [Show an inspirational video]({{ promote/videos }}).                                                                                                                                                                                                                                                                                                         |
+| 5-10 minutes  | Introduce yourself and learn more about the students: </ul><li>What do you work, what do you do, and what do you love most about your job?</li><li>What or who inspired you?</li><li>How did you get interested in computer science?</li><li>Did you have a mentor?</li><li>Share a story about how tech affects everyone.</li><br>Ask the students questions and leave time for Q&A.</br> <li> What jobs are they interested in, what are their favorite tech gadgets or apps, and how do they think they are built? </li><li> Do the students have any questions for you?</ul> |
+| 30-60 minutes | **Code!** Walk around, answer questions, and guide them through tough puzzles. Try not to give students the solution outright, instead, try asking them questions so they can answer themselves what went wrong, and encourage students to ask each other if they have questions. Learning from each other is a great learning opportunity.                  |
+| 1-3 minutes   | Thank everyone and share inspirational parting words. Hand out any of your company swag (stickers are awesome)!                                                                                                                                                                                                                                              |
+| After         | **Make a lasting change:** Talk to the teacher about turning the Hour of Code into a full computer science course! Go to [code.org/yourschool](https://code.org/yourschool) with your teacher to fill in what this school teaches today and encourage them to pledge to bring ccomputer science to their classroom.                                          |
+
+### After the Event:
+- Share your photos and stories with Code.org at giving@code.org.
+- Remember to enter in your volunteer hours in your company’s volunteer tracking portal.
+- Share about your experience on social media #HourOfCode!
+- If you do take pictures/videos during the event, **especially with students**, make sure you get teacher/parent permission if you would like to post your stories on social media.
+- And, check back in a month: Is the teacher interested in offering a computer science course? Share [resources and professional learning opportunities to help them do this](https://code.org/yourschool).
+
+## How you get selected as a technical volunteer of guest speaker
+- Teachers will be searching for volunteers on our [volunteer map](https://code.org/volunteer/local).
+- Try to make your profile as complete as possible to increase the chance that a teacher will select you.
+- A teacher will contact you through this form (your email address will never be shared with the teacher). *If you are receiving too many requests from teachers, you can always update your preferences by clicking the link to edit your information or unsubscribe, provided at the bottom of any email from a teacher.*
+
+## Volunteering during the Hour of Code FAQ
+
+### I haven't been contacted by a teacher yet. How can I still volunteer?
+Try searching for local schools and call the principal/teacher/front office and ask how you can help.
+
+### How long do classroom visits last for?
+An in-person classroom visit usually lasts 60-90 minutes while a virtual classroom visit usually lasts 20-30 minutes.
+
+### What age group is the Hour of Code activity appropriate for?
+Code.org and our partners design all the Hour of Code activities to engage students of all grade levels (K-12), boys and girls, from all backgrounds. Everyone, even adults can have fun playing!
+
+
+
+{{ signup_button }}

--- a/i18n/locales/sm-WS/hourofcode/how-to/volunteers.md
+++ b/i18n/locales/sm-WS/hourofcode/how-to/volunteers.md
@@ -1,0 +1,264 @@
+---
+title: Hour of Code How-To Guide for Volunteers
+---
+
+# How to volunteer with a school or classroom
+
+### Thousands of teachers are looking for volunteers to inspire their students. Make a difference today!
+
+[<button>Sign up to volunteer</button>]({{ urls/volunteer }})
+
+* * *
+
+Computational thinking helps nurture problem-solving skills, logic, and creativity. And technology is transforming every industry on the planet. Students today should learn how to create technology, not just use it.
+
+The Hour of Code is a one-hour introduction to computer science designed to demystify “code,” show that anybody can learn the basics, and to broaden participation in the field of computer science. You can help raise awareness of the computer science movement and volunteer to inspire more students to try computer science, particularly young women and students from historically marginalized racial and ethnic groups.
+
+- [Who can volunteer?](#who-can-volunteer)
+- [Why volunteer?](#why-volunteer)
+- [How do volunteers get selected?](#selection)
+- [What if I want to volunteer with a specific school?](#choose-a-school)
+- [How to prepare](#how-to-prepare)
+- [When you're hosting an event](#hosting-an-event)
+- [Spread the word about the Hour of Code](#promote-hour-of-code)
+- [More ways to support the Hour of Code](#support-hour-of-code)
+- [Volunteer FAQ](#faq)
+
+Whether you volunteer virtually, in-person, or with your company, your efforts can make a huge impact on the way students view computer science and their own potential. Take a look at our [volunteer toolkit if you still have questions]({{ localized_files/hoc_volunteer_toolkit }}).
+
+* * *
+
+<a id="who-can-volunteer"></a>
+
+## Who can volunteer?
+
+Anyone passionate about computer science education and increasing diversity in tech can be a volunteer! We’d love to see volunteers of all backgrounds participate. The Hour of Code features a large variety of activities for all ages and skill levels, so you don’t need to be a programming expert to volunteer!
+
+You can be a guest speaker in a classroom, or help a teacher run the activity. [Sign up today](https://code.org/volunteer) to inspire students to keep learning computer science.
+
+* * *
+
+<a id="why-volunteer"></a>
+
+## Why volunteer?
+
+Computer science is the defining field of the 21st century, yet most schools still don’t teach it. One Hour of Code may be the most access to computer science that these students receive in a given year. By volunteering, you can make it even easier for teachers to bring CS into their classroom.
+
+[![](/images/fit-600/Marketing/HoC-2015-ACE-HS--42.jpg)]({{ urls/learn }})
+
+Check out some testimonials from past volunteers:
+
+- “The best part of my experience was that the entire class were women and people of color. It bodes well for the future of our industry to have a chance to reach and excite these kids.”
+- “Especially enjoyed getting to encourage young girls in technology. Felt like I was helping the next generation in my local area.”
+- “I LOVED seeing how excited the kids were. One amazing thing was that the teachers noticed that some of the students who didn’t do as well academically were excelling at thinking like a developer and helping others - giving them a place to feel confident.”
+
+[<button>Sign up to volunteer</button>]({{ urls/volunteer }})
+
+* * *
+
+<a id="selection"></a>
+
+## How do volunteers get selected?
+
+Teachers can search for volunteers on our [volunteer map](http://code.org/volunteer/local). If you’re located near their classroom, teachers will review your profile on the map, so try to complete as much as possible to increase the chance that a teacher will contact you.
+
+[![](/images/fit-600/Marketing/2018_HoC-489-resized.jpg)]({{ urls/learn }})
+
+When selected, a teacher will contact you through the volunteer platform (we will never share your email address with the teacher). Work with them to determine how you can best contribute to their event, and if you’ll be visiting in-person or volunteering virtually.
+
+If you are receiving too many requests from teachers, you can always update your preferences or unsubscribe by clicking the link provided at the bottom of any email request from a teacher.
+
+* * *
+
+<a id="choose-a-school"></a>
+
+## What if I want to volunteer with a specific school?
+
+You don’t have to use our volunteer map in order to volunteer! In fact, we recommend reaching out to teachers and administrators directly if there’s a classroom you’d like to volunteer with.
+
+To get started: - If you’re a parent or guardian, send [this email](https://hourofcode.com/us/promote/resources#help-schools) to your child’s teacher offering to help them run an Hour of Code. - If you have another school in mind, visit their website to find appropriate contacts to reach out to such as a principal or vice principal, technology or computer science instructors, or even the school’s PTSA. You could also partner with organizations such as the Boys & Girls Clubs of America, Junior Achievement, a YMCA branch, and more to co-host an event. - If you’re unable to find a school that is hosting an Hour of Code, you can volunteer to help run your own event with your company. Check out our [How-To Guide for Companies](https://hourofcode.com/us/how-to/companies) to learn more and get inspired.
+
+* * *
+
+<a id="how-to-prepare"></a>
+
+## How to prepare
+
+Whether you’re attending an Hour of Code event remotely or in-person, you’ll have a much smoother experience if you make these preparations beforehand.
+
+[![](/images/fit-600/Marketing/4Q9A5575.jpg)]({{ urls/learn }})
+
+### Meet with the Organizer
+
+If you’re volunteering with a classroom, discuss these logistics with the teacher ahead of time:
+
+- Your role at the event. If you work in tech, you might be asked to share your personal experiences or story: How did you get involved in a career in tech? Why is computer science important to you? What are some things you do as part of your job and how does that relate to technology?
+- If you’ll be volunteering in-person, make sure you both understand local and school health and safety guidelines. Depending on their procedures you may need to arrive a little early.
+- If you’ll be volunteering virtually or in-person as this can determine what times you need to be present and in what capacity.
+- If you’re volunteering virtually, work with the teacher to determine the best video conferencing platform to use and try conducting a test run of the event together.
+- If the teacher has predetermined Hour of Code activities for the event, be aware so that you can [explore them](https://hourofcode.com/us/learn) ahead of time.
+
+### Think about your participants
+
+- Consider the students you will be speaking to and what might resonate with them. As a volunteer, you can help them to realize that computing is everywhere and they too can become computer scientists. Consider their ages, backgrounds, and gender identities and come prepared with topics that may appeal to their interests. Here is additional guidance on how to inspire [young women](http://code.org/girls) to participate.
+- Get the students excited! Work with the teacher to pick out an [inspirational video](https://hourofcode.com/us/promote/resources#videos) that can help focus the class and get them excited to do an Hour of Code.
+- If you are a virtual volunteer, consider making a few slides as part of your presentation to help keep students engaged.
+
+Need more resources? [Check out these other tips](https://code.org/files/CSTT_Volunteers.pdf).
+
+* * *
+
+<a id="hosting-an-event"></a>
+
+## When you're hosting an event
+
+If you are the host of an event with a classroom, use the sample agenda to guide you. Confirm the agreed schedule for the day and discuss any talking points with the teacher beforehand. If you are physically visiting the class, make sure you sign in with the school and greet the teacher the day-of your event.
+
+If you’re considering hosting the Hour of Code at home or in the community, we recommend taking a look at some of our in-depth How-To Guides for [parents](https://hourofcode.com/us/how-to/parents) and [organizations or companies](https://hourofcode.com/us/how-to/companies).
+
+### 1. Matamata i le video lea e fa'asino atu auala e faatino ai galuega.  <iframe width="500" height="255" src="//www.youtube.com/embed/SrnvvWDm73k" frameborder="0" allowfullscreen></iframe> 
+
+### 2. Determine a date, format, and location for your event
+
+Work with the school or teacher to discuss what makes the most sense. We’ve seen events that are [virtual](https://hourofcode.com/us/how-to/virtual) or in-person, at the company office or held in the community, and for students of all ages! You can also take a look at what other [corporate partners](https://medium.com/@codeorg/amazon-microsoft-google-vista-and-more-rally-to-bring-the-hour-of-code-to-students-worldwide-4641325542cf) and [donors](https://medium.com/@codeorg/how-code-orgs-corporate-supporters-helped-spread-the-love-for-2019-s-hour-of-code-73a3c088f10f) have done in the past for some inspiring ideas.
+
+<br />
+
+#### Sample Agenda:
+
+|Time | Agenda Item | |\---\---\---\---\---\---\---\---\---\---\---\---\---\---\---\---- | \---\---\---\---\----- | |1-5 minutes | Show an [inspirational video](https://hourofcode.com/us/promote/resources#videos)| |5-10 minutes | Introduce yourself and learn more about the students: Where do you work, what do you do, and what do you love most about your job? What or who inspired you? How did you get interested in computer science? Did you have a mentor? Ask the students questions and leave time for Q&A. | |30-60 minutes | Code! If your event is in-person, this is the time to answer questions and guide students through tough puzzles. Try not to give them the solution outright, instead, try asking them questions so they can answer themselves what went wrong, and encourage students to ask each other if they have questions. If you are volunteering virtually, work with the teacher on what the best approach might be. It may make more sense to return at the end of the session to see what progress students have made. | | |1-3 minutes | Thank everyone and share inspirational parting words. Hand out any of your company swag ([stickers](#celebrate) are awesome)! | | <br />
+
+#### Other ideas to add to your event
+
+- Explain ways technology impacts our lives, with examples that students of all backgrounds will care about - talk about technology that’s saving lives, helping people, connecting people.
+- If you are a tech company, demo fun, innovative products your company is working on. If you aren’t a tech company, discuss ways your company uses technology to solve problems and accomplish goals.
+- Valaaulia inisia o polokalame tau komepiuta mai lau kamupani e fa'amatala le mafua'aga ua latou filifili ai ma fiafia i le mataupu o le computer science ma ni poloketi o loo latou galulue ai. 
+- If you have a group of staff that will be facilitating your event or volunteering with a local school, consider ordering [custom t-shirts](http://blog.code.org/post/132608499493/hour-of-code-shirts-and-more) for your group.
+
+### 3. Plan your technology needs
+
+[![](/images/fit-600/Marketing/Excel-Charter-SchoolHoC-2015-stills-9.jpg)]({{ urls/learn }})
+
+#### Devices:
+
+O le Hour of Code e sili ona lelei le fa'aaogaina pe afai o se komepiuta o fesootai ma le upega tafailagi Ae e le faapea o le a manaomia e tamaiti uma se komepiuta, ma e mafai lava ona fa'aaoga le Hour of Code e aunoa ma se komepiuta. For unplugged activities, simply filter the Classroom Technology section to show options for “No computers or devices”.
+
+- **Test activities** on computers or devices. Make sure they work properly on browsers with sound and video.
+- **Don't have enough devices?** Use pair programming. A galulue faatasi tamaiti i paga, e mafai ona fesoasoani le tasi i le isi nai lo le lagolago i le faiaoga. E iloa ma vaaitino foi i latou i galuega tau komepiuta e faigofie ai ona mafai ona fesootai ma galulue faatasi ai. 
+- **Provide headphones** for your participants or ask them to bring their own if they’ll be trying tutorials that work best with sounds.
+- **Have low bandwidth**? Plan to show videos at the front of the event, so each participant isn't downloading their own videos. Or try the unplugged / offline activities.
+
+#### Virtual Events:
+
+If your event is going to be virtual, you’ll want to decide on your conference platform (and test it) prior to your event. This may impact the number of students you feel comfortable engaging, so it’s best to determine this prior to inviting a classroom or promoting your event. For ideas on how to run a remote Hour of Code, read our [tips for a virtual Hour of Code event](https://hourofcode.com/us/how-to/virtual).
+
+### 4. Choose an activity
+
+We provide a variety of fun, student-guided tutorials for all age groups and experience levels. It’s popular for students to try self-led tutorials, though you may want to begin the event with an [inspirational video](https://hourofcode.com/us/promote/resources#videos) for everyone to view together.
+
+<a href="https://hourofcode.com/us/learn">Explore the activities</a> and decide ahead of time if you want to choose a single tutorial for all of your guests, or let each child pick their own. **All Hour of Code activities** require minimal prep-time, and are self-guided - allowing participants to work at their own pace and skill-level.
+
+[![](/images/tutorials.png)]({{ urls/learn }})
+
+Once you have a solid roadmap for your event, you can then start inviting students, a school, or the larger community. We recommend starting with a local school you have a relationship with or [browsing our map](https://hourofcode.com/us/map) of Hour of Code events.
+
+<a id="celebrate"></a>
+
+### 5. Celebrate
+
+[![](/images/fit-600/Marketing/2018_HoC-391.jpg)]({{ urls/learn }})
+
+After students or guests have completed their Hour of Code, it’s time to celebrate their success. Here are some ideas for making your event even more fun:
+
+- [Share certificates]({{ urls/certificates }}) for participants and students.
+- [Print "I did an Hour of Code! stickers"]({{ promote/resources_stickers }}) or find other prizes and swag on the [Code.org Amazon Store](https://code.org/shop).
+- Fa'ailoa ma fa'aali ata ma videos o lau Hour of Code i luga o ala fesootaiga. Fa'aaoga le #HourOfCode ma le @codeorg ina ia mafai ona fa'ailoa atu lou ausia foi o se tulaga manuia!
+
+* * *
+
+<a id="promote-hour-of-code"></a>
+
+## Spread the word about the Hour of Code
+
+One of the best ways to help is to spread the word and promote the Hour of Code.
+
+[![](/images/fit-600/Marketing/g8TUlHzF.jpeg)]({{ urls/learn }})
+
+### 1. Register Your Event
+
+When you [sign up your Hour of Code event](/#join), you’ll receive helpful email communications with news and tips for hosting a successful Hour of Code. It’s also how you can let local schools or parents know that you’re hosting an event near them.
+
+### 2. Post on Social Media
+
+Help raise awareness of the computer science movement with this sample content to post on social media and share with your employees.
+
+#### Hour of Code general announcement
+
+- Computer science is changing our world. Help students be part of this change starting with one #HourOfCode. https://hourofcode.com/
+- Don’t just use technology—learn how to build it. Help someone start with an #HourOfCode. https://hourofcode.com/
+
+#### Stats
+
+- Did you know only 53% of U.S. schools teach computer science? Give every student the chance to learn one #HourOfCode https://hourofcode.com/
+- In the U.S., only 26% of software professionals are women. Introduce more young women to computer science with #HourOfCode https://hourofcode.com/
+- 67% of computing jobs in the U.S. are not in the tech sector. Help put computer science in the standard curriculum with #HourOfCode https://hourofcode.com/
+
+#### Create your own
+
+- One #HourOfCode can lead to [fill in your story]. https://hourofcode.com/
+- I’m supporting #HourOfCode because [fill in your thoughts]. Join us https://hourofcode.com
+
+#### Engineer-specific
+
+- If your very first line of code changed your life, help students near you write their first #HourOfCode https://code.org/volunteer
+- If you learned to code—what’s your story? Inspire a student near you through their first #HourOfCode https://code.org/volunteer
+
+<a href="https://hourofcode.com/promote/resources#posters">Learn more</a> about posters, videos, stickers and other ways to promote your event to your community.
+
+* * *
+
+<a id="support-hour-of-code"></a>
+
+## More ways to support the Hour of Code
+
+[![](/images/fit-600/Marketing/girl-strong-coding.png)]({{ urls/learn }})
+
+- Spread awareness by wearing [Code.org swag](https://store.code.org/) (all proceeds go to supporting more students gain access to computer science education).
+- Choose to benefit Code.org when you shop on [AmazonSmile](https://code.org/donate/amazonsmile).
+- Ask your CEO to send a company-wide email emphasizing the importance of computer science and encouraging employees to spread the word.
+- Have some fun with co-workers in a [giving campaign](https://medium.com/@codeorg/how-a-haircut-happy-hour-turned-into-a-fundraiser-for-code-org-1952b197faa2).
+- [Sign this petition](https://code.org/promote) to make sure that every student has the opportunity to learn computer science.
+- [Donate](https://code.org/donate) to Code.org so that we can keep our educational resources free and accessible to all.
+
+For more suggestions on how to support Code.org and the Hour of Code, visit [Code.org/Help](https://code.org/help)
+
+* * *
+
+<a id="faq"></a>
+
+## Volunteering FAQ
+
+### I haven't been contacted by a teacher yet. How can I still volunteer?
+
+Try searching for local schools and call the principal/teacher/front office and ask how you can help.  
+
+
+### How long do classroom visits last for?
+
+An in-person classroom visit usually lasts 60-90 minutes while a virtual classroom visit usually lasts 20-30 minutes.   
+
+
+### What age group is the Hour of Code activity appropriate for?
+
+Code.org and our partners design all the Hour of Code activities to engage students of all grade levels (K-12) from all backgrounds. Everyone - even adults - can have fun playing!   
+
+
+### How do I get selected as a technical volunteer or guest speaker?
+
+Teachers will be searching for volunteers on our [volunteer map](https://code.org/volunteer/local). Try to make your profile as complete as possible to increase the chance that a teacher will select you. If you have a preference on how you’d like to volunteer, such as being a guest speaker or as technical support, please indicate that in the description of your profile.   
+
+
+When selected, a teacher will contact you through the volunteer platform (your email address will never be shared with the teacher). If you are receiving too many requests from teachers, you can always update your preferences by clicking the link to edit your information or unsubscribe, provided at the bottom of any email from a teacher.   
+
+
+[<button>Sign up to volunteer</button>]({{ urls/volunteer }})

--- a/i18n/locales/sm-WS/hourofcode/international-partners.md
+++ b/i18n/locales/sm-WS/hourofcode/international-partners.md
@@ -1,0 +1,17 @@
+---
+title: Contact International Partners
+---
+
+{{ signup_button }}
+
+# Contact International Partners
+
+Code.org works with many organizations around the world to make the Hour of Code a truly international movement. Did you know that in 2017, 60% of all Hour of Code events occurred outside of the U.S.?
+
+You, too, can play a leading role to get more people in your country involved! If you're in one of the countries below, reach out to the listed partner and get connected with your local Hour of Code.
+
+*Don't see your country listed here?* [Apply to become an Hour of Code International Partner](https://airtable.com/shreokz55rqubug8F)! <br /> <br />
+
+{{ international_partners_table }}
+
+{{ signup_button }}

--- a/i18n/locales/sm-WS/hourofcode/partners.md
+++ b/i18n/locales/sm-WS/hourofcode/partners.md
@@ -1,0 +1,39 @@
+---
+title: Partners
+---
+
+The Hour of Code is driven by the Hour of Code Review Committee.
+
+The [Review Committee]({{ urls/review_committee }}) is composed of 12 current and former educators across K-12 grade bands that assess and recommend activities using a rubric established by an advisory committee. These educators review student-led activities and teacher-led lesson plans submitted by hundreds of activity partners, evaluating the activities' educational value, ability to engage learners, and potential appeal to diverse sets of students.
+
+The committee's work and dedication have contributed to the success of the Hour of Code and its vision of offering an introduction to computer science for every student.
+
+# Major Partners and Corporate Supporters
+
+{{ partners/major_partners_corporate_supporters }}
+
+* * *
+
+# International Partners
+
+{{ partners/international_partners }}
+
+* * *
+
+# Curriculum and Tutorial Partners
+
+{{ partners/curriculum_tutorial_partners }}
+
+* * *
+
+# Infrastructure Partners and Tools
+
+{{ partners/infrastructure_partners_tools }}
+
+* * *
+
+# Additional Partners
+
+{{ partners/additional_partners }}
+
+{{ signup_button }}

--- a/i18n/locales/sm-WS/hourofcode/promote/index.md
+++ b/i18n/locales/sm-WS/hourofcode/promote/index.md
@@ -1,0 +1,31 @@
+---
+title: Spread the word
+---
+
+{{ signup_button }}
+
+# Get your community involved in the Hour of Code
+
+## 1. Spread the word
+
+Tell your friends about the **#HourOfCode**!
+
+{{ promote/share_buttons }}
+
+## 2. Ask your whole school to offer an Hour of Code
+
+[Send this email]({{ promote/sample_emails }}) to your principal and challenge every classroom at your school to sign up.
+
+## 3. Ask your employer to get involved
+
+[Send this email]({{ promote/sample_emails }}) to your manager or company's CEO.
+
+## 4. Promote Hour of Code in your community
+
+[Recruit a local group]({{ promote/sample_emails }})— boy/girl scouts club, church, university, veterans group, labor union, or even some friends. You don't have to be in school to learn new skills. Use these [posters, banners, stickers, videos and more](/promote/resources) for your own event.
+
+## 5. Ask a local elected official to support the Hour of Code
+
+[Send this email]({{ promote/sample_emails }}) to your local representatives, city council, or school board and invite them to visit your school for the Hour of Code. It can help build support for computer science in your area beyond one hour.
+
+{{ signup_button }}

--- a/i18n/locales/sm-WS/hourofcode/promote/official-press-release.md
+++ b/i18n/locales/sm-WS/hourofcode/promote/official-press-release.md
@@ -1,0 +1,46 @@
+---
+title: Hour of Code Press Release for Elected Officials
+---
+
+{{ signup_button }}
+
+# Sample press release for elected officials
+
+### Use this sample press release language to help craft your message about participating in the Hour of Code.
+
+* * *
+
+#### For Immediate Release  
+
+
+#### [DATE]  
+
+
+#### Contact: [CONTACT INFORMATION]
+
+<br />
+
+**GOVERNOR/SENATOR/ASSEMBLYMEMBER/REPRESENTATIVE/MAYOR/ COUNCILMEMBER [INSERT NAME] PARTICIPATED IN THE HOUR OF CODE WITH LOCAL STUDENTS** <br />
+
+Community comes together to raise awareness about importance of computer science education by participating in Computer Science Education Week <br /> <br />
+
+**DATE** - [**INSERT NAME**] joined the principal and faculty members of [**INSERT NAME OF SCHOOL**], business leaders, and local families today for [**NAME OF EVENT**] and participated in the Hour of Code as part of Computer Science Education Week . [**INSERT NAME**] and community members were among tens of millions of people around the world to take part in the largest learning event in history. <br />
+
+[**INSERT DETAILS OF EVENT, USE DESCRIPTIVE AND QUANTIFIABLE LANGUAGE. FOR EXAMPLE:**]  
+“Daniels Run Elementary school held a school-wide Hour of Code event to introduce its students to computer science. More than 700 students from all grades did at least one Hour of Code. A dozen parents and volunteers from the community helped with the day and brought the kids together for an assembly showcasing why computer science matters in the lives of these students.” <br />
+
+[**SAMPLE STOCK TEXT FOR CONTEXT:**]  
+Computers are everywhere, but fewer schools teach computer science than 10 years ago. Girls and students of color are severely underrepresented. The good news is we’re changing this for the better. The Hour of Code is gateway toward providing all students with access to high-quality computer science education. <br />
+
+Over 100 million students worldwide have already tried an Hour of Code. Thanks to the Hour of Code, computer science was on homepages of Google, MSN, Yahoo!, and Disney. President Obama, Shakira, and Ashton Kutcher have all kicked off the Hour of Code with videos. Over 100 partners came together to support this movement. <br />
+
+[**INSERT QUOTE FROM SPOKESPERSON, EXAMPLE BELOW:**]  
+“We need to encourage and embrace our students’ interest in computer science,” said [**INSERT NAME**]. “Every student deserves the chance to learn computer science to access the best careers of the 21st century.” <br />
+
+[**INSERT MORE INFORMATION ABOUT YOUR EVENT AND/OR YOUR ORGANIZATION**] <br />
+
+[**INSERT QUOTE FROM ANOTHER ORGANIZATION OR SOMEONE WHO ATTENDED THE EVENT**] <br />
+
+For more information about [**EVENT/PROGRAM/ETC**], visit [**INSERT WEBSITE**] or contact [**INSERT CONTACT INFORMATION**]
+
+{{ signup_button }}

--- a/i18n/locales/sm-WS/hourofcode/promote/op-ed.md
+++ b/i18n/locales/sm-WS/hourofcode/promote/op-ed.md
@@ -1,0 +1,47 @@
+---
+title: Sample Op-ed Supportive of Computer Science Education Week and Hour of Code
+---
+
+{{ signup_button }}
+
+# Write an op-ed in support of Computer Science Education Week
+
+### Below is a sample op-ed supportive of Computer Science Education Week–and its goals–that can be used by state and local legislators, business leaders, and more.
+
+### Visit [advocacy.code.org]({{ urls/advocacy }}) to find state specific information about computer science.
+
+* * *
+
+#### Title: Computing…Where the Jobs Are
+
+#### By [NAME] and [CONSIDER CO-AUTHORING WITH EDUCATOR, SUPERINTENDENT OR BUSINESS LEADER]
+
+Computers are everywhere. They’re in our pockets. They’re on our walls. They’re in our cars. They’re a critical piece of our infrastructure, from power grids to traffic lights to the inner workings of our financial markets. And all of these computers have one thing in common. They depend on software to tell them what to do.
+
+But who exactly is going to write this software?
+
+Considering how fast our world is being transformed by technology, you might expect the number of students studying computer science in K-12 education today to be at an all-time high. You’d be wrong. In fact, fewer students are studying computer science, and fewer schools are teaching it, than a decade ago.
+
+At a time when demand for skilled programmers has never been higher, we’re turning out fewer computer scientists. Even in this time of high unemployment, thousands of jobs, many of them right here in **[INSERT STATE/CITY]**, are going unfilled for lack of enough individuals with the right skill sets.
+
+Why is this? And how can we address it?
+
+The problem begins in our middle and high schools. Nine out of ten of our schools do not offer computer programming classes. In **[SCHOOL DISTRICT]** last year, only **[NUMBER]** students took the college-level Advanced Placement (AP) Computer Science Exam, just **[%]** of all students who took an AP in our state. We’re simply not doing enough to prepare or encourage our students to pursue these high-paying, vital careers.
+
+Nearly all major computing innovations were invented here in this country, but we’re at risk of losing that leadership if we don’t do something now.
+
+We need to make some changes.
+
+**[OPTIONAL FOR STATES WHERE THIS APPLIES]**
+
+One positive change would be to allow rigorous computer science courses to satisfy a high school math or science graduation requirement. In **[INSERT STATE]**, computer science courses are electives. Given academic demands, students cannot afford to take elective computer science courses. And making this change can have a big impact. In states where computer science courses count toward graduation requirements, courses are fifty percent larger with much higher rates of participation by underserved minorities than states that treat computer science as an elective.
+
+We should also work with students at a young age to spark their interest in computer science and coding. Our children should not just know how to use apps and play video games – they should know how to create them. Children can learn the basics of coding as early as the second grade.
+
+We need to recruit more computer science teachers and encourage professional development within their field. Today there are many online resources that can help teachers access and keep up to date with the latest technology for their students.
+
+According to the Bureau of Labor Statistics, by 2020, there will be 9.2 million jobs in STEM fields. Half of those jobs—4.6 million—will be in computing or information technology. And computer science is increasingly foundational knowledge for the 21st Century. Who will fill these jobs if our children are not given the opportunity to gain the skills needed?
+
+This week, {{ campaign_date/full }}, is Computer Science Education Week. In schools throughout **[STATE]**, our students will be participating in a national Hour of Code, demystifying the subject of computer science and hopefully whetting their appetites to go on and learn more. I will be joining them, and I invite you to join in as well. Everyone should learn how to code. Visit https://hourofcode.com/{{ country }} to learn more and get started. And support our efforts to bring computer science to more schools in **[STATE]**.
+
+{{ signup_button }}

--- a/i18n/locales/sm-WS/hourofcode/promote/press-kit.md
+++ b/i18n/locales/sm-WS/hourofcode/promote/press-kit.md
@@ -1,0 +1,85 @@
+---
+title: Press Kit
+---
+
+{{ signup_button }}
+
+# How to attract media to your Hour of Code event
+
+### Make a splash with your Hour of Code event and invite local media to see why computer science is important at your school.
+
+*For all press and media inquiries, contact <press@code.org>*
+
+* * *
+
+## Key Tips
+
+- Reach out to media two weeks before your event via email. Follow up by email and phone if you don't receive an initial response.
+- Ask a school staff member or volunteer to take photos to share online or send to press.
+- Write about the Hour of Code on your website’s homepage and in your school newspaper. Post your event details, and pictures of student activities.
+- On Facebook and Twitter, share updates on your plans, announce your events, and post pictures during {{ campaign_date/year }}. Use the hashtag **#HourOfCode** so Code.org can see and promote your events.
+
+## Step-by-step guide
+
+### 1. Plan your event
+
+- Plan an assembly to kick off the Hour of Code.
+- Send [a letter]({{ promote/sample_emails }}) to parents and ask them to spread the word.
+- Send [a letter]({{ promote/sample_emails }}) to invite your local mayor, member of Congress, governor, or influential businessperson to attend and speak to your students.
+- Organize group activities (like a demonstration of an ‘unplugged’ programming activity), or show off student-created and led activities.
+- Show Code.org’s [Hour of Code video]({{ urls/home }}) or one of [these videos]({{ promote/videos }}) to inspire students. <br />
+
+### 2. Identify specific reporters that cover education or local events
+
+Like local newspapers, TV station or radio stations, or blogs. <br />
+
+### 3. Contact local media
+
+The best way to reach out is by email. It should be short and should communicate "why should other people care about this event"? Include contact information (including a cellphone number) for who will be on site at the event. **[See a sample pitch to media]({{ promote/press-kit-emails }})**.
+
+Look online to find reporter contact information. If you can't find it, call the publication to ask, or email the organization's general email address and ask for your message to be directed to the correct reporter. <br />
+
+### 4. Prepare to field questions about your school event. Here are some examples:
+
+#### Why is your school doing an Hour of Code?
+
+While all of us know that it’s important for students to learn how to navigate today’s tech-saturated world, many teachers aren’t experienced in computer science and don’t know where to start. This event is a chance for all of us to see what computer science is about.
+
+We hope it’ll spark interest in students to keep learning. Research also shows that kids can pick up programming concepts before they know how to read and write. In fact, their brains are more receptive to computer languages at a young age, just like foreign languages. <br /> <br />
+
+#### Why is this important?
+
+Technology is transforming every industry on the planet. In 2015, 7 million openings in the U.S. were in occupations—including art and design—that value coding skills. But 60 percent of schools in the U.S. don't teach computer science. It’s time for us to catch up to the 21st-century. We know that regardless of what our students do when they grow up, whether they go into medicine, business, politics, or the arts, knowing how to build technology will give them confidence and a competitive edge. <br />
+
+<a id="sample-emails"></a>
+
+## Sample email to send to invite local media to your event
+
+**Subject line**: Local school joins mission to introduce students to computer science
+
+Computers are everywhere, changing every industry on the planet, but fewer than half of all schools teach computer science. Young women and students from marginalized racial and ethnic groups are severely underrepresented in computer science classes, and in the tech industry. Good news is, we’re on our way to change this.
+
+With the Hour of Code, computer science has been on homepages of Google, MSN, Yahoo!, and Disney. Over 100 partners have joined together to support this movement. Every Apple Store in the world has hosted an Hour of Code. Even President Obama wrote his first line of code as part of the campaign.
+
+That’s why every one of the [X number] students at [SCHOOL NAME] are joining in on the largest learning event in history: The Hour of Code, during Computer Science Education Week (December 3-9).
+
+I'm writing to invite you to attend our kickoff assembly and to see kids start the activity on [DATE].
+
+The Hour of Code, organized by the nonprofit Code.org and over 100 others, is a global movement that believes the students of today are ready to learn critical skills for 21st-century success. Please join us.
+
+Contact: [YOUR NAME], [TITLE], cell: (212) 555-5555 When: [DATE and TIME of your event] Where: [ADDRESS and DIRECTIONS]
+
+I look forward to being in touch. <br />
+
+## Additional details and a quote you can use in materials
+
+"The Hour of Code is designed to demystify code and show that computer science is not rocket science—anybody can learn the basics," said Hadi Partovi, founder and CEO of Code.org. "Over 100 million students worldwide have tried an Hour of Code. The demand for relevant 21st-century computer science education crosses all borders and knows no boundaries." <br /> <br />
+
+#### About Code.org
+
+Code.org is a 501c3 public non-profit dedicated to expanding participation in computer science and increasing participation by young women and students from other underrepresented groups. Its vision is that every student in every school has the opportunity to learn computer programming. After launching in 2013, Code.org organized the Hour of Code campaign – which has introduced over 100 million students to computer science to date – and partnered with 70 public school districts nationwide to expand computer science programs. Code.org is supported by philanthropic donations from corporations, foundations and generous individuals, including Microsoft, Facebook, Infosys Foundation USA, Amazon, and others. For more information, please visit: [code.org]({{ urls/codeorg }}).
+
+  
+Find more resources and sample emails [here]({{ promote/sample_emails }}).
+
+{{ signup_button }}

--- a/i18n/locales/sm-WS/hourofcode/promote/previous-posters.md
+++ b/i18n/locales/sm-WS/hourofcode/promote/previous-posters.md
@@ -1,0 +1,17 @@
+---
+title: Past Hour of Code Posters
+---
+
+{{ signup_button }}
+
+# Past Hour of Code Posters
+
+### Find our posters from previous years to print and hang in your classroom! Looking for the newest posters? [Click here]({{ promote/promote_posters_url }}).
+
+* * *
+
+<br />
+
+{{ promote_posters }}
+
+{{ signup_button }}

--- a/i18n/locales/sm-WS/hourofcode/promote/proclamation.md
+++ b/i18n/locales/sm-WS/hourofcode/promote/proclamation.md
@@ -1,0 +1,58 @@
+---
+title: Sample Resolution Supportive of Computer Science Education Week and Hour of Code
+---
+
+{{ signup_button }}
+
+# Sample Computer Science Education Week resolution
+
+### Below is language for a sample resolution supportive of Computer Science Education Week and its goals that can be used by state and local legislators.
+
+* * *
+
+#### **RESOLUTION**  
+
+
+#### Supporting the goals and ideals of "Computer Science Education Week"
+
+Whereas Computer Science Education Week highlights the crucial role that computer science plays in transforming our society and how computer science enables innovation and creates economic opportunities;
+
+Whereas computing technology is an integral part of modern culture and is transforming how people interact with each other and the world around them;
+
+Whereas computer science is transforming industry, creating new fields of commerce, driving innovation in all fields of science, and bolstering productivity in established economic sectors;
+
+Whereas the field of computer science underpins the information technology sector of our economy, which is a significant contributor to United States economic output;
+
+Whereas the field of computer science is a foundational science for the digital age;
+
+Whereas the information technology sector is uniquely positioned to help with economic recovery through the research and development of new innovations;
+
+Whereas the outlook for computer science jobs is bright with over 500,000 open computing positions across the country;
+
+Whereas providing students the chance to participate in high-quality computer science activities exposes them to the rich opportunities the field offers and provides critical thinking skills that will serve them throughout their lives;
+
+Whereas all students deserve a thorough preparation in computer science education, including access to the qualified teachers, technology, and age-appropriate curriculum needed to learn computer science at the elementary and secondary levels of education;
+
+Whereas computer science education has challenges to address, including counting computer science classes towards high school graduation requirements, and providing professional development for computer science teachers;
+
+Whereas participating in an Hour of Code during Computer Science Education Week can serve to demystify the field of computer science and encourage more students to take up further studies of computer science;
+
+Whereas the field of computer science has significant equity barriers to address, including attracting more participation by females and underrepresented minorities to all levels and branches;
+
+Whereas Grace Murray Hopper, one of the first females in the field of computer science, engineered new programming languages and pioneered standards for computer systems which laid the foundation for many advancements in computer science; and
+
+Whereas the week of {{ campaign_date/start_long }}, in honor of Grace Hopper's birthday, is designated as ‘Computer Science Education Week’: Now, therefore, be it <br />
+
+Resolved, That the (HOUSE OR SENATE, STATE, COUNTY, CITY OR SCHOOL BOARD) --
+
+(1) supports the designation of Computer Science Education Week ({{ campaign_date/full }});
+
+(2) encourages schools, educators, parents and policymakers to participate in Computer Science Education Week by enabling their students to participate in the Hour of Code;
+
+(3) encourages schools, teachers, researchers, universities, business leaders, and policymakers to identify mechanisms for teachers to receive cutting edge professional development to provide sustainable learning experiences in computer science at all educational levels and encourage students to be exposed to computer science concepts;
+
+(4) encourages policymakers to remove barriers that prevent computer science classes from being counted as math or science credits toward graduation requirements;
+
+(5) encourages opportunities, including through existing programs, for females and underrepresented minorities in computer science.
+
+{{ signup_button }}

--- a/i18n/locales/sm-WS/hourofcode/promote/resources.md
+++ b/i18n/locales/sm-WS/hourofcode/promote/resources.md
@@ -1,0 +1,183 @@
+---
+title: Resources
+---
+
+{{ signup_button }}
+
+<link rel="stylesheet" type="text/css" href="/css/promote-page.css"></link>
+
+# Promote the Hour of Code
+
+### Find all the resources you need to bring attention to your Hour of Code. Not sure where to begin? Start with our [how-to guide for hosting an Hour of Code]({{ how_to_url }})!
+
+* * *
+
+{{ promote_handouts }} {{ promote_videos }}
+
+<a id="posters"></a>
+
+## Hang these posters in your school
+
+A new poster set is available featuring Malala, Stephen Curry, Shakira and more! This year, each set will also come with 6 posters and 126 "I did the Hour of Code" stickers. Supplies are limited, so [order your posters](https://smile.amazon.com/Code-Hour-Poster-Set-2018/dp/B07J6T18DH) soon. To print on your own, simply click an image below to view and save a printable version.
+
+{{ promote_new_posters }}
+
+* Looking for our posters from previous years? [Find them here]({{ promote/previous_posters_url }})!
+
+<a id="social"></a>
+
+## Post these on social media
+
+[![image](/images/social-media/fit-250/social-2.png)](/images/social-media/social-2.png)&nbsp;&nbsp;&nbsp;&nbsp; [![image](/images/social-media/fit-250/social-3.png)](/images/social-media/social-3.png)&nbsp;&nbsp;&nbsp;&nbsp;
+
+[![image](/images/social-media/fit-250/malala_yousafzai.png)](/images/social-media/malala_yousafzai.png)&nbsp;&nbsp;&nbsp;&nbsp; [![image](/images/social-media/fit-250/chris_bosh.png)](/images/social-media/chris_bosh.png)&nbsp;&nbsp;&nbsp;&nbsp;
+
+[![image](/images/social-media/fit-250/karlie_kloss.png)](/images/social-media/karlie_kloss.png)&nbsp;&nbsp;&nbsp;&nbsp; [![image](/images/social-media/fit-250/satya_nadella.png)](/images/social-media/satya_nadella.png)&nbsp;&nbsp;&nbsp;&nbsp; [![image](/images/social-media/fit-250/jeff_bezos.png)](/images/social-media/jeff_bezos.png)&nbsp;&nbsp;&nbsp;&nbsp;
+
+<a id="logo"></a>
+
+## Use the Hour of Code logo to spread the word
+
+[![image]({{ hoc_logo_fit_200 }})]({{ hoc_logo }}) [![image]({{ hdc_logo_fit_200 }})]({{ hdc_logo }})
+
+[Download hi-res versions](https://images.code.org/share/hour-of-code-logo.zip)
+
+**"Hour of Code" and "Hora del Código" are trademarked. We don't want to prevent their usage, but we do want to make sure usage fits within a few limits:**
+
+1. Any reference to "Hour of Code" or "Hora del Código" should be used in a fashion that doesn't suggest that it's your own brand name, but rather referencing the Hour of Code as a grassroots movement.
+
+<ul style="margin-top: 0px">
+  <li>
+    <strong>Good example</strong>: "Participate in the Hour of Code™ at YOUR-COMPANY.com."
+  </li>
+  <li>
+    <strong>Bad example</strong>: "Try Hour of Code by YOUR-COMPANY."
+  </li>
+</ul>
+
+1. Use a "TM" superscript in the most prominent places you mention "Hour of Code" and a "Ⓡ" superscript in the most prominent places you mention "Hora del Código", both on your web site and in app descriptions.
+2. Include language on your page (or in the footer), including links to the CSEdWeek and [Code.org]({{ codeorg_link }}) websites, that says the following:
+    
+    *“The 'Hour of Code™'/'Hora del Código®' is a global initiative by Computer Science Education Week [csedweek.org] and Code.org [code.org] to introduce millions of students to one hour of computer science and computer programming.”*
+
+3. No use of "Hour of Code" or "Hora del Código" in app names.
+
+<a id="stickers"></a>
+
+## Print these stickers to give to your students
+
+(Stickers are 1" diameter, 63 per sheet) <br />
+
+[![image](/images/fit-250/hour-of-code-stickers.png)](/images/hour-of-code-stickers.pdf)
+
+<a id="sample-emails"></a>
+
+## Invite people in your community to your Hour of Code and promote your event through email
+
+### Find [more information and language you can use]({{ promote/stats_url }}) when talking about the Hour of Code.
+
+* * *
+
+<a id="email"></a>
+
+### Ask your school, employer, or friends to sign up:
+
+**Subject line:** Join me and over 100 million students for an Hour of Code <br />
+
+Computers are everywhere, changing every industry on the planet. But only 51% of all high schools offer computer science. Good news is, we’re on our way to change this! If you've heard about the Hour of Code before, you might know it made history. More than 100 million students have tried an Hour of Code.
+
+With the Hour of Code, computer science has been on homepages of Google, MSN, Yahoo!, and Disney. Over 100 partners have joined together to support this movement. Every Apple Store in the world has hosted an Hour of Code, and leaders like President Obama and Canadian Prime Minister Justin Trudeau wrote their first lines of code as part of the campaign.
+
+This year, let's make it even bigger. I’m asking you to join the Hour of Code {{ campaign_date/year }}. Please get involved with an Hour of Code event during Computer Science Education Week, {{ campaign_date/full }}.
+
+Get the word out. Host an event. Ask a local school to sign up. Or try the Hour of Code yourself—everyone can benefit from learning the basics.
+
+Get started at http://hourofcode.com/{{ country_language }} <br />
+
+* * *
+
+<a id="help-schools"></a>
+
+### Volunteer at a school:
+
+#### [Find more resources and information about volunteering in schools here]({{ how_to_volunteers_url }}).
+
+**Subject line:** Can we help you host an Hour of Code?
+
+Between {{ campaign_date/short }}, ten percent of students around the world will celebrate Computer Science Education Week by doing an Hour of Code at their school. It’s an opportunity for every child to learn how the technology around us works.
+
+[Our organization/My name] would love to help [school name] run an Hour of Code event. We can help teachers host an Hour of Code in their classrooms (we don’t even need computers!) or if you would like to host a school assembly, we can arrange for a speaker to talk about how technology works and what it’s like to be a software engineer.
+
+The students will create their own apps or games they can show their parents, and we’ll also print Hour of Code certificates they can bring home. And, it’s fun! With interactive, hands-on activities, students will learn computational thinking skills in an approachable way.
+
+Computers are everywhere, changing every industry on the planet. But only 51% of all high schools offer computer science. The good news is, we’re on our way to change this! If you've heard about the Hour of Code before, you might know it made history - more than 100 million students around the world have tried an Hour of Code. Even leaders like President Obama and Canadian Prime Minister Justin Trudeau wrote their first lines of code as part of the campaign.
+
+You can read more about the event at http://hourofcode.com. Or, let us know if you’d like to schedule some time to talk about how [school name] can participate. <br />
+
+* * *
+
+<a id="parents"></a>
+
+### Tell parents about your school's event:
+
+**Subject line:** Our students are changing the future with an Hour of Code
+
+Dear Parents,
+
+We live in a world surrounded by technology. And we know that whatever field our students choose to go into as adults, their ability to succeed will increasingly depend on understanding how technology works.
+
+But only a fraction of us are learning **how** technology works. Only 51% of all high schools offer computer science.
+
+That’s why our entire school is joining in on the largest learning event in history: The Hour of Code, during Computer Science Education Week ({{ campaign_date/full }}). More than 100 million students worldwide have already tried an Hour of Code. Our Hour of Code is making a statement that [SCHOOL NAME] is ready to teach these foundational 21st-century skills. To continue bringing programming activities to your students, we want to make our Hour of Code event huge. I encourage you to volunteer, reach out to local media, share the news on social media channels and consider hosting additional Hour of Code events in the community.
+
+This is a chance to change the future of education in [TOWN/CITY NAME].
+
+See http://hourofcode.com/{{ country_language }} for details, and help spread the word. <br />
+
+* * *
+
+<a id="media-pitch"></a>
+
+### Invite media to attend your event:
+
+#### [Check out our press kit for more information on inviting media to your event.]({{ promote/press_kit_url }})
+
+**Subject line**: Local school joins mission to introduce students to computer science
+
+Computers are everywhere, changing every industry on the planet, but only 51% of all high schools offer computer science. Young women and students from marginalized racial and ethnic groups are severely underrepresented in computer science classes, and in the tech industry. Good news is, we’re on our way to change this.
+
+With the Hour of Code, computer science has been on homepages of Google, MSN, Yahoo!, and Disney. Over 100 partners have joined together to support this movement. Every Apple Store in the world has hosted an Hour of Code. Even President Obama wrote his first line of code as part of the campaign.
+
+That’s why every one of the [X number] students at [SCHOOL NAME] are joining in on the largest learning event in history: The Hour of Code, during Computer Science Education Week (December 6-12).
+
+I'm writing to invite you to attend our kickoff assembly and to see kids start the activity on [DATE].
+
+The Hour of Code, organized by the nonprofit Code.org and over 100 others, is a global movement that believes the students of today are ready to learn critical skills for 21st-century success. Please join us.
+
+Contact: [YOUR NAME], [TITLE], cell: (212) 555-5555 When: [DATE and TIME of your event] Where: [ADDRESS and DIRECTIONS]
+
+I look forward to being in touch. <br />
+
+* * *
+
+<a id="politicians"></a>
+
+### Invite a local politician to your school's event:
+
+#### [Need more info? Take a look at our resources for inviting politicians to attend your event]({{ how_to_public_officials_url }}).
+
+**Subject line**: Join our school as we change the future with an Hour of Code
+
+Dear [Mayor/Governor/Representative/Senator LAST NAME]:
+
+Did you know that computing is the #1 source of wages in the U.S.? There are more than 500,000 computing jobs open nationwide, but last year only 42,969 computer science students graduated into the workforce.
+
+Computer science is foundational for every industry today, yet most schools don’t offer it. At [SCHOOL NAME], we are trying to change that.
+
+That’s why our entire school is joining in on the largest learning event in history: The Hour of Code, during Computer Science Education Week ({{ campaign_date/full }}). More than 100 million students worldwide have already tried an Hour of Code.
+
+I'm writing to invite you to join our Hour of Code event and speak at our kickoff assembly. It’ll take place on [DATE, TIME, PLACE], and will make a strong statement that [State or City name] is ready to teach our students critical 21st-century skills. We want to ensure that our students are on the forefront of creating technology of the future—not just consuming it.
+
+Please contact me at [PHONE NUMBER OR EMAIL ADDRESS]. I look forward to your response.
+
+{{ signup_button }}

--- a/i18n/locales/sm-WS/hourofcode/promote/stats.md
+++ b/i18n/locales/sm-WS/hourofcode/promote/stats.md
@@ -1,0 +1,53 @@
+---
+title: Blurbs and useful stats
+---
+
+<a id="blurb"></a>
+
+{{ signup_button }}
+
+# Blurbs and useful stats
+
+### Use the following messaging if you're looking for ways to promote the Hour of Code in your newsletters and communications.
+
+* * *
+
+## Use this short blurb in newsletters
+
+#### Bring computer science to your school. Start with an Hour of Code!
+
+With technology changing every industry on the planet, computing knowledge has become part of a well-rounded skill set. But just half of all schools offer computer science! Good news is, we’re on our way to change this. If you've heard about the Hour of Code, you might know that it has made history. More than 100 million students have now discovered how accessible and fun computer science can be by doing just one Hour of Code.
+
+The Hour of Code is a one-hour introduction to computer science, designed to demystify code and show that anybody can learn the basics. Learn more at [http://HourOfCode.com](http://HourofCode.com), try an hour yourself, or host an Hour of Code event to introduce others to the world of computing!
+
+## Messaging for frequently asked questions
+
+#### Why is your school doing an Hour of Code?
+
+While all of us know that it’s important for students to learn how to navigate today’s tech-saturated world, many teachers aren’t experienced in computer science and don’t know where to start. This event is a chance for all of us to see what computer science is about.
+
+We hope it’ll spark interest in students to keep learning. Research also shows that kids can pick up programming concepts before they know how to read and write. In fact, their brains are more receptive to computer languages at a young age, just like foreign languages. <br /> <br />
+
+#### Why is this important?
+
+There are nearly 700,000 open computing jobs in the US, but only 80,000 computer science students graduated into the workforce last year. And, 47 percent of schools in the U.S. don't offer computer science. It’s time for us to catch up to the 21st century. We know that regardless of what our students do when they grow up, whether they go into medicine, business, politics, or the arts, knowing how to build technology will give them confidence and a competitive edge. <br /> <br />
+
+#### A quote you can use in materials
+
+"The Hour of Code is designed to demystify code and show that computer science is not rocket science—anybody can learn the basics," said Hadi Partovi, founder and CEO of Code.org. "Over 100 million students worldwide have tried an Hour of Code. The demand for relevant 21st-century computer science education crosses all borders and knows no boundaries." <br /> <br />
+
+#### About Code.org
+
+Code.org is a 501c3 public non-profit dedicated to expanding participation in computer science and increasing participation by young women and students from other underrepresented groups. Its vision is that every student in every school has the opportunity to learn computer programming. After launching in 2013, Code.org organized the Hour of Code campaign – which has introduced over 100 million students to computer science to date – and partnered with 70 public school districts nationwide to expand computer science programs. Code.org is supported by philanthropic donations from corporations, foundations and generous individuals, including Microsoft, Facebook, Infosys Foundation USA, Amazon, and others. For more information, please visit: [code.org]({{ codeorg_link }}).
+
+## Share these on social media and in emails
+
+[![image](/images/social-media/fit-250/social-1.png)](/images/social-media/social-1.png)&nbsp;&nbsp;&nbsp;&nbsp; [![image](/images/social-media/fit-250/social-2.png)](/images/social-media/social-2.png)&nbsp;&nbsp;&nbsp;&nbsp; [![image](/images/social-media/fit-250/social-3.png)](/images/social-media/social-3.png)&nbsp;&nbsp;&nbsp;&nbsp;
+
+<a id="infographics"></a>
+
+## Infographics
+
+{{ stats_carousel }}
+
+{{ signup_button }}

--- a/i18n/locales/sm-WS/hourofcode/sm.yml
+++ b/i18n/locales/sm-WS/hourofcode/sm.yml
@@ -1,0 +1,11577 @@
+---
+sm:
+  site_name: HOUR of CODE
+  hour_of_code: Hour of Code
+  language: English
+  front_title: Join the largest learning event in history, %{campaign_date}
+  coming_soon: Coming Soon
+  campaign_date_start_short: Dec. 5
+  campaign_date_start_long: December 5
+  campaign_date_short: Dec. 5-11
+  campaign_date_full: December 5-11
+  campaign_date_year: '2022'
+  campaign_date_full_year: December 5-11, 2022
+  nonus_campaign_date_start_short: Oct. 1
+  nonus_campaign_date_start_long: October 1
+  nonus_campaign_date_short: Oct. 1 - Dec. 18
+  nonus_campaign_date_full: October 1 - December 18
+  nonus_campaign_date_year: '2022'
+  nonus_campaign_date_full_year: October 1, 2022 - December 18, 2022
+  latam_campaign_date_start_short: Oct. 1
+  latam_campaign_date_start_long: October 1
+  latam_campaign_date_short: Oct. 1 - Dec. 18
+  latam_campaign_date_full: October 1 - December 18
+  latam_campaign_date_year: '2022'
+  latam_campaign_date_full_year: October 1, 2022 - December 18, 2022
+  europe_campaign_date_start_short: Oct. 1
+  europe_campaign_date_start_long: October 1
+  europe_campaign_date_short: Oct. 1 - Dec. 18
+  europe_campaign_date_full: October 1 - December 18
+  europe_campaign_date_year: '2022'
+  europe_campaign_date_full_year: October 1, 2022 - December 18, 2022
+  africa_campaign_date_start_short: Oct. 1
+  africa_campaign_date_start_long: October 1
+  africa_campaign_date_short: Oct. 1 - Dec. 18
+  africa_campaign_date_full: October 1 - December 18
+  africa_campaign_date_year: '2022'
+  africa_campaign_date_full_year: October 1, 2022 - December 18, 2022
+  hoc2022_header: Explore, Play, Create!
+  social_hoc2022_explore_play_create: Use computer science to explore, play, and create!
+  codeorg_homepage_hoc2022_body: Explore the universe, score a goal, bust a move —
+    there are so many ways to try computer science.
+  hoc2022_codeorg_title: Celebrate Hour of Code with NASA and more
+  hoc2022_codeorg_description: The 10th Hour of Code is out of this world! Come explore,
+    play, and create with us.
+  social_hoc2022_dance: Featuring Beyoncé, Harry Styles, Lizzo, Lil Nas X, Selena
+    Gomez, music from Disney's "Encanto," and more!
+  social_hoc2021_cse: 'During the #HourOfCode, we''re celebrating #CSEverywhere. Discover
+    the connections!'
+  hoc2020_header: Learn today, build a brighter tomorrow.
+  hoc2020_header_with_line_break_markdown: |-
+    Learn today,
+
+    build a brighter tomorrow.
+  social_hoc2020_cs_important: 'CS is more important than ever. Let''s build the future
+    we want. #CSforGood'
+  social_hoc2020_hoc_is_about_csforgood: 'The #HourOfCode is about #CSforGood. Learn
+    today, build a brighter tomorrow.'
+  social_hoc2020_global_movement: The Hour of Code is a global movement reaching tens
+    of millions of students. One-hour tutorials are available in 45+ languages for
+    all ages.
+  social_hoc2020_coming_dates: The Hour of Code is coming December 7-13, 2020. Computer
+    science is foundational for every student to learn.
+  hoc2020_ai_subheader: The Hour of Code 2020 is coming!
+  hoc2020_ai_header: Explore Artificial Intelligence
+  hoc2020_ai_description: AI and Machine Learning are impacting our entire world.
+    Join us to explore AI in a new video series, train AI for Oceans in 25+ languages,
+    discuss ethics and AI, and more...
+  hoc2019_header: Learn computer science. Change the world.
+  hoc2019_header_line1_mobile: Learn computer science.
+  hoc2019_header_line2_mobile: Change the world.
+  social_hoc2019_every_sudent: 'Every student has the potential to change the world.
+    Help them get started. #CSforGood'
+  social_hoc2019_learn_computer_science: 'Learn computer science. Change the world.
+    #CSforGood #HourOfCode'
+  social_hoc_is_coming: The Hour of Code is coming!
+  social_hoc2019_hoc_is_about_csforgood: 'The #HourOfCode is about #CSforGood. Learn
+    computer science. Change the world.'
+  social_hoc2019_coming_dates: The Hour of Code is coming December 9-15, 2019. Computer
+    science is foundational for every student to learn.
+  social_hoc2019_dance: Featuring Katy Perry, Shawn Mendes, Panic! At The Disco, Lil
+    Nas X, Jonas Brothers, Nicki Minaj, and 34 more!
+  social_hoc_anybody: 'Hour of Code: Anybody can Learn'
+  oceans_landing_title: AI for Oceans
+  oceans_landing_description: Learn about machine learning and ethical use of AI.
+  cs_for_good_hashtag: "#CSforGood"
+  oceans_landing_specs: Available in 25+ languages | Grades 3+
+  oceans_landing_explanation: Computer science is about so much more than coding!
+    Learn about artificial intelligence (AI), machine learning, training data, and
+    bias, while exploring ethical issues and how AI can be used to address world problems.
+    Enjoy Code.org's first step in a new journey to teach more about AI. When you
+    use the AI for Oceans activity you are training real machine learning models.
+    <a href='#behind-the-scenes'>Learn more</a>.
+  oceans_landing_explanation_markdown: Computer science is about so much more than
+    coding! Learn about artificial intelligence (AI), machine learning, training data,
+    and bias, while exploring ethical issues and how AI can be used to address world
+    problems. Enjoy Code.org's first step in a new journey to teach more about AI.
+    When you use the AI for Oceans activity you are training real machine learning
+    models. [Learn more](#behind-the-scenes).
+  oceans_landing_teacher_resources: Teacher Resources
+  oceans_landing_teacher_resources_desc: Lesson plans and activities to help you teach
+    AI, machine learning, training data, and bias, while exploring ethical issues.
+  oceans_landing_resource_button: View Resources
+  oceans_landing_cs_for_good: CS for Good
+  oceans_landing_cs_for_good_desc: Resources to help students understand the role
+    computer science could play in creating a more equitable world.
+  oceans_landing_videos: Videos about AI and Machine Learning
+  oceans_behind_the_scenes: 'AI for Oceans: Behind the Scenes'
+  oceans_behind_the_scenes_1: Levels 2-4 use a pretrained model provided by the <a
+    href="https://www.tensorflow.org/" >TensorFlow</a> <a href="https://github.com/tensorflow/models/blob/master/research/slim/nets/mobilenet_v1.md">
+    MobileNet </a> project. A MobileNet model is a <a href="https://developers.google.com/machine-learning/practica/image-classification/convolutional-neural-networks">convolutional
+    neural network</a> that has been trained on <a href="http://www.image-net.org/">ImageNet</a>,
+    a dataset of over 14 million images hand-annotated with words such as "balloon"
+    or "strawberry". In order to customize this model with the labeled training data
+    the student generates in this activity, we use a technique called <a href="https://en.wikipedia.org/wiki/Transfer_learning">Transfer
+    Learning</a>. Each image in the training dataset is fed to MobileNet, as pixels,
+    to obtain a list of annotations that are most likely to apply to it. Then, for
+    a new image, we feed it to MobileNet and compare its resulting list of annotations
+    to those from the training dataset. We classify the new image with the same label
+    (such as "fish" or "not fish") as the images from the training set with the most
+    similar results.
+  oceans_behind_the_scenes_1_markdown: Levels 2-4 use a pretrained model provided
+    by the [TensorFlow](https://www.tensorflow.org/) [MobileNet](https://github.com/tensorflow/models/blob/master/research/slim/nets/mobilenet_v1.md)
+    project. A MobileNet model is a [convolutional neural network](https://developers.google.com/machine-learning/practica/image-classification/convolutional-neural-networks)
+    that has been trained on [ImageNet](http://www.image-net.org/), a dataset of over
+    14 million images hand-annotated with words such as "balloon" or "strawberry".
+    In order to customize this model with the labeled training data the student generates
+    in this activity, we use a technique called [Transfer Learning](https://en.wikipedia.org/wiki/Transfer_learning).
+    Each image in the training dataset is fed to MobileNet, as pixels, to obtain a
+    list of annotations that are most likely to apply to it. Then, for a new image,
+    we feed it to MobileNet and compare its resulting list of annotations to those
+    from the training dataset. We classify the new image with the same label (such
+    as "fish" or "not fish") as the images from the training set with the most similar
+    results.
+  oceans_behind_the_scenes_2: Levels 6-8 use a <a href="https://en.wikipedia.org/wiki/Support-vector_machine">Support-Vector
+    Machine</a> (SVM). We look at each component of the fish (such as eyes, mouth,
+    body) and assemble all of the metadata for the components (such as number of teeth,
+    body shape) into a vector of numbers for each fish. We use these vectors to train
+    the SVM. Based on the training data, the SVM separates the "space" of all possible
+    fish into two parts, which correspond to the classes we are trying to learn (such
+    as "blue" or "not blue").
+  oceans_behind_the_scenes_2_markdown: Levels 6-8 use a [Support-Vector Machine](https://en.wikipedia.org/wiki/Support-vector_machine)
+    (SVM). We look at each component of the fish (such as eyes, mouth, body) and assemble
+    all of the metadata for the components (such as number of teeth, body shape) into
+    a vector of numbers for each fish. We use these vectors to train the SVM. Based
+    on the training data, the SVM separates the "space" of all possible fish into
+    two parts, which correspond to the classes we are trying to learn (such as "blue"
+    or "not blue").
+  heading_additional_resources: Additional resources
+  call_to_action_learn_more: Learn more
+  call_to_action_watch_now: Watch now
+  call_to_action_try_activity: Try activity
+  social_hoc2019_oceans_title: 'AI for Oceans #CSforGood'
+  social_hoc2019_oceans_desc: Learn about AI, machine learning, training data, and
+    bias, while exploring ethical issues and how AI can be used to address world problems.
+    Computer science is about so much more than coding! Enjoy Code.org's first step
+    in a new journey to teach more about AI throughout our curriculum.
+  social_coldplay_title: Create with Coldplay & Code.org
+  social_coldplay_desc: Show us your best moves! Code, dance, share with the world,
+    and you could win.
+  social_maker_title: I'm a Maker!
+  social_maker_desc: Code.org physical computing and maker resources for grades 6-12.
+  social_blockchain_title: How Blockchain Works
+  social_blockchain_desc: Videos and lessons that explore what blockchain is and why
+    it's important.
+  pl_superhero_title: Help students become superheroes!
+  pl_superhero_desc: Join our highly supportive Professional Learning Program for
+    middle and high school educators.
+  blockchain_hero_heading: How Blockchain Works
+  blockchain_hero_desc: Dive into the world of blockchain with "How Blockchain Works,"
+    our new video series and accompanying lessons!
+  blockchain_intro_heading: See how blockchain works
+  blockchain_intro_desc: The video series, made in partnership with Coinbase, features
+    industry experts and aims to demystify this technology.
+  blockchain_intro_list_heading: 'This series will:'
+  blockchain_intro_list_item_01: Explain what blockchain is
+  blockchain_intro_list_item_02: Explore why it's important
+  blockchain_intro_list_item_03: Unpack its societal impacts — both good and bad
+  blockchain_video_title_01: Introduction to Blockchain
+  blockchain_video_title_02: Why Blockchain
+  blockchain_video_title_03: Under the Hood
+  blockchain_video_title_04: Beyond Currencies
+  blockchain_video_title_05: Marketplace and Price
+  blockchain_video_title_06: Trustworthy or a Scam?
+  blockchain_video_title_07: Societal Impact
+  blockchain_lessons_heading: Blockchain lessons for your class
+  blockchain_lessons_desc: The first five lessons can be taught as part of a "How
+    Blockchain Works" series or can stand alone. The last lesson condenses the whole
+    series to a single day.
+  blockchain_resources_desc: Interested in learning more about blockchain? Here are
+    some additional resources that can help extend your students' learning.
+  blockchain_resources_01_heading: Coinbase Learn
+  blockchain_resources_01_desc: Crypto questions answered, beginner guides, practical
+    tips, and market updates for first-timers, experienced investors, and everyone
+    in between.
+  blockchain_resources_01_button_label: Visit the Coinbase Learn website
+  blockchain_resources_02_heading: Whiteboard Crypto
+  blockchain_resources_02_desc: Watch videos from Whiteboard Crypto's YouTube channel
+    to learn even more about blockchain technology.
+  blockchain_resources_02_button_label: Visit the Whiteboard Crypto YouTube channel
+  blockchain_resources_03_heading: Hour of Code Activity
+  blockchain_resources_03_desc: Try a crypto memory game created by Coinbase.
+  blockchain_resources_03_button_label: Try the Crypto Memory Game activity
+  hoc_live: Hour of Code Live
+  hoc_live_sign_up_title: Sign up for Hour of Code Live
+  hoc_live_learn_title: Learn with Hour of Code Live
+  hoc_live_sign_up_message: Learn in real time alongside special guests! Students
+    of all ages and abilities, including those without computers, are welcome. Join
+    our mailing list to receive recordings of the episodes and resources to continue
+    learning at home. See past episodes [here](%{episodes_url}).
+  hoc_live_learn_message: Learn basic concepts of computer science alongside special
+    guests! Students of all ages and abilities, including those without computers,
+    are welcome to our virtual workshop. Continue learning at home through our Hour
+    of Code Live episodes.
+  hoc_live_join_us: Join us
+  hoc_live_learn_more: Learn more
+  hoc_overview_oceans_tutorial_header: AI for Oceans
+  hoc_overview_oceans_tutorial_desc: Learn about artificial intelligence (AI), machine
+    learning, training data, and bias, while exploring ethical issues and how AI can
+    be used to address world problems.
+  hoc_overview_csc_header: Introducing CS Connections
+  hoc_overview_csc_desc: Our newest curriculum highlights the connections between
+    computer science and other subjects like math, language arts, science, and social
+    studies. Through these modules, projects, and lessons, classrooms can explore
+    their usual subjects in exciting new ways!
+  hoc_overview_csc_learn_more: Learn more about CS Connections
+  hoc_danceparty_alt_text: Animated characters dancing to music underneath the text
+    'Code your own dance party'
+  hoc_ai_alt_text: A floating, white, artificial intelligence character with an antennae,
+    a scanner on the bottom, and an LED face
+  hoc_banner_alt_text: Hour of Code banner
+  ai_video_title_what_is_ai: What is AI?
+  ai_video_title_algorithm_bias: Fighting bias in algorithms
+  ai_video_title_phone_knows_dog: How does your phone know this is a dog?
+  ai_video_title_what_is_ml: What is Machine Learning?
+  ai_video_title_ml_big_small_prickly: 'Machine Learning: Solving Problems Big, Small
+    and Prickly'
+  ai_video_title_ethics_of_ai: Ethics of AI
+  ai_video_title_ml_human_bias: Machine Learning and Human Bias
+  ai_video_title_seeing_ai: 'Seeing AI: Making the visual world more accessible'
+  activity: Activity
+  name: Name
+  description: Description
+  audience: Audience
+  ai_resource_header: Teach and Learn about AI
+  ai_resource_minecraft: Minecraft AI for Good
+  ai_resource_minecraft_desc: 'Access free resources including a lesson plan, videos,
+    computer science curriculum, and teacher trainings. (Requires Minecraft: Education
+    Edition)'
+  ai_resource_ml_for_kids: Machine Learning for Kids
+  ai_resource_ml_for_kids_desc: Train a machine learning model with text, numbers,
+    or images, and use it to make games in Scratch.
+  ai_resource_ibm_ml_for_kids: 'IBM: Machine Learning for Kids'
+  ai_resouce_ibm_ml_for_kids_desc: Hands-on activities to introduce simple machine
+    learning models to students through games and interactive projects.
+  ai_resource_ecs: 'ECS: Artificial Intelligence (AI)'
+  ai_resource_ecs_desc: A new alternate curriculum unit for the Exploring Computer
+    Science (ECS) curriculum.
+  ai_resource_elements_ai: Elements of AI
+  ai_resource_elements_ai_desc: A series of free online courses created by Reaktor
+    and the University of Helsinki.
+  ai_resource_cognimates: Cognimates
+  ai_resource_cognimates_desc: An AI education platform for building games, programming
+    robots and training.
+  ai_audience_k12: K-12 (Reading required)
+  ai_audience_hs: High school
+  ai_activity_header: Activities Powered by AI and ML
+  ai_activity_seeing_ai: Seeing AI
+  ai_activity_seeing_ai_desc: A free app that narrates the world around you in a variety
+    of languages.
+  ai_activity_quick_draw: Quick, Draw!
+  ai_activity_quick_draw_desc: Can a neural network learn to recognize doodling?
+  ai_activity_teachable: Teachable Machine
+  ai_activity_teachable_desc: Train a computer to recognize your own images, sounds,
+    and poses.
+  ai_activity_experiments: AI Experiments with Google
+  ai_activity_experiments_desc: Start exploring machine learning through pictures,
+    drawings, language, music, and more.
+  ai_activity_zooniverse: Zooniverse - Snapshot Mountain Zebra
+  ai_activity_zooniverse_desc: Help protect the endangered Cape Mountain Zebra by
+    identifying the different animals in the images.
+  codeorg_homepage_hoc2018_curriculum: Go further with <a href="%{studio_url}/courses"
+    class="hoc2018-curriculum-link">Code.org courses</a>
+  codeorg_homepage_hoc2018_dance_heading: Create your own <span class="highlight-word">Dance&nbsp;Party</span>
+  codeorg_homepage_hoc2018_header_line1: The Hour of Code is coming...
+  codeorg_homepage_hoc2018_header_line2_desktop: What will you <span class="hoc2018-highlight-word">create?</span>
+  codeorg_homepage_hoc2018_header_line2_mobile: What will you create?
+  codeorg_homepage_hoc2018_header_line3: Give flight to imagination and birth to innovation.
+    Start with an Hour of Code and your own brand of creativity, whatever it may be.
+  codeorg_homepage_hoc2018_musician_before: Featuring
+  codeorg_homepage_hoc2018_musician_after: and more!
+  codeorg_homepage_hoc2018_video: Watch our video
+  hourofcode_homepage_hoc2018_header_line1: Anyone, anywhere can organize an Hour
+    of Code event. One-hour tutorials in over 45 languages. No experience needed.
+  hourofcode_homepage_hoc2018_header_line2: Ages 4 to 104.
+  codeorg_homepage_hoc_is_coming: The Hour of Code is coming.
+  codeorg_homepage_celebrate_cse: Celebrate computer science everywhere!
+  codeorg_homepage_csc: Computer science meets language arts, math, and more in CS
+    Connections
+  codeorg_homepage_csc_long: See how computer science meets language arts, math, and
+    more in our curriculum!
+  codeorg_homepage_csc_title: CS Connections
+  hoc2018_tutorial_mchoc_description: Minecraft is back for the Hour of Code with
+    a brand new activity! Journey through Minecraft with code.
+  codeorg_homepage_hoc2019_dance_heading: Code a <span class="highlight-word">Dance&nbsp;Party!</span>
+  codeorg_homepage_hoc2019_dance_heading_markdown: Code a **Dance&nbsp;Party!**
+  codeorg_homepage_special2020_body1: Support for parents and teachers facing school
+    closures.
+  codeorg_homepage_special2020_body2: See our suggested learning resources.
+  codeorg_homepage_special2020_body: Keep learning this summer! Take a look at our
+    resources for learning at home.
+  codeorg_homepage_remote2020_body: Are you teaching in a remote or socially-distanced
+    classroom this semester? View our resources.
+  codeorg_homepage_special2020_link_text: Get started
+  codeorg_homepage_code_break_body: Take a Code Break! Your weekly dose of inspiration,
+    community, and computer science.
+  codeorg_homepage_code_break_link_text: Learn more
+  cookie_banner_message: By continuing to browse our site or clicking "I agree," you
+    agree to the storing of cookies on your computer or device.
+  cookie_banner_more_information: See Code.org's Privacy Policy.
+  cookie_banner_accept: I agree
+  front_header_banner: Join the largest learning event in history, %{campaign_date}
+  front_intro_default: The Hour of Code is a global movement reaching tens of millions
+    of students in 180+ countries. Anyone, anywhere can organize an Hour of Code event.
+    One-hour tutorials are available in over 45 languages. No experience needed. <strong>Ages
+    4 to 104.</strong>
+  front_intro_default_2: A global movement in 180+ countries.
+  front_watch_video: Watch the new video
+  front_watch_regular_video: Watch the video
+  front_volunteers: Technical volunteers wanted
+  front_start_learning: Start learning
+  header_menu_resources: Resources
+  header_menu_faq: FAQ
+  header_menu_how_to: How-To
+  header_menu_promote: Promote
+  header_menu_activities: Activities
+  not_found_title: Page Not Found
+  not_found_desc: The requested page was not found
+  not_found_instructions: Check the web address and resubmit or choose a link from
+    the list below.
+  company_4-H: 4-H Youth Development
+  company_asa: Afterschool Alliance
+  company_asos: ASOS
+  company_bgca: Boys and Girls Club of America
+  company_bsusa: Boy Scouts of America
+  company_cgcs: Council of the Great City Schools
+  company_gsusa: Girl Scouts of America
+  company_khanacademy: Khan Academy
+  company_kipp: KIPP
+  company_mesa: Mathematics Engineering Science Achievement
+  company_napcs: National Alliance of Public Charter Schools
+  company_ngcp: National Girls Collaborative Project
+  company_teachforall: Teach for All
+  company_teachforamerica: Teach for America
+  company_tntp: TNTP
+  company_abss: Alamance-Burlington School System
+  company_aldineisd: Aldine Independent School District
+  company_afterschool: after school
+  company_laalliance: Alliance College Ready Public Schools
+  company_asd: Arlington Public Schools
+  company_arlingtonpublicschools: Arlington Public Schools
+  company_bisd303: Bainbridge Island School District
+  company_beavertonschooldistrict: Beaverton School District
+  company_bellevuepublicschools: Bellevue Public Schools
+  company_blan: Blanchester Local Schools
+  company_bremertonschools: Bremerton School District
+  company_browardschools: Broward County Schools
+  company_cajonvalley: Cajon Valley School District
+  company_calistogajointunified: Calistoga Joint Unified School District
+  company_canalwinchesterschools: Canal Winchester Local Schools
+  company_canyonsdistrict: Canyons School District
+  company_centralunified: Central Unified School District
+  company_cvsd: Central Valley School District
+  company_ccboe: Charles County Public Schools
+  company_ChathamCountySchools: Chatham County Schools
+  company_chelmsfordpublicschooldistrict: Chelmsford School District
+  company_cheneysd: Cheney School District
+  company_chesterfieldschools: Chesterfield County Public Schools
+  company_codebrooklyn: Code Brooklyn
+  company_cps: Chicago Public Schools
+  company_ccsd: Clark County School District
+  company_cloverparkschooldistrict: Clover Park School District
+  company_ccsoh: Columbus City School District
+  company_cresskillboe: Cresskill Public Schools
+  company_dallasisd: Dallas Independent School District
+  company_disney: Disney
+  company_dpsk12: Denver Public Schools
+  company_dcsdk12: Douglas County Schools
+  company_dpsnc: Durham Public Schools
+  company_evsd: East Valley School District
+  company_eastonvilleschooldistrict: Eatonville School District
+  company_enumclawschooldistrict: Enumclaw School District
+  company_everettsd: Everette Public Schools
+  company_fsusd: Fairfield-Suisun Unified School District
+  company_fayettecountypublicschools: Fayette County Public Schools
+  company_forsythcountyschools: Forsyth County Schools
+  company_fcschools: Franklin County School
+  company_fpschools: Franklin Pierce School District
+  company_frederickcountypublicschools: Frederick County Public Schools
+  company_fultonschools: Fulton County Schools
+  company_vadoe: Governor's School Programs
+  company_gcs: Granville County Schools
+  company_gcisd: Grapevine-Colleyville ISD
+  company_godaddy: Go Daddy
+  company_greenupcountyschooldistrict: Greenup County Schools
+  company_gwinnettcountypublicschools: Gwinnett County Public Schools
+  company_HamptonCitySchools: Hampton City Schools
+  company_HanoverCountyPublicSchools: Hanover County Public Schools
+  company_HenricoCountyPublicSchools: Henrico County Public Schools
+  company_highlineschools: Highline School District
+  company_houstonisd: Houston Independent School District
+  company_hcpss: Howard County Public Schools
+  company_idla: Idaho Digital Learning Academy
+  company_janesvilleschooldistrict: Janesville School District
+  company_johnstoncountyschools: Johnston County Schools
+  company_lps: Lincoln Public School
+  company_littletonpublicschools: Littleton Public Schools
+  company_lausd: Los Angeles Unified School District
+  company_lcps: Louisa County Public Schools
+  company_lcsedu: Lynchburg City Schools
+  company_msvl: Marysville School District
+  company_dadeschools: Miami-Dade Public Schools
+  company_miltonps: Milton Public Schools
+  company_montgomeryschoolsmd: Montgomery County Public Schools
+  company_needhampublicschools: Needham Public Schools
+  company_NelsonCountyPublicSchools: Nelson County Public Schools
+  company_newalbanyschools: New Albany Plain Local Schools
+  company_newkentschools: New Kent County Public Schools
+  company_newarkcityschools: Newark City Schools
+  company_nnschools: Newport News Public Schools
+  company_newtonpublicschools: Newton Public Schools
+  company_nps: Norfolk Public Schools
+  company_nycdoe: NYC Department of Education
+  company_ohlsd: Oak Hills Local School District
+  company_oneclay: One Clay County School District
+  company_ocps: Orange County Schools
+  company_orangeusd: Orange Unified School District
+  company_pbsd: Palm Beach School District
+  company_pvusd: Paradise Valley Unified School District
+  company_PetersburgCityPublicSchools: Petersburg City Public Schools
+  company_pylusd: Placentia-Yorba Linda Union School District
+  company_PowhatanCountyPublicSchools: Powhatan County Public Schools
+  company_pgcps: Prince Georges County Public Schools
+  company_provocityschooldistrict: Provo Public Schools
+  company_reyn: Reynoldsburg City School District
+  company_RichmondPublicSchools: Richmond Public Schools
+  company_RockinghamCountySchools: Rockingham County Schools
+  company_svusd: Saddleback Valley Unified School District
+  company_sfusd: San Francisco Unified School District
+  company_ShenandoahCountyPublicSchools: Shenandoah County Public Schools
+  company_shorelineschools: Shoreline School District
+  company_sjusd: San Juan Unified School District
+  company_sky: Sky
+  company_spokaneschools: Spokane Public Schools
+  company_StaffordCountyPublicSchools: Stafford County Public Schools
+  company_strongnet: Strongsville School District
+  company_TukwilaSchoolDistrict: Tukwila School District
+  company_vermilionschools: Vermilion Local School District
+  company_vista-equity-partners: Vista Equity Partners
+  company_walthampublicschools: Waltham Public Schools
+  company_warrencountyschools: Warren County Schools
+  company_WaynesboroPublicSchools: Waynesboro Public Schools
+  company_WellesleyPublicSchools: Wellesley Public Schools
+  company_wvsd208: West Valley School District
+  company_wuhsd: Whittier Union High School District
+  company_wcschools: Wilson County Schools
+  company_yelp: Yelp
+  nav_back_to_resources: Back to Resources
+  how_to_nav_educators: For educators
+  how_to_nav_after_school: For after school
+  how_to_nav_parents: For parents
+  how_to_nav_public_officials: For public officials
+  how_to_nav_districts: For districts
+  how_to_nav_assemblies: For school assemblies
+  how_to_nav_organizations: For organizations
+  how_to_nav_companies: For companies
+  how_to_nav_afterschool_educators: For after-school educators
+  how_to_nav_volunteers: For volunteers
+  how_to_nav_virtual: For virtual events
+  whats_next_header: What's next?
+  whats_next_description: We'll send you materials and helpful tips for your event.
+    <a href='http://code.org/learn'>Try current tutorials</a> for any browser, smartphone
+    – or even no computer!
+  whats_next_how_to: "<a href='/how-to'>How to run an Hour of Code</a>"
+  whats_next_promote: "<a href='/promote'>Promote the Hour of Code</a>"
+  whats_next_how_to_promote: "<a href='/promote/resources'>How to promote the Hour
+    of Code</a>"
+  whats_next_how_to_promote_link: "<a href='/promote'>How to promote the Hour of Code</a>"
+  whats_next_try: "<a href='%{learn_url}'>Try tutorials</a>"
+  whats_next_try_button: Try tutorials
+  n_have_learned_an_hoc: "<h1>Try an</h1><h2>Hour of Code</h2><h3># served</h3>"
+  anybody_can_learn: Anybody can learn.
+  get_started: Start
+  beyond_an_hour: Beyond an Hour of Code
+  register_now: Register Now
+  share_on_facebook: Share on Facebook
+  share_on_twitter: Share on Twitter
+  promote_additional_resources: Additional resources coming soon!
+  front_join_us_heading: An Hour of Code for every student.
+  front_join_us_announcements: Announcements
+  front_join_us_anybody_can_learn: Anybody can learn
+  front_join_us_description: Computer science is a foundation for every student. Help
+    us introduce it to 100 million.
+  front_join_us_description_short: Computer science is a foundation for every student.
+  front_join_us_button: Join us
+  front_what_is_hoc: What is the Hour of Code?
+  front_join_us_header: Anyone can learn the basics, and have fun doing it!
+  front_join_us_volunteer_header: Volunteers for the Hour of Code
+  front_join_us_tutorials: Choose your Hour of Code tutorial!
+  front_join_us_tutorials_link: Filter and browse <i>over 200 tutorials and lesson
+    plans</i>! Find activities for different subject areas, multiple hardware needs,
+    and students at any experience level.
+  front_join_us_robotics: Win robots or circuits!
+  front_join_us_robotics_link: Do you want a set of robots or physical computing kits
+    to use with your students? Our generous partners are donating sets to 75 classrooms!
+    Sign up for the Hour of Code to participate. (Classrooms selected by Code.org,
+    US Only)
+  front_join_us_teacher: Are you a teacher?
+  front_join_us_inspire: Inspire students with
+  front_join_us_inspire_link: an Hour of Code in the classroom.
+  front_join_us_teacher_link: Inspire students with an Hour of Code in the classroom
+  front_join_us_teacher_volunteer: Search for local volunteers who can visit your
+    classroom or inspire your students remotely.
+  front_join_us_parent: Are you a parent?
+  front_join_us_ask_link: Ask your local school
+  front_join_us_ask: to host an Hour of Code.
+  front_join_us_parent_link: Ask your local school to host an Hour of Code
+  front_join_us_computer_science: Just love computer science?
+  front_join_us_cs_volunteer: Passionate about computer science education?
+  front_join_us_spread: Spread the word.
+  front_join_us_spread_word: Spread the word in your community
+  front_join_us_spread_word_work: Spread the word in your community or workplace
+  front_join_us_sign_up_volunteer: Sign up to volunteer at a local classroom or through
+    a video chat.
+  front_join_us_organize: Or organize an Hour of Code event yourself.
+  front_join_us_how_to_run: Here's how to run an Hour of Code
+  front_join_us_help_promote: Help promote the Hour of Code
+  front_join_us_students: Students
+  front_join_us_teachers: Teachers
+  front_join_us_everyone: Everyone
+  front_join_us_try: Try it
+  front_join_us_sign_up: Sign up
+  front_join_us_host: Host it
+  front_join_us_support: Support it
+  front_join_us_more_info: For more information, please visit <a href='https://code.org'>code.org</a>.
+  front_join_us_code_info: For more information, please visit code.org
+  front_join_us_n_students_served: "# served."
+  front_join_us_challenge: Win a video chat for your classroom with a celebrity!
+  front_join_us_learn_more: Learn more
+  cta_see_whats_new: See what's new
+  cta_try_more_activities: Try more activities
+  cta_try_an_activity: Try an activity
+  hoc_homepage_join_the_movement_heading: Join the movement
+  hoc_homepage_join_the_movement_description: Hour of Code is available year-round,
+    but every year in December your class can join millions of students around the
+    world celebrating Computer Science Education Week with the Hour of Code. Registration
+    for the annual celebration starts each year in October.
+  hoc_homepage_what_is_hoc_subhead: One-hour tutorials in over 45 languages. No experience
+    needed. Hour of Code activities are available for free year-round.
+  hoc_homepage_what_is_hoc_description: The Hour of Code is a one-hour introduction
+    to computer science, using fun tutorials to show that anybody can learn the basics.
+    This grassroots campaign is supported by over 400 partners and 200,000 educators
+    worldwide.
+  hoc_homepage_what_is_hoc_cta_how_to_guide: "[Read our How-to guide](%{howto_guide_url})
+    to plan an event for your class."
+  hoc_homepage_highlights_heading: Hour of Code highlights
+  hoc_homepage_organized_by: The Hour of Code is organized by [Code.org](%{codeorg_url}).
+  signup_closed: Registration for the Hour of Code is now closed. Please check again
+    in October to sign up for the next Hour of Code.
+  signup_registration_not_required: You don't need to register to participate! The
+    Hour of Code activities are available year-round. <a href='%{hoc_activities_url}'>Try
+    an activity</a> or read our <a href='%{howto_guide_url}'>How-to guide</a> to plan
+    an event for your class.
+  signup_registration_not_required_markdown: You don't need to register to participate!
+    The Hour of Code activities are available year-round. [Try an activity](%{hoc_activities_url})
+    or read our [How-to guide](%{howto_guide_url}) to plan an event for your class.
+  signup_registration_closed: And every year in December, your class can join millions
+    of students around the world celebrating Computer Science Education Week with
+    the Hour of Code. We'll open registration for the annual celebration in October.
+  signup_registration_closed_2022_markdown: 'Registration for this year''s Hour of
+    Code event map is currently closed, but you can still [host an Hour of Code](%{hoc_activities_url})
+    and join in the celebration on social media! Post fun pictures or video of your
+    event using the #HourOfCode hashtag!'
+  signup_header: Organize an Hour of Code during %{campaign_date}, and register it
+    here.
+  signup_name_label: Your name
+  signup_name_error: Name is required.
+  signup_email_label: Your email
+  signup_email_error: Email is required
+  signup_invalid_email_error: The email address you entered is invalid
+  signup_organization_name_label: Organization name
+  signup_organization_name_error: Organization name is required.
+  signup_event_type_label: Event type
+  signup_event_type_error: Event type is required.
+  signup_event_entire_school_label: My entire school is participating
+  signup_event_location_label: Event location
+  signup_event_location_error: Event location is required.
+  signup_special_event_flag_label: My event will involve an entire district, members
+    of the community, and/or other special plans to go beyond an hour
+  signup_special_event_details_label: Apply to be highlighted as a special event
+  signup_send_posters_flag_label: Send <a href= "/resources/promote#posters">posters</a>
+    to my school or organization (US only, while supplies last)
+  signup_send_posters_address_label: Address of school or organization
+  signup_whole_school_flag_label: This event is for a whole school
+  signup_your_event: Sign up your event
+  signup_host_an_hour: Host an hour
+  signup_match_volunteer: Help me find a local software engineer to inspire my students
+  signup_email_preference_opt_in: Can we email you about updates to Code.org courses,
+    local opportunities, or other computer science news?
+  signup_email_preference_privacy: "(See our privacy policy)"
+  signup_email_preference_yes: 'Yes'
+  signup_email_preference_no: 'No'
+  signup_email_preference_error: Email preference is required
+  signup_multiple_event_warning: We will put your school name and city on the map
+    when you register. If you're hosting multiple events, please submit a unique name
+    or email for each one. We only count one event per name and email combination.
+  signup_name_placeholder: Your Name
+  signup_email_placeholder: you@example.com
+  signup_organization_name_placeholder: For example, Lincoln High School
+  signup_event_country_label: Event country
+  signup_event_country_error: Country is required.
+  signup_event_location_placeholder: Postal code and country OR full address.
+  signup_special_event_details_placeholder: Describe what makes this a special event
+  signup_send_posters_address_placeholder: This address will not be shared on our
+    map
+  signup_event_type_in_school: School
+  signup_event_type_after_school: After school program
+  signup_event_type_out_of_school: Organization/Company
+  signup_event_type_at_home: Home
+  signup_submit_census_label: Submit
+  signup_submit_census_error_message: We're sorry. An error occurred. Please try submitting
+    the form again.
+  signup_submit_label: Sign up
+  signup_submit_error_message: An error occurred. Please check to make sure all required
+    fields have been filled out properly.
+  signup_submit_and_continue_label: Submit and Continue
+  signup_continue_label: Continue
+  signup_thank_you_header: Thank you for signing-up to host an Hour of Code event.
+  signup_thank_you_message: We sent you a confirmation email with information to help
+    you get started.
+  social_hoc2018_code_org_what_create: 'Code.org: What will you create?'
+  social_hoc2018_creativity_in_are_you: 'The #HourOfCode is about creativity. I’m
+    in! Are you?'
+  social_hoc2018_dance_party: 'Hour of Code: Dance Party'
+  social_hoc2018_dance_what_create: Featuring Katy Perry, Madonna, J. Balvin, Sia,
+    Keith Urban, Ciara, and 25 more!
+  social_hoc2018_every_student: Every student deserves the opportunity to express
+    their creativity with computer science.
+  social_hoc2018_every_student_try_what_create: Every student deserves the opportunity
+    to express their creativity with computer science. Try your hand at the new tutorials.
+    What will you create?
+  social_hoc2018_hoc_coming_create: The Hour of Code is coming. What will you create?
+  social_hoc2018_hoc_here: The Hour of Code is here!
+  social_hoc2018_join: 'Hour of Code: Join the Movement'
+  social_hoc2018_mc: Minecraft is back for the Hour of Code, and you’re the hero!
+    Write code to journey through Minecraft biomes.
+  social_hoc2018_mc_creativity: Use your creativity and problem solving skills to
+    explore and build underwater worlds with code.
+  social_hoc2018_what_create: What will you create?
+  social_hoc2018_global_movement: The Hour of Code is a global movement reaching tens
+    of millions of students. One-hour tutorials are available in 45+ languages for
+    all ages.
+  map_title: Hour of Code map
+  map_header: "# events registered for Hour of Code 2017"
+  map_header_count_year: "%{event_count} events registered in %{year}"
+  see_all_events: See all events
+  map_header_company: "# by company organizers"
+  map_header_country: "# in %{country}"
+  map_search_placeholder: Search for Hour of Code events
+  map_search_search: Search
+  map_search_reset: Reset
+  map_legend_title: Legend
+  map_legend_hoc_events: Hour of Code Event
+  map_legend_cs_tech_jam: Special Event
+  map_warning: A full list of the events can be viewed on the <a href='%{events_url}'>events
+    page.</a>
+  map_warning_markdown: A full list of the events can be viewed on the [events page.](%{events_url})
+  meta_tag_og_title: 'Hour of Code: Join the Movement'
+  meta_tag_og_description: The Hour of Code is a global movement reaching tens of
+    millions of students of all ages in 180+ countries and over 45 languages.
+  meta_tag_twitter_title: 'Hour of Code: Join the Movement'
+  meta_tag_twitter_description: The Hour of Code is a global movement reaching tens
+    of millions of students of all ages in 180+ countries and over 45 languages.
+  meta_tag_og_title_cs_movement: 'Hour of Code: Join the Computer Science Movement'
+  meta_tag_og_description_campaign: The Hour of Code is a global campaign reaching
+    and inspiring tens of millions of students of all ages to learn computer science
+    in 180+ countries and over 45 languages.
+  twitter_default_text: 'I''m participating in this year''s #HourOfCode, are you?
+    @codeorg'
+  twitter_donor_text: 'This year''s #HourOfCode is about creativity. I’m in! Are you?
+    (Thanks %{random_donor} for supporting @codeorg)'
+  twitter_donor_text_2019: 'This year''s #HourOfCode is about #CSforGood. I’m in!
+    Are you? (Thanks %{random_donor} for supporting @codeorg)'
+  twitter_default_text_donor: 'I''m participating in this year''s #HourOfCode, are
+    you? (Thanks %{random_donor} for supporting @codeorg)'
+  hoc_faq_title: FAQs
+  hoc_faq_what_is_hoc_q: What is the Hour of Code?
+  hoc_faq_what_is_hoc_a: The Hour of Code started as a one-hour introduction to computer
+    science, designed to demystify "code", to show that anybody can learn the basics,
+    and to broaden participation in the field of computer science. It has since become
+    a worldwide effort to celebrate computer science, starting with 1-hour coding
+    activities but expanding to all sorts of community efforts. Check out the <a href='%{tutorials}'>tutorials
+    and activities</a>. This grassroots campaign is supported by over <a href='%{partners}'>400
+    partners</a> and 200,000 educators worldwide.
+  hoc_faq_what_is_hoc_a_markdown: The Hour of Code started as a one-hour introduction
+    to computer science, designed to demystify "code", to show that anybody can learn
+    the basics, and to broaden participation in the field of computer science. It
+    has since become a worldwide effort to celebrate computer science, starting with
+    1-hour coding activities but expanding to all sorts of community efforts. Check
+    out the [tutorials and activities](%{tutorials}). This grassroots campaign is
+    supported by over [400 partners](%{partners}) and 200,000 educators worldwide.
+  hoc_faq_last_year: Try the tutorials
+  hoc_faq_when_is_hoc_q: When is the Hour of Code?
+  hoc_faq_when_is_hoc_a: The Hour of Code takes place each year during <a href='%{csedweek_url}'>Computer
+    Science Education Week</a>. The %{campaign_date_year} Computer Science Education
+    Week will be %{campaign_date_full}, but you can host an Hour of Code all year-round.
+    Computer Science Education Week is held annually in recognition of the birthday
+    of computing pioneer <a href='%{grace_hopper}'>Admiral Grace Murray Hopper</a>
+    (December 9, 1906).
+  hoc_faq_when_is_hoc_a_markdown: The Hour of Code takes place each year during [Computer
+    Science Education Week](%{csedweek_url}). The %{campaign_date_year} Computer Science
+    Education Week will be %{campaign_date_full}, but you can host an Hour of Code
+    all year-round. Computer Science Education Week is held annually in recognition
+    of the birthday of computing pioneer [Admiral Grace Murray Hopper](%{grace_hopper})
+    (December 9, 1906).
+  hoc_faq_why_cs_q: Why computer science?
+  hoc_faq_why_cs_a: "<i>Every</i> student should have the opportunity to learn computer
+    science. It helps nurture problem-solving skills, logic and creativity. By starting
+    early, students will have a foundation for success in any 21st-century career
+    path. See more stats <a href='%{stats_url}'>here</a>."
+  hoc_faq_why_cs_a_markdown: _Every_ student should have the opportunity to learn
+    computer science. It helps nurture problem-solving skills, logic and creativity.
+    By starting early, students will have a foundation for success in any 21st-century
+    career path. See more stats [here](%{stats_url}).
+  hoc_faq_how_participate_q: How do I participate in the Hour of Code?
+  hoc_faq_how_participate_a: "<a href='/how-to'>Start planning here</a> by reviewing
+    our how-to guide. You can organize an Hour of Code event at your school or in
+    your community &mdash; like in an extracurricular club, non-profit or at work.
+    Or, just try it yourself when %{campaign_date} arrives."
+  hoc_faq_how_participate_a_markdown: "[Start planning here](%{howto}) by reviewing
+    our how-to guide. You can organize an Hour of Code event at your school or in
+    your community — like in an extracurricular club, non-profit or at work. Or, just
+    try it yourself when %{campaign_date} arrives."
+  hoc_faq_behind_hoc_q: Who is behind the Hour of Code?
+  hoc_faq_behind_hoc_a: The Hour of Code is organized by Code.org and driven by the
+    Hour of Code Review Committee as well as an unprecedented coalition of <a href='%{partner_url}'>partners</a>
+    that have come together to support the Hour of Code — including Microsoft, Apple,
+    Amazon, Boys and Girls Clubs of America and the College Board.
+  hoc_faq_behind_hoc_a_markdown: The Hour of Code is organized by Code.org and driven
+    by the Hour of Code Review Committee as well as an unprecedented coalition of
+    [partners](%{partner_url}) that have come together to support the Hour of Code
+    — including Microsoft, Apple, Amazon, Boys and Girls Clubs of America and the
+    College Board.
+  hoc_faq_host_q: I don't know anything about coding. Can I still host an event?
+  hoc_faq_host_a: Of course. Hour of Code activities are self-guided. All you have
+    to do is <a href='%{codeorg_url}/learn'>try our current tutorials</a>, pick the
+    tutorial you want, and pick an hour &mdash; we take care of the rest. We also
+    have options for every age and experience-level, from kindergarten and up. Start
+    planning your event by reading our <a href='/how-to'>how to guide</a>.
+  hoc_faq_host_a_markdown: Of course. Hour of Code activities are self-guided. All
+    you have to do is [try our current tutorials](%{codeorg_url}/learn), pick the
+    tutorial you want, and pick an hour — we take care of the rest. We also have options
+    for every age and experience-level, from kindergarten and up. Start planning your
+    event by reading our [how to guide](%{howto}).
+  hoc_faq_devices_q: What devices should I use for my students?
+  hoc_faq_devices_a: Code.org tutorials work on all devices and browsers. You can
+    see more information about Code.org's tutorial tech needs <a href='%{codeorg_url}/educate/it'>here</a>.
+    Tech needs for non-Code.org tutorials can be found on <a href='%{codeorg_url}/learn'>%{partner_url}/learn</a>
+    in the tutorial specific description. Don't forget we also offer <a href='%{unplugged_url}'>unplugged
+    activities</a> if your school can't accommodate the tutorials!
+  hoc_faq_devices_a_markdown: Code.org tutorials work on all devices and browsers.
+    You can see more information about Code.org's tutorial tech needs [here](%{codeorg_url}/educate/it).
+    Tech needs for non-Code.org tutorials can be found on [%{partner_url}/learn](%{codeorg_url}/learn)
+    in the tutorial specific description. Don't forget we also offer [unplugged activities](%{unplugged_url})
+    if your school can't accommodate the tutorials!
+  hoc_faq_need_computers_q: Do I need computers for every participant?
+  hoc_faq_need_computers_a: No. We have Hour of Code tutorials that work on PCs, smartphones,
+    tablets, and some that require no computer at all! You can join wherever you are,
+    with whatever you have. <p><i>Here are a few options:</i> <br> <ul> <li><b>Work
+    in pairs.</b> <a href='%{pair_programming_research}'>Research shows</a> students
+    learn best with <a href='%{pair_programming_video}'>pair programming</a>, sharing
+    a computer and working together. Encourage your students to double up. <li><b>Use
+    a projected screen.</b> If you have a projector and screen for a Web-connected
+    computer, your entire group can do an Hour of Code together. Watch video portions
+    together and take turns solving puzzles or answering questions. <li><b>Go unplugged.</b>
+    We offer <a href='%{unplugged_url}'>tutorials that require no computer</a> at
+    all. </ul>
+  hoc_faq_need_computers_a_markdown: |-
+    No. We have Hour of Code tutorials that work on PCs, smartphones, tablets, and some that require no computer at all! You can join wherever you are, with whatever you have.
+
+    _Here are a few options:_
+
+    - **Work in pairs.** [Research shows](%{pair_programming_research}) students learn best with [pair programming](%{pair_programming_video}), sharing a computer and working together. Encourage your students to double up.
+    - **Use a projected screen.** If you have a projector and screen for a Web-connected computer, your entire group can do an Hour of Code together. Watch video portions together and take turns solving puzzles or answering questions.
+    - **Go unplugged.** We offer [tutorials that require no computer](%{unplugged_url}) at all.
+  hoc_faq_international_q: I am in <country>. How do I participate internationally?
+  hoc_faq_international_a: Anyone can organize an Hour of Code event, anywhere in
+    the world. Last year, students worldwide joined together for the Hour of Code.
+    Find out more <a href='/promote'>here</a>.
+  hoc_faq_international_a_markdown: Anyone can organize an Hour of Code event, anywhere
+    in the world. Last year, students worldwide joined together for the Hour of Code.
+    Find out more [here](%{promote}).
+  hoc_faq_tutorial_q: How can I make an Hour of Code tutorial?
+  hoc_faq_tutorial_a: If you're interested in becoming a tutorial partner, <a href='/tutorial-guidelines'>see
+    our guidelines and instructions</a>. We'd like to host a variety of engaging options,
+    but the primary goal is to optimize the experience for students and teachers who
+    are new to computer science.
+  hoc_faq_tutorial_a_markdown: If you're interested in becoming a tutorial partner,
+    [see our guidelines and instructions](%{tutorial_guidelines}). We'd like to host
+    a variety of engaging options, but the primary goal is to optimize the experience
+    for students and teachers who are new to computer science.
+  hoc_faq_account_q: Do students need to log on using an account?
+  hoc_faq_account_a: No. Absolutely no signup or login is required for students to
+    try the Hour of Code. Most of the <a href='%{codeorg_url}/learn/beyond'>follow-on
+    courses</a> require account creation to save student progress. Also, signing up
+    for the Hour of Code does NOT automatically create a Code Studio account. If you
+    do want to create accounts for your students, please follow these <a href='https://youtu.be/_smelV_KISE'>instructions</a>.
+  hoc_faq_account_a_markdown: No. Absolutely no signup or login is required for students
+    to try the Hour of Code. Most of the [follow-on courses](%{codeorg_url}/learn/beyond)
+    require account creation to save student progress. Also, signing up for the Hour
+    of Code does NOT automatically create a Code Studio account. If you do want to
+    create accounts for your students, please follow these [instructions](%{section_instructions_url}).
+  hoc_faq_high_school_q: Which activity should I do with high school students?
+  hoc_faq_high_school_a: Our Star Wars and Minecraft tutorials are great for high
+    schoolers, especially the Star Wars JavaScript version and the free play level
+    on both tutorials. Alternately, we recommend trying one of the beginner tutorials
+    on <a href='%{codeorg_url}/learn'>%{partner_url}/learn</a> to start, such as the
+    tutorial with Angry Birds or with Anna and Elsa. A high school student should
+    be able to finish one of these in 30 minutes and can then try a more advanced
+    tutorial in JavaScript, such as Khan Academy or CodeHS.
+  hoc_faq_high_school_a_markdown: Our Star Wars and Minecraft tutorials are great
+    for high schoolers, especially the Star Wars JavaScript version and the free play
+    level on both tutorials. Alternately, we recommend trying one of the beginner
+    tutorials on [%{partner_url}/learn](%{codeorg_url}/learn) to start, such as the
+    tutorial with Angry Birds or with Anna and Elsa. A high school student should
+    be able to finish one of these in 30 minutes and can then try a more advanced
+    tutorial in JavaScript, such as Khan Academy or CodeHS.
+  hoc_faq_scratch_q: I am doing Scratch for Hour of Code, but what if my students
+    have iPads rather than laptops?
+  hoc_faq_scratch_a: Scratch doesn't run on tablets. If your students are young, they
+    can use the ScratchJR iPad app (for early-readers). If you look at the tutorials
+    on <a href='%{codeorg_url}/learn'>%{partner_url}/learn</a>, you can find other
+    tutorials that work on iPads - from Code.org, Tynker, Lightbot, or CodeSpark.
+  hoc_faq_scratch_a_markdown: Scratch doesn't run on tablets. If your students are
+    young, they can use the ScratchJR iPad app (for early-readers). If you look at
+    the tutorials on [%{partner_url}/learn](%{codeorg_url}/learn), you can find other
+    tutorials that work on iPads - from Code.org, Tynker, Lightbot, or CodeSpark.
+  hoc_faq_count_hoc_q: How do you count Hours of Code?
+  hoc_faq_map_q: Why don't I see my dot on the map?
+  hoc_faq_map_a: We're so sorry you aren't seeing your event on the Hour of Code map.
+    Because of the tens of thousands of organizers who sign up, the map aggregates
+    the data and displays one point for several events. If you click the <a href='%{events_url}'>events
+    page</a> link below the map you will be directed to a list of all events by state
+    and can find your event listed there. Additionally, given the thousands of people
+    signing up for the Hour of Code, the map and event list usually takes 48 hours
+    to update. Check back in a few days!
+  hoc_faq_map_a_markdown: We're so sorry you aren't seeing your event on the Hour
+    of Code map. Because of the tens of thousands of organizers who sign up, the map
+    aggregates the data and displays one point for several events. If you click the
+    [events page](%{events_url}) link below the map you will be directed to a list
+    of all events by state and can find your event listed there. Additionally, given
+    the thousands of people signing up for the Hour of Code, the map and event list
+    usually takes 48 hours to update. Check back in a few days!
+  hoc_faq_count_hoc_a: The Hour of Code tracker isn't an exact measurement of usage.
+    We do not count unique student IDs perfectly when tracking participation in the
+    Hour of Code, especially because we don't require students to log in or register.
+    As a result, we both over-count and under-count participants at the same time.
+    Read all the details <a href='%{codeorg_url}/loc'>here</a>.
+  hoc_faq_count_hoc_a_markdown: 'We do not count unique student IDs perfectly when
+    tracking participation in the Hour of Code. Why? Partly because we don''t want
+    the friction of prompting to “login / register” before a student or classroom
+    tries learning for the first time, and partly because there are may activities
+    we cannot track online. We do take certain steps to reduce double-counting, but
+    without a login prompt, this can''t work perfectly. At the same time, there are
+    MANY student activities in the Hour of Code that aren''t tracked at all. For example:
+    (1) students who use a mobile/tablet app to try the Hour of Code are typically
+    not counted (2) students who share a screen for pair-programming or group-programming
+    may be counted as one (3) students trying an unplugged classroom activity cannot
+    be counted online (4) teachers who create their own Hour of Code activities. As
+    a result, there is some under-counting and some double-counting, and so we do
+    not view the Hour of Code tracker to be an exact measure of usage. It is certainly
+    directionally correct, and shows that many tens of millions of students have participated.'
+  hoc_faq_one_hour_q: How much can one learn in an hour?
+  hoc_faq_one_hour_a: The goal of the Hour of Code is not to teach anybody to become
+    an expert computer scientist in one hour. One hour is only enough to learn that
+    computer science is fun and creative, that it is accessible at all ages, for all
+    students, regardless of background. The measure of success of this campaign is
+    not in how much CS students learn - the success is reflected in broad participation
+    across gender and ethnic and socioeconomic groups, and the resulting increase
+    in enrollment and participation we see in CS courses at all grade levels. Millions
+    of the participating teachers and students have decided to go beyond one hour
+    -  to learn for a whole day or a whole week or longer, and many students have
+    decided to enroll in a whole course (or even a college major) as a result. <br/><br/>
+    Besides the students, another "learner" is the educator who gains the confidence
+    after one hour that they can teach computer science even though they may not have
+    a college degree as a computer scientist. Tens of thousands of teachers decide
+    to pursue computer science further, either attending PD or offering follow-on
+    online courses, or both. And this applies to school administrators too, who realize
+    that computer science is something their students want and their teachers are
+    capable of. <br/><br/> Above all, what all participants can learn in an hour is
+    that we can do this.
+  hoc_faq_one_hour_a_markdown: |-
+    The goal of the Hour of Code is not to teach anybody to become an expert computer scientist in one hour. One hour is only enough to learn that computer science is fun and creative, that it is accessible at all ages, for all students, regardless of background. The measure of success of this campaign is not in how much CS students learn - the success is reflected in broad participation across gender, racial/ethnic, and socioeconomic groups, and the resulting increase in enrollment and participation we see in CS courses at all grade levels. Millions of the participating teachers and students have decided to go beyond one hour -  to learn for a whole day or a whole week or longer, and many students have decided to enroll in a whole course (or even a college major) as a result.
+
+    Besides the students, another "learner" is the educator who gains the confidence after one hour that they can teach computer science even though they may not have a college degree as a computer scientist. Tens of thousands of teachers decide to pursue computer science further, either attending PD or offering follow-on online courses, or both. And this applies to school administrators too, who realize that computer science is something their students want and their teachers are capable of.
+
+    Above all, what all participants can learn in an hour is that we can do this.
+  hoc_faq_more_questions_q: Still have more questions?
+  hoc_faq_more_questions_a: Try finding an answer in our <a href='http://support.code.org'>support
+    forum</a>.
+  hoc_faq_more_questions_a_markdown: Try finding an answer in our [support forum](http://support.code.org).
+  hoc_faq_keep_learning_q: How do I keep learning after the Hour of Code?
+  hoc_faq_keep_learning_a: Anyone can host an Hour of Code at any time. The tutorials
+    stay up year-round. You can expect all our tutorials and curriculum to be available
+    on our site in perpetuity. Please go to <a href='/promote'>our resources</a> for
+    event how-to guides and other resources to help make your Hour of Code event a
+    success.
+  hoc_faq_keep_learning_a_markdown: Anyone can host an Hour of Code at any time. The
+    tutorials stay up year-round. You can expect all our tutorials and curriculum
+    to be available on our site in perpetuity. Please go to [our resources](%{promote})
+    for event how-to guides and other resources to help make your Hour of Code event
+    a success.
+  hoc_faq_certificates_q: Where can I print certificates for my students?
+  hoc_faq_certificates_a: Go to our <a href='%{codeorg_url}/certificates'>certificates
+    page</a> where you can print certificates for your entire class ahead of time.
+    You can also print out <a href='%{codeorg_url}/certificates?course=mc'>special
+    certificates</a> for students doing the Minecraft tutorial.
+  hoc_faq_certificates_a_markdown: Go to our [certificates page](%{codeorg_url}/certificates)
+    where you can print certificates for your entire class ahead of time. You can
+    also print out [special certificates](%{codeorg_url}/certificates?course=mc) for
+    students doing the Minecraft tutorial.
+  hoc_faq_logo_q: Are there limitations to how I can use the Hour of Code logo or
+    name?
+  hoc_faq_logo_a: Hour of Code is trademarked. We don't want to prevent its usage,
+    but we want to make sure its usage fits within a few limits. Please see <a href='%{logo_url}'>these
+    guidelines for usage</a>.
+  hoc_faq_logo_a_markdown: Hour of Code is trademarked. We don't want to prevent its
+    usage, but we want to make sure its usage fits within a few limits. Please see
+    [these guidelines for usage](%{logo_url}).
+  stats_hoc_2013_image_alt: Stats from 2013 Hour of Code
+  stats_growth: It was the fastest to reach 15 million users.
+  stats_i18n: Students are learning in over 45 languages
+  stats_tumblr: 'Tumblr: 3.5 years'
+  stats_facebook: 'Facebook: 3 years'
+  stats_twitter: 'Twitter: 2.5 years'
+  stats_pinterest: 'Pinterest: 2 years'
+  stats_instagram: 'Instagram: 14 months'
+  stats_hoc: 'The Hour of Code: 5 days'
+  stats_global: Over 100M students have tried an Hour of Code
+  stats_girls_more: More girls tried computer science than in the last 70 years
+  stats_females: Participation of female students in computer science is only 20-25%
+    of high school courses, university courses, and the workforce.
+  stats_females_more: During the Hour of Code, female students make up <b>50% of all
+    participants</b>!
+  stats_females_more_markdown: During the Hour of Code, female students make up **50%
+    of all participants**!
+  stats_nina: '"Every single day yielded the same results&mdash; 100% engagement."
+    - Nina Nichols Peery, Teacher'
+  stats_student: '"I knew this was a <b>once-in-a-lifetime</b> chance." - Mariana
+    Alzate, 5th grader'
+  stats_michael: '"I have <b>never, ever</b> seen my students so excited about learning."
+    - Michael Clark, Teacher'
+  resources_how_to: How-to guide for teachers
+  resources_how_to_events: Event how-to guide
+  resources_how_to_districts: How-to guide for districts
+  resources_how_to_officials: How-to guide for public officials
+  resources_handouts: Handouts to spread the word
+  resources_one_pager: One-page handout
+  resources_brochure: Brochure
+  resources_posters: Posters
+  resources_videos: Videos
+  resources_banners: Social media
+  resources_emails: Sample emails
+  resources_logo: Hour of Code logo
+  resources_stats: Stats and blurbs
+  resources_press_kit: Press Kit
+  resources_social: Social
+  resources_country_resources: Country Specific Resources
+  resources_stickers: Stickers
+  resources_how_to_guides: How-to guides
+  resources_promote: Promote
+  resources_nav_tutorials: Try the tutorials
+  resources_nav_promote: Spread the word
+  resources_nav_spread_word: How to get involved
+  resources_banner_promote_text: Promote
+  resources_banner_promote_button: Encourage others to sign up with brochures, inspirational
+    posters and social media banners.
+  resources_banner_howto_text: How-to
+  resources_banner_howto_button: Resources for educators, parents and districts to
+    host an Hour of Code.
+  handouts_section: Share these handouts
+  handouts_onepager: Spread the word with this one page handout
+  handouts_brochure: Give this brochure to teachers and schools
+  handouts_participationguide: Plan your Hour of Code with this participation guide
+  videos_title: Show these videos to inspire students
+  videos_what_most_schools_dont_teach: What Most Schools Don't Teach (5 min)
+  videos_hoc_2014: Hour of Code is Here - Anybody Can Learn
+  videos_obama_cs: President Obama on computer science
+  videos_anybody_can_learn: Anybody Can Learn (1 min)
+  videos_creativity: What is Creativity?
+  videos_creativity_series: What is Creativity? View Full Series.
+  title_country_resources: Country Specific Resources
+  title_hoc_advisory_committee: Hour of Code and CSEdWeek Advisory Committee
+  title_hoc_review_committee: Hour of Code and CSEdWeek Review Committee
+  title_how_to_promote: Spread the word
+  title_how_to_districts: Hour of Code How-To for Districts
+  title_how_to_events: Hour of Code Event How-To
+  title_how_to_organizations: How to host an Hour of Code - Organizations
+  title_how_to_companies: How to host an Hour of Code - Companies
+  title_how_to_officials: How-to guide for public officials
+  title_how_to_volunteers: How-to guide for Hour of Code volunteers
+  title_how_to_parents: How-to guide for parents
+  title_how_to: How-to Guide
+  title_international_partners: Contact International Partners
+  title_press_release: Hour of Code Press Release for Elected Officials
+  title_op_ed: Sample Op-ed Supportive of Computer Science Education Week and Hour
+    of Code
+  title_press_kit: Press Kit
+  title_proclamation: Sample Resolution Supportive of Computer Science Education Week
+    and Hour of Code
+  title_stats: Blurbs and Stats
+  title_partners: Partners
+  title_resources: Resources
+  title_past_posters: Past Hour of Code Posters
+  title_signup_thanks: Thanks for signing up to host an Hour of Code!
+  title_tutorial_guidelines: Activity Guidelines
+  title_whole_school: Whole School Participation
+  events_nav_title: Hour of Code Events
+  events_nav_all: All Events
+  events_nav_whole_schools: Whole Schools
+  events_nav_special: Special Events
+  events_nav_orgs: Organizations
+  events_all_old_title: All @year Hour of Code events
+  events_all_title: All Hour of Code events
+  events_whole_school_title: Whole-school Hour of Code events
+  events_special_title: Hour of Code Special Events
+  events_orgs_title: All Hour of Code events organized by Partner Organizations
+  event: event
+  events: events
+  highlights_title: Highlights
+  highlights_header: Hour of Code Highlights
+  highlights_description: Some of our favorite moments from the Hour of Code campaign.
+  highlights_previous: Highlights from previous years
+  highlights_see_more: See more highlights
+  highlights_readmore: Read more
+  highlights_watchvideo: Watch the video
+  highlights_facebook: Share on Facebook
+  highlights_constant_alba_heading: The actress, activist, and entrepreneur hosted
+    an Hour of Code with the entire staff at The Honest Company.
+  highlights_constant_alba_short_heading: Jessica Alba learns an Hour of Code
+  highlights_constant_obama_heading: President Obama is the first president to write
+    a line of code, hosting a historic Hour of Code for students at the White House.
+  highlights_constant_obama_short_heading: Coder in Chief
+  highlights_constant_malala_heading: '"Every girl deserves to take part in creating
+    the technology that''ll change our world, and change who runs it."'
+  highlights_constant_malala_short_heading: Nobel Peace Prize winner Malala
+  highlights_constant_trudeau_heading: Canadian Prime Minister Justin Trudeau coded
+    a simple game featuring his favorite sport.
+  highlights_constant_trudeau_short_heading: Prime Minister Justin Trudeau codes a
+    game
+  highlights_constant_ny_heading: After an epic battle, 80% of Brooklyn schools did
+    the Hour of Code vs. 60% in Chicago. Not bad!
+  highlights_constant_ny_short_heading: Brooklyn beats Chicago
+  highlights_constant_athletes_heading: Champions and gold medalists Serena Williams,
+    Neymar Jr, Carmelo Anthony and more inspire students to push themselves.
+  highlights_constant_athletes_short_heading: Push yourself
+  footer_copyright_message: Copyright %{current_year} Code.org. All rights reserved.
+  footer_trademark_message: Hour of Code® and Hora del Código® are trademarks of Code.org.
+  footer_built_on_github: Built on GitHub from Microsoft
+  footer_menu_partners: Partners
+  footer_menu_contact: Contact us
+  footer_menu_support: Support
+  footer_menu_terms: Terms
+  footer_menu_privacy: Privacy Policy
+  footer_menu_cookie: Cookie Notice
+  footer_menu_facebook: Code.org on Facebook
+  footer_menu_twitter: Code.org on Twitter
+  footer_menu_instagram: Code.org on Instagram
+  footer_menu_medium: Code.org on Medium.com
+  learn_banner_heading: Hour of Code Activities
+  learn_banner_blurb: Try a one-hour tutorial designed for all ages in over 45 languages.  Join
+    millions of students and teachers in over 180 countries starting with an Hour
+    of Code.
+  learn_banner_beyond: Want to keep learning?  <a id='learn_banner_beyond'>Go beyond
+    an hour</a>
+  learn_banner_beyond_markdown: Want to keep learning? [Go beyond an hour](%{url})
+  learn_banner_teachers: 'Teachers: <a id=''teacher_banner_host''>Host an hour</a>
+    or <a id=''teacher_banner_howto''>read the How-To Guide</a>'
+  learn_banner_teachers_markdown: 'Teachers: [Host an hour](%{host_url}) or [read
+    the How-To Guide](%{howto_url})'
+  tutorial_dance2019_name: Dance Party
+  tutorial_danceparty_name: Dance Party
+  tutorial_chibitronics_name: 'Chibitronics: Illuminated Story'
+  tutorial_athlete_name: Code your own sports game
+  tutorial_moana_name: 'Moana: Wayfinding with Code'
+  tutorial_star-wars_name: 'Star Wars: Building a Galaxy with Code'
+  tutorial_gumadventure_name: Gumball's Coding Adventure
+  tutorial_mchoc_name: Minecraft Hour of Code
+  tutorial_vidnews_name: 'Vidcode: Code the News'
+  tutorial_kodable-pre_name: Kodable (pre-readers welcome)
+  tutorial_highseas_name: Adventure on the High Seas
+  tutorial_capython_name: Python Turtle Graphics
+  tutorial_frzn_name: Code with Anna and Elsa
+  tutorial_cocom_name: 'CodeCombat: Escape the Dungeon!'
+  tutorial_play-lab_name: Play Lab
+  tutorial_boxisland_name: Box Island
+  tutorial_textcomp_name: Text Compression
+  tutorial_encryption_name: Simple Encryption
+  tutorial_kanopixel_name: Kano Pixel Hack
+  tutorial_foos_name: codeSpark Academy with The Foos
+  tutorial_tynkerdd_name: Dragon Dash
+  tutorial_tynkerana_name: Analog Clock STEM Kit
+  tutorial_vidcard_name: 'Vidcode: Bestie Greeting Card'
+  tutorial_spritebox_name: Spritebox Coding
+  tutorial_tynkerch_name: Counter Hack
+  tutorial_lightbot_name: Lightbot
+  tutorial_hoc_name: Placeholder for new code.org/hoc
+  tutorial_code_name: Write your first computer program
+  tutorial_tinspire_name: 10 Minutes of Code for the TI-Nspire CX
+  tutorial_itchbounceball_name: ITCH Bouncing Ball (in Scratch)
+  tutorial_vidclim_name: 'Vidcode: Climate Science & Code'
+  tutorial_matlab_name: Learn to Code with MATLAB
+  tutorial_flap_name: Make a Flappy game
+  tutorial_galaxy_name: Galaxy Game Jam
+  tutorial_inf_name: Infinity Play Lab
+  tutorial_tynkersol_name: Solar System STEM Kit
+  tutorial_itchg_name: ITCH Name IT - Geography
+  tutorial_como_name: Coding Adventure
+  tutorial_processfound_name: The Processing Foundation - Hello Processing
+  tutorial_tynkerhomo_name: Homophones STEM Kit
+  tutorial_art_name: Artist
+  tutorial_tynkerbrick_name: Brick Breaker Game Kit
+  tutorial_itchbio_name: ITCH Name IT - Parts of the Biological Cell
+  tutorial_itchj_name: ITCH Jumping (in Scratch)
+  tutorial_tickleo_name: Swimming Orca - by Tickle App
+  tutorial_hopgeo_name: Geometry Jumper
+  tutorial_tynkermult_name: Multiplication Escape STEM Kit
+  tutorial_monster_name: Mystery Island Coding Quest
+  tutorial_tynkerapp_name: Build an App
+  tutorial_tynkerpup_name: Puppy Adventure
+  tutorial_livecode_name: LiveCode Sound Boards
+  tutorial_cocomgame_name: 'CodeCombat: Build Your Own Game!'
+  tutorial_tynkerspin_name: Spin Draw Animation Kit
+  tutorial_code-avengers_name: Build a Game with JavaScript
+  tutorial_tynkercq_name: Candy Quest
+  tutorial_cmgame_name: CodeMonkey's Game Builder
+  tutorial_codesters_name: Codesters
+  tutorial_qrm_name: Accessible programming (with screenreader support)
+  tutorial_texas-instruments_name: 10 Minutes of Code
+  tutorial_cajava_name: Drawing Flags with JavaScript
+  tutorial_codehs_name: Learn to Code with Karel the Dog
+  tutorial_hopemo_name: Emoji Draw
+  tutorial_tynkercm_name: Code Monsters
+  tutorial_codesterswintergreet_name: Winter Greetings
+  tutorial_codestersc_name: The Coordinate Plane
+  tutorial_codestersturtle_name: 'Codesters: Turtle Traffic'
+  tutorial_penjee_name: Learn Python with Penjee the Penguin
+  tutorial_trinket_name: Trinket's Hour of Python
+  tutorial_frogger_name: Make your own 3D Frogger game
+  tutorial_tynkereco_name: Ecological Pyramid STEM Kit
+  tutorial_mitedarc_name: MIT Education Arcade
+  tutorial_khan_name: 'Khan Academy: Drawing with Code'
+  tutorial_tynkerd_name: Debugger
+  tutorial_cdmy_name: Codecademy
+  tutorial_codestersdance_name: Dance Moves
+  tutorial_codestersbasketball_name: Basketball
+  tutorial_nclkarel_name: Learn How to Code with Karel the Robot
+  tutorial_buildpong_name: Build Pong with AI
+  tutorial_tynkerdrones_name: Program Drones and Robots
+  tutorial_carla_name: Programming with Carla
+  tutorial_zulama_name: Zulama MakeQuest Video Game Activity
+  tutorial_capost_name: Build a Digital Postcard with HTML and CSS
+  tutorial_marco_name: Run Marco!
+  tutorial_codestersflappybike_name: Flappy Bike
+  tutorial_kanopong_name: Kano Computing - Make Pong
+  tutorial_tynkerright_name: Bill of Rights STEM Kit
+  tutorial_touchdevelop_name: TouchDevelop
+  tutorial_tynkercc_name: Code Commander
+  tutorial_bamboo_name: Bamboo JS
+  tutorial_robojav_name: 'Robots and Java: An introduction to Java'
+  tutorial_roboba_name: Learn Algebra with RoboBlockly
+  tutorial_knodsnake_name: JavaScript Snake
+  tutorial_soccharater_name: Character Building
+  tutorial_silent_name: Silent Teacher
+  tutorial_robomesh_name: Program VEX IQ Robots with Blockly
+  tutorial_amaze_name: A-Maze-thing
+  tutorial_codestersds_name: Dream Sequence
+  tutorial_knodtext_name: 'Text Adventure: Python'
+  tutorial_alicegar_name: Animating with Alice and Garfield
+  tutorial_codesterstransform_name: Transformation Puzzles
+  tutorial_flexfrog_name: Flexbox Froggy
+  tutorial_codemoji_name: Codemoji
+  tutorial_robobii_name: Learn Coding with RoboBlockly
+  tutorial_robobm_name: Learn Math with RoboBlockly
+  tutorial_codingrobots_name: Learn One Hour Coding with RoboBlockly
+  tutorial_robob_name: Learn Robotics with RoboBlockly
+  tutorial_coders_name: 'Coders Strike Back: an introduction to bot programming'
+  tutorial_tynkerhw_name: Learn to Code with Hot Wheels
+  tutorial_tynkermh_name: Learn to Code with Monster High
+  tutorial_caphoto_name: Build a Photo Booth App
+  tutorial_mozillahw_name: Mozilla Homework Excuse Generator
+  tutorial_ticklep_name: Parrot Wonder
+  tutorial_bbot_name: Bomberbot Fun and Easy Coding Activities
+  tutorial_scratchg_name: Programming Games in Scratch
+  tutorial_sjforest_name: 'ScratchJr: Can I Make a Spooky Forest?'
+  tutorial_sjgreet_name: 'ScratchJr: Can I Make My Characters Greet Each Other?'
+  tutorial_sjsunset_name: 'ScratchJr: Can I Make the Sun Set?'
+  tutorial_fufafrenz_name: fuzzFamily Frenzy
+  tutorial_bbcgeo_name: Bitsbox Coding + Geometry
+  tutorial_chspixel_name: CodeHS Pixel Art
+  tutorial_hummingbird_name: Creating a Game with Hummingbird
+  tutorial_recoloring_name: Recoloring the Universe
+  tutorial_bbcchem_name: Bitsbox Coding + Chemistry
+  tutorial_floalgo_name: 'Coding: Algorithms Lesson Plan'
+  tutorial_flocond_name: 'Coding: Conditionals Lesson Plan'
+  tutorial_floloops_name: 'Coding: For Loops Lesson Plan'
+  tutorial_pgts_name: Rock, Paper, Scissors
+  tutorial_ozo_name: The OzoBlockly Tutorial
+  tutorial_bbcla_name: Bitsbox Coding + Language Arts
+  tutorial_bbcsci_name: Bitsbox Coding + Science
+  tutorial_tlctour_name: Tour Guide Activity
+  tutorial_codesterstj_name: CS Tech Jam
+  tutorial_tlclocked_name: Locked-In
+  tutorial_baubles_name: Binary Baubles
+  tutorial_bbcart_name: Bitsbox Coding + Art
+  tutorial_tlcknight_name: Knight's Tour Activity
+  tutorial_fufafit_name: fuzzFamily Fitness
+  tutorial_ozodance_name: Ozobot Dance-Off
+  tutorial_codingrobotics_name: Intro to Coding through Robotics (ft. Wonder Workshop)
+  tutorial_box_name: Box Island
+  tutorial_hopgame_name: Hopscotch Game Design Workshop
+  tutorial_icontrol_name: iControl
+  tutorial_cocomteach_name: 'CodeCombat: Teacher-Led Activities'
+  tutorial_bbcmathii_name: Bitsbox Coding + Math (K-2)
+  tutorial_bbcphys_name: Bitsbox Coding + Physics
+  tutorial_bitsbox_name: Build Crazy Apps with Bitsbox
+  tutorial_tlcemo_name: 'Emotion Machine: Create-a-Face Card'
+  tutorial_crd_name: Conditionals with Cards
+  tutorial_bbcbio_name: Bitsbox Coding + Biology
+  tutorial_ticklebb8_name: BB-8 Swing
+  tutorial_grok_name: Grok Learning
+  tutorial_ijournalist_name: iJournalist
+  tutorial_bbcmusic_name: Bitsbox Coding + Music
+  tutorial_secretcodes_name: Secret Codes Activity
+  tutorial_tlchex_name: HexaHexaFlexagon Automata Activity
+  tutorial_tickles_name: Sphero Run
+  tutorial_ozogame_name: Create an Ozobot Game Level
+  tutorial_vidcodeio_name: Input and Output, Math Activity
+  tutorial_tlcbrain_name: Brain-in-a-bag Activity
+  tutorial_hopquiz_name: Quiz Creator
+  tutorial_unfortunate_name: A Series of Unfortunate Events
+  tutorial_cha_name: Computer History Activity
+  tutorial_elaseq_name: 'Writing and Coding: ELA Integration with Common Core Standards'
+  tutorial_bbcmathi_name: Bitsbox Coding + Math (3-5)
+  tutorial_tlcpixel_name: Pixel Puzzles
+  tutorial_introrobo_name: Introduction to Robotics
+  tutorial_tlcinvis_name: Invisible Palming Activity
+  tutorial_tlcjflap_name: 'JFLAP: Creating Finite State Machines'
+  tutorial_procolor_name: Drive to School with Ozobot
+  tutorial_spiralsfinch_name: Spirals with the Finch
+  tutorial_ozoi_name: Ozobot and OzoCodes Intro
+  tutorial_ticklel_name: LEGO Bricker
+  tutorial_spiralsdash_name: Draw Spirals with Dash
+  tutorial_ghdebug_name: Grace Hopper Debugging Activity
+  tutorial_tlckk_name: Kriss-Kross Puzzles
+  tutorial_firstcomp_name: My First Computer
+  tutorial_mazefinch_name: Through the Maze with the Finch Robot
+  tutorial_tlccc_name: Compression Code Puzzles
+  tutorial_tlcdoodle_name: Algorithmic Doodle Art
+  tutorial_tlcpunch_name: Punch Card Searching Activity
+  tutorial_finchfract_name: Finch Fractals
+  tutorial_tlcmind_name: The Red Black Mind Meld Activity
+  tutorial_tlctelebot_name: The Teleporting Robot Activity
+  tutorial_tlcaus_name: Australian Magician's Dream Activity
+  tutorial_tlcmicro_name: Microwave Racing Video Activity
+  tutorial_imathematician_name: iMathematician
+  tutorial_tlcmagic_name: Magical Book Magic
+  tutorial_scratchmus_name: Make Music with Scratch
+  tutorial_scratchanim_name: Animate Your Name with Scratch
+  tutorial_scratchfly_name: Make it Fly with Scratch
+  tutorial_tynkerarc_name: Undersea Arcade Game Kit
+  tutorial_grokffpython_name: Frozen Fractals (Python Turtle)
+  tutorial_grokffblock_name: Frozen Fractals (Blockly Turtle)
+  tutorial_grokeliza_name: Is Eliza Human? (Python)
+  tutorial_tynkercan_name: Physics Cannon 2-Player Game Kit
+  tutorial_grokflags_name: Flags of the World (Python Turtle)
+  tutorial_robomind_name: Program a virtual robot with RoboMind
+  tutorial_adventureq_name: Adventure with Q
+  tutorial_khan-es_name: An introduction to JavaScript
+  tutorial_kpt_name: An introduction to JavaScript
+  tutorial_kpl_name: An introduction to JavaScript
+  tutorial_khe_name: An introduction to JavaScript
+  tutorial_kfr_name: An introduction to JavaScript
+  tutorial_app-inventor_name: AppInventor Hour of Code
+  tutorial_blockly_name: Blockly Games Offline
+  tutorial_tynker_name: Build your own game
+  tutorial_baypt_name: Code Baymax
+  tutorial_code-combat_name: CodeCombat
+  tutorial_mky_name: CodeMonkey
+  tutorial_pirates_name: Coding Pirates
+  tutorial_csfirst_name: CS First
+  tutorial_loopedy_name: Dance the Loopedy-Loop
+  tutorial_dsw_name: Disney Star Wars
+  tutorial_dswb_name: Disney Star Wars
+  tutorial_ssw_name: Disney Star Wars
+  tutorial_sswb_name: Disney Star Wars
+  tutorial_kodable-unplugged_name: fuzzFamily Frenzy
+  tutorial_scratch_name: Get creative with coding
+  tutorial_bayes_name: Grandes Heroes
+  tutorial_gumball_name: Gumball Play Lab
+  tutorial_hrm_name: Human Resource Machine
+  tutorial_ice-age_name: Ice Age Play Lab
+  tutorial_koapp_name: Kodable (pre-readers welcome)
+  tutorial_lightbot-intl_name: Lightbot
+  tutorial_rmc_name: Minecraft Hour of Code
+  tutorial_smc_name: Minecraft Hour of Code
+  tutorial_minecraft-2016_name: Minecraft Hour of Code
+  tutorial_thinkersmith-es_name: Mis Amigos Roboticos
+  tutorial_pixie_name: PIXIE Challenges
+  tutorial_play_name: Play Lab
+  tutorial_robomind-nl_name: Program a virtual robot
+  tutorial_spheroi_name: 'Blocks 1: Intro'
+  tutorial_spherol_name: 'Blocks 3: Lights'
+  tutorial_spherov_name: 'Blocks 4: Variables'
+  tutorial_swb_name: 'Star Wars: Building a Galaxy with Code'
+  tutorial_build-a-galaxy_name: 'Star Wars: Building a Galaxy with Code'
+  tutorial_alicesims_name: Storyboarding and Programming with Alice and The Sims
+  tutorial_tchr_name: Teacher Led Lesson Plans
+  tutorial_robogame_name: The Robot Games
+  tutorial_tap_name: Tynker on Tablets
+  tutorial_cintl_name: Write your first computer program
+  tutorial_itchstop_name: ITCH Stop Frame Animation (Scratch)
+  tutorial_tynkerpn_name: 'Peep: Nature Walk'
+  tutorial_tynkerpd_name: 'Peep: Dance with Friends'
+  tutorial_persistence_name: 'Persistence: Building a Foundation'
+  tutorial_getloopy_name: Getting Loopy
+  tutorial_createface_name: Create-a-Face
+  tutorial_happymaps_name: Happy Maps
+  tutorial_moveit_name: Move it, Move it!
+  tutorial_bigevent_name: The Big Event
+  tutorial_gpp_name: Graph Paper Programming
+  tutorial_foosgame_name: codeSpark Academy with the Foos - GameMaker
+  tutorial_solopython_name: My First Python Code
+  tutorial_kodableint_name: Introduction to Programming
+  tutorial_kodableadv_name: Advanced Programming Concepts
+  tutorial_tynkertj_name: Toxic Jungle
+  tutorial_wolframa_name: Age in Days
+  tutorial_wolframm_name: Random Melodies
+  tutorial_wolframspi_name: Sound of PI
+  tutorial_wolframsph_name: Draw a Sphere
+  tutorial_wolframp_name: Draw a Polygon
+  tutorial_wolframn_name: Ninja Name Generator
+  tutorial_soloweb_name: Your First Webpage in an Hour!
+  tutorial_khanweb_name: 'Khan Academy: Webpages'
+  tutorial_khandata_name: 'Khan Academy: Databases'
+  tutorial_googlelogo_name: My Google Logo
+  tutorial_playtune_name: Play That Tune App
+  tutorial_computeit_name: Compute it
+  tutorial_codesterssj_name: Space Jokes
+  tutorial_cmchat_name: Trivia Chatbot
+  tutorial_tynkerdb_name: Dragon Blast
+  tutorial_cmbuild_name: Game Builder
+  tutorial_robotrattle_name: Robot Rattle
+  tutorial_codestersh_name: Hedgehog Designs
+  tutorial_codehsdigipixel_name: Digital Art in Pixels with CodeHS
+  tutorial_ccbinary_name: Binary Hero
+  tutorial_codehsturtle_name: Program in Python with Tracy the Turtle
+  tutorial_grokhd_name: Hydrangea Danger
+  tutorial_grokem_name: Emoticon Madness
+  tutorial_kodmaze_name: Maze Maker Challenges
+  tutorial_codestersa_name: Asteroid Dodge
+  tutorial_cmdodo_name: Dodo Does Math
+  tutorial_tynkerspace_name: Space Quest
+  tutorial_gfbloons_name: Bloons Trigonometry Defense
+  tutorial_raspipong_name: Sense HAT Pong
+  tutorial_codehsvr_name: Create Virtual Worlds with CodeHS
+  tutorial_codesterstp_name: Transformation Puzzles
+  tutorial_codestersbb_name: Basketball
+  tutorial_gfcrossyroad_name: Learn to Code with Crossy Road
+  tutorial_googleww_name: Wonder Woman
+  tutorial_codehsjsapp_name: Make a Real App with JavaScript
+  tutorial_gfmihi_name: Mihi Maker
+  tutorial_hopdropphone_name: Make "Don't Drop the Phone" on iPad/iPhone
+  tutorial_techfaa_name: Flocking Autonomous Agents
+  tutorial_codehsjsgraph_name: JavaScript Graphics with CodeHS
+  tutorial_thunkable_name: Learn How to Build 10 Apps in 1 Hour!
+  tutorial_hopcrossyroad_name: Make Crossy Road on iPad/iPhone
+  tutorial_switchglitch_name: 'Switch & Glitch: Robot Adventure'
+  tutorial_codecar_name: Code Car Simulator
+  tutorial_codesterscp_name: The Coordinate Plane
+  tutorial_grokpetblock_name: Virtual Pet (micro:bit Blockly)
+  tutorial_techbim_name: Basic Image Manipulation
+  tutorial_techfpp_name: Introduction to Functional Programming with Python
+  tutorial_codesterscr_name: Cheer Routines
+  tutorial_grokdisease_name: Disease Epidemic
+  tutorial_techec_name: Explaining Closures in JS
+  tutorial_rgbegin_name: RoboGarden Coding - Beginner
+  tutorial_myradream_name: 'Actimator: Myra''s Dream'
+  tutorial_thinkfun_name: 'Robot Repair: Can You Fix the Robot Brain?'
+  tutorial_hopfireworks_name: Make a Fireworks App on iPad/iPhone
+  tutorial_grokspace_name: Space (Blockly)
+  tutorial_codehspython_name: Code in Python with CodeHS
+  tutorial_codehsjava_name: Coding in Java with CodeHS
+  tutorial_techioda_name: Shortest Paths with Dijkstra's Algorithm
+  tutorial_grokmonster_name: Monster Maker!
+  tutorial_techmjs_name: Embrace Modern JavaScript - ES6 and Beyond
+  tutorial_techga_name: Genetic Algorithms
+  tutorial_techioan_name: Avoiding Null Anti Patterns
+  tutorial_techiogsr_name: Getting Started With Rust
+  tutorial_groktunnel_name: The Dark Tunnel
+  tutorial_stemcod_name: The Physics of Video Games!
+  tutorial_techikb_name: Interactive Kotlin Basics
+  tutorial_kanostreet_name: Street Artist
+  tutorial_codemojijs_name: Beginning JavaScript
+  tutorial_techapf_name: Advanced Python Features
+  tutorial_techfpjs_name: Practical Introduction to Functional Programming with JS
+  tutorial_techlinq_name: Using C# LINQ - A Practical Overview
+  tutorial_gpbcatapult_name: Build a Catapult
+  tutorial_quorumastro_name: Coding in Astronomy
+  tutorial_alicewonder_name: Alice in Wonderland
+  tutorial_rginter_name: RoboGarden Coding - Intermediate
+  tutorial_cssgrid_name: Grid Garden
+  tutorial_jshero_name: JS Hero
+  tutorial_codemojipy_name: Python Lab
+  tutorial_nclabdrone_name: Let's Build a Drone!
+  tutorial_gpbcircle_name: Make an Interactive Color Circle
+  tutorial_gpbpaint_name: Make Your Own Paint Editor
+  tutorial_cocomarcade_name: 'CodeCombat: Build an Arcade Game!'
+  tutorial_beetik_name: Code the Music of Franz Liszt
+  tutorial_codedj_name: Compose Music with Code DJ
+  tutorial_rgadvan_name: RoboGarden Coding - Advanced
+  tutorial_codehsrn_name: Creating Apps with React Native
+  tutorial_codehswd_name: Web Design with CodeHS
+  tutorial_turtlerobot_name: Turtle Robot
+  tutorial_ozoevo_name: 'Intro to Evo: Evo''s Force Field'
+  tutorial_ozoexped_name: Ozobot Expedition to Neptune
+  tutorial_ozojourney_name: Magellan's Journey
+  tutorial_ozocodes_name: Write your Name with OzoCodes
+  tutorial_ozoeclipse_name: Eclipses and Celestial Mechanics
+  tutorial_ozosimulator_name: Program Simulator
+  tutorial_ozoalgorithm_name: Make a Multiplication Algorithm
+  tutorial_ozotimer_name: Ozobot Second Timer
+  tutorial_ozohabits_name: Modeling Animal Habits and Habitats
+  tutorial_ozoprogram_name: How to Program Robots
+  tutorial_ozopair_name: Pair Programming with Ozobot
+  tutorial_codesnoopy_name: Snoopy Snow Brawl
+  tutorial_applabintro_name: Intro to App Lab
+  tutorial_cslartist_name: The Little Artist In Your Computer Activity Pack
+  tutorial_cslscratchjr_name: Let's Play with the ScratchJr Kitten! Activity Pack
+  tutorial_floevents_name: Writing and interpreting Events
+  tutorial_florobot_name: Design a Robot
+  tutorial_isavesanta_name: iSave Santa!
+  tutorial_iorder_name: iOrder
+  tutorial_ianimate_name: iAnimate
+  tutorial_iloveada_name: iLove Ada
+  tutorial_kodflash_name: If Flash, Then Clap!
+  tutorial_kodchoose_name: Choose Your Own (Fuzzy) Adventure!
+  tutorial_kodpizzapre_name: Pizza Party! (pre-reader)
+  tutorial_kodpizza_name: Pizza Party!
+  tutorial_kodwomen_name: Women in Tech
+  tutorial_tfunplug_name: 'Robot Repair: Can You Fix the Robot Brain? (Unplugged)'
+  tutorial_lbvariables_name: Variables with Littlebits
+  tutorial_lbfunctions_name: Fun with Functions & littleBits
+  tutorial_lblogic_name: Lessons in Logic with littleBits
+  tutorial_lbworld_name: 'littleBits: Change the world arcade challenge'
+  tutorial_lbloops_name: Leap into loops with littleBits!
+  tutorial_lbtug_name: 'littleBits: Tug of War'
+  tutorial_lbpotato_name: 'littleBits: Hot Potato...of Doom!'
+  tutorial_lbguitar_name: 'littlebits: Rockstar Guitar'
+  tutorial_lbio_name: Inputs & Outputs with littleBits
+  tutorial_wonpuppy_name: Dash the Puppy (E3)
+  tutorial_woncue_name: Cue's Starter Guide
+  tutorial_wonzoo_name: Dot at the Petting Zoo (B2)
+  tutorial_wontrip_name: Dash's Road Trip (F2)
+  tutorial_woncollect_name: Dash the Collector (B1)
+  tutorial_wonsecret_name: Cue's Secret Message
+  tutorial_hsscience_name: 'Hopscotch: Make Interactive Science Models on Your iPad/iPhone!'
+  tutorial_popculture_name: Pop Culture Data Science
+  tutorial_legorobust_name: Robust Structures – LEGO® Education WeDo 2.0
+  tutorial_legoplants_name: Plants and Pollinators – LEGO® Education WeDo 2.0
+  tutorial_legopark_name: Autonomous Parking – LEGO® MINDSTORMS® Education EV3
+  tutorial_legodetect_name: Object Detection – LEGO® MINDSTORMS® Education EV3
+  tutorial_legolight_name: Automatic Headlights – LEGO® MINDSTORMS® Education EV3
+  tutorial_alexa_name: 'Amazon Alexa Fact Skill Tutorial: My School Facts'
+  tutorial_grokpetmicro_name: Virtual Pet (micro:bit MicroPython)
+  tutorial_pirateplunder_name: Pirate Plunder
+  tutorial_cadj_name: DR DJ Device
+  tutorial_cacrazy_name: Code Crazy Creatures
+  tutorial_cajump_name: Jumping Jam
+  tutorial_carest_name: Robo-restaurant puzzler
+  tutorial_accai_name: Accenture Intelligent Space Exploration
+  tutorial_vceclipse_name: Code the Eclipse
+  tutorial_pmzero_name: Pac-Man ZERO
+  tutorial_hsela_name: 'Telling stories: ELA + coding'
+  tutorial_ticklear_name: What's AR?
+  tutorial_bcrobot_name: BlocksCAD Robot
+  tutorial_bcsnow_name: BlocksCAD Snowflake
+  tutorial_ifly_name: iFly
+  tutorial_idowedo_name: iDo WeDo
+  tutorial_diggindwarf_name: Diggin' Dwarf
+  tutorial_spheroit_name: 'Blocks 2: If/Then Else'
+  tutorial_gameofcodes_name: Game Of Codes
+  tutorial_blocklygames_name: Blockly Games
+  tutorial_spherohello_name: 'Text 1: Hello World'
+  tutorial_spheroarcade_name: Sphero Arcade Playground
+  tutorial_bcpy1_name: World of Python
+  tutorial_bcpy2_name: World of Python 2
+  tutorial_bcjs1_name: World of JavaScript
+  tutorial_bcjs2_name: World of JavaScript 2
+  tutorial_3dbearmars_name: The Mars Pioneers
+  tutorial_bitsboxyak_name: Yak Attack! Make a Card with Typed Code
+  tutorial_blockscadbargraphs_name: BlocksCAD Bar Graphs
+  tutorial_blockscadbirdhouses_name: BlocksCAD Birdhouses
+  tutorial_blockscadclock_name: BlocksCAD Analog Clock
+  tutorial_blockscaddinner_name: BlocksCAD Dinner Robot
+  tutorial_blockscadicecream_name: BlocksCAD Ice Cream Machine
+  tutorial_blockscadpizza_name: BlocksCAD Pizza Printer
+  tutorial_blockscadsugar_name: Sugar Cubes
+  tutorial_bsgridlight_name: 'GridLight: Hello World'
+  tutorial_bpartscratch_name: 'Art & Music: Color (Scratch)'
+  tutorial_bpartvid_name: 'Art & Music: Color (Vidcode)'
+  tutorial_bpenglishscratch_name: 'English: Biography (Scratch)'
+  tutorial_bpenglishvid_name: 'English: Biography (Vidcode)'
+  tutorial_bphealthscratch_name: 'Health: DNA (Scratch)'
+  tutorial_bphealthvid_name: 'Health: DNA (Vidcode)'
+  tutorial_bpmathscratch_name: 'Math: Multiplication (Scratch)'
+  tutorial_bpmathvid_name: 'Math: Multiplication (Vidcode)'
+  tutorial_bpmlkscratch_name: 'Social Studies: Martin Luther King Jr. (Scratch)'
+  tutorial_bpmlkvid_name: 'Social Studies: Martin Luther King Jr. (Vidcode)'
+  tutorial_bpsafetyscratch_name: 'Digital Citizenship: Online Safety (Scratch)'
+  tutorial_bpsafetyvid_name: 'Digital Citizenship: Online Safety (Vidcode)'
+  tutorial_bpsciencescratch_name: 'Science: Food Chains (Scratch)'
+  tutorial_bpsciencevid_name: 'Science: Food Chains (Vidcode)'
+  tutorial_bptechscratch_name: 'Engineering & Tech: Computer Programming (Scratch)'
+  tutorial_bptechvid_name: 'Engineering & Tech: Computer Programming (Vidcode)'
+  tutorial_caflags_name: Drawing Flags with Blocks
+  tutorial_matariki_name: 'Matariki: Māori New Year'
+  tutorial_carestaurant_name: Robo-Restaurant Decorator
+  tutorial_casea_name: Sea Creature Sequences
+  tutorial_cashield_name: Shield Design Showdown
+  tutorial_ccwslimer_name: 'Super Slimer: Code Your Adventure'
+  tutorial_codinggalaxy_name: Coding Galaxy - Adventure Planet
+  tutorial_boatrace_name: Boat Race
+  tutorial_ccplay_name: 'CodeCombat: Code, Play, Create'
+  tutorial_grinch_name: 'The Grinch: Saving Christmas with Code'
+  tutorial_codehsart_name: Generating Art with Code
+  tutorial_codehsbitcoin_name: 'Cryptocurrency: Explore the Bitcoin Ledger '
+  tutorial_codehsblockchain_name: 'Cryptocurrency: Explore Blockchain Technology'
+  tutorial_codehscipher_name: Caesar Cipher Wheel
+  tutorial_codehscollision_name: Coding Collision Simulations
+  tutorial_codehsmath_name: Coding Mathematical Models
+  tutorial_codehsmusic_name: Coding in Music
+  tutorial_codehssports_name: Coding in Sports
+  tutorial_codemojipizza_name: Make Pizza with JavaScript
+  tutorial_moonlander_name: Moon Lander
+  tutorial_sushicards_name: Beginner Scratch Sushi Cards
+  tutorial_codesparkcreate_name: 'codeSpark Academy with The Foos: Create Games'
+  tutorial_hardvsoft_name: Team Hardware vs. Team Software
+  tutorial_codestersecard_name: Code an Interactive eCard
+  tutorial_codesterslogo_name: Design Your Own Logo
+  tutorial_codesterstshirt_name: Code Your Initials
+  tutorial_codewards_name: Rescue the underwater city!
+  tutorial_olympics_name: C.A.T.S. go for Robot Olympics
+  tutorial_codinismhero_name: Programming Hero
+  tutorial_discovery_name: An Unusual Discovery
+  tutorial_csfirstname_name: Animate a Name
+  tutorial_edisonmove_name: 'Edison and EdPy: Get Edison moving'
+  tutorial_edisonspider_name: Edison and the spiralling spider trap
+  tutorial_edisonspotlight_name: Perform in the spotlight with Edison
+  tutorial_firiapython_name: Learn Python with the micro:bit
+  tutorial_gamefrootsquid_name: Code your own colossal squid game
+  tutorial_duckpiano_name: Make a Duck Piano
+  tutorial_gpsound_name: Make a Sound Recorder
+  tutorial_groklearningpython_name: 'Python + Biology: Build an animal classifier!'
+  tutorial_htmltimetravel_name: 'CSS Animations: Travel Through Time'
+  tutorial_hp_flappy_name: Build a Flappy Birds clone with hyperPad
+  tutorial_appytappin_name: appy Tappin'
+  tutorial_icipher_name: iCipher
+  tutorial_iguess_name: 'iGuess Beasts: QR Code Activity'
+  tutorial_imake_name: iMake Algorithms
+  tutorial_imorse_name: iMorse - Cryptography with Morse Code & Sphero
+  tutorial_kanohp_name: 'Harry Potter: Learn to Code and Make Magic '
+  tutorial_khanwebpages_name: Making Webpages
+  tutorial_kibobowl_name: Measure and Predict with KIBO Robot Bowling
+  tutorial_kibodance_name: Teach Your KIBO Robot to Dance!
+  tutorial_buildcharacters_name: Build Your Own Kodable Fuzz
+  tutorial_designgames_name: Create Games with Javascript
+  tutorial_makelevels_name: Make Your Own Kodable Mazes
+  tutorial_wizard_name: Code Wizard Castle
+  tutorial_mbscratchcards_name: Scratch cards for micro:bit
+  tutorial_mbswiftplaygrounds_name: 'Swift Playgrounds: Intro to the micro:bit'
+  tutorial_mbbuttons_name: 'Introducing the BBC micro:bit: Animation and Buttons'
+  tutorial_meteor_name: Make a Falling Meteors Game for the BBC micro:bit
+  tutorial_ballbounce_name: Ball Bounce Mobile App
+  tutorial_mitcodi_name: Codi the Bee
+  tutorial_mitdoodle_name: Digital Doodle Mobile App
+  tutorial_talktome_name: Talk to Me Mobile App
+  tutorial_mobilecspmap_name: Map Tour App
+  tutorial_ozorandom_name: Ozobot Random Story Generator
+  tutorial_ozotroll_name: Evo the Troll
+  tutorial_peblioart_name: 'Interactive Art: Bringing Art to Life with Code'
+  tutorial_astropi_name: 'Astro Pi: Mission Zero'
+  tutorial_rgart_name: RoboGarden STEAM - Art
+  tutorial_rgengineer_name: RoboGarden STEAM - Engineering
+  tutorial_rgmath_name: RoboGarden STEAM - Math
+  tutorial_rgscience_name: RoboGarden STEAM - Science
+  tutorial_rgtech_name: RoboGarden STEAM - Technology
+  tutorial_robotmagic3d_name: " Animate a 3D Logo"
+  tutorial_robotmagicflappy_name: 3D Flappy Bird
+  tutorial_scratchadventure_name: Animate an Adventure Game
+  tutorial_scratchtalk_name: Create Animations That Talk
+  tutorial_scratchjrstory_name: 'We Can Create a Story Together! '
+  tutorial_scratchjrtwinkle_name: Twinkle, Twinkle Little Star Class Collaboration
+  tutorial_spherocomm_name: Communication
+  tutorial_spherocommunity_name: Your Community
+  tutorial_spherofunctions_name: Fun Fun Functions
+  tutorial_spheroinfrared_name: 'BOLT: Infrared'
+  tutorial_spherolightsensor_name: 'BOLT: Light Sensor'
+  tutorial_spheromansion_name: 'Jurassic Code: Mansion Mayhem'
+  tutorial_roadblocks_name: Roadblocks
+  tutorial_spherotext2_name: 'Text 2: Conditionals'
+  tutorial_spherotext3_name: 'Text 3: Lights'
+  tutorial_spherotext4_name: 'Text 4: Variables'
+  tutorial_spheroraptor_name: 'Jurassic Code: Spheroraptor Escape'
+  tutorial_stempiday_name: Pi day!
+  tutorial_stemplanetoids_name: Planetoids and Lunar Descent
+  tutorial_stempong_name: Pong & Bonk.io
+  tutorial_algobot_name: 'AlgoBot: Coding Action'
+  tutorial_thunkableapps_name: Build Your Own Apps with Thunkable
+  tutorial_toxicodedot_name: Little Dot Adventure
+  tutorial_gcactions_name: 'GameCode: Actions in a video game'
+  tutorial_gccomparators_name: 'GameCode: Comparators and Logic in a video game'
+  tutorial_gcconditions_name: 'GameCode: Conditions in a video game'
+  tutorial_gccreate_name: 'GameCode: create your own video game'
+  tutorial_gcevents_name: 'GameCode: Events in a video game'
+  tutorial_gcloops_name: 'GameCode: Loops in a video game'
+  tutorial_gcvariables_name: 'GameCode: Variables in a video game'
+  tutorial_beanything_name: Barbie You Can Be Anything
+  tutorial_change_name: Change the World
+  tutorial_cooking_name: Cooking Game
+  tutorial_crystal_name: 'Crystal Clash '
+  tutorial_landscape_name: Landscape Generator
+  tutorial_pets_name: Pets Game
+  tutorial_petvet_name: Barbie Pet Vet
+  tutorial_superhero_name: Create a Superhero Mask
+  tutorial_vidcodeplastic_name: Plastic Pollution PSA
+  tutorial_vidcodetypeface_name: Create your own typeface!
+  tutorial_washustorm_name: Stormy Science
+  tutorial_activitypackets_name: Wonder Workshop Activity Packets
+  tutorial_googlerookie_name: Rookie Collage
+  tutorial_tommyturtle_name: 'Tommy the Turtle: Learn to Code'
+  tutorial_mazyad_name: Mazyad's Adventures
+  tutorial_gamemaker_name: Game Maker
+  tutorial_duckrace_name: The Big Duck Race
+  tutorial_allcancodeapps_name: 'Allcancode Platform: Build web and mobile apps in
+    Blockly'
+  tutorial_n2y_name: Bitt Bott Explores Earth
+  tutorial_microsoftarcade_name: Play, Design & Code Retro Arcade Games
+  tutorial_csfirstunplugged_name: CS First Unplugged
+  tutorial_toxicodepython_name: Discover Python with Silent Teacher
+  tutorial_codecombatozaria_name: 'Ozaria: Your Journey Begins'
+  tutorial_vidcodedate_name: Climate Clock
+  tutorial_codemonkeyspace_name: 'Space Adventure: Write Code and Catch Bananas!'
+  tutorial_codespeakhappy_name: Code a Happy Place Meditation App
+  tutorial_grokimage_name: Image Magic with Python
+  tutorial_icomputelearn_name: Learn Coding with iCompute
+  tutorial_rpstress_name: 'Stress Ball: Code a clickable onscreen stress ball'
+  tutorial_bsdcause_name: Support My Cause
+  tutorial_vidcodeanimoji_name: Animoji
+  tutorial_vidcodeanimojies_name: Animoji
+  tutorial_bsdinspire_name: People who Inspire Me
+  tutorial_tttractor_name: Tractor Traversal
+  tutorial_codeillusionmickey_name: 'Disney Codeillusion: Media Art Adventure with
+    Mickey'
+  tutorial_scigirlsquest_name: 'SciGirls: Code Quest'
+  tutorial_codespeakbreathe_name: Code a Meditation Breathing App
+  tutorial_vidcodeface_name: Facetracking
+  tutorial_educodemaze_name: Design Your Own Maze!
+  tutorial_educoderace_name: Code your own racing game!
+  tutorial_codespeakchatbot_name: Code a Chatbot with the Female CS Pioneers
+  tutorial_gamefrootgames_name: 'Games Industry Activity: Code a Platformer game '
+  tutorial_codespeakgrandparent_name: Code a Grandparent Card in Scratch
+  tutorial_educodekingdom_name: Defend the Kingdom!
+  tutorial_codehsdata_name: Coding with Data Visualizations
+  tutorial_educodecake_name: Bake a Cake With HTML!
+  tutorial_ttsecond_name: Second Team
+  tutorial_bsdtrivia_name: Trivia Game Maker
+  tutorial_csfirstdialogue_name: Dialogue
+  tutorial_codemonkeybeaver_name: Beaver Achiever
+  tutorial_codestersdistance_name: 'Codesters: Social Distancing Sprites'
+  tutorial_itchspace_name: 'iTCHcode: Space Invaders - RokCoder'
+  tutorial_vidcodemagic_name: SFX Magic
+  tutorial_vidcodemagices_name: SFX Magic
+  tutorial_codespeakmeal_name: Code a Healthy Meal App
+  tutorial_itchfish_name: 'iTCHcode: Fish scratch game'
+  tutorial_bsdwebsite_name: My Favorites Website
+  tutorial_codespeaktime_name: Code a Time Capsule in Scratch
+  tutorial_itchwebcam_name: 'iTCHcode: Webcam Augmented Reality'
+  tutorial_itchball_name: 'iTCHcode: Bouncing Ball'
+  tutorial_ttrace_name: Race Condition
+  tutorial_plethora_name: 'Plethora: Cause and Effect'
+  tutorial_educodesecret_name: Uncover the Agency's Secrets!
+  tutorial_itchshapes_name: 'iTCHcode: Shapes & Angles'
+  tutorial_codeguppytext_name: Introduction to text based coding
+  tutorial_vidcodeplastiche_name: Plastic Pollution PSA
+  tutorial_educativechatbot_name: Build your own chatbot in Python
+  tutorial_educodebasics_name: Learn the Basics!
+  tutorial_codehsdesign_name: Supporting Artists with Code
+  tutorial_htmlacademyphp_name: 'Intro to PHP: Create an Online Store from Scratch'
+  tutorial_gamefrootdistance_name: 'COVID-19 Simulator: Learn about social distancing
+    through computer science.'
+  tutorial_codesterscovid_name: 'Codesters: We Can Stop COVID PSA'
+  tutorial_ttbunker_name: The Bunker
+  tutorial_cuttle_name: Computational Thinking and Programming Challenge
+  tutorial_bsdjokes_name: Jokes and Riddles
+  tutorial_rptree_name: Tree life simulator
+  tutorial_codestersunity_name: 'Codesters: Unity Mural'
+  tutorial_codesterssoccer_name: 'Codesters: Soccer Shot'
+  tutorial_breakoutlock_name: 'Haspy and Lockit: Code Buddies'
+  tutorial_thunkablemask_name: Beaver in a Mask
+  tutorial_cafarming_name: Old MacDonald hacked a farm. AI, AI drone!
+  tutorial_blocksmithyeti_name: Don't Yeet the Yeti
+  tutorial_codecapture_name: Learn Programming With JavaScript​ In A Jiffy​
+  tutorial_codehslitter_name: Coding for a Litter-Free Community
+  tutorial_bsdocean_name: Life Below Water
+  tutorial_itchplatformer_name: 'iTCHcode: Scratch 3.0 Platformer Tutorial'
+  tutorial_codejika_name: 'CodeJIKA: 5 Minute Website'
+  tutorial_gamefrootclicker_name: Learn Variables. Code your own Clicker Game.
+  tutorial_rmagicequity_name: Equity vs. Equality
+  tutorial_ttfreestyle_name: Functional Freestyle
+  tutorial_ozobotcolor2_name: 'Introduction to Color Codes 02:  Drawing Color Codes'
+  tutorial_ozobotcolor3_name: 'Introduction to Color Codes 03: Directionality'
+  tutorial_clcarbon_name: Build Your Own Carbon Calculator
+  tutorial_kodablebasics_name: 'Coding Basics: Unplugged'
+  tutorial_scigirlscc_name: 'SciGirls: Code Creators'
+  tutorial_irobotpicture_name: 'Seeing the Whole Picture: Coded Messages'
+  tutorial_kcjmyself_name: Let me introduce myself!
+  tutorial_nearpodalgorithms_name: 'Coding: Algorithms '
+  tutorial_kibodrop_name: KIBO Craft and Build Drop Test
+  tutorial_ozobotcolor1_name: 'Introduction to Color Codes 01: Line Following'
+  tutorial_scigirlspixels_name: 'SciGirls: Passion for Pixels'
+  tutorial_kcjheroines_name: Our Heroines
+  tutorial_ozobotvalue_name: What's My Value?
+  tutorial_icodebytes_name: 'A Byte of iCompute: Unplugged'
+  tutorial_clfashion2_name: Fashionistas of Data Science - Class 2
+  tutorial_ai4all_name: 'AI4ALL: AI & Drawing'
+  tutorial_cldata_name: Welcome to Data Superpower
+  tutorial_spheroinputs_name: Inputs and Outputs Unplugged
+  tutorial_edisoncount_name: Teach Edison to count to 9
+  tutorial_spheroloops_name: Loops Unplugged
+  tutorial_kiboprogram_name: Let's Program Each Other
+  tutorial_hellorubycsin60_name: Computer Science in 60 seconds
+  tutorial_clfashion1_name: Fashionistas of Data Science - Class 1
+  tutorial_irobottraffic_name: 'Traffic Bot: Code Your Own Traffic Signal'
+  tutorial_edisonmystery_name: Edison and the mystery line
+  tutorial_microbitseaturtles_name: Saving Sea Turtles
+  tutorial_ozobotknow_name: 'Introduction to Ozobot: Get to Know Evo'
+  tutorial_imagilabs_name: 'Imagine it. Code it. Wear it. '
+  tutorial_irobotsimulator_name: Simulator Code Break
+  tutorial_irobotkind_name: 'Robot Feelings: The Kind Playground'
+  tutorial_firiavirtual_name: 'CodeSpace: Virtual Robotics with Python'
+  tutorial_irobotguesscode_name: Guess the Code
+  tutorial_ozobotnouns_name: Picking Out Irregular Plural Nouns
+  tutorial_nasa3d_name: 'Universe in 3D:  modeling and printing cosmic objects'
+  tutorial_blupants_name: 'BluPants: Learn Coding with Real Robots'
+  tutorial_legodance_name: Break Dance
+  tutorial_nearpodcoding_name: 'Topic Spark: Coding '
+  tutorial_kcjplastic_name: "#kids2030 Plastics Challenge"
+  tutorial_legojourney_name: Create a Journey with LEGO Education
+  tutorial_legohopper_name: Hopper Race
+  tutorial_catrobatembroidery_name: Coded Embroidery
+  tutorial_irobotphone_name: Telephone Drawing
+  tutorial_codeguppydraw_name: Draw with code
+  tutorial_codejumper_name: 'Networks: Messages of Kindness'
+  tutorial_meeempathy_name: A Minecraft Tale of Two Villages
+  tutorial_danceparty_shortdescription: Code a Dance Party to share with your friends.
+    Featuring Katy Perry, Madonna, J. Balvin, Sia, Keith Urban, Ciara, and 25 more!
+  tutorial_chibitronics_shortdescription: Program a paper circuit to light up your
+    own story.
+  tutorial_athlete_shortdescription: Choose between making a basketball game or mix
+    and match across sports!
+  tutorial_moana_shortdescription: Moana is brave, fearless, and is determined to
+    find her own path.
+  tutorial_star-wars_shortdescription: Learn to program droids, and create your own
+    Star Wars game in a galaxy far, far away.
+  tutorial_gumadventure_shortdescription: Use code to continue an episode of The Amazing
+    World of Gumball.
+  tutorial_mchoc_shortdescription: Minecraft is back for the Hour of Code with a brand
+    new activity! Journey through Minecraft with code.
+  tutorial_vidnews_shortdescription: Code effects and graphics to make a news story
+    all about tech, diversity, kids, and coding.
+  tutorial_kodable-pre_shortdescription: A fun game to teach computer programming
+    concepts
+  tutorial_highseas_shortdescription: In this activity, you'll create an adventure
+    story with two characters that takes place on the high seas!
+  tutorial_capython_shortdescription: Use Python code to draw fun pictures with turtles.
+  tutorial_frzn_shortdescription: Let's use code to join Anna and Elsa as they explore
+    the magic and beauty of ice.
+  tutorial_cocom_shortdescription: Learn Python and Javascript by coding your way
+    through Kithgard Dungeon!
+  tutorial_play-lab_shortdescription: Create a story or make a game with Play Lab!
+  tutorial_boxisland_shortdescription: Take a trip on Box Island and collect all the
+    stars!
+  tutorial_textcomp_shortdescription: Investigate lossless compression techniques
+    with the Text Compression Widget
+  tutorial_encryption_shortdescription: Introduces the need for encryption and simple
+    techniques for cracking secret messages.
+  tutorial_kanopixel_shortdescription: Code your way through iconic images from video
+    game history, from Tetris through Minecraft!
+  tutorial_foos_shortdescription: '"The Foos" is a fun, pre-reader friendly game to
+    learn about programming.'
+  tutorial_tynkerdd_shortdescription: Go on an epic quest for treasure.
+  tutorial_tynkerana_shortdescription: Create a working analog clock.
+  tutorial_vidcard_shortdescription: Learn how to make a greeting card with JavaScript!
+  tutorial_spritebox_shortdescription: Run, jump, and code your way through three
+    different worlds to collect the stars and make it to the finish line! Learn sequencing,
+    debugging and loops, and code in Swift, Java, or with Icons.
+  tutorial_tynkerch_shortdescription: Learn Javascript as you defeat viruses!
+  tutorial_lightbot_shortdescription: Program Lightbot to solve puzzles using procedures
+    and loops!
+  tutorial_hoc_shortdescription: Placeholder for new code.org/hoc
+  tutorial_code_shortdescription: Learn to code with Mark Zuckerberg and Angry Birds!
+  tutorial_tinspire_shortdescription: Get students started coding on their TI-Nspire
+    CX handhelds in just 10 minutes at a time.
+  tutorial_itchbounceball_shortdescription: Use ITCH - Scratch integrated with a video
+    lesson to make your own bouncing ball project
+  tutorial_vidclim_shortdescription: Combine CS & Environmental Science, and record
+    a video about climate.
+  tutorial_matlab_shortdescription: Find the closest location to meet your friends
+    using MATLAB!
+  tutorial_flap_shortdescription: Make your own game - Flappy Bird, Shark, or Submarine
+  tutorial_galaxy_shortdescription: Create your own Android Galaxy games, animations,
+    and interactive stories!
+  tutorial_inf_shortdescription: Use Play Lab to create a story or game starring Disney
+    Infinity characters.
+  tutorial_tynkersol_shortdescription: Program a moving model of the Solar System.
+  tutorial_itchg_shortdescription: Create an interactive naming game for the States
+    of Australia (Geography) with Itch (Scratch for Teachers)
+  tutorial_como_shortdescription: 'Learn and teach coding in CoffeeScript, a real-world
+    programming language. '
+  tutorial_processfound_shortdescription: 'Take a look at programming in the context
+    of the visual arts. '
+  tutorial_tynkerhomo_shortdescription: Make a storytelling game about homophones!
+  tutorial_art_shortdescription: Draw cool pictures and designs with the Artist!
+  tutorial_tynkerbrick_shortdescription: Make your own version of this arcade classic.
+  tutorial_itchbio_shortdescription: Create your own game to name the parts of a biological
+    cell with ITCH (Scratch for Classrooms)
+  tutorial_itchj_shortdescription: Learn how to make a character jump and land on
+    platform with ITCH (Scratch for Teachers)
+  tutorial_tickleo_shortdescription: With Tickle, a user-friendly coding app, you
+    can easily program the Orca to swim in a number of ways by simply dragging and
+    dropping coding blocks to create a command for it to follow.
+  tutorial_hopgeo_shortdescription: 'Build your own Geometry Jumper game: dodge obstacles
+    as they fly at you!'
+  tutorial_tynkermult_shortdescription: Make a fun multiplication game!
+  tutorial_monster_shortdescription: A colorful self-guided programming adventure
+    for children.
+  tutorial_tynkerapp_shortdescription: Program a custom version of your favorite game!
+  tutorial_tynkerpup_shortdescription: Help Pixel the puppy get home!
+  tutorial_livecode_shortdescription: Make some noise!
+  tutorial_cocomgame_shortdescription: Build your own game by levelling up your Python
+    and Javascript skills!
+  tutorial_tynkerspin_shortdescription: Create a fun pen that draws a rotating image.
+  tutorial_code-avengers_shortdescription: Learn "JavaScript" programming, in a web-browser.
+  tutorial_tynkercq_shortdescription: Go on a quest for candy!
+  tutorial_cmgame_shortdescription: 'Create your own online game using CoffeeScript,
+    a real-world programming language. '
+  tutorial_codesters_shortdescription: Create your own games, animations, and artwork
+    using Python.
+  tutorial_qrm_shortdescription: Join Mary in her first week programming in a biology
+    lab as she learns Quorum.
+  tutorial_texas-instruments_shortdescription: Learn basic coding using the TI-84™
+    Plus calculator.
+  tutorial_cajava_shortdescription: Learn about shapes, coordinates and colors by
+    drawing flags in JavaScript.
+  tutorial_codehs_shortdescription: Start coding with Karel the Dog, a fun and visual
+    intro to programming.
+  tutorial_hopemo_shortdescription: Code a drawing app that creates beautiful art
+    with your favorite emoijs.
+  tutorial_tynkercm_shortdescription: Collect, train, and battle your monsters!
+  tutorial_codesterswintergreet_shortdescription: 'Create your own custom greeting
+    card to celebrate winter! '
+  tutorial_codestersc_shortdescription: 'Learn to navigate the coordinate plane with
+    code! '
+  tutorial_codestersturtle_shortdescription: 'Guide turtle out a maze and create spiral
+    art! '
+  tutorial_penjee_shortdescription: 'Visually learn Python by moving a Penguin around
+    an ice world. '
+  tutorial_trinket_shortdescription: Learn the basics of Python with lessons, challenges
+    and tutorials!
+  tutorial_frogger_shortdescription: 'Create and share your own 3D game '
+  tutorial_tynkereco_shortdescription: Code an interactive ecological pyramid.
+  tutorial_mitedarc_shortdescription: Have your sprite collect coins and get points.
+  tutorial_khan_shortdescription: 'Khan Academy: Drawing with Code teaches you how
+    to code using JavaScript by designing your very own snowman'
+  tutorial_tynkerd_shortdescription: Fight bugs to save the motherboard!
+  tutorial_cdmy_shortdescription: Learn JavaScript programming, in a web-browser
+  tutorial_codestersdance_shortdescription: 'Design your own dance routine and program
+    a sprite to perform it! '
+  tutorial_codestersbasketball_shortdescription: 'Build your own pull and shoot basketball
+    game! '
+  tutorial_nclkarel_shortdescription: Learn to code with Karel the Robot as you travel
+    the world together solving problems.
+  tutorial_buildpong_shortdescription: Build the arcade classic and give the computer
+    artificial intelligence to play against you.
+  tutorial_tynkerdrones_shortdescription: Program a controller for your robot or drone.
+  tutorial_carla_shortdescription: Learn to code by programming a talking virtual
+    robot named Carla!
+  tutorial_zulama_shortdescription: Go on a MakeQuest! Modify code to beat our game,
+    then build your own!
+  tutorial_capost_shortdescription: Use code to build a great looking holiday or birthday
+    card.
+  tutorial_marco_shortdescription: An immersive game to guide Marco with a visual
+    programming language.
+  tutorial_codestersflappybike_shortdescription: Create a game with player controls.
+    Keep the bike in the air while dodging the obstacles!
+  tutorial_kanopong_shortdescription: Change the game. Break the rules. Win with code.
+  tutorial_tynkerright_shortdescription: Program a quiz about the Bill of Rights!
+  tutorial_touchdevelop_shortdescription: 'Solve puzzles, create games, and learn
+    coding all on your phone. '
+  tutorial_tynkercc_shortdescription: Build and train your army for battle!
+  tutorial_bamboo_shortdescription: The Bamboo JS activity was created by Codemoji
+    to teach students basic Javascript concepts.
+  tutorial_robojav_shortdescription: Build a small world on your screen for simulated
+    robots and creatures.
+  tutorial_roboba_shortdescription: 'RoboBlockly is designed for beginners to learn
+    Algebra 1 with robots in Blockly. '
+  tutorial_knodsnake_shortdescription: 'Learn to create a Snake game in JavaScript! '
+  tutorial_soccharater_shortdescription: Code your very own pixel character with HTML,
+    CSS, and JavaScript.
+  tutorial_silent_shortdescription: Discover the basic concepts of programming without
+    any word or explanation
+  tutorial_robomesh_shortdescription: Program either a virtual online robot, or a
+    real VEX IQ robot.
+  tutorial_amaze_shortdescription: Build and customize an exciting maze game with
+    with crazy physics obstacles and a grand prize!
+  tutorial_codestersds_shortdescription: Write a story using transition words while
+    learning computer science in this Common Core aligned ELA project.
+  tutorial_knodtext_shortdescription: Learn to make a text adventure game in Python!
+  tutorial_alicegar_shortdescription: 'Tell stories and be creative while learning
+    to code. '
+  tutorial_codesterstransform_shortdescription: Explore, identify, and perform transformations
+    on the coordinate plane in this Common Core aligned Math project.
+  tutorial_flexfrog_shortdescription: A game for learning CSS flexbox
+  tutorial_codemoji_shortdescription: 'Codemoji teachers students basic website design
+    and coding concepts using Emoji''s as the key to keep students engaged and learning
+    real coding concepts. '
+  tutorial_robobii_shortdescription: 'RoboBlockly is designed for beginners to learn
+    coding with robots in Blockly. '
+  tutorial_robobm_shortdescription: 'RoboBlockly is designed for beginners to learn
+    math with robots in Blockly. '
+  tutorial_codingrobots_shortdescription: 'RoboBlockly is designed for beginners to
+    learn coding and math with robots. '
+  tutorial_robob_shortdescription: 'RoboBlockly is designed for beginners to learn
+    robotics in Blockly. '
+  tutorial_coders_shortdescription: Discover bot programming through a starship race
+    game! (age 14+)
+  tutorial_tynkerhw_shortdescription: Solve fun coding puzzles to navigate your Hot
+    Wheels car and win the race!
+  tutorial_tynkermh_shortdescription: Solve fun coding puzzles with the ghouls of
+    Monster High.
+  tutorial_caphoto_shortdescription: Build an app that lets you customize photos with
+    stickers and filters.
+  tutorial_mozillahw_shortdescription: Learners will remix JavaScript code to change
+    the words on a website
+  tutorial_ticklep_shortdescription: With Tickle, a user-friendly coding app, you
+    can easily program Parrot Drone to swim in a number of ways by simply dragging
+    and dropping coding blocks to create a command for it to follow.
+  tutorial_bbot_shortdescription: Teach your students (ages 7 and up) programming
+    in a fun and easy way. No prior programming knowledge or experience needed!
+  tutorial_scratchg_shortdescription: Learn how to program games in Scratch
+  tutorial_sjforest_shortdescription: Use the ScratchJr programming app to make a
+    program in which different animals move in a dark forest setting.
+  tutorial_sjgreet_shortdescription: Use the ScratchJr programming app to make a program
+    in which a kitten and a dog "meet" each other and exchange hellos.
+  tutorial_sjsunset_shortdescription: Use the ScratchJr programming app to make a
+    program in which the sun sets over a city landscape.
+  tutorial_fufafrenz_shortdescription: 'Learn sequence to program a "robot"! '
+  tutorial_bbcgeo_shortdescription: Standards-based lesson plan for levels 6-10.
+  tutorial_chspixel_shortdescription: This offline lesson plan covers the basics of
+    computer graphics.
+  tutorial_hummingbird_shortdescription: Create your own game with a microcontroller,
+    a sensor, and lights!
+  tutorial_recoloring_shortdescription: 'Recoloring the Universe helps show just how
+    integral coding is in the pursuit of learning about our Universe.  '
+  tutorial_bbcchem_shortdescription: 'Standards-based lesson plan for levels K-5. '
+  tutorial_floalgo_shortdescription: 'A lesson plan to get students writing algorithms
+    with educational hip hop. '
+  tutorial_flocond_shortdescription: Teach the coding concept of conditionals with
+    this educational hip-hop video and lesson plan.
+  tutorial_floloops_shortdescription: Teach the coding concept of loops with this
+    educational hip-hop video and lesson plan.
+  tutorial_pgts_shortdescription: Try modeling and simulation using rock/paper/scissors
+  tutorial_ozo_shortdescription: Introduce students to coding by playing the Ozobot
+    Games with the programmable robot Ozobot.
+  tutorial_bbcla_shortdescription: 'Standards-based lesson plan for levels K-5. '
+  tutorial_bbcsci_shortdescription: 'Standards-based lesson plan for levels K-5. '
+  tutorial_tlctour_shortdescription: Devise a tour that gets a tourist from their
+    hotel to all the city sights and back to their hotel.
+  tutorial_codesterstj_shortdescription: 'learn about digital citizenship! Teach others
+    how to be responsible digital citizens! '
+  tutorial_tlclocked_shortdescription: Explore the design of an algorithm to allow
+    someone with locked-in syndrome to communicate.
+  tutorial_baubles_shortdescription: Learn how computers use 1s and 0s to represent
+    information
+  tutorial_bbcart_shortdescription: 'Standards-based lesson plan for levels K-5. '
+  tutorial_tlcknight_shortdescription: Solve a puzzle where you must find a way for
+    a knight to visit every square on a board exactly once.
+  tutorial_fufafit_shortdescription: 'Use functions to shorten the code that will
+    help the fuzzFamily build their strength! '
+  tutorial_ozodance_shortdescription: Help Ozobot learn to dance! Create and program
+    a dance routine for the Ozobot robot.
+  tutorial_codingrobotics_shortdescription: Students will focus on communication as
+    it relates to programming.
+  tutorial_box_shortdescription: Take a coding trip on Box Island with the brave Hiro.
+  tutorial_hopgame_shortdescription: Lead a coding workshop, club, or a hackathon
+    with this 6-lesson guide.
+  tutorial_icontrol_shortdescription: Programming physical systems with iPads and
+    Sphero
+  tutorial_cocomteach_shortdescription: Lead your students to programming glory with
+    CodeCombat's intro curriculum!
+  tutorial_bbcmathii_shortdescription: Standards-based lesson plan for levels K-2.
+  tutorial_bbcphys_shortdescription: Standards-based lesson plan for levels K-5.
+  tutorial_bitsbox_shortdescription: Code five crazy mini-apps with real typed Javascript!
+    Beginners welcome.
+  tutorial_tlcemo_shortdescription: Program a card robot face to show different emotions
+    one after another.
+  tutorial_crd_shortdescription: Learn algorithms with a deck of cards
+  tutorial_bbcbio_shortdescription: 'Standards-based lesson plan for levels K-5. '
+  tutorial_ticklebb8_shortdescription: With Tickle, a user-friendly coding app, you
+    can easily program BB-8 to move in a number of ways by simply dragging and dropping
+    coding blocks to create a command for it to follow.
+  tutorial_grok_shortdescription: Draw flags, create snowflakes or build a robot using
+    Python.
+  tutorial_ijournalist_shortdescription: Use basic HTML/CSS to write an online news
+    report about a fictional robbery at your school
+  tutorial_bbcmusic_shortdescription: Standards-based lesson plan for levels K-5.
+  tutorial_secretcodes_shortdescription: Learn about the role computers have played
+    to help save the world.
+  tutorial_tlchex_shortdescription: Make the flexagon and explore it while at the
+    same time learning about computing and computational thinking and how it can help.
+  tutorial_tickles_shortdescription: Team up with your Sphero for a good run! Move,
+    spin and give it a few rounds of good turns. Just put some code blocks together
+    on Tickle app to run your Sphero as you want it to.
+  tutorial_ozogame_shortdescription: Introduce students to coding by playing the Ozobot
+    Games and creating their own game level with the programmable robot Ozobot.
+  tutorial_vidcodeio_shortdescription: Connect JavaScript functions to both math and
+    real world problems.
+  tutorial_tlcbrain_shortdescription: Explore how the human brain works by creating
+    a computational model of neurones out of students that plays Snap.
+  tutorial_hopquiz_shortdescription: Code a multiple-choice quiz to test a friend's
+    knowledge in any subject!
+  tutorial_unfortunate_shortdescription: Teach Dash and Dot to respond to events that
+    happen around them!
+  tutorial_cha_shortdescription: Learn about some key events in Computer History
+  tutorial_elaseq_shortdescription: Students will learn about sequence, the most foundational
+    programming concept, as it relates to reading and writing.
+  tutorial_bbcmathi_shortdescription: 'Standards-based lesson plan for levels 3-5. '
+  tutorial_tlcpixel_shortdescription: 'Solve simple colour-by-number and logical thinking
+    puzzles and gain a deeper understanding of image representation and compression. '
+  tutorial_introrobo_shortdescription: Students will get to know Dash and Dot while
+    being introduced to the ideas of Robotics and Programming.
+  tutorial_tlcinvis_shortdescription: Do a trick where you magically move a card from
+    one pile to another by palming it invisibly!
+  tutorial_tlcjflap_shortdescription: Create executable finite state machine versions
+    of graphs you have created or used to solve problems.
+  tutorial_procolor_shortdescription: Program the robot Ozobot by using paper and
+    markers - no computer or tablet required!
+  tutorial_spiralsfinch_shortdescription: 'Draw spirals with a robot! '
+  tutorial_ozoi_shortdescription: Learn about how the Ozobot robot works and program
+    Ozobot using paper and markers - no computer or tablet required!
+  tutorial_ticklel_shortdescription: Brick by brick, build up your wildest LEGO imagination.
+    By putting some codes together on Tickle app, you can make your LEGO WeDo do some
+    amazing things.
+  tutorial_spiralsdash_shortdescription: Learn the basics of using variables while
+    using a robot to create art!
+  tutorial_ghdebug_shortdescription: Help students learn about Grace Hopper and why
+    this week is CS EdWeek.
+  tutorial_tlckk_shortdescription: Solve these word puzzles as a way to develop logical
+    thinking and pattern matching skills needed to enjoy both computing and maths,
+    while practicing spelling.
+  tutorial_firstcomp_shortdescription: My First Computer is an introduction to the
+    amazing and complicated machine that is the computer.
+  tutorial_mazefinch_shortdescription: Use the Finch robot to complete a maze!
+  tutorial_tlccc_shortdescription: Solve compression code puzzles, simple puzzles
+    about words that involve decoding compressed messages.
+  tutorial_tlcdoodle_shortdescription: 'Follow simple algorithms to draw pictures
+    reminiscent of nature. '
+  tutorial_tlcpunch_shortdescription: Show how early computers searched for data using
+    a magic trick.
+  tutorial_finchfract_shortdescription: Use recursion to draw fractals with a Finch
+    robot!
+  tutorial_tlcmind_shortdescription: Do a trick where you control the actions of another
+    by the power of your mind!
+  tutorial_tlctelebot_shortdescription: You put together a jigsaw that has 17 robots,
+    but then put it together again and now it only has 16.
+  tutorial_tlcaus_shortdescription: Do a magic trick where your predict a chosen card,
+    introducing both search algorithms and computational thinking.
+  tutorial_tlcmicro_shortdescription: People race different microwave designs to see
+    which is easiest to use to do a simple task. Some are seen to be far more complicated
+    than others.
+  tutorial_imathematician_shortdescription: Use Mathematics (Game Theory) & Computer
+    Science to program a variation of the Prisoner's Dilemma
+  tutorial_tlcmagic_shortdescription: Explore a magic trick based on an intriguing
+    computational property about words.
+  tutorial_scratchmus_shortdescription: Choose musical instruments, add sounds, and
+    press keys to play music.
+  tutorial_scratchanim_shortdescription: Make your name come to life! Animate the
+    letters by coding in Scratch.
+  tutorial_scratchfly_shortdescription: Choose a character and make a flying animation!
+  tutorial_tynkerarc_shortdescription: Create a top-down arcade shooter game.
+  tutorial_grokffpython_shortdescription: Use the programming language Python and
+    instruct a turtle to draw fantastic snowflakes with code! Brrr, is it getting
+    cold in here?
+  tutorial_grokffblock_shortdescription: Build programs using friendly blocks and
+    instruct a turtle to draw fantastic snowflakes with code! Brrr, is it getting
+    cold in here?
+  tutorial_grokeliza_shortdescription: Use the programming language Python to build
+    a friendly chatbot called "Eliza". Can she fool your friends into thinking she's
+    a human?
+  tutorial_tynkercan_shortdescription: Make a 2-player physics game!
+  tutorial_grokflags_shortdescription: Use the programming language Python and instruct
+    a turtle to draw flags from around the world! How many countries do you know?
+  tutorial_robomind_shortdescription: Write code for a virtual robot.
+  tutorial_adventureq_shortdescription: Use programming blocks (physical or in game)
+    to learn programming logics.
+  tutorial_khan-es_shortdescription: Learn to draw in JavaScript
+  tutorial_kpt_shortdescription: Learn to draw in JavaScript
+  tutorial_kpl_shortdescription: Learn to draw in JavaScript
+  tutorial_khe_shortdescription: Learn to draw in JavaScript
+  tutorial_kfr_shortdescription: Learn to draw in JavaScript
+  tutorial_app-inventor_shortdescription: Make your own app. (Android-only)
+  tutorial_blockly_shortdescription: Download a ZIP file to learn offline.
+  tutorial_tynker_shortdescription: Learn to code by solving fun puzzles and build
+    your own games.
+  tutorial_baypt_shortdescription: Code Baymax
+  tutorial_code-combat_shortdescription: Defeat ogres to learn Python or JavaScript
+    in this epic programming game!
+  tutorial_mky_shortdescription: Students program a monkey to catch bananas.
+  tutorial_pirates_shortdescription: Navigate the crystal waters of the southern hemisphere,
+    code your treasure maps and discover the riches that lie on the golden shores.
+    A fun way to learn the basic concepts of coding.
+  tutorial_csfirst_shortdescription: Animate a story about two characters on the ocean.
+    Add your own style!
+  tutorial_loopedy_shortdescription: Make a dance using loops!
+  tutorial_dsw_shortdescription: Learn to program droids, and create your own Star
+    Wars game in a galaxy far, far away.
+  tutorial_dswb_shortdescription: Learn to program droids, and create your own Star
+    Wars game in a galaxy far, far away.
+  tutorial_ssw_shortdescription: Learn to program droids, and create your own Star
+    Wars game in a galaxy far, far away.
+  tutorial_sswb_shortdescription: Learn to program droids, and create your own Star
+    Wars game in a galaxy far, far away.
+  tutorial_kodable-unplugged_shortdescription: A fun unplugged exercise
+  tutorial_scratch_shortdescription: Create your own interactive games, stories, and
+    animations with Scratch!
+  tutorial_bayes_shortdescription: Grandes Heroes
+  tutorial_gumball_shortdescription: Create a Gumball story or make a game with Play
+    Lab!
+  tutorial_hrm_shortdescription: Program little office workers to solve puzzles. Be
+    a good employee! The machines are coming... for your job.
+  tutorial_ice-age_shortdescription: Create an Ice Age story or make a game with Play
+    Lab!
+  tutorial_koapp_shortdescription: A fun iPad game to teach computer programming concepts
+  tutorial_lightbot-intl_shortdescription: A game to teach coding concepts
+  tutorial_rmc_shortdescription: Use blocks of code to take Alex or Steve on an adventure
+    through this Minecraft world.
+  tutorial_smc_shortdescription: Use blocks of code to take Alex or Steve on an adventure
+    through this Minecraft world.
+  tutorial_minecraft-2016_shortdescription: Build a Minecraft game. Create your own
+    versions of chicken, sheep, Creepers, zombies and more.
+  tutorial_thinkersmith-es_shortdescription: Tutorial para un grupo sin computadoras
+  tutorial_pixie_shortdescription: A visual language to learn to code step by step
+    through challenges and games.
+  tutorial_play_shortdescription: Create a story or make a game with Play Lab!
+  tutorial_robomind-nl_shortdescription: Write code for a virtual robot
+  tutorial_spheroi_shortdescription: Introduction to Lightning Lab, The Sphero App
+    for programming Sphero robots.
+  tutorial_spherol_shortdescription: Learn how to control Sphero's lights and get
+    creative with programming.
+  tutorial_spherov_shortdescription: Bring Hot Potato to life with Sphero!
+  tutorial_swb_shortdescription: Learn to program droids, and create your own Star
+    Wars game in a galaxy far, far away.
+  tutorial_build-a-galaxy_shortdescription: Learn to program droids, and create your
+    own Star Wars game in a galaxy far, far away.
+  tutorial_alicesims_shortdescription: 'Tell stories and be creative while learning
+    to code. '
+  tutorial_tchr_shortdescription: Be inspired to design your own Hour of Code event
+    with these lesson plans.
+  tutorial_robogame_shortdescription: The grit, the games, the fun!
+  tutorial_tap_shortdescription: Learn to program by solving fun coding puzzles.
+  tutorial_cintl_shortdescription: Learn to code with Mark Zuckerberg and Angry Birds!
+  tutorial_itchstop_shortdescription: Learn to create your own Stop Frame Animations
+    in Scratch
+  tutorial_tynkerpn_shortdescription: Go for a nature walk with Peep!
+  tutorial_tynkerpd_shortdescription: Make Peep and his friends dance!
+  tutorial_persistence_shortdescription: This lesson teaches that failure is not the
+    end of a journey, but a hint for how to succeed.
+  tutorial_getloopy_shortdescription: In this lesson, students will practice converting
+    sets of actions into a single loop.
+  tutorial_createface_shortdescription: This is an exploration of affective computing,
+    which relates to moods and emotions. The class makes an affective (relating to
+    moods and emotions) robot face out of card, tubes and themselves.
+  tutorial_happymaps_shortdescription: Students create simple algorithms (sets of
+    instructions) to move a character through a maze using a single command.
+  tutorial_moveit_shortdescription: Students create simple algorithms (sets of instructions)
+    to move a character through a maze using a single command.
+  tutorial_bigevent_shortdescription: Students are introduced to the programming concept
+    of "events," which are actions that a computer constantly monitors for.
+  tutorial_gpp_shortdescription: Students write an algorithm (a set of instructions)
+    using a set of predefined commands to direct their classmates to reproduce a drawing.
+  tutorial_foosgame_shortdescription: Design and code your own video game with codeSpark
+    Academy with The Foos.
+  tutorial_solopython_shortdescription: Letter Counter in Python
+  tutorial_kodableint_shortdescription: 'Students will be introduced to programming
+    with the most foundational concept: Sequence.'
+  tutorial_kodableadv_shortdescription: Students will build on foundational programming
+    concepts and learn about higher level, JavaScript code.
+  tutorial_tynkertj_shortdescription: Use Python to save the toxic jungle!
+  tutorial_wolframa_shortdescription: Want to find out how old you are in seconds?
+  tutorial_wolframm_shortdescription: Create music through code! Can you play your
+    favorite melody using Wolfram Language?
+  tutorial_wolframspi_shortdescription: 'Have you ever wondered what the famous number
+    PI would sound like on a musical instrument? '
+  tutorial_wolframsph_shortdescription: How many 3D shapes can you create?
+  tutorial_wolframp_shortdescription: Explore creating amazing polygon shapes!
+  tutorial_wolframn_shortdescription: What is your ninja name?
+  tutorial_soloweb_shortdescription: Create and share a Webpage with your favorite
+    joke!
+  tutorial_khanweb_shortdescription: Learn how to make webpages with HTML tags and
+    CSS, finishing up by making your very own greeting card.
+  tutorial_khandata_shortdescription: Like playing with data? Learn how to manipulate
+    data in a database and make your own custom store
+  tutorial_googlelogo_shortdescription: Bring the Google logo to life using your imagination
+    and a bit of code.
+  tutorial_playtune_shortdescription: Use coding skills to solve musical puzzles and
+    create an Android app
+  tutorial_computeit_shortdescription: This time YOU are the computer! Interpret the
+    program to find the path.
+  tutorial_codesterssj_shortdescription: Create an interactive joke teller that you
+    can share!
+  tutorial_cmchat_shortdescription: Learn Python through coding and creating a chatbot.
+  tutorial_tynkerdb_shortdescription: Train your dragons to hunt for treasure with
+    code!
+  tutorial_cmbuild_shortdescription: Game design courses teach students 14+ game design
+    and creation elements.
+  tutorial_robotrattle_shortdescription: Operate a physically simulated robot, learn
+    to move its joints via angles, and program it to push and grab objects.
+  tutorial_codestersh_shortdescription: Guide your sprite around the stage to create
+    your own geometric art work!
+  tutorial_codehsdigipixel_shortdescription: Code your own digital images!
+  tutorial_ccbinary_shortdescription: Make a Scratch game in which you play the notes
+    of a song as they scroll down the stage.
+  tutorial_codehsturtle_shortdescription: Write programs to make art with Tracy the
+    Turtle!
+  tutorial_grokhd_shortdescription: This activity is designed to introduce branching
+    decisions in programming. Use the Blockly version of Python and its turtle module
+    to draw and colour hydrangea flowers!
+  tutorial_grokem_shortdescription: This activity is designed to give you your first
+    experience programming, and has been specially designed for the Hour of Code.
+    Use the programming language Python to explore emoticons and text manipulation.
+  tutorial_kodmaze_shortdescription: Build your own mazes to solve and share to challenge
+    others!
+  tutorial_codestersa_shortdescription: Design your own fast-paced space adventure
+    game with player controls!
+  tutorial_cmdodo_shortdescription: Teach addition, angle and degree measurement,
+    and multiplication with new characters.
+  tutorial_tynkerspace_shortdescription: Learn to code in space!
+  tutorial_gfbloons_shortdescription: Code your own mini-game and learn the maths
+    in Bloons TD5.
+  tutorial_raspipong_shortdescription: Create a Pong game using a Sense HAT and some
+    Python code.
+  tutorial_codehsvr_shortdescription: Create virtual reality worlds using the A-Frame
+    JavaScript Library!
+  tutorial_codesterstp_shortdescription: Learn about transformations as you guide
+    your shapes around the coordinate plane!
+  tutorial_codestersbb_shortdescription: Program your own pull-and-shoot basketball
+    game!
+  tutorial_gfcrossyroad_shortdescription: Code your own Crossy Road mini-game and
+    learn to think like a computer.
+  tutorial_googleww_shortdescription: Discover your coding superpowers on an adventure
+    with Wonder Woman.
+  tutorial_codehsjsapp_shortdescription: Code your first real app with JavaScript!
+  tutorial_gfmihi_shortdescription: Code your own mini-game and learn how to introduce
+    yourself in Te Reo Maori (the indigenous language of New Zealand)
+  tutorial_hopdropphone_shortdescription: Make "Don't Drop the Phone" on iPad/iPhone
+  tutorial_techfaa_shortdescription: Simulate a visually impressive life-like behavior
+    of group entities
+  tutorial_codehsjsgraph_shortdescription: Make your own graphics and drawing programs!
+  tutorial_thunkable_shortdescription: 1 hour, 10 apps
+  tutorial_hopcrossyroad_shortdescription: Make Crossy Road on iPad/iPhone
+  tutorial_switchglitch_shortdescription: Program cute robots and help them save the
+    galaxy!
+  tutorial_codecar_shortdescription: Use typed code to control the lights and buttons
+    of a simulated Code Car!
+  tutorial_codesterscp_shortdescription: Learn about the coordinate plane by sending
+    your sprite to pick up all its missing winter clothes!
+  tutorial_grokpetblock_shortdescription: This activity is designed to introduce you
+    to embedded programming using friendly blocks, and has been specially designed
+    for the Hour of Code. Use the blocks and a micro:bit to make a pet that you can
+    feed and play with. No BBC micro:bit? No problem! This course includes a full
+    micro:bit simulator, so you'll be able to do everything you'd do on a real micro:bit!
+  tutorial_techbim_shortdescription: Learn how to manipulate images without the use
+    of external libraries
+  tutorial_techfpp_shortdescription: Functional Programming made easy with Python!
+  tutorial_codesterscr_shortdescription: In this activity, you'll design a cheer routine
+    that your sprite will perform!
+  tutorial_grokdisease_shortdescription: This activity is designed to give you your
+    first experience programming, and has been specially designed for the Hour of
+    Code. Use the programming language Python to model a disease outbreak. Can you
+    solve the curious case of the glowing nose?
+  tutorial_techec_shortdescription: Confused about Closures in JS? Don't worry you're
+    not alone!
+  tutorial_rgbegin_shortdescription: At RoboGarden, we believe in giving learners
+    the opportunity to take an active role in their education
+  tutorial_myradream_shortdescription: Use code blocks to help Myra on a journey to
+    get her dream back.
+  tutorial_thinkfun_shortdescription: Enjoy this fun CS activity that teaches Boolean
+    logic concepts.
+  tutorial_hopfireworks_shortdescription: Make a Fireworks App on iPad/iPhone
+  tutorial_grokspace_shortdescription: This activity is designed to give you your
+    first experience programming, and has been specially designed for the Hour of
+    Code. Use the visual programming language Blockly to investigate space and reach
+    for the stars.
+  tutorial_codehspython_shortdescription: Code programs in Python!
+  tutorial_codehsjava_shortdescription: Code programs in Java!
+  tutorial_techioda_shortdescription: Use Dijkstra's Algorithm to calculate the shortest
+    path in a graph
+  tutorial_grokmonster_shortdescription: Get kids into coding with this friendly course
+    specially designed for the Hour of Code! Use drag-and-drop blocks to write your
+    own programs, learn about sequence and ordering, and create fun monster characters!
+  tutorial_techmjs_shortdescription: Modern Javascript features that will improve
+    your JS code
+  tutorial_techga_shortdescription: Introduction to Genetic Algorithms
+  tutorial_techioan_shortdescription: Stop being stuck in Java because of Null patterns!
+  tutorial_techiogsr_shortdescription: New to Rust? Everything you need to get started
+    is here!
+  tutorial_groktunnel_shortdescription: This activity is designed to give you your
+    first experience programming, and has been specially designed for the Hour of
+    Code. Use the programming language Python to create a simple game (or MUD). Can
+    you find your way through the dark tunnel?
+  tutorial_stemcod_shortdescription: Explore the Physics of Video Games! Learn to
+    code classic games!
+  tutorial_techikb_shortdescription: Basics Kotlin features in a nutshell
+  tutorial_kanostreet_shortdescription: Make beautiful, unique artwork with Kano's
+    Street Art coding challenges
+  tutorial_codemojijs_shortdescription: Codemoji designed Beginning Javascript to
+    get students typing real javascript commands that will in turn animate the different
+    characters.
+  tutorial_techapf_shortdescription: 7 useful tricks to master Python like a Pro!
+  tutorial_techfpjs_shortdescription: Functional programming made easy with Javascript!
+  tutorial_techlinq_shortdescription: A useful introduction to using the LINQ library
+    in C#
+  tutorial_gpbcatapult_shortdescription: Make your own game like Angry Birds.
+  tutorial_quorumastro_shortdescription: Learn about coding and astronomy in this
+    accessible online tutorial.
+  tutorial_alicewonder_shortdescription: Guide Alice in wonderland using JavaScript.
+  tutorial_rginter_shortdescription: At RoboGarden, we believe in giving learners
+    the opportunity to take an active role in their education.
+  tutorial_cssgrid_shortdescription: A game for learning CSS Grid.
+  tutorial_jshero_shortdescription: JS Hero provides you with an introduction to programming
+    by means of JavaScript. It provides general programming concepts such as variables,
+    conditions, loops, functions and a lot more. These concepts form the basis of
+    many programming languages.
+  tutorial_codemojipy_shortdescription: Python Lab is an IOS based activity that teaches
+    basic python.
+  tutorial_nclabdrone_shortdescription: Build a drone frame with NCLab's 3D Modeling
+    app. 3D print it and make a real flying drone!
+  tutorial_gpbcircle_shortdescription: Make beautiful colors interactively.
+  tutorial_gpbpaint_shortdescription: Create and customize a drawing application.
+  tutorial_cocomarcade_shortdescription: Build your own arcade survival game and challenge
+    your friends!
+  tutorial_beetik_shortdescription: Use code to hack the music of composer Franz Liszt.
+  tutorial_codedj_shortdescription: Learn Javascript basics and start composing your
+    own beats with Code DJ
+  tutorial_rgadvan_shortdescription: At RoboGarden, we believe in giving learners
+    the opportunity to take an active role in their education.
+  tutorial_codehsrn_shortdescription: Make real apps using React Native!
+  tutorial_codehswd_shortdescription: Build a website!
+  tutorial_turtlerobot_shortdescription: A programming game meant for kids 2 - 6.
+    Helps teach function calling.
+  tutorial_ozoevo_shortdescription: Use the force field of Evo by Ozobot to play,
+    then create awesome games
+  tutorial_ozoexped_shortdescription: Color code your way through space!
+  tutorial_ozojourney_shortdescription: Program your Ozobot robot to circumnavigate
+    the world.
+  tutorial_ozocodes_shortdescription: Pre-readers place Ozocodes logically on a drawing
+    of their name so Ozobot robots can walk from left to right.
+  tutorial_ozoeclipse_shortdescription: Model orbiting bodies, eclipses and lunar
+    phases with Ozobot robots.
+  tutorial_ozosimulator_shortdescription: Learn about programming languages using
+    a marker and paper.
+  tutorial_ozoalgorithm_shortdescription: Write an algorithm for Ozobot robots to
+    show and answer multiplication problems.
+  tutorial_ozotimer_shortdescription: Ozobot programmers are challenged to create
+    a 10-second timer.
+  tutorial_ozohabits_shortdescription: Young Ozobot programmers model nature with
+    their markers and a rabbit hill map.
+  tutorial_ozoprogram_shortdescription: Students without robots can discover how to
+    program them with Ozobot Games.
+  tutorial_ozopair_shortdescription: Students learn about Pair Programming roles,
+    then work together to program Bit or Evo by Ozobot to complete a maze.
+  tutorial_codesnoopy_shortdescription: Code to win in Snoopy Snow Brawl - who will
+    be the last scout standing?
+  tutorial_applabintro_shortdescription: Create your own app in JavaScript using blocks
+    or text.
+  tutorial_cslartist_shortdescription: A fun-filled coding + art challenge for students
+    K-4
+  tutorial_cslscratchjr_shortdescription: 'Read Aloud Coding Story for Pre-Readers
+    with Worksheets and a Follow-up Coding Project '
+  tutorial_floevents_shortdescription: Watch a hip-hop video about events. Then write
+    and act out your own!
+  tutorial_florobot_shortdescription: Watch a hip-hop video about robots, read about
+    them and design your own!
+  tutorial_isavesanta_shortdescription: It's Christmas Eve and Santa is off on his
+    travels around the world delivering presents when catastrophe strikes! He's fallen
+    out of his Sleigh! Create algorithms and program Santa to get back into his sleigh
+    in any way you know how.
+  tutorial_iorder_shortdescription: Summer time and the weather is sweet. Makes you
+    want to make a nice cool treat. Create algorithms and program an ice-cream simulation/game
+    using Scratch 2.0. Includes lesson plan, pupil support materials, and pre-written
+    program templates.
+  tutorial_ianimate_shortdescription: Create an animated GIF for the festive season
+    using animation software. Add artwork, backgrounds and objects and make them come
+    to life!
+  tutorial_iloveada_shortdescription: Teach computing with history. This teacher-led
+    activity involves conducting online research about Ada Lovelace, a female pioneer
+    in STEM and the world's first computer programmer!
+  tutorial_kodflash_shortdescription: If there is lightning, then thunder will follow!
+  tutorial_kodchoose_shortdescription: Write a Choose Your Own Adventure story using
+    "If statements"!
+  tutorial_kodpizzapre_shortdescription: Help Dominic's Pizza develop an algorithm
+    for their new mobile app!
+  tutorial_kodpizza_shortdescription: Help Dominic's Pizza develop an algorithm for
+    their new mobile app!
+  tutorial_kodwomen_shortdescription: 'Technology: is it for all or just some? Explore
+    inequalities in tech.'
+  tutorial_tfunplug_shortdescription: Enjoy this fun, unplugged CS activity that teaches
+    Boolean logic concepts.
+  tutorial_lbvariables_shortdescription: Having fun is not a variable with this littleBits
+    Code Kit tutorial.
+  tutorial_lbfunctions_shortdescription: The fun don't stop when you combine function-based
+    code blocks & littleBits.
+  tutorial_lblogic_shortdescription: The choice is yours with conditional logic &
+    littleBits.
+  tutorial_lbworld_shortdescription: You can change the world with code, one game
+    at a time.
+  tutorial_lbloops_shortdescription: From special effects to secret messages, loops
+    are your secret game weapon.
+  tutorial_lbtug_shortdescription: Make the classic Tug of War epic with functions
+    & littleBits.
+  tutorial_lbpotato_shortdescription: Build & code your own game of Hot Potato. Can
+    you stand the heat?
+  tutorial_lbguitar_shortdescription: Build it. Code it. Rock it!
+  tutorial_lbio_shortdescription: Let's make controllers with littleBits and code!
+  tutorial_wonpuppy_shortdescription: Program Dash the robot to tackle 3 coding challenges
+    while performing different puppy tricks!
+  tutorial_woncue_shortdescription: Program the CUE robot through fun challenges and
+    demos that will show you how to code using blocks, JavaScript, or state machines!
+  tutorial_wonzoo_shortdescription: Program Dot the robot to tackle 3 coding challenges
+    at the Petting Zoo!
+  tutorial_wontrip_shortdescription: Program Dash the robot to tackle 3 coding challenges
+    while preparing for a road trip!
+  tutorial_woncollect_shortdescription: Use the Wonder Workshop Blockly app and Dash
+    the robot to tackle 3 coding challenges!
+  tutorial_wonsecret_shortdescription: Let's use the Wonder Workshop Cue app with
+    Cue the robot to make a secret message system.
+  tutorial_hsscience_shortdescription: Make interactive science models on your iPad/iPhone!
+  tutorial_popculture_shortdescription: Vote on Pop Culture items then analyze data
+    to see what is trendy.
+  tutorial_legorobust_shortdescription: Investigating what characteristics of a building
+    would help make it resistant to an earthquake, using an earthquake simulator constructed
+    from LEGO bricks.
+  tutorial_legoplants_shortdescription: Model the relationship between a pollinator
+    and flower during the reproduction phase.
+  tutorial_legopark_shortdescription: Design cars that can park themselves safely
+    without driver intervention.
+  tutorial_legodetect_shortdescription: Design ways to avoid accidents between vehicles
+    and objects in the road.
+  tutorial_legolight_shortdescription: Design car features that will improve nighttime
+    driving safety.
+  tutorial_alexa_shortdescription: Alexa is the voice service that powers Amazon Echo.
+    In this tutorial, you will create fact skills unique to your school for this lab.
+  tutorial_grokpetmicro_shortdescription: Use the MicroPython programming language
+    to make a pet that you can feed and play with.
+  tutorial_pirateplunder_shortdescription: Use the MicroPython programming language
+    to make a pet that you can feed and play with.
+  tutorial_cadj_shortdescription: Use the MicroPython programming language to make
+    a pet that you can feed and play with.
+  tutorial_cacrazy_shortdescription: Use the MicroPython programming language to make
+    a pet that you can feed and play with.
+  tutorial_cajump_shortdescription: Use the MicroPython programming language to make
+    a pet that you can feed and play with.
+  tutorial_carest_shortdescription: Use the MicroPython programming language to make
+    a pet that you can feed and play with.
+  tutorial_accai_shortdescription: Teach an Artificial Intelligence robot to explore
+    a new planet!
+  tutorial_vceclipse_shortdescription: Code a solar eclipse simulation with JavaScript!
+  tutorial_pmzero_shortdescription: Create and program a 3D Pac-Man Maze World
+  tutorial_hsela_shortdescription: 'Telling stories: ELA + coding'
+  tutorial_ticklear_shortdescription: Anyone can now code virtual and AR characters
+    and program real devices to interact with them – seamlessly blending imagination
+    and reality into a single experience!
+  tutorial_bcrobot_shortdescription: With only two blocks, students can design, create,
+    and think in 3D! They can build their own robot, while learning underlying math
+    and computational thinking concepts.
+  tutorial_bcsnow_shortdescription: Students will use BlocksCAD to think, design,
+    and create in 3D!
+  tutorial_ifly_shortdescription: It's Christmas Eve and Santa's sleigh has developed
+    a fault! Luckily one of his trusty elves has secretly been working on developing
+    a sleigh drone. It's no Santa's sleigh but it works and is ready save Christmas
+    day!
+  tutorial_idowedo_shortdescription: Design and build a robotic vehicle then program
+    it to transport mini figures.
+  tutorial_diggindwarf_shortdescription: Dwarfs need your help to navigate, dig, and
+    collect gems using JavaScript.
+  tutorial_spheroit_shortdescription: Learn about if/then, else conditions while building
+    your very own animal sound game we like to call "Animal Toss!"
+  tutorial_gameofcodes_shortdescription: Build your awesome Dragon game and export
+    it as a standalone app.
+  tutorial_blocklygames_shortdescription: Blockly Games is a series of educational
+    games that teach programming.
+  tutorial_spherohello_shortdescription: Let's go beyond blocks and learn to WRITE
+    code. Say hello to the world of JavaScript.
+  tutorial_spheroarcade_shortdescription: Learn to code classic home and arcade games
+    with Sphero and Apple's Swift Playgrounds.
+  tutorial_bcpy1_shortdescription: Build your virtual 3D world with Python.
+  tutorial_bcpy2_shortdescription: Build your own world with Python.
+  tutorial_bcjs1_shortdescription: Build your own world with JavaScript.
+  tutorial_bcjs2_shortdescription: Build your world in JavaScript.
+  tutorial_3dbearmars_shortdescription: The Mars Pioneers is a project-based learning
+    module that teaches facts about Mars and the crucial conditions for human beings
+    to survive there. The students will build a colony using Augmented Reality and
+    3D-print the colony facilities.
+  tutorial_bitsboxyak_shortdescription: Type modified JavaScript code to make a greeting
+    card that you can email to friends and family. Yak Attack! is a completely open-ended
+    activity that introduces variables, motion commands, loop functions, and more.
+  tutorial_blockscadbargraphs_shortdescription: 'Students will write code that lets
+    them quickly customize and analyze their own bar graphs. '
+  tutorial_blockscadbirdhouses_shortdescription: 'Students will run a birdhouse-building
+    company, converting units, calculating dimensions, and using variables to scale
+    their products. '
+  tutorial_blockscadclock_shortdescription: 'Students will program a 3D model of an
+    analog clock that can be set to show any time. '
+  tutorial_blockscaddinner_shortdescription: Students will write a program using variables
+    and coordinates to help a robot set their dinner table for them!
+  tutorial_blockscadicecream_shortdescription: Students will program an ice cream
+    machine to create 3D ice cream cones with different numbers and sizes of ice cream
+    scoops.
+  tutorial_blockscadpizza_shortdescription: Students will program a module to create
+    a 3D pizza, calculating circumferences and areas and using loops along the way.
+  tutorial_blockscadsugar_shortdescription: 'Students will use a programmed sugar-cube
+    generator to explore volume and variables. '
+  tutorial_bsgridlight_shortdescription: Choose a Bot friend to help prepare for the
+    Lighthouse Festival. Code your Bot to stop those pesky rogue bots and save the
+    day!
+  tutorial_bpartscratch_shortdescription: 'Creative Coding - developed with Scratch
+    and Vidcode - pairs block- and text-based projects with hundreds of cross-curricular
+    topics. '
+  tutorial_bpartvid_shortdescription: 'Creative Coding - developed with Scratch and
+    Vidcode - pairs block- and text-based projects with hundreds of cross-curricular
+    topics. '
+  tutorial_bpenglishscratch_shortdescription: 'Creative Coding - developed with Scratch
+    and Vidcode - pairs block- and text-based projects with hundreds of cross-curricular
+    topics. '
+  tutorial_bpenglishvid_shortdescription: 'Creative Coding - developed with Scratch
+    and Vidcode - pairs block- and text-based projects with hundreds of cross-curricular
+    topics. '
+  tutorial_bphealthscratch_shortdescription: 'Creative Coding - developed with Scratch
+    and Vidcode - pairs block- and text-based projects with hundreds of cross-curricular
+    topics. '
+  tutorial_bphealthvid_shortdescription: 'Creative Coding - developed with Scratch
+    and Vidcode - pairs block- and text-based projects with hundreds of cross-curricular
+    topics. '
+  tutorial_bpmathscratch_shortdescription: 'Creative Coding - developed with Scratch
+    and Vidcode - pairs block- and text-based projects with hundreds of cross-curricular
+    topics. '
+  tutorial_bpmathvid_shortdescription: 'Creative Coding - developed with Scratch and
+    Vidcode - pairs block- and text-based projects with hundreds of cross-curricular
+    topics. '
+  tutorial_bpmlkscratch_shortdescription: 'Creative Coding - developed with Scratch
+    and Vidcode - pairs block- and text-based projects with hundreds of cross-curricular
+    topics. '
+  tutorial_bpmlkvid_shortdescription: 'Creative Coding - developed with Scratch and
+    Vidcode - pairs block- and text-based projects with hundreds of cross-curricular
+    topics. '
+  tutorial_bpsafetyscratch_shortdescription: 'Creative Coding - developed with Scratch
+    and Vidcode - pairs block- and text-based projects with hundreds of cross-curricular
+    topics. '
+  tutorial_bpsafetyvid_shortdescription: 'Creative Coding - developed with Scratch
+    and Vidcode - pairs block- and text-based projects with hundreds of cross-curricular
+    topics. '
+  tutorial_bpsciencescratch_shortdescription: 'Creative Coding - developed with Scratch
+    and Vidcode - pairs block- and text-based projects with hundreds of cross-curricular
+    topics. '
+  tutorial_bpsciencevid_shortdescription: 'Creative Coding - developed with Scratch
+    and Vidcode - pairs block- and text-based projects with hundreds of cross-curricular
+    topics. '
+  tutorial_bptechscratch_shortdescription: 'Creative Coding - developed with Scratch
+    and Vidcode - pairs block- and text-based projects with hundreds of cross-curricular
+    topics. '
+  tutorial_bptechvid_shortdescription: 'Creative Coding - developed with Scratch and
+    Vidcode - pairs block- and text-based projects with hundreds of cross-curricular
+    topics. '
+  tutorial_caflags_shortdescription: Learn some basic programming concepts with blockly.
+    Develop your computational thinking by using simple shapes, colors and coordinates
+    to draw the flags of the world.
+  tutorial_matariki_shortdescription: 'Maia and Charlie are from New Zealand.  Maia''s
+    family are getting ready to celebrate Matariki: the Māori new year.  She''s invited
+    her friend Charlie to come and stay at her family''s marae (traditional meeting
+    house).'
+  tutorial_carestaurant_shortdescription: Charlie and Tilley have decided that if
+    they program Ross properly he will be able to help do some painting to make Food
+    Avengers more attractive.
+  tutorial_casea_shortdescription: Alex and Lonnie create fancy fish and super sea
+    creatures with blocks. Help them sort the sequences into order and debug by spotting
+    and fixing the mistakes.
+  tutorial_cashield_shortdescription: It's the summer holidays and Alex, her family,
+    and Lonnie are going on holiday to Finland. Alex's older brother Reuben is creating
+    an app about shield blazonry and shows Alex and Lonnie how to use it.
+  tutorial_ccwslimer_shortdescription: Learn how to program your own shareable game
+    with multiple levels and challenges!
+  tutorial_codinggalaxy_shortdescription: For your first mission on Adventure Planet,
+    your duty is to solve coding puzzles to save the beautiful planet.
+  tutorial_boatrace_shortdescription: Learn how to make a boat racing game. The player
+    uses the mouse to navigate a boat to a desert island without bumping into obstacles.
+  tutorial_ccplay_shortdescription: Code and play a series of game levels while learning
+    important computer science concepts. On the final level, show off your creativity
+    and skills to code your own game from scratch!
+  tutorial_grinch_shortdescription: 'Learn to program drones and a high tech sleigh
+    with coding magic to capture presents and navigate down the mountain to return
+    Christmas to Whoville. '
+  tutorial_codehsart_shortdescription: Memes! Memes! Memes! Students explore the intersection
+    of coding and art by building a computer program that allows them to create custom
+    memes to share with friends.
+  tutorial_codehsbitcoin_shortdescription: In this Hour of Code activity, students
+    are introduced to the Bitcoin blockchain ledger and some Bitcoin statistics.
+  tutorial_codehsblockchain_shortdescription: Students learn about the foundations
+    of cryptocurrencies by exploring cryptography, hashing, and blockchain technology!
+  tutorial_codehscipher_shortdescription: 'In this Hour of Code activity, students
+    are introduced to cryptography by using the classic Caesar cipher to decrypt and
+    encrypt some messages, and also discover the cipher''s flaw and how to improve
+    upon it. '
+  tutorial_codehscollision_shortdescription: Students will explore how simulations
+    are used in research. They will study how mass and speed affect elastic collisions
+    by using conservation of momentum and conservation of kinetic energy equations/
+  tutorial_codehsmath_shortdescription: 'Students are introduced to Tracy the Turtle
+    and learn how to code different mathematical models in Python! No coding experience
+    is necessary, but students should have completed Algebra I or higher. '
+  tutorial_codehsmusic_shortdescription: Students explore how coding is used in music
+    creation by building their own dynamic eight-count beats and patterns with JavaScript
+    blocks!
+  tutorial_codehssports_shortdescription: Students learn about how coding is used
+    in sports and game design by building an original sports video game that can be
+    shared with their friends immediately!
+  tutorial_codemojipizza_shortdescription: This course is designed to teach students
+    the fundamentals of JavaScript objects. Students will learn the basic types of
+    data that can be stored in variables.
+  tutorial_moonlander_shortdescription: Moon Lander is a Game Builder course with
+    17 exercises that guides students on how to build their own physics-based game.
+  tutorial_sushicards_shortdescription: Make a game where you move a shark around
+    to try and catch fish.
+  tutorial_codesparkcreate_shortdescription: Ever wanted to design and code your own
+    video game? Choose from two game kits that guide you through creating and coding
+    a Mario-style video game using codeSpark Academy's no words interface. Beginner
+    coders and pre-readers welcome!
+  tutorial_hardvsoft_shortdescription: Through an illustrated children's story and
+    worksheets, your students will learn the differences between hardware and software.
+  tutorial_codestersecard_shortdescription: 'Build up your programming skills as you
+    learn how to create an electronic greeting card that you can share with your teacher,
+    family, or friends! '
+  tutorial_codesterslogo_shortdescription: Use code to get creative and design your
+    own company logo! You'll learn coding basics in the programming language, Python.
+    After you work through the tutorial, you'll have all the skills you need to create
+    the logo for your personal brand!
+  tutorial_codesterstshirt_shortdescription: 'Learn basic programming skills and practice
+    moving around the coordinate plane as you create your own monogrammed t-shirt
+    design! '
+  tutorial_codewards_shortdescription: Join an exciting mission to save the underwater
+    city. Experience the work of a rescue engineer fixing damaged city systems with
+    commands and algorithms. Overcome various challenges to proveyour skills, intelligence
+    and courage!
+  tutorial_olympics_shortdescription: 'Together with Elsie get prepared for Robot
+    Olympics! Along with programming concepts learn how to drive, collect details
+    and create tools, build and test your mighty robot. '
+  tutorial_codinismhero_shortdescription: Learn the basics of programming through
+    fun examples, and build a game while learning!
+  tutorial_discovery_shortdescription: Two characters meet in a world, and discover
+    a surprising object. What happens next? With Scratch and CS First, anyone can
+    create their own unique story with code.
+  tutorial_csfirstname_shortdescription: Pick a name and bring the letters of the
+    word to life using code. Choose a nickname, a pet's name, an animal, a sport,
+    a place or a hobby.
+  tutorial_edisonmove_shortdescription: Introduce text-based programming and the key
+    computational concept of sequence to your students using Edison robots and EdPy,
+    a text-based programming language based on Python.
+  tutorial_edisonspider_shortdescription: Introduce the key computational concepts
+    of variables and data, two of the most fundamental parts of general-purpose programming
+    languages, using Edison robots and the Scratch-based programming language EdScratch.
+  tutorial_edisonspotlight_shortdescription: Introduce Edison robots to your students,
+    helping them begin to explore what a robot is and how it can sense, and react,
+    to the world.
+  tutorial_firiapython_shortdescription: Get your micro:bit ready, and level-up to
+    Python coding! CodeSpace will guide you step-by-step from your very first line
+    of Python to coding an interactive program with buttons and LEDs.
+  tutorial_gamefrootsquid_shortdescription: Colossal squid are the largest invertebrates
+    in the world. In this coding game for beginners you'll learn the basics of coding
+    and create a game that explores the squid's life under the ocean.
+  tutorial_duckpiano_shortdescription: In this project you'll make keys on your computer
+    play quack sounds at different pitches, like a piano that sounds like a duck.
+  tutorial_gpsound_shortdescription: In this project you'll write a program to record
+    sound from your computer microphone, play it back, and draw a picture of the recorded
+    sound. You can then process your recording to add effects such as pitch-shift,
+    reverse, or echo.
+  tutorial_groklearningpython_shortdescription: Develop your programming skills and
+    build your own animal classifier! In this course you'll use the programming language
+    Python to classify animals based on their characteristics.
+  tutorial_htmltimetravel_shortdescription: Take an adventurous travel through time
+    and conquer deep space while learning how to move, rotate and transform objects
+    using the basics of animation in CSS.
+  tutorial_hp_flappy_shortdescription: Learn logical thinking and programming concept
+    by creating your own Flappy Birds style game on hyperPad.
+  tutorial_appytappin_shortdescription: This teacher-led activity, adapted for the
+    Hour of Code, introduces children to using a text-based programming language to
+    develop a mobile games app.
+  tutorial_icipher_shortdescription: This teacher led activity, adapted for the Hour
+    of Code teaches children about communicating securely. The children learn that
+    messages throughout time have been encrypted and decrypted using ciphers.
+  tutorial_iguess_shortdescription: Introducing Quick Response codes to children aged
+    3-5. Use tablets to scan QR codes and guess the mini-beast from a given habitat.
+  tutorial_imake_shortdescription: This unplugged teacher-led activity, for children
+    aged 3-5, uses classic nursery rhymes to introduce the concept of algorithms,
+    sequence and repetition.
+  tutorial_imorse_shortdescription: Explore cryptography with Morse Code and Sphero.
+    Learn that physical systems can be programmed and write code for Sphero to communicate.
+  tutorial_kanohp_shortdescription: Learn to code and make magic on screen with creative
+    challenges. Make feathers fly and fire flow, compose music, and more.
+  tutorial_khanwebpages_shortdescription: Learn how to make webpages with HTML tags
+    and CSS, and finish up by making your very own greeting card to share with friends
+    or family.
+  tutorial_kibobowl_shortdescription: Crash! How far does KIBO have to move to get
+    from the start of the bowling lane to the pins? You can create a single straight
+    lane or a more complicated path.
+  tutorial_kibodance_shortdescription: Let's have a KIBO Robot dance party! Set up
+    a music player to play a favorite classroom song, or a song connected to a world
+    culture you're exploring.
+  tutorial_buildcharacters_shortdescription: The most popular pre-reader app now includes
+    a digital Maker Space! Make levels, design games, or build characters. Choose
+    your activity and start creating with Kodable!  Featuring JavaScript for upper
+    elementary.
+  tutorial_designgames_shortdescription: The most popular pre-reader app now includes
+    a digital Maker Space! Make levels, design games, or build characters. Choose
+    your activity and start creating with Kodable!  Featuring JavaScript for upper
+    elementary.
+  tutorial_makelevels_shortdescription: The most popular pre-reader app now includes
+    a digital Maker Space! Make levels, design games, or build characters. Choose
+    your activity and start creating with Kodable!  Featuring JavaScript for upper
+    elementary.
+  tutorial_wizard_shortdescription: Journey into the world of Code Magic as a Code
+    Wizard. Learn to create and cast spells to customize your castle.
+  tutorial_mbscratchcards_shortdescription: Connect the physical world of micro:bit
+    with the virtual world of Scratch.
+  tutorial_mbswiftplaygrounds_shortdescription: Use the micro:bit with an iPad to
+    learn Swift.
+  tutorial_mbbuttons_shortdescription: In this introductory project, you'll make pictures
+    or animations appear on the micro:bit display when buttons are pressed.
+  tutorial_meteor_shortdescription: In this project, you'll create a Falling Meteors
+    game for the BBC micro:bit. Using the buttons, the player will move a shield to
+    catch falling meteors and save the Earth.
+  tutorial_ballbounce_shortdescription: Learn to make a mobile app where the user
+    flings a ball across the screen and it bounces off the edges.
+  tutorial_mitcodi_shortdescription: Learn to make your own interactive mobile app.
+    Press the bee and hear it buzz!
+  tutorial_mitdoodle_shortdescription: Make a mobile app where you can draw pictures
+    on the screen!
+  tutorial_talktome_shortdescription: Learn to make a mobile app that makes your phone
+    talk to you!
+  tutorial_mobilecspmap_shortdescription: Use App Inventor to create a Map Tour of
+    landmarks in your town, state, or anywhere in the world.
+  tutorial_ozorandom_shortdescription: 'Learn how computers create random numbers
+    and use them, then use a random movement program to help seed ideas for a story. '
+  tutorial_ozotroll_shortdescription: 'Learn the difference between Internet trolls
+    and fairy tale trolls, then teach Evo how to be a good troll that protects you. '
+  tutorial_peblioart_shortdescription: 'Learn to draw and animate shapes with code
+    to create interactive artwork inspired by artists. '
+  tutorial_astropi_shortdescription: Code a message and check the ambient air temperature
+    on board the ISS using an online simulator of the Astro Pi computer's Sense HAT.
+  tutorial_rgart_shortdescription: RoboGarden STEAM Activities has fused code practicing
+    with STEAM learning and gamified missions in multiple activities.
+  tutorial_rgengineer_shortdescription: RoboGarden STEAM Activities has fused code
+    practicing with STEAM learning and gamified missions in multiple activities.
+  tutorial_rgmath_shortdescription: RoboGarden STEAM Activities has fused code practicing
+    with STEAM learning and gamified missions in multiple activities.
+  tutorial_rgscience_shortdescription: RoboGarden STEAM Activities has fused code
+    practicing with STEAM learning and gamified missions in multiple activities.
+  tutorial_rgtech_shortdescription: RoboGarden STEAM Activities has fused code practicing
+    with STEAM learning and gamified missions in multiple activities.
+  tutorial_robotmagic3d_shortdescription: Use code to make 3D models and letters come
+    alive with fun. At the end you can download an animated sticker of your creation
+    and share it with friends.
+  tutorial_robotmagicflappy_shortdescription: Use your imagination to create a 3D
+    Flappy Bird game. Use code to make 3D models come alive with fun. At the end you
+    can share your creation with friends and challenge them to a high score.
+  tutorial_scratchadventure_shortdescription: Send your favorite Cartoon Network characters
+    on a quest, from the farthest reaches of the universe, to the edge of Craig's
+    creek. Unlock secret treasures and discover new characters while creating an adventure
+    game.
+  tutorial_scratchtalk_shortdescription: Create a rapping robot or an interactive
+    animation that talks. This project will show you how to create talking animations
+    that spin, zoom and change colors.
+  tutorial_scratchjrstory_shortdescription: Through this activity and continued time
+    with ScratchJr, students will have the opportunity to think creatively, improve
+    their storytelling and collaborate with peers.
+  tutorial_scratchjrtwinkle_shortdescription: Through this activity, students will
+    have the opportunity to think creatively, become storytellers, and improve upon
+    mathematical reasoning and sequencing skills.
+  tutorial_spherocomm_shortdescription: Learn about miscommunication in both a community
+    and in a computer program. Use this knowledge to resolve any miscommunication,
+    or bugs, in a program in an effort to help BOLT find its way home.
+  tutorial_spherocommunity_shortdescription: Design a simple path that represents
+    a common route that you travel everyday. You will create two programs, a drawn
+    path and a block-based program path through your community route.
+  tutorial_spherofunctions_shortdescription: Learn how to use and invoke functions
+    to turn Sphero into a calculator.
+  tutorial_spheroinfrared_shortdescription: Become an epidemiologist in order to stop
+    the spread of a rare robot infection that is plaguing a community of BOLT robots.
+  tutorial_spherolightsensor_shortdescription: Learn how to create a program that
+    uses the ambient light sensor to measure lux values and chase BOLT.
+  tutorial_spheromansion_shortdescription: Keeping a bunch of dinosaurs at your house
+    shouldn't be an issue, right? As you would imagine, this doesn't to end well.
+    You are trapped in the mansion's library and must program your way out.
+  tutorial_roadblocks_shortdescription: As a continuation of Your Community, you will
+    modify your blocks program as you and your partner encounter different roadblocks
+    along the route.
+  tutorial_spherotext2_shortdescription: Learn your first conditional by building
+    a fun game where you will be throwing Sphero and guessing animal sounds. This
+    is a great activity after you complete Text 1.
+  tutorial_spherotext3_shortdescription: Learn to change Sphero's main LEDs based
+    on the gyroscope's spin rate. You will also learn about normalization and absolute
+    value. This is a great activity after you complete Text 1 and 2.
+  tutorial_spherotext4_shortdescription: Use variables to build a hot potato game
+    powered by Sphero. This is a great activity after you complete Text 2 or 3.
+  tutorial_spheroraptor_shortdescription: Create a fortified pen to keep the Spheroraptors
+    at bay, while also writing the code to the Spheroraptors escape. From loops, to
+    conditionals, to operators and even comparators, you will need as much coding
+    know-how as you can muster.
+  tutorial_stempiday_shortdescription: In this coding activity you will randomly generate
+    points similar to a very bad player shooting darts at a dart board.
+  tutorial_stemplanetoids_shortdescription: In this activity you will fix a broken
+    asteroids game where the ship only moves in a straight line. Then you will add
+    gravity to the game and try to land the ship on the moon!
+  tutorial_stempong_shortdescription: In this activity you will fix a broken version
+    of the Pong game so that objects bounce like they should. Then you will add gravity
+    to create a Bonk.io clone.
+  tutorial_algobot_shortdescription: Players command AlgoBot, a smart little service
+    droid, and learn to use a visual programming language to help him contain the
+    crisis!
+  tutorial_thunkableapps_shortdescription: 'Learn how to build your own apps with
+    blocks-based coding! '
+  tutorial_toxicodedot_shortdescription: Select a card from your deck and interpret
+    its code in order to progress through the world. Use your intuitive abilities
+    to guess the rules and learn from your own mistakes.
+  tutorial_gcactions_shortdescription: Discover actions, one of the key building blocks
+    in coding, and use them to code a video game! Explore digital culture and learn
+    about robots and what they can actually do.
+  tutorial_gccomparators_shortdescription: Discover comparators and logical rules,
+    which are key building blocks in coding, and use them to code a video game! Explore
+    digital culture and learn about the tracking of our online activities.
+  tutorial_gcconditions_shortdescription: Discover conditions, one of the key building
+    blocks in coding, and use them to code a video game! Explore digital culture and
+    learn about the algorithms that power our online world.
+  tutorial_gccreate_shortdescription: Create your first full videogame with GameCode!
+    Create new characters, make them (a bit) smarter, give the player superpowers...Sky's
+    the limit!
+  tutorial_gcevents_shortdescription: 'Discover events, one of the key building blocks
+    in coding, and use them to code a video game! Explore digital culture and learn
+    about Artificial Intelligence, and how it might be meaningful in your life. '
+  tutorial_gcloops_shortdescription: Discover loops, one of the key building blocks
+    in coding, and use them to code a video game! Explore digital culture and learn
+    about the echo chamber phenomenon on social networks.
+  tutorial_gcvariables_shortdescription: Discover variables, one of the key building
+    blocks in coding, and use them to code a video game! Explore digital culture and
+    learn about what data is and how it works.
+  tutorial_beanything_shortdescription: Use programming to animate characters, compose
+    music, tell stories, design games, and even create art.
+  tutorial_change_shortdescription: Create a project that shows how you would change
+    the world! Whether you are passionate about recycling or have an idea to achieve
+    world peace, share your vision with code!
+  tutorial_cooking_shortdescription: Show off your skills - create an interactive
+    cooking game. Beginners can use the self-guided tutorial while more advanced coders
+    have the option to start off with a blank project.
+  tutorial_crystal_shortdescription: Cast spells, collect power-ups, and defeat enemies
+    as you battle in a wild 4-player arena that is shrinking amidst lava!
+  tutorial_landscape_shortdescription: Use Python's pen drawing feature to compose
+    a landscape using code. Use the landscape items already created for you or design
+    your own structures. Publish and share your creations!
+  tutorial_pets_shortdescription: Create a fun game about pets – either real or imaginary!
+    Beginners can use the self-guided tutorial while more advanced coders have the
+    option to start off with a blank project.
+  tutorial_petvet_shortdescription: From guiding pets into the Examination Room to
+    diagnosing their sniffles, boo-boos, and itches, you'll find every puzzle has
+    a solution to make the pets feel better than ever!
+  tutorial_superhero_shortdescription: Use HTML and CSS pixel art to create your favorite
+    superhero masks. Publish and share your creations!
+  tutorial_vidcodeplastic_shortdescription: Learn to use loops, sine waves and customized
+    emojis to make a unique project.
+  tutorial_vidcodetypeface_shortdescription: Create your own typeface using shapes
+    and elements of typography. Type has more elements than you may have realized!
+  tutorial_washustorm_shortdescription: Learn how to program an incoming storm.
+  tutorial_activitypackets_shortdescription: Find hours of family-friendly fun with
+    Wonder Workshop's printable packets of creative coding activities. Bring coding
+    to life with Dash, Dot, and Cue robots by downloading these online and offline
+    activities to use during Hour of Code and beyond!
+  tutorial_googlerookie_shortdescription: In this activity, you'll code a Rookie themed
+    collage using Blockly, an introductory coding language. You'll use sequences,
+    variables and loops to create a unique piece that highlights your creativity!
+  tutorial_tommyturtle_shortdescription: 'Help young kids learn the basics of coding
+    with Tommy the Turtle! '
+  tutorial_mazyad_shortdescription: This product will broaden our boundaries to create
+    an integrated paper version with computerized applications and an alternative
+    if the computer is not used for any reason. It will also serve as an introduction
+    to understanding programming in general.
+  tutorial_gamemaker_shortdescription: Game Maker is an open ended activity where
+    students can create anything they want using a simple code wizard. Just click
+    on the picture of a cute little monster and choose one of the options in the menu.
+    More advanced tutorials are also included for those wanting to go deeper into
+    game making.
+  tutorial_duckrace_shortdescription: In this course you will solve programming tasks
+    to help Toni the duck collect coins for its holiday savings. At the end of the
+    course you create your own game.
+  tutorial_allcancodeapps_shortdescription: Use the Allcancode Platform to create
+    web and mobile apps from design to delivery.
+  tutorial_n2y_shortdescription: Help Bitt Bott explore Earth using direction arrows.
+  tutorial_dance2019_longdescription: Code a Dance Party to share with your friends.
+    Featuring Katy Perry, Shawn Mendes, Lil Nas X, Panic! At The Disco, Jonas Brothers,
+    and many more!
+  tutorial_danceparty_longdescription: Code a Dance Party to share with your friends.
+    Featuring Katy Perry, Madonna, J. Balvin, Sia, Keith Urban, Ciara, and 25 more!
+  tutorial_chibitronics_longdescription: Program a paper circuit to light up your
+    own story.
+  tutorial_athlete_longdescription: Choose between making a basketball game or mix
+    and match across sports!
+  tutorial_moana_longdescription: The new Disney Hour of Code tutorial uses a visual
+    programming language using blocks where students simply drag and drop visual blocks
+    to write code. Visual programming is a fun and easily understood way to teach
+    the logic of coding. Exposure to visual programming lays the foundation for text-based
+    programming, a more complex activity. The tutorial is targeted for kids ages 8+
+    and those trying coding for the first time. Available in 23 languages and localized
+    outside of the United States. This tutorial is available free online and includes
+    a digital toolkit in English and Spanish for educators and event organizers.
+  tutorial_star-wars_longdescription: Learn to program droids, and create your own
+    Star Wars game in a galaxy far, far away.
+  tutorial_gumadventure_longdescription: In the Amazing World of Gumball episode "The
+    Signal," a glitch affects how the characters relate to each other. In this activity,
+    continue the story by making your own glitch and imagining how Gumball and his
+    friends would react to it.
+  tutorial_mchoc_longdescription: Minecraft is back for the Hour of Code with a brand
+    new activity! Journey through Minecraft with code.
+  tutorial_vidnews_longdescription: 'It''s the HOC News! Videos and graphics are all
+    about tech, diversity, kids, and coding. Finished projects can be uploaded to
+    school website as the report on the HOC itself. Teachers can encourage students
+    to use the news to report on what they learned, or a statistic for their school.
+    "Breaking News: 400 students at Roosevelt participate in the Hour of Code"'
+  tutorial_kodable-pre_longdescription: Kodable is a self-guided game that introduces
+    kids 5+ to programming basics. Having a teacher or parent nearby is optimal, but
+    not necessary. Happy koding!
+  tutorial_highseas_longdescription: Animate an ocean wave to create a setting, then
+    tell a story that takes place on the high seas.
+  tutorial_capython_longdescription: Python is an engaging and simple language to
+    learn. Learn about using modules, functions, loops, and lists, all while creating
+    fun images with the help of your turtle buddies. Geometry has never been so much
+    fun!
+  tutorial_frzn_longdescription: Let's use code to join Anna and Elsa as they explore
+    the magic and beauty of ice. You will create snowflakes and patterns as you ice-skate
+    and make a winter wonderland that you can then share with your friends!
+  tutorial_cocom_longdescription: Choose your hero and code your way through the ogre
+    patrols, lava pits, and laser beams of Kithgard Dungeon. Level up, earn gems,
+    and loot magic items to unlock new programming powers!
+  tutorial_play-lab_longdescription: Create a story or make a game with Play Lab!
+    Make animals, pirates, zombies, ninjas, and many more characters move, make sounds,
+    score points, and even throw fireballs!
+  tutorial_boxisland_longdescription: Take a trip on Box Island and collect all the
+    stars! Box Island is a beautiful mobile coding game that takes kids on an exciting
+    adventure on the charming island. In this tutorial you will learn the basics of
+    algorithms, sequences, loops and conditionals!
+  tutorial_textcomp_longdescription: 'At some point we reach a physical limit of how
+    fast we can send bits, and if we want to send a large amount of information faster,
+    we have to find a way to represent the same information with fewer bits - we must
+    compress the data. In this lesson, students will use the Text Compression Widget
+    to compress segments of English text by looking for patterns and substituting
+    symbols for larger patterns of text. '
+  tutorial_encryption_longdescription: 'Students are introduced to the need for encryption
+    and simple techniques for breaking (or cracking) secret messages. They try their
+    own hand at cracking a message encoded with the classic Caesar cipher and also
+    a Random Substitution Cipher. Students should become well-acquainted with the
+    need for secrecy when sending information over the Internet, and that in an age
+    of powerful computational tools, techniques of encryption will need to be more
+    sophisticated. '
+  tutorial_kanopixel_longdescription: Creators of all ages learn to code in a real
+    programming language and watch their commands come to life by drawing a sequence
+    of 13 pictures with code. They'll learn along the way about video game art history
+    from Pong and other retro games through 8-bit art and Minecraft, weaving together
+    computer science with art, history, and storytelling. The implementation is flexible––you
+    can spend 1 hour or a few hours over one or multiple sessions. Learners can complete
+    Pixel Hack on their own using guidance within the challenges, or you can turn
+    Pixel Hack into an instructor-led journey, with a comprehensive educator manual
+    full of suggestions. Students will be encouraged to add their own creative flair
+    by hacking our challenges, to earn the Pixel Hacker Certificate.
+  tutorial_foos_longdescription: Code the adorable Foos to solve puzzles that teach
+    fundamental computer science concepts like sequencing and loops. Everyone everywhere
+    can learn to code with codeSpark Academy's award-winning "no words" interface.
+    Beginner coders and pre-readers welcome!
+  tutorial_tynkerdd_longdescription: Design your own custom dragon, then use programming
+    to guide it through fun puzzles on its quest for treasure and coins! You'll have
+    to navigate through complex castles, find power-ups, and conquer knights to get
+    all the treasure.
+  tutorial_tynkerana_longdescription: Use your knowledge of math and geometry to create
+    a working analog clock with moving second, minute, and hour hands. You'll need
+    to calculate the angle that each hand should point based on what time it is. When
+    you're done, you can add in reminders about what you need to do throughout the
+    day to make your own alarm clock!
+  tutorial_vidcard_longdescription: |-
+    Learn how to make a greeting card with JavaScript!
+
+    You will learn how to manipulate your own videos by accessing each and every pixel and telling it what to do with CODE!
+
+    You can also upload and record your own footage to personalize the experience.
+
+    Created in partnership with GSGNY.
+  tutorial_spritebox_longdescription: Run, jump, and code your way through three different
+    worlds to collect the stars and make it to the finish line! Learn sequencing,
+    debugging and loops, and code in Swift, Java, or with Icons.
+  tutorial_tynkerch_longdescription: Save the computer from a malicious virus! You'll
+    have to hack your way through the system by deleting viruses, opening doors, solving
+    mazes, and navigating through the portals. Watch out for viruses and glitches!
+  tutorial_lightbot_longdescription: Lightbot is a game that asks players to use programming
+    logic to solve puzzles! Gain a practical understanding of basic coding concepts
+    by guiding Lightbot to light up all the blue tiles in each level. Learn how to
+    sequence instructions, write procedures, and utilize loops along the way in this
+    self-guided activity. Great for all ages and all skill levels.
+  tutorial_hoc_longdescription: Placeholder for new code.org/hoc
+  tutorial_code_longdescription: Learn the basic concepts of Computer Science with
+    drag and drop programming. This is a game-like, self-directed tutorial starring
+    video lectures by Bill Gates, Mark Zuckerberg, Angry Birds and Plants vs. Zombies.
+    Learn repeat-loops, conditionals, and basic algorithms. Available in 37 languages.
+  tutorial_tinspire_longdescription: Introduce students to the basics of coding –
+    in just 10 minutes at a time – using the TI technology they carry in their backpacks
+    every day. These lessons give students an easy-entry into programming that can
+    help spark their interest in coding and computer science.  Students will write
+    programs that can strengthen math concepts using the TI Basic language that is
+    ready-to-use on their TI-Nspire handhelds.
+  tutorial_itchbounceball_longdescription: |-
+    We take you through an introduction to Itch, utilizing the Scratch visual programming language.
+
+    This lesson provides a video and text directions for the code students need to add to get a ball bouncing zanily around the screen.
+
+    Once students complete this activity there is an opportunity to explore with ideas for other changes and activities that can be made.  There is no set goal or outcome as it's an open learning environment, but with just this starting code students come up with amazing projects!
+
+    All instruction is contained within the Itch environment so there is no need to be switching screens to follow along with the project. Headphones are recommended.
+  tutorial_vidclim_longdescription: Students research a fact about the Earth's climate,
+    engaging with the work of scientists and artists in response to climate change.
+    Students take their research and plan a video sharing their fact. Videos can be
+    about understanding climate changes and its effects, public responses to climate
+    change, how climate change impacts everyday life, and the actions you can take
+    to make a difference.
+  tutorial_matlab_longdescription: Learn to Code is an engaging, online, interactive
+    tutorial where you learn how to code. Use MATLAB to find out if the closest meet-up
+    location with your friends is the movies, the mall, or the cafe. Break the problem
+    up into smaller chunks and learn basic programming concepts along the way. By
+    the end of the hour, create an algorithm to find the shortest path to your friends!
+  tutorial_flap_longdescription: Use drag-and-drop programming to make your own Flappy
+    Bird game, and customize it to look different (Flappy Shark, Flappy Santa, whatever).
+    Add the game to your phone in one click.
+  tutorial_galaxy_longdescription: "Grab your Android smartphone and explore distant
+    galaxies! At the #GalaxyGameJam you can create your very own Android app. Design
+    it with our free Pocket Code app and become part of our mission to outer space.
+    With Pocket Code we aim to inspire kids, teenagers, and young adults to create
+    their very own games, animations, and interactive stories directly on their smartphones.
+    \n"
+  tutorial_inf_longdescription: Use Play Lab to create a story or game starring Disney
+    Infinity characters.
+  tutorial_tynkersol_longdescription: Program an interactive model of our Solar System.
+    This project comes with step-by-step instructions that guide you through creating
+    a simulation with planets orbiting the Sun. Then add facts about each planet that
+    pop up when clicked.
+  tutorial_itchg_longdescription: "Name-IT has you create a game of recognition! \n\nThe
+    ending project has students creating a game to name the States of Australia!\n\nYou'll
+    first walk through and follow directions to create a game to label the three phases
+    of the water cycle. You'll make a fully functioning game, including scoring!\n\nFrom
+    the coding side you'll learn about variables, conditionals, lists, concatenating
+    strings and much, much more. These are coding techniques you'll be able to re-use
+    in other projects as you progress on to build your new coding skills!\n\nYou can
+    take the activity even further by adding your own image and labels (along with
+    many other extra project options, the fun never ends). Headphones are recommended."
+  tutorial_como_longdescription: Help a cute monkey catch bananas in 30 fun-filled
+    coding challenges! As you play, you will meet different animals that will guide
+    you along the way. You will use code and think outside the box to win as many
+    stars as possible. Good luck!
+  tutorial_processfound_longdescription: What does it mean to write software to do
+    the things that you often do with your hands, with paper, with pencil, with paint?
+    Could you use a computer to create drawings? To create animations? To create images?
+  tutorial_tynkerhomo_longdescription: You'll follow step-by-step instructions to
+    animate an interactive story with a lot of homophones in it! Each time a character
+    says a word that is a homophone, ask the player which homophone is the correct
+    word for that context. The player better know their homophones, or else the dialog
+    won't make any sense!
+  tutorial_art_longdescription: Draw cool pictures and designs with the Artist!
+  tutorial_tynkerbrick_longdescription: Use Tynker's physics engine to make your own
+    personalized version of this classic arcade game. Start by programming the paddle
+    to move when the arrow keys are pressed, then add a ball and some bricks. You'll
+    personalize the game by adding custom assets for the ball, bricks, and paddle.
+  tutorial_itchbio_longdescription: |-
+    Name-IT has you create a game of recognition!
+
+    Create a game to name the parts of a biological cell. Learn the parts of the cell while you make the game, and play it again as many times as you need to refresh your memory!
+
+    You'll first walk through and follow directions to create a game to label the three phases of the water cycle. You'll make a fully functioning game, including scoring!
+
+    From the coding side you'll learn about variables, conditionals, lists, concatenating strings and much, much more. These are coding techniques you'll be able to re-use in other projects as you progress on to build your new coding skills!
+
+    You can take the activity even further by adding your own image and labels (along with many other extra project options, the fun never ends). Headphones are recommended.
+  tutorial_itchj_longdescription: |-
+    Our Jumping activity provides you the coding skills to get a character to jump onto platforms that is used in many arcade style games.
+
+    Use the Jumping skills and create your own game goal.
+
+    This uses a cartesian coordinate system so you'll get to learn a little about screen coordinates here.
+
+    Enjoy learning all about jumping with Itch! Headphones are recommended.
+  tutorial_tickleo_longdescription: With Tickle, a user-friendly coding app, you can
+    easily program the Orca to swim in a number of ways by simply dragging and dropping
+    coding blocks to create a command for it to follow.
+  tutorial_hopgeo_longdescription: Create your own version of the highly-engaging
+    Geometry Jumper game in Hopscotch's open-ended programming environment! Along
+    the way, you'll gain hands-on experience with concepts like sequence, loops, variables,
+    and debugging. No prior experience is needed to complete or facilitate this activity;
+    it includes a fun in-app video tutorial and a step-by-step facilitation guide.
+  tutorial_tynkermult_longdescription: Code your own math game! Your character needs
+    to escape the cave without getting hit by falling boulders. But the only way the
+    character can run forward is by correctly answering math questions! You'll follow
+    step-by-step instructions to program this fun multiplication quiz game.
+  tutorial_monster_longdescription: The Mystery Island Coding Quest by Monster Coding
+    offers a fun filled self guided adventure that teaches several key programming
+    concepts to children. Each block based activity builds on the previous, introducing
+    kids to Functions, Boolean Values, Loops, If/Else Statements, and Arrays, using
+    colorful animated graphics, audio instructions.
+  tutorial_tynkerapp_longdescription: Build your own version of your favorite game.
+    Choose from tons of options, like platformer games, classic arcade games, racing
+    games, programming art, storytelling projects, and more! You'll personalize your
+    game by creating more levels, uploading or drawing custom assets, and programming
+    more fun features.
+  tutorial_tynkerpup_longdescription: Pixel the puppy was enjoying a nice day out
+    with his family, but they forgot to put him in the car and left without him! Can
+    you program Pixel to find his way home? In each puzzle, you'll navigate Pixel
+    to avoid obstacles so he can get back home to his family.
+  tutorial_livecode_longdescription: When you use our LiveCode tutorial for the Hour
+    of Code, your students get to create their own soundboards. After creating soundboards
+    with animal and piano sounds, students will be free to make their own customized
+    soundboards with their own image and music selections!
+  tutorial_cocomgame_longdescription: First, level up your Python or JavaScript programming
+    skills by coding your way out of danger and grabbing sweet loot. Then use your
+    programming powers to build your own game and see if your friends can beat it!
+  tutorial_tynkerspin_longdescription: In this project, you'll create an awesome customizable
+    drawing tool. Program your pen, choose an image (or upload your own), and you'll
+    be able to draw a rotating version of that image.
+  tutorial_code-avengers_longdescription: Build a 2 player 2D top-down game with JavaScript
+    in 10 short tasks. Then continue learning some basics of programming (variables
+    and if statements) as you create a Quiz to share with friends. Along the way  earn
+    points and badges as you compete to reach the top of the class leaderboard.
+  tutorial_tynkercq_longdescription: Design your own candy troll character and go
+    on a multi-level quest for candy to help your character find its way home. You'll
+    solve coding puzzles to navigate your character through the human world, while
+    avoiding obstacles and collecting gumdrops and mints.
+  tutorial_cmgame_longdescription: Take your coding skills to the next level by learning
+    to build your own games. In this course, you will learn keyboard user-interface
+    and game mechanics as you build a Super Mario™-styled game. Afterwards, you will
+    be able to share your game!
+  tutorial_codesters_longdescription: 'Create your own games, animations, and artwork
+    using Python.  Once you''re done, share them with friends! Program in Python,
+    a real programming language used every day at companies - our drag and drop toolkit
+    makes it easy to learn!  Try building a basketball game, choreographing a dance,
+    or designing an animated card! '
+  tutorial_qrm_longdescription: Join Mary in learning the Quorum programming language
+    as part of a light hearted and entertaining journey in biology. The activities
+    are student-guided, with online examples, and are accessible to the blind and
+    visually impaired.
+  tutorial_texas-instruments_longdescription: 'The 10 Minutes of Code activities can
+    be used in class as a way to spark students'' interest in coding with the TI technology
+    they carry in their backpacks everyday.  Learn the basics of coding using the
+    TI-84™ Plus and get started programming in just 10 minutes – no experience needed!  '
+  tutorial_cajava_longdescription: Drawing with JavaScript is easier than you might
+    think. Learn more about the flags of the world as you draw flags for each level
+    that increase in complexity. Learn about shapes, coordinates, and colors as well
+    as the importance of sequence in coding.
+  tutorial_codehs_longdescription: Giving commands to a computer, which is what programming
+    is all about, is just like giving commands to a dog. Learn how to code with Karel
+    the Dog—a fun, accessible, and visual introduction to text-based programming that
+    teaches fundamental concepts like commands and functions to absolute beginners.
+    Already have some experience? Try our JavaScript Graphics tutorial instead!
+  tutorial_hopemo_longdescription: "Build a drawing app that creates beautiful, interactive
+    art featuring your favorite emojis. \n\nExplore the creative side of coding, making
+    an app that friends can use to express themselves. In the process, learn about
+    sequence, events, loops, and variables. \n\nNo prior experience is needed to complete
+    or facilitate this activity; it includes an in-app video tutorial and a step-by-step
+    facilitation guide."
+  tutorial_tynkercm_longdescription: Explore the enchanted forest to capture monsters
+    and learn how to program them by completing coding puzzles. Collect, code, and
+    evolve all the unique monsters. Devise strategies based on your monsters' abilities
+    so they can battle in the multiplayer arena. Whose code will win?
+  tutorial_codesterswintergreet_longdescription: 'In this activity, students use our
+    drag to text toolkit to start programming in Python right away! Winter Greetings
+    teachers students about basic syntax, sprites and dot notation, as well as events.
+    Students learn by creating a winter greeting card that they can save and share! '
+  tutorial_codestersc_longdescription: 'In this lesson students explore all four quadrants
+    of the coordinate plane!  They use Python and our drag-to-text toolkit to send
+    a sprite to various locations on the stage! There are demonstration and debugging
+    activities included to help students become comfortable with navigating the coordinate
+    plane. '
+  tutorial_codestersturtle_longdescription: Learn the basics of coding in Python while
+    creating your own turtle-crossing game! Use lists and loops to set up your game,
+    and events to create cars and control the turtle! Can you safely cross the road?
+  tutorial_penjee_longdescription: 'A  visual way for students to begin their first
+    language. Students write Python code to move a Penguin around an ice world. Our
+    editor highlights each line of code as it executes, helping kids connect their
+    to code to changes in the Penguin''s world.  Our curriculum is differentiated,
+    based on student readiness, and molds itself to each student''s needs. '
+  tutorial_trinket_longdescription: |-
+    Choose from lessons, challenges, and tutorials about the Python programming language.  Make turtle-based animations and solve puzzles, all while learning the basics of this powerful language.
+
+    Activities range from block-based programming to real Python code, with activities appropriate for most age levels.  Select lessons available in Spanish, Korean and Chinese!
+  tutorial_frogger_longdescription: Become a Computational Thinker. Create 3D Objects
+    by drawing 2D images that you turn into amazing 3D shapes. Create 3D Worlds by
+    assembling the shapes you just built into exciting worlds. Rule your World! Bring
+    your world to life by programming using simple drag and drop rules. Play on computers,
+    tablets and smartphones. Share your 3D game with your friends through email and
+    Facebook.
+  tutorial_tynkereco_longdescription: Create an interactive ecological pyramid to
+    track how energy flows through an ecosystem! This project comes with step-by-step
+    instructions that guide you through creating an ecological pyramid for any ecosystem
+    with animals and plants that glide to the proper location in the pyramid when
+    clicked.
+  tutorial_mitedarc_longdescription: Have your sprite collect coins and get points.
+  tutorial_khan_longdescription: Learn how to program drawings using JavaScript by
+    designing your very own snowman. Try it on your own or with your class!
+  tutorial_tynkerd_longdescription: Design a custom hero and play as that character
+    through this multi-level adventure game. You'll need to use your coding skills
+    to solve puzzles, fight bugs, and save the motherboard!
+  tutorial_cdmy_longdescription: Codecademy is an interactive platform for learning
+    STEM skills that are critical for today's jobs. Join millions of Codecademy students
+    and learn the basics of coding and computer science by taking our fun Hour of
+    Code courses. By the end of each course, you'll have a real project that you can
+    show off to your friends and family.
+  tutorial_codestersdance_longdescription: 'Students use a drag-to-text toolkit that
+    allows them to start coding in Python right away! Students complete a set of guided
+    practice activities in which they learn how to use and modify a variety of programming
+    commands. Then, they apply these skills to create their own dance routine! '
+  tutorial_codestersbasketball_longdescription: 'Students use our drag-to-text toolkit
+    to start coding in Python right away! In this self-guided activity, students complete
+    a series of direct-instruction activities in which they build a pull and shoot
+    basketball game! Students explore variables, events, basic syntax, creating random
+    coordinates. '
+  tutorial_nclkarel_longdescription: Learn to code and solve problems by guiding Karel
+    the Robot through jungles, mountains, and deserts. Karel follows your instructions,
+    just like a real robot. Start programming with simple commands such as go, get,
+    and put. Next you will learn how to build repeat loops and conditions into your
+    programs. Finally define custom commands for Karel. You can create your own games
+    with NCLab's app! Have fun while learning skills that you can use in any programming
+    language.
+  tutorial_buildpong_longdescription: Pong is one of the earliest arcade video games
+    and the very first sports arcade video game. It is a table tennis sports game
+    featuring simple two-dimensional graphics. The aim of the game is for the PLAYER
+    to score on the COMPUTER while defending its GOAL. In this project, the COMPUTER
+    is programmed with basic artificial intelligence so it can respond to the PLAYER.
+  tutorial_tynkerdrones_longdescription: Learn to program connected devices by solving
+    the "Crash Course" puzzles, where you navigate virtual drones and robots through
+    obstacles. Then you're ready to create programs to control real drones and robots.
+    Requires an iPad or Android tablet and a supported toy.
+  tutorial_carla_longdescription: '"Programming with Carla" is a series of short activities
+    that guide students through building a simple chatbot, whilst learning about core
+    concepts like variables and conditionals. The activities have been carefully designed
+    to address common misconceptions that new programmers have about these topics
+    by offering many opportunities for practice, as well as targeted hints and feedback.
+
+'
+  tutorial_zulama_longdescription: In this activity you will learn to edit JavaScript
+    code through a playful action game and master computer science concepts like variables
+    and functions. Create your own game in the Sandbox by remixing and expanding on
+    existing game code. Then publish and share your game with friends and family.
+  tutorial_capost_longdescription: Starting to learn HTML and CSS is easy and fun
+    with this digital postcard. Learn about adding headings, paragraphs, images and
+    links to create a holiday card or birthday celebration to share with friends and
+    family.
+  tutorial_marco_longdescription: Students play an adventure game based on an original
+    story. They guide Marco - the main character - through each level by giving him
+    step-by-step instructions in the form of the visual programming language used
+    by the Hour of Code. They get introduced to sequencing commands, iteration and
+    conditions without even noticing it.
+  tutorial_codestersflappybike_longdescription: 'In this activity, students use our
+    drag-to-text toolkit to start coding in Python right away! Students are guided
+    through a series of learning activities that teach them to build a complete game!
+    After they finish, they are challenged to use what they learned about syntax,
+    dot notation, events, variables, parameters and game mechanics to create a new
+    game. '
+  tutorial_kanopong_longdescription: Learn to code by building this classic arcade
+    game in an hour!
+  tutorial_tynkerright_longdescription: 'Create your own Bill of Rights project: change
+    the background, add more questions, keep score, add animations.'
+  tutorial_touchdevelop_longdescription: 'The touch-friendly editor will guide you
+    in creating pixel art, solving the bear puzzle, or making your own jumping bird
+    game. '
+  tutorial_tynkercc_longdescription: Prepare your army for battle! Code the attack
+    logic of each member of your army to exploit your enemy's weaknesses and emerge
+    from battles victorious. As you learn, you unlock new characters that you can
+    program. Build up your army, then battle with friends. Whose code is best?
+  tutorial_bamboo_longdescription: 'Bamboo JS is an activity design by Codemoji to
+    teach students basic Javascript concepts.  Bamboo the panda and his awesome toast
+    friends will walk students though basic commands and structure.  The Bamboo JS
+    activity is design for students who want a little more animation and more art
+    and design in their coding. The Bamboo activity is great for students of all ages. '
+  tutorial_robojav_longdescription: Learn the basics of Java programming in an hour,
+    while building a small world on your screen for simulated robots and customized
+    creatures. No prior programming experience is required. Topics covered include
+    objects, methods, parameters, and simple graphics.
+  tutorial_roboba_longdescription: "RoboBlockly is designed for beginners to learn
+    math with robots in Blockly. The Algebra 1 activities are self-guided. \nRoboBlockly
+    prepares students to be ready to program in C/C++.\n"
+  tutorial_knodsnake_longdescription: 'Learn to create a Snake game in JavaScript! '
+  tutorial_soccharater_longdescription: Code your very own pixel character! Use HTML
+    to build your character, CSS to style it, and JavaScript to animate your cute
+    pixel person. Code by yourself, or invite a friend and code together with our
+    team coding game.
+  tutorial_silent_longdescription: |-
+    Discover the basic concepts of programming without any word or explanation.
+    Our silent teacher will ask you several series of questions that will lead you to guess some rules and learn from your own mistakes.
+    Because there is no text in the game, it is accessible to any player whatever his language.
+  tutorial_robomesh_longdescription: Students write Google Blockly code to control
+    popular VEX IQ robots. They can choose to write code for either a virtual robot,
+    or a real VEX IQ robot that they built themselves, and both options are available
+    in the same web-based development interface. Students learn about basic robot
+    movement, and how to use a sensor and an output device. It is easy and fun.
+  tutorial_amaze_longdescription: In this project, a CHARACTER starts at HOME BASE
+    and follows a PATH while avoiding OBSTACLES to get a PRIZE. To win, the character
+    brings the prize back to home base. The character isn't allowed to touch the OBSTACLES.
+    If it does, it's "zapped" and starts over from HOME BASE.  For extra credit, the
+    player has a limited amount of time to complete the game.
+  tutorial_codestersds_longdescription: 'In this Common Core ELA aligned lesson, student
+    use programming to tell a story that prompts users for appropriate transition
+    words. Students will learn about basic syntax, strings, variables, and user input.
+    They will use the platform and a sprite to tell a story and lead the user through
+    a variety of scene changes. '
+  tutorial_knodtext_longdescription: Learn to make a text adventure game in Python!
+  tutorial_alicegar_longdescription: 'Follow the animation production process from
+    storyboarding to programming with Alice and Garfield.  Let creativity and storytelling
+    drive your learning in a drag and drop coding environment.  The project will guide
+    you through what is a storyboard, translating a storyboard into a programmable
+    script, and how to program a short 3D animation. '
+  tutorial_codesterstransform_longdescription: 'In this activity, students use Python
+    to practice performing transformations on the coordinate plane! The lesson includes
+    demonstrations, direct instruction, and challenges that ask students to program
+    and identify various static transformations! '
+  tutorial_flexfrog_longdescription: Learn some web development with this educational
+    game where you help Froggy and friends make it to their lily pads. By the end
+    of the game, you'll learn how to use write code using new CSS properties called
+    flexbox. No prior coding experience required!
+  tutorial_codemoji_longdescription: The Codemoji activity is a web based activity
+    for students 1st-6th grade to learn basic coding concepts using Emoji's.  After
+    students do the activity they have learned about basic HTML tags and concepts.
+    This helps them do the coding project where the student builds a basic website
+    in just a few steps.  After the students do the Codemoji activity the students
+    walk away with real coding skills.
+  tutorial_robobii_longdescription: "RoboBlockly is designed for beginners to learn
+    coding with robots in Blockly. The coding activities are self-guided with tutorial
+    videos. \nRoboBlockly prepares students to be ready to program in C/C++.\n"
+  tutorial_robobm_longdescription: "RoboBlockly is designed for beginners to learn
+    math with robots in Blockly. The math activities are self-guided. \nRoboBlockly
+    prepares students to be ready to program in C/C++.\n"
+  tutorial_codingrobots_longdescription: "RoboBlockly is designed for beginners to
+    learn coding and math with robots. The activities are student-guided with tutorial
+    videos. \nRoboBlockly prepares students to be ready to program in C/C++.\n"
+  tutorial_robob_longdescription: "RoboBlockly is designed for beginners to learn
+    robotics with coding in Blockly. The robotics activities are self-guided with
+    tutorial videos. \nRoboBlockly prepares students to be ready to program in C/C++.\n"
+  tutorial_coders_longdescription: "This step-by-step puzzle game provides an easy
+    introduction to bot programming. \n\nThe aim is to win a starship race against
+    other players.\n\nThe game is simple to start and only requires a few lines of
+    code to have a ship move around, but there are near-infinite possibilities of
+    improvement to create more sophisticated bots. "
+  tutorial_tynkerhw_longdescription: Learn to program with Hot Wheels in this high-octane
+    racing game! Choose from a wide selection of cars, then learn to program as you
+    navigate through complex race tracks. Jump over obstacles, skid around corners,
+    and win the race. You can even program your own race tracks and challenge your
+    friends to race on them.
+  tutorial_tynkermh_longdescription: Monster High is hosting a scavenger hunt! Solve
+    coding puzzles with drag-and-drop blocks to help Frankie, Draculaura, Clawdeen,
+    Cleo, and Ghoulia. Avoid obstacles and find all the school crests as you quest
+    through the halls of Monster High. Then program your own dance party music video
+    with the ghouls and share it with friends.
+  tutorial_caphoto_longdescription: This challenging and exciting project will teach
+    you how to create a Photo Booth app.  Using JavaScript, CSS and HTML you will
+    connect buttons that let you use a camera, upload images and customize your photos
+    by inserting stickers and applying filters.
+  tutorial_mozillahw_longdescription: Learners will remix JavaScript code to change
+    the words on a website, learning about composing for the web, coding JavaScript
+    values, and remixing Web content.
+  tutorial_ticklep_longdescription: With Tickle, a user-friendly coding app, you can
+    easily program Parrot Drone to swim in a number of ways by simply dragging and
+    dropping coding blocks to create a command for it to follow.
+  tutorial_bbot_longdescription: "With these 3 one-hour coding activities, you don't
+    need any programming knowledge or experience to teach your students about programming!
+    You can teach programming in a fun and easy way. Go over the activities and download
+    our lesson materials including presentation slides, unplugged materials, and solutions
+    guides and you will find yourself ready to teach your first lesson in 20 - 40
+    minutes! \n\nOur activities include both offline and online exercises to teach
+    your students (ages 7 and up) about programming and fundamental programming concepts
+    like for loops and algorithms. Students will apply their knowledge and skills
+    in the Bomberbot online game, where they will program their robot to solve logic-based
+    puzzles in the most efficient way. "
+  tutorial_scratchg_longdescription: Kids love playing games on their phones and on
+    computers. But how are they programmed? This activity introduces students to the
+    Scratch programming language and then shows them how to program different styles
+    of games. All the necessary art for the games are provided, and students have
+    to work out how to connect everything together to make a functioning game.
+  tutorial_sjforest_longdescription: '"Can I Make a Spooky Forest?" is an intermediate
+    activity meant for children in kindergarten through second grade who have some
+    prior experience with programming to learn about and master more advanced features
+    of ScratchJr. Later, children can use the skills they have learned in doing this
+    activity to create their own unique projects, or build upon what they created
+    in the "Can I Make a Spooky Forest?" program. Through this activity and continued
+    time with ScratchJr, students will have the opportunity to think creatively, become
+    storytellers, and improve upon mathematical reasoning and sequencing skills.'
+  tutorial_sjgreet_longdescription: '"Can I Make My Characters Greet Each Other?"
+    is an advanced activity meant for children in kindergarten through second grade
+    who have prior experience with programming to master more advanced features of
+    ScratchJr. Later, children can use the skills they have learned in doing this
+    activity to create their own unique projects, or build upon what they have created
+    in "Can I Make My Characters Greet Each Other?" program. Through this activity
+    and continued time in ScratchJr, students will have the opportunity to think creatively,
+    become storytellers, and improve upon mathematical reasoning and sequencing skills.'
+  tutorial_sjsunset_longdescription: '"Can I Make the Sun Set?" is an introductory
+    activity meant for children in kindergarten through second grade with little to
+    no programming experience to learn the basic features of ScratchJr and the elementary
+    concepts of coding. Through this activity and continued time with ScratchJr, students
+    will have the opportunity to think creatively, become storytellers, and improve
+    upon mathematical reasoning and sequencing skills. Later, children can use the
+    skills they have learned to create their own unique projects.'
+  tutorial_fufafrenz_longdescription: Beginner lessons on Sequence (K-5). This is
+    an introduction to the most basic programming concept, sequence. This is the third
+    grade example, we have lesson plans on this concept scaffolded for K-5.
+  tutorial_bbcgeo_longdescription: Standards-based lesson plan for grades K-5. Take
+    your kids to the computer lab with worksheets in hand, and build apps involving
+    geometry.
+  tutorial_chspixel_longdescription: After learning about how graphics work, students
+    will create their own Color by Pixel programs. The lesson plan consists of four
+    parts, each covering a specific topic. The entire five-part Color by Pixel lesson
+    is designed to run approximately one hour.
+  tutorial_hummingbird_longdescription: In this activity, you will create your very
+    own game! You will use a Hummingbird board and a sensor to detect when the player
+    throws a ball into a box. You will write a program to keep score and turn on lights
+    when the player makes a basket. Then you can customize your game to make it unique!
+    For this activity, you can use a laptop or a Chromebook; you don't need any prior
+    programming experience.
+  tutorial_recoloring_longdescription: 'Students with no prior coding experience can
+    learn how to use computers to create images and understand astronomical data.
+    Participants learn basic coding starting with familiar concepts such as shape
+    and color and graduating to astronomical objects. Following a scaffolded set of
+    activities, and working with data from NASA orbiting telescopes on sources from
+    exploded stars to black holes, students can experience real world application
+    of science, technology & art.        '
+  tutorial_bbcchem_longdescription: Standards-based lesson plan for grades K-5. Take
+    your kids to the computer lab with worksheets in hand, and build apps involving
+    chemistry.
+  tutorial_floalgo_longdescription: In this lesson, students will explore algorithms,
+    a key concept that allows computer programmers to solve problems. They will write
+    efficient, precise algorithms in English and pseudocode to complete tasks and
+    solve problems. They'll also evaluate competing algorithms based on efficiency
+    and other factors.
+  tutorial_flocond_longdescription: This is a lesson plan in which students explore
+    conditional statements, a concept used across coding languages. Students will
+    watch an educational hip-hop video about conditionals and answer discussion questions.
+    They'll then practice determining whether conditions are true and carrying out
+    actions accordingly. Finally, they'll write their own conditional statements and
+    evaluate statements to predict the outcome of programs.
+  tutorial_floloops_longdescription: This is a lesson plan in which students explore
+    loops, a concept used across programming languages that allows programmers to
+    easily repeat code. Students will watch an educational hip-hop video about loops
+    and answer discussion questions about their use in programming. They will then
+    practice key vocabulary and complete an activity sequence in which they write
+    loops and interpret given loops to generate their outputs.
+  tutorial_pgts_longdescription: This "unplugged" activity helps students learn how
+    modeling and simulation works by having a group of students play different versions
+    of the Rock / Paper / Scissors game, and see the results as different modeling
+    experiments.
+  tutorial_ozo_longdescription: "This teacher-led tutorial introduces students to
+    the concept of coding with the help of Ozobot, a small programmable robot. Students
+    will be learning how to code by playing Ozobot games, called Shape Tracer Games.
+    They can still play the simulated version of the games even if they don't have
+    an Ozobot Bit or Evo robot.The Ozobot games will teach students how to code with
+    OzoBlockly, a visual programming language based on Blockly. \n\nThe games are
+    followed by a project idea that can be done beyond the Hour of Code.The project
+    challenges students to take everything they learned and design and program an
+    action scene for Ozobot.\n\nNo programming experience or knowledge of Ozobot is
+    required for this tutorial. However, even students with some programming experience
+    will be engaged by the Ozobot games. The tutorial is designed for grades 1-12
+    and can be customized for your students' abilities."
+  tutorial_bbcla_longdescription: Standards-based lesson plan for grades K-5. Take
+    your kids to the computer lab with worksheets in hand, and build apps involving
+    language arts.
+  tutorial_bbcsci_longdescription: Standards-based lesson plan for grades K-5. Take
+    your kids to the computer lab with worksheets in hand, and build apps involving
+    general science.
+  tutorial_tlctour_longdescription: This activity is an example of creating an algorithm
+    that is a simple sequence of instructions to do in order. It shows that if we
+    have written down a solution to the problem in the form of an algorithm then we
+    are able to do tours in future just by following the steps, without having to
+    work it out from scratch again. Also if we write down the algorithm we can check
+    that it definitely works by following it step by step on paper. This activity
+    leads on to the Knight's Tour activity.
+  tutorial_codesterstj_longdescription: 'IN this multi-lesson project students learn
+    about digital citizenship and follow a design thinking model to solve a problem
+    that they choose! Students will create a game intended to teach users a lesson
+    about responsible digital citizenship. All resources are located in-platform. '
+  tutorial_tlclocked_longdescription: This activity aims to introduce computational
+    thinking based problem solving, leading to an understanding of what an algorithm
+    is, what linear search is and how algorithms can be compared on the basis of efficiency.
+    It also illustrates how computational thinking is about more than just creating
+    computer-based solutions. Computing is about solving problems for people.
+  tutorial_baubles_longdescription: Students learn about representing and storing
+    letters in binary, as functions of on and off. At the end, the class gets to encode
+    their own initials to take home with them.
+  tutorial_bbcart_longdescription: Standards-based lesson plan for grades K-5. Take
+    your kids to the computer lab with worksheets in hand, and build apps involving
+    visual arts.
+  tutorial_tlcknight_longdescription: This activity involves trying to solve a puzzle
+    using two different representations. To start with it is fairly hard, but when
+    the representation of the board and moves is changed it becomes really easy. Create
+    graphs to represent the problem. See the power of using abstraction and how the
+    choice of representation can make a problem much easier. This activity follows
+    from the Tour Guide activity.
+  tutorial_fufafit_longdescription: Students will learn advanced programming concepts
+    (functions) through a lesson and kinesthetic activity. Students will apply knowledge
+    of functions on-screen to run a program.  This lesson is for students and teachers
+    who have some experience with sequence, conditions, loops, or other foundational
+    programming concepts.
+  tutorial_ozodance_longdescription: |-
+    This teacher-led tutorial introduces students to the concept of coding with the help of Ozobot, a small programmable robot. Students will be learning how to code by creating and programming a dance routine for Ozobot! They will use OzoBlockly, a visual programming language based on Blockly, to program the dance and then have fun see their choreography come alive when Ozobot performs their dance.
+
+    No programming experience or knowledge of Ozobot is required for this tutorial. However, even students with some programming experience will be engaged by the Ozobot games. The tutorial is designed for grades 1-12 and can be customized to your students' abilities.
+  tutorial_codingrobotics_longdescription: Students will learn about foundational
+    programming concepts and apply new knowledge to robotics. Working with both Kodable
+    and Wonder Workshop, students will use programming knowledge to command "Dash"
+    the robot in the Path app.
+  tutorial_box_longdescription: Take a trip on Box Island and help Hiro collect all
+    the clocks scattered in the wilderness! In this tutorial you will learn the basics
+    of algorithms, sequences, loops and conditionals!
+  tutorial_hopgame_longdescription: "Keep the fun going! Use this project-based guide
+    to facilitate a game design workshop, hackathon, or in-class series. Make Cross
+    the Road, Geometry Jumper, Quiz Creator, Falling Bird, Subway Skaters, and Escape
+    the Room. Each includes discussion questions, differentiation, and a video tutorial.
+    \n\nStudents can build off your instructions to customize their games. No prior
+    experience required."
+  tutorial_icontrol_longdescription: |-
+    This teacher facilitated lesson, adapted for the Hour of Code, provides pupils with an opportunity to explore physical programming through robotics - Sphero.
+
+    Using a drag-and-drop programming environment and a programmable robotic sphere, pupils will learn that physical systems can be programmed and controlled.
+  tutorial_cocomteach_longdescription: Introduce your students to Python or JavaScript
+    in CodeCombat's free, one-hour Introduction to Computer Science course. We've
+    got a dedicated lesson plan for you to help explain concepts to your students,
+    including basic syntax, strings, arguments, loops, variables, and x- and y-coordinates,
+    using gem-packed dungeon mazes and hero-vs-ogre battles.
+  tutorial_bbcmathii_longdescription: Standards-based lesson plan for grades K-2.
+    Take your kids to the computer lab with worksheets in hand, and build apps involving
+    arithmetic, visualization of numbers, and geometric shapes.
+  tutorial_bbcphys_longdescription: Standards-based lesson plan for grades K-5. Take
+    your kids to the computer lab with worksheets in hand, and build apps involving
+    physics.
+  tutorial_bitsbox_longdescription: 'Follow the prompts to code five fun mini-apps
+    using real, typed Javascript. From blowing up pie in ''Food Fight'' to flushing
+    a notebook down a black hole in ''So Long, Homework!'', each app is designed to
+    delight kids while illustrating variables, methods, and more. These apps are also
+    completely open-ended; kids can use them as a starting point for their own app
+    creations. Beginners welcome!
+
+'
+  tutorial_tlcemo_longdescription: Students create and program a 2D robot made of
+    card to show different emotions. They create a table that can be used to translate
+    emotions (high level commands) into low level machine instructions.
+  tutorial_crd_longdescription: Learn about algorithms and conditional statements
+    in this "unplugged" activity using a deck of cards. Students do this activity
+    in teams, and need one deck of cards per team.
+  tutorial_bbcbio_longdescription: Standards-based lesson plan for grades K-5. Take
+    your kids to the computer lab with worksheets in hand, and learn about growth,
+    species diversity, and pollination.
+  tutorial_ticklebb8_longdescription: With Tickle, a user-friendly coding app, you
+    can easily program BB-8 to move in a number of ways by simply dragging and dropping
+    coding blocks to create a command for it to follow.
+  tutorial_grok_longdescription: 'Use drag-and-drop blocks or the text-based language
+    Python to draw flags from around the world, create fantastic snowflakes, or build
+    a chatbot called "Eliza". '
+  tutorial_ijournalist_longdescription: "This teacher facilitated lesson teaches Computer
+    Science and Language Arts.  Pupils begin to develop a journalistic style that
+    considers the interest of the reader and presentation of information for an online
+    news story.  Pupils use basic HTML and CSS to create and present an online news
+    story about a fictional school robbery.\n\nIt sets computer science within a meaningful
+    context enabling children to understand the value of computer science in other
+    subject areas. \n\n"
+  tutorial_bbcmusic_longdescription: Standards-based lesson plan for grades K-5. Take
+    your kids to the computer lab with worksheets in hand, and build apps involving
+    music.
+  tutorial_secretcodes_longdescription: Learn about the role computers have played
+    to help save the world.
+  tutorial_tlchex_longdescription: You make a red and yellow hexahexa exagon by folding
+    and gluing a multicoloured paper strip in a special way. Once made you start to
+    explore it. As you fold and unfold it, you magically reveal new sides as the exagon
+    changes colour.
+  tutorial_tickles_longdescription: Team up with your Sphero for a good run! Move,
+    spin and give it a few rounds of good turns. Just put some code blocks together
+    on Tickle app to run your Sphero as you want it to.
+  tutorial_ozogame_longdescription: "This teacher-led tutorial introduces students
+    to the concept of coding with the help of Ozobot, a small programmable robot.
+    Students will be learning how to code by playing Ozobot games, called Shape Tracer
+    Games. They can still play the simulated version of the games even if they don't
+    have an Ozobot Bit or Evo robot.The Ozobot games will teach students how to code
+    with OzoBlockly, a visual programming language based on Blockly. \n\nOnce students
+    have solved all ten levels of the Shape Tracer Games, they are challenged to take
+    everything they learned and design and program their own game level 11.\n\nNo
+    programming experience or knowledge of Ozobot is required for this tutorial. However,
+    even students with some programming experience will be engaged by the Ozobot games.
+    The tutorial is designed for grades 2-12 and can be customized to your students'
+    abilities."
+  tutorial_vidcodeio_longdescription: In this exercise, you'll walk through with your
+    students how this relates to what they already know about math by solving a math
+    equation with programming.
+  tutorial_tlcbrain_longdescription: This activity explores how computational modelling
+    (a key part of computational thinking) can be used to help understand biological
+    systems – here neurones. We see how the way our brains work has also been the
+    inspiration for a new way to program computers and so give them intelligent abilities.
+  tutorial_hopquiz_longdescription: 'This lesson plan is a template that you can adapt
+    and use in any subject—Science, Language Arts, World Languages, or History. It
+    includes step-by-step instructions and explanations that you can use to help your
+    students code multiple choice quizzes. During the process, they will practice
+    and explore core coding concepts like sequence, loops, variables, and conditionals. '
+  tutorial_unfortunate_longdescription: We all react to events that happen around
+    us, be it cheering when the school team wins, crying at a sad movie, or dancing
+    when we hear music. In this lesson, students will learn how to teach Dash and
+    Dot to respond to events that happen around them!
+  tutorial_cha_longdescription: The history of computers is fascinating. This is your
+    chance to learn more.
+  tutorial_elaseq_longdescription: Students will examine the concept of sequence in
+    the context of reading and writing. Through grade level aligned ELA lessons, students
+    will apply their knowledge of sequence to further their understanding of the role
+    sequence plays in programming.
+  tutorial_bbcmathi_longdescription: Standards-based lesson plan for grades 3-5. Take
+    your kids to the computer lab with worksheets in hand, and build apps involving
+    fractions, variables, and formulas.
+  tutorial_tlcpixel_longdescription: Pixel puzzles turn the ways images are represented
+    as a series of numbers representing pixels into puzzles. They come in various
+    forms from a simple variant of colour-by-numbers to more complex puzzles based
+    on compression where images are represented by fewer numbers so take up less storage
+    – but can you get them back! Each representation needs its own algorithm to follow
+    to get the image back.
+  tutorial_introrobo_longdescription: 'In this lesson, students will get to know Dash
+    and Dot while being introduced to the ideas of Robotics and Programming. Students
+    will gain an understanding of what a robot is, how they sense the world around
+    them, and how programs can control robots. '
+  tutorial_tlcinvis_longdescription: This introduces what an algorithm is and what
+    a computer program is. It can also be used to explore human computer interaction
+    and the importance of feedback and building a correct mental model.
+  tutorial_tlcjflap_longdescription: A finite state machine is a very useful tools
+    in the computational thinking toolbox. They are an important way for describing
+    what computer systems do and of simulating things in the real world. JFLAP is
+    an easy to use and free tool for creating finite state machines. This activity
+    involves creating a simple finite state machine and simulating it, then going
+    on to create more complex finite state machines that represent puzzles, gadgets,
+    web pages and games.
+  tutorial_procolor_longdescription: |-
+    This teacher-led tutorial introduces your students to programming and computational thinking and it also explains what kind of robot Ozobot is. This activity is "unplugged", which means that the coding is not done on a computer or tablet, but on a piece of paper with markers. Students will be giving commands to Ozobot using OzoCodes, which are special color sequences. After learning about how to program Ozobot with markers and paper, students are challenged to solve a maze and help Ozobot find the way to school.
+
+    No programming experience or knowledge of Ozobot is required for this tutorial. However, even students with some programming experience will be engaged by programming Ozobot. The tutorial is designed for grades K-12 and can be customized to your students' abilities.
+  tutorial_spiralsfinch_longdescription: 'The Finch is a small robot designed to inspire
+    and delight students learning computer science by providing them a tangible and
+    physical representation of their code. In this activity, you will learn to write
+    programs that make the Finch move and turn. Then you will use a variable to program
+    the robot to move in a spiral pattern. For this activity, you can program the
+    Finch with either Scratch or Snap! using either laptops or Chromebooks. You do
+    not need any prior programming experience. '
+  tutorial_ozoi_longdescription: |-
+    This tutorial introduces students to programming and computational thinking and it also explains what kind of robot Ozobot is. This activity is "unplugged", which means that the coding is not done on a computer or tablet, but on a piece of paper with markers. Students will be learning about how the robot works and then give commands to Ozobot using OzoCodes, which are special color sequences. After learning about how to program Ozobot with markers and paper, students are challenged to solve a maze and help Ozobot find the way to the store.
+
+    No programming experience or knowledge of Ozobot is required for this tutorial. However, even students with some programming experience will be engaged by programming Ozobot. The tutorial is designed for grades K-12 and can be customized to your students' abilities.
+  tutorial_ticklel_longdescription: Brick by brick, build up your wildest LEGO imagination.
+    By putting some codes together on Tickle app, you can make your LEGO WeDo do some
+    amazing things.
+  tutorial_spiralsdash_longdescription: Learn the basics of using variables in a program
+    while using a robot to create art! Use variables in Blockly to dynamically control
+    the wheel speeds of a Dash robot. After completing the lesson, you will understand
+    how to assign a variable, access a variable, and dynamically change a variable
+    using a loop. By changing the value of a variable over time, you can make Dash
+    draw a spectacular spiral!
+  tutorial_ghdebug_longdescription: Help students learn about Grace Hopper and why
+    this week is CS EdWeek.
+  tutorial_tlckk_longdescription: Kriss-kross puzzles combine a love of words with
+    a love of logic. Given a list of words of different lengths, you must fit them
+    all in to the grid.
+  tutorial_firstcomp_longdescription: Few things are as exciting as computers. And
+    now you'll get to design your very own one - this time out of paper. Get to know
+    the CPU, RAM and ROM, Mass Storage and GPU. Draw your first application. Get your
+    scissors, pens and papers out!
+  tutorial_mazefinch_longdescription: 'In this activity, you will use a very simple
+    programming language to make the Finch robot move and turn. Then you will write
+    programs to help the robot complete a maze! You do not need any prior programming
+    experience, and you can use a laptop or a Chromebook. '
+  tutorial_tlccc_longdescription: Data on computers is stored as long sequences of
+    characters – ultimately as binary 1s and 0s. The idea with compression is that
+    we use an algorithm to change the way the information is represented so that fewer
+    characters are needed to store exactly the same information.
+  tutorial_tlcdoodle_longdescription: 'Scenery in films is often computer generated.
+    Ever wondered how they do it? Next time you find yourself drawing doodles, draw
+    an algorithmic doodle and explore algorithms for drawing nature. The algorithms
+    are recursive: that is they describe one step and then tell you just to draw the
+    next step in the same way, following the algorithm from the start.'
+  tutorial_tlcpunch_longdescription: Demonstrate how early computers were able to
+    find data stored on punch cards and show that it is the same algorithm as the
+    magic trick in the 'Australian Magician's Dream' Activity. It aims to show in
+    a visual way how a search algorithm works. In doing so you demonstrate a practical
+    use of binary numbers, a divide and conquer algorithm for searching and explore
+    the computational thinking trick of translating solutions between problem areas.
+  tutorial_finchfract_longdescription: This activity uses recursion to draw Koch fractals
+    with the Finch robot. It assumes that students have been introduced to the idea
+    of recursion, but completing this activity will help them to develop a deeper
+    understanding of this concept via a physical representation of recursion. This
+    activity is appropriate for students taking introductory or advanced computer
+    science courses that use Python or Java.
+  tutorial_tlcmind_longdescription: This introduces the use of logical reasoning through
+    the use of algebra to prove that an algorithm always works. It shows how abstraction
+    and logical reasoning can be used to evaluate algorithms.
+  tutorial_tlctelebot_longdescription: This trick illustrates how apparently simple
+    things can be too complex for our brains to take in. An important design principle
+    is that interfaces should be clear and simple, not cluttered. It also illustrates
+    aspects of computational thinking such as simplifying the problem and the importance
+    of understanding people.
+  tutorial_tlcaus_longdescription: This activity introduces a range of computing concepts
+    in a memorable way. It introduces a magic trick and show how abstraction, logical
+    reasoning and computational modelling can be used to check the algorithm works.
+    Combined with the 'Punch card searching' activity it introduces a divide and conquer
+    algorithm used by early computers.
+  tutorial_tlcmicro_longdescription: This video can be used as a general introduction
+    to human computer interaction (HCI) and in particular why so many gadgets areharder
+    to use than need be. Design does make a difference and it is important that interfaces
+    are evaluated to check they are easy to use.
+  tutorial_imathematician_longdescription: "This teacher led activity provides the
+    opportunity for pupils to use a cross curricular approach to computer science
+    and mathematics.  \n\nPupils will create a computer program to solve a variation
+    of a famous problem in a branch of Mathematics (Game Theory), called The Prisoner's
+    Dilemma.\n"
+  tutorial_tlcmagic_longdescription: 'In exploring how the magic works, you learn
+    about computational thinking: especially the importance of evaluation to algorithmic
+    thinking. You explore both testing and hazard analysis. The magic trick shows
+    how computer scientists, engineers (and magicians) have to check their algorithms
+    thoroughly. They must think carefully about how things might go wrong as well
+    as checking they will go right.'
+  tutorial_scratchmus_longdescription: With Scratch, you can create your own interactive
+    games, stories, animations -- and share them with your friends. To get started,
+    make an interactive music project. Activity cards and a workshop guide are also
+    available for free on scratch.mit.edu
+  tutorial_scratchanim_longdescription: With Scratch, you can create your own interactive
+    games, stories, animations -- and share them with your friends. To get started,
+    animate the letters of your name, initials, or a favorite word. Activity cards
+    and a workshop guide are also available for free on scratch.mit.edu.
+  tutorial_scratchfly_longdescription: 'With Scratch, you can create your own interactive
+    games, stories, animations -- and share them with your friends. To get started,
+    learn how to make your own flying character. Activity cards and a workshop guide
+    are also available for free on scratch.mit.edu. '
+  tutorial_tynkerarc_longdescription: Make your own top-down arcade shooter game.
+    Start by programming the fish to move up and down when the arrow keys are pressed,
+    then code the sharks to swim across the screen. You'll personalize the game by
+    adding custom assets for the hero, the villain, and the background. Your game
+    could be set at the beach, in the forest, or even in outer space!
+  tutorial_grokffpython_longdescription: 'This activity is designed to give you your
+    first experience programming, and has been specially designed for the Hour of
+    Code. Use the programming language Python and instruct a turtle to draw fantastic
+    snowflakes with code! '
+  tutorial_grokffblock_longdescription: This activity is designed to give you your
+    first experience programming, and has been specially designed for the Hour of
+    Code. Build programs using friendly blocks and instruct a turtle to draw fantastic
+    snowflakes with code!
+  tutorial_grokeliza_longdescription: This activity is designed to give you your first
+    experience programming, and has been specially designed for the Hour of Code.
+    Use the programming language Python to build a friendly chatbot called "Eliza".
+  tutorial_tynkercan_longdescription: Make an awesome 2-player cannon game and challenge
+    your friends to play with you! You'll start with a partially programmed version
+    of the game, so you need to program the left cannon. Once you've got both cannons
+    firing, you'll set up platforms and other items to knock over. Make it your own
+    by adding extra features and customizing the theme!
+  tutorial_grokflags_longdescription: This activity is designed to give you your first
+    experience programming, and has been specially designed for the Hour of Code.
+    Use the programming language Python and its turtle module to draw flags from around
+    the world!
+  tutorial_robomind_longdescription: 'Students learn the basics of programming by
+    controlling their own virtual robot. The online course is fully self-contained
+    with short presentations, movies, quizzes and automatic guidance/hints to help
+    with the programming exercises. '
+  tutorial_adventureq_longdescription: 'Adventure with Q is a lesson plan for teachers
+    (or anyone) to use to introduce programming logic in a group setting. The activity
+    consists of different quests for kids to complete. Kids learn the basic commands
+    through helping Q the alien in his forest adventure. '
+  tutorial_khan-es_longdescription: Learn the basics of JavaScript programming while
+    creating fun drawings with your code. Do it on your own or with your class!
+  tutorial_kpt_longdescription: Learn the basics of JavaScript programming while creating
+    fun drawings with your code. Do it on your own or with your class!
+  tutorial_kpl_longdescription: Learn the basics of JavaScript programming while creating
+    fun drawings with your code. Do it on your own or with your class!
+  tutorial_khe_longdescription: Learn the basics of JavaScript programming while creating
+    fun drawings with your code. Do it on your own or with your class!
+  tutorial_kfr_longdescription: Learn the basics of JavaScript programming while creating
+    fun drawings with your code. Do it on your own or with your class!
+  tutorial_app-inventor_longdescription: Entertaining, quick video tutorials walk
+    you through building three simple apps for your Android phone or tablet. Designed
+    for novices and experts alike, this hour of code will get you ready to start building
+    your own apps before you know it. Imagine sharing your own app creations with
+    your friends! These activities are suitable for individuals and for teachers leading
+    classes.
+  tutorial_blockly_longdescription: Got computers with slow (or non-existent) Internet
+    access? Download the offline version of Blockly Games - a single 3MB ZIP file
+    can be loaded onto any computer or used off a memory stick.
+  tutorial_tynker_longdescription: Play fun coding games to learn to code. Use programming
+    to complete a spooktacular Monster High scavenger hunt, program a Hot Wheels car,
+    plan your war strategy against invading goblins, and even battle monsters. Learn
+    key programming concepts and computational thinking skills as you play. Then build
+    your own games and share them with friends!
+  tutorial_baypt_longdescription: Code Baymax
+  tutorial_code-combat_longdescription: Defeat ogres to learn Python or JavaScript
+    in this epic programming game!
+  tutorial_mky_longdescription: Learn and teach coding in CoffeeScript, a real-world
+    programming language. CodeMonkey is a fun, award-winning game, suitable for everybody,
+    with or without any coding experience. CodeMonkey's adaptive platform will give
+    you all the instructions and hints you need, and will reward you star scores.
+    Write code. Catch Bananas. Save the world.
+  tutorial_pirates_longdescription: 'Captain Hack is a pirate looking for treasure.
+    He also writes treasure maps, and writing those like writing code. He (the player)
+    uses "pirate code" for this. It is a symbol-based programming language, used for
+    instructions and even AI behaviors. movements, loops, GO-TO''s, true/false-statements
+    are all core parts of the game. The players are guided through a tutorial and
+    presented for the posibilities, step by step. There are no correct solution for
+    the tutorial levels, so the user can chose whatever solution they like. '
+  tutorial_csfirst_longdescription: Create a story about two characters at sea. Animate
+    the water, and customize the scenery to add your own flair. Use code to tell the
+    story you want to tell!
+  tutorial_loopedy_longdescription: The goal of a good programmer is to write a program
+    that is a short, clear, and effective as possible. In this lesson, students will
+    learn how write programs using loops.
+  tutorial_dsw_longdescription: Learn to program droids, and create your own Star
+    Wars game in a galaxy far, far away.
+  tutorial_dswb_longdescription: Learn to program droids, and create your own Star
+    Wars game in a galaxy far, far away.
+  tutorial_ssw_longdescription: Learn to program droids, and create your own Star
+    Wars game in a galaxy far, far away.
+  tutorial_sswb_longdescription: Learn to program droids, and create your own Star
+    Wars game in a galaxy far, far away.
+  tutorial_kodable-unplugged_longdescription: 'Designed for use with plain paper,
+    the fuzzFamily Frenzy is an introduction to programming logic for kids 5 and up.
+    A teacher should explain the game, then students program a partner to complete
+    a simple obstacle course. '
+  tutorial_scratch_longdescription: With Scratch, you can create your own interactive
+    games, stories, animations — and share them with your friends. To get started,
+    animate your name, create a dance scene, or make a hide-and-seek game featuring
+    Cartoon Network's We Bare Bears!
+  tutorial_bayes_longdescription: Grandes Heroes
+  tutorial_gumball_longdescription: Create a story or make a game with Play Lab! Make
+    Gumball characters move, make sounds, score points, and even throw bananas!
+  tutorial_hrm_longdescription: |-
+    Human Resource Machine is a puzzle game. In each level, your boss gives you a job. Automate it by programming your little office worker! If you succeed, you'll be promoted up to the next level for another year of work in the vast office building. Congratulations!
+
+    Don't worry if you've never programmed before - programming is just puzzle solving. If you strip away all the 1's and 0's and scary squiggly brackets, programming is actually simple, logical, beautiful, and something that anyone can understand and have fun with!
+  tutorial_ice-age_longdescription: Create a story or make a game with Play Lab! Make
+    Ice Age characters move, make sounds, score points, and even throw snow flakes!
+  tutorial_koapp_longdescription: Kodable is a self-guided iPad game that introduces
+    kids 5+ to programming basics. Having a teacher or parent nearby is optimal, but
+    not necessary.
+  tutorial_lightbot-intl_longdescription: Learn core programming logic, starting from
+    super-basic programming, for ages 4+, on iOS or Android (or Web browser) . Learn
+    how to sequence commands, identify patterns, use procedures, and utilize loops!
+  tutorial_rmc_longdescription: Use blocks of code to take Alex or Steve on an adventure
+    through this Minecraft world.
+  tutorial_smc_longdescription: Use blocks of code to take Alex or Steve on an adventure
+    through this Minecraft world.
+  tutorial_minecraft-2016_longdescription: Build a Minecraft game. Create your own
+    versions of chicken, sheep, Creepers, zombies and more.
+  tutorial_thinkersmith-es_longdescription: Mediante el uso de un "Vocabulario Robot"
+    predefinido, los estudiantes descubrir&aacute;n como guiarse de modo tal de llevar
+    a cabo tareas espec&iacute;ficas sin ser estas discutidas previamente. Este segmento
+    ense&ntilde;a a los estudiantes la conexi&oacute;n entre s&iacute;mbolos y acciones
+    as&iacute; como la valiosa habilidad de depuraci&oacute;n.
+  tutorial_pixie_longdescription: Hour of Code tutorial with Pixie
+  tutorial_play_longdescription: Create a story or make a game with Play Lab! Make
+    animals, pirates, zombies, ninjas, and many more characters move, make sounds,
+    score points, and even throw fireballs!
+  tutorial_robomind-nl_longdescription: 'Students learn the basics of programming
+    by controlling their own virtual robot. The online course is fully self-contained
+    with short presentations, movies, quizzes and automatic guidance/hints to help
+    with the programming exercises. '
+  tutorial_spheroi_longdescription: Welcome to your first blocks activity! This is
+    a great place to start for most users, and can be used for the "Hour of Code."
+    Follow the steps to get an overview of the app, learn how to create programs using
+    block coding, and gain an understanding of loops and operators.
+  tutorial_spherol_longdescription: You will learn a new use for the lights on your
+    robot. In this activity, you will build a spinning top program where the gyroscopic
+    spin rate will control the main LEDs, and you will use the concepts of normalization
+    and absolute value. This is a great activity after you complete Blocks 2, and
+    can be used for the "Hour of Code."
+  tutorial_spherov_longdescription: It's time for another classic game powered by
+    Sphero. Learn how to use variables, loop until, and randomness within bounds to
+    bring Hot Potato to life. When you're all done, grab some friends and start tossing.
+    Don't get caught with the Sphero when the time runs out!
+  tutorial_swb_longdescription: Learn to program droids, and create your own Star
+    Wars game in a galaxy far, far away.
+  tutorial_build-a-galaxy_longdescription: Learn to program droids, and create your
+    own Star Wars game in a galaxy far, far away.
+  tutorial_alicesims_longdescription: 'Follow the animation production process from
+    storyboarding to programming with Alice and The Sims.  Let creativity and storytelling
+    drive your learning in a drag and drop coding environment.  The project will guide
+    you through what is a storyboard, translating a storyboard into a programmable
+    script, and how to program a short 3D animation. '
+  tutorial_tchr_longdescription: Now that tens of thousands of educators have tried
+    the Hour of Code, many classrooms are ready for more creative, less one-size-fits-all
+    activities that teach the basics of computer science. To help teachers find inspiration,
+    we collected and curated one-hour teacher-led lesson and activity plans designed
+    for different subject areas for Hour of Code veterans.
+  tutorial_robogame_longdescription: Challenge your school to compete in the Robot
+    Games! Students will compete in a series of mathematics themed activities where
+    they use Dash and Dot to solve a problem and earn points for themselves, their
+    grade, and/or their school.
+  tutorial_tap_longdescription: Learn the basics of coding with one of our six fun
+    puzzle sets. Then choose from over 100 beginner, intermediate, and advanced tutorials.
+    These tutorials come with step-by-step instructions to create drawing, music,
+    animation, storytelling, physics, and arcade game projects. When you're done,
+    you can publish your projects and explore what other kids are making in our fully
+    moderated community.
+  tutorial_cintl_longdescription: Learn the basic concepts of Computer Science with
+    drag and drop programming. This is a game-like, self-directed tutorial starring
+    video lectures by Bill Gates, Mark Zuckerberg, Angry Birds and Plants vs. Zombies.
+    Learn repeat-loops, conditionals, and basic algorithms. Available in 37 languages.
+  tutorial_itchstop_longdescription: We'll be using Itch to build our own stop frame
+    animation projects. Note that headphones are recommended for this course. We will
+    use some existing sprites that support animations and show the code we need to
+    add to animate our characters. We'll also go over how to create our very own animation
+    effects and drawings. We'll learn how to change a sprite costume in scratch repeatedly
+    for animation effects (similar to a flip-book animation) and the code behind it.
+    All instruction is contained within the Itch environment so there is no need to
+    be switching screens to follow along with the project.
+  tutorial_tynkerpn_longdescription: Follow Peep as he explores the big wide world!
+    In this project, you'll create an interactive scene in which Peep goes on a nature
+    walk and sees lots of interesting items. You'll make different items show up or
+    disappear depending on where Peep is walking. You can even make the items talk
+    and add music to your scene!
+  tutorial_tynkerpd_longdescription: Are you ready to make Peep and his friends dance?
+    Learn how to use code to animate the birds. In this project, you will use costumes
+    and delays to animate the birds, one frame at a time. You can add your own background
+    and music and even make Peep and his friends talk!
+  tutorial_persistence_longdescription: New and unsolved problems are often pretty
+    hard. If we want to have any chance of making something creative, useful, and
+    clever, then we need to be willing to attack hard problems even if it means failing
+    a few times before we succeed. This lesson teaches that failure is not the end
+    of a journey, but a hint for how to succeed.
+  tutorial_getloopy_longdescription: Loops are a handy way of describing actions that
+    repeat a certain numbers of times. In this lesson, students will practice converting
+    sets of actions into a single loop.
+  tutorial_createface_longdescription: The aim of this activity is to demonstrate
+    how apparently complicated behaviour can be programmed using some simple rules.
+    It also shows how programs are just rules followed by computers and specifically
+    introduces object-based programming. The activity shows how breaking a program
+    into objects can be much easier to write than trying to write it in one go. The
+    class get to write some simple programs to control the face they created.
+  tutorial_happymaps_longdescription: At the root of all computer science is something
+    called an algorithm. The word "algorithm" may sound like something complicated,
+    but really it's just a list of instructions that someone can follow to achieve
+    a result. To provide a solid base for the rest of your students' computer science
+    education, we're going to focus on building a secure relationship with algorithms.
+  tutorial_moveit_longdescription: This lesson will help students realize that in
+    order to give clear instructions, they need a common language. Students will practice
+    controlling one another using a simple combination of hand gestures. Once they
+    understand the language, they will begin to "program" one another by giving multiple
+    instructions in advance.
+  tutorial_bigevent_longdescription: Events are a great way to add variety to a pre-written
+    algorithm. Sometimes you want your program to be able to respond to the user exactly
+    when the user wants it to. That is what events are for.
+  tutorial_gpp_longdescription: By "programming" one another to draw pictures, students
+    will begin to understand what programming is really about. The activity will begin
+    by having students instruct each other to color squares in on graph paper in an
+    effort to reproduce an existing picture.
+  tutorial_foosgame_longdescription: Code your own video game with codeSpark Academy
+    with The Foos' new Game Kits. This activity guides students brand new to game
+    design using a "paint-by-numbers" approach. Students will follow the on screen
+    prompts to design and program a fun video game that they can share with their
+    family and friends.
+  tutorial_solopython_longdescription: Learn Python basics using the first two modules
+    on SoloLearn's Python app, consult discussions and comments to help you understand
+    better, run code examples in the compiler to help with material retention. Write
+    and compile a simple program that takes your name as input, counts the number
+    of letters, and outputs the result. Share and get community upvotes.
+  tutorial_kodableint_longdescription: Students will learn about the role of a programmer
+    in making machines function. Students will focus on sequence and practice giving
+    instructions in order. This activity includes an unplugged group practice, as
+    well as on-screen, independent practice.
+  tutorial_kodableadv_longdescription: Students will engage in developmentally appropriate
+    lessons on higher level programming concepts such as loops, functions, variables,
+    and object-oriented programming. Lessons included unplugged instruction, guided
+    practice, and on-screen independent practice.
+  tutorial_tynkertj_longdescription: Learn Python to help Fletch collect the satchels
+    of pixie dust to unlock the mysteries of the jungle and restore the islands to
+    their original beauty. You'll use Python commands and syntax to solve puzzles
+    as you navigate Fletch through the islands and avoid the carnivorous plants. Along
+    the way, you'll practice computational and algorithmic thinking skills.
+  tutorial_wolframa_longdescription: In this activity, you will create a web-form
+    that calculates your age in days, hours, nanoseconds, any unit of time that you
+    specify!
+  tutorial_wolframm_longdescription: In this activity, students create random melodies
+    using various musical scales and instruments. Create music through code!
+  tutorial_wolframspi_longdescription: In this activity, there are a series of steps
+    with code ready to run. Students start with a piece of code that works, and then
+    modify it to do different things. Students can play melodies based on the digits
+    of PI and explore what PI sounds like using many musical instruments.
+  tutorial_wolframsph_longdescription: Explore 3D graphics in this activity and create
+    your own shapes.
+  tutorial_wolframp_longdescription: Explore creating different polygon shapes in
+    this activity.
+  tutorial_wolframn_longdescription: In this activity, students develop a name generator
+    that transforms their name into ninja names.
+  tutorial_soloweb_longdescription: Go to www.sololearn.com and install HTML and CSS
+    apps or open the relevant lessons on the web (Android users can install the unified
+    SoloLearn app).  Complete 2 modules (Overview and HTML Basics) in HTML and 2 modules
+    (The Basics and Working w/Text) and first 5 lessons of the 3rd module (Properties)
+    in CSS. Get the template at https://code.sololearn.com/WKeg2CtzpRts/ and follow
+    the instructions.
+  tutorial_khanweb_longdescription: 'Khan Academy: Webpages teaches you how to make
+    webpages with HTML tags and CSS, finishing up by making your very own greeting
+    card.'
+  tutorial_khandata_longdescription: 'Khan Academy: Databases teaches you to manipulate
+    data in a database and make your own custom store.'
+  tutorial_googlelogo_longdescription: Use your creativity and imagination to bring
+    the Google logo to life using code. Make the letters dance, tell a story or create
+    a game. With Scratch and CS First, anyone can become a designer and programmer
+    for the day!
+  tutorial_playtune_longdescription: A blocks language is used to solve musical puzzles
+    by writing code to match tunes played on a piano keyboard. Sequence, selection,
+    and repetition algorithms are needed to solve the puzzles. After the 9th level,
+    users can create their own tune and download it as an app for an Android device.
+    Students can also modify the app by following a link to the App Inventor source
+    code.
+  tutorial_computeit_longdescription: Let's switch roles. This time YOU are the computer!
+    Read and interpret the programs to find the right trajectory and win the challenges.
+    You will have to focus and use your intuitive abilities to understand some core
+    concepts of programming.
+  tutorial_codesterssj_longdescription: In this activity, students use our drag-to-text
+    toolkit to start coding in Python right away! As they work through introductory
+    skill building activities, students begin to learn about basic syntax, variables,
+    and events! They'll use multiple sprites to set up a joke telling scenario that
+    they can share with their friends! *Electronic sharing requires student sign up.
+  tutorial_cmchat_longdescription: Join a robot monkey in an hour-long course where
+    you will learn the basics of Python and chatbot programming. In the activity,
+    you will advance through a 15 exercise-long course in which you will learn how
+    to program your very own trivia chatbot.
+  tutorial_tynkerdb_longdescription: Choose a dragon, then embark on a quest for treasure.
+    Blast through obstacles and gain cool power-ups as you journey through a mystical
+    jungle. Learn sequencing, loops, conditional logic, and debugging skills along
+    the way.
+  tutorial_cmbuild_longdescription: Take your coding skills to the next level by learning
+    to build your own games. In this course, you will learn keyboard user-interface
+    and game mechanics as you build a Super Mario™-styled game. Afterwards, you will
+    be able to share your game!
+  tutorial_robotrattle_longdescription: Robot Rattle teaches students to operate a
+    fully physically simulated robot with the help of a visual coding language by
+    easily dragging & dropping blocks to write code instructions. Students are introduced
+    to the robot and its various moving joints, and learn to move its joints with
+    the use of angles. The robot can push and grab objects in order to direct them
+    to the goal, but also break if moved against obstacles. This activity is targeted
+    to kids aged 13+ and offers easy-to-grasp insights into physical behaviour and
+    robotics. On top of that, anyone with a smartphone and a mobile VR headset will
+    be able to watch the full-scale robot performing the written code.
+  tutorial_codestersh_longdescription: In this activity, designed for beginning coders,
+    students use a drag-to-text toolkit to start coding in Python right away! First,
+    work through some skill building activities where you learn how to assign and
+    modify commands for your sprite. Then, program your own commands to create shareable
+    electronic art! *Sharing requires student sign up.
+  tutorial_codehsdigipixel_longdescription: Learn how images are stored and displayed
+    on computers using pixels. Explore how images are encoded as a grid of color values,
+    and make your own digital images using binary and hexadecimal color codes!
+  tutorial_ccbinary_longdescription: Make a Scratch game in which you play the notes
+    of a song as they scroll down the stage. You'll score ten points for every correct
+    note you play. Each note corresponds to a binary number.
+  tutorial_codehsturtle_longdescription: Learn the basics of programming by drawing
+    shapes on your screen with Tracy the Turtle! Turtle Graphics (or LOGO) is a beginner
+    friendly way to explore programming concepts and bring creativity into programming
+    in a visual way.
+  tutorial_grokhd_longdescription: 'Continue those Blockly programming skills! This
+    course builds on what you learned in the Frozen Fractals activity: https://hourofcode.com/grokffblock.
+    This activity is designed to introduce branching decisions in programming. Use
+    the Blockly version of Python and its turtle module to draw and colour hydrangea
+    flowers!'
+  tutorial_grokem_longdescription: This activity is designed to give you your first
+    experience programming, and has been specially designed for the Hour of Code.
+    Use the programming language Python to explore emoticons and text manipulation.
+  tutorial_kodmaze_longdescription: Build your own mazes to solve and share! Students
+    will pair geometry with programming to build solvable mazes based on given challenges.
+    Challenges include mazes with simple shapes, fractions, symmetry, and specified
+    angles.
+  tutorial_codestersa_longdescription: 'In this activity, designed for students with
+    some coding experience, students use our drag-to-text toolkit to build an game
+    with player controls! Students learn about variables, randomly generated numbers,
+    game design, and multiple types of events and event triggers, all while scrambling
+    to stay out of the way as asteroids hurtle toward their spaceship! Prereq: variables,
+    parameters.'
+  tutorial_cmdodo_longdescription: In this hour-long course, you will write real code
+    as you add, subtract and measure distances to help a dodo find her missing eggs!
+  tutorial_tynkerspace_longdescription: Your astronaut's ship has crash-landed!  Luckily,
+    you're there to help. Use drag-and-drop programming to help your character collect
+    spare parts while avoiding aliens and obstacles. Can you find a ship to bring
+    your astronaut home?
+  tutorial_gfbloons_longdescription: In this lesson you will code a shooting monkey
+    tower from the popular Bloons Tower Defense game. By the end of the lesson you
+    will know the angle finding maths and algorithms commonly used in many of today's
+    most popular tower defense games. You will be able to apply this knowledge in
+    your own game. Gamefroot Hour of Code tutorials use a visual programming language
+    using blocks where students simply drag and drop visual blocks to write code.
+  tutorial_raspipong_longdescription: Recreate the classic game of Pong using a Sense
+    HAT and some Python code. This activity can be completed online using the Sense
+    HAT emulator, or by using a Raspberry Pi and the Sense HAT hardware.
+  tutorial_codehsvr_longdescription: Learn the basics of building virtual reality
+    worlds using HTML and the A-Frame JavaScript Library. Through this activity, students
+    will build their own virtual reality worlds that are compatible with VR devices,
+    including smartphone VR headsets!
+  tutorial_codesterstp_longdescription: In this activity, students use Python to practice
+    performing transformations on the coordinate plane! The lesson includes demonstrations,
+    direct instruction, and challenges that ask students to program and identify various
+    static transformations!
+  tutorial_codestersbb_longdescription: 'Students use our drag-to-text toolkit to
+    start coding in Python right away! In this self-guided activity, students complete
+    a series of direct-instruction activities in which they build a pull and shoot
+    basketball game! Students explore variables, events, basic syntax, creating random
+    coordinates. Advised prereq knowledge: variables, dot notation, events, negative
+    numbers'
+  tutorial_gfcrossyroad_longdescription: In this suite of introductory coding lessons
+    you will learn about making your own Crossy Road style mini-game. You will learn
+    how to code algorithms and sequences, inputs / outputs, loops and iteration, selection
+    and if-statements, and comparative operators and think like a computer scientist.
+    This suite of lessons is aligned with the New Zealand and Australian (Victorian)
+    digital technologies curriculum and designed to help young people AND educators
+    embrace coding in their schools, classrooms and coding clubs. Gamefroot Hour of
+    Code tutorials use a visual programming language using blocks where students simply
+    drag and drop visual blocks to write code.
+  tutorial_googleww_longdescription: In this activity, you'll code three unique scenes
+    from the film using Blockly, an introductory coding language, to help Wonder Woman
+    navigate obstacles and reach her goal. You'll use the power of sequences, variables,
+    loops and conditionals to help Diana train against her opponents.
+  tutorial_codehsjsapp_longdescription: CodeHS is compatible with all up-to-date browsers
+    except Internet Explorer. Chrome is our preferred / recommended browser, but Firefox
+    and Safari should work fine as well, assuming they are up to date.
+  tutorial_gfmihi_longdescription: Kia ora! In this activity you will code your own
+    mini-game and learn how to introduce yourself in Te Reo Maori - the indigenous
+    language of New Zealand. Mihi Maker is a fun easy to use activity that combines
+    coding, social studies and indigenous culture. You will learn how game designers
+    program basic collision detection algorithms. Collision detection is a program
+    used by a computer to help it understand when two objects will hit into each other.
+    Gamefroot Hour of Code tutorials use a visual programming language using blocks
+    where students simply drag and drop visual blocks to write code.
+  tutorial_hopdropphone_longdescription: 'Hopscotch is a simple programming tool on
+    the iPad/iPhone, beloved by millions of students for its freedom of creative expression.
+    Watch your students squeal with delight as they create their own "Don''t Drop
+    the Phone" games! This self-guided video tutorial teaches kids ages 8+ programming
+    basics while they code customized editions of this popular game. '
+  tutorial_techfaa_longdescription: This interactive tutorial will introduce you to
+    "Flocking", a type of algorithm which is intended to simulate life-like behavior
+    of Autonomous Agents in a group. The embedded viewer makes it easy for you to
+    see the rendering of the code.
+  tutorial_codehsjsgraph_longdescription: CodeHS is compatible with all up-to-date
+    browsers except Internet Explorer. Chrome is our preferred / recommended browser,
+    but Firefox and Safari should work fine as well, assuming they are up to date.
+  tutorial_thunkable_longdescription: Using the language of blocks, learn how to build
+    10 simple apps in 1 hour. This funny tutorial series will start you on your path
+    to becoming a mobile app developer!
+  tutorial_hopcrossyroad_longdescription: Hopscotch is a simple programming tool on
+    the iPad/iPhone, beloved by millions of students for its freedom of creative expression.
+    With this self-guided video tutorial, your students will make their own versions
+    of Crossy Road! Kids ages 8+ will be exposed to the basics of programming while
+    they code customized editions of this App Store favorite.
+  tutorial_switchglitch_longdescription: Switch & Glitch lets your students play the
+    hero! Using a visual interface, they program cute robots and help them save the
+    day. This activity teaches children aged 5-10 the basics of programming, loops,
+    and the art of debugging. The galaxy needs you!
+  tutorial_codecar_longdescription: Code a simulated car circuit board! You'll type
+    real C++ code that controls the lights and buttons of a car-shaped circuit board.
+    Through 7 lessons, you'll flash the tail light, code a brake pedal, and more on
+    the simulated Code Car. This activity teaches loops, if statements, and logic
+    with typed code and includes a lesson plan with alignments to ISTE, NGSS, Common
+    Core, and CSTA standards.
+  tutorial_codesterscp_longdescription: In this lesson students explore all four quadrants
+    of the coordinate plane! They use Python and our drag-to-text toolkit to send
+    a sprite to various locations on the stage! There are demonstration and debugging
+    activities included to help students become comfortable with navigating the coordinate
+    plane.
+  tutorial_grokpetblock_longdescription: This activity is designed to introduce you
+    to embedded programming using friendly blocks, and has been specially designed
+    for the Hour of Code. Use the blocks and a micro:bit to make a pet that you can
+    feed and play with. No BBC micro:bit? No problem! This course includes a full
+    micro:bit simulator, so you'll be able to do everything you'd do on a real micro:bit!
+  tutorial_techbim_longdescription: 'This hands-on tutorial is intended for people
+    curious to know how to programatically perform some simple image manipulations
+    such as rotation, colorization, increase of contrast, blur, edge detection, etc.,
+    without the help of advanced libraries. '
+  tutorial_techfpp_longdescription: Python is well known for its object oriented programming
+    features (classes, methods, inheritance…), however, it cannot be restricted to
+    these! This interactive tutorial shows the useful, but lesser known, functional
+    programming features and techniques of Python.
+  tutorial_codesterscr_longdescription: Students use a drag-to-text toolkit that allows
+    them to start coding in Python right away! Students complete a set of guided practice
+    activities in which they learn how to use and modify a variety of programming
+    commands. Then, they apply these skills to create their own cheer routine!
+  tutorial_grokdisease_longdescription: This activity is designed to give you your
+    first experience programming, and has been specially designed for the Hour of
+    Code. Use the programming language Python to model a disease outbreak. Can you
+    solve the curious case of the glowing nose?
+  tutorial_techec_longdescription: Closures are a crucial aspect of Javascript, yet
+    they remain mysterious and developers do not understand them easily. This interactive
+    tutorial will teach you how powerful and useful Closures are to boost your Javascript
+    practice!
+  tutorial_rgbegin_longdescription: RoboGarden is an easy to understand, hands-on
+    educational app where students take part in active learning. Fully equipped to
+    teach coding literacy from scratch, RoboGarden reduces the need for a tech-savvy
+    teacher.
+  tutorial_myradream_longdescription: Monsters have taken Myra's dream. Learn coding
+    skills to help her cross bridges, fly through the air, and swim underwater to
+    get back her dream. Actimator is a Web-based visual environment for creating games
+    and science simulations collaboratively, as well as publishing them for the Web
+    and as mobile apps.
+  tutorial_thinkfun_longdescription: We'll take you through the process of fixing
+    a Robot's brain, step by step! Along the way you'll solve puzzles based on the
+    famous 'Boolean Satisfiability Problem,' and within an hour you'll be a Boolean
+    Master and have an understanding of advanced programming concepts! All instruction
+    is contained on one screen, and volume is optional.
+  tutorial_hopfireworks_longdescription: 'Your students will be so excited when they
+    code their own (explosion free!) fireworks app! Hopscotch is a simple programming
+    tool on the iPad/iPhone, beloved by millions of students for its freedom of creative
+    expression. This self-guided video tutorial teaches kids age 8+ programming basics
+    while they code custom versions of interactive fireworks. '
+  tutorial_grokspace_longdescription: This activity is designed to give you your first
+    experience programming, and has been specially designed for the Hour of Code.
+    Use the visual programming language Blockly to investigate space and reach for
+    the stars.
+  tutorial_codehspython_longdescription: Learn the basics of coding with the Python
+    programming language by writing programs that you can interact with! This hour
+    will cover printing, variables, math, and getting information from users. Write
+    a program that takes in and stores data from a user and returns a unique response!
+  tutorial_codehsjava_longdescription: Coding in Java with CodeHS
+  tutorial_techioda_longdescription: This useful tutorial will interactively teach
+    you how to be able to calculate the shortest path between two nodes in a graph
+    in advance, thanks to the Dijkstra's algorithm.
+  tutorial_grokmonster_longdescription: Get kids into coding with this friendly course
+    specially designed for the Hour of Code! Use drag-and-drop blocks to write your
+    own programs, learn about sequence and ordering, and create fun monster characters!
+  tutorial_techmjs_longdescription: JavaScript has been an international standard
+    since 1997. In this interactive tutorial, we will explore the modern features
+    of the language that will make your code more robust, concise, and easier to read.
+  tutorial_techga_longdescription: Genetic Algorithms make use of the evolution theory
+    to powerfully solve problems where deterministic algorithms are too costly, such
+    as the Travelling salesman problem. This interactive tutorial is a clear and simple
+    introduction to help you understand how Genetic Algorithms work.
+  tutorial_techioan_longdescription: In this interactive tutorial, we will learn why
+    Java's "null" value should always be avoided and what solutions exist to bypass
+    it.
+  tutorial_techiogsr_longdescription: Rust is a recent System Programming Language
+    designed with memory safety and performance in mind. It was originally released
+    in 2010. In this interactive tutorial, discover the basics of this fun to use
+    language, with performances comparable to C and C++!
+  tutorial_groktunnel_longdescription: This activity is designed to give you your
+    first experience programming, and has been specially designed for the Hour of
+    Code. Use the programming language Python to create a simple game (or MUD). Can
+    you find your way through the dark tunnel?
+  tutorial_stemcod_longdescription: Do you play video games? Have you ever thought
+    about how some games are super-realistic and other games are cartoon-ish? In this
+    activity we will talk about the physics of video games and you will learn to modify
+    a computer code to simulate the motion of an object. Our activities are all based
+    on classic video games. No install required. 100% Chromebook compatible.
+  tutorial_techikb_longdescription: Kotlin is a new open-source programming language
+    from JetBrains. It can be of greatest interest to people who work with Java today,
+    although it could also appeal to all programmers who use a garbage collected runtime
+    (Scala, Go, Python, Ruby and JavaScript). Discover Kotlin's basics in this interactive
+    tutorial!
+  tutorial_kanostreet_longdescription: Art and technology unite! With Kano's Street
+    Art Hour of Code challenges, creative minds of all abilities will code with a
+    paintbrush, making beautiful, unique artwork. Along the way, makers will learn
+    computer science principles while using a real programming language in an intuitive
+    and engaging way. With our teacher resources and guided content, everyone can
+    get in on the fun.
+  tutorial_codemojijs_longdescription: Beginning JavaScript is designed to get students
+    typing simple commands that have a big impact on the characters' actions. The
+    students will type commands that make the characters do everything from backflips
+    to make sounds and even talk. This activity will help you learn basic JavaScript
+    ideas and commands.
+  tutorial_techapf_longdescription: The interactive tutorial aims to introduce you
+    to useful advanced Python features and tricks you may not know yet to improve
+    your mastery of the Python language.
+  tutorial_techfpjs_longdescription: Functional programming is one of those things
+    that may look too hard or too theoretical to try. Wait no more! In this interactive
+    tutorial, you'll discover functional programming through hands-on examples and
+    exercises in JavaScript.
+  tutorial_techlinq_longdescription: The C# programming language is quite popular
+    with developers, in a large part because of its many powerful and intuitive language
+    features. One of these is LINQ, a library used to execute queries directly in
+    C# syntax against many types of data. This interactive tutorial will show you
+    how to use it, step by step.
+  tutorial_gpbcatapult_longdescription: Participants will build a catapult to launch
+    a ball from one side of the stage to the other, as in the game Angry Birds.
+  tutorial_quorumastro_longdescription: Learn about coding using themes from computational
+    astronomy in this accessible online tutorial. In it, students will discover how
+    to control telescopes while also practicing with the Quorum programming language's
+    computer graphics engine. By the final lesson, students will create a graphical
+    and accessible map of the stars to find items in the universe.
+  tutorial_alicewonder_longdescription: Alice in Wonderland is a self-guided puzzle
+    designed for 6+ kids without prior programming experience. You will guide Alice
+    using functions with and without parameters.
+  tutorial_rginter_longdescription: RoboGarden is an easy to understand, hands-on
+    educational app where students take part in active learning. Fully equipped to
+    teach coding literacy from scratch, RoboGarden reduces the need for a tech-savvy
+    teacher.
+  tutorial_cssgrid_longdescription: Learn all about CSS Grid by tending to your vegetable
+    garden.
+  tutorial_jshero_longdescription: JS Hero wants to take you into the world of JavaScript
+    programming. On each page you will find a small lesson and a small programming
+    task. The task can be answered directly on the page. And you are immediately told
+    if you have solved the problem correctly or if you made a mistake.
+  tutorial_codemojipy_longdescription: Python Lab is an IOS based activity that teaches
+    the basics of the programming language python. Users will learn about loops, arrays,
+    booleans and much more.
+  tutorial_nclabdrone_longdescription: 'Build a drone frame in ten steps with NCLab''s
+    3D Modeling app. The drone frame can be 3D printed and used to build a real working
+    drone!  Each step includes tutorials and instructions. Complete the code and immediately
+    see the results.  3D Modeling is a vital part of 21st century engineering, manufacturing,
+    art, science, medicine, and more.  This is a great way to get started! '
+  tutorial_gpbcircle_longdescription: Participants will make a circle that changes
+    color and brightness as you move the mouse. In the process, they will explore
+    the hue, saturation, and brightness color model.
+  tutorial_gpbpaint_longdescription: Participants will create a paint editor to draw
+    with the mouse, then add features such as a clear button and the ability to fill
+    areas with color.
+  tutorial_cocomarcade_longdescription: Ready to create an even cooler game? Brush
+    up on advanced coding concepts like functions and events using Python or JavaScript,
+    then use those skills to build your own arcade survival game!
+  tutorial_beetik_longdescription: In this activity, students reconstruct a small
+    part of a famous piece by composer Franz Liszt. Students will learn how to embed
+    loops and how they're used in both computer science and music. This is a step-by-step
+    guide that will introduce algorithmic thinking in music with elements of computer
+    science. In the last level of this activity, students will 'hack' the music by
+    changing elements such as tempo, key, repetitions, notes, etc with the objective
+    of making original variations based on what they learned. This activity intersects
+    classical music with computer science.
+  tutorial_codedj_longdescription: In Code DJ, you will first discover the basics
+    of Javascript by answering questions that will progressively become more like
+    code. You will then reach a second world where you will actually start to make
+    music directly with code, just by changing numbers at first, and as your mastery
+    increases, by manipulating rhythm loops and more! You will then unlock the ability
+    to create music freely in the Code DJ app and get it as an mp3!
+  tutorial_rgadvan_longdescription: RoboGarden is an easy to understand, hands-on
+    educational app where students take part in active learning. Fully equipped to
+    teach coding literacy from scratch, RoboGarden reduces the need for a tech-savvy
+    teacher.
+  tutorial_codehsrn_longdescription: This activity gives you some examples on how
+    to make your first real mobile apps and how to test them out on your phone using
+    React Native. To run apps on a smartphone phone, students will need to download
+    the Expo app. Find more information about Expo at https://expo.io/.
+  tutorial_codehswd_longdescription: CodeHS is compatible with all up-to-date browsers
+    except Internet Explorer. Chrome is our preferred / recommended browser, but Firefox
+    and Safari should work fine as well, assuming they are up to date.
+  tutorial_turtlerobot_longdescription: A take on the board game Robot Turtles that
+    allows the student to practice without the help of a teacher.
+  tutorial_ozoevo_longdescription: Evo by Ozobot is packed with tons of cool technology,
+    like proximity sensors, programmable LEDs, motion and sounds, and light and color
+    sensors underneath so it can see colors and follow lines. This introduction to
+    Evo presents an OzoBlockly program that makes Evo move when its proximity sensors
+    are activated by your hands, and play a victory dance once it has walked on certain
+    colors.
+  tutorial_ozoexped_longdescription: Students practice drawing lines and color codes
+    that Ozobot can follow in a fun way with this printable board game. Both luck
+    and skill play a role through a series of fun timed challenges that require them
+    to combine a shape and color codes. As students are successful, they will get
+    to move closer the their destination. The activity includes challenge cards students
+    can use to increase the difficulty for their opponents as part of their strategy.
+  tutorial_ozojourney_longdescription: As a class, students will program their Ozobot
+    to complete the journey of Ferdinand Magellan. The educator should cut out and
+    assemble the paper continents ahead of time. Students will use the OzoBlockly
+    language to program an Ozobot robot to navigate around the continents along the
+    path Magellan took. Along the way students will label different parts of world
+    geography.
+  tutorial_ozocodes_longdescription: This tutorial helps Pre-readers get in on the
+    Ozobot coding fun by having them to write their names in thick black lines that
+    Ozobot can walk on and place OzoCodes in logical places to help the robot walk,
+    and jump, from the first letter to the last. Students test a first draft and iterate
+    to create a working final product.  This lesson encourages fine motor skills,
+    computer science concepts and adds to students' OzoCode experience.
+  tutorial_ozoeclipse_longdescription: Discover the magic of eclipses, lunar phases,
+    and celestial mechanics (changing speeds of orbiting bodies) using Ozobot robots
+    on a simple map based on the Moon's orbit around Earth. Even with little Ozobot
+    programming experience, a class can create a demonstration of eclipses with two
+    bots and a flashlight, then create a map of the changing speeds of an orbiting
+    body with simple OzoCodes, drawn with markers.
+  tutorial_ozosimulator_longdescription: This activity teaches about programming languages
+    without students needing to use a computer or bot. The student is the computer
+    in this activity that uses psuedocode to teach the basics of how to write a program
+    a computer can read using a brain-teasing maze in which students must first read
+    and execute commands, and then write a program for a maze using what they've learned.
+  tutorial_ozoalgorithm_longdescription: Students with several programming concepts
+    under their belts will enjoy the challenge of making Ozobot choose a random multiplication
+    fact, then draw the array of the fact on a grid and blink and/or say the answers.
+    Programming concepts students should know ahead of time include loops, math, variables,
+    random number generation, and the OzoBlockly specific concepts of line following,
+    setting LED lights, timers and "say" for Evo audio capabilities.
+  tutorial_ozotimer_longdescription: Could we turn Ozobot Bit into a timer - specifically
+    a timer for measuring seconds? This challenge lesson will involve the student's
+    knowledge of concepts from geometry and physical science, as well as his or her
+    ability to write Level 4 (Advanced) OzoBlockly code using light effects, line
+    navigation, and timing. An OzoMap is provided as a basis for which the OzoBlockly
+    program can then be designed. A stop-watch or a cell phone stop-watch app is needed
+    to calibrate the Ozobot Bit second timer.
+  tutorial_ozohabits_longdescription: When students know how to draw lines and OzoCodes
+    to program Ozobot, they're ready to integrate this programming method in the real
+    world. This tutorial shows how Ozobot can be used to model nature similar to computer
+    simulations. This lesson begins with the educator explaining how Point OzoCodes
+    work, and how they can be used to bring Ozobot to a stop. This functionality will
+    be applied to modeling how a rabbit living on a grassy hill eats its fill and
+    stops.
+  tutorial_ozoprogram_longdescription: Students find out how easy it is to program
+    robots, even if their classroom doesn't have any. This teacher-guided online tutorial
+    helps students develop programming skills and gain confidence in their ability
+    to understand computer science through Ozobot's Blockly games. Students discover
+    how Bit and Evo by Ozobot will upload the program through a unique method - colors
+    flash onto the robot's light sensors and teach the it the program.
+  tutorial_ozopair_longdescription: Students who know the OzoBlockly block-based programming
+    language learn how to work in teams as Drivers and Navigators, and then practice
+    by creating a single program on one computer for one Ozobot robot. This is a teacher-led
+    tutorial that requires videos to be shown at the beginning, and then guidance
+    to help students through completing their program when needed.
+  tutorial_codesnoopy_longdescription: Team up with friends and practice your coding
+    skills by programming Snoopy's Beagle Scouts in a fun and silly snowball fight!
+    Beginners and pre-readers welcome - teams write their code in secret while trying
+    to outsmart each other. With words-free code, everyone can get in on the fun!
+    This activity supports 1- 4 players on the same device - play against friends
+    or the computer.
+  tutorial_applabintro_longdescription: Create your own app in JavaScript using blocks
+    or text. You'll make a simple app with buttons, images, sounds and multiple screens
+    that you can share with your friends or publish to a public gallery. If you've
+    already done some coding with blocks, take your skills to the next level.
+  tutorial_cslartist_longdescription: Did you know that there's a little artist who
+    lives inside every computer? This PDF contains a fun story embedded with puzzles
+    that will teach your students the fundamentals of digital art as they make their
+    own creations using pixels, algorithms and repeat loops.
+  tutorial_cslscratchjr_longdescription: CodeSpeak's "Let's Play with the ScratchJr
+    Kitten!" Activity Pack is a Read Aloud Story with accompanying worksheets. The
+    Story walks through the code for a great first project for brand new coders. A
+    grown-up can read the story to a class of pre-reader students and then guide students
+    to code the story in their tablets using the ScratchJr app. Students with early
+    reading skills can read the story themselves and independently complete the Activity
+    Pack.
+  tutorial_floevents_longdescription: Students will explore events, a concept that
+    allows programs to respond to specific stimuli. Events are determined in bits
+    of code called event handlers, which listen for specific events and contain instructions
+    on how to respond. Students will learn key vocabulary and write text for event
+    handlers in a Mad Libs-style exercise in which they create and act out event handlers
+    of their own.
+  tutorial_florobot_longdescription: In this lesson, students will build their literacy
+    skills while diving into the field of robotics. They'll watch Flocabulary's educational
+    hip-hop video to find out what a robot is and see examples of robots in daily
+    life. They'll close-read short passages about robots, discuss tasks that robots
+    are well suited for and finish the lesson by designing their own robot to solve
+    a specific problem.
+  tutorial_isavesanta_longdescription: In this teacher-led festive activity, adapted
+    for the Hour of Code, the children create a computer game using Scratch to save
+    Santa. They design algorithms, use conditional statements as well as test and
+    debug their work. Includes step-by-step lesson plan, pupil resources, support
+    cards and pre-written program templates.
+  tutorial_iorder_longdescription: This teacher led activity, adapted for the Hour
+    of Code, develops computational thinking and coding skills using Scratch 2.0.
+    The children program an ice-cream stand simulation and/or game and, in doing so,
+    design algorithms, use repetition, conditional statements, test and debug their
+    work. Includes step-by-step lesson plan, pupil support materials, and pre-written
+    Scratch 2.0 program templates for teacher and pupils.
+  tutorial_ianimate_longdescription: 'This teacher-led seasonal activity, adapted
+    for the Hour of Code, introduces children to creating computer animations. The
+    children will create frames, add artwork and animate a simple Christmas scene.
+    Lots of ideas for differentiation, extension and enrichment from making a very
+    simple animated sequence to more able pupils: animating backgrounds as well as
+    characters and objects, adding 3D effects (e.g. shadows), creating more frames
+    for smoother movement, switching backgrounds to create scene changes, and animating
+    more than one object.'
+  tutorial_iloveada_longdescription: This teacher-led lesson activity, adapted for
+    the Hour of Code, provides an opportunity to teach cross-curricular computing
+    with history. Children research Ada Lovelace an important historical figure in
+    computer science and the world's first computer programmer! They then use basic
+    HTML to create a multimedia webpage showcasing their findings and skills as web
+    masters. Includes a step-by-step activity plan, associated teacher and pupil resources
+    and ideas for extension and enrichment to take learning further.
+  tutorial_kodflash_longdescription: Flash! Clap! This hands-on, wild weather lesson
+    teaches conditional statements with lightning and thunder. Students will learn
+    about why thunder always follows lightning and will examine the logic statement
+    "if there is lightning, then thunder will follow." Count the seconds between the
+    two to see how far away the storm is!
+  tutorial_kodchoose_longdescription: Choose your own adventure! Through a series
+    of "If statements", students will alter the storyline and ending to a narrative
+    they write. Like a program's path changes based on conditions, the path a character
+    takes through a narrative can change too. Get creative and lead the Kodable fuzzFamily
+    on multiple adventures within one story that can have varying conclusions.
+  tutorial_kodpizzapre_longdescription: In a 3-part unit, students will connect math
+    and programming to develop solutions for a restaurant's mobile ordering app. Dominic's
+    Pizza restaurant is creating an algorithm for their new app and it's up to students
+    to help calculate pizza costs. At the end of the unit, students will make and
+    deliver their "pizza" after calculating the cost of the order.
+  tutorial_kodpizza_longdescription: In a 3-part unit, students will connect math
+    and programming to develop solutions for a restaurant's mobile ordering app. Dominic's
+    Pizza restaurant is creating an algorithm for their new app and it's up to students
+    to help calculate pizza costs. At the end of the unit, students will make and
+    deliver their "pizza" after calculating the cost of the order.
+  tutorial_kodwomen_longdescription: This 3-part unit explores gender inequality and
+    engages students in activities and discussions around different experiences and
+    perspectives. Highlighting influential women in the history of tech, students
+    learn about past pioneers and form their own opinions on equality in the tech
+    field. At the end of the unit, students express their opinions in writing to effect
+    change in their school community.
+  tutorial_tfunplug_longdescription: We'll take you through the process of fixing
+    a Robot's brain, step by step! Along the way you'll solve puzzles based on the
+    famous 'Boolean Satisfiability Problem,' and within an hour you'll be a Boolean
+    Master and have an understanding of advanced programming concepts! No computers
+    required – everything you'll need can be printed out from our supplied PDF.
+  tutorial_lbvariables_longdescription: Having fun is not a variable! Short activities
+    and fun videos provide an overview of the core coding concepts that students will
+    encounter in the app. The variables lesson teaches students to create variables
+    to add countdowns, characters, and extra players to games.
+  tutorial_lbfunctions_longdescription: Short activities and fun videos provide an
+    overview of the core coding concepts that students will encounter in the app.
+    The functions lesson teaches students to create their own unique code blocks to
+    level-up their game.
+  tutorial_lblogic_longdescription: Logic-defying fun activities and videos provide
+    an overview of the core coding concepts that students will encounter in the app.
+    The logic lesson teaches students to use conditional statements to program rules
+    and choices into their games.
+  tutorial_lbworld_longdescription: Code for good! Students design a game that will
+    help make life easier for people in their community. At the end, each group will
+    present their prototypes at a "Change the World Arcade" that will be open to community
+    members.
+  tutorial_lbloops_longdescription: Loops are the secret weapon of every game ninja.
+    Short activities and fun videos provide an overview of the core coding concepts
+    that students will encounter in the app. The loops lesson teaches students how
+    to use loops to create animations.
+  tutorial_lbtug_longdescription: Bring a whole new meaning to the term "button-masher".
+    Students will create and remix the Tug of War game to explore how functions are
+    used to structure code.
+  tutorial_lbpotato_longdescription: Students will use loops, conditional logic, and
+    variables to create a new spin on the game of Hot Potato. This lesson provides
+    a choice between a beginner or intermediate level exploration into understanding
+    the invention code.
+  tutorial_lbguitar_longdescription: Students will work together to design a musical
+    instrument that makes it easy for anyone, even for those who cannot read music,
+    to play simple songs.
+  tutorial_lbio_longdescription: Short activities and fun videos provide an overview
+    of the core coding concepts that students will encounter in the app. The inputs
+    and outputs lesson teaches students how to control images, sound, and motion.
+  tutorial_wonpuppy_longdescription: Use the Wonder Workshop Blockly app and Dash
+    the robot to tackle 3 coding challenges! In this series of challenges, you will
+    train Dash the puppy to perform tricks. This series is part 3 of the Hour of Code
+    Dash and Dot Challenge Card activities. It is recommended for students who have
+    coding experience with functions.
+  tutorial_woncue_longdescription: Use Wonder Workshop's cue app to program your CUE
+    robot in different ways. Challenges and demos in the app will show you how to
+    program using blocks, JavaScript, or state machines. You'll also get to know the
+    robot's 4 different personalities as you code!
+  tutorial_wonzoo_longdescription: Use the Wonder Workshop Blockly app and Dot the
+    robot to tackle 3 coding challenges! In this series of challenges, you will help
+    Dot play with the animals at the petting zoo. This series is part 2 of the Hour
+    of Code Dash and Dot Challenge Card activities.
+  tutorial_wontrip_longdescription: Use the Wonder Workshop Blockly app and Dash the
+    robot to tackle 3 coding challenges! In this series of challenges, you will help
+    Dash prepare for a road trip. This series is part 4 of the Hour of Code Dash and
+    Dot Challenge Card activities. It is recommended for students who have coding
+    experience with event handlers and conditionals.
+  tutorial_woncollect_longdescription: Use the Wonder Workshop Blockly app and Dash
+    the robot to tackle 3 coding challenges! In this series of challenges, you will
+    help Dash collect different objects like seashells and candy. Don't forget to
+    make some space on the floor for your robot to move around. This series is part
+    1 of the Hour of Code Dash and Dot Challenge Card activities.
+  tutorial_wonsecret_longdescription: Let's use the Wonder Workshop Cue app with Cue
+    the robot to make a secret message system. This activity is recommended for students
+    who have experience coding in JavaScript.
+  tutorial_hsscience_longdescription: Imagine if your students could easily make their
+    own computer models of natural phenomena! This hour-long lesson plan uses the
+    water cycle as an example for building an interactive computer model using an
+    iPad-based kid's programming tool called Hopscotch. You can adapt it to simulate
+    any dynamic system being studied. No prior experience required!
+  tutorial_popculture_longdescription: This activity gives beginners an accessible
+    introduction to crowd-sourcing data, visualization, and data analysis using interactive
+    tools. The aim is to demonstrate that anybody can contribute to data science projects
+    and that computer science can be connected to a wide variety of topics (even trends
+    in popular culture) making it relevant to a variety of people. In this activity,
+    students practice asking their own questions about popular culture and seeking
+    answers to those questions using computational tools.
+  tutorial_legorobust_longdescription: Investigating what characteristics of a building
+    would help make it resistant to an earthquake, using an earthquake simulator constructed
+    from LEGO bricks. Students will explore the origin and nature of earthquakes.
+    Create and program a device that will allow you to test building designs. Document
+    evidence and present your findings about which structure design(s) are best for
+    withstanding earthquakes.
+  tutorial_legoplants_longdescription: Model the relationship between a pollinator
+    and flower during the reproduction phase using a LEGO representation. Students
+    will explore how different organisms take an active role in plant reproduction.
+    Create and program a model of a bee and flower to mimic the relationship between
+    the pollinator and the plant. Present and document the different models you have
+    created of plants and their pollinators.
+  tutorial_legopark_longdescription: Design cars that can park themselves safely without
+    driver intervention. Students will understand that algorithms are capable of carrying
+    out a series of instructions in order. Explore the concept of Outputs by comparing
+    different ways in which a wheeled robot can move.
+  tutorial_legodetect_longdescription: Design ways to avoid accidents between vehicles
+    and objects in the road.
+  tutorial_legolight_longdescription: Design car features that will improve nighttime
+    driving safety. Students will explore the concept of inputs and the way to control
+    them.
+  tutorial_alexa_longdescription: Alexa is the voice service that powers Amazon Echo.
+    Alexa provides capabilities, called "skills", which enable customers to interact
+    with devices using voice. In this tutorial, you will build a web service to handle
+    notifications from Alexa. You will create fact skills unique to your school for
+    this lab. By the end of this lab, you will be able to create an Alexa Fact skill
+    in the Amazon Developer Portal, create and configure an interaction model for
+    the Alexa skill, and test the skill using Developer tools and optionally an Alexa
+    device or simulator.
+  tutorial_grokpetmicro_longdescription: This activity is designed to introduce you
+    to embedded programming, and has been specially designed for the Hour of Code.
+    Use the MicroPython programming language to make a pet that you can feed and play
+    with. Don't have a BBC micro:bit? No problem! This course includes a full micro:bit
+    simulator, so you'll be able to do everything you'd do on a real micro:bit!
+  tutorial_pirateplunder_longdescription: Pirate Plunder takes place in an engaging
+    3D environment in which students help our pirate captain to reach his treasure
+    by dragging and dropping visual blocks to write code. Students climb, fight, collect,
+    and walk their way through challenges of increasing complexity while learning
+    to create efficient code with loops and write intelligent behaviour with conditions.
+    This actvitiy is targeted to kids aged 7+ and first-time-coders. On top of that,
+    anyone with a smartphone and a mobile VR headset will be able to explore their
+    solved tasks in VR.
+  tutorial_cadj_longdescription: Join Cody and Ava as they learn about Data Representation
+    using a fun and interactive DJ Device. Discover how your name can be represented
+    using numbers, images and sound while creating your very own colorful musical
+    melody!
+  tutorial_cacrazy_longdescription: Join Alex and Lonnie as they learn about coding
+    by creating fun, interactive pictures. Learn about sequence, loops, events, and
+    actions as you create crazy creatures in this exciting adventure!
+  tutorial_cajump_longdescription: Join Charlie and Tilley as they design a sport-themed
+    platformer game for Lucy's birthday.
+  tutorial_carest_longdescription: Join Ross at the Food Avengers restaurant. Use
+    your computational thinking skills to help Ross solve problems and serve dinner
+    to 8 excited kids.
+  tutorial_accai_longdescription: A robot is sent to an unknown planet to discover
+    if humanity could establish a new settlement. It explores the planet to find shelter
+    and discovers and interacts with the local population. As the player, you will
+    experience various Artificial Intelligence techniques to teach the robot how to
+    recognize animals and plants, understand a new language, dialogue with the inhabitants
+    etc.
+  tutorial_vceclipse_longdescription: 2017 gave us one of the most spectacular natural
+    phenomena of our lives, and now we're going to simulate the solar eclipse with
+    JavaScript! Looking at the eclipse as a system of moving parts, we can decompose
+    the problem into bite-sized chunks, using objects with methods, loops, and conditionals
+    to make an interactive app that models our observations.
+  tutorial_pmzero_longdescription: In one hour you create a simple version of a Pac-Man
+    game. You draw the characters in 2D and turn them into 3D. You create your own
+    maze. Then you program the game using AgentCubes. With only 11 IF/THEN rules you
+    create sophisticated AI. Even with just two smart ghosts you will have your hands
+    full to win the game.
+  tutorial_hsela_longdescription: Students will practice identifying narrative elements
+    while bringing their favorite story, poem or historical event to life. Learning
+    to code gives students another format and media for expressing their creativity
+    and communicating with others. Show them how to program their own interactive
+    stories, and wait for the smiles. 1-hour lesson plan, no prior coding experience
+    required.
+  tutorial_ticklear_longdescription: You will learn the basic concept of AR (Augmented
+    Reality), its current applications and its possibilities in the future and the
+    basic concepts of programming using motion blocks and event blocks under an AR/3D
+    environment.
+  tutorial_bcrobot_longdescription: Using BlocksCAD, a free online software designed
+    to teach students coding and Computer Aided Design, students will design a 3D
+    Robot. Using shapes, translate, and rotate blocks, students will be exposed to
+    computational thinking to construct something they can 3D print!
+  tutorial_bcsnow_longdescription: Using BlocksCAD, a free online software designed
+    to teach students coding and Computer Aided Design, students will design a 3D
+    snowflake. Using shapes, translate, rotate, and loop blocks, students will be
+    exposed to computational thinking to construct something they can 3D print!
+  tutorial_ifly_longdescription: This teacher-led lesson activity, adapted for the
+    Hour of Code, provides opportunities to explore physical systems through robotics.
+    Using a visual drag-and-drop programming environment and drones, pupils learn
+    that physical systems can be programmed and controlled through algorithms and
+    code. Includes a step-by-step activity plan, associated teacher and pupil resources
+    and ideas for extension and enrichment to take learning further.
+  tutorial_idowedo_longdescription: This teacher-led lesson activity, adapted for
+    the Hour of Code, provides opportunities to explore physical programming (robotics).
+    Children design and build models using construction bricks and bring them to life
+    with code! Using a visual drag-and-drop programming environment and LEGO™ WeDo
+    parts (motor and hub and optional sensors), pupils learn that physical systems
+    can be programmed and controlled using algorithms and code. Includes a step-by-step
+    activity plan, associated teacher and pupil resources and ideas for extension
+    and enrichment to take learning further.
+  tutorial_diggindwarf_longdescription: Dwarfs need your help to navigate, dig, and
+    collect gems!  Learn how to use JavaScript to guide your dwarf through mazes and
+    puzzles.
+  tutorial_spheroit_longdescription: Learn your first "if/then, else" condition by
+    building a fun game where you will be throwing Sphero and guessing animal sounds.
+    This is a great activity after you complete Blocks 1, and can be used for the
+    "Hour of Code."
+  tutorial_gameofcodes_longdescription: Build an awesome Dragon game to defend the
+    wall, then export it as a standalone app (for iOS, Android, PC, and Mac).
+  tutorial_blocklygames_longdescription: Blockly Games is a series of educational
+    games that teach programming. It is designed for children who have not had prior
+    experience with computer programming but who wish to learn at a more challenging
+    pace. By the end of these games, players are ready to use conventional text-based
+    languages.
+  tutorial_spherohello_longdescription: Have you conquered Blocks and need a new challenge?
+    Take the logic you have learned with block-based programming and begin to learn
+    how to program with just text. In this first Text activity learn the basics of
+    the text canvas, loops, and some tips to get started with your first lines of
+    JavaScript code.
+  tutorial_spheroarcade_longdescription: In this arcade-style playground, you can
+    recreate classic games with a Sphero SPRK+ robot while learning the basics of
+    game design. You'll build your very own robotic renditions of some famous games
+    like Pong, Bop It, and Pac-Man. Each game uses Sphero in a different way such
+    as rolling on the floor, detecting gestures, or using Sphero as a joystick.
+  tutorial_bcpy1_longdescription: 'This Hour of Code lesson teaches you some basic
+    concepts of coding in Python, based on the CodeCraft 3D game by BuzzCoder.com.
+    CodeCraft is a new game to learn programming by building whatever you imagine
+    in a virtual 3D world. You can start from building simple blocks, columns, and
+    walls, then large buildings, bridges, and even trees. When you are ready to delve
+    into more advanced levels, you will be able to build more complex structures:
+    growing flowers, flickering stars, and even invisible drones to move around and
+    build or destroy things at your command. You''ll have fun learning how to code
+    while playing this game!'
+  tutorial_bcpy2_longdescription: 'This Hour of Code lesson is a follow-up course
+    to World of Python. You''ll learn more advanced coding concepts in Python based
+    on the CodeCraft 3D game by BuzzCoder.com. CodeCraft is a new game to learn programming
+    by building whatever you imagine in a virtual 3D world. You can start from building
+    simple blocks, columns, and walls, then large buildings, bridges, and even trees.
+    When you are ready to delve into more advanced levels, you will be able to build
+    more complex structures: growing flowers, flickering stars, and even invisible
+    drones to move around and build or destroy things at your command. You''ll have
+    fun learning how to code while playing this game!'
+  tutorial_bcjs1_longdescription: 'This Hour of Code lesson teaches you some basic
+    concepts of coding in JavaScript, based on the CodeCraft 3D game by BuzzCoder.com.
+    CodeCraft is a new game to learn programming by building whatever you imagine
+    in a virtual 3D world. You can start from building simple blocks, columns, and
+    walls, then large buildings, bridges, and even trees. When you are ready to delve
+    into more advanced levels, you will be able to build more complex structures:
+    growing flowers, flickering stars, and even invisible drones to move around and
+    build or destroy things at your command. You''ll have fun learning how to code
+    while playing this game!'
+  tutorial_bcjs2_longdescription: 'This Hour of Code lesson is a follow-up course
+    to World of JavaScript. You''ll learn more advanced coding concepts in JavaScript
+    based on the CodeCraft 3D game by BuzzCoder.com. CodeCraft is a new game to learn
+    programming by building whatever you imagine in a virtual 3D world. You can start
+    from building simple blocks, columns, and walls, then large buildings, bridges,
+    and even trees. When you are ready to delve into more advanced levels, you will
+    be able to build more complex structures: growing flowers, flickering stars, and
+    even invisible drones to move around and build or destroy things at your command.
+    You''ll have fun learning how to code while playing this game!'
+  tutorial_3dbearmars_longdescription: The Mars Pioneers is a project-based learning
+    module that teaches facts about Mars and the crucial conditions for human beings
+    to survive there. The students will build a colony using Augmented Reality and
+    3D-print the colony facilities.
+  tutorial_bitsboxyak_longdescription: Type modified JavaScript code to make a greeting
+    card that you can email to friends and family. Yak Attack! is a completely open-ended
+    activity that introduces variables, motion commands, loop functions, and more.
+    Perfect for kids (and teachers) who are ready to try typed coding for the first
+    time.
+  tutorial_blockscadbargraphs_longdescription: 'Students will write code that lets
+    them quickly customize and analyze their own bar graphs. '
+  tutorial_blockscadbirdhouses_longdescription: 'Students will run a birdhouse-building
+    company, converting units, calculating dimensions, and using variables to scale
+    their products. '
+  tutorial_blockscadclock_longdescription: 'Students will program a 3D model of an
+    analog clock that can be set to show any time. '
+  tutorial_blockscaddinner_longdescription: Students will write a program using variables
+    and coordinates to help a robot set their dinner table for them!
+  tutorial_blockscadicecream_longdescription: Students will program an ice cream machine
+    to create 3D ice cream cones with different numbers and sizes of ice cream scoops.
+    They will work with variables, modules, and functions to calculate the cost of
+    a particular ice cream cone based on the area of the spherical ice cream scoops.
+  tutorial_blockscadpizza_longdescription: Students will program a module to create
+    a 3D pizza, calculating circumferences and areas and using loops along the way.
+  tutorial_blockscadsugar_longdescription: 'Students will use a programmed sugar-cube
+    generator to explore volume and variables. '
+  tutorial_bsgridlight_longdescription: Choose a Bot friend to help prepare for the
+    Lighthouse Festival. Code your Bot to stop those pesky rogue bots and save the
+    day!
+  tutorial_bpartscratch_longdescription: Creative Coding - developed with Scratch
+    and Vidcode - pairs block- and text-based projects with hundreds of cross-curricular
+    topics. Projects are scaffolded so that teachers of any subject - regardless of
+    prior experience - can easily introduce coding. The project-based approach positions
+    coding as a means of self-expression for students and gives them a creative way
+    to show what they know.
+  tutorial_bpartvid_longdescription: Creative Coding - developed with Scratch and
+    Vidcode - pairs block- and text-based projects with hundreds of cross-curricular
+    topics. Projects are scaffolded so that teachers of any subject - regardless of
+    prior experience - can easily introduce coding. The project-based approach positions
+    coding as a means of self-expression for students and gives them a creative way
+    to show what they know.
+  tutorial_bpenglishscratch_longdescription: Creative Coding - developed with Scratch
+    and Vidcode - pairs block- and text-based projects with hundreds of cross-curricular
+    topics. Projects are scaffolded so that teachers of any subject - regardless of
+    prior experience - can easily introduce coding. The project-based approach positions
+    coding as a means of self-expression for students and gives them a creative way
+    to show what they know.
+  tutorial_bpenglishvid_longdescription: Creative Coding - developed with Scratch
+    and Vidcode - pairs block- and text-based projects with hundreds of cross-curricular
+    topics. Projects are scaffolded so that teachers of any subject - regardless of
+    prior experience - can easily introduce coding. The project-based approach positions
+    coding as a means of self-expression for students and gives them a creative way
+    to show what they know.
+  tutorial_bphealthscratch_longdescription: Creative Coding - developed with Scratch
+    and Vidcode - pairs block- and text-based projects with hundreds of cross-curricular
+    topics. Projects are scaffolded so that teachers of any subject - regardless of
+    prior experience - can easily introduce coding. The project-based approach positions
+    coding as a means of self-expression for students and gives them a creative way
+    to show what they know.
+  tutorial_bphealthvid_longdescription: Creative Coding - developed with Scratch and
+    Vidcode - pairs block- and text-based projects with hundreds of cross-curricular
+    topics. Projects are scaffolded so that teachers of any subject - regardless of
+    prior experience - can easily introduce coding. The project-based approach positions
+    coding as a means of self-expression for students and gives them a creative way
+    to show what they know.
+  tutorial_bpmathscratch_longdescription: Creative Coding - developed with Scratch
+    and Vidcode - pairs block- and text-based projects with hundreds of cross-curricular
+    topics. Projects are scaffolded so that teachers of any subject - regardless of
+    prior experience - can easily introduce coding. The project-based approach positions
+    coding as a means of self-expression for students and gives them a creative way
+    to show what they know.
+  tutorial_bpmathvid_longdescription: Creative Coding - developed with Scratch and
+    Vidcode - pairs block- and text-based projects with hundreds of cross-curricular
+    topics. Projects are scaffolded so that teachers of any subject - regardless of
+    prior experience - can easily introduce coding. The project-based approach positions
+    coding as a means of self-expression for students and gives them a creative way
+    to show what they know.
+  tutorial_bpmlkscratch_longdescription: Creative Coding - developed with Scratch
+    and Vidcode - pairs block- and text-based projects with hundreds of cross-curricular
+    topics. Projects are scaffolded so that teachers of any subject - regardless of
+    prior experience - can easily introduce coding. The project-based approach positions
+    coding as a means of self-expression for students and gives them a creative way
+    to show what they know.
+  tutorial_bpmlkvid_longdescription: Creative Coding - developed with Scratch and
+    Vidcode - pairs block- and text-based projects with hundreds of cross-curricular
+    topics. Projects are scaffolded so that teachers of any subject - regardless of
+    prior experience - can easily introduce coding. The project-based approach positions
+    coding as a means of self-expression for students and gives them a creative way
+    to show what they know.
+  tutorial_bpsafetyscratch_longdescription: Creative Coding - developed with Scratch
+    and Vidcode - pairs block- and text-based projects with hundreds of cross-curricular
+    topics. Projects are scaffolded so that teachers of any subject - regardless of
+    prior experience - can easily introduce coding. The project-based approach positions
+    coding as a means of self-expression for students and gives them a creative way
+    to show what they know.
+  tutorial_bpsafetyvid_longdescription: Creative Coding - developed with Scratch and
+    Vidcode - pairs block- and text-based projects with hundreds of cross-curricular
+    topics. Projects are scaffolded so that teachers of any subject - regardless of
+    prior experience - can easily introduce coding. The project-based approach positions
+    coding as a means of self-expression for students and gives them a creative way
+    to show what they know.
+  tutorial_bpsciencescratch_longdescription: Creative Coding - developed with Scratch
+    and Vidcode - pairs block- and text-based projects with hundreds of cross-curricular
+    topics. Projects are scaffolded so that teachers of any subject - regardless of
+    prior experience - can easily introduce coding. The project-based approach positions
+    coding as a means of self-expression for students and gives them a creative way
+    to show what they know.
+  tutorial_bpsciencevid_longdescription: Creative Coding - developed with Scratch
+    and Vidcode - pairs block- and text-based projects with hundreds of cross-curricular
+    topics. Projects are scaffolded so that teachers of any subject - regardless of
+    prior experience - can easily introduce coding. The project-based approach positions
+    coding as a means of self-expression for students and gives them a creative way
+    to show what they know.
+  tutorial_bptechscratch_longdescription: Creative Coding - developed with Scratch
+    and Vidcode - pairs block- and text-based projects with hundreds of cross-curricular
+    topics. Projects are scaffolded so that teachers of any subject - regardless of
+    prior experience - can easily introduce coding. The project-based approach positions
+    coding as a means of self-expression for students and gives them a creative way
+    to show what they know.
+  tutorial_bptechvid_longdescription: Creative Coding - developed with Scratch and
+    Vidcode - pairs block- and text-based projects with hundreds of cross-curricular
+    topics. Projects are scaffolded so that teachers of any subject - regardless of
+    prior experience - can easily introduce coding. The project-based approach positions
+    coding as a means of self-expression for students and gives them a creative way
+    to show what they know.
+  tutorial_caflags_longdescription: Learn some basic programming concepts with blockly.
+    Develop your computational thinking by using simple shapes, colors and coordinates
+    to draw the flags of the world. Discover your creativity as you explore different
+    sequences of blocks and values to build your own exciting flag masterpieces.
+  tutorial_matariki_longdescription: 'Maia and Charlie are from New Zealand.  Maia''s
+    family are getting ready to celebrate Matariki: the Māori new year.  She''s invited
+    her friend Charlie to come and stay at her family''s marae (traditional meeting
+    house). There are lots of exciting problem-solving tasks and activities to do
+    for Matariki! Use your Computational Thinking skills to help Maia and Charlie
+    prepare for the celebration.'
+  tutorial_carestaurant_longdescription: Charlie and Tilley have decided that if they
+    program Ross properly he will be able to help do some painting to make Food Avengers
+    more attractive. Make sure their algorithms are correct though - a misdirected
+    robot with a paintbrush could do some serious damage!
+  tutorial_casea_longdescription: Alex and Lonnie create fancy fish and super sea
+    creatures with blocks. Help them sort the sequences into order and debug by spotting
+    and fixing the mistakes. Customize your own ocean scene and bring your characters
+    to life by adding interactivity. Beginner coders and pre-readers welcome!
+  tutorial_cashield_longdescription: It's the summer holidays and Alex, her family,
+    and Lonnie are going on holiday to Finland. Alex's older brother Reuben is creating
+    an app about shield blazonry and shows Alex and Lonnie how to use it. Join them
+    as they learn how to sequence blocks to design some amazing shields of their own!
+  tutorial_ccwslimer_longdescription: Learn how to program your own shareable game
+    with multiple levels and challenges!
+  tutorial_codinggalaxy_longdescription: For your first mission on Adventure Planet,
+    your duty is to solve coding puzzles to save the beautiful planet.
+  tutorial_boatrace_longdescription: Learn how to make a boat racing game. The player
+    uses the mouse to navigate a boat to a desert island without bumping into obstacles.
+  tutorial_ccplay_longdescription: Code and play a series of game levels while learning
+    important computer science concepts. On the final level, show off your creativity
+    and skills to code your own game from scratch!
+  tutorial_grinch_longdescription: 'Learn to program drones and a high tech sleigh
+    with coding magic to capture presents and navigate down the mountain to return
+    Christmas to Whoville. '
+  tutorial_codehsart_longdescription: Memes! Memes! Memes! Students explore the intersection
+    of coding and art by building a computer program that allows them to create custom
+    memes to share with friends.
+  tutorial_codehsbitcoin_longdescription: In this Hour of Code activity, students
+    are introduced to the Bitcoin blockchain ledger and some Bitcoin statistics. Students
+    look at how a transactions works on the Bitcoin ledger and and investigate the
+    overall performance of the Bitcoin blockchain.
+  tutorial_codehsblockchain_longdescription: Students learn about the foundations
+    of cryptocurrencies by exploring cryptography, hashing, and blockchain technology!
+  tutorial_codehscipher_longdescription: 'In this Hour of Code activity, students
+    are introduced to cryptography by using the classic Caesar cipher to decrypt and
+    encrypt some messages, and also discover the cipher''s flaw and how to improve
+    upon it. '
+  tutorial_codehscollision_longdescription: Students will explore how simulations
+    are used in research. They will study how mass and speed affect elastic collisions
+    by using conservation of momentum and conservation of kinetic energy equations
+    to verify final speed values as calculated by a simulation. Students should have
+    prior knowledge of solving mathematical equations using basic algebra.
+  tutorial_codehsmath_longdescription: 'Students are introduced to Tracy the Turtle
+    and learn how to code different mathematical models in Python! No coding experience
+    is necessary, but students should have completed Algebra I or higher. '
+  tutorial_codehsmusic_longdescription: Students explore how coding is used in music
+    creation by building their own dynamic eight-count beats and patterns with JavaScript
+    blocks!
+  tutorial_codehssports_longdescription: Students learn about how coding is used in
+    sports and game design by building an original sports video game that can be shared
+    with their friends immediately!
+  tutorial_codemojipizza_longdescription: 'This course is designed to teach students
+    the fundamentals of JavaScript objects. Students will learn the basic types of
+    data that can be stored in variables, from their first boolean all the way to
+    creating their own objects with multiple properties. The activity makes complex
+    concepts easy to understand by using everyone''s favourite food: Pizza!'
+  tutorial_moonlander_longdescription: Learn Physics as you code! Moon Lander is a
+    Game Builder course with 17 exercises that guides you on how to build your own
+    physics-based game. In the game, you will use code and 6-9th grade physics concepts
+    in order to help a spaceship land safely on the moon.
+  tutorial_sushicards_longdescription: Make a game where you move a shark around to
+    try and catch fish.
+  tutorial_codesparkcreate_longdescription: Ever wanted to design and code your own
+    video game? Choose from two game kits that guide you through creating and coding
+    a Mario-style video game using codeSpark Academy's no words interface. Beginner
+    coders and pre-readers welcome!
+  tutorial_hardvsoft_longdescription: Through an illustrated children's story and
+    worksheets, your students will learn the differences between hardware and software.
+  tutorial_codestersecard_longdescription: 'Build up your programming skills as you
+    learn how to create an electronic greeting card that you can share with your teacher,
+    family, or friends! '
+  tutorial_codesterslogo_longdescription: Use code to get creative and design your
+    own company logo! You'll learn coding basics in the programming language, Python.
+    After you work through the tutorial, you'll have all the skills you need to create
+    the logo for your personal brand!
+  tutorial_codesterstshirt_longdescription: 'Learn basic programming skills and practice
+    moving around the coordinate plane as you create your own monogrammed t-shirt
+    design! '
+  tutorial_codewards_longdescription: Join an exciting mission to save the underwater
+    city. Experience the work of a rescue engineer fixing damaged city systems with
+    commands and algorithms. Overcome various challenges to prove your skills, intelligence
+    and courage!
+  tutorial_olympics_longdescription: 'Together with Elsie get prepared for Robot Olympics!
+    Along with programming concepts learn how to drive, collect details and create
+    tools, build and test your mighty robot. '
+  tutorial_codinismhero_longdescription: Learn the basics of programming through fun
+    examples, and build a game while learning!
+  tutorial_discovery_longdescription: Two characters meet in a world, and discover
+    a surprising object. What happens next? With Scratch and CS First, anyone can
+    create their own unique story with code.
+  tutorial_csfirstname_longdescription: Pick a name and bring the letters of the word
+    to life using code. Choose a nickname, a pet's name, an animal, a sport, a place
+    or a hobby.
+  tutorial_edisonmove_longdescription: Introduce text-based programming and the key
+    computational concept of sequence to your students using Edison robots and EdPy,
+    a text-based programming language based on Python. Explore computer science and
+    programming basics including functions, inputs, input parameters and outputs.
+    Then take on a coding challenge and write your own program to get your Edison
+    robot through a maze.
+  tutorial_edisonspider_longdescription: Introduce the key computational concepts
+    of variables and data, two of the most fundamental parts of general-purpose programming
+    languages, using Edison robots and the Scratch-based programming language EdScratch.
+    Students can work through this lesson independently learning what variables are,
+    why we use them and then applying their knowledge to program Edison to drive like
+    a spider laying a trap.
+  tutorial_edisonspotlight_longdescription: Introduce Edison robots to your students,
+    helping them begin to explore what a robot is and how it can sense, and react,
+    to the world. Students can work through this lesson independently as they program
+    the Edison robot using the block-based programming language EdBlocks, practicing
+    computer science fundamentals including sequence, loops and conditionals.
+  tutorial_firiapython_longdescription: Get your micro:bit ready, and level-up to
+    Python coding! CodeSpace will guide you step-by-step from your very first line
+    of Python to coding an interactive program with buttons and LEDs. Learn the basics
+    of programming embedded devices, monitoring inputs and controlling outputs. Learn
+    how variables and if statements control the flow of code, and finish with a fast
+    and fun micro-game!
+  tutorial_gamefrootsquid_longdescription: Colossal squid are the largest invertebrates
+    in the world. In this coding game for beginners you'll learn the basics of coding
+    and create a game that explores the squid's life under the ocean. You'll discover
+    the secret life of the colossal squid, how to code keyboard game controls (inputs/outputs),
+    the Google Blockly coding language, how to publish your own computer game.
+  tutorial_duckpiano_longdescription: In this project you'll make keys on your computer
+    play quack sounds at different pitches, like a piano that sounds like a duck.
+    You can use your duck piano to play simple tunes. Later, you can try other sounds,
+    such as dog barks or even sounds you record yourself. This project works best
+    on a computer with a keyboard, but it could be adapted to work on a tablet.
+  tutorial_gpsound_longdescription: In this project you'll write a program to record
+    sound from your computer microphone, play it back, and draw a picture of the recorded
+    sound. You can then process your recording to add effects such as pitch-shift,
+    reverse, or echo.
+  tutorial_groklearningpython_longdescription: Develop your programming skills and
+    build your own animal classifier! In this course you'll use the programming language
+    Python to classify animals based on their characteristics. You'll learn about
+    the differences between animals, and how biologists use programming to help them
+    do science! This activity has some assumed knowledge (variables, print and input).
+  tutorial_htmltimetravel_longdescription: Take an adventurous travel through time
+    and conquer deep space while learning how to move, rotate and transform objects
+    using the basics of animation in CSS.
+  tutorial_hp_flappy_longdescription: Learn logical thinking and programming concept
+    by creating your own Flappy Birds style game on hyperPad.
+  tutorial_appytappin_longdescription: This teacher-led activity, adapted for the
+    Hour of Code, introduces children to using a text-based programming language to
+    develop a mobile games app. They design algorithms and use variables and functions,
+    as well as test and debug their work. Includes a step-by-step lesson plan, pupil
+    resources, support cards and pre-written program template.
+  tutorial_icipher_longdescription: This teacher led activity, adapted for the Hour
+    of Code teaches children about communicating securely. The children learn that
+    messages throughout time have been encrypted and decrypted using ciphers. They
+    explore cryptography and gain an understanding of need for secure communications.
+  tutorial_iguess_longdescription: Introducing Quick Response codes to children aged
+    3-5. Use tablets to scan QR codes and guess the mini-beast from a given habitat.
+  tutorial_imake_longdescription: This unplugged teacher-led activity, for children
+    aged 3-5, uses classic nursery rhymes to introduce the concept of algorithms,
+    sequence and repetition. By identifying the steps and patterns in popular rhymes,
+    children begin to understand that algorithms are all around us.
+  tutorial_imorse_longdescription: Explore cryptography with Morse Code and Sphero.
+    Learn that physical systems can be programmed and write code for Sphero to communicate.
+  tutorial_kanohp_longdescription: Learn to code and make magic on screen with creative
+    challenges. Make feathers fly and fire flow, compose music, and more.
+  tutorial_khanwebpages_longdescription: Learn how to make webpages with HTML tags
+    and CSS, and finish up by making your very own greeting card to share with friends
+    or family.
+  tutorial_kibobowl_longdescription: Crash! How far does KIBO have to move to get
+    from the start of the bowling lane to the pins? You can create a single straight
+    lane or a more complicated path. Students will use estimation and measurement
+    to create a program to travel the length of the lane. They'll test how far a single
+    forward block carries KIBO, then improve their programs using the Engineering
+    Design Process.
+  tutorial_kibodance_longdescription: Let's have a KIBO Robot dance party! Set up
+    a music player to play a favorite classroom song, or a song connected to a world
+    culture you're exploring. Students will decorate their KIBO as a dancer, then
+    they will create a program to teach their KIBO to dance to the music. Students
+    will learn how to create a program to express an idea (in this case, a dance),
+    with a focus on sequencing ability.
+  tutorial_buildcharacters_longdescription: What are some character traits you can
+    identify in books or people you know? Design your own fuzz and use code to modify
+    its properties and bring your character to life! Featuring JavaScript for upper
+    elementary.
+  tutorial_designgames_longdescription: The most popular pre-reader app now includes
+    a digital Maker Space! Make levels, design games, or build characters. Choose
+    your activity and start creating with Kodable!  Featuring JavaScript for upper
+    elementary.
+  tutorial_makelevels_longdescription: Can you build a symmetrical maze? A maze with
+    right angles? Get creative and complete maze-building challenges with basic coding
+    concepts. Aligned with K-5 Common Core math.
+  tutorial_wizard_longdescription: Journey into the world of Code Magic as a Code
+    Wizard. Learn to create and cast spells to customize your castle.
+  tutorial_mbscratchcards_longdescription: Connect the physical world of micro:bit
+    with the virtual world of Scratch.
+  tutorial_mbswiftplaygrounds_longdescription: Use the micro:bit with an iPad to learn
+    Swift.
+  tutorial_mbbuttons_longdescription: In this introductory project, you'll make pictures
+    or animations appear on the micro:bit display when buttons are pressed. This activity
+    is suitable for those who have never programmed before or those seeking a simple
+    introduction to programming the BBC micro:bit. It uses MicroBlocks, a Scratch-like
+    programming system that lets you see your code running on the micro:bit immediately.
+  tutorial_meteor_longdescription: In this project, you'll create a Falling Meteors
+    game for the BBC micro:bit. Using the buttons, the player will move a shield to
+    catch falling meteors and save the Earth. The techniques you learn in this project
+    can be used to make many other games for the BBC micro:bit, including classics
+    such as Pong and Space Invaders.
+  tutorial_ballbounce_longdescription: Learn to make a mobile app where the user flings
+    a ball across the screen and it bounces off the edges.
+  tutorial_mitcodi_longdescription: Learn to make your own interactive mobile app.
+    Press the bee and hear it buzz!
+  tutorial_mitdoodle_longdescription: Make a mobile app where you can draw pictures
+    on the screen!
+  tutorial_talktome_longdescription: Learn to make a mobile app that makes your phone
+    talk to you!
+  tutorial_mobilecspmap_longdescription: Use App Inventor to create a Map Tour of
+    landmarks in your town, state, or anywhere in the world. Self-guided video and
+    text tutorials lead students through building a user interface and coding a mobile
+    app, using a map component and determining locations by latitude and longitude.
+  tutorial_ozorandom_longdescription: 'Learn how computers create random numbers and
+    use them, then use a random movement program to help seed ideas for a story. '
+  tutorial_ozotroll_longdescription: 'Learn the difference between Internet trolls
+    and fairy tale trolls, then teach Evo how to be a good troll that protects you. '
+  tutorial_peblioart_longdescription: 'Learn to draw and animate shapes with code
+    to create interactive artwork inspired by artists. '
+  tutorial_astropi_longdescription: Code a message and check the ambient air temperature
+    on board the ISS using an online simulator of the Astro Pi computer's Sense HAT.
+  tutorial_rgart_longdescription: Looking for an easy and intuitive way to teach your
+    students to code? RoboGarden STEAM has fused code practicing with STEAM learning
+    and gamified missions in multiple activities. In the art activity, the student
+    understand color mixing concepts while using coding blocks to solve challenges
+    in the birthday party.
+  tutorial_rgengineer_longdescription: Looking for an easy and intuitive way to teach
+    your students to code? RoboGarden STEAM has fused code practicing with STEAM learning
+    and gamified missions in multiple activities. In the engineering activity, the
+    student learns basic robotics while using coding blocks to solve challenges in
+    the Christmas party.
+  tutorial_rgmath_longdescription: Looking for an easy and intuitive way to teach
+    your students to code? RoboGarden STEAM has fused code practicing with STEAM learning
+    and gamified missions in multiple activities. In the math activity, the student
+    practices counting, addition and subtraction while solving some coding challenges.
+  tutorial_rgscience_longdescription: Looking for an easy and intuitive way to teach
+    your students to code? RoboGarden STEAM has fused code practicing with STEAM learning
+    and gamified missions in multiple activities. In the science activity, the student
+    goes through a journey to the space solving multiple coding challenges and know
+    more about space elements and science facts.
+  tutorial_rgtech_longdescription: Looking for an easy and intuitive way to teach
+    your students to code? RoboGarden STEAM has fused code practicing with STEAM learning
+    and gamified missions in multiple activities. In the technology activity, the
+    student goes through a journey to the volcanic islands solving multiple coding
+    challenges by understanding basic concepts of Technology.
+  tutorial_robotmagic3d_longdescription: Use your imagination to create an animated
+    3D logo of your name, your favorite sports team or anything you want. Use code
+    to make 3D models and letters come alive with fun. At the end you can download
+    an animated sticker of your creation and share it with friends.
+  tutorial_robotmagicflappy_longdescription: Use your imagination to create a 3D Flappy
+    Bird game. Use code to make 3D models come alive with fun. At the end you can
+    share your creation with friends and challenge them to a high score.
+  tutorial_scratchadventure_longdescription: Send your favorite Cartoon Network characters
+    on a quest, from the farthest reaches of the universe, to the edge of Craig's
+    creek. Unlock secret treasures and discover new characters while creating an adventure
+    game.
+  tutorial_scratchtalk_longdescription: Bring your characters to life in Scratch using
+    new Text-to-Speech blocks powered by Amazon. Create a rapping robot or an interactive
+    animation that talks. This project will show you how to create talking animations
+    that spin, zoom and change colors. The possibilities are endless!
+  tutorial_scratchjrstory_longdescription: An intermediate activity meant for children
+    in 2nd-5th grades with some experience with ScratchJr. Through this activity and
+    continued time with ScratchJr, students will have the opportunity to think creatively,
+    improve their storytelling and collaborate with peers.
+  tutorial_scratchjrtwinkle_longdescription: Twinkle, Twinkle Little Star Class Collaboration
+    is an introductory activity meant for children in kindergarten through second
+    grade with little to no programming experience. Through this activity, students
+    will have the opportunity to think creatively, become storytellers, and improve
+    upon mathematical reasoning and sequencing skills.
+  tutorial_spherocomm_longdescription: Learn about miscommunication in both a community
+    and in a computer program. Use this knowledge to resolve any miscommunication,
+    or bugs, in a program in an effort to help BOLT find its way home.
+  tutorial_spherocommunity_longdescription: Design a simple path that represents a
+    common route that you travel everyday. You will create two programs, a drawn path
+    and a block-based program path through your community route.
+  tutorial_spherofunctions_longdescription: Learn how to use and invoke functions
+    to turn Sphero into a calculator.
+  tutorial_spheroinfrared_longdescription: Become an epidemiologist in order to stop
+    the spread of a rare robot infection that is plaguing a community of BOLT robots.
+  tutorial_spherolightsensor_longdescription: Learn how to create a program that uses
+    the ambient light sensor to measure lux values and chase BOLT.
+  tutorial_spheromansion_longdescription: Keeping a bunch of dinosaurs at your house
+    shouldn't be an issue, right? As you would imagine, this doesn't to end well.
+    You are trapped in the mansion's library and must program your way out.
+  tutorial_roadblocks_longdescription: As a continuation of Your Community, you will
+    modify your blocks program as you and your partner encounter different roadblocks
+    along the route.
+  tutorial_spherotext2_longdescription: Learn your first conditional by building a
+    fun game where you will be throwing Sphero and guessing animal sounds. This is
+    a great activity after you complete Text 1.
+  tutorial_spherotext3_longdescription: Learn to change Sphero's main LEDs based on
+    the gyroscope's spin rate. You will also learn about normalization and absolute
+    value. This is a great activity after you complete Text 1 and 2.
+  tutorial_spherotext4_longdescription: Use variables to build a hot potato game powered
+    by Sphero. You will use pseudocode and read documentation to bring this classic
+    game to life. You will also learn about technical concepts like loop until and
+    randomness within bounds. This is a great activity after you complete Text 2 or
+    3.
+  tutorial_spheroraptor_longdescription: Create a fortified pen to keep the Spheroraptors
+    at bay, while also writing the code to the Spheroraptors escape. From loops, to
+    conditionals, to operators and even comparators, you will need as much coding
+    know-how as you can muster.
+  tutorial_stempiday_longdescription: We use the number Pi to calculate the circumference
+    and area of a circle, but have you ever wondered where this number comes from
+    or how to calculate it? In this coding activity you will randomly generate points
+    similar to a very bad player shooting darts at a dart board. The percentage of
+    darts that land inside the circle can help us calculate Pi. Then change the colors
+    of the points just for fun!
+  tutorial_stemplanetoids_longdescription: Did you know that the code behind the classic
+    Asteroids and Lunar Lander games is simpler than you might think? Did you know
+    that both of these games have accurate physics? In this activity you will fix
+    a broken asteroids game where the ship only moves in a straight line. Then you
+    will add gravity to the game and try to land the ship on the moon! Works with
+    chromebooks and other devices!
+  tutorial_stempong_longdescription: Did you know that the code behind the popular
+    game Bonk.io and the classic Pong game is simpler than you might think? Did you
+    know that both of these games have accurate physics? In this activity you will
+    fix a broken version of the Pong game so that objects bounce like they should.
+    Then you will add gravity to create a Bonk.io clone. Works with chromebooks and
+    other devices!
+  tutorial_algobot_longdescription: AlgoBot is a puzzle game that takes place on the
+    Europa, a pan-galactic colonisation ship, where a recycling mission goes horribly
+    wrong. Players command AlgoBot, a smart little service droid, and learn to use
+    a visual programming language to help him contain the crisis!
+  tutorial_thunkableapps_longdescription: 'Learn how to build your own apps with blocks-based
+    coding! '
+  tutorial_toxicodedot_longdescription: 'Select a card from your deck and interpret
+    its code in order to progress through the world. Use your intuitive abilities
+    to guess the rules and learn from your own mistakes. Made with care by the team
+    behind Compute it and Silent Teacher, with the same fundamentals: trial-and-error
+    instead of verbose explanations, smooth progression, no code to type, accessibility
+    to absolute beginners.'
+  tutorial_gcactions_longdescription: Discover actions, one of the key building blocks
+    in coding, and use them to code a video game! Explore digital culture and learn
+    about robots and what they can actually do.
+  tutorial_gccomparators_longdescription: Discover comparators and logical rules,
+    which are key building blocks in coding, and use them to code a video game! Explore
+    digital culture and learn about the tracking of our online activities.
+  tutorial_gcconditions_longdescription: Discover conditions, one of the key building
+    blocks in coding, and use them to code a video game! Explore digital culture and
+    learn about the algorithms that power our online world.
+  tutorial_gccreate_longdescription: Create your first full videogame with GameCode!
+    Create new characters, make them (a bit) smarter, give the player superpowers...Sky's
+    the limit!
+  tutorial_gcevents_longdescription: 'Discover events, one of the key building blocks
+    in coding, and use them to code a video game! Explore digital culture and learn
+    about Artificial Intelligence, and how it might be meaningful in your life. '
+  tutorial_gcloops_longdescription: Discover loops, one of the key building blocks
+    in coding, and use them to code a video game! Explore digital culture and learn
+    about the echo chamber phenomenon on social networks.
+  tutorial_gcvariables_longdescription: Discover variables, one of the key building
+    blocks in coding, and use them to code a video game! Explore digital culture and
+    learn about what data is and how it works.
+  tutorial_beanything_longdescription: Explore six cool careers and see how coding
+    can be applied to each one! Discover what it's like to be a Robotics Engineer,
+    a Musician, an Astronaut, a Farmer, a Beekeeper, and a Pastry Chef. Use programming
+    to animate characters, compose music, tell stories, design games, and even create
+    art.
+  tutorial_change_longdescription: Create a project that shows how you would change
+    the world! Whether you are passionate about recycling or have an idea to achieve
+    world peace, share your vision with code!
+  tutorial_cooking_longdescription: Show off your skills - create an interactive cooking
+    game. Beginners can use the self-guided tutorial while more advanced coders have
+    the option to start off with a blank project.
+  tutorial_crystal_longdescription: Battle with friends in this multiplayer game.
+    Apply your own strategies and pit your code against the entire Tynker community
+    to see who the true coding champion is! Cast spells, collect power-ups, and defeat
+    enemies as you battle in a wild 4-player arena that is shrinking amidst lava!
+  tutorial_landscape_longdescription: Use Python's pen drawing feature to compose
+    a landscape using code. Use the landscape items already created for you or design
+    our own structures. Publish and share your creations!
+  tutorial_pets_longdescription: Create a fun game about pets – either real or imaginary!
+    Beginners can use the self-guided tutorial while more advanced coders have the
+    option to start off with a blank project.
+  tutorial_petvet_longdescription: A busy day at the Pet Vet leads to fun as you and
+    Barbie help a variety of pets through their very first checkups. From guiding
+    pets into the Examination Room to diagnosing their sniffles, boo-boos, and itches,
+    you'll find every puzzle has a solution to make the pets feel better than ever!
+  tutorial_superhero_longdescription: Use HTML and CSS pixel art to create your favorite
+    superhero masks. Publish and share your creations!
+  tutorial_vidcodeplastic_longdescription: The problem of plastic filling our oceans
+    continues to worsen. Luckily, you can make your voice heard with code through
+    the Plastic Pollution PSA. After coding a PSA on plastic pollution using JavaScript,
+    you can make a second video about any subject you care about! Learn to use loops,
+    sine waves and customized emojis to make a unique project.
+  tutorial_vidcodetypeface_longdescription: Create your own typeface using shapes
+    and elements of typography. Type has more elements than you may have realized!
+    So far we have talked about fonts and how they are different styles of text. Fonts
+    are actually just different styles of a typeface. A typeface is a family of fonts
+    that have similar features.
+  tutorial_washustorm_longdescription: Learn how to program an incoming storm.
+  tutorial_activitypackets_longdescription: Find hours of family-friendly fun with
+    Wonder Workshop's printable packets of creative coding activities. Bring coding
+    to life with Dash, Dot, and Cue robots by downloading these online and offline
+    activities to use during Hour of Code and beyond!
+  tutorial_googlerookie_longdescription: In this activity, you'll code a Rookie themed
+    collage using Blockly, an introductory coding language. You'll use sequences,
+    variables and loops to create a unique piece that highlights your creativity!
+  tutorial_tommyturtle_longdescription: Help young kids learn the basics of coding
+    with Tommy the Turtle! Gold Award Winner for Best Educational App by Best Mobile
+    App Awards. Connects with STEMdash to enable parents and teachers to track learning
+    progress, chat with your child to provide encouragement, or limit their playtime.
+  tutorial_mazyad_longdescription: This product will broaden our boundaries to create
+    an integrated paper version with computerized applications and an alternative
+    if the computer is not used for any reason. It will also serve as an introduction
+    to understanding programming in general.
+  tutorial_gamemaker_longdescription: Game Maker is an open ended activity where students
+    can create anything they want using a simple code wizard. Just click on the picture
+    of a cute little monster and choose one of the options in the menu. More advanced
+    tutorials are also included for those wanting to go deeper into game making.
+  tutorial_duckrace_longdescription: In this course you will solve programming tasks
+    to help Toni the duck collect coins for its holiday savings. At the end of the
+    course you create your own game.
+  tutorial_allcancodeapps_longdescription: Use the Allcancode Platform to create web
+    and mobile apps from design to delivery. Application logic is written in Google
+    Blockly, the programming language used in most Code.org activities.
+  tutorial_n2y_longdescription: In these printable activities, students can help a
+    little robot named Bitt Bott explore different landforms on Earth. Students give
+    Bitt Bott simple directions by choosing and circling appropriate directional arrows.
+    Each of the six activities includes simple directions that are supported with
+    symbols from the n2y® SymbolStix PRIME® collection. The symbols help non-readers
+    and beginning readers understand and follow the directions.
+  tutorial_microsoftarcade_longdescription: Play fun arcade games, design your own
+    sprites, and learn the basics of coding your own game with MakeCode Arcade.
+  tutorial_csfirstunplugged_longdescription: No computer or internet? No problem.
+    Try the CS First Unplugged activities to explore how computer science can solve
+    problems like helping people stay connected while apart. 'Plugged in' Scratch
+    activities are available too!
+  tutorial_toxicodepython_longdescription: Discover the basics of Python without any
+    word or explanation. Our silent teacher will give you several series of challenges
+    that will lead you to guess some rules and learn from your own mistakes.
+  tutorial_codecombatozaria_longdescription: Enter the world of Ozaria where you become
+    a hero in an epic adventure. You must use the power of coding to defeat a darkness
+    that has taken over the world! Along the way, you’ll meet interesting characters
+    and travel to different lands, practicing coding concepts like sequences, loops,
+    debugging, and decomposition. In the end, you’ll design a playable game that you
+    can share with your friends!
+  tutorial_vidcodedate_longdescription: 'The Climate Clock project is a culturally
+    relevant intersection of math, environmental science, and computer science. In
+    this Hour of Code activity, students will be guided through the construction of
+    their own climate clock. They will engage with objects, properties, variables,
+    functions, and loops, and customize their message to convey their message for
+    the world and their hopes for the future. '
+  tutorial_codemonkeyspace_longdescription: 'Write real code to help the monkey astronaut
+    catch bananas in space! '
+  tutorial_codespeakhappy_longdescription: Learn to program a meditation app that
+    transports you to your 'happy place.'
+  tutorial_grokimage_longdescription: Use the programming language Python to make
+    speedy changes to images. Make fun image editing programs and make your own image
+    filter!
+  tutorial_icomputelearn_longdescription: When you learn to code with iCompute you
+    program your own fantastic interactive stories, games, and animations. Following
+    our creative, fun, activities means that you will develop computational thinking
+    as well as coding skills!
+  tutorial_rpstress_longdescription: Use Scratch blocks to create and personalise
+    your clickable stress ball with graphic effects, costume animation, and sound
+    effects.
+  tutorial_bsdcause_longdescription: 'This course allows students to use code as a
+    way to share what is important or interesting to them. They can follow the lesson
+    or create unique projects while learning HTML, CSS and JavaScript. They are guided
+    with video tutorials, live coding and access to the code glossary. The Support
+    My Cause focuses on designing and coding a landing page that will collect data
+    from supporters of your favorite cause. #codeisyourvoice'
+  tutorial_vidcodeanimoji_longdescription: Use a loop to iterate over an array, causing
+    an emoji to animate through multiple options.
+  tutorial_vidcodeanimojies_longdescription: Use a loop to iterate over an array,
+    causing an emoji to animate through multiple options.
+  tutorial_bsdinspire_longdescription: 'This course allows students to use code as
+    a way to share what is important or interesting to them.They can follow the lesson
+    or create unique projects while learning HTML, CSS and JavaScript. They are guided
+    with video tutorials, live coding and access to the code glossary. The People
+    Who Inspire Me focuses on creating a webpage to showcase the top 3 people who
+    have been an inspiration to you. #codeisyourvoice'
+  tutorial_tttractor_longdescription: Help bring the fields back to life. Farmer Hayao's
+    down on his luck, and his fields have become a mess. But he's just obtained a
+    fancy new tractor with a repeating code system using loops that just might save
+    everything. Help learn how the tractor works to water all the crops in his fields.
+  tutorial_codeillusionmickey_longdescription: Embark on a magical coding adventure
+    with Mickey! Learn how to draw, color, and move shapes as you master the introduction
+    to Media Art using JavaScript.
+  tutorial_scigirlsquest_longdescription: 'In this online coding adventure, youth
+    take Subby the submarine through underwater challenges, using code to find various
+    items and collect scientific data on the ocean floor. '
+  tutorial_codespeakbreathe_longdescription: Learn to program meditation app that
+    will guide users through a mindful breathing exercise.
+  tutorial_vidcodeface_longdescription: Use a facetracking library to code your own
+    custom face filter, like the ones you use on social media.
+  tutorial_educodemaze_longdescription: Design a maze, complete with monsters and
+    locked passages. Use variables, loops, and strings to help your hero navigate
+    the world you've created.
+  tutorial_educoderace_longdescription: Learn computer science as you unleash the
+    racer in you! Invent and customize your very own car, all while gaining a deeper
+    understanding of objects and how video games are made.
+  tutorial_codespeakchatbot_longdescription: Learn how to code a chatbot, a computer
+    program you can have a conversation with, while learning about the famous women
+    pioneers of computer science.
+  tutorial_gamefrootgames_longdescription: Learn to code a real game like Super Mario
+    Bros. Students that are ready to go beyond Scratch and Tynker will be introduced
+    to real games industry practice, creative coding concepts, how to publish their
+    own unique game and start working towards a career in the games industry. The
+    tutorial is all about level design, choosing a character, animating and coding
+    your character to move around.
+  tutorial_codespeakgrandparent_longdescription: Learn to code a digital card to spread
+    joy to someone special in your life.
+  tutorial_educodekingdom_longdescription: The Kingdom is under attack! Plan powerful
+    defenses to help repel the invaders. Master the power of arrays in order to create
+    your very own wave of monsters in your own tower defense game!
+  tutorial_codehsdata_longdescription: Learn about the power of using data visualizations
+    to display data in meaningful and easy to understand ways. Use our graph generator
+    to create visually appealing graphs and learn how coding is used to create beautiful
+    data.
+  tutorial_educodecake_longdescription: Learn HTML as you bake a cake with chef Roland.
+    Shape and style your custom creation with your newfound knowledge of tags and
+    classes.
+  tutorial_ttsecond_longdescription: Can you deliver the Open Protocol? You've snuck
+    aboard the capital ship, and now you must evade the security drones long enough
+    to open access for all. Quickly examine conditional statements to find out whether
+    you're safe or not from the dastardly cybervision. If not, it's to the airlock!
+  tutorial_bsdtrivia_longdescription: 'This course allows students to use code as
+    a way to share what is important or interesting to them. They can follow the lesson
+    or create unique projects while learning HTML, CSS and JavaScript. They are guided
+    with video tutorials, live coding and access to the code glossary. The Trivia
+    Game Maker focuses on building an interactive trivia game where you also get to
+    come up with the trivia questions. #codeisyourvoice'
+  tutorial_csfirstdialogue_longdescription: Program a conversation between two sprites.
+    Get creative while communicating with code in Scratch with CS First!
+  tutorial_codemonkeybeaver_longdescription: Help a Beaver achieve its goals! Dive
+    into this beaver's natural habitat with a fun-packed coding activity that will
+    jump-start your coding education. Beavers can swim, collect wood, and build dams.
+    This little beaver needs your help. Use the simple blocks of code to complete
+    the dam in the lake so the water remains calm, build a house, and make smoothies!
+  tutorial_codestersdistance_longdescription: Learn the basics of coding in Python,
+    then create a program that calculates the distance between two sprites to make
+    sure they are social distancing or need to wear a mask.
+  tutorial_itchspace_longdescription: This tutorial takes you through the creation
+    of a classic Space Invaders game using the Scratch MIT programming language. Subscribe
+    to the RokCoder YouTube channel for more Scratch-based videos and tutorials! Each
+    video is a bite-sized tutorial (approximately ten minutes in length) that contains
+    its own specific end goals. The final result is a high quality Scratch arcade
+    game.
+  tutorial_vidcodemagic_longdescription: Make flashes appear randomly around the screen
+    using a loop.
+  tutorial_vidcodemagices_longdescription: Make flashes appear randomly around the
+    screen using a loop.
+  tutorial_codespeakmeal_longdescription: Learn to code an app that helps users make
+    healthy food decisions.
+  tutorial_itchfish_longdescription: Scratch 3.0 tutorial for making a game with a
+    shark chasing and eating fish disrupted when a diver is eaten accidentally.
+  tutorial_bsdwebsite_longdescription: 'This course allows students to use code as
+    a way to share what is important or interesting to them. They can follow the lesson
+    or create unique projects while learning HTML, CSS and JavaScript. They are guided
+    with video tutorials, live coding and access to the code glossary. ''The My Favourites
+    Website focuses on creating a webpage of the top 3 things you are interested in
+    or love doing. #codeisyourvoice'
+  tutorial_codespeaktime_longdescription: Learn how to code a digital time capsule
+    to record and reflect on your life right now.
+  tutorial_itchwebcam_longdescription: Learn about augmented reality and make your
+    own augmented reality virtual space.
+  tutorial_itchball_longdescription: Get a ball to bounce around the screen. Learn
+    about loops and conditionals within loops.
+  tutorial_ttrace_longdescription: By calling functions and designing classes, players
+    program their own race car to be fast, nimble, and powerful; during races, they
+    can then hack their competitors' vehicles to scramble their controls.
+  tutorial_plethora_longdescription: 'In this Plethora activity you will solve visual
+    fun challenges and learn the concepts of cause and effect and user interaction. '
+  tutorial_educodesecret_longdescription: Explore the worlds of secrets with Agent
+    Smith as you dive deeper into learning if statements, strings, for-in loops. Help
+    Agent Smith find the culprits and configure the Agency's operating system for
+    their new users with Python.
+  tutorial_itchshapes_longdescription: Learn how to draw shapes in Scratch. You will
+    also learn how to calculate how much you need to turn for any shape.
+  tutorial_codeguppytext_longdescription: Learn the basics of text based coding by
+    creating your first program in an online coding editor.
+  tutorial_vidcodeplastiche_longdescription: The problem of plastic filling our oceans
+    continues to worsen. Luckily, you can make your voice heard with code through
+    the Plastic Pollution PSA. After coding a PSA on plastic pollution using JavaScript,
+    you can make a second video about any subject you care about! Learn to use loops,
+    sine waves and customized emojis to make a unique project.
+  tutorial_educativechatbot_longdescription: Learn about the realm of Artificial intelligence
+    and Machine Learning, as well as programming your own chatbot!
+  tutorial_educodebasics_longdescription: Learn some programming fundamentals and
+    create your own game in the process!
+  tutorial_codehsdesign_longdescription: 'Coders will learn how programming can support
+    artists and build their own Online Shop mockup, using HTML. '
+  tutorial_htmlacademyphp_longdescription: Meet Dumpo the Little Elephant, a senior
+    programmer at a web design studio, who is developing an online store. Together
+    you will learn the basics of PHP in an engaging way. You will work with web scripts
+    and learn the variables, add PHP-scripts into the layout and interact with databases
+    while creating a true-to-life web project.
+  tutorial_gamefrootdistance_longdescription: 'In COVID-19: Stop the Spread, you can
+    modify the ''Staying home'' factor and code a simple news clicker. The activity
+    illustrates how social distancing has a direct impact on how fast a virus like
+    COVID-19 can spread. Students and teachers will gain a small insight into virus
+    science, the effects a virus can have on society, and at the same time level up
+    their digital fluency skills.'
+  tutorial_codesterscovid_longdescription: Learn the basics of coding in Python while
+    creating your own PSA about how we can stop the spread of COVID-19. Design your
+    own animated interactive PSA to share critical information about the importance
+    of social distancing, wearing a mask, quarantining, and other measures.
+  tutorial_ttbunker_longdescription: You found The Bunker, and all its secrets will
+    be yours, once you crack its encryption. An army approaches, and you must hold
+    the perimeter using the power of programming. Code individual towers, setting
+    range, damage, and more special powers by adding new lines of code and changing
+    values. Survive long enough to learn how classes and instances can make you even
+    more powerful.
+  tutorial_cuttle_longdescription: Challenge yourself with these fun and interactive
+    tasks and learn all about computational thinking.
+  tutorial_bsdjokes_longdescription: 'This course allows students to use code as a
+    way to share what is important or interesting to them. They can follow the lesson
+    or create unique projects while learning HTML, CSS and JavaScript. They are guided
+    with video tutorials, live coding and access to the code glossary. The Jokes and
+    Riddles focuses on creating a set of interactive cards that contain your favorite
+    jokes and riddles and the answers! #codeisyourvoice'
+  tutorial_rptree_longdescription: Use Scratch to create a simulation that shows how
+    varying the health of a forest and levels of deforestation impact trees, wildlife
+    and the amount of CO2 absorbed. You should already know how Scratch coordinates
+    and variables work.
+  tutorial_codestersunity_longdescription: Learn the basics of coding in Python including
+    lists, loops, and sprites. Then create a mural using a loop to access each sprite
+    stored in a list.
+  tutorial_codesterssoccer_longdescription: Learn the basics of coding in Python,
+    then create a program that shoots a soccer ball into the goal. To aim your shot
+    you'll first need to estimate the slope of the line. Good luck!
+  tutorial_breakoutlock_longdescription: 'Haspy the Robot needs your help! She needs
+    your knowledge of loops, algorithms, and coding to help her fix Lockit''s code
+    and reboot her system. '
+  tutorial_thunkablemask_longdescription: Learn how to build a mobile app that gives
+    you points for knowing how to wear your mask correctly!
+  tutorial_cafarming_longdescription: Computer science can help feed a hungry world.
+    Farmers are using technology to grow food in smarter and more sustainable ways.
+    Agribots and drones can monitor, water, and spray crops, and even tackle those
+    pesky weeds! Learn about how AI, Computer Vision, and the Internet of Things are
+    used on the farm.
+  tutorial_blocksmithyeti_longdescription: Oh no! Someone trapped the Yeti! Only YOU
+    and your programmable smart cannon can save the Yeti and feed their friends. Students
+    will use JavaScript to save the Yeti with this fun interactive self-paced lesson.
+  tutorial_codecapture_longdescription: 'Take your first steps into the world of programming
+    with JavaScript, using just pen-and-paper and your mobile phone! '
+  tutorial_codehslitter_longdescription: 'Learn how you can use programming to help
+    solve one of the world''s biggest problems: litter and waste! In this Choose-Your-Own-Adventure
+    Hour of Code, you have the choice between the basics of Python or the basics of
+    Web Design. Whichever you choose, you will explore how you can use computer science
+    to decrease the amount of litter in your community.'
+  tutorial_bsdocean_longdescription: Life below Water sheds light on a pressing issue
+    that we face nowadays - our environment. This project focuses on guiding you to
+    code your very own webpage on protecting our waters.
+  tutorial_itchplatformer_longdescription: An easy to follow tutorial for how to create
+    a simple platformer game using Scratch.
+  tutorial_codejika_longdescription: A great introduction to coding using HTML and
+    CSS. Code a few lines, see immediate output without getting caught up in the Hows
+    and Whys by creating a nice landing page with a two-color gradient background,
+    name and website launch date.
+  tutorial_gamefrootclicker_longdescription: Learners code their own Clicker Game
+    and in the process learn about variables, different data types, conditional logic,
+    comparative operators, and gain some valuable insights into how professional game
+    developers design and make real games. By the end of the tutorial you will have
+    coded different variable types, published a game, and engaged with computer science
+    in an indigenous context.
+  tutorial_rmagicequity_longdescription: 'Explore concepts related to reducing inequality
+    with code: limited resources, equality, equity and liberation. Use variables and
+    functions in a self guided block environment. Finish by animating the 3D actors.'
+  tutorial_ttfreestyle_longdescription: You're the choreographer and director of a
+    new music video! Type real code to place and control dancers, scenery, and more.
+    Just make sure to capitalize and punctuate correctly, otherwise the whole thing
+    will just be static.
+  tutorial_ozobotcolor2_longdescription: Students will learn the basic functionality
+    of Ozobot. Students will learn how to draw Color Codes Ozobot can read.
+  tutorial_ozobotcolor3_longdescription: Students will learn how to program the bot
+    to travel left, right, and straight with Color Codes.
+  tutorial_clcarbon_longdescription: A python lesson plan that will teach students
+    how to make a carbon footprint calculator that calculates footprint based on a
+    short quiz about daily life, then gives comparison metrics (ie this is the same
+    amount of carbon as xxxx), and suggests ways to be more eco-friendly.
+  tutorial_kodablebasics_longdescription: No computer? No problem! Learn basic programming
+    skills and practice using core coding commands without the use of a device.
+  tutorial_scigirlscc_longdescription: Help your students learn to write pseudocode!
+    Computer programmers often start projects by using everyday language to write
+    out what they want to happen in their code–this is called pseudocode.Youth will
+    work in groups to write pseudocode for a simple movement or dance move.
+  tutorial_irobotpicture_longdescription: Robots have lots of sensors that work together
+    to help the robot understand everything around it. Just like sensors, our friends
+    can often see, hear, feel or understand things that we cannot. In this activity,
+    work together to help decode secret messages and crack the code!
+  tutorial_kcjmyself_longdescription: In this activity, you'll learn how to use Scratch
+    to code an animation all about you! Design a custom character to represent yourself,
+    make it move around, and add different backdrops to show off your hometown. This
+    project is simple enough for kids to complete by themselves or with support from
+    a grown up.
+  tutorial_nearpodalgorithms_longdescription: 'In this Nearpod lesson, students identify
+    an algorithm as a set of step-by-step directions. Students learn to create, test,
+    and fix an algorithm to complete a specific task. '
+  tutorial_kibodrop_longdescription: Engineering is about persistence and grit. Today
+    the students will become engineers, learning the steps of the Engineering Design
+    Process. They will create models out of craft and recycled materials, then they
+    will test the sturdiness of their models by dropping them from ankle height. This
+    is an unplugged activity; KIBO robots are optional.
+  tutorial_ozobotcolor1_longdescription: Students will learn the basic functionality
+    of Ozobot, including how to calibrate the bot's sensors, and how to draw lines
+    for the bot to follow.
+  tutorial_scigirlspixels_longdescription: 'In this unplugged activity, you will learn
+    what a pixel is and how to send a simple black and white image to a friend! '
+  tutorial_kcjheroines_longdescription: In this activity, you'll learn about different
+    Canadian women who have made history. Using Scratch, you'll learn how to code
+    a video game celebrating their lives and accomplishments. Choose a heroine, customize
+    their costume and backdrop, code movements and goals for your game, and keep score.
+    This project is simple enough for kids to complete by themselves or with support
+    from a grown up.
+  tutorial_ozobotvalue_longdescription: Students will use their Ozobot to randomly
+    select a place value, identify the same place value in a three-digit number, and
+    write out the number.
+  tutorial_icodebytes_longdescription: Learn computer science without tech! Fun unplugged
+    computing activities for children aged 5-7 to do in class or at home with their
+    families. The activities help develop computational thinking skills in a really
+    fun way. Divided into the fundamental principles of computer science, and involve
+    creating algorithms, thinking logically, spotting patterns and finding or making
+    rules.
+  tutorial_clfashion2_longdescription: Are you a fashion conscious data scientist
+    with an interest in code? Join in the Fashionista of Data Science classes to learn
+    how coding & fashion go hand-in-hand! We will use SQL code along with data science
+    to investigate marketing, line styles, and store operations.
+  tutorial_ai4all_longdescription: 'This Byte of AI is meant to be a quick and fun
+    teacher-facilitated way to begin to become familiar with some core ideas of modern
+    AI including: how data becomes output in an AI model, how human biases enter datasets,
+    and how AI can be used in diverse fields including art and creativity. Students
+    learn these things by exploring drawing in Google Quick, Draw!'
+  tutorial_cldata_longdescription: 'Discover data science, one of the most valuable
+    skills, and see the world! Does data science sound dry and scary, like math? Fear
+    not. This introductory class will show you that you are already experts of data
+    and data science is full of fun and interesting insights related to topics such
+    as soccer, music, art, and your favorite books. Materials ready for in person
+    or remote learning settings. '
+  tutorial_spheroinputs_longdescription: 'This activity will get you thinking about
+    the common computer science coding concept of inputs and outputs and how this
+    idea relates to using computer science for good. '
+  tutorial_edisoncount_longdescription: 'Introduce the key computational concepts
+    of inputs and outputs using Edison robots and the block-based programming language
+    EdBlocks in this student led activity. Utilize the Edison robot''s drive function
+    through a set of progressive programming tasks. Creating programs for the robot
+    to ''trace'' requires the application of sequential thinking and an understanding
+    of the input-process-output cycle. '
+  tutorial_spheroloops_longdescription: 'This activity will get you thinking about
+    the common computer science coding concept of loops and how this concept relates
+    to using computer science for good. '
+  tutorial_kiboprogram_longdescription: In this lesson, children will learn about
+    sequencing in programming and about the symbols that make up a programming language
+    like KIBO's. Students will create their own programming symbols and act out programs
+    with their own movement. Finally, they can translate these movement programs into
+    programs for KIBO.
+  tutorial_hellorubycsin60_longdescription: 'Have you ever wondered what travels inside
+    the wires of your computer? Or why computer parts look like a tiny city? Or what
+    really is an algorithm? These 30 self-paced one minute videos are aimed for 5-9
+    year olds, followed by an activity the kids can complete at home. Topics include
+    code, hardware, networks, AI and other interesting ideas. '
+  tutorial_clfashion1_longdescription: Are you a fashion conscious data scientist
+    with an interest in code? Join in the Fashionista of Data Science classes to learn
+    how coding & fashion go hand-in-hand! We will use SQL code along with data science
+    to investigate marketing, line styles, and store operations.
+  tutorial_irobottraffic_longdescription: Traffic signals are a staple of safety in
+    our everyday lives. Code your own traffic light with the Root robot and learn
+    about the inventor!
+  tutorial_edisonmystery_longdescription: Kick-start student's exploration of using
+    Edison's line tracker using Edison robots and the Scratch-based programming language
+    EdScratch in this student led activity. Students first become familiar with the
+    Edison robot's line tracking sensor technology and experiment with the red LED
+    on different colored surfaces. They will then move on to mastering a mystery line
+    using the concept of algorithms.
+  tutorial_microbitseaturtles_longdescription: Create a prototype of a low-power,
+    red LED beach light that can be used for lighting on beach paths which is also
+    safe for sea turtles.
+  tutorial_ozobotknow_longdescription: In this lesson, students will be introduced
+    to the hardware and robotics components of Ozobot Evo.
+  tutorial_imagilabs_longdescription: 'Program a blinking heart, a rocketship taking
+    off, your name, or anything your imagination comes up with! To start off, we''ll
+    teach you how to program a heart in your favourite color and then make it blink
+    to the rhythm of your favorite song. Join our community of imagiCoders to share
+    and exchange designs. Upload your creations on your imagiCharm so you can proudly
+    wear your code wherever you go! '
+  tutorial_irobotsimulator_longdescription: Learn how to create and download coding
+    projects with this activity packet! Solve all puzzles with the Root simbot in
+    the virtual arena to reveal the secret message at the end!
+  tutorial_irobotkind_longdescription: Our robot is still learning how to make kind
+    choices when playing with friends. In this game, help Root practice by making
+    four kind decisions in a row. If Root makes a bad choice, it has to start all
+    the way at the beginning again! Let's play together!
+  tutorial_firiavirtual_longdescription: Learn Python programming with a powerful
+    3D robotics simulator. You'll complete challenging missions in a virtual environment
+    with realistic physics. Missions teach you the code to control motors, LEDs, and
+    other peripherals on CodeBot. And Sandbox mode lets you get creative with unlimited
+    Python coding possibilities. It's easy to get started with CodeSpace Simulation!
+  tutorial_irobotguesscode_longdescription: Put a new spin on Pictionary through code!
+    Students can use code to make predictions about what pictures, songs, or words
+    the Root SimBot will create. Code your own Pictionary creation, too!
+  tutorial_ozobotnouns_longdescription: In this lesson, students will identify the
+    correct way to spell and use irregular plural nouns and use Color Codes to program
+    their Ozobot to move to the correct irregular plural nouns by either turning left
+    or right and use the noun in a sentence.
+  tutorial_nasa3d_longdescription: Learn about exploding stars, 3D models and codeblocks!  This
+    spacey activity takes you through the basics of 3D modeling in astronomy using
+    the free browser-based Tinkercad. Students can progress from creating simple 3D
+    shapes to working with actual NASA data on exploded stars, testing in augmented
+    reality, and using loops and time-based changes with codeblocks.
+  tutorial_blupants_longdescription: Train a real autonomous robot to pick up blocks
+    and deploy them to the goal by navigating through an obstacle course. Start with
+    drag-and-drop interface, and advance to Python as you get more experienced.
+  tutorial_legodance_longdescription: Synchronize motor movements of a break dancer
+    to keep in rhythm with light and beats.
+  tutorial_nearpodcoding_longdescription: In this 25-30 minute Nearpod featuring Flocabulary
+    topic spark, students are introduced to coding through a hip hop video and Nearpod's
+    signature interactive features. This lesson features the Flocabulary video Coding.
+  tutorial_kcjplastic_longdescription: We're challenging you to use data visualization
+    to develop a plastic pollution solution! Discover where plastic waste comes from
+    and why it has become a global problem. Then reflect on your own plastic use,
+    estimate how much waste you could reduce over time, and design an invention or
+    alternative that could help. Kids can complete this project by themselves or with
+    support from a grown up.
+  tutorial_legojourney_longdescription: 'Journeys are exciting!  Challenge students
+    to remix our Grasshopper Journey project in order to create a new journey and
+    find different ways for a SPIKE Prime inspired virtual grasshopper to move using
+    Scratch 3.0! In addition to CS skills, this teacher facilitated activity can also
+    be used to support areas such as language arts, science and the arts. '
+  tutorial_legohopper_longdescription: Design multiple prototypes to find the most
+    effective way to move a robot without using wheels.
+  tutorial_catrobatembroidery_longdescription: Code your design on your Android phone
+    and stitch it on your T-shirt, pants, gym bag, or shoes!
+  tutorial_irobotphone_longdescription: In this coding challenge, students will work
+    together remotely to create a collective program that draws a picture. Modeled
+    after the classic game of Telephone, students will receive, remix, and pass along
+    code down the telephone chain. Will your team fulfill the Picture Goal by the
+    time you reach the end?
+  tutorial_codeguppydraw_longdescription: Quick introduction to text-based coding
+    using fun and engaging type-in JavaScript programs
+  tutorial_codejumper_longdescription: In this lesson from the Code Jumper curriculum,
+    learners explore networks in a hands-on unplugged experience using typical materials
+    found in a classroom. The theme for this lesson is around messages of kindness
+    to others. This lesson has been specifically designed to be accessible for students
+    with visual impairments.
+  tutorial_meeempathy_longdescription: For centuries, the Villagers and Illagers shared
+    the same space but seldom interacted with each other. Now you can use the power
+    of code to bring the two villages together. Players will experience empathy and
+    compassion for their neighbors, learn cooperation and inclusion, and embrace the
+    diversity that makes us all uniquely special.
+  tutorial_dance2019_string_detail_grades: Grades 2+
+  tutorial_danceparty_string_detail_grades: Grades 2+
+  tutorial_chibitronics_string_detail_grades: Grades 2-5
+  tutorial_athlete_string_detail_grades: Grades 2+
+  tutorial_moana_string_detail_grades: Grades 2+
+  tutorial_star-wars_string_detail_grades: Grades 2+
+  tutorial_gumadventure_string_detail_grades: Grades 6-8
+  tutorial_mchoc_string_detail_grades: Grades 2+
+  tutorial_vidnews_string_detail_grades: Grades 6+
+  tutorial_kodable-pre_string_detail_grades: Pre-reader - Grade 5
+  tutorial_highseas_string_detail_grades: Grades 2-8
+  tutorial_capython_string_detail_grades: Grades 6+
+  tutorial_frzn_string_detail_grades: Grades 2+
+  tutorial_cocom_string_detail_grades: Grades 2+
+  tutorial_play-lab_string_detail_grades: Grades 2+
+  tutorial_boxisland_string_detail_grades: All ages
+  tutorial_textcomp_string_detail_grades: Grades 9+
+  tutorial_encryption_string_detail_grades: Grades 9+
+  tutorial_kanopixel_string_detail_grades: Grades 2+
+  tutorial_foos_string_detail_grades: Pre-reader - Grade 5
+  tutorial_tynkerdd_string_detail_grades: Grades 2-8
+  tutorial_tynkerana_string_detail_grades: Grades 6+
+  tutorial_vidcard_string_detail_grades: Grades 2+
+  tutorial_spritebox_string_detail_grades: Grades 2-8
+  tutorial_tynkerch_string_detail_grades: Grades 6+
+  tutorial_lightbot_string_detail_grades: Pre-reader - Grade 5
+  tutorial_hoc_string_detail_grades: do-not-show
+  tutorial_code_string_detail_grades: Grades 2+
+  tutorial_tinspire_string_detail_grades: Grades 6+
+  tutorial_itchbounceball_string_detail_grades: Grades 2-8
+  tutorial_vidclim_string_detail_grades: Grades 6+
+  tutorial_matlab_string_detail_grades: Grades 6+
+  tutorial_flap_string_detail_grades: Grades 2+
+  tutorial_galaxy_string_detail_grades: Grades 6+
+  tutorial_inf_string_detail_grades: Grades 2-8
+  tutorial_tynkersol_string_detail_grades: Grades 2+
+  tutorial_itchg_string_detail_grades: Grades 6+
+  tutorial_como_string_detail_grades: Grades 2+
+  tutorial_processfound_string_detail_grades: Grades 9+
+  tutorial_tynkerhomo_string_detail_grades: Grades 6+
+  tutorial_art_string_detail_grades: Grades 2+
+  tutorial_tynkerbrick_string_detail_grades: Grades 2+
+  tutorial_itchbio_string_detail_grades: Grades 6+
+  tutorial_itchj_string_detail_grades: Grades 6-8
+  tutorial_tickleo_string_detail_grades: Grades 2+
+  tutorial_hopgeo_string_detail_grades: Grades 2-8
+  tutorial_tynkermult_string_detail_grades: Grades 2-8
+  tutorial_monster_string_detail_grades: Pre-reader - Grade 8
+  tutorial_tynkerapp_string_detail_grades: do-not-show
+  tutorial_tynkerpup_string_detail_grades: Grades 2-5
+  tutorial_livecode_string_detail_grades: Grades 9+
+  tutorial_cocomgame_string_detail_grades: Grades 2+
+  tutorial_tynkerspin_string_detail_grades: Grades 2-5
+  tutorial_code-avengers_string_detail_grades: Grades 6+
+  tutorial_tynkercq_string_detail_grades: Grades 2-5
+  tutorial_cmgame_string_detail_grades: Grades 6+
+  tutorial_codesters_string_detail_grades: do-not-show
+  tutorial_qrm_string_detail_grades: Grades 6+
+  tutorial_texas-instruments_string_detail_grades: Grades 6+
+  tutorial_cajava_string_detail_grades: Grades 6+
+  tutorial_codehs_string_detail_grades: Grades 9+
+  tutorial_hopemo_string_detail_grades: Grades 2-8
+  tutorial_tynkercm_string_detail_grades: Grades 2+
+  tutorial_codesterswintergreet_string_detail_grades: Grades 2+
+  tutorial_codestersc_string_detail_grades: Grades 6+
+  tutorial_codestersturtle_string_detail_grades: Grades 6-8
+  tutorial_penjee_string_detail_grades: Grades 6+
+  tutorial_trinket_string_detail_grades: Grades 2+
+  tutorial_frogger_string_detail_grades: Grades 6+
+  tutorial_tynkereco_string_detail_grades: Grades 2-8
+  tutorial_mitedarc_string_detail_grades: Grades 6-8
+  tutorial_khan_string_detail_grades: Grades 6+
+  tutorial_tynkerd_string_detail_grades: Grades 6+
+  tutorial_cdmy_string_detail_grades: Grades 9+
+  tutorial_codestersdance_string_detail_grades: Grades 6+
+  tutorial_codestersbasketball_string_detail_grades: Grades 6+
+  tutorial_nclkarel_string_detail_grades: Grades 6+
+  tutorial_buildpong_string_detail_grades: Grades 2+
+  tutorial_tynkerdrones_string_detail_grades: Grades 2+
+  tutorial_carla_string_detail_grades: Grades 6+
+  tutorial_zulama_string_detail_grades: Grades 6+
+  tutorial_capost_string_detail_grades: Grades 6+
+  tutorial_marco_string_detail_grades: Grades 2-8
+  tutorial_codestersflappybike_string_detail_grades: Grades 6+
+  tutorial_kanopong_string_detail_grades: Grades 6-8
+  tutorial_tynkerright_string_detail_grades: Grades 2-8
+  tutorial_touchdevelop_string_detail_grades: do-not-show
+  tutorial_tynkercc_string_detail_grades: Grades 6+
+  tutorial_bamboo_string_detail_grades: Grades 2-5
+  tutorial_robojav_string_detail_grades: Grades 6+
+  tutorial_roboba_string_detail_grades: Grades 6+
+  tutorial_knodsnake_string_detail_grades: Grades 6-8
+  tutorial_soccharater_string_detail_grades: Grades 6+
+  tutorial_silent_string_detail_grades: Grades 6+
+  tutorial_robomesh_string_detail_grades: Grades 2+
+  tutorial_amaze_string_detail_grades: Grades 2+
+  tutorial_codestersds_string_detail_grades: Grades 2+
+  tutorial_knodtext_string_detail_grades: Grades 6-8
+  tutorial_alicegar_string_detail_grades: Grades 6+
+  tutorial_codesterstransform_string_detail_grades: Grades 6+
+  tutorial_flexfrog_string_detail_grades: Grades 6+
+  tutorial_codemoji_string_detail_grades: do-not-show
+  tutorial_robobii_string_detail_grades: Grades 6+
+  tutorial_robobm_string_detail_grades: Grades 6-8
+  tutorial_codingrobots_string_detail_grades: Grades 2+
+  tutorial_robob_string_detail_grades: Grades 6+
+  tutorial_coders_string_detail_grades: Grades 9+
+  tutorial_tynkerhw_string_detail_grades: Grades 2-8
+  tutorial_tynkermh_string_detail_grades: Grades 2-8
+  tutorial_caphoto_string_detail_grades: Grades 6+
+  tutorial_mozillahw_string_detail_grades: Grades 6-8
+  tutorial_ticklep_string_detail_grades: do-not-show
+  tutorial_bbot_string_detail_grades: Grades 2+
+  tutorial_scratchg_string_detail_grades: Grades 6+
+  tutorial_sjforest_string_detail_grades: Pre-reader - Grade 5
+  tutorial_sjgreet_string_detail_grades: Pre-reader - Grade 5
+  tutorial_sjsunset_string_detail_grades: Pre-reader - Grade 5
+  tutorial_fufafrenz_string_detail_grades: Pre-reader - Grade 5
+  tutorial_bbcgeo_string_detail_grades: do-not-show
+  tutorial_chspixel_string_detail_grades: Grades 9+
+  tutorial_hummingbird_string_detail_grades: Grades 6+
+  tutorial_recoloring_string_detail_grades: Grades 6+
+  tutorial_bbcchem_string_detail_grades: do-not-show
+  tutorial_floalgo_string_detail_grades: Grades 2+
+  tutorial_flocond_string_detail_grades: Grades 2+
+  tutorial_floloops_string_detail_grades: Grades 2+
+  tutorial_pgts_string_detail_grades: Grades 6+
+  tutorial_ozo_string_detail_grades: All ages
+  tutorial_bbcla_string_detail_grades: do-not-show
+  tutorial_bbcsci_string_detail_grades: do-not-show
+  tutorial_tlctour_string_detail_grades: Grades 2+
+  tutorial_codesterstj_string_detail_grades: Grades 2+
+  tutorial_tlclocked_string_detail_grades: Grades 6+
+  tutorial_baubles_string_detail_grades: Grades 2-8
+  tutorial_bbcart_string_detail_grades: do-not-show
+  tutorial_tlcknight_string_detail_grades: Grades 2+
+  tutorial_fufafit_string_detail_grades: Grades 2-5
+  tutorial_ozodance_string_detail_grades: All ages
+  tutorial_codingrobotics_string_detail_grades: Pre-reader - Grade 5
+  tutorial_box_string_detail_grades: do-not-show
+  tutorial_hopgame_string_detail_grades: Grades 2-8
+  tutorial_icontrol_string_detail_grades: Pre-reader - Grade 5
+  tutorial_cocomteach_string_detail_grades: Grades 2+
+  tutorial_bbcmathii_string_detail_grades: do-not-show
+  tutorial_bbcphys_string_detail_grades: do-not-show
+  tutorial_bitsbox_string_detail_grades: Grades 2-8
+  tutorial_tlcemo_string_detail_grades: Grades 2-8
+  tutorial_crd_string_detail_grades: Grades 6-8
+  tutorial_bbcbio_string_detail_grades: do-not-show
+  tutorial_ticklebb8_string_detail_grades: Grades 2+
+  tutorial_grok_string_detail_grades: do-not-show
+  tutorial_ijournalist_string_detail_grades: Grades 2-8
+  tutorial_bbcmusic_string_detail_grades: do-not-show
+  tutorial_secretcodes_string_detail_grades: Grades 6-8
+  tutorial_tlchex_string_detail_grades: Grades 6+
+  tutorial_tickles_string_detail_grades: Grades 2+
+  tutorial_ozogame_string_detail_grades: All ages
+  tutorial_vidcodeio_string_detail_grades: Grades 2+
+  tutorial_tlcbrain_string_detail_grades: Grades 6+
+  tutorial_hopquiz_string_detail_grades: Grades 6-8
+  tutorial_unfortunate_string_detail_grades: Grades 2-5
+  tutorial_cha_string_detail_grades: Grades 6-8
+  tutorial_elaseq_string_detail_grades: Pre-reader - Grade 5
+  tutorial_bbcmathi_string_detail_grades: do-not-show
+  tutorial_tlcpixel_string_detail_grades: Grades 2-8
+  tutorial_introrobo_string_detail_grades: Grades 2-5
+  tutorial_tlcinvis_string_detail_grades: Grades 2+
+  tutorial_tlcjflap_string_detail_grades: Grades 6+
+  tutorial_procolor_string_detail_grades: Pre-reader - Grade 8
+  tutorial_spiralsfinch_string_detail_grades: Grades 2+
+  tutorial_ozoi_string_detail_grades: All ages
+  tutorial_ticklel_string_detail_grades: Grades 2+
+  tutorial_spiralsdash_string_detail_grades: Grades 2-8
+  tutorial_ghdebug_string_detail_grades: Grades 2-8
+  tutorial_tlckk_string_detail_grades: Grades 2-5
+  tutorial_firstcomp_string_detail_grades: Pre-reader - Grade 1
+  tutorial_mazefinch_string_detail_grades: Pre-reader - Grade 5
+  tutorial_tlccc_string_detail_grades: Grades 2-8
+  tutorial_tlcdoodle_string_detail_grades: Grades 2-8
+  tutorial_tlcpunch_string_detail_grades: Grades 6+
+  tutorial_finchfract_string_detail_grades: Grades 9+
+  tutorial_tlcmind_string_detail_grades: Grades 6+
+  tutorial_tlctelebot_string_detail_grades: Grades 2+
+  tutorial_tlcaus_string_detail_grades: Grades 6+
+  tutorial_tlcmicro_string_detail_grades: Grades 2+
+  tutorial_imathematician_string_detail_grades: Grades 2-8
+  tutorial_tlcmagic_string_detail_grades: Grades 6+
+  tutorial_scratchmus_string_detail_grades: Grades 2-8
+  tutorial_scratchanim_string_detail_grades: Grades 2-8
+  tutorial_scratchfly_string_detail_grades: Grades 2-8
+  tutorial_tynkerarc_string_detail_grades: Grades 2+
+  tutorial_grokffpython_string_detail_grades: Grades 6+
+  tutorial_grokffblock_string_detail_grades: Grades 6+
+  tutorial_grokeliza_string_detail_grades: Grades 6+
+  tutorial_tynkercan_string_detail_grades: Grades 2+
+  tutorial_grokflags_string_detail_grades: Grades 6+
+  tutorial_robomind_string_detail_grades: Grades 2-8
+  tutorial_adventureq_string_detail_grades: Grades 2-5
+  tutorial_khan-es_string_detail_grades: Grades 6+
+  tutorial_kpt_string_detail_grades: Grades 6+
+  tutorial_kpl_string_detail_grades: Grades 6+
+  tutorial_khe_string_detail_grades: Grades 6+
+  tutorial_kfr_string_detail_grades: Grades 6+
+  tutorial_app-inventor_string_detail_grades: Grades 6+
+  tutorial_blockly_string_detail_grades: Grades 6+
+  tutorial_tynker_string_detail_grades: do-not-show
+  tutorial_baypt_string_detail_grades: All ages
+  tutorial_code-combat_string_detail_grades: do-not-show
+  tutorial_mky_string_detail_grades: Grades 2+
+  tutorial_pirates_string_detail_grades: Grades 2-8
+  tutorial_csfirst_string_detail_grades: Grades 2+
+  tutorial_loopedy_string_detail_grades: Grades 2-5
+  tutorial_dsw_string_detail_grades: do-not-show
+  tutorial_dswb_string_detail_grades: do-not-show
+  tutorial_ssw_string_detail_grades: do-not-show
+  tutorial_sswb_string_detail_grades: do-not-show
+  tutorial_kodable-unplugged_string_detail_grades: Grades 2-8
+  tutorial_scratch_string_detail_grades: Grades 2-5
+  tutorial_bayes_string_detail_grades: All ages
+  tutorial_gumball_string_detail_grades: do-not-show
+  tutorial_hrm_string_detail_grades: Grades 6+
+  tutorial_ice-age_string_detail_grades: do-not-show
+  tutorial_koapp_string_detail_grades: do-not-show
+  tutorial_lightbot-intl_string_detail_grades: Pre-reader - Grade 8
+  tutorial_rmc_string_detail_grades: do-not-show
+  tutorial_smc_string_detail_grades: do-not-show
+  tutorial_minecraft-2016_string_detail_grades: do-not-show
+  tutorial_thinkersmith-es_string_detail_grades: Grades 2-5
+  tutorial_pixie_string_detail_grades: Grades 2+
+  tutorial_play_string_detail_grades: do-not-show
+  tutorial_robomind-nl_string_detail_grades: Grades 2-8
+  tutorial_spheroi_string_detail_grades: Grades 2+
+  tutorial_spherol_string_detail_grades: Grades 2+
+  tutorial_spherov_string_detail_grades: Grades 2+
+  tutorial_swb_string_detail_grades: do-not-show
+  tutorial_build-a-galaxy_string_detail_grades: do-not-show
+  tutorial_alicesims_string_detail_grades: Grades 6+
+  tutorial_tchr_string_detail_grades: do-not-show
+  tutorial_robogame_string_detail_grades: Pre-reader - Grade 5
+  tutorial_tap_string_detail_grades: Grades 2+
+  tutorial_cintl_string_detail_grades: do-not-show
+  tutorial_itchstop_string_detail_grades: Grades 2-8
+  tutorial_tynkerpn_string_detail_grades: Grades 2-5
+  tutorial_tynkerpd_string_detail_grades: Grades 2-5
+  tutorial_persistence_string_detail_grades: Pre-reader+
+  tutorial_getloopy_string_detail_grades: Pre-reader+
+  tutorial_createface_string_detail_grades: Grades 2+
+  tutorial_happymaps_string_detail_grades: Pre-reader+
+  tutorial_moveit_string_detail_grades: Pre-reader+
+  tutorial_bigevent_string_detail_grades: Pre-reader+
+  tutorial_gpp_string_detail_grades: Grades 2+
+  tutorial_foosgame_string_detail_grades: Pre-reader - Grade 5
+  tutorial_solopython_string_detail_grades: Grades 9+
+  tutorial_kodableint_string_detail_grades: Pre-reader - Grade 5
+  tutorial_kodableadv_string_detail_grades: Pre-reader - Grade 5
+  tutorial_tynkertj_string_detail_grades: Grades 6+
+  tutorial_wolframa_string_detail_grades: Grades 6+
+  tutorial_wolframm_string_detail_grades: Grades 6+
+  tutorial_wolframspi_string_detail_grades: Grades 6+
+  tutorial_wolframsph_string_detail_grades: Grades 6+
+  tutorial_wolframp_string_detail_grades: Grades 6+
+  tutorial_wolframn_string_detail_grades: Grades 6+
+  tutorial_soloweb_string_detail_grades: Grades 9+
+  tutorial_khanweb_string_detail_grades: Grades 2+
+  tutorial_khandata_string_detail_grades: Grades 6+
+  tutorial_googlelogo_string_detail_grades: Grades 2-8
+  tutorial_playtune_string_detail_grades: Grades 6+
+  tutorial_computeit_string_detail_grades: Grades 2+
+  tutorial_codesterssj_string_detail_grades: Grades 2-8
+  tutorial_cmchat_string_detail_grades: Grades 6+
+  tutorial_tynkerdb_string_detail_grades: Grades 2-5
+  tutorial_cmbuild_string_detail_grades: Grades 6+
+  tutorial_robotrattle_string_detail_grades: Grades 2-8
+  tutorial_codestersh_string_detail_grades: Grades 2-8
+  tutorial_codehsdigipixel_string_detail_grades: Grades 6+
+  tutorial_ccbinary_string_detail_grades: Grades 6+
+  tutorial_codehsturtle_string_detail_grades: Grades 6+
+  tutorial_grokhd_string_detail_grades: Grades 6+
+  tutorial_grokem_string_detail_grades: Grades 6+
+  tutorial_kodmaze_string_detail_grades: Pre-reader - Grade 5
+  tutorial_codestersa_string_detail_grades: Grades 2-8
+  tutorial_cmdodo_string_detail_grades: Grades 3-5
+  tutorial_tynkerspace_string_detail_grades: Grades 2-5
+  tutorial_gfbloons_string_detail_grades: Grades 9+
+  tutorial_raspipong_string_detail_grades: Grades 9+
+  tutorial_codehsvr_string_detail_grades: Grades 6+
+  tutorial_codesterstp_string_detail_grades: Grades 6-8
+  tutorial_codestersbb_string_detail_grades: Grades 6-8
+  tutorial_gfcrossyroad_string_detail_grades: Grades 9+
+  tutorial_googleww_string_detail_grades: Grades 9+
+  tutorial_codehsjsapp_string_detail_grades: Grades 6+
+  tutorial_gfmihi_string_detail_grades: Grades 9+
+  tutorial_hopdropphone_string_detail_grades: Grades 2-8
+  tutorial_techfaa_string_detail_grades: University
+  tutorial_codehsjsgraph_string_detail_grades: Grades 9+
+  tutorial_thunkable_string_detail_grades: Grades 6+
+  tutorial_hopcrossyroad_string_detail_grades: Grades 2-8
+  tutorial_switchglitch_string_detail_grades: Grades 2-5
+  tutorial_codecar_string_detail_grades: Grades 6+
+  tutorial_codesterscp_string_detail_grades: Grades 6-8
+  tutorial_grokpetblock_string_detail_grades: Grades 6-8
+  tutorial_techbim_string_detail_grades: University
+  tutorial_techfpp_string_detail_grades: University
+  tutorial_codesterscr_string_detail_grades: Grades 2-8
+  tutorial_grokdisease_string_detail_grades: Grades 9+
+  tutorial_techec_string_detail_grades: University
+  tutorial_rgbegin_string_detail_grades: Grades 2-5
+  tutorial_myradream_string_detail_grades: Grades 2-8
+  tutorial_thinkfun_string_detail_grades: Grades 2-8
+  tutorial_hopfireworks_string_detail_grades: Grades 2-8
+  tutorial_grokspace_string_detail_grades: Grades 6+
+  tutorial_codehspython_string_detail_grades: Grades 6+
+  tutorial_codehsjava_string_detail_grades: Grades 9+
+  tutorial_techioda_string_detail_grades: University
+  tutorial_grokmonster_string_detail_grades: Grades 2-5
+  tutorial_techmjs_string_detail_grades: University
+  tutorial_techga_string_detail_grades: University
+  tutorial_techioan_string_detail_grades: University
+  tutorial_techiogsr_string_detail_grades: University
+  tutorial_groktunnel_string_detail_grades: Grades 6+
+  tutorial_stemcod_string_detail_grades: Grades 6+
+  tutorial_techikb_string_detail_grades: University
+  tutorial_kanostreet_string_detail_grades: Grades 2-5
+  tutorial_codemojijs_string_detail_grades: Grades 2-5
+  tutorial_techapf_string_detail_grades: University
+  tutorial_techfpjs_string_detail_grades: University
+  tutorial_techlinq_string_detail_grades: University
+  tutorial_gpbcatapult_string_detail_grades: Grades 6+
+  tutorial_quorumastro_string_detail_grades: Grades 6+
+  tutorial_alicewonder_string_detail_grades: Grades 2-5
+  tutorial_rginter_string_detail_grades: Grades 6-8
+  tutorial_cssgrid_string_detail_grades: Grades 6+
+  tutorial_jshero_string_detail_grades: Grades 9+
+  tutorial_codemojipy_string_detail_grades: Grades 2-5
+  tutorial_nclabdrone_string_detail_grades: Grades 6+
+  tutorial_gpbcircle_string_detail_grades: Grades 6+
+  tutorial_gpbpaint_string_detail_grades: Grades 6+
+  tutorial_cocomarcade_string_detail_grades: Grades 6+
+  tutorial_beetik_string_detail_grades: Grades 6-8
+  tutorial_codedj_string_detail_grades: Grades 6+
+  tutorial_rgadvan_string_detail_grades: Grades 6+
+  tutorial_codehsrn_string_detail_grades: Grades 9+
+  tutorial_codehswd_string_detail_grades: Grades 6+
+  tutorial_turtlerobot_string_detail_grades: Pre-reader - Grade 5
+  tutorial_ozoevo_string_detail_grades: Grades 6+
+  tutorial_ozoexped_string_detail_grades: Grades 6+
+  tutorial_ozojourney_string_detail_grades: Grades 2-8
+  tutorial_ozocodes_string_detail_grades: All ages
+  tutorial_ozoeclipse_string_detail_grades: Grades 2+
+  tutorial_ozosimulator_string_detail_grades: Grades 6+
+  tutorial_ozoalgorithm_string_detail_grades: Grades 6+
+  tutorial_ozotimer_string_detail_grades: Grades 6+
+  tutorial_ozohabits_string_detail_grades: All ages
+  tutorial_ozoprogram_string_detail_grades: Grades 2-8
+  tutorial_ozopair_string_detail_grades: Grades 2+
+  tutorial_codesnoopy_string_detail_grades: Pre-reader - Grade 5
+  tutorial_applabintro_string_detail_grades: Grades 9+
+  tutorial_cslartist_string_detail_grades: Pre-reader - Grade 5
+  tutorial_cslscratchjr_string_detail_grades: Pre-reader - Grade 5
+  tutorial_floevents_string_detail_grades: Grades 2-8
+  tutorial_florobot_string_detail_grades: Grades 2-8
+  tutorial_isavesanta_string_detail_grades: Grades 2-8
+  tutorial_iorder_string_detail_grades: Grades 2-8
+  tutorial_ianimate_string_detail_grades: Grades 2-8
+  tutorial_iloveada_string_detail_grades: Grades 2-5
+  tutorial_kodflash_string_detail_grades: Pre-reader - Grade 5
+  tutorial_kodchoose_string_detail_grades: Grades 2-5
+  tutorial_kodpizzapre_string_detail_grades: Pre-reader - Grade 1
+  tutorial_kodpizza_string_detail_grades: Grades 2-5
+  tutorial_kodwomen_string_detail_grades: Grades 2-8
+  tutorial_tfunplug_string_detail_grades: Grades 6-8
+  tutorial_lbvariables_string_detail_grades: Grades 2-8
+  tutorial_lbfunctions_string_detail_grades: Grades 2-8
+  tutorial_lblogic_string_detail_grades: Grades 2+
+  tutorial_lbworld_string_detail_grades: Grades 6+
+  tutorial_lbloops_string_detail_grades: Grades 2-8
+  tutorial_lbtug_string_detail_grades: Grades 6+
+  tutorial_lbpotato_string_detail_grades: Grades 2+
+  tutorial_lbguitar_string_detail_grades: Grades 2+
+  tutorial_lbio_string_detail_grades: Grades 2-8
+  tutorial_wonpuppy_string_detail_grades: Grades 2-5
+  tutorial_woncue_string_detail_grades: Grades 2+
+  tutorial_wonzoo_string_detail_grades: Grades 2-5
+  tutorial_wontrip_string_detail_grades: Grades 2-8
+  tutorial_woncollect_string_detail_grades: Pre-reader - Grade 5
+  tutorial_wonsecret_string_detail_grades: Grades 6+
+  tutorial_hsscience_string_detail_grades: Grades 2-8
+  tutorial_popculture_string_detail_grades: Grades 6+
+  tutorial_legorobust_string_detail_grades: Grades 2+
+  tutorial_legoplants_string_detail_grades: Grades 2+
+  tutorial_legopark_string_detail_grades: Grades 6+
+  tutorial_legodetect_string_detail_grades: Grades 6+
+  tutorial_legolight_string_detail_grades: Grades 6+
+  tutorial_alexa_string_detail_grades: Grades 9+
+  tutorial_grokpetmicro_string_detail_grades: Grades 6-8
+  tutorial_pirateplunder_string_detail_grades: Grades 2-8
+  tutorial_cadj_string_detail_grades: Grades 6-8
+  tutorial_cacrazy_string_detail_grades: Grades 2-8
+  tutorial_cajump_string_detail_grades: Grades 2-8
+  tutorial_carest_string_detail_grades: Grades 2-8
+  tutorial_accai_string_detail_grades: Grades 2-8
+  tutorial_vceclipse_string_detail_grades: Grades 6+
+  tutorial_pmzero_string_detail_grades: Grades 6+
+  tutorial_hsela_string_detail_grades: Grades 2-8
+  tutorial_ticklear_string_detail_grades: Grades 2-8
+  tutorial_bcrobot_string_detail_grades: Grades 2-8
+  tutorial_bcsnow_string_detail_grades: Grades 6+
+  tutorial_ifly_string_detail_grades: Grades 2+
+  tutorial_idowedo_string_detail_grades: Grades 2-8
+  tutorial_diggindwarf_string_detail_grades: Grades 6+
+  tutorial_spheroit_string_detail_grades: Grades 2+
+  tutorial_gameofcodes_string_detail_grades: Grades 2+
+  tutorial_blocklygames_string_detail_grades: Grades 6+
+  tutorial_spherohello_string_detail_grades: Grades 6+
+  tutorial_spheroarcade_string_detail_grades: Grades 6+
+  tutorial_bcpy1_string_detail_grades: Grades 6+
+  tutorial_bcpy2_string_detail_grades: Grades 6+
+  tutorial_bcjs1_string_detail_grades: Grades 6+
+  tutorial_bcjs2_string_detail_grades: Grades 9+
+  tutorial_3dbearmars_string_detail_grades: Grades 2-8
+  tutorial_bitsboxyak_string_detail_grades: Grades 2-8
+  tutorial_blockscadbargraphs_string_detail_grades: Grades 2-5
+  tutorial_blockscadbirdhouses_string_detail_grades: Grades 2-5
+  tutorial_blockscadclock_string_detail_grades: Grades 9+
+  tutorial_blockscaddinner_string_detail_grades: Grades 2-5
+  tutorial_blockscadicecream_string_detail_grades: Grades 6+
+  tutorial_blockscadpizza_string_detail_grades: Grades 6-8
+  tutorial_blockscadsugar_string_detail_grades: Grades 6-8
+  tutorial_bsgridlight_string_detail_grades: Grades 2+
+  tutorial_bpartscratch_string_detail_grades: Grades 6+
+  tutorial_bpartvid_string_detail_grades: Grades 6+
+  tutorial_bpenglishscratch_string_detail_grades: Grades 2-8
+  tutorial_bpenglishvid_string_detail_grades: Grades 2-8
+  tutorial_bphealthscratch_string_detail_grades: Grades 2+
+  tutorial_bphealthvid_string_detail_grades: Grades 6+
+  tutorial_bpmathscratch_string_detail_grades: Grades 2-5
+  tutorial_bpmathvid_string_detail_grades: Grades 6+
+  tutorial_bpmlkscratch_string_detail_grades: Grades 2-8
+  tutorial_bpmlkvid_string_detail_grades: Grades 6-8
+  tutorial_bpsafetyscratch_string_detail_grades: Grades 2-5
+  tutorial_bpsafetyvid_string_detail_grades: Grades 6-8
+  tutorial_bpsciencescratch_string_detail_grades: Grades 2-5
+  tutorial_bpsciencevid_string_detail_grades: Grades 6-8
+  tutorial_bptechscratch_string_detail_grades: Grades 6+
+  tutorial_bptechvid_string_detail_grades: Grades 6+
+  tutorial_caflags_string_detail_grades: Grades 6+
+  tutorial_matariki_string_detail_grades: Grades 2-5
+  tutorial_carestaurant_string_detail_grades: Grades 2+
+  tutorial_casea_string_detail_grades: Grades 2-5
+  tutorial_cashield_string_detail_grades: Grades 2-8
+  tutorial_ccwslimer_string_detail_grades: Grades 2-8
+  tutorial_codinggalaxy_string_detail_grades: Pre-reader - Grade 8
+  tutorial_boatrace_string_detail_grades: Grades 2+
+  tutorial_ccplay_string_detail_grades: Grades 6+
+  tutorial_grinch_string_detail_grades: Grades 2-8
+  tutorial_codehsart_string_detail_grades: Grades 9+
+  tutorial_codehsbitcoin_string_detail_grades: Grades 9+
+  tutorial_codehsblockchain_string_detail_grades: Grades 9+
+  tutorial_codehscipher_string_detail_grades: Grades 6+
+  tutorial_codehscollision_string_detail_grades: Grades 9+
+  tutorial_codehsmath_string_detail_grades: Grades 6+
+  tutorial_codehsmusic_string_detail_grades: Grades 6+
+  tutorial_codehssports_string_detail_grades: Grades 6+
+  tutorial_codemojipizza_string_detail_grades: Grades 2-8
+  tutorial_moonlander_string_detail_grades: Grades 6+
+  tutorial_sushicards_string_detail_grades: Grades 2-8
+  tutorial_codesparkcreate_string_detail_grades: Pre-reader - Grade 5
+  tutorial_hardvsoft_string_detail_grades: Pre-reader - Grade 5
+  tutorial_codestersecard_string_detail_grades: Grades 6-8
+  tutorial_codesterslogo_string_detail_grades: Grades 6+
+  tutorial_codesterstshirt_string_detail_grades: Grades 6+
+  tutorial_codewards_string_detail_grades: Grades 2-8
+  tutorial_olympics_string_detail_grades: Grades 2-8
+  tutorial_codinismhero_string_detail_grades: Grades 2+
+  tutorial_discovery_string_detail_grades: Grades 2+
+  tutorial_csfirstname_string_detail_grades: Grades 2+
+  tutorial_edisonmove_string_detail_grades: Grades 6+
+  tutorial_edisonspider_string_detail_grades: Grades 6+
+  tutorial_edisonspotlight_string_detail_grades: Grades 2-8
+  tutorial_firiapython_string_detail_grades: Grades 6+
+  tutorial_gamefrootsquid_string_detail_grades: Grades 6+
+  tutorial_duckpiano_string_detail_grades: Grades 6+
+  tutorial_gpsound_string_detail_grades: Grades 6+
+  tutorial_groklearningpython_string_detail_grades: Grades 9+
+  tutorial_htmltimetravel_string_detail_grades: Grades 9+
+  tutorial_hp_flappy_string_detail_grades: Grades 9+
+  tutorial_appytappin_string_detail_grades: Grades 2-5
+  tutorial_icipher_string_detail_grades: Grades 2-5
+  tutorial_iguess_string_detail_grades: Pre-reader - Grade 5
+  tutorial_imake_string_detail_grades: Pre-reader - Grade 1
+  tutorial_imorse_string_detail_grades: Grades 2-8
+  tutorial_kanohp_string_detail_grades: Grades 2-8
+  tutorial_khanwebpages_string_detail_grades: Grades 6+
+  tutorial_kibobowl_string_detail_grades: Pre-reader - Grade 5
+  tutorial_kibodance_string_detail_grades: Pre-reader - Grade 5
+  tutorial_buildcharacters_string_detail_grades: Pre-reader - Grade 5
+  tutorial_designgames_string_detail_grades: Grades 2-5
+  tutorial_makelevels_string_detail_grades: Pre-reader - Grade 5
+  tutorial_wizard_string_detail_grades: Grades 6+
+  tutorial_mbscratchcards_string_detail_grades: Grades 2+
+  tutorial_mbswiftplaygrounds_string_detail_grades: Grades 2+
+  tutorial_mbbuttons_string_detail_grades: Grades 6+
+  tutorial_meteor_string_detail_grades: Grades 6+
+  tutorial_ballbounce_string_detail_grades: Grades 6+
+  tutorial_mitcodi_string_detail_grades: Grades 6+
+  tutorial_mitdoodle_string_detail_grades: Grades 6+
+  tutorial_talktome_string_detail_grades: Grades 6+
+  tutorial_mobilecspmap_string_detail_grades: Grades 6+
+  tutorial_ozorandom_string_detail_grades: Grades 2+
+  tutorial_ozotroll_string_detail_grades: Grades 6-8
+  tutorial_peblioart_string_detail_grades: Grades 9+
+  tutorial_astropi_string_detail_grades: Grades 6+
+  tutorial_rgart_string_detail_grades: Grades 2-5
+  tutorial_rgengineer_string_detail_grades: Grades 2-5
+  tutorial_rgmath_string_detail_grades: Grades 2-5
+  tutorial_rgscience_string_detail_grades: Grades 2-5
+  tutorial_rgtech_string_detail_grades: Grades 2-5
+  tutorial_robotmagic3d_string_detail_grades: Grades 6+
+  tutorial_robotmagicflappy_string_detail_grades: Grades 9+
+  tutorial_scratchadventure_string_detail_grades: Grades 2+
+  tutorial_scratchtalk_string_detail_grades: Grades 2+
+  tutorial_scratchjrstory_string_detail_grades: Grades 2-5
+  tutorial_scratchjrtwinkle_string_detail_grades: Pre-reader
+  tutorial_spherocomm_string_detail_grades: Grades 2-8
+  tutorial_spherocommunity_string_detail_grades: Grades 2-5
+  tutorial_spherofunctions_string_detail_grades: Grades 6+
+  tutorial_spheroinfrared_string_detail_grades: Grades 6-8
+  tutorial_spherolightsensor_string_detail_grades: Grades 2-8
+  tutorial_spheromansion_string_detail_grades: Grades 2-8
+  tutorial_roadblocks_string_detail_grades: Grades 2-8
+  tutorial_spherotext2_string_detail_grades: Grades 6+
+  tutorial_spherotext3_string_detail_grades: Grades 6+
+  tutorial_spherotext4_string_detail_grades: Grades 6+
+  tutorial_spheroraptor_string_detail_grades: Grades 2-8
+  tutorial_stempiday_string_detail_grades: 'Grades 9+ '
+  tutorial_stemplanetoids_string_detail_grades: Grades 9+
+  tutorial_stempong_string_detail_grades: Grades 9+
+  tutorial_algobot_string_detail_grades: Grades 2-8
+  tutorial_thunkableapps_string_detail_grades: Grades 9+
+  tutorial_toxicodedot_string_detail_grades: Grades 2-8
+  tutorial_gcactions_string_detail_grades: Grades 6+
+  tutorial_gccomparators_string_detail_grades: Grades 6+
+  tutorial_gcconditions_string_detail_grades: Grades 6+
+  tutorial_gccreate_string_detail_grades: Grades 6+
+  tutorial_gcevents_string_detail_grades: Grades 6+
+  tutorial_gcloops_string_detail_grades: Grades 6+
+  tutorial_gcvariables_string_detail_grades: Grades 6+
+  tutorial_beanything_string_detail_grades: Grades 2-5
+  tutorial_change_string_detail_grades: Grades 2-8
+  tutorial_cooking_string_detail_grades: Grades 2-5
+  tutorial_crystal_string_detail_grades: Grades 2+
+  tutorial_landscape_string_detail_grades: Grades 6+
+  tutorial_pets_string_detail_grades: Grades 2-5
+  tutorial_petvet_string_detail_grades: Grades 2-5
+  tutorial_superhero_string_detail_grades: Grades 6+
+  tutorial_vidcodeplastic_string_detail_grades: Grades 6+
+  tutorial_vidcodetypeface_string_detail_grades: Grades 6+
+  tutorial_washustorm_string_detail_grades: Grades 2-5
+  tutorial_activitypackets_string_detail_grades: Pre-reader - Grade 8
+  tutorial_googlerookie_string_detail_grades: Grades 6+
+  tutorial_tommyturtle_string_detail_grades: Pre-reader - Grade 5
+  tutorial_mazyad_string_detail_grades: Pre-reader - Grade 5
+  tutorial_gamemaker_string_detail_grades: Grades 2+
+  tutorial_duckrace_string_detail_grades: Grades 2+
+  tutorial_allcancodeapps_string_detail_grades: Grades 6+
+  tutorial_n2y_string_detail_grades: Pre-reader+
+  tutorial_microsoftarcade_string_detail_grades: Grades 2+
+  tutorial_csfirstunplugged_string_detail_grades: Grades 2-8
+  tutorial_toxicodepython_string_detail_grades: Grades 6+
+  tutorial_codecombatozaria_string_detail_grades: Grades 6-8
+  tutorial_vidcodedate_string_detail_grades: Grades 6+
+  tutorial_codemonkeyspace_string_detail_grades: Grades 2-8
+  tutorial_codespeakhappy_string_detail_grades: Grades 2-8
+  tutorial_grokimage_string_detail_grades: Grades 6+
+  tutorial_icomputelearn_string_detail_grades: Pre-reader - Grade 8
+  tutorial_rpstress_string_detail_grades: Grades 2+
+  tutorial_bsdcause_string_detail_grades: Grades 9+
+  tutorial_vidcodeanimoji_string_detail_grades: Grades 2+
+  tutorial_vidcodeanimojies_string_detail_grades: Grades 2+
+  tutorial_bsdinspire_string_detail_grades: Grades 6+
+  tutorial_tttractor_string_detail_grades: Grades 6+
+  tutorial_codeillusionmickey_string_detail_grades: Grades 2-8
+  tutorial_scigirlsquest_string_detail_grades: Grades 2-8
+  tutorial_codespeakbreathe_string_detail_grades: Grades 2+
+  tutorial_vidcodeface_string_detail_grades: Grades 6+
+  tutorial_educodemaze_string_detail_grades: Grades 6+
+  tutorial_educoderace_string_detail_grades: Grades 6+
+  tutorial_codespeakchatbot_string_detail_grades: Grades 2-8
+  tutorial_gamefrootgames_string_detail_grades: Grades 6+
+  tutorial_codespeakgrandparent_string_detail_grades: Grades 2-8
+  tutorial_educodekingdom_string_detail_grades: Grades 6+
+  tutorial_codehsdata_string_detail_grades: Grades 9+
+  tutorial_educodecake_string_detail_grades: Grades 6+
+  tutorial_ttsecond_string_detail_grades: Grades 6+
+  tutorial_bsdtrivia_string_detail_grades: Grades 6+
+  tutorial_csfirstdialogue_string_detail_grades: Grades 2-8
+  tutorial_codemonkeybeaver_string_detail_grades: Pre-reader - Grade 5
+  tutorial_codestersdistance_string_detail_grades: Grades 6+
+  tutorial_itchspace_string_detail_grades: Grades 6+
+  tutorial_vidcodemagic_string_detail_grades: Grades 2+
+  tutorial_vidcodemagices_string_detail_grades: Grades 2+
+  tutorial_codespeakmeal_string_detail_grades: Grades 6+
+  tutorial_itchfish_string_detail_grades: Grades 2-8
+  tutorial_bsdwebsite_string_detail_grades: Grades 6+
+  tutorial_codespeaktime_string_detail_grades: Grades 2-8
+  tutorial_itchwebcam_string_detail_grades: Grades 6+
+  tutorial_itchball_string_detail_grades: Grades 2-8
+  tutorial_ttrace_string_detail_grades: Grades 6-8
+  tutorial_plethora_string_detail_grades: Grades 2+
+  tutorial_educodesecret_string_detail_grades: Grades 6+
+  tutorial_itchshapes_string_detail_grades: Grades 6+
+  tutorial_codeguppytext_string_detail_grades: Grades 6-8
+  tutorial_vidcodeplastiche_string_detail_grades: Grades 6+
+  tutorial_educativechatbot_string_detail_grades: Grades 9+
+  tutorial_educodebasics_string_detail_grades: Grades 6+
+  tutorial_codehsdesign_string_detail_grades: Grades 6+
+  tutorial_htmlacademyphp_string_detail_grades: Grades 6+
+  tutorial_gamefrootdistance_string_detail_grades: Grades 2+
+  tutorial_codesterscovid_string_detail_grades: 'Grades 6-8 '
+  tutorial_ttbunker_string_detail_grades: Grades 6-8
+  tutorial_cuttle_string_detail_grades: Grades 6+
+  tutorial_bsdjokes_string_detail_grades: Grades 6-8
+  tutorial_rptree_string_detail_grades: Grades 6+
+  tutorial_codestersunity_string_detail_grades: Grades 6+
+  tutorial_codesterssoccer_string_detail_grades: Grades 6+
+  tutorial_breakoutlock_string_detail_grades: Grades 2-8
+  tutorial_thunkablemask_string_detail_grades: Grades 6+
+  tutorial_cafarming_string_detail_grades: Grades 2-8
+  tutorial_blocksmithyeti_string_detail_grades: Grades 9+
+  tutorial_codecapture_string_detail_grades: Grades 6+
+  tutorial_codehslitter_string_detail_grades: Grades 6-8
+  tutorial_bsdocean_string_detail_grades: Grades 6-8
+  tutorial_itchplatformer_string_detail_grades: Grades 6+
+  tutorial_codejika_string_detail_grades: Grades 6+
+  tutorial_gamefrootclicker_string_detail_grades: Grades 6-8
+  tutorial_rmagicequity_string_detail_grades: Grades 6-8
+  tutorial_ttfreestyle_string_detail_grades: Grades 6-8
+  tutorial_ozobotcolor2_string_detail_grades: Grades 2+
+  tutorial_ozobotcolor3_string_detail_grades: Grades 2+
+  tutorial_clcarbon_string_detail_grades: Grades 6+
+  tutorial_kodablebasics_string_detail_grades: Pre-reader - Grade 5
+  tutorial_scigirlscc_string_detail_grades: Grades 2+
+  tutorial_irobotpicture_string_detail_grades: Grades 2-8
+  tutorial_kcjmyself_string_detail_grades: Grades 2-8
+  tutorial_nearpodalgorithms_string_detail_grades: Pre-reader - Grade 5
+  tutorial_kibodrop_string_detail_grades: Pre-reader - Grade 5
+  tutorial_ozobotcolor1_string_detail_grades: Grades 2+
+  tutorial_scigirlspixels_string_detail_grades: Grades 2+
+  tutorial_kcjheroines_string_detail_grades: Grades 2-8
+  tutorial_ozobotvalue_string_detail_grades: Grades 2-5
+  tutorial_icodebytes_string_detail_grades: Pre-reader
+  tutorial_clfashion2_string_detail_grades: Grades 6+
+  tutorial_ai4all_string_detail_grades: Grades 6+
+  tutorial_cldata_string_detail_grades: Grades 6+
+  tutorial_spheroinputs_string_detail_grades: Grades 2-8
+  tutorial_edisoncount_string_detail_grades: Grades 2-8
+  tutorial_spheroloops_string_detail_grades: Grades 2-8
+  tutorial_kiboprogram_string_detail_grades: Pre-reader - Grade 5
+  tutorial_hellorubycsin60_string_detail_grades: Pre-reader - Grade 5
+  tutorial_clfashion1_string_detail_grades: Grades 6+
+  tutorial_irobottraffic_string_detail_grades: Grades 2-5
+  tutorial_edisonmystery_string_detail_grades: Grades 6-8
+  tutorial_microbitseaturtles_string_detail_grades: Grades 6-8
+  tutorial_ozobotknow_string_detail_grades: Grades 2+
+  tutorial_imagilabs_string_detail_grades: Grades 2-8
+  tutorial_irobotsimulator_string_detail_grades: Grades 2-8
+  tutorial_irobotkind_string_detail_grades: Pre-reader - Grade 5
+  tutorial_firiavirtual_string_detail_grades: Grades 6+
+  tutorial_irobotguesscode_string_detail_grades: Grades 2-8
+  tutorial_ozobotnouns_string_detail_grades: Grades 2-5
+  tutorial_nasa3d_string_detail_grades: Grades 6+
+  tutorial_blupants_string_detail_grades: Grades 6+
+  tutorial_legodance_string_detail_grades: Grades 6-8
+  tutorial_nearpodcoding_string_detail_grades: Grades 9+
+  tutorial_kcjplastic_string_detail_grades: Grades 2+
+  tutorial_legojourney_string_detail_grades: Grades 2-8
+  tutorial_legohopper_string_detail_grades: Grades 2-8
+  tutorial_catrobatembroidery_string_detail_grades: Grades 6+
+  tutorial_irobotphone_string_detail_grades: Grades 2-8
+  tutorial_codeguppydraw_string_detail_grades: Grades 6-8
+  tutorial_codejumper_string_detail_grades: Grades 2-8
+  tutorial_meeempathy_string_detail_grades: Grades 2+
+  tutorial_dance2019_string_platforms: All modern browsers, Android tablet, iPad,
+    Unplugged
+  tutorial_danceparty_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_chibitronics_string_platforms: All modern browsers, Screen reader
+  tutorial_athlete_string_platforms: All modern browsers
+  tutorial_moana_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_star-wars_string_platforms: All modern browsers, Android tablet, iPad,
+    Android phone, iPhone
+  tutorial_gumadventure_string_platforms: All modern browsers
+  tutorial_mchoc_string_platforms: All modern browsers, Android tablet, iPad, Android
+    phone, iPhone
+  tutorial_vidnews_string_platforms: Chrome, Firefox
+  tutorial_kodable-pre_string_platforms: All modern browsers, Android tablet, iPad,
+    Unplugged
+  tutorial_highseas_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Firefox, Safari
+  tutorial_capython_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Firefox, Safari
+  tutorial_frzn_string_platforms: All modern browsers, Android, iOS
+  tutorial_cocom_string_platforms: All modern browsers
+  tutorial_play-lab_string_platforms: All modern browsers, Android, iOS
+  tutorial_boxisland_string_platforms: iPad, iPhone
+  tutorial_textcomp_string_platforms: All modern browsers
+  tutorial_encryption_string_platforms: All modern browsers
+  tutorial_kanopixel_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Firefox, Safari, Android tablet, iPad
+  tutorial_foos_string_platforms: All modern browsers, Android tablet, iPad, Android
+    phone, iPhone
+  tutorial_tynkerdd_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Firefox, Safari
+  tutorial_tynkerana_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Firefox, Safari, Android tablet, iPad
+  tutorial_vidcard_string_platforms: Chrome
+  tutorial_spritebox_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_tynkerch_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Firefox, Safari
+  tutorial_lightbot_string_platforms: All modern browsers, Android tablet, iPad, Android
+    phone, iPhone
+  tutorial_hoc_string_platforms: do-not-show
+  tutorial_code_string_platforms: All modern browsers, Android, iOS
+  tutorial_tinspire_string_platforms: TI-Nspire handheld
+  tutorial_itchbounceball_string_platforms: Chrome, Firefox, Android Tablet
+  tutorial_vidclim_string_platforms: Chrome, Firefox, Safari
+  tutorial_matlab_string_platforms: All modern browsers
+  tutorial_flap_string_platforms: All modern browsers, Android, iOS
+  tutorial_galaxy_string_platforms: Android tablet, Android phone
+  tutorial_inf_string_platforms: All modern browsers, Android tablet, iPad, Android
+    phone, iPhone
+  tutorial_tynkersol_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Firefox, Safari, Android tablet, iPad
+  tutorial_itchg_string_platforms: Chrome, Firefox, Android Tablet
+  tutorial_como_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_processfound_string_platforms: Chrome, Firefox, Safari
+  tutorial_tynkerhomo_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Firefox, Safari, Android tablet, iPad
+  tutorial_art_string_platforms: All modern browsers, Android tablet, iPad, Android
+    phone, iPhone
+  tutorial_tynkerbrick_string_platforms: All modern browsers
+  tutorial_itchbio_string_platforms: Chrome, Firefox
+  tutorial_itchj_string_platforms: Chrome, Firefox, Android Tablet
+  tutorial_tickleo_string_platforms: All modern browsers, iPad, iPhone
+  tutorial_hopgeo_string_platforms: iPad and iPhone
+  tutorial_tynkermult_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Firefox, Safari, Android tablet, iPad
+  tutorial_monster_string_platforms: All modern browsers
+  tutorial_tynkerapp_string_platforms: do-not-show
+  tutorial_tynkerpup_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Firefox, Safari
+  tutorial_livecode_string_platforms: All modern browsers, Android tablet, iPad, Android
+    phone, iPhone
+  tutorial_cocomgame_string_platforms: All modern browsers
+  tutorial_tynkerspin_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Firefox, Safari, Android tablet, iPad
+  tutorial_code-avengers_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Firefox, Safari
+  tutorial_tynkercq_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Firefox, Safari, Android tablet, iPad
+  tutorial_cmgame_string_platforms: All modern browsers
+  tutorial_codesters_string_platforms: do-not-show
+  tutorial_qrm_string_platforms: All modern browsers, Screen reader
+  tutorial_texas-instruments_string_platforms: TI-84, TI-83 graphing calculators
+  tutorial_cajava_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Firefox, Safari
+  tutorial_codehs_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Firefox, Safari
+  tutorial_hopemo_string_platforms: iPad and iPhone
+  tutorial_tynkercm_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Firefox, Safari
+  tutorial_codesterswintergreet_string_platforms: All modern browsers
+  tutorial_codestersc_string_platforms: All modern browsers
+  tutorial_codestersturtle_string_platforms: All modern browsers
+  tutorial_penjee_string_platforms: All modern browsers
+  tutorial_trinket_string_platforms: All modern browsers
+  tutorial_frogger_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Firefox, Safari
+  tutorial_tynkereco_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Firefox, Safari, Android tablet, iPad
+  tutorial_mitedarc_string_platforms: All modern browsers
+  tutorial_khan_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome, Firefox,
+    Safari
+  tutorial_tynkerd_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Firefox, Safari
+  tutorial_cdmy_string_platforms: Internet Explorer 11, Chrome, Firefox, Safari
+  tutorial_codestersdance_string_platforms: All modern browsers
+  tutorial_codestersbasketball_string_platforms: All modern browsers
+  tutorial_nclkarel_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Firefox, Safari
+  tutorial_buildpong_string_platforms: All modern browsers, Android tablet, Android
+    phone, iPad
+  tutorial_tynkerdrones_string_platforms: Android tablet, iPad
+  tutorial_carla_string_platforms: All modern browsers
+  tutorial_zulama_string_platforms: Internet Explorer 11, Chrome, Firefox, Safari
+  tutorial_capost_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Firefox, Safari
+  tutorial_marco_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_codestersflappybike_string_platforms: All modern browsers
+  tutorial_kanopong_string_platforms: All modern browsers
+  tutorial_tynkerright_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Firefox, Safari, Android tablet, iPad
+  tutorial_touchdevelop_string_platforms: do-not-show
+  tutorial_tynkercc_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Firefox, Safari
+  tutorial_bamboo_string_platforms: Chrome
+  tutorial_robojav_string_platforms: All modern browsers
+  tutorial_roboba_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_knodsnake_string_platforms: All modern browsers
+  tutorial_soccharater_string_platforms: All modern browsers
+  tutorial_silent_string_platforms: All modern browsers
+  tutorial_robomesh_string_platforms: Internet Explorer 11, Chrome, Firefox
+  tutorial_amaze_string_platforms: All modern browsers, Android tablet, iPad, Android
+    phone
+  tutorial_codestersds_string_platforms: All modern browsers
+  tutorial_knodtext_string_platforms: All modern browsers
+  tutorial_alicegar_string_platforms: All modern browsers
+  tutorial_codesterstransform_string_platforms: All modern browsers
+  tutorial_flexfrog_string_platforms: All modern browsers
+  tutorial_codemoji_string_platforms: do-not-show
+  tutorial_robobii_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_robobm_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_codingrobots_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_robob_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_coders_string_platforms: All modern browsers
+  tutorial_tynkerhw_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Firefox, Safari
+  tutorial_tynkermh_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Firefox, Safari, Android tablet, iPad
+  tutorial_caphoto_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Firefox, Safari
+  tutorial_mozillahw_string_platforms: All modern browsers
+  tutorial_ticklep_string_platforms: do-not-show
+  tutorial_bbot_string_platforms: All modern browsers
+  tutorial_scratchg_string_platforms: All modern browsers
+  tutorial_sjforest_string_platforms: iPad app
+  tutorial_sjgreet_string_platforms: iPad app
+  tutorial_sjsunset_string_platforms: iPad app
+  tutorial_fufafrenz_string_platforms: Unplugged
+  tutorial_bbcgeo_string_platforms: do-not-show
+  tutorial_chspixel_string_platforms: Unplugged
+  tutorial_hummingbird_string_platforms: PC, Mac, Linux, Chromebook downloadable,
+    Hummingbird robot
+  tutorial_recoloring_string_platforms: All modern browsers
+  tutorial_bbcchem_string_platforms: do-not-show
+  tutorial_floalgo_string_platforms: Unplugged
+  tutorial_flocond_string_platforms: Unplugged
+  tutorial_floloops_string_platforms: Unplugged
+  tutorial_pgts_string_platforms: Unplugged
+  tutorial_ozo_string_platforms: All modern browsers, iPad, iPhone, Android tablet,
+    Andriod phone, Ozobot robot
+  tutorial_bbcla_string_platforms: do-not-show
+  tutorial_bbcsci_string_platforms: do-not-show
+  tutorial_tlctour_string_platforms: Unplugged
+  tutorial_codesterstj_string_platforms: All modern browsers
+  tutorial_tlclocked_string_platforms: Unplugged
+  tutorial_baubles_string_platforms: Unplugged
+  tutorial_bbcart_string_platforms: do-not-show
+  tutorial_tlcknight_string_platforms: Unplugged
+  tutorial_fufafit_string_platforms: Unplugged
+  tutorial_ozodance_string_platforms: All modern browsers, iPad, iPhone, Android tablet,
+    Andriod phone, Ozobot robot
+  tutorial_codingrobotics_string_platforms: iPad, Dash robot
+  tutorial_box_string_platforms: do-not-show
+  tutorial_hopgame_string_platforms: iPad and iPhone
+  tutorial_icontrol_string_platforms: iPad, Sphero robot
+  tutorial_cocomteach_string_platforms: All modern browsers
+  tutorial_bbcmathii_string_platforms: do-not-show
+  tutorial_bbcphys_string_platforms: do-not-show
+  tutorial_bitsbox_string_platforms: All modern browsers, iOS
+  tutorial_tlcemo_string_platforms: Unplugged
+  tutorial_crd_string_platforms: Unplugged
+  tutorial_bbcbio_string_platforms: do-not-show
+  tutorial_ticklebb8_string_platforms: iPad, iPhone, BB-8 robot
+  tutorial_grok_string_platforms: do-not-show
+  tutorial_ijournalist_string_platforms: All modern browsers
+  tutorial_bbcmusic_string_platforms: do-not-show
+  tutorial_secretcodes_string_platforms: All modern browsers
+  tutorial_tlchex_string_platforms: Unplugged
+  tutorial_tickles_string_platforms: iPad, iPhone, Sphero robot
+  tutorial_ozogame_string_platforms: All modern browsers, iPad, iPhone, Android tablet,
+    Andriod phone, Ozobot robot
+  tutorial_vidcodeio_string_platforms: Unplugged
+  tutorial_tlcbrain_string_platforms: Unplugged
+  tutorial_hopquiz_string_platforms: iPad and iPhone
+  tutorial_unfortunate_string_platforms: Dash and Dot robot
+  tutorial_cha_string_platforms: All modern browsers
+  tutorial_elaseq_string_platforms: Unplugged, All modern browsers, iPad, Android
+    tablet
+  tutorial_bbcmathi_string_platforms: do-not-show
+  tutorial_tlcpixel_string_platforms: Unplugged
+  tutorial_introrobo_string_platforms: iPad, Android tablet, Dash and Dot robot
+  tutorial_tlcinvis_string_platforms: Unplugged
+  tutorial_tlcjflap_string_platforms: All modern browsers
+  tutorial_procolor_string_platforms: Ozobot robot
+  tutorial_spiralsfinch_string_platforms: PC, Mac, Linux, Chromebook downloadable,
+    Finch robot
+  tutorial_ozoi_string_platforms: Ozobot robot
+  tutorial_ticklel_string_platforms: All modern browsers, iPad, iPhone, LEGO WeDo
+    robot
+  tutorial_spiralsdash_string_platforms: Android tablet, Android phone, Dash robot
+  tutorial_ghdebug_string_platforms: All modern browsers
+  tutorial_tlckk_string_platforms: Unplugged
+  tutorial_firstcomp_string_platforms: Unplugged
+  tutorial_mazefinch_string_platforms: All modern browsers, Finch robot
+  tutorial_tlccc_string_platforms: Unplugged
+  tutorial_tlcdoodle_string_platforms: Unplugged
+  tutorial_tlcpunch_string_platforms: Unplugged
+  tutorial_finchfract_string_platforms: PC, Mac, Linux, Chromebook downloadable, Finch
+    robot
+  tutorial_tlcmind_string_platforms: Unplugged
+  tutorial_tlctelebot_string_platforms: Unplugged
+  tutorial_tlcaus_string_platforms: Unplugged
+  tutorial_tlcmicro_string_platforms: Unplugged
+  tutorial_imathematician_string_platforms: All modern browsers
+  tutorial_tlcmagic_string_platforms: Unplugged
+  tutorial_scratchmus_string_platforms: All modern browsers
+  tutorial_scratchanim_string_platforms: All modern browsers
+  tutorial_scratchfly_string_platforms: All modern browsers
+  tutorial_tynkerarc_string_platforms: All modern browsers
+  tutorial_grokffpython_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_grokffblock_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_grokeliza_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_tynkercan_string_platforms: All modern browsers
+  tutorial_grokflags_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Firefox, Safari, Android Chrome (mobile-optimized), iOS (mobile-optimized)
+  tutorial_robomind_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Firefox, Safari, Android tablet, iPad
+  tutorial_adventureq_string_platforms: iPad
+  tutorial_khan-es_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Firefox, Safari
+  tutorial_kpt_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome, Firefox,
+    Safari
+  tutorial_kpl_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome, Firefox,
+    Safari
+  tutorial_khe_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome, Firefox,
+    Safari
+  tutorial_kfr_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome, Firefox,
+    Safari
+  tutorial_app-inventor_string_platforms: Android
+  tutorial_blockly_string_platforms: All modern browsers
+  tutorial_tynker_string_platforms: do-not-show
+  tutorial_baypt_string_platforms: All modern browsers
+  tutorial_code-combat_string_platforms: do-not-show
+  tutorial_mky_string_platforms: All modern browsers
+  tutorial_pirates_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Firefox, Safari, Android tablet, iPad, Android phone, iPhone
+  tutorial_csfirst_string_platforms: All modern browsers
+  tutorial_loopedy_string_platforms: iPad, iPhone, Android tablet, Android phone,
+    Dash and Dot robot
+  tutorial_dsw_string_platforms: do-not-show
+  tutorial_dswb_string_platforms: do-not-show
+  tutorial_ssw_string_platforms: do-not-show
+  tutorial_sswb_string_platforms: do-not-show
+  tutorial_kodable-unplugged_string_platforms: Unplugged
+  tutorial_scratch_string_platforms: All modern browsers
+  tutorial_bayes_string_platforms: All modern browsers
+  tutorial_gumball_string_platforms: do-not-show
+  tutorial_hrm_string_platforms: PC and Mac downloadable
+  tutorial_ice-age_string_platforms: do-not-show
+  tutorial_koapp_string_platforms: do-not-show
+  tutorial_lightbot-intl_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Firefox, Safari, Android tablet, iPad, Android phone, iPhone
+  tutorial_rmc_string_platforms: do-not-show
+  tutorial_smc_string_platforms: do-not-show
+  tutorial_minecraft-2016_string_platforms: do-not-show
+  tutorial_thinkersmith-es_string_platforms: All modern browsers, iOS
+  tutorial_pixie_string_platforms: All modern browsers
+  tutorial_play_string_platforms: do-not-show
+  tutorial_robomind-nl_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Firefox, Safari, Android tablet, iPad
+  tutorial_spheroi_string_platforms: iPad, Android tablet, iPhone, Android phone,
+    Sphero robot
+  tutorial_spherol_string_platforms: iPad, Android tablet, iPhone, Android phone,
+    Sphero robot
+  tutorial_spherov_string_platforms: iPad, Android tablet, iPhone, Android phone,
+    Sphero robot
+  tutorial_swb_string_platforms: do-not-show
+  tutorial_build-a-galaxy_string_platforms: do-not-show
+  tutorial_alicesims_string_platforms: All modern browsers
+  tutorial_tchr_string_platforms: do-not-show
+  tutorial_robogame_string_platforms: Android tablet, iPad, Android phone, iPhone,
+    Dash and Dot robot
+  tutorial_tap_string_platforms: Android tablet, iPad
+  tutorial_cintl_string_platforms: do-not-show
+  tutorial_itchstop_string_platforms: All modern browsers
+  tutorial_tynkerpn_string_platforms: All modern browsers, iPad, Android tablet
+  tutorial_tynkerpd_string_platforms: All modern browsers, iPad, Android tablet
+  tutorial_persistence_string_platforms: Unplugged
+  tutorial_getloopy_string_platforms: Unplugged
+  tutorial_createface_string_platforms: Unplugged
+  tutorial_happymaps_string_platforms: Unplugged
+  tutorial_moveit_string_platforms: Unplugged
+  tutorial_bigevent_string_platforms: Unplugged
+  tutorial_gpp_string_platforms: Unplugged
+  tutorial_foosgame_string_platforms: Android tablet, iPad
+  tutorial_solopython_string_platforms: All modern browsers, Android tablet, Android
+    phone, iPad, iPhone
+  tutorial_kodableint_string_platforms: Unplugged, All modern browsers, iPad, Android
+    tablet
+  tutorial_kodableadv_string_platforms: Unplugged, All modern browsers, iPad, Android
+    tablet
+  tutorial_tynkertj_string_platforms: All modern browsers
+  tutorial_wolframa_string_platforms: All modern browsers
+  tutorial_wolframm_string_platforms: All modern browsers
+  tutorial_wolframspi_string_platforms: All modern browsers
+  tutorial_wolframsph_string_platforms: All modern browsers
+  tutorial_wolframp_string_platforms: All modern browsers
+  tutorial_wolframn_string_platforms: All modern browsers
+  tutorial_soloweb_string_platforms: All modern browsers, Android tablet, Android
+    phone, iPad, iPhone
+  tutorial_khanweb_string_platforms: All modern browsers, Android tablet
+  tutorial_khandata_string_platforms: All modern browsers
+  tutorial_googlelogo_string_platforms: All modern browsers
+  tutorial_playtune_string_platforms: Chrome, Firefox, Safari
+  tutorial_computeit_string_platforms: All modern browsers
+  tutorial_codesterssj_string_platforms: All modern browsers
+  tutorial_cmchat_string_platforms: All modern browsers
+  tutorial_tynkerdb_string_platforms: All modern browsers, iPad
+  tutorial_cmbuild_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_robotrattle_string_platforms: Chrome, Firefox, Android tablet, iPad
+  tutorial_codestersh_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_codehsdigipixel_string_platforms: Chrome, Firefox, Safari
+  tutorial_ccbinary_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome
+  tutorial_codehsturtle_string_platforms: Chrome, Firefox, Safari
+  tutorial_grokhd_string_platforms: All modern browsers
+  tutorial_grokem_string_platforms: All modern browsers
+  tutorial_kodmaze_string_platforms: All modern browsers, iPad
+  tutorial_codestersa_string_platforms: All modern browsers
+  tutorial_cmdodo_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_tynkerspace_string_platforms: All modern browsers, iPad, Unplugged
+  tutorial_gfbloons_string_platforms: All modern browsers
+  tutorial_raspipong_string_platforms: Chrome
+  tutorial_codehsvr_string_platforms: Chrome, Firefox, Safari
+  tutorial_codesterstp_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_codestersbb_string_platforms: All modern browsers
+  tutorial_gfcrossyroad_string_platforms: All modern browsers
+  tutorial_googleww_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_codehsjsapp_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_gfmihi_string_platforms: All modern browsers
+  tutorial_hopdropphone_string_platforms: iPad, iPhone
+  tutorial_techfaa_string_platforms: All modern browsers, Android tablet, iPad, Windows
+    phone, Android phone, iPhone
+  tutorial_codehsjsgraph_string_platforms: Chrome, Firefox, Safari
+  tutorial_thunkable_string_platforms: All modern browsers
+  tutorial_hopcrossyroad_string_platforms: iPad, iPhone
+  tutorial_switchglitch_string_platforms: All modern browsers, Android tablet, iPad,
+    Android phone, iPhone
+  tutorial_codecar_string_platforms: Chrome, Firefox
+  tutorial_codesterscp_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_grokpetblock_string_platforms: All modern browsers
+  tutorial_techbim_string_platforms: All modern browsers, Android tablet, iPad, Windows
+    phone, Android phone, iPhone
+  tutorial_techfpp_string_platforms: All modern browsers, Android tablet, iPad, Windows
+    phone, Android phone, iPhone
+  tutorial_codesterscr_string_platforms: All modern browsers
+  tutorial_grokdisease_string_platforms: All modern browsers
+  tutorial_techec_string_platforms: All modern browsers, Android tablet, iPad, Windows
+    phone, Android phone, iPhone
+  tutorial_rgbegin_string_platforms: Chrome, Firefox
+  tutorial_myradream_string_platforms: All modern browsers
+  tutorial_thinkfun_string_platforms: Chrome, Firefox, Safari
+  tutorial_hopfireworks_string_platforms: iPad, iPhone
+  tutorial_grokspace_string_platforms: All modern browsers
+  tutorial_codehspython_string_platforms: Chrome, Firefox, Safari
+  tutorial_codehsjava_string_platforms: Chrome, Firefox, Safari
+  tutorial_techioda_string_platforms: All modern browsers, Android tablet, iPad, Windows
+    phone, Android phone, iPhone
+  tutorial_grokmonster_string_platforms: All modern browsers
+  tutorial_techmjs_string_platforms: All modern browsers, Android tablet, iPad, Windows
+    phone, Android phone, iPhone
+  tutorial_techga_string_platforms: All modern browsers, Android tablet, iPad, Windows
+    phone, Android phone, iPhone
+  tutorial_techioan_string_platforms: All modern browsers, Android tablet, iPad, Windows
+    phone, Android phone, iPhone
+  tutorial_techiogsr_string_platforms: All modern browsers, Android tablet, iPad,
+    Windows phone, Android phone, iPhone
+  tutorial_groktunnel_string_platforms: All modern browsers
+  tutorial_stemcod_string_platforms: Chrome, Firefox, Safari, Android tablet, iPad
+  tutorial_techikb_string_platforms: All modern browsers, Android tablet, iPad, Windows
+    phone, Android phone, iPhone
+  tutorial_kanostreet_string_platforms: All modern browsers
+  tutorial_codemojijs_string_platforms: All modern browsers
+  tutorial_techapf_string_platforms: All modern browsers, Android tablet, iPad, Windows
+    phone, Android phone, iPhone
+  tutorial_techfpjs_string_platforms: All modern browsers, Android tablet, iPad, Windows
+    phone, Android phone, iPhone
+  tutorial_techlinq_string_platforms: All modern browsers, Android tablet, iPad, Windows
+    phone, Android phone, iPhone
+  tutorial_gpbcatapult_string_platforms: All modern browsers
+  tutorial_quorumastro_string_platforms: All modern browsers, Android tablet, iPad,
+    Windows phone, Android phone, iPhone, Screen reader
+  tutorial_alicewonder_string_platforms: All modern browsers
+  tutorial_rginter_string_platforms: Chrome, Firefox, Android tablet
+  tutorial_cssgrid_string_platforms: All modern browsers
+  tutorial_jshero_string_platforms: All modern browsers, Android tablet, Android phone
+  tutorial_codemojipy_string_platforms: iPad, iPhone
+  tutorial_nclabdrone_string_platforms: All modern browsers
+  tutorial_gpbcircle_string_platforms: All modern browsers
+  tutorial_gpbpaint_string_platforms: All modern browsers
+  tutorial_cocomarcade_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Firefox
+  tutorial_beetik_string_platforms: Chrome, Firefox, Android tablet, iPad
+  tutorial_codedj_string_platforms: Chrome, Firefox, Safari, Android tablet, iPad
+  tutorial_rgadvan_string_platforms: Chrome, Firefox, Android tablet
+  tutorial_codehsrn_string_platforms: Chrome, Firefox, Safari, Android phone, iPhone
+  tutorial_codehswd_string_platforms: Chrome, Firefox, Safari
+  tutorial_turtlerobot_string_platforms: Chrome, Android tablet, iPad, Android phone,
+    iPhone
+  tutorial_ozoevo_string_platforms: All modern browsers, Android tablets, iPads, Ozobot
+    Evo robot
+  tutorial_ozoexped_string_platforms: All modern browsers, Android tablets, iPads,
+    Ozobot Bit or Evo robot
+  tutorial_ozojourney_string_platforms: All modern browsers, Android tablets, iPads,
+    Ozobot Bit or Evo robot
+  tutorial_ozocodes_string_platforms: All modern browsers, Android tablets, iPads,
+    Ozobot Bit or Evo robot
+  tutorial_ozoeclipse_string_platforms: All modern browsers, Android tablets, iPads,
+    Ozobot Bit or Evo robot
+  tutorial_ozosimulator_string_platforms: Unplugged
+  tutorial_ozoalgorithm_string_platforms: All modern browsers, Android tablets, iPads,
+    Ozobot Bit or Evo robot
+  tutorial_ozotimer_string_platforms: All modern browsers, Android tablets, iPads,
+    Ozobot Bit or Evo robot
+  tutorial_ozohabits_string_platforms: All modern browsers, Android tablets, iPads,
+    Ozobot Bit or Evo robot
+  tutorial_ozoprogram_string_platforms: All modern browsers
+  tutorial_ozopair_string_platforms: All modern browsers, Android tablets, iPads,
+    Ozobot Bit or Evo robot
+  tutorial_codesnoopy_string_platforms: All modern browsers, Android tablet, iPad,
+    Android phone, iPhone
+  tutorial_applabintro_string_platforms: All modern browsers
+  tutorial_cslartist_string_platforms: Unplugged
+  tutorial_cslscratchjr_string_platforms: Unplugged
+  tutorial_floevents_string_platforms: Unplugged
+  tutorial_florobot_string_platforms: Unplugged
+  tutorial_isavesanta_string_platforms: All modern browsers
+  tutorial_iorder_string_platforms: All modern borwsers
+  tutorial_ianimate_string_platforms: All modern browsers, iPad
+  tutorial_iloveada_string_platforms: All modern borwsers
+  tutorial_kodflash_string_platforms: Unplugged
+  tutorial_kodchoose_string_platforms: Unplugged
+  tutorial_kodpizzapre_string_platforms: Unplugged
+  tutorial_kodpizza_string_platforms: Unplugged
+  tutorial_kodwomen_string_platforms: Unplugged
+  tutorial_tfunplug_string_platforms: Unplugged
+  tutorial_lbvariables_string_platforms: All modern browsers, littleBits Code Kit
+  tutorial_lbfunctions_string_platforms: All modern browsers, littleBits Code Kit
+  tutorial_lblogic_string_platforms: All modern browsers, littleBits Code Kit
+  tutorial_lbworld_string_platforms: All modern browsers, littleBits Code Kit
+  tutorial_lbloops_string_platforms: All modern browsers, littleBits Code Kit
+  tutorial_lbtug_string_platforms: All modern browsers, littleBits Code Kit
+  tutorial_lbpotato_string_platforms: All modern browsers, littleBits Code Kit
+  tutorial_lbguitar_string_platforms: All modern browsers, littleBits Code Kit
+  tutorial_lbio_string_platforms: All modern browsers, littleBits Code Kit
+  tutorial_wonpuppy_string_platforms: iPads, iPhones, Android tablets, Android phones,
+    Dash robot
+  tutorial_woncue_string_platforms: iPads, iPhones, Android tablets, Android phones,
+    Cue robot
+  tutorial_wonzoo_string_platforms: iPads, iPhones, Android tablets, Android phones,
+    Dot robot
+  tutorial_wontrip_string_platforms: iPads, iPhones, Android tablets, Android phones,
+    Dash robot
+  tutorial_woncollect_string_platforms: iPads, iPhones, Android tablets, Android phones,
+    Dash robot
+  tutorial_wonsecret_string_platforms: iPads, iPhones, Android tablets, Android phones,
+    Cue robot
+  tutorial_hsscience_string_platforms: iPad, iPhone
+  tutorial_popculture_string_platforms: All modern browsers, Android tablet, Android
+    phone
+  tutorial_legorobust_string_platforms: All modern browsers, Android tablet, iPad,
+    WeDo 2.0
+  tutorial_legoplants_string_platforms: All modern browsers, Android tablet, iPad,
+    WeDo 2.0
+  tutorial_legopark_string_platforms: All modern browsers, Android tablet, iPad, MINDSTORMS®
+    EV3
+  tutorial_legodetect_string_platforms: All modern browsers, Android tablet, iPad,
+    MINDSTORMS® EV3
+  tutorial_legolight_string_platforms: All modern browsers, Android tablet, iPad,
+    MINDSTORMS® EV3
+  tutorial_alexa_string_platforms: All modern browsers
+  tutorial_grokpetmicro_string_platforms: All modern browsers
+  tutorial_pirateplunder_string_platforms: Chrome, Firefox
+  tutorial_cadj_string_platforms: Chrome, Firefox, Safari
+  tutorial_cacrazy_string_platforms: Chrome, Firefox, Safari
+  tutorial_cajump_string_platforms: Chrome, Firefox, Safari
+  tutorial_carest_string_platforms: Chrome, Firefox, Safari
+  tutorial_accai_string_platforms: All modern browsers
+  tutorial_vceclipse_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_pmzero_string_platforms: All modern browsers
+  tutorial_hsela_string_platforms: iPad, iPhone
+  tutorial_ticklear_string_platforms: iPad, iPhone
+  tutorial_bcrobot_string_platforms: Chrome, Firefox, Safari
+  tutorial_bcsnow_string_platforms: Chrome, Firefox, Safari
+  tutorial_ifly_string_platforms: Android tablet, iPad, Parrot Minidrones
+  tutorial_idowedo_string_platforms: All modern browsers, Android tablet, iPad, WeDo
+  tutorial_diggindwarf_string_platforms: Chrome, Firefox, Safari
+  tutorial_spheroit_string_platforms: iPad, Android tablet, iPhone, Android phone,
+    Sphero robot
+  tutorial_gameofcodes_string_platforms: All modern browsers, Android tablet, Android
+    phone, iPad
+  tutorial_blocklygames_string_platforms: All modern browsers
+  tutorial_spherohello_string_platforms: iPad, Android tablet, iPhone, Android phone,
+    Sphero robot
+  tutorial_spheroarcade_string_platforms: iPad, Android tablet, iPhone, Android phone,
+    Sphero robot
+  tutorial_bcpy1_string_platforms: All modern browsers
+  tutorial_bcpy2_string_platforms: All modern browsers
+  tutorial_bcjs1_string_platforms: All modern browsers
+  tutorial_bcjs2_string_platforms: All modern browsers
+  tutorial_3dbearmars_string_platforms: Android tablet, iPad, Android phone, iPhone
+  tutorial_bitsboxyak_string_platforms: All modern browsers
+  tutorial_blockscadbargraphs_string_platforms: All modern browsers
+  tutorial_blockscadbirdhouses_string_platforms: All modern browsers
+  tutorial_blockscadclock_string_platforms: All modern browsers
+  tutorial_blockscaddinner_string_platforms: All modern browsers
+  tutorial_blockscadicecream_string_platforms: All modern browsers
+  tutorial_blockscadpizza_string_platforms: All modern browsers
+  tutorial_blockscadsugar_string_platforms: All modern browsers
+  tutorial_bsgridlight_string_platforms: All modern browsers
+  tutorial_bpartscratch_string_platforms: All modern browsers, Android tablet, iPad,
+    Screen reader
+  tutorial_bpartvid_string_platforms: All modern browsers, Android tablet, iPad, Screen
+    reader
+  tutorial_bpenglishscratch_string_platforms: All modern browsers, Android tablet,
+    iPad, Screen reader
+  tutorial_bpenglishvid_string_platforms: All modern browsers, Android tablet, iPad,
+    Screen reader
+  tutorial_bphealthscratch_string_platforms: All modern browsers, Android tablet,
+    iPad, Screen reader
+  tutorial_bphealthvid_string_platforms: All modern browsers, Android tablet, iPad,
+    Screen reader
+  tutorial_bpmathscratch_string_platforms: All modern browsers, Android tablet, iPad,
+    Screen reader
+  tutorial_bpmathvid_string_platforms: All modern browsers, Android tablet, iPad,
+    Screen reader
+  tutorial_bpmlkscratch_string_platforms: All modern browsers, Android tablet, iPad,
+    Screen reader
+  tutorial_bpmlkvid_string_platforms: All modern browsers, Android tablet, iPad, Screen
+    reader
+  tutorial_bpsafetyscratch_string_platforms: All modern browsers, Android tablet,
+    iPad, Screen reader
+  tutorial_bpsafetyvid_string_platforms: All modern browsers, Android tablet, iPad,
+    Screen reader
+  tutorial_bpsciencescratch_string_platforms: All modern browsers, Android tablet,
+    iPad, Screen reader
+  tutorial_bpsciencevid_string_platforms: All modern browsers, Android tablet, iPad,
+    Screen reader
+  tutorial_bptechscratch_string_platforms: All modern browsers, Android tablet, iPad,
+    Screen reader
+  tutorial_bptechvid_string_platforms: All modern browsers, Android tablet, iPad,
+    Screen reader
+  tutorial_caflags_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_matariki_string_platforms: All modern browsers, Android tablet, iPad, Unplugged
+  tutorial_carestaurant_string_platforms: All modern browsers, Android tablet, iPad,
+    Unplugged
+  tutorial_casea_string_platforms: All modern browsers, iPad, Unplugged (no technology
+    needed)
+  tutorial_cashield_string_platforms: All modern browsers, Android tablet, iPad, Unplugged
+  tutorial_ccwslimer_string_platforms: Microsoft Edge, Chrome, Safari, iPad
+  tutorial_codinggalaxy_string_platforms: Android tablet, iPad, iPhone, Unplugged
+    (no technology needed)
+  tutorial_boatrace_string_platforms: All modern browsers
+  tutorial_ccplay_string_platforms: All modern browsers
+  tutorial_grinch_string_platforms: All modern browsers
+  tutorial_codehsart_string_platforms: All modern browsers
+  tutorial_codehsbitcoin_string_platforms: All modern browsers
+  tutorial_codehsblockchain_string_platforms: All modern browsers
+  tutorial_codehscipher_string_platforms: Unplugged
+  tutorial_codehscollision_string_platforms: All modern browsers
+  tutorial_codehsmath_string_platforms: All modern browsers
+  tutorial_codehsmusic_string_platforms: All modern browsers
+  tutorial_codehssports_string_platforms: All modern browsers
+  tutorial_codemojipizza_string_platforms: All modern browsers
+  tutorial_moonlander_string_platforms: All modern browsers
+  tutorial_sushicards_string_platforms: All modern browsers
+  tutorial_codesparkcreate_string_platforms: All modern browsers, Android tablet,
+    iPad, Android phone, iPhone
+  tutorial_hardvsoft_string_platforms: Unplugged
+  tutorial_codestersecard_string_platforms: All modern browsers, Screen reader
+  tutorial_codesterslogo_string_platforms: All modern browsers, Screen reader
+  tutorial_codesterstshirt_string_platforms: All modern browsers, Screen reader
+  tutorial_codewards_string_platforms: All modern browsers
+  tutorial_olympics_string_platforms: All modern browsers
+  tutorial_codinismhero_string_platforms: Android tablet, Android phone
+  tutorial_discovery_string_platforms: All modern browsers
+  tutorial_csfirstname_string_platforms: All modern browsers
+  tutorial_edisonmove_string_platforms: All modern browsers
+  tutorial_edisonspider_string_platforms: All modern browsers, iPad, Android tablets
+  tutorial_edisonspotlight_string_platforms: All modern browsers, iPad, Android tablets
+  tutorial_firiapython_string_platforms: All modern browsers
+  tutorial_gamefrootsquid_string_platforms: All modern browsers, iPad
+  tutorial_duckpiano_string_platforms: All modern browsers
+  tutorial_gpsound_string_platforms: All modern browsers
+  tutorial_groklearningpython_string_platforms: All modern browsers, Screen reader
+  tutorial_htmltimetravel_string_platforms: All modern browsers
+  tutorial_hp_flappy_string_platforms: iPad
+  tutorial_appytappin_string_platforms: All modern browsers
+  tutorial_icipher_string_platforms: Unplugged
+  tutorial_iguess_string_platforms: Android tablet, iPad, iPhone
+  tutorial_imake_string_platforms: Unplugged
+  tutorial_imorse_string_platforms: Unplugged
+  tutorial_kanohp_string_platforms: Chrome, Safari, Android, iOS
+  tutorial_khanwebpages_string_platforms: All modern browsers
+  tutorial_kibobowl_string_platforms: ''
+  tutorial_kibodance_string_platforms: ''
+  tutorial_buildcharacters_string_platforms: All modern browsers, iPad, iPhone
+  tutorial_designgames_string_platforms: All modern browsers, iPad, iPhone
+  tutorial_makelevels_string_platforms: All modern browsers, iPad, iPhone
+  tutorial_wizard_string_platforms: Chrome
+  tutorial_mbscratchcards_string_platforms: ''
+  tutorial_mbswiftplaygrounds_string_platforms: iPad
+  tutorial_mbbuttons_string_platforms: Windows, Mac OS, Linux, or Chromebook
+  tutorial_meteor_string_platforms: Windows, Mac OS, Linux, or Chromebook
+  tutorial_ballbounce_string_platforms: Chrome, Firefox, Safari, Android tablet, Android
+    phone, iPad, iPhone
+  tutorial_mitcodi_string_platforms: Chrome, Firefox, Safari, Android tablet, Android
+    phone, iPad, iPhone
+  tutorial_mitdoodle_string_platforms: Chrome, Firefox, Safari, Android tablet, Android
+    phone, iPad, iPhone
+  tutorial_talktome_string_platforms: Chrome, Firefox, Safari, Android tablet, Android
+    phone, iPad, iPhone
+  tutorial_mobilecspmap_string_platforms: Chrome, Firefox, Android tablet, Android
+    phone
+  tutorial_ozorandom_string_platforms: ''
+  tutorial_ozotroll_string_platforms: ''
+  tutorial_peblioart_string_platforms: Chrome, Firefox, Safari
+  tutorial_astropi_string_platforms: All modern browsers
+  tutorial_rgart_string_platforms: Chrome, Firefox, Safari, Android tablet, iPad,
+    Android phone, iPhone
+  tutorial_rgengineer_string_platforms: Chrome, Firefox, Safari, Android tablet, iPad,
+    Android phone, iPhone
+  tutorial_rgmath_string_platforms: Chrome, Firefox, Safari, Android tablet, iPad,
+    Android phone, iPhone
+  tutorial_rgscience_string_platforms: Chrome, Firefox, Safari, Android tablet, iPad,
+    Android phone, iPhone
+  tutorial_rgtech_string_platforms: Chrome, Firefox, Safari, Android tablet, iPad,
+    Android phone, iPhone
+  tutorial_robotmagic3d_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Android tablet, iPad
+  tutorial_robotmagicflappy_string_platforms: All modern browsers, Android tablet,
+    iPad
+  tutorial_scratchadventure_string_platforms: Chrome, Safari, Android tablet, iPad
+  tutorial_scratchtalk_string_platforms: Chrome, Safari, Android tablet, iPad
+  tutorial_scratchjrstory_string_platforms: Android tablet, iPad
+  tutorial_scratchjrtwinkle_string_platforms: Android tablet, iPad
+  tutorial_spherocomm_string_platforms: All modern browsers, Android tablet, iPad,
+    Android phone, iPhone, Screen reader
+  tutorial_spherocommunity_string_platforms: All modern browsers, Android tablet,
+    iPad, Android phone, iPhone, Screen reader
+  tutorial_spherofunctions_string_platforms: All modern browsers, Android tablet,
+    iPad, Android phone, iPhone, Screen reader
+  tutorial_spheroinfrared_string_platforms: All modern browsers, Android tablet, iPad,
+    Android phone, iPhone, Screen reader
+  tutorial_spherolightsensor_string_platforms: All modern browsers, Android tablet,
+    iPad, Android phone, iPhone, Screen reader
+  tutorial_spheromansion_string_platforms: All modern browsers, Android tablet, iPad,
+    Android phone, iPhone, Screen reader
+  tutorial_roadblocks_string_platforms: All modern browsers, Android tablet, iPad,
+    Android phone, iPhone, Screen reader
+  tutorial_spherotext2_string_platforms: All modern browsers, Android tablet, iPad,
+    Android phone, iPhone, Screen reader
+  tutorial_spherotext3_string_platforms: All modern browsers, Android tablet, iPad,
+    Android phone, iPhone, Screen reader
+  tutorial_spherotext4_string_platforms: All modern browsers, Android tablet, iPad,
+    Android phone, iPhone, Screen reader
+  tutorial_spheroraptor_string_platforms: All modern browsers, Android tablet, iPad,
+    Android phone, iPhone, Screen reader
+  tutorial_stempiday_string_platforms: Chrome, Firefox, Safari, Android tablet, iPad
+  tutorial_stemplanetoids_string_platforms: Chrome, Firefox, Safari, Android tablet,
+    iPad
+  tutorial_stempong_string_platforms: Chrome, Firefox, Safari, Android tablet, iPad
+  tutorial_algobot_string_platforms: All modern browsers, Android tablet, iPad, Android
+    phone, iPhone
+  tutorial_thunkableapps_string_platforms: Chrome, Firefox, Safari, Android tablet,
+    iPad, Android phone, iPhone
+  tutorial_toxicodedot_string_platforms: All modern browsers
+  tutorial_gcactions_string_platforms: Chrome, Firefox, Android tablet, iPad
+  tutorial_gccomparators_string_platforms: Chrome, Firefox, Android tablet, iPad
+  tutorial_gcconditions_string_platforms: Chrome, Firefox, Android tablet, iPad
+  tutorial_gccreate_string_platforms: Chrome, Firefox, Android tablet, iPad
+  tutorial_gcevents_string_platforms: Chrome, Firefox, Android tablet, iPad
+  tutorial_gcloops_string_platforms: Chrome, Firefox, Android tablet, iPad
+  tutorial_gcvariables_string_platforms: Chrome, Firefox, Android tablet, iPad
+  tutorial_beanything_string_platforms: All modern browsers, iPad
+  tutorial_change_string_platforms: All modern browsers, iPad
+  tutorial_cooking_string_platforms: All modern browsers
+  tutorial_crystal_string_platforms: All modern browsers
+  tutorial_landscape_string_platforms: All modern browsers
+  tutorial_pets_string_platforms: All modern browsers, iPad
+  tutorial_petvet_string_platforms: All modern browsers
+  tutorial_superhero_string_platforms: All modern browsers
+  tutorial_vidcodeplastic_string_platforms: All modern browsers, iPad
+  tutorial_vidcodetypeface_string_platforms: All modern browsers, iPad
+  tutorial_washustorm_string_platforms: All modern browsers
+  tutorial_activitypackets_string_platforms: Unplugged, iOS, Android, Kindle, Chrome*
+    (*Cue only)
+  tutorial_googlerookie_string_platforms: All modern browsers, Android tablet, iPad,
+    Android phone, iPhone
+  tutorial_tommyturtle_string_platforms: Android tablet, iPad, Android phone, iPhone
+  tutorial_mazyad_string_platforms: Unplugged
+  tutorial_gamemaker_string_platforms: All modern browsers, iPad
+  tutorial_duckrace_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_allcancodeapps_string_platforms: All modern browsers
+  tutorial_n2y_string_platforms: Unplugged
+  tutorial_microsoftarcade_string_platforms: All modern browsers, Screen reader
+  tutorial_csfirstunplugged_string_platforms: All modern browsers, Unplugged
+  tutorial_toxicodepython_string_platforms: All modern browsers
+  tutorial_codecombatozaria_string_platforms: All modern browsers
+  tutorial_vidcodedate_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_codemonkeyspace_string_platforms: All modern browsers
+  tutorial_codespeakhappy_string_platforms: Chrome, Firefox
+  tutorial_grokimage_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_icomputelearn_string_platforms: All modern browsers
+  tutorial_rpstress_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_bsdcause_string_platforms: Chrome
+  tutorial_vidcodeanimoji_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_vidcodeanimojies_string_platforms: All modern browsers, Android tablet,
+    iPad
+  tutorial_bsdinspire_string_platforms: Chrome
+  tutorial_tttractor_string_platforms: Chrome
+  tutorial_codeillusionmickey_string_platforms: Chrome
+  tutorial_scigirlsquest_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_codespeakbreathe_string_platforms: Chrome, Firefox
+  tutorial_vidcodeface_string_platforms: Chrome, Firefox
+  tutorial_educodemaze_string_platforms: All modern browsers
+  tutorial_educoderace_string_platforms: All modern browsers
+  tutorial_codespeakchatbot_string_platforms: Chrome, Firefox
+  tutorial_gamefrootgames_string_platforms: All modern browsers, Android tablet, iPad,
+    Windows phone
+  tutorial_codespeakgrandparent_string_platforms: Chrome, Firefox
+  tutorial_educodekingdom_string_platforms: All modern browsers
+  tutorial_codehsdata_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_educodecake_string_platforms: All modern browsers
+  tutorial_ttsecond_string_platforms: Chrome
+  tutorial_bsdtrivia_string_platforms: Chrome
+  tutorial_csfirstdialogue_string_platforms: All modern browsers
+  tutorial_codemonkeybeaver_string_platforms: All modern browsers, Android tablet,
+    iPad
+  tutorial_codestersdistance_string_platforms: All modern browsers, Screen reader
+  tutorial_itchspace_string_platforms: All modern browsers
+  tutorial_vidcodemagic_string_platforms: All modern browsers, Android tablet, iPad,
+    Screen reader
+  tutorial_vidcodemagices_string_platforms: All modern browsers, Android tablet, iPad,
+    Screen reader
+  tutorial_codespeakmeal_string_platforms: Chrome, Firefox
+  tutorial_itchfish_string_platforms: All modern browsers
+  tutorial_bsdwebsite_string_platforms: Chrome
+  tutorial_codespeaktime_string_platforms: Chrome, Firefox
+  tutorial_itchwebcam_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_itchball_string_platforms: All modern browsers
+  tutorial_ttrace_string_platforms: Chrome
+  tutorial_plethora_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_educodesecret_string_platforms: All modern browsers
+  tutorial_itchshapes_string_platforms: All modern browsers
+  tutorial_codeguppytext_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_vidcodeplastiche_string_platforms: All modern browsers, iPad
+  tutorial_educativechatbot_string_platforms: All modern browsers
+  tutorial_educodebasics_string_platforms: All modern browsers
+  tutorial_codehsdesign_string_platforms: All modern browsers, Android tablet, iPad,
+    Windows phone, Android phone, iPhone
+  tutorial_htmlacademyphp_string_platforms: All modern browsers, Screen reader
+  tutorial_gamefrootdistance_string_platforms: All modern browsers, Android tablet,
+    iPad
+  tutorial_codesterscovid_string_platforms: All modern browsers, Screen reader
+  tutorial_ttbunker_string_platforms: Chrome
+  tutorial_cuttle_string_platforms: All modern browsers, Android tablet, iPad, Windows
+    phone, Android phone, iPhone
+  tutorial_bsdjokes_string_platforms: Chrome
+  tutorial_rptree_string_platforms: Chrome, Firefox
+  tutorial_codestersunity_string_platforms: All modern browsers, Screen reader
+  tutorial_codesterssoccer_string_platforms: All modern browsers, Screen reader
+  tutorial_breakoutlock_string_platforms: All modern browsers, Android tablet, iPad,
+    Android phone, iPhone
+  tutorial_thunkablemask_string_platforms: All modern browsers
+  tutorial_cafarming_string_platforms: Chrome, Firefox
+  tutorial_blocksmithyeti_string_platforms: All modern browsers
+  tutorial_codecapture_string_platforms: All modern browsers, Android phone, iPhone
+  tutorial_codehslitter_string_platforms: All modern browsers, Android tablet, iPad,
+    Windows phone, Android phone, iPhone
+  tutorial_bsdocean_string_platforms: Chrome
+  tutorial_itchplatformer_string_platforms: All modern browsers
+  tutorial_codejika_string_platforms: All modern browsers, Android tablet, iPad, Windows
+    phone, Android phone, iPhone
+  tutorial_gamefrootclicker_string_platforms: All modern browsers, iPad
+  tutorial_rmagicequity_string_platforms: All modern browsers, Android tablet, iPad,
+    Windows phone, Android phone, iPhone, Game console app
+  tutorial_ttfreestyle_string_platforms: Chrome
+  tutorial_ozobotcolor2_string_platforms: All modern browsers
+  tutorial_ozobotcolor3_string_platforms: All modern browsers
+  tutorial_clcarbon_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_kodablebasics_string_platforms: Unplugged
+  tutorial_scigirlscc_string_platforms: Unplugged
+  tutorial_irobotpicture_string_platforms: Unplugged
+  tutorial_kcjmyself_string_platforms: All modern browsers
+  tutorial_nearpodalgorithms_string_platforms: All modern browsers, Screen reader
+  tutorial_kibodrop_string_platforms: Unplugged
+  tutorial_ozobotcolor1_string_platforms: All modern browsers
+  tutorial_scigirlspixels_string_platforms: Unplugged
+  tutorial_kcjheroines_string_platforms: All modern browsers
+  tutorial_ozobotvalue_string_platforms: All modern browsers
+  tutorial_icodebytes_string_platforms: Unplugged
+  tutorial_clfashion2_string_platforms: All modern browsers
+  tutorial_ai4all_string_platforms: All modern browsers
+  tutorial_cldata_string_platforms: All modern browsers
+  tutorial_spheroinputs_string_platforms: Unplugged
+  tutorial_edisoncount_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_spheroloops_string_platforms: Unplugged
+  tutorial_kiboprogram_string_platforms: Unplugged
+  tutorial_hellorubycsin60_string_platforms: Unplugged
+  tutorial_clfashion1_string_platforms: All modern browsers
+  tutorial_irobottraffic_string_platforms: Chrome, Android tablet, Android phone
+  tutorial_edisonmystery_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_microbitseaturtles_string_platforms: All modern browsers, Android tablet,
+    iPad, Windows phone, Android phone, iPhone
+  tutorial_ozobotknow_string_platforms: All modern browsers
+  tutorial_imagilabs_string_platforms: Android phone, iPhone, Unplugged
+  tutorial_irobotsimulator_string_platforms: All modern browsers, Android tablet,
+    iPad, Windows phone, Android phone, iPhone
+  tutorial_irobotkind_string_platforms: All modern browsers
+  tutorial_firiavirtual_string_platforms: Microsoft Edge, Chrome
+  tutorial_irobotguesscode_string_platforms: Chrome, Android tablet, Android phone
+  tutorial_ozobotnouns_string_platforms: All modern browsers
+  tutorial_nasa3d_string_platforms: All modern browsers
+  tutorial_blupants_string_platforms: All modern browsers
+  tutorial_legodance_string_platforms: All modern browsers
+  tutorial_nearpodcoding_string_platforms: All modern browsers, Screen reader
+  tutorial_kcjplastic_string_platforms: All modern browsers
+  tutorial_legojourney_string_platforms: All modern browsers
+  tutorial_legohopper_string_platforms: All modern browsers
+  tutorial_catrobatembroidery_string_platforms: Android phone, Screen reader
+  tutorial_irobotphone_string_platforms: All modern browsers
+  tutorial_codeguppydraw_string_platforms: All modern browsers
+  tutorial_codejumper_string_platforms: Unplugged, Sreen reader
+  tutorial_meeempathy_string_platforms: All modern browsers, Mac, Windows, Chromebook,
+    iPhone, iPad, Android phone, Android tablet
+  tutorial_dance2019_string_detail_platforms: ''
+  tutorial_danceparty_string_detail_platforms: ''
+  tutorial_chibitronics_string_detail_platforms: Chibitronics Chibi Chip and Circuit
+    Sticker LEDs
+  tutorial_athlete_string_detail_platforms: ''
+  tutorial_moana_string_detail_platforms: ''
+  tutorial_star-wars_string_detail_platforms: ''
+  tutorial_gumadventure_string_detail_platforms: ''
+  tutorial_mchoc_string_detail_platforms: ''
+  tutorial_vidnews_string_detail_platforms: ''
+  tutorial_kodable-pre_string_detail_platforms: All modern browsers, iPad app
+  tutorial_highseas_string_detail_platforms: ''
+  tutorial_capython_string_detail_platforms: ''
+  tutorial_frzn_string_detail_platforms: ''
+  tutorial_cocom_string_detail_platforms: ''
+  tutorial_play-lab_string_detail_platforms: ''
+  tutorial_boxisland_string_detail_platforms: ''
+  tutorial_textcomp_string_detail_platforms: ''
+  tutorial_encryption_string_detail_platforms: ''
+  tutorial_kanopixel_string_detail_platforms: ''
+  tutorial_foos_string_detail_platforms: ''
+  tutorial_tynkerdd_string_detail_platforms: ''
+  tutorial_tynkerana_string_detail_platforms: ''
+  tutorial_vidcard_string_detail_platforms: ''
+  tutorial_spritebox_string_detail_platforms: ''
+  tutorial_tynkerch_string_detail_platforms: ''
+  tutorial_lightbot_string_detail_platforms: ''
+  tutorial_hoc_string_detail_platforms: do-not-show
+  tutorial_code_string_detail_platforms: ''
+  tutorial_tinspire_string_detail_platforms: TI-Nspire handheld
+  tutorial_itchbounceball_string_detail_platforms: ''
+  tutorial_vidclim_string_detail_platforms: ''
+  tutorial_matlab_string_detail_platforms: ''
+  tutorial_flap_string_detail_platforms: ''
+  tutorial_galaxy_string_detail_platforms: Android
+  tutorial_inf_string_detail_platforms: ''
+  tutorial_tynkersol_string_detail_platforms: ''
+  tutorial_itchg_string_detail_platforms: ''
+  tutorial_como_string_detail_platforms: ''
+  tutorial_processfound_string_detail_platforms: ''
+  tutorial_tynkerhomo_string_detail_platforms: ''
+  tutorial_art_string_detail_platforms: ''
+  tutorial_tynkerbrick_string_detail_platforms: ''
+  tutorial_itchbio_string_detail_platforms: ''
+  tutorial_itchj_string_detail_platforms: ''
+  tutorial_tickleo_string_detail_platforms: ''
+  tutorial_hopgeo_string_detail_platforms: iOS app
+  tutorial_tynkermult_string_detail_platforms: ''
+  tutorial_monster_string_detail_platforms: ''
+  tutorial_tynkerapp_string_detail_platforms: do-not-show
+  tutorial_tynkerpup_string_detail_platforms: ''
+  tutorial_livecode_string_detail_platforms: ''
+  tutorial_cocomgame_string_detail_platforms: ''
+  tutorial_tynkerspin_string_detail_platforms: ''
+  tutorial_code-avengers_string_detail_platforms: ''
+  tutorial_tynkercq_string_detail_platforms: ''
+  tutorial_cmgame_string_detail_platforms: ''
+  tutorial_codesters_string_detail_platforms: do-not-show
+  tutorial_qrm_string_detail_platforms: ''
+  tutorial_texas-instruments_string_detail_platforms: TI-84, TI-83 graphing calculators
+  tutorial_cajava_string_detail_platforms: ''
+  tutorial_codehs_string_detail_platforms: ''
+  tutorial_hopemo_string_detail_platforms: iOS app
+  tutorial_tynkercm_string_detail_platforms: ''
+  tutorial_codesterswintergreet_string_detail_platforms: ''
+  tutorial_codestersc_string_detail_platforms: ''
+  tutorial_codestersturtle_string_detail_platforms: ''
+  tutorial_penjee_string_detail_platforms: ''
+  tutorial_trinket_string_detail_platforms: ''
+  tutorial_frogger_string_detail_platforms: ''
+  tutorial_tynkereco_string_detail_platforms: ''
+  tutorial_mitedarc_string_detail_platforms: ''
+  tutorial_khan_string_detail_platforms: ''
+  tutorial_tynkerd_string_detail_platforms: ''
+  tutorial_cdmy_string_detail_platforms: ''
+  tutorial_codestersdance_string_detail_platforms: ''
+  tutorial_codestersbasketball_string_detail_platforms: ''
+  tutorial_nclkarel_string_detail_platforms: ''
+  tutorial_buildpong_string_detail_platforms: ''
+  tutorial_tynkerdrones_string_detail_platforms: Parrot drone, Sphero robot, Ollie
+    robot
+  tutorial_carla_string_detail_platforms: ''
+  tutorial_zulama_string_detail_platforms: ''
+  tutorial_capost_string_detail_platforms: ''
+  tutorial_marco_string_detail_platforms: ''
+  tutorial_codestersflappybike_string_detail_platforms: ''
+  tutorial_kanopong_string_detail_platforms: ''
+  tutorial_tynkerright_string_detail_platforms: ''
+  tutorial_touchdevelop_string_detail_platforms: do-not-show
+  tutorial_tynkercc_string_detail_platforms: ''
+  tutorial_bamboo_string_detail_platforms: ''
+  tutorial_robojav_string_detail_platforms: ''
+  tutorial_roboba_string_detail_platforms: ''
+  tutorial_knodsnake_string_detail_platforms: ''
+  tutorial_soccharater_string_detail_platforms: ''
+  tutorial_silent_string_detail_platforms: ''
+  tutorial_robomesh_string_detail_platforms: ''
+  tutorial_amaze_string_detail_platforms: ''
+  tutorial_codestersds_string_detail_platforms: ''
+  tutorial_knodtext_string_detail_platforms: ''
+  tutorial_alicegar_string_detail_platforms: ''
+  tutorial_codesterstransform_string_detail_platforms: ''
+  tutorial_flexfrog_string_detail_platforms: ''
+  tutorial_codemoji_string_detail_platforms: do-not-show
+  tutorial_robobii_string_detail_platforms: ''
+  tutorial_robobm_string_detail_platforms: ''
+  tutorial_codingrobots_string_detail_platforms: ''
+  tutorial_robob_string_detail_platforms: ''
+  tutorial_coders_string_detail_platforms: ''
+  tutorial_tynkerhw_string_detail_platforms: ''
+  tutorial_tynkermh_string_detail_platforms: ''
+  tutorial_caphoto_string_detail_platforms: ''
+  tutorial_mozillahw_string_detail_platforms: ''
+  tutorial_ticklep_string_detail_platforms: do-not-show
+  tutorial_bbot_string_detail_platforms: ''
+  tutorial_scratchg_string_detail_platforms: ''
+  tutorial_sjforest_string_detail_platforms: iPad app
+  tutorial_sjgreet_string_detail_platforms: iPad app
+  tutorial_sjsunset_string_detail_platforms: iPad app
+  tutorial_fufafrenz_string_detail_platforms: Unplugged
+  tutorial_bbcgeo_string_detail_platforms: do-not-show
+  tutorial_chspixel_string_detail_platforms: Unplugged
+  tutorial_hummingbird_string_detail_platforms: Hummingbird robot
+  tutorial_recoloring_string_detail_platforms: ''
+  tutorial_bbcchem_string_detail_platforms: do-not-show
+  tutorial_floalgo_string_detail_platforms: Unplugged
+  tutorial_flocond_string_detail_platforms: Unplugged
+  tutorial_floloops_string_detail_platforms: Unplugged
+  tutorial_pgts_string_detail_platforms: Unplugged
+  tutorial_ozo_string_detail_platforms: Ozobot robot
+  tutorial_bbcla_string_detail_platforms: do-not-show
+  tutorial_bbcsci_string_detail_platforms: do-not-show
+  tutorial_tlctour_string_detail_platforms: Unplugged
+  tutorial_codesterstj_string_detail_platforms: ''
+  tutorial_tlclocked_string_detail_platforms: Unplugged
+  tutorial_baubles_string_detail_platforms: Unplugged
+  tutorial_bbcart_string_detail_platforms: do-not-show
+  tutorial_tlcknight_string_detail_platforms: Unplugged
+  tutorial_fufafit_string_detail_platforms: Unplugged
+  tutorial_ozodance_string_detail_platforms: Ozobot robot
+  tutorial_codingrobotics_string_detail_platforms: iPad app, Dash robot
+  tutorial_box_string_detail_platforms: do-not-show
+  tutorial_hopgame_string_detail_platforms: iOS app
+  tutorial_icontrol_string_detail_platforms: Sphero robot
+  tutorial_cocomteach_string_detail_platforms: ''
+  tutorial_bbcmathii_string_detail_platforms: do-not-show
+  tutorial_bbcphys_string_detail_platforms: do-not-show
+  tutorial_bitsbox_string_detail_platforms: ''
+  tutorial_tlcemo_string_detail_platforms: Unplugged
+  tutorial_crd_string_detail_platforms: Unplugged
+  tutorial_bbcbio_string_detail_platforms: do-not-show
+  tutorial_ticklebb8_string_detail_platforms: BB-8 robot
+  tutorial_grok_string_detail_platforms: do-not-show
+  tutorial_ijournalist_string_detail_platforms: ''
+  tutorial_bbcmusic_string_detail_platforms: do-not-show
+  tutorial_secretcodes_string_detail_platforms: ''
+  tutorial_tlchex_string_detail_platforms: Unplugged
+  tutorial_tickles_string_detail_platforms: Sphero robot
+  tutorial_ozogame_string_detail_platforms: Ozobot robot
+  tutorial_vidcodeio_string_detail_platforms: Unplugged
+  tutorial_tlcbrain_string_detail_platforms: Unplugged
+  tutorial_hopquiz_string_detail_platforms: iOS app
+  tutorial_unfortunate_string_detail_platforms: Dash and Dot robot
+  tutorial_cha_string_detail_platforms: ''
+  tutorial_elaseq_string_detail_platforms: Unplugged
+  tutorial_bbcmathi_string_detail_platforms: do-not-show
+  tutorial_tlcpixel_string_detail_platforms: Unplugged
+  tutorial_introrobo_string_detail_platforms: Dash and Dot robot
+  tutorial_tlcinvis_string_detail_platforms: Unplugged
+  tutorial_tlcjflap_string_detail_platforms: ''
+  tutorial_procolor_string_detail_platforms: Ozobot robot
+  tutorial_spiralsfinch_string_detail_platforms: Finch robot
+  tutorial_ozoi_string_detail_platforms: Ozobot robot
+  tutorial_ticklel_string_detail_platforms: LEGO WeDo robot
+  tutorial_spiralsdash_string_detail_platforms: Dash robot
+  tutorial_ghdebug_string_detail_platforms: ''
+  tutorial_tlckk_string_detail_platforms: Unplugged
+  tutorial_firstcomp_string_detail_platforms: Unplugged
+  tutorial_mazefinch_string_detail_platforms: Finch robot
+  tutorial_tlccc_string_detail_platforms: Unplugged
+  tutorial_tlcdoodle_string_detail_platforms: Unplugged
+  tutorial_tlcpunch_string_detail_platforms: Unplugged
+  tutorial_finchfract_string_detail_platforms: Finch robot
+  tutorial_tlcmind_string_detail_platforms: Unplugged
+  tutorial_tlctelebot_string_detail_platforms: Unplugged
+  tutorial_tlcaus_string_detail_platforms: Unplugged
+  tutorial_tlcmicro_string_detail_platforms: Unplugged
+  tutorial_imathematician_string_detail_platforms: ''
+  tutorial_tlcmagic_string_detail_platforms: Unplugged
+  tutorial_scratchmus_string_detail_platforms: ''
+  tutorial_scratchanim_string_detail_platforms: ''
+  tutorial_scratchfly_string_detail_platforms: ''
+  tutorial_tynkerarc_string_detail_platforms: ''
+  tutorial_grokffpython_string_detail_platforms: ''
+  tutorial_grokffblock_string_detail_platforms: ''
+  tutorial_grokeliza_string_detail_platforms: ''
+  tutorial_tynkercan_string_detail_platforms: ''
+  tutorial_grokflags_string_detail_platforms: ''
+  tutorial_robomind_string_detail_platforms: ''
+  tutorial_adventureq_string_detail_platforms: ''
+  tutorial_khan-es_string_detail_platforms: ''
+  tutorial_kpt_string_detail_platforms: ''
+  tutorial_kpl_string_detail_platforms: ''
+  tutorial_khe_string_detail_platforms: ''
+  tutorial_kfr_string_detail_platforms: ''
+  tutorial_app-inventor_string_detail_platforms: Android
+  tutorial_blockly_string_detail_platforms: ''
+  tutorial_tynker_string_detail_platforms: do-not-show
+  tutorial_baypt_string_detail_platforms: ''
+  tutorial_code-combat_string_detail_platforms: do-not-show
+  tutorial_mky_string_detail_platforms: ''
+  tutorial_pirates_string_detail_platforms: ''
+  tutorial_csfirst_string_detail_platforms: ''
+  tutorial_loopedy_string_detail_platforms: Dash and Dot robot
+  tutorial_dsw_string_detail_platforms: do-not-show
+  tutorial_dswb_string_detail_platforms: do-not-show
+  tutorial_ssw_string_detail_platforms: do-not-show
+  tutorial_sswb_string_detail_platforms: do-not-show
+  tutorial_kodable-unplugged_string_detail_platforms: Unplugged
+  tutorial_scratch_string_detail_platforms: ''
+  tutorial_bayes_string_detail_platforms: ''
+  tutorial_gumball_string_detail_platforms: do-not-show
+  tutorial_hrm_string_detail_platforms: ''
+  tutorial_ice-age_string_detail_platforms: do-not-show
+  tutorial_koapp_string_detail_platforms: do-not-show
+  tutorial_lightbot-intl_string_detail_platforms: ''
+  tutorial_rmc_string_detail_platforms: do-not-show
+  tutorial_smc_string_detail_platforms: do-not-show
+  tutorial_minecraft-2016_string_detail_platforms: do-not-show
+  tutorial_thinkersmith-es_string_detail_platforms: ''
+  tutorial_pixie_string_detail_platforms: ''
+  tutorial_play_string_detail_platforms: do-not-show
+  tutorial_robomind-nl_string_detail_platforms: ''
+  tutorial_spheroi_string_detail_platforms: Sphero robot
+  tutorial_spherol_string_detail_platforms: Sphero robot
+  tutorial_spherov_string_detail_platforms: Sphero robot
+  tutorial_swb_string_detail_platforms: do-not-show
+  tutorial_build-a-galaxy_string_detail_platforms: do-not-show
+  tutorial_alicesims_string_detail_platforms: ''
+  tutorial_tchr_string_detail_platforms: do-not-show
+  tutorial_robogame_string_detail_platforms: Dash and Dot robot
+  tutorial_tap_string_detail_platforms: ''
+  tutorial_cintl_string_detail_platforms: do-not-show
+  tutorial_itchstop_string_detail_platforms: ''
+  tutorial_tynkerpn_string_detail_platforms: ''
+  tutorial_tynkerpd_string_detail_platforms: ''
+  tutorial_persistence_string_detail_platforms: Unplugged
+  tutorial_getloopy_string_detail_platforms: Unplugged
+  tutorial_createface_string_detail_platforms: Unplugged
+  tutorial_happymaps_string_detail_platforms: Unplugged
+  tutorial_moveit_string_detail_platforms: Unplugged
+  tutorial_bigevent_string_detail_platforms: Unplugged
+  tutorial_gpp_string_detail_platforms: Unplugged
+  tutorial_foosgame_string_detail_platforms: ''
+  tutorial_solopython_string_detail_platforms: ''
+  tutorial_kodableint_string_detail_platforms: Unplugged
+  tutorial_kodableadv_string_detail_platforms: Unplugged
+  tutorial_tynkertj_string_detail_platforms: ''
+  tutorial_wolframa_string_detail_platforms: ''
+  tutorial_wolframm_string_detail_platforms: ''
+  tutorial_wolframspi_string_detail_platforms: ''
+  tutorial_wolframsph_string_detail_platforms: ''
+  tutorial_wolframp_string_detail_platforms: ''
+  tutorial_wolframn_string_detail_platforms: ''
+  tutorial_soloweb_string_detail_platforms: ''
+  tutorial_khanweb_string_detail_platforms: ''
+  tutorial_khandata_string_detail_platforms: ''
+  tutorial_googlelogo_string_detail_platforms: ''
+  tutorial_playtune_string_detail_platforms: ''
+  tutorial_computeit_string_detail_platforms: ''
+  tutorial_codesterssj_string_detail_platforms: ''
+  tutorial_cmchat_string_detail_platforms: ''
+  tutorial_tynkerdb_string_detail_platforms: ''
+  tutorial_cmbuild_string_detail_platforms: ''
+  tutorial_robotrattle_string_detail_platforms: ''
+  tutorial_codestersh_string_detail_platforms: ''
+  tutorial_codehsdigipixel_string_detail_platforms: ''
+  tutorial_ccbinary_string_detail_platforms: ''
+  tutorial_codehsturtle_string_detail_platforms: ''
+  tutorial_grokhd_string_detail_platforms: ''
+  tutorial_grokem_string_detail_platforms: ''
+  tutorial_kodmaze_string_detail_platforms: ''
+  tutorial_codestersa_string_detail_platforms: ''
+  tutorial_cmdodo_string_detail_platforms: ''
+  tutorial_tynkerspace_string_detail_platforms: ''
+  tutorial_gfbloons_string_detail_platforms: ''
+  tutorial_raspipong_string_detail_platforms: ''
+  tutorial_codehsvr_string_detail_platforms: ''
+  tutorial_codesterstp_string_detail_platforms: ''
+  tutorial_codestersbb_string_detail_platforms: ''
+  tutorial_gfcrossyroad_string_detail_platforms: ''
+  tutorial_googleww_string_detail_platforms: ''
+  tutorial_codehsjsapp_string_detail_platforms: ''
+  tutorial_gfmihi_string_detail_platforms: ''
+  tutorial_hopdropphone_string_detail_platforms: ''
+  tutorial_techfaa_string_detail_platforms: ''
+  tutorial_codehsjsgraph_string_detail_platforms: ''
+  tutorial_thunkable_string_detail_platforms: ''
+  tutorial_hopcrossyroad_string_detail_platforms: ''
+  tutorial_switchglitch_string_detail_platforms: ''
+  tutorial_codecar_string_detail_platforms: ''
+  tutorial_codesterscp_string_detail_platforms: ''
+  tutorial_grokpetblock_string_detail_platforms: ''
+  tutorial_techbim_string_detail_platforms: ''
+  tutorial_techfpp_string_detail_platforms: ''
+  tutorial_codesterscr_string_detail_platforms: ''
+  tutorial_grokdisease_string_detail_platforms: ''
+  tutorial_techec_string_detail_platforms: ''
+  tutorial_rgbegin_string_detail_platforms: ''
+  tutorial_myradream_string_detail_platforms: ''
+  tutorial_thinkfun_string_detail_platforms: ''
+  tutorial_hopfireworks_string_detail_platforms: ''
+  tutorial_grokspace_string_detail_platforms: ''
+  tutorial_codehspython_string_detail_platforms: ''
+  tutorial_codehsjava_string_detail_platforms: ''
+  tutorial_techioda_string_detail_platforms: ''
+  tutorial_grokmonster_string_detail_platforms: ''
+  tutorial_techmjs_string_detail_platforms: ''
+  tutorial_techga_string_detail_platforms: ''
+  tutorial_techioan_string_detail_platforms: ''
+  tutorial_techiogsr_string_detail_platforms: ''
+  tutorial_groktunnel_string_detail_platforms: ''
+  tutorial_stemcod_string_detail_platforms: ''
+  tutorial_techikb_string_detail_platforms: ''
+  tutorial_kanostreet_string_detail_platforms: ''
+  tutorial_codemojijs_string_detail_platforms: ''
+  tutorial_techapf_string_detail_platforms: ''
+  tutorial_techfpjs_string_detail_platforms: ''
+  tutorial_techlinq_string_detail_platforms: ''
+  tutorial_gpbcatapult_string_detail_platforms: ''
+  tutorial_quorumastro_string_detail_platforms: ''
+  tutorial_alicewonder_string_detail_platforms: ''
+  tutorial_rginter_string_detail_platforms: ''
+  tutorial_cssgrid_string_detail_platforms: ''
+  tutorial_jshero_string_detail_platforms: ''
+  tutorial_codemojipy_string_detail_platforms: ''
+  tutorial_nclabdrone_string_detail_platforms: ''
+  tutorial_gpbcircle_string_detail_platforms: ''
+  tutorial_gpbpaint_string_detail_platforms: ''
+  tutorial_cocomarcade_string_detail_platforms: ''
+  tutorial_beetik_string_detail_platforms: ''
+  tutorial_codedj_string_detail_platforms: ''
+  tutorial_rgadvan_string_detail_platforms: ''
+  tutorial_codehsrn_string_detail_platforms: ''
+  tutorial_codehswd_string_detail_platforms: ''
+  tutorial_turtlerobot_string_detail_platforms: ''
+  tutorial_ozoevo_string_detail_platforms: Ozobot Evo robot
+  tutorial_ozoexped_string_detail_platforms: Ozobot Bit or Evo robot
+  tutorial_ozojourney_string_detail_platforms: Ozobot Bit or Evo robot
+  tutorial_ozocodes_string_detail_platforms: Ozobot Bit or Evo robot
+  tutorial_ozoeclipse_string_detail_platforms: Ozobot Bit or Evo robot
+  tutorial_ozosimulator_string_detail_platforms: Unplugged
+  tutorial_ozoalgorithm_string_detail_platforms: Ozobot Bit or Evo robot
+  tutorial_ozotimer_string_detail_platforms: Ozobot Bit or Evo robot
+  tutorial_ozohabits_string_detail_platforms: Ozobot Bit or Evo robot
+  tutorial_ozoprogram_string_detail_platforms: ''
+  tutorial_ozopair_string_detail_platforms: Ozobot Bit or Evo robot
+  tutorial_codesnoopy_string_detail_platforms: ''
+  tutorial_applabintro_string_detail_platforms: ''
+  tutorial_cslartist_string_detail_platforms: Unplugged
+  tutorial_cslscratchjr_string_detail_platforms: Unplugged
+  tutorial_floevents_string_detail_platforms: Unplugged
+  tutorial_florobot_string_detail_platforms: Unplugged
+  tutorial_isavesanta_string_detail_platforms: ''
+  tutorial_iorder_string_detail_platforms: ''
+  tutorial_ianimate_string_detail_platforms: ''
+  tutorial_iloveada_string_detail_platforms: ''
+  tutorial_kodflash_string_detail_platforms: Unplugged
+  tutorial_kodchoose_string_detail_platforms: Unplugged
+  tutorial_kodpizzapre_string_detail_platforms: Unplugged
+  tutorial_kodpizza_string_detail_platforms: Unplugged
+  tutorial_kodwomen_string_detail_platforms: Unplugged
+  tutorial_tfunplug_string_detail_platforms: Unplugged
+  tutorial_lbvariables_string_detail_platforms: littleBits Code Kit
+  tutorial_lbfunctions_string_detail_platforms: littleBits Code Kit
+  tutorial_lblogic_string_detail_platforms: littleBits Code Kit
+  tutorial_lbworld_string_detail_platforms: littleBits Code Kit
+  tutorial_lbloops_string_detail_platforms: littleBits Code Kit
+  tutorial_lbtug_string_detail_platforms: littleBits Code Kit
+  tutorial_lbpotato_string_detail_platforms: littleBits Code Kit
+  tutorial_lbguitar_string_detail_platforms: littleBits Code Kit
+  tutorial_lbio_string_detail_platforms: littleBits Code Kit
+  tutorial_wonpuppy_string_detail_platforms: Dash robot
+  tutorial_woncue_string_detail_platforms: Cue robot
+  tutorial_wonzoo_string_detail_platforms: Dot robot
+  tutorial_wontrip_string_detail_platforms: Dash robot
+  tutorial_woncollect_string_detail_platforms: Dash robot
+  tutorial_wonsecret_string_detail_platforms: Cue robot
+  tutorial_hsscience_string_detail_platforms: ''
+  tutorial_popculture_string_detail_platforms: ''
+  tutorial_legorobust_string_detail_platforms: WeDo 2.0
+  tutorial_legoplants_string_detail_platforms: WeDo 2.0
+  tutorial_legopark_string_detail_platforms: MINDSTORMS® EV3
+  tutorial_legodetect_string_detail_platforms: MINDSTORMS® EV3
+  tutorial_legolight_string_detail_platforms: MINDSTORMS® EV3
+  tutorial_alexa_string_detail_platforms: ''
+  tutorial_grokpetmicro_string_detail_platforms: ''
+  tutorial_pirateplunder_string_detail_platforms: ''
+  tutorial_cadj_string_detail_platforms: ''
+  tutorial_cacrazy_string_detail_platforms: ''
+  tutorial_cajump_string_detail_platforms: ''
+  tutorial_carest_string_detail_platforms: ''
+  tutorial_accai_string_detail_platforms: ''
+  tutorial_vceclipse_string_detail_platforms: ''
+  tutorial_pmzero_string_detail_platforms: ''
+  tutorial_hsela_string_detail_platforms: ''
+  tutorial_ticklear_string_detail_platforms: ''
+  tutorial_bcrobot_string_detail_platforms: ''
+  tutorial_bcsnow_string_detail_platforms: ''
+  tutorial_ifly_string_detail_platforms: Parrot Minidrones
+  tutorial_idowedo_string_detail_platforms: WeDo
+  tutorial_diggindwarf_string_detail_platforms: ''
+  tutorial_spheroit_string_detail_platforms: Sphero robot
+  tutorial_gameofcodes_string_detail_platforms: ''
+  tutorial_blocklygames_string_detail_platforms: ''
+  tutorial_spherohello_string_detail_platforms: Sphero robot
+  tutorial_spheroarcade_string_detail_platforms: Sphero robot
+  tutorial_bcpy1_string_detail_platforms: ''
+  tutorial_bcpy2_string_detail_platforms: ''
+  tutorial_bcjs1_string_detail_platforms: ''
+  tutorial_bcjs2_string_detail_platforms: ''
+  tutorial_3dbearmars_string_detail_platforms: 3D printer
+  tutorial_bitsboxyak_string_detail_platforms: ''
+  tutorial_blockscadbargraphs_string_detail_platforms: ''
+  tutorial_blockscadbirdhouses_string_detail_platforms: ''
+  tutorial_blockscadclock_string_detail_platforms: ''
+  tutorial_blockscaddinner_string_detail_platforms: ''
+  tutorial_blockscadicecream_string_detail_platforms: ''
+  tutorial_blockscadpizza_string_detail_platforms: ''
+  tutorial_blockscadsugar_string_detail_platforms: ''
+  tutorial_bsgridlight_string_detail_platforms: ''
+  tutorial_bpartscratch_string_detail_platforms: ''
+  tutorial_bpartvid_string_detail_platforms: ''
+  tutorial_bpenglishscratch_string_detail_platforms: ''
+  tutorial_bpenglishvid_string_detail_platforms: ''
+  tutorial_bphealthscratch_string_detail_platforms: ''
+  tutorial_bphealthvid_string_detail_platforms: ''
+  tutorial_bpmathscratch_string_detail_platforms: ''
+  tutorial_bpmathvid_string_detail_platforms: ''
+  tutorial_bpmlkscratch_string_detail_platforms: ''
+  tutorial_bpmlkvid_string_detail_platforms: ''
+  tutorial_bpsafetyscratch_string_detail_platforms: ''
+  tutorial_bpsafetyvid_string_detail_platforms: ''
+  tutorial_bpsciencescratch_string_detail_platforms: ''
+  tutorial_bpsciencevid_string_detail_platforms: ''
+  tutorial_bptechscratch_string_detail_platforms: ''
+  tutorial_bptechvid_string_detail_platforms: ''
+  tutorial_caflags_string_detail_platforms: ''
+  tutorial_matariki_string_detail_platforms: ''
+  tutorial_carestaurant_string_detail_platforms: ''
+  tutorial_casea_string_detail_platforms: ''
+  tutorial_cashield_string_detail_platforms: ''
+  tutorial_ccwslimer_string_detail_platforms: ''
+  tutorial_codinggalaxy_string_detail_platforms: ''
+  tutorial_boatrace_string_detail_platforms: ''
+  tutorial_ccplay_string_detail_platforms: ''
+  tutorial_grinch_string_detail_platforms: ''
+  tutorial_codehsart_string_detail_platforms: ''
+  tutorial_codehsbitcoin_string_detail_platforms: ''
+  tutorial_codehsblockchain_string_detail_platforms: ''
+  tutorial_codehscipher_string_detail_platforms: ''
+  tutorial_codehscollision_string_detail_platforms: ''
+  tutorial_codehsmath_string_detail_platforms: ''
+  tutorial_codehsmusic_string_detail_platforms: ''
+  tutorial_codehssports_string_detail_platforms: ''
+  tutorial_codemojipizza_string_detail_platforms: ''
+  tutorial_moonlander_string_detail_platforms: ''
+  tutorial_sushicards_string_detail_platforms: ''
+  tutorial_codesparkcreate_string_detail_platforms: ''
+  tutorial_hardvsoft_string_detail_platforms: ''
+  tutorial_codestersecard_string_detail_platforms: ''
+  tutorial_codesterslogo_string_detail_platforms: ''
+  tutorial_codesterstshirt_string_detail_platforms: ''
+  tutorial_codewards_string_detail_platforms: ''
+  tutorial_olympics_string_detail_platforms: ''
+  tutorial_codinismhero_string_detail_platforms: ''
+  tutorial_discovery_string_detail_platforms: ''
+  tutorial_csfirstname_string_detail_platforms: ''
+  tutorial_edisonmove_string_detail_platforms: Edison robot
+  tutorial_edisonspider_string_detail_platforms: Edison robot
+  tutorial_edisonspotlight_string_detail_platforms: Edison robot
+  tutorial_firiapython_string_detail_platforms: BBC micro:bit
+  tutorial_gamefrootsquid_string_detail_platforms: ''
+  tutorial_duckpiano_string_detail_platforms: ''
+  tutorial_gpsound_string_detail_platforms: ''
+  tutorial_groklearningpython_string_detail_platforms: ''
+  tutorial_htmltimetravel_string_detail_platforms: ''
+  tutorial_hp_flappy_string_detail_platforms: iPad app
+  tutorial_appytappin_string_detail_platforms: ''
+  tutorial_icipher_string_detail_platforms: ''
+  tutorial_iguess_string_detail_platforms: ''
+  tutorial_imake_string_detail_platforms: Arduino
+  tutorial_imorse_string_detail_platforms: ''
+  tutorial_kanohp_string_detail_platforms: ''
+  tutorial_khanwebpages_string_detail_platforms: ''
+  tutorial_kibobowl_string_detail_platforms: KIBO Robot Kit
+  tutorial_kibodance_string_detail_platforms: KIBO Robot Kit
+  tutorial_buildcharacters_string_detail_platforms: ''
+  tutorial_designgames_string_detail_platforms: ''
+  tutorial_makelevels_string_detail_platforms: ''
+  tutorial_wizard_string_detail_platforms: ''
+  tutorial_mbscratchcards_string_detail_platforms: micro:bit
+  tutorial_mbswiftplaygrounds_string_detail_platforms: micro:bit
+  tutorial_mbbuttons_string_detail_platforms: BBC micro:bit
+  tutorial_meteor_string_detail_platforms: BBC micro:bit
+  tutorial_ballbounce_string_detail_platforms: ''
+  tutorial_mitcodi_string_detail_platforms: ''
+  tutorial_mitdoodle_string_detail_platforms: ''
+  tutorial_talktome_string_detail_platforms: ''
+  tutorial_mobilecspmap_string_detail_platforms: ''
+  tutorial_ozorandom_string_detail_platforms: Ozobot robot
+  tutorial_ozotroll_string_detail_platforms: Ozobot robot
+  tutorial_peblioart_string_detail_platforms: ''
+  tutorial_astropi_string_detail_platforms: ''
+  tutorial_rgart_string_detail_platforms: ''
+  tutorial_rgengineer_string_detail_platforms: ''
+  tutorial_rgmath_string_detail_platforms: ''
+  tutorial_rgscience_string_detail_platforms: ''
+  tutorial_rgtech_string_detail_platforms: ''
+  tutorial_robotmagic3d_string_detail_platforms: ''
+  tutorial_robotmagicflappy_string_detail_platforms: ''
+  tutorial_scratchadventure_string_detail_platforms: ''
+  tutorial_scratchtalk_string_detail_platforms: ''
+  tutorial_scratchjrstory_string_detail_platforms: ''
+  tutorial_scratchjrtwinkle_string_detail_platforms: ''
+  tutorial_spherocomm_string_detail_platforms: Sphero robot
+  tutorial_spherocommunity_string_detail_platforms: Sphero robot
+  tutorial_spherofunctions_string_detail_platforms: Sphero robot
+  tutorial_spheroinfrared_string_detail_platforms: BOLT robot
+  tutorial_spherolightsensor_string_detail_platforms: BOLT robot
+  tutorial_spheromansion_string_detail_platforms: Sphero robot
+  tutorial_roadblocks_string_detail_platforms: Sphero robot
+  tutorial_spherotext2_string_detail_platforms: Sphero robot
+  tutorial_spherotext3_string_detail_platforms: Sphero robot
+  tutorial_spherotext4_string_detail_platforms: Sphero robot
+  tutorial_spheroraptor_string_detail_platforms: Sphero robot
+  tutorial_stempiday_string_detail_platforms: ''
+  tutorial_stemplanetoids_string_detail_platforms: ''
+  tutorial_stempong_string_detail_platforms: ''
+  tutorial_algobot_string_detail_platforms: ''
+  tutorial_thunkableapps_string_detail_platforms: ''
+  tutorial_toxicodedot_string_detail_platforms: ''
+  tutorial_gcactions_string_detail_platforms: ''
+  tutorial_gccomparators_string_detail_platforms: ''
+  tutorial_gcconditions_string_detail_platforms: ''
+  tutorial_gccreate_string_detail_platforms: ''
+  tutorial_gcevents_string_detail_platforms: ''
+  tutorial_gcloops_string_detail_platforms: ''
+  tutorial_gcvariables_string_detail_platforms: ''
+  tutorial_beanything_string_detail_platforms: ''
+  tutorial_change_string_detail_platforms: ''
+  tutorial_cooking_string_detail_platforms: ''
+  tutorial_crystal_string_detail_platforms: ''
+  tutorial_landscape_string_detail_platforms: ''
+  tutorial_pets_string_detail_platforms: ''
+  tutorial_petvet_string_detail_platforms: ''
+  tutorial_superhero_string_detail_platforms: ''
+  tutorial_vidcodeplastic_string_detail_platforms: ''
+  tutorial_vidcodetypeface_string_detail_platforms: ''
+  tutorial_washustorm_string_detail_platforms: ''
+  tutorial_activitypackets_string_detail_platforms: Dash or Cue robot
+  tutorial_googlerookie_string_detail_platforms: ''
+  tutorial_tommyturtle_string_detail_platforms: ''
+  tutorial_mazyad_string_detail_platforms: ''
+  tutorial_gamemaker_string_detail_platforms: ''
+  tutorial_duckrace_string_detail_platforms: ''
+  tutorial_allcancodeapps_string_detail_platforms: ''
+  tutorial_n2y_string_detail_platforms: ''
+  tutorial_microsoftarcade_string_detail_platforms: ''
+  tutorial_csfirstunplugged_string_detail_platforms: ''
+  tutorial_toxicodepython_string_detail_platforms: ''
+  tutorial_codecombatozaria_string_detail_platforms: ''
+  tutorial_vidcodedate_string_detail_platforms: ''
+  tutorial_codemonkeyspace_string_detail_platforms: ''
+  tutorial_codespeakhappy_string_detail_platforms: ''
+  tutorial_grokimage_string_detail_platforms: ''
+  tutorial_icomputelearn_string_detail_platforms: ''
+  tutorial_rpstress_string_detail_platforms: ''
+  tutorial_bsdcause_string_detail_platforms: ''
+  tutorial_vidcodeanimoji_string_detail_platforms: ''
+  tutorial_vidcodeanimojies_string_detail_platforms: ''
+  tutorial_bsdinspire_string_detail_platforms: ''
+  tutorial_tttractor_string_detail_platforms: ''
+  tutorial_codeillusionmickey_string_detail_platforms: ''
+  tutorial_scigirlsquest_string_detail_platforms: ''
+  tutorial_codespeakbreathe_string_detail_platforms: ''
+  tutorial_vidcodeface_string_detail_platforms: ''
+  tutorial_educodemaze_string_detail_platforms: ''
+  tutorial_educoderace_string_detail_platforms: ''
+  tutorial_codespeakchatbot_string_detail_platforms: ''
+  tutorial_gamefrootgames_string_detail_platforms: ''
+  tutorial_codespeakgrandparent_string_detail_platforms: ''
+  tutorial_educodekingdom_string_detail_platforms: ''
+  tutorial_codehsdata_string_detail_platforms: ''
+  tutorial_educodecake_string_detail_platforms: ''
+  tutorial_ttsecond_string_detail_platforms: ''
+  tutorial_bsdtrivia_string_detail_platforms: ''
+  tutorial_csfirstdialogue_string_detail_platforms: ''
+  tutorial_codemonkeybeaver_string_detail_platforms: ''
+  tutorial_codestersdistance_string_detail_platforms: ''
+  tutorial_itchspace_string_detail_platforms: ''
+  tutorial_vidcodemagic_string_detail_platforms: ''
+  tutorial_vidcodemagices_string_detail_platforms: ''
+  tutorial_codespeakmeal_string_detail_platforms: ''
+  tutorial_itchfish_string_detail_platforms: ''
+  tutorial_bsdwebsite_string_detail_platforms: ''
+  tutorial_codespeaktime_string_detail_platforms: ''
+  tutorial_itchwebcam_string_detail_platforms: ''
+  tutorial_itchball_string_detail_platforms: ''
+  tutorial_ttrace_string_detail_platforms: ''
+  tutorial_plethora_string_detail_platforms: ''
+  tutorial_educodesecret_string_detail_platforms: ''
+  tutorial_itchshapes_string_detail_platforms: ''
+  tutorial_codeguppytext_string_detail_platforms: ''
+  tutorial_vidcodeplastiche_string_detail_platforms: ''
+  tutorial_educativechatbot_string_detail_platforms: ''
+  tutorial_educodebasics_string_detail_platforms: ''
+  tutorial_codehsdesign_string_detail_platforms: ''
+  tutorial_htmlacademyphp_string_detail_platforms: ''
+  tutorial_gamefrootdistance_string_detail_platforms: ''
+  tutorial_codesterscovid_string_detail_platforms: ''
+  tutorial_ttbunker_string_detail_platforms: ''
+  tutorial_cuttle_string_detail_platforms: ''
+  tutorial_bsdjokes_string_detail_platforms: ''
+  tutorial_rptree_string_detail_platforms: ''
+  tutorial_codestersunity_string_detail_platforms: ''
+  tutorial_codesterssoccer_string_detail_platforms: ''
+  tutorial_breakoutlock_string_detail_platforms: ''
+  tutorial_thunkablemask_string_detail_platforms: ''
+  tutorial_cafarming_string_detail_platforms: ''
+  tutorial_blocksmithyeti_string_detail_platforms: ''
+  tutorial_codecapture_string_detail_platforms: ''
+  tutorial_codehslitter_string_detail_platforms: ''
+  tutorial_bsdocean_string_detail_platforms: ''
+  tutorial_itchplatformer_string_detail_platforms: ''
+  tutorial_codejika_string_detail_platforms: ''
+  tutorial_gamefrootclicker_string_detail_platforms: ''
+  tutorial_rmagicequity_string_detail_platforms: ''
+  tutorial_ttfreestyle_string_detail_platforms: ''
+  tutorial_ozobotcolor2_string_detail_platforms: 'Ozobot Evo  '
+  tutorial_ozobotcolor3_string_detail_platforms: 'Ozobot Evo  '
+  tutorial_clcarbon_string_detail_platforms: ''
+  tutorial_kodablebasics_string_detail_platforms: ''
+  tutorial_scigirlscc_string_detail_platforms: ''
+  tutorial_irobotpicture_string_detail_platforms: ''
+  tutorial_kcjmyself_string_detail_platforms: ''
+  tutorial_nearpodalgorithms_string_detail_platforms: ''
+  tutorial_kibodrop_string_detail_platforms: KIBO Robot Kit (optional)
+  tutorial_ozobotcolor1_string_detail_platforms: 'Ozobot Evo  '
+  tutorial_scigirlspixels_string_detail_platforms: ''
+  tutorial_kcjheroines_string_detail_platforms: ''
+  tutorial_ozobotvalue_string_detail_platforms: 'Ozobot Evo  '
+  tutorial_icodebytes_string_detail_platforms: ''
+  tutorial_clfashion2_string_detail_platforms: ''
+  tutorial_ai4all_string_detail_platforms: ''
+  tutorial_cldata_string_detail_platforms: ''
+  tutorial_spheroinputs_string_detail_platforms: ''
+  tutorial_edisoncount_string_detail_platforms: ''
+  tutorial_spheroloops_string_detail_platforms: ''
+  tutorial_kiboprogram_string_detail_platforms: KIBO Robot Kit (optional)
+  tutorial_hellorubycsin60_string_detail_platforms: ''
+  tutorial_clfashion1_string_detail_platforms: ''
+  tutorial_irobottraffic_string_detail_platforms: Root robot
+  tutorial_edisonmystery_string_detail_platforms: ''
+  tutorial_microbitseaturtles_string_detail_platforms: ''
+  tutorial_ozobotknow_string_detail_platforms: Ozobot Evo (optional)
+  tutorial_imagilabs_string_detail_platforms: imagiCharm
+  tutorial_irobotsimulator_string_detail_platforms: ''
+  tutorial_irobotkind_string_detail_platforms: Root robot (optional)
+  tutorial_firiavirtual_string_detail_platforms: ''
+  tutorial_irobotguesscode_string_detail_platforms: Root robot
+  tutorial_ozobotnouns_string_detail_platforms: 'Ozobot Evo  '
+  tutorial_nasa3d_string_detail_platforms: ''
+  tutorial_blupants_string_detail_platforms: Lego Ev3, Alphabot2, DIY Raspberry Pi
+    robot or DIY Beaglebone Blue robot
+  tutorial_legodance_string_detail_platforms: LEGO Education SPIKE Prime
+  tutorial_nearpodcoding_string_detail_platforms: ''
+  tutorial_kcjplastic_string_detail_platforms: ''
+  tutorial_legojourney_string_detail_platforms: ''
+  tutorial_legohopper_string_detail_platforms: LEGO Education SPIKE Prime robot
+  tutorial_catrobatembroidery_string_detail_platforms: Embroidery machine for stitching
+    and USB or network port, plus support of the DST format (standard embroidery file
+    format).
+  tutorial_irobotphone_string_detail_platforms: Root robot (optional)
+  tutorial_codeguppydraw_string_detail_platforms: ''
+  tutorial_codejumper_string_detail_platforms: ''
+  tutorial_meeempathy_string_detail_platforms: ''
+  tutorial_dance2019_string_detail_programming_languages: Blocks
+  tutorial_danceparty_string_detail_programming_languages: Blocks
+  tutorial_chibitronics_string_detail_programming_languages: Blocks
+  tutorial_athlete_string_detail_programming_languages: Blocks
+  tutorial_moana_string_detail_programming_languages: Blocks
+  tutorial_star-wars_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_gumadventure_string_detail_programming_languages: Blocks, Scratch
+  tutorial_mchoc_string_detail_programming_languages: Blocks
+  tutorial_vidnews_string_detail_programming_languages: JavaScript
+  tutorial_kodable-pre_string_detail_programming_languages: Blocks
+  tutorial_highseas_string_detail_programming_languages: Blocks, Scratch
+  tutorial_capython_string_detail_programming_languages: Python
+  tutorial_frzn_string_detail_programming_languages: Blocks
+  tutorial_cocom_string_detail_programming_languages: JavaScript, Python, Lua, CoffeeScript
+  tutorial_play-lab_string_detail_programming_languages: Blocks
+  tutorial_boxisland_string_detail_programming_languages: Blocks
+  tutorial_textcomp_string_detail_programming_languages: Language independent
+  tutorial_encryption_string_detail_programming_languages: Language independent
+  tutorial_kanopixel_string_detail_programming_languages: JavaScript, Coffeescript
+  tutorial_foos_string_detail_programming_languages: Blocks
+  tutorial_tynkerdd_string_detail_programming_languages: Blocks, Tynker, JavaScript,
+    Python
+  tutorial_tynkerana_string_detail_programming_languages: Blocks, Tynker, JavaScript,
+    Python
+  tutorial_vidcard_string_detail_programming_languages: JavaScript
+  tutorial_spritebox_string_detail_programming_languages: Blocks, Java, iOS/Swift
+  tutorial_tynkerch_string_detail_programming_languages: JavaScript
+  tutorial_lightbot_string_detail_programming_languages: Blocks
+  tutorial_hoc_string_detail_programming_languages: do-not-show
+  tutorial_code_string_detail_programming_languages: Blocks
+  tutorial_tinspire_string_detail_programming_languages: TI Basic
+  tutorial_itchbounceball_string_detail_programming_languages: Blocks, Scratch
+  tutorial_vidclim_string_detail_programming_languages: JavaScript
+  tutorial_matlab_string_detail_programming_languages: MATLAB
+  tutorial_flap_string_detail_programming_languages: Blocks
+  tutorial_galaxy_string_detail_programming_languages: Blocks
+  tutorial_inf_string_detail_programming_languages: Blocks
+  tutorial_tynkersol_string_detail_programming_languages: Blocks, Tynker, JavaScript,
+    Python
+  tutorial_itchg_string_detail_programming_languages: Blocks
+  tutorial_como_string_detail_programming_languages: CoffeeScript
+  tutorial_processfound_string_detail_programming_languages: Java
+  tutorial_tynkerhomo_string_detail_programming_languages: Blocks, Tynker, JavaScript,
+    Python
+  tutorial_art_string_detail_programming_languages: Blocks
+  tutorial_tynkerbrick_string_detail_programming_languages: Blocks, Tynker, JavaScript,
+    Python
+  tutorial_itchbio_string_detail_programming_languages: Blocks
+  tutorial_itchj_string_detail_programming_languages: Blocks
+  tutorial_tickleo_string_detail_programming_languages: Blocks
+  tutorial_hopgeo_string_detail_programming_languages: Hopscotch
+  tutorial_tynkermult_string_detail_programming_languages: Blocks, Tynker, JavaScript,
+    Python
+  tutorial_monster_string_detail_programming_languages: Blocks
+  tutorial_tynkerapp_string_detail_programming_languages: do-not-show
+  tutorial_tynkerpup_string_detail_programming_languages: Blocks, Tynker
+  tutorial_livecode_string_detail_programming_languages: Language independent
+  tutorial_cocomgame_string_detail_programming_languages: JavaScript, Python, Lua,
+    CoffeeScript
+  tutorial_tynkerspin_string_detail_programming_languages: Blocks, Tynker, JavaScript,
+    Python
+  tutorial_code-avengers_string_detail_programming_languages: JavaScript
+  tutorial_tynkercq_string_detail_programming_languages: Blocks, Tynker
+  tutorial_cmgame_string_detail_programming_languages: CoffeeScript
+  tutorial_codesters_string_detail_programming_languages: do-not-show
+  tutorial_qrm_string_detail_programming_languages: Quorum
+  tutorial_texas-instruments_string_detail_programming_languages: TI Basic
+  tutorial_cajava_string_detail_programming_languages: JavaScript
+  tutorial_codehs_string_detail_programming_languages: JavaScript
+  tutorial_hopemo_string_detail_programming_languages: Hopscotch
+  tutorial_tynkercm_string_detail_programming_languages: Blocks, Tynker, JavaScript,
+    Python
+  tutorial_codesterswintergreet_string_detail_programming_languages: Python
+  tutorial_codestersc_string_detail_programming_languages: Python
+  tutorial_codestersturtle_string_detail_programming_languages: Python
+  tutorial_penjee_string_detail_programming_languages: Python
+  tutorial_trinket_string_detail_programming_languages: Blocks, Kano Code
+  tutorial_frogger_string_detail_programming_languages: Blocks
+  tutorial_tynkereco_string_detail_programming_languages: Blocks, Tynker, JavaScript,
+    Python
+  tutorial_mitedarc_string_detail_programming_languages: Blocks
+  tutorial_khan_string_detail_programming_languages: JavaScript
+  tutorial_tynkerd_string_detail_programming_languages: Blocks, Tynker, JavaScript,
+    Python
+  tutorial_cdmy_string_detail_programming_languages: JavaScript
+  tutorial_codestersdance_string_detail_programming_languages: Blocks, Python
+  tutorial_codestersbasketball_string_detail_programming_languages: Python
+  tutorial_nclkarel_string_detail_programming_languages: Karel (simplified Python)
+  tutorial_buildpong_string_detail_programming_languages: Blocks, Ready, Unity
+  tutorial_tynkerdrones_string_detail_programming_languages: Blocks
+  tutorial_carla_string_detail_programming_languages: Coffeescript
+  tutorial_zulama_string_detail_programming_languages: JavaScript
+  tutorial_capost_string_detail_programming_languages: HTML, CSS
+  tutorial_marco_string_detail_programming_languages: Blocks
+  tutorial_codestersflappybike_string_detail_programming_languages: Python
+  tutorial_kanopong_string_detail_programming_languages: JavaScript
+  tutorial_tynkerright_string_detail_programming_languages: Blocks
+  tutorial_touchdevelop_string_detail_programming_languages: do-not-show
+  tutorial_tynkercc_string_detail_programming_languages: Blocks, Tynker, JavaScript,
+    Python
+  tutorial_bamboo_string_detail_programming_languages: JavaScript
+  tutorial_robojav_string_detail_programming_languages: Java
+  tutorial_roboba_string_detail_programming_languages: Blocks, Ch/C/C++
+  tutorial_knodsnake_string_detail_programming_languages: JavaScript
+  tutorial_soccharater_string_detail_programming_languages: JavaScript
+  tutorial_silent_string_detail_programming_languages: JavaScript
+  tutorial_robomesh_string_detail_programming_languages: Blocks, Python
+  tutorial_amaze_string_detail_programming_languages: Blocks, Ready, Unity
+  tutorial_codestersds_string_detail_programming_languages: Blocks
+  tutorial_knodtext_string_detail_programming_languages: Python
+  tutorial_alicegar_string_detail_programming_languages: Blocks
+  tutorial_codesterstransform_string_detail_programming_languages: Python
+  tutorial_flexfrog_string_detail_programming_languages: CSS
+  tutorial_codemoji_string_detail_programming_languages: do-not-show
+  tutorial_robobii_string_detail_programming_languages: Blocks, Ch/C/C++
+  tutorial_robobm_string_detail_programming_languages: Blocks, Ch/C/C++
+  tutorial_codingrobots_string_detail_programming_languages: Blocks, Ch/C/C++
+  tutorial_robob_string_detail_programming_languages: Blocks, Ch/C/C++
+  tutorial_coders_string_detail_programming_languages: Language independent
+  tutorial_tynkerhw_string_detail_programming_languages: Blocks, Tynker, JavaScript,
+    Python
+  tutorial_tynkermh_string_detail_programming_languages: Blocks, Tynker, JavaScript,
+    Python
+  tutorial_caphoto_string_detail_programming_languages: JavaScript, HTML, CSS
+  tutorial_mozillahw_string_detail_programming_languages: JavaScript
+  tutorial_ticklep_string_detail_programming_languages: do-not-show
+  tutorial_bbot_string_detail_programming_languages: Visual programming language
+  tutorial_scratchg_string_detail_programming_languages: Language independent
+  tutorial_sjforest_string_detail_programming_languages: Blocks
+  tutorial_sjgreet_string_detail_programming_languages: Blocks
+  tutorial_sjsunset_string_detail_programming_languages: Blocks
+  tutorial_fufafrenz_string_detail_programming_languages: Language independent
+  tutorial_bbcgeo_string_detail_programming_languages: do-not-show
+  tutorial_chspixel_string_detail_programming_languages: JavaScript
+  tutorial_hummingbird_string_detail_programming_languages: Blocks
+  tutorial_recoloring_string_detail_programming_languages: Coffee Script (Pencil Code)
+  tutorial_bbcchem_string_detail_programming_languages: do-not-show
+  tutorial_floalgo_string_detail_programming_languages: Language independent
+  tutorial_flocond_string_detail_programming_languages: Blocks, Language independent
+  tutorial_floloops_string_detail_programming_languages: Blocks, Language independent
+  tutorial_pgts_string_detail_programming_languages: Language independent
+  tutorial_ozo_string_detail_programming_languages: Blocks
+  tutorial_bbcla_string_detail_programming_languages: do-not-show
+  tutorial_bbcsci_string_detail_programming_languages: do-not-show
+  tutorial_tlctour_string_detail_programming_languages: Language independent
+  tutorial_codesterstj_string_detail_programming_languages: Python
+  tutorial_tlclocked_string_detail_programming_languages: Language independent
+  tutorial_baubles_string_detail_programming_languages: Language independent
+  tutorial_bbcart_string_detail_programming_languages: do-not-show
+  tutorial_tlcknight_string_detail_programming_languages: Language independent
+  tutorial_fufafit_string_detail_programming_languages: Language independent
+  tutorial_ozodance_string_detail_programming_languages: Blocks
+  tutorial_codingrobotics_string_detail_programming_languages: Language independent
+  tutorial_box_string_detail_programming_languages: do-not-show
+  tutorial_hopgame_string_detail_programming_languages: Hopscotch
+  tutorial_icontrol_string_detail_programming_languages: Tickle
+  tutorial_cocomteach_string_detail_programming_languages: JavaScript, Python, Lua,
+    CoffeeScript
+  tutorial_bbcmathii_string_detail_programming_languages: do-not-show
+  tutorial_bbcphys_string_detail_programming_languages: do-not-show
+  tutorial_bitsbox_string_detail_programming_languages: JavaScript
+  tutorial_tlcemo_string_detail_programming_languages: Language independent
+  tutorial_crd_string_detail_programming_languages: Language independent
+  tutorial_bbcbio_string_detail_programming_languages: do-not-show
+  tutorial_ticklebb8_string_detail_programming_languages: Blocks
+  tutorial_grok_string_detail_programming_languages: do-not-show
+  tutorial_ijournalist_string_detail_programming_languages: HTML, CSS
+  tutorial_bbcmusic_string_detail_programming_languages: do-not-show
+  tutorial_secretcodes_string_detail_programming_languages: Blocks
+  tutorial_tlchex_string_detail_programming_languages: Language independent
+  tutorial_tickles_string_detail_programming_languages: Blocks
+  tutorial_ozogame_string_detail_programming_languages: Blocks
+  tutorial_vidcodeio_string_detail_programming_languages: Language independent
+  tutorial_tlcbrain_string_detail_programming_languages: Language independent
+  tutorial_hopquiz_string_detail_programming_languages: Hopscotch
+  tutorial_unfortunate_string_detail_programming_languages: Blocks
+  tutorial_cha_string_detail_programming_languages: Language independent
+  tutorial_elaseq_string_detail_programming_languages: Language independent
+  tutorial_bbcmathi_string_detail_programming_languages: do-not-show
+  tutorial_tlcpixel_string_detail_programming_languages: Language independent
+  tutorial_introrobo_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_tlcinvis_string_detail_programming_languages: Language independent
+  tutorial_tlcjflap_string_detail_programming_languages: Language independent
+  tutorial_procolor_string_detail_programming_languages: Language independent
+  tutorial_spiralsfinch_string_detail_programming_languages: Blocks
+  tutorial_ozoi_string_detail_programming_languages: Language independent
+  tutorial_ticklel_string_detail_programming_languages: Blocks
+  tutorial_spiralsdash_string_detail_programming_languages: Blocks
+  tutorial_ghdebug_string_detail_programming_languages: Blocks
+  tutorial_tlckk_string_detail_programming_languages: Language independent
+  tutorial_firstcomp_string_detail_programming_languages: Language independent
+  tutorial_mazefinch_string_detail_programming_languages: Blocks
+  tutorial_tlccc_string_detail_programming_languages: Language independent
+  tutorial_tlcdoodle_string_detail_programming_languages: Language independent
+  tutorial_tlcpunch_string_detail_programming_languages: Language independent
+  tutorial_finchfract_string_detail_programming_languages: Java, Python
+  tutorial_tlcmind_string_detail_programming_languages: Language independent
+  tutorial_tlctelebot_string_detail_programming_languages: Language independent
+  tutorial_tlcaus_string_detail_programming_languages: Language independent
+  tutorial_tlcmicro_string_detail_programming_languages: Language independent
+  tutorial_imathematician_string_detail_programming_languages: Scratch
+  tutorial_tlcmagic_string_detail_programming_languages: Language independent
+  tutorial_scratchmus_string_detail_programming_languages: Blocks, Scratch
+  tutorial_scratchanim_string_detail_programming_languages: Blocks, Scratch
+  tutorial_scratchfly_string_detail_programming_languages: Blocks, Scratch
+  tutorial_tynkerarc_string_detail_programming_languages: Blocks, Tynker, JavaScript,
+    Python
+  tutorial_grokffpython_string_detail_programming_languages: Python
+  tutorial_grokffblock_string_detail_programming_languages: Blocks
+  tutorial_grokeliza_string_detail_programming_languages: Python
+  tutorial_tynkercan_string_detail_programming_languages: Blocks, Tynker, JavaScript,
+    Python
+  tutorial_grokflags_string_detail_programming_languages: Python
+  tutorial_robomind_string_detail_programming_languages: Blocks
+  tutorial_adventureq_string_detail_programming_languages: Blocks
+  tutorial_khan-es_string_detail_programming_languages: JavaScript
+  tutorial_kpt_string_detail_programming_languages: JavaScript
+  tutorial_kpl_string_detail_programming_languages: JavaScript
+  tutorial_khe_string_detail_programming_languages: JavaScript
+  tutorial_kfr_string_detail_programming_languages: JavaScript
+  tutorial_app-inventor_string_detail_programming_languages: Blocks
+  tutorial_blockly_string_detail_programming_languages: Blocks
+  tutorial_tynker_string_detail_programming_languages: do-not-show
+  tutorial_baypt_string_detail_programming_languages: Blocks
+  tutorial_code-combat_string_detail_programming_languages: do-not-show
+  tutorial_mky_string_detail_programming_languages: CoffeeScript
+  tutorial_pirates_string_detail_programming_languages: Blocks, Pirate code
+  tutorial_csfirst_string_detail_programming_languages: Scratch
+  tutorial_loopedy_string_detail_programming_languages: Blocks
+  tutorial_dsw_string_detail_programming_languages: do-not-show
+  tutorial_dswb_string_detail_programming_languages: do-not-show
+  tutorial_ssw_string_detail_programming_languages: do-not-show
+  tutorial_sswb_string_detail_programming_languages: do-not-show
+  tutorial_kodable-unplugged_string_detail_programming_languages: Language independent
+  tutorial_scratch_string_detail_programming_languages: Language independent
+  tutorial_bayes_string_detail_programming_languages: Blocks
+  tutorial_gumball_string_detail_programming_languages: do-not-show
+  tutorial_hrm_string_detail_programming_languages: Assembly
+  tutorial_ice-age_string_detail_programming_languages: do-not-show
+  tutorial_koapp_string_detail_programming_languages: do-not-show
+  tutorial_lightbot-intl_string_detail_programming_languages: Blocks
+  tutorial_rmc_string_detail_programming_languages: do-not-show
+  tutorial_smc_string_detail_programming_languages: do-not-show
+  tutorial_minecraft-2016_string_detail_programming_languages: do-not-show
+  tutorial_thinkersmith-es_string_detail_programming_languages: JavaScript
+  tutorial_pixie_string_detail_programming_languages: Blocks
+  tutorial_play_string_detail_programming_languages: do-not-show
+  tutorial_robomind-nl_string_detail_programming_languages: Blocks
+  tutorial_spheroi_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_spherol_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_spherov_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_swb_string_detail_programming_languages: do-not-show
+  tutorial_build-a-galaxy_string_detail_programming_languages: do-not-show
+  tutorial_alicesims_string_detail_programming_languages: Blocks
+  tutorial_tchr_string_detail_programming_languages: do-not-show
+  tutorial_robogame_string_detail_programming_languages: Blocks
+  tutorial_tap_string_detail_programming_languages: Blocks, Tynker, JavaScript, Python
+  tutorial_cintl_string_detail_programming_languages: do-not-show
+  tutorial_itchstop_string_detail_programming_languages: Blocks
+  tutorial_tynkerpn_string_detail_programming_languages: Blocks, Tynker
+  tutorial_tynkerpd_string_detail_programming_languages: Blocks, Tynker
+  tutorial_persistence_string_detail_programming_languages: Language independent
+  tutorial_getloopy_string_detail_programming_languages: Language independent
+  tutorial_createface_string_detail_programming_languages: Language independent
+  tutorial_happymaps_string_detail_programming_languages: Language independent
+  tutorial_moveit_string_detail_programming_languages: Language independent
+  tutorial_bigevent_string_detail_programming_languages: Language independent
+  tutorial_gpp_string_detail_programming_languages: Language independent
+  tutorial_foosgame_string_detail_programming_languages: Blocks
+  tutorial_solopython_string_detail_programming_languages: Python
+  tutorial_kodableint_string_detail_programming_languages: Language independent, Symbols
+  tutorial_kodableadv_string_detail_programming_languages: Language independent, Javascript
+  tutorial_tynkertj_string_detail_programming_languages: Python
+  tutorial_wolframa_string_detail_programming_languages: Wolfram Language
+  tutorial_wolframm_string_detail_programming_languages: Wolfram Language
+  tutorial_wolframspi_string_detail_programming_languages: Wolfram Language
+  tutorial_wolframsph_string_detail_programming_languages: Wolfram Language
+  tutorial_wolframp_string_detail_programming_languages: Wolfram Language
+  tutorial_wolframn_string_detail_programming_languages: Wolfram Language
+  tutorial_soloweb_string_detail_programming_languages: HTML, CSS
+  tutorial_khanweb_string_detail_programming_languages: HTML & CSS
+  tutorial_khandata_string_detail_programming_languages: SQL
+  tutorial_googlelogo_string_detail_programming_languages: Blocks
+  tutorial_playtune_string_detail_programming_languages: Blocks
+  tutorial_computeit_string_detail_programming_languages: Language independent
+  tutorial_codesterssj_string_detail_programming_languages: Blocks, Python
+  tutorial_cmchat_string_detail_programming_languages: Python
+  tutorial_tynkerdb_string_detail_programming_languages: Blocks, Tynker, JavaScript,
+    Python
+  tutorial_cmbuild_string_detail_programming_languages: CoffeeScript
+  tutorial_robotrattle_string_detail_programming_languages: Blocks
+  tutorial_codestersh_string_detail_programming_languages: Blocks, Python
+  tutorial_codehsdigipixel_string_detail_programming_languages: Language independent
+  tutorial_ccbinary_string_detail_programming_languages: Blocks
+  tutorial_codehsturtle_string_detail_programming_languages: Python
+  tutorial_grokhd_string_detail_programming_languages: Blocks
+  tutorial_grokem_string_detail_programming_languages: Python
+  tutorial_kodmaze_string_detail_programming_languages: Language independent
+  tutorial_codestersa_string_detail_programming_languages: Python
+  tutorial_cmdodo_string_detail_programming_languages: CoffeeScript
+  tutorial_tynkerspace_string_detail_programming_languages: Blocks, Tynker, JavaScript,
+    Python
+  tutorial_gfbloons_string_detail_programming_languages: Blocks
+  tutorial_raspipong_string_detail_programming_languages: Python
+  tutorial_codehsvr_string_detail_programming_languages: JavaScript
+  tutorial_codesterstp_string_detail_programming_languages: Blocks, Python
+  tutorial_codestersbb_string_detail_programming_languages: Blocks, Python
+  tutorial_gfcrossyroad_string_detail_programming_languages: Blocks
+  tutorial_googleww_string_detail_programming_languages: Blocks
+  tutorial_codehsjsapp_string_detail_programming_languages: JavaScript
+  tutorial_gfmihi_string_detail_programming_languages: Blocks
+  tutorial_hopdropphone_string_detail_programming_languages: Hopscotch
+  tutorial_techfaa_string_detail_programming_languages: JavaScript, Language independent
+  tutorial_codehsjsgraph_string_detail_programming_languages: JavaScript
+  tutorial_thunkable_string_detail_programming_languages: Blocks
+  tutorial_hopcrossyroad_string_detail_programming_languages: Hopscotch
+  tutorial_switchglitch_string_detail_programming_languages: Language independent
+  tutorial_codecar_string_detail_programming_languages: C/C++
+  tutorial_codesterscp_string_detail_programming_languages: Blocks, Python
+  tutorial_grokpetblock_string_detail_programming_languages: Blocks
+  tutorial_techbim_string_detail_programming_languages: Language independent
+  tutorial_techfpp_string_detail_programming_languages: Python
+  tutorial_codesterscr_string_detail_programming_languages: Python
+  tutorial_grokdisease_string_detail_programming_languages: Python
+  tutorial_techec_string_detail_programming_languages: JavaScript
+  tutorial_rgbegin_string_detail_programming_languages: Blocks
+  tutorial_myradream_string_detail_programming_languages: Blocks
+  tutorial_thinkfun_string_detail_programming_languages: Language independent
+  tutorial_hopfireworks_string_detail_programming_languages: Hopscotch
+  tutorial_grokspace_string_detail_programming_languages: Blocks
+  tutorial_codehspython_string_detail_programming_languages: Python
+  tutorial_codehsjava_string_detail_programming_languages: Java
+  tutorial_techioda_string_detail_programming_languages: Language independent
+  tutorial_grokmonster_string_detail_programming_languages: Blocks
+  tutorial_techmjs_string_detail_programming_languages: JavaScript
+  tutorial_techga_string_detail_programming_languages: Language independent
+  tutorial_techioan_string_detail_programming_languages: Java
+  tutorial_techiogsr_string_detail_programming_languages: Rust
+  tutorial_groktunnel_string_detail_programming_languages: Python
+  tutorial_stemcod_string_detail_programming_languages: JavaScript
+  tutorial_techikb_string_detail_programming_languages: Kotlin
+  tutorial_kanostreet_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_codemojijs_string_detail_programming_languages: JavaScript
+  tutorial_techapf_string_detail_programming_languages: Python
+  tutorial_techfpjs_string_detail_programming_languages: JavaScript
+  tutorial_techlinq_string_detail_programming_languages: C#
+  tutorial_gpbcatapult_string_detail_programming_languages: Blocks
+  tutorial_quorumastro_string_detail_programming_languages: Quorum
+  tutorial_alicewonder_string_detail_programming_languages: JavaScript
+  tutorial_rginter_string_detail_programming_languages: Blocks
+  tutorial_cssgrid_string_detail_programming_languages: CSS
+  tutorial_jshero_string_detail_programming_languages: JavaScript
+  tutorial_codemojipy_string_detail_programming_languages: iOS/Swift, Python
+  tutorial_nclabdrone_string_detail_programming_languages: Python
+  tutorial_gpbcircle_string_detail_programming_languages: Blocks
+  tutorial_gpbpaint_string_detail_programming_languages: Blocks
+  tutorial_cocomarcade_string_detail_programming_languages: JavaScript, Python
+  tutorial_beetik_string_detail_programming_languages: Blocks
+  tutorial_codedj_string_detail_programming_languages: JavaScript
+  tutorial_rgadvan_string_detail_programming_languages: Blocks, JavaScript, Python
+  tutorial_codehsrn_string_detail_programming_languages: JavaScript
+  tutorial_codehswd_string_detail_programming_languages: HTML
+  tutorial_turtlerobot_string_detail_programming_languages: Language independent
+  tutorial_ozoevo_string_detail_programming_languages: Blocks
+  tutorial_ozoexped_string_detail_programming_languages: OzoCodes
+  tutorial_ozojourney_string_detail_programming_languages: Blocks
+  tutorial_ozocodes_string_detail_programming_languages: OzoCodes
+  tutorial_ozoeclipse_string_detail_programming_languages: Blocks, OzoCodes
+  tutorial_ozosimulator_string_detail_programming_languages: Language independent
+  tutorial_ozoalgorithm_string_detail_programming_languages: Blocks
+  tutorial_ozotimer_string_detail_programming_languages: Blocks
+  tutorial_ozohabits_string_detail_programming_languages: OzoCodes
+  tutorial_ozoprogram_string_detail_programming_languages: Blocks
+  tutorial_ozopair_string_detail_programming_languages: Blocks
+  tutorial_codesnoopy_string_detail_programming_languages: Blocks
+  tutorial_applabintro_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_cslartist_string_detail_programming_languages: Blocks
+  tutorial_cslscratchjr_string_detail_programming_languages: Blocks
+  tutorial_floevents_string_detail_programming_languages: Language independent
+  tutorial_florobot_string_detail_programming_languages: Language independent
+  tutorial_isavesanta_string_detail_programming_languages: Blocks, Scratch
+  tutorial_iorder_string_detail_programming_languages: Blocks, Scratch
+  tutorial_ianimate_string_detail_programming_languages: Language independent
+  tutorial_iloveada_string_detail_programming_languages: ChildScript
+  tutorial_kodflash_string_detail_programming_languages: Language independent
+  tutorial_kodchoose_string_detail_programming_languages: Language independent
+  tutorial_kodpizzapre_string_detail_programming_languages: Language independent
+  tutorial_kodpizza_string_detail_programming_languages: Language independent
+  tutorial_kodwomen_string_detail_programming_languages: Language independent
+  tutorial_tfunplug_string_detail_programming_languages: Language independent
+  tutorial_lbvariables_string_detail_programming_languages: Blocks
+  tutorial_lbfunctions_string_detail_programming_languages: Blocks
+  tutorial_lblogic_string_detail_programming_languages: Blocks
+  tutorial_lbworld_string_detail_programming_languages: Blocks
+  tutorial_lbloops_string_detail_programming_languages: Blocks
+  tutorial_lbtug_string_detail_programming_languages: Blocks
+  tutorial_lbpotato_string_detail_programming_languages: Blocks
+  tutorial_lbguitar_string_detail_programming_languages: Blocks
+  tutorial_lbio_string_detail_programming_languages: Blocks
+  tutorial_wonpuppy_string_detail_programming_languages: Blocks
+  tutorial_woncue_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_wonzoo_string_detail_programming_languages: Blocks
+  tutorial_wontrip_string_detail_programming_languages: Blocks
+  tutorial_woncollect_string_detail_programming_languages: Blocks
+  tutorial_wonsecret_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_hsscience_string_detail_programming_languages: Hopscotch
+  tutorial_popculture_string_detail_programming_languages: Language independent
+  tutorial_legorobust_string_detail_programming_languages: Blocks
+  tutorial_legoplants_string_detail_programming_languages: Blocks
+  tutorial_legopark_string_detail_programming_languages: Blocks
+  tutorial_legodetect_string_detail_programming_languages: Blocks
+  tutorial_legolight_string_detail_programming_languages: Blocks
+  tutorial_alexa_string_detail_programming_languages: JavaScript
+  tutorial_grokpetmicro_string_detail_programming_languages: Python, MicroPython
+  tutorial_pirateplunder_string_detail_programming_languages: Blocks
+  tutorial_cadj_string_detail_programming_languages: Language independent
+  tutorial_cacrazy_string_detail_programming_languages: Blocks
+  tutorial_cajump_string_detail_programming_languages: Language independent
+  tutorial_carest_string_detail_programming_languages: Blocks
+  tutorial_accai_string_detail_programming_languages: Language independent
+  tutorial_vceclipse_string_detail_programming_languages: JavaScript
+  tutorial_pmzero_string_detail_programming_languages: Blocks
+  tutorial_hsela_string_detail_programming_languages: Hopscotch
+  tutorial_ticklear_string_detail_programming_languages: Blocks
+  tutorial_bcrobot_string_detail_programming_languages: Blocks
+  tutorial_bcsnow_string_detail_programming_languages: Blocks
+  tutorial_ifly_string_detail_programming_languages: Tynker
+  tutorial_idowedo_string_detail_programming_languages: Scratch
+  tutorial_diggindwarf_string_detail_programming_languages: JavaScript
+  tutorial_spheroit_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_gameofcodes_string_detail_programming_languages: Blocks, Ready, Unity
+  tutorial_blocklygames_string_detail_programming_languages: Blocks
+  tutorial_spherohello_string_detail_programming_languages: JavaScript
+  tutorial_spheroarcade_string_detail_programming_languages: iOS/Swift
+  tutorial_bcpy1_string_detail_programming_languages: Python
+  tutorial_bcpy2_string_detail_programming_languages: Python
+  tutorial_bcjs1_string_detail_programming_languages: JavaScript
+  tutorial_bcjs2_string_detail_programming_languages: JavaScript
+  tutorial_3dbearmars_string_detail_programming_languages: Language independent (can
+    be taught in multiple languages), Uses 3D modeling in augmented reality
+  tutorial_bitsboxyak_string_detail_programming_languages: JavaScript
+  tutorial_blockscadbargraphs_string_detail_programming_languages: Blocks
+  tutorial_blockscadbirdhouses_string_detail_programming_languages: Blocks
+  tutorial_blockscadclock_string_detail_programming_languages: Blocks
+  tutorial_blockscaddinner_string_detail_programming_languages: Blocks
+  tutorial_blockscadicecream_string_detail_programming_languages: Blocks
+  tutorial_blockscadpizza_string_detail_programming_languages: Blocks
+  tutorial_blockscadsugar_string_detail_programming_languages: Blocks
+  tutorial_bsgridlight_string_detail_programming_languages: Blocks
+  tutorial_bpartscratch_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_bpartvid_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_bpenglishscratch_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_bpenglishvid_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_bphealthscratch_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_bphealthvid_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_bpmathscratch_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_bpmathvid_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_bpmlkscratch_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_bpmlkvid_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_bpsafetyscratch_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_bpsafetyvid_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_bpsciencescratch_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_bpsciencevid_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_bptechscratch_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_bptechvid_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_caflags_string_detail_programming_languages: Blocks
+  tutorial_matariki_string_detail_programming_languages: Blocks
+  tutorial_carestaurant_string_detail_programming_languages: Blocks
+  tutorial_casea_string_detail_programming_languages: Blocks
+  tutorial_cashield_string_detail_programming_languages: Blocks
+  tutorial_ccwslimer_string_detail_programming_languages: Blocks
+  tutorial_codinggalaxy_string_detail_programming_languages: Blocks
+  tutorial_boatrace_string_detail_programming_languages: Blocks
+  tutorial_ccplay_string_detail_programming_languages: JavaScript, Python
+  tutorial_grinch_string_detail_programming_languages: Blocks
+  tutorial_codehsart_string_detail_programming_languages: Blocks
+  tutorial_codehsbitcoin_string_detail_programming_languages: Language independent
+    (can be taught in multiple languages)
+  tutorial_codehsblockchain_string_detail_programming_languages: Language independent
+    (can be taught in multiple languages)
+  tutorial_codehscipher_string_detail_programming_languages: Language independent
+    (can be taught in multiple languages)
+  tutorial_codehscollision_string_detail_programming_languages: JavaScript
+  tutorial_codehsmath_string_detail_programming_languages: Python
+  tutorial_codehsmusic_string_detail_programming_languages: Blocks
+  tutorial_codehssports_string_detail_programming_languages: Blocks
+  tutorial_codemojipizza_string_detail_programming_languages: JavaScript
+  tutorial_moonlander_string_detail_programming_languages: CoffeeScript
+  tutorial_sushicards_string_detail_programming_languages: Blocks
+  tutorial_codesparkcreate_string_detail_programming_languages: Blocks
+  tutorial_hardvsoft_string_detail_programming_languages: ''
+  tutorial_codestersecard_string_detail_programming_languages: Blocks, Python
+  tutorial_codesterslogo_string_detail_programming_languages: Python
+  tutorial_codesterstshirt_string_detail_programming_languages: Blocks, Python
+  tutorial_codewards_string_detail_programming_languages: CoffeeScript
+  tutorial_olympics_string_detail_programming_languages: CoffeeScript
+  tutorial_codinismhero_string_detail_programming_languages: Python
+  tutorial_discovery_string_detail_programming_languages: Blocks, Scratch
+  tutorial_csfirstname_string_detail_programming_languages: Blocks, Scratch
+  tutorial_edisonmove_string_detail_programming_languages: Python, EdPy, a text-based
+    programming language based on Python.
+  tutorial_edisonspider_string_detail_programming_languages: Blocks
+  tutorial_edisonspotlight_string_detail_programming_languages: Blocks
+  tutorial_firiapython_string_detail_programming_languages: Python
+  tutorial_gamefrootsquid_string_detail_programming_languages: Blocks
+  tutorial_duckpiano_string_detail_programming_languages: Blocks
+  tutorial_gpsound_string_detail_programming_languages: Blocks
+  tutorial_groklearningpython_string_detail_programming_languages: Python
+  tutorial_htmltimetravel_string_detail_programming_languages: HTML and CSS
+  tutorial_hp_flappy_string_detail_programming_languages: Blocks, hyperPad Visual
+    Behaviours
+  tutorial_appytappin_string_detail_programming_languages: BitsBox
+  tutorial_icipher_string_detail_programming_languages: ''
+  tutorial_iguess_string_detail_programming_languages: ''
+  tutorial_imake_string_detail_programming_languages: Unplugged
+  tutorial_imorse_string_detail_programming_languages: Blocks
+  tutorial_kanohp_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_khanwebpages_string_detail_programming_languages: HTML/CSS
+  tutorial_kibobowl_string_detail_programming_languages: Blocks
+  tutorial_kibodance_string_detail_programming_languages: Blocks
+  tutorial_buildcharacters_string_detail_programming_languages: JavaScript, Language
+    independent (can be taught in multiple languages)
+  tutorial_designgames_string_detail_programming_languages: JavaScript, Language independent
+    (can be taught in multiple languages)
+  tutorial_makelevels_string_detail_programming_languages: JavaScript, Language independent
+    (can be taught in multiple languages)
+  tutorial_wizard_string_detail_programming_languages: JavaScript
+  tutorial_mbscratchcards_string_detail_programming_languages: Blocks
+  tutorial_mbswiftplaygrounds_string_detail_programming_languages: iOS/Swift
+  tutorial_mbbuttons_string_detail_programming_languages: Blocks
+  tutorial_meteor_string_detail_programming_languages: Blocks
+  tutorial_ballbounce_string_detail_programming_languages: Blocks
+  tutorial_mitcodi_string_detail_programming_languages: Blocks
+  tutorial_mitdoodle_string_detail_programming_languages: Blocks
+  tutorial_talktome_string_detail_programming_languages: Blocks
+  tutorial_mobilecspmap_string_detail_programming_languages: Blocks, App Inventor
+  tutorial_ozorandom_string_detail_programming_languages: Blocks
+  tutorial_ozotroll_string_detail_programming_languages: Blocks
+  tutorial_peblioart_string_detail_programming_languages: JavaScript
+  tutorial_astropi_string_detail_programming_languages: Python
+  tutorial_rgart_string_detail_programming_languages: Blocks
+  tutorial_rgengineer_string_detail_programming_languages: Blocks
+  tutorial_rgmath_string_detail_programming_languages: Blocks
+  tutorial_rgscience_string_detail_programming_languages: Blocks
+  tutorial_rgtech_string_detail_programming_languages: Blocks
+  tutorial_robotmagic3d_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_robotmagicflappy_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_scratchadventure_string_detail_programming_languages: Blocks
+  tutorial_scratchtalk_string_detail_programming_languages: Blocks
+  tutorial_scratchjrstory_string_detail_programming_languages: 'ScratchJr. '
+  tutorial_scratchjrtwinkle_string_detail_programming_languages: ScratchJr.
+  tutorial_spherocomm_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_spherocommunity_string_detail_programming_languages: Blocks, Draw
+  tutorial_spherofunctions_string_detail_programming_languages: JavaScript
+  tutorial_spheroinfrared_string_detail_programming_languages: Blocks
+  tutorial_spherolightsensor_string_detail_programming_languages: Blocks
+  tutorial_spheromansion_string_detail_programming_languages: Blocks
+  tutorial_roadblocks_string_detail_programming_languages: Blocks
+  tutorial_spherotext2_string_detail_programming_languages: JavaScript
+  tutorial_spherotext3_string_detail_programming_languages: JavaScript
+  tutorial_spherotext4_string_detail_programming_languages: JavaScript
+  tutorial_spheroraptor_string_detail_programming_languages: Blocks
+  tutorial_stempiday_string_detail_programming_languages: JavaScript
+  tutorial_stemplanetoids_string_detail_programming_languages: JavaScript
+  tutorial_stempong_string_detail_programming_languages: JavaScript
+  tutorial_algobot_string_detail_programming_languages: Language independent (can
+    be taught in multiple languages)
+  tutorial_thunkableapps_string_detail_programming_languages: Blocks
+  tutorial_toxicodedot_string_detail_programming_languages: Language independent (can
+    be taught in multiple languages)
+  tutorial_gcactions_string_detail_programming_languages: Blocks
+  tutorial_gccomparators_string_detail_programming_languages: Blocks
+  tutorial_gcconditions_string_detail_programming_languages: Blocks
+  tutorial_gccreate_string_detail_programming_languages: Blocks
+  tutorial_gcevents_string_detail_programming_languages: Blocks
+  tutorial_gcloops_string_detail_programming_languages: Blocks
+  tutorial_gcvariables_string_detail_programming_languages: Blocks
+  tutorial_beanything_string_detail_programming_languages: Blocks, Tynker
+  tutorial_change_string_detail_programming_languages: Blocks, Tynker
+  tutorial_cooking_string_detail_programming_languages: Blocks, Tynker
+  tutorial_crystal_string_detail_programming_languages: Blocks, Tynker
+  tutorial_landscape_string_detail_programming_languages: Python
+  tutorial_pets_string_detail_programming_languages: Blocks, Tynker
+  tutorial_petvet_string_detail_programming_languages: Blocks, JavaScript, Python,
+    Tynker
+  tutorial_superhero_string_detail_programming_languages: HTML, CSS
+  tutorial_vidcodeplastic_string_detail_programming_languages: JavaScript
+  tutorial_vidcodetypeface_string_detail_programming_languages: JavaScript
+  tutorial_washustorm_string_detail_programming_languages: Blocks
+  tutorial_activitypackets_string_detail_programming_languages: Blocks, Wonder, Xylo,
+    Blockly
+  tutorial_googlerookie_string_detail_programming_languages: Blocks
+  tutorial_tommyturtle_string_detail_programming_languages: Language independent
+  tutorial_mazyad_string_detail_programming_languages: Blocks
+  tutorial_gamemaker_string_detail_programming_languages: JavaScript
+  tutorial_duckrace_string_detail_programming_languages: Blocks
+  tutorial_allcancodeapps_string_detail_programming_languages: Blocks
+  tutorial_n2y_string_detail_programming_languages: Unplugged
+  tutorial_microsoftarcade_string_detail_programming_languages: Blocks
+  tutorial_csfirstunplugged_string_detail_programming_languages: Blocks, Unplugged,
+    Scratch
+  tutorial_toxicodepython_string_detail_programming_languages: Python
+  tutorial_codecombatozaria_string_detail_programming_languages: JavaScript, Python
+  tutorial_vidcodedate_string_detail_programming_languages: JavaScript
+  tutorial_codemonkeyspace_string_detail_programming_languages: CoffeeScript
+  tutorial_codespeakhappy_string_detail_programming_languages: Blocks
+  tutorial_grokimage_string_detail_programming_languages: Python
+  tutorial_icomputelearn_string_detail_programming_languages: Blocks, JavaScript,
+    Scratch
+  tutorial_rpstress_string_detail_programming_languages: Blocks
+  tutorial_bsdcause_string_detail_programming_languages: JavaScript, HTML, CSS
+  tutorial_vidcodeanimoji_string_detail_programming_languages: JavaScript
+  tutorial_vidcodeanimojies_string_detail_programming_languages: JavaScript
+  tutorial_bsdinspire_string_detail_programming_languages: JavaScript, HTML, CSS
+  tutorial_tttractor_string_detail_programming_languages: JavaScript
+  tutorial_codeillusionmickey_string_detail_programming_languages: JavaScript
+  tutorial_scigirlsquest_string_detail_programming_languages: Blocks
+  tutorial_codespeakbreathe_string_detail_programming_languages: Blocks
+  tutorial_vidcodeface_string_detail_programming_languages: JavaScript
+  tutorial_educodemaze_string_detail_programming_languages: JavaScript
+  tutorial_educoderace_string_detail_programming_languages: JavaScript
+  tutorial_codespeakchatbot_string_detail_programming_languages: Blocks
+  tutorial_gamefrootgames_string_detail_programming_languages: Blocks
+  tutorial_codespeakgrandparent_string_detail_programming_languages: Blocks
+  tutorial_educodekingdom_string_detail_programming_languages: JavaScript
+  tutorial_codehsdata_string_detail_programming_languages: JavaScript
+  tutorial_educodecake_string_detail_programming_languages: HTML + CSS
+  tutorial_ttsecond_string_detail_programming_languages: JavaScript
+  tutorial_bsdtrivia_string_detail_programming_languages: JavaScript, HTML, CSS
+  tutorial_csfirstdialogue_string_detail_programming_languages: Blocks, Scratch
+  tutorial_codemonkeybeaver_string_detail_programming_languages: Blocks
+  tutorial_codestersdistance_string_detail_programming_languages: Python
+  tutorial_itchspace_string_detail_programming_languages: Blocks
+  tutorial_vidcodemagic_string_detail_programming_languages: JavaScript
+  tutorial_vidcodemagices_string_detail_programming_languages: JavaScript
+  tutorial_codespeakmeal_string_detail_programming_languages: JavaScript
+  tutorial_itchfish_string_detail_programming_languages: Blocks
+  tutorial_bsdwebsite_string_detail_programming_languages: JavaScript, HTML, CSS
+  tutorial_codespeaktime_string_detail_programming_languages: Blocks
+  tutorial_itchwebcam_string_detail_programming_languages: Blocks
+  tutorial_itchball_string_detail_programming_languages: Blocks
+  tutorial_ttrace_string_detail_programming_languages: JavaScript, CoffeeScript
+  tutorial_plethora_string_detail_programming_languages: Language independent (can
+    be taught in multiple languages)
+  tutorial_educodesecret_string_detail_programming_languages: Python
+  tutorial_itchshapes_string_detail_programming_languages: Blocks
+  tutorial_codeguppytext_string_detail_programming_languages: JavaScript
+  tutorial_vidcodeplastiche_string_detail_programming_languages: JavaScript
+  tutorial_educativechatbot_string_detail_programming_languages: Python
+  tutorial_educodebasics_string_detail_programming_languages: JavaScript
+  tutorial_codehsdesign_string_detail_programming_languages: HTML
+  tutorial_htmlacademyphp_string_detail_programming_languages: PHP
+  tutorial_gamefrootdistance_string_detail_programming_languages: Blocks
+  tutorial_codesterscovid_string_detail_programming_languages: Python
+  tutorial_ttbunker_string_detail_programming_languages: JavaScript
+  tutorial_cuttle_string_detail_programming_languages: Blocks, Language independent
+    (can be taught in multiple languages)
+  tutorial_bsdjokes_string_detail_programming_languages: JavaScript, HTML, CSS
+  tutorial_rptree_string_detail_programming_languages: Blocks
+  tutorial_codestersunity_string_detail_programming_languages: Python
+  tutorial_codesterssoccer_string_detail_programming_languages: Python
+  tutorial_breakoutlock_string_detail_programming_languages: Blocks, Language independent
+    (can be taught in multiple languages)
+  tutorial_thunkablemask_string_detail_programming_languages: Blocks
+  tutorial_cafarming_string_detail_programming_languages: Theory course on impacts
+    of computing.
+  tutorial_blocksmithyeti_string_detail_programming_languages: JavaScript
+  tutorial_codecapture_string_detail_programming_languages: JavaScript
+  tutorial_codehslitter_string_detail_programming_languages: Python, HTML
+  tutorial_bsdocean_string_detail_programming_languages: JavaScript, HTML, CSS
+  tutorial_itchplatformer_string_detail_programming_languages: Blocks
+  tutorial_codejika_string_detail_programming_languages: JavaScript, HTML, CSS
+  tutorial_gamefrootclicker_string_detail_programming_languages: Blocks
+  tutorial_rmagicequity_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_ttfreestyle_string_detail_programming_languages: JavaScript
+  tutorial_ozobotcolor2_string_detail_programming_languages: Ozobot Color Codes
+  tutorial_ozobotcolor3_string_detail_programming_languages: Ozobot Color Codes
+  tutorial_clcarbon_string_detail_programming_languages: Python
+  tutorial_kodablebasics_string_detail_programming_languages: Blocks, JavaScript,
+    Language independent (can be taught in multiple languages)
+  tutorial_scigirlscc_string_detail_programming_languages: Language independent (can
+    be taught in multiple languages)
+  tutorial_irobotpicture_string_detail_programming_languages: No specific programming
+    languages required; unplugged decoding activity with words/phrases
+  tutorial_kcjmyself_string_detail_programming_languages: Blocks
+  tutorial_nearpodalgorithms_string_detail_programming_languages: Language independent
+    (can be taught in multiple languages)
+  tutorial_kibodrop_string_detail_programming_languages: Blocks
+  tutorial_ozobotcolor1_string_detail_programming_languages: Ozobot Line Following
+    and Color Codes
+  tutorial_scigirlspixels_string_detail_programming_languages: Language independent
+    (can be taught in multiple languages)
+  tutorial_kcjheroines_string_detail_programming_languages: Blocks
+  tutorial_ozobotvalue_string_detail_programming_languages: Ozobot Color Codes
+  tutorial_icodebytes_string_detail_programming_languages: Language independent (can
+    be taught in multiple languages)
+  tutorial_clfashion2_string_detail_programming_languages: SQL
+  tutorial_ai4all_string_detail_programming_languages: Language independent (can be
+    taught in multiple languages)
+  tutorial_cldata_string_detail_programming_languages: Language independent (can be
+    taught in multiple languages)
+  tutorial_spheroinputs_string_detail_programming_languages: Blocks
+  tutorial_edisoncount_string_detail_programming_languages: Blocks
+  tutorial_spheroloops_string_detail_programming_languages: Blocks
+  tutorial_kiboprogram_string_detail_programming_languages: Blocks
+  tutorial_hellorubycsin60_string_detail_programming_languages: Language independent
+    (can be taught in multiple languages)
+  tutorial_clfashion1_string_detail_programming_languages: SQL
+  tutorial_irobottraffic_string_detail_programming_languages: Blocks, iOS/Swift
+  tutorial_edisonmystery_string_detail_programming_languages: Blocks
+  tutorial_microbitseaturtles_string_detail_programming_languages: Blocks, JavaScript,
+    Python
+  tutorial_ozobotknow_string_detail_programming_languages: Language independent (can
+    be taught in multiple languages)
+  tutorial_imagilabs_string_detail_programming_languages: Python
+  tutorial_irobotsimulator_string_detail_programming_languages: Blocks
+  tutorial_irobotkind_string_detail_programming_languages: Blocks
+  tutorial_firiavirtual_string_detail_programming_languages: Python
+  tutorial_irobotguesscode_string_detail_programming_languages: Blocks, iOS/Swift
+  tutorial_ozobotnouns_string_detail_programming_languages: Ozobot Color Codes
+  tutorial_nasa3d_string_detail_programming_languages: Tinkercad Codeblocks
+  tutorial_blupants_string_detail_programming_languages: Blocks, Python
+  tutorial_legodance_string_detail_programming_languages: Blocks
+  tutorial_nearpodcoding_string_detail_programming_languages: Language independent
+    (can be taught in multiple languages)
+  tutorial_kcjplastic_string_detail_programming_languages: Blocks, Also has use of
+    a spreadsheet.
+  tutorial_legojourney_string_detail_programming_languages: Blocks
+  tutorial_legohopper_string_detail_programming_languages: Blocks
+  tutorial_catrobatembroidery_string_detail_programming_languages: Blocks
+  tutorial_irobotphone_string_detail_programming_languages: Blocks, iOS/Swift
+  tutorial_codeguppydraw_string_detail_programming_languages: JavaScript
+  tutorial_codejumper_string_detail_programming_languages: Unplugged
+  tutorial_meeempathy_string_detail_programming_languages: Blocks, Python
+  tutorial_scratchimagine_name: Imagine a World
+  tutorial_codesterspsa_name: 'Codesters: Code Your Own PSA'
+  tutorial_googlehero_name: Code Your Hero
+  tutorial_codestersbball_name: 'Codesters: Basketball'
+  tutorial_scratchcartoon_name: Code a Cartoon
+  tutorial_codemonkeyjr_name: 'CodeMonkey Jr.: Pre-coding for Preschoolers'
+  tutorial_bananatales_name: 'Banana Tales: Python Coding Game'
+  tutorial_scratchtales_name: Talking Tales
+  tutorial_msemoji_name: Quick Draw Emoji with Machine Learning
+  tutorial_cacolor_name: Professor Photon's Color Conundrum
+  tutorial_kodablebeach_name: Beach Cleanup with Kodable
+  tutorial_tynkeren_name: Affordable and Clean Energy
+  tutorial_tynkerjavapro_name: Responsible Consumption and Production (JavaScript)
+  tutorial_grasshopperhack_name: Hack a Game
+  tutorial_pbskids_name: PBS KIDS Scratch Jr
+  tutorial_nclabdata_name: Data Power!
+  tutorial_grasshopperphoto_name: Filter a Photo
+  tutorial_tynkerpyland_name: Life on Land (Python)
+  tutorial_codeitimages_name: Code it! - Images and Animations
+  tutorial_hyperpadenemy_name: Create a Smarter Enemy AI in hyperPad
+  tutorial_tynkerpro_name: Responsible Consumption and Production
+  tutorial_trashtag_name: 'Eco Warriors #Trashtag'
+  tutorial_casiege_name: Security Siege
+  tutorial_thunkableyeet_name: 'Let''s Get This Bread: Learn How to Build Two Apps'
+  tutorial_vidcodedeal_name: 'Vidcode: Deal With It'
+  tutorial_codehsgeno_name: Exploring Genotypes with Code
+  tutorial_hyperpadpong_name: Making a Pong Game in hyperPad
+  tutorial_tynkerland_name: Life on Land
+  tutorial_trinketgirl_name: 'Code Like a Girl: A Storyteller'
+  tutorial_rpimosquito_name: Mosquito patrol
+  tutorial_tynkermars_name: NASA Moon 2 Mars
+  tutorial_cityx_name: 'Coding Galaxy: City X'
+  tutorial_vidcodemap_name: 'Vidcode: Map Your Community'
+  tutorial_robotmagicfarm_name: 'FarmBot: Plant with Code'
+  tutorial_codehstriangle_name: Triangle Computations with CodeHS
+  tutorial_ttwhitehouse_name: White House
+  tutorial_modulo_name: 'Modulo Code: Code E.D.'
+  tutorial_codingtown_name: Coding Town
+  tutorial_kanoart_name: Art Playground
+  tutorial_dragonscript_name: 'DragonScript Arena: a Javascript coding game with Dragons'
+  tutorial_uwcloud_name: Cloud Constructor
+  tutorial_htmlmuffin_name: Master the Web with Muffin the Cat
+  tutorial_microsoftpizza_name: Chase the Pizza!
+  tutorial_stemc_blckhole_name: Escape Velocity and Black Holes!
+  tutorial_careconfigure_name: ReconFigure of Speech
+  tutorial_rpiscratch_name: Scratch 3.0 phrasebook
+  tutorial_ozaria_name: Ozaria by CodeCombat
+  tutorial_ttovum_name: Ovun City
+  tutorial_ttpassage_name: The Passage
+  tutorial_tynkerhtmlen_name: Affordable and Clean Energy (HTML)
+  tutorial_ttfrog_name: Frog Squash
+  tutorial_codemojijava_name: Learn Basic Java
+  tutorial_ccfirewall_name: Firewall
+  tutorial_htmljs_name: 'Intro to JavaScript: from variables to your first program'
+  tutorial_ttaqueducts_name: Aqueducts
+  tutorial_vtgame_name: 'Game Changineer: Create with English'
+  tutorial_baroborav_name: Robot Autonomous Vehicle
+  tutorial_baroboobstacle_name: Linkbot Obstacle Course
+  tutorial_pbstorytelling_name: Interactive Storytelling
+  tutorial_kibosnow_name: KIBO Snowplow - Important Jobs in the Community
+  tutorial_kibohappy_name: Expressing Happiness with KIBO
+  tutorial_rubylove_name: 'Hello Ruby: Love Letters for Computers'
+  tutorial_spherosmiles_name: Super Smiles
+  tutorial_spherobaby_name: Sphero Baby Steps
+  tutorial_toxarchitect_name: Utopian Architect
+  tutorial_idodge_name: Ice Cream Dodge
+  tutorial_firiacodebot_name: Intro to Python with CodeBot
+  tutorial_modlighthouse_name: Lighthouse Design Challenge with Cubelets
+  tutorial_spherogreen_name: Sphero Goes Green
+  tutorial_ozopopstar_name: PopStar|Creating Functions With OzoBlockly
+  tutorial_eddesign_name: Edison the designer
+  tutorial_edshapeup_name: Robot shape-up with Edison
+  tutorial_ozocolor_name: Pop Star|Creating Functions With Ozobot Color Codes
+  tutorial_icomputeeggs_name: iHide Eggs
+  tutorial_rootunplugged_name: iRobot Code Break
+  tutorial_rgtreasure_name: RoboGarden Puzzles - Robo Treasure Chest
+  tutorial_peblioportraits_name: 'Computational Portraiture: Art for Good '
+  tutorial_rootcodebreak_name: iRobot Code Break with Root
+  tutorial_microbit14_name: 'micro:bit: coding towards Global Goal 14, Life Below
+    Water'
+  tutorial_barobomoon_name: Moon Base SOS with Arduino
+  tutorial_eddog_name: Code a guard dog with Edison
+  tutorial_microbit15_name: 'micro:bit: coding towards Global Goal 15, Life on Land'
+  tutorial_unity_name: 'Unity Game Development Creator Kit: Beginner Code'
+  tutorial_blockscadtarget_name: BlocksCAD Transformation Target Practice
+  tutorial_tcadicicles_name: Designing Icicles With Codeblocks in Tinkercad
+  tutorial_blockscadscale_name: BlocksCAD Scale City
+  tutorial_tcadloops_name: Using Loops in Tinkercad to Design a Bursting Star
+  tutorial_phidgets_name: A Phidgets Theremin with Processing
+  tutorial_modvariables_name: Investigating Variables & Block Values using Cubelets
+  tutorial_codestersmicro_name: 'Codesters: Create a Micro Ball Game'
+  tutorial_codestersdata_name: 'Codesters: Code & Graph micro:bit Data'
+  tutorial_ikodexmas_name: iKode Xmas
+  tutorial_rpisensehat_name: Sense HAT data logger
+  tutorial_mee_name: 'Minecraft Hour of Code: AI for Good'
+  tutorial_kuborobo_name: KUBO Robotics Coding Routes
+  tutorial_ai-oceans_name: AI for Oceans
+  tutorial_scratchimagine_longdescription: Imagine a world where anything is possible,
+    then bring it to life with Scratch!
+  tutorial_codesterspsa_longdescription: Learn the basics of coding in Python while
+    creating your own Public Service Announcement. Choose a topic you find important
+    and design you own animated or interactive PSA to share critical information about
+    how to make a positive impact on the world.
+  tutorial_googlehero_longdescription: Turn an everyday hero from your life or community
+    into a superhero by programming them to fly over buildings, spin, work with a
+    sidekick, and score points by touching objects in a game. In Code Your Hero, show
+    off your hero's special powers and your own creativity with CS First and Scratch.
+  tutorial_codestersbball_longdescription: Learn the basics of coding in Python while
+    creating your own Basketball game. You'll learn how to add backgrounds and sprites,
+    and how to use events to control the motion of sprites on the stage.
+  tutorial_scratchcartoon_longdescription: Bring some of your favorite Cartoon Network
+    characters to life by coding your own animation. Add more characters and make
+    them jump, fly, and talk.
+  tutorial_codemonkeyjr_longdescription: In a world filled with captivating creatures
+    and bright colors, 4-6 year olds will join a monkey on a mission to collect bananas
+    and unlock treasure chests. All the while, they will explore and learn the basics
+    of code as they use blocks to program a monkey's journey through the world.
+  tutorial_bananatales_longdescription: Teach Python by helping a baby monkey. Twin
+    baby monkeys were separated by an earthquake - leaving one of the monkeys with
+    no way to get bananas! Now, it is up to your students to use code to rebuild the
+    path and feed the baby monkey.
+  tutorial_scratchtales_longdescription: Take characters on a journey and have them
+    speak aloud using Text-to-Speech blocks powered by Amazon. Choose a voice for
+    each character, then type what you want to say. Make your story interactive by
+    coding your characters to ask questions and travel to different scenes. Experiment
+    with creative new ways of making stories come alive!
+  tutorial_msemoji_longdescription: Build a live interactive website that uses a Machine
+    Learning model to recognize your and your friends' hand-drawn emojis! Along the
+    way you'll get hands-on practice with core concepts of Machine Learning - 1) gathering
+    data, 2) cleaning and formatting the data, 3) training the model, and 4) using
+    the trained model to make predictions.
+  tutorial_cacolor_longdescription: Professor Photon is a highly regarded physicist
+    gone rogue. She has eliminated color from all digital devices! In this Escape
+    Room style project, the learner joins Marlee and Tyrell as they learn about binary
+    numbers, light, color, and more to unravel Professor Photon's Color Conundrum,
+    and restore color to the world's devices.
+  tutorial_kodablebeach_longdescription: Save the beach babies! Learn to program using
+    basic commands and clean up the beach to protect ocean life.
+  tutorial_tynkeren_longdescription: 'Part of the UN Sustainable Development Goals
+    project, this coding prompt shows off projects exploring renewable energy, energy
+    efficiency, and access to energy. Readers can play with working projects and advanced
+    programmers can create their own original projects. '
+  tutorial_tynkerjavapro_longdescription: 'Part of the UN Sustainable Development
+    Goals project, this coding prompt shows off a short project exploring recycling
+    and reuse. Readers can create their own game by expanding the project. '
+  tutorial_grasshopperhack_longdescription: Learn coding skills to hack this game
+    to make it possible to play.
+  tutorial_pbskids_longdescription: With PBS KIDS Scratch Jr, kids can create their
+    own interactive stories and games through programming games and lessons. Learn
+    to code through games and activities featuring characters from Odd Squad, Wild
+    Kratts, Nature Cat, Arthur, WordGirl, Peg + Cat, and Ready Jet Go! The storytelling
+    possibilities are endless with this creative coding app for children ages 5-8.
+  tutorial_nclabdata_longdescription: The world thrives on good data! In this hands-on
+    NCLab tutorial, you will write simple queries, the first step in data analysis.
+    Get acquainted with the power of the PostgreSQL language, used by governments
+    and businesses to manage database systems all over the world. PostgreSQL is written
+    in plain English and is easy to learn. Try it out!
+  tutorial_grasshopperphoto_longdescription: Learn coding skills to create filters
+    to apply to different photos.
+  tutorial_tynkerpyland_longdescription: 'Part of the UN Sustainable Development Goals
+    project, this Python project will have you create your own tree-planting game. '
+  tutorial_codeitimages_longdescription: Learn to program your own amazing images
+    and animations.
+  tutorial_hyperpadenemy_longdescription: 'Learn logical thinking and programming
+    by creating a platformer game enemy AI. '
+  tutorial_tynkerpro_longdescription: 'Part of the UN Sustainable Development Goals
+    project, this coding prompt shows off projects exploring issues surrounding recycling
+    and reuse. Beginners can play with working projects and advanced programmers can
+    create their own projects from scratch. '
+  tutorial_trashtag_longdescription: 'Code your own game and raise awareness for protecting
+    our environment. '
+  tutorial_casiege_longdescription: Join Niko and Sakura on their virtual reality
+    journey to Tubrosos Castle. Learn what it's like to be a gray hat hacker by helping
+    the wizard elf, Cyrena find the Crown of Knowledge. You will expose the poor security
+    systems used at the castle and learn how to avoid becoming the victim of a scam.
+  tutorial_thunkableyeet_longdescription: Learn how to build two apps that will help
+    your city! Yeet!
+  tutorial_vidcodedeal_longdescription: Start coding for good by creating animations
+    featuring notable women leaders and quotes that express their point of view.
+  tutorial_codehsgeno_longdescription: In this hour of code, students will create
+    a program that will solve for allele pairs based on user input. Students will
+    program with Tracy the Turtle in Python to make this happen. Students should have
+    prior knowledge of basic biology concepts and Punnett Squares before beginning
+    this activity.
+  tutorial_hyperpadpong_longdescription: 'Learn to program a pong game with a smart
+    AI opponent. '
+  tutorial_tynkerland_longdescription: 'Part of the UN Sustainable Development Goals
+    project, this coding prompt shows off projects exploring the importance of forests
+    to the world''s ecosystem. Readers can play with working projects and advanced
+    programmers can create their own original projects. '
+  tutorial_trinketgirl_longdescription: Learn to program a big story using Python,
+    and then change it up to create your own story!
+  tutorial_rpimosquito_longdescription: Make a game where you protect people from
+    malaria by making a parrot catch mosquitoes.
+  tutorial_tynkermars_longdescription: Explore NASA's exciting new efforts to reach
+    the Moon and then Mars. Students can design their own animated mission patch,
+    imagine their life as an Artemis astronaut on the Lunar Gateway, and more. Beginners
+    can try step-by-step tutorials, while experienced programmers can create their
+    own original projects with block or text coding.
+  tutorial_cityx_longdescription: Your first quest in City X is to help an old farmer
+    to manage his farm. Let's solve his problem with innovative technology! You will
+    learn the basic concept of watering system and make a gardening robot with incredible
+    fun! Students will apply design thinking concepts to investigate problems while
+    developing their technological awareness, thereby honing their high-level thinking
+    skills.
+  tutorial_vidcodemap_longdescription: Collect and analyze data for community engagement,
+    by coding your own community map!
+  tutorial_robotmagicfarm_longdescription: Code the FarmBot to plant seeds. Start
+    planting simple fields then add complexity.  Finish by growing art of your own
+    design.
+  tutorial_codehstriangle_longdescription: In this hour of code, we'll explore how
+    to create a simulator that will calculate the area of a triangle with dimensions
+    chosen by a user. We'll program with Tracy the Turtle in Python to make this happen.
+    Students should have prior knowledge of basic geometry concepts before beginning
+    this activity.
+  tutorial_ttwhitehouse_longdescription: In this colorful adventure, restore color
+    to a white world through a self-guided first person game. Solve puzzles and complete
+    challenges in order to advance the game and your coding knowledge. After completion,
+    players will be familiarized with color hex values and CSS attributes and comfortable
+    enough to recognize them in real world applications. Don't be afraid to share
+    your creations.
+  tutorial_modulo_longdescription: Out in the deepest of space, the Exploratory Databot,
+    known as E.D. has just discovered a new habitable planet for humankind! Who knows
+    what surprises lay ahead on this remote sandy planet? Unexpectedly while landing,
+    E.D. gets a shock to its motherboard wiping out all its programs. It's up to you
+    to program E.D. to help it through this strange alien's terrain. Are you up for
+    the challenge?
+  tutorial_codingtown_longdescription: Build your own business, code and have fun.
+  tutorial_kanoart_longdescription: Use block code to draw a scene, then bring it
+    to life with animation and mouse interaction. Code your own paintbrushes, add
+    stickers, and get creative!
+  tutorial_dragonscript_longdescription: Welcome to DragonScript Arena – the programming
+    strategy game and coding club. Level up your Javascript & Software Engineering
+    as you play! Build your own Dragon A.I. Imagine Battlebots but with robot Dragons.
+  tutorial_uwcloud_longdescription: Learn the basics of cloud computing by building
+    your own cloud! Build servers, upgrade them, and connect clients to keep up with
+    network demand. Play the role of a Cloud Architect in this interactive game and
+    test your skills in the endless mode.
+  tutorial_htmlmuffin_longdescription: Get ready for a fun and exciting adventure
+    with Muffin the Cat, who will guide you through the basics of HTML and CSS. Together
+    you will make your first landing page and understand the main principles of a
+    website layout.
+  tutorial_microsoftpizza_longdescription: Create a simple Arcade game where your
+    player eats as much pizza as you can before the time runs out!
+  tutorial_stemc_blckhole_longdescription: Did you see the images of the black hole
+    that were released in Spring 2019? Do you want to know more about black holes
+    and how to escape from them? Check out this coding activity on how fast you need
+    to go to escape from a gravitational field and what happens when not even light
+    can escape!
+  tutorial_careconfigure_longdescription: Our story-telling app retells a fairytale,
+    with weird and funny results! But the program is poorly written. Writing good
+    code is vital. Help refine this app into something amazing. Look at word classes
+    in English, and use variables, consonants, lists, and functions to reconfigure
+    this program. If you have written a program before and want some style, this is
+    for you.
+  tutorial_rpiscratch_longdescription: Create an interactive phrasebook that translates
+    useful phrases into different languages.
+  tutorial_ozaria_longdescription: Customize your hero and journey to the Sky Mountain
+    where you learn to type real code, navigate through 15 game levels, and make your
+    own game in order to help save the world of Ozaria.
+  tutorial_ttovum_longdescription: Can you control the chaos? Hack your way into the
+    cyberpunk world of Ovun City. Debug broken code, solve puzzles, and upgrade your
+    hardware as you explore self guided open world. Don't get caught by the drones!
+    It's up to you how Ovun City evolves.
+  tutorial_ttpassage_longdescription: Immerse yourself in an alien world to help Ada
+    escape unknown dangers. Play through this 2D platforming self-guided adventure
+    and learn coding techniques along the way. Players will become familiar with coding
+    techniques and syntax as they solve puzzles, fight monsters and beat the final
+    boss. Some previous familiarity with JavaScript might be useful but isn't required.
+  tutorial_tynkerhtmlen_longdescription: 'Part of the UN Sustainable Development Goals
+    project, this coding project has you create your own webpage exploring renewable
+    energy, energy efficiency, and access to energy. Design your own page showcasing
+    sustainability issues! '
+  tutorial_ttfrog_longdescription: Nostalgia turns educational in this familiar game
+    with a new twist! In an easy-to-understand and self-guided game, you will use
+    codeblocks and programming concepts to help your frog friend safely cross the
+    treacherous lands. Perfect for beginners and experts alike!
+  tutorial_codemojijava_longdescription: This activity introduces students to the
+    basics of Java programming using the Codemoji Terminal. Students learn everything
+    from basic types and variables to functions. Each lesson features an in depth
+    explanation of what each line of code does in order to ensure the students understand
+    what is happening. Each line of code in the lesson is guided for student success.
+  tutorial_ccfirewall_longdescription: Learn how to program your own shareable game!
+    Use code to teach a Hero magic spells to defeat waves and waves of baddies.
+  tutorial_htmljs_longdescription: Meet your new boss, Muffin the Cat, who is getting
+    ready for a CatFashion Expo. He needs a program to track the calories and is asking
+    you to help. In this fun and engaging activity, you will learn the basics of JavaScript
+    by looking at variables, operations, and data types and write MufFit – your first
+    program in JavaScript.
+  tutorial_ttaqueducts_longdescription: In this puzzle game, you're the hero bringing
+    water back to your village! Make your way through the levels in this self-guided
+    isometric experience. Levels will start simple, exposing players to basic coding
+    fundamentals. As you play, you will learn more complex coding techniques. Afterwards,
+    design and build your own levels and puzzles to share.
+  tutorial_vtgame_longdescription: Introduction to computational thinking and programming
+    video games in English. Create your video game in just minutes. Computing concepts
+    of abstraction, object-oriented design, algorithmic thinking, problem solving,
+    debugging, and critical thinking are incorporated. Target students are Grades
+    5 through 12. No prior programming experience necessary.
+  tutorial_baroborav_longdescription: Guide Linkbot as a robotic autonomous vehicle
+    (RAV) through a grid of streets! Students will learn to control a Linkbot robot
+    (virtual or hardware) using a drag-and-drop interface. They will also learn about
+    the important concept of loops and get practice using the Pythagorean theorem
+    to traverse triangular paths.
+  tutorial_baroboobstacle_longdescription: This series of 6 activities will introduce
+    students to basic coding and robotics concepts by using a drag-and-drop interface
+    to maneuver Linkbot robots (virtual and/or hardware) through a variety of obstacle
+    courses.
+  tutorial_pbstorytelling_longdescription: Dive into the world of interactive storytelling.
+    Learn the basics of how to create a story in Twine. Examine different story patterns
+    and structures that are unique to interactive stories. See some ways that interactive
+    storytelling differs from traditional creative writing.
+  tutorial_kibosnow_longdescription: 'The city is covered in snow, and we need to
+    design a KIBO snowplow to help clean up! Students will engage in the engineering
+    design process as they design, test, and improve snowplow robots that can help
+    clean up the cotton-ball snow. Students will also learn more about the many important
+    jobs that make a community function. '
+  tutorial_kibohappy_longdescription: If you're happy and you know it flash your light!
+    In this robotics lesson that also engages with music and social-emotional learning,
+    students collaboratively create a program for KIBO including both input and output
+    that expresses a feeling of happiness. Students learn that robots have output
+    parts that allow them to send information out into the world.
+  tutorial_rubylove_longdescription: 'Love Letters for Computers is a 10 part YouTube
+    series with classroom materials, to help primary school teachers to make computer
+    science more playful, whimsical and gentle for children. '
+  tutorial_spherosmiles_longdescription: Did you know a smile has super powers?! Program
+    your Sphero BOLT to brighten someone's day.
+  tutorial_spherobaby_longdescription: Learn to program "baby steps" to help teach
+    a friend to code.
+  tutorial_toxarchitect_longdescription: Code your builder robot in order to create
+    buildings and landscapes. Utopian Architect is a sandbox designed to facilitate
+    the discovery and the learning of the concept of function. Join us through our
+    activities that quickly raise questions related to the architecture of a program,
+    to the art of organizing thoughts and knowing how to break down big problems into
+    smaller problems.
+  tutorial_idodge_longdescription: This activity, adapted for the Hour of Code, develops
+    children's programming skills by creating apps using text - a simplified JavaScript
+    language. Using the PRIMM approach for teaching programming, the children explore
+    programs and use their computational thinking skills to problem solve, modify
+    and design/develop apps.
+  tutorial_firiacodebot_longdescription: Python fits your brain! Even if you've never
+    used a text-based language before, this activity will teach you everything you
+    need to get your Robot moving, lighting up, and responding to user inputs. CodeBot
+    is a revolutionary platform for authentic real-world coding, combining a real
+    programming language with powerful hardware. Your CODE is in complete control
+    of all the robot's functions!
+  tutorial_modlighthouse_longdescription: 'Students design a lighthouse based on design
+    criteria and constraints.  Then students iterate on that design to make it automatic,
+    and to customize its message. '
+  tutorial_spherogreen_longdescription: 'Learn how to use a counting number variable
+    to keep track of all your classrooms recycling. '
+  tutorial_ozopopstar_longdescription: 'Students will write and call functions, and
+    execute them with the Ozobot. This is the second of two lessons. '
+  tutorial_eddesign_longdescription: Introduce the key computational concepts of loops,
+    nested loops and sequential order using Edison robots and the Scratch-based programming
+    language EdScratch. Students can work through this lesson independently focusing
+    on the idea of patterns, including geometric shapes, and exploring how loops can
+    be used in programs which contain repeating code.
+  tutorial_edshapeup_longdescription: Introduce the key computational concepts of
+    definite loops and variables using Edison robots and EdPy, a text-based programming
+    language based on Python. Students can work through this lesson independently
+    as they practice using definite loops and pattern recognition in order to drive
+    familiar regular polygons before taking on the challenge of less common regular
+    polygons and irregular shapes.
+  tutorial_ozocolor_longdescription: 'Students will be introduced to the concept of
+    functions by using color codes to represent a function. This lesson is an introductory
+    and unplugged lesson to introduce the concept of functions. It is the first lesson
+    of a two lesson series, but either lesson can be taught in isolation. The second
+    lesson utilizes OzoBlockly to build on the concept of functions. '
+  tutorial_icomputeeggs_longdescription: This teacher-led activity, adapted for the
+    Hour of Code, provides pupils with an opportunity to explore physical programming
+    through robotics. Using a drag-and-drop programming environment and a programmable
+    robotic sphere, pupils design algorithms to program a robot to hide Easter eggs.
+    Includes step-by-step lesson plan, teacher/pupil resources and assessment guidance.
+  tutorial_rootunplugged_longdescription: Solve offline printable puzzles using the
+    power of programming, math and more to crack the code to where the Root Robot
+    is hiding!
+  tutorial_rgtreasure_longdescription: Robo Treasure Chest is an unplugged activity
+    that teaches students computational thinking and programming fundamentals in an
+    easy and enjoyable way. Students will learn simple movement commands and new programming
+    expressions like 'Bug' and 'Debug'. This activity also teaches multi-label scenarios
+    concept.
+  tutorial_peblioportraits_longdescription: 'Learn to program animated portraits for
+    a cause you believe in. '
+  tutorial_rootcodebreak_longdescription: Use your Root Robot and the Root Coding
+    app to power through printable puzzles and challenges to crack the code to where
+    Root is hiding.
+  tutorial_microbit14_longdescription: Code your way to preserving the oceans using
+    micro:bit. Find out more about Global Goal 14, Life Below Water and learn to code
+    a sea turtle beach light.
+  tutorial_barobomoon_longdescription: You're one of the pioneer astronauts at the
+    first permanent moon base, and while on an expedition away from base, a malfunction
+    incapacitates your lunar rover and radio. But with a little ingenuity you can
+    create a light-signaling device using an Arduino microcontroller, an LED, and
+    drag-and-drop coding to send an SOS.
+  tutorial_eddog_longdescription: Introduce the key computational concepts of loops
+    and conditionals using Edison robots and the programming language EdBlocks. Students
+    can work through this lesson independently, utilizing the Edison robot's IR light
+    sensors while applying sequential programming and decomposition to a set of progressive
+    programming challenges, exploring how robots can sense and react to the world.
+  tutorial_microbit15_longdescription: Code your way to protecting local wildlife
+    using micro:bit. Find out more about Global Goal 15, Life on Land and learn to
+    code a wildlife species counter.
+  tutorial_unity_longdescription: Create a real video game using C# computer code
+    and Unity, a professional platform for game development! All activity assets and
+    step-by-step tutorials are included. This project can be either teacher-led or
+    student-guided. For efficiency, we recommend that students complete one of the
+    preceding no-code Unity Creator Kits to learn the Unity interface prior to this
+    activity.
+  tutorial_blockscadtarget_longdescription: Test your target-hitting abilities by
+    writing code to move triangles around in three dimensions!
+  tutorial_tcadicicles_longdescription: Combine the power of code and computer-aided
+    design (CAD) to create a 3D icicle design. Then, learn how to print your design
+    if you have access to a 3D printer!
+  tutorial_blockscadscale_longdescription: Write code to create and 3D print scale
+    models of the world's most famous buildings!
+  tutorial_tcadloops_longdescription: Learn how code and computer-aided design (CAD)
+    can be combined to create a 3D model of a bursting star.
+  tutorial_phidgets_longdescription: Create an awesome musical instrument with Phidgets
+    and Processing!
+  tutorial_modvariables_longdescription: 'Students investigate how data flows through
+    a network using Cubelets robot blocks. This lesson assumes students are already
+    familiar with how Cubelets robot blocks work in general.  Visit modrobotics.com/thehub
+    for free "Meet Your Cubelets" lessons to introduce this computational thinking
+    tool to your students. '
+  tutorial_codestersmicro_longdescription: Connect your micro:bit to Codesters and
+    unlock a world of possibilities. Use your micro:bit as a game controller to help
+    your player head a soccer ball. Don't let the ball hit the ground! Micro Ball
+    is a simple, fun game that even a beginning coder can make.
+  tutorial_codestersdata_longdescription: Connect your micro:bit to Codesters and
+    unlock a world of possibilities. Learn how to collect and store data from micro:bit
+    sensors. Then graph the data as a scatter plot in Codesters. Prior knowledge of
+    loops, lists, and events is encouraged.
+  tutorial_ikodexmas_longdescription: This teacher-led activity, adapted for the Hour
+    of Code, introduces children to using a tile-based programming language to develop
+    coding skills. The children use algorithms, programming and computational thinking
+    skills to program Kodu to deliver presents on Christmas Eve. Includes step-by-step
+    lesson plan, pupil tutorial and assessment guidance.
+  tutorial_rpisensehat_longdescription: Learn how use the Sense HAT hardware to build
+    a data-logging device which can capture a range of information about its immediate
+    environment.
+  tutorial_mee_longdescription: Program the Minecraft Agent to collect data about
+    forest fires. Then write code to help prevent the spread of fire, save the village,
+    and bring life back to the forest. Learn coding basics and explore a real-world
+    example of artificial intelligence.
+  tutorial_kuborobo_longdescription: In this activity, students put their logic and
+    sequencing skills to the test as they use the Tagtiles to program their KUBO robot
+    to travel to various locations on a printed map.
+  tutorial_ai-oceans_longdescription: Computer science is about so much more than
+    coding! Learn about AI, machine learning, training data, and bias, while exploring
+    ethical issues and how AI can be used to address world problems.
+  tutorial_scratchimagine_string_detail_grades: Grades 2+
+  tutorial_codesterspsa_string_detail_grades: Grades 6+
+  tutorial_googlehero_string_detail_grades: Grades 2-8
+  tutorial_codestersbball_string_detail_grades: Grades 6+
+  tutorial_scratchcartoon_string_detail_grades: Grades 2+
+  tutorial_codemonkeyjr_string_detail_grades: Pre-reader
+  tutorial_bananatales_string_detail_grades: Grades 2-8
+  tutorial_scratchtales_string_detail_grades: Grades 2-8
+  tutorial_msemoji_string_detail_grades: Grades 6+
+  tutorial_cacolor_string_detail_grades: Grades 6+
+  tutorial_kodablebeach_string_detail_grades: Pre-reader - Grade 5
+  tutorial_tynkeren_string_detail_grades: Grades 2-8
+  tutorial_tynkerjavapro_string_detail_grades: Grades 6+
+  tutorial_grasshopperhack_string_detail_grades: Grades 9+
+  tutorial_pbskids_string_detail_grades: Pre-reader-Grade 5
+  tutorial_nclabdata_string_detail_grades: Grades 9+
+  tutorial_grasshopperphoto_string_detail_grades: Grades 9+
+  tutorial_tynkerpyland_string_detail_grades: Grades 6+
+  tutorial_codeitimages_string_detail_grades: Grades 2+
+  tutorial_hyperpadenemy_string_detail_grades: Grades 9+
+  tutorial_tynkerpro_string_detail_grades: Grades 2-8
+  tutorial_trashtag_string_detail_grades: Grades 6+
+  tutorial_casiege_string_detail_grades: Grades 2-8
+  tutorial_thunkableyeet_string_detail_grades: Grades 6+
+  tutorial_vidcodedeal_string_detail_grades: Grades 6+
+  tutorial_codehsgeno_string_detail_grades: Grades 9+
+  tutorial_hyperpadpong_string_detail_grades: Grades 9+
+  tutorial_tynkerland_string_detail_grades: Grades 2-8
+  tutorial_trinketgirl_string_detail_grades: Grades 6+
+  tutorial_rpimosquito_string_detail_grades: Grades 6-8
+  tutorial_tynkermars_string_detail_grades: Grades 6+
+  tutorial_cityx_string_detail_grades: Grades 6+
+  tutorial_vidcodemap_string_detail_grades: Grades 6+
+  tutorial_robotmagicfarm_string_detail_grades: Grades 2-8
+  tutorial_codehstriangle_string_detail_grades: Grades 6+
+  tutorial_ttwhitehouse_string_detail_grades: Grades 2+
+  tutorial_modulo_string_detail_grades: Grades 6+
+  tutorial_codingtown_string_detail_grades: Grades 2-5
+  tutorial_kanoart_string_detail_grades: Grades 2-5
+  tutorial_dragonscript_string_detail_grades: Grades 9+
+  tutorial_uwcloud_string_detail_grades: Grades 2+
+  tutorial_htmlmuffin_string_detail_grades: Grades 6-8
+  tutorial_microsoftpizza_string_detail_grades: Grades 6-8
+  tutorial_stemc_blckhole_string_detail_grades: Grades 9+
+  tutorial_careconfigure_string_detail_grades: Grades 6+
+  tutorial_rpiscratch_string_detail_grades: Grades 2-5
+  tutorial_ozaria_string_detail_grades: Grades 2+
+  tutorial_ttovum_string_detail_grades: Grades 6+
+  tutorial_ttpassage_string_detail_grades: Grades 2-8
+  tutorial_tynkerhtmlen_string_detail_grades: Grades 2+
+  tutorial_ttfrog_string_detail_grades: Grades 2-8
+  tutorial_codemojijava_string_detail_grades: Grades 6-8
+  tutorial_ccfirewall_string_detail_grades: Grades 6+
+  tutorial_htmljs_string_detail_grades: Grades 6-8
+  tutorial_ttaqueducts_string_detail_grades: Grades 6-8
+  tutorial_vtgame_string_detail_grades: Grades 6+
+  tutorial_baroborav_string_detail_grades: Grades 6+
+  tutorial_baroboobstacle_string_detail_grades: Grades 2+
+  tutorial_pbstorytelling_string_detail_grades: Grades 6+
+  tutorial_kibosnow_string_detail_grades: Pre-reader-Grade 5
+  tutorial_kibohappy_string_detail_grades: Pre-reader-Grade 5
+  tutorial_rubylove_string_detail_grades: Pre-reader-Grade 8
+  tutorial_spherosmiles_string_detail_grades: Grades 2+
+  tutorial_spherobaby_string_detail_grades: Pre-reader - Grade 8
+  tutorial_toxarchitect_string_detail_grades: Grades 6+
+  tutorial_idodge_string_detail_grades: Grades 2-8
+  tutorial_firiacodebot_string_detail_grades: Grades 6+
+  tutorial_modlighthouse_string_detail_grades: Pre-reader+
+  tutorial_spherogreen_string_detail_grades: Grades 2-8
+  tutorial_ozopopstar_string_detail_grades: Grades 2-8
+  tutorial_eddesign_string_detail_grades: Grades 6+
+  tutorial_edshapeup_string_detail_grades: Grades 6+
+  tutorial_ozocolor_string_detail_grades: Grades 2-8
+  tutorial_icomputeeggs_string_detail_grades: Grades 2-8
+  tutorial_rootunplugged_string_detail_grades: Grades 2-8
+  tutorial_rgtreasure_string_detail_grades: Pre-reader - Grade 5
+  tutorial_peblioportraits_string_detail_grades: Grades 9+
+  tutorial_rootcodebreak_string_detail_grades: Grades 2-8
+  tutorial_microbit14_string_detail_grades: Grades 2-8
+  tutorial_barobomoon_string_detail_grades: Grades 6+
+  tutorial_eddog_string_detail_grades: Grades 2-6
+  tutorial_microbit15_string_detail_grades: Grades 2-8
+  tutorial_unity_string_detail_grades: Grades 9+
+  tutorial_blockscadtarget_string_detail_grades: Grades 6+
+  tutorial_tcadicicles_string_detail_grades: Grades 7-8
+  tutorial_blockscadscale_string_detail_grades: Grades 6+
+  tutorial_tcadloops_string_detail_grades: Grades 5-6
+  tutorial_phidgets_string_detail_grades: Grades 9+
+  tutorial_modvariables_string_detail_grades: Grades 6+
+  tutorial_codestersmicro_string_detail_grades: Grades 6-8
+  tutorial_codestersdata_string_detail_grades: Grades 6-8
+  tutorial_ikodexmas_string_detail_grades: Grades 2-5
+  tutorial_rpisensehat_string_detail_grades: Grades 6+
+  tutorial_mee_string_detail_grades: Grades 2+
+  tutorial_kuborobo_string_detail_grades: Pre-reader - Grades 8
+  tutorial_ai-oceans_string_detail_grades: Grades 3+
+  tutorial_scratchimagine_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_codesterspsa_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_googlehero_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_codestersbball_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_scratchcartoon_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_codemonkeyjr_string_platforms: All modern browsers, Android tablet, iPad,
+    Android phone, iPhone
+  tutorial_bananatales_string_platforms: All modern browsers
+  tutorial_scratchtales_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_msemoji_string_platforms: Chrome, Safari
+  tutorial_cacolor_string_platforms: All modern browsers
+  tutorial_kodablebeach_string_platforms: All modern browsers, iPad, iPhone
+  tutorial_tynkeren_string_platforms: All modern browsers, iPad
+  tutorial_tynkerjavapro_string_platforms: 'All modern browsers '
+  tutorial_grasshopperhack_string_platforms: All modern browsers
+  tutorial_pbskids_string_platforms: Android tablet, iPad, Windows phone, Android
+    phone, iPhone, Game console app
+  tutorial_nclabdata_string_platforms: All modern browsers
+  tutorial_grasshopperphoto_string_platforms: All modern browsers
+  tutorial_tynkerpyland_string_platforms: 'All modern browsers '
+  tutorial_codeitimages_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_hyperpadenemy_string_platforms: iPad
+  tutorial_tynkerpro_string_platforms: All modern browsers, iPad
+  tutorial_trashtag_string_platforms: All modern browsers
+  tutorial_casiege_string_platforms: All modern browsers
+  tutorial_thunkableyeet_string_platforms: All modern browsers
+  tutorial_vidcodedeal_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_codehsgeno_string_platforms: All modern browsers
+  tutorial_hyperpadpong_string_platforms: iPad
+  tutorial_tynkerland_string_platforms: All modern browsers, iPad
+  tutorial_trinketgirl_string_platforms: All modern browsers, Android tablet, iPad,
+    Windows phone, Android phone, iPhone, Screen reader
+  tutorial_rpimosquito_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_tynkermars_string_platforms: All modern browsers, iPad
+  tutorial_cityx_string_platforms: Android tablet, iPad, Android phone, iPhone
+  tutorial_vidcodemap_string_platforms: All modern browsers
+  tutorial_robotmagicfarm_string_platforms: All modern browsers, Android tablet, iPad,
+    Windows phone, Android phone, iPhone
+  tutorial_codehstriangle_string_platforms: All modern browsers
+  tutorial_ttwhitehouse_string_platforms: Chrome, Firefox
+  tutorial_modulo_string_platforms: PCs
+  tutorial_codingtown_string_platforms: All modern browsers
+  tutorial_kanoart_string_platforms: Microsoft Edge, Chrome, Android tablet, iPad
+  tutorial_dragonscript_string_platforms: Chrome
+  tutorial_uwcloud_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_htmlmuffin_string_platforms: All modern browsers
+  tutorial_microsoftpizza_string_platforms: All modern browsers, Screen reader
+  tutorial_stemc_blckhole_string_platforms: All modern browsers, iPad
+  tutorial_careconfigure_string_platforms: All modern browsers
+  tutorial_rpiscratch_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_ozaria_string_platforms: All modern browsers
+  tutorial_ttovum_string_platforms: Chrome, Firefox
+  tutorial_ttpassage_string_platforms: Chrome, Firefox
+  tutorial_tynkerhtmlen_string_platforms: 'All modern browsers '
+  tutorial_ttfrog_string_platforms: Chrome, Firefox
+  tutorial_codemojijava_string_platforms: All modern browsers
+  tutorial_ccfirewall_string_platforms: All modern browsers, iPad
+  tutorial_htmljs_string_platforms: All modern browsers, Screen reader
+  tutorial_ttaqueducts_string_platforms: Chrome, Firefox
+  tutorial_vtgame_string_platforms: All modern browsers, iPad
+  tutorial_baroborav_string_platforms: All modern browsers
+  tutorial_baroboobstacle_string_platforms: All modern browsers
+  tutorial_pbstorytelling_string_platforms: All modern browsers
+  tutorial_kibosnow_string_platforms: KIBO Robot Kit
+  tutorial_kibohappy_string_platforms: KIBO Robot Kit
+  tutorial_rubylove_string_platforms: All modern browsers, Unplugged
+  tutorial_spherosmiles_string_platforms: All modern browsers, Android tablet, iPad,
+    Android phone, iPhone
+  tutorial_spherobaby_string_platforms: All modern browsers, Android tablet, iPad,
+    Android phone, iPhone
+  tutorial_toxarchitect_string_platforms: All modern browsers
+  tutorial_idodge_string_platforms: All modern browsers
+  tutorial_firiacodebot_string_platforms: All modern browsers
+  tutorial_modlighthouse_string_platforms: All modern browsers, Android tablet, Android
+    phone, iPad, iPhone
+  tutorial_spherogreen_string_platforms: All modern browsers, Android tablet, iPad,
+    Android phone, iPhone
+  tutorial_ozopopstar_string_platforms: All modern browsers
+  tutorial_eddesign_string_platforms: All modern browsers, iPad, Android tablets
+  tutorial_edshapeup_string_platforms: All modern browsers
+  tutorial_ozocolor_string_platforms: Unplugged
+  tutorial_icomputeeggs_string_platforms: All modern browers, Android phone, Android
+    tablet, iPad, iPhone
+  tutorial_rootunplugged_string_platforms: Unplugged
+  tutorial_rgtreasure_string_platforms: Unplugged
+  tutorial_peblioportraits_string_platforms: Chrome
+  tutorial_rootcodebreak_string_platforms: iPad
+  tutorial_microbit14_string_platforms: All modern browsers
+  tutorial_barobomoon_string_platforms: All modern browsers
+  tutorial_eddog_string_platforms: All modern browsers, iPad, Android tablets
+  tutorial_microbit15_string_platforms: All modern browsers
+  tutorial_unity_string_platforms: All modern browsers
+  tutorial_blockscadtarget_string_platforms: All modern browsers
+  tutorial_tcadicicles_string_platforms: All modern browsers
+  tutorial_blockscadscale_string_platforms: All modern browsers
+  tutorial_tcadloops_string_platforms: All modern browsers
+  tutorial_phidgets_string_platforms: All modern browsers
+  tutorial_modvariables_string_platforms: All modern browsers, Android tablet, Android
+    phone, iPad, iPhone
+  tutorial_codestersmicro_string_platforms: 'All modern browsers '
+  tutorial_codestersdata_string_platforms: 'All modern browsers '
+  tutorial_ikodexmas_string_platforms: All modern browsers
+  tutorial_rpisensehat_string_platforms: All modern browsers
+  tutorial_mee_string_platforms: All modern browsers, Mac, Windows, Chromebook, iPhone,
+    iPad, Android phone, Android tablet
+  tutorial_kuborobo_string_platforms: Unplugged
+  tutorial_ai-oceans_string_platforms: All modern browsers, modern Android tablets,
+    iPads, modern Android phones, iPhones
+  tutorial_scratchimagine_string_detail_platforms: ''
+  tutorial_codesterspsa_string_detail_platforms: ''
+  tutorial_googlehero_string_detail_platforms: ''
+  tutorial_codestersbball_string_detail_platforms: ''
+  tutorial_scratchcartoon_string_detail_platforms: ''
+  tutorial_codemonkeyjr_string_detail_platforms: ''
+  tutorial_bananatales_string_detail_platforms: ''
+  tutorial_scratchtales_string_detail_platforms: ''
+  tutorial_msemoji_string_detail_platforms: ''
+  tutorial_cacolor_string_detail_platforms: ''
+  tutorial_kodablebeach_string_detail_platforms: ''
+  tutorial_tynkeren_string_detail_platforms: ''
+  tutorial_tynkerjavapro_string_detail_platforms: ''
+  tutorial_grasshopperhack_string_detail_platforms: ''
+  tutorial_pbskids_string_detail_platforms: ''
+  tutorial_nclabdata_string_detail_platforms: ''
+  tutorial_grasshopperphoto_string_detail_platforms: ''
+  tutorial_tynkerpyland_string_detail_platforms: ''
+  tutorial_codeitimages_string_detail_platforms: ''
+  tutorial_hyperpadenemy_string_detail_platforms: ''
+  tutorial_tynkerpro_string_detail_platforms: ''
+  tutorial_trashtag_string_detail_platforms: ''
+  tutorial_casiege_string_detail_platforms: ''
+  tutorial_thunkableyeet_string_detail_platforms: ''
+  tutorial_vidcodedeal_string_detail_platforms: ''
+  tutorial_codehsgeno_string_detail_platforms: ''
+  tutorial_hyperpadpong_string_detail_platforms: ''
+  tutorial_tynkerland_string_detail_platforms: ''
+  tutorial_trinketgirl_string_detail_platforms: ''
+  tutorial_rpimosquito_string_detail_platforms: ''
+  tutorial_tynkermars_string_detail_platforms: ''
+  tutorial_cityx_string_detail_platforms: ''
+  tutorial_vidcodemap_string_detail_platforms: ''
+  tutorial_robotmagicfarm_string_detail_platforms: ''
+  tutorial_codehstriangle_string_detail_platforms: ''
+  tutorial_ttwhitehouse_string_detail_platforms: ''
+  tutorial_modulo_string_detail_platforms: ''
+  tutorial_codingtown_string_detail_platforms: ''
+  tutorial_kanoart_string_detail_platforms: ''
+  tutorial_dragonscript_string_detail_platforms: ''
+  tutorial_uwcloud_string_detail_platforms: ''
+  tutorial_htmlmuffin_string_detail_platforms: ''
+  tutorial_microsoftpizza_string_detail_platforms: ''
+  tutorial_stemc_blckhole_string_detail_platforms: ''
+  tutorial_careconfigure_string_detail_platforms: ''
+  tutorial_rpiscratch_string_detail_platforms: ''
+  tutorial_ozaria_string_detail_platforms: ''
+  tutorial_ttovum_string_detail_platforms: ''
+  tutorial_ttpassage_string_detail_platforms: ''
+  tutorial_tynkerhtmlen_string_detail_platforms: ''
+  tutorial_ttfrog_string_detail_platforms: ''
+  tutorial_codemojijava_string_detail_platforms: ''
+  tutorial_ccfirewall_string_detail_platforms: ''
+  tutorial_htmljs_string_detail_platforms: ''
+  tutorial_ttaqueducts_string_detail_platforms: ''
+  tutorial_vtgame_string_detail_platforms: ''
+  tutorial_baroborav_string_detail_platforms: ''
+  tutorial_baroboobstacle_string_detail_platforms: ''
+  tutorial_pbstorytelling_string_detail_platforms: ''
+  tutorial_kibosnow_string_detail_platforms: KIBO Robot Kit
+  tutorial_kibohappy_string_detail_platforms: KIBO Robot Kit
+  tutorial_rubylove_string_detail_platforms: ''
+  tutorial_spherosmiles_string_detail_platforms: Sphero BOLT
+  tutorial_spherobaby_string_detail_platforms: Sphero SPRK+, Sphero Mini, or Sphero
+    BOLT
+  tutorial_toxarchitect_string_detail_platforms: ''
+  tutorial_idodge_string_detail_platforms: ''
+  tutorial_firiacodebot_string_detail_platforms: CodeBot robot
+  tutorial_modlighthouse_string_detail_platforms: Cubelets Robot Blocks
+  tutorial_spherogreen_string_detail_platforms: Sphero BOLT, Sphero SPRK+, or Sphero
+    Mini
+  tutorial_ozopopstar_string_detail_platforms: Ozobot
+  tutorial_eddesign_string_detail_platforms: Edison robot
+  tutorial_edshapeup_string_detail_platforms: Edison robot
+  tutorial_ozocolor_string_detail_platforms: Ozobot
+  tutorial_icomputeeggs_string_detail_platforms: Sphero
+  tutorial_rootunplugged_string_detail_platforms: ''
+  tutorial_rgtreasure_string_detail_platforms: ''
+  tutorial_peblioportraits_string_detail_platforms: ''
+  tutorial_rootcodebreak_string_detail_platforms: Root robot
+  tutorial_microbit14_string_detail_platforms: micro:bit
+  tutorial_barobomoon_string_detail_platforms: Barobo Arduino Starter Kit
+  tutorial_eddog_string_detail_platforms: Edison robot
+  tutorial_microbit15_string_detail_platforms: micro:bit
+  tutorial_unity_string_detail_platforms: Unity software
+  tutorial_blockscadtarget_string_detail_platforms: ''
+  tutorial_tcadicicles_string_detail_platforms: ''
+  tutorial_blockscadscale_string_detail_platforms: ''
+  tutorial_tcadloops_string_detail_platforms: ''
+  tutorial_phidgets_string_detail_platforms: Phidgets Getting Started Kit, Phidgets
+    Distance Sensors.
+  tutorial_modvariables_string_detail_platforms: Cubelets Robot Blocks
+  tutorial_codestersmicro_string_detail_platforms: BBC micro:bit
+  tutorial_codestersdata_string_detail_platforms: BBC micro:bit
+  tutorial_ikodexmas_string_detail_platforms: Microsoft Kodu
+  tutorial_rpisensehat_string_detail_platforms: Raspbian (software), SenseHAT
+  tutorial_mee_string_detail_platforms: ''
+  tutorial_kuborobo_string_detail_platforms: KUBO robot
+  tutorial_ai-oceans_string_detail_platforms: ''
+  tutorial_scratchimagine_string_detail_programming_languages: Blocks
+  tutorial_codesterspsa_string_detail_programming_languages: Python
+  tutorial_googlehero_string_detail_programming_languages: Blocks, Scratch
+  tutorial_codestersbball_string_detail_programming_languages: Python
+  tutorial_scratchcartoon_string_detail_programming_languages: Blocks
+  tutorial_codemonkeyjr_string_detail_programming_languages: Blocks
+  tutorial_bananatales_string_detail_programming_languages: Python
+  tutorial_scratchtales_string_detail_programming_languages: Blocks
+  tutorial_msemoji_string_detail_programming_languages: JavaScript, Python
+  tutorial_cacolor_string_detail_programming_languages: Computational Thinking focused
+    so no language
+  tutorial_kodablebeach_string_detail_programming_languages: Language independent
+    (can be taught in multiple languages)
+  tutorial_tynkeren_string_detail_programming_languages: Blocks
+  tutorial_tynkerjavapro_string_detail_programming_languages: JavaScript, HTML, CSS
+  tutorial_grasshopperhack_string_detail_programming_languages: JavaScript
+  tutorial_pbskids_string_detail_programming_languages: Blocks
+  tutorial_nclabdata_string_detail_programming_languages: Structured Query Language
+    (SQL), specifically PostgreSQL
+  tutorial_grasshopperphoto_string_detail_programming_languages: JavaScript
+  tutorial_tynkerpyland_string_detail_programming_languages: Python
+  tutorial_codeitimages_string_detail_programming_languages: Blocks
+  tutorial_hyperpadenemy_string_detail_programming_languages: hyperPad Visual Programming
+  tutorial_tynkerpro_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_trashtag_string_detail_programming_languages: Blocks
+  tutorial_casiege_string_detail_programming_languages: Security theory based
+  tutorial_thunkableyeet_string_detail_programming_languages: Blocks
+  tutorial_vidcodedeal_string_detail_programming_languages: JavaScript
+  tutorial_codehsgeno_string_detail_programming_languages: Python
+  tutorial_hyperpadpong_string_detail_programming_languages: hyperPad Visual Programming
+  tutorial_tynkerland_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_trinketgirl_string_detail_programming_languages: Python
+  tutorial_rpimosquito_string_detail_programming_languages: Scratch
+  tutorial_tynkermars_string_detail_programming_languages: Blocks, JavaScript, Python,
+    HTML, CSS
+  tutorial_cityx_string_detail_programming_languages: Python
+  tutorial_vidcodemap_string_detail_programming_languages: JavaScript
+  tutorial_robotmagicfarm_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_codehstriangle_string_detail_programming_languages: Python
+  tutorial_ttwhitehouse_string_detail_programming_languages: SCSS, CSS
+  tutorial_modulo_string_detail_programming_languages: Lua
+  tutorial_codingtown_string_detail_programming_languages: JavaScript
+  tutorial_kanoart_string_detail_programming_languages: Blocks
+  tutorial_dragonscript_string_detail_programming_languages: JavaScript, HTML
+  tutorial_uwcloud_string_detail_programming_languages: Language independent (can
+    be taught in multiple languages)
+  tutorial_htmlmuffin_string_detail_programming_languages: HTML and CSS
+  tutorial_microsoftpizza_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_stemc_blckhole_string_detail_programming_languages: JavaScript
+  tutorial_careconfigure_string_detail_programming_languages: Python
+  tutorial_rpiscratch_string_detail_programming_languages: Scratch
+  tutorial_ozaria_string_detail_programming_languages: JavaScript, Python
+  tutorial_ttovum_string_detail_programming_languages: JavaScript
+  tutorial_ttpassage_string_detail_programming_languages: JavaScript
+  tutorial_tynkerhtmlen_string_detail_programming_languages: HTML, CSS
+  tutorial_ttfrog_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_codemojijava_string_detail_programming_languages: Java
+  tutorial_ccfirewall_string_detail_programming_languages: Blocks
+  tutorial_htmljs_string_detail_programming_languages: JavaScript
+  tutorial_ttaqueducts_string_detail_programming_languages: JavaScript, CoffeeScript
+  tutorial_vtgame_string_detail_programming_languages: English
+  tutorial_baroborav_string_detail_programming_languages: Blocks, C/C++
+  tutorial_baroboobstacle_string_detail_programming_languages: Blocks, C/C++
+  tutorial_pbstorytelling_string_detail_programming_languages: Twine (Harlowe variant)
+  tutorial_kibosnow_string_detail_programming_languages: Blocks, Tangible blocks (no
+    screen use)
+  tutorial_kibohappy_string_detail_programming_languages: Blocks, Tangible blocks
+    (no screen use)
+  tutorial_rubylove_string_detail_programming_languages: Blocks, Language independent
+    (can be taught in multiple languages)
+  tutorial_spherosmiles_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_spherobaby_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_toxarchitect_string_detail_programming_languages: JavaScript
+  tutorial_idodge_string_detail_programming_languages: Simplified version of JavaScript
+  tutorial_firiacodebot_string_detail_programming_languages: Python
+  tutorial_modlighthouse_string_detail_programming_languages: Language independent
+    (can be taught in multiple languages)
+  tutorial_spherogreen_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_ozopopstar_string_detail_programming_languages: Blocks
+  tutorial_eddesign_string_detail_programming_languages: Blocks
+  tutorial_edshapeup_string_detail_programming_languages: Python, EdPy, a text-based
+    programming language based on Python.
+  tutorial_ozocolor_string_detail_programming_languages: Blocks
+  tutorial_icomputeeggs_string_detail_programming_languages: Blocks
+  tutorial_rootunplugged_string_detail_programming_languages: Blocks
+  tutorial_rgtreasure_string_detail_programming_languages: Blocks
+  tutorial_peblioportraits_string_detail_programming_languages: JavaScript
+  tutorial_rootcodebreak_string_detail_programming_languages: Blocks
+  tutorial_microbit14_string_detail_programming_languages: Blocks
+  tutorial_barobomoon_string_detail_programming_languages: Blocks, C/C++
+  tutorial_eddog_string_detail_programming_languages: Blocks
+  tutorial_microbit15_string_detail_programming_languages: Blocks
+  tutorial_unity_string_detail_programming_languages: C#
+  tutorial_blockscadtarget_string_detail_programming_languages: Blocks
+  tutorial_tcadicicles_string_detail_programming_languages: Blocks
+  tutorial_blockscadscale_string_detail_programming_languages: Blocks
+  tutorial_tcadloops_string_detail_programming_languages: Blocks
+  tutorial_phidgets_string_detail_programming_languages: Java, Phidgets support ALL
+    major programming languages. Can easily adapt this project to another language/environment.
+  tutorial_modvariables_string_detail_programming_languages: Language independent
+    (can be taught in multiple languages)
+  tutorial_codestersmicro_string_detail_programming_languages: Python
+  tutorial_codestersdata_string_detail_programming_languages: Python
+  tutorial_ikodexmas_string_detail_programming_languages: Microsoft Kodu
+  tutorial_rpisensehat_string_detail_programming_languages: Python
+  tutorial_mee_string_detail_programming_languages: Blocks
+  tutorial_kuborobo_string_detail_programming_languages: Tagtiles that students piece
+    together
+  tutorial_ai-oceans_string_detail_programming_languages: AI and Machine Learning
+  tutorial_hello_name: Hello World
+  tutorial_raspispace_name: 'Space Talk: Launch into Scratch coding'
+  tutorial_codemonkeyjump_name: 'Blocks Jumper: Game Creation'
+  tutorial_poemart_name: Poem Art
+  tutorial_kodablehero_name: Design your Hero
+  tutorial_cacloud_name: Operation Cloud
+  tutorial_blocksmithbot_name: Bot is sus?!
+  tutorial_hatchmario_name: 'Mario''s Secret Adventure: Build Your Own 3D Mario Game'
+  tutorial_microsoftforest_name: Save the Forest!
+  tutorial_blackbirdscreen_name: Screen Saver
+  tutorial_toxicodecompute2_name: Discover Python with Compute it
+  tutorial_minecrafttimecraft_name: Minecraft Timecraft
+  tutorial_blackbirdtether_name: Tetherball
+  tutorial_ob_name: Outbreak Simulator
+  tutorial_codeartportrait_name: Code Your Self-Portrait
+  tutorial_shelly_name: 'Shelly: Learn programming by drawing!'
+  tutorial_weavly_name: 'Weavly: Activities at Home'
+  tutorial_codespeakpassword_name: Program a Strong Password Generator in Python
+  tutorial_kodableshapes_name: Make Shapes with Code
+  tutorial_nasabinary_name: 'Binary Code: How to Talk to a Spacecraft'
+  tutorial_3dmaker_name: 3D Maker
+  tutorial_itchstart_name: 'iTCHcode: Scratch 5 Block Starter'
+  tutorial_hopsub_name: Build Subway Surfers with a Friend
+  tutorial_itchmundos_name: Los mundos en mi mundo_E2
+  tutorial_itchtenacity_name: Tenacity
+  tutorial_kcjskiing_name: 'Sport + Code: Skiing'
+  tutorial_groksecurity_name: 'Cyber Security: Defence Against the Dark Hats'
+  tutorial_creaticode_name: 3D Programming with Scratch Blocks
+  tutorial_kcjhockey_name: 'Sport + Code: Hockey'
+  tutorial_ttdungeon_name: Binary Dungeon
+  tutorial_ccai_name: Road to the AI League
+  tutorial_bsdai_name: AI Webcam Image Classifier
+  tutorial_stemdata_name: 'Data Science: Earth Day'
+  tutorial_thunkableinfo_name: Build an Informational App on Thunkable
+  tutorial_educodespace_name: Space Solo
+  tutorial_kcjtennis_name: 'Sport + Code: Tennis'
+  tutorial_robotmagictower_name: Hanoi Tower Game - recursive functions
+  tutorial_ttdragons_name: Dragon's Apprentice Chapter 1
+  tutorial_kcjarchery_name: 'Sport + Code: Archery'
+  tutorial_ttsprouts_name: Crowded Sprouts
+  tutorial_ttmaze_name: The Maze
+  tutorial_codetribe_name: 'Code Tribe: 10 Minute Program'
+  tutorial_ttcanyon_name: 'The Canyon: Battle Arena'
+  tutorial_kcjxtrail_name: 'Sport + Code: Xtrail'
+  tutorial_codespeakroad_name: Build a Road Game in Scratch
+  tutorial_educodelair_name: Chiroptera's Lair
+  tutorial_ibmhourofz_name: IBM Hour of Z
+  tutorial_gamefrootbacteria_name: Coding Bacteria with Gamefroot
+  tutorial_educodeforest_name: The Frosted Forest
+  tutorial_educodehorus_name: Temple of Horus
+  tutorial_codespeakpokemon_name: Code a Pokemon Evolution Game
+  tutorial_stemholiday_name: Code a Virtual Holiday Card
+  tutorial_codespeakpixel_name: Code a Pixel Art Editor in Bitsbox
+  tutorial_codespellsnexus_name: 'CodeSpells: The Nexus'
+  tutorial_carnegieslime_name: Super Slime Battle
+  tutorial_ozotown_name: 'Ozobot Blockly Challenge: OzoTown'
+  tutorial_milnedash_name: Dash Joins a Dance Circle
+  tutorial_microbitpet_name: micro:bit pet
+  tutorial_spherotriad_name: CIA Triad and Cybersecurity
+  tutorial_spheropassword_name: Password Security and Protection
+  tutorial_codequilt_name: CodeQuilt
+  tutorial_ozoshape1_name: 'Ozobot Blockly Challenge: ShapeTracer 1'
+  tutorial_ozoshape2_name: 'Ozobot Blockly Challenge: ShapeTracer 2'
+  tutorial_hopescape_name: Can You Escape? Build an Escape Room with Hopscotch
+  tutorial_ozorace_name: 50 cm Race
+  tutorial_ozoequestrian_name: Equestrian Event
+  tutorial_irobotpizza_name: Robot Pizza Party
+  tutorial_ai4alldance_name: 'AI4ALL: AI & Dance'
+  tutorial_ai4allneural_name: How Convolutional Neural Networks Work
+  tutorial_spheroinout_name: Inputs and Outputs
+  tutorial_edisonblueprint_name: Edison the Blueprint Designer
+  tutorial_edisonmaze_name: Edison the Maze Racer
+  tutorial_milnefunctions_name: Dash Joins a Dance Circle (with Functions)
+  tutorial_sasmap_name: 'Show With Code: Features on a Map'
+  tutorial_firstrobotics_name: FIRST Tech Challenge Simulator
+  tutorial_sasdata_name: Building Data Fundamentals
+  tutorial_carnegiesensabot_name: Sensabot Challenge
+  tutorial_robotical4_name: Hour of Code Activity 4 - Getting Started with MartyBlocks
+  tutorial_kinderadd_name: Adding and Subtracting with KIBO
+  tutorial_imagipython_name: Creative Coding in Python
+  tutorial_robotical2_name: Hour of Code Activity 2 - the Marty Controller
+  tutorial_robotical3_name: Hour of Code Activity 3 - Getting Started with Marty Blocks
+    Jr
+  tutorial_blockscadvirus_name: BlocksCAD Modeling a Virus with Code
+  tutorial_robotical1_name: Hour of Code Activity 1 - Marty Unplugged
+  tutorial_irobotshapes_name: 'Robotics for K-2: Robot Shapes'
+  tutorial_irobotparts_name: 'Robotics for K-2: Robot Parts'
+  tutorial_irobottools_name: 'Robotics for K-2: Robot Tools'
+  tutorial_kindercar_name: Create Your Dream Car with KIBO
+  tutorial_caavatar_name: 'AVATAR: Big Data & Digital Footprints'
+  tutorial_hello_longdescription: Learn the basics of computer science by programming
+    in Sprite Lab. You will create and animate sprites, and make your own interactive
+    scenes.
+  tutorial_raspispace_longdescription: Create a space scene with characters that 'emote'
+    to share their thoughts or feelings using sounds, colours, and actions. Use Scratch
+    blocks to code your characters with graphic effects, costume animation, speech
+    bubbles and sound effects.
+  tutorial_codemonkeyjump_longdescription: Create games and projects with block coding!
+    In this short course students will learn to create a simple jumper game using
+    basic event and function blocks.
+  tutorial_poemart_longdescription: Illustrate the mood of a poem with code.
+  tutorial_kodablehero_longdescription: Welcome to Bug World! The Kodable fuzzFamily
+    needs your coding help. Use your real-life heroes and your imagination to design
+    a character who will protect the fuzzFamily. You'll choose the properties your
+    hero possesses and put their strength to the test against the buggy slimes of
+    Bug World!
+  tutorial_cacloud_longdescription: Felix posts a seemingly innocent photo of Juno
+    on social media. She desperately wants it removed. Max, her friend, is quick to
+    turn the situation into a secret mission. Join them as they learn about cloud
+    computing and try to track down the photo on a server, stored in an ultra secure
+    data centre. Is there anyway to locate and destroy the photo?
+  tutorial_blocksmithbot_longdescription: Lasers, traps and marvelous mazes! Help
+    Bot0 escape before she gets ejected! Bot0 is a friendly, harmless helper robot.
+    Or is she? Her teammates believe otherwise. Program Bot0 to make her way through
+    the underbelly of the space ship and escape before they find her.
+  tutorial_hatchmario_longdescription: Build your very own 3D Mario game, while learning
+    the basics of programming. Learn about the fundamentals of game development; form
+    an understanding of motion in 3D space; learn to add score, lives and cool sound
+    effects to your game, all in less than an hour. And the best part, you can share
+    your game with your family and friends in just one click and play with them on
+    any device in your home.
+  tutorial_microsoftforest_longdescription: Code a game with Microsoft MakeCode Arcade
+    that recreates the conditions for a forest fire, and then code your fire-fighting
+    airtanker plane to spray water and put out the flames!
+  tutorial_blackbirdscreen_longdescription: Learn how to use conditional statements
+    to create a cool 90s style screen saver.
+  tutorial_toxicodecompute2_longdescription: Let's switch roles. This time YOU are
+    the computer! Read and interpret Python programs to find the right trajectory
+    and win the challenges. You will have to focus and use your intuitive abilities
+    to understand some core concepts of Python.
+  tutorial_minecrafttimecraft_longdescription: 'Travel back in time to save the future
+    in this free Hour of Code lesson in Minecraft: Education Edition. Students will
+    choose their own adventure and learn basic coding concepts to correct mysterious
+    mishaps throughout history. Along the way, they''ll connect with great innovators
+    and inventions in science, architecture, music, engineering, and more.'
+  tutorial_blackbirdtether_longdescription: Learn to use objects to program a fun,
+    physics-based game.
+  tutorial_ob_longdescription: Write code to create and run your own simulation of
+    the virus outbreak at Monster Town. A simulation is a computer model of a process
+    or system. Learn to code and make predictions about what will happen to the neighbors
+    of Monster Town.
+  tutorial_codeartportrait_longdescription: 'Learn to program your portrait using
+    p5.js. Express yourself creatively through code by incorporating your favorite
+    artistic styles and personal touches to create a true masterpiece! You may be
+    eligible to submit your finished project to Code/Art’s CodeYourSelf competition
+    for U.S. girls in grades 3-12. '
+  tutorial_shelly_longdescription: Shelly is a programming language for drawing. Drawing
+    is done by issuing instructions to a turtle. The turtle draws lines and shapes
+    as it moves, using various colors and styles. Challenge and creative modes are
+    available. The challenge mode includes a step-by-step tutorial, which introduces
+    the basics of the Shelly language and of programming in general.
+  tutorial_weavly_longdescription: In these short activities, go on a series of missions,
+    from exploring planets, to visiting animals on a safari, to hunting for sunken
+    treasure!
+  tutorial_codespeakpassword_longdescription: Learn to code a password generator in
+    Python and stay safe against hackers.
+  tutorial_kodableshapes_longdescription: 'Math is a part of our lives everywhere.
+    Use math and coding skills to make your own maze and then try to solve it. Start
+    with a basic square and then see how many different shapes you can include in
+    your maze designs! '
+  tutorial_nasabinary_longdescription: Learn how we use binary code to talk to a spacecraft,
+    and then try it yourself by translating your name into binary code on a name tag,
+    bracelet, pin, or even sound.
+  tutorial_3dmaker_longdescription: Make your own really cool, rotatable, 3D objects
+    fast and easily.
+  tutorial_itchstart_longdescription: This lesson is a good entry point for kids grade
+    2 or 3 that are just trying out Scratch for the very first time. They will get
+    to start with a set of 5 blocks that they need to put together to make their character
+    perform some actions.
+  tutorial_hopsub_longdescription: Learn how to pair program with a friend or classmate,
+    and create your own subway surfer with Hopscotch characters!
+  tutorial_itchmundos_longdescription: Conocerán Scratch, una herramienta para programar.
+    Agregarán objetos y fondos, usarán bloques de eventos y apariencia para dar vida
+    a su programa.
+  tutorial_itchtenacity_longdescription: En este proyecto programan en Scratch el
+    simulador de un robot que limpia las aguas marinas.
+  tutorial_kcjskiing_longdescription: 'It''s all fun and games until someone crashes
+    into a tree… or IS that the fun part? Strap on those skis and bend at the knees
+    as you guide your character down a hill of frozen obstacles using code in this
+    Scratch activity. Design the course, add movement and sensing, plus a bit of collision-interaction
+    and boom - you''ve got yourself a mountain of fun. '
+  tutorial_groksecurity_longdescription: Put your cyber-sleuthing hat on in this short
+    introduction to staying safe online. You'll learn about secure passwords, phishing,
+    security settings, social media and more!
+  tutorial_creaticode_longdescription: Learn to build stunning 3D projects using Scratch
+    blocks!
+  tutorial_kcjhockey_longdescription: You shoot, you SCORE - the crowd goes wild!
+    No need to lace up your skates when building this game, but be ready to sharpen
+    your coding skills! Learn how to code your own hockey game and test our skills
+    against an npc goalie in Scratch. Using movement, sensing, and variables, your
+    digital player can dodge and glide the puck to score the winning goal.
+  tutorial_ttdungeon_longdescription: The evil wizard Nullonor poses a grave threat
+    to the realm, and only you have the power to banish them forever. However, Nullonor
+    is as cunning as he is dangerous. He hides in his magical tower of ever-shifting
+    rooms, and no hero has successfully reached the top floor yet. As the champion
+    of the Index Knights, do you have what it takes to find and defeat Nullonor?
+  tutorial_ccai_longdescription: 'Competitive coding has never been so epic! No coding
+    experience...No problem. Enter the dungeon where you will level up your programming
+    powers by learning the coding strategies and tactics you will need to compete.
+    Once you''ve made it through the dungeon you''ll be ready to take on coders from
+    around the world in the CodeCombat AI League esports arena! '
+  tutorial_bsdai_longdescription: There is a specific set of neural networks and algorithms
+    that we call machine learning. In this project, we will explore an Artificial
+    Intelligence (AI) Image Recognition tool and learn how AI sees images, makes predictions,
+    and how we can make sure that those predictions are accurate and free of bias.
+  tutorial_stemdata_longdescription: Create a simple model for the climate where you
+    live and then use it to understand how a few degrees of increased temperature
+    can have a significant impact on the natural world. Includes an option to download
+    the data to a spreadsheet for further analysis.
+  tutorial_thunkableinfo_longdescription: Learn how to build an informational app
+    with code blocks and a data table
+  tutorial_educodespace_longdescription: The people of planet Allegrus have lost their
+    ancestral songs. Follow this tutorial to build your own musical side-scrolling
+    game and recover the lost melodies. Customize every aspect of the game, while
+    learning the basics of game development, physics and collisions. No coding or
+    musical knowledge required.
+  tutorial_kcjtennis_longdescription: Serve up a challenge and go head-to-head with
+    your own AI opponent in this digital tennis match. Using Scratch, this activity
+    will teach you how to code back-and-forth sprite interactions through broadcasting,
+    variables, and movement. Incorporate win/loss conditionals and kiss your 'love'
+    score good bye. Complete this project by yourself or with support from a grown
+    up.
+  tutorial_robotmagictower_longdescription: Learn about the Hanoi Tower game and how
+    to use recursive functions to solve problems.
+  tutorial_ttdragons_longdescription: 'An evil force has spread its way across the
+    land of Ovun and is threatening to destroy this peaceful city. Explore hidden
+    temples, learn magic runes that let you program and control the elements around
+    you, and battle the shadow fiends. Find all the keys in the Dragon Temples to
+    awaken the dragon. Be the hero that Ovun needs! '
+  tutorial_kcjarchery_longdescription: Stay on target and guide your arrow to the
+    bullseye using code! Learn how to code your own archery game using Scratch and
+    our step-by-step instructions. With the help of colour-sensing sprites, costume
+    changes, and motion sequences, you too can aim for gold and code your way to victory
+    - plus, add a score counter to up the ante. Complete this project by yourself
+    or with support from a grown up.
+  tutorial_ttsprouts_longdescription: Gardening is a full-time job! Start with just
+    a single bench of pots and tend to the plants within a greenhouse by accessing
+    an array. As you seed, water, and harvest each plant, earn money for all your
+    fruits and veggies! Use an increasingly complicated multidimensional array to
+    locate each pot as the greenhouse gets crowded.
+  tutorial_ttmaze_longdescription: You have landed on an alien planet in a pocket
+    universe and must find a way to escape so you can continue on your journey. Explore
+    the ruins of an advanced robotic civilization, navigate your way through mazes
+    and puzzles and fight off enemy robots. With the help of your trusty sidekick
+    F3lix, learn and use new programming concepts to hack your way to victory.
+  tutorial_codetribe_longdescription: A great intro to coding using HTML, CSS and
+    JavaScript. Code a few lines, and create your first application to verify the
+    age of people attending your party.
+  tutorial_ttcanyon_longdescription: You are trapped on an alien planet and must survive
+    the Arena, an endless fight with alien monsters! Use your hacking blaster to change
+    the programming of your sidekick, your opponents, and your environment. Your trusty
+    feline sidekick F3lix can help heal and support you, while you can reprogram enemies
+    and traps to disable them or fight each other.
+  tutorial_kcjxtrail_longdescription: Hit the trails with this cross country biking
+    activity using code and Scratch. Utilizing colour sensing blocks and movement,
+    you will design your course, integrate stops and interactions along the way, and
+    track your progress by coding a score keeper with functions. Don't forget your
+    helmet because we could be in for a wild ride! Complete this project by yourself
+    or with support from a grown up.
+  tutorial_codespeakroad_longdescription: Create a game where the user plays the role
+    of a civil engineer to plan out a road.
+  tutorial_educodelair_longdescription: George is being chased in Chiroptera's Lair
+    and needs your help to escape! Design your own complete 2D puzzle game by following
+    this tutorial and learning the basics of game development. Code your way out of
+    our level, or make your own to challenge your friends!
+  tutorial_ibmhourofz_longdescription: 'Have you ever withdrawn money from an ATM?
+    Used a credit card to pay for something? All these actions have one thing in common:
+    they all start with a simple click. But what''s really happening behind that click?
+    That''s Enterprise Computing. Get started learning more about how enterprise computing
+    works today with IBM Hour of Z.'
+  tutorial_gamefrootbacteria_longdescription: 'Students learn about the conditions
+    in which salmonella bacteria can survive while coding a fun simulation game in
+    Gamefroot! This activity is designed for science teachers AND Digital Technologies
+    teachers looking to engage their students in multiple subject areas. '
+  tutorial_educodeforest_longdescription: Alex has been trapped in the Frosted Forest
+    for a while. Can you help them escape? This easy-to-follow tutorial teaches you
+    how to build and customize a complete puzzle game that runs in any modern browser.
+    Try to beat our level, or create your own to challenge your friends!
+  tutorial_educodehorus_longdescription: Help Lisa solve Horus's enigma and escape
+    his temple. Follow this tutorial to code and customize your very own puzzle game
+    in a few steps. Try to beat our level, or edit it to make it as easy or challenging
+    as you want. Learn the basics of game development while playing!
+  tutorial_codespeakpokemon_longdescription: Code your favorite Pokemon to level up
+    and evolve.
+  tutorial_stemholiday_longdescription: STEMscopes Coding powered by BitsBox allows
+    students to build and share their own virtual holiday card using typed JavaScript
+    code. Our program is easy to use and requires no prior coding experience. We offer
+    embedded support throughout the program, and students can easily figure it out
+    on their own. Get excited to code your own virtual card to share with friends
+    and family this holiday season!
+  tutorial_codespeakpixel_longdescription: Learn to create a pixel art editor to create
+    your own custom character designs and art.
+  tutorial_codespellsnexus_longdescription: Under the mentorship of a mysterious sock
+    puppet, you must infiltrate and reprogram a super-intelligent 'Learn to Code'
+    app that seeks global domination. Solve puzzles. Learn to code. Hack the Nexus.
+  tutorial_carnegieslime_longdescription: Every year the Minions of Scarecorp try
+    to steal your candy crops. Booville High's Baddest Slimeball crew have come together
+    to protect the candy crops with slime weapons. Players play as teen monsters who
+    program their collaborative robot (aka 'cobot') pets to help take down the Minions
+    of Scarecorp who are after their town's candy harvest. Choose between four characters
+    and their cobotic pets.
+  tutorial_ozotown_longdescription: The Ozobot Blockly OzoTown will teach advanced
+    sequencing as students utilize logic, reasoning, and computer science skills to
+    navigate real life scenarios. No bot needed!
+  tutorial_milnedash_longdescription: Dash wants to learn how to dance! Can you help
+    her drive in and out and show her stuff in the middle? This activity is student-directed
+    and will teach the user about sequencing and loops.
+  tutorial_microbitpet_longdescription: 'Code your own electronic pet and customize
+    it to make it your own. '
+  tutorial_spherotriad_longdescription: 'Explore what each of the fundamental principles
+    of cybersecurity mean and learn how to find a balance to achieve a secure system
+    that works for all users. '
+  tutorial_spheropassword_longdescription: Explore how to make strong password combinations
+    using littleBits inventions and coding.
+  tutorial_codequilt_longdescription: Reflect on who gets to code and what can be
+    made with code while becoming familiar with Scratch.
+  tutorial_ozoshape1_longdescription: The Ozobot Blockly ShapeTracer will teach sequencing
+    and debugging skills. Students will utilize logic, reasoning, and computer science
+    skills. No bot needed!
+  tutorial_ozoshape2_longdescription: The Ozobot Blockly ShapeTracer 2 will teach
+    advanced sequencing and looping skills. Students will utilize logic, reasoning,
+    and computer science skills. No bot needed!
+  tutorial_hopescape_longdescription: Code an open-ended logic escape room game, and
+    learn about concepts such as iteration and other important game design elements.
+  tutorial_ozorace_longdescription: Students will plan and execute a program with
+    a variety of parameters, practice measurement, sequencing and debugging as they
+    create a racetrack for Ozobot.
+  tutorial_ozoequestrian_longdescription: Students will use Color Codes to program
+    their mount (Evo) to complete a course.
+  tutorial_irobotpizza_longdescription: Looking to make coding a collaborative, social
+    and super fun experience at your school?  In this out-of-the-box digital event
+    kit, we provide all the tools you'll need to host the perfect family code challenge.
+    At the iRobot Pizza Party, families come together to share a meal and code virtual
+    robots to complete challenges, designed for both beginners and advanced coders.
+  tutorial_ai4alldance_longdescription: In this short, fun byte of AI, students explore
+    how AI tools can help humans innovate, and how human innovators can help improve
+    AI.
+  tutorial_ai4allneural_longdescription: This curriculum is an introductory hands-on
+    deep dive into the technical details about how some AI systems can find objects
+    in images, or other patterns in context. In the end, students will teach others
+    what they have learned. If your students did AI & Dance, they may want to check
+    this out after to learn how that system worked.
+  tutorial_spheroinout_longdescription: indi is ready to learn more about how it and
+    other computers work. In this lesson, discover inputs and outputs through this
+    hands-on exploration.
+  tutorial_edisonblueprint_longdescription: Can you program Edison to drive in different
+    shapes so that the robot can draw different blueprints?
+  tutorial_edisonmaze_longdescription: Let's get the Edison robot to race along a
+    Euler Path shape!
+  tutorial_milnefunctions_longdescription: Dash wants to learn how to dance! Can you
+    help her drive in and out and show her stuff in the middle? This activity is student-directed
+    and will teach the user about sequencing, loops and functions.
+  tutorial_sasmap_longdescription: 'In this lesson, students will use code to demonstrate
+    an understanding of the difference between human and physical features on a map.
+    They will identity a path through a grid of math features such that a robot will
+    land only on human features. Students will then work in teams to write code that
+    will navigate their robot along the correct path. '
+  tutorial_firstrobotics_longdescription: Learn to code with FTC Sim, an online block-based
+    programming language that includes a live simulator so students can instantly
+    see the robot moving based on the code that they have written.
+  tutorial_sasdata_longdescription: Engage students with data through quick polls
+    that generate real-time interactive data visualizations. Students will identify,
+    interpret and communicate about data– important foundational skills for understanding
+    our data-rich world.
+  tutorial_carnegiesensabot_longdescription: Learn how to program a virtual EV3 robot
+    to complete the real-world Sensabot challenge in this activity the Carnegie Mellon
+    Robotics Academy.
+  tutorial_robotical4_longdescription: MartyBlocks is put together in a vertical format,
+    which is more common for writing code. Learners will be presented with a larger
+    workspace and greater functionality for controlling Marty and eventually having
+    them interact with the environment. This lesson will familiarize learners with
+    the sections, layout, comparing this new environment with MartyBlocks Jr.
+  tutorial_kinderadd_longdescription: In this lesson, students will use algorithms
+    and moving robots to model mathematical concepts. KIBO will travel along a physical
+    number line to model counting, addition, and subtraction. Students will create
+    algorithms (optionally including repeat loops) to solve problems, just like programmers
+    do at work!
+  tutorial_imagipython_longdescription: Join the world's first social network for
+    pre-teens who like to code. Design your first colorful project in minutes with
+    the free imagi app.
+  tutorial_robotical2_longdescription: Learners will create a sequence of steps to
+    allow a partner to travel a route to a goal, making use of the Marty Controller.
+    Each of the directional symbols has an attached movement; in this lesson, learners
+    will be encouraged to experiment with the directional arrows but the focus will
+    be on the forward arrow.
+  tutorial_robotical3_longdescription: Learners will explore the new interface for
+    Marty, where their instructions will stay on the device screen. Learners will
+    be estimating how many steps they think Marty will need to reach a goal.
+  tutorial_blockscadvirus_longdescription: 'Use a 3D design platform to model a virus
+    and learn about how our bodies use geometry to fight these invaders. '
+  tutorial_robotical1_longdescription: Learners will see Marty the Robot moving with
+    the Unplugged color cards. Learners will then guide a partner to move forward
+    and stop, making use of colored paper. Each of Robotical's colored cards has an
+    instruction built into it, that Marty understands, without the need to write or
+    arrange any code.
+  tutorial_irobotshapes_longdescription: Learn about different shapes through pattern
+    recognition and sequencing in this unplugged, printable robot-themed workbook!
+  tutorial_irobotparts_longdescription: Learn about the different pieces used to build
+    a robot through exploring your senses and practicing math basics.
+  tutorial_irobottools_longdescription: This workbook explores all of the different
+    kinds of tools used when building a robot through matching, counting, scavenger
+    hunts and measuring activities,
+  tutorial_kindercar_longdescription: Students will become engineers, learning the
+    steps of the Engineering Design Process. Inspired by the book 'If I Built a Car'
+    by Chris Van Dusen, students will follow the engineering design process to create
+    their own dream cars out of craft and recycled materials. They will scan a short
+    programming sequence to get their cars moving!
+  tutorial_caavatar_longdescription: 'AVATAR is the latest interactive attraction
+    at ThrillVille theme park. Sakura and Nikau can''t wait to visit it and experience
+    the world of tomorrow! In this interactive short course, the learner joins Sakura
+    and Nikau to learn about data, digital footprints, the Internet of things, Big
+    Data, and the implications these have for us as people, and our future.   '
+  tutorial_hello_language: Bulgarian, Corsican, Danish, Dutch, English, English (UK),
+    Estonian, French, Georgian, German, Hungarian, Icelandic, Indonesian, Irish, Japanese,
+    Nepali, Norwegian (Bokmål), Norwegian (Nynorsk), Other, Pashto, Portuguese (Portugal),
+    Romanian, Serbian (Cyrillic), Spanish (Spain), Spanish (Mexico), Turkish, Vietnamese
+  tutorial_raspispace_language: Arabic, Dutch, English, English (UK), French, Greek
+  tutorial_codemonkeyjump_language: English
+  tutorial_poemart_language: Bulgarian, Corsican, Danish, Dutch, English, Estonian,
+    French, Georgian, German, Hungarian, Icelandic, Indonesian, Irish, Japanese, Nepali,
+    Norwegian (Bokmål), Norwegian (Nynorsk), Other, Pashto, Portuguese (Brazil), Portuguese
+    (Portugal), Romanian, Serbian (Cyrillic), Spanish (Spain), Spanish (Mexico), Turkish,
+    Vietnamese
+  tutorial_kodablehero_language: English
+  tutorial_cacloud_language: English, English (UK)
+  tutorial_blocksmithbot_language: English
+  tutorial_hatchmario_language: English
+  tutorial_microsoftforest_language: English
+  tutorial_blackbirdscreen_language: English
+  tutorial_toxicodecompute2_language: English
+  tutorial_minecrafttimecraft_language: Bulgarian, Chinese (Simplified), Chinese (Traditional),
+    Czech, Danish, Dutch, English, Finnish, French, German, Greek, Hungarian, Indonesian,
+    Italian, Japanese, Korean, Norwegian (Bokmål), Norwegian (Nynorsk), Polish, Portuguese
+    (Brazil), Portuguese (Portugal), Russian, Slovenian, Spanish (Spain), Spanish
+    (Mexico), Swedish, Turkish, Ukrainian
+  tutorial_blackbirdtether_language: English
+  tutorial_ob_language: Arabic, Chinese (Simplified), Chinese (Traditional), Czech,
+    Danish, Dutch, English, French, German, Greek, Hindi, Indonesian, Italian, Japanese,
+    Korean, Malay, Other, Portuguese (Brazil), Portuguese (Portugal), Romanian, Serbian
+    (Cyrillic), Slovenian, Spanish (Spain), Spanish (Mexico), Swedish, Tamil, Thai,
+    Turkish, Ukrainian, Urdu (Pakistan), Vietnamese
+  tutorial_codeartportrait_language: English
+  tutorial_shelly_language: English, Polish
+  tutorial_weavly_language: English
+  tutorial_codespeakpassword_language: English
+  tutorial_codecombatozaria_language: English, English (UK), Spanish (Spain), Spanish
+    (Mexico)
+  tutorial_kodableshapes_language: English
+  tutorial_nasabinary_language: English
+  tutorial_3dmaker_language: English
+  tutorial_itchstart_language: English
+  tutorial_hopsub_language: Chinese (Simplified), English, Spanish (Spain), Spanish
+    (Mexico)
+  tutorial_itchmundos_language: Spanish (Mexico)
+  tutorial_itchtenacity_language: Spanish (Mexico)
+  tutorial_kcjskiing_language: English, French
+  tutorial_groksecurity_language: English
+  tutorial_creaticode_language: Chinese (Simplified), Chinese (Traditional), English
+  tutorial_kcjhockey_language: English, French
+  tutorial_ttdungeon_language: English
+  tutorial_ccai_language: Arabic, Bulgarian, Catalan, Chinese (Simplified), Chinese
+    (Traditional), Czech, Danish, Dutch, English, English (UK), Finnish, French, Galician,
+    German, Greek, Hebrew, Hungarian, Indonesian, Italian, Japanese, Korean, Lithuanian,
+    Macedonian (FRYOM), Malay, Norwegian (Bokmål), Norwegian (Nynorsk), Polish, Portuguese
+    (Brazil), Portuguese (Portugal), Romanian, Russian, Serbian (Cyrillic), Slovenian,
+    Spanish (Spain), Spanish (Mexico), Swedish, Thai, Turkish, Ukrainian, Vietnamese
+  tutorial_bsdai_language: English, English (UK)
+  tutorial_stemdata_language: English
+  tutorial_thunkableinfo_language: English
+  tutorial_educodespace_language: English
+  tutorial_kcjtennis_language: English, French
+  tutorial_robotmagictower_language: English
+  tutorial_ttdragons_language: English
+  tutorial_kcjarchery_language: English, French
+  tutorial_ttsprouts_language: English
+  tutorial_ttmaze_language: English
+  tutorial_codetribe_language: English, English (UK)
+  tutorial_ttcanyon_language: English
+  tutorial_kcjxtrail_language: English, French
+  tutorial_codespeakroad_language: English
+  tutorial_educodelair_language: English
+  tutorial_ibmhourofz_language: English, English (UK)
+  tutorial_gamefrootbacteria_language: English
+  tutorial_educodeforest_language: English
+  tutorial_educodehorus_language: English
+  tutorial_codespeakpokemon_language: English
+  tutorial_stemholiday_language: English
+  tutorial_codespeakpixel_language: English
+  tutorial_codespellsnexus_language: English
+  tutorial_carnegieslime_language: English
+  tutorial_ozotown_language: English
+  tutorial_milnedash_language: English
+  tutorial_microbitpet_language: English, Spanish (Mexico), French, Croatian, Korean,
+    Portuguese (Brazil), Portuguese (Portugal), Serbian, Chinese (Simplified)
+  tutorial_spherotriad_language: English
+  tutorial_spheropassword_language: English
+  tutorial_codequilt_language: English
+  tutorial_ozoshape1_language: English
+  tutorial_ozoshape2_language: English
+  tutorial_hopescape_language: Chinese (Simplified), English, Spanish (Spain), Spanish
+    (Mexico)
+  tutorial_ozorace_language: English
+  tutorial_ozoequestrian_language: English
+  tutorial_irobotpizza_language: English
+  tutorial_ai4alldance_language: English
+  tutorial_ai4allneural_language: English
+  tutorial_spheroinout_language: English
+  tutorial_edisonblueprint_language: English
+  tutorial_edisonmaze_language: English
+  tutorial_milnefunctions_language: English
+  tutorial_sasmap_language: English
+  tutorial_firstrobotics_language: English
+  tutorial_sasdata_language: English
+  tutorial_carnegiesensabot_language: English
+  tutorial_robotical4_language: English
+  tutorial_kinderadd_language: English, English (UK)
+  tutorial_imagipython_language: English, Swedish
+  tutorial_robotical2_language: English
+  tutorial_robotical3_language: English
+  tutorial_blockscadvirus_language: English
+  tutorial_robotical1_language: English
+  tutorial_irobotshapes_language: English
+  tutorial_irobotparts_language: English
+  tutorial_irobottools_language: English
+  tutorial_kindercar_language: English, English (UK)
+  tutorial_caavatar_language: English, English (UK)
+  tutorial_hello_string_detail_grades: Grades 2+
+  tutorial_raspispace_string_detail_grades: Grades 2-8
+  tutorial_codemonkeyjump_string_detail_grades: Grades 2-8
+  tutorial_poemart_string_detail_grades: Grades 2-8
+  tutorial_kodablehero_string_detail_grades: Pre-reader - Grade 5
+  tutorial_cacloud_string_detail_grades: Grades 6+
+  tutorial_blocksmithbot_string_detail_grades: Grades 2-8
+  tutorial_hatchmario_string_detail_grades: Grades 2+
+  tutorial_microsoftforest_string_detail_grades: Grades 2+
+  tutorial_blackbirdscreen_string_detail_grades: Grades 6+
+  tutorial_toxicodecompute2_string_detail_grades: Grades 2+
+  tutorial_minecrafttimecraft_string_detail_grades: Grades 2+
+  tutorial_blackbirdtether_string_detail_grades: Grades 6+
+  tutorial_ob_string_detail_grades: Grades 2+
+  tutorial_codeartportrait_string_detail_grades: Grades 6+
+  tutorial_shelly_string_detail_grades: Grades 2-8
+  tutorial_weavly_string_detail_grades: Grades 2-8
+  tutorial_codespeakpassword_string_detail_grades: Grades 2+
+  tutorial_kodableshapes_string_detail_grades: Pre-reader - Grade 5
+  tutorial_nasabinary_string_detail_grades: Grades 6+
+  tutorial_3dmaker_string_detail_grades: Grades 2-8
+  tutorial_itchstart_string_detail_grades: Grades 2-8
+  tutorial_hopsub_string_detail_grades: Grades 2-8
+  tutorial_itchmundos_string_detail_grades: Grades 2+
+  tutorial_itchtenacity_string_detail_grades: Grades 2+
+  tutorial_kcjskiing_string_detail_grades: Grades 2+
+  tutorial_groksecurity_string_detail_grades: Grades 6+
+  tutorial_creaticode_string_detail_grades: Grades 6+
+  tutorial_kcjhockey_string_detail_grades: Grades 2+
+  tutorial_ttdungeon_string_detail_grades: Grades 6+
+  tutorial_ccai_string_detail_grades: Grades 6-8
+  tutorial_bsdai_string_detail_grades: Grades 6+
+  tutorial_stemdata_string_detail_grades: Grades 9+
+  tutorial_thunkableinfo_string_detail_grades: Grades 6+
+  tutorial_educodespace_string_detail_grades: Grades 6+
+  tutorial_kcjtennis_string_detail_grades: Grades 2+
+  tutorial_robotmagictower_string_detail_grades: Grades 6+
+  tutorial_ttdragons_string_detail_grades: Grades 6+
+  tutorial_kcjarchery_string_detail_grades: Grades 2+
+  tutorial_ttsprouts_string_detail_grades: Grades 2+
+  tutorial_ttmaze_string_detail_grades: Grades 6+
+  tutorial_codetribe_string_detail_grades: Grades 2-8
+  tutorial_ttcanyon_string_detail_grades: Grades 6-8
+  tutorial_kcjxtrail_string_detail_grades: Grades 2-8
+  tutorial_codespeakroad_string_detail_grades: Grades 2-8
+  tutorial_educodelair_string_detail_grades: Grades 6+
+  tutorial_ibmhourofz_string_detail_grades: Grades 9+
+  tutorial_gamefrootbacteria_string_detail_grades: Grades 6+
+  tutorial_educodeforest_string_detail_grades: Grades 6+
+  tutorial_educodehorus_string_detail_grades: Grades 6+
+  tutorial_codespeakpokemon_string_detail_grades: Grades 6+
+  tutorial_stemholiday_string_detail_grades: Grades 6-8
+  tutorial_codespeakpixel_string_detail_grades: Grades 6+
+  tutorial_codespellsnexus_string_detail_grades: Grades 6+
+  tutorial_carnegieslime_string_detail_grades: Grades 2-8
+  tutorial_ozotown_string_detail_grades: Grades 2+
+  tutorial_milnedash_string_detail_grades: Pre-reader
+  tutorial_microbitpet_string_detail_grades: Grades 2-8
+  tutorial_spherotriad_string_detail_grades: Grades 2+
+  tutorial_spheropassword_string_detail_grades: Grades 2-8
+  tutorial_codequilt_string_detail_grades: Grades 6+
+  tutorial_ozoshape1_string_detail_grades: Grades 2+
+  tutorial_ozoshape2_string_detail_grades: Grades 2+
+  tutorial_hopescape_string_detail_grades: Grades 2+
+  tutorial_ozorace_string_detail_grades: Pre-reader - Grade 5
+  tutorial_ozoequestrian_string_detail_grades: Pre-reader - Grade 5
+  tutorial_irobotpizza_string_detail_grades: Grades 2-8
+  tutorial_ai4alldance_string_detail_grades: Grades 6+
+  tutorial_ai4allneural_string_detail_grades: Grades 6+
+  tutorial_spheroinout_string_detail_grades: Pre-reader - Grade 5
+  tutorial_edisonblueprint_string_detail_grades: Grades 6+
+  tutorial_edisonmaze_string_detail_grades: Grades 2-8
+  tutorial_milnefunctions_string_detail_grades: Grades 6-8
+  tutorial_sasmap_string_detail_grades: Grades 2-5
+  tutorial_firstrobotics_string_detail_grades: Grades 6+
+  tutorial_sasdata_string_detail_grades: Grades 2+
+  tutorial_carnegiesensabot_string_detail_grades: Grades 2-8
+  tutorial_robotical4_string_detail_grades: Grades 2-5
+  tutorial_kinderadd_string_detail_grades: Pre-reader - Grade 5
+  tutorial_imagipython_string_detail_grades: Grades 2-8
+  tutorial_robotical2_string_detail_grades: Pre-reader - Grade 5
+  tutorial_robotical3_string_detail_grades: Grades 2-5
+  tutorial_blockscadvirus_string_detail_grades: Grades 6+
+  tutorial_robotical1_string_detail_grades: Pre-reader - Grade 5
+  tutorial_irobotshapes_string_detail_grades: Pre-reader
+  tutorial_irobotparts_string_detail_grades: Pre-reader
+  tutorial_irobottools_string_detail_grades: Pre-reader
+  tutorial_kindercar_string_detail_grades: Pre-reader
+  tutorial_caavatar_string_detail_grades: Grades 6+
+  tutorial_hello_string_platforms: All modern browsers, Android tablet, iPad, Windows
+    phone, Android phone, iPhone
+  tutorial_raspispace_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_codemonkeyjump_string_platforms: All modern browsers
+  tutorial_poemart_string_platforms: All modern browsers, Android tablet, iPad, Windows
+    phone, Android phone, iPhone, Game console app, Screen reader
+  tutorial_kodablehero_string_platforms: All modern browsers, iPad, iPhone
+  tutorial_cacloud_string_platforms: All modern browsers
+  tutorial_blocksmithbot_string_platforms: All modern browsers
+  tutorial_hatchmario_string_platforms: All modern browsers
+  tutorial_microsoftforest_string_platforms: All modern browsers
+  tutorial_blackbirdscreen_string_platforms: Chrome
+  tutorial_toxicodecompute2_string_platforms: All modern browsers
+  tutorial_minecrafttimecraft_string_platforms: All modern browsers, Mac, Windows,
+    Chromebook, iPhone, iPad, Android phone, Android tablet
+  tutorial_blackbirdtether_string_platforms: Chrome
+  tutorial_ob_string_platforms: All modern browsers, Screen reader
+  tutorial_codeartportrait_string_platforms: All modern browsers, Android tablet,
+    iPad
+  tutorial_shelly_string_platforms: All modern browsers
+  tutorial_weavly_string_platforms: All modern browsers, Screen reader
+  tutorial_codespeakpassword_string_platforms: All modern browsers
+  tutorial_kodableshapes_string_platforms: All modern browsers, iPad, iPhone
+  tutorial_nasabinary_string_platforms: Unplugged, Screen reader
+  tutorial_3dmaker_string_platforms: All modern browsers, Android tablet, iPad, Windows
+    phone, Android phone, iPhone
+  tutorial_itchstart_string_platforms: All modern browsers, iPad
+  tutorial_hopsub_string_platforms: iPad, iPhone
+  tutorial_itchmundos_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_itchtenacity_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_kcjskiing_string_platforms: All modern browsers
+  tutorial_groksecurity_string_platforms: All modern browsers, Android tablet, iPad,
+    Windows phone, Android phone, iPhone
+  tutorial_creaticode_string_platforms: All modern browsers, Android tablet, iPad,
+    Windows phone, Android phone, iPhone
+  tutorial_kcjhockey_string_platforms: All modern browsers
+  tutorial_ttdungeon_string_platforms: Chrome, Firefox
+  tutorial_ccai_string_platforms: All modern browsers
+  tutorial_bsdai_string_platforms: Chrome, Firefox
+  tutorial_stemdata_string_platforms: All modern browsers, iPad
+  tutorial_thunkableinfo_string_platforms: Chrome, Safari
+  tutorial_educodespace_string_platforms: All modern browsers
+  tutorial_kcjtennis_string_platforms: All modern browsers
+  tutorial_robotmagictower_string_platforms: All modern browsers
+  tutorial_ttdragons_string_platforms: Chrome, Firefox
+  tutorial_kcjarchery_string_platforms: All modern browsers
+  tutorial_ttsprouts_string_platforms: Chrome, Firefox
+  tutorial_ttmaze_string_platforms: Chrome, Firefox
+  tutorial_codetribe_string_platforms: All modern browsers, Android tablet, iPad,
+    Windows phone, Android phone, iPhone
+  tutorial_ttcanyon_string_platforms: Chrome, Firefox
+  tutorial_kcjxtrail_string_platforms: All modern browsers
+  tutorial_codespeakroad_string_platforms: Chrome
+  tutorial_educodelair_string_platforms: All modern browsers, iPad
+  tutorial_ibmhourofz_string_platforms: Chrome, Firefox, Android phone, iPhone
+  tutorial_gamefrootbacteria_string_platforms: All modern browsers
+  tutorial_educodeforest_string_platforms: All modern browsers, iPad
+  tutorial_educodehorus_string_platforms: All modern browsers, iPad
+  tutorial_codespeakpokemon_string_platforms: All modern browsers
+  tutorial_stemholiday_string_platforms: Chrome
+  tutorial_codespeakpixel_string_platforms: All modern browsers
+  tutorial_codespellsnexus_string_platforms: Chrome, Firefox
+  tutorial_carnegieslime_string_platforms: All modern browsers
+  tutorial_ozotown_string_platforms: All modern browsers
+  tutorial_milnedash_string_platforms: All modern browsers, Screen reader
+  tutorial_microbitpet_string_platforms: All modern browsers, Screen reader
+  tutorial_spherotriad_string_platforms: Android tablet, iPad, Android phone, iPhone,
+    Windows 10, macOS, ChromeOS
+  tutorial_spheropassword_string_platforms: All modern browsers, Android tablet, iPad,
+    Windows phone, Android phone, iPhone
+  tutorial_codequilt_string_platforms: All modern browsers
+  tutorial_ozoshape1_string_platforms: All modern browsers
+  tutorial_ozoshape2_string_platforms: All modern browsers
+  tutorial_hopescape_string_platforms: iPad, iPhone
+  tutorial_ozorace_string_platforms: All modern browsers
+  tutorial_ozoequestrian_string_platforms: All modern browsers
+  tutorial_irobotpizza_string_platforms: Unplugged
+  tutorial_ai4alldance_string_platforms: All modern browsers
+  tutorial_ai4allneural_string_platforms: All modern browsers
+  tutorial_spheroinout_string_platforms: Unplugged
+  tutorial_edisonblueprint_string_platforms: All modern browsers
+  tutorial_edisonmaze_string_platforms: All modern browsers
+  tutorial_milnefunctions_string_platforms: All modern browsers, Screen reader
+  tutorial_sasmap_string_platforms: All modern browsers, iPad, Screen reader
+  tutorial_firstrobotics_string_platforms: All modern browsers
+  tutorial_sasdata_string_platforms: All modern browsers
+  tutorial_carnegiesensabot_string_platforms: All modern browsers
+  tutorial_robotical4_string_platforms: All modern browsers
+  tutorial_kinderadd_string_platforms: Unplugged
+  tutorial_imagipython_string_platforms: Chrome, Firefox, Android tablet, iPad, Android
+    phone, iPhone
+  tutorial_robotical2_string_platforms: Unplugged
+  tutorial_robotical3_string_platforms: All modern browsers
+  tutorial_blockscadvirus_string_platforms: All modern browsers
+  tutorial_robotical1_string_platforms: Unplugged
+  tutorial_irobotshapes_string_platforms: Unplugged
+  tutorial_irobotparts_string_platforms: Unplugged
+  tutorial_irobottools_string_platforms: Unplugged
+  tutorial_kindercar_string_platforms: Unplugged
+  tutorial_caavatar_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_hello_string_detail_platforms: ''
+  tutorial_raspispace_string_detail_platforms: ''
+  tutorial_codemonkeyjump_string_detail_platforms: ''
+  tutorial_poemart_string_detail_platforms: ''
+  tutorial_kodablehero_string_detail_platforms: ''
+  tutorial_cacloud_string_detail_platforms: ''
+  tutorial_blocksmithbot_string_detail_platforms: Internet Explorer 11, Microsoft
+    Edge, Chrome, Firefox, Safari
+  tutorial_hatchmario_string_detail_platforms: ''
+  tutorial_microsoftforest_string_detail_platforms: ''
+  tutorial_blackbirdscreen_string_detail_platforms: ''
+  tutorial_toxicodecompute2_string_detail_platforms: Microsoft Edge, Chrome, Firefox,
+    Safari
+  tutorial_minecrafttimecraft_string_detail_platforms: ''
+  tutorial_blackbirdtether_string_detail_platforms: ''
+  tutorial_ob_string_detail_platforms: ''
+  tutorial_codeartportrait_string_detail_platforms: ''
+  tutorial_shelly_string_detail_platforms: ''
+  tutorial_weavly_string_detail_platforms: ''
+  tutorial_codespeakpassword_string_detail_platforms: Chrome, Firefox, Safari
+  tutorial_kodableshapes_string_detail_platforms: ''
+  tutorial_nasabinary_string_detail_platforms: ''
+  tutorial_3dmaker_string_detail_platforms: ''
+  tutorial_itchstart_string_detail_platforms: ''
+  tutorial_hopsub_string_detail_platforms: ''
+  tutorial_itchmundos_string_detail_platforms: ''
+  tutorial_itchtenacity_string_detail_platforms: ''
+  tutorial_kcjskiing_string_detail_platforms: ''
+  tutorial_groksecurity_string_detail_platforms: ''
+  tutorial_creaticode_string_detail_platforms: ''
+  tutorial_kcjhockey_string_detail_platforms: ''
+  tutorial_ttdungeon_string_detail_platforms: ''
+  tutorial_ccai_string_detail_platforms: ''
+  tutorial_bsdai_string_detail_platforms: ''
+  tutorial_stemdata_string_detail_platforms: ''
+  tutorial_thunkableinfo_string_detail_platforms: ''
+  tutorial_educodespace_string_detail_platforms: ''
+  tutorial_kcjtennis_string_detail_platforms: ''
+  tutorial_robotmagictower_string_detail_platforms: ''
+  tutorial_ttdragons_string_detail_platforms: ''
+  tutorial_kcjarchery_string_detail_platforms: ''
+  tutorial_ttsprouts_string_detail_platforms: ''
+  tutorial_ttmaze_string_detail_platforms: ''
+  tutorial_codetribe_string_detail_platforms: ''
+  tutorial_ttcanyon_string_detail_platforms: ''
+  tutorial_kcjxtrail_string_detail_platforms: ''
+  tutorial_codespeakroad_string_detail_platforms: ''
+  tutorial_educodelair_string_detail_platforms: ''
+  tutorial_ibmhourofz_string_detail_platforms: ''
+  tutorial_gamefrootbacteria_string_detail_platforms: Microsoft Edge, Chrome, Firefox,
+    Safari
+  tutorial_educodeforest_string_detail_platforms: ''
+  tutorial_educodehorus_string_detail_platforms: ''
+  tutorial_codespeakpokemon_string_detail_platforms: ''
+  tutorial_stemholiday_string_detail_platforms: ''
+  tutorial_codespeakpixel_string_detail_platforms: Chrome, Firefox, Safari
+  tutorial_codespellsnexus_string_detail_platforms: ''
+  tutorial_carnegieslime_string_detail_platforms: ''
+  tutorial_ozotown_string_detail_platforms: Ozobot
+  tutorial_milnedash_string_detail_platforms: Dash robot
+  tutorial_microbitpet_string_detail_platforms: micro:bit
+  tutorial_spherotriad_string_detail_platforms: Sphero Bolt
+  tutorial_spheropassword_string_detail_platforms: littleBits STEAM+ Coding Kit
+  tutorial_codequilt_string_detail_platforms: ''
+  tutorial_ozoshape1_string_detail_platforms: Ozobot
+  tutorial_ozoshape2_string_detail_platforms: Ozobot
+  tutorial_hopescape_string_detail_platforms: ''
+  tutorial_ozorace_string_detail_platforms: Ozobot
+  tutorial_ozoequestrian_string_detail_platforms: Ozobot
+  tutorial_irobotpizza_string_detail_platforms: ''
+  tutorial_ai4alldance_string_detail_platforms: ''
+  tutorial_ai4allneural_string_detail_platforms: ''
+  tutorial_spheroinout_string_detail_platforms: Sphero indi
+  tutorial_edisonblueprint_string_detail_platforms: Edison robot
+  tutorial_edisonmaze_string_detail_platforms: Edison robots
+  tutorial_milnefunctions_string_detail_platforms: Dash robot
+  tutorial_sasmap_string_detail_platforms: iPad, the free app and one robot. Supports
+    BOLT, SPRK+, Sphero Mini, SPRK, Sphero, and Ollie robots.
+  tutorial_firstrobotics_string_detail_platforms: ''
+  tutorial_sasdata_string_detail_platforms: ''
+  tutorial_carnegiesensabot_string_detail_platforms: ''
+  tutorial_robotical4_string_detail_platforms: Marty the Robot
+  tutorial_kinderadd_string_detail_platforms: KIBO Robot Kit
+  tutorial_imagipython_string_detail_platforms: ''
+  tutorial_robotical2_string_detail_platforms: Marty the Robot
+  tutorial_robotical3_string_detail_platforms: Marty the Robot
+  tutorial_blockscadvirus_string_detail_platforms: ''
+  tutorial_robotical1_string_detail_platforms: Marty the Robot
+  tutorial_irobotshapes_string_detail_platforms: ''
+  tutorial_irobotparts_string_detail_platforms: ''
+  tutorial_irobottools_string_detail_platforms: ''
+  tutorial_kindercar_string_detail_platforms: KIBO Robot Kit
+  tutorial_caavatar_string_detail_platforms: ''
+  tutorial_hello_string_detail_programming_languages: Blocks
+  tutorial_raspispace_string_detail_programming_languages: Blocks, Scratch
+  tutorial_codemonkeyjump_string_detail_programming_languages: Blocks
+  tutorial_poemart_string_detail_programming_languages: Blocks
+  tutorial_kodablehero_string_detail_programming_languages: JavaScript, iOS/Swift,
+    Language independent (can be taught in multiple languages)
+  tutorial_cacloud_string_detail_programming_languages: Theory Based
+  tutorial_blocksmithbot_string_detail_programming_languages: JavaScript
+  tutorial_hatchmario_string_detail_programming_languages: Blocks
+  tutorial_microsoftforest_string_detail_programming_languages: Blocks
+  tutorial_blackbirdscreen_string_detail_programming_languages: JavaScript
+  tutorial_toxicodecompute2_string_detail_programming_languages: Python
+  tutorial_minecrafttimecraft_string_detail_programming_languages: Blocks, Python
+  tutorial_blackbirdtether_string_detail_programming_languages: JavaScript
+  tutorial_ob_string_detail_programming_languages: Blocks
+  tutorial_codeartportrait_string_detail_programming_languages: JavaScript, p5.js
+  tutorial_shelly_string_detail_programming_languages: A Logo-like language
+  tutorial_weavly_string_detail_programming_languages: Blocks
+  tutorial_codespeakpassword_string_detail_programming_languages: Python
+  tutorial_kodableshapes_string_detail_programming_languages: JavaScript, Language
+    independent (can be taught in multiple languages)
+  tutorial_nasabinary_string_detail_programming_languages: Binary code
+  tutorial_3dmaker_string_detail_programming_languages: Blocks
+  tutorial_itchstart_string_detail_programming_languages: Blocks
+  tutorial_hopsub_string_detail_programming_languages: Hopscotch
+  tutorial_itchmundos_string_detail_programming_languages: Blocks
+  tutorial_itchtenacity_string_detail_programming_languages: Blocks
+  tutorial_kcjskiing_string_detail_programming_languages: Blocks
+  tutorial_groksecurity_string_detail_programming_languages: None - no programming
+    required
+  tutorial_creaticode_string_detail_programming_languages: Blocks
+  tutorial_kcjhockey_string_detail_programming_languages: Blocks
+  tutorial_ttdungeon_string_detail_programming_languages: Algorithms
+  tutorial_ccai_string_detail_programming_languages: JavaScript, Python
+  tutorial_bsdai_string_detail_programming_languages: HTML, CSS and JavaScript
+  tutorial_stemdata_string_detail_programming_languages: JavaScript, Includes option
+    to download and analyze data in Google Sheets and Excel
+  tutorial_thunkableinfo_string_detail_programming_languages: Blocks
+  tutorial_educodespace_string_detail_programming_languages: JavaScript
+  tutorial_kcjtennis_string_detail_programming_languages: Blocks
+  tutorial_robotmagictower_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_ttdragons_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_kcjarchery_string_detail_programming_languages: Blocks
+  tutorial_ttsprouts_string_detail_programming_languages: JavaScript, C#
+  tutorial_ttmaze_string_detail_programming_languages: JavaScript
+  tutorial_codetribe_string_detail_programming_languages: JavaScript, HTML and CSS.
+  tutorial_ttcanyon_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_kcjxtrail_string_detail_programming_languages: Blocks
+  tutorial_codespeakroad_string_detail_programming_languages: Blocks
+  tutorial_educodelair_string_detail_programming_languages: JavaScript
+  tutorial_ibmhourofz_string_detail_programming_languages: Python, COBOL
+  tutorial_gamefrootbacteria_string_detail_programming_languages: Blocks
+  tutorial_educodeforest_string_detail_programming_languages: JavaScript
+  tutorial_educodehorus_string_detail_programming_languages: JavaScript
+  tutorial_codespeakpokemon_string_detail_programming_languages: Blocks
+  tutorial_stemholiday_string_detail_programming_languages: JavaScript, HTML5
+  tutorial_codespeakpixel_string_detail_programming_languages: JavaScript
+  tutorial_codespellsnexus_string_detail_programming_languages: Blocks, JavaScript,
+    Racket
+  tutorial_carnegieslime_string_detail_programming_languages: Blocks
+  tutorial_ozotown_string_detail_programming_languages: Blocks
+  tutorial_milnedash_string_detail_programming_languages: Blocks
+  tutorial_microbitpet_string_detail_programming_languages: Python, MakeCode
+  tutorial_spherotriad_string_detail_programming_languages: Blocks
+  tutorial_spheropassword_string_detail_programming_languages: Blocks
+  tutorial_codequilt_string_detail_programming_languages: Blocks
+  tutorial_ozoshape1_string_detail_programming_languages: Blocks
+  tutorial_ozoshape2_string_detail_programming_languages: Blocks
+  tutorial_hopescape_string_detail_programming_languages: Blocks, Hopscotch
+  tutorial_ozorace_string_detail_programming_languages: Ozobot Color Codes
+  tutorial_ozoequestrian_string_detail_programming_languages: Color Codes
+  tutorial_irobotpizza_string_detail_programming_languages: Blocks
+  tutorial_ai4alldance_string_detail_programming_languages: No programming required.
+  tutorial_ai4allneural_string_detail_programming_languages: No programming required.
+  tutorial_spheroinout_string_detail_programming_languages: None - color tiles
+  tutorial_edisonblueprint_string_detail_programming_languages: Blocks
+  tutorial_edisonmaze_string_detail_programming_languages: Blocks
+  tutorial_milnefunctions_string_detail_programming_languages: Blocks
+  tutorial_sasmap_string_detail_programming_languages: Blocks
+  tutorial_firstrobotics_string_detail_programming_languages: Blocks, OnbotJava
+  tutorial_sasdata_string_detail_programming_languages: 'No programming languages. '
+  tutorial_carnegiesensabot_string_detail_programming_languages: Blocks
+  tutorial_robotical4_string_detail_programming_languages: Blocks
+  tutorial_kinderadd_string_detail_programming_languages: Tangible KIBO blocks
+  tutorial_imagipython_string_detail_programming_languages: Python
+  tutorial_robotical2_string_detail_programming_languages: This makes use of a paper
+    printout of the Marty Controller
+  tutorial_robotical3_string_detail_programming_languages: Blocks
+  tutorial_blockscadvirus_string_detail_programming_languages: Blocks
+  tutorial_robotical1_string_detail_programming_languages: Language independent (can
+    be taught in multiple languages), Color cards are used to command the device featured
+    in the video and to instruct partners.
+  tutorial_irobotshapes_string_detail_programming_languages: pre-reader computational
+    thinking activity
+  tutorial_irobotparts_string_detail_programming_languages: pre-reader computational
+    thinking activity
+  tutorial_irobottools_string_detail_programming_languages: pre-reader computational
+    thinking activity
+  tutorial_kindercar_string_detail_programming_languages: KIBO tangible blocks
+  tutorial_caavatar_string_detail_programming_languages: CS Conceptual so no language
+    needed
+  tutorial_icomputefireworks_name: 'Fireworks Display: Created with Code'
+  tutorial_icomputefireworks_longdescription: Create your own fireworks display using
+    code.
+  tutorial_icomputefireworks_language: English, English (UK)
+  tutorial_icomputefireworks_string_detail_grades: Grades 2-5
+  tutorial_icomputefireworks_string_platforms: All modern browsers
+  tutorial_icomputefireworks_string_detail_platforms: ''
+  tutorial_icomputefireworks_string_detail_programming_languages: Blocks
+  tutorial_rpccw_name: 'Code Club World: Make cool stuff with free coding games and
+    activities'
+  tutorial_rpledfirefly_name: 'LED firefly: Meet the Raspberry Pi Pico'
+  tutorial_rpcharting_name: 'Charting champions: The power of Python lists'
+  tutorial_rpsolar_name: 'Solar system simulator: Python models and dictionaries'
+  tutorial_rpwebcards_name: 'Flip treat webcards: Create interactive hover cards that
+    flip'
+  tutorial_codeclubhworld_name: 'Hello world: Say hello to Python coding'
+  tutorial_codeclubspells_name: 'Broadcasting spells: Scratch coding beyond the basics'
+  tutorial_coderdojoanime_name: 'Anime expressions: Create and style a webpage for
+    an anime drawing tutorial'
+  tutorial_coderdojotarget_name: 'Target practice: Introduction to Python graphics'
+  tutorial_creaticodescratch_name: Advanced Scratch Coding (2D/3D/AR/AI)
+  tutorial_bbsierpinski_name: 'Sierpinski Triangle: Make Art with Math!'
+  tutorial_bbstopwatch_name: Stopwatch Builder
+  tutorial_idrpatterns_name: Creating patterns with code
+  tutorial_idrshapes_name: Drawing shapes with code
+  tutorial_edisondetect_name: Detect and avoid with Edison
+  tutorial_edisonmusical_name: Edison's musical talents
+  tutorial_codemonkeydiglit_name: Digital Literacy - Mini Course
+  tutorial_bsdrockpaper_name: Rock, Paper, Scissors with Python
+  tutorial_microbitreaction_name: micro:bit reaction game
+  tutorial_kinderanimal_name: KIBO the Playful Animal
+  tutorial_kindersinger_name: KIBO the Singer
+  tutorial_microbitwwn_name: micro:bit which way now? activity
+  tutorial_grokcyberlive_name: Cyber Live
+  tutorial_codemojimaze_name: 'Unplugged: Code A Maze '
+  tutorial_codemojisnake_name: 'Scratch: Create Your Own Snake Game'
+  tutorial_carnegietoxibots_name: 'Zillah City: Fall of the Toxibots'
+  tutorial_carnegieiris_name: Iris Rover Challenge with VICE Virtual Robot
+  tutorial_carnegiespike_name: " Virtual SPIKE Prime Coding - Iris Rover Challenge"
+  tutorial_spheroincolor_name: indi Color Contest
+  tutorial_kcjdominos_name: Simulating Dominos Using JavaScript
+  tutorial_spherocolortheory_name: Additive Color Theory (RGB) with BOLT
+  tutorial_codecombatesports_name: 'Esports Bootcamp: AI League'
+  tutorial_spherodigdisplay_name: The Technology of Digital Displays with littleBits
+  tutorial_spherorvrincolor_name: RVR+ in Color!
+  tutorial_clbinary_name: Learn How Binary Works with Computers using Minecraft
+  tutorial_sascollabcode_name: 'SAS CodeSnaps: Collaborative coding for blind, low
+    vision and sighted students'
+  tutorial_codecombatgoblins_name: 'CodeCombat: Goblins ''n'' Glory'
+  tutorial_scratchstorytelling_name: Anything is Possible! Storytelling with Scratch
+  tutorial_crayolasymbols_name: 'Unplugged Coding from Crayola Education: Visual Symbols
+    Convey Meaning'
+  tutorial_crayoladrawacode_name: 'Unplugged Coding from Crayola Education: Draw A
+    Code'
+  tutorial_crayolafollowmycode_name: 'Unplugged Coding from Crayola Education: Follow
+    My Code'
+  tutorial_madpicturethis_name: Picture This! HTML Decoded
+  tutorial_mindmakersmaps_name: Maps
+  tutorial_mindmakersjorel_name: Jorel's Brother
+  tutorial_mindmakersroboland_name: Roboland
+  tutorial_mindmakersrobolandjr_name: Roboland Jr
+  tutorial_codehsdraw_name: Drawing and Scratch
+  tutorial_codehscamouflage_name: 'Programming an Adaptation: Camouflage'
+  tutorial_firiapythoncodex_name: Python with CodeX
+  tutorial_bekidscoding_name: bekids Coding Challenges
+  tutorial_rodocodehr_name: 'Rodocodo: Code Hour'
+  tutorial_microbitdice_name: micro:bit dice
+  tutorial_madflashcard_name: Deconstructing Code in a Flash(card)
+  tutorial_madappwars_name: App Wars
+  tutorial_kodablepuppies_name: 'Robots and Puppies '
+  tutorial_googlesuperhero_name: Build a Superhero
+  tutorial_googlename _name: Design Your Name
+  tutorial_carnegiezillah_name: Zillah Beats
+  tutorial_nasachspacejam_name: NASA's Space Jam
+  tutorial_hatchxrsolar_name: Build a 3D/AR Solar System
+  tutorial_hatchxrspace_name: Code a 3D Space Invaders Game
+  tutorial_hatchxrtrex_name: Create a 3D T-Rex Game
+  tutorial_blocksmithguinea_name: Guinea Pig Survivors
+  tutorial_pickcodeshapes_name: 'Pickcode: Shapes and Spirals'
+  tutorial_codesterssketch_name: 'Codesters: Etch-a-Sketch'
+  tutorial_pickcodechatbot_name: 'Pickcode: Ad Libs Chatbot'
+  tutorial_codestersfish_name: 'Codesters: Feed the Fish'
+  tutorial_codestershedgehog_name: 'Codesters: Star Hedgehog'
+  tutorial_pickcodeggame_name: 'Pickcode: Guessing Game Chatbot'
+  tutorial_codestersdino_name: 'Codesters: Flappy Dino'
+  tutorial_pickcodemtpaint_name: 'Pickcode: Mobius Triangle Painting'
+  tutorial_microsoftcarnival_name: Code a Carnival
+  tutorial_thunkablescavenger_name: Build a Scavenger Hunt App with Code Blocks
+  tutorial_codeillusionfund_name: 'Disney Codeillusion: Computer Fundamentals'
+  tutorial_codeillusiongoofybeg_name: 'Disney Codeillusion: Game Development Adventure
+    with Goofy for Beginners'
+  tutorial_codeillusiongoofyint_name: 'Disney Codeillusion: Game Development Adventure
+    with Goofy for Intermediates'
+  tutorial_robotmagicescape_name: 'Escape Room: Code with Bots'
+  tutorial_codespeakclimate_name: Create a Website to Spread Awareness About Climate
+    Change
+  tutorial_codespeaktwinkle_name: Coding Twinkle Little Star in ScratchJr
+  tutorial_coinbasecrypto_name: The Crypto Memory Game
+  tutorial_codespeakcomp_name: Build a Composting Game in Scratch
+  tutorial_codespeaksnake_name: 'Coding Snake: Story Time with ScratchJr'
+  tutorial_prstemalexa_name: Alexa in Space
+  tutorial_coderzfarm_name: 'Code Farm: Plant a Garden'
+  tutorial_intelinofield_name: 'intelino Mission: Field Trip'
+  tutorial_cablockchain_name: New Kids on the Blockchain
+  tutorial_nasaparachute_name: 'NASA: Mars Perseverance Parachute Coding Activity'
+  tutorial_nasascratch_name: 'NASA: Explore Mars With Scratch'
+  tutorial_nasaorbit_name: 'NASA: Crew Orbital Docking Simulation'
+  tutorial_nasapackage_name: 'NASA: Package Delivery Drone Simulation Coding Activity '
+  tutorial_nasalunar_name: 'NASA: Lunar Coding Challenge'
+  tutorial_meeestate_name: Escape Estate
+  tutorial_imagipixelart_name: Code your own pixel art!
+  tutorial_kcjhealth_name: The Health & Well-Being Challenge
+  tutorial_msftwakanda_name: Long Live Wakanda
+  tutorial_nafbrand_name: Code your Brand
+  tutorial_rpccw_longdescription: Create your own character, design a T-shirt, and
+    create some music. Earn badges for each completed project.
+  tutorial_rpledfirefly_longdescription: Use a Raspberry Pi Pico microcontroller and
+    basic electronic components to create a blinking LED firefly. Write MicroPython
+    code to light your firefly and create a switch from jumper wires to mimic fireflies
+    in the wild when the switch is closed.
+  tutorial_rpcharting_longdescription: Discover the power of lists in the Python programming
+    language by storing Olympic medal data then use the pygal library to create an
+    interactive chart. Use data analysis skills to uncover patterns and anomalies.
+  tutorial_rpsolar_longdescription: Create an animated, interactive, solar system
+    model using the Python programming language and the p5 graphics library. Use dictionaries
+    to store planet facts that load when an orbiting planet is clicked.
+  tutorial_rpwebcards_longdescription: Create a set of webcards that flip when you
+    hover over them. Use CSS styling and animations then customise with fancy fonts
+    and colour gradients.
+  tutorial_codeclubhworld_longdescription: Write Python text-based code to create
+    an interactive project with user input that prints text and emoji. Use variables
+    to store text and numbers, and functions to organize your code.
+  tutorial_codeclubspells_longdescription: Use Scratch blocks to code a wand that
+    casts spells to turn sprites into toads, grow, and shrink them. Edit and reverse
+    sound to make spell sound effects. Broadcast spell messages so that multiple sprites
+    transform when the message is received.
+  tutorial_coderdojoanime_longdescription: Create a responsive webpage with text and
+    images for an anime drawing tutorial. Use HTML to structure the webpage and CSS
+    styles to apply layout, colour palettes and fonts.
+  tutorial_coderdojotarget_longdescription: Use Python with the p5 graphics library
+    to draw a target and score points by hitting it with arrows. Learn about RGB colours
+    and position your target with x & y coordinates. Use if, elif and else conditions
+    to make scoring decisions.
+  tutorial_creaticodescratch_longdescription: CreatiCode.com offers a wide range of
+    coding activities in many topics, such as 3D games, 3D arts, Augmented Reality
+    games, Artificial Intelligence apps, Youtube video remixing, and UN's sustainable
+    development goals. Scratch-based blocks are used in all activities, so students
+    do not need to learn a different programming language or user interface to code
+    and share their projects.
+  tutorial_bbsierpinski_longdescription: In this short series of lessons, you'll learn
+    to create amazing and colorful math art!
+  tutorial_bbstopwatch_longdescription: In this short series of lessons, you'll learn
+    to create a real, working stopwatch!
+  tutorial_idrpatterns_longdescription: Use the Loop action block in the Weavly coding
+    environment to create geometric patterns like crystals, stars, or other exciting
+    shapes with repeated elements.
+  tutorial_idrshapes_longdescription: 'In this activity, players use the Weavly action
+    blocks to draw simple shapes, such squares, rectangles, triangles, hexagons, and
+    stars. '
+  tutorial_edisondetect_longdescription: Introduce the key computational concepts
+    of loops and an understanding of infrared light using Edison robots and the block
+    based programming language, EdBlocks. This lesson utilizes the Edison robot's
+    drive and obstacle detection functions through a set of progressive programming
+    tasks.
+  tutorial_edisonmusical_longdescription: Simple musical tunes are a great example
+    of sequence in action. Using Edison and the Scratch-based programming language,
+    EdScratch, students can create music and tie together sequence and inputs-outputs
+    into enjoyable programs.
+  tutorial_codemonkeydiglit_longdescription: 'Introduction to some important topics
+    in the digital world: How to use computers, what is software and hardware, possible
+    online threats and protecting your privacy. The course includes 2 lessons - digital
+    use and digital citizenship. Each lesson is made of self guided slides with interactive
+    questions and surveys, 3 mini games and 5 review questions to check the student''s
+    understanding.'
+  tutorial_bsdrockpaper_longdescription: Use the Python programming language to build
+    a 'Rock, Paper, Scissors' game. Don't worry if you have never tried Python, we
+    will walk you through each step.
+  tutorial_microbitreaction_longdescription: Make a micro:bit reaction game with real
+    physical switches made from scrap cardboard and kitchen foil.
+  tutorial_kinderanimal_longdescription: In this lesson, students will turn KIBO into
+    a playful animal that moves in response to a program the children create. Students
+    can also experiment with KIBO's input and output options to take it further.
+  tutorial_kindersinger_longdescription: In this lesson, students will dress KIBO
+    up in a performer's outfit and teach KIBO to sing a favorite song! With KIBO's
+    Sound Record/Playback Module, children will use their sequencing skills to program
+    KIBO to play back their song in the correct order. This lesson is meant for children
+    with prior KIBO experience.
+  tutorial_microbitwwn_longdescription: Shake your micro:bit and be given a random
+    direction to walk.
+  tutorial_grokcyberlive_longdescription: A Navy captain is held captive inside his
+    ship. A major landmark has gone dark. And weapons are pointed at Sydney's busiest
+    sites…It's all connected, and it's up to you to free the captain, track down the
+    culprit, and stop them. Students will need to trace clues, solve puzzles, and
+    figure out how to stop a large-scale simulated cyber attack before it's too late.
+  tutorial_codemojimaze_longdescription: Learn about sequences to help Deeno complete
+    the maze.
+  tutorial_codemojisnake_longdescription: In this unit students will learn how to
+    use coding blocks on Scratch to create a snake game.
+  tutorial_carnegietoxibots_longdescription: No one sleeps on Zillah City. You play
+    as one of the Zeds, a crew dedicated to stamping out the menace of Toxibots, malware-corrupted
+    robots that belong to Toxicorp, a giant corporation. Most of the Toxibots were
+    destroyed, but there are still some around wreaking havoc. Get geared up in the
+    Zed Clubhouse, and program your collaborative robot (aka 'cobot') Beastie to help
+    capture them.
+  tutorial_carnegieiris_longdescription: The Iris Rover Challenge with VICE Virtual
+    Robot provides a structured sequence of programming activities in a real-world
+    project-based context. It is designed to get students thinking about the patterns
+    and structure of not just robotics, but also programming and problem-solving more
+    generally. This lesson includes videos, animations, and a built-in coding environment
+    with the virtual robot.
+  tutorial_carnegiespike_longdescription: The Virtual SPIKE Prime Coding - Iris Rover
+    Challenge provides a structured sequence of programming activities in a real-world
+    project-based context. It is designed to get students thinking about the patterns
+    and structure of not just robotics, but also programming and problem-solving more
+    generally. This lesson includes videos, animations, and a built-in coding environment
+    with virtual robot.
+  tutorial_spheroincolor_longdescription: Sphero indi can see color much like you
+    and me. But who is faster at recognizing colors? Who can recognize the most? In
+    this lesson, discover how we see color and challenge indi to a color contest!
+  tutorial_kcjdominos_longdescription: In this lesson we will simulate falling dominos
+    using JavaScript. Along the way we will learn about variables, functions, loops,
+    mouse events and knocking things over!
+  tutorial_spherocolortheory_longdescription: Mix up your colors by tilting and rotating
+    Sphero BOLT! Explore how additive color theory works by adding different values
+    of red, green, and blue to make many different colors. Learn how you can use your
+    BOLT's sensors to measure its orientation and change colors.
+  tutorial_codecombatesports_longdescription: Competitive coding has never been so
+    epic! Learn the skills you need to play like the pros in our Esports Bootcamp.
+    No coding experience needed. Start by training in the dungeon and discovering
+    the coding strategies and tactics you'll need to compete. After honing your skills,
+    put your code to the test in our esports arena against other players worldwide!
+    Are you our next AI League grand champion?
+  tutorial_spherodigdisplay_longdescription: Digital Displays are all around us, from
+    phones to computer monitors to television to modern billboards. But how do they
+    work? Dig into the graphic technology behind digital displays and get hands-on
+    experience by programming images and animations with the littleBits codeBit and
+    LED matrix.
+  tutorial_spherorvrincolor_longdescription: 'Visible light is made up of waves of
+    varying lengths which the eye detects as color. While RVR+ doesn''t have eyes
+    (well at least ones that can see) it does have a sensor that is able to detect
+    a wide range of colors. Learn the capabilities of RVR+''s color sensor and how
+    to program it. '
+  tutorial_clbinary_longdescription: Using restone components in Minecraft, participants
+    will learn how binary counting works, create AND and OR logic gates, and use binary
+    counting to create a combination lock for opening a locked door.
+  tutorial_sascollabcode_longdescription: It can be challenging to find resources
+    to teach coding to students with visual impairments. SAS believes that every student
+    should have the opportunity to learn to code and aims to accomplish this using
+    braille code blocks with SAS CodeSnaps - a collaborative coding environment that
+    can get an entire classroom coding with just a single iPad and a Sphero robot.
+  tutorial_codecombatgoblins_longdescription: We need your help! Embark on an epic
+    quest where you take control of the game through your powers of programming. Become
+    the hero, unlock loot, and expand your arsenal of code to rescue the town. Then
+    use AI strategies to assemble a party for a final goblin boss battle!
+  tutorial_scratchstorytelling_longdescription: Animate your own story with Scratch!
+    Add sprites, backgrounds, and interactive graphic effects to bring your story
+    to life. Includes an educator facilitation guide, Scratch project tutorial, and
+    coding cards. This activity aligned with Common Core English Language Arts Standards.
+  tutorial_crayolasymbols_longdescription: A picture is worth a thousand words—even
+    small images say a lot! Visual symbols are everywhere, directing us to public
+    restrooms, hospitals, wheelchair ramps, and bus stops. Use shapes and lines to
+    design original symbols that others can count on.
+  tutorial_crayoladrawacode_longdescription: Explore codes from yesterday and today.
+    Ancient people drew symbols on cave walls to tell stories. Ancient Egyptians carved
+    hieroglyphs, a language of visual symbols representing people, objects, and actions,
+    into stone. Create add-on stories with visual codes.
+  tutorial_crayolafollowmycode_longdescription: Create coding dance by sketching visual
+    symbols such as arrows, spirals, and footsteps to create a pattern that you and
+    others will follow. Or make small characters from Model Magic and use them to
+    follow your dance code!
+  tutorial_madpicturethis_longdescription: This lesson will introduce students to
+    HTML language and teach them how to decode it, even if they have never interacted
+    with HTML code before.  By making observations, students will notice patterns
+    and gain a better understanding of how HTML code is written and interpreted.
+  tutorial_mindmakersmaps_longdescription: In this universe, maps of different types
+    serve as a backdrop for fun challenges with autonomous vehicles that obey your
+    programs. To win, you will have to interpret each map and program not only the
+    movements, but adapt to the unexpected using sensors for obstacles and natural
+    events such as weather, temperature, and the passage of time. Have a good trip!
+  tutorial_mindmakersjorel_longdescription: The fun universe of Jorel's Brother is
+    now under your control! But for that, you need to master the fundamentals of programming
+    and develop skills like algorithmic thinking, problem decomposition, pattern identification
+    and abstraction... work hard and maybe you'll find out the name of Jorel's brother!
+  tutorial_mindmakersroboland_longdescription: Program the weird and fun robots Mustachebot
+    and Ladybot! You help them overcome challenges, and they help you develop computational
+    thinking. The more advanced the challenge, the more you learn about algorithms,
+    decomposition, patterns, and abstraction... Work hard and have fun!
+  tutorial_mindmakersrobolandjr_longdescription: Program the weird and funny robots
+    Mustachebot and Ladybot. Whenever you manage to solve a challenge, you get a little
+    green ball and move on to the next one. Capriche!
+  tutorial_codehsdraw_longdescription: Create your own drawing program in Scratch
+    using keyboard and mouse inputs. Anyone will be able to use it make fun and creative
+    digital art!
+  tutorial_codehscamouflage_longdescription: Use ScratchJr to program an animal to
+    show its adaptation of using camouflage in its environment!
+  tutorial_firiapythoncodex_longdescription: Simple step-by-step lessons teach Python
+    coding as you unlock new capabilities, from the beautiful color display to the
+    hi-fi audio system. Use the built-in accelerometer, light sensor, and microphone
+    to code your own unique and interactive projects. And you can directly connect
+    servo motors and external sensors for unlimited expansion possibilities. CodeX
+    = games, music, sensors, art, and more!
+  tutorial_bekidscoding_longdescription: Join Grace, Zak and Dot the Robot on an adventure
+    in the Loop Galaxy! Code with blocks to complete exciting tasks, and learn the
+    basics of algorithms, sequences and loops!
+  tutorial_rodocodehr_longdescription: 'Rodocodo: Code Hour is a self-guided coding
+    game for 4-11 year olds. It teaches the fundamentals of coding such as sequencing,
+    debugging, loops and functions. It also teaches techniques for solving problems
+    so children become more confident, independent learners.'
+  tutorial_microbitdice_longdescription: Shake your micro:bit to make random numbers.
+  tutorial_madflashcard_longdescription: This lesson exposes students to HTML and
+    CSS code and provides them the opportunity to interact with it and see their results
+    in real-time.
+  tutorial_madappwars_longdescription: 'This lesson provides students with the opportunity
+    to explore the business side of app development.  In this activity, students compare
+    two apps that fall under the same umbrella category (example: two travel apps)
+    and evaluate which is better based on specific criteria.'
+  tutorial_kodablepuppies_longdescription: Students will meet Kodable's fluffy friends
+    and learn how to care for them! 'Pets' are in-game puppies that require a lot
+    of love and attention. Students will program Carebots to help with the responsibility
+    of being a new paw-rent using coding concepts such as functions and conditional
+    statements.
+  tutorial_googlesuperhero_longdescription: Turn an everyday hero from your life or
+    community into a superhero by programming them to fly over buildings, spin, work
+    with a sidekick, and score points by touching objects in a game. In Code Your
+    Hero, show off your hero's special powers and your own creativity with CS First
+    and Scratch.
+  tutorial_googlename _longdescription: Pick a name and bring the letters of the word
+    to life using code. Choose a nickname, a pet's name, an animal, a sport, a place
+    or a hobby.
+  tutorial_carnegiezillah_longdescription: Zillah City is thriving, and music is in
+    the air. Rumor has it, the famed Gargantua bot is online and sending the last
+    Toxibots to trash the city block by block…. Grab your cobot hoverboard and get
+    ready to groove, move, and finish off what you started! Players program their
+    cobot hoverbots to change lanes, avoid obstacles, and take out many Toxibots in
+    this rhythm-styled game.
+  tutorial_nasachspacejam_longdescription: Create a solar system that really rocks!
+    Learn about music, astronomy, and coding in this self-guided activity (no coding
+    experience required). Program planets to make music, creating your own musical
+    solar system, complete with spacey melodies.
+  tutorial_hatchxrsolar_longdescription: 'Explore the stars and build your own solar
+    system using concepts of block based programming. Learn about the basics of 3D
+    space, and dive into your imagination to build a universe of your dreams, all
+    in less than an hour. And guess what, you can run your project in AR on any iOS
+    device using the HatchXR app. Don''t forget to share your creations with us using
+    #hatchxr #HourOfCode'
+  tutorial_hatchxrspace_longdescription: 'Code the classic space invaders game in
+    3D, while learning about the basic of game development, motion in 3D space and
+    learn fundamental programming concepts like loops, conditionals, variables, and
+    keyboard events, all in less than an hour. Don''t forget to share your creations
+    with us using #hatchxr #HourOfCode'
+  tutorial_hatchxrtrex_longdescription: 'Build the classic chrome''s T-rex dino game
+    in 3D, while learning about the basic of game development, motion in 3D space
+    and learn fundamental programming concepts like loops, conditionals, variables,
+    and keyboard events, all in less than an hour. Don''t forget to share your creations
+    with us using #hatchxr #HourOfCode'
+  tutorial_blocksmithguinea_longdescription: The guinea pigs are coming and they are
+    hungry. For each round, program Bot to fire carrots, launch lettuce or invoke
+    the mighty Apple shield in this furious, fast-paced coding game. Collect hearts
+    to unlock more tools and contain the feeding frenzy while hoping that your code
+    doesn't break.
+  tutorial_pickcodeshapes_longdescription: Learn to use Pickcode to write code that
+    creates a variety of shapes. Once the course is done, you'll be able to get creative
+    and make whatever design you'd like!
+  tutorial_codesterssketch_longdescription: Learn the basics of coding in Python while
+    creating your own custom Etch-a-Sketch! Learn how to control an onscreen sprite
+    with different key events, accept user input to set the pen width, and use a list
+    to control the pen color.
+  tutorial_pickcodechatbot_longdescription: In this course, you'll learn how to make
+    a simple chatbot that plays a quick ad libs game.
+  tutorial_codestersfish_longdescription: Learn the basics of coding in Python while
+    creating your own falling-object game! You'll learn how to add a background and
+    sprites, and how to use events to create and control sprites on the stage.
+  tutorial_codestershedgehog_longdescription: Learn the basics of coding in Python,
+    then create a game that shoots a sprite to the stars! To shoot your shot you'll
+    first need to learn how to create key, interval, and collision events. BLAST OFF!
+  tutorial_pickcodeggame_longdescription: Learn to make a two player guessing game
+    where one player enters a number into a chatbot, and the chatbot gives hints to
+    the other player as they try to guess.
+  tutorial_codestersdino_longdescription: Learn Python functions and events while
+    creating your own Flappy Dino game. Once the game starts, the dino drops! If you
+    hit a block, you lose.  How many blocks can you navigate the dino through?
+  tutorial_pickcodemtpaint_longdescription: In this course, you'll learn how to use
+    functions to draw a pretty intricate shape (like a mobius strip but in triangle
+    form). After this lesson, you'll have the building blocks for making a ton of
+    different designs.
+  tutorial_microsoftcarnival_longdescription: Code your own classroom carnival with
+    games like Whack-the-Mole, Burstin' Balloons, and Target Practice.
+  tutorial_thunkablescavenger_longdescription: Learn to build your own Scavenger Hunt
+    app in Thunkable, and use your app to hunt for items on your mobile device as
+    soon as your code is complete.
+  tutorial_codeillusionfund_longdescription: Enter into the magical world of coding
+    and computer science as you learn and familiarize yourself with the fundamentals
+    of a computer! This will include practicing clicking and scrolling, dragging and
+    dropping, copy and pasting and typing.
+  tutorial_codeillusiongoofybeg_longdescription: Embark on a magical coding adventure
+    with Goofy! Learn how to draw, color and move shapes, as well as load images and
+    sounds as you master the basics of Game Development using JavaScript.
+  tutorial_codeillusiongoofyint_longdescription: 'Create your very own interactive,
+    digital band with Goofy as you explore the joy of Game Development using JavaScript.
+    This activity will build on what you learned in our introductory activity, Disney
+    Codeillusion: Game Development Adventure with Goofy for Beginners.'
+  tutorial_robotmagicescape_longdescription: Escape from a haunted 3D room with help
+    from programmable bots.
+  tutorial_codespeakclimate_longdescription: Learn how to responsibly build a basic
+    website using HTML and help educate others about climate change.
+  tutorial_codespeaktwinkle_longdescription: Listen to a read aloud of 'Coding Twinkle'
+    and then learn to code it using the ScratchJr app
+  tutorial_coinbasecrypto_longdescription: Test your memory and learn the basics of
+    crypto!
+  tutorial_codespeakcomp_longdescription: Learn about worm composting and build a
+    game in Scratch!
+  tutorial_codespeaksnake_longdescription: Listen to a story about Snake, a classic
+    mobile game star, and code your own game in ScratchJr
+  tutorial_prstemalexa_longdescription: Students will explore voice artificial intelligence
+    - or voice AI - by coding two Alexa skills. Students will start by watching a
+    video covering voice AI basics, and then build a voice AI-powered program in MIT
+    App Inventor that says 'Hello Moon' and a program that can recite random space
+    facts. The lesson ends with a vocabulary review and discussion.
+  tutorial_coderzfarm_longdescription: Program a robot to plant a garden, and learn
+    how robots help farmers in the real world.
+  tutorial_intelinofield_longdescription: Learn to program the intelino smart train
+    unplugged with action snaps and complete the mission of driving students across
+    town on their field trip.
+  tutorial_cablockchain_longdescription: This interactive course explores blockchain
+    technology and cryptocurrencies, the driving force of the next generation web.
+    Follow our characters as they enter the metaverse on a hunt to find a potential
+    scammer. They discover a range of creative applications of blockchain and consider
+    how it could impact society in the future.
+  tutorial_nasaparachute_longdescription: In this activity, you will learn how JPL
+    engineers used a binary code to include a hidden message in the parachute used
+    to help the Mars rover, Perseverance, land successfully on Mars. You will also
+    have the opportunity to create your own hidden message.
+  tutorial_nasascratch_longdescription: Create a Moon or Mars exploration game using
+    Scratch, a visual programming language. Think like NASA space-mission planners
+    to design your game!
+  tutorial_nasaorbit_longdescription: In this activity, students use Scratch, Snap!,
+    or another programming language to create an interactive simulation of a spacecraft
+    docking to the International Space Station. The Crew Orbital Docking Simulation
+    (CODing Sim) engages students in computational thinking, problem-solving, and
+    real-world applications of mathematics.
+  tutorial_nasapackage_longdescription: In this activity, students use Scratch, Snap!,
+    or another programming language to create an interactive simulation of a drone
+    navigating around a geofenced area to deliver a package. The simulation engages
+    students in computational thinking, problem solving, and real-world application
+    of mathematics.
+  tutorial_nasalunar_longdescription: 'Students learn about the Artemis 1 mission
+    and the NASA App Development Challenge (ADC). The goal is for students to follow-along
+    steps we''ve created using Code.org''s App Lab to learn basic programming utilizing
+    block code. '
+  tutorial_meeestate_longdescription: 'Solve puzzles to escape from Dr. Breakowski''s
+    mysterious mansion in the new Minecraft Hour of Code: Escape Estate. Use coding
+    and computational thinking to unlock secrets, open trap doors, and reveal hidden
+    clues. Code your way out by dawn and earn a million emeralds! With coding in blocks
+    or Python, Hour of Code offers a learning pathway for anyone to learn the basics
+    of code.'
+  tutorial_imagipixelart_longdescription: Learn Python and create your own colorful
+    animations in this 1 hour crash course!
+  tutorial_kcjhealth_longdescription: 'Learn about data visualization, algorithmic
+    art and coding, while exploring SDG #3 ''Good Health and Well-Being''.'
+  tutorial_msftwakanda_longdescription: 'Shuri, Okoye, and Riri must band together
+    to help Wakanda. Code your own action-packed activity inspired by Marvel Studios''
+    ''Black Panther: Wakanda Forever''!'
+  tutorial_nafbrand_longdescription: In Code your Brand, you will be creating a virtual
+    contact file to create a personalized QR code with your contact details. After
+    you complete this activity, you will be equipped with a modern business card that
+    you can share while you're networking with people who can help or guide you in
+    your career or college journey.
+  tutorial_rpccw_string_detail_grades: Grades 2-5
+  tutorial_rpledfirefly_string_detail_grades: Grades 6-8
+  tutorial_rpcharting_string_detail_grades: Grades 9+
+  tutorial_rpsolar_string_detail_grades: Grades 9+
+  tutorial_rpwebcards_string_detail_grades: Grades 6-8
+  tutorial_codeclubhworld_string_detail_grades: Grades 6-8
+  tutorial_codeclubspells_string_detail_grades: Grades 2-5
+  tutorial_coderdojoanime_string_detail_grades: Grades 6-8
+  tutorial_coderdojotarget_string_detail_grades: Grades 6-8
+  tutorial_creaticodescratch_string_detail_grades: Grades 6+
+  tutorial_bbsierpinski_string_detail_grades: Grades 6-8
+  tutorial_bbstopwatch_string_detail_grades: Grades 6+
+  tutorial_idrpatterns_string_detail_grades: Pre-reader - Grade 5
+  tutorial_idrshapes_string_detail_grades: Pre-reader - Grade 5
+  tutorial_edisondetect_string_detail_grades: Grades 2-8
+  tutorial_edisonmusical_string_detail_grades: Grades 6+
+  tutorial_codemonkeydiglit_string_detail_grades: Grades 2-8
+  tutorial_bsdrockpaper_string_detail_grades: Grades 6-8
+  tutorial_microbitreaction_string_detail_grades: Grades 2-5
+  tutorial_kinderanimal_string_detail_grades: Pre-reader - Grade 5
+  tutorial_kindersinger_string_detail_grades: Pre-reader - Grade 5
+  tutorial_microbitwwn_string_detail_grades: Grades 2-5
+  tutorial_grokcyberlive_string_detail_grades: Grades 6+
+  tutorial_codemojimaze_string_detail_grades: Pre-reader - Grade 5
+  tutorial_codemojisnake_string_detail_grades: Pre-reader - Grade 5
+  tutorial_carnegietoxibots_string_detail_grades: Grades 2-8
+  tutorial_carnegieiris_string_detail_grades: Grades 2-8
+  tutorial_carnegiespike_string_detail_grades: Grades 2-8
+  tutorial_spheroincolor_string_detail_grades: Pre-reader - Grade 5
+  tutorial_kcjdominos_string_detail_grades: Grades 2-8
+  tutorial_spherocolortheory_string_detail_grades: Grades 6+
+  tutorial_codecombatesports_string_detail_grades: Grades 6-8
+  tutorial_spherodigdisplay_string_detail_grades: Grades 2-8
+  tutorial_spherorvrincolor_string_detail_grades: Grades 6+
+  tutorial_clbinary_string_detail_grades: Grades 2+
+  tutorial_sascollabcode_string_detail_grades: Pre-reader +
+  tutorial_codecombatgoblins_string_detail_grades: Grades 6-8
+  tutorial_scratchstorytelling_string_detail_grades: Grades 2-8
+  tutorial_crayolasymbols_string_detail_grades: Grades 2+
+  tutorial_crayoladrawacode_string_detail_grades: Pre-reader - Grade 8
+  tutorial_crayolafollowmycode_string_detail_grades: Pre-reader - Grade 8
+  tutorial_madpicturethis_string_detail_grades: Grades 6-8
+  tutorial_mindmakersmaps_string_detail_grades: Grades 9+
+  tutorial_mindmakersjorel_string_detail_grades: Grades 6-8
+  tutorial_mindmakersroboland_string_detail_grades: Grades 2-5
+  tutorial_mindmakersrobolandjr_string_detail_grades: Pre-reader - Grade 1
+  tutorial_codehsdraw_string_detail_grades: Grades 2-8
+  tutorial_codehscamouflage_string_detail_grades: Pre-reader - Grade 5
+  tutorial_firiapythoncodex_string_detail_grades: Pre-reader +
+  tutorial_bekidscoding_string_detail_grades: Pre-reader - Grade 5
+  tutorial_rodocodehr_string_detail_grades: Pre-reader - Grade 5
+  tutorial_microbitdice_string_detail_grades: Grades 2-5
+  tutorial_madflashcard_string_detail_grades: Grades 6-8
+  tutorial_madappwars_string_detail_grades: Grades 6+
+  tutorial_kodablepuppies_string_detail_grades: Pre-reader - Grade 5
+  tutorial_googlesuperhero_string_detail_grades: Grades 2-8
+  tutorial_googlename _string_detail_grades: Grades 2-8
+  tutorial_carnegiezillah_string_detail_grades: Grades 2-9
+  tutorial_nasachspacejam_string_detail_grades: Grades 2+
+  tutorial_hatchxrsolar_string_detail_grades: Grades 2+
+  tutorial_hatchxrspace_string_detail_grades: Grades 2+
+  tutorial_hatchxrtrex_string_detail_grades: Grades 2+
+  tutorial_blocksmithguinea_string_detail_grades: Grades 2+
+  tutorial_pickcodeshapes_string_detail_grades: Grades 6+
+  tutorial_codesterssketch_string_detail_grades: Grades 6-8
+  tutorial_pickcodechatbot_string_detail_grades: Grades 6+
+  tutorial_codestersfish_string_detail_grades: Grades 6-8
+  tutorial_codestershedgehog_string_detail_grades: Grades 6-8
+  tutorial_pickcodeggame_string_detail_grades: Grades 9+
+  tutorial_codestersdino_string_detail_grades: Grades 6-8
+  tutorial_pickcodemtpaint_string_detail_grades: Grades 9+
+  tutorial_microsoftcarnival_string_detail_grades: Grades 2+
+  tutorial_thunkablescavenger_string_detail_grades: Grades 6-8
+  tutorial_codeillusionfund_string_detail_grades: Pre-reader - Grade 5
+  tutorial_codeillusiongoofybeg_string_detail_grades: Grades 2+
+  tutorial_codeillusiongoofyint_string_detail_grades: Grades 6+
+  tutorial_robotmagicescape_string_detail_grades: Grades 2+
+  tutorial_codespeakclimate_string_detail_grades: Grades 2+
+  tutorial_codespeaktwinkle_string_detail_grades: Pre-reader - Grade 1
+  tutorial_coinbasecrypto_string_detail_grades: Grades 2-8
+  tutorial_codespeakcomp_string_detail_grades: Grades 2+
+  tutorial_codespeaksnake_string_detail_grades: Pre-reader - Grade 1
+  tutorial_prstemalexa_string_detail_grades: Grades 9+
+  tutorial_coderzfarm_string_detail_grades: Grades 2-8
+  tutorial_intelinofield_string_detail_grades: Pre-reader - Grade 5
+  tutorial_cablockchain_string_detail_grades: Grades 6+
+  tutorial_nasaparachute_string_detail_grades: Grades 2-5
+  tutorial_nasascratch_string_detail_grades: Grades 6-8
+  tutorial_nasaorbit_string_detail_grades: Grades 6-8
+  tutorial_nasapackage_string_detail_grades: Grades 6-8
+  tutorial_nasalunar_string_detail_grades: Grades 6-8
+  tutorial_meeestate_string_detail_grades: Grades 2+
+  tutorial_imagipixelart_string_detail_grades: Grades 2-8
+  tutorial_kcjhealth_string_detail_grades: Grades 6+
+  tutorial_msftwakanda_string_detail_grades: Grades 6+
+  tutorial_nafbrand_string_detail_grades: Grades 9+
+  tutorial_rpccw_string_platforms: All modern browsers, Android tablet, iPad, Windows
+    phone, Android phone, iPhone
+  tutorial_rpledfirefly_string_platforms: All modern browsers
+  tutorial_rpcharting_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_rpsolar_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_rpwebcards_string_platforms: All modern browsers, Android tablet, iPad,
+    Windows phone, Android phone, iPhone
+  tutorial_codeclubhworld_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_codeclubspells_string_platforms: All modern browsers, Android tablet, iPad,
+    Windows phone, Android phone, iPhone
+  tutorial_coderdojoanime_string_platforms: All modern browsers, Android tablet, iPad,
+    Windows phone, Android phone, iPhone
+  tutorial_coderdojotarget_string_platforms: All modern browsers, Android tablet,
+    iPad, Windows phone, Android phone, iPhone
+  tutorial_creaticodescratch_string_platforms: All modern browsers, Android tablet,
+    iPad, Windows phone, Android phone, iPhone
+  tutorial_bbsierpinski_string_platforms: All modern browsers
+  tutorial_bbstopwatch_string_platforms: All modern browsers
+  tutorial_idrpatterns_string_platforms: All modern browsers
+  tutorial_idrshapes_string_platforms: All modern browsers
+  tutorial_edisondetect_string_platforms: All modern browsers
+  tutorial_edisonmusical_string_platforms: All modern browsers
+  tutorial_codemonkeydiglit_string_platforms: All modern browsers, Android tablet,
+    iPad, Windows phone, Android phone, iPhone
+  tutorial_bsdrockpaper_string_platforms: Chrome, Firefox
+  tutorial_microbitreaction_string_platforms: All modern browsers
+  tutorial_kinderanimal_string_platforms: Unplugged
+  tutorial_kindersinger_string_platforms: Unplugged
+  tutorial_microbitwwn_string_platforms: All modern browsers
+  tutorial_grokcyberlive_string_platforms: All modern browsers
+  tutorial_codemojimaze_string_platforms: Unplugged
+  tutorial_codemojisnake_string_platforms: Chrome
+  tutorial_carnegietoxibots_string_platforms: All modern browsers
+  tutorial_carnegieiris_string_platforms: All modern browsers
+  tutorial_carnegiespike_string_platforms: All modern browsers
+  tutorial_spheroincolor_string_platforms: Unplugged
+  tutorial_kcjdominos_string_platforms: All modern browsers
+  tutorial_spherocolortheory_string_platforms: All modern browsers, Android tablet,
+    iPad, Windows phone, Android phone, iPhone
+  tutorial_codecombatesports_string_platforms: All modern browsers
+  tutorial_spherodigdisplay_string_platforms: All modern browsers, Android tablet,
+    iPad, Windows phone, Android phone, iPhone
+  tutorial_spherorvrincolor_string_platforms: All modern browsers, Android tablet,
+    iPad, Windows phone, Android phone, iPhone
+  tutorial_clbinary_string_platforms: Unplugged
+  tutorial_sascollabcode_string_platforms: iPad
+  tutorial_codecombatgoblins_string_platforms: All modern browsers
+  tutorial_scratchstorytelling_string_platforms: All modern browsers
+  tutorial_crayolasymbols_string_platforms: Unplugged
+  tutorial_crayoladrawacode_string_platforms: Unplugged
+  tutorial_crayolafollowmycode_string_platforms: Unplugged
+  tutorial_madpicturethis_string_platforms: Unplugged
+  tutorial_mindmakersmaps_string_platforms: All modern browsers
+  tutorial_mindmakersjorel_string_platforms: All modern browsers
+  tutorial_mindmakersroboland_string_platforms: All modern browsers
+  tutorial_mindmakersrobolandjr_string_platforms: All modern browsers
+  tutorial_codehsdraw_string_platforms: Unplugged
+  tutorial_codehscamouflage_string_platforms: Unplugged
+  tutorial_firiapythoncodex_string_platforms: Chrome
+  tutorial_bekidscoding_string_platforms: All modern browsers, Android tablet, iPad,
+    Windows phone, Android phone, iPhone
+  tutorial_rodocodehr_string_platforms: All modern browsers, Android tablet, iPad,
+    Windows phone, Android phone, iPhone
+  tutorial_microbitdice_string_platforms: All modern browsers, Android tablet, iPad,
+    Windows phone, Android phone, iPhone
+  tutorial_madflashcard_string_platforms: All modern browsers
+  tutorial_madappwars_string_platforms: All modern browsers
+  tutorial_kodablepuppies_string_platforms: All modern browsers, Android tablet, iPad,
+    Windows phone, Android phone, iPhone
+  tutorial_googlesuperhero_string_platforms: All modern browsers
+  tutorial_googlename _string_platforms: All modern browsers
+  tutorial_carnegiezillah_string_platforms: All modern browsers
+  tutorial_nasachspacejam_string_platforms: All modern browsers
+  tutorial_hatchxrsolar_string_platforms: All modern browsers, Android tablet, iPad,
+    Windows phone, Android phone, iPhone
+  tutorial_hatchxrspace_string_platforms: All modern browsers, Android tablet, iPad,
+    Windows phone, Android phone, iPhone
+  tutorial_hatchxrtrex_string_platforms: All modern browsers, Android tablet, iPad,
+    Windows phone, Android phone, iPhone
+  tutorial_blocksmithguinea_string_platforms: All modern browsers, Android tablet,
+    iPad, Windows phone, Android phone, iPhone
+  tutorial_pickcodeshapes_string_platforms: All modern browsers
+  tutorial_codesterssketch_string_platforms: All modern browsers
+  tutorial_pickcodechatbot_string_platforms: All modern browsers, Android tablet,
+    iPad, Windows phone, Android phone, iPhone
+  tutorial_codestersfish_string_platforms: All modern browsers
+  tutorial_codestershedgehog_string_platforms: All modern browsers
+  tutorial_pickcodeggame_string_platforms: All modern browsers
+  tutorial_codestersdino_string_platforms: All modern browsers
+  tutorial_pickcodemtpaint_string_platforms: All modern browsers
+  tutorial_microsoftcarnival_string_platforms: All modern browsers, Android tablet,
+    iPad, Windows phone, Android phone, iPhone
+  tutorial_thunkablescavenger_string_platforms: All modern browsers
+  tutorial_codeillusionfund_string_platforms: Chrome
+  tutorial_codeillusiongoofybeg_string_platforms: Chrome
+  tutorial_codeillusiongoofyint_string_platforms: Chrome
+  tutorial_robotmagicescape_string_platforms: All modern browsers, Android tablet,
+    iPad, Windows phone, Android phone, iPhone
+  tutorial_codespeakclimate_string_platforms: All modern browsers
+  tutorial_codespeaktwinkle_string_platforms: Android tablet, iPad, Windows phone,
+    Android phone, iPhone
+  tutorial_coinbasecrypto_string_platforms: All modern browsers, Android tablet, iPad,
+    Windows phone, Android phone, iPhone
+  tutorial_codespeakcomp_string_platforms: All modern browsers
+  tutorial_codespeaksnake_string_platforms: Android tablet, iPad, Windows phone, Android
+    phone, iPhone
+  tutorial_prstemalexa_string_platforms: All modern browsers
+  tutorial_coderzfarm_string_platforms: All modern browsers
+  tutorial_intelinofield_string_platforms: Unplugged
+  tutorial_cablockchain_string_platforms: Android tablet, iPad, Windows phone, Android
+    phone, iPhone
+  tutorial_nasaparachute_string_platforms: Unplugged
+  tutorial_nasascratch_string_platforms: Android tablet, iPad, Windows phone, Android
+    phone, iPhone
+  tutorial_nasaorbit_string_platforms: All modern browsers
+  tutorial_nasapackage_string_platforms: All modern browsers
+  tutorial_nasalunar_string_platforms: All modern browsers, iPad, iPhone
+  tutorial_meeestate_string_platforms: All modern browsers, Mac, Windows, Chromebook,
+    iPhone, iPad, Android phone, Android tablet
+  tutorial_imagipixelart_string_platforms: All modern browsers, iPad, Android tablets,
+    Windows phone, Android phone, iPhone
+  tutorial_kcjhealth_string_platforms: All modern browsers
+  tutorial_msftwakanda_string_platforms: All modern browsers
+  tutorial_nafbrand_string_platforms: All modern browsers, Android tablet, iPad, Windows
+    phone, Android phone, iPhone
+  tutorial_rpccw_string_detail_platforms: ''
+  tutorial_rpledfirefly_string_detail_platforms: Raspberry Pi Pico
+  tutorial_rpcharting_string_detail_platforms: ''
+  tutorial_rpsolar_string_detail_platforms: ''
+  tutorial_rpwebcards_string_detail_platforms: ''
+  tutorial_codeclubhworld_string_detail_platforms: ''
+  tutorial_codeclubspells_string_detail_platforms: ''
+  tutorial_coderdojoanime_string_detail_platforms: ''
+  tutorial_coderdojotarget_string_detail_platforms: ''
+  tutorial_creaticodescratch_string_detail_platforms: ''
+  tutorial_bbsierpinski_string_detail_platforms: ''
+  tutorial_bbstopwatch_string_detail_platforms: ''
+  tutorial_idrpatterns_string_detail_platforms: ''
+  tutorial_idrshapes_string_detail_platforms: ''
+  tutorial_edisondetect_string_detail_platforms: Edison Robot
+  tutorial_edisonmusical_string_detail_platforms: Edison Robot
+  tutorial_codemonkeydiglit_string_detail_platforms: ''
+  tutorial_bsdrockpaper_string_detail_platforms: ''
+  tutorial_microbitreaction_string_detail_platforms: BBC micro:bit
+  tutorial_kinderanimal_string_detail_platforms: KIBO 10 Robot Kit
+  tutorial_kindersinger_string_detail_platforms: KIBO 21 Robot Kit
+  tutorial_microbitwwn_string_detail_platforms: BBC micro:bit
+  tutorial_grokcyberlive_string_detail_platforms: ''
+  tutorial_codemojimaze_string_detail_platforms: ''
+  tutorial_codemojisnake_string_detail_platforms: ''
+  tutorial_carnegietoxibots_string_detail_platforms: ''
+  tutorial_carnegieiris_string_detail_platforms: ''
+  tutorial_carnegiespike_string_detail_platforms: ''
+  tutorial_spheroincolor_string_detail_platforms: Sphero Indi Robot
+  tutorial_kcjdominos_string_detail_platforms: ''
+  tutorial_spherocolortheory_string_detail_platforms: Sphero Indi Robot
+  tutorial_codecombatesports_string_detail_platforms: ''
+  tutorial_spherodigdisplay_string_detail_platforms: littleBits STEAM+ Coding Kit
+  tutorial_spherorvrincolor_string_detail_platforms: Sphero
+  tutorial_clbinary_string_detail_platforms: ''
+  tutorial_sascollabcode_string_detail_platforms: iPad, Sphero robot (BOLT, Sphero
+    Mini, or SPRK+)
+  tutorial_codecombatgoblins_string_detail_platforms: ''
+  tutorial_scratchstorytelling_string_detail_platforms: ''
+  tutorial_crayolasymbols_string_detail_platforms: ''
+  tutorial_crayoladrawacode_string_detail_platforms: ''
+  tutorial_crayolafollowmycode_string_detail_platforms: ''
+  tutorial_madpicturethis_string_detail_platforms: ''
+  tutorial_mindmakersmaps_string_detail_platforms: ''
+  tutorial_mindmakersjorel_string_detail_platforms: ''
+  tutorial_mindmakersroboland_string_detail_platforms: ''
+  tutorial_mindmakersrobolandjr_string_detail_platforms: ''
+  tutorial_codehsdraw_string_detail_platforms: ''
+  tutorial_codehscamouflage_string_detail_platforms: ''
+  tutorial_firiapythoncodex_string_detail_platforms: CodeX
+  tutorial_bekidscoding_string_detail_platforms: ''
+  tutorial_rodocodehr_string_detail_platforms: ''
+  tutorial_microbitdice_string_detail_platforms: micro:bit
+  tutorial_madflashcard_string_detail_platforms: ''
+  tutorial_madappwars_string_detail_platforms: ''
+  tutorial_kodablepuppies_string_detail_platforms: ''
+  tutorial_googlesuperhero_string_detail_platforms: ''
+  tutorial_googlename _string_detail_platforms: ''
+  tutorial_carnegiezillah_string_detail_platforms: ''
+  tutorial_nasachspacejam_string_detail_platforms: ''
+  tutorial_hatchxrsolar_string_detail_platforms: ''
+  tutorial_hatchxrspace_string_detail_platforms: ''
+  tutorial_hatchxrtrex_string_detail_platforms: ''
+  tutorial_blocksmithguinea_string_detail_platforms: ''
+  tutorial_pickcodeshapes_string_detail_platforms: ''
+  tutorial_codesterssketch_string_detail_platforms: ''
+  tutorial_pickcodechatbot_string_detail_platforms: ''
+  tutorial_codestersfish_string_detail_platforms: ''
+  tutorial_codestershedgehog_string_detail_platforms: ''
+  tutorial_pickcodeggame_string_detail_platforms: ''
+  tutorial_codestersdino_string_detail_platforms: ''
+  tutorial_pickcodemtpaint_string_detail_platforms: ''
+  tutorial_microsoftcarnival_string_detail_platforms: ''
+  tutorial_thunkablescavenger_string_detail_platforms: ''
+  tutorial_codeillusionfund_string_detail_platforms: ''
+  tutorial_codeillusiongoofybeg_string_detail_platforms: ''
+  tutorial_codeillusiongoofyint_string_detail_platforms: ''
+  tutorial_robotmagicescape_string_detail_platforms: ''
+  tutorial_codespeakclimate_string_detail_platforms: ''
+  tutorial_codespeaktwinkle_string_detail_platforms: ''
+  tutorial_coinbasecrypto_string_detail_platforms: ''
+  tutorial_codespeakcomp_string_detail_platforms: ''
+  tutorial_codespeaksnake_string_detail_platforms: ''
+  tutorial_prstemalexa_string_detail_platforms: ''
+  tutorial_coderzfarm_string_detail_platforms: ''
+  tutorial_intelinofield_string_detail_platforms: intelino J-1 smart train set
+  tutorial_cablockchain_string_detail_platforms: ''
+  tutorial_nasaparachute_string_detail_platforms: ''
+  tutorial_nasascratch_string_detail_platforms: ''
+  tutorial_nasaorbit_string_detail_platforms: ''
+  tutorial_nasapackage_string_detail_platforms: ''
+  tutorial_nasalunar_string_detail_platforms: ''
+  tutorial_meeestate_string_detail_platforms: ''
+  tutorial_imagipixelart_string_detail_platforms: ''
+  tutorial_kcjhealth_string_detail_platforms: ''
+  tutorial_msftwakanda_string_detail_platforms: ''
+  tutorial_nafbrand_string_detail_platforms: ''
+  tutorial_rpccw_string_detail_programming_languages: Blocks
+  tutorial_rpledfirefly_string_detail_programming_languages: Python
+  tutorial_rpcharting_string_detail_programming_languages: Python
+  tutorial_rpsolar_string_detail_programming_languages: Python
+  tutorial_rpwebcards_string_detail_programming_languages: HTML, CSS
+  tutorial_codeclubhworld_string_detail_programming_languages: Python
+  tutorial_codeclubspells_string_detail_programming_languages: Blocks
+  tutorial_coderdojoanime_string_detail_programming_languages: HTML, CSS
+  tutorial_coderdojotarget_string_detail_programming_languages: Python
+  tutorial_creaticodescratch_string_detail_programming_languages: Blocks
+  tutorial_bbsierpinski_string_detail_programming_languages: JavaScript
+  tutorial_bbstopwatch_string_detail_programming_languages: JavaScript
+  tutorial_idrpatterns_string_detail_programming_languages: Blocks
+  tutorial_idrshapes_string_detail_programming_languages: Blocks
+  tutorial_edisondetect_string_detail_programming_languages: Blocks
+  tutorial_edisonmusical_string_detail_programming_languages: Blocks
+  tutorial_codemonkeydiglit_string_detail_programming_languages: Digital Literacy
+  tutorial_bsdrockpaper_string_detail_programming_languages: Python
+  tutorial_microbitreaction_string_detail_programming_languages: Blocks, Python, MakeCode
+  tutorial_kinderanimal_string_detail_programming_languages: Unplugged
+  tutorial_kindersinger_string_detail_programming_languages: Unplugged
+  tutorial_microbitwwn_string_detail_programming_languages: Blocks, Python, MakeCode
+  tutorial_grokcyberlive_string_detail_programming_languages: Cybersecurity concepts
+  tutorial_codemojimaze_string_detail_programming_languages: Unplugged, Sequences
+  tutorial_codemojisnake_string_detail_programming_languages: Blocks
+  tutorial_carnegietoxibots_string_detail_programming_languages: Blocks
+  tutorial_carnegieiris_string_detail_programming_languages: Blocks
+  tutorial_carnegiespike_string_detail_programming_languages: Blocks
+  tutorial_spheroincolor_string_detail_programming_languages: Language independent,
+    Color tiles
+  tutorial_kcjdominos_string_detail_programming_languages: JavaScript
+  tutorial_spherocolortheory_string_detail_programming_languages: Blocks
+  tutorial_codecombatesports_string_detail_programming_languages: JavaScript, Python
+  tutorial_spherodigdisplay_string_detail_programming_languages: Blocks
+  tutorial_spherorvrincolor_string_detail_programming_languages: Blocks
+  tutorial_clbinary_string_detail_programming_languages: Unplugged
+  tutorial_sascollabcode_string_detail_programming_languages: Blocks, Tactile braille
+    blocks
+  tutorial_codecombatgoblins_string_detail_programming_languages: JavaScript, Python
+  tutorial_scratchstorytelling_string_detail_programming_languages: Blocks
+  tutorial_crayolasymbols_string_detail_programming_languages: Unplugged
+  tutorial_crayoladrawacode_string_detail_programming_languages: Unplugged
+  tutorial_crayolafollowmycode_string_detail_programming_languages: Unplugged
+  tutorial_madpicturethis_string_detail_programming_languages: Unplugged, HTML
+  tutorial_mindmakersmaps_string_detail_programming_languages: Blocks
+  tutorial_mindmakersjorel_string_detail_programming_languages: Blocks
+  tutorial_mindmakersroboland_string_detail_programming_languages: Blocks
+  tutorial_mindmakersrobolandjr_string_detail_programming_languages: Blocks
+  tutorial_codehsdraw_string_detail_programming_languages: Blocks
+  tutorial_codehscamouflage_string_detail_programming_languages: Blocks
+  tutorial_firiapythoncodex_string_detail_programming_languages: Python
+  tutorial_bekidscoding_string_detail_programming_languages: Blocks
+  tutorial_rodocodehr_string_detail_programming_languages: Blocks
+  tutorial_microbitdice_string_detail_programming_languages: Blocks, Python, MakeCode
+  tutorial_madflashcard_string_detail_programming_languages: HTML, CSS
+  tutorial_madappwars_string_detail_programming_languages: HTML, CSS
+  tutorial_kodablepuppies_string_detail_programming_languages: C/C++, JavaScript,
+    iOS/Swift
+  tutorial_googlesuperhero_string_detail_programming_languages: Blocks
+  tutorial_googlename _string_detail_programming_languages: Blocks
+  tutorial_carnegiezillah_string_detail_programming_languages: Blocks
+  tutorial_nasachspacejam_string_detail_programming_languages: Blocks
+  tutorial_hatchxrsolar_string_detail_programming_languages: Blocks
+  tutorial_hatchxrspace_string_detail_programming_languages: Blocks
+  tutorial_hatchxrtrex_string_detail_programming_languages: Blocks
+  tutorial_blocksmithguinea_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_pickcodeshapes_string_detail_programming_languages: JavaScript
+  tutorial_codesterssketch_string_detail_programming_languages: Python
+  tutorial_pickcodechatbot_string_detail_programming_languages: JavaScript
+  tutorial_codestersfish_string_detail_programming_languages: Python
+  tutorial_codestershedgehog_string_detail_programming_languages: Python
+  tutorial_pickcodeggame_string_detail_programming_languages: JavaScript
+  tutorial_codestersdino_string_detail_programming_languages: Python
+  tutorial_pickcodemtpaint_string_detail_programming_languages: JavaScript
+  tutorial_microsoftcarnival_string_detail_programming_languages: Blocks
+  tutorial_thunkablescavenger_string_detail_programming_languages: Blocks
+  tutorial_codeillusionfund_string_detail_programming_languages: Computer Basics /
+    Fundamentals of a PC
+  tutorial_codeillusiongoofybeg_string_detail_programming_languages: JavaScript
+  tutorial_codeillusiongoofyint_string_detail_programming_languages: JavaScript
+  tutorial_robotmagicescape_string_detail_programming_languages: Blocks,JavaScript
+  tutorial_codespeakclimate_string_detail_programming_languages: HTML
+  tutorial_codespeaktwinkle_string_detail_programming_languages: Blocks
+  tutorial_coinbasecrypto_string_detail_programming_languages: Cryptocurrency concepts
+  tutorial_codespeakcomp_string_detail_programming_languages: Blocks
+  tutorial_codespeaksnake_string_detail_programming_languages: Blocks
+  tutorial_prstemalexa_string_detail_programming_languages: Blocks
+  tutorial_coderzfarm_string_detail_programming_languages: Blocks
+  tutorial_intelinofield_string_detail_programming_languages: Unplugged
+  tutorial_cablockchain_string_detail_programming_languages: Computational Thinking
+  tutorial_nasaparachute_string_detail_programming_languages: Unplugged, Binary Code
+  tutorial_nasascratch_string_detail_programming_languages: Blocks
+  tutorial_nasaorbit_string_detail_programming_languages: Blocks
+  tutorial_nasapackage_string_detail_programming_languages: Blocks
+  tutorial_nasalunar_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_meeestate_string_detail_programming_languages: Blocks, Python
+  tutorial_imagipixelart_string_detail_programming_languages: Typing
+  tutorial_kcjhealth_string_detail_programming_languages: Blocks
+  tutorial_msftwakanda_string_detail_programming_languages: Blocks
+  tutorial_nafbrand_string_detail_programming_languages: Python
+  school_not_found_heading: We couldn't find your school. Please enter more information.
+  school_name: School name
+  school_name_error: School name is required.
+  school_city: School city
+  school_state: School state
+  school_zip: Postal code
+  school_zip_error: School postal code is required.
+  census_thanks: Thanks for signing up!
+  census_header: Please take a few minutes to tell us about your school (Optional).
+  census_heading: Please share how much coding/computer programming is taught at this
+    school. Assume for the purposes of the following questions that coding/computer
+    programming does not include HTML/CSS, Web design, or how to use apps.
+  census_how_many_hoc: How many students will do an Hour of Code?
+  census_how_many_after_school: How many students do computer programming in an after-school
+    program?
+  census_how_many_ten_hours: How many students take at least 10 hours of computer
+    programming integrated into a non-Computer Science course (such as TechEd, Math,
+    Science, Art, Library or general classroom/homeroom)?
+  census_how_many_twenty_hours: How many students take a semester or year-long computer
+    science course that includes at least 20 hours of coding/computer programming?
+  census_other_cs: This school teaches other computing classes that do not include
+    at least 20 hours of coding/computer programming. (For example, learning to use
+    applications, computer literacy, web design, HTML/CSS, or other)
+  census_connection: What is your connection to this school?
+  census_pledge: I pledge to expand computer science offerings at my school, and to
+    engage a diverse group of students, to bring opportunity to all.
+  census_followup_heading: Your school offers a semester or year-long computer science
+    class! What topics does this course include?
+  census_followup_frequency: How often per week does this class meet?
+  less_than_one: "< 1 hour per week"
+  one_to_three: 1-3 hours per week
+  three_plus: 3+ hours per week
+  census_followup_more: Please tell us more about this course.
+  census_followup_more_placeholder: For example, name of the class, how often it meets,
+    description of what is taught.
+  census_topics_blocks: Block-based programming
+  census_topics_text: "  Text-based programming in a language such as Java, JavaScript,
+    Python, C++, etc. (Excluding HTML or CSS)"
+  census_topics_robots: Robotics / Physical Computing
+  census_topics_internet: Internet and networking
+  census_topics_security: Cybersecurity
+  census_topics_data: Data analysis
+  census_topics_web_design: Web design using HTML and CSS
+  census_topics_game_design: Game design using game layout tools without coding or
+    computer programming
+  teacher: Teacher
+  administrator: Administrator
+  parent: Parent
+  volunteer_or_advocate: Volunteer/Community Advocate
+  other: Other
+  other_describe: Other (please describe below)
+  none: None
+  some: Some
+  all: All
+  dont_know: I don't know
+  language_label: Language
+  team_page_full_team_alt_text: Nearly 100 Code.org employees in matching blue and
+    yellow t-shirts pose in a hotel conference room for the company's summer 2022
+    Codechella event.
+  careers_page_code_pride_alt_text: Two feminine-presenting employees smile while
+    holding the ends of a Code.org-branded rainbow banner. Behind them, several people
+    are wearing Code.org shirts and waving rainbow flags while walking alongside a
+    multi-colored Volkswagen bug.
+  language_code:
+    ar: Arabic
+    az: Azerbaijani
+    bg: Bulgarian
+    bn: Bengali
+    br: Breton
+    bs: Bosnian
+    ca: Catalan
+    co: Corsican
+    cs: Czech
+    da: Danish
+    de: German
+    dv: Dhivehi
+    el: Greek
+    en: English
+    es: Spanish
+    et: Estonian
+    eu: Basque
+    fa: Persian
+    fi: Finnish
+    fil: Filipino
+    fr: French
+    ga: Irish
+    gl: Galician
+    haw: Hawaiian
+    he: Hebrew
+    hi: Hindi
+    hr: Croatian
+    hu: Hungarian
+    hy: Armenian
+    ia: Interlingua (International Auxiliary Language Association)
+    id: Indonesian
+    is: Icelandic
+    it: Italian
+    ja: Japanese
+    ka: Georgian
+    kk: Kazakh
+    km: Khmer
+    kn: Kannada
+    ko: Korean
+    ku: Kurdish
+    ky: Kyrgyz
+    lt: Lithuanian
+    lv: Latvian
+    mi: Maori
+    mk: Macedonian
+    mn: Mongolian
+    mr: Marathi
+    ms: Malay
+    mt: Maltese
+    my: Burmese
+    ne: Nepali
+    nl: Dutch
+    nn: Norwegian (Nynorsk)
+    false: Norwegian (Bokmål)
+    pl: Polish
+    ps: Pashto
+    pt: Portuguese
+    ro: Romanian
+    ru: Russian
+    se: Northern Sami
+    si: Sinhalese
+    sk: Slovak
+    sl: Slovenian
+    sq: Albanian
+    sr: Serbian
+    sv: Swedish
+    sw: Kiswahili
+    ta: Tamil
+    te: Telugu
+    tg: Tajik
+    th: Thai
+    tl: Tagalog
+    tr: Turkish
+    uk: Ukrainian
+    ur: Urdu
+    uz: Uzbek
+    vi: Vietnamese
+    zh: Chinese (Simplified)
+    zu: Zulu
+  locale_code:
+    ar-sa: Arabic
+    az-az: Azerbaijani
+    bg-bg: Bulgarian
+    bn-bd: Bengali
+    bs-ba: Bosnian
+    ca-es: Catalan
+    co-co: Corsican
+    cs-cz: Czech
+    da-dk: Danish
+    de-de: German
+    dv-mv: Dhivehi
+    el-gr: Greek
+    en-gb: English (United Kingdom)
+    en-us: English
+    es-es: Spanish (Spain)
+    es-mx: Spanish (Mexico)
+    et-ee: Estonian
+    eu-es: Basque
+    fa-af: Dari
+    fa-ir: Persian
+    fi-fi: Finnish
+    fil-ph: Filipino
+    fr-fr: French
+    ga-ie: Irish
+    gl-es: Galician
+    haw-hi: Hawaiian
+    he-il: Hebrew
+    hi-in: Hindi
+    hr-hr: Croatian
+    hu-hu: Hungarian
+    hy-am: Armenian
+    id-id: Indonesian
+    is-is: Icelandic
+    it-it: Italian
+    ja-jp: Japanese
+    ka-ge: Georgian
+    kk-kz: Kazakh
+    km-kh: Khmer
+    kn-in: Kannada
+    ko-kr: Korean
+    ku-iq: Kurdish
+    ky-kg: Kyrgyz
+    lt-lt: Lithuanian
+    lv-lv: Latvian
+    mi-nz: Maori
+    mk-mk: Macedonian
+    mn-mn: Mongolian
+    mr-in: Marathi
+    ms-my: Malay
+    mt-mt: Maltese
+    my-mm: Burmese
+    ne-np: Nepali
+    nl-nl: Dutch
+    nn-no: Norwegian (Nynorsk)
+    no-no: Norwegian (Bokmål)
+    pl-pl: Polish
+    ps-af: Pashto
+    pt-br: Portuguese (Brazil)
+    pt-pt: Portuguese (Portugal)
+    ro-ro: Romanian
+    ru-ru: Russian
+    se-fi: Northern Sami
+    si-lk: Sinhalese
+    sk-sk: Slovak
+    sl-si: Slovenian
+    sq-al: Albanian
+    sr-sp: Serbian
+    sv-se: Swedish
+    ta-in: Tamil
+    te-in: Telugu
+    tg-tj: Tajik
+    th-th: Thai
+    tr-tr: Turkish
+    uk-ua: Ukrainian
+    ur-in: Urdu (India)
+    ur-pk: Urdu (Pakistan)
+    uz-uz: Uzbek
+    vi-vn: Vietnamese
+    zh-cn: Chinese (Simplified)
+    zh-hans: Chinese (Simplified)
+    zh-hant: Chinese (Traditional)
+    zh-tw: Chinese (Traditional)
+    zu-za: Zulu

--- a/i18n/locales/sm-WS/hourofcode/supporting-special-needs-students.md
+++ b/i18n/locales/sm-WS/hourofcode/supporting-special-needs-students.md
@@ -1,0 +1,33 @@
+---
+title: Supporting special needs students for the Hour of Code
+---
+
+# Supporting students with disabilities for the Hour of Code
+
+Anyone can try an Hour of Code during Computer Science Education Week. Often, students with autism, ADHD or other learning differences find they love programming. Encourage all the students in your classroom to give it a try! In setting up the experience for your classroom, reward participation rather than completion. You can give everyone a [certificate]({{ supporting-special-needs-students/certificate }}) no matter how many puzzles or challenges they complete within the hour. [Pair programming](https://www.youtube.com/watch?v=vgkahOzFH2Q) is another great way to teach collaboration and have students work together to solve problems.
+
+## Fit a variety of needs with unplugged and online tutorials
+
+In finding the right activity for everyone in your class, consider both online and “unplugged” options that do not require computers. Unplugged activities allow students to get hands on with computer science concepts. The [Big Event](https://studio.code.org/s/course1/lessons/15/levels/1) puts teachers in control over the actions of students, allowing for a great opportunity to tailor the content to the abilities of each student.
+
+For other students, the accommodations available on the computer may allow them to participate better than an unplugged choice. For example, students who are deaf or hard of hearing can participate fully in the online tutorials.
+
+The most inclusive choice may also depend on whether you have an accessible computer lab or laptops.
+
+For example, do your students have reduced mobility or dexterity? If all your students have access to technology at your school, ask your students or tech teacher what accommodations your students typically use with the computers available.
+
+## Sensory Impairments
+
+### Students who are blind or low vision
+
+For students who use a screen reader, the [Quorum tutorial for beginners](https://quorumlanguage.com/hourofcode/astro1.html) or the [Quorum tutorial for comfortable students](https://quorumlanguage.com/hourofcode/part1.html) is a great place to start. Quorum started as an interpreted language designed to be accessible to screen reader users. Eventually, it became a general purpose programming language designed for any user. You can use these Hour of Code tutorials with your entire classroom. And, if you want to go beyond an Hour of Code, the team at Quorum has additional tools and curriculum.
+
+If your student uses other accommodations in technology classes, you may use those to help with Hour of Code as well. These can include larger monitors, software screen magnification, high contrast settings in their operating system, voice control and more.
+
+### Students who are deaf or hard of hearing
+
+The [Code.org tutorials](https://studio.code.org/) are all designed to be used with or without sound. All the videos have captions. Some students can also benefit from headphones set to a higher volume.
+
+## Learn more
+
+To learn more about computer science education and special needs students, we recommend this [online book]({{ supporting-special-needs-students/book }}).

--- a/i18n/locales/sm-WS/hourofcode/thanks.md
+++ b/i18n/locales/sm-WS/hourofcode/thanks.md
@@ -1,0 +1,33 @@
+---
+title: Thanks for signing up to host an Hour of Code!
+---
+
+# Thanks for signing up to host an Hour of Code!
+
+<br /> **The Hour of Code runs during {{ campaign_date/full }} and we'll be in touch about new tutorials and other exciting updates as they come out. In the meantime, what can you do now?**
+
+## 1. Spread the word in your school and community
+
+You just joined the Hour of Code movement. Tell your friends with **#HourOfCode**!
+
+{{ social_media_hoc }} <br /> Encourage others to participate [with our sample emails.]({{ promote/sample_emails }}) Contact your principal and challenge every classroom at your school to sign up. Recruit a local group — boy/girl scouts club, church, university, veterans group, labor union, or even some friends. You don't have to be in school to learn new skills. Invite a local politician or policy maker to visit your school for the Hour of Code. It can help build support for computer science in your area beyond one hour.
+
+Use these [posters, banners, stickers, videos and more]({{ promote/resources }}) for your own event.
+
+## 2. Find a local volunteer to help you with your event.
+
+[Search our volunteer map]({{ urls/volunteer_local }}) for volunteers who can visit your classroom or video chat remotely to inspire your students about the breadth of possibilities with computer science.
+
+## 3. Plan your Hour of Code
+
+Choose an [Hour of Code activity](https://hourofcode.com/learn) for your classroom and [review this how-to guide]({{ urls/how_to_guide }}).
+
+### 4. Stock up on swag
+
+Order materials to help get students excited about your event by heading to the Code.org [Amazon store](https://www.amazon.com/stores/page/8557B2A6-EBF2-4C9F-95C5-C3256FBA0220). Order posters, Hour of Code kits, stickers, and more! But hurry, supplies are limited.
+
+# Go beyond an Hour of Code
+
+{{ go_beyond_hoc }}
+
+{{ popup_window.js }}

--- a/i18n/locales/sm-WS/hourofcode/whole-school.md
+++ b/i18n/locales/sm-WS/hourofcode/whole-school.md
@@ -1,0 +1,9 @@
+---
+title: Whole School Participation
+---
+
+{{ signup_button }}
+
+# Get your whole school to participate
+
+Information about getting whole schools to participate in the Hour of Code will go here.

--- a/pegasus/sites.v3/hourofcode.com/i18n/sm.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/sm.yml
@@ -1,0 +1,11577 @@
+---
+sm:
+  site_name: HOUR of CODE
+  hour_of_code: Hour of Code
+  language: English
+  front_title: Join the largest learning event in history, %{campaign_date}
+  coming_soon: Coming Soon
+  campaign_date_start_short: Dec. 5
+  campaign_date_start_long: December 5
+  campaign_date_short: Dec. 5-11
+  campaign_date_full: December 5-11
+  campaign_date_year: '2022'
+  campaign_date_full_year: December 5-11, 2022
+  nonus_campaign_date_start_short: Oct. 1
+  nonus_campaign_date_start_long: October 1
+  nonus_campaign_date_short: Oct. 1 - Dec. 18
+  nonus_campaign_date_full: October 1 - December 18
+  nonus_campaign_date_year: '2022'
+  nonus_campaign_date_full_year: October 1, 2022 - December 18, 2022
+  latam_campaign_date_start_short: Oct. 1
+  latam_campaign_date_start_long: October 1
+  latam_campaign_date_short: Oct. 1 - Dec. 18
+  latam_campaign_date_full: October 1 - December 18
+  latam_campaign_date_year: '2022'
+  latam_campaign_date_full_year: October 1, 2022 - December 18, 2022
+  europe_campaign_date_start_short: Oct. 1
+  europe_campaign_date_start_long: October 1
+  europe_campaign_date_short: Oct. 1 - Dec. 18
+  europe_campaign_date_full: October 1 - December 18
+  europe_campaign_date_year: '2022'
+  europe_campaign_date_full_year: October 1, 2022 - December 18, 2022
+  africa_campaign_date_start_short: Oct. 1
+  africa_campaign_date_start_long: October 1
+  africa_campaign_date_short: Oct. 1 - Dec. 18
+  africa_campaign_date_full: October 1 - December 18
+  africa_campaign_date_year: '2022'
+  africa_campaign_date_full_year: October 1, 2022 - December 18, 2022
+  hoc2022_header: Explore, Play, Create!
+  social_hoc2022_explore_play_create: Use computer science to explore, play, and create!
+  codeorg_homepage_hoc2022_body: Explore the universe, score a goal, bust a move —
+    there are so many ways to try computer science.
+  hoc2022_codeorg_title: Celebrate Hour of Code with NASA and more
+  hoc2022_codeorg_description: The 10th Hour of Code is out of this world! Come explore,
+    play, and create with us.
+  social_hoc2022_dance: Featuring Beyoncé, Harry Styles, Lizzo, Lil Nas X, Selena
+    Gomez, music from Disney's "Encanto," and more!
+  social_hoc2021_cse: 'During the #HourOfCode, we''re celebrating #CSEverywhere. Discover
+    the connections!'
+  hoc2020_header: Learn today, build a brighter tomorrow.
+  hoc2020_header_with_line_break_markdown: |-
+    Learn today,
+
+    build a brighter tomorrow.
+  social_hoc2020_cs_important: 'CS is more important than ever. Let''s build the future
+    we want. #CSforGood'
+  social_hoc2020_hoc_is_about_csforgood: 'The #HourOfCode is about #CSforGood. Learn
+    today, build a brighter tomorrow.'
+  social_hoc2020_global_movement: The Hour of Code is a global movement reaching tens
+    of millions of students. One-hour tutorials are available in 45+ languages for
+    all ages.
+  social_hoc2020_coming_dates: The Hour of Code is coming December 7-13, 2020. Computer
+    science is foundational for every student to learn.
+  hoc2020_ai_subheader: The Hour of Code 2020 is coming!
+  hoc2020_ai_header: Explore Artificial Intelligence
+  hoc2020_ai_description: AI and Machine Learning are impacting our entire world.
+    Join us to explore AI in a new video series, train AI for Oceans in 25+ languages,
+    discuss ethics and AI, and more...
+  hoc2019_header: Learn computer science. Change the world.
+  hoc2019_header_line1_mobile: Learn computer science.
+  hoc2019_header_line2_mobile: Change the world.
+  social_hoc2019_every_sudent: 'Every student has the potential to change the world.
+    Help them get started. #CSforGood'
+  social_hoc2019_learn_computer_science: 'Learn computer science. Change the world.
+    #CSforGood #HourOfCode'
+  social_hoc_is_coming: The Hour of Code is coming!
+  social_hoc2019_hoc_is_about_csforgood: 'The #HourOfCode is about #CSforGood. Learn
+    computer science. Change the world.'
+  social_hoc2019_coming_dates: The Hour of Code is coming December 9-15, 2019. Computer
+    science is foundational for every student to learn.
+  social_hoc2019_dance: Featuring Katy Perry, Shawn Mendes, Panic! At The Disco, Lil
+    Nas X, Jonas Brothers, Nicki Minaj, and 34 more!
+  social_hoc_anybody: 'Hour of Code: Anybody can Learn'
+  oceans_landing_title: AI for Oceans
+  oceans_landing_description: Learn about machine learning and ethical use of AI.
+  cs_for_good_hashtag: "#CSforGood"
+  oceans_landing_specs: Available in 25+ languages | Grades 3+
+  oceans_landing_explanation: Computer science is about so much more than coding!
+    Learn about artificial intelligence (AI), machine learning, training data, and
+    bias, while exploring ethical issues and how AI can be used to address world problems.
+    Enjoy Code.org's first step in a new journey to teach more about AI. When you
+    use the AI for Oceans activity you are training real machine learning models.
+    <a href='#behind-the-scenes'>Learn more</a>.
+  oceans_landing_explanation_markdown: Computer science is about so much more than
+    coding! Learn about artificial intelligence (AI), machine learning, training data,
+    and bias, while exploring ethical issues and how AI can be used to address world
+    problems. Enjoy Code.org's first step in a new journey to teach more about AI.
+    When you use the AI for Oceans activity you are training real machine learning
+    models. [Learn more](#behind-the-scenes).
+  oceans_landing_teacher_resources: Teacher Resources
+  oceans_landing_teacher_resources_desc: Lesson plans and activities to help you teach
+    AI, machine learning, training data, and bias, while exploring ethical issues.
+  oceans_landing_resource_button: View Resources
+  oceans_landing_cs_for_good: CS for Good
+  oceans_landing_cs_for_good_desc: Resources to help students understand the role
+    computer science could play in creating a more equitable world.
+  oceans_landing_videos: Videos about AI and Machine Learning
+  oceans_behind_the_scenes: 'AI for Oceans: Behind the Scenes'
+  oceans_behind_the_scenes_1: Levels 2-4 use a pretrained model provided by the <a
+    href="https://www.tensorflow.org/" >TensorFlow</a> <a href="https://github.com/tensorflow/models/blob/master/research/slim/nets/mobilenet_v1.md">
+    MobileNet </a> project. A MobileNet model is a <a href="https://developers.google.com/machine-learning/practica/image-classification/convolutional-neural-networks">convolutional
+    neural network</a> that has been trained on <a href="http://www.image-net.org/">ImageNet</a>,
+    a dataset of over 14 million images hand-annotated with words such as "balloon"
+    or "strawberry". In order to customize this model with the labeled training data
+    the student generates in this activity, we use a technique called <a href="https://en.wikipedia.org/wiki/Transfer_learning">Transfer
+    Learning</a>. Each image in the training dataset is fed to MobileNet, as pixels,
+    to obtain a list of annotations that are most likely to apply to it. Then, for
+    a new image, we feed it to MobileNet and compare its resulting list of annotations
+    to those from the training dataset. We classify the new image with the same label
+    (such as "fish" or "not fish") as the images from the training set with the most
+    similar results.
+  oceans_behind_the_scenes_1_markdown: Levels 2-4 use a pretrained model provided
+    by the [TensorFlow](https://www.tensorflow.org/) [MobileNet](https://github.com/tensorflow/models/blob/master/research/slim/nets/mobilenet_v1.md)
+    project. A MobileNet model is a [convolutional neural network](https://developers.google.com/machine-learning/practica/image-classification/convolutional-neural-networks)
+    that has been trained on [ImageNet](http://www.image-net.org/), a dataset of over
+    14 million images hand-annotated with words such as "balloon" or "strawberry".
+    In order to customize this model with the labeled training data the student generates
+    in this activity, we use a technique called [Transfer Learning](https://en.wikipedia.org/wiki/Transfer_learning).
+    Each image in the training dataset is fed to MobileNet, as pixels, to obtain a
+    list of annotations that are most likely to apply to it. Then, for a new image,
+    we feed it to MobileNet and compare its resulting list of annotations to those
+    from the training dataset. We classify the new image with the same label (such
+    as "fish" or "not fish") as the images from the training set with the most similar
+    results.
+  oceans_behind_the_scenes_2: Levels 6-8 use a <a href="https://en.wikipedia.org/wiki/Support-vector_machine">Support-Vector
+    Machine</a> (SVM). We look at each component of the fish (such as eyes, mouth,
+    body) and assemble all of the metadata for the components (such as number of teeth,
+    body shape) into a vector of numbers for each fish. We use these vectors to train
+    the SVM. Based on the training data, the SVM separates the "space" of all possible
+    fish into two parts, which correspond to the classes we are trying to learn (such
+    as "blue" or "not blue").
+  oceans_behind_the_scenes_2_markdown: Levels 6-8 use a [Support-Vector Machine](https://en.wikipedia.org/wiki/Support-vector_machine)
+    (SVM). We look at each component of the fish (such as eyes, mouth, body) and assemble
+    all of the metadata for the components (such as number of teeth, body shape) into
+    a vector of numbers for each fish. We use these vectors to train the SVM. Based
+    on the training data, the SVM separates the "space" of all possible fish into
+    two parts, which correspond to the classes we are trying to learn (such as "blue"
+    or "not blue").
+  heading_additional_resources: Additional resources
+  call_to_action_learn_more: Learn more
+  call_to_action_watch_now: Watch now
+  call_to_action_try_activity: Try activity
+  social_hoc2019_oceans_title: 'AI for Oceans #CSforGood'
+  social_hoc2019_oceans_desc: Learn about AI, machine learning, training data, and
+    bias, while exploring ethical issues and how AI can be used to address world problems.
+    Computer science is about so much more than coding! Enjoy Code.org's first step
+    in a new journey to teach more about AI throughout our curriculum.
+  social_coldplay_title: Create with Coldplay & Code.org
+  social_coldplay_desc: Show us your best moves! Code, dance, share with the world,
+    and you could win.
+  social_maker_title: I'm a Maker!
+  social_maker_desc: Code.org physical computing and maker resources for grades 6-12.
+  social_blockchain_title: How Blockchain Works
+  social_blockchain_desc: Videos and lessons that explore what blockchain is and why
+    it's important.
+  pl_superhero_title: Help students become superheroes!
+  pl_superhero_desc: Join our highly supportive Professional Learning Program for
+    middle and high school educators.
+  blockchain_hero_heading: How Blockchain Works
+  blockchain_hero_desc: Dive into the world of blockchain with "How Blockchain Works,"
+    our new video series and accompanying lessons!
+  blockchain_intro_heading: See how blockchain works
+  blockchain_intro_desc: The video series, made in partnership with Coinbase, features
+    industry experts and aims to demystify this technology.
+  blockchain_intro_list_heading: 'This series will:'
+  blockchain_intro_list_item_01: Explain what blockchain is
+  blockchain_intro_list_item_02: Explore why it's important
+  blockchain_intro_list_item_03: Unpack its societal impacts — both good and bad
+  blockchain_video_title_01: Introduction to Blockchain
+  blockchain_video_title_02: Why Blockchain
+  blockchain_video_title_03: Under the Hood
+  blockchain_video_title_04: Beyond Currencies
+  blockchain_video_title_05: Marketplace and Price
+  blockchain_video_title_06: Trustworthy or a Scam?
+  blockchain_video_title_07: Societal Impact
+  blockchain_lessons_heading: Blockchain lessons for your class
+  blockchain_lessons_desc: The first five lessons can be taught as part of a "How
+    Blockchain Works" series or can stand alone. The last lesson condenses the whole
+    series to a single day.
+  blockchain_resources_desc: Interested in learning more about blockchain? Here are
+    some additional resources that can help extend your students' learning.
+  blockchain_resources_01_heading: Coinbase Learn
+  blockchain_resources_01_desc: Crypto questions answered, beginner guides, practical
+    tips, and market updates for first-timers, experienced investors, and everyone
+    in between.
+  blockchain_resources_01_button_label: Visit the Coinbase Learn website
+  blockchain_resources_02_heading: Whiteboard Crypto
+  blockchain_resources_02_desc: Watch videos from Whiteboard Crypto's YouTube channel
+    to learn even more about blockchain technology.
+  blockchain_resources_02_button_label: Visit the Whiteboard Crypto YouTube channel
+  blockchain_resources_03_heading: Hour of Code Activity
+  blockchain_resources_03_desc: Try a crypto memory game created by Coinbase.
+  blockchain_resources_03_button_label: Try the Crypto Memory Game activity
+  hoc_live: Hour of Code Live
+  hoc_live_sign_up_title: Sign up for Hour of Code Live
+  hoc_live_learn_title: Learn with Hour of Code Live
+  hoc_live_sign_up_message: Learn in real time alongside special guests! Students
+    of all ages and abilities, including those without computers, are welcome. Join
+    our mailing list to receive recordings of the episodes and resources to continue
+    learning at home. See past episodes [here](%{episodes_url}).
+  hoc_live_learn_message: Learn basic concepts of computer science alongside special
+    guests! Students of all ages and abilities, including those without computers,
+    are welcome to our virtual workshop. Continue learning at home through our Hour
+    of Code Live episodes.
+  hoc_live_join_us: Join us
+  hoc_live_learn_more: Learn more
+  hoc_overview_oceans_tutorial_header: AI for Oceans
+  hoc_overview_oceans_tutorial_desc: Learn about artificial intelligence (AI), machine
+    learning, training data, and bias, while exploring ethical issues and how AI can
+    be used to address world problems.
+  hoc_overview_csc_header: Introducing CS Connections
+  hoc_overview_csc_desc: Our newest curriculum highlights the connections between
+    computer science and other subjects like math, language arts, science, and social
+    studies. Through these modules, projects, and lessons, classrooms can explore
+    their usual subjects in exciting new ways!
+  hoc_overview_csc_learn_more: Learn more about CS Connections
+  hoc_danceparty_alt_text: Animated characters dancing to music underneath the text
+    'Code your own dance party'
+  hoc_ai_alt_text: A floating, white, artificial intelligence character with an antennae,
+    a scanner on the bottom, and an LED face
+  hoc_banner_alt_text: Hour of Code banner
+  ai_video_title_what_is_ai: What is AI?
+  ai_video_title_algorithm_bias: Fighting bias in algorithms
+  ai_video_title_phone_knows_dog: How does your phone know this is a dog?
+  ai_video_title_what_is_ml: What is Machine Learning?
+  ai_video_title_ml_big_small_prickly: 'Machine Learning: Solving Problems Big, Small
+    and Prickly'
+  ai_video_title_ethics_of_ai: Ethics of AI
+  ai_video_title_ml_human_bias: Machine Learning and Human Bias
+  ai_video_title_seeing_ai: 'Seeing AI: Making the visual world more accessible'
+  activity: Activity
+  name: Name
+  description: Description
+  audience: Audience
+  ai_resource_header: Teach and Learn about AI
+  ai_resource_minecraft: Minecraft AI for Good
+  ai_resource_minecraft_desc: 'Access free resources including a lesson plan, videos,
+    computer science curriculum, and teacher trainings. (Requires Minecraft: Education
+    Edition)'
+  ai_resource_ml_for_kids: Machine Learning for Kids
+  ai_resource_ml_for_kids_desc: Train a machine learning model with text, numbers,
+    or images, and use it to make games in Scratch.
+  ai_resource_ibm_ml_for_kids: 'IBM: Machine Learning for Kids'
+  ai_resouce_ibm_ml_for_kids_desc: Hands-on activities to introduce simple machine
+    learning models to students through games and interactive projects.
+  ai_resource_ecs: 'ECS: Artificial Intelligence (AI)'
+  ai_resource_ecs_desc: A new alternate curriculum unit for the Exploring Computer
+    Science (ECS) curriculum.
+  ai_resource_elements_ai: Elements of AI
+  ai_resource_elements_ai_desc: A series of free online courses created by Reaktor
+    and the University of Helsinki.
+  ai_resource_cognimates: Cognimates
+  ai_resource_cognimates_desc: An AI education platform for building games, programming
+    robots and training.
+  ai_audience_k12: K-12 (Reading required)
+  ai_audience_hs: High school
+  ai_activity_header: Activities Powered by AI and ML
+  ai_activity_seeing_ai: Seeing AI
+  ai_activity_seeing_ai_desc: A free app that narrates the world around you in a variety
+    of languages.
+  ai_activity_quick_draw: Quick, Draw!
+  ai_activity_quick_draw_desc: Can a neural network learn to recognize doodling?
+  ai_activity_teachable: Teachable Machine
+  ai_activity_teachable_desc: Train a computer to recognize your own images, sounds,
+    and poses.
+  ai_activity_experiments: AI Experiments with Google
+  ai_activity_experiments_desc: Start exploring machine learning through pictures,
+    drawings, language, music, and more.
+  ai_activity_zooniverse: Zooniverse - Snapshot Mountain Zebra
+  ai_activity_zooniverse_desc: Help protect the endangered Cape Mountain Zebra by
+    identifying the different animals in the images.
+  codeorg_homepage_hoc2018_curriculum: Go further with <a href="%{studio_url}/courses"
+    class="hoc2018-curriculum-link">Code.org courses</a>
+  codeorg_homepage_hoc2018_dance_heading: Create your own <span class="highlight-word">Dance&nbsp;Party</span>
+  codeorg_homepage_hoc2018_header_line1: The Hour of Code is coming...
+  codeorg_homepage_hoc2018_header_line2_desktop: What will you <span class="hoc2018-highlight-word">create?</span>
+  codeorg_homepage_hoc2018_header_line2_mobile: What will you create?
+  codeorg_homepage_hoc2018_header_line3: Give flight to imagination and birth to innovation.
+    Start with an Hour of Code and your own brand of creativity, whatever it may be.
+  codeorg_homepage_hoc2018_musician_before: Featuring
+  codeorg_homepage_hoc2018_musician_after: and more!
+  codeorg_homepage_hoc2018_video: Watch our video
+  hourofcode_homepage_hoc2018_header_line1: Anyone, anywhere can organize an Hour
+    of Code event. One-hour tutorials in over 45 languages. No experience needed.
+  hourofcode_homepage_hoc2018_header_line2: Ages 4 to 104.
+  codeorg_homepage_hoc_is_coming: The Hour of Code is coming.
+  codeorg_homepage_celebrate_cse: Celebrate computer science everywhere!
+  codeorg_homepage_csc: Computer science meets language arts, math, and more in CS
+    Connections
+  codeorg_homepage_csc_long: See how computer science meets language arts, math, and
+    more in our curriculum!
+  codeorg_homepage_csc_title: CS Connections
+  hoc2018_tutorial_mchoc_description: Minecraft is back for the Hour of Code with
+    a brand new activity! Journey through Minecraft with code.
+  codeorg_homepage_hoc2019_dance_heading: Code a <span class="highlight-word">Dance&nbsp;Party!</span>
+  codeorg_homepage_hoc2019_dance_heading_markdown: Code a **Dance&nbsp;Party!**
+  codeorg_homepage_special2020_body1: Support for parents and teachers facing school
+    closures.
+  codeorg_homepage_special2020_body2: See our suggested learning resources.
+  codeorg_homepage_special2020_body: Keep learning this summer! Take a look at our
+    resources for learning at home.
+  codeorg_homepage_remote2020_body: Are you teaching in a remote or socially-distanced
+    classroom this semester? View our resources.
+  codeorg_homepage_special2020_link_text: Get started
+  codeorg_homepage_code_break_body: Take a Code Break! Your weekly dose of inspiration,
+    community, and computer science.
+  codeorg_homepage_code_break_link_text: Learn more
+  cookie_banner_message: By continuing to browse our site or clicking "I agree," you
+    agree to the storing of cookies on your computer or device.
+  cookie_banner_more_information: See Code.org's Privacy Policy.
+  cookie_banner_accept: I agree
+  front_header_banner: Join the largest learning event in history, %{campaign_date}
+  front_intro_default: The Hour of Code is a global movement reaching tens of millions
+    of students in 180+ countries. Anyone, anywhere can organize an Hour of Code event.
+    One-hour tutorials are available in over 45 languages. No experience needed. <strong>Ages
+    4 to 104.</strong>
+  front_intro_default_2: A global movement in 180+ countries.
+  front_watch_video: Watch the new video
+  front_watch_regular_video: Watch the video
+  front_volunteers: Technical volunteers wanted
+  front_start_learning: Start learning
+  header_menu_resources: Resources
+  header_menu_faq: FAQ
+  header_menu_how_to: How-To
+  header_menu_promote: Promote
+  header_menu_activities: Activities
+  not_found_title: Page Not Found
+  not_found_desc: The requested page was not found
+  not_found_instructions: Check the web address and resubmit or choose a link from
+    the list below.
+  company_4-H: 4-H Youth Development
+  company_asa: Afterschool Alliance
+  company_asos: ASOS
+  company_bgca: Boys and Girls Club of America
+  company_bsusa: Boy Scouts of America
+  company_cgcs: Council of the Great City Schools
+  company_gsusa: Girl Scouts of America
+  company_khanacademy: Khan Academy
+  company_kipp: KIPP
+  company_mesa: Mathematics Engineering Science Achievement
+  company_napcs: National Alliance of Public Charter Schools
+  company_ngcp: National Girls Collaborative Project
+  company_teachforall: Teach for All
+  company_teachforamerica: Teach for America
+  company_tntp: TNTP
+  company_abss: Alamance-Burlington School System
+  company_aldineisd: Aldine Independent School District
+  company_afterschool: after school
+  company_laalliance: Alliance College Ready Public Schools
+  company_asd: Arlington Public Schools
+  company_arlingtonpublicschools: Arlington Public Schools
+  company_bisd303: Bainbridge Island School District
+  company_beavertonschooldistrict: Beaverton School District
+  company_bellevuepublicschools: Bellevue Public Schools
+  company_blan: Blanchester Local Schools
+  company_bremertonschools: Bremerton School District
+  company_browardschools: Broward County Schools
+  company_cajonvalley: Cajon Valley School District
+  company_calistogajointunified: Calistoga Joint Unified School District
+  company_canalwinchesterschools: Canal Winchester Local Schools
+  company_canyonsdistrict: Canyons School District
+  company_centralunified: Central Unified School District
+  company_cvsd: Central Valley School District
+  company_ccboe: Charles County Public Schools
+  company_ChathamCountySchools: Chatham County Schools
+  company_chelmsfordpublicschooldistrict: Chelmsford School District
+  company_cheneysd: Cheney School District
+  company_chesterfieldschools: Chesterfield County Public Schools
+  company_codebrooklyn: Code Brooklyn
+  company_cps: Chicago Public Schools
+  company_ccsd: Clark County School District
+  company_cloverparkschooldistrict: Clover Park School District
+  company_ccsoh: Columbus City School District
+  company_cresskillboe: Cresskill Public Schools
+  company_dallasisd: Dallas Independent School District
+  company_disney: Disney
+  company_dpsk12: Denver Public Schools
+  company_dcsdk12: Douglas County Schools
+  company_dpsnc: Durham Public Schools
+  company_evsd: East Valley School District
+  company_eastonvilleschooldistrict: Eatonville School District
+  company_enumclawschooldistrict: Enumclaw School District
+  company_everettsd: Everette Public Schools
+  company_fsusd: Fairfield-Suisun Unified School District
+  company_fayettecountypublicschools: Fayette County Public Schools
+  company_forsythcountyschools: Forsyth County Schools
+  company_fcschools: Franklin County School
+  company_fpschools: Franklin Pierce School District
+  company_frederickcountypublicschools: Frederick County Public Schools
+  company_fultonschools: Fulton County Schools
+  company_vadoe: Governor's School Programs
+  company_gcs: Granville County Schools
+  company_gcisd: Grapevine-Colleyville ISD
+  company_godaddy: Go Daddy
+  company_greenupcountyschooldistrict: Greenup County Schools
+  company_gwinnettcountypublicschools: Gwinnett County Public Schools
+  company_HamptonCitySchools: Hampton City Schools
+  company_HanoverCountyPublicSchools: Hanover County Public Schools
+  company_HenricoCountyPublicSchools: Henrico County Public Schools
+  company_highlineschools: Highline School District
+  company_houstonisd: Houston Independent School District
+  company_hcpss: Howard County Public Schools
+  company_idla: Idaho Digital Learning Academy
+  company_janesvilleschooldistrict: Janesville School District
+  company_johnstoncountyschools: Johnston County Schools
+  company_lps: Lincoln Public School
+  company_littletonpublicschools: Littleton Public Schools
+  company_lausd: Los Angeles Unified School District
+  company_lcps: Louisa County Public Schools
+  company_lcsedu: Lynchburg City Schools
+  company_msvl: Marysville School District
+  company_dadeschools: Miami-Dade Public Schools
+  company_miltonps: Milton Public Schools
+  company_montgomeryschoolsmd: Montgomery County Public Schools
+  company_needhampublicschools: Needham Public Schools
+  company_NelsonCountyPublicSchools: Nelson County Public Schools
+  company_newalbanyschools: New Albany Plain Local Schools
+  company_newkentschools: New Kent County Public Schools
+  company_newarkcityschools: Newark City Schools
+  company_nnschools: Newport News Public Schools
+  company_newtonpublicschools: Newton Public Schools
+  company_nps: Norfolk Public Schools
+  company_nycdoe: NYC Department of Education
+  company_ohlsd: Oak Hills Local School District
+  company_oneclay: One Clay County School District
+  company_ocps: Orange County Schools
+  company_orangeusd: Orange Unified School District
+  company_pbsd: Palm Beach School District
+  company_pvusd: Paradise Valley Unified School District
+  company_PetersburgCityPublicSchools: Petersburg City Public Schools
+  company_pylusd: Placentia-Yorba Linda Union School District
+  company_PowhatanCountyPublicSchools: Powhatan County Public Schools
+  company_pgcps: Prince Georges County Public Schools
+  company_provocityschooldistrict: Provo Public Schools
+  company_reyn: Reynoldsburg City School District
+  company_RichmondPublicSchools: Richmond Public Schools
+  company_RockinghamCountySchools: Rockingham County Schools
+  company_svusd: Saddleback Valley Unified School District
+  company_sfusd: San Francisco Unified School District
+  company_ShenandoahCountyPublicSchools: Shenandoah County Public Schools
+  company_shorelineschools: Shoreline School District
+  company_sjusd: San Juan Unified School District
+  company_sky: Sky
+  company_spokaneschools: Spokane Public Schools
+  company_StaffordCountyPublicSchools: Stafford County Public Schools
+  company_strongnet: Strongsville School District
+  company_TukwilaSchoolDistrict: Tukwila School District
+  company_vermilionschools: Vermilion Local School District
+  company_vista-equity-partners: Vista Equity Partners
+  company_walthampublicschools: Waltham Public Schools
+  company_warrencountyschools: Warren County Schools
+  company_WaynesboroPublicSchools: Waynesboro Public Schools
+  company_WellesleyPublicSchools: Wellesley Public Schools
+  company_wvsd208: West Valley School District
+  company_wuhsd: Whittier Union High School District
+  company_wcschools: Wilson County Schools
+  company_yelp: Yelp
+  nav_back_to_resources: Back to Resources
+  how_to_nav_educators: For educators
+  how_to_nav_after_school: For after school
+  how_to_nav_parents: For parents
+  how_to_nav_public_officials: For public officials
+  how_to_nav_districts: For districts
+  how_to_nav_assemblies: For school assemblies
+  how_to_nav_organizations: For organizations
+  how_to_nav_companies: For companies
+  how_to_nav_afterschool_educators: For after-school educators
+  how_to_nav_volunteers: For volunteers
+  how_to_nav_virtual: For virtual events
+  whats_next_header: What's next?
+  whats_next_description: We'll send you materials and helpful tips for your event.
+    <a href='http://code.org/learn'>Try current tutorials</a> for any browser, smartphone
+    – or even no computer!
+  whats_next_how_to: "<a href='/how-to'>How to run an Hour of Code</a>"
+  whats_next_promote: "<a href='/promote'>Promote the Hour of Code</a>"
+  whats_next_how_to_promote: "<a href='/promote/resources'>How to promote the Hour
+    of Code</a>"
+  whats_next_how_to_promote_link: "<a href='/promote'>How to promote the Hour of Code</a>"
+  whats_next_try: "<a href='%{learn_url}'>Try tutorials</a>"
+  whats_next_try_button: Try tutorials
+  n_have_learned_an_hoc: "<h1>Try an</h1><h2>Hour of Code</h2><h3># served</h3>"
+  anybody_can_learn: Anybody can learn.
+  get_started: Start
+  beyond_an_hour: Beyond an Hour of Code
+  register_now: Register Now
+  share_on_facebook: Share on Facebook
+  share_on_twitter: Share on Twitter
+  promote_additional_resources: Additional resources coming soon!
+  front_join_us_heading: An Hour of Code for every student.
+  front_join_us_announcements: Announcements
+  front_join_us_anybody_can_learn: Anybody can learn
+  front_join_us_description: Computer science is a foundation for every student. Help
+    us introduce it to 100 million.
+  front_join_us_description_short: Computer science is a foundation for every student.
+  front_join_us_button: Join us
+  front_what_is_hoc: What is the Hour of Code?
+  front_join_us_header: Anyone can learn the basics, and have fun doing it!
+  front_join_us_volunteer_header: Volunteers for the Hour of Code
+  front_join_us_tutorials: Choose your Hour of Code tutorial!
+  front_join_us_tutorials_link: Filter and browse <i>over 200 tutorials and lesson
+    plans</i>! Find activities for different subject areas, multiple hardware needs,
+    and students at any experience level.
+  front_join_us_robotics: Win robots or circuits!
+  front_join_us_robotics_link: Do you want a set of robots or physical computing kits
+    to use with your students? Our generous partners are donating sets to 75 classrooms!
+    Sign up for the Hour of Code to participate. (Classrooms selected by Code.org,
+    US Only)
+  front_join_us_teacher: Are you a teacher?
+  front_join_us_inspire: Inspire students with
+  front_join_us_inspire_link: an Hour of Code in the classroom.
+  front_join_us_teacher_link: Inspire students with an Hour of Code in the classroom
+  front_join_us_teacher_volunteer: Search for local volunteers who can visit your
+    classroom or inspire your students remotely.
+  front_join_us_parent: Are you a parent?
+  front_join_us_ask_link: Ask your local school
+  front_join_us_ask: to host an Hour of Code.
+  front_join_us_parent_link: Ask your local school to host an Hour of Code
+  front_join_us_computer_science: Just love computer science?
+  front_join_us_cs_volunteer: Passionate about computer science education?
+  front_join_us_spread: Spread the word.
+  front_join_us_spread_word: Spread the word in your community
+  front_join_us_spread_word_work: Spread the word in your community or workplace
+  front_join_us_sign_up_volunteer: Sign up to volunteer at a local classroom or through
+    a video chat.
+  front_join_us_organize: Or organize an Hour of Code event yourself.
+  front_join_us_how_to_run: Here's how to run an Hour of Code
+  front_join_us_help_promote: Help promote the Hour of Code
+  front_join_us_students: Students
+  front_join_us_teachers: Teachers
+  front_join_us_everyone: Everyone
+  front_join_us_try: Try it
+  front_join_us_sign_up: Sign up
+  front_join_us_host: Host it
+  front_join_us_support: Support it
+  front_join_us_more_info: For more information, please visit <a href='https://code.org'>code.org</a>.
+  front_join_us_code_info: For more information, please visit code.org
+  front_join_us_n_students_served: "# served."
+  front_join_us_challenge: Win a video chat for your classroom with a celebrity!
+  front_join_us_learn_more: Learn more
+  cta_see_whats_new: See what's new
+  cta_try_more_activities: Try more activities
+  cta_try_an_activity: Try an activity
+  hoc_homepage_join_the_movement_heading: Join the movement
+  hoc_homepage_join_the_movement_description: Hour of Code is available year-round,
+    but every year in December your class can join millions of students around the
+    world celebrating Computer Science Education Week with the Hour of Code. Registration
+    for the annual celebration starts each year in October.
+  hoc_homepage_what_is_hoc_subhead: One-hour tutorials in over 45 languages. No experience
+    needed. Hour of Code activities are available for free year-round.
+  hoc_homepage_what_is_hoc_description: The Hour of Code is a one-hour introduction
+    to computer science, using fun tutorials to show that anybody can learn the basics.
+    This grassroots campaign is supported by over 400 partners and 200,000 educators
+    worldwide.
+  hoc_homepage_what_is_hoc_cta_how_to_guide: "[Read our How-to guide](%{howto_guide_url})
+    to plan an event for your class."
+  hoc_homepage_highlights_heading: Hour of Code highlights
+  hoc_homepage_organized_by: The Hour of Code is organized by [Code.org](%{codeorg_url}).
+  signup_closed: Registration for the Hour of Code is now closed. Please check again
+    in October to sign up for the next Hour of Code.
+  signup_registration_not_required: You don't need to register to participate! The
+    Hour of Code activities are available year-round. <a href='%{hoc_activities_url}'>Try
+    an activity</a> or read our <a href='%{howto_guide_url}'>How-to guide</a> to plan
+    an event for your class.
+  signup_registration_not_required_markdown: You don't need to register to participate!
+    The Hour of Code activities are available year-round. [Try an activity](%{hoc_activities_url})
+    or read our [How-to guide](%{howto_guide_url}) to plan an event for your class.
+  signup_registration_closed: And every year in December, your class can join millions
+    of students around the world celebrating Computer Science Education Week with
+    the Hour of Code. We'll open registration for the annual celebration in October.
+  signup_registration_closed_2022_markdown: 'Registration for this year''s Hour of
+    Code event map is currently closed, but you can still [host an Hour of Code](%{hoc_activities_url})
+    and join in the celebration on social media! Post fun pictures or video of your
+    event using the #HourOfCode hashtag!'
+  signup_header: Organize an Hour of Code during %{campaign_date}, and register it
+    here.
+  signup_name_label: Your name
+  signup_name_error: Name is required.
+  signup_email_label: Your email
+  signup_email_error: Email is required
+  signup_invalid_email_error: The email address you entered is invalid
+  signup_organization_name_label: Organization name
+  signup_organization_name_error: Organization name is required.
+  signup_event_type_label: Event type
+  signup_event_type_error: Event type is required.
+  signup_event_entire_school_label: My entire school is participating
+  signup_event_location_label: Event location
+  signup_event_location_error: Event location is required.
+  signup_special_event_flag_label: My event will involve an entire district, members
+    of the community, and/or other special plans to go beyond an hour
+  signup_special_event_details_label: Apply to be highlighted as a special event
+  signup_send_posters_flag_label: Send <a href= "/resources/promote#posters">posters</a>
+    to my school or organization (US only, while supplies last)
+  signup_send_posters_address_label: Address of school or organization
+  signup_whole_school_flag_label: This event is for a whole school
+  signup_your_event: Sign up your event
+  signup_host_an_hour: Host an hour
+  signup_match_volunteer: Help me find a local software engineer to inspire my students
+  signup_email_preference_opt_in: Can we email you about updates to Code.org courses,
+    local opportunities, or other computer science news?
+  signup_email_preference_privacy: "(See our privacy policy)"
+  signup_email_preference_yes: 'Yes'
+  signup_email_preference_no: 'No'
+  signup_email_preference_error: Email preference is required
+  signup_multiple_event_warning: We will put your school name and city on the map
+    when you register. If you're hosting multiple events, please submit a unique name
+    or email for each one. We only count one event per name and email combination.
+  signup_name_placeholder: Your Name
+  signup_email_placeholder: you@example.com
+  signup_organization_name_placeholder: For example, Lincoln High School
+  signup_event_country_label: Event country
+  signup_event_country_error: Country is required.
+  signup_event_location_placeholder: Postal code and country OR full address.
+  signup_special_event_details_placeholder: Describe what makes this a special event
+  signup_send_posters_address_placeholder: This address will not be shared on our
+    map
+  signup_event_type_in_school: School
+  signup_event_type_after_school: After school program
+  signup_event_type_out_of_school: Organization/Company
+  signup_event_type_at_home: Home
+  signup_submit_census_label: Submit
+  signup_submit_census_error_message: We're sorry. An error occurred. Please try submitting
+    the form again.
+  signup_submit_label: Sign up
+  signup_submit_error_message: An error occurred. Please check to make sure all required
+    fields have been filled out properly.
+  signup_submit_and_continue_label: Submit and Continue
+  signup_continue_label: Continue
+  signup_thank_you_header: Thank you for signing-up to host an Hour of Code event.
+  signup_thank_you_message: We sent you a confirmation email with information to help
+    you get started.
+  social_hoc2018_code_org_what_create: 'Code.org: What will you create?'
+  social_hoc2018_creativity_in_are_you: 'The #HourOfCode is about creativity. I’m
+    in! Are you?'
+  social_hoc2018_dance_party: 'Hour of Code: Dance Party'
+  social_hoc2018_dance_what_create: Featuring Katy Perry, Madonna, J. Balvin, Sia,
+    Keith Urban, Ciara, and 25 more!
+  social_hoc2018_every_student: Every student deserves the opportunity to express
+    their creativity with computer science.
+  social_hoc2018_every_student_try_what_create: Every student deserves the opportunity
+    to express their creativity with computer science. Try your hand at the new tutorials.
+    What will you create?
+  social_hoc2018_hoc_coming_create: The Hour of Code is coming. What will you create?
+  social_hoc2018_hoc_here: The Hour of Code is here!
+  social_hoc2018_join: 'Hour of Code: Join the Movement'
+  social_hoc2018_mc: Minecraft is back for the Hour of Code, and you’re the hero!
+    Write code to journey through Minecraft biomes.
+  social_hoc2018_mc_creativity: Use your creativity and problem solving skills to
+    explore and build underwater worlds with code.
+  social_hoc2018_what_create: What will you create?
+  social_hoc2018_global_movement: The Hour of Code is a global movement reaching tens
+    of millions of students. One-hour tutorials are available in 45+ languages for
+    all ages.
+  map_title: Hour of Code map
+  map_header: "# events registered for Hour of Code 2017"
+  map_header_count_year: "%{event_count} events registered in %{year}"
+  see_all_events: See all events
+  map_header_company: "# by company organizers"
+  map_header_country: "# in %{country}"
+  map_search_placeholder: Search for Hour of Code events
+  map_search_search: Search
+  map_search_reset: Reset
+  map_legend_title: Legend
+  map_legend_hoc_events: Hour of Code Event
+  map_legend_cs_tech_jam: Special Event
+  map_warning: A full list of the events can be viewed on the <a href='%{events_url}'>events
+    page.</a>
+  map_warning_markdown: A full list of the events can be viewed on the [events page.](%{events_url})
+  meta_tag_og_title: 'Hour of Code: Join the Movement'
+  meta_tag_og_description: The Hour of Code is a global movement reaching tens of
+    millions of students of all ages in 180+ countries and over 45 languages.
+  meta_tag_twitter_title: 'Hour of Code: Join the Movement'
+  meta_tag_twitter_description: The Hour of Code is a global movement reaching tens
+    of millions of students of all ages in 180+ countries and over 45 languages.
+  meta_tag_og_title_cs_movement: 'Hour of Code: Join the Computer Science Movement'
+  meta_tag_og_description_campaign: The Hour of Code is a global campaign reaching
+    and inspiring tens of millions of students of all ages to learn computer science
+    in 180+ countries and over 45 languages.
+  twitter_default_text: 'I''m participating in this year''s #HourOfCode, are you?
+    @codeorg'
+  twitter_donor_text: 'This year''s #HourOfCode is about creativity. I’m in! Are you?
+    (Thanks %{random_donor} for supporting @codeorg)'
+  twitter_donor_text_2019: 'This year''s #HourOfCode is about #CSforGood. I’m in!
+    Are you? (Thanks %{random_donor} for supporting @codeorg)'
+  twitter_default_text_donor: 'I''m participating in this year''s #HourOfCode, are
+    you? (Thanks %{random_donor} for supporting @codeorg)'
+  hoc_faq_title: FAQs
+  hoc_faq_what_is_hoc_q: What is the Hour of Code?
+  hoc_faq_what_is_hoc_a: The Hour of Code started as a one-hour introduction to computer
+    science, designed to demystify "code", to show that anybody can learn the basics,
+    and to broaden participation in the field of computer science. It has since become
+    a worldwide effort to celebrate computer science, starting with 1-hour coding
+    activities but expanding to all sorts of community efforts. Check out the <a href='%{tutorials}'>tutorials
+    and activities</a>. This grassroots campaign is supported by over <a href='%{partners}'>400
+    partners</a> and 200,000 educators worldwide.
+  hoc_faq_what_is_hoc_a_markdown: The Hour of Code started as a one-hour introduction
+    to computer science, designed to demystify "code", to show that anybody can learn
+    the basics, and to broaden participation in the field of computer science. It
+    has since become a worldwide effort to celebrate computer science, starting with
+    1-hour coding activities but expanding to all sorts of community efforts. Check
+    out the [tutorials and activities](%{tutorials}). This grassroots campaign is
+    supported by over [400 partners](%{partners}) and 200,000 educators worldwide.
+  hoc_faq_last_year: Try the tutorials
+  hoc_faq_when_is_hoc_q: When is the Hour of Code?
+  hoc_faq_when_is_hoc_a: The Hour of Code takes place each year during <a href='%{csedweek_url}'>Computer
+    Science Education Week</a>. The %{campaign_date_year} Computer Science Education
+    Week will be %{campaign_date_full}, but you can host an Hour of Code all year-round.
+    Computer Science Education Week is held annually in recognition of the birthday
+    of computing pioneer <a href='%{grace_hopper}'>Admiral Grace Murray Hopper</a>
+    (December 9, 1906).
+  hoc_faq_when_is_hoc_a_markdown: The Hour of Code takes place each year during [Computer
+    Science Education Week](%{csedweek_url}). The %{campaign_date_year} Computer Science
+    Education Week will be %{campaign_date_full}, but you can host an Hour of Code
+    all year-round. Computer Science Education Week is held annually in recognition
+    of the birthday of computing pioneer [Admiral Grace Murray Hopper](%{grace_hopper})
+    (December 9, 1906).
+  hoc_faq_why_cs_q: Why computer science?
+  hoc_faq_why_cs_a: "<i>Every</i> student should have the opportunity to learn computer
+    science. It helps nurture problem-solving skills, logic and creativity. By starting
+    early, students will have a foundation for success in any 21st-century career
+    path. See more stats <a href='%{stats_url}'>here</a>."
+  hoc_faq_why_cs_a_markdown: _Every_ student should have the opportunity to learn
+    computer science. It helps nurture problem-solving skills, logic and creativity.
+    By starting early, students will have a foundation for success in any 21st-century
+    career path. See more stats [here](%{stats_url}).
+  hoc_faq_how_participate_q: How do I participate in the Hour of Code?
+  hoc_faq_how_participate_a: "<a href='/how-to'>Start planning here</a> by reviewing
+    our how-to guide. You can organize an Hour of Code event at your school or in
+    your community &mdash; like in an extracurricular club, non-profit or at work.
+    Or, just try it yourself when %{campaign_date} arrives."
+  hoc_faq_how_participate_a_markdown: "[Start planning here](%{howto}) by reviewing
+    our how-to guide. You can organize an Hour of Code event at your school or in
+    your community — like in an extracurricular club, non-profit or at work. Or, just
+    try it yourself when %{campaign_date} arrives."
+  hoc_faq_behind_hoc_q: Who is behind the Hour of Code?
+  hoc_faq_behind_hoc_a: The Hour of Code is organized by Code.org and driven by the
+    Hour of Code Review Committee as well as an unprecedented coalition of <a href='%{partner_url}'>partners</a>
+    that have come together to support the Hour of Code — including Microsoft, Apple,
+    Amazon, Boys and Girls Clubs of America and the College Board.
+  hoc_faq_behind_hoc_a_markdown: The Hour of Code is organized by Code.org and driven
+    by the Hour of Code Review Committee as well as an unprecedented coalition of
+    [partners](%{partner_url}) that have come together to support the Hour of Code
+    — including Microsoft, Apple, Amazon, Boys and Girls Clubs of America and the
+    College Board.
+  hoc_faq_host_q: I don't know anything about coding. Can I still host an event?
+  hoc_faq_host_a: Of course. Hour of Code activities are self-guided. All you have
+    to do is <a href='%{codeorg_url}/learn'>try our current tutorials</a>, pick the
+    tutorial you want, and pick an hour &mdash; we take care of the rest. We also
+    have options for every age and experience-level, from kindergarten and up. Start
+    planning your event by reading our <a href='/how-to'>how to guide</a>.
+  hoc_faq_host_a_markdown: Of course. Hour of Code activities are self-guided. All
+    you have to do is [try our current tutorials](%{codeorg_url}/learn), pick the
+    tutorial you want, and pick an hour — we take care of the rest. We also have options
+    for every age and experience-level, from kindergarten and up. Start planning your
+    event by reading our [how to guide](%{howto}).
+  hoc_faq_devices_q: What devices should I use for my students?
+  hoc_faq_devices_a: Code.org tutorials work on all devices and browsers. You can
+    see more information about Code.org's tutorial tech needs <a href='%{codeorg_url}/educate/it'>here</a>.
+    Tech needs for non-Code.org tutorials can be found on <a href='%{codeorg_url}/learn'>%{partner_url}/learn</a>
+    in the tutorial specific description. Don't forget we also offer <a href='%{unplugged_url}'>unplugged
+    activities</a> if your school can't accommodate the tutorials!
+  hoc_faq_devices_a_markdown: Code.org tutorials work on all devices and browsers.
+    You can see more information about Code.org's tutorial tech needs [here](%{codeorg_url}/educate/it).
+    Tech needs for non-Code.org tutorials can be found on [%{partner_url}/learn](%{codeorg_url}/learn)
+    in the tutorial specific description. Don't forget we also offer [unplugged activities](%{unplugged_url})
+    if your school can't accommodate the tutorials!
+  hoc_faq_need_computers_q: Do I need computers for every participant?
+  hoc_faq_need_computers_a: No. We have Hour of Code tutorials that work on PCs, smartphones,
+    tablets, and some that require no computer at all! You can join wherever you are,
+    with whatever you have. <p><i>Here are a few options:</i> <br> <ul> <li><b>Work
+    in pairs.</b> <a href='%{pair_programming_research}'>Research shows</a> students
+    learn best with <a href='%{pair_programming_video}'>pair programming</a>, sharing
+    a computer and working together. Encourage your students to double up. <li><b>Use
+    a projected screen.</b> If you have a projector and screen for a Web-connected
+    computer, your entire group can do an Hour of Code together. Watch video portions
+    together and take turns solving puzzles or answering questions. <li><b>Go unplugged.</b>
+    We offer <a href='%{unplugged_url}'>tutorials that require no computer</a> at
+    all. </ul>
+  hoc_faq_need_computers_a_markdown: |-
+    No. We have Hour of Code tutorials that work on PCs, smartphones, tablets, and some that require no computer at all! You can join wherever you are, with whatever you have.
+
+    _Here are a few options:_
+
+    - **Work in pairs.** [Research shows](%{pair_programming_research}) students learn best with [pair programming](%{pair_programming_video}), sharing a computer and working together. Encourage your students to double up.
+    - **Use a projected screen.** If you have a projector and screen for a Web-connected computer, your entire group can do an Hour of Code together. Watch video portions together and take turns solving puzzles or answering questions.
+    - **Go unplugged.** We offer [tutorials that require no computer](%{unplugged_url}) at all.
+  hoc_faq_international_q: I am in <country>. How do I participate internationally?
+  hoc_faq_international_a: Anyone can organize an Hour of Code event, anywhere in
+    the world. Last year, students worldwide joined together for the Hour of Code.
+    Find out more <a href='/promote'>here</a>.
+  hoc_faq_international_a_markdown: Anyone can organize an Hour of Code event, anywhere
+    in the world. Last year, students worldwide joined together for the Hour of Code.
+    Find out more [here](%{promote}).
+  hoc_faq_tutorial_q: How can I make an Hour of Code tutorial?
+  hoc_faq_tutorial_a: If you're interested in becoming a tutorial partner, <a href='/tutorial-guidelines'>see
+    our guidelines and instructions</a>. We'd like to host a variety of engaging options,
+    but the primary goal is to optimize the experience for students and teachers who
+    are new to computer science.
+  hoc_faq_tutorial_a_markdown: If you're interested in becoming a tutorial partner,
+    [see our guidelines and instructions](%{tutorial_guidelines}). We'd like to host
+    a variety of engaging options, but the primary goal is to optimize the experience
+    for students and teachers who are new to computer science.
+  hoc_faq_account_q: Do students need to log on using an account?
+  hoc_faq_account_a: No. Absolutely no signup or login is required for students to
+    try the Hour of Code. Most of the <a href='%{codeorg_url}/learn/beyond'>follow-on
+    courses</a> require account creation to save student progress. Also, signing up
+    for the Hour of Code does NOT automatically create a Code Studio account. If you
+    do want to create accounts for your students, please follow these <a href='https://youtu.be/_smelV_KISE'>instructions</a>.
+  hoc_faq_account_a_markdown: No. Absolutely no signup or login is required for students
+    to try the Hour of Code. Most of the [follow-on courses](%{codeorg_url}/learn/beyond)
+    require account creation to save student progress. Also, signing up for the Hour
+    of Code does NOT automatically create a Code Studio account. If you do want to
+    create accounts for your students, please follow these [instructions](%{section_instructions_url}).
+  hoc_faq_high_school_q: Which activity should I do with high school students?
+  hoc_faq_high_school_a: Our Star Wars and Minecraft tutorials are great for high
+    schoolers, especially the Star Wars JavaScript version and the free play level
+    on both tutorials. Alternately, we recommend trying one of the beginner tutorials
+    on <a href='%{codeorg_url}/learn'>%{partner_url}/learn</a> to start, such as the
+    tutorial with Angry Birds or with Anna and Elsa. A high school student should
+    be able to finish one of these in 30 minutes and can then try a more advanced
+    tutorial in JavaScript, such as Khan Academy or CodeHS.
+  hoc_faq_high_school_a_markdown: Our Star Wars and Minecraft tutorials are great
+    for high schoolers, especially the Star Wars JavaScript version and the free play
+    level on both tutorials. Alternately, we recommend trying one of the beginner
+    tutorials on [%{partner_url}/learn](%{codeorg_url}/learn) to start, such as the
+    tutorial with Angry Birds or with Anna and Elsa. A high school student should
+    be able to finish one of these in 30 minutes and can then try a more advanced
+    tutorial in JavaScript, such as Khan Academy or CodeHS.
+  hoc_faq_scratch_q: I am doing Scratch for Hour of Code, but what if my students
+    have iPads rather than laptops?
+  hoc_faq_scratch_a: Scratch doesn't run on tablets. If your students are young, they
+    can use the ScratchJR iPad app (for early-readers). If you look at the tutorials
+    on <a href='%{codeorg_url}/learn'>%{partner_url}/learn</a>, you can find other
+    tutorials that work on iPads - from Code.org, Tynker, Lightbot, or CodeSpark.
+  hoc_faq_scratch_a_markdown: Scratch doesn't run on tablets. If your students are
+    young, they can use the ScratchJR iPad app (for early-readers). If you look at
+    the tutorials on [%{partner_url}/learn](%{codeorg_url}/learn), you can find other
+    tutorials that work on iPads - from Code.org, Tynker, Lightbot, or CodeSpark.
+  hoc_faq_count_hoc_q: How do you count Hours of Code?
+  hoc_faq_map_q: Why don't I see my dot on the map?
+  hoc_faq_map_a: We're so sorry you aren't seeing your event on the Hour of Code map.
+    Because of the tens of thousands of organizers who sign up, the map aggregates
+    the data and displays one point for several events. If you click the <a href='%{events_url}'>events
+    page</a> link below the map you will be directed to a list of all events by state
+    and can find your event listed there. Additionally, given the thousands of people
+    signing up for the Hour of Code, the map and event list usually takes 48 hours
+    to update. Check back in a few days!
+  hoc_faq_map_a_markdown: We're so sorry you aren't seeing your event on the Hour
+    of Code map. Because of the tens of thousands of organizers who sign up, the map
+    aggregates the data and displays one point for several events. If you click the
+    [events page](%{events_url}) link below the map you will be directed to a list
+    of all events by state and can find your event listed there. Additionally, given
+    the thousands of people signing up for the Hour of Code, the map and event list
+    usually takes 48 hours to update. Check back in a few days!
+  hoc_faq_count_hoc_a: The Hour of Code tracker isn't an exact measurement of usage.
+    We do not count unique student IDs perfectly when tracking participation in the
+    Hour of Code, especially because we don't require students to log in or register.
+    As a result, we both over-count and under-count participants at the same time.
+    Read all the details <a href='%{codeorg_url}/loc'>here</a>.
+  hoc_faq_count_hoc_a_markdown: 'We do not count unique student IDs perfectly when
+    tracking participation in the Hour of Code. Why? Partly because we don''t want
+    the friction of prompting to “login / register” before a student or classroom
+    tries learning for the first time, and partly because there are may activities
+    we cannot track online. We do take certain steps to reduce double-counting, but
+    without a login prompt, this can''t work perfectly. At the same time, there are
+    MANY student activities in the Hour of Code that aren''t tracked at all. For example:
+    (1) students who use a mobile/tablet app to try the Hour of Code are typically
+    not counted (2) students who share a screen for pair-programming or group-programming
+    may be counted as one (3) students trying an unplugged classroom activity cannot
+    be counted online (4) teachers who create their own Hour of Code activities. As
+    a result, there is some under-counting and some double-counting, and so we do
+    not view the Hour of Code tracker to be an exact measure of usage. It is certainly
+    directionally correct, and shows that many tens of millions of students have participated.'
+  hoc_faq_one_hour_q: How much can one learn in an hour?
+  hoc_faq_one_hour_a: The goal of the Hour of Code is not to teach anybody to become
+    an expert computer scientist in one hour. One hour is only enough to learn that
+    computer science is fun and creative, that it is accessible at all ages, for all
+    students, regardless of background. The measure of success of this campaign is
+    not in how much CS students learn - the success is reflected in broad participation
+    across gender and ethnic and socioeconomic groups, and the resulting increase
+    in enrollment and participation we see in CS courses at all grade levels. Millions
+    of the participating teachers and students have decided to go beyond one hour
+    -  to learn for a whole day or a whole week or longer, and many students have
+    decided to enroll in a whole course (or even a college major) as a result. <br/><br/>
+    Besides the students, another "learner" is the educator who gains the confidence
+    after one hour that they can teach computer science even though they may not have
+    a college degree as a computer scientist. Tens of thousands of teachers decide
+    to pursue computer science further, either attending PD or offering follow-on
+    online courses, or both. And this applies to school administrators too, who realize
+    that computer science is something their students want and their teachers are
+    capable of. <br/><br/> Above all, what all participants can learn in an hour is
+    that we can do this.
+  hoc_faq_one_hour_a_markdown: |-
+    The goal of the Hour of Code is not to teach anybody to become an expert computer scientist in one hour. One hour is only enough to learn that computer science is fun and creative, that it is accessible at all ages, for all students, regardless of background. The measure of success of this campaign is not in how much CS students learn - the success is reflected in broad participation across gender, racial/ethnic, and socioeconomic groups, and the resulting increase in enrollment and participation we see in CS courses at all grade levels. Millions of the participating teachers and students have decided to go beyond one hour -  to learn for a whole day or a whole week or longer, and many students have decided to enroll in a whole course (or even a college major) as a result.
+
+    Besides the students, another "learner" is the educator who gains the confidence after one hour that they can teach computer science even though they may not have a college degree as a computer scientist. Tens of thousands of teachers decide to pursue computer science further, either attending PD or offering follow-on online courses, or both. And this applies to school administrators too, who realize that computer science is something their students want and their teachers are capable of.
+
+    Above all, what all participants can learn in an hour is that we can do this.
+  hoc_faq_more_questions_q: Still have more questions?
+  hoc_faq_more_questions_a: Try finding an answer in our <a href='http://support.code.org'>support
+    forum</a>.
+  hoc_faq_more_questions_a_markdown: Try finding an answer in our [support forum](http://support.code.org).
+  hoc_faq_keep_learning_q: How do I keep learning after the Hour of Code?
+  hoc_faq_keep_learning_a: Anyone can host an Hour of Code at any time. The tutorials
+    stay up year-round. You can expect all our tutorials and curriculum to be available
+    on our site in perpetuity. Please go to <a href='/promote'>our resources</a> for
+    event how-to guides and other resources to help make your Hour of Code event a
+    success.
+  hoc_faq_keep_learning_a_markdown: Anyone can host an Hour of Code at any time. The
+    tutorials stay up year-round. You can expect all our tutorials and curriculum
+    to be available on our site in perpetuity. Please go to [our resources](%{promote})
+    for event how-to guides and other resources to help make your Hour of Code event
+    a success.
+  hoc_faq_certificates_q: Where can I print certificates for my students?
+  hoc_faq_certificates_a: Go to our <a href='%{codeorg_url}/certificates'>certificates
+    page</a> where you can print certificates for your entire class ahead of time.
+    You can also print out <a href='%{codeorg_url}/certificates?course=mc'>special
+    certificates</a> for students doing the Minecraft tutorial.
+  hoc_faq_certificates_a_markdown: Go to our [certificates page](%{codeorg_url}/certificates)
+    where you can print certificates for your entire class ahead of time. You can
+    also print out [special certificates](%{codeorg_url}/certificates?course=mc) for
+    students doing the Minecraft tutorial.
+  hoc_faq_logo_q: Are there limitations to how I can use the Hour of Code logo or
+    name?
+  hoc_faq_logo_a: Hour of Code is trademarked. We don't want to prevent its usage,
+    but we want to make sure its usage fits within a few limits. Please see <a href='%{logo_url}'>these
+    guidelines for usage</a>.
+  hoc_faq_logo_a_markdown: Hour of Code is trademarked. We don't want to prevent its
+    usage, but we want to make sure its usage fits within a few limits. Please see
+    [these guidelines for usage](%{logo_url}).
+  stats_hoc_2013_image_alt: Stats from 2013 Hour of Code
+  stats_growth: It was the fastest to reach 15 million users.
+  stats_i18n: Students are learning in over 45 languages
+  stats_tumblr: 'Tumblr: 3.5 years'
+  stats_facebook: 'Facebook: 3 years'
+  stats_twitter: 'Twitter: 2.5 years'
+  stats_pinterest: 'Pinterest: 2 years'
+  stats_instagram: 'Instagram: 14 months'
+  stats_hoc: 'The Hour of Code: 5 days'
+  stats_global: Over 100M students have tried an Hour of Code
+  stats_girls_more: More girls tried computer science than in the last 70 years
+  stats_females: Participation of female students in computer science is only 20-25%
+    of high school courses, university courses, and the workforce.
+  stats_females_more: During the Hour of Code, female students make up <b>50% of all
+    participants</b>!
+  stats_females_more_markdown: During the Hour of Code, female students make up **50%
+    of all participants**!
+  stats_nina: '"Every single day yielded the same results&mdash; 100% engagement."
+    - Nina Nichols Peery, Teacher'
+  stats_student: '"I knew this was a <b>once-in-a-lifetime</b> chance." - Mariana
+    Alzate, 5th grader'
+  stats_michael: '"I have <b>never, ever</b> seen my students so excited about learning."
+    - Michael Clark, Teacher'
+  resources_how_to: How-to guide for teachers
+  resources_how_to_events: Event how-to guide
+  resources_how_to_districts: How-to guide for districts
+  resources_how_to_officials: How-to guide for public officials
+  resources_handouts: Handouts to spread the word
+  resources_one_pager: One-page handout
+  resources_brochure: Brochure
+  resources_posters: Posters
+  resources_videos: Videos
+  resources_banners: Social media
+  resources_emails: Sample emails
+  resources_logo: Hour of Code logo
+  resources_stats: Stats and blurbs
+  resources_press_kit: Press Kit
+  resources_social: Social
+  resources_country_resources: Country Specific Resources
+  resources_stickers: Stickers
+  resources_how_to_guides: How-to guides
+  resources_promote: Promote
+  resources_nav_tutorials: Try the tutorials
+  resources_nav_promote: Spread the word
+  resources_nav_spread_word: How to get involved
+  resources_banner_promote_text: Promote
+  resources_banner_promote_button: Encourage others to sign up with brochures, inspirational
+    posters and social media banners.
+  resources_banner_howto_text: How-to
+  resources_banner_howto_button: Resources for educators, parents and districts to
+    host an Hour of Code.
+  handouts_section: Share these handouts
+  handouts_onepager: Spread the word with this one page handout
+  handouts_brochure: Give this brochure to teachers and schools
+  handouts_participationguide: Plan your Hour of Code with this participation guide
+  videos_title: Show these videos to inspire students
+  videos_what_most_schools_dont_teach: What Most Schools Don't Teach (5 min)
+  videos_hoc_2014: Hour of Code is Here - Anybody Can Learn
+  videos_obama_cs: President Obama on computer science
+  videos_anybody_can_learn: Anybody Can Learn (1 min)
+  videos_creativity: What is Creativity?
+  videos_creativity_series: What is Creativity? View Full Series.
+  title_country_resources: Country Specific Resources
+  title_hoc_advisory_committee: Hour of Code and CSEdWeek Advisory Committee
+  title_hoc_review_committee: Hour of Code and CSEdWeek Review Committee
+  title_how_to_promote: Spread the word
+  title_how_to_districts: Hour of Code How-To for Districts
+  title_how_to_events: Hour of Code Event How-To
+  title_how_to_organizations: How to host an Hour of Code - Organizations
+  title_how_to_companies: How to host an Hour of Code - Companies
+  title_how_to_officials: How-to guide for public officials
+  title_how_to_volunteers: How-to guide for Hour of Code volunteers
+  title_how_to_parents: How-to guide for parents
+  title_how_to: How-to Guide
+  title_international_partners: Contact International Partners
+  title_press_release: Hour of Code Press Release for Elected Officials
+  title_op_ed: Sample Op-ed Supportive of Computer Science Education Week and Hour
+    of Code
+  title_press_kit: Press Kit
+  title_proclamation: Sample Resolution Supportive of Computer Science Education Week
+    and Hour of Code
+  title_stats: Blurbs and Stats
+  title_partners: Partners
+  title_resources: Resources
+  title_past_posters: Past Hour of Code Posters
+  title_signup_thanks: Thanks for signing up to host an Hour of Code!
+  title_tutorial_guidelines: Activity Guidelines
+  title_whole_school: Whole School Participation
+  events_nav_title: Hour of Code Events
+  events_nav_all: All Events
+  events_nav_whole_schools: Whole Schools
+  events_nav_special: Special Events
+  events_nav_orgs: Organizations
+  events_all_old_title: All @year Hour of Code events
+  events_all_title: All Hour of Code events
+  events_whole_school_title: Whole-school Hour of Code events
+  events_special_title: Hour of Code Special Events
+  events_orgs_title: All Hour of Code events organized by Partner Organizations
+  event: event
+  events: events
+  highlights_title: Highlights
+  highlights_header: Hour of Code Highlights
+  highlights_description: Some of our favorite moments from the Hour of Code campaign.
+  highlights_previous: Highlights from previous years
+  highlights_see_more: See more highlights
+  highlights_readmore: Read more
+  highlights_watchvideo: Watch the video
+  highlights_facebook: Share on Facebook
+  highlights_constant_alba_heading: The actress, activist, and entrepreneur hosted
+    an Hour of Code with the entire staff at The Honest Company.
+  highlights_constant_alba_short_heading: Jessica Alba learns an Hour of Code
+  highlights_constant_obama_heading: President Obama is the first president to write
+    a line of code, hosting a historic Hour of Code for students at the White House.
+  highlights_constant_obama_short_heading: Coder in Chief
+  highlights_constant_malala_heading: '"Every girl deserves to take part in creating
+    the technology that''ll change our world, and change who runs it."'
+  highlights_constant_malala_short_heading: Nobel Peace Prize winner Malala
+  highlights_constant_trudeau_heading: Canadian Prime Minister Justin Trudeau coded
+    a simple game featuring his favorite sport.
+  highlights_constant_trudeau_short_heading: Prime Minister Justin Trudeau codes a
+    game
+  highlights_constant_ny_heading: After an epic battle, 80% of Brooklyn schools did
+    the Hour of Code vs. 60% in Chicago. Not bad!
+  highlights_constant_ny_short_heading: Brooklyn beats Chicago
+  highlights_constant_athletes_heading: Champions and gold medalists Serena Williams,
+    Neymar Jr, Carmelo Anthony and more inspire students to push themselves.
+  highlights_constant_athletes_short_heading: Push yourself
+  footer_copyright_message: Copyright %{current_year} Code.org. All rights reserved.
+  footer_trademark_message: Hour of Code® and Hora del Código® are trademarks of Code.org.
+  footer_built_on_github: Built on GitHub from Microsoft
+  footer_menu_partners: Partners
+  footer_menu_contact: Contact us
+  footer_menu_support: Support
+  footer_menu_terms: Terms
+  footer_menu_privacy: Privacy Policy
+  footer_menu_cookie: Cookie Notice
+  footer_menu_facebook: Code.org on Facebook
+  footer_menu_twitter: Code.org on Twitter
+  footer_menu_instagram: Code.org on Instagram
+  footer_menu_medium: Code.org on Medium.com
+  learn_banner_heading: Hour of Code Activities
+  learn_banner_blurb: Try a one-hour tutorial designed for all ages in over 45 languages.  Join
+    millions of students and teachers in over 180 countries starting with an Hour
+    of Code.
+  learn_banner_beyond: Want to keep learning?  <a id='learn_banner_beyond'>Go beyond
+    an hour</a>
+  learn_banner_beyond_markdown: Want to keep learning? [Go beyond an hour](%{url})
+  learn_banner_teachers: 'Teachers: <a id=''teacher_banner_host''>Host an hour</a>
+    or <a id=''teacher_banner_howto''>read the How-To Guide</a>'
+  learn_banner_teachers_markdown: 'Teachers: [Host an hour](%{host_url}) or [read
+    the How-To Guide](%{howto_url})'
+  tutorial_dance2019_name: Dance Party
+  tutorial_danceparty_name: Dance Party
+  tutorial_chibitronics_name: 'Chibitronics: Illuminated Story'
+  tutorial_athlete_name: Code your own sports game
+  tutorial_moana_name: 'Moana: Wayfinding with Code'
+  tutorial_star-wars_name: 'Star Wars: Building a Galaxy with Code'
+  tutorial_gumadventure_name: Gumball's Coding Adventure
+  tutorial_mchoc_name: Minecraft Hour of Code
+  tutorial_vidnews_name: 'Vidcode: Code the News'
+  tutorial_kodable-pre_name: Kodable (pre-readers welcome)
+  tutorial_highseas_name: Adventure on the High Seas
+  tutorial_capython_name: Python Turtle Graphics
+  tutorial_frzn_name: Code with Anna and Elsa
+  tutorial_cocom_name: 'CodeCombat: Escape the Dungeon!'
+  tutorial_play-lab_name: Play Lab
+  tutorial_boxisland_name: Box Island
+  tutorial_textcomp_name: Text Compression
+  tutorial_encryption_name: Simple Encryption
+  tutorial_kanopixel_name: Kano Pixel Hack
+  tutorial_foos_name: codeSpark Academy with The Foos
+  tutorial_tynkerdd_name: Dragon Dash
+  tutorial_tynkerana_name: Analog Clock STEM Kit
+  tutorial_vidcard_name: 'Vidcode: Bestie Greeting Card'
+  tutorial_spritebox_name: Spritebox Coding
+  tutorial_tynkerch_name: Counter Hack
+  tutorial_lightbot_name: Lightbot
+  tutorial_hoc_name: Placeholder for new code.org/hoc
+  tutorial_code_name: Write your first computer program
+  tutorial_tinspire_name: 10 Minutes of Code for the TI-Nspire CX
+  tutorial_itchbounceball_name: ITCH Bouncing Ball (in Scratch)
+  tutorial_vidclim_name: 'Vidcode: Climate Science & Code'
+  tutorial_matlab_name: Learn to Code with MATLAB
+  tutorial_flap_name: Make a Flappy game
+  tutorial_galaxy_name: Galaxy Game Jam
+  tutorial_inf_name: Infinity Play Lab
+  tutorial_tynkersol_name: Solar System STEM Kit
+  tutorial_itchg_name: ITCH Name IT - Geography
+  tutorial_como_name: Coding Adventure
+  tutorial_processfound_name: The Processing Foundation - Hello Processing
+  tutorial_tynkerhomo_name: Homophones STEM Kit
+  tutorial_art_name: Artist
+  tutorial_tynkerbrick_name: Brick Breaker Game Kit
+  tutorial_itchbio_name: ITCH Name IT - Parts of the Biological Cell
+  tutorial_itchj_name: ITCH Jumping (in Scratch)
+  tutorial_tickleo_name: Swimming Orca - by Tickle App
+  tutorial_hopgeo_name: Geometry Jumper
+  tutorial_tynkermult_name: Multiplication Escape STEM Kit
+  tutorial_monster_name: Mystery Island Coding Quest
+  tutorial_tynkerapp_name: Build an App
+  tutorial_tynkerpup_name: Puppy Adventure
+  tutorial_livecode_name: LiveCode Sound Boards
+  tutorial_cocomgame_name: 'CodeCombat: Build Your Own Game!'
+  tutorial_tynkerspin_name: Spin Draw Animation Kit
+  tutorial_code-avengers_name: Build a Game with JavaScript
+  tutorial_tynkercq_name: Candy Quest
+  tutorial_cmgame_name: CodeMonkey's Game Builder
+  tutorial_codesters_name: Codesters
+  tutorial_qrm_name: Accessible programming (with screenreader support)
+  tutorial_texas-instruments_name: 10 Minutes of Code
+  tutorial_cajava_name: Drawing Flags with JavaScript
+  tutorial_codehs_name: Learn to Code with Karel the Dog
+  tutorial_hopemo_name: Emoji Draw
+  tutorial_tynkercm_name: Code Monsters
+  tutorial_codesterswintergreet_name: Winter Greetings
+  tutorial_codestersc_name: The Coordinate Plane
+  tutorial_codestersturtle_name: 'Codesters: Turtle Traffic'
+  tutorial_penjee_name: Learn Python with Penjee the Penguin
+  tutorial_trinket_name: Trinket's Hour of Python
+  tutorial_frogger_name: Make your own 3D Frogger game
+  tutorial_tynkereco_name: Ecological Pyramid STEM Kit
+  tutorial_mitedarc_name: MIT Education Arcade
+  tutorial_khan_name: 'Khan Academy: Drawing with Code'
+  tutorial_tynkerd_name: Debugger
+  tutorial_cdmy_name: Codecademy
+  tutorial_codestersdance_name: Dance Moves
+  tutorial_codestersbasketball_name: Basketball
+  tutorial_nclkarel_name: Learn How to Code with Karel the Robot
+  tutorial_buildpong_name: Build Pong with AI
+  tutorial_tynkerdrones_name: Program Drones and Robots
+  tutorial_carla_name: Programming with Carla
+  tutorial_zulama_name: Zulama MakeQuest Video Game Activity
+  tutorial_capost_name: Build a Digital Postcard with HTML and CSS
+  tutorial_marco_name: Run Marco!
+  tutorial_codestersflappybike_name: Flappy Bike
+  tutorial_kanopong_name: Kano Computing - Make Pong
+  tutorial_tynkerright_name: Bill of Rights STEM Kit
+  tutorial_touchdevelop_name: TouchDevelop
+  tutorial_tynkercc_name: Code Commander
+  tutorial_bamboo_name: Bamboo JS
+  tutorial_robojav_name: 'Robots and Java: An introduction to Java'
+  tutorial_roboba_name: Learn Algebra with RoboBlockly
+  tutorial_knodsnake_name: JavaScript Snake
+  tutorial_soccharater_name: Character Building
+  tutorial_silent_name: Silent Teacher
+  tutorial_robomesh_name: Program VEX IQ Robots with Blockly
+  tutorial_amaze_name: A-Maze-thing
+  tutorial_codestersds_name: Dream Sequence
+  tutorial_knodtext_name: 'Text Adventure: Python'
+  tutorial_alicegar_name: Animating with Alice and Garfield
+  tutorial_codesterstransform_name: Transformation Puzzles
+  tutorial_flexfrog_name: Flexbox Froggy
+  tutorial_codemoji_name: Codemoji
+  tutorial_robobii_name: Learn Coding with RoboBlockly
+  tutorial_robobm_name: Learn Math with RoboBlockly
+  tutorial_codingrobots_name: Learn One Hour Coding with RoboBlockly
+  tutorial_robob_name: Learn Robotics with RoboBlockly
+  tutorial_coders_name: 'Coders Strike Back: an introduction to bot programming'
+  tutorial_tynkerhw_name: Learn to Code with Hot Wheels
+  tutorial_tynkermh_name: Learn to Code with Monster High
+  tutorial_caphoto_name: Build a Photo Booth App
+  tutorial_mozillahw_name: Mozilla Homework Excuse Generator
+  tutorial_ticklep_name: Parrot Wonder
+  tutorial_bbot_name: Bomberbot Fun and Easy Coding Activities
+  tutorial_scratchg_name: Programming Games in Scratch
+  tutorial_sjforest_name: 'ScratchJr: Can I Make a Spooky Forest?'
+  tutorial_sjgreet_name: 'ScratchJr: Can I Make My Characters Greet Each Other?'
+  tutorial_sjsunset_name: 'ScratchJr: Can I Make the Sun Set?'
+  tutorial_fufafrenz_name: fuzzFamily Frenzy
+  tutorial_bbcgeo_name: Bitsbox Coding + Geometry
+  tutorial_chspixel_name: CodeHS Pixel Art
+  tutorial_hummingbird_name: Creating a Game with Hummingbird
+  tutorial_recoloring_name: Recoloring the Universe
+  tutorial_bbcchem_name: Bitsbox Coding + Chemistry
+  tutorial_floalgo_name: 'Coding: Algorithms Lesson Plan'
+  tutorial_flocond_name: 'Coding: Conditionals Lesson Plan'
+  tutorial_floloops_name: 'Coding: For Loops Lesson Plan'
+  tutorial_pgts_name: Rock, Paper, Scissors
+  tutorial_ozo_name: The OzoBlockly Tutorial
+  tutorial_bbcla_name: Bitsbox Coding + Language Arts
+  tutorial_bbcsci_name: Bitsbox Coding + Science
+  tutorial_tlctour_name: Tour Guide Activity
+  tutorial_codesterstj_name: CS Tech Jam
+  tutorial_tlclocked_name: Locked-In
+  tutorial_baubles_name: Binary Baubles
+  tutorial_bbcart_name: Bitsbox Coding + Art
+  tutorial_tlcknight_name: Knight's Tour Activity
+  tutorial_fufafit_name: fuzzFamily Fitness
+  tutorial_ozodance_name: Ozobot Dance-Off
+  tutorial_codingrobotics_name: Intro to Coding through Robotics (ft. Wonder Workshop)
+  tutorial_box_name: Box Island
+  tutorial_hopgame_name: Hopscotch Game Design Workshop
+  tutorial_icontrol_name: iControl
+  tutorial_cocomteach_name: 'CodeCombat: Teacher-Led Activities'
+  tutorial_bbcmathii_name: Bitsbox Coding + Math (K-2)
+  tutorial_bbcphys_name: Bitsbox Coding + Physics
+  tutorial_bitsbox_name: Build Crazy Apps with Bitsbox
+  tutorial_tlcemo_name: 'Emotion Machine: Create-a-Face Card'
+  tutorial_crd_name: Conditionals with Cards
+  tutorial_bbcbio_name: Bitsbox Coding + Biology
+  tutorial_ticklebb8_name: BB-8 Swing
+  tutorial_grok_name: Grok Learning
+  tutorial_ijournalist_name: iJournalist
+  tutorial_bbcmusic_name: Bitsbox Coding + Music
+  tutorial_secretcodes_name: Secret Codes Activity
+  tutorial_tlchex_name: HexaHexaFlexagon Automata Activity
+  tutorial_tickles_name: Sphero Run
+  tutorial_ozogame_name: Create an Ozobot Game Level
+  tutorial_vidcodeio_name: Input and Output, Math Activity
+  tutorial_tlcbrain_name: Brain-in-a-bag Activity
+  tutorial_hopquiz_name: Quiz Creator
+  tutorial_unfortunate_name: A Series of Unfortunate Events
+  tutorial_cha_name: Computer History Activity
+  tutorial_elaseq_name: 'Writing and Coding: ELA Integration with Common Core Standards'
+  tutorial_bbcmathi_name: Bitsbox Coding + Math (3-5)
+  tutorial_tlcpixel_name: Pixel Puzzles
+  tutorial_introrobo_name: Introduction to Robotics
+  tutorial_tlcinvis_name: Invisible Palming Activity
+  tutorial_tlcjflap_name: 'JFLAP: Creating Finite State Machines'
+  tutorial_procolor_name: Drive to School with Ozobot
+  tutorial_spiralsfinch_name: Spirals with the Finch
+  tutorial_ozoi_name: Ozobot and OzoCodes Intro
+  tutorial_ticklel_name: LEGO Bricker
+  tutorial_spiralsdash_name: Draw Spirals with Dash
+  tutorial_ghdebug_name: Grace Hopper Debugging Activity
+  tutorial_tlckk_name: Kriss-Kross Puzzles
+  tutorial_firstcomp_name: My First Computer
+  tutorial_mazefinch_name: Through the Maze with the Finch Robot
+  tutorial_tlccc_name: Compression Code Puzzles
+  tutorial_tlcdoodle_name: Algorithmic Doodle Art
+  tutorial_tlcpunch_name: Punch Card Searching Activity
+  tutorial_finchfract_name: Finch Fractals
+  tutorial_tlcmind_name: The Red Black Mind Meld Activity
+  tutorial_tlctelebot_name: The Teleporting Robot Activity
+  tutorial_tlcaus_name: Australian Magician's Dream Activity
+  tutorial_tlcmicro_name: Microwave Racing Video Activity
+  tutorial_imathematician_name: iMathematician
+  tutorial_tlcmagic_name: Magical Book Magic
+  tutorial_scratchmus_name: Make Music with Scratch
+  tutorial_scratchanim_name: Animate Your Name with Scratch
+  tutorial_scratchfly_name: Make it Fly with Scratch
+  tutorial_tynkerarc_name: Undersea Arcade Game Kit
+  tutorial_grokffpython_name: Frozen Fractals (Python Turtle)
+  tutorial_grokffblock_name: Frozen Fractals (Blockly Turtle)
+  tutorial_grokeliza_name: Is Eliza Human? (Python)
+  tutorial_tynkercan_name: Physics Cannon 2-Player Game Kit
+  tutorial_grokflags_name: Flags of the World (Python Turtle)
+  tutorial_robomind_name: Program a virtual robot with RoboMind
+  tutorial_adventureq_name: Adventure with Q
+  tutorial_khan-es_name: An introduction to JavaScript
+  tutorial_kpt_name: An introduction to JavaScript
+  tutorial_kpl_name: An introduction to JavaScript
+  tutorial_khe_name: An introduction to JavaScript
+  tutorial_kfr_name: An introduction to JavaScript
+  tutorial_app-inventor_name: AppInventor Hour of Code
+  tutorial_blockly_name: Blockly Games Offline
+  tutorial_tynker_name: Build your own game
+  tutorial_baypt_name: Code Baymax
+  tutorial_code-combat_name: CodeCombat
+  tutorial_mky_name: CodeMonkey
+  tutorial_pirates_name: Coding Pirates
+  tutorial_csfirst_name: CS First
+  tutorial_loopedy_name: Dance the Loopedy-Loop
+  tutorial_dsw_name: Disney Star Wars
+  tutorial_dswb_name: Disney Star Wars
+  tutorial_ssw_name: Disney Star Wars
+  tutorial_sswb_name: Disney Star Wars
+  tutorial_kodable-unplugged_name: fuzzFamily Frenzy
+  tutorial_scratch_name: Get creative with coding
+  tutorial_bayes_name: Grandes Heroes
+  tutorial_gumball_name: Gumball Play Lab
+  tutorial_hrm_name: Human Resource Machine
+  tutorial_ice-age_name: Ice Age Play Lab
+  tutorial_koapp_name: Kodable (pre-readers welcome)
+  tutorial_lightbot-intl_name: Lightbot
+  tutorial_rmc_name: Minecraft Hour of Code
+  tutorial_smc_name: Minecraft Hour of Code
+  tutorial_minecraft-2016_name: Minecraft Hour of Code
+  tutorial_thinkersmith-es_name: Mis Amigos Roboticos
+  tutorial_pixie_name: PIXIE Challenges
+  tutorial_play_name: Play Lab
+  tutorial_robomind-nl_name: Program a virtual robot
+  tutorial_spheroi_name: 'Blocks 1: Intro'
+  tutorial_spherol_name: 'Blocks 3: Lights'
+  tutorial_spherov_name: 'Blocks 4: Variables'
+  tutorial_swb_name: 'Star Wars: Building a Galaxy with Code'
+  tutorial_build-a-galaxy_name: 'Star Wars: Building a Galaxy with Code'
+  tutorial_alicesims_name: Storyboarding and Programming with Alice and The Sims
+  tutorial_tchr_name: Teacher Led Lesson Plans
+  tutorial_robogame_name: The Robot Games
+  tutorial_tap_name: Tynker on Tablets
+  tutorial_cintl_name: Write your first computer program
+  tutorial_itchstop_name: ITCH Stop Frame Animation (Scratch)
+  tutorial_tynkerpn_name: 'Peep: Nature Walk'
+  tutorial_tynkerpd_name: 'Peep: Dance with Friends'
+  tutorial_persistence_name: 'Persistence: Building a Foundation'
+  tutorial_getloopy_name: Getting Loopy
+  tutorial_createface_name: Create-a-Face
+  tutorial_happymaps_name: Happy Maps
+  tutorial_moveit_name: Move it, Move it!
+  tutorial_bigevent_name: The Big Event
+  tutorial_gpp_name: Graph Paper Programming
+  tutorial_foosgame_name: codeSpark Academy with the Foos - GameMaker
+  tutorial_solopython_name: My First Python Code
+  tutorial_kodableint_name: Introduction to Programming
+  tutorial_kodableadv_name: Advanced Programming Concepts
+  tutorial_tynkertj_name: Toxic Jungle
+  tutorial_wolframa_name: Age in Days
+  tutorial_wolframm_name: Random Melodies
+  tutorial_wolframspi_name: Sound of PI
+  tutorial_wolframsph_name: Draw a Sphere
+  tutorial_wolframp_name: Draw a Polygon
+  tutorial_wolframn_name: Ninja Name Generator
+  tutorial_soloweb_name: Your First Webpage in an Hour!
+  tutorial_khanweb_name: 'Khan Academy: Webpages'
+  tutorial_khandata_name: 'Khan Academy: Databases'
+  tutorial_googlelogo_name: My Google Logo
+  tutorial_playtune_name: Play That Tune App
+  tutorial_computeit_name: Compute it
+  tutorial_codesterssj_name: Space Jokes
+  tutorial_cmchat_name: Trivia Chatbot
+  tutorial_tynkerdb_name: Dragon Blast
+  tutorial_cmbuild_name: Game Builder
+  tutorial_robotrattle_name: Robot Rattle
+  tutorial_codestersh_name: Hedgehog Designs
+  tutorial_codehsdigipixel_name: Digital Art in Pixels with CodeHS
+  tutorial_ccbinary_name: Binary Hero
+  tutorial_codehsturtle_name: Program in Python with Tracy the Turtle
+  tutorial_grokhd_name: Hydrangea Danger
+  tutorial_grokem_name: Emoticon Madness
+  tutorial_kodmaze_name: Maze Maker Challenges
+  tutorial_codestersa_name: Asteroid Dodge
+  tutorial_cmdodo_name: Dodo Does Math
+  tutorial_tynkerspace_name: Space Quest
+  tutorial_gfbloons_name: Bloons Trigonometry Defense
+  tutorial_raspipong_name: Sense HAT Pong
+  tutorial_codehsvr_name: Create Virtual Worlds with CodeHS
+  tutorial_codesterstp_name: Transformation Puzzles
+  tutorial_codestersbb_name: Basketball
+  tutorial_gfcrossyroad_name: Learn to Code with Crossy Road
+  tutorial_googleww_name: Wonder Woman
+  tutorial_codehsjsapp_name: Make a Real App with JavaScript
+  tutorial_gfmihi_name: Mihi Maker
+  tutorial_hopdropphone_name: Make "Don't Drop the Phone" on iPad/iPhone
+  tutorial_techfaa_name: Flocking Autonomous Agents
+  tutorial_codehsjsgraph_name: JavaScript Graphics with CodeHS
+  tutorial_thunkable_name: Learn How to Build 10 Apps in 1 Hour!
+  tutorial_hopcrossyroad_name: Make Crossy Road on iPad/iPhone
+  tutorial_switchglitch_name: 'Switch & Glitch: Robot Adventure'
+  tutorial_codecar_name: Code Car Simulator
+  tutorial_codesterscp_name: The Coordinate Plane
+  tutorial_grokpetblock_name: Virtual Pet (micro:bit Blockly)
+  tutorial_techbim_name: Basic Image Manipulation
+  tutorial_techfpp_name: Introduction to Functional Programming with Python
+  tutorial_codesterscr_name: Cheer Routines
+  tutorial_grokdisease_name: Disease Epidemic
+  tutorial_techec_name: Explaining Closures in JS
+  tutorial_rgbegin_name: RoboGarden Coding - Beginner
+  tutorial_myradream_name: 'Actimator: Myra''s Dream'
+  tutorial_thinkfun_name: 'Robot Repair: Can You Fix the Robot Brain?'
+  tutorial_hopfireworks_name: Make a Fireworks App on iPad/iPhone
+  tutorial_grokspace_name: Space (Blockly)
+  tutorial_codehspython_name: Code in Python with CodeHS
+  tutorial_codehsjava_name: Coding in Java with CodeHS
+  tutorial_techioda_name: Shortest Paths with Dijkstra's Algorithm
+  tutorial_grokmonster_name: Monster Maker!
+  tutorial_techmjs_name: Embrace Modern JavaScript - ES6 and Beyond
+  tutorial_techga_name: Genetic Algorithms
+  tutorial_techioan_name: Avoiding Null Anti Patterns
+  tutorial_techiogsr_name: Getting Started With Rust
+  tutorial_groktunnel_name: The Dark Tunnel
+  tutorial_stemcod_name: The Physics of Video Games!
+  tutorial_techikb_name: Interactive Kotlin Basics
+  tutorial_kanostreet_name: Street Artist
+  tutorial_codemojijs_name: Beginning JavaScript
+  tutorial_techapf_name: Advanced Python Features
+  tutorial_techfpjs_name: Practical Introduction to Functional Programming with JS
+  tutorial_techlinq_name: Using C# LINQ - A Practical Overview
+  tutorial_gpbcatapult_name: Build a Catapult
+  tutorial_quorumastro_name: Coding in Astronomy
+  tutorial_alicewonder_name: Alice in Wonderland
+  tutorial_rginter_name: RoboGarden Coding - Intermediate
+  tutorial_cssgrid_name: Grid Garden
+  tutorial_jshero_name: JS Hero
+  tutorial_codemojipy_name: Python Lab
+  tutorial_nclabdrone_name: Let's Build a Drone!
+  tutorial_gpbcircle_name: Make an Interactive Color Circle
+  tutorial_gpbpaint_name: Make Your Own Paint Editor
+  tutorial_cocomarcade_name: 'CodeCombat: Build an Arcade Game!'
+  tutorial_beetik_name: Code the Music of Franz Liszt
+  tutorial_codedj_name: Compose Music with Code DJ
+  tutorial_rgadvan_name: RoboGarden Coding - Advanced
+  tutorial_codehsrn_name: Creating Apps with React Native
+  tutorial_codehswd_name: Web Design with CodeHS
+  tutorial_turtlerobot_name: Turtle Robot
+  tutorial_ozoevo_name: 'Intro to Evo: Evo''s Force Field'
+  tutorial_ozoexped_name: Ozobot Expedition to Neptune
+  tutorial_ozojourney_name: Magellan's Journey
+  tutorial_ozocodes_name: Write your Name with OzoCodes
+  tutorial_ozoeclipse_name: Eclipses and Celestial Mechanics
+  tutorial_ozosimulator_name: Program Simulator
+  tutorial_ozoalgorithm_name: Make a Multiplication Algorithm
+  tutorial_ozotimer_name: Ozobot Second Timer
+  tutorial_ozohabits_name: Modeling Animal Habits and Habitats
+  tutorial_ozoprogram_name: How to Program Robots
+  tutorial_ozopair_name: Pair Programming with Ozobot
+  tutorial_codesnoopy_name: Snoopy Snow Brawl
+  tutorial_applabintro_name: Intro to App Lab
+  tutorial_cslartist_name: The Little Artist In Your Computer Activity Pack
+  tutorial_cslscratchjr_name: Let's Play with the ScratchJr Kitten! Activity Pack
+  tutorial_floevents_name: Writing and interpreting Events
+  tutorial_florobot_name: Design a Robot
+  tutorial_isavesanta_name: iSave Santa!
+  tutorial_iorder_name: iOrder
+  tutorial_ianimate_name: iAnimate
+  tutorial_iloveada_name: iLove Ada
+  tutorial_kodflash_name: If Flash, Then Clap!
+  tutorial_kodchoose_name: Choose Your Own (Fuzzy) Adventure!
+  tutorial_kodpizzapre_name: Pizza Party! (pre-reader)
+  tutorial_kodpizza_name: Pizza Party!
+  tutorial_kodwomen_name: Women in Tech
+  tutorial_tfunplug_name: 'Robot Repair: Can You Fix the Robot Brain? (Unplugged)'
+  tutorial_lbvariables_name: Variables with Littlebits
+  tutorial_lbfunctions_name: Fun with Functions & littleBits
+  tutorial_lblogic_name: Lessons in Logic with littleBits
+  tutorial_lbworld_name: 'littleBits: Change the world arcade challenge'
+  tutorial_lbloops_name: Leap into loops with littleBits!
+  tutorial_lbtug_name: 'littleBits: Tug of War'
+  tutorial_lbpotato_name: 'littleBits: Hot Potato...of Doom!'
+  tutorial_lbguitar_name: 'littlebits: Rockstar Guitar'
+  tutorial_lbio_name: Inputs & Outputs with littleBits
+  tutorial_wonpuppy_name: Dash the Puppy (E3)
+  tutorial_woncue_name: Cue's Starter Guide
+  tutorial_wonzoo_name: Dot at the Petting Zoo (B2)
+  tutorial_wontrip_name: Dash's Road Trip (F2)
+  tutorial_woncollect_name: Dash the Collector (B1)
+  tutorial_wonsecret_name: Cue's Secret Message
+  tutorial_hsscience_name: 'Hopscotch: Make Interactive Science Models on Your iPad/iPhone!'
+  tutorial_popculture_name: Pop Culture Data Science
+  tutorial_legorobust_name: Robust Structures – LEGO® Education WeDo 2.0
+  tutorial_legoplants_name: Plants and Pollinators – LEGO® Education WeDo 2.0
+  tutorial_legopark_name: Autonomous Parking – LEGO® MINDSTORMS® Education EV3
+  tutorial_legodetect_name: Object Detection – LEGO® MINDSTORMS® Education EV3
+  tutorial_legolight_name: Automatic Headlights – LEGO® MINDSTORMS® Education EV3
+  tutorial_alexa_name: 'Amazon Alexa Fact Skill Tutorial: My School Facts'
+  tutorial_grokpetmicro_name: Virtual Pet (micro:bit MicroPython)
+  tutorial_pirateplunder_name: Pirate Plunder
+  tutorial_cadj_name: DR DJ Device
+  tutorial_cacrazy_name: Code Crazy Creatures
+  tutorial_cajump_name: Jumping Jam
+  tutorial_carest_name: Robo-restaurant puzzler
+  tutorial_accai_name: Accenture Intelligent Space Exploration
+  tutorial_vceclipse_name: Code the Eclipse
+  tutorial_pmzero_name: Pac-Man ZERO
+  tutorial_hsela_name: 'Telling stories: ELA + coding'
+  tutorial_ticklear_name: What's AR?
+  tutorial_bcrobot_name: BlocksCAD Robot
+  tutorial_bcsnow_name: BlocksCAD Snowflake
+  tutorial_ifly_name: iFly
+  tutorial_idowedo_name: iDo WeDo
+  tutorial_diggindwarf_name: Diggin' Dwarf
+  tutorial_spheroit_name: 'Blocks 2: If/Then Else'
+  tutorial_gameofcodes_name: Game Of Codes
+  tutorial_blocklygames_name: Blockly Games
+  tutorial_spherohello_name: 'Text 1: Hello World'
+  tutorial_spheroarcade_name: Sphero Arcade Playground
+  tutorial_bcpy1_name: World of Python
+  tutorial_bcpy2_name: World of Python 2
+  tutorial_bcjs1_name: World of JavaScript
+  tutorial_bcjs2_name: World of JavaScript 2
+  tutorial_3dbearmars_name: The Mars Pioneers
+  tutorial_bitsboxyak_name: Yak Attack! Make a Card with Typed Code
+  tutorial_blockscadbargraphs_name: BlocksCAD Bar Graphs
+  tutorial_blockscadbirdhouses_name: BlocksCAD Birdhouses
+  tutorial_blockscadclock_name: BlocksCAD Analog Clock
+  tutorial_blockscaddinner_name: BlocksCAD Dinner Robot
+  tutorial_blockscadicecream_name: BlocksCAD Ice Cream Machine
+  tutorial_blockscadpizza_name: BlocksCAD Pizza Printer
+  tutorial_blockscadsugar_name: Sugar Cubes
+  tutorial_bsgridlight_name: 'GridLight: Hello World'
+  tutorial_bpartscratch_name: 'Art & Music: Color (Scratch)'
+  tutorial_bpartvid_name: 'Art & Music: Color (Vidcode)'
+  tutorial_bpenglishscratch_name: 'English: Biography (Scratch)'
+  tutorial_bpenglishvid_name: 'English: Biography (Vidcode)'
+  tutorial_bphealthscratch_name: 'Health: DNA (Scratch)'
+  tutorial_bphealthvid_name: 'Health: DNA (Vidcode)'
+  tutorial_bpmathscratch_name: 'Math: Multiplication (Scratch)'
+  tutorial_bpmathvid_name: 'Math: Multiplication (Vidcode)'
+  tutorial_bpmlkscratch_name: 'Social Studies: Martin Luther King Jr. (Scratch)'
+  tutorial_bpmlkvid_name: 'Social Studies: Martin Luther King Jr. (Vidcode)'
+  tutorial_bpsafetyscratch_name: 'Digital Citizenship: Online Safety (Scratch)'
+  tutorial_bpsafetyvid_name: 'Digital Citizenship: Online Safety (Vidcode)'
+  tutorial_bpsciencescratch_name: 'Science: Food Chains (Scratch)'
+  tutorial_bpsciencevid_name: 'Science: Food Chains (Vidcode)'
+  tutorial_bptechscratch_name: 'Engineering & Tech: Computer Programming (Scratch)'
+  tutorial_bptechvid_name: 'Engineering & Tech: Computer Programming (Vidcode)'
+  tutorial_caflags_name: Drawing Flags with Blocks
+  tutorial_matariki_name: 'Matariki: Māori New Year'
+  tutorial_carestaurant_name: Robo-Restaurant Decorator
+  tutorial_casea_name: Sea Creature Sequences
+  tutorial_cashield_name: Shield Design Showdown
+  tutorial_ccwslimer_name: 'Super Slimer: Code Your Adventure'
+  tutorial_codinggalaxy_name: Coding Galaxy - Adventure Planet
+  tutorial_boatrace_name: Boat Race
+  tutorial_ccplay_name: 'CodeCombat: Code, Play, Create'
+  tutorial_grinch_name: 'The Grinch: Saving Christmas with Code'
+  tutorial_codehsart_name: Generating Art with Code
+  tutorial_codehsbitcoin_name: 'Cryptocurrency: Explore the Bitcoin Ledger '
+  tutorial_codehsblockchain_name: 'Cryptocurrency: Explore Blockchain Technology'
+  tutorial_codehscipher_name: Caesar Cipher Wheel
+  tutorial_codehscollision_name: Coding Collision Simulations
+  tutorial_codehsmath_name: Coding Mathematical Models
+  tutorial_codehsmusic_name: Coding in Music
+  tutorial_codehssports_name: Coding in Sports
+  tutorial_codemojipizza_name: Make Pizza with JavaScript
+  tutorial_moonlander_name: Moon Lander
+  tutorial_sushicards_name: Beginner Scratch Sushi Cards
+  tutorial_codesparkcreate_name: 'codeSpark Academy with The Foos: Create Games'
+  tutorial_hardvsoft_name: Team Hardware vs. Team Software
+  tutorial_codestersecard_name: Code an Interactive eCard
+  tutorial_codesterslogo_name: Design Your Own Logo
+  tutorial_codesterstshirt_name: Code Your Initials
+  tutorial_codewards_name: Rescue the underwater city!
+  tutorial_olympics_name: C.A.T.S. go for Robot Olympics
+  tutorial_codinismhero_name: Programming Hero
+  tutorial_discovery_name: An Unusual Discovery
+  tutorial_csfirstname_name: Animate a Name
+  tutorial_edisonmove_name: 'Edison and EdPy: Get Edison moving'
+  tutorial_edisonspider_name: Edison and the spiralling spider trap
+  tutorial_edisonspotlight_name: Perform in the spotlight with Edison
+  tutorial_firiapython_name: Learn Python with the micro:bit
+  tutorial_gamefrootsquid_name: Code your own colossal squid game
+  tutorial_duckpiano_name: Make a Duck Piano
+  tutorial_gpsound_name: Make a Sound Recorder
+  tutorial_groklearningpython_name: 'Python + Biology: Build an animal classifier!'
+  tutorial_htmltimetravel_name: 'CSS Animations: Travel Through Time'
+  tutorial_hp_flappy_name: Build a Flappy Birds clone with hyperPad
+  tutorial_appytappin_name: appy Tappin'
+  tutorial_icipher_name: iCipher
+  tutorial_iguess_name: 'iGuess Beasts: QR Code Activity'
+  tutorial_imake_name: iMake Algorithms
+  tutorial_imorse_name: iMorse - Cryptography with Morse Code & Sphero
+  tutorial_kanohp_name: 'Harry Potter: Learn to Code and Make Magic '
+  tutorial_khanwebpages_name: Making Webpages
+  tutorial_kibobowl_name: Measure and Predict with KIBO Robot Bowling
+  tutorial_kibodance_name: Teach Your KIBO Robot to Dance!
+  tutorial_buildcharacters_name: Build Your Own Kodable Fuzz
+  tutorial_designgames_name: Create Games with Javascript
+  tutorial_makelevels_name: Make Your Own Kodable Mazes
+  tutorial_wizard_name: Code Wizard Castle
+  tutorial_mbscratchcards_name: Scratch cards for micro:bit
+  tutorial_mbswiftplaygrounds_name: 'Swift Playgrounds: Intro to the micro:bit'
+  tutorial_mbbuttons_name: 'Introducing the BBC micro:bit: Animation and Buttons'
+  tutorial_meteor_name: Make a Falling Meteors Game for the BBC micro:bit
+  tutorial_ballbounce_name: Ball Bounce Mobile App
+  tutorial_mitcodi_name: Codi the Bee
+  tutorial_mitdoodle_name: Digital Doodle Mobile App
+  tutorial_talktome_name: Talk to Me Mobile App
+  tutorial_mobilecspmap_name: Map Tour App
+  tutorial_ozorandom_name: Ozobot Random Story Generator
+  tutorial_ozotroll_name: Evo the Troll
+  tutorial_peblioart_name: 'Interactive Art: Bringing Art to Life with Code'
+  tutorial_astropi_name: 'Astro Pi: Mission Zero'
+  tutorial_rgart_name: RoboGarden STEAM - Art
+  tutorial_rgengineer_name: RoboGarden STEAM - Engineering
+  tutorial_rgmath_name: RoboGarden STEAM - Math
+  tutorial_rgscience_name: RoboGarden STEAM - Science
+  tutorial_rgtech_name: RoboGarden STEAM - Technology
+  tutorial_robotmagic3d_name: " Animate a 3D Logo"
+  tutorial_robotmagicflappy_name: 3D Flappy Bird
+  tutorial_scratchadventure_name: Animate an Adventure Game
+  tutorial_scratchtalk_name: Create Animations That Talk
+  tutorial_scratchjrstory_name: 'We Can Create a Story Together! '
+  tutorial_scratchjrtwinkle_name: Twinkle, Twinkle Little Star Class Collaboration
+  tutorial_spherocomm_name: Communication
+  tutorial_spherocommunity_name: Your Community
+  tutorial_spherofunctions_name: Fun Fun Functions
+  tutorial_spheroinfrared_name: 'BOLT: Infrared'
+  tutorial_spherolightsensor_name: 'BOLT: Light Sensor'
+  tutorial_spheromansion_name: 'Jurassic Code: Mansion Mayhem'
+  tutorial_roadblocks_name: Roadblocks
+  tutorial_spherotext2_name: 'Text 2: Conditionals'
+  tutorial_spherotext3_name: 'Text 3: Lights'
+  tutorial_spherotext4_name: 'Text 4: Variables'
+  tutorial_spheroraptor_name: 'Jurassic Code: Spheroraptor Escape'
+  tutorial_stempiday_name: Pi day!
+  tutorial_stemplanetoids_name: Planetoids and Lunar Descent
+  tutorial_stempong_name: Pong & Bonk.io
+  tutorial_algobot_name: 'AlgoBot: Coding Action'
+  tutorial_thunkableapps_name: Build Your Own Apps with Thunkable
+  tutorial_toxicodedot_name: Little Dot Adventure
+  tutorial_gcactions_name: 'GameCode: Actions in a video game'
+  tutorial_gccomparators_name: 'GameCode: Comparators and Logic in a video game'
+  tutorial_gcconditions_name: 'GameCode: Conditions in a video game'
+  tutorial_gccreate_name: 'GameCode: create your own video game'
+  tutorial_gcevents_name: 'GameCode: Events in a video game'
+  tutorial_gcloops_name: 'GameCode: Loops in a video game'
+  tutorial_gcvariables_name: 'GameCode: Variables in a video game'
+  tutorial_beanything_name: Barbie You Can Be Anything
+  tutorial_change_name: Change the World
+  tutorial_cooking_name: Cooking Game
+  tutorial_crystal_name: 'Crystal Clash '
+  tutorial_landscape_name: Landscape Generator
+  tutorial_pets_name: Pets Game
+  tutorial_petvet_name: Barbie Pet Vet
+  tutorial_superhero_name: Create a Superhero Mask
+  tutorial_vidcodeplastic_name: Plastic Pollution PSA
+  tutorial_vidcodetypeface_name: Create your own typeface!
+  tutorial_washustorm_name: Stormy Science
+  tutorial_activitypackets_name: Wonder Workshop Activity Packets
+  tutorial_googlerookie_name: Rookie Collage
+  tutorial_tommyturtle_name: 'Tommy the Turtle: Learn to Code'
+  tutorial_mazyad_name: Mazyad's Adventures
+  tutorial_gamemaker_name: Game Maker
+  tutorial_duckrace_name: The Big Duck Race
+  tutorial_allcancodeapps_name: 'Allcancode Platform: Build web and mobile apps in
+    Blockly'
+  tutorial_n2y_name: Bitt Bott Explores Earth
+  tutorial_microsoftarcade_name: Play, Design & Code Retro Arcade Games
+  tutorial_csfirstunplugged_name: CS First Unplugged
+  tutorial_toxicodepython_name: Discover Python with Silent Teacher
+  tutorial_codecombatozaria_name: 'Ozaria: Your Journey Begins'
+  tutorial_vidcodedate_name: Climate Clock
+  tutorial_codemonkeyspace_name: 'Space Adventure: Write Code and Catch Bananas!'
+  tutorial_codespeakhappy_name: Code a Happy Place Meditation App
+  tutorial_grokimage_name: Image Magic with Python
+  tutorial_icomputelearn_name: Learn Coding with iCompute
+  tutorial_rpstress_name: 'Stress Ball: Code a clickable onscreen stress ball'
+  tutorial_bsdcause_name: Support My Cause
+  tutorial_vidcodeanimoji_name: Animoji
+  tutorial_vidcodeanimojies_name: Animoji
+  tutorial_bsdinspire_name: People who Inspire Me
+  tutorial_tttractor_name: Tractor Traversal
+  tutorial_codeillusionmickey_name: 'Disney Codeillusion: Media Art Adventure with
+    Mickey'
+  tutorial_scigirlsquest_name: 'SciGirls: Code Quest'
+  tutorial_codespeakbreathe_name: Code a Meditation Breathing App
+  tutorial_vidcodeface_name: Facetracking
+  tutorial_educodemaze_name: Design Your Own Maze!
+  tutorial_educoderace_name: Code your own racing game!
+  tutorial_codespeakchatbot_name: Code a Chatbot with the Female CS Pioneers
+  tutorial_gamefrootgames_name: 'Games Industry Activity: Code a Platformer game '
+  tutorial_codespeakgrandparent_name: Code a Grandparent Card in Scratch
+  tutorial_educodekingdom_name: Defend the Kingdom!
+  tutorial_codehsdata_name: Coding with Data Visualizations
+  tutorial_educodecake_name: Bake a Cake With HTML!
+  tutorial_ttsecond_name: Second Team
+  tutorial_bsdtrivia_name: Trivia Game Maker
+  tutorial_csfirstdialogue_name: Dialogue
+  tutorial_codemonkeybeaver_name: Beaver Achiever
+  tutorial_codestersdistance_name: 'Codesters: Social Distancing Sprites'
+  tutorial_itchspace_name: 'iTCHcode: Space Invaders - RokCoder'
+  tutorial_vidcodemagic_name: SFX Magic
+  tutorial_vidcodemagices_name: SFX Magic
+  tutorial_codespeakmeal_name: Code a Healthy Meal App
+  tutorial_itchfish_name: 'iTCHcode: Fish scratch game'
+  tutorial_bsdwebsite_name: My Favorites Website
+  tutorial_codespeaktime_name: Code a Time Capsule in Scratch
+  tutorial_itchwebcam_name: 'iTCHcode: Webcam Augmented Reality'
+  tutorial_itchball_name: 'iTCHcode: Bouncing Ball'
+  tutorial_ttrace_name: Race Condition
+  tutorial_plethora_name: 'Plethora: Cause and Effect'
+  tutorial_educodesecret_name: Uncover the Agency's Secrets!
+  tutorial_itchshapes_name: 'iTCHcode: Shapes & Angles'
+  tutorial_codeguppytext_name: Introduction to text based coding
+  tutorial_vidcodeplastiche_name: Plastic Pollution PSA
+  tutorial_educativechatbot_name: Build your own chatbot in Python
+  tutorial_educodebasics_name: Learn the Basics!
+  tutorial_codehsdesign_name: Supporting Artists with Code
+  tutorial_htmlacademyphp_name: 'Intro to PHP: Create an Online Store from Scratch'
+  tutorial_gamefrootdistance_name: 'COVID-19 Simulator: Learn about social distancing
+    through computer science.'
+  tutorial_codesterscovid_name: 'Codesters: We Can Stop COVID PSA'
+  tutorial_ttbunker_name: The Bunker
+  tutorial_cuttle_name: Computational Thinking and Programming Challenge
+  tutorial_bsdjokes_name: Jokes and Riddles
+  tutorial_rptree_name: Tree life simulator
+  tutorial_codestersunity_name: 'Codesters: Unity Mural'
+  tutorial_codesterssoccer_name: 'Codesters: Soccer Shot'
+  tutorial_breakoutlock_name: 'Haspy and Lockit: Code Buddies'
+  tutorial_thunkablemask_name: Beaver in a Mask
+  tutorial_cafarming_name: Old MacDonald hacked a farm. AI, AI drone!
+  tutorial_blocksmithyeti_name: Don't Yeet the Yeti
+  tutorial_codecapture_name: Learn Programming With JavaScript​ In A Jiffy​
+  tutorial_codehslitter_name: Coding for a Litter-Free Community
+  tutorial_bsdocean_name: Life Below Water
+  tutorial_itchplatformer_name: 'iTCHcode: Scratch 3.0 Platformer Tutorial'
+  tutorial_codejika_name: 'CodeJIKA: 5 Minute Website'
+  tutorial_gamefrootclicker_name: Learn Variables. Code your own Clicker Game.
+  tutorial_rmagicequity_name: Equity vs. Equality
+  tutorial_ttfreestyle_name: Functional Freestyle
+  tutorial_ozobotcolor2_name: 'Introduction to Color Codes 02:  Drawing Color Codes'
+  tutorial_ozobotcolor3_name: 'Introduction to Color Codes 03: Directionality'
+  tutorial_clcarbon_name: Build Your Own Carbon Calculator
+  tutorial_kodablebasics_name: 'Coding Basics: Unplugged'
+  tutorial_scigirlscc_name: 'SciGirls: Code Creators'
+  tutorial_irobotpicture_name: 'Seeing the Whole Picture: Coded Messages'
+  tutorial_kcjmyself_name: Let me introduce myself!
+  tutorial_nearpodalgorithms_name: 'Coding: Algorithms '
+  tutorial_kibodrop_name: KIBO Craft and Build Drop Test
+  tutorial_ozobotcolor1_name: 'Introduction to Color Codes 01: Line Following'
+  tutorial_scigirlspixels_name: 'SciGirls: Passion for Pixels'
+  tutorial_kcjheroines_name: Our Heroines
+  tutorial_ozobotvalue_name: What's My Value?
+  tutorial_icodebytes_name: 'A Byte of iCompute: Unplugged'
+  tutorial_clfashion2_name: Fashionistas of Data Science - Class 2
+  tutorial_ai4all_name: 'AI4ALL: AI & Drawing'
+  tutorial_cldata_name: Welcome to Data Superpower
+  tutorial_spheroinputs_name: Inputs and Outputs Unplugged
+  tutorial_edisoncount_name: Teach Edison to count to 9
+  tutorial_spheroloops_name: Loops Unplugged
+  tutorial_kiboprogram_name: Let's Program Each Other
+  tutorial_hellorubycsin60_name: Computer Science in 60 seconds
+  tutorial_clfashion1_name: Fashionistas of Data Science - Class 1
+  tutorial_irobottraffic_name: 'Traffic Bot: Code Your Own Traffic Signal'
+  tutorial_edisonmystery_name: Edison and the mystery line
+  tutorial_microbitseaturtles_name: Saving Sea Turtles
+  tutorial_ozobotknow_name: 'Introduction to Ozobot: Get to Know Evo'
+  tutorial_imagilabs_name: 'Imagine it. Code it. Wear it. '
+  tutorial_irobotsimulator_name: Simulator Code Break
+  tutorial_irobotkind_name: 'Robot Feelings: The Kind Playground'
+  tutorial_firiavirtual_name: 'CodeSpace: Virtual Robotics with Python'
+  tutorial_irobotguesscode_name: Guess the Code
+  tutorial_ozobotnouns_name: Picking Out Irregular Plural Nouns
+  tutorial_nasa3d_name: 'Universe in 3D:  modeling and printing cosmic objects'
+  tutorial_blupants_name: 'BluPants: Learn Coding with Real Robots'
+  tutorial_legodance_name: Break Dance
+  tutorial_nearpodcoding_name: 'Topic Spark: Coding '
+  tutorial_kcjplastic_name: "#kids2030 Plastics Challenge"
+  tutorial_legojourney_name: Create a Journey with LEGO Education
+  tutorial_legohopper_name: Hopper Race
+  tutorial_catrobatembroidery_name: Coded Embroidery
+  tutorial_irobotphone_name: Telephone Drawing
+  tutorial_codeguppydraw_name: Draw with code
+  tutorial_codejumper_name: 'Networks: Messages of Kindness'
+  tutorial_meeempathy_name: A Minecraft Tale of Two Villages
+  tutorial_danceparty_shortdescription: Code a Dance Party to share with your friends.
+    Featuring Katy Perry, Madonna, J. Balvin, Sia, Keith Urban, Ciara, and 25 more!
+  tutorial_chibitronics_shortdescription: Program a paper circuit to light up your
+    own story.
+  tutorial_athlete_shortdescription: Choose between making a basketball game or mix
+    and match across sports!
+  tutorial_moana_shortdescription: Moana is brave, fearless, and is determined to
+    find her own path.
+  tutorial_star-wars_shortdescription: Learn to program droids, and create your own
+    Star Wars game in a galaxy far, far away.
+  tutorial_gumadventure_shortdescription: Use code to continue an episode of The Amazing
+    World of Gumball.
+  tutorial_mchoc_shortdescription: Minecraft is back for the Hour of Code with a brand
+    new activity! Journey through Minecraft with code.
+  tutorial_vidnews_shortdescription: Code effects and graphics to make a news story
+    all about tech, diversity, kids, and coding.
+  tutorial_kodable-pre_shortdescription: A fun game to teach computer programming
+    concepts
+  tutorial_highseas_shortdescription: In this activity, you'll create an adventure
+    story with two characters that takes place on the high seas!
+  tutorial_capython_shortdescription: Use Python code to draw fun pictures with turtles.
+  tutorial_frzn_shortdescription: Let's use code to join Anna and Elsa as they explore
+    the magic and beauty of ice.
+  tutorial_cocom_shortdescription: Learn Python and Javascript by coding your way
+    through Kithgard Dungeon!
+  tutorial_play-lab_shortdescription: Create a story or make a game with Play Lab!
+  tutorial_boxisland_shortdescription: Take a trip on Box Island and collect all the
+    stars!
+  tutorial_textcomp_shortdescription: Investigate lossless compression techniques
+    with the Text Compression Widget
+  tutorial_encryption_shortdescription: Introduces the need for encryption and simple
+    techniques for cracking secret messages.
+  tutorial_kanopixel_shortdescription: Code your way through iconic images from video
+    game history, from Tetris through Minecraft!
+  tutorial_foos_shortdescription: '"The Foos" is a fun, pre-reader friendly game to
+    learn about programming.'
+  tutorial_tynkerdd_shortdescription: Go on an epic quest for treasure.
+  tutorial_tynkerana_shortdescription: Create a working analog clock.
+  tutorial_vidcard_shortdescription: Learn how to make a greeting card with JavaScript!
+  tutorial_spritebox_shortdescription: Run, jump, and code your way through three
+    different worlds to collect the stars and make it to the finish line! Learn sequencing,
+    debugging and loops, and code in Swift, Java, or with Icons.
+  tutorial_tynkerch_shortdescription: Learn Javascript as you defeat viruses!
+  tutorial_lightbot_shortdescription: Program Lightbot to solve puzzles using procedures
+    and loops!
+  tutorial_hoc_shortdescription: Placeholder for new code.org/hoc
+  tutorial_code_shortdescription: Learn to code with Mark Zuckerberg and Angry Birds!
+  tutorial_tinspire_shortdescription: Get students started coding on their TI-Nspire
+    CX handhelds in just 10 minutes at a time.
+  tutorial_itchbounceball_shortdescription: Use ITCH - Scratch integrated with a video
+    lesson to make your own bouncing ball project
+  tutorial_vidclim_shortdescription: Combine CS & Environmental Science, and record
+    a video about climate.
+  tutorial_matlab_shortdescription: Find the closest location to meet your friends
+    using MATLAB!
+  tutorial_flap_shortdescription: Make your own game - Flappy Bird, Shark, or Submarine
+  tutorial_galaxy_shortdescription: Create your own Android Galaxy games, animations,
+    and interactive stories!
+  tutorial_inf_shortdescription: Use Play Lab to create a story or game starring Disney
+    Infinity characters.
+  tutorial_tynkersol_shortdescription: Program a moving model of the Solar System.
+  tutorial_itchg_shortdescription: Create an interactive naming game for the States
+    of Australia (Geography) with Itch (Scratch for Teachers)
+  tutorial_como_shortdescription: 'Learn and teach coding in CoffeeScript, a real-world
+    programming language. '
+  tutorial_processfound_shortdescription: 'Take a look at programming in the context
+    of the visual arts. '
+  tutorial_tynkerhomo_shortdescription: Make a storytelling game about homophones!
+  tutorial_art_shortdescription: Draw cool pictures and designs with the Artist!
+  tutorial_tynkerbrick_shortdescription: Make your own version of this arcade classic.
+  tutorial_itchbio_shortdescription: Create your own game to name the parts of a biological
+    cell with ITCH (Scratch for Classrooms)
+  tutorial_itchj_shortdescription: Learn how to make a character jump and land on
+    platform with ITCH (Scratch for Teachers)
+  tutorial_tickleo_shortdescription: With Tickle, a user-friendly coding app, you
+    can easily program the Orca to swim in a number of ways by simply dragging and
+    dropping coding blocks to create a command for it to follow.
+  tutorial_hopgeo_shortdescription: 'Build your own Geometry Jumper game: dodge obstacles
+    as they fly at you!'
+  tutorial_tynkermult_shortdescription: Make a fun multiplication game!
+  tutorial_monster_shortdescription: A colorful self-guided programming adventure
+    for children.
+  tutorial_tynkerapp_shortdescription: Program a custom version of your favorite game!
+  tutorial_tynkerpup_shortdescription: Help Pixel the puppy get home!
+  tutorial_livecode_shortdescription: Make some noise!
+  tutorial_cocomgame_shortdescription: Build your own game by levelling up your Python
+    and Javascript skills!
+  tutorial_tynkerspin_shortdescription: Create a fun pen that draws a rotating image.
+  tutorial_code-avengers_shortdescription: Learn "JavaScript" programming, in a web-browser.
+  tutorial_tynkercq_shortdescription: Go on a quest for candy!
+  tutorial_cmgame_shortdescription: 'Create your own online game using CoffeeScript,
+    a real-world programming language. '
+  tutorial_codesters_shortdescription: Create your own games, animations, and artwork
+    using Python.
+  tutorial_qrm_shortdescription: Join Mary in her first week programming in a biology
+    lab as she learns Quorum.
+  tutorial_texas-instruments_shortdescription: Learn basic coding using the TI-84™
+    Plus calculator.
+  tutorial_cajava_shortdescription: Learn about shapes, coordinates and colors by
+    drawing flags in JavaScript.
+  tutorial_codehs_shortdescription: Start coding with Karel the Dog, a fun and visual
+    intro to programming.
+  tutorial_hopemo_shortdescription: Code a drawing app that creates beautiful art
+    with your favorite emoijs.
+  tutorial_tynkercm_shortdescription: Collect, train, and battle your monsters!
+  tutorial_codesterswintergreet_shortdescription: 'Create your own custom greeting
+    card to celebrate winter! '
+  tutorial_codestersc_shortdescription: 'Learn to navigate the coordinate plane with
+    code! '
+  tutorial_codestersturtle_shortdescription: 'Guide turtle out a maze and create spiral
+    art! '
+  tutorial_penjee_shortdescription: 'Visually learn Python by moving a Penguin around
+    an ice world. '
+  tutorial_trinket_shortdescription: Learn the basics of Python with lessons, challenges
+    and tutorials!
+  tutorial_frogger_shortdescription: 'Create and share your own 3D game '
+  tutorial_tynkereco_shortdescription: Code an interactive ecological pyramid.
+  tutorial_mitedarc_shortdescription: Have your sprite collect coins and get points.
+  tutorial_khan_shortdescription: 'Khan Academy: Drawing with Code teaches you how
+    to code using JavaScript by designing your very own snowman'
+  tutorial_tynkerd_shortdescription: Fight bugs to save the motherboard!
+  tutorial_cdmy_shortdescription: Learn JavaScript programming, in a web-browser
+  tutorial_codestersdance_shortdescription: 'Design your own dance routine and program
+    a sprite to perform it! '
+  tutorial_codestersbasketball_shortdescription: 'Build your own pull and shoot basketball
+    game! '
+  tutorial_nclkarel_shortdescription: Learn to code with Karel the Robot as you travel
+    the world together solving problems.
+  tutorial_buildpong_shortdescription: Build the arcade classic and give the computer
+    artificial intelligence to play against you.
+  tutorial_tynkerdrones_shortdescription: Program a controller for your robot or drone.
+  tutorial_carla_shortdescription: Learn to code by programming a talking virtual
+    robot named Carla!
+  tutorial_zulama_shortdescription: Go on a MakeQuest! Modify code to beat our game,
+    then build your own!
+  tutorial_capost_shortdescription: Use code to build a great looking holiday or birthday
+    card.
+  tutorial_marco_shortdescription: An immersive game to guide Marco with a visual
+    programming language.
+  tutorial_codestersflappybike_shortdescription: Create a game with player controls.
+    Keep the bike in the air while dodging the obstacles!
+  tutorial_kanopong_shortdescription: Change the game. Break the rules. Win with code.
+  tutorial_tynkerright_shortdescription: Program a quiz about the Bill of Rights!
+  tutorial_touchdevelop_shortdescription: 'Solve puzzles, create games, and learn
+    coding all on your phone. '
+  tutorial_tynkercc_shortdescription: Build and train your army for battle!
+  tutorial_bamboo_shortdescription: The Bamboo JS activity was created by Codemoji
+    to teach students basic Javascript concepts.
+  tutorial_robojav_shortdescription: Build a small world on your screen for simulated
+    robots and creatures.
+  tutorial_roboba_shortdescription: 'RoboBlockly is designed for beginners to learn
+    Algebra 1 with robots in Blockly. '
+  tutorial_knodsnake_shortdescription: 'Learn to create a Snake game in JavaScript! '
+  tutorial_soccharater_shortdescription: Code your very own pixel character with HTML,
+    CSS, and JavaScript.
+  tutorial_silent_shortdescription: Discover the basic concepts of programming without
+    any word or explanation
+  tutorial_robomesh_shortdescription: Program either a virtual online robot, or a
+    real VEX IQ robot.
+  tutorial_amaze_shortdescription: Build and customize an exciting maze game with
+    with crazy physics obstacles and a grand prize!
+  tutorial_codestersds_shortdescription: Write a story using transition words while
+    learning computer science in this Common Core aligned ELA project.
+  tutorial_knodtext_shortdescription: Learn to make a text adventure game in Python!
+  tutorial_alicegar_shortdescription: 'Tell stories and be creative while learning
+    to code. '
+  tutorial_codesterstransform_shortdescription: Explore, identify, and perform transformations
+    on the coordinate plane in this Common Core aligned Math project.
+  tutorial_flexfrog_shortdescription: A game for learning CSS flexbox
+  tutorial_codemoji_shortdescription: 'Codemoji teachers students basic website design
+    and coding concepts using Emoji''s as the key to keep students engaged and learning
+    real coding concepts. '
+  tutorial_robobii_shortdescription: 'RoboBlockly is designed for beginners to learn
+    coding with robots in Blockly. '
+  tutorial_robobm_shortdescription: 'RoboBlockly is designed for beginners to learn
+    math with robots in Blockly. '
+  tutorial_codingrobots_shortdescription: 'RoboBlockly is designed for beginners to
+    learn coding and math with robots. '
+  tutorial_robob_shortdescription: 'RoboBlockly is designed for beginners to learn
+    robotics in Blockly. '
+  tutorial_coders_shortdescription: Discover bot programming through a starship race
+    game! (age 14+)
+  tutorial_tynkerhw_shortdescription: Solve fun coding puzzles to navigate your Hot
+    Wheels car and win the race!
+  tutorial_tynkermh_shortdescription: Solve fun coding puzzles with the ghouls of
+    Monster High.
+  tutorial_caphoto_shortdescription: Build an app that lets you customize photos with
+    stickers and filters.
+  tutorial_mozillahw_shortdescription: Learners will remix JavaScript code to change
+    the words on a website
+  tutorial_ticklep_shortdescription: With Tickle, a user-friendly coding app, you
+    can easily program Parrot Drone to swim in a number of ways by simply dragging
+    and dropping coding blocks to create a command for it to follow.
+  tutorial_bbot_shortdescription: Teach your students (ages 7 and up) programming
+    in a fun and easy way. No prior programming knowledge or experience needed!
+  tutorial_scratchg_shortdescription: Learn how to program games in Scratch
+  tutorial_sjforest_shortdescription: Use the ScratchJr programming app to make a
+    program in which different animals move in a dark forest setting.
+  tutorial_sjgreet_shortdescription: Use the ScratchJr programming app to make a program
+    in which a kitten and a dog "meet" each other and exchange hellos.
+  tutorial_sjsunset_shortdescription: Use the ScratchJr programming app to make a
+    program in which the sun sets over a city landscape.
+  tutorial_fufafrenz_shortdescription: 'Learn sequence to program a "robot"! '
+  tutorial_bbcgeo_shortdescription: Standards-based lesson plan for levels 6-10.
+  tutorial_chspixel_shortdescription: This offline lesson plan covers the basics of
+    computer graphics.
+  tutorial_hummingbird_shortdescription: Create your own game with a microcontroller,
+    a sensor, and lights!
+  tutorial_recoloring_shortdescription: 'Recoloring the Universe helps show just how
+    integral coding is in the pursuit of learning about our Universe.  '
+  tutorial_bbcchem_shortdescription: 'Standards-based lesson plan for levels K-5. '
+  tutorial_floalgo_shortdescription: 'A lesson plan to get students writing algorithms
+    with educational hip hop. '
+  tutorial_flocond_shortdescription: Teach the coding concept of conditionals with
+    this educational hip-hop video and lesson plan.
+  tutorial_floloops_shortdescription: Teach the coding concept of loops with this
+    educational hip-hop video and lesson plan.
+  tutorial_pgts_shortdescription: Try modeling and simulation using rock/paper/scissors
+  tutorial_ozo_shortdescription: Introduce students to coding by playing the Ozobot
+    Games with the programmable robot Ozobot.
+  tutorial_bbcla_shortdescription: 'Standards-based lesson plan for levels K-5. '
+  tutorial_bbcsci_shortdescription: 'Standards-based lesson plan for levels K-5. '
+  tutorial_tlctour_shortdescription: Devise a tour that gets a tourist from their
+    hotel to all the city sights and back to their hotel.
+  tutorial_codesterstj_shortdescription: 'learn about digital citizenship! Teach others
+    how to be responsible digital citizens! '
+  tutorial_tlclocked_shortdescription: Explore the design of an algorithm to allow
+    someone with locked-in syndrome to communicate.
+  tutorial_baubles_shortdescription: Learn how computers use 1s and 0s to represent
+    information
+  tutorial_bbcart_shortdescription: 'Standards-based lesson plan for levels K-5. '
+  tutorial_tlcknight_shortdescription: Solve a puzzle where you must find a way for
+    a knight to visit every square on a board exactly once.
+  tutorial_fufafit_shortdescription: 'Use functions to shorten the code that will
+    help the fuzzFamily build their strength! '
+  tutorial_ozodance_shortdescription: Help Ozobot learn to dance! Create and program
+    a dance routine for the Ozobot robot.
+  tutorial_codingrobotics_shortdescription: Students will focus on communication as
+    it relates to programming.
+  tutorial_box_shortdescription: Take a coding trip on Box Island with the brave Hiro.
+  tutorial_hopgame_shortdescription: Lead a coding workshop, club, or a hackathon
+    with this 6-lesson guide.
+  tutorial_icontrol_shortdescription: Programming physical systems with iPads and
+    Sphero
+  tutorial_cocomteach_shortdescription: Lead your students to programming glory with
+    CodeCombat's intro curriculum!
+  tutorial_bbcmathii_shortdescription: Standards-based lesson plan for levels K-2.
+  tutorial_bbcphys_shortdescription: Standards-based lesson plan for levels K-5.
+  tutorial_bitsbox_shortdescription: Code five crazy mini-apps with real typed Javascript!
+    Beginners welcome.
+  tutorial_tlcemo_shortdescription: Program a card robot face to show different emotions
+    one after another.
+  tutorial_crd_shortdescription: Learn algorithms with a deck of cards
+  tutorial_bbcbio_shortdescription: 'Standards-based lesson plan for levels K-5. '
+  tutorial_ticklebb8_shortdescription: With Tickle, a user-friendly coding app, you
+    can easily program BB-8 to move in a number of ways by simply dragging and dropping
+    coding blocks to create a command for it to follow.
+  tutorial_grok_shortdescription: Draw flags, create snowflakes or build a robot using
+    Python.
+  tutorial_ijournalist_shortdescription: Use basic HTML/CSS to write an online news
+    report about a fictional robbery at your school
+  tutorial_bbcmusic_shortdescription: Standards-based lesson plan for levels K-5.
+  tutorial_secretcodes_shortdescription: Learn about the role computers have played
+    to help save the world.
+  tutorial_tlchex_shortdescription: Make the flexagon and explore it while at the
+    same time learning about computing and computational thinking and how it can help.
+  tutorial_tickles_shortdescription: Team up with your Sphero for a good run! Move,
+    spin and give it a few rounds of good turns. Just put some code blocks together
+    on Tickle app to run your Sphero as you want it to.
+  tutorial_ozogame_shortdescription: Introduce students to coding by playing the Ozobot
+    Games and creating their own game level with the programmable robot Ozobot.
+  tutorial_vidcodeio_shortdescription: Connect JavaScript functions to both math and
+    real world problems.
+  tutorial_tlcbrain_shortdescription: Explore how the human brain works by creating
+    a computational model of neurones out of students that plays Snap.
+  tutorial_hopquiz_shortdescription: Code a multiple-choice quiz to test a friend's
+    knowledge in any subject!
+  tutorial_unfortunate_shortdescription: Teach Dash and Dot to respond to events that
+    happen around them!
+  tutorial_cha_shortdescription: Learn about some key events in Computer History
+  tutorial_elaseq_shortdescription: Students will learn about sequence, the most foundational
+    programming concept, as it relates to reading and writing.
+  tutorial_bbcmathi_shortdescription: 'Standards-based lesson plan for levels 3-5. '
+  tutorial_tlcpixel_shortdescription: 'Solve simple colour-by-number and logical thinking
+    puzzles and gain a deeper understanding of image representation and compression. '
+  tutorial_introrobo_shortdescription: Students will get to know Dash and Dot while
+    being introduced to the ideas of Robotics and Programming.
+  tutorial_tlcinvis_shortdescription: Do a trick where you magically move a card from
+    one pile to another by palming it invisibly!
+  tutorial_tlcjflap_shortdescription: Create executable finite state machine versions
+    of graphs you have created or used to solve problems.
+  tutorial_procolor_shortdescription: Program the robot Ozobot by using paper and
+    markers - no computer or tablet required!
+  tutorial_spiralsfinch_shortdescription: 'Draw spirals with a robot! '
+  tutorial_ozoi_shortdescription: Learn about how the Ozobot robot works and program
+    Ozobot using paper and markers - no computer or tablet required!
+  tutorial_ticklel_shortdescription: Brick by brick, build up your wildest LEGO imagination.
+    By putting some codes together on Tickle app, you can make your LEGO WeDo do some
+    amazing things.
+  tutorial_spiralsdash_shortdescription: Learn the basics of using variables while
+    using a robot to create art!
+  tutorial_ghdebug_shortdescription: Help students learn about Grace Hopper and why
+    this week is CS EdWeek.
+  tutorial_tlckk_shortdescription: Solve these word puzzles as a way to develop logical
+    thinking and pattern matching skills needed to enjoy both computing and maths,
+    while practicing spelling.
+  tutorial_firstcomp_shortdescription: My First Computer is an introduction to the
+    amazing and complicated machine that is the computer.
+  tutorial_mazefinch_shortdescription: Use the Finch robot to complete a maze!
+  tutorial_tlccc_shortdescription: Solve compression code puzzles, simple puzzles
+    about words that involve decoding compressed messages.
+  tutorial_tlcdoodle_shortdescription: 'Follow simple algorithms to draw pictures
+    reminiscent of nature. '
+  tutorial_tlcpunch_shortdescription: Show how early computers searched for data using
+    a magic trick.
+  tutorial_finchfract_shortdescription: Use recursion to draw fractals with a Finch
+    robot!
+  tutorial_tlcmind_shortdescription: Do a trick where you control the actions of another
+    by the power of your mind!
+  tutorial_tlctelebot_shortdescription: You put together a jigsaw that has 17 robots,
+    but then put it together again and now it only has 16.
+  tutorial_tlcaus_shortdescription: Do a magic trick where your predict a chosen card,
+    introducing both search algorithms and computational thinking.
+  tutorial_tlcmicro_shortdescription: People race different microwave designs to see
+    which is easiest to use to do a simple task. Some are seen to be far more complicated
+    than others.
+  tutorial_imathematician_shortdescription: Use Mathematics (Game Theory) & Computer
+    Science to program a variation of the Prisoner's Dilemma
+  tutorial_tlcmagic_shortdescription: Explore a magic trick based on an intriguing
+    computational property about words.
+  tutorial_scratchmus_shortdescription: Choose musical instruments, add sounds, and
+    press keys to play music.
+  tutorial_scratchanim_shortdescription: Make your name come to life! Animate the
+    letters by coding in Scratch.
+  tutorial_scratchfly_shortdescription: Choose a character and make a flying animation!
+  tutorial_tynkerarc_shortdescription: Create a top-down arcade shooter game.
+  tutorial_grokffpython_shortdescription: Use the programming language Python and
+    instruct a turtle to draw fantastic snowflakes with code! Brrr, is it getting
+    cold in here?
+  tutorial_grokffblock_shortdescription: Build programs using friendly blocks and
+    instruct a turtle to draw fantastic snowflakes with code! Brrr, is it getting
+    cold in here?
+  tutorial_grokeliza_shortdescription: Use the programming language Python to build
+    a friendly chatbot called "Eliza". Can she fool your friends into thinking she's
+    a human?
+  tutorial_tynkercan_shortdescription: Make a 2-player physics game!
+  tutorial_grokflags_shortdescription: Use the programming language Python and instruct
+    a turtle to draw flags from around the world! How many countries do you know?
+  tutorial_robomind_shortdescription: Write code for a virtual robot.
+  tutorial_adventureq_shortdescription: Use programming blocks (physical or in game)
+    to learn programming logics.
+  tutorial_khan-es_shortdescription: Learn to draw in JavaScript
+  tutorial_kpt_shortdescription: Learn to draw in JavaScript
+  tutorial_kpl_shortdescription: Learn to draw in JavaScript
+  tutorial_khe_shortdescription: Learn to draw in JavaScript
+  tutorial_kfr_shortdescription: Learn to draw in JavaScript
+  tutorial_app-inventor_shortdescription: Make your own app. (Android-only)
+  tutorial_blockly_shortdescription: Download a ZIP file to learn offline.
+  tutorial_tynker_shortdescription: Learn to code by solving fun puzzles and build
+    your own games.
+  tutorial_baypt_shortdescription: Code Baymax
+  tutorial_code-combat_shortdescription: Defeat ogres to learn Python or JavaScript
+    in this epic programming game!
+  tutorial_mky_shortdescription: Students program a monkey to catch bananas.
+  tutorial_pirates_shortdescription: Navigate the crystal waters of the southern hemisphere,
+    code your treasure maps and discover the riches that lie on the golden shores.
+    A fun way to learn the basic concepts of coding.
+  tutorial_csfirst_shortdescription: Animate a story about two characters on the ocean.
+    Add your own style!
+  tutorial_loopedy_shortdescription: Make a dance using loops!
+  tutorial_dsw_shortdescription: Learn to program droids, and create your own Star
+    Wars game in a galaxy far, far away.
+  tutorial_dswb_shortdescription: Learn to program droids, and create your own Star
+    Wars game in a galaxy far, far away.
+  tutorial_ssw_shortdescription: Learn to program droids, and create your own Star
+    Wars game in a galaxy far, far away.
+  tutorial_sswb_shortdescription: Learn to program droids, and create your own Star
+    Wars game in a galaxy far, far away.
+  tutorial_kodable-unplugged_shortdescription: A fun unplugged exercise
+  tutorial_scratch_shortdescription: Create your own interactive games, stories, and
+    animations with Scratch!
+  tutorial_bayes_shortdescription: Grandes Heroes
+  tutorial_gumball_shortdescription: Create a Gumball story or make a game with Play
+    Lab!
+  tutorial_hrm_shortdescription: Program little office workers to solve puzzles. Be
+    a good employee! The machines are coming... for your job.
+  tutorial_ice-age_shortdescription: Create an Ice Age story or make a game with Play
+    Lab!
+  tutorial_koapp_shortdescription: A fun iPad game to teach computer programming concepts
+  tutorial_lightbot-intl_shortdescription: A game to teach coding concepts
+  tutorial_rmc_shortdescription: Use blocks of code to take Alex or Steve on an adventure
+    through this Minecraft world.
+  tutorial_smc_shortdescription: Use blocks of code to take Alex or Steve on an adventure
+    through this Minecraft world.
+  tutorial_minecraft-2016_shortdescription: Build a Minecraft game. Create your own
+    versions of chicken, sheep, Creepers, zombies and more.
+  tutorial_thinkersmith-es_shortdescription: Tutorial para un grupo sin computadoras
+  tutorial_pixie_shortdescription: A visual language to learn to code step by step
+    through challenges and games.
+  tutorial_play_shortdescription: Create a story or make a game with Play Lab!
+  tutorial_robomind-nl_shortdescription: Write code for a virtual robot
+  tutorial_spheroi_shortdescription: Introduction to Lightning Lab, The Sphero App
+    for programming Sphero robots.
+  tutorial_spherol_shortdescription: Learn how to control Sphero's lights and get
+    creative with programming.
+  tutorial_spherov_shortdescription: Bring Hot Potato to life with Sphero!
+  tutorial_swb_shortdescription: Learn to program droids, and create your own Star
+    Wars game in a galaxy far, far away.
+  tutorial_build-a-galaxy_shortdescription: Learn to program droids, and create your
+    own Star Wars game in a galaxy far, far away.
+  tutorial_alicesims_shortdescription: 'Tell stories and be creative while learning
+    to code. '
+  tutorial_tchr_shortdescription: Be inspired to design your own Hour of Code event
+    with these lesson plans.
+  tutorial_robogame_shortdescription: The grit, the games, the fun!
+  tutorial_tap_shortdescription: Learn to program by solving fun coding puzzles.
+  tutorial_cintl_shortdescription: Learn to code with Mark Zuckerberg and Angry Birds!
+  tutorial_itchstop_shortdescription: Learn to create your own Stop Frame Animations
+    in Scratch
+  tutorial_tynkerpn_shortdescription: Go for a nature walk with Peep!
+  tutorial_tynkerpd_shortdescription: Make Peep and his friends dance!
+  tutorial_persistence_shortdescription: This lesson teaches that failure is not the
+    end of a journey, but a hint for how to succeed.
+  tutorial_getloopy_shortdescription: In this lesson, students will practice converting
+    sets of actions into a single loop.
+  tutorial_createface_shortdescription: This is an exploration of affective computing,
+    which relates to moods and emotions. The class makes an affective (relating to
+    moods and emotions) robot face out of card, tubes and themselves.
+  tutorial_happymaps_shortdescription: Students create simple algorithms (sets of
+    instructions) to move a character through a maze using a single command.
+  tutorial_moveit_shortdescription: Students create simple algorithms (sets of instructions)
+    to move a character through a maze using a single command.
+  tutorial_bigevent_shortdescription: Students are introduced to the programming concept
+    of "events," which are actions that a computer constantly monitors for.
+  tutorial_gpp_shortdescription: Students write an algorithm (a set of instructions)
+    using a set of predefined commands to direct their classmates to reproduce a drawing.
+  tutorial_foosgame_shortdescription: Design and code your own video game with codeSpark
+    Academy with The Foos.
+  tutorial_solopython_shortdescription: Letter Counter in Python
+  tutorial_kodableint_shortdescription: 'Students will be introduced to programming
+    with the most foundational concept: Sequence.'
+  tutorial_kodableadv_shortdescription: Students will build on foundational programming
+    concepts and learn about higher level, JavaScript code.
+  tutorial_tynkertj_shortdescription: Use Python to save the toxic jungle!
+  tutorial_wolframa_shortdescription: Want to find out how old you are in seconds?
+  tutorial_wolframm_shortdescription: Create music through code! Can you play your
+    favorite melody using Wolfram Language?
+  tutorial_wolframspi_shortdescription: 'Have you ever wondered what the famous number
+    PI would sound like on a musical instrument? '
+  tutorial_wolframsph_shortdescription: How many 3D shapes can you create?
+  tutorial_wolframp_shortdescription: Explore creating amazing polygon shapes!
+  tutorial_wolframn_shortdescription: What is your ninja name?
+  tutorial_soloweb_shortdescription: Create and share a Webpage with your favorite
+    joke!
+  tutorial_khanweb_shortdescription: Learn how to make webpages with HTML tags and
+    CSS, finishing up by making your very own greeting card.
+  tutorial_khandata_shortdescription: Like playing with data? Learn how to manipulate
+    data in a database and make your own custom store
+  tutorial_googlelogo_shortdescription: Bring the Google logo to life using your imagination
+    and a bit of code.
+  tutorial_playtune_shortdescription: Use coding skills to solve musical puzzles and
+    create an Android app
+  tutorial_computeit_shortdescription: This time YOU are the computer! Interpret the
+    program to find the path.
+  tutorial_codesterssj_shortdescription: Create an interactive joke teller that you
+    can share!
+  tutorial_cmchat_shortdescription: Learn Python through coding and creating a chatbot.
+  tutorial_tynkerdb_shortdescription: Train your dragons to hunt for treasure with
+    code!
+  tutorial_cmbuild_shortdescription: Game design courses teach students 14+ game design
+    and creation elements.
+  tutorial_robotrattle_shortdescription: Operate a physically simulated robot, learn
+    to move its joints via angles, and program it to push and grab objects.
+  tutorial_codestersh_shortdescription: Guide your sprite around the stage to create
+    your own geometric art work!
+  tutorial_codehsdigipixel_shortdescription: Code your own digital images!
+  tutorial_ccbinary_shortdescription: Make a Scratch game in which you play the notes
+    of a song as they scroll down the stage.
+  tutorial_codehsturtle_shortdescription: Write programs to make art with Tracy the
+    Turtle!
+  tutorial_grokhd_shortdescription: This activity is designed to introduce branching
+    decisions in programming. Use the Blockly version of Python and its turtle module
+    to draw and colour hydrangea flowers!
+  tutorial_grokem_shortdescription: This activity is designed to give you your first
+    experience programming, and has been specially designed for the Hour of Code.
+    Use the programming language Python to explore emoticons and text manipulation.
+  tutorial_kodmaze_shortdescription: Build your own mazes to solve and share to challenge
+    others!
+  tutorial_codestersa_shortdescription: Design your own fast-paced space adventure
+    game with player controls!
+  tutorial_cmdodo_shortdescription: Teach addition, angle and degree measurement,
+    and multiplication with new characters.
+  tutorial_tynkerspace_shortdescription: Learn to code in space!
+  tutorial_gfbloons_shortdescription: Code your own mini-game and learn the maths
+    in Bloons TD5.
+  tutorial_raspipong_shortdescription: Create a Pong game using a Sense HAT and some
+    Python code.
+  tutorial_codehsvr_shortdescription: Create virtual reality worlds using the A-Frame
+    JavaScript Library!
+  tutorial_codesterstp_shortdescription: Learn about transformations as you guide
+    your shapes around the coordinate plane!
+  tutorial_codestersbb_shortdescription: Program your own pull-and-shoot basketball
+    game!
+  tutorial_gfcrossyroad_shortdescription: Code your own Crossy Road mini-game and
+    learn to think like a computer.
+  tutorial_googleww_shortdescription: Discover your coding superpowers on an adventure
+    with Wonder Woman.
+  tutorial_codehsjsapp_shortdescription: Code your first real app with JavaScript!
+  tutorial_gfmihi_shortdescription: Code your own mini-game and learn how to introduce
+    yourself in Te Reo Maori (the indigenous language of New Zealand)
+  tutorial_hopdropphone_shortdescription: Make "Don't Drop the Phone" on iPad/iPhone
+  tutorial_techfaa_shortdescription: Simulate a visually impressive life-like behavior
+    of group entities
+  tutorial_codehsjsgraph_shortdescription: Make your own graphics and drawing programs!
+  tutorial_thunkable_shortdescription: 1 hour, 10 apps
+  tutorial_hopcrossyroad_shortdescription: Make Crossy Road on iPad/iPhone
+  tutorial_switchglitch_shortdescription: Program cute robots and help them save the
+    galaxy!
+  tutorial_codecar_shortdescription: Use typed code to control the lights and buttons
+    of a simulated Code Car!
+  tutorial_codesterscp_shortdescription: Learn about the coordinate plane by sending
+    your sprite to pick up all its missing winter clothes!
+  tutorial_grokpetblock_shortdescription: This activity is designed to introduce you
+    to embedded programming using friendly blocks, and has been specially designed
+    for the Hour of Code. Use the blocks and a micro:bit to make a pet that you can
+    feed and play with. No BBC micro:bit? No problem! This course includes a full
+    micro:bit simulator, so you'll be able to do everything you'd do on a real micro:bit!
+  tutorial_techbim_shortdescription: Learn how to manipulate images without the use
+    of external libraries
+  tutorial_techfpp_shortdescription: Functional Programming made easy with Python!
+  tutorial_codesterscr_shortdescription: In this activity, you'll design a cheer routine
+    that your sprite will perform!
+  tutorial_grokdisease_shortdescription: This activity is designed to give you your
+    first experience programming, and has been specially designed for the Hour of
+    Code. Use the programming language Python to model a disease outbreak. Can you
+    solve the curious case of the glowing nose?
+  tutorial_techec_shortdescription: Confused about Closures in JS? Don't worry you're
+    not alone!
+  tutorial_rgbegin_shortdescription: At RoboGarden, we believe in giving learners
+    the opportunity to take an active role in their education
+  tutorial_myradream_shortdescription: Use code blocks to help Myra on a journey to
+    get her dream back.
+  tutorial_thinkfun_shortdescription: Enjoy this fun CS activity that teaches Boolean
+    logic concepts.
+  tutorial_hopfireworks_shortdescription: Make a Fireworks App on iPad/iPhone
+  tutorial_grokspace_shortdescription: This activity is designed to give you your
+    first experience programming, and has been specially designed for the Hour of
+    Code. Use the visual programming language Blockly to investigate space and reach
+    for the stars.
+  tutorial_codehspython_shortdescription: Code programs in Python!
+  tutorial_codehsjava_shortdescription: Code programs in Java!
+  tutorial_techioda_shortdescription: Use Dijkstra's Algorithm to calculate the shortest
+    path in a graph
+  tutorial_grokmonster_shortdescription: Get kids into coding with this friendly course
+    specially designed for the Hour of Code! Use drag-and-drop blocks to write your
+    own programs, learn about sequence and ordering, and create fun monster characters!
+  tutorial_techmjs_shortdescription: Modern Javascript features that will improve
+    your JS code
+  tutorial_techga_shortdescription: Introduction to Genetic Algorithms
+  tutorial_techioan_shortdescription: Stop being stuck in Java because of Null patterns!
+  tutorial_techiogsr_shortdescription: New to Rust? Everything you need to get started
+    is here!
+  tutorial_groktunnel_shortdescription: This activity is designed to give you your
+    first experience programming, and has been specially designed for the Hour of
+    Code. Use the programming language Python to create a simple game (or MUD). Can
+    you find your way through the dark tunnel?
+  tutorial_stemcod_shortdescription: Explore the Physics of Video Games! Learn to
+    code classic games!
+  tutorial_techikb_shortdescription: Basics Kotlin features in a nutshell
+  tutorial_kanostreet_shortdescription: Make beautiful, unique artwork with Kano's
+    Street Art coding challenges
+  tutorial_codemojijs_shortdescription: Codemoji designed Beginning Javascript to
+    get students typing real javascript commands that will in turn animate the different
+    characters.
+  tutorial_techapf_shortdescription: 7 useful tricks to master Python like a Pro!
+  tutorial_techfpjs_shortdescription: Functional programming made easy with Javascript!
+  tutorial_techlinq_shortdescription: A useful introduction to using the LINQ library
+    in C#
+  tutorial_gpbcatapult_shortdescription: Make your own game like Angry Birds.
+  tutorial_quorumastro_shortdescription: Learn about coding and astronomy in this
+    accessible online tutorial.
+  tutorial_alicewonder_shortdescription: Guide Alice in wonderland using JavaScript.
+  tutorial_rginter_shortdescription: At RoboGarden, we believe in giving learners
+    the opportunity to take an active role in their education.
+  tutorial_cssgrid_shortdescription: A game for learning CSS Grid.
+  tutorial_jshero_shortdescription: JS Hero provides you with an introduction to programming
+    by means of JavaScript. It provides general programming concepts such as variables,
+    conditions, loops, functions and a lot more. These concepts form the basis of
+    many programming languages.
+  tutorial_codemojipy_shortdescription: Python Lab is an IOS based activity that teaches
+    basic python.
+  tutorial_nclabdrone_shortdescription: Build a drone frame with NCLab's 3D Modeling
+    app. 3D print it and make a real flying drone!
+  tutorial_gpbcircle_shortdescription: Make beautiful colors interactively.
+  tutorial_gpbpaint_shortdescription: Create and customize a drawing application.
+  tutorial_cocomarcade_shortdescription: Build your own arcade survival game and challenge
+    your friends!
+  tutorial_beetik_shortdescription: Use code to hack the music of composer Franz Liszt.
+  tutorial_codedj_shortdescription: Learn Javascript basics and start composing your
+    own beats with Code DJ
+  tutorial_rgadvan_shortdescription: At RoboGarden, we believe in giving learners
+    the opportunity to take an active role in their education.
+  tutorial_codehsrn_shortdescription: Make real apps using React Native!
+  tutorial_codehswd_shortdescription: Build a website!
+  tutorial_turtlerobot_shortdescription: A programming game meant for kids 2 - 6.
+    Helps teach function calling.
+  tutorial_ozoevo_shortdescription: Use the force field of Evo by Ozobot to play,
+    then create awesome games
+  tutorial_ozoexped_shortdescription: Color code your way through space!
+  tutorial_ozojourney_shortdescription: Program your Ozobot robot to circumnavigate
+    the world.
+  tutorial_ozocodes_shortdescription: Pre-readers place Ozocodes logically on a drawing
+    of their name so Ozobot robots can walk from left to right.
+  tutorial_ozoeclipse_shortdescription: Model orbiting bodies, eclipses and lunar
+    phases with Ozobot robots.
+  tutorial_ozosimulator_shortdescription: Learn about programming languages using
+    a marker and paper.
+  tutorial_ozoalgorithm_shortdescription: Write an algorithm for Ozobot robots to
+    show and answer multiplication problems.
+  tutorial_ozotimer_shortdescription: Ozobot programmers are challenged to create
+    a 10-second timer.
+  tutorial_ozohabits_shortdescription: Young Ozobot programmers model nature with
+    their markers and a rabbit hill map.
+  tutorial_ozoprogram_shortdescription: Students without robots can discover how to
+    program them with Ozobot Games.
+  tutorial_ozopair_shortdescription: Students learn about Pair Programming roles,
+    then work together to program Bit or Evo by Ozobot to complete a maze.
+  tutorial_codesnoopy_shortdescription: Code to win in Snoopy Snow Brawl - who will
+    be the last scout standing?
+  tutorial_applabintro_shortdescription: Create your own app in JavaScript using blocks
+    or text.
+  tutorial_cslartist_shortdescription: A fun-filled coding + art challenge for students
+    K-4
+  tutorial_cslscratchjr_shortdescription: 'Read Aloud Coding Story for Pre-Readers
+    with Worksheets and a Follow-up Coding Project '
+  tutorial_floevents_shortdescription: Watch a hip-hop video about events. Then write
+    and act out your own!
+  tutorial_florobot_shortdescription: Watch a hip-hop video about robots, read about
+    them and design your own!
+  tutorial_isavesanta_shortdescription: It's Christmas Eve and Santa is off on his
+    travels around the world delivering presents when catastrophe strikes! He's fallen
+    out of his Sleigh! Create algorithms and program Santa to get back into his sleigh
+    in any way you know how.
+  tutorial_iorder_shortdescription: Summer time and the weather is sweet. Makes you
+    want to make a nice cool treat. Create algorithms and program an ice-cream simulation/game
+    using Scratch 2.0. Includes lesson plan, pupil support materials, and pre-written
+    program templates.
+  tutorial_ianimate_shortdescription: Create an animated GIF for the festive season
+    using animation software. Add artwork, backgrounds and objects and make them come
+    to life!
+  tutorial_iloveada_shortdescription: Teach computing with history. This teacher-led
+    activity involves conducting online research about Ada Lovelace, a female pioneer
+    in STEM and the world's first computer programmer!
+  tutorial_kodflash_shortdescription: If there is lightning, then thunder will follow!
+  tutorial_kodchoose_shortdescription: Write a Choose Your Own Adventure story using
+    "If statements"!
+  tutorial_kodpizzapre_shortdescription: Help Dominic's Pizza develop an algorithm
+    for their new mobile app!
+  tutorial_kodpizza_shortdescription: Help Dominic's Pizza develop an algorithm for
+    their new mobile app!
+  tutorial_kodwomen_shortdescription: 'Technology: is it for all or just some? Explore
+    inequalities in tech.'
+  tutorial_tfunplug_shortdescription: Enjoy this fun, unplugged CS activity that teaches
+    Boolean logic concepts.
+  tutorial_lbvariables_shortdescription: Having fun is not a variable with this littleBits
+    Code Kit tutorial.
+  tutorial_lbfunctions_shortdescription: The fun don't stop when you combine function-based
+    code blocks & littleBits.
+  tutorial_lblogic_shortdescription: The choice is yours with conditional logic &
+    littleBits.
+  tutorial_lbworld_shortdescription: You can change the world with code, one game
+    at a time.
+  tutorial_lbloops_shortdescription: From special effects to secret messages, loops
+    are your secret game weapon.
+  tutorial_lbtug_shortdescription: Make the classic Tug of War epic with functions
+    & littleBits.
+  tutorial_lbpotato_shortdescription: Build & code your own game of Hot Potato. Can
+    you stand the heat?
+  tutorial_lbguitar_shortdescription: Build it. Code it. Rock it!
+  tutorial_lbio_shortdescription: Let's make controllers with littleBits and code!
+  tutorial_wonpuppy_shortdescription: Program Dash the robot to tackle 3 coding challenges
+    while performing different puppy tricks!
+  tutorial_woncue_shortdescription: Program the CUE robot through fun challenges and
+    demos that will show you how to code using blocks, JavaScript, or state machines!
+  tutorial_wonzoo_shortdescription: Program Dot the robot to tackle 3 coding challenges
+    at the Petting Zoo!
+  tutorial_wontrip_shortdescription: Program Dash the robot to tackle 3 coding challenges
+    while preparing for a road trip!
+  tutorial_woncollect_shortdescription: Use the Wonder Workshop Blockly app and Dash
+    the robot to tackle 3 coding challenges!
+  tutorial_wonsecret_shortdescription: Let's use the Wonder Workshop Cue app with
+    Cue the robot to make a secret message system.
+  tutorial_hsscience_shortdescription: Make interactive science models on your iPad/iPhone!
+  tutorial_popculture_shortdescription: Vote on Pop Culture items then analyze data
+    to see what is trendy.
+  tutorial_legorobust_shortdescription: Investigating what characteristics of a building
+    would help make it resistant to an earthquake, using an earthquake simulator constructed
+    from LEGO bricks.
+  tutorial_legoplants_shortdescription: Model the relationship between a pollinator
+    and flower during the reproduction phase.
+  tutorial_legopark_shortdescription: Design cars that can park themselves safely
+    without driver intervention.
+  tutorial_legodetect_shortdescription: Design ways to avoid accidents between vehicles
+    and objects in the road.
+  tutorial_legolight_shortdescription: Design car features that will improve nighttime
+    driving safety.
+  tutorial_alexa_shortdescription: Alexa is the voice service that powers Amazon Echo.
+    In this tutorial, you will create fact skills unique to your school for this lab.
+  tutorial_grokpetmicro_shortdescription: Use the MicroPython programming language
+    to make a pet that you can feed and play with.
+  tutorial_pirateplunder_shortdescription: Use the MicroPython programming language
+    to make a pet that you can feed and play with.
+  tutorial_cadj_shortdescription: Use the MicroPython programming language to make
+    a pet that you can feed and play with.
+  tutorial_cacrazy_shortdescription: Use the MicroPython programming language to make
+    a pet that you can feed and play with.
+  tutorial_cajump_shortdescription: Use the MicroPython programming language to make
+    a pet that you can feed and play with.
+  tutorial_carest_shortdescription: Use the MicroPython programming language to make
+    a pet that you can feed and play with.
+  tutorial_accai_shortdescription: Teach an Artificial Intelligence robot to explore
+    a new planet!
+  tutorial_vceclipse_shortdescription: Code a solar eclipse simulation with JavaScript!
+  tutorial_pmzero_shortdescription: Create and program a 3D Pac-Man Maze World
+  tutorial_hsela_shortdescription: 'Telling stories: ELA + coding'
+  tutorial_ticklear_shortdescription: Anyone can now code virtual and AR characters
+    and program real devices to interact with them – seamlessly blending imagination
+    and reality into a single experience!
+  tutorial_bcrobot_shortdescription: With only two blocks, students can design, create,
+    and think in 3D! They can build their own robot, while learning underlying math
+    and computational thinking concepts.
+  tutorial_bcsnow_shortdescription: Students will use BlocksCAD to think, design,
+    and create in 3D!
+  tutorial_ifly_shortdescription: It's Christmas Eve and Santa's sleigh has developed
+    a fault! Luckily one of his trusty elves has secretly been working on developing
+    a sleigh drone. It's no Santa's sleigh but it works and is ready save Christmas
+    day!
+  tutorial_idowedo_shortdescription: Design and build a robotic vehicle then program
+    it to transport mini figures.
+  tutorial_diggindwarf_shortdescription: Dwarfs need your help to navigate, dig, and
+    collect gems using JavaScript.
+  tutorial_spheroit_shortdescription: Learn about if/then, else conditions while building
+    your very own animal sound game we like to call "Animal Toss!"
+  tutorial_gameofcodes_shortdescription: Build your awesome Dragon game and export
+    it as a standalone app.
+  tutorial_blocklygames_shortdescription: Blockly Games is a series of educational
+    games that teach programming.
+  tutorial_spherohello_shortdescription: Let's go beyond blocks and learn to WRITE
+    code. Say hello to the world of JavaScript.
+  tutorial_spheroarcade_shortdescription: Learn to code classic home and arcade games
+    with Sphero and Apple's Swift Playgrounds.
+  tutorial_bcpy1_shortdescription: Build your virtual 3D world with Python.
+  tutorial_bcpy2_shortdescription: Build your own world with Python.
+  tutorial_bcjs1_shortdescription: Build your own world with JavaScript.
+  tutorial_bcjs2_shortdescription: Build your world in JavaScript.
+  tutorial_3dbearmars_shortdescription: The Mars Pioneers is a project-based learning
+    module that teaches facts about Mars and the crucial conditions for human beings
+    to survive there. The students will build a colony using Augmented Reality and
+    3D-print the colony facilities.
+  tutorial_bitsboxyak_shortdescription: Type modified JavaScript code to make a greeting
+    card that you can email to friends and family. Yak Attack! is a completely open-ended
+    activity that introduces variables, motion commands, loop functions, and more.
+  tutorial_blockscadbargraphs_shortdescription: 'Students will write code that lets
+    them quickly customize and analyze their own bar graphs. '
+  tutorial_blockscadbirdhouses_shortdescription: 'Students will run a birdhouse-building
+    company, converting units, calculating dimensions, and using variables to scale
+    their products. '
+  tutorial_blockscadclock_shortdescription: 'Students will program a 3D model of an
+    analog clock that can be set to show any time. '
+  tutorial_blockscaddinner_shortdescription: Students will write a program using variables
+    and coordinates to help a robot set their dinner table for them!
+  tutorial_blockscadicecream_shortdescription: Students will program an ice cream
+    machine to create 3D ice cream cones with different numbers and sizes of ice cream
+    scoops.
+  tutorial_blockscadpizza_shortdescription: Students will program a module to create
+    a 3D pizza, calculating circumferences and areas and using loops along the way.
+  tutorial_blockscadsugar_shortdescription: 'Students will use a programmed sugar-cube
+    generator to explore volume and variables. '
+  tutorial_bsgridlight_shortdescription: Choose a Bot friend to help prepare for the
+    Lighthouse Festival. Code your Bot to stop those pesky rogue bots and save the
+    day!
+  tutorial_bpartscratch_shortdescription: 'Creative Coding - developed with Scratch
+    and Vidcode - pairs block- and text-based projects with hundreds of cross-curricular
+    topics. '
+  tutorial_bpartvid_shortdescription: 'Creative Coding - developed with Scratch and
+    Vidcode - pairs block- and text-based projects with hundreds of cross-curricular
+    topics. '
+  tutorial_bpenglishscratch_shortdescription: 'Creative Coding - developed with Scratch
+    and Vidcode - pairs block- and text-based projects with hundreds of cross-curricular
+    topics. '
+  tutorial_bpenglishvid_shortdescription: 'Creative Coding - developed with Scratch
+    and Vidcode - pairs block- and text-based projects with hundreds of cross-curricular
+    topics. '
+  tutorial_bphealthscratch_shortdescription: 'Creative Coding - developed with Scratch
+    and Vidcode - pairs block- and text-based projects with hundreds of cross-curricular
+    topics. '
+  tutorial_bphealthvid_shortdescription: 'Creative Coding - developed with Scratch
+    and Vidcode - pairs block- and text-based projects with hundreds of cross-curricular
+    topics. '
+  tutorial_bpmathscratch_shortdescription: 'Creative Coding - developed with Scratch
+    and Vidcode - pairs block- and text-based projects with hundreds of cross-curricular
+    topics. '
+  tutorial_bpmathvid_shortdescription: 'Creative Coding - developed with Scratch and
+    Vidcode - pairs block- and text-based projects with hundreds of cross-curricular
+    topics. '
+  tutorial_bpmlkscratch_shortdescription: 'Creative Coding - developed with Scratch
+    and Vidcode - pairs block- and text-based projects with hundreds of cross-curricular
+    topics. '
+  tutorial_bpmlkvid_shortdescription: 'Creative Coding - developed with Scratch and
+    Vidcode - pairs block- and text-based projects with hundreds of cross-curricular
+    topics. '
+  tutorial_bpsafetyscratch_shortdescription: 'Creative Coding - developed with Scratch
+    and Vidcode - pairs block- and text-based projects with hundreds of cross-curricular
+    topics. '
+  tutorial_bpsafetyvid_shortdescription: 'Creative Coding - developed with Scratch
+    and Vidcode - pairs block- and text-based projects with hundreds of cross-curricular
+    topics. '
+  tutorial_bpsciencescratch_shortdescription: 'Creative Coding - developed with Scratch
+    and Vidcode - pairs block- and text-based projects with hundreds of cross-curricular
+    topics. '
+  tutorial_bpsciencevid_shortdescription: 'Creative Coding - developed with Scratch
+    and Vidcode - pairs block- and text-based projects with hundreds of cross-curricular
+    topics. '
+  tutorial_bptechscratch_shortdescription: 'Creative Coding - developed with Scratch
+    and Vidcode - pairs block- and text-based projects with hundreds of cross-curricular
+    topics. '
+  tutorial_bptechvid_shortdescription: 'Creative Coding - developed with Scratch and
+    Vidcode - pairs block- and text-based projects with hundreds of cross-curricular
+    topics. '
+  tutorial_caflags_shortdescription: Learn some basic programming concepts with blockly.
+    Develop your computational thinking by using simple shapes, colors and coordinates
+    to draw the flags of the world.
+  tutorial_matariki_shortdescription: 'Maia and Charlie are from New Zealand.  Maia''s
+    family are getting ready to celebrate Matariki: the Māori new year.  She''s invited
+    her friend Charlie to come and stay at her family''s marae (traditional meeting
+    house).'
+  tutorial_carestaurant_shortdescription: Charlie and Tilley have decided that if
+    they program Ross properly he will be able to help do some painting to make Food
+    Avengers more attractive.
+  tutorial_casea_shortdescription: Alex and Lonnie create fancy fish and super sea
+    creatures with blocks. Help them sort the sequences into order and debug by spotting
+    and fixing the mistakes.
+  tutorial_cashield_shortdescription: It's the summer holidays and Alex, her family,
+    and Lonnie are going on holiday to Finland. Alex's older brother Reuben is creating
+    an app about shield blazonry and shows Alex and Lonnie how to use it.
+  tutorial_ccwslimer_shortdescription: Learn how to program your own shareable game
+    with multiple levels and challenges!
+  tutorial_codinggalaxy_shortdescription: For your first mission on Adventure Planet,
+    your duty is to solve coding puzzles to save the beautiful planet.
+  tutorial_boatrace_shortdescription: Learn how to make a boat racing game. The player
+    uses the mouse to navigate a boat to a desert island without bumping into obstacles.
+  tutorial_ccplay_shortdescription: Code and play a series of game levels while learning
+    important computer science concepts. On the final level, show off your creativity
+    and skills to code your own game from scratch!
+  tutorial_grinch_shortdescription: 'Learn to program drones and a high tech sleigh
+    with coding magic to capture presents and navigate down the mountain to return
+    Christmas to Whoville. '
+  tutorial_codehsart_shortdescription: Memes! Memes! Memes! Students explore the intersection
+    of coding and art by building a computer program that allows them to create custom
+    memes to share with friends.
+  tutorial_codehsbitcoin_shortdescription: In this Hour of Code activity, students
+    are introduced to the Bitcoin blockchain ledger and some Bitcoin statistics.
+  tutorial_codehsblockchain_shortdescription: Students learn about the foundations
+    of cryptocurrencies by exploring cryptography, hashing, and blockchain technology!
+  tutorial_codehscipher_shortdescription: 'In this Hour of Code activity, students
+    are introduced to cryptography by using the classic Caesar cipher to decrypt and
+    encrypt some messages, and also discover the cipher''s flaw and how to improve
+    upon it. '
+  tutorial_codehscollision_shortdescription: Students will explore how simulations
+    are used in research. They will study how mass and speed affect elastic collisions
+    by using conservation of momentum and conservation of kinetic energy equations/
+  tutorial_codehsmath_shortdescription: 'Students are introduced to Tracy the Turtle
+    and learn how to code different mathematical models in Python! No coding experience
+    is necessary, but students should have completed Algebra I or higher. '
+  tutorial_codehsmusic_shortdescription: Students explore how coding is used in music
+    creation by building their own dynamic eight-count beats and patterns with JavaScript
+    blocks!
+  tutorial_codehssports_shortdescription: Students learn about how coding is used
+    in sports and game design by building an original sports video game that can be
+    shared with their friends immediately!
+  tutorial_codemojipizza_shortdescription: This course is designed to teach students
+    the fundamentals of JavaScript objects. Students will learn the basic types of
+    data that can be stored in variables.
+  tutorial_moonlander_shortdescription: Moon Lander is a Game Builder course with
+    17 exercises that guides students on how to build their own physics-based game.
+  tutorial_sushicards_shortdescription: Make a game where you move a shark around
+    to try and catch fish.
+  tutorial_codesparkcreate_shortdescription: Ever wanted to design and code your own
+    video game? Choose from two game kits that guide you through creating and coding
+    a Mario-style video game using codeSpark Academy's no words interface. Beginner
+    coders and pre-readers welcome!
+  tutorial_hardvsoft_shortdescription: Through an illustrated children's story and
+    worksheets, your students will learn the differences between hardware and software.
+  tutorial_codestersecard_shortdescription: 'Build up your programming skills as you
+    learn how to create an electronic greeting card that you can share with your teacher,
+    family, or friends! '
+  tutorial_codesterslogo_shortdescription: Use code to get creative and design your
+    own company logo! You'll learn coding basics in the programming language, Python.
+    After you work through the tutorial, you'll have all the skills you need to create
+    the logo for your personal brand!
+  tutorial_codesterstshirt_shortdescription: 'Learn basic programming skills and practice
+    moving around the coordinate plane as you create your own monogrammed t-shirt
+    design! '
+  tutorial_codewards_shortdescription: Join an exciting mission to save the underwater
+    city. Experience the work of a rescue engineer fixing damaged city systems with
+    commands and algorithms. Overcome various challenges to proveyour skills, intelligence
+    and courage!
+  tutorial_olympics_shortdescription: 'Together with Elsie get prepared for Robot
+    Olympics! Along with programming concepts learn how to drive, collect details
+    and create tools, build and test your mighty robot. '
+  tutorial_codinismhero_shortdescription: Learn the basics of programming through
+    fun examples, and build a game while learning!
+  tutorial_discovery_shortdescription: Two characters meet in a world, and discover
+    a surprising object. What happens next? With Scratch and CS First, anyone can
+    create their own unique story with code.
+  tutorial_csfirstname_shortdescription: Pick a name and bring the letters of the
+    word to life using code. Choose a nickname, a pet's name, an animal, a sport,
+    a place or a hobby.
+  tutorial_edisonmove_shortdescription: Introduce text-based programming and the key
+    computational concept of sequence to your students using Edison robots and EdPy,
+    a text-based programming language based on Python.
+  tutorial_edisonspider_shortdescription: Introduce the key computational concepts
+    of variables and data, two of the most fundamental parts of general-purpose programming
+    languages, using Edison robots and the Scratch-based programming language EdScratch.
+  tutorial_edisonspotlight_shortdescription: Introduce Edison robots to your students,
+    helping them begin to explore what a robot is and how it can sense, and react,
+    to the world.
+  tutorial_firiapython_shortdescription: Get your micro:bit ready, and level-up to
+    Python coding! CodeSpace will guide you step-by-step from your very first line
+    of Python to coding an interactive program with buttons and LEDs.
+  tutorial_gamefrootsquid_shortdescription: Colossal squid are the largest invertebrates
+    in the world. In this coding game for beginners you'll learn the basics of coding
+    and create a game that explores the squid's life under the ocean.
+  tutorial_duckpiano_shortdescription: In this project you'll make keys on your computer
+    play quack sounds at different pitches, like a piano that sounds like a duck.
+  tutorial_gpsound_shortdescription: In this project you'll write a program to record
+    sound from your computer microphone, play it back, and draw a picture of the recorded
+    sound. You can then process your recording to add effects such as pitch-shift,
+    reverse, or echo.
+  tutorial_groklearningpython_shortdescription: Develop your programming skills and
+    build your own animal classifier! In this course you'll use the programming language
+    Python to classify animals based on their characteristics.
+  tutorial_htmltimetravel_shortdescription: Take an adventurous travel through time
+    and conquer deep space while learning how to move, rotate and transform objects
+    using the basics of animation in CSS.
+  tutorial_hp_flappy_shortdescription: Learn logical thinking and programming concept
+    by creating your own Flappy Birds style game on hyperPad.
+  tutorial_appytappin_shortdescription: This teacher-led activity, adapted for the
+    Hour of Code, introduces children to using a text-based programming language to
+    develop a mobile games app.
+  tutorial_icipher_shortdescription: This teacher led activity, adapted for the Hour
+    of Code teaches children about communicating securely. The children learn that
+    messages throughout time have been encrypted and decrypted using ciphers.
+  tutorial_iguess_shortdescription: Introducing Quick Response codes to children aged
+    3-5. Use tablets to scan QR codes and guess the mini-beast from a given habitat.
+  tutorial_imake_shortdescription: This unplugged teacher-led activity, for children
+    aged 3-5, uses classic nursery rhymes to introduce the concept of algorithms,
+    sequence and repetition.
+  tutorial_imorse_shortdescription: Explore cryptography with Morse Code and Sphero.
+    Learn that physical systems can be programmed and write code for Sphero to communicate.
+  tutorial_kanohp_shortdescription: Learn to code and make magic on screen with creative
+    challenges. Make feathers fly and fire flow, compose music, and more.
+  tutorial_khanwebpages_shortdescription: Learn how to make webpages with HTML tags
+    and CSS, and finish up by making your very own greeting card to share with friends
+    or family.
+  tutorial_kibobowl_shortdescription: Crash! How far does KIBO have to move to get
+    from the start of the bowling lane to the pins? You can create a single straight
+    lane or a more complicated path.
+  tutorial_kibodance_shortdescription: Let's have a KIBO Robot dance party! Set up
+    a music player to play a favorite classroom song, or a song connected to a world
+    culture you're exploring.
+  tutorial_buildcharacters_shortdescription: The most popular pre-reader app now includes
+    a digital Maker Space! Make levels, design games, or build characters. Choose
+    your activity and start creating with Kodable!  Featuring JavaScript for upper
+    elementary.
+  tutorial_designgames_shortdescription: The most popular pre-reader app now includes
+    a digital Maker Space! Make levels, design games, or build characters. Choose
+    your activity and start creating with Kodable!  Featuring JavaScript for upper
+    elementary.
+  tutorial_makelevels_shortdescription: The most popular pre-reader app now includes
+    a digital Maker Space! Make levels, design games, or build characters. Choose
+    your activity and start creating with Kodable!  Featuring JavaScript for upper
+    elementary.
+  tutorial_wizard_shortdescription: Journey into the world of Code Magic as a Code
+    Wizard. Learn to create and cast spells to customize your castle.
+  tutorial_mbscratchcards_shortdescription: Connect the physical world of micro:bit
+    with the virtual world of Scratch.
+  tutorial_mbswiftplaygrounds_shortdescription: Use the micro:bit with an iPad to
+    learn Swift.
+  tutorial_mbbuttons_shortdescription: In this introductory project, you'll make pictures
+    or animations appear on the micro:bit display when buttons are pressed.
+  tutorial_meteor_shortdescription: In this project, you'll create a Falling Meteors
+    game for the BBC micro:bit. Using the buttons, the player will move a shield to
+    catch falling meteors and save the Earth.
+  tutorial_ballbounce_shortdescription: Learn to make a mobile app where the user
+    flings a ball across the screen and it bounces off the edges.
+  tutorial_mitcodi_shortdescription: Learn to make your own interactive mobile app.
+    Press the bee and hear it buzz!
+  tutorial_mitdoodle_shortdescription: Make a mobile app where you can draw pictures
+    on the screen!
+  tutorial_talktome_shortdescription: Learn to make a mobile app that makes your phone
+    talk to you!
+  tutorial_mobilecspmap_shortdescription: Use App Inventor to create a Map Tour of
+    landmarks in your town, state, or anywhere in the world.
+  tutorial_ozorandom_shortdescription: 'Learn how computers create random numbers
+    and use them, then use a random movement program to help seed ideas for a story. '
+  tutorial_ozotroll_shortdescription: 'Learn the difference between Internet trolls
+    and fairy tale trolls, then teach Evo how to be a good troll that protects you. '
+  tutorial_peblioart_shortdescription: 'Learn to draw and animate shapes with code
+    to create interactive artwork inspired by artists. '
+  tutorial_astropi_shortdescription: Code a message and check the ambient air temperature
+    on board the ISS using an online simulator of the Astro Pi computer's Sense HAT.
+  tutorial_rgart_shortdescription: RoboGarden STEAM Activities has fused code practicing
+    with STEAM learning and gamified missions in multiple activities.
+  tutorial_rgengineer_shortdescription: RoboGarden STEAM Activities has fused code
+    practicing with STEAM learning and gamified missions in multiple activities.
+  tutorial_rgmath_shortdescription: RoboGarden STEAM Activities has fused code practicing
+    with STEAM learning and gamified missions in multiple activities.
+  tutorial_rgscience_shortdescription: RoboGarden STEAM Activities has fused code
+    practicing with STEAM learning and gamified missions in multiple activities.
+  tutorial_rgtech_shortdescription: RoboGarden STEAM Activities has fused code practicing
+    with STEAM learning and gamified missions in multiple activities.
+  tutorial_robotmagic3d_shortdescription: Use code to make 3D models and letters come
+    alive with fun. At the end you can download an animated sticker of your creation
+    and share it with friends.
+  tutorial_robotmagicflappy_shortdescription: Use your imagination to create a 3D
+    Flappy Bird game. Use code to make 3D models come alive with fun. At the end you
+    can share your creation with friends and challenge them to a high score.
+  tutorial_scratchadventure_shortdescription: Send your favorite Cartoon Network characters
+    on a quest, from the farthest reaches of the universe, to the edge of Craig's
+    creek. Unlock secret treasures and discover new characters while creating an adventure
+    game.
+  tutorial_scratchtalk_shortdescription: Create a rapping robot or an interactive
+    animation that talks. This project will show you how to create talking animations
+    that spin, zoom and change colors.
+  tutorial_scratchjrstory_shortdescription: Through this activity and continued time
+    with ScratchJr, students will have the opportunity to think creatively, improve
+    their storytelling and collaborate with peers.
+  tutorial_scratchjrtwinkle_shortdescription: Through this activity, students will
+    have the opportunity to think creatively, become storytellers, and improve upon
+    mathematical reasoning and sequencing skills.
+  tutorial_spherocomm_shortdescription: Learn about miscommunication in both a community
+    and in a computer program. Use this knowledge to resolve any miscommunication,
+    or bugs, in a program in an effort to help BOLT find its way home.
+  tutorial_spherocommunity_shortdescription: Design a simple path that represents
+    a common route that you travel everyday. You will create two programs, a drawn
+    path and a block-based program path through your community route.
+  tutorial_spherofunctions_shortdescription: Learn how to use and invoke functions
+    to turn Sphero into a calculator.
+  tutorial_spheroinfrared_shortdescription: Become an epidemiologist in order to stop
+    the spread of a rare robot infection that is plaguing a community of BOLT robots.
+  tutorial_spherolightsensor_shortdescription: Learn how to create a program that
+    uses the ambient light sensor to measure lux values and chase BOLT.
+  tutorial_spheromansion_shortdescription: Keeping a bunch of dinosaurs at your house
+    shouldn't be an issue, right? As you would imagine, this doesn't to end well.
+    You are trapped in the mansion's library and must program your way out.
+  tutorial_roadblocks_shortdescription: As a continuation of Your Community, you will
+    modify your blocks program as you and your partner encounter different roadblocks
+    along the route.
+  tutorial_spherotext2_shortdescription: Learn your first conditional by building
+    a fun game where you will be throwing Sphero and guessing animal sounds. This
+    is a great activity after you complete Text 1.
+  tutorial_spherotext3_shortdescription: Learn to change Sphero's main LEDs based
+    on the gyroscope's spin rate. You will also learn about normalization and absolute
+    value. This is a great activity after you complete Text 1 and 2.
+  tutorial_spherotext4_shortdescription: Use variables to build a hot potato game
+    powered by Sphero. This is a great activity after you complete Text 2 or 3.
+  tutorial_spheroraptor_shortdescription: Create a fortified pen to keep the Spheroraptors
+    at bay, while also writing the code to the Spheroraptors escape. From loops, to
+    conditionals, to operators and even comparators, you will need as much coding
+    know-how as you can muster.
+  tutorial_stempiday_shortdescription: In this coding activity you will randomly generate
+    points similar to a very bad player shooting darts at a dart board.
+  tutorial_stemplanetoids_shortdescription: In this activity you will fix a broken
+    asteroids game where the ship only moves in a straight line. Then you will add
+    gravity to the game and try to land the ship on the moon!
+  tutorial_stempong_shortdescription: In this activity you will fix a broken version
+    of the Pong game so that objects bounce like they should. Then you will add gravity
+    to create a Bonk.io clone.
+  tutorial_algobot_shortdescription: Players command AlgoBot, a smart little service
+    droid, and learn to use a visual programming language to help him contain the
+    crisis!
+  tutorial_thunkableapps_shortdescription: 'Learn how to build your own apps with
+    blocks-based coding! '
+  tutorial_toxicodedot_shortdescription: Select a card from your deck and interpret
+    its code in order to progress through the world. Use your intuitive abilities
+    to guess the rules and learn from your own mistakes.
+  tutorial_gcactions_shortdescription: Discover actions, one of the key building blocks
+    in coding, and use them to code a video game! Explore digital culture and learn
+    about robots and what they can actually do.
+  tutorial_gccomparators_shortdescription: Discover comparators and logical rules,
+    which are key building blocks in coding, and use them to code a video game! Explore
+    digital culture and learn about the tracking of our online activities.
+  tutorial_gcconditions_shortdescription: Discover conditions, one of the key building
+    blocks in coding, and use them to code a video game! Explore digital culture and
+    learn about the algorithms that power our online world.
+  tutorial_gccreate_shortdescription: Create your first full videogame with GameCode!
+    Create new characters, make them (a bit) smarter, give the player superpowers...Sky's
+    the limit!
+  tutorial_gcevents_shortdescription: 'Discover events, one of the key building blocks
+    in coding, and use them to code a video game! Explore digital culture and learn
+    about Artificial Intelligence, and how it might be meaningful in your life. '
+  tutorial_gcloops_shortdescription: Discover loops, one of the key building blocks
+    in coding, and use them to code a video game! Explore digital culture and learn
+    about the echo chamber phenomenon on social networks.
+  tutorial_gcvariables_shortdescription: Discover variables, one of the key building
+    blocks in coding, and use them to code a video game! Explore digital culture and
+    learn about what data is and how it works.
+  tutorial_beanything_shortdescription: Use programming to animate characters, compose
+    music, tell stories, design games, and even create art.
+  tutorial_change_shortdescription: Create a project that shows how you would change
+    the world! Whether you are passionate about recycling or have an idea to achieve
+    world peace, share your vision with code!
+  tutorial_cooking_shortdescription: Show off your skills - create an interactive
+    cooking game. Beginners can use the self-guided tutorial while more advanced coders
+    have the option to start off with a blank project.
+  tutorial_crystal_shortdescription: Cast spells, collect power-ups, and defeat enemies
+    as you battle in a wild 4-player arena that is shrinking amidst lava!
+  tutorial_landscape_shortdescription: Use Python's pen drawing feature to compose
+    a landscape using code. Use the landscape items already created for you or design
+    your own structures. Publish and share your creations!
+  tutorial_pets_shortdescription: Create a fun game about pets – either real or imaginary!
+    Beginners can use the self-guided tutorial while more advanced coders have the
+    option to start off with a blank project.
+  tutorial_petvet_shortdescription: From guiding pets into the Examination Room to
+    diagnosing their sniffles, boo-boos, and itches, you'll find every puzzle has
+    a solution to make the pets feel better than ever!
+  tutorial_superhero_shortdescription: Use HTML and CSS pixel art to create your favorite
+    superhero masks. Publish and share your creations!
+  tutorial_vidcodeplastic_shortdescription: Learn to use loops, sine waves and customized
+    emojis to make a unique project.
+  tutorial_vidcodetypeface_shortdescription: Create your own typeface using shapes
+    and elements of typography. Type has more elements than you may have realized!
+  tutorial_washustorm_shortdescription: Learn how to program an incoming storm.
+  tutorial_activitypackets_shortdescription: Find hours of family-friendly fun with
+    Wonder Workshop's printable packets of creative coding activities. Bring coding
+    to life with Dash, Dot, and Cue robots by downloading these online and offline
+    activities to use during Hour of Code and beyond!
+  tutorial_googlerookie_shortdescription: In this activity, you'll code a Rookie themed
+    collage using Blockly, an introductory coding language. You'll use sequences,
+    variables and loops to create a unique piece that highlights your creativity!
+  tutorial_tommyturtle_shortdescription: 'Help young kids learn the basics of coding
+    with Tommy the Turtle! '
+  tutorial_mazyad_shortdescription: This product will broaden our boundaries to create
+    an integrated paper version with computerized applications and an alternative
+    if the computer is not used for any reason. It will also serve as an introduction
+    to understanding programming in general.
+  tutorial_gamemaker_shortdescription: Game Maker is an open ended activity where
+    students can create anything they want using a simple code wizard. Just click
+    on the picture of a cute little monster and choose one of the options in the menu.
+    More advanced tutorials are also included for those wanting to go deeper into
+    game making.
+  tutorial_duckrace_shortdescription: In this course you will solve programming tasks
+    to help Toni the duck collect coins for its holiday savings. At the end of the
+    course you create your own game.
+  tutorial_allcancodeapps_shortdescription: Use the Allcancode Platform to create
+    web and mobile apps from design to delivery.
+  tutorial_n2y_shortdescription: Help Bitt Bott explore Earth using direction arrows.
+  tutorial_dance2019_longdescription: Code a Dance Party to share with your friends.
+    Featuring Katy Perry, Shawn Mendes, Lil Nas X, Panic! At The Disco, Jonas Brothers,
+    and many more!
+  tutorial_danceparty_longdescription: Code a Dance Party to share with your friends.
+    Featuring Katy Perry, Madonna, J. Balvin, Sia, Keith Urban, Ciara, and 25 more!
+  tutorial_chibitronics_longdescription: Program a paper circuit to light up your
+    own story.
+  tutorial_athlete_longdescription: Choose between making a basketball game or mix
+    and match across sports!
+  tutorial_moana_longdescription: The new Disney Hour of Code tutorial uses a visual
+    programming language using blocks where students simply drag and drop visual blocks
+    to write code. Visual programming is a fun and easily understood way to teach
+    the logic of coding. Exposure to visual programming lays the foundation for text-based
+    programming, a more complex activity. The tutorial is targeted for kids ages 8+
+    and those trying coding for the first time. Available in 23 languages and localized
+    outside of the United States. This tutorial is available free online and includes
+    a digital toolkit in English and Spanish for educators and event organizers.
+  tutorial_star-wars_longdescription: Learn to program droids, and create your own
+    Star Wars game in a galaxy far, far away.
+  tutorial_gumadventure_longdescription: In the Amazing World of Gumball episode "The
+    Signal," a glitch affects how the characters relate to each other. In this activity,
+    continue the story by making your own glitch and imagining how Gumball and his
+    friends would react to it.
+  tutorial_mchoc_longdescription: Minecraft is back for the Hour of Code with a brand
+    new activity! Journey through Minecraft with code.
+  tutorial_vidnews_longdescription: 'It''s the HOC News! Videos and graphics are all
+    about tech, diversity, kids, and coding. Finished projects can be uploaded to
+    school website as the report on the HOC itself. Teachers can encourage students
+    to use the news to report on what they learned, or a statistic for their school.
+    "Breaking News: 400 students at Roosevelt participate in the Hour of Code"'
+  tutorial_kodable-pre_longdescription: Kodable is a self-guided game that introduces
+    kids 5+ to programming basics. Having a teacher or parent nearby is optimal, but
+    not necessary. Happy koding!
+  tutorial_highseas_longdescription: Animate an ocean wave to create a setting, then
+    tell a story that takes place on the high seas.
+  tutorial_capython_longdescription: Python is an engaging and simple language to
+    learn. Learn about using modules, functions, loops, and lists, all while creating
+    fun images with the help of your turtle buddies. Geometry has never been so much
+    fun!
+  tutorial_frzn_longdescription: Let's use code to join Anna and Elsa as they explore
+    the magic and beauty of ice. You will create snowflakes and patterns as you ice-skate
+    and make a winter wonderland that you can then share with your friends!
+  tutorial_cocom_longdescription: Choose your hero and code your way through the ogre
+    patrols, lava pits, and laser beams of Kithgard Dungeon. Level up, earn gems,
+    and loot magic items to unlock new programming powers!
+  tutorial_play-lab_longdescription: Create a story or make a game with Play Lab!
+    Make animals, pirates, zombies, ninjas, and many more characters move, make sounds,
+    score points, and even throw fireballs!
+  tutorial_boxisland_longdescription: Take a trip on Box Island and collect all the
+    stars! Box Island is a beautiful mobile coding game that takes kids on an exciting
+    adventure on the charming island. In this tutorial you will learn the basics of
+    algorithms, sequences, loops and conditionals!
+  tutorial_textcomp_longdescription: 'At some point we reach a physical limit of how
+    fast we can send bits, and if we want to send a large amount of information faster,
+    we have to find a way to represent the same information with fewer bits - we must
+    compress the data. In this lesson, students will use the Text Compression Widget
+    to compress segments of English text by looking for patterns and substituting
+    symbols for larger patterns of text. '
+  tutorial_encryption_longdescription: 'Students are introduced to the need for encryption
+    and simple techniques for breaking (or cracking) secret messages. They try their
+    own hand at cracking a message encoded with the classic Caesar cipher and also
+    a Random Substitution Cipher. Students should become well-acquainted with the
+    need for secrecy when sending information over the Internet, and that in an age
+    of powerful computational tools, techniques of encryption will need to be more
+    sophisticated. '
+  tutorial_kanopixel_longdescription: Creators of all ages learn to code in a real
+    programming language and watch their commands come to life by drawing a sequence
+    of 13 pictures with code. They'll learn along the way about video game art history
+    from Pong and other retro games through 8-bit art and Minecraft, weaving together
+    computer science with art, history, and storytelling. The implementation is flexible––you
+    can spend 1 hour or a few hours over one or multiple sessions. Learners can complete
+    Pixel Hack on their own using guidance within the challenges, or you can turn
+    Pixel Hack into an instructor-led journey, with a comprehensive educator manual
+    full of suggestions. Students will be encouraged to add their own creative flair
+    by hacking our challenges, to earn the Pixel Hacker Certificate.
+  tutorial_foos_longdescription: Code the adorable Foos to solve puzzles that teach
+    fundamental computer science concepts like sequencing and loops. Everyone everywhere
+    can learn to code with codeSpark Academy's award-winning "no words" interface.
+    Beginner coders and pre-readers welcome!
+  tutorial_tynkerdd_longdescription: Design your own custom dragon, then use programming
+    to guide it through fun puzzles on its quest for treasure and coins! You'll have
+    to navigate through complex castles, find power-ups, and conquer knights to get
+    all the treasure.
+  tutorial_tynkerana_longdescription: Use your knowledge of math and geometry to create
+    a working analog clock with moving second, minute, and hour hands. You'll need
+    to calculate the angle that each hand should point based on what time it is. When
+    you're done, you can add in reminders about what you need to do throughout the
+    day to make your own alarm clock!
+  tutorial_vidcard_longdescription: |-
+    Learn how to make a greeting card with JavaScript!
+
+    You will learn how to manipulate your own videos by accessing each and every pixel and telling it what to do with CODE!
+
+    You can also upload and record your own footage to personalize the experience.
+
+    Created in partnership with GSGNY.
+  tutorial_spritebox_longdescription: Run, jump, and code your way through three different
+    worlds to collect the stars and make it to the finish line! Learn sequencing,
+    debugging and loops, and code in Swift, Java, or with Icons.
+  tutorial_tynkerch_longdescription: Save the computer from a malicious virus! You'll
+    have to hack your way through the system by deleting viruses, opening doors, solving
+    mazes, and navigating through the portals. Watch out for viruses and glitches!
+  tutorial_lightbot_longdescription: Lightbot is a game that asks players to use programming
+    logic to solve puzzles! Gain a practical understanding of basic coding concepts
+    by guiding Lightbot to light up all the blue tiles in each level. Learn how to
+    sequence instructions, write procedures, and utilize loops along the way in this
+    self-guided activity. Great for all ages and all skill levels.
+  tutorial_hoc_longdescription: Placeholder for new code.org/hoc
+  tutorial_code_longdescription: Learn the basic concepts of Computer Science with
+    drag and drop programming. This is a game-like, self-directed tutorial starring
+    video lectures by Bill Gates, Mark Zuckerberg, Angry Birds and Plants vs. Zombies.
+    Learn repeat-loops, conditionals, and basic algorithms. Available in 37 languages.
+  tutorial_tinspire_longdescription: Introduce students to the basics of coding –
+    in just 10 minutes at a time – using the TI technology they carry in their backpacks
+    every day. These lessons give students an easy-entry into programming that can
+    help spark their interest in coding and computer science.  Students will write
+    programs that can strengthen math concepts using the TI Basic language that is
+    ready-to-use on their TI-Nspire handhelds.
+  tutorial_itchbounceball_longdescription: |-
+    We take you through an introduction to Itch, utilizing the Scratch visual programming language.
+
+    This lesson provides a video and text directions for the code students need to add to get a ball bouncing zanily around the screen.
+
+    Once students complete this activity there is an opportunity to explore with ideas for other changes and activities that can be made.  There is no set goal or outcome as it's an open learning environment, but with just this starting code students come up with amazing projects!
+
+    All instruction is contained within the Itch environment so there is no need to be switching screens to follow along with the project. Headphones are recommended.
+  tutorial_vidclim_longdescription: Students research a fact about the Earth's climate,
+    engaging with the work of scientists and artists in response to climate change.
+    Students take their research and plan a video sharing their fact. Videos can be
+    about understanding climate changes and its effects, public responses to climate
+    change, how climate change impacts everyday life, and the actions you can take
+    to make a difference.
+  tutorial_matlab_longdescription: Learn to Code is an engaging, online, interactive
+    tutorial where you learn how to code. Use MATLAB to find out if the closest meet-up
+    location with your friends is the movies, the mall, or the cafe. Break the problem
+    up into smaller chunks and learn basic programming concepts along the way. By
+    the end of the hour, create an algorithm to find the shortest path to your friends!
+  tutorial_flap_longdescription: Use drag-and-drop programming to make your own Flappy
+    Bird game, and customize it to look different (Flappy Shark, Flappy Santa, whatever).
+    Add the game to your phone in one click.
+  tutorial_galaxy_longdescription: "Grab your Android smartphone and explore distant
+    galaxies! At the #GalaxyGameJam you can create your very own Android app. Design
+    it with our free Pocket Code app and become part of our mission to outer space.
+    With Pocket Code we aim to inspire kids, teenagers, and young adults to create
+    their very own games, animations, and interactive stories directly on their smartphones.
+    \n"
+  tutorial_inf_longdescription: Use Play Lab to create a story or game starring Disney
+    Infinity characters.
+  tutorial_tynkersol_longdescription: Program an interactive model of our Solar System.
+    This project comes with step-by-step instructions that guide you through creating
+    a simulation with planets orbiting the Sun. Then add facts about each planet that
+    pop up when clicked.
+  tutorial_itchg_longdescription: "Name-IT has you create a game of recognition! \n\nThe
+    ending project has students creating a game to name the States of Australia!\n\nYou'll
+    first walk through and follow directions to create a game to label the three phases
+    of the water cycle. You'll make a fully functioning game, including scoring!\n\nFrom
+    the coding side you'll learn about variables, conditionals, lists, concatenating
+    strings and much, much more. These are coding techniques you'll be able to re-use
+    in other projects as you progress on to build your new coding skills!\n\nYou can
+    take the activity even further by adding your own image and labels (along with
+    many other extra project options, the fun never ends). Headphones are recommended."
+  tutorial_como_longdescription: Help a cute monkey catch bananas in 30 fun-filled
+    coding challenges! As you play, you will meet different animals that will guide
+    you along the way. You will use code and think outside the box to win as many
+    stars as possible. Good luck!
+  tutorial_processfound_longdescription: What does it mean to write software to do
+    the things that you often do with your hands, with paper, with pencil, with paint?
+    Could you use a computer to create drawings? To create animations? To create images?
+  tutorial_tynkerhomo_longdescription: You'll follow step-by-step instructions to
+    animate an interactive story with a lot of homophones in it! Each time a character
+    says a word that is a homophone, ask the player which homophone is the correct
+    word for that context. The player better know their homophones, or else the dialog
+    won't make any sense!
+  tutorial_art_longdescription: Draw cool pictures and designs with the Artist!
+  tutorial_tynkerbrick_longdescription: Use Tynker's physics engine to make your own
+    personalized version of this classic arcade game. Start by programming the paddle
+    to move when the arrow keys are pressed, then add a ball and some bricks. You'll
+    personalize the game by adding custom assets for the ball, bricks, and paddle.
+  tutorial_itchbio_longdescription: |-
+    Name-IT has you create a game of recognition!
+
+    Create a game to name the parts of a biological cell. Learn the parts of the cell while you make the game, and play it again as many times as you need to refresh your memory!
+
+    You'll first walk through and follow directions to create a game to label the three phases of the water cycle. You'll make a fully functioning game, including scoring!
+
+    From the coding side you'll learn about variables, conditionals, lists, concatenating strings and much, much more. These are coding techniques you'll be able to re-use in other projects as you progress on to build your new coding skills!
+
+    You can take the activity even further by adding your own image and labels (along with many other extra project options, the fun never ends). Headphones are recommended.
+  tutorial_itchj_longdescription: |-
+    Our Jumping activity provides you the coding skills to get a character to jump onto platforms that is used in many arcade style games.
+
+    Use the Jumping skills and create your own game goal.
+
+    This uses a cartesian coordinate system so you'll get to learn a little about screen coordinates here.
+
+    Enjoy learning all about jumping with Itch! Headphones are recommended.
+  tutorial_tickleo_longdescription: With Tickle, a user-friendly coding app, you can
+    easily program the Orca to swim in a number of ways by simply dragging and dropping
+    coding blocks to create a command for it to follow.
+  tutorial_hopgeo_longdescription: Create your own version of the highly-engaging
+    Geometry Jumper game in Hopscotch's open-ended programming environment! Along
+    the way, you'll gain hands-on experience with concepts like sequence, loops, variables,
+    and debugging. No prior experience is needed to complete or facilitate this activity;
+    it includes a fun in-app video tutorial and a step-by-step facilitation guide.
+  tutorial_tynkermult_longdescription: Code your own math game! Your character needs
+    to escape the cave without getting hit by falling boulders. But the only way the
+    character can run forward is by correctly answering math questions! You'll follow
+    step-by-step instructions to program this fun multiplication quiz game.
+  tutorial_monster_longdescription: The Mystery Island Coding Quest by Monster Coding
+    offers a fun filled self guided adventure that teaches several key programming
+    concepts to children. Each block based activity builds on the previous, introducing
+    kids to Functions, Boolean Values, Loops, If/Else Statements, and Arrays, using
+    colorful animated graphics, audio instructions.
+  tutorial_tynkerapp_longdescription: Build your own version of your favorite game.
+    Choose from tons of options, like platformer games, classic arcade games, racing
+    games, programming art, storytelling projects, and more! You'll personalize your
+    game by creating more levels, uploading or drawing custom assets, and programming
+    more fun features.
+  tutorial_tynkerpup_longdescription: Pixel the puppy was enjoying a nice day out
+    with his family, but they forgot to put him in the car and left without him! Can
+    you program Pixel to find his way home? In each puzzle, you'll navigate Pixel
+    to avoid obstacles so he can get back home to his family.
+  tutorial_livecode_longdescription: When you use our LiveCode tutorial for the Hour
+    of Code, your students get to create their own soundboards. After creating soundboards
+    with animal and piano sounds, students will be free to make their own customized
+    soundboards with their own image and music selections!
+  tutorial_cocomgame_longdescription: First, level up your Python or JavaScript programming
+    skills by coding your way out of danger and grabbing sweet loot. Then use your
+    programming powers to build your own game and see if your friends can beat it!
+  tutorial_tynkerspin_longdescription: In this project, you'll create an awesome customizable
+    drawing tool. Program your pen, choose an image (or upload your own), and you'll
+    be able to draw a rotating version of that image.
+  tutorial_code-avengers_longdescription: Build a 2 player 2D top-down game with JavaScript
+    in 10 short tasks. Then continue learning some basics of programming (variables
+    and if statements) as you create a Quiz to share with friends. Along the way  earn
+    points and badges as you compete to reach the top of the class leaderboard.
+  tutorial_tynkercq_longdescription: Design your own candy troll character and go
+    on a multi-level quest for candy to help your character find its way home. You'll
+    solve coding puzzles to navigate your character through the human world, while
+    avoiding obstacles and collecting gumdrops and mints.
+  tutorial_cmgame_longdescription: Take your coding skills to the next level by learning
+    to build your own games. In this course, you will learn keyboard user-interface
+    and game mechanics as you build a Super Mario™-styled game. Afterwards, you will
+    be able to share your game!
+  tutorial_codesters_longdescription: 'Create your own games, animations, and artwork
+    using Python.  Once you''re done, share them with friends! Program in Python,
+    a real programming language used every day at companies - our drag and drop toolkit
+    makes it easy to learn!  Try building a basketball game, choreographing a dance,
+    or designing an animated card! '
+  tutorial_qrm_longdescription: Join Mary in learning the Quorum programming language
+    as part of a light hearted and entertaining journey in biology. The activities
+    are student-guided, with online examples, and are accessible to the blind and
+    visually impaired.
+  tutorial_texas-instruments_longdescription: 'The 10 Minutes of Code activities can
+    be used in class as a way to spark students'' interest in coding with the TI technology
+    they carry in their backpacks everyday.  Learn the basics of coding using the
+    TI-84™ Plus and get started programming in just 10 minutes – no experience needed!  '
+  tutorial_cajava_longdescription: Drawing with JavaScript is easier than you might
+    think. Learn more about the flags of the world as you draw flags for each level
+    that increase in complexity. Learn about shapes, coordinates, and colors as well
+    as the importance of sequence in coding.
+  tutorial_codehs_longdescription: Giving commands to a computer, which is what programming
+    is all about, is just like giving commands to a dog. Learn how to code with Karel
+    the Dog—a fun, accessible, and visual introduction to text-based programming that
+    teaches fundamental concepts like commands and functions to absolute beginners.
+    Already have some experience? Try our JavaScript Graphics tutorial instead!
+  tutorial_hopemo_longdescription: "Build a drawing app that creates beautiful, interactive
+    art featuring your favorite emojis. \n\nExplore the creative side of coding, making
+    an app that friends can use to express themselves. In the process, learn about
+    sequence, events, loops, and variables. \n\nNo prior experience is needed to complete
+    or facilitate this activity; it includes an in-app video tutorial and a step-by-step
+    facilitation guide."
+  tutorial_tynkercm_longdescription: Explore the enchanted forest to capture monsters
+    and learn how to program them by completing coding puzzles. Collect, code, and
+    evolve all the unique monsters. Devise strategies based on your monsters' abilities
+    so they can battle in the multiplayer arena. Whose code will win?
+  tutorial_codesterswintergreet_longdescription: 'In this activity, students use our
+    drag to text toolkit to start programming in Python right away! Winter Greetings
+    teachers students about basic syntax, sprites and dot notation, as well as events.
+    Students learn by creating a winter greeting card that they can save and share! '
+  tutorial_codestersc_longdescription: 'In this lesson students explore all four quadrants
+    of the coordinate plane!  They use Python and our drag-to-text toolkit to send
+    a sprite to various locations on the stage! There are demonstration and debugging
+    activities included to help students become comfortable with navigating the coordinate
+    plane. '
+  tutorial_codestersturtle_longdescription: Learn the basics of coding in Python while
+    creating your own turtle-crossing game! Use lists and loops to set up your game,
+    and events to create cars and control the turtle! Can you safely cross the road?
+  tutorial_penjee_longdescription: 'A  visual way for students to begin their first
+    language. Students write Python code to move a Penguin around an ice world. Our
+    editor highlights each line of code as it executes, helping kids connect their
+    to code to changes in the Penguin''s world.  Our curriculum is differentiated,
+    based on student readiness, and molds itself to each student''s needs. '
+  tutorial_trinket_longdescription: |-
+    Choose from lessons, challenges, and tutorials about the Python programming language.  Make turtle-based animations and solve puzzles, all while learning the basics of this powerful language.
+
+    Activities range from block-based programming to real Python code, with activities appropriate for most age levels.  Select lessons available in Spanish, Korean and Chinese!
+  tutorial_frogger_longdescription: Become a Computational Thinker. Create 3D Objects
+    by drawing 2D images that you turn into amazing 3D shapes. Create 3D Worlds by
+    assembling the shapes you just built into exciting worlds. Rule your World! Bring
+    your world to life by programming using simple drag and drop rules. Play on computers,
+    tablets and smartphones. Share your 3D game with your friends through email and
+    Facebook.
+  tutorial_tynkereco_longdescription: Create an interactive ecological pyramid to
+    track how energy flows through an ecosystem! This project comes with step-by-step
+    instructions that guide you through creating an ecological pyramid for any ecosystem
+    with animals and plants that glide to the proper location in the pyramid when
+    clicked.
+  tutorial_mitedarc_longdescription: Have your sprite collect coins and get points.
+  tutorial_khan_longdescription: Learn how to program drawings using JavaScript by
+    designing your very own snowman. Try it on your own or with your class!
+  tutorial_tynkerd_longdescription: Design a custom hero and play as that character
+    through this multi-level adventure game. You'll need to use your coding skills
+    to solve puzzles, fight bugs, and save the motherboard!
+  tutorial_cdmy_longdescription: Codecademy is an interactive platform for learning
+    STEM skills that are critical for today's jobs. Join millions of Codecademy students
+    and learn the basics of coding and computer science by taking our fun Hour of
+    Code courses. By the end of each course, you'll have a real project that you can
+    show off to your friends and family.
+  tutorial_codestersdance_longdescription: 'Students use a drag-to-text toolkit that
+    allows them to start coding in Python right away! Students complete a set of guided
+    practice activities in which they learn how to use and modify a variety of programming
+    commands. Then, they apply these skills to create their own dance routine! '
+  tutorial_codestersbasketball_longdescription: 'Students use our drag-to-text toolkit
+    to start coding in Python right away! In this self-guided activity, students complete
+    a series of direct-instruction activities in which they build a pull and shoot
+    basketball game! Students explore variables, events, basic syntax, creating random
+    coordinates. '
+  tutorial_nclkarel_longdescription: Learn to code and solve problems by guiding Karel
+    the Robot through jungles, mountains, and deserts. Karel follows your instructions,
+    just like a real robot. Start programming with simple commands such as go, get,
+    and put. Next you will learn how to build repeat loops and conditions into your
+    programs. Finally define custom commands for Karel. You can create your own games
+    with NCLab's app! Have fun while learning skills that you can use in any programming
+    language.
+  tutorial_buildpong_longdescription: Pong is one of the earliest arcade video games
+    and the very first sports arcade video game. It is a table tennis sports game
+    featuring simple two-dimensional graphics. The aim of the game is for the PLAYER
+    to score on the COMPUTER while defending its GOAL. In this project, the COMPUTER
+    is programmed with basic artificial intelligence so it can respond to the PLAYER.
+  tutorial_tynkerdrones_longdescription: Learn to program connected devices by solving
+    the "Crash Course" puzzles, where you navigate virtual drones and robots through
+    obstacles. Then you're ready to create programs to control real drones and robots.
+    Requires an iPad or Android tablet and a supported toy.
+  tutorial_carla_longdescription: '"Programming with Carla" is a series of short activities
+    that guide students through building a simple chatbot, whilst learning about core
+    concepts like variables and conditionals. The activities have been carefully designed
+    to address common misconceptions that new programmers have about these topics
+    by offering many opportunities for practice, as well as targeted hints and feedback.
+
+'
+  tutorial_zulama_longdescription: In this activity you will learn to edit JavaScript
+    code through a playful action game and master computer science concepts like variables
+    and functions. Create your own game in the Sandbox by remixing and expanding on
+    existing game code. Then publish and share your game with friends and family.
+  tutorial_capost_longdescription: Starting to learn HTML and CSS is easy and fun
+    with this digital postcard. Learn about adding headings, paragraphs, images and
+    links to create a holiday card or birthday celebration to share with friends and
+    family.
+  tutorial_marco_longdescription: Students play an adventure game based on an original
+    story. They guide Marco - the main character - through each level by giving him
+    step-by-step instructions in the form of the visual programming language used
+    by the Hour of Code. They get introduced to sequencing commands, iteration and
+    conditions without even noticing it.
+  tutorial_codestersflappybike_longdescription: 'In this activity, students use our
+    drag-to-text toolkit to start coding in Python right away! Students are guided
+    through a series of learning activities that teach them to build a complete game!
+    After they finish, they are challenged to use what they learned about syntax,
+    dot notation, events, variables, parameters and game mechanics to create a new
+    game. '
+  tutorial_kanopong_longdescription: Learn to code by building this classic arcade
+    game in an hour!
+  tutorial_tynkerright_longdescription: 'Create your own Bill of Rights project: change
+    the background, add more questions, keep score, add animations.'
+  tutorial_touchdevelop_longdescription: 'The touch-friendly editor will guide you
+    in creating pixel art, solving the bear puzzle, or making your own jumping bird
+    game. '
+  tutorial_tynkercc_longdescription: Prepare your army for battle! Code the attack
+    logic of each member of your army to exploit your enemy's weaknesses and emerge
+    from battles victorious. As you learn, you unlock new characters that you can
+    program. Build up your army, then battle with friends. Whose code is best?
+  tutorial_bamboo_longdescription: 'Bamboo JS is an activity design by Codemoji to
+    teach students basic Javascript concepts.  Bamboo the panda and his awesome toast
+    friends will walk students though basic commands and structure.  The Bamboo JS
+    activity is design for students who want a little more animation and more art
+    and design in their coding. The Bamboo activity is great for students of all ages. '
+  tutorial_robojav_longdescription: Learn the basics of Java programming in an hour,
+    while building a small world on your screen for simulated robots and customized
+    creatures. No prior programming experience is required. Topics covered include
+    objects, methods, parameters, and simple graphics.
+  tutorial_roboba_longdescription: "RoboBlockly is designed for beginners to learn
+    math with robots in Blockly. The Algebra 1 activities are self-guided. \nRoboBlockly
+    prepares students to be ready to program in C/C++.\n"
+  tutorial_knodsnake_longdescription: 'Learn to create a Snake game in JavaScript! '
+  tutorial_soccharater_longdescription: Code your very own pixel character! Use HTML
+    to build your character, CSS to style it, and JavaScript to animate your cute
+    pixel person. Code by yourself, or invite a friend and code together with our
+    team coding game.
+  tutorial_silent_longdescription: |-
+    Discover the basic concepts of programming without any word or explanation.
+    Our silent teacher will ask you several series of questions that will lead you to guess some rules and learn from your own mistakes.
+    Because there is no text in the game, it is accessible to any player whatever his language.
+  tutorial_robomesh_longdescription: Students write Google Blockly code to control
+    popular VEX IQ robots. They can choose to write code for either a virtual robot,
+    or a real VEX IQ robot that they built themselves, and both options are available
+    in the same web-based development interface. Students learn about basic robot
+    movement, and how to use a sensor and an output device. It is easy and fun.
+  tutorial_amaze_longdescription: In this project, a CHARACTER starts at HOME BASE
+    and follows a PATH while avoiding OBSTACLES to get a PRIZE. To win, the character
+    brings the prize back to home base. The character isn't allowed to touch the OBSTACLES.
+    If it does, it's "zapped" and starts over from HOME BASE.  For extra credit, the
+    player has a limited amount of time to complete the game.
+  tutorial_codestersds_longdescription: 'In this Common Core ELA aligned lesson, student
+    use programming to tell a story that prompts users for appropriate transition
+    words. Students will learn about basic syntax, strings, variables, and user input.
+    They will use the platform and a sprite to tell a story and lead the user through
+    a variety of scene changes. '
+  tutorial_knodtext_longdescription: Learn to make a text adventure game in Python!
+  tutorial_alicegar_longdescription: 'Follow the animation production process from
+    storyboarding to programming with Alice and Garfield.  Let creativity and storytelling
+    drive your learning in a drag and drop coding environment.  The project will guide
+    you through what is a storyboard, translating a storyboard into a programmable
+    script, and how to program a short 3D animation. '
+  tutorial_codesterstransform_longdescription: 'In this activity, students use Python
+    to practice performing transformations on the coordinate plane! The lesson includes
+    demonstrations, direct instruction, and challenges that ask students to program
+    and identify various static transformations! '
+  tutorial_flexfrog_longdescription: Learn some web development with this educational
+    game where you help Froggy and friends make it to their lily pads. By the end
+    of the game, you'll learn how to use write code using new CSS properties called
+    flexbox. No prior coding experience required!
+  tutorial_codemoji_longdescription: The Codemoji activity is a web based activity
+    for students 1st-6th grade to learn basic coding concepts using Emoji's.  After
+    students do the activity they have learned about basic HTML tags and concepts.
+    This helps them do the coding project where the student builds a basic website
+    in just a few steps.  After the students do the Codemoji activity the students
+    walk away with real coding skills.
+  tutorial_robobii_longdescription: "RoboBlockly is designed for beginners to learn
+    coding with robots in Blockly. The coding activities are self-guided with tutorial
+    videos. \nRoboBlockly prepares students to be ready to program in C/C++.\n"
+  tutorial_robobm_longdescription: "RoboBlockly is designed for beginners to learn
+    math with robots in Blockly. The math activities are self-guided. \nRoboBlockly
+    prepares students to be ready to program in C/C++.\n"
+  tutorial_codingrobots_longdescription: "RoboBlockly is designed for beginners to
+    learn coding and math with robots. The activities are student-guided with tutorial
+    videos. \nRoboBlockly prepares students to be ready to program in C/C++.\n"
+  tutorial_robob_longdescription: "RoboBlockly is designed for beginners to learn
+    robotics with coding in Blockly. The robotics activities are self-guided with
+    tutorial videos. \nRoboBlockly prepares students to be ready to program in C/C++.\n"
+  tutorial_coders_longdescription: "This step-by-step puzzle game provides an easy
+    introduction to bot programming. \n\nThe aim is to win a starship race against
+    other players.\n\nThe game is simple to start and only requires a few lines of
+    code to have a ship move around, but there are near-infinite possibilities of
+    improvement to create more sophisticated bots. "
+  tutorial_tynkerhw_longdescription: Learn to program with Hot Wheels in this high-octane
+    racing game! Choose from a wide selection of cars, then learn to program as you
+    navigate through complex race tracks. Jump over obstacles, skid around corners,
+    and win the race. You can even program your own race tracks and challenge your
+    friends to race on them.
+  tutorial_tynkermh_longdescription: Monster High is hosting a scavenger hunt! Solve
+    coding puzzles with drag-and-drop blocks to help Frankie, Draculaura, Clawdeen,
+    Cleo, and Ghoulia. Avoid obstacles and find all the school crests as you quest
+    through the halls of Monster High. Then program your own dance party music video
+    with the ghouls and share it with friends.
+  tutorial_caphoto_longdescription: This challenging and exciting project will teach
+    you how to create a Photo Booth app.  Using JavaScript, CSS and HTML you will
+    connect buttons that let you use a camera, upload images and customize your photos
+    by inserting stickers and applying filters.
+  tutorial_mozillahw_longdescription: Learners will remix JavaScript code to change
+    the words on a website, learning about composing for the web, coding JavaScript
+    values, and remixing Web content.
+  tutorial_ticklep_longdescription: With Tickle, a user-friendly coding app, you can
+    easily program Parrot Drone to swim in a number of ways by simply dragging and
+    dropping coding blocks to create a command for it to follow.
+  tutorial_bbot_longdescription: "With these 3 one-hour coding activities, you don't
+    need any programming knowledge or experience to teach your students about programming!
+    You can teach programming in a fun and easy way. Go over the activities and download
+    our lesson materials including presentation slides, unplugged materials, and solutions
+    guides and you will find yourself ready to teach your first lesson in 20 - 40
+    minutes! \n\nOur activities include both offline and online exercises to teach
+    your students (ages 7 and up) about programming and fundamental programming concepts
+    like for loops and algorithms. Students will apply their knowledge and skills
+    in the Bomberbot online game, where they will program their robot to solve logic-based
+    puzzles in the most efficient way. "
+  tutorial_scratchg_longdescription: Kids love playing games on their phones and on
+    computers. But how are they programmed? This activity introduces students to the
+    Scratch programming language and then shows them how to program different styles
+    of games. All the necessary art for the games are provided, and students have
+    to work out how to connect everything together to make a functioning game.
+  tutorial_sjforest_longdescription: '"Can I Make a Spooky Forest?" is an intermediate
+    activity meant for children in kindergarten through second grade who have some
+    prior experience with programming to learn about and master more advanced features
+    of ScratchJr. Later, children can use the skills they have learned in doing this
+    activity to create their own unique projects, or build upon what they created
+    in the "Can I Make a Spooky Forest?" program. Through this activity and continued
+    time with ScratchJr, students will have the opportunity to think creatively, become
+    storytellers, and improve upon mathematical reasoning and sequencing skills.'
+  tutorial_sjgreet_longdescription: '"Can I Make My Characters Greet Each Other?"
+    is an advanced activity meant for children in kindergarten through second grade
+    who have prior experience with programming to master more advanced features of
+    ScratchJr. Later, children can use the skills they have learned in doing this
+    activity to create their own unique projects, or build upon what they have created
+    in "Can I Make My Characters Greet Each Other?" program. Through this activity
+    and continued time in ScratchJr, students will have the opportunity to think creatively,
+    become storytellers, and improve upon mathematical reasoning and sequencing skills.'
+  tutorial_sjsunset_longdescription: '"Can I Make the Sun Set?" is an introductory
+    activity meant for children in kindergarten through second grade with little to
+    no programming experience to learn the basic features of ScratchJr and the elementary
+    concepts of coding. Through this activity and continued time with ScratchJr, students
+    will have the opportunity to think creatively, become storytellers, and improve
+    upon mathematical reasoning and sequencing skills. Later, children can use the
+    skills they have learned to create their own unique projects.'
+  tutorial_fufafrenz_longdescription: Beginner lessons on Sequence (K-5). This is
+    an introduction to the most basic programming concept, sequence. This is the third
+    grade example, we have lesson plans on this concept scaffolded for K-5.
+  tutorial_bbcgeo_longdescription: Standards-based lesson plan for grades K-5. Take
+    your kids to the computer lab with worksheets in hand, and build apps involving
+    geometry.
+  tutorial_chspixel_longdescription: After learning about how graphics work, students
+    will create their own Color by Pixel programs. The lesson plan consists of four
+    parts, each covering a specific topic. The entire five-part Color by Pixel lesson
+    is designed to run approximately one hour.
+  tutorial_hummingbird_longdescription: In this activity, you will create your very
+    own game! You will use a Hummingbird board and a sensor to detect when the player
+    throws a ball into a box. You will write a program to keep score and turn on lights
+    when the player makes a basket. Then you can customize your game to make it unique!
+    For this activity, you can use a laptop or a Chromebook; you don't need any prior
+    programming experience.
+  tutorial_recoloring_longdescription: 'Students with no prior coding experience can
+    learn how to use computers to create images and understand astronomical data.
+    Participants learn basic coding starting with familiar concepts such as shape
+    and color and graduating to astronomical objects. Following a scaffolded set of
+    activities, and working with data from NASA orbiting telescopes on sources from
+    exploded stars to black holes, students can experience real world application
+    of science, technology & art.        '
+  tutorial_bbcchem_longdescription: Standards-based lesson plan for grades K-5. Take
+    your kids to the computer lab with worksheets in hand, and build apps involving
+    chemistry.
+  tutorial_floalgo_longdescription: In this lesson, students will explore algorithms,
+    a key concept that allows computer programmers to solve problems. They will write
+    efficient, precise algorithms in English and pseudocode to complete tasks and
+    solve problems. They'll also evaluate competing algorithms based on efficiency
+    and other factors.
+  tutorial_flocond_longdescription: This is a lesson plan in which students explore
+    conditional statements, a concept used across coding languages. Students will
+    watch an educational hip-hop video about conditionals and answer discussion questions.
+    They'll then practice determining whether conditions are true and carrying out
+    actions accordingly. Finally, they'll write their own conditional statements and
+    evaluate statements to predict the outcome of programs.
+  tutorial_floloops_longdescription: This is a lesson plan in which students explore
+    loops, a concept used across programming languages that allows programmers to
+    easily repeat code. Students will watch an educational hip-hop video about loops
+    and answer discussion questions about their use in programming. They will then
+    practice key vocabulary and complete an activity sequence in which they write
+    loops and interpret given loops to generate their outputs.
+  tutorial_pgts_longdescription: This "unplugged" activity helps students learn how
+    modeling and simulation works by having a group of students play different versions
+    of the Rock / Paper / Scissors game, and see the results as different modeling
+    experiments.
+  tutorial_ozo_longdescription: "This teacher-led tutorial introduces students to
+    the concept of coding with the help of Ozobot, a small programmable robot. Students
+    will be learning how to code by playing Ozobot games, called Shape Tracer Games.
+    They can still play the simulated version of the games even if they don't have
+    an Ozobot Bit or Evo robot.The Ozobot games will teach students how to code with
+    OzoBlockly, a visual programming language based on Blockly. \n\nThe games are
+    followed by a project idea that can be done beyond the Hour of Code.The project
+    challenges students to take everything they learned and design and program an
+    action scene for Ozobot.\n\nNo programming experience or knowledge of Ozobot is
+    required for this tutorial. However, even students with some programming experience
+    will be engaged by the Ozobot games. The tutorial is designed for grades 1-12
+    and can be customized for your students' abilities."
+  tutorial_bbcla_longdescription: Standards-based lesson plan for grades K-5. Take
+    your kids to the computer lab with worksheets in hand, and build apps involving
+    language arts.
+  tutorial_bbcsci_longdescription: Standards-based lesson plan for grades K-5. Take
+    your kids to the computer lab with worksheets in hand, and build apps involving
+    general science.
+  tutorial_tlctour_longdescription: This activity is an example of creating an algorithm
+    that is a simple sequence of instructions to do in order. It shows that if we
+    have written down a solution to the problem in the form of an algorithm then we
+    are able to do tours in future just by following the steps, without having to
+    work it out from scratch again. Also if we write down the algorithm we can check
+    that it definitely works by following it step by step on paper. This activity
+    leads on to the Knight's Tour activity.
+  tutorial_codesterstj_longdescription: 'IN this multi-lesson project students learn
+    about digital citizenship and follow a design thinking model to solve a problem
+    that they choose! Students will create a game intended to teach users a lesson
+    about responsible digital citizenship. All resources are located in-platform. '
+  tutorial_tlclocked_longdescription: This activity aims to introduce computational
+    thinking based problem solving, leading to an understanding of what an algorithm
+    is, what linear search is and how algorithms can be compared on the basis of efficiency.
+    It also illustrates how computational thinking is about more than just creating
+    computer-based solutions. Computing is about solving problems for people.
+  tutorial_baubles_longdescription: Students learn about representing and storing
+    letters in binary, as functions of on and off. At the end, the class gets to encode
+    their own initials to take home with them.
+  tutorial_bbcart_longdescription: Standards-based lesson plan for grades K-5. Take
+    your kids to the computer lab with worksheets in hand, and build apps involving
+    visual arts.
+  tutorial_tlcknight_longdescription: This activity involves trying to solve a puzzle
+    using two different representations. To start with it is fairly hard, but when
+    the representation of the board and moves is changed it becomes really easy. Create
+    graphs to represent the problem. See the power of using abstraction and how the
+    choice of representation can make a problem much easier. This activity follows
+    from the Tour Guide activity.
+  tutorial_fufafit_longdescription: Students will learn advanced programming concepts
+    (functions) through a lesson and kinesthetic activity. Students will apply knowledge
+    of functions on-screen to run a program.  This lesson is for students and teachers
+    who have some experience with sequence, conditions, loops, or other foundational
+    programming concepts.
+  tutorial_ozodance_longdescription: |-
+    This teacher-led tutorial introduces students to the concept of coding with the help of Ozobot, a small programmable robot. Students will be learning how to code by creating and programming a dance routine for Ozobot! They will use OzoBlockly, a visual programming language based on Blockly, to program the dance and then have fun see their choreography come alive when Ozobot performs their dance.
+
+    No programming experience or knowledge of Ozobot is required for this tutorial. However, even students with some programming experience will be engaged by the Ozobot games. The tutorial is designed for grades 1-12 and can be customized to your students' abilities.
+  tutorial_codingrobotics_longdescription: Students will learn about foundational
+    programming concepts and apply new knowledge to robotics. Working with both Kodable
+    and Wonder Workshop, students will use programming knowledge to command "Dash"
+    the robot in the Path app.
+  tutorial_box_longdescription: Take a trip on Box Island and help Hiro collect all
+    the clocks scattered in the wilderness! In this tutorial you will learn the basics
+    of algorithms, sequences, loops and conditionals!
+  tutorial_hopgame_longdescription: "Keep the fun going! Use this project-based guide
+    to facilitate a game design workshop, hackathon, or in-class series. Make Cross
+    the Road, Geometry Jumper, Quiz Creator, Falling Bird, Subway Skaters, and Escape
+    the Room. Each includes discussion questions, differentiation, and a video tutorial.
+    \n\nStudents can build off your instructions to customize their games. No prior
+    experience required."
+  tutorial_icontrol_longdescription: |-
+    This teacher facilitated lesson, adapted for the Hour of Code, provides pupils with an opportunity to explore physical programming through robotics - Sphero.
+
+    Using a drag-and-drop programming environment and a programmable robotic sphere, pupils will learn that physical systems can be programmed and controlled.
+  tutorial_cocomteach_longdescription: Introduce your students to Python or JavaScript
+    in CodeCombat's free, one-hour Introduction to Computer Science course. We've
+    got a dedicated lesson plan for you to help explain concepts to your students,
+    including basic syntax, strings, arguments, loops, variables, and x- and y-coordinates,
+    using gem-packed dungeon mazes and hero-vs-ogre battles.
+  tutorial_bbcmathii_longdescription: Standards-based lesson plan for grades K-2.
+    Take your kids to the computer lab with worksheets in hand, and build apps involving
+    arithmetic, visualization of numbers, and geometric shapes.
+  tutorial_bbcphys_longdescription: Standards-based lesson plan for grades K-5. Take
+    your kids to the computer lab with worksheets in hand, and build apps involving
+    physics.
+  tutorial_bitsbox_longdescription: 'Follow the prompts to code five fun mini-apps
+    using real, typed Javascript. From blowing up pie in ''Food Fight'' to flushing
+    a notebook down a black hole in ''So Long, Homework!'', each app is designed to
+    delight kids while illustrating variables, methods, and more. These apps are also
+    completely open-ended; kids can use them as a starting point for their own app
+    creations. Beginners welcome!
+
+'
+  tutorial_tlcemo_longdescription: Students create and program a 2D robot made of
+    card to show different emotions. They create a table that can be used to translate
+    emotions (high level commands) into low level machine instructions.
+  tutorial_crd_longdescription: Learn about algorithms and conditional statements
+    in this "unplugged" activity using a deck of cards. Students do this activity
+    in teams, and need one deck of cards per team.
+  tutorial_bbcbio_longdescription: Standards-based lesson plan for grades K-5. Take
+    your kids to the computer lab with worksheets in hand, and learn about growth,
+    species diversity, and pollination.
+  tutorial_ticklebb8_longdescription: With Tickle, a user-friendly coding app, you
+    can easily program BB-8 to move in a number of ways by simply dragging and dropping
+    coding blocks to create a command for it to follow.
+  tutorial_grok_longdescription: 'Use drag-and-drop blocks or the text-based language
+    Python to draw flags from around the world, create fantastic snowflakes, or build
+    a chatbot called "Eliza". '
+  tutorial_ijournalist_longdescription: "This teacher facilitated lesson teaches Computer
+    Science and Language Arts.  Pupils begin to develop a journalistic style that
+    considers the interest of the reader and presentation of information for an online
+    news story.  Pupils use basic HTML and CSS to create and present an online news
+    story about a fictional school robbery.\n\nIt sets computer science within a meaningful
+    context enabling children to understand the value of computer science in other
+    subject areas. \n\n"
+  tutorial_bbcmusic_longdescription: Standards-based lesson plan for grades K-5. Take
+    your kids to the computer lab with worksheets in hand, and build apps involving
+    music.
+  tutorial_secretcodes_longdescription: Learn about the role computers have played
+    to help save the world.
+  tutorial_tlchex_longdescription: You make a red and yellow hexahexa exagon by folding
+    and gluing a multicoloured paper strip in a special way. Once made you start to
+    explore it. As you fold and unfold it, you magically reveal new sides as the exagon
+    changes colour.
+  tutorial_tickles_longdescription: Team up with your Sphero for a good run! Move,
+    spin and give it a few rounds of good turns. Just put some code blocks together
+    on Tickle app to run your Sphero as you want it to.
+  tutorial_ozogame_longdescription: "This teacher-led tutorial introduces students
+    to the concept of coding with the help of Ozobot, a small programmable robot.
+    Students will be learning how to code by playing Ozobot games, called Shape Tracer
+    Games. They can still play the simulated version of the games even if they don't
+    have an Ozobot Bit or Evo robot.The Ozobot games will teach students how to code
+    with OzoBlockly, a visual programming language based on Blockly. \n\nOnce students
+    have solved all ten levels of the Shape Tracer Games, they are challenged to take
+    everything they learned and design and program their own game level 11.\n\nNo
+    programming experience or knowledge of Ozobot is required for this tutorial. However,
+    even students with some programming experience will be engaged by the Ozobot games.
+    The tutorial is designed for grades 2-12 and can be customized to your students'
+    abilities."
+  tutorial_vidcodeio_longdescription: In this exercise, you'll walk through with your
+    students how this relates to what they already know about math by solving a math
+    equation with programming.
+  tutorial_tlcbrain_longdescription: This activity explores how computational modelling
+    (a key part of computational thinking) can be used to help understand biological
+    systems – here neurones. We see how the way our brains work has also been the
+    inspiration for a new way to program computers and so give them intelligent abilities.
+  tutorial_hopquiz_longdescription: 'This lesson plan is a template that you can adapt
+    and use in any subject—Science, Language Arts, World Languages, or History. It
+    includes step-by-step instructions and explanations that you can use to help your
+    students code multiple choice quizzes. During the process, they will practice
+    and explore core coding concepts like sequence, loops, variables, and conditionals. '
+  tutorial_unfortunate_longdescription: We all react to events that happen around
+    us, be it cheering when the school team wins, crying at a sad movie, or dancing
+    when we hear music. In this lesson, students will learn how to teach Dash and
+    Dot to respond to events that happen around them!
+  tutorial_cha_longdescription: The history of computers is fascinating. This is your
+    chance to learn more.
+  tutorial_elaseq_longdescription: Students will examine the concept of sequence in
+    the context of reading and writing. Through grade level aligned ELA lessons, students
+    will apply their knowledge of sequence to further their understanding of the role
+    sequence plays in programming.
+  tutorial_bbcmathi_longdescription: Standards-based lesson plan for grades 3-5. Take
+    your kids to the computer lab with worksheets in hand, and build apps involving
+    fractions, variables, and formulas.
+  tutorial_tlcpixel_longdescription: Pixel puzzles turn the ways images are represented
+    as a series of numbers representing pixels into puzzles. They come in various
+    forms from a simple variant of colour-by-numbers to more complex puzzles based
+    on compression where images are represented by fewer numbers so take up less storage
+    – but can you get them back! Each representation needs its own algorithm to follow
+    to get the image back.
+  tutorial_introrobo_longdescription: 'In this lesson, students will get to know Dash
+    and Dot while being introduced to the ideas of Robotics and Programming. Students
+    will gain an understanding of what a robot is, how they sense the world around
+    them, and how programs can control robots. '
+  tutorial_tlcinvis_longdescription: This introduces what an algorithm is and what
+    a computer program is. It can also be used to explore human computer interaction
+    and the importance of feedback and building a correct mental model.
+  tutorial_tlcjflap_longdescription: A finite state machine is a very useful tools
+    in the computational thinking toolbox. They are an important way for describing
+    what computer systems do and of simulating things in the real world. JFLAP is
+    an easy to use and free tool for creating finite state machines. This activity
+    involves creating a simple finite state machine and simulating it, then going
+    on to create more complex finite state machines that represent puzzles, gadgets,
+    web pages and games.
+  tutorial_procolor_longdescription: |-
+    This teacher-led tutorial introduces your students to programming and computational thinking and it also explains what kind of robot Ozobot is. This activity is "unplugged", which means that the coding is not done on a computer or tablet, but on a piece of paper with markers. Students will be giving commands to Ozobot using OzoCodes, which are special color sequences. After learning about how to program Ozobot with markers and paper, students are challenged to solve a maze and help Ozobot find the way to school.
+
+    No programming experience or knowledge of Ozobot is required for this tutorial. However, even students with some programming experience will be engaged by programming Ozobot. The tutorial is designed for grades K-12 and can be customized to your students' abilities.
+  tutorial_spiralsfinch_longdescription: 'The Finch is a small robot designed to inspire
+    and delight students learning computer science by providing them a tangible and
+    physical representation of their code. In this activity, you will learn to write
+    programs that make the Finch move and turn. Then you will use a variable to program
+    the robot to move in a spiral pattern. For this activity, you can program the
+    Finch with either Scratch or Snap! using either laptops or Chromebooks. You do
+    not need any prior programming experience. '
+  tutorial_ozoi_longdescription: |-
+    This tutorial introduces students to programming and computational thinking and it also explains what kind of robot Ozobot is. This activity is "unplugged", which means that the coding is not done on a computer or tablet, but on a piece of paper with markers. Students will be learning about how the robot works and then give commands to Ozobot using OzoCodes, which are special color sequences. After learning about how to program Ozobot with markers and paper, students are challenged to solve a maze and help Ozobot find the way to the store.
+
+    No programming experience or knowledge of Ozobot is required for this tutorial. However, even students with some programming experience will be engaged by programming Ozobot. The tutorial is designed for grades K-12 and can be customized to your students' abilities.
+  tutorial_ticklel_longdescription: Brick by brick, build up your wildest LEGO imagination.
+    By putting some codes together on Tickle app, you can make your LEGO WeDo do some
+    amazing things.
+  tutorial_spiralsdash_longdescription: Learn the basics of using variables in a program
+    while using a robot to create art! Use variables in Blockly to dynamically control
+    the wheel speeds of a Dash robot. After completing the lesson, you will understand
+    how to assign a variable, access a variable, and dynamically change a variable
+    using a loop. By changing the value of a variable over time, you can make Dash
+    draw a spectacular spiral!
+  tutorial_ghdebug_longdescription: Help students learn about Grace Hopper and why
+    this week is CS EdWeek.
+  tutorial_tlckk_longdescription: Kriss-kross puzzles combine a love of words with
+    a love of logic. Given a list of words of different lengths, you must fit them
+    all in to the grid.
+  tutorial_firstcomp_longdescription: Few things are as exciting as computers. And
+    now you'll get to design your very own one - this time out of paper. Get to know
+    the CPU, RAM and ROM, Mass Storage and GPU. Draw your first application. Get your
+    scissors, pens and papers out!
+  tutorial_mazefinch_longdescription: 'In this activity, you will use a very simple
+    programming language to make the Finch robot move and turn. Then you will write
+    programs to help the robot complete a maze! You do not need any prior programming
+    experience, and you can use a laptop or a Chromebook. '
+  tutorial_tlccc_longdescription: Data on computers is stored as long sequences of
+    characters – ultimately as binary 1s and 0s. The idea with compression is that
+    we use an algorithm to change the way the information is represented so that fewer
+    characters are needed to store exactly the same information.
+  tutorial_tlcdoodle_longdescription: 'Scenery in films is often computer generated.
+    Ever wondered how they do it? Next time you find yourself drawing doodles, draw
+    an algorithmic doodle and explore algorithms for drawing nature. The algorithms
+    are recursive: that is they describe one step and then tell you just to draw the
+    next step in the same way, following the algorithm from the start.'
+  tutorial_tlcpunch_longdescription: Demonstrate how early computers were able to
+    find data stored on punch cards and show that it is the same algorithm as the
+    magic trick in the 'Australian Magician's Dream' Activity. It aims to show in
+    a visual way how a search algorithm works. In doing so you demonstrate a practical
+    use of binary numbers, a divide and conquer algorithm for searching and explore
+    the computational thinking trick of translating solutions between problem areas.
+  tutorial_finchfract_longdescription: This activity uses recursion to draw Koch fractals
+    with the Finch robot. It assumes that students have been introduced to the idea
+    of recursion, but completing this activity will help them to develop a deeper
+    understanding of this concept via a physical representation of recursion. This
+    activity is appropriate for students taking introductory or advanced computer
+    science courses that use Python or Java.
+  tutorial_tlcmind_longdescription: This introduces the use of logical reasoning through
+    the use of algebra to prove that an algorithm always works. It shows how abstraction
+    and logical reasoning can be used to evaluate algorithms.
+  tutorial_tlctelebot_longdescription: This trick illustrates how apparently simple
+    things can be too complex for our brains to take in. An important design principle
+    is that interfaces should be clear and simple, not cluttered. It also illustrates
+    aspects of computational thinking such as simplifying the problem and the importance
+    of understanding people.
+  tutorial_tlcaus_longdescription: This activity introduces a range of computing concepts
+    in a memorable way. It introduces a magic trick and show how abstraction, logical
+    reasoning and computational modelling can be used to check the algorithm works.
+    Combined with the 'Punch card searching' activity it introduces a divide and conquer
+    algorithm used by early computers.
+  tutorial_tlcmicro_longdescription: This video can be used as a general introduction
+    to human computer interaction (HCI) and in particular why so many gadgets areharder
+    to use than need be. Design does make a difference and it is important that interfaces
+    are evaluated to check they are easy to use.
+  tutorial_imathematician_longdescription: "This teacher led activity provides the
+    opportunity for pupils to use a cross curricular approach to computer science
+    and mathematics.  \n\nPupils will create a computer program to solve a variation
+    of a famous problem in a branch of Mathematics (Game Theory), called The Prisoner's
+    Dilemma.\n"
+  tutorial_tlcmagic_longdescription: 'In exploring how the magic works, you learn
+    about computational thinking: especially the importance of evaluation to algorithmic
+    thinking. You explore both testing and hazard analysis. The magic trick shows
+    how computer scientists, engineers (and magicians) have to check their algorithms
+    thoroughly. They must think carefully about how things might go wrong as well
+    as checking they will go right.'
+  tutorial_scratchmus_longdescription: With Scratch, you can create your own interactive
+    games, stories, animations -- and share them with your friends. To get started,
+    make an interactive music project. Activity cards and a workshop guide are also
+    available for free on scratch.mit.edu
+  tutorial_scratchanim_longdescription: With Scratch, you can create your own interactive
+    games, stories, animations -- and share them with your friends. To get started,
+    animate the letters of your name, initials, or a favorite word. Activity cards
+    and a workshop guide are also available for free on scratch.mit.edu.
+  tutorial_scratchfly_longdescription: 'With Scratch, you can create your own interactive
+    games, stories, animations -- and share them with your friends. To get started,
+    learn how to make your own flying character. Activity cards and a workshop guide
+    are also available for free on scratch.mit.edu. '
+  tutorial_tynkerarc_longdescription: Make your own top-down arcade shooter game.
+    Start by programming the fish to move up and down when the arrow keys are pressed,
+    then code the sharks to swim across the screen. You'll personalize the game by
+    adding custom assets for the hero, the villain, and the background. Your game
+    could be set at the beach, in the forest, or even in outer space!
+  tutorial_grokffpython_longdescription: 'This activity is designed to give you your
+    first experience programming, and has been specially designed for the Hour of
+    Code. Use the programming language Python and instruct a turtle to draw fantastic
+    snowflakes with code! '
+  tutorial_grokffblock_longdescription: This activity is designed to give you your
+    first experience programming, and has been specially designed for the Hour of
+    Code. Build programs using friendly blocks and instruct a turtle to draw fantastic
+    snowflakes with code!
+  tutorial_grokeliza_longdescription: This activity is designed to give you your first
+    experience programming, and has been specially designed for the Hour of Code.
+    Use the programming language Python to build a friendly chatbot called "Eliza".
+  tutorial_tynkercan_longdescription: Make an awesome 2-player cannon game and challenge
+    your friends to play with you! You'll start with a partially programmed version
+    of the game, so you need to program the left cannon. Once you've got both cannons
+    firing, you'll set up platforms and other items to knock over. Make it your own
+    by adding extra features and customizing the theme!
+  tutorial_grokflags_longdescription: This activity is designed to give you your first
+    experience programming, and has been specially designed for the Hour of Code.
+    Use the programming language Python and its turtle module to draw flags from around
+    the world!
+  tutorial_robomind_longdescription: 'Students learn the basics of programming by
+    controlling their own virtual robot. The online course is fully self-contained
+    with short presentations, movies, quizzes and automatic guidance/hints to help
+    with the programming exercises. '
+  tutorial_adventureq_longdescription: 'Adventure with Q is a lesson plan for teachers
+    (or anyone) to use to introduce programming logic in a group setting. The activity
+    consists of different quests for kids to complete. Kids learn the basic commands
+    through helping Q the alien in his forest adventure. '
+  tutorial_khan-es_longdescription: Learn the basics of JavaScript programming while
+    creating fun drawings with your code. Do it on your own or with your class!
+  tutorial_kpt_longdescription: Learn the basics of JavaScript programming while creating
+    fun drawings with your code. Do it on your own or with your class!
+  tutorial_kpl_longdescription: Learn the basics of JavaScript programming while creating
+    fun drawings with your code. Do it on your own or with your class!
+  tutorial_khe_longdescription: Learn the basics of JavaScript programming while creating
+    fun drawings with your code. Do it on your own or with your class!
+  tutorial_kfr_longdescription: Learn the basics of JavaScript programming while creating
+    fun drawings with your code. Do it on your own or with your class!
+  tutorial_app-inventor_longdescription: Entertaining, quick video tutorials walk
+    you through building three simple apps for your Android phone or tablet. Designed
+    for novices and experts alike, this hour of code will get you ready to start building
+    your own apps before you know it. Imagine sharing your own app creations with
+    your friends! These activities are suitable for individuals and for teachers leading
+    classes.
+  tutorial_blockly_longdescription: Got computers with slow (or non-existent) Internet
+    access? Download the offline version of Blockly Games - a single 3MB ZIP file
+    can be loaded onto any computer or used off a memory stick.
+  tutorial_tynker_longdescription: Play fun coding games to learn to code. Use programming
+    to complete a spooktacular Monster High scavenger hunt, program a Hot Wheels car,
+    plan your war strategy against invading goblins, and even battle monsters. Learn
+    key programming concepts and computational thinking skills as you play. Then build
+    your own games and share them with friends!
+  tutorial_baypt_longdescription: Code Baymax
+  tutorial_code-combat_longdescription: Defeat ogres to learn Python or JavaScript
+    in this epic programming game!
+  tutorial_mky_longdescription: Learn and teach coding in CoffeeScript, a real-world
+    programming language. CodeMonkey is a fun, award-winning game, suitable for everybody,
+    with or without any coding experience. CodeMonkey's adaptive platform will give
+    you all the instructions and hints you need, and will reward you star scores.
+    Write code. Catch Bananas. Save the world.
+  tutorial_pirates_longdescription: 'Captain Hack is a pirate looking for treasure.
+    He also writes treasure maps, and writing those like writing code. He (the player)
+    uses "pirate code" for this. It is a symbol-based programming language, used for
+    instructions and even AI behaviors. movements, loops, GO-TO''s, true/false-statements
+    are all core parts of the game. The players are guided through a tutorial and
+    presented for the posibilities, step by step. There are no correct solution for
+    the tutorial levels, so the user can chose whatever solution they like. '
+  tutorial_csfirst_longdescription: Create a story about two characters at sea. Animate
+    the water, and customize the scenery to add your own flair. Use code to tell the
+    story you want to tell!
+  tutorial_loopedy_longdescription: The goal of a good programmer is to write a program
+    that is a short, clear, and effective as possible. In this lesson, students will
+    learn how write programs using loops.
+  tutorial_dsw_longdescription: Learn to program droids, and create your own Star
+    Wars game in a galaxy far, far away.
+  tutorial_dswb_longdescription: Learn to program droids, and create your own Star
+    Wars game in a galaxy far, far away.
+  tutorial_ssw_longdescription: Learn to program droids, and create your own Star
+    Wars game in a galaxy far, far away.
+  tutorial_sswb_longdescription: Learn to program droids, and create your own Star
+    Wars game in a galaxy far, far away.
+  tutorial_kodable-unplugged_longdescription: 'Designed for use with plain paper,
+    the fuzzFamily Frenzy is an introduction to programming logic for kids 5 and up.
+    A teacher should explain the game, then students program a partner to complete
+    a simple obstacle course. '
+  tutorial_scratch_longdescription: With Scratch, you can create your own interactive
+    games, stories, animations — and share them with your friends. To get started,
+    animate your name, create a dance scene, or make a hide-and-seek game featuring
+    Cartoon Network's We Bare Bears!
+  tutorial_bayes_longdescription: Grandes Heroes
+  tutorial_gumball_longdescription: Create a story or make a game with Play Lab! Make
+    Gumball characters move, make sounds, score points, and even throw bananas!
+  tutorial_hrm_longdescription: |-
+    Human Resource Machine is a puzzle game. In each level, your boss gives you a job. Automate it by programming your little office worker! If you succeed, you'll be promoted up to the next level for another year of work in the vast office building. Congratulations!
+
+    Don't worry if you've never programmed before - programming is just puzzle solving. If you strip away all the 1's and 0's and scary squiggly brackets, programming is actually simple, logical, beautiful, and something that anyone can understand and have fun with!
+  tutorial_ice-age_longdescription: Create a story or make a game with Play Lab! Make
+    Ice Age characters move, make sounds, score points, and even throw snow flakes!
+  tutorial_koapp_longdescription: Kodable is a self-guided iPad game that introduces
+    kids 5+ to programming basics. Having a teacher or parent nearby is optimal, but
+    not necessary.
+  tutorial_lightbot-intl_longdescription: Learn core programming logic, starting from
+    super-basic programming, for ages 4+, on iOS or Android (or Web browser) . Learn
+    how to sequence commands, identify patterns, use procedures, and utilize loops!
+  tutorial_rmc_longdescription: Use blocks of code to take Alex or Steve on an adventure
+    through this Minecraft world.
+  tutorial_smc_longdescription: Use blocks of code to take Alex or Steve on an adventure
+    through this Minecraft world.
+  tutorial_minecraft-2016_longdescription: Build a Minecraft game. Create your own
+    versions of chicken, sheep, Creepers, zombies and more.
+  tutorial_thinkersmith-es_longdescription: Mediante el uso de un "Vocabulario Robot"
+    predefinido, los estudiantes descubrir&aacute;n como guiarse de modo tal de llevar
+    a cabo tareas espec&iacute;ficas sin ser estas discutidas previamente. Este segmento
+    ense&ntilde;a a los estudiantes la conexi&oacute;n entre s&iacute;mbolos y acciones
+    as&iacute; como la valiosa habilidad de depuraci&oacute;n.
+  tutorial_pixie_longdescription: Hour of Code tutorial with Pixie
+  tutorial_play_longdescription: Create a story or make a game with Play Lab! Make
+    animals, pirates, zombies, ninjas, and many more characters move, make sounds,
+    score points, and even throw fireballs!
+  tutorial_robomind-nl_longdescription: 'Students learn the basics of programming
+    by controlling their own virtual robot. The online course is fully self-contained
+    with short presentations, movies, quizzes and automatic guidance/hints to help
+    with the programming exercises. '
+  tutorial_spheroi_longdescription: Welcome to your first blocks activity! This is
+    a great place to start for most users, and can be used for the "Hour of Code."
+    Follow the steps to get an overview of the app, learn how to create programs using
+    block coding, and gain an understanding of loops and operators.
+  tutorial_spherol_longdescription: You will learn a new use for the lights on your
+    robot. In this activity, you will build a spinning top program where the gyroscopic
+    spin rate will control the main LEDs, and you will use the concepts of normalization
+    and absolute value. This is a great activity after you complete Blocks 2, and
+    can be used for the "Hour of Code."
+  tutorial_spherov_longdescription: It's time for another classic game powered by
+    Sphero. Learn how to use variables, loop until, and randomness within bounds to
+    bring Hot Potato to life. When you're all done, grab some friends and start tossing.
+    Don't get caught with the Sphero when the time runs out!
+  tutorial_swb_longdescription: Learn to program droids, and create your own Star
+    Wars game in a galaxy far, far away.
+  tutorial_build-a-galaxy_longdescription: Learn to program droids, and create your
+    own Star Wars game in a galaxy far, far away.
+  tutorial_alicesims_longdescription: 'Follow the animation production process from
+    storyboarding to programming with Alice and The Sims.  Let creativity and storytelling
+    drive your learning in a drag and drop coding environment.  The project will guide
+    you through what is a storyboard, translating a storyboard into a programmable
+    script, and how to program a short 3D animation. '
+  tutorial_tchr_longdescription: Now that tens of thousands of educators have tried
+    the Hour of Code, many classrooms are ready for more creative, less one-size-fits-all
+    activities that teach the basics of computer science. To help teachers find inspiration,
+    we collected and curated one-hour teacher-led lesson and activity plans designed
+    for different subject areas for Hour of Code veterans.
+  tutorial_robogame_longdescription: Challenge your school to compete in the Robot
+    Games! Students will compete in a series of mathematics themed activities where
+    they use Dash and Dot to solve a problem and earn points for themselves, their
+    grade, and/or their school.
+  tutorial_tap_longdescription: Learn the basics of coding with one of our six fun
+    puzzle sets. Then choose from over 100 beginner, intermediate, and advanced tutorials.
+    These tutorials come with step-by-step instructions to create drawing, music,
+    animation, storytelling, physics, and arcade game projects. When you're done,
+    you can publish your projects and explore what other kids are making in our fully
+    moderated community.
+  tutorial_cintl_longdescription: Learn the basic concepts of Computer Science with
+    drag and drop programming. This is a game-like, self-directed tutorial starring
+    video lectures by Bill Gates, Mark Zuckerberg, Angry Birds and Plants vs. Zombies.
+    Learn repeat-loops, conditionals, and basic algorithms. Available in 37 languages.
+  tutorial_itchstop_longdescription: We'll be using Itch to build our own stop frame
+    animation projects. Note that headphones are recommended for this course. We will
+    use some existing sprites that support animations and show the code we need to
+    add to animate our characters. We'll also go over how to create our very own animation
+    effects and drawings. We'll learn how to change a sprite costume in scratch repeatedly
+    for animation effects (similar to a flip-book animation) and the code behind it.
+    All instruction is contained within the Itch environment so there is no need to
+    be switching screens to follow along with the project.
+  tutorial_tynkerpn_longdescription: Follow Peep as he explores the big wide world!
+    In this project, you'll create an interactive scene in which Peep goes on a nature
+    walk and sees lots of interesting items. You'll make different items show up or
+    disappear depending on where Peep is walking. You can even make the items talk
+    and add music to your scene!
+  tutorial_tynkerpd_longdescription: Are you ready to make Peep and his friends dance?
+    Learn how to use code to animate the birds. In this project, you will use costumes
+    and delays to animate the birds, one frame at a time. You can add your own background
+    and music and even make Peep and his friends talk!
+  tutorial_persistence_longdescription: New and unsolved problems are often pretty
+    hard. If we want to have any chance of making something creative, useful, and
+    clever, then we need to be willing to attack hard problems even if it means failing
+    a few times before we succeed. This lesson teaches that failure is not the end
+    of a journey, but a hint for how to succeed.
+  tutorial_getloopy_longdescription: Loops are a handy way of describing actions that
+    repeat a certain numbers of times. In this lesson, students will practice converting
+    sets of actions into a single loop.
+  tutorial_createface_longdescription: The aim of this activity is to demonstrate
+    how apparently complicated behaviour can be programmed using some simple rules.
+    It also shows how programs are just rules followed by computers and specifically
+    introduces object-based programming. The activity shows how breaking a program
+    into objects can be much easier to write than trying to write it in one go. The
+    class get to write some simple programs to control the face they created.
+  tutorial_happymaps_longdescription: At the root of all computer science is something
+    called an algorithm. The word "algorithm" may sound like something complicated,
+    but really it's just a list of instructions that someone can follow to achieve
+    a result. To provide a solid base for the rest of your students' computer science
+    education, we're going to focus on building a secure relationship with algorithms.
+  tutorial_moveit_longdescription: This lesson will help students realize that in
+    order to give clear instructions, they need a common language. Students will practice
+    controlling one another using a simple combination of hand gestures. Once they
+    understand the language, they will begin to "program" one another by giving multiple
+    instructions in advance.
+  tutorial_bigevent_longdescription: Events are a great way to add variety to a pre-written
+    algorithm. Sometimes you want your program to be able to respond to the user exactly
+    when the user wants it to. That is what events are for.
+  tutorial_gpp_longdescription: By "programming" one another to draw pictures, students
+    will begin to understand what programming is really about. The activity will begin
+    by having students instruct each other to color squares in on graph paper in an
+    effort to reproduce an existing picture.
+  tutorial_foosgame_longdescription: Code your own video game with codeSpark Academy
+    with The Foos' new Game Kits. This activity guides students brand new to game
+    design using a "paint-by-numbers" approach. Students will follow the on screen
+    prompts to design and program a fun video game that they can share with their
+    family and friends.
+  tutorial_solopython_longdescription: Learn Python basics using the first two modules
+    on SoloLearn's Python app, consult discussions and comments to help you understand
+    better, run code examples in the compiler to help with material retention. Write
+    and compile a simple program that takes your name as input, counts the number
+    of letters, and outputs the result. Share and get community upvotes.
+  tutorial_kodableint_longdescription: Students will learn about the role of a programmer
+    in making machines function. Students will focus on sequence and practice giving
+    instructions in order. This activity includes an unplugged group practice, as
+    well as on-screen, independent practice.
+  tutorial_kodableadv_longdescription: Students will engage in developmentally appropriate
+    lessons on higher level programming concepts such as loops, functions, variables,
+    and object-oriented programming. Lessons included unplugged instruction, guided
+    practice, and on-screen independent practice.
+  tutorial_tynkertj_longdescription: Learn Python to help Fletch collect the satchels
+    of pixie dust to unlock the mysteries of the jungle and restore the islands to
+    their original beauty. You'll use Python commands and syntax to solve puzzles
+    as you navigate Fletch through the islands and avoid the carnivorous plants. Along
+    the way, you'll practice computational and algorithmic thinking skills.
+  tutorial_wolframa_longdescription: In this activity, you will create a web-form
+    that calculates your age in days, hours, nanoseconds, any unit of time that you
+    specify!
+  tutorial_wolframm_longdescription: In this activity, students create random melodies
+    using various musical scales and instruments. Create music through code!
+  tutorial_wolframspi_longdescription: In this activity, there are a series of steps
+    with code ready to run. Students start with a piece of code that works, and then
+    modify it to do different things. Students can play melodies based on the digits
+    of PI and explore what PI sounds like using many musical instruments.
+  tutorial_wolframsph_longdescription: Explore 3D graphics in this activity and create
+    your own shapes.
+  tutorial_wolframp_longdescription: Explore creating different polygon shapes in
+    this activity.
+  tutorial_wolframn_longdescription: In this activity, students develop a name generator
+    that transforms their name into ninja names.
+  tutorial_soloweb_longdescription: Go to www.sololearn.com and install HTML and CSS
+    apps or open the relevant lessons on the web (Android users can install the unified
+    SoloLearn app).  Complete 2 modules (Overview and HTML Basics) in HTML and 2 modules
+    (The Basics and Working w/Text) and first 5 lessons of the 3rd module (Properties)
+    in CSS. Get the template at https://code.sololearn.com/WKeg2CtzpRts/ and follow
+    the instructions.
+  tutorial_khanweb_longdescription: 'Khan Academy: Webpages teaches you how to make
+    webpages with HTML tags and CSS, finishing up by making your very own greeting
+    card.'
+  tutorial_khandata_longdescription: 'Khan Academy: Databases teaches you to manipulate
+    data in a database and make your own custom store.'
+  tutorial_googlelogo_longdescription: Use your creativity and imagination to bring
+    the Google logo to life using code. Make the letters dance, tell a story or create
+    a game. With Scratch and CS First, anyone can become a designer and programmer
+    for the day!
+  tutorial_playtune_longdescription: A blocks language is used to solve musical puzzles
+    by writing code to match tunes played on a piano keyboard. Sequence, selection,
+    and repetition algorithms are needed to solve the puzzles. After the 9th level,
+    users can create their own tune and download it as an app for an Android device.
+    Students can also modify the app by following a link to the App Inventor source
+    code.
+  tutorial_computeit_longdescription: Let's switch roles. This time YOU are the computer!
+    Read and interpret the programs to find the right trajectory and win the challenges.
+    You will have to focus and use your intuitive abilities to understand some core
+    concepts of programming.
+  tutorial_codesterssj_longdescription: In this activity, students use our drag-to-text
+    toolkit to start coding in Python right away! As they work through introductory
+    skill building activities, students begin to learn about basic syntax, variables,
+    and events! They'll use multiple sprites to set up a joke telling scenario that
+    they can share with their friends! *Electronic sharing requires student sign up.
+  tutorial_cmchat_longdescription: Join a robot monkey in an hour-long course where
+    you will learn the basics of Python and chatbot programming. In the activity,
+    you will advance through a 15 exercise-long course in which you will learn how
+    to program your very own trivia chatbot.
+  tutorial_tynkerdb_longdescription: Choose a dragon, then embark on a quest for treasure.
+    Blast through obstacles and gain cool power-ups as you journey through a mystical
+    jungle. Learn sequencing, loops, conditional logic, and debugging skills along
+    the way.
+  tutorial_cmbuild_longdescription: Take your coding skills to the next level by learning
+    to build your own games. In this course, you will learn keyboard user-interface
+    and game mechanics as you build a Super Mario™-styled game. Afterwards, you will
+    be able to share your game!
+  tutorial_robotrattle_longdescription: Robot Rattle teaches students to operate a
+    fully physically simulated robot with the help of a visual coding language by
+    easily dragging & dropping blocks to write code instructions. Students are introduced
+    to the robot and its various moving joints, and learn to move its joints with
+    the use of angles. The robot can push and grab objects in order to direct them
+    to the goal, but also break if moved against obstacles. This activity is targeted
+    to kids aged 13+ and offers easy-to-grasp insights into physical behaviour and
+    robotics. On top of that, anyone with a smartphone and a mobile VR headset will
+    be able to watch the full-scale robot performing the written code.
+  tutorial_codestersh_longdescription: In this activity, designed for beginning coders,
+    students use a drag-to-text toolkit to start coding in Python right away! First,
+    work through some skill building activities where you learn how to assign and
+    modify commands for your sprite. Then, program your own commands to create shareable
+    electronic art! *Sharing requires student sign up.
+  tutorial_codehsdigipixel_longdescription: Learn how images are stored and displayed
+    on computers using pixels. Explore how images are encoded as a grid of color values,
+    and make your own digital images using binary and hexadecimal color codes!
+  tutorial_ccbinary_longdescription: Make a Scratch game in which you play the notes
+    of a song as they scroll down the stage. You'll score ten points for every correct
+    note you play. Each note corresponds to a binary number.
+  tutorial_codehsturtle_longdescription: Learn the basics of programming by drawing
+    shapes on your screen with Tracy the Turtle! Turtle Graphics (or LOGO) is a beginner
+    friendly way to explore programming concepts and bring creativity into programming
+    in a visual way.
+  tutorial_grokhd_longdescription: 'Continue those Blockly programming skills! This
+    course builds on what you learned in the Frozen Fractals activity: https://hourofcode.com/grokffblock.
+    This activity is designed to introduce branching decisions in programming. Use
+    the Blockly version of Python and its turtle module to draw and colour hydrangea
+    flowers!'
+  tutorial_grokem_longdescription: This activity is designed to give you your first
+    experience programming, and has been specially designed for the Hour of Code.
+    Use the programming language Python to explore emoticons and text manipulation.
+  tutorial_kodmaze_longdescription: Build your own mazes to solve and share! Students
+    will pair geometry with programming to build solvable mazes based on given challenges.
+    Challenges include mazes with simple shapes, fractions, symmetry, and specified
+    angles.
+  tutorial_codestersa_longdescription: 'In this activity, designed for students with
+    some coding experience, students use our drag-to-text toolkit to build an game
+    with player controls! Students learn about variables, randomly generated numbers,
+    game design, and multiple types of events and event triggers, all while scrambling
+    to stay out of the way as asteroids hurtle toward their spaceship! Prereq: variables,
+    parameters.'
+  tutorial_cmdodo_longdescription: In this hour-long course, you will write real code
+    as you add, subtract and measure distances to help a dodo find her missing eggs!
+  tutorial_tynkerspace_longdescription: Your astronaut's ship has crash-landed!  Luckily,
+    you're there to help. Use drag-and-drop programming to help your character collect
+    spare parts while avoiding aliens and obstacles. Can you find a ship to bring
+    your astronaut home?
+  tutorial_gfbloons_longdescription: In this lesson you will code a shooting monkey
+    tower from the popular Bloons Tower Defense game. By the end of the lesson you
+    will know the angle finding maths and algorithms commonly used in many of today's
+    most popular tower defense games. You will be able to apply this knowledge in
+    your own game. Gamefroot Hour of Code tutorials use a visual programming language
+    using blocks where students simply drag and drop visual blocks to write code.
+  tutorial_raspipong_longdescription: Recreate the classic game of Pong using a Sense
+    HAT and some Python code. This activity can be completed online using the Sense
+    HAT emulator, or by using a Raspberry Pi and the Sense HAT hardware.
+  tutorial_codehsvr_longdescription: Learn the basics of building virtual reality
+    worlds using HTML and the A-Frame JavaScript Library. Through this activity, students
+    will build their own virtual reality worlds that are compatible with VR devices,
+    including smartphone VR headsets!
+  tutorial_codesterstp_longdescription: In this activity, students use Python to practice
+    performing transformations on the coordinate plane! The lesson includes demonstrations,
+    direct instruction, and challenges that ask students to program and identify various
+    static transformations!
+  tutorial_codestersbb_longdescription: 'Students use our drag-to-text toolkit to
+    start coding in Python right away! In this self-guided activity, students complete
+    a series of direct-instruction activities in which they build a pull and shoot
+    basketball game! Students explore variables, events, basic syntax, creating random
+    coordinates. Advised prereq knowledge: variables, dot notation, events, negative
+    numbers'
+  tutorial_gfcrossyroad_longdescription: In this suite of introductory coding lessons
+    you will learn about making your own Crossy Road style mini-game. You will learn
+    how to code algorithms and sequences, inputs / outputs, loops and iteration, selection
+    and if-statements, and comparative operators and think like a computer scientist.
+    This suite of lessons is aligned with the New Zealand and Australian (Victorian)
+    digital technologies curriculum and designed to help young people AND educators
+    embrace coding in their schools, classrooms and coding clubs. Gamefroot Hour of
+    Code tutorials use a visual programming language using blocks where students simply
+    drag and drop visual blocks to write code.
+  tutorial_googleww_longdescription: In this activity, you'll code three unique scenes
+    from the film using Blockly, an introductory coding language, to help Wonder Woman
+    navigate obstacles and reach her goal. You'll use the power of sequences, variables,
+    loops and conditionals to help Diana train against her opponents.
+  tutorial_codehsjsapp_longdescription: CodeHS is compatible with all up-to-date browsers
+    except Internet Explorer. Chrome is our preferred / recommended browser, but Firefox
+    and Safari should work fine as well, assuming they are up to date.
+  tutorial_gfmihi_longdescription: Kia ora! In this activity you will code your own
+    mini-game and learn how to introduce yourself in Te Reo Maori - the indigenous
+    language of New Zealand. Mihi Maker is a fun easy to use activity that combines
+    coding, social studies and indigenous culture. You will learn how game designers
+    program basic collision detection algorithms. Collision detection is a program
+    used by a computer to help it understand when two objects will hit into each other.
+    Gamefroot Hour of Code tutorials use a visual programming language using blocks
+    where students simply drag and drop visual blocks to write code.
+  tutorial_hopdropphone_longdescription: 'Hopscotch is a simple programming tool on
+    the iPad/iPhone, beloved by millions of students for its freedom of creative expression.
+    Watch your students squeal with delight as they create their own "Don''t Drop
+    the Phone" games! This self-guided video tutorial teaches kids ages 8+ programming
+    basics while they code customized editions of this popular game. '
+  tutorial_techfaa_longdescription: This interactive tutorial will introduce you to
+    "Flocking", a type of algorithm which is intended to simulate life-like behavior
+    of Autonomous Agents in a group. The embedded viewer makes it easy for you to
+    see the rendering of the code.
+  tutorial_codehsjsgraph_longdescription: CodeHS is compatible with all up-to-date
+    browsers except Internet Explorer. Chrome is our preferred / recommended browser,
+    but Firefox and Safari should work fine as well, assuming they are up to date.
+  tutorial_thunkable_longdescription: Using the language of blocks, learn how to build
+    10 simple apps in 1 hour. This funny tutorial series will start you on your path
+    to becoming a mobile app developer!
+  tutorial_hopcrossyroad_longdescription: Hopscotch is a simple programming tool on
+    the iPad/iPhone, beloved by millions of students for its freedom of creative expression.
+    With this self-guided video tutorial, your students will make their own versions
+    of Crossy Road! Kids ages 8+ will be exposed to the basics of programming while
+    they code customized editions of this App Store favorite.
+  tutorial_switchglitch_longdescription: Switch & Glitch lets your students play the
+    hero! Using a visual interface, they program cute robots and help them save the
+    day. This activity teaches children aged 5-10 the basics of programming, loops,
+    and the art of debugging. The galaxy needs you!
+  tutorial_codecar_longdescription: Code a simulated car circuit board! You'll type
+    real C++ code that controls the lights and buttons of a car-shaped circuit board.
+    Through 7 lessons, you'll flash the tail light, code a brake pedal, and more on
+    the simulated Code Car. This activity teaches loops, if statements, and logic
+    with typed code and includes a lesson plan with alignments to ISTE, NGSS, Common
+    Core, and CSTA standards.
+  tutorial_codesterscp_longdescription: In this lesson students explore all four quadrants
+    of the coordinate plane! They use Python and our drag-to-text toolkit to send
+    a sprite to various locations on the stage! There are demonstration and debugging
+    activities included to help students become comfortable with navigating the coordinate
+    plane.
+  tutorial_grokpetblock_longdescription: This activity is designed to introduce you
+    to embedded programming using friendly blocks, and has been specially designed
+    for the Hour of Code. Use the blocks and a micro:bit to make a pet that you can
+    feed and play with. No BBC micro:bit? No problem! This course includes a full
+    micro:bit simulator, so you'll be able to do everything you'd do on a real micro:bit!
+  tutorial_techbim_longdescription: 'This hands-on tutorial is intended for people
+    curious to know how to programatically perform some simple image manipulations
+    such as rotation, colorization, increase of contrast, blur, edge detection, etc.,
+    without the help of advanced libraries. '
+  tutorial_techfpp_longdescription: Python is well known for its object oriented programming
+    features (classes, methods, inheritance…), however, it cannot be restricted to
+    these! This interactive tutorial shows the useful, but lesser known, functional
+    programming features and techniques of Python.
+  tutorial_codesterscr_longdescription: Students use a drag-to-text toolkit that allows
+    them to start coding in Python right away! Students complete a set of guided practice
+    activities in which they learn how to use and modify a variety of programming
+    commands. Then, they apply these skills to create their own cheer routine!
+  tutorial_grokdisease_longdescription: This activity is designed to give you your
+    first experience programming, and has been specially designed for the Hour of
+    Code. Use the programming language Python to model a disease outbreak. Can you
+    solve the curious case of the glowing nose?
+  tutorial_techec_longdescription: Closures are a crucial aspect of Javascript, yet
+    they remain mysterious and developers do not understand them easily. This interactive
+    tutorial will teach you how powerful and useful Closures are to boost your Javascript
+    practice!
+  tutorial_rgbegin_longdescription: RoboGarden is an easy to understand, hands-on
+    educational app where students take part in active learning. Fully equipped to
+    teach coding literacy from scratch, RoboGarden reduces the need for a tech-savvy
+    teacher.
+  tutorial_myradream_longdescription: Monsters have taken Myra's dream. Learn coding
+    skills to help her cross bridges, fly through the air, and swim underwater to
+    get back her dream. Actimator is a Web-based visual environment for creating games
+    and science simulations collaboratively, as well as publishing them for the Web
+    and as mobile apps.
+  tutorial_thinkfun_longdescription: We'll take you through the process of fixing
+    a Robot's brain, step by step! Along the way you'll solve puzzles based on the
+    famous 'Boolean Satisfiability Problem,' and within an hour you'll be a Boolean
+    Master and have an understanding of advanced programming concepts! All instruction
+    is contained on one screen, and volume is optional.
+  tutorial_hopfireworks_longdescription: 'Your students will be so excited when they
+    code their own (explosion free!) fireworks app! Hopscotch is a simple programming
+    tool on the iPad/iPhone, beloved by millions of students for its freedom of creative
+    expression. This self-guided video tutorial teaches kids age 8+ programming basics
+    while they code custom versions of interactive fireworks. '
+  tutorial_grokspace_longdescription: This activity is designed to give you your first
+    experience programming, and has been specially designed for the Hour of Code.
+    Use the visual programming language Blockly to investigate space and reach for
+    the stars.
+  tutorial_codehspython_longdescription: Learn the basics of coding with the Python
+    programming language by writing programs that you can interact with! This hour
+    will cover printing, variables, math, and getting information from users. Write
+    a program that takes in and stores data from a user and returns a unique response!
+  tutorial_codehsjava_longdescription: Coding in Java with CodeHS
+  tutorial_techioda_longdescription: This useful tutorial will interactively teach
+    you how to be able to calculate the shortest path between two nodes in a graph
+    in advance, thanks to the Dijkstra's algorithm.
+  tutorial_grokmonster_longdescription: Get kids into coding with this friendly course
+    specially designed for the Hour of Code! Use drag-and-drop blocks to write your
+    own programs, learn about sequence and ordering, and create fun monster characters!
+  tutorial_techmjs_longdescription: JavaScript has been an international standard
+    since 1997. In this interactive tutorial, we will explore the modern features
+    of the language that will make your code more robust, concise, and easier to read.
+  tutorial_techga_longdescription: Genetic Algorithms make use of the evolution theory
+    to powerfully solve problems where deterministic algorithms are too costly, such
+    as the Travelling salesman problem. This interactive tutorial is a clear and simple
+    introduction to help you understand how Genetic Algorithms work.
+  tutorial_techioan_longdescription: In this interactive tutorial, we will learn why
+    Java's "null" value should always be avoided and what solutions exist to bypass
+    it.
+  tutorial_techiogsr_longdescription: Rust is a recent System Programming Language
+    designed with memory safety and performance in mind. It was originally released
+    in 2010. In this interactive tutorial, discover the basics of this fun to use
+    language, with performances comparable to C and C++!
+  tutorial_groktunnel_longdescription: This activity is designed to give you your
+    first experience programming, and has been specially designed for the Hour of
+    Code. Use the programming language Python to create a simple game (or MUD). Can
+    you find your way through the dark tunnel?
+  tutorial_stemcod_longdescription: Do you play video games? Have you ever thought
+    about how some games are super-realistic and other games are cartoon-ish? In this
+    activity we will talk about the physics of video games and you will learn to modify
+    a computer code to simulate the motion of an object. Our activities are all based
+    on classic video games. No install required. 100% Chromebook compatible.
+  tutorial_techikb_longdescription: Kotlin is a new open-source programming language
+    from JetBrains. It can be of greatest interest to people who work with Java today,
+    although it could also appeal to all programmers who use a garbage collected runtime
+    (Scala, Go, Python, Ruby and JavaScript). Discover Kotlin's basics in this interactive
+    tutorial!
+  tutorial_kanostreet_longdescription: Art and technology unite! With Kano's Street
+    Art Hour of Code challenges, creative minds of all abilities will code with a
+    paintbrush, making beautiful, unique artwork. Along the way, makers will learn
+    computer science principles while using a real programming language in an intuitive
+    and engaging way. With our teacher resources and guided content, everyone can
+    get in on the fun.
+  tutorial_codemojijs_longdescription: Beginning JavaScript is designed to get students
+    typing simple commands that have a big impact on the characters' actions. The
+    students will type commands that make the characters do everything from backflips
+    to make sounds and even talk. This activity will help you learn basic JavaScript
+    ideas and commands.
+  tutorial_techapf_longdescription: The interactive tutorial aims to introduce you
+    to useful advanced Python features and tricks you may not know yet to improve
+    your mastery of the Python language.
+  tutorial_techfpjs_longdescription: Functional programming is one of those things
+    that may look too hard or too theoretical to try. Wait no more! In this interactive
+    tutorial, you'll discover functional programming through hands-on examples and
+    exercises in JavaScript.
+  tutorial_techlinq_longdescription: The C# programming language is quite popular
+    with developers, in a large part because of its many powerful and intuitive language
+    features. One of these is LINQ, a library used to execute queries directly in
+    C# syntax against many types of data. This interactive tutorial will show you
+    how to use it, step by step.
+  tutorial_gpbcatapult_longdescription: Participants will build a catapult to launch
+    a ball from one side of the stage to the other, as in the game Angry Birds.
+  tutorial_quorumastro_longdescription: Learn about coding using themes from computational
+    astronomy in this accessible online tutorial. In it, students will discover how
+    to control telescopes while also practicing with the Quorum programming language's
+    computer graphics engine. By the final lesson, students will create a graphical
+    and accessible map of the stars to find items in the universe.
+  tutorial_alicewonder_longdescription: Alice in Wonderland is a self-guided puzzle
+    designed for 6+ kids without prior programming experience. You will guide Alice
+    using functions with and without parameters.
+  tutorial_rginter_longdescription: RoboGarden is an easy to understand, hands-on
+    educational app where students take part in active learning. Fully equipped to
+    teach coding literacy from scratch, RoboGarden reduces the need for a tech-savvy
+    teacher.
+  tutorial_cssgrid_longdescription: Learn all about CSS Grid by tending to your vegetable
+    garden.
+  tutorial_jshero_longdescription: JS Hero wants to take you into the world of JavaScript
+    programming. On each page you will find a small lesson and a small programming
+    task. The task can be answered directly on the page. And you are immediately told
+    if you have solved the problem correctly or if you made a mistake.
+  tutorial_codemojipy_longdescription: Python Lab is an IOS based activity that teaches
+    the basics of the programming language python. Users will learn about loops, arrays,
+    booleans and much more.
+  tutorial_nclabdrone_longdescription: 'Build a drone frame in ten steps with NCLab''s
+    3D Modeling app. The drone frame can be 3D printed and used to build a real working
+    drone!  Each step includes tutorials and instructions. Complete the code and immediately
+    see the results.  3D Modeling is a vital part of 21st century engineering, manufacturing,
+    art, science, medicine, and more.  This is a great way to get started! '
+  tutorial_gpbcircle_longdescription: Participants will make a circle that changes
+    color and brightness as you move the mouse. In the process, they will explore
+    the hue, saturation, and brightness color model.
+  tutorial_gpbpaint_longdescription: Participants will create a paint editor to draw
+    with the mouse, then add features such as a clear button and the ability to fill
+    areas with color.
+  tutorial_cocomarcade_longdescription: Ready to create an even cooler game? Brush
+    up on advanced coding concepts like functions and events using Python or JavaScript,
+    then use those skills to build your own arcade survival game!
+  tutorial_beetik_longdescription: In this activity, students reconstruct a small
+    part of a famous piece by composer Franz Liszt. Students will learn how to embed
+    loops and how they're used in both computer science and music. This is a step-by-step
+    guide that will introduce algorithmic thinking in music with elements of computer
+    science. In the last level of this activity, students will 'hack' the music by
+    changing elements such as tempo, key, repetitions, notes, etc with the objective
+    of making original variations based on what they learned. This activity intersects
+    classical music with computer science.
+  tutorial_codedj_longdescription: In Code DJ, you will first discover the basics
+    of Javascript by answering questions that will progressively become more like
+    code. You will then reach a second world where you will actually start to make
+    music directly with code, just by changing numbers at first, and as your mastery
+    increases, by manipulating rhythm loops and more! You will then unlock the ability
+    to create music freely in the Code DJ app and get it as an mp3!
+  tutorial_rgadvan_longdescription: RoboGarden is an easy to understand, hands-on
+    educational app where students take part in active learning. Fully equipped to
+    teach coding literacy from scratch, RoboGarden reduces the need for a tech-savvy
+    teacher.
+  tutorial_codehsrn_longdescription: This activity gives you some examples on how
+    to make your first real mobile apps and how to test them out on your phone using
+    React Native. To run apps on a smartphone phone, students will need to download
+    the Expo app. Find more information about Expo at https://expo.io/.
+  tutorial_codehswd_longdescription: CodeHS is compatible with all up-to-date browsers
+    except Internet Explorer. Chrome is our preferred / recommended browser, but Firefox
+    and Safari should work fine as well, assuming they are up to date.
+  tutorial_turtlerobot_longdescription: A take on the board game Robot Turtles that
+    allows the student to practice without the help of a teacher.
+  tutorial_ozoevo_longdescription: Evo by Ozobot is packed with tons of cool technology,
+    like proximity sensors, programmable LEDs, motion and sounds, and light and color
+    sensors underneath so it can see colors and follow lines. This introduction to
+    Evo presents an OzoBlockly program that makes Evo move when its proximity sensors
+    are activated by your hands, and play a victory dance once it has walked on certain
+    colors.
+  tutorial_ozoexped_longdescription: Students practice drawing lines and color codes
+    that Ozobot can follow in a fun way with this printable board game. Both luck
+    and skill play a role through a series of fun timed challenges that require them
+    to combine a shape and color codes. As students are successful, they will get
+    to move closer the their destination. The activity includes challenge cards students
+    can use to increase the difficulty for their opponents as part of their strategy.
+  tutorial_ozojourney_longdescription: As a class, students will program their Ozobot
+    to complete the journey of Ferdinand Magellan. The educator should cut out and
+    assemble the paper continents ahead of time. Students will use the OzoBlockly
+    language to program an Ozobot robot to navigate around the continents along the
+    path Magellan took. Along the way students will label different parts of world
+    geography.
+  tutorial_ozocodes_longdescription: This tutorial helps Pre-readers get in on the
+    Ozobot coding fun by having them to write their names in thick black lines that
+    Ozobot can walk on and place OzoCodes in logical places to help the robot walk,
+    and jump, from the first letter to the last. Students test a first draft and iterate
+    to create a working final product.  This lesson encourages fine motor skills,
+    computer science concepts and adds to students' OzoCode experience.
+  tutorial_ozoeclipse_longdescription: Discover the magic of eclipses, lunar phases,
+    and celestial mechanics (changing speeds of orbiting bodies) using Ozobot robots
+    on a simple map based on the Moon's orbit around Earth. Even with little Ozobot
+    programming experience, a class can create a demonstration of eclipses with two
+    bots and a flashlight, then create a map of the changing speeds of an orbiting
+    body with simple OzoCodes, drawn with markers.
+  tutorial_ozosimulator_longdescription: This activity teaches about programming languages
+    without students needing to use a computer or bot. The student is the computer
+    in this activity that uses psuedocode to teach the basics of how to write a program
+    a computer can read using a brain-teasing maze in which students must first read
+    and execute commands, and then write a program for a maze using what they've learned.
+  tutorial_ozoalgorithm_longdescription: Students with several programming concepts
+    under their belts will enjoy the challenge of making Ozobot choose a random multiplication
+    fact, then draw the array of the fact on a grid and blink and/or say the answers.
+    Programming concepts students should know ahead of time include loops, math, variables,
+    random number generation, and the OzoBlockly specific concepts of line following,
+    setting LED lights, timers and "say" for Evo audio capabilities.
+  tutorial_ozotimer_longdescription: Could we turn Ozobot Bit into a timer - specifically
+    a timer for measuring seconds? This challenge lesson will involve the student's
+    knowledge of concepts from geometry and physical science, as well as his or her
+    ability to write Level 4 (Advanced) OzoBlockly code using light effects, line
+    navigation, and timing. An OzoMap is provided as a basis for which the OzoBlockly
+    program can then be designed. A stop-watch or a cell phone stop-watch app is needed
+    to calibrate the Ozobot Bit second timer.
+  tutorial_ozohabits_longdescription: When students know how to draw lines and OzoCodes
+    to program Ozobot, they're ready to integrate this programming method in the real
+    world. This tutorial shows how Ozobot can be used to model nature similar to computer
+    simulations. This lesson begins with the educator explaining how Point OzoCodes
+    work, and how they can be used to bring Ozobot to a stop. This functionality will
+    be applied to modeling how a rabbit living on a grassy hill eats its fill and
+    stops.
+  tutorial_ozoprogram_longdescription: Students find out how easy it is to program
+    robots, even if their classroom doesn't have any. This teacher-guided online tutorial
+    helps students develop programming skills and gain confidence in their ability
+    to understand computer science through Ozobot's Blockly games. Students discover
+    how Bit and Evo by Ozobot will upload the program through a unique method - colors
+    flash onto the robot's light sensors and teach the it the program.
+  tutorial_ozopair_longdescription: Students who know the OzoBlockly block-based programming
+    language learn how to work in teams as Drivers and Navigators, and then practice
+    by creating a single program on one computer for one Ozobot robot. This is a teacher-led
+    tutorial that requires videos to be shown at the beginning, and then guidance
+    to help students through completing their program when needed.
+  tutorial_codesnoopy_longdescription: Team up with friends and practice your coding
+    skills by programming Snoopy's Beagle Scouts in a fun and silly snowball fight!
+    Beginners and pre-readers welcome - teams write their code in secret while trying
+    to outsmart each other. With words-free code, everyone can get in on the fun!
+    This activity supports 1- 4 players on the same device - play against friends
+    or the computer.
+  tutorial_applabintro_longdescription: Create your own app in JavaScript using blocks
+    or text. You'll make a simple app with buttons, images, sounds and multiple screens
+    that you can share with your friends or publish to a public gallery. If you've
+    already done some coding with blocks, take your skills to the next level.
+  tutorial_cslartist_longdescription: Did you know that there's a little artist who
+    lives inside every computer? This PDF contains a fun story embedded with puzzles
+    that will teach your students the fundamentals of digital art as they make their
+    own creations using pixels, algorithms and repeat loops.
+  tutorial_cslscratchjr_longdescription: CodeSpeak's "Let's Play with the ScratchJr
+    Kitten!" Activity Pack is a Read Aloud Story with accompanying worksheets. The
+    Story walks through the code for a great first project for brand new coders. A
+    grown-up can read the story to a class of pre-reader students and then guide students
+    to code the story in their tablets using the ScratchJr app. Students with early
+    reading skills can read the story themselves and independently complete the Activity
+    Pack.
+  tutorial_floevents_longdescription: Students will explore events, a concept that
+    allows programs to respond to specific stimuli. Events are determined in bits
+    of code called event handlers, which listen for specific events and contain instructions
+    on how to respond. Students will learn key vocabulary and write text for event
+    handlers in a Mad Libs-style exercise in which they create and act out event handlers
+    of their own.
+  tutorial_florobot_longdescription: In this lesson, students will build their literacy
+    skills while diving into the field of robotics. They'll watch Flocabulary's educational
+    hip-hop video to find out what a robot is and see examples of robots in daily
+    life. They'll close-read short passages about robots, discuss tasks that robots
+    are well suited for and finish the lesson by designing their own robot to solve
+    a specific problem.
+  tutorial_isavesanta_longdescription: In this teacher-led festive activity, adapted
+    for the Hour of Code, the children create a computer game using Scratch to save
+    Santa. They design algorithms, use conditional statements as well as test and
+    debug their work. Includes step-by-step lesson plan, pupil resources, support
+    cards and pre-written program templates.
+  tutorial_iorder_longdescription: This teacher led activity, adapted for the Hour
+    of Code, develops computational thinking and coding skills using Scratch 2.0.
+    The children program an ice-cream stand simulation and/or game and, in doing so,
+    design algorithms, use repetition, conditional statements, test and debug their
+    work. Includes step-by-step lesson plan, pupil support materials, and pre-written
+    Scratch 2.0 program templates for teacher and pupils.
+  tutorial_ianimate_longdescription: 'This teacher-led seasonal activity, adapted
+    for the Hour of Code, introduces children to creating computer animations. The
+    children will create frames, add artwork and animate a simple Christmas scene.
+    Lots of ideas for differentiation, extension and enrichment from making a very
+    simple animated sequence to more able pupils: animating backgrounds as well as
+    characters and objects, adding 3D effects (e.g. shadows), creating more frames
+    for smoother movement, switching backgrounds to create scene changes, and animating
+    more than one object.'
+  tutorial_iloveada_longdescription: This teacher-led lesson activity, adapted for
+    the Hour of Code, provides an opportunity to teach cross-curricular computing
+    with history. Children research Ada Lovelace an important historical figure in
+    computer science and the world's first computer programmer! They then use basic
+    HTML to create a multimedia webpage showcasing their findings and skills as web
+    masters. Includes a step-by-step activity plan, associated teacher and pupil resources
+    and ideas for extension and enrichment to take learning further.
+  tutorial_kodflash_longdescription: Flash! Clap! This hands-on, wild weather lesson
+    teaches conditional statements with lightning and thunder. Students will learn
+    about why thunder always follows lightning and will examine the logic statement
+    "if there is lightning, then thunder will follow." Count the seconds between the
+    two to see how far away the storm is!
+  tutorial_kodchoose_longdescription: Choose your own adventure! Through a series
+    of "If statements", students will alter the storyline and ending to a narrative
+    they write. Like a program's path changes based on conditions, the path a character
+    takes through a narrative can change too. Get creative and lead the Kodable fuzzFamily
+    on multiple adventures within one story that can have varying conclusions.
+  tutorial_kodpizzapre_longdescription: In a 3-part unit, students will connect math
+    and programming to develop solutions for a restaurant's mobile ordering app. Dominic's
+    Pizza restaurant is creating an algorithm for their new app and it's up to students
+    to help calculate pizza costs. At the end of the unit, students will make and
+    deliver their "pizza" after calculating the cost of the order.
+  tutorial_kodpizza_longdescription: In a 3-part unit, students will connect math
+    and programming to develop solutions for a restaurant's mobile ordering app. Dominic's
+    Pizza restaurant is creating an algorithm for their new app and it's up to students
+    to help calculate pizza costs. At the end of the unit, students will make and
+    deliver their "pizza" after calculating the cost of the order.
+  tutorial_kodwomen_longdescription: This 3-part unit explores gender inequality and
+    engages students in activities and discussions around different experiences and
+    perspectives. Highlighting influential women in the history of tech, students
+    learn about past pioneers and form their own opinions on equality in the tech
+    field. At the end of the unit, students express their opinions in writing to effect
+    change in their school community.
+  tutorial_tfunplug_longdescription: We'll take you through the process of fixing
+    a Robot's brain, step by step! Along the way you'll solve puzzles based on the
+    famous 'Boolean Satisfiability Problem,' and within an hour you'll be a Boolean
+    Master and have an understanding of advanced programming concepts! No computers
+    required – everything you'll need can be printed out from our supplied PDF.
+  tutorial_lbvariables_longdescription: Having fun is not a variable! Short activities
+    and fun videos provide an overview of the core coding concepts that students will
+    encounter in the app. The variables lesson teaches students to create variables
+    to add countdowns, characters, and extra players to games.
+  tutorial_lbfunctions_longdescription: Short activities and fun videos provide an
+    overview of the core coding concepts that students will encounter in the app.
+    The functions lesson teaches students to create their own unique code blocks to
+    level-up their game.
+  tutorial_lblogic_longdescription: Logic-defying fun activities and videos provide
+    an overview of the core coding concepts that students will encounter in the app.
+    The logic lesson teaches students to use conditional statements to program rules
+    and choices into their games.
+  tutorial_lbworld_longdescription: Code for good! Students design a game that will
+    help make life easier for people in their community. At the end, each group will
+    present their prototypes at a "Change the World Arcade" that will be open to community
+    members.
+  tutorial_lbloops_longdescription: Loops are the secret weapon of every game ninja.
+    Short activities and fun videos provide an overview of the core coding concepts
+    that students will encounter in the app. The loops lesson teaches students how
+    to use loops to create animations.
+  tutorial_lbtug_longdescription: Bring a whole new meaning to the term "button-masher".
+    Students will create and remix the Tug of War game to explore how functions are
+    used to structure code.
+  tutorial_lbpotato_longdescription: Students will use loops, conditional logic, and
+    variables to create a new spin on the game of Hot Potato. This lesson provides
+    a choice between a beginner or intermediate level exploration into understanding
+    the invention code.
+  tutorial_lbguitar_longdescription: Students will work together to design a musical
+    instrument that makes it easy for anyone, even for those who cannot read music,
+    to play simple songs.
+  tutorial_lbio_longdescription: Short activities and fun videos provide an overview
+    of the core coding concepts that students will encounter in the app. The inputs
+    and outputs lesson teaches students how to control images, sound, and motion.
+  tutorial_wonpuppy_longdescription: Use the Wonder Workshop Blockly app and Dash
+    the robot to tackle 3 coding challenges! In this series of challenges, you will
+    train Dash the puppy to perform tricks. This series is part 3 of the Hour of Code
+    Dash and Dot Challenge Card activities. It is recommended for students who have
+    coding experience with functions.
+  tutorial_woncue_longdescription: Use Wonder Workshop's cue app to program your CUE
+    robot in different ways. Challenges and demos in the app will show you how to
+    program using blocks, JavaScript, or state machines. You'll also get to know the
+    robot's 4 different personalities as you code!
+  tutorial_wonzoo_longdescription: Use the Wonder Workshop Blockly app and Dot the
+    robot to tackle 3 coding challenges! In this series of challenges, you will help
+    Dot play with the animals at the petting zoo. This series is part 2 of the Hour
+    of Code Dash and Dot Challenge Card activities.
+  tutorial_wontrip_longdescription: Use the Wonder Workshop Blockly app and Dash the
+    robot to tackle 3 coding challenges! In this series of challenges, you will help
+    Dash prepare for a road trip. This series is part 4 of the Hour of Code Dash and
+    Dot Challenge Card activities. It is recommended for students who have coding
+    experience with event handlers and conditionals.
+  tutorial_woncollect_longdescription: Use the Wonder Workshop Blockly app and Dash
+    the robot to tackle 3 coding challenges! In this series of challenges, you will
+    help Dash collect different objects like seashells and candy. Don't forget to
+    make some space on the floor for your robot to move around. This series is part
+    1 of the Hour of Code Dash and Dot Challenge Card activities.
+  tutorial_wonsecret_longdescription: Let's use the Wonder Workshop Cue app with Cue
+    the robot to make a secret message system. This activity is recommended for students
+    who have experience coding in JavaScript.
+  tutorial_hsscience_longdescription: Imagine if your students could easily make their
+    own computer models of natural phenomena! This hour-long lesson plan uses the
+    water cycle as an example for building an interactive computer model using an
+    iPad-based kid's programming tool called Hopscotch. You can adapt it to simulate
+    any dynamic system being studied. No prior experience required!
+  tutorial_popculture_longdescription: This activity gives beginners an accessible
+    introduction to crowd-sourcing data, visualization, and data analysis using interactive
+    tools. The aim is to demonstrate that anybody can contribute to data science projects
+    and that computer science can be connected to a wide variety of topics (even trends
+    in popular culture) making it relevant to a variety of people. In this activity,
+    students practice asking their own questions about popular culture and seeking
+    answers to those questions using computational tools.
+  tutorial_legorobust_longdescription: Investigating what characteristics of a building
+    would help make it resistant to an earthquake, using an earthquake simulator constructed
+    from LEGO bricks. Students will explore the origin and nature of earthquakes.
+    Create and program a device that will allow you to test building designs. Document
+    evidence and present your findings about which structure design(s) are best for
+    withstanding earthquakes.
+  tutorial_legoplants_longdescription: Model the relationship between a pollinator
+    and flower during the reproduction phase using a LEGO representation. Students
+    will explore how different organisms take an active role in plant reproduction.
+    Create and program a model of a bee and flower to mimic the relationship between
+    the pollinator and the plant. Present and document the different models you have
+    created of plants and their pollinators.
+  tutorial_legopark_longdescription: Design cars that can park themselves safely without
+    driver intervention. Students will understand that algorithms are capable of carrying
+    out a series of instructions in order. Explore the concept of Outputs by comparing
+    different ways in which a wheeled robot can move.
+  tutorial_legodetect_longdescription: Design ways to avoid accidents between vehicles
+    and objects in the road.
+  tutorial_legolight_longdescription: Design car features that will improve nighttime
+    driving safety. Students will explore the concept of inputs and the way to control
+    them.
+  tutorial_alexa_longdescription: Alexa is the voice service that powers Amazon Echo.
+    Alexa provides capabilities, called "skills", which enable customers to interact
+    with devices using voice. In this tutorial, you will build a web service to handle
+    notifications from Alexa. You will create fact skills unique to your school for
+    this lab. By the end of this lab, you will be able to create an Alexa Fact skill
+    in the Amazon Developer Portal, create and configure an interaction model for
+    the Alexa skill, and test the skill using Developer tools and optionally an Alexa
+    device or simulator.
+  tutorial_grokpetmicro_longdescription: This activity is designed to introduce you
+    to embedded programming, and has been specially designed for the Hour of Code.
+    Use the MicroPython programming language to make a pet that you can feed and play
+    with. Don't have a BBC micro:bit? No problem! This course includes a full micro:bit
+    simulator, so you'll be able to do everything you'd do on a real micro:bit!
+  tutorial_pirateplunder_longdescription: Pirate Plunder takes place in an engaging
+    3D environment in which students help our pirate captain to reach his treasure
+    by dragging and dropping visual blocks to write code. Students climb, fight, collect,
+    and walk their way through challenges of increasing complexity while learning
+    to create efficient code with loops and write intelligent behaviour with conditions.
+    This actvitiy is targeted to kids aged 7+ and first-time-coders. On top of that,
+    anyone with a smartphone and a mobile VR headset will be able to explore their
+    solved tasks in VR.
+  tutorial_cadj_longdescription: Join Cody and Ava as they learn about Data Representation
+    using a fun and interactive DJ Device. Discover how your name can be represented
+    using numbers, images and sound while creating your very own colorful musical
+    melody!
+  tutorial_cacrazy_longdescription: Join Alex and Lonnie as they learn about coding
+    by creating fun, interactive pictures. Learn about sequence, loops, events, and
+    actions as you create crazy creatures in this exciting adventure!
+  tutorial_cajump_longdescription: Join Charlie and Tilley as they design a sport-themed
+    platformer game for Lucy's birthday.
+  tutorial_carest_longdescription: Join Ross at the Food Avengers restaurant. Use
+    your computational thinking skills to help Ross solve problems and serve dinner
+    to 8 excited kids.
+  tutorial_accai_longdescription: A robot is sent to an unknown planet to discover
+    if humanity could establish a new settlement. It explores the planet to find shelter
+    and discovers and interacts with the local population. As the player, you will
+    experience various Artificial Intelligence techniques to teach the robot how to
+    recognize animals and plants, understand a new language, dialogue with the inhabitants
+    etc.
+  tutorial_vceclipse_longdescription: 2017 gave us one of the most spectacular natural
+    phenomena of our lives, and now we're going to simulate the solar eclipse with
+    JavaScript! Looking at the eclipse as a system of moving parts, we can decompose
+    the problem into bite-sized chunks, using objects with methods, loops, and conditionals
+    to make an interactive app that models our observations.
+  tutorial_pmzero_longdescription: In one hour you create a simple version of a Pac-Man
+    game. You draw the characters in 2D and turn them into 3D. You create your own
+    maze. Then you program the game using AgentCubes. With only 11 IF/THEN rules you
+    create sophisticated AI. Even with just two smart ghosts you will have your hands
+    full to win the game.
+  tutorial_hsela_longdescription: Students will practice identifying narrative elements
+    while bringing their favorite story, poem or historical event to life. Learning
+    to code gives students another format and media for expressing their creativity
+    and communicating with others. Show them how to program their own interactive
+    stories, and wait for the smiles. 1-hour lesson plan, no prior coding experience
+    required.
+  tutorial_ticklear_longdescription: You will learn the basic concept of AR (Augmented
+    Reality), its current applications and its possibilities in the future and the
+    basic concepts of programming using motion blocks and event blocks under an AR/3D
+    environment.
+  tutorial_bcrobot_longdescription: Using BlocksCAD, a free online software designed
+    to teach students coding and Computer Aided Design, students will design a 3D
+    Robot. Using shapes, translate, and rotate blocks, students will be exposed to
+    computational thinking to construct something they can 3D print!
+  tutorial_bcsnow_longdescription: Using BlocksCAD, a free online software designed
+    to teach students coding and Computer Aided Design, students will design a 3D
+    snowflake. Using shapes, translate, rotate, and loop blocks, students will be
+    exposed to computational thinking to construct something they can 3D print!
+  tutorial_ifly_longdescription: This teacher-led lesson activity, adapted for the
+    Hour of Code, provides opportunities to explore physical systems through robotics.
+    Using a visual drag-and-drop programming environment and drones, pupils learn
+    that physical systems can be programmed and controlled through algorithms and
+    code. Includes a step-by-step activity plan, associated teacher and pupil resources
+    and ideas for extension and enrichment to take learning further.
+  tutorial_idowedo_longdescription: This teacher-led lesson activity, adapted for
+    the Hour of Code, provides opportunities to explore physical programming (robotics).
+    Children design and build models using construction bricks and bring them to life
+    with code! Using a visual drag-and-drop programming environment and LEGO™ WeDo
+    parts (motor and hub and optional sensors), pupils learn that physical systems
+    can be programmed and controlled using algorithms and code. Includes a step-by-step
+    activity plan, associated teacher and pupil resources and ideas for extension
+    and enrichment to take learning further.
+  tutorial_diggindwarf_longdescription: Dwarfs need your help to navigate, dig, and
+    collect gems!  Learn how to use JavaScript to guide your dwarf through mazes and
+    puzzles.
+  tutorial_spheroit_longdescription: Learn your first "if/then, else" condition by
+    building a fun game where you will be throwing Sphero and guessing animal sounds.
+    This is a great activity after you complete Blocks 1, and can be used for the
+    "Hour of Code."
+  tutorial_gameofcodes_longdescription: Build an awesome Dragon game to defend the
+    wall, then export it as a standalone app (for iOS, Android, PC, and Mac).
+  tutorial_blocklygames_longdescription: Blockly Games is a series of educational
+    games that teach programming. It is designed for children who have not had prior
+    experience with computer programming but who wish to learn at a more challenging
+    pace. By the end of these games, players are ready to use conventional text-based
+    languages.
+  tutorial_spherohello_longdescription: Have you conquered Blocks and need a new challenge?
+    Take the logic you have learned with block-based programming and begin to learn
+    how to program with just text. In this first Text activity learn the basics of
+    the text canvas, loops, and some tips to get started with your first lines of
+    JavaScript code.
+  tutorial_spheroarcade_longdescription: In this arcade-style playground, you can
+    recreate classic games with a Sphero SPRK+ robot while learning the basics of
+    game design. You'll build your very own robotic renditions of some famous games
+    like Pong, Bop It, and Pac-Man. Each game uses Sphero in a different way such
+    as rolling on the floor, detecting gestures, or using Sphero as a joystick.
+  tutorial_bcpy1_longdescription: 'This Hour of Code lesson teaches you some basic
+    concepts of coding in Python, based on the CodeCraft 3D game by BuzzCoder.com.
+    CodeCraft is a new game to learn programming by building whatever you imagine
+    in a virtual 3D world. You can start from building simple blocks, columns, and
+    walls, then large buildings, bridges, and even trees. When you are ready to delve
+    into more advanced levels, you will be able to build more complex structures:
+    growing flowers, flickering stars, and even invisible drones to move around and
+    build or destroy things at your command. You''ll have fun learning how to code
+    while playing this game!'
+  tutorial_bcpy2_longdescription: 'This Hour of Code lesson is a follow-up course
+    to World of Python. You''ll learn more advanced coding concepts in Python based
+    on the CodeCraft 3D game by BuzzCoder.com. CodeCraft is a new game to learn programming
+    by building whatever you imagine in a virtual 3D world. You can start from building
+    simple blocks, columns, and walls, then large buildings, bridges, and even trees.
+    When you are ready to delve into more advanced levels, you will be able to build
+    more complex structures: growing flowers, flickering stars, and even invisible
+    drones to move around and build or destroy things at your command. You''ll have
+    fun learning how to code while playing this game!'
+  tutorial_bcjs1_longdescription: 'This Hour of Code lesson teaches you some basic
+    concepts of coding in JavaScript, based on the CodeCraft 3D game by BuzzCoder.com.
+    CodeCraft is a new game to learn programming by building whatever you imagine
+    in a virtual 3D world. You can start from building simple blocks, columns, and
+    walls, then large buildings, bridges, and even trees. When you are ready to delve
+    into more advanced levels, you will be able to build more complex structures:
+    growing flowers, flickering stars, and even invisible drones to move around and
+    build or destroy things at your command. You''ll have fun learning how to code
+    while playing this game!'
+  tutorial_bcjs2_longdescription: 'This Hour of Code lesson is a follow-up course
+    to World of JavaScript. You''ll learn more advanced coding concepts in JavaScript
+    based on the CodeCraft 3D game by BuzzCoder.com. CodeCraft is a new game to learn
+    programming by building whatever you imagine in a virtual 3D world. You can start
+    from building simple blocks, columns, and walls, then large buildings, bridges,
+    and even trees. When you are ready to delve into more advanced levels, you will
+    be able to build more complex structures: growing flowers, flickering stars, and
+    even invisible drones to move around and build or destroy things at your command.
+    You''ll have fun learning how to code while playing this game!'
+  tutorial_3dbearmars_longdescription: The Mars Pioneers is a project-based learning
+    module that teaches facts about Mars and the crucial conditions for human beings
+    to survive there. The students will build a colony using Augmented Reality and
+    3D-print the colony facilities.
+  tutorial_bitsboxyak_longdescription: Type modified JavaScript code to make a greeting
+    card that you can email to friends and family. Yak Attack! is a completely open-ended
+    activity that introduces variables, motion commands, loop functions, and more.
+    Perfect for kids (and teachers) who are ready to try typed coding for the first
+    time.
+  tutorial_blockscadbargraphs_longdescription: 'Students will write code that lets
+    them quickly customize and analyze their own bar graphs. '
+  tutorial_blockscadbirdhouses_longdescription: 'Students will run a birdhouse-building
+    company, converting units, calculating dimensions, and using variables to scale
+    their products. '
+  tutorial_blockscadclock_longdescription: 'Students will program a 3D model of an
+    analog clock that can be set to show any time. '
+  tutorial_blockscaddinner_longdescription: Students will write a program using variables
+    and coordinates to help a robot set their dinner table for them!
+  tutorial_blockscadicecream_longdescription: Students will program an ice cream machine
+    to create 3D ice cream cones with different numbers and sizes of ice cream scoops.
+    They will work with variables, modules, and functions to calculate the cost of
+    a particular ice cream cone based on the area of the spherical ice cream scoops.
+  tutorial_blockscadpizza_longdescription: Students will program a module to create
+    a 3D pizza, calculating circumferences and areas and using loops along the way.
+  tutorial_blockscadsugar_longdescription: 'Students will use a programmed sugar-cube
+    generator to explore volume and variables. '
+  tutorial_bsgridlight_longdescription: Choose a Bot friend to help prepare for the
+    Lighthouse Festival. Code your Bot to stop those pesky rogue bots and save the
+    day!
+  tutorial_bpartscratch_longdescription: Creative Coding - developed with Scratch
+    and Vidcode - pairs block- and text-based projects with hundreds of cross-curricular
+    topics. Projects are scaffolded so that teachers of any subject - regardless of
+    prior experience - can easily introduce coding. The project-based approach positions
+    coding as a means of self-expression for students and gives them a creative way
+    to show what they know.
+  tutorial_bpartvid_longdescription: Creative Coding - developed with Scratch and
+    Vidcode - pairs block- and text-based projects with hundreds of cross-curricular
+    topics. Projects are scaffolded so that teachers of any subject - regardless of
+    prior experience - can easily introduce coding. The project-based approach positions
+    coding as a means of self-expression for students and gives them a creative way
+    to show what they know.
+  tutorial_bpenglishscratch_longdescription: Creative Coding - developed with Scratch
+    and Vidcode - pairs block- and text-based projects with hundreds of cross-curricular
+    topics. Projects are scaffolded so that teachers of any subject - regardless of
+    prior experience - can easily introduce coding. The project-based approach positions
+    coding as a means of self-expression for students and gives them a creative way
+    to show what they know.
+  tutorial_bpenglishvid_longdescription: Creative Coding - developed with Scratch
+    and Vidcode - pairs block- and text-based projects with hundreds of cross-curricular
+    topics. Projects are scaffolded so that teachers of any subject - regardless of
+    prior experience - can easily introduce coding. The project-based approach positions
+    coding as a means of self-expression for students and gives them a creative way
+    to show what they know.
+  tutorial_bphealthscratch_longdescription: Creative Coding - developed with Scratch
+    and Vidcode - pairs block- and text-based projects with hundreds of cross-curricular
+    topics. Projects are scaffolded so that teachers of any subject - regardless of
+    prior experience - can easily introduce coding. The project-based approach positions
+    coding as a means of self-expression for students and gives them a creative way
+    to show what they know.
+  tutorial_bphealthvid_longdescription: Creative Coding - developed with Scratch and
+    Vidcode - pairs block- and text-based projects with hundreds of cross-curricular
+    topics. Projects are scaffolded so that teachers of any subject - regardless of
+    prior experience - can easily introduce coding. The project-based approach positions
+    coding as a means of self-expression for students and gives them a creative way
+    to show what they know.
+  tutorial_bpmathscratch_longdescription: Creative Coding - developed with Scratch
+    and Vidcode - pairs block- and text-based projects with hundreds of cross-curricular
+    topics. Projects are scaffolded so that teachers of any subject - regardless of
+    prior experience - can easily introduce coding. The project-based approach positions
+    coding as a means of self-expression for students and gives them a creative way
+    to show what they know.
+  tutorial_bpmathvid_longdescription: Creative Coding - developed with Scratch and
+    Vidcode - pairs block- and text-based projects with hundreds of cross-curricular
+    topics. Projects are scaffolded so that teachers of any subject - regardless of
+    prior experience - can easily introduce coding. The project-based approach positions
+    coding as a means of self-expression for students and gives them a creative way
+    to show what they know.
+  tutorial_bpmlkscratch_longdescription: Creative Coding - developed with Scratch
+    and Vidcode - pairs block- and text-based projects with hundreds of cross-curricular
+    topics. Projects are scaffolded so that teachers of any subject - regardless of
+    prior experience - can easily introduce coding. The project-based approach positions
+    coding as a means of self-expression for students and gives them a creative way
+    to show what they know.
+  tutorial_bpmlkvid_longdescription: Creative Coding - developed with Scratch and
+    Vidcode - pairs block- and text-based projects with hundreds of cross-curricular
+    topics. Projects are scaffolded so that teachers of any subject - regardless of
+    prior experience - can easily introduce coding. The project-based approach positions
+    coding as a means of self-expression for students and gives them a creative way
+    to show what they know.
+  tutorial_bpsafetyscratch_longdescription: Creative Coding - developed with Scratch
+    and Vidcode - pairs block- and text-based projects with hundreds of cross-curricular
+    topics. Projects are scaffolded so that teachers of any subject - regardless of
+    prior experience - can easily introduce coding. The project-based approach positions
+    coding as a means of self-expression for students and gives them a creative way
+    to show what they know.
+  tutorial_bpsafetyvid_longdescription: Creative Coding - developed with Scratch and
+    Vidcode - pairs block- and text-based projects with hundreds of cross-curricular
+    topics. Projects are scaffolded so that teachers of any subject - regardless of
+    prior experience - can easily introduce coding. The project-based approach positions
+    coding as a means of self-expression for students and gives them a creative way
+    to show what they know.
+  tutorial_bpsciencescratch_longdescription: Creative Coding - developed with Scratch
+    and Vidcode - pairs block- and text-based projects with hundreds of cross-curricular
+    topics. Projects are scaffolded so that teachers of any subject - regardless of
+    prior experience - can easily introduce coding. The project-based approach positions
+    coding as a means of self-expression for students and gives them a creative way
+    to show what they know.
+  tutorial_bpsciencevid_longdescription: Creative Coding - developed with Scratch
+    and Vidcode - pairs block- and text-based projects with hundreds of cross-curricular
+    topics. Projects are scaffolded so that teachers of any subject - regardless of
+    prior experience - can easily introduce coding. The project-based approach positions
+    coding as a means of self-expression for students and gives them a creative way
+    to show what they know.
+  tutorial_bptechscratch_longdescription: Creative Coding - developed with Scratch
+    and Vidcode - pairs block- and text-based projects with hundreds of cross-curricular
+    topics. Projects are scaffolded so that teachers of any subject - regardless of
+    prior experience - can easily introduce coding. The project-based approach positions
+    coding as a means of self-expression for students and gives them a creative way
+    to show what they know.
+  tutorial_bptechvid_longdescription: Creative Coding - developed with Scratch and
+    Vidcode - pairs block- and text-based projects with hundreds of cross-curricular
+    topics. Projects are scaffolded so that teachers of any subject - regardless of
+    prior experience - can easily introduce coding. The project-based approach positions
+    coding as a means of self-expression for students and gives them a creative way
+    to show what they know.
+  tutorial_caflags_longdescription: Learn some basic programming concepts with blockly.
+    Develop your computational thinking by using simple shapes, colors and coordinates
+    to draw the flags of the world. Discover your creativity as you explore different
+    sequences of blocks and values to build your own exciting flag masterpieces.
+  tutorial_matariki_longdescription: 'Maia and Charlie are from New Zealand.  Maia''s
+    family are getting ready to celebrate Matariki: the Māori new year.  She''s invited
+    her friend Charlie to come and stay at her family''s marae (traditional meeting
+    house). There are lots of exciting problem-solving tasks and activities to do
+    for Matariki! Use your Computational Thinking skills to help Maia and Charlie
+    prepare for the celebration.'
+  tutorial_carestaurant_longdescription: Charlie and Tilley have decided that if they
+    program Ross properly he will be able to help do some painting to make Food Avengers
+    more attractive. Make sure their algorithms are correct though - a misdirected
+    robot with a paintbrush could do some serious damage!
+  tutorial_casea_longdescription: Alex and Lonnie create fancy fish and super sea
+    creatures with blocks. Help them sort the sequences into order and debug by spotting
+    and fixing the mistakes. Customize your own ocean scene and bring your characters
+    to life by adding interactivity. Beginner coders and pre-readers welcome!
+  tutorial_cashield_longdescription: It's the summer holidays and Alex, her family,
+    and Lonnie are going on holiday to Finland. Alex's older brother Reuben is creating
+    an app about shield blazonry and shows Alex and Lonnie how to use it. Join them
+    as they learn how to sequence blocks to design some amazing shields of their own!
+  tutorial_ccwslimer_longdescription: Learn how to program your own shareable game
+    with multiple levels and challenges!
+  tutorial_codinggalaxy_longdescription: For your first mission on Adventure Planet,
+    your duty is to solve coding puzzles to save the beautiful planet.
+  tutorial_boatrace_longdescription: Learn how to make a boat racing game. The player
+    uses the mouse to navigate a boat to a desert island without bumping into obstacles.
+  tutorial_ccplay_longdescription: Code and play a series of game levels while learning
+    important computer science concepts. On the final level, show off your creativity
+    and skills to code your own game from scratch!
+  tutorial_grinch_longdescription: 'Learn to program drones and a high tech sleigh
+    with coding magic to capture presents and navigate down the mountain to return
+    Christmas to Whoville. '
+  tutorial_codehsart_longdescription: Memes! Memes! Memes! Students explore the intersection
+    of coding and art by building a computer program that allows them to create custom
+    memes to share with friends.
+  tutorial_codehsbitcoin_longdescription: In this Hour of Code activity, students
+    are introduced to the Bitcoin blockchain ledger and some Bitcoin statistics. Students
+    look at how a transactions works on the Bitcoin ledger and and investigate the
+    overall performance of the Bitcoin blockchain.
+  tutorial_codehsblockchain_longdescription: Students learn about the foundations
+    of cryptocurrencies by exploring cryptography, hashing, and blockchain technology!
+  tutorial_codehscipher_longdescription: 'In this Hour of Code activity, students
+    are introduced to cryptography by using the classic Caesar cipher to decrypt and
+    encrypt some messages, and also discover the cipher''s flaw and how to improve
+    upon it. '
+  tutorial_codehscollision_longdescription: Students will explore how simulations
+    are used in research. They will study how mass and speed affect elastic collisions
+    by using conservation of momentum and conservation of kinetic energy equations
+    to verify final speed values as calculated by a simulation. Students should have
+    prior knowledge of solving mathematical equations using basic algebra.
+  tutorial_codehsmath_longdescription: 'Students are introduced to Tracy the Turtle
+    and learn how to code different mathematical models in Python! No coding experience
+    is necessary, but students should have completed Algebra I or higher. '
+  tutorial_codehsmusic_longdescription: Students explore how coding is used in music
+    creation by building their own dynamic eight-count beats and patterns with JavaScript
+    blocks!
+  tutorial_codehssports_longdescription: Students learn about how coding is used in
+    sports and game design by building an original sports video game that can be shared
+    with their friends immediately!
+  tutorial_codemojipizza_longdescription: 'This course is designed to teach students
+    the fundamentals of JavaScript objects. Students will learn the basic types of
+    data that can be stored in variables, from their first boolean all the way to
+    creating their own objects with multiple properties. The activity makes complex
+    concepts easy to understand by using everyone''s favourite food: Pizza!'
+  tutorial_moonlander_longdescription: Learn Physics as you code! Moon Lander is a
+    Game Builder course with 17 exercises that guides you on how to build your own
+    physics-based game. In the game, you will use code and 6-9th grade physics concepts
+    in order to help a spaceship land safely on the moon.
+  tutorial_sushicards_longdescription: Make a game where you move a shark around to
+    try and catch fish.
+  tutorial_codesparkcreate_longdescription: Ever wanted to design and code your own
+    video game? Choose from two game kits that guide you through creating and coding
+    a Mario-style video game using codeSpark Academy's no words interface. Beginner
+    coders and pre-readers welcome!
+  tutorial_hardvsoft_longdescription: Through an illustrated children's story and
+    worksheets, your students will learn the differences between hardware and software.
+  tutorial_codestersecard_longdescription: 'Build up your programming skills as you
+    learn how to create an electronic greeting card that you can share with your teacher,
+    family, or friends! '
+  tutorial_codesterslogo_longdescription: Use code to get creative and design your
+    own company logo! You'll learn coding basics in the programming language, Python.
+    After you work through the tutorial, you'll have all the skills you need to create
+    the logo for your personal brand!
+  tutorial_codesterstshirt_longdescription: 'Learn basic programming skills and practice
+    moving around the coordinate plane as you create your own monogrammed t-shirt
+    design! '
+  tutorial_codewards_longdescription: Join an exciting mission to save the underwater
+    city. Experience the work of a rescue engineer fixing damaged city systems with
+    commands and algorithms. Overcome various challenges to prove your skills, intelligence
+    and courage!
+  tutorial_olympics_longdescription: 'Together with Elsie get prepared for Robot Olympics!
+    Along with programming concepts learn how to drive, collect details and create
+    tools, build and test your mighty robot. '
+  tutorial_codinismhero_longdescription: Learn the basics of programming through fun
+    examples, and build a game while learning!
+  tutorial_discovery_longdescription: Two characters meet in a world, and discover
+    a surprising object. What happens next? With Scratch and CS First, anyone can
+    create their own unique story with code.
+  tutorial_csfirstname_longdescription: Pick a name and bring the letters of the word
+    to life using code. Choose a nickname, a pet's name, an animal, a sport, a place
+    or a hobby.
+  tutorial_edisonmove_longdescription: Introduce text-based programming and the key
+    computational concept of sequence to your students using Edison robots and EdPy,
+    a text-based programming language based on Python. Explore computer science and
+    programming basics including functions, inputs, input parameters and outputs.
+    Then take on a coding challenge and write your own program to get your Edison
+    robot through a maze.
+  tutorial_edisonspider_longdescription: Introduce the key computational concepts
+    of variables and data, two of the most fundamental parts of general-purpose programming
+    languages, using Edison robots and the Scratch-based programming language EdScratch.
+    Students can work through this lesson independently learning what variables are,
+    why we use them and then applying their knowledge to program Edison to drive like
+    a spider laying a trap.
+  tutorial_edisonspotlight_longdescription: Introduce Edison robots to your students,
+    helping them begin to explore what a robot is and how it can sense, and react,
+    to the world. Students can work through this lesson independently as they program
+    the Edison robot using the block-based programming language EdBlocks, practicing
+    computer science fundamentals including sequence, loops and conditionals.
+  tutorial_firiapython_longdescription: Get your micro:bit ready, and level-up to
+    Python coding! CodeSpace will guide you step-by-step from your very first line
+    of Python to coding an interactive program with buttons and LEDs. Learn the basics
+    of programming embedded devices, monitoring inputs and controlling outputs. Learn
+    how variables and if statements control the flow of code, and finish with a fast
+    and fun micro-game!
+  tutorial_gamefrootsquid_longdescription: Colossal squid are the largest invertebrates
+    in the world. In this coding game for beginners you'll learn the basics of coding
+    and create a game that explores the squid's life under the ocean. You'll discover
+    the secret life of the colossal squid, how to code keyboard game controls (inputs/outputs),
+    the Google Blockly coding language, how to publish your own computer game.
+  tutorial_duckpiano_longdescription: In this project you'll make keys on your computer
+    play quack sounds at different pitches, like a piano that sounds like a duck.
+    You can use your duck piano to play simple tunes. Later, you can try other sounds,
+    such as dog barks or even sounds you record yourself. This project works best
+    on a computer with a keyboard, but it could be adapted to work on a tablet.
+  tutorial_gpsound_longdescription: In this project you'll write a program to record
+    sound from your computer microphone, play it back, and draw a picture of the recorded
+    sound. You can then process your recording to add effects such as pitch-shift,
+    reverse, or echo.
+  tutorial_groklearningpython_longdescription: Develop your programming skills and
+    build your own animal classifier! In this course you'll use the programming language
+    Python to classify animals based on their characteristics. You'll learn about
+    the differences between animals, and how biologists use programming to help them
+    do science! This activity has some assumed knowledge (variables, print and input).
+  tutorial_htmltimetravel_longdescription: Take an adventurous travel through time
+    and conquer deep space while learning how to move, rotate and transform objects
+    using the basics of animation in CSS.
+  tutorial_hp_flappy_longdescription: Learn logical thinking and programming concept
+    by creating your own Flappy Birds style game on hyperPad.
+  tutorial_appytappin_longdescription: This teacher-led activity, adapted for the
+    Hour of Code, introduces children to using a text-based programming language to
+    develop a mobile games app. They design algorithms and use variables and functions,
+    as well as test and debug their work. Includes a step-by-step lesson plan, pupil
+    resources, support cards and pre-written program template.
+  tutorial_icipher_longdescription: This teacher led activity, adapted for the Hour
+    of Code teaches children about communicating securely. The children learn that
+    messages throughout time have been encrypted and decrypted using ciphers. They
+    explore cryptography and gain an understanding of need for secure communications.
+  tutorial_iguess_longdescription: Introducing Quick Response codes to children aged
+    3-5. Use tablets to scan QR codes and guess the mini-beast from a given habitat.
+  tutorial_imake_longdescription: This unplugged teacher-led activity, for children
+    aged 3-5, uses classic nursery rhymes to introduce the concept of algorithms,
+    sequence and repetition. By identifying the steps and patterns in popular rhymes,
+    children begin to understand that algorithms are all around us.
+  tutorial_imorse_longdescription: Explore cryptography with Morse Code and Sphero.
+    Learn that physical systems can be programmed and write code for Sphero to communicate.
+  tutorial_kanohp_longdescription: Learn to code and make magic on screen with creative
+    challenges. Make feathers fly and fire flow, compose music, and more.
+  tutorial_khanwebpages_longdescription: Learn how to make webpages with HTML tags
+    and CSS, and finish up by making your very own greeting card to share with friends
+    or family.
+  tutorial_kibobowl_longdescription: Crash! How far does KIBO have to move to get
+    from the start of the bowling lane to the pins? You can create a single straight
+    lane or a more complicated path. Students will use estimation and measurement
+    to create a program to travel the length of the lane. They'll test how far a single
+    forward block carries KIBO, then improve their programs using the Engineering
+    Design Process.
+  tutorial_kibodance_longdescription: Let's have a KIBO Robot dance party! Set up
+    a music player to play a favorite classroom song, or a song connected to a world
+    culture you're exploring. Students will decorate their KIBO as a dancer, then
+    they will create a program to teach their KIBO to dance to the music. Students
+    will learn how to create a program to express an idea (in this case, a dance),
+    with a focus on sequencing ability.
+  tutorial_buildcharacters_longdescription: What are some character traits you can
+    identify in books or people you know? Design your own fuzz and use code to modify
+    its properties and bring your character to life! Featuring JavaScript for upper
+    elementary.
+  tutorial_designgames_longdescription: The most popular pre-reader app now includes
+    a digital Maker Space! Make levels, design games, or build characters. Choose
+    your activity and start creating with Kodable!  Featuring JavaScript for upper
+    elementary.
+  tutorial_makelevels_longdescription: Can you build a symmetrical maze? A maze with
+    right angles? Get creative and complete maze-building challenges with basic coding
+    concepts. Aligned with K-5 Common Core math.
+  tutorial_wizard_longdescription: Journey into the world of Code Magic as a Code
+    Wizard. Learn to create and cast spells to customize your castle.
+  tutorial_mbscratchcards_longdescription: Connect the physical world of micro:bit
+    with the virtual world of Scratch.
+  tutorial_mbswiftplaygrounds_longdescription: Use the micro:bit with an iPad to learn
+    Swift.
+  tutorial_mbbuttons_longdescription: In this introductory project, you'll make pictures
+    or animations appear on the micro:bit display when buttons are pressed. This activity
+    is suitable for those who have never programmed before or those seeking a simple
+    introduction to programming the BBC micro:bit. It uses MicroBlocks, a Scratch-like
+    programming system that lets you see your code running on the micro:bit immediately.
+  tutorial_meteor_longdescription: In this project, you'll create a Falling Meteors
+    game for the BBC micro:bit. Using the buttons, the player will move a shield to
+    catch falling meteors and save the Earth. The techniques you learn in this project
+    can be used to make many other games for the BBC micro:bit, including classics
+    such as Pong and Space Invaders.
+  tutorial_ballbounce_longdescription: Learn to make a mobile app where the user flings
+    a ball across the screen and it bounces off the edges.
+  tutorial_mitcodi_longdescription: Learn to make your own interactive mobile app.
+    Press the bee and hear it buzz!
+  tutorial_mitdoodle_longdescription: Make a mobile app where you can draw pictures
+    on the screen!
+  tutorial_talktome_longdescription: Learn to make a mobile app that makes your phone
+    talk to you!
+  tutorial_mobilecspmap_longdescription: Use App Inventor to create a Map Tour of
+    landmarks in your town, state, or anywhere in the world. Self-guided video and
+    text tutorials lead students through building a user interface and coding a mobile
+    app, using a map component and determining locations by latitude and longitude.
+  tutorial_ozorandom_longdescription: 'Learn how computers create random numbers and
+    use them, then use a random movement program to help seed ideas for a story. '
+  tutorial_ozotroll_longdescription: 'Learn the difference between Internet trolls
+    and fairy tale trolls, then teach Evo how to be a good troll that protects you. '
+  tutorial_peblioart_longdescription: 'Learn to draw and animate shapes with code
+    to create interactive artwork inspired by artists. '
+  tutorial_astropi_longdescription: Code a message and check the ambient air temperature
+    on board the ISS using an online simulator of the Astro Pi computer's Sense HAT.
+  tutorial_rgart_longdescription: Looking for an easy and intuitive way to teach your
+    students to code? RoboGarden STEAM has fused code practicing with STEAM learning
+    and gamified missions in multiple activities. In the art activity, the student
+    understand color mixing concepts while using coding blocks to solve challenges
+    in the birthday party.
+  tutorial_rgengineer_longdescription: Looking for an easy and intuitive way to teach
+    your students to code? RoboGarden STEAM has fused code practicing with STEAM learning
+    and gamified missions in multiple activities. In the engineering activity, the
+    student learns basic robotics while using coding blocks to solve challenges in
+    the Christmas party.
+  tutorial_rgmath_longdescription: Looking for an easy and intuitive way to teach
+    your students to code? RoboGarden STEAM has fused code practicing with STEAM learning
+    and gamified missions in multiple activities. In the math activity, the student
+    practices counting, addition and subtraction while solving some coding challenges.
+  tutorial_rgscience_longdescription: Looking for an easy and intuitive way to teach
+    your students to code? RoboGarden STEAM has fused code practicing with STEAM learning
+    and gamified missions in multiple activities. In the science activity, the student
+    goes through a journey to the space solving multiple coding challenges and know
+    more about space elements and science facts.
+  tutorial_rgtech_longdescription: Looking for an easy and intuitive way to teach
+    your students to code? RoboGarden STEAM has fused code practicing with STEAM learning
+    and gamified missions in multiple activities. In the technology activity, the
+    student goes through a journey to the volcanic islands solving multiple coding
+    challenges by understanding basic concepts of Technology.
+  tutorial_robotmagic3d_longdescription: Use your imagination to create an animated
+    3D logo of your name, your favorite sports team or anything you want. Use code
+    to make 3D models and letters come alive with fun. At the end you can download
+    an animated sticker of your creation and share it with friends.
+  tutorial_robotmagicflappy_longdescription: Use your imagination to create a 3D Flappy
+    Bird game. Use code to make 3D models come alive with fun. At the end you can
+    share your creation with friends and challenge them to a high score.
+  tutorial_scratchadventure_longdescription: Send your favorite Cartoon Network characters
+    on a quest, from the farthest reaches of the universe, to the edge of Craig's
+    creek. Unlock secret treasures and discover new characters while creating an adventure
+    game.
+  tutorial_scratchtalk_longdescription: Bring your characters to life in Scratch using
+    new Text-to-Speech blocks powered by Amazon. Create a rapping robot or an interactive
+    animation that talks. This project will show you how to create talking animations
+    that spin, zoom and change colors. The possibilities are endless!
+  tutorial_scratchjrstory_longdescription: An intermediate activity meant for children
+    in 2nd-5th grades with some experience with ScratchJr. Through this activity and
+    continued time with ScratchJr, students will have the opportunity to think creatively,
+    improve their storytelling and collaborate with peers.
+  tutorial_scratchjrtwinkle_longdescription: Twinkle, Twinkle Little Star Class Collaboration
+    is an introductory activity meant for children in kindergarten through second
+    grade with little to no programming experience. Through this activity, students
+    will have the opportunity to think creatively, become storytellers, and improve
+    upon mathematical reasoning and sequencing skills.
+  tutorial_spherocomm_longdescription: Learn about miscommunication in both a community
+    and in a computer program. Use this knowledge to resolve any miscommunication,
+    or bugs, in a program in an effort to help BOLT find its way home.
+  tutorial_spherocommunity_longdescription: Design a simple path that represents a
+    common route that you travel everyday. You will create two programs, a drawn path
+    and a block-based program path through your community route.
+  tutorial_spherofunctions_longdescription: Learn how to use and invoke functions
+    to turn Sphero into a calculator.
+  tutorial_spheroinfrared_longdescription: Become an epidemiologist in order to stop
+    the spread of a rare robot infection that is plaguing a community of BOLT robots.
+  tutorial_spherolightsensor_longdescription: Learn how to create a program that uses
+    the ambient light sensor to measure lux values and chase BOLT.
+  tutorial_spheromansion_longdescription: Keeping a bunch of dinosaurs at your house
+    shouldn't be an issue, right? As you would imagine, this doesn't to end well.
+    You are trapped in the mansion's library and must program your way out.
+  tutorial_roadblocks_longdescription: As a continuation of Your Community, you will
+    modify your blocks program as you and your partner encounter different roadblocks
+    along the route.
+  tutorial_spherotext2_longdescription: Learn your first conditional by building a
+    fun game where you will be throwing Sphero and guessing animal sounds. This is
+    a great activity after you complete Text 1.
+  tutorial_spherotext3_longdescription: Learn to change Sphero's main LEDs based on
+    the gyroscope's spin rate. You will also learn about normalization and absolute
+    value. This is a great activity after you complete Text 1 and 2.
+  tutorial_spherotext4_longdescription: Use variables to build a hot potato game powered
+    by Sphero. You will use pseudocode and read documentation to bring this classic
+    game to life. You will also learn about technical concepts like loop until and
+    randomness within bounds. This is a great activity after you complete Text 2 or
+    3.
+  tutorial_spheroraptor_longdescription: Create a fortified pen to keep the Spheroraptors
+    at bay, while also writing the code to the Spheroraptors escape. From loops, to
+    conditionals, to operators and even comparators, you will need as much coding
+    know-how as you can muster.
+  tutorial_stempiday_longdescription: We use the number Pi to calculate the circumference
+    and area of a circle, but have you ever wondered where this number comes from
+    or how to calculate it? In this coding activity you will randomly generate points
+    similar to a very bad player shooting darts at a dart board. The percentage of
+    darts that land inside the circle can help us calculate Pi. Then change the colors
+    of the points just for fun!
+  tutorial_stemplanetoids_longdescription: Did you know that the code behind the classic
+    Asteroids and Lunar Lander games is simpler than you might think? Did you know
+    that both of these games have accurate physics? In this activity you will fix
+    a broken asteroids game where the ship only moves in a straight line. Then you
+    will add gravity to the game and try to land the ship on the moon! Works with
+    chromebooks and other devices!
+  tutorial_stempong_longdescription: Did you know that the code behind the popular
+    game Bonk.io and the classic Pong game is simpler than you might think? Did you
+    know that both of these games have accurate physics? In this activity you will
+    fix a broken version of the Pong game so that objects bounce like they should.
+    Then you will add gravity to create a Bonk.io clone. Works with chromebooks and
+    other devices!
+  tutorial_algobot_longdescription: AlgoBot is a puzzle game that takes place on the
+    Europa, a pan-galactic colonisation ship, where a recycling mission goes horribly
+    wrong. Players command AlgoBot, a smart little service droid, and learn to use
+    a visual programming language to help him contain the crisis!
+  tutorial_thunkableapps_longdescription: 'Learn how to build your own apps with blocks-based
+    coding! '
+  tutorial_toxicodedot_longdescription: 'Select a card from your deck and interpret
+    its code in order to progress through the world. Use your intuitive abilities
+    to guess the rules and learn from your own mistakes. Made with care by the team
+    behind Compute it and Silent Teacher, with the same fundamentals: trial-and-error
+    instead of verbose explanations, smooth progression, no code to type, accessibility
+    to absolute beginners.'
+  tutorial_gcactions_longdescription: Discover actions, one of the key building blocks
+    in coding, and use them to code a video game! Explore digital culture and learn
+    about robots and what they can actually do.
+  tutorial_gccomparators_longdescription: Discover comparators and logical rules,
+    which are key building blocks in coding, and use them to code a video game! Explore
+    digital culture and learn about the tracking of our online activities.
+  tutorial_gcconditions_longdescription: Discover conditions, one of the key building
+    blocks in coding, and use them to code a video game! Explore digital culture and
+    learn about the algorithms that power our online world.
+  tutorial_gccreate_longdescription: Create your first full videogame with GameCode!
+    Create new characters, make them (a bit) smarter, give the player superpowers...Sky's
+    the limit!
+  tutorial_gcevents_longdescription: 'Discover events, one of the key building blocks
+    in coding, and use them to code a video game! Explore digital culture and learn
+    about Artificial Intelligence, and how it might be meaningful in your life. '
+  tutorial_gcloops_longdescription: Discover loops, one of the key building blocks
+    in coding, and use them to code a video game! Explore digital culture and learn
+    about the echo chamber phenomenon on social networks.
+  tutorial_gcvariables_longdescription: Discover variables, one of the key building
+    blocks in coding, and use them to code a video game! Explore digital culture and
+    learn about what data is and how it works.
+  tutorial_beanything_longdescription: Explore six cool careers and see how coding
+    can be applied to each one! Discover what it's like to be a Robotics Engineer,
+    a Musician, an Astronaut, a Farmer, a Beekeeper, and a Pastry Chef. Use programming
+    to animate characters, compose music, tell stories, design games, and even create
+    art.
+  tutorial_change_longdescription: Create a project that shows how you would change
+    the world! Whether you are passionate about recycling or have an idea to achieve
+    world peace, share your vision with code!
+  tutorial_cooking_longdescription: Show off your skills - create an interactive cooking
+    game. Beginners can use the self-guided tutorial while more advanced coders have
+    the option to start off with a blank project.
+  tutorial_crystal_longdescription: Battle with friends in this multiplayer game.
+    Apply your own strategies and pit your code against the entire Tynker community
+    to see who the true coding champion is! Cast spells, collect power-ups, and defeat
+    enemies as you battle in a wild 4-player arena that is shrinking amidst lava!
+  tutorial_landscape_longdescription: Use Python's pen drawing feature to compose
+    a landscape using code. Use the landscape items already created for you or design
+    our own structures. Publish and share your creations!
+  tutorial_pets_longdescription: Create a fun game about pets – either real or imaginary!
+    Beginners can use the self-guided tutorial while more advanced coders have the
+    option to start off with a blank project.
+  tutorial_petvet_longdescription: A busy day at the Pet Vet leads to fun as you and
+    Barbie help a variety of pets through their very first checkups. From guiding
+    pets into the Examination Room to diagnosing their sniffles, boo-boos, and itches,
+    you'll find every puzzle has a solution to make the pets feel better than ever!
+  tutorial_superhero_longdescription: Use HTML and CSS pixel art to create your favorite
+    superhero masks. Publish and share your creations!
+  tutorial_vidcodeplastic_longdescription: The problem of plastic filling our oceans
+    continues to worsen. Luckily, you can make your voice heard with code through
+    the Plastic Pollution PSA. After coding a PSA on plastic pollution using JavaScript,
+    you can make a second video about any subject you care about! Learn to use loops,
+    sine waves and customized emojis to make a unique project.
+  tutorial_vidcodetypeface_longdescription: Create your own typeface using shapes
+    and elements of typography. Type has more elements than you may have realized!
+    So far we have talked about fonts and how they are different styles of text. Fonts
+    are actually just different styles of a typeface. A typeface is a family of fonts
+    that have similar features.
+  tutorial_washustorm_longdescription: Learn how to program an incoming storm.
+  tutorial_activitypackets_longdescription: Find hours of family-friendly fun with
+    Wonder Workshop's printable packets of creative coding activities. Bring coding
+    to life with Dash, Dot, and Cue robots by downloading these online and offline
+    activities to use during Hour of Code and beyond!
+  tutorial_googlerookie_longdescription: In this activity, you'll code a Rookie themed
+    collage using Blockly, an introductory coding language. You'll use sequences,
+    variables and loops to create a unique piece that highlights your creativity!
+  tutorial_tommyturtle_longdescription: Help young kids learn the basics of coding
+    with Tommy the Turtle! Gold Award Winner for Best Educational App by Best Mobile
+    App Awards. Connects with STEMdash to enable parents and teachers to track learning
+    progress, chat with your child to provide encouragement, or limit their playtime.
+  tutorial_mazyad_longdescription: This product will broaden our boundaries to create
+    an integrated paper version with computerized applications and an alternative
+    if the computer is not used for any reason. It will also serve as an introduction
+    to understanding programming in general.
+  tutorial_gamemaker_longdescription: Game Maker is an open ended activity where students
+    can create anything they want using a simple code wizard. Just click on the picture
+    of a cute little monster and choose one of the options in the menu. More advanced
+    tutorials are also included for those wanting to go deeper into game making.
+  tutorial_duckrace_longdescription: In this course you will solve programming tasks
+    to help Toni the duck collect coins for its holiday savings. At the end of the
+    course you create your own game.
+  tutorial_allcancodeapps_longdescription: Use the Allcancode Platform to create web
+    and mobile apps from design to delivery. Application logic is written in Google
+    Blockly, the programming language used in most Code.org activities.
+  tutorial_n2y_longdescription: In these printable activities, students can help a
+    little robot named Bitt Bott explore different landforms on Earth. Students give
+    Bitt Bott simple directions by choosing and circling appropriate directional arrows.
+    Each of the six activities includes simple directions that are supported with
+    symbols from the n2y® SymbolStix PRIME® collection. The symbols help non-readers
+    and beginning readers understand and follow the directions.
+  tutorial_microsoftarcade_longdescription: Play fun arcade games, design your own
+    sprites, and learn the basics of coding your own game with MakeCode Arcade.
+  tutorial_csfirstunplugged_longdescription: No computer or internet? No problem.
+    Try the CS First Unplugged activities to explore how computer science can solve
+    problems like helping people stay connected while apart. 'Plugged in' Scratch
+    activities are available too!
+  tutorial_toxicodepython_longdescription: Discover the basics of Python without any
+    word or explanation. Our silent teacher will give you several series of challenges
+    that will lead you to guess some rules and learn from your own mistakes.
+  tutorial_codecombatozaria_longdescription: Enter the world of Ozaria where you become
+    a hero in an epic adventure. You must use the power of coding to defeat a darkness
+    that has taken over the world! Along the way, you’ll meet interesting characters
+    and travel to different lands, practicing coding concepts like sequences, loops,
+    debugging, and decomposition. In the end, you’ll design a playable game that you
+    can share with your friends!
+  tutorial_vidcodedate_longdescription: 'The Climate Clock project is a culturally
+    relevant intersection of math, environmental science, and computer science. In
+    this Hour of Code activity, students will be guided through the construction of
+    their own climate clock. They will engage with objects, properties, variables,
+    functions, and loops, and customize their message to convey their message for
+    the world and their hopes for the future. '
+  tutorial_codemonkeyspace_longdescription: 'Write real code to help the monkey astronaut
+    catch bananas in space! '
+  tutorial_codespeakhappy_longdescription: Learn to program a meditation app that
+    transports you to your 'happy place.'
+  tutorial_grokimage_longdescription: Use the programming language Python to make
+    speedy changes to images. Make fun image editing programs and make your own image
+    filter!
+  tutorial_icomputelearn_longdescription: When you learn to code with iCompute you
+    program your own fantastic interactive stories, games, and animations. Following
+    our creative, fun, activities means that you will develop computational thinking
+    as well as coding skills!
+  tutorial_rpstress_longdescription: Use Scratch blocks to create and personalise
+    your clickable stress ball with graphic effects, costume animation, and sound
+    effects.
+  tutorial_bsdcause_longdescription: 'This course allows students to use code as a
+    way to share what is important or interesting to them. They can follow the lesson
+    or create unique projects while learning HTML, CSS and JavaScript. They are guided
+    with video tutorials, live coding and access to the code glossary. The Support
+    My Cause focuses on designing and coding a landing page that will collect data
+    from supporters of your favorite cause. #codeisyourvoice'
+  tutorial_vidcodeanimoji_longdescription: Use a loop to iterate over an array, causing
+    an emoji to animate through multiple options.
+  tutorial_vidcodeanimojies_longdescription: Use a loop to iterate over an array,
+    causing an emoji to animate through multiple options.
+  tutorial_bsdinspire_longdescription: 'This course allows students to use code as
+    a way to share what is important or interesting to them.They can follow the lesson
+    or create unique projects while learning HTML, CSS and JavaScript. They are guided
+    with video tutorials, live coding and access to the code glossary. The People
+    Who Inspire Me focuses on creating a webpage to showcase the top 3 people who
+    have been an inspiration to you. #codeisyourvoice'
+  tutorial_tttractor_longdescription: Help bring the fields back to life. Farmer Hayao's
+    down on his luck, and his fields have become a mess. But he's just obtained a
+    fancy new tractor with a repeating code system using loops that just might save
+    everything. Help learn how the tractor works to water all the crops in his fields.
+  tutorial_codeillusionmickey_longdescription: Embark on a magical coding adventure
+    with Mickey! Learn how to draw, color, and move shapes as you master the introduction
+    to Media Art using JavaScript.
+  tutorial_scigirlsquest_longdescription: 'In this online coding adventure, youth
+    take Subby the submarine through underwater challenges, using code to find various
+    items and collect scientific data on the ocean floor. '
+  tutorial_codespeakbreathe_longdescription: Learn to program meditation app that
+    will guide users through a mindful breathing exercise.
+  tutorial_vidcodeface_longdescription: Use a facetracking library to code your own
+    custom face filter, like the ones you use on social media.
+  tutorial_educodemaze_longdescription: Design a maze, complete with monsters and
+    locked passages. Use variables, loops, and strings to help your hero navigate
+    the world you've created.
+  tutorial_educoderace_longdescription: Learn computer science as you unleash the
+    racer in you! Invent and customize your very own car, all while gaining a deeper
+    understanding of objects and how video games are made.
+  tutorial_codespeakchatbot_longdescription: Learn how to code a chatbot, a computer
+    program you can have a conversation with, while learning about the famous women
+    pioneers of computer science.
+  tutorial_gamefrootgames_longdescription: Learn to code a real game like Super Mario
+    Bros. Students that are ready to go beyond Scratch and Tynker will be introduced
+    to real games industry practice, creative coding concepts, how to publish their
+    own unique game and start working towards a career in the games industry. The
+    tutorial is all about level design, choosing a character, animating and coding
+    your character to move around.
+  tutorial_codespeakgrandparent_longdescription: Learn to code a digital card to spread
+    joy to someone special in your life.
+  tutorial_educodekingdom_longdescription: The Kingdom is under attack! Plan powerful
+    defenses to help repel the invaders. Master the power of arrays in order to create
+    your very own wave of monsters in your own tower defense game!
+  tutorial_codehsdata_longdescription: Learn about the power of using data visualizations
+    to display data in meaningful and easy to understand ways. Use our graph generator
+    to create visually appealing graphs and learn how coding is used to create beautiful
+    data.
+  tutorial_educodecake_longdescription: Learn HTML as you bake a cake with chef Roland.
+    Shape and style your custom creation with your newfound knowledge of tags and
+    classes.
+  tutorial_ttsecond_longdescription: Can you deliver the Open Protocol? You've snuck
+    aboard the capital ship, and now you must evade the security drones long enough
+    to open access for all. Quickly examine conditional statements to find out whether
+    you're safe or not from the dastardly cybervision. If not, it's to the airlock!
+  tutorial_bsdtrivia_longdescription: 'This course allows students to use code as
+    a way to share what is important or interesting to them. They can follow the lesson
+    or create unique projects while learning HTML, CSS and JavaScript. They are guided
+    with video tutorials, live coding and access to the code glossary. The Trivia
+    Game Maker focuses on building an interactive trivia game where you also get to
+    come up with the trivia questions. #codeisyourvoice'
+  tutorial_csfirstdialogue_longdescription: Program a conversation between two sprites.
+    Get creative while communicating with code in Scratch with CS First!
+  tutorial_codemonkeybeaver_longdescription: Help a Beaver achieve its goals! Dive
+    into this beaver's natural habitat with a fun-packed coding activity that will
+    jump-start your coding education. Beavers can swim, collect wood, and build dams.
+    This little beaver needs your help. Use the simple blocks of code to complete
+    the dam in the lake so the water remains calm, build a house, and make smoothies!
+  tutorial_codestersdistance_longdescription: Learn the basics of coding in Python,
+    then create a program that calculates the distance between two sprites to make
+    sure they are social distancing or need to wear a mask.
+  tutorial_itchspace_longdescription: This tutorial takes you through the creation
+    of a classic Space Invaders game using the Scratch MIT programming language. Subscribe
+    to the RokCoder YouTube channel for more Scratch-based videos and tutorials! Each
+    video is a bite-sized tutorial (approximately ten minutes in length) that contains
+    its own specific end goals. The final result is a high quality Scratch arcade
+    game.
+  tutorial_vidcodemagic_longdescription: Make flashes appear randomly around the screen
+    using a loop.
+  tutorial_vidcodemagices_longdescription: Make flashes appear randomly around the
+    screen using a loop.
+  tutorial_codespeakmeal_longdescription: Learn to code an app that helps users make
+    healthy food decisions.
+  tutorial_itchfish_longdescription: Scratch 3.0 tutorial for making a game with a
+    shark chasing and eating fish disrupted when a diver is eaten accidentally.
+  tutorial_bsdwebsite_longdescription: 'This course allows students to use code as
+    a way to share what is important or interesting to them. They can follow the lesson
+    or create unique projects while learning HTML, CSS and JavaScript. They are guided
+    with video tutorials, live coding and access to the code glossary. ''The My Favourites
+    Website focuses on creating a webpage of the top 3 things you are interested in
+    or love doing. #codeisyourvoice'
+  tutorial_codespeaktime_longdescription: Learn how to code a digital time capsule
+    to record and reflect on your life right now.
+  tutorial_itchwebcam_longdescription: Learn about augmented reality and make your
+    own augmented reality virtual space.
+  tutorial_itchball_longdescription: Get a ball to bounce around the screen. Learn
+    about loops and conditionals within loops.
+  tutorial_ttrace_longdescription: By calling functions and designing classes, players
+    program their own race car to be fast, nimble, and powerful; during races, they
+    can then hack their competitors' vehicles to scramble their controls.
+  tutorial_plethora_longdescription: 'In this Plethora activity you will solve visual
+    fun challenges and learn the concepts of cause and effect and user interaction. '
+  tutorial_educodesecret_longdescription: Explore the worlds of secrets with Agent
+    Smith as you dive deeper into learning if statements, strings, for-in loops. Help
+    Agent Smith find the culprits and configure the Agency's operating system for
+    their new users with Python.
+  tutorial_itchshapes_longdescription: Learn how to draw shapes in Scratch. You will
+    also learn how to calculate how much you need to turn for any shape.
+  tutorial_codeguppytext_longdescription: Learn the basics of text based coding by
+    creating your first program in an online coding editor.
+  tutorial_vidcodeplastiche_longdescription: The problem of plastic filling our oceans
+    continues to worsen. Luckily, you can make your voice heard with code through
+    the Plastic Pollution PSA. After coding a PSA on plastic pollution using JavaScript,
+    you can make a second video about any subject you care about! Learn to use loops,
+    sine waves and customized emojis to make a unique project.
+  tutorial_educativechatbot_longdescription: Learn about the realm of Artificial intelligence
+    and Machine Learning, as well as programming your own chatbot!
+  tutorial_educodebasics_longdescription: Learn some programming fundamentals and
+    create your own game in the process!
+  tutorial_codehsdesign_longdescription: 'Coders will learn how programming can support
+    artists and build their own Online Shop mockup, using HTML. '
+  tutorial_htmlacademyphp_longdescription: Meet Dumpo the Little Elephant, a senior
+    programmer at a web design studio, who is developing an online store. Together
+    you will learn the basics of PHP in an engaging way. You will work with web scripts
+    and learn the variables, add PHP-scripts into the layout and interact with databases
+    while creating a true-to-life web project.
+  tutorial_gamefrootdistance_longdescription: 'In COVID-19: Stop the Spread, you can
+    modify the ''Staying home'' factor and code a simple news clicker. The activity
+    illustrates how social distancing has a direct impact on how fast a virus like
+    COVID-19 can spread. Students and teachers will gain a small insight into virus
+    science, the effects a virus can have on society, and at the same time level up
+    their digital fluency skills.'
+  tutorial_codesterscovid_longdescription: Learn the basics of coding in Python while
+    creating your own PSA about how we can stop the spread of COVID-19. Design your
+    own animated interactive PSA to share critical information about the importance
+    of social distancing, wearing a mask, quarantining, and other measures.
+  tutorial_ttbunker_longdescription: You found The Bunker, and all its secrets will
+    be yours, once you crack its encryption. An army approaches, and you must hold
+    the perimeter using the power of programming. Code individual towers, setting
+    range, damage, and more special powers by adding new lines of code and changing
+    values. Survive long enough to learn how classes and instances can make you even
+    more powerful.
+  tutorial_cuttle_longdescription: Challenge yourself with these fun and interactive
+    tasks and learn all about computational thinking.
+  tutorial_bsdjokes_longdescription: 'This course allows students to use code as a
+    way to share what is important or interesting to them. They can follow the lesson
+    or create unique projects while learning HTML, CSS and JavaScript. They are guided
+    with video tutorials, live coding and access to the code glossary. The Jokes and
+    Riddles focuses on creating a set of interactive cards that contain your favorite
+    jokes and riddles and the answers! #codeisyourvoice'
+  tutorial_rptree_longdescription: Use Scratch to create a simulation that shows how
+    varying the health of a forest and levels of deforestation impact trees, wildlife
+    and the amount of CO2 absorbed. You should already know how Scratch coordinates
+    and variables work.
+  tutorial_codestersunity_longdescription: Learn the basics of coding in Python including
+    lists, loops, and sprites. Then create a mural using a loop to access each sprite
+    stored in a list.
+  tutorial_codesterssoccer_longdescription: Learn the basics of coding in Python,
+    then create a program that shoots a soccer ball into the goal. To aim your shot
+    you'll first need to estimate the slope of the line. Good luck!
+  tutorial_breakoutlock_longdescription: 'Haspy the Robot needs your help! She needs
+    your knowledge of loops, algorithms, and coding to help her fix Lockit''s code
+    and reboot her system. '
+  tutorial_thunkablemask_longdescription: Learn how to build a mobile app that gives
+    you points for knowing how to wear your mask correctly!
+  tutorial_cafarming_longdescription: Computer science can help feed a hungry world.
+    Farmers are using technology to grow food in smarter and more sustainable ways.
+    Agribots and drones can monitor, water, and spray crops, and even tackle those
+    pesky weeds! Learn about how AI, Computer Vision, and the Internet of Things are
+    used on the farm.
+  tutorial_blocksmithyeti_longdescription: Oh no! Someone trapped the Yeti! Only YOU
+    and your programmable smart cannon can save the Yeti and feed their friends. Students
+    will use JavaScript to save the Yeti with this fun interactive self-paced lesson.
+  tutorial_codecapture_longdescription: 'Take your first steps into the world of programming
+    with JavaScript, using just pen-and-paper and your mobile phone! '
+  tutorial_codehslitter_longdescription: 'Learn how you can use programming to help
+    solve one of the world''s biggest problems: litter and waste! In this Choose-Your-Own-Adventure
+    Hour of Code, you have the choice between the basics of Python or the basics of
+    Web Design. Whichever you choose, you will explore how you can use computer science
+    to decrease the amount of litter in your community.'
+  tutorial_bsdocean_longdescription: Life below Water sheds light on a pressing issue
+    that we face nowadays - our environment. This project focuses on guiding you to
+    code your very own webpage on protecting our waters.
+  tutorial_itchplatformer_longdescription: An easy to follow tutorial for how to create
+    a simple platformer game using Scratch.
+  tutorial_codejika_longdescription: A great introduction to coding using HTML and
+    CSS. Code a few lines, see immediate output without getting caught up in the Hows
+    and Whys by creating a nice landing page with a two-color gradient background,
+    name and website launch date.
+  tutorial_gamefrootclicker_longdescription: Learners code their own Clicker Game
+    and in the process learn about variables, different data types, conditional logic,
+    comparative operators, and gain some valuable insights into how professional game
+    developers design and make real games. By the end of the tutorial you will have
+    coded different variable types, published a game, and engaged with computer science
+    in an indigenous context.
+  tutorial_rmagicequity_longdescription: 'Explore concepts related to reducing inequality
+    with code: limited resources, equality, equity and liberation. Use variables and
+    functions in a self guided block environment. Finish by animating the 3D actors.'
+  tutorial_ttfreestyle_longdescription: You're the choreographer and director of a
+    new music video! Type real code to place and control dancers, scenery, and more.
+    Just make sure to capitalize and punctuate correctly, otherwise the whole thing
+    will just be static.
+  tutorial_ozobotcolor2_longdescription: Students will learn the basic functionality
+    of Ozobot. Students will learn how to draw Color Codes Ozobot can read.
+  tutorial_ozobotcolor3_longdescription: Students will learn how to program the bot
+    to travel left, right, and straight with Color Codes.
+  tutorial_clcarbon_longdescription: A python lesson plan that will teach students
+    how to make a carbon footprint calculator that calculates footprint based on a
+    short quiz about daily life, then gives comparison metrics (ie this is the same
+    amount of carbon as xxxx), and suggests ways to be more eco-friendly.
+  tutorial_kodablebasics_longdescription: No computer? No problem! Learn basic programming
+    skills and practice using core coding commands without the use of a device.
+  tutorial_scigirlscc_longdescription: Help your students learn to write pseudocode!
+    Computer programmers often start projects by using everyday language to write
+    out what they want to happen in their code–this is called pseudocode.Youth will
+    work in groups to write pseudocode for a simple movement or dance move.
+  tutorial_irobotpicture_longdescription: Robots have lots of sensors that work together
+    to help the robot understand everything around it. Just like sensors, our friends
+    can often see, hear, feel or understand things that we cannot. In this activity,
+    work together to help decode secret messages and crack the code!
+  tutorial_kcjmyself_longdescription: In this activity, you'll learn how to use Scratch
+    to code an animation all about you! Design a custom character to represent yourself,
+    make it move around, and add different backdrops to show off your hometown. This
+    project is simple enough for kids to complete by themselves or with support from
+    a grown up.
+  tutorial_nearpodalgorithms_longdescription: 'In this Nearpod lesson, students identify
+    an algorithm as a set of step-by-step directions. Students learn to create, test,
+    and fix an algorithm to complete a specific task. '
+  tutorial_kibodrop_longdescription: Engineering is about persistence and grit. Today
+    the students will become engineers, learning the steps of the Engineering Design
+    Process. They will create models out of craft and recycled materials, then they
+    will test the sturdiness of their models by dropping them from ankle height. This
+    is an unplugged activity; KIBO robots are optional.
+  tutorial_ozobotcolor1_longdescription: Students will learn the basic functionality
+    of Ozobot, including how to calibrate the bot's sensors, and how to draw lines
+    for the bot to follow.
+  tutorial_scigirlspixels_longdescription: 'In this unplugged activity, you will learn
+    what a pixel is and how to send a simple black and white image to a friend! '
+  tutorial_kcjheroines_longdescription: In this activity, you'll learn about different
+    Canadian women who have made history. Using Scratch, you'll learn how to code
+    a video game celebrating their lives and accomplishments. Choose a heroine, customize
+    their costume and backdrop, code movements and goals for your game, and keep score.
+    This project is simple enough for kids to complete by themselves or with support
+    from a grown up.
+  tutorial_ozobotvalue_longdescription: Students will use their Ozobot to randomly
+    select a place value, identify the same place value in a three-digit number, and
+    write out the number.
+  tutorial_icodebytes_longdescription: Learn computer science without tech! Fun unplugged
+    computing activities for children aged 5-7 to do in class or at home with their
+    families. The activities help develop computational thinking skills in a really
+    fun way. Divided into the fundamental principles of computer science, and involve
+    creating algorithms, thinking logically, spotting patterns and finding or making
+    rules.
+  tutorial_clfashion2_longdescription: Are you a fashion conscious data scientist
+    with an interest in code? Join in the Fashionista of Data Science classes to learn
+    how coding & fashion go hand-in-hand! We will use SQL code along with data science
+    to investigate marketing, line styles, and store operations.
+  tutorial_ai4all_longdescription: 'This Byte of AI is meant to be a quick and fun
+    teacher-facilitated way to begin to become familiar with some core ideas of modern
+    AI including: how data becomes output in an AI model, how human biases enter datasets,
+    and how AI can be used in diverse fields including art and creativity. Students
+    learn these things by exploring drawing in Google Quick, Draw!'
+  tutorial_cldata_longdescription: 'Discover data science, one of the most valuable
+    skills, and see the world! Does data science sound dry and scary, like math? Fear
+    not. This introductory class will show you that you are already experts of data
+    and data science is full of fun and interesting insights related to topics such
+    as soccer, music, art, and your favorite books. Materials ready for in person
+    or remote learning settings. '
+  tutorial_spheroinputs_longdescription: 'This activity will get you thinking about
+    the common computer science coding concept of inputs and outputs and how this
+    idea relates to using computer science for good. '
+  tutorial_edisoncount_longdescription: 'Introduce the key computational concepts
+    of inputs and outputs using Edison robots and the block-based programming language
+    EdBlocks in this student led activity. Utilize the Edison robot''s drive function
+    through a set of progressive programming tasks. Creating programs for the robot
+    to ''trace'' requires the application of sequential thinking and an understanding
+    of the input-process-output cycle. '
+  tutorial_spheroloops_longdescription: 'This activity will get you thinking about
+    the common computer science coding concept of loops and how this concept relates
+    to using computer science for good. '
+  tutorial_kiboprogram_longdescription: In this lesson, children will learn about
+    sequencing in programming and about the symbols that make up a programming language
+    like KIBO's. Students will create their own programming symbols and act out programs
+    with their own movement. Finally, they can translate these movement programs into
+    programs for KIBO.
+  tutorial_hellorubycsin60_longdescription: 'Have you ever wondered what travels inside
+    the wires of your computer? Or why computer parts look like a tiny city? Or what
+    really is an algorithm? These 30 self-paced one minute videos are aimed for 5-9
+    year olds, followed by an activity the kids can complete at home. Topics include
+    code, hardware, networks, AI and other interesting ideas. '
+  tutorial_clfashion1_longdescription: Are you a fashion conscious data scientist
+    with an interest in code? Join in the Fashionista of Data Science classes to learn
+    how coding & fashion go hand-in-hand! We will use SQL code along with data science
+    to investigate marketing, line styles, and store operations.
+  tutorial_irobottraffic_longdescription: Traffic signals are a staple of safety in
+    our everyday lives. Code your own traffic light with the Root robot and learn
+    about the inventor!
+  tutorial_edisonmystery_longdescription: Kick-start student's exploration of using
+    Edison's line tracker using Edison robots and the Scratch-based programming language
+    EdScratch in this student led activity. Students first become familiar with the
+    Edison robot's line tracking sensor technology and experiment with the red LED
+    on different colored surfaces. They will then move on to mastering a mystery line
+    using the concept of algorithms.
+  tutorial_microbitseaturtles_longdescription: Create a prototype of a low-power,
+    red LED beach light that can be used for lighting on beach paths which is also
+    safe for sea turtles.
+  tutorial_ozobotknow_longdescription: In this lesson, students will be introduced
+    to the hardware and robotics components of Ozobot Evo.
+  tutorial_imagilabs_longdescription: 'Program a blinking heart, a rocketship taking
+    off, your name, or anything your imagination comes up with! To start off, we''ll
+    teach you how to program a heart in your favourite color and then make it blink
+    to the rhythm of your favorite song. Join our community of imagiCoders to share
+    and exchange designs. Upload your creations on your imagiCharm so you can proudly
+    wear your code wherever you go! '
+  tutorial_irobotsimulator_longdescription: Learn how to create and download coding
+    projects with this activity packet! Solve all puzzles with the Root simbot in
+    the virtual arena to reveal the secret message at the end!
+  tutorial_irobotkind_longdescription: Our robot is still learning how to make kind
+    choices when playing with friends. In this game, help Root practice by making
+    four kind decisions in a row. If Root makes a bad choice, it has to start all
+    the way at the beginning again! Let's play together!
+  tutorial_firiavirtual_longdescription: Learn Python programming with a powerful
+    3D robotics simulator. You'll complete challenging missions in a virtual environment
+    with realistic physics. Missions teach you the code to control motors, LEDs, and
+    other peripherals on CodeBot. And Sandbox mode lets you get creative with unlimited
+    Python coding possibilities. It's easy to get started with CodeSpace Simulation!
+  tutorial_irobotguesscode_longdescription: Put a new spin on Pictionary through code!
+    Students can use code to make predictions about what pictures, songs, or words
+    the Root SimBot will create. Code your own Pictionary creation, too!
+  tutorial_ozobotnouns_longdescription: In this lesson, students will identify the
+    correct way to spell and use irregular plural nouns and use Color Codes to program
+    their Ozobot to move to the correct irregular plural nouns by either turning left
+    or right and use the noun in a sentence.
+  tutorial_nasa3d_longdescription: Learn about exploding stars, 3D models and codeblocks!  This
+    spacey activity takes you through the basics of 3D modeling in astronomy using
+    the free browser-based Tinkercad. Students can progress from creating simple 3D
+    shapes to working with actual NASA data on exploded stars, testing in augmented
+    reality, and using loops and time-based changes with codeblocks.
+  tutorial_blupants_longdescription: Train a real autonomous robot to pick up blocks
+    and deploy them to the goal by navigating through an obstacle course. Start with
+    drag-and-drop interface, and advance to Python as you get more experienced.
+  tutorial_legodance_longdescription: Synchronize motor movements of a break dancer
+    to keep in rhythm with light and beats.
+  tutorial_nearpodcoding_longdescription: In this 25-30 minute Nearpod featuring Flocabulary
+    topic spark, students are introduced to coding through a hip hop video and Nearpod's
+    signature interactive features. This lesson features the Flocabulary video Coding.
+  tutorial_kcjplastic_longdescription: We're challenging you to use data visualization
+    to develop a plastic pollution solution! Discover where plastic waste comes from
+    and why it has become a global problem. Then reflect on your own plastic use,
+    estimate how much waste you could reduce over time, and design an invention or
+    alternative that could help. Kids can complete this project by themselves or with
+    support from a grown up.
+  tutorial_legojourney_longdescription: 'Journeys are exciting!  Challenge students
+    to remix our Grasshopper Journey project in order to create a new journey and
+    find different ways for a SPIKE Prime inspired virtual grasshopper to move using
+    Scratch 3.0! In addition to CS skills, this teacher facilitated activity can also
+    be used to support areas such as language arts, science and the arts. '
+  tutorial_legohopper_longdescription: Design multiple prototypes to find the most
+    effective way to move a robot without using wheels.
+  tutorial_catrobatembroidery_longdescription: Code your design on your Android phone
+    and stitch it on your T-shirt, pants, gym bag, or shoes!
+  tutorial_irobotphone_longdescription: In this coding challenge, students will work
+    together remotely to create a collective program that draws a picture. Modeled
+    after the classic game of Telephone, students will receive, remix, and pass along
+    code down the telephone chain. Will your team fulfill the Picture Goal by the
+    time you reach the end?
+  tutorial_codeguppydraw_longdescription: Quick introduction to text-based coding
+    using fun and engaging type-in JavaScript programs
+  tutorial_codejumper_longdescription: In this lesson from the Code Jumper curriculum,
+    learners explore networks in a hands-on unplugged experience using typical materials
+    found in a classroom. The theme for this lesson is around messages of kindness
+    to others. This lesson has been specifically designed to be accessible for students
+    with visual impairments.
+  tutorial_meeempathy_longdescription: For centuries, the Villagers and Illagers shared
+    the same space but seldom interacted with each other. Now you can use the power
+    of code to bring the two villages together. Players will experience empathy and
+    compassion for their neighbors, learn cooperation and inclusion, and embrace the
+    diversity that makes us all uniquely special.
+  tutorial_dance2019_string_detail_grades: Grades 2+
+  tutorial_danceparty_string_detail_grades: Grades 2+
+  tutorial_chibitronics_string_detail_grades: Grades 2-5
+  tutorial_athlete_string_detail_grades: Grades 2+
+  tutorial_moana_string_detail_grades: Grades 2+
+  tutorial_star-wars_string_detail_grades: Grades 2+
+  tutorial_gumadventure_string_detail_grades: Grades 6-8
+  tutorial_mchoc_string_detail_grades: Grades 2+
+  tutorial_vidnews_string_detail_grades: Grades 6+
+  tutorial_kodable-pre_string_detail_grades: Pre-reader - Grade 5
+  tutorial_highseas_string_detail_grades: Grades 2-8
+  tutorial_capython_string_detail_grades: Grades 6+
+  tutorial_frzn_string_detail_grades: Grades 2+
+  tutorial_cocom_string_detail_grades: Grades 2+
+  tutorial_play-lab_string_detail_grades: Grades 2+
+  tutorial_boxisland_string_detail_grades: All ages
+  tutorial_textcomp_string_detail_grades: Grades 9+
+  tutorial_encryption_string_detail_grades: Grades 9+
+  tutorial_kanopixel_string_detail_grades: Grades 2+
+  tutorial_foos_string_detail_grades: Pre-reader - Grade 5
+  tutorial_tynkerdd_string_detail_grades: Grades 2-8
+  tutorial_tynkerana_string_detail_grades: Grades 6+
+  tutorial_vidcard_string_detail_grades: Grades 2+
+  tutorial_spritebox_string_detail_grades: Grades 2-8
+  tutorial_tynkerch_string_detail_grades: Grades 6+
+  tutorial_lightbot_string_detail_grades: Pre-reader - Grade 5
+  tutorial_hoc_string_detail_grades: do-not-show
+  tutorial_code_string_detail_grades: Grades 2+
+  tutorial_tinspire_string_detail_grades: Grades 6+
+  tutorial_itchbounceball_string_detail_grades: Grades 2-8
+  tutorial_vidclim_string_detail_grades: Grades 6+
+  tutorial_matlab_string_detail_grades: Grades 6+
+  tutorial_flap_string_detail_grades: Grades 2+
+  tutorial_galaxy_string_detail_grades: Grades 6+
+  tutorial_inf_string_detail_grades: Grades 2-8
+  tutorial_tynkersol_string_detail_grades: Grades 2+
+  tutorial_itchg_string_detail_grades: Grades 6+
+  tutorial_como_string_detail_grades: Grades 2+
+  tutorial_processfound_string_detail_grades: Grades 9+
+  tutorial_tynkerhomo_string_detail_grades: Grades 6+
+  tutorial_art_string_detail_grades: Grades 2+
+  tutorial_tynkerbrick_string_detail_grades: Grades 2+
+  tutorial_itchbio_string_detail_grades: Grades 6+
+  tutorial_itchj_string_detail_grades: Grades 6-8
+  tutorial_tickleo_string_detail_grades: Grades 2+
+  tutorial_hopgeo_string_detail_grades: Grades 2-8
+  tutorial_tynkermult_string_detail_grades: Grades 2-8
+  tutorial_monster_string_detail_grades: Pre-reader - Grade 8
+  tutorial_tynkerapp_string_detail_grades: do-not-show
+  tutorial_tynkerpup_string_detail_grades: Grades 2-5
+  tutorial_livecode_string_detail_grades: Grades 9+
+  tutorial_cocomgame_string_detail_grades: Grades 2+
+  tutorial_tynkerspin_string_detail_grades: Grades 2-5
+  tutorial_code-avengers_string_detail_grades: Grades 6+
+  tutorial_tynkercq_string_detail_grades: Grades 2-5
+  tutorial_cmgame_string_detail_grades: Grades 6+
+  tutorial_codesters_string_detail_grades: do-not-show
+  tutorial_qrm_string_detail_grades: Grades 6+
+  tutorial_texas-instruments_string_detail_grades: Grades 6+
+  tutorial_cajava_string_detail_grades: Grades 6+
+  tutorial_codehs_string_detail_grades: Grades 9+
+  tutorial_hopemo_string_detail_grades: Grades 2-8
+  tutorial_tynkercm_string_detail_grades: Grades 2+
+  tutorial_codesterswintergreet_string_detail_grades: Grades 2+
+  tutorial_codestersc_string_detail_grades: Grades 6+
+  tutorial_codestersturtle_string_detail_grades: Grades 6-8
+  tutorial_penjee_string_detail_grades: Grades 6+
+  tutorial_trinket_string_detail_grades: Grades 2+
+  tutorial_frogger_string_detail_grades: Grades 6+
+  tutorial_tynkereco_string_detail_grades: Grades 2-8
+  tutorial_mitedarc_string_detail_grades: Grades 6-8
+  tutorial_khan_string_detail_grades: Grades 6+
+  tutorial_tynkerd_string_detail_grades: Grades 6+
+  tutorial_cdmy_string_detail_grades: Grades 9+
+  tutorial_codestersdance_string_detail_grades: Grades 6+
+  tutorial_codestersbasketball_string_detail_grades: Grades 6+
+  tutorial_nclkarel_string_detail_grades: Grades 6+
+  tutorial_buildpong_string_detail_grades: Grades 2+
+  tutorial_tynkerdrones_string_detail_grades: Grades 2+
+  tutorial_carla_string_detail_grades: Grades 6+
+  tutorial_zulama_string_detail_grades: Grades 6+
+  tutorial_capost_string_detail_grades: Grades 6+
+  tutorial_marco_string_detail_grades: Grades 2-8
+  tutorial_codestersflappybike_string_detail_grades: Grades 6+
+  tutorial_kanopong_string_detail_grades: Grades 6-8
+  tutorial_tynkerright_string_detail_grades: Grades 2-8
+  tutorial_touchdevelop_string_detail_grades: do-not-show
+  tutorial_tynkercc_string_detail_grades: Grades 6+
+  tutorial_bamboo_string_detail_grades: Grades 2-5
+  tutorial_robojav_string_detail_grades: Grades 6+
+  tutorial_roboba_string_detail_grades: Grades 6+
+  tutorial_knodsnake_string_detail_grades: Grades 6-8
+  tutorial_soccharater_string_detail_grades: Grades 6+
+  tutorial_silent_string_detail_grades: Grades 6+
+  tutorial_robomesh_string_detail_grades: Grades 2+
+  tutorial_amaze_string_detail_grades: Grades 2+
+  tutorial_codestersds_string_detail_grades: Grades 2+
+  tutorial_knodtext_string_detail_grades: Grades 6-8
+  tutorial_alicegar_string_detail_grades: Grades 6+
+  tutorial_codesterstransform_string_detail_grades: Grades 6+
+  tutorial_flexfrog_string_detail_grades: Grades 6+
+  tutorial_codemoji_string_detail_grades: do-not-show
+  tutorial_robobii_string_detail_grades: Grades 6+
+  tutorial_robobm_string_detail_grades: Grades 6-8
+  tutorial_codingrobots_string_detail_grades: Grades 2+
+  tutorial_robob_string_detail_grades: Grades 6+
+  tutorial_coders_string_detail_grades: Grades 9+
+  tutorial_tynkerhw_string_detail_grades: Grades 2-8
+  tutorial_tynkermh_string_detail_grades: Grades 2-8
+  tutorial_caphoto_string_detail_grades: Grades 6+
+  tutorial_mozillahw_string_detail_grades: Grades 6-8
+  tutorial_ticklep_string_detail_grades: do-not-show
+  tutorial_bbot_string_detail_grades: Grades 2+
+  tutorial_scratchg_string_detail_grades: Grades 6+
+  tutorial_sjforest_string_detail_grades: Pre-reader - Grade 5
+  tutorial_sjgreet_string_detail_grades: Pre-reader - Grade 5
+  tutorial_sjsunset_string_detail_grades: Pre-reader - Grade 5
+  tutorial_fufafrenz_string_detail_grades: Pre-reader - Grade 5
+  tutorial_bbcgeo_string_detail_grades: do-not-show
+  tutorial_chspixel_string_detail_grades: Grades 9+
+  tutorial_hummingbird_string_detail_grades: Grades 6+
+  tutorial_recoloring_string_detail_grades: Grades 6+
+  tutorial_bbcchem_string_detail_grades: do-not-show
+  tutorial_floalgo_string_detail_grades: Grades 2+
+  tutorial_flocond_string_detail_grades: Grades 2+
+  tutorial_floloops_string_detail_grades: Grades 2+
+  tutorial_pgts_string_detail_grades: Grades 6+
+  tutorial_ozo_string_detail_grades: All ages
+  tutorial_bbcla_string_detail_grades: do-not-show
+  tutorial_bbcsci_string_detail_grades: do-not-show
+  tutorial_tlctour_string_detail_grades: Grades 2+
+  tutorial_codesterstj_string_detail_grades: Grades 2+
+  tutorial_tlclocked_string_detail_grades: Grades 6+
+  tutorial_baubles_string_detail_grades: Grades 2-8
+  tutorial_bbcart_string_detail_grades: do-not-show
+  tutorial_tlcknight_string_detail_grades: Grades 2+
+  tutorial_fufafit_string_detail_grades: Grades 2-5
+  tutorial_ozodance_string_detail_grades: All ages
+  tutorial_codingrobotics_string_detail_grades: Pre-reader - Grade 5
+  tutorial_box_string_detail_grades: do-not-show
+  tutorial_hopgame_string_detail_grades: Grades 2-8
+  tutorial_icontrol_string_detail_grades: Pre-reader - Grade 5
+  tutorial_cocomteach_string_detail_grades: Grades 2+
+  tutorial_bbcmathii_string_detail_grades: do-not-show
+  tutorial_bbcphys_string_detail_grades: do-not-show
+  tutorial_bitsbox_string_detail_grades: Grades 2-8
+  tutorial_tlcemo_string_detail_grades: Grades 2-8
+  tutorial_crd_string_detail_grades: Grades 6-8
+  tutorial_bbcbio_string_detail_grades: do-not-show
+  tutorial_ticklebb8_string_detail_grades: Grades 2+
+  tutorial_grok_string_detail_grades: do-not-show
+  tutorial_ijournalist_string_detail_grades: Grades 2-8
+  tutorial_bbcmusic_string_detail_grades: do-not-show
+  tutorial_secretcodes_string_detail_grades: Grades 6-8
+  tutorial_tlchex_string_detail_grades: Grades 6+
+  tutorial_tickles_string_detail_grades: Grades 2+
+  tutorial_ozogame_string_detail_grades: All ages
+  tutorial_vidcodeio_string_detail_grades: Grades 2+
+  tutorial_tlcbrain_string_detail_grades: Grades 6+
+  tutorial_hopquiz_string_detail_grades: Grades 6-8
+  tutorial_unfortunate_string_detail_grades: Grades 2-5
+  tutorial_cha_string_detail_grades: Grades 6-8
+  tutorial_elaseq_string_detail_grades: Pre-reader - Grade 5
+  tutorial_bbcmathi_string_detail_grades: do-not-show
+  tutorial_tlcpixel_string_detail_grades: Grades 2-8
+  tutorial_introrobo_string_detail_grades: Grades 2-5
+  tutorial_tlcinvis_string_detail_grades: Grades 2+
+  tutorial_tlcjflap_string_detail_grades: Grades 6+
+  tutorial_procolor_string_detail_grades: Pre-reader - Grade 8
+  tutorial_spiralsfinch_string_detail_grades: Grades 2+
+  tutorial_ozoi_string_detail_grades: All ages
+  tutorial_ticklel_string_detail_grades: Grades 2+
+  tutorial_spiralsdash_string_detail_grades: Grades 2-8
+  tutorial_ghdebug_string_detail_grades: Grades 2-8
+  tutorial_tlckk_string_detail_grades: Grades 2-5
+  tutorial_firstcomp_string_detail_grades: Pre-reader - Grade 1
+  tutorial_mazefinch_string_detail_grades: Pre-reader - Grade 5
+  tutorial_tlccc_string_detail_grades: Grades 2-8
+  tutorial_tlcdoodle_string_detail_grades: Grades 2-8
+  tutorial_tlcpunch_string_detail_grades: Grades 6+
+  tutorial_finchfract_string_detail_grades: Grades 9+
+  tutorial_tlcmind_string_detail_grades: Grades 6+
+  tutorial_tlctelebot_string_detail_grades: Grades 2+
+  tutorial_tlcaus_string_detail_grades: Grades 6+
+  tutorial_tlcmicro_string_detail_grades: Grades 2+
+  tutorial_imathematician_string_detail_grades: Grades 2-8
+  tutorial_tlcmagic_string_detail_grades: Grades 6+
+  tutorial_scratchmus_string_detail_grades: Grades 2-8
+  tutorial_scratchanim_string_detail_grades: Grades 2-8
+  tutorial_scratchfly_string_detail_grades: Grades 2-8
+  tutorial_tynkerarc_string_detail_grades: Grades 2+
+  tutorial_grokffpython_string_detail_grades: Grades 6+
+  tutorial_grokffblock_string_detail_grades: Grades 6+
+  tutorial_grokeliza_string_detail_grades: Grades 6+
+  tutorial_tynkercan_string_detail_grades: Grades 2+
+  tutorial_grokflags_string_detail_grades: Grades 6+
+  tutorial_robomind_string_detail_grades: Grades 2-8
+  tutorial_adventureq_string_detail_grades: Grades 2-5
+  tutorial_khan-es_string_detail_grades: Grades 6+
+  tutorial_kpt_string_detail_grades: Grades 6+
+  tutorial_kpl_string_detail_grades: Grades 6+
+  tutorial_khe_string_detail_grades: Grades 6+
+  tutorial_kfr_string_detail_grades: Grades 6+
+  tutorial_app-inventor_string_detail_grades: Grades 6+
+  tutorial_blockly_string_detail_grades: Grades 6+
+  tutorial_tynker_string_detail_grades: do-not-show
+  tutorial_baypt_string_detail_grades: All ages
+  tutorial_code-combat_string_detail_grades: do-not-show
+  tutorial_mky_string_detail_grades: Grades 2+
+  tutorial_pirates_string_detail_grades: Grades 2-8
+  tutorial_csfirst_string_detail_grades: Grades 2+
+  tutorial_loopedy_string_detail_grades: Grades 2-5
+  tutorial_dsw_string_detail_grades: do-not-show
+  tutorial_dswb_string_detail_grades: do-not-show
+  tutorial_ssw_string_detail_grades: do-not-show
+  tutorial_sswb_string_detail_grades: do-not-show
+  tutorial_kodable-unplugged_string_detail_grades: Grades 2-8
+  tutorial_scratch_string_detail_grades: Grades 2-5
+  tutorial_bayes_string_detail_grades: All ages
+  tutorial_gumball_string_detail_grades: do-not-show
+  tutorial_hrm_string_detail_grades: Grades 6+
+  tutorial_ice-age_string_detail_grades: do-not-show
+  tutorial_koapp_string_detail_grades: do-not-show
+  tutorial_lightbot-intl_string_detail_grades: Pre-reader - Grade 8
+  tutorial_rmc_string_detail_grades: do-not-show
+  tutorial_smc_string_detail_grades: do-not-show
+  tutorial_minecraft-2016_string_detail_grades: do-not-show
+  tutorial_thinkersmith-es_string_detail_grades: Grades 2-5
+  tutorial_pixie_string_detail_grades: Grades 2+
+  tutorial_play_string_detail_grades: do-not-show
+  tutorial_robomind-nl_string_detail_grades: Grades 2-8
+  tutorial_spheroi_string_detail_grades: Grades 2+
+  tutorial_spherol_string_detail_grades: Grades 2+
+  tutorial_spherov_string_detail_grades: Grades 2+
+  tutorial_swb_string_detail_grades: do-not-show
+  tutorial_build-a-galaxy_string_detail_grades: do-not-show
+  tutorial_alicesims_string_detail_grades: Grades 6+
+  tutorial_tchr_string_detail_grades: do-not-show
+  tutorial_robogame_string_detail_grades: Pre-reader - Grade 5
+  tutorial_tap_string_detail_grades: Grades 2+
+  tutorial_cintl_string_detail_grades: do-not-show
+  tutorial_itchstop_string_detail_grades: Grades 2-8
+  tutorial_tynkerpn_string_detail_grades: Grades 2-5
+  tutorial_tynkerpd_string_detail_grades: Grades 2-5
+  tutorial_persistence_string_detail_grades: Pre-reader+
+  tutorial_getloopy_string_detail_grades: Pre-reader+
+  tutorial_createface_string_detail_grades: Grades 2+
+  tutorial_happymaps_string_detail_grades: Pre-reader+
+  tutorial_moveit_string_detail_grades: Pre-reader+
+  tutorial_bigevent_string_detail_grades: Pre-reader+
+  tutorial_gpp_string_detail_grades: Grades 2+
+  tutorial_foosgame_string_detail_grades: Pre-reader - Grade 5
+  tutorial_solopython_string_detail_grades: Grades 9+
+  tutorial_kodableint_string_detail_grades: Pre-reader - Grade 5
+  tutorial_kodableadv_string_detail_grades: Pre-reader - Grade 5
+  tutorial_tynkertj_string_detail_grades: Grades 6+
+  tutorial_wolframa_string_detail_grades: Grades 6+
+  tutorial_wolframm_string_detail_grades: Grades 6+
+  tutorial_wolframspi_string_detail_grades: Grades 6+
+  tutorial_wolframsph_string_detail_grades: Grades 6+
+  tutorial_wolframp_string_detail_grades: Grades 6+
+  tutorial_wolframn_string_detail_grades: Grades 6+
+  tutorial_soloweb_string_detail_grades: Grades 9+
+  tutorial_khanweb_string_detail_grades: Grades 2+
+  tutorial_khandata_string_detail_grades: Grades 6+
+  tutorial_googlelogo_string_detail_grades: Grades 2-8
+  tutorial_playtune_string_detail_grades: Grades 6+
+  tutorial_computeit_string_detail_grades: Grades 2+
+  tutorial_codesterssj_string_detail_grades: Grades 2-8
+  tutorial_cmchat_string_detail_grades: Grades 6+
+  tutorial_tynkerdb_string_detail_grades: Grades 2-5
+  tutorial_cmbuild_string_detail_grades: Grades 6+
+  tutorial_robotrattle_string_detail_grades: Grades 2-8
+  tutorial_codestersh_string_detail_grades: Grades 2-8
+  tutorial_codehsdigipixel_string_detail_grades: Grades 6+
+  tutorial_ccbinary_string_detail_grades: Grades 6+
+  tutorial_codehsturtle_string_detail_grades: Grades 6+
+  tutorial_grokhd_string_detail_grades: Grades 6+
+  tutorial_grokem_string_detail_grades: Grades 6+
+  tutorial_kodmaze_string_detail_grades: Pre-reader - Grade 5
+  tutorial_codestersa_string_detail_grades: Grades 2-8
+  tutorial_cmdodo_string_detail_grades: Grades 3-5
+  tutorial_tynkerspace_string_detail_grades: Grades 2-5
+  tutorial_gfbloons_string_detail_grades: Grades 9+
+  tutorial_raspipong_string_detail_grades: Grades 9+
+  tutorial_codehsvr_string_detail_grades: Grades 6+
+  tutorial_codesterstp_string_detail_grades: Grades 6-8
+  tutorial_codestersbb_string_detail_grades: Grades 6-8
+  tutorial_gfcrossyroad_string_detail_grades: Grades 9+
+  tutorial_googleww_string_detail_grades: Grades 9+
+  tutorial_codehsjsapp_string_detail_grades: Grades 6+
+  tutorial_gfmihi_string_detail_grades: Grades 9+
+  tutorial_hopdropphone_string_detail_grades: Grades 2-8
+  tutorial_techfaa_string_detail_grades: University
+  tutorial_codehsjsgraph_string_detail_grades: Grades 9+
+  tutorial_thunkable_string_detail_grades: Grades 6+
+  tutorial_hopcrossyroad_string_detail_grades: Grades 2-8
+  tutorial_switchglitch_string_detail_grades: Grades 2-5
+  tutorial_codecar_string_detail_grades: Grades 6+
+  tutorial_codesterscp_string_detail_grades: Grades 6-8
+  tutorial_grokpetblock_string_detail_grades: Grades 6-8
+  tutorial_techbim_string_detail_grades: University
+  tutorial_techfpp_string_detail_grades: University
+  tutorial_codesterscr_string_detail_grades: Grades 2-8
+  tutorial_grokdisease_string_detail_grades: Grades 9+
+  tutorial_techec_string_detail_grades: University
+  tutorial_rgbegin_string_detail_grades: Grades 2-5
+  tutorial_myradream_string_detail_grades: Grades 2-8
+  tutorial_thinkfun_string_detail_grades: Grades 2-8
+  tutorial_hopfireworks_string_detail_grades: Grades 2-8
+  tutorial_grokspace_string_detail_grades: Grades 6+
+  tutorial_codehspython_string_detail_grades: Grades 6+
+  tutorial_codehsjava_string_detail_grades: Grades 9+
+  tutorial_techioda_string_detail_grades: University
+  tutorial_grokmonster_string_detail_grades: Grades 2-5
+  tutorial_techmjs_string_detail_grades: University
+  tutorial_techga_string_detail_grades: University
+  tutorial_techioan_string_detail_grades: University
+  tutorial_techiogsr_string_detail_grades: University
+  tutorial_groktunnel_string_detail_grades: Grades 6+
+  tutorial_stemcod_string_detail_grades: Grades 6+
+  tutorial_techikb_string_detail_grades: University
+  tutorial_kanostreet_string_detail_grades: Grades 2-5
+  tutorial_codemojijs_string_detail_grades: Grades 2-5
+  tutorial_techapf_string_detail_grades: University
+  tutorial_techfpjs_string_detail_grades: University
+  tutorial_techlinq_string_detail_grades: University
+  tutorial_gpbcatapult_string_detail_grades: Grades 6+
+  tutorial_quorumastro_string_detail_grades: Grades 6+
+  tutorial_alicewonder_string_detail_grades: Grades 2-5
+  tutorial_rginter_string_detail_grades: Grades 6-8
+  tutorial_cssgrid_string_detail_grades: Grades 6+
+  tutorial_jshero_string_detail_grades: Grades 9+
+  tutorial_codemojipy_string_detail_grades: Grades 2-5
+  tutorial_nclabdrone_string_detail_grades: Grades 6+
+  tutorial_gpbcircle_string_detail_grades: Grades 6+
+  tutorial_gpbpaint_string_detail_grades: Grades 6+
+  tutorial_cocomarcade_string_detail_grades: Grades 6+
+  tutorial_beetik_string_detail_grades: Grades 6-8
+  tutorial_codedj_string_detail_grades: Grades 6+
+  tutorial_rgadvan_string_detail_grades: Grades 6+
+  tutorial_codehsrn_string_detail_grades: Grades 9+
+  tutorial_codehswd_string_detail_grades: Grades 6+
+  tutorial_turtlerobot_string_detail_grades: Pre-reader - Grade 5
+  tutorial_ozoevo_string_detail_grades: Grades 6+
+  tutorial_ozoexped_string_detail_grades: Grades 6+
+  tutorial_ozojourney_string_detail_grades: Grades 2-8
+  tutorial_ozocodes_string_detail_grades: All ages
+  tutorial_ozoeclipse_string_detail_grades: Grades 2+
+  tutorial_ozosimulator_string_detail_grades: Grades 6+
+  tutorial_ozoalgorithm_string_detail_grades: Grades 6+
+  tutorial_ozotimer_string_detail_grades: Grades 6+
+  tutorial_ozohabits_string_detail_grades: All ages
+  tutorial_ozoprogram_string_detail_grades: Grades 2-8
+  tutorial_ozopair_string_detail_grades: Grades 2+
+  tutorial_codesnoopy_string_detail_grades: Pre-reader - Grade 5
+  tutorial_applabintro_string_detail_grades: Grades 9+
+  tutorial_cslartist_string_detail_grades: Pre-reader - Grade 5
+  tutorial_cslscratchjr_string_detail_grades: Pre-reader - Grade 5
+  tutorial_floevents_string_detail_grades: Grades 2-8
+  tutorial_florobot_string_detail_grades: Grades 2-8
+  tutorial_isavesanta_string_detail_grades: Grades 2-8
+  tutorial_iorder_string_detail_grades: Grades 2-8
+  tutorial_ianimate_string_detail_grades: Grades 2-8
+  tutorial_iloveada_string_detail_grades: Grades 2-5
+  tutorial_kodflash_string_detail_grades: Pre-reader - Grade 5
+  tutorial_kodchoose_string_detail_grades: Grades 2-5
+  tutorial_kodpizzapre_string_detail_grades: Pre-reader - Grade 1
+  tutorial_kodpizza_string_detail_grades: Grades 2-5
+  tutorial_kodwomen_string_detail_grades: Grades 2-8
+  tutorial_tfunplug_string_detail_grades: Grades 6-8
+  tutorial_lbvariables_string_detail_grades: Grades 2-8
+  tutorial_lbfunctions_string_detail_grades: Grades 2-8
+  tutorial_lblogic_string_detail_grades: Grades 2+
+  tutorial_lbworld_string_detail_grades: Grades 6+
+  tutorial_lbloops_string_detail_grades: Grades 2-8
+  tutorial_lbtug_string_detail_grades: Grades 6+
+  tutorial_lbpotato_string_detail_grades: Grades 2+
+  tutorial_lbguitar_string_detail_grades: Grades 2+
+  tutorial_lbio_string_detail_grades: Grades 2-8
+  tutorial_wonpuppy_string_detail_grades: Grades 2-5
+  tutorial_woncue_string_detail_grades: Grades 2+
+  tutorial_wonzoo_string_detail_grades: Grades 2-5
+  tutorial_wontrip_string_detail_grades: Grades 2-8
+  tutorial_woncollect_string_detail_grades: Pre-reader - Grade 5
+  tutorial_wonsecret_string_detail_grades: Grades 6+
+  tutorial_hsscience_string_detail_grades: Grades 2-8
+  tutorial_popculture_string_detail_grades: Grades 6+
+  tutorial_legorobust_string_detail_grades: Grades 2+
+  tutorial_legoplants_string_detail_grades: Grades 2+
+  tutorial_legopark_string_detail_grades: Grades 6+
+  tutorial_legodetect_string_detail_grades: Grades 6+
+  tutorial_legolight_string_detail_grades: Grades 6+
+  tutorial_alexa_string_detail_grades: Grades 9+
+  tutorial_grokpetmicro_string_detail_grades: Grades 6-8
+  tutorial_pirateplunder_string_detail_grades: Grades 2-8
+  tutorial_cadj_string_detail_grades: Grades 6-8
+  tutorial_cacrazy_string_detail_grades: Grades 2-8
+  tutorial_cajump_string_detail_grades: Grades 2-8
+  tutorial_carest_string_detail_grades: Grades 2-8
+  tutorial_accai_string_detail_grades: Grades 2-8
+  tutorial_vceclipse_string_detail_grades: Grades 6+
+  tutorial_pmzero_string_detail_grades: Grades 6+
+  tutorial_hsela_string_detail_grades: Grades 2-8
+  tutorial_ticklear_string_detail_grades: Grades 2-8
+  tutorial_bcrobot_string_detail_grades: Grades 2-8
+  tutorial_bcsnow_string_detail_grades: Grades 6+
+  tutorial_ifly_string_detail_grades: Grades 2+
+  tutorial_idowedo_string_detail_grades: Grades 2-8
+  tutorial_diggindwarf_string_detail_grades: Grades 6+
+  tutorial_spheroit_string_detail_grades: Grades 2+
+  tutorial_gameofcodes_string_detail_grades: Grades 2+
+  tutorial_blocklygames_string_detail_grades: Grades 6+
+  tutorial_spherohello_string_detail_grades: Grades 6+
+  tutorial_spheroarcade_string_detail_grades: Grades 6+
+  tutorial_bcpy1_string_detail_grades: Grades 6+
+  tutorial_bcpy2_string_detail_grades: Grades 6+
+  tutorial_bcjs1_string_detail_grades: Grades 6+
+  tutorial_bcjs2_string_detail_grades: Grades 9+
+  tutorial_3dbearmars_string_detail_grades: Grades 2-8
+  tutorial_bitsboxyak_string_detail_grades: Grades 2-8
+  tutorial_blockscadbargraphs_string_detail_grades: Grades 2-5
+  tutorial_blockscadbirdhouses_string_detail_grades: Grades 2-5
+  tutorial_blockscadclock_string_detail_grades: Grades 9+
+  tutorial_blockscaddinner_string_detail_grades: Grades 2-5
+  tutorial_blockscadicecream_string_detail_grades: Grades 6+
+  tutorial_blockscadpizza_string_detail_grades: Grades 6-8
+  tutorial_blockscadsugar_string_detail_grades: Grades 6-8
+  tutorial_bsgridlight_string_detail_grades: Grades 2+
+  tutorial_bpartscratch_string_detail_grades: Grades 6+
+  tutorial_bpartvid_string_detail_grades: Grades 6+
+  tutorial_bpenglishscratch_string_detail_grades: Grades 2-8
+  tutorial_bpenglishvid_string_detail_grades: Grades 2-8
+  tutorial_bphealthscratch_string_detail_grades: Grades 2+
+  tutorial_bphealthvid_string_detail_grades: Grades 6+
+  tutorial_bpmathscratch_string_detail_grades: Grades 2-5
+  tutorial_bpmathvid_string_detail_grades: Grades 6+
+  tutorial_bpmlkscratch_string_detail_grades: Grades 2-8
+  tutorial_bpmlkvid_string_detail_grades: Grades 6-8
+  tutorial_bpsafetyscratch_string_detail_grades: Grades 2-5
+  tutorial_bpsafetyvid_string_detail_grades: Grades 6-8
+  tutorial_bpsciencescratch_string_detail_grades: Grades 2-5
+  tutorial_bpsciencevid_string_detail_grades: Grades 6-8
+  tutorial_bptechscratch_string_detail_grades: Grades 6+
+  tutorial_bptechvid_string_detail_grades: Grades 6+
+  tutorial_caflags_string_detail_grades: Grades 6+
+  tutorial_matariki_string_detail_grades: Grades 2-5
+  tutorial_carestaurant_string_detail_grades: Grades 2+
+  tutorial_casea_string_detail_grades: Grades 2-5
+  tutorial_cashield_string_detail_grades: Grades 2-8
+  tutorial_ccwslimer_string_detail_grades: Grades 2-8
+  tutorial_codinggalaxy_string_detail_grades: Pre-reader - Grade 8
+  tutorial_boatrace_string_detail_grades: Grades 2+
+  tutorial_ccplay_string_detail_grades: Grades 6+
+  tutorial_grinch_string_detail_grades: Grades 2-8
+  tutorial_codehsart_string_detail_grades: Grades 9+
+  tutorial_codehsbitcoin_string_detail_grades: Grades 9+
+  tutorial_codehsblockchain_string_detail_grades: Grades 9+
+  tutorial_codehscipher_string_detail_grades: Grades 6+
+  tutorial_codehscollision_string_detail_grades: Grades 9+
+  tutorial_codehsmath_string_detail_grades: Grades 6+
+  tutorial_codehsmusic_string_detail_grades: Grades 6+
+  tutorial_codehssports_string_detail_grades: Grades 6+
+  tutorial_codemojipizza_string_detail_grades: Grades 2-8
+  tutorial_moonlander_string_detail_grades: Grades 6+
+  tutorial_sushicards_string_detail_grades: Grades 2-8
+  tutorial_codesparkcreate_string_detail_grades: Pre-reader - Grade 5
+  tutorial_hardvsoft_string_detail_grades: Pre-reader - Grade 5
+  tutorial_codestersecard_string_detail_grades: Grades 6-8
+  tutorial_codesterslogo_string_detail_grades: Grades 6+
+  tutorial_codesterstshirt_string_detail_grades: Grades 6+
+  tutorial_codewards_string_detail_grades: Grades 2-8
+  tutorial_olympics_string_detail_grades: Grades 2-8
+  tutorial_codinismhero_string_detail_grades: Grades 2+
+  tutorial_discovery_string_detail_grades: Grades 2+
+  tutorial_csfirstname_string_detail_grades: Grades 2+
+  tutorial_edisonmove_string_detail_grades: Grades 6+
+  tutorial_edisonspider_string_detail_grades: Grades 6+
+  tutorial_edisonspotlight_string_detail_grades: Grades 2-8
+  tutorial_firiapython_string_detail_grades: Grades 6+
+  tutorial_gamefrootsquid_string_detail_grades: Grades 6+
+  tutorial_duckpiano_string_detail_grades: Grades 6+
+  tutorial_gpsound_string_detail_grades: Grades 6+
+  tutorial_groklearningpython_string_detail_grades: Grades 9+
+  tutorial_htmltimetravel_string_detail_grades: Grades 9+
+  tutorial_hp_flappy_string_detail_grades: Grades 9+
+  tutorial_appytappin_string_detail_grades: Grades 2-5
+  tutorial_icipher_string_detail_grades: Grades 2-5
+  tutorial_iguess_string_detail_grades: Pre-reader - Grade 5
+  tutorial_imake_string_detail_grades: Pre-reader - Grade 1
+  tutorial_imorse_string_detail_grades: Grades 2-8
+  tutorial_kanohp_string_detail_grades: Grades 2-8
+  tutorial_khanwebpages_string_detail_grades: Grades 6+
+  tutorial_kibobowl_string_detail_grades: Pre-reader - Grade 5
+  tutorial_kibodance_string_detail_grades: Pre-reader - Grade 5
+  tutorial_buildcharacters_string_detail_grades: Pre-reader - Grade 5
+  tutorial_designgames_string_detail_grades: Grades 2-5
+  tutorial_makelevels_string_detail_grades: Pre-reader - Grade 5
+  tutorial_wizard_string_detail_grades: Grades 6+
+  tutorial_mbscratchcards_string_detail_grades: Grades 2+
+  tutorial_mbswiftplaygrounds_string_detail_grades: Grades 2+
+  tutorial_mbbuttons_string_detail_grades: Grades 6+
+  tutorial_meteor_string_detail_grades: Grades 6+
+  tutorial_ballbounce_string_detail_grades: Grades 6+
+  tutorial_mitcodi_string_detail_grades: Grades 6+
+  tutorial_mitdoodle_string_detail_grades: Grades 6+
+  tutorial_talktome_string_detail_grades: Grades 6+
+  tutorial_mobilecspmap_string_detail_grades: Grades 6+
+  tutorial_ozorandom_string_detail_grades: Grades 2+
+  tutorial_ozotroll_string_detail_grades: Grades 6-8
+  tutorial_peblioart_string_detail_grades: Grades 9+
+  tutorial_astropi_string_detail_grades: Grades 6+
+  tutorial_rgart_string_detail_grades: Grades 2-5
+  tutorial_rgengineer_string_detail_grades: Grades 2-5
+  tutorial_rgmath_string_detail_grades: Grades 2-5
+  tutorial_rgscience_string_detail_grades: Grades 2-5
+  tutorial_rgtech_string_detail_grades: Grades 2-5
+  tutorial_robotmagic3d_string_detail_grades: Grades 6+
+  tutorial_robotmagicflappy_string_detail_grades: Grades 9+
+  tutorial_scratchadventure_string_detail_grades: Grades 2+
+  tutorial_scratchtalk_string_detail_grades: Grades 2+
+  tutorial_scratchjrstory_string_detail_grades: Grades 2-5
+  tutorial_scratchjrtwinkle_string_detail_grades: Pre-reader
+  tutorial_spherocomm_string_detail_grades: Grades 2-8
+  tutorial_spherocommunity_string_detail_grades: Grades 2-5
+  tutorial_spherofunctions_string_detail_grades: Grades 6+
+  tutorial_spheroinfrared_string_detail_grades: Grades 6-8
+  tutorial_spherolightsensor_string_detail_grades: Grades 2-8
+  tutorial_spheromansion_string_detail_grades: Grades 2-8
+  tutorial_roadblocks_string_detail_grades: Grades 2-8
+  tutorial_spherotext2_string_detail_grades: Grades 6+
+  tutorial_spherotext3_string_detail_grades: Grades 6+
+  tutorial_spherotext4_string_detail_grades: Grades 6+
+  tutorial_spheroraptor_string_detail_grades: Grades 2-8
+  tutorial_stempiday_string_detail_grades: 'Grades 9+ '
+  tutorial_stemplanetoids_string_detail_grades: Grades 9+
+  tutorial_stempong_string_detail_grades: Grades 9+
+  tutorial_algobot_string_detail_grades: Grades 2-8
+  tutorial_thunkableapps_string_detail_grades: Grades 9+
+  tutorial_toxicodedot_string_detail_grades: Grades 2-8
+  tutorial_gcactions_string_detail_grades: Grades 6+
+  tutorial_gccomparators_string_detail_grades: Grades 6+
+  tutorial_gcconditions_string_detail_grades: Grades 6+
+  tutorial_gccreate_string_detail_grades: Grades 6+
+  tutorial_gcevents_string_detail_grades: Grades 6+
+  tutorial_gcloops_string_detail_grades: Grades 6+
+  tutorial_gcvariables_string_detail_grades: Grades 6+
+  tutorial_beanything_string_detail_grades: Grades 2-5
+  tutorial_change_string_detail_grades: Grades 2-8
+  tutorial_cooking_string_detail_grades: Grades 2-5
+  tutorial_crystal_string_detail_grades: Grades 2+
+  tutorial_landscape_string_detail_grades: Grades 6+
+  tutorial_pets_string_detail_grades: Grades 2-5
+  tutorial_petvet_string_detail_grades: Grades 2-5
+  tutorial_superhero_string_detail_grades: Grades 6+
+  tutorial_vidcodeplastic_string_detail_grades: Grades 6+
+  tutorial_vidcodetypeface_string_detail_grades: Grades 6+
+  tutorial_washustorm_string_detail_grades: Grades 2-5
+  tutorial_activitypackets_string_detail_grades: Pre-reader - Grade 8
+  tutorial_googlerookie_string_detail_grades: Grades 6+
+  tutorial_tommyturtle_string_detail_grades: Pre-reader - Grade 5
+  tutorial_mazyad_string_detail_grades: Pre-reader - Grade 5
+  tutorial_gamemaker_string_detail_grades: Grades 2+
+  tutorial_duckrace_string_detail_grades: Grades 2+
+  tutorial_allcancodeapps_string_detail_grades: Grades 6+
+  tutorial_n2y_string_detail_grades: Pre-reader+
+  tutorial_microsoftarcade_string_detail_grades: Grades 2+
+  tutorial_csfirstunplugged_string_detail_grades: Grades 2-8
+  tutorial_toxicodepython_string_detail_grades: Grades 6+
+  tutorial_codecombatozaria_string_detail_grades: Grades 6-8
+  tutorial_vidcodedate_string_detail_grades: Grades 6+
+  tutorial_codemonkeyspace_string_detail_grades: Grades 2-8
+  tutorial_codespeakhappy_string_detail_grades: Grades 2-8
+  tutorial_grokimage_string_detail_grades: Grades 6+
+  tutorial_icomputelearn_string_detail_grades: Pre-reader - Grade 8
+  tutorial_rpstress_string_detail_grades: Grades 2+
+  tutorial_bsdcause_string_detail_grades: Grades 9+
+  tutorial_vidcodeanimoji_string_detail_grades: Grades 2+
+  tutorial_vidcodeanimojies_string_detail_grades: Grades 2+
+  tutorial_bsdinspire_string_detail_grades: Grades 6+
+  tutorial_tttractor_string_detail_grades: Grades 6+
+  tutorial_codeillusionmickey_string_detail_grades: Grades 2-8
+  tutorial_scigirlsquest_string_detail_grades: Grades 2-8
+  tutorial_codespeakbreathe_string_detail_grades: Grades 2+
+  tutorial_vidcodeface_string_detail_grades: Grades 6+
+  tutorial_educodemaze_string_detail_grades: Grades 6+
+  tutorial_educoderace_string_detail_grades: Grades 6+
+  tutorial_codespeakchatbot_string_detail_grades: Grades 2-8
+  tutorial_gamefrootgames_string_detail_grades: Grades 6+
+  tutorial_codespeakgrandparent_string_detail_grades: Grades 2-8
+  tutorial_educodekingdom_string_detail_grades: Grades 6+
+  tutorial_codehsdata_string_detail_grades: Grades 9+
+  tutorial_educodecake_string_detail_grades: Grades 6+
+  tutorial_ttsecond_string_detail_grades: Grades 6+
+  tutorial_bsdtrivia_string_detail_grades: Grades 6+
+  tutorial_csfirstdialogue_string_detail_grades: Grades 2-8
+  tutorial_codemonkeybeaver_string_detail_grades: Pre-reader - Grade 5
+  tutorial_codestersdistance_string_detail_grades: Grades 6+
+  tutorial_itchspace_string_detail_grades: Grades 6+
+  tutorial_vidcodemagic_string_detail_grades: Grades 2+
+  tutorial_vidcodemagices_string_detail_grades: Grades 2+
+  tutorial_codespeakmeal_string_detail_grades: Grades 6+
+  tutorial_itchfish_string_detail_grades: Grades 2-8
+  tutorial_bsdwebsite_string_detail_grades: Grades 6+
+  tutorial_codespeaktime_string_detail_grades: Grades 2-8
+  tutorial_itchwebcam_string_detail_grades: Grades 6+
+  tutorial_itchball_string_detail_grades: Grades 2-8
+  tutorial_ttrace_string_detail_grades: Grades 6-8
+  tutorial_plethora_string_detail_grades: Grades 2+
+  tutorial_educodesecret_string_detail_grades: Grades 6+
+  tutorial_itchshapes_string_detail_grades: Grades 6+
+  tutorial_codeguppytext_string_detail_grades: Grades 6-8
+  tutorial_vidcodeplastiche_string_detail_grades: Grades 6+
+  tutorial_educativechatbot_string_detail_grades: Grades 9+
+  tutorial_educodebasics_string_detail_grades: Grades 6+
+  tutorial_codehsdesign_string_detail_grades: Grades 6+
+  tutorial_htmlacademyphp_string_detail_grades: Grades 6+
+  tutorial_gamefrootdistance_string_detail_grades: Grades 2+
+  tutorial_codesterscovid_string_detail_grades: 'Grades 6-8 '
+  tutorial_ttbunker_string_detail_grades: Grades 6-8
+  tutorial_cuttle_string_detail_grades: Grades 6+
+  tutorial_bsdjokes_string_detail_grades: Grades 6-8
+  tutorial_rptree_string_detail_grades: Grades 6+
+  tutorial_codestersunity_string_detail_grades: Grades 6+
+  tutorial_codesterssoccer_string_detail_grades: Grades 6+
+  tutorial_breakoutlock_string_detail_grades: Grades 2-8
+  tutorial_thunkablemask_string_detail_grades: Grades 6+
+  tutorial_cafarming_string_detail_grades: Grades 2-8
+  tutorial_blocksmithyeti_string_detail_grades: Grades 9+
+  tutorial_codecapture_string_detail_grades: Grades 6+
+  tutorial_codehslitter_string_detail_grades: Grades 6-8
+  tutorial_bsdocean_string_detail_grades: Grades 6-8
+  tutorial_itchplatformer_string_detail_grades: Grades 6+
+  tutorial_codejika_string_detail_grades: Grades 6+
+  tutorial_gamefrootclicker_string_detail_grades: Grades 6-8
+  tutorial_rmagicequity_string_detail_grades: Grades 6-8
+  tutorial_ttfreestyle_string_detail_grades: Grades 6-8
+  tutorial_ozobotcolor2_string_detail_grades: Grades 2+
+  tutorial_ozobotcolor3_string_detail_grades: Grades 2+
+  tutorial_clcarbon_string_detail_grades: Grades 6+
+  tutorial_kodablebasics_string_detail_grades: Pre-reader - Grade 5
+  tutorial_scigirlscc_string_detail_grades: Grades 2+
+  tutorial_irobotpicture_string_detail_grades: Grades 2-8
+  tutorial_kcjmyself_string_detail_grades: Grades 2-8
+  tutorial_nearpodalgorithms_string_detail_grades: Pre-reader - Grade 5
+  tutorial_kibodrop_string_detail_grades: Pre-reader - Grade 5
+  tutorial_ozobotcolor1_string_detail_grades: Grades 2+
+  tutorial_scigirlspixels_string_detail_grades: Grades 2+
+  tutorial_kcjheroines_string_detail_grades: Grades 2-8
+  tutorial_ozobotvalue_string_detail_grades: Grades 2-5
+  tutorial_icodebytes_string_detail_grades: Pre-reader
+  tutorial_clfashion2_string_detail_grades: Grades 6+
+  tutorial_ai4all_string_detail_grades: Grades 6+
+  tutorial_cldata_string_detail_grades: Grades 6+
+  tutorial_spheroinputs_string_detail_grades: Grades 2-8
+  tutorial_edisoncount_string_detail_grades: Grades 2-8
+  tutorial_spheroloops_string_detail_grades: Grades 2-8
+  tutorial_kiboprogram_string_detail_grades: Pre-reader - Grade 5
+  tutorial_hellorubycsin60_string_detail_grades: Pre-reader - Grade 5
+  tutorial_clfashion1_string_detail_grades: Grades 6+
+  tutorial_irobottraffic_string_detail_grades: Grades 2-5
+  tutorial_edisonmystery_string_detail_grades: Grades 6-8
+  tutorial_microbitseaturtles_string_detail_grades: Grades 6-8
+  tutorial_ozobotknow_string_detail_grades: Grades 2+
+  tutorial_imagilabs_string_detail_grades: Grades 2-8
+  tutorial_irobotsimulator_string_detail_grades: Grades 2-8
+  tutorial_irobotkind_string_detail_grades: Pre-reader - Grade 5
+  tutorial_firiavirtual_string_detail_grades: Grades 6+
+  tutorial_irobotguesscode_string_detail_grades: Grades 2-8
+  tutorial_ozobotnouns_string_detail_grades: Grades 2-5
+  tutorial_nasa3d_string_detail_grades: Grades 6+
+  tutorial_blupants_string_detail_grades: Grades 6+
+  tutorial_legodance_string_detail_grades: Grades 6-8
+  tutorial_nearpodcoding_string_detail_grades: Grades 9+
+  tutorial_kcjplastic_string_detail_grades: Grades 2+
+  tutorial_legojourney_string_detail_grades: Grades 2-8
+  tutorial_legohopper_string_detail_grades: Grades 2-8
+  tutorial_catrobatembroidery_string_detail_grades: Grades 6+
+  tutorial_irobotphone_string_detail_grades: Grades 2-8
+  tutorial_codeguppydraw_string_detail_grades: Grades 6-8
+  tutorial_codejumper_string_detail_grades: Grades 2-8
+  tutorial_meeempathy_string_detail_grades: Grades 2+
+  tutorial_dance2019_string_platforms: All modern browsers, Android tablet, iPad,
+    Unplugged
+  tutorial_danceparty_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_chibitronics_string_platforms: All modern browsers, Screen reader
+  tutorial_athlete_string_platforms: All modern browsers
+  tutorial_moana_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_star-wars_string_platforms: All modern browsers, Android tablet, iPad,
+    Android phone, iPhone
+  tutorial_gumadventure_string_platforms: All modern browsers
+  tutorial_mchoc_string_platforms: All modern browsers, Android tablet, iPad, Android
+    phone, iPhone
+  tutorial_vidnews_string_platforms: Chrome, Firefox
+  tutorial_kodable-pre_string_platforms: All modern browsers, Android tablet, iPad,
+    Unplugged
+  tutorial_highseas_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Firefox, Safari
+  tutorial_capython_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Firefox, Safari
+  tutorial_frzn_string_platforms: All modern browsers, Android, iOS
+  tutorial_cocom_string_platforms: All modern browsers
+  tutorial_play-lab_string_platforms: All modern browsers, Android, iOS
+  tutorial_boxisland_string_platforms: iPad, iPhone
+  tutorial_textcomp_string_platforms: All modern browsers
+  tutorial_encryption_string_platforms: All modern browsers
+  tutorial_kanopixel_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Firefox, Safari, Android tablet, iPad
+  tutorial_foos_string_platforms: All modern browsers, Android tablet, iPad, Android
+    phone, iPhone
+  tutorial_tynkerdd_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Firefox, Safari
+  tutorial_tynkerana_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Firefox, Safari, Android tablet, iPad
+  tutorial_vidcard_string_platforms: Chrome
+  tutorial_spritebox_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_tynkerch_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Firefox, Safari
+  tutorial_lightbot_string_platforms: All modern browsers, Android tablet, iPad, Android
+    phone, iPhone
+  tutorial_hoc_string_platforms: do-not-show
+  tutorial_code_string_platforms: All modern browsers, Android, iOS
+  tutorial_tinspire_string_platforms: TI-Nspire handheld
+  tutorial_itchbounceball_string_platforms: Chrome, Firefox, Android Tablet
+  tutorial_vidclim_string_platforms: Chrome, Firefox, Safari
+  tutorial_matlab_string_platforms: All modern browsers
+  tutorial_flap_string_platforms: All modern browsers, Android, iOS
+  tutorial_galaxy_string_platforms: Android tablet, Android phone
+  tutorial_inf_string_platforms: All modern browsers, Android tablet, iPad, Android
+    phone, iPhone
+  tutorial_tynkersol_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Firefox, Safari, Android tablet, iPad
+  tutorial_itchg_string_platforms: Chrome, Firefox, Android Tablet
+  tutorial_como_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_processfound_string_platforms: Chrome, Firefox, Safari
+  tutorial_tynkerhomo_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Firefox, Safari, Android tablet, iPad
+  tutorial_art_string_platforms: All modern browsers, Android tablet, iPad, Android
+    phone, iPhone
+  tutorial_tynkerbrick_string_platforms: All modern browsers
+  tutorial_itchbio_string_platforms: Chrome, Firefox
+  tutorial_itchj_string_platforms: Chrome, Firefox, Android Tablet
+  tutorial_tickleo_string_platforms: All modern browsers, iPad, iPhone
+  tutorial_hopgeo_string_platforms: iPad and iPhone
+  tutorial_tynkermult_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Firefox, Safari, Android tablet, iPad
+  tutorial_monster_string_platforms: All modern browsers
+  tutorial_tynkerapp_string_platforms: do-not-show
+  tutorial_tynkerpup_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Firefox, Safari
+  tutorial_livecode_string_platforms: All modern browsers, Android tablet, iPad, Android
+    phone, iPhone
+  tutorial_cocomgame_string_platforms: All modern browsers
+  tutorial_tynkerspin_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Firefox, Safari, Android tablet, iPad
+  tutorial_code-avengers_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Firefox, Safari
+  tutorial_tynkercq_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Firefox, Safari, Android tablet, iPad
+  tutorial_cmgame_string_platforms: All modern browsers
+  tutorial_codesters_string_platforms: do-not-show
+  tutorial_qrm_string_platforms: All modern browsers, Screen reader
+  tutorial_texas-instruments_string_platforms: TI-84, TI-83 graphing calculators
+  tutorial_cajava_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Firefox, Safari
+  tutorial_codehs_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Firefox, Safari
+  tutorial_hopemo_string_platforms: iPad and iPhone
+  tutorial_tynkercm_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Firefox, Safari
+  tutorial_codesterswintergreet_string_platforms: All modern browsers
+  tutorial_codestersc_string_platforms: All modern browsers
+  tutorial_codestersturtle_string_platforms: All modern browsers
+  tutorial_penjee_string_platforms: All modern browsers
+  tutorial_trinket_string_platforms: All modern browsers
+  tutorial_frogger_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Firefox, Safari
+  tutorial_tynkereco_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Firefox, Safari, Android tablet, iPad
+  tutorial_mitedarc_string_platforms: All modern browsers
+  tutorial_khan_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome, Firefox,
+    Safari
+  tutorial_tynkerd_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Firefox, Safari
+  tutorial_cdmy_string_platforms: Internet Explorer 11, Chrome, Firefox, Safari
+  tutorial_codestersdance_string_platforms: All modern browsers
+  tutorial_codestersbasketball_string_platforms: All modern browsers
+  tutorial_nclkarel_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Firefox, Safari
+  tutorial_buildpong_string_platforms: All modern browsers, Android tablet, Android
+    phone, iPad
+  tutorial_tynkerdrones_string_platforms: Android tablet, iPad
+  tutorial_carla_string_platforms: All modern browsers
+  tutorial_zulama_string_platforms: Internet Explorer 11, Chrome, Firefox, Safari
+  tutorial_capost_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Firefox, Safari
+  tutorial_marco_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_codestersflappybike_string_platforms: All modern browsers
+  tutorial_kanopong_string_platforms: All modern browsers
+  tutorial_tynkerright_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Firefox, Safari, Android tablet, iPad
+  tutorial_touchdevelop_string_platforms: do-not-show
+  tutorial_tynkercc_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Firefox, Safari
+  tutorial_bamboo_string_platforms: Chrome
+  tutorial_robojav_string_platforms: All modern browsers
+  tutorial_roboba_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_knodsnake_string_platforms: All modern browsers
+  tutorial_soccharater_string_platforms: All modern browsers
+  tutorial_silent_string_platforms: All modern browsers
+  tutorial_robomesh_string_platforms: Internet Explorer 11, Chrome, Firefox
+  tutorial_amaze_string_platforms: All modern browsers, Android tablet, iPad, Android
+    phone
+  tutorial_codestersds_string_platforms: All modern browsers
+  tutorial_knodtext_string_platforms: All modern browsers
+  tutorial_alicegar_string_platforms: All modern browsers
+  tutorial_codesterstransform_string_platforms: All modern browsers
+  tutorial_flexfrog_string_platforms: All modern browsers
+  tutorial_codemoji_string_platforms: do-not-show
+  tutorial_robobii_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_robobm_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_codingrobots_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_robob_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_coders_string_platforms: All modern browsers
+  tutorial_tynkerhw_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Firefox, Safari
+  tutorial_tynkermh_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Firefox, Safari, Android tablet, iPad
+  tutorial_caphoto_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Firefox, Safari
+  tutorial_mozillahw_string_platforms: All modern browsers
+  tutorial_ticklep_string_platforms: do-not-show
+  tutorial_bbot_string_platforms: All modern browsers
+  tutorial_scratchg_string_platforms: All modern browsers
+  tutorial_sjforest_string_platforms: iPad app
+  tutorial_sjgreet_string_platforms: iPad app
+  tutorial_sjsunset_string_platforms: iPad app
+  tutorial_fufafrenz_string_platforms: Unplugged
+  tutorial_bbcgeo_string_platforms: do-not-show
+  tutorial_chspixel_string_platforms: Unplugged
+  tutorial_hummingbird_string_platforms: PC, Mac, Linux, Chromebook downloadable,
+    Hummingbird robot
+  tutorial_recoloring_string_platforms: All modern browsers
+  tutorial_bbcchem_string_platforms: do-not-show
+  tutorial_floalgo_string_platforms: Unplugged
+  tutorial_flocond_string_platforms: Unplugged
+  tutorial_floloops_string_platforms: Unplugged
+  tutorial_pgts_string_platforms: Unplugged
+  tutorial_ozo_string_platforms: All modern browsers, iPad, iPhone, Android tablet,
+    Andriod phone, Ozobot robot
+  tutorial_bbcla_string_platforms: do-not-show
+  tutorial_bbcsci_string_platforms: do-not-show
+  tutorial_tlctour_string_platforms: Unplugged
+  tutorial_codesterstj_string_platforms: All modern browsers
+  tutorial_tlclocked_string_platforms: Unplugged
+  tutorial_baubles_string_platforms: Unplugged
+  tutorial_bbcart_string_platforms: do-not-show
+  tutorial_tlcknight_string_platforms: Unplugged
+  tutorial_fufafit_string_platforms: Unplugged
+  tutorial_ozodance_string_platforms: All modern browsers, iPad, iPhone, Android tablet,
+    Andriod phone, Ozobot robot
+  tutorial_codingrobotics_string_platforms: iPad, Dash robot
+  tutorial_box_string_platforms: do-not-show
+  tutorial_hopgame_string_platforms: iPad and iPhone
+  tutorial_icontrol_string_platforms: iPad, Sphero robot
+  tutorial_cocomteach_string_platforms: All modern browsers
+  tutorial_bbcmathii_string_platforms: do-not-show
+  tutorial_bbcphys_string_platforms: do-not-show
+  tutorial_bitsbox_string_platforms: All modern browsers, iOS
+  tutorial_tlcemo_string_platforms: Unplugged
+  tutorial_crd_string_platforms: Unplugged
+  tutorial_bbcbio_string_platforms: do-not-show
+  tutorial_ticklebb8_string_platforms: iPad, iPhone, BB-8 robot
+  tutorial_grok_string_platforms: do-not-show
+  tutorial_ijournalist_string_platforms: All modern browsers
+  tutorial_bbcmusic_string_platforms: do-not-show
+  tutorial_secretcodes_string_platforms: All modern browsers
+  tutorial_tlchex_string_platforms: Unplugged
+  tutorial_tickles_string_platforms: iPad, iPhone, Sphero robot
+  tutorial_ozogame_string_platforms: All modern browsers, iPad, iPhone, Android tablet,
+    Andriod phone, Ozobot robot
+  tutorial_vidcodeio_string_platforms: Unplugged
+  tutorial_tlcbrain_string_platforms: Unplugged
+  tutorial_hopquiz_string_platforms: iPad and iPhone
+  tutorial_unfortunate_string_platforms: Dash and Dot robot
+  tutorial_cha_string_platforms: All modern browsers
+  tutorial_elaseq_string_platforms: Unplugged, All modern browsers, iPad, Android
+    tablet
+  tutorial_bbcmathi_string_platforms: do-not-show
+  tutorial_tlcpixel_string_platforms: Unplugged
+  tutorial_introrobo_string_platforms: iPad, Android tablet, Dash and Dot robot
+  tutorial_tlcinvis_string_platforms: Unplugged
+  tutorial_tlcjflap_string_platforms: All modern browsers
+  tutorial_procolor_string_platforms: Ozobot robot
+  tutorial_spiralsfinch_string_platforms: PC, Mac, Linux, Chromebook downloadable,
+    Finch robot
+  tutorial_ozoi_string_platforms: Ozobot robot
+  tutorial_ticklel_string_platforms: All modern browsers, iPad, iPhone, LEGO WeDo
+    robot
+  tutorial_spiralsdash_string_platforms: Android tablet, Android phone, Dash robot
+  tutorial_ghdebug_string_platforms: All modern browsers
+  tutorial_tlckk_string_platforms: Unplugged
+  tutorial_firstcomp_string_platforms: Unplugged
+  tutorial_mazefinch_string_platforms: All modern browsers, Finch robot
+  tutorial_tlccc_string_platforms: Unplugged
+  tutorial_tlcdoodle_string_platforms: Unplugged
+  tutorial_tlcpunch_string_platforms: Unplugged
+  tutorial_finchfract_string_platforms: PC, Mac, Linux, Chromebook downloadable, Finch
+    robot
+  tutorial_tlcmind_string_platforms: Unplugged
+  tutorial_tlctelebot_string_platforms: Unplugged
+  tutorial_tlcaus_string_platforms: Unplugged
+  tutorial_tlcmicro_string_platforms: Unplugged
+  tutorial_imathematician_string_platforms: All modern browsers
+  tutorial_tlcmagic_string_platforms: Unplugged
+  tutorial_scratchmus_string_platforms: All modern browsers
+  tutorial_scratchanim_string_platforms: All modern browsers
+  tutorial_scratchfly_string_platforms: All modern browsers
+  tutorial_tynkerarc_string_platforms: All modern browsers
+  tutorial_grokffpython_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_grokffblock_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_grokeliza_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_tynkercan_string_platforms: All modern browsers
+  tutorial_grokflags_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Firefox, Safari, Android Chrome (mobile-optimized), iOS (mobile-optimized)
+  tutorial_robomind_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Firefox, Safari, Android tablet, iPad
+  tutorial_adventureq_string_platforms: iPad
+  tutorial_khan-es_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Firefox, Safari
+  tutorial_kpt_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome, Firefox,
+    Safari
+  tutorial_kpl_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome, Firefox,
+    Safari
+  tutorial_khe_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome, Firefox,
+    Safari
+  tutorial_kfr_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome, Firefox,
+    Safari
+  tutorial_app-inventor_string_platforms: Android
+  tutorial_blockly_string_platforms: All modern browsers
+  tutorial_tynker_string_platforms: do-not-show
+  tutorial_baypt_string_platforms: All modern browsers
+  tutorial_code-combat_string_platforms: do-not-show
+  tutorial_mky_string_platforms: All modern browsers
+  tutorial_pirates_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Firefox, Safari, Android tablet, iPad, Android phone, iPhone
+  tutorial_csfirst_string_platforms: All modern browsers
+  tutorial_loopedy_string_platforms: iPad, iPhone, Android tablet, Android phone,
+    Dash and Dot robot
+  tutorial_dsw_string_platforms: do-not-show
+  tutorial_dswb_string_platforms: do-not-show
+  tutorial_ssw_string_platforms: do-not-show
+  tutorial_sswb_string_platforms: do-not-show
+  tutorial_kodable-unplugged_string_platforms: Unplugged
+  tutorial_scratch_string_platforms: All modern browsers
+  tutorial_bayes_string_platforms: All modern browsers
+  tutorial_gumball_string_platforms: do-not-show
+  tutorial_hrm_string_platforms: PC and Mac downloadable
+  tutorial_ice-age_string_platforms: do-not-show
+  tutorial_koapp_string_platforms: do-not-show
+  tutorial_lightbot-intl_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Firefox, Safari, Android tablet, iPad, Android phone, iPhone
+  tutorial_rmc_string_platforms: do-not-show
+  tutorial_smc_string_platforms: do-not-show
+  tutorial_minecraft-2016_string_platforms: do-not-show
+  tutorial_thinkersmith-es_string_platforms: All modern browsers, iOS
+  tutorial_pixie_string_platforms: All modern browsers
+  tutorial_play_string_platforms: do-not-show
+  tutorial_robomind-nl_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Firefox, Safari, Android tablet, iPad
+  tutorial_spheroi_string_platforms: iPad, Android tablet, iPhone, Android phone,
+    Sphero robot
+  tutorial_spherol_string_platforms: iPad, Android tablet, iPhone, Android phone,
+    Sphero robot
+  tutorial_spherov_string_platforms: iPad, Android tablet, iPhone, Android phone,
+    Sphero robot
+  tutorial_swb_string_platforms: do-not-show
+  tutorial_build-a-galaxy_string_platforms: do-not-show
+  tutorial_alicesims_string_platforms: All modern browsers
+  tutorial_tchr_string_platforms: do-not-show
+  tutorial_robogame_string_platforms: Android tablet, iPad, Android phone, iPhone,
+    Dash and Dot robot
+  tutorial_tap_string_platforms: Android tablet, iPad
+  tutorial_cintl_string_platforms: do-not-show
+  tutorial_itchstop_string_platforms: All modern browsers
+  tutorial_tynkerpn_string_platforms: All modern browsers, iPad, Android tablet
+  tutorial_tynkerpd_string_platforms: All modern browsers, iPad, Android tablet
+  tutorial_persistence_string_platforms: Unplugged
+  tutorial_getloopy_string_platforms: Unplugged
+  tutorial_createface_string_platforms: Unplugged
+  tutorial_happymaps_string_platforms: Unplugged
+  tutorial_moveit_string_platforms: Unplugged
+  tutorial_bigevent_string_platforms: Unplugged
+  tutorial_gpp_string_platforms: Unplugged
+  tutorial_foosgame_string_platforms: Android tablet, iPad
+  tutorial_solopython_string_platforms: All modern browsers, Android tablet, Android
+    phone, iPad, iPhone
+  tutorial_kodableint_string_platforms: Unplugged, All modern browsers, iPad, Android
+    tablet
+  tutorial_kodableadv_string_platforms: Unplugged, All modern browsers, iPad, Android
+    tablet
+  tutorial_tynkertj_string_platforms: All modern browsers
+  tutorial_wolframa_string_platforms: All modern browsers
+  tutorial_wolframm_string_platforms: All modern browsers
+  tutorial_wolframspi_string_platforms: All modern browsers
+  tutorial_wolframsph_string_platforms: All modern browsers
+  tutorial_wolframp_string_platforms: All modern browsers
+  tutorial_wolframn_string_platforms: All modern browsers
+  tutorial_soloweb_string_platforms: All modern browsers, Android tablet, Android
+    phone, iPad, iPhone
+  tutorial_khanweb_string_platforms: All modern browsers, Android tablet
+  tutorial_khandata_string_platforms: All modern browsers
+  tutorial_googlelogo_string_platforms: All modern browsers
+  tutorial_playtune_string_platforms: Chrome, Firefox, Safari
+  tutorial_computeit_string_platforms: All modern browsers
+  tutorial_codesterssj_string_platforms: All modern browsers
+  tutorial_cmchat_string_platforms: All modern browsers
+  tutorial_tynkerdb_string_platforms: All modern browsers, iPad
+  tutorial_cmbuild_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_robotrattle_string_platforms: Chrome, Firefox, Android tablet, iPad
+  tutorial_codestersh_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_codehsdigipixel_string_platforms: Chrome, Firefox, Safari
+  tutorial_ccbinary_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome
+  tutorial_codehsturtle_string_platforms: Chrome, Firefox, Safari
+  tutorial_grokhd_string_platforms: All modern browsers
+  tutorial_grokem_string_platforms: All modern browsers
+  tutorial_kodmaze_string_platforms: All modern browsers, iPad
+  tutorial_codestersa_string_platforms: All modern browsers
+  tutorial_cmdodo_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_tynkerspace_string_platforms: All modern browsers, iPad, Unplugged
+  tutorial_gfbloons_string_platforms: All modern browsers
+  tutorial_raspipong_string_platforms: Chrome
+  tutorial_codehsvr_string_platforms: Chrome, Firefox, Safari
+  tutorial_codesterstp_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_codestersbb_string_platforms: All modern browsers
+  tutorial_gfcrossyroad_string_platforms: All modern browsers
+  tutorial_googleww_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_codehsjsapp_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_gfmihi_string_platforms: All modern browsers
+  tutorial_hopdropphone_string_platforms: iPad, iPhone
+  tutorial_techfaa_string_platforms: All modern browsers, Android tablet, iPad, Windows
+    phone, Android phone, iPhone
+  tutorial_codehsjsgraph_string_platforms: Chrome, Firefox, Safari
+  tutorial_thunkable_string_platforms: All modern browsers
+  tutorial_hopcrossyroad_string_platforms: iPad, iPhone
+  tutorial_switchglitch_string_platforms: All modern browsers, Android tablet, iPad,
+    Android phone, iPhone
+  tutorial_codecar_string_platforms: Chrome, Firefox
+  tutorial_codesterscp_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_grokpetblock_string_platforms: All modern browsers
+  tutorial_techbim_string_platforms: All modern browsers, Android tablet, iPad, Windows
+    phone, Android phone, iPhone
+  tutorial_techfpp_string_platforms: All modern browsers, Android tablet, iPad, Windows
+    phone, Android phone, iPhone
+  tutorial_codesterscr_string_platforms: All modern browsers
+  tutorial_grokdisease_string_platforms: All modern browsers
+  tutorial_techec_string_platforms: All modern browsers, Android tablet, iPad, Windows
+    phone, Android phone, iPhone
+  tutorial_rgbegin_string_platforms: Chrome, Firefox
+  tutorial_myradream_string_platforms: All modern browsers
+  tutorial_thinkfun_string_platforms: Chrome, Firefox, Safari
+  tutorial_hopfireworks_string_platforms: iPad, iPhone
+  tutorial_grokspace_string_platforms: All modern browsers
+  tutorial_codehspython_string_platforms: Chrome, Firefox, Safari
+  tutorial_codehsjava_string_platforms: Chrome, Firefox, Safari
+  tutorial_techioda_string_platforms: All modern browsers, Android tablet, iPad, Windows
+    phone, Android phone, iPhone
+  tutorial_grokmonster_string_platforms: All modern browsers
+  tutorial_techmjs_string_platforms: All modern browsers, Android tablet, iPad, Windows
+    phone, Android phone, iPhone
+  tutorial_techga_string_platforms: All modern browsers, Android tablet, iPad, Windows
+    phone, Android phone, iPhone
+  tutorial_techioan_string_platforms: All modern browsers, Android tablet, iPad, Windows
+    phone, Android phone, iPhone
+  tutorial_techiogsr_string_platforms: All modern browsers, Android tablet, iPad,
+    Windows phone, Android phone, iPhone
+  tutorial_groktunnel_string_platforms: All modern browsers
+  tutorial_stemcod_string_platforms: Chrome, Firefox, Safari, Android tablet, iPad
+  tutorial_techikb_string_platforms: All modern browsers, Android tablet, iPad, Windows
+    phone, Android phone, iPhone
+  tutorial_kanostreet_string_platforms: All modern browsers
+  tutorial_codemojijs_string_platforms: All modern browsers
+  tutorial_techapf_string_platforms: All modern browsers, Android tablet, iPad, Windows
+    phone, Android phone, iPhone
+  tutorial_techfpjs_string_platforms: All modern browsers, Android tablet, iPad, Windows
+    phone, Android phone, iPhone
+  tutorial_techlinq_string_platforms: All modern browsers, Android tablet, iPad, Windows
+    phone, Android phone, iPhone
+  tutorial_gpbcatapult_string_platforms: All modern browsers
+  tutorial_quorumastro_string_platforms: All modern browsers, Android tablet, iPad,
+    Windows phone, Android phone, iPhone, Screen reader
+  tutorial_alicewonder_string_platforms: All modern browsers
+  tutorial_rginter_string_platforms: Chrome, Firefox, Android tablet
+  tutorial_cssgrid_string_platforms: All modern browsers
+  tutorial_jshero_string_platforms: All modern browsers, Android tablet, Android phone
+  tutorial_codemojipy_string_platforms: iPad, iPhone
+  tutorial_nclabdrone_string_platforms: All modern browsers
+  tutorial_gpbcircle_string_platforms: All modern browsers
+  tutorial_gpbpaint_string_platforms: All modern browsers
+  tutorial_cocomarcade_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Firefox
+  tutorial_beetik_string_platforms: Chrome, Firefox, Android tablet, iPad
+  tutorial_codedj_string_platforms: Chrome, Firefox, Safari, Android tablet, iPad
+  tutorial_rgadvan_string_platforms: Chrome, Firefox, Android tablet
+  tutorial_codehsrn_string_platforms: Chrome, Firefox, Safari, Android phone, iPhone
+  tutorial_codehswd_string_platforms: Chrome, Firefox, Safari
+  tutorial_turtlerobot_string_platforms: Chrome, Android tablet, iPad, Android phone,
+    iPhone
+  tutorial_ozoevo_string_platforms: All modern browsers, Android tablets, iPads, Ozobot
+    Evo robot
+  tutorial_ozoexped_string_platforms: All modern browsers, Android tablets, iPads,
+    Ozobot Bit or Evo robot
+  tutorial_ozojourney_string_platforms: All modern browsers, Android tablets, iPads,
+    Ozobot Bit or Evo robot
+  tutorial_ozocodes_string_platforms: All modern browsers, Android tablets, iPads,
+    Ozobot Bit or Evo robot
+  tutorial_ozoeclipse_string_platforms: All modern browsers, Android tablets, iPads,
+    Ozobot Bit or Evo robot
+  tutorial_ozosimulator_string_platforms: Unplugged
+  tutorial_ozoalgorithm_string_platforms: All modern browsers, Android tablets, iPads,
+    Ozobot Bit or Evo robot
+  tutorial_ozotimer_string_platforms: All modern browsers, Android tablets, iPads,
+    Ozobot Bit or Evo robot
+  tutorial_ozohabits_string_platforms: All modern browsers, Android tablets, iPads,
+    Ozobot Bit or Evo robot
+  tutorial_ozoprogram_string_platforms: All modern browsers
+  tutorial_ozopair_string_platforms: All modern browsers, Android tablets, iPads,
+    Ozobot Bit or Evo robot
+  tutorial_codesnoopy_string_platforms: All modern browsers, Android tablet, iPad,
+    Android phone, iPhone
+  tutorial_applabintro_string_platforms: All modern browsers
+  tutorial_cslartist_string_platforms: Unplugged
+  tutorial_cslscratchjr_string_platforms: Unplugged
+  tutorial_floevents_string_platforms: Unplugged
+  tutorial_florobot_string_platforms: Unplugged
+  tutorial_isavesanta_string_platforms: All modern browsers
+  tutorial_iorder_string_platforms: All modern borwsers
+  tutorial_ianimate_string_platforms: All modern browsers, iPad
+  tutorial_iloveada_string_platforms: All modern borwsers
+  tutorial_kodflash_string_platforms: Unplugged
+  tutorial_kodchoose_string_platforms: Unplugged
+  tutorial_kodpizzapre_string_platforms: Unplugged
+  tutorial_kodpizza_string_platforms: Unplugged
+  tutorial_kodwomen_string_platforms: Unplugged
+  tutorial_tfunplug_string_platforms: Unplugged
+  tutorial_lbvariables_string_platforms: All modern browsers, littleBits Code Kit
+  tutorial_lbfunctions_string_platforms: All modern browsers, littleBits Code Kit
+  tutorial_lblogic_string_platforms: All modern browsers, littleBits Code Kit
+  tutorial_lbworld_string_platforms: All modern browsers, littleBits Code Kit
+  tutorial_lbloops_string_platforms: All modern browsers, littleBits Code Kit
+  tutorial_lbtug_string_platforms: All modern browsers, littleBits Code Kit
+  tutorial_lbpotato_string_platforms: All modern browsers, littleBits Code Kit
+  tutorial_lbguitar_string_platforms: All modern browsers, littleBits Code Kit
+  tutorial_lbio_string_platforms: All modern browsers, littleBits Code Kit
+  tutorial_wonpuppy_string_platforms: iPads, iPhones, Android tablets, Android phones,
+    Dash robot
+  tutorial_woncue_string_platforms: iPads, iPhones, Android tablets, Android phones,
+    Cue robot
+  tutorial_wonzoo_string_platforms: iPads, iPhones, Android tablets, Android phones,
+    Dot robot
+  tutorial_wontrip_string_platforms: iPads, iPhones, Android tablets, Android phones,
+    Dash robot
+  tutorial_woncollect_string_platforms: iPads, iPhones, Android tablets, Android phones,
+    Dash robot
+  tutorial_wonsecret_string_platforms: iPads, iPhones, Android tablets, Android phones,
+    Cue robot
+  tutorial_hsscience_string_platforms: iPad, iPhone
+  tutorial_popculture_string_platforms: All modern browsers, Android tablet, Android
+    phone
+  tutorial_legorobust_string_platforms: All modern browsers, Android tablet, iPad,
+    WeDo 2.0
+  tutorial_legoplants_string_platforms: All modern browsers, Android tablet, iPad,
+    WeDo 2.0
+  tutorial_legopark_string_platforms: All modern browsers, Android tablet, iPad, MINDSTORMS®
+    EV3
+  tutorial_legodetect_string_platforms: All modern browsers, Android tablet, iPad,
+    MINDSTORMS® EV3
+  tutorial_legolight_string_platforms: All modern browsers, Android tablet, iPad,
+    MINDSTORMS® EV3
+  tutorial_alexa_string_platforms: All modern browsers
+  tutorial_grokpetmicro_string_platforms: All modern browsers
+  tutorial_pirateplunder_string_platforms: Chrome, Firefox
+  tutorial_cadj_string_platforms: Chrome, Firefox, Safari
+  tutorial_cacrazy_string_platforms: Chrome, Firefox, Safari
+  tutorial_cajump_string_platforms: Chrome, Firefox, Safari
+  tutorial_carest_string_platforms: Chrome, Firefox, Safari
+  tutorial_accai_string_platforms: All modern browsers
+  tutorial_vceclipse_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_pmzero_string_platforms: All modern browsers
+  tutorial_hsela_string_platforms: iPad, iPhone
+  tutorial_ticklear_string_platforms: iPad, iPhone
+  tutorial_bcrobot_string_platforms: Chrome, Firefox, Safari
+  tutorial_bcsnow_string_platforms: Chrome, Firefox, Safari
+  tutorial_ifly_string_platforms: Android tablet, iPad, Parrot Minidrones
+  tutorial_idowedo_string_platforms: All modern browsers, Android tablet, iPad, WeDo
+  tutorial_diggindwarf_string_platforms: Chrome, Firefox, Safari
+  tutorial_spheroit_string_platforms: iPad, Android tablet, iPhone, Android phone,
+    Sphero robot
+  tutorial_gameofcodes_string_platforms: All modern browsers, Android tablet, Android
+    phone, iPad
+  tutorial_blocklygames_string_platforms: All modern browsers
+  tutorial_spherohello_string_platforms: iPad, Android tablet, iPhone, Android phone,
+    Sphero robot
+  tutorial_spheroarcade_string_platforms: iPad, Android tablet, iPhone, Android phone,
+    Sphero robot
+  tutorial_bcpy1_string_platforms: All modern browsers
+  tutorial_bcpy2_string_platforms: All modern browsers
+  tutorial_bcjs1_string_platforms: All modern browsers
+  tutorial_bcjs2_string_platforms: All modern browsers
+  tutorial_3dbearmars_string_platforms: Android tablet, iPad, Android phone, iPhone
+  tutorial_bitsboxyak_string_platforms: All modern browsers
+  tutorial_blockscadbargraphs_string_platforms: All modern browsers
+  tutorial_blockscadbirdhouses_string_platforms: All modern browsers
+  tutorial_blockscadclock_string_platforms: All modern browsers
+  tutorial_blockscaddinner_string_platforms: All modern browsers
+  tutorial_blockscadicecream_string_platforms: All modern browsers
+  tutorial_blockscadpizza_string_platforms: All modern browsers
+  tutorial_blockscadsugar_string_platforms: All modern browsers
+  tutorial_bsgridlight_string_platforms: All modern browsers
+  tutorial_bpartscratch_string_platforms: All modern browsers, Android tablet, iPad,
+    Screen reader
+  tutorial_bpartvid_string_platforms: All modern browsers, Android tablet, iPad, Screen
+    reader
+  tutorial_bpenglishscratch_string_platforms: All modern browsers, Android tablet,
+    iPad, Screen reader
+  tutorial_bpenglishvid_string_platforms: All modern browsers, Android tablet, iPad,
+    Screen reader
+  tutorial_bphealthscratch_string_platforms: All modern browsers, Android tablet,
+    iPad, Screen reader
+  tutorial_bphealthvid_string_platforms: All modern browsers, Android tablet, iPad,
+    Screen reader
+  tutorial_bpmathscratch_string_platforms: All modern browsers, Android tablet, iPad,
+    Screen reader
+  tutorial_bpmathvid_string_platforms: All modern browsers, Android tablet, iPad,
+    Screen reader
+  tutorial_bpmlkscratch_string_platforms: All modern browsers, Android tablet, iPad,
+    Screen reader
+  tutorial_bpmlkvid_string_platforms: All modern browsers, Android tablet, iPad, Screen
+    reader
+  tutorial_bpsafetyscratch_string_platforms: All modern browsers, Android tablet,
+    iPad, Screen reader
+  tutorial_bpsafetyvid_string_platforms: All modern browsers, Android tablet, iPad,
+    Screen reader
+  tutorial_bpsciencescratch_string_platforms: All modern browsers, Android tablet,
+    iPad, Screen reader
+  tutorial_bpsciencevid_string_platforms: All modern browsers, Android tablet, iPad,
+    Screen reader
+  tutorial_bptechscratch_string_platforms: All modern browsers, Android tablet, iPad,
+    Screen reader
+  tutorial_bptechvid_string_platforms: All modern browsers, Android tablet, iPad,
+    Screen reader
+  tutorial_caflags_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_matariki_string_platforms: All modern browsers, Android tablet, iPad, Unplugged
+  tutorial_carestaurant_string_platforms: All modern browsers, Android tablet, iPad,
+    Unplugged
+  tutorial_casea_string_platforms: All modern browsers, iPad, Unplugged (no technology
+    needed)
+  tutorial_cashield_string_platforms: All modern browsers, Android tablet, iPad, Unplugged
+  tutorial_ccwslimer_string_platforms: Microsoft Edge, Chrome, Safari, iPad
+  tutorial_codinggalaxy_string_platforms: Android tablet, iPad, iPhone, Unplugged
+    (no technology needed)
+  tutorial_boatrace_string_platforms: All modern browsers
+  tutorial_ccplay_string_platforms: All modern browsers
+  tutorial_grinch_string_platforms: All modern browsers
+  tutorial_codehsart_string_platforms: All modern browsers
+  tutorial_codehsbitcoin_string_platforms: All modern browsers
+  tutorial_codehsblockchain_string_platforms: All modern browsers
+  tutorial_codehscipher_string_platforms: Unplugged
+  tutorial_codehscollision_string_platforms: All modern browsers
+  tutorial_codehsmath_string_platforms: All modern browsers
+  tutorial_codehsmusic_string_platforms: All modern browsers
+  tutorial_codehssports_string_platforms: All modern browsers
+  tutorial_codemojipizza_string_platforms: All modern browsers
+  tutorial_moonlander_string_platforms: All modern browsers
+  tutorial_sushicards_string_platforms: All modern browsers
+  tutorial_codesparkcreate_string_platforms: All modern browsers, Android tablet,
+    iPad, Android phone, iPhone
+  tutorial_hardvsoft_string_platforms: Unplugged
+  tutorial_codestersecard_string_platforms: All modern browsers, Screen reader
+  tutorial_codesterslogo_string_platforms: All modern browsers, Screen reader
+  tutorial_codesterstshirt_string_platforms: All modern browsers, Screen reader
+  tutorial_codewards_string_platforms: All modern browsers
+  tutorial_olympics_string_platforms: All modern browsers
+  tutorial_codinismhero_string_platforms: Android tablet, Android phone
+  tutorial_discovery_string_platforms: All modern browsers
+  tutorial_csfirstname_string_platforms: All modern browsers
+  tutorial_edisonmove_string_platforms: All modern browsers
+  tutorial_edisonspider_string_platforms: All modern browsers, iPad, Android tablets
+  tutorial_edisonspotlight_string_platforms: All modern browsers, iPad, Android tablets
+  tutorial_firiapython_string_platforms: All modern browsers
+  tutorial_gamefrootsquid_string_platforms: All modern browsers, iPad
+  tutorial_duckpiano_string_platforms: All modern browsers
+  tutorial_gpsound_string_platforms: All modern browsers
+  tutorial_groklearningpython_string_platforms: All modern browsers, Screen reader
+  tutorial_htmltimetravel_string_platforms: All modern browsers
+  tutorial_hp_flappy_string_platforms: iPad
+  tutorial_appytappin_string_platforms: All modern browsers
+  tutorial_icipher_string_platforms: Unplugged
+  tutorial_iguess_string_platforms: Android tablet, iPad, iPhone
+  tutorial_imake_string_platforms: Unplugged
+  tutorial_imorse_string_platforms: Unplugged
+  tutorial_kanohp_string_platforms: Chrome, Safari, Android, iOS
+  tutorial_khanwebpages_string_platforms: All modern browsers
+  tutorial_kibobowl_string_platforms: ''
+  tutorial_kibodance_string_platforms: ''
+  tutorial_buildcharacters_string_platforms: All modern browsers, iPad, iPhone
+  tutorial_designgames_string_platforms: All modern browsers, iPad, iPhone
+  tutorial_makelevels_string_platforms: All modern browsers, iPad, iPhone
+  tutorial_wizard_string_platforms: Chrome
+  tutorial_mbscratchcards_string_platforms: ''
+  tutorial_mbswiftplaygrounds_string_platforms: iPad
+  tutorial_mbbuttons_string_platforms: Windows, Mac OS, Linux, or Chromebook
+  tutorial_meteor_string_platforms: Windows, Mac OS, Linux, or Chromebook
+  tutorial_ballbounce_string_platforms: Chrome, Firefox, Safari, Android tablet, Android
+    phone, iPad, iPhone
+  tutorial_mitcodi_string_platforms: Chrome, Firefox, Safari, Android tablet, Android
+    phone, iPad, iPhone
+  tutorial_mitdoodle_string_platforms: Chrome, Firefox, Safari, Android tablet, Android
+    phone, iPad, iPhone
+  tutorial_talktome_string_platforms: Chrome, Firefox, Safari, Android tablet, Android
+    phone, iPad, iPhone
+  tutorial_mobilecspmap_string_platforms: Chrome, Firefox, Android tablet, Android
+    phone
+  tutorial_ozorandom_string_platforms: ''
+  tutorial_ozotroll_string_platforms: ''
+  tutorial_peblioart_string_platforms: Chrome, Firefox, Safari
+  tutorial_astropi_string_platforms: All modern browsers
+  tutorial_rgart_string_platforms: Chrome, Firefox, Safari, Android tablet, iPad,
+    Android phone, iPhone
+  tutorial_rgengineer_string_platforms: Chrome, Firefox, Safari, Android tablet, iPad,
+    Android phone, iPhone
+  tutorial_rgmath_string_platforms: Chrome, Firefox, Safari, Android tablet, iPad,
+    Android phone, iPhone
+  tutorial_rgscience_string_platforms: Chrome, Firefox, Safari, Android tablet, iPad,
+    Android phone, iPhone
+  tutorial_rgtech_string_platforms: Chrome, Firefox, Safari, Android tablet, iPad,
+    Android phone, iPhone
+  tutorial_robotmagic3d_string_platforms: Internet Explorer 11, Microsoft Edge, Chrome,
+    Android tablet, iPad
+  tutorial_robotmagicflappy_string_platforms: All modern browsers, Android tablet,
+    iPad
+  tutorial_scratchadventure_string_platforms: Chrome, Safari, Android tablet, iPad
+  tutorial_scratchtalk_string_platforms: Chrome, Safari, Android tablet, iPad
+  tutorial_scratchjrstory_string_platforms: Android tablet, iPad
+  tutorial_scratchjrtwinkle_string_platforms: Android tablet, iPad
+  tutorial_spherocomm_string_platforms: All modern browsers, Android tablet, iPad,
+    Android phone, iPhone, Screen reader
+  tutorial_spherocommunity_string_platforms: All modern browsers, Android tablet,
+    iPad, Android phone, iPhone, Screen reader
+  tutorial_spherofunctions_string_platforms: All modern browsers, Android tablet,
+    iPad, Android phone, iPhone, Screen reader
+  tutorial_spheroinfrared_string_platforms: All modern browsers, Android tablet, iPad,
+    Android phone, iPhone, Screen reader
+  tutorial_spherolightsensor_string_platforms: All modern browsers, Android tablet,
+    iPad, Android phone, iPhone, Screen reader
+  tutorial_spheromansion_string_platforms: All modern browsers, Android tablet, iPad,
+    Android phone, iPhone, Screen reader
+  tutorial_roadblocks_string_platforms: All modern browsers, Android tablet, iPad,
+    Android phone, iPhone, Screen reader
+  tutorial_spherotext2_string_platforms: All modern browsers, Android tablet, iPad,
+    Android phone, iPhone, Screen reader
+  tutorial_spherotext3_string_platforms: All modern browsers, Android tablet, iPad,
+    Android phone, iPhone, Screen reader
+  tutorial_spherotext4_string_platforms: All modern browsers, Android tablet, iPad,
+    Android phone, iPhone, Screen reader
+  tutorial_spheroraptor_string_platforms: All modern browsers, Android tablet, iPad,
+    Android phone, iPhone, Screen reader
+  tutorial_stempiday_string_platforms: Chrome, Firefox, Safari, Android tablet, iPad
+  tutorial_stemplanetoids_string_platforms: Chrome, Firefox, Safari, Android tablet,
+    iPad
+  tutorial_stempong_string_platforms: Chrome, Firefox, Safari, Android tablet, iPad
+  tutorial_algobot_string_platforms: All modern browsers, Android tablet, iPad, Android
+    phone, iPhone
+  tutorial_thunkableapps_string_platforms: Chrome, Firefox, Safari, Android tablet,
+    iPad, Android phone, iPhone
+  tutorial_toxicodedot_string_platforms: All modern browsers
+  tutorial_gcactions_string_platforms: Chrome, Firefox, Android tablet, iPad
+  tutorial_gccomparators_string_platforms: Chrome, Firefox, Android tablet, iPad
+  tutorial_gcconditions_string_platforms: Chrome, Firefox, Android tablet, iPad
+  tutorial_gccreate_string_platforms: Chrome, Firefox, Android tablet, iPad
+  tutorial_gcevents_string_platforms: Chrome, Firefox, Android tablet, iPad
+  tutorial_gcloops_string_platforms: Chrome, Firefox, Android tablet, iPad
+  tutorial_gcvariables_string_platforms: Chrome, Firefox, Android tablet, iPad
+  tutorial_beanything_string_platforms: All modern browsers, iPad
+  tutorial_change_string_platforms: All modern browsers, iPad
+  tutorial_cooking_string_platforms: All modern browsers
+  tutorial_crystal_string_platforms: All modern browsers
+  tutorial_landscape_string_platforms: All modern browsers
+  tutorial_pets_string_platforms: All modern browsers, iPad
+  tutorial_petvet_string_platforms: All modern browsers
+  tutorial_superhero_string_platforms: All modern browsers
+  tutorial_vidcodeplastic_string_platforms: All modern browsers, iPad
+  tutorial_vidcodetypeface_string_platforms: All modern browsers, iPad
+  tutorial_washustorm_string_platforms: All modern browsers
+  tutorial_activitypackets_string_platforms: Unplugged, iOS, Android, Kindle, Chrome*
+    (*Cue only)
+  tutorial_googlerookie_string_platforms: All modern browsers, Android tablet, iPad,
+    Android phone, iPhone
+  tutorial_tommyturtle_string_platforms: Android tablet, iPad, Android phone, iPhone
+  tutorial_mazyad_string_platforms: Unplugged
+  tutorial_gamemaker_string_platforms: All modern browsers, iPad
+  tutorial_duckrace_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_allcancodeapps_string_platforms: All modern browsers
+  tutorial_n2y_string_platforms: Unplugged
+  tutorial_microsoftarcade_string_platforms: All modern browsers, Screen reader
+  tutorial_csfirstunplugged_string_platforms: All modern browsers, Unplugged
+  tutorial_toxicodepython_string_platforms: All modern browsers
+  tutorial_codecombatozaria_string_platforms: All modern browsers
+  tutorial_vidcodedate_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_codemonkeyspace_string_platforms: All modern browsers
+  tutorial_codespeakhappy_string_platforms: Chrome, Firefox
+  tutorial_grokimage_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_icomputelearn_string_platforms: All modern browsers
+  tutorial_rpstress_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_bsdcause_string_platforms: Chrome
+  tutorial_vidcodeanimoji_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_vidcodeanimojies_string_platforms: All modern browsers, Android tablet,
+    iPad
+  tutorial_bsdinspire_string_platforms: Chrome
+  tutorial_tttractor_string_platforms: Chrome
+  tutorial_codeillusionmickey_string_platforms: Chrome
+  tutorial_scigirlsquest_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_codespeakbreathe_string_platforms: Chrome, Firefox
+  tutorial_vidcodeface_string_platforms: Chrome, Firefox
+  tutorial_educodemaze_string_platforms: All modern browsers
+  tutorial_educoderace_string_platforms: All modern browsers
+  tutorial_codespeakchatbot_string_platforms: Chrome, Firefox
+  tutorial_gamefrootgames_string_platforms: All modern browsers, Android tablet, iPad,
+    Windows phone
+  tutorial_codespeakgrandparent_string_platforms: Chrome, Firefox
+  tutorial_educodekingdom_string_platforms: All modern browsers
+  tutorial_codehsdata_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_educodecake_string_platforms: All modern browsers
+  tutorial_ttsecond_string_platforms: Chrome
+  tutorial_bsdtrivia_string_platforms: Chrome
+  tutorial_csfirstdialogue_string_platforms: All modern browsers
+  tutorial_codemonkeybeaver_string_platforms: All modern browsers, Android tablet,
+    iPad
+  tutorial_codestersdistance_string_platforms: All modern browsers, Screen reader
+  tutorial_itchspace_string_platforms: All modern browsers
+  tutorial_vidcodemagic_string_platforms: All modern browsers, Android tablet, iPad,
+    Screen reader
+  tutorial_vidcodemagices_string_platforms: All modern browsers, Android tablet, iPad,
+    Screen reader
+  tutorial_codespeakmeal_string_platforms: Chrome, Firefox
+  tutorial_itchfish_string_platforms: All modern browsers
+  tutorial_bsdwebsite_string_platforms: Chrome
+  tutorial_codespeaktime_string_platforms: Chrome, Firefox
+  tutorial_itchwebcam_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_itchball_string_platforms: All modern browsers
+  tutorial_ttrace_string_platforms: Chrome
+  tutorial_plethora_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_educodesecret_string_platforms: All modern browsers
+  tutorial_itchshapes_string_platforms: All modern browsers
+  tutorial_codeguppytext_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_vidcodeplastiche_string_platforms: All modern browsers, iPad
+  tutorial_educativechatbot_string_platforms: All modern browsers
+  tutorial_educodebasics_string_platforms: All modern browsers
+  tutorial_codehsdesign_string_platforms: All modern browsers, Android tablet, iPad,
+    Windows phone, Android phone, iPhone
+  tutorial_htmlacademyphp_string_platforms: All modern browsers, Screen reader
+  tutorial_gamefrootdistance_string_platforms: All modern browsers, Android tablet,
+    iPad
+  tutorial_codesterscovid_string_platforms: All modern browsers, Screen reader
+  tutorial_ttbunker_string_platforms: Chrome
+  tutorial_cuttle_string_platforms: All modern browsers, Android tablet, iPad, Windows
+    phone, Android phone, iPhone
+  tutorial_bsdjokes_string_platforms: Chrome
+  tutorial_rptree_string_platforms: Chrome, Firefox
+  tutorial_codestersunity_string_platforms: All modern browsers, Screen reader
+  tutorial_codesterssoccer_string_platforms: All modern browsers, Screen reader
+  tutorial_breakoutlock_string_platforms: All modern browsers, Android tablet, iPad,
+    Android phone, iPhone
+  tutorial_thunkablemask_string_platforms: All modern browsers
+  tutorial_cafarming_string_platforms: Chrome, Firefox
+  tutorial_blocksmithyeti_string_platforms: All modern browsers
+  tutorial_codecapture_string_platforms: All modern browsers, Android phone, iPhone
+  tutorial_codehslitter_string_platforms: All modern browsers, Android tablet, iPad,
+    Windows phone, Android phone, iPhone
+  tutorial_bsdocean_string_platforms: Chrome
+  tutorial_itchplatformer_string_platforms: All modern browsers
+  tutorial_codejika_string_platforms: All modern browsers, Android tablet, iPad, Windows
+    phone, Android phone, iPhone
+  tutorial_gamefrootclicker_string_platforms: All modern browsers, iPad
+  tutorial_rmagicequity_string_platforms: All modern browsers, Android tablet, iPad,
+    Windows phone, Android phone, iPhone, Game console app
+  tutorial_ttfreestyle_string_platforms: Chrome
+  tutorial_ozobotcolor2_string_platforms: All modern browsers
+  tutorial_ozobotcolor3_string_platforms: All modern browsers
+  tutorial_clcarbon_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_kodablebasics_string_platforms: Unplugged
+  tutorial_scigirlscc_string_platforms: Unplugged
+  tutorial_irobotpicture_string_platforms: Unplugged
+  tutorial_kcjmyself_string_platforms: All modern browsers
+  tutorial_nearpodalgorithms_string_platforms: All modern browsers, Screen reader
+  tutorial_kibodrop_string_platforms: Unplugged
+  tutorial_ozobotcolor1_string_platforms: All modern browsers
+  tutorial_scigirlspixels_string_platforms: Unplugged
+  tutorial_kcjheroines_string_platforms: All modern browsers
+  tutorial_ozobotvalue_string_platforms: All modern browsers
+  tutorial_icodebytes_string_platforms: Unplugged
+  tutorial_clfashion2_string_platforms: All modern browsers
+  tutorial_ai4all_string_platforms: All modern browsers
+  tutorial_cldata_string_platforms: All modern browsers
+  tutorial_spheroinputs_string_platforms: Unplugged
+  tutorial_edisoncount_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_spheroloops_string_platforms: Unplugged
+  tutorial_kiboprogram_string_platforms: Unplugged
+  tutorial_hellorubycsin60_string_platforms: Unplugged
+  tutorial_clfashion1_string_platforms: All modern browsers
+  tutorial_irobottraffic_string_platforms: Chrome, Android tablet, Android phone
+  tutorial_edisonmystery_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_microbitseaturtles_string_platforms: All modern browsers, Android tablet,
+    iPad, Windows phone, Android phone, iPhone
+  tutorial_ozobotknow_string_platforms: All modern browsers
+  tutorial_imagilabs_string_platforms: Android phone, iPhone, Unplugged
+  tutorial_irobotsimulator_string_platforms: All modern browsers, Android tablet,
+    iPad, Windows phone, Android phone, iPhone
+  tutorial_irobotkind_string_platforms: All modern browsers
+  tutorial_firiavirtual_string_platforms: Microsoft Edge, Chrome
+  tutorial_irobotguesscode_string_platforms: Chrome, Android tablet, Android phone
+  tutorial_ozobotnouns_string_platforms: All modern browsers
+  tutorial_nasa3d_string_platforms: All modern browsers
+  tutorial_blupants_string_platforms: All modern browsers
+  tutorial_legodance_string_platforms: All modern browsers
+  tutorial_nearpodcoding_string_platforms: All modern browsers, Screen reader
+  tutorial_kcjplastic_string_platforms: All modern browsers
+  tutorial_legojourney_string_platforms: All modern browsers
+  tutorial_legohopper_string_platforms: All modern browsers
+  tutorial_catrobatembroidery_string_platforms: Android phone, Screen reader
+  tutorial_irobotphone_string_platforms: All modern browsers
+  tutorial_codeguppydraw_string_platforms: All modern browsers
+  tutorial_codejumper_string_platforms: Unplugged, Sreen reader
+  tutorial_meeempathy_string_platforms: All modern browsers, Mac, Windows, Chromebook,
+    iPhone, iPad, Android phone, Android tablet
+  tutorial_dance2019_string_detail_platforms: ''
+  tutorial_danceparty_string_detail_platforms: ''
+  tutorial_chibitronics_string_detail_platforms: Chibitronics Chibi Chip and Circuit
+    Sticker LEDs
+  tutorial_athlete_string_detail_platforms: ''
+  tutorial_moana_string_detail_platforms: ''
+  tutorial_star-wars_string_detail_platforms: ''
+  tutorial_gumadventure_string_detail_platforms: ''
+  tutorial_mchoc_string_detail_platforms: ''
+  tutorial_vidnews_string_detail_platforms: ''
+  tutorial_kodable-pre_string_detail_platforms: All modern browsers, iPad app
+  tutorial_highseas_string_detail_platforms: ''
+  tutorial_capython_string_detail_platforms: ''
+  tutorial_frzn_string_detail_platforms: ''
+  tutorial_cocom_string_detail_platforms: ''
+  tutorial_play-lab_string_detail_platforms: ''
+  tutorial_boxisland_string_detail_platforms: ''
+  tutorial_textcomp_string_detail_platforms: ''
+  tutorial_encryption_string_detail_platforms: ''
+  tutorial_kanopixel_string_detail_platforms: ''
+  tutorial_foos_string_detail_platforms: ''
+  tutorial_tynkerdd_string_detail_platforms: ''
+  tutorial_tynkerana_string_detail_platforms: ''
+  tutorial_vidcard_string_detail_platforms: ''
+  tutorial_spritebox_string_detail_platforms: ''
+  tutorial_tynkerch_string_detail_platforms: ''
+  tutorial_lightbot_string_detail_platforms: ''
+  tutorial_hoc_string_detail_platforms: do-not-show
+  tutorial_code_string_detail_platforms: ''
+  tutorial_tinspire_string_detail_platforms: TI-Nspire handheld
+  tutorial_itchbounceball_string_detail_platforms: ''
+  tutorial_vidclim_string_detail_platforms: ''
+  tutorial_matlab_string_detail_platforms: ''
+  tutorial_flap_string_detail_platforms: ''
+  tutorial_galaxy_string_detail_platforms: Android
+  tutorial_inf_string_detail_platforms: ''
+  tutorial_tynkersol_string_detail_platforms: ''
+  tutorial_itchg_string_detail_platforms: ''
+  tutorial_como_string_detail_platforms: ''
+  tutorial_processfound_string_detail_platforms: ''
+  tutorial_tynkerhomo_string_detail_platforms: ''
+  tutorial_art_string_detail_platforms: ''
+  tutorial_tynkerbrick_string_detail_platforms: ''
+  tutorial_itchbio_string_detail_platforms: ''
+  tutorial_itchj_string_detail_platforms: ''
+  tutorial_tickleo_string_detail_platforms: ''
+  tutorial_hopgeo_string_detail_platforms: iOS app
+  tutorial_tynkermult_string_detail_platforms: ''
+  tutorial_monster_string_detail_platforms: ''
+  tutorial_tynkerapp_string_detail_platforms: do-not-show
+  tutorial_tynkerpup_string_detail_platforms: ''
+  tutorial_livecode_string_detail_platforms: ''
+  tutorial_cocomgame_string_detail_platforms: ''
+  tutorial_tynkerspin_string_detail_platforms: ''
+  tutorial_code-avengers_string_detail_platforms: ''
+  tutorial_tynkercq_string_detail_platforms: ''
+  tutorial_cmgame_string_detail_platforms: ''
+  tutorial_codesters_string_detail_platforms: do-not-show
+  tutorial_qrm_string_detail_platforms: ''
+  tutorial_texas-instruments_string_detail_platforms: TI-84, TI-83 graphing calculators
+  tutorial_cajava_string_detail_platforms: ''
+  tutorial_codehs_string_detail_platforms: ''
+  tutorial_hopemo_string_detail_platforms: iOS app
+  tutorial_tynkercm_string_detail_platforms: ''
+  tutorial_codesterswintergreet_string_detail_platforms: ''
+  tutorial_codestersc_string_detail_platforms: ''
+  tutorial_codestersturtle_string_detail_platforms: ''
+  tutorial_penjee_string_detail_platforms: ''
+  tutorial_trinket_string_detail_platforms: ''
+  tutorial_frogger_string_detail_platforms: ''
+  tutorial_tynkereco_string_detail_platforms: ''
+  tutorial_mitedarc_string_detail_platforms: ''
+  tutorial_khan_string_detail_platforms: ''
+  tutorial_tynkerd_string_detail_platforms: ''
+  tutorial_cdmy_string_detail_platforms: ''
+  tutorial_codestersdance_string_detail_platforms: ''
+  tutorial_codestersbasketball_string_detail_platforms: ''
+  tutorial_nclkarel_string_detail_platforms: ''
+  tutorial_buildpong_string_detail_platforms: ''
+  tutorial_tynkerdrones_string_detail_platforms: Parrot drone, Sphero robot, Ollie
+    robot
+  tutorial_carla_string_detail_platforms: ''
+  tutorial_zulama_string_detail_platforms: ''
+  tutorial_capost_string_detail_platforms: ''
+  tutorial_marco_string_detail_platforms: ''
+  tutorial_codestersflappybike_string_detail_platforms: ''
+  tutorial_kanopong_string_detail_platforms: ''
+  tutorial_tynkerright_string_detail_platforms: ''
+  tutorial_touchdevelop_string_detail_platforms: do-not-show
+  tutorial_tynkercc_string_detail_platforms: ''
+  tutorial_bamboo_string_detail_platforms: ''
+  tutorial_robojav_string_detail_platforms: ''
+  tutorial_roboba_string_detail_platforms: ''
+  tutorial_knodsnake_string_detail_platforms: ''
+  tutorial_soccharater_string_detail_platforms: ''
+  tutorial_silent_string_detail_platforms: ''
+  tutorial_robomesh_string_detail_platforms: ''
+  tutorial_amaze_string_detail_platforms: ''
+  tutorial_codestersds_string_detail_platforms: ''
+  tutorial_knodtext_string_detail_platforms: ''
+  tutorial_alicegar_string_detail_platforms: ''
+  tutorial_codesterstransform_string_detail_platforms: ''
+  tutorial_flexfrog_string_detail_platforms: ''
+  tutorial_codemoji_string_detail_platforms: do-not-show
+  tutorial_robobii_string_detail_platforms: ''
+  tutorial_robobm_string_detail_platforms: ''
+  tutorial_codingrobots_string_detail_platforms: ''
+  tutorial_robob_string_detail_platforms: ''
+  tutorial_coders_string_detail_platforms: ''
+  tutorial_tynkerhw_string_detail_platforms: ''
+  tutorial_tynkermh_string_detail_platforms: ''
+  tutorial_caphoto_string_detail_platforms: ''
+  tutorial_mozillahw_string_detail_platforms: ''
+  tutorial_ticklep_string_detail_platforms: do-not-show
+  tutorial_bbot_string_detail_platforms: ''
+  tutorial_scratchg_string_detail_platforms: ''
+  tutorial_sjforest_string_detail_platforms: iPad app
+  tutorial_sjgreet_string_detail_platforms: iPad app
+  tutorial_sjsunset_string_detail_platforms: iPad app
+  tutorial_fufafrenz_string_detail_platforms: Unplugged
+  tutorial_bbcgeo_string_detail_platforms: do-not-show
+  tutorial_chspixel_string_detail_platforms: Unplugged
+  tutorial_hummingbird_string_detail_platforms: Hummingbird robot
+  tutorial_recoloring_string_detail_platforms: ''
+  tutorial_bbcchem_string_detail_platforms: do-not-show
+  tutorial_floalgo_string_detail_platforms: Unplugged
+  tutorial_flocond_string_detail_platforms: Unplugged
+  tutorial_floloops_string_detail_platforms: Unplugged
+  tutorial_pgts_string_detail_platforms: Unplugged
+  tutorial_ozo_string_detail_platforms: Ozobot robot
+  tutorial_bbcla_string_detail_platforms: do-not-show
+  tutorial_bbcsci_string_detail_platforms: do-not-show
+  tutorial_tlctour_string_detail_platforms: Unplugged
+  tutorial_codesterstj_string_detail_platforms: ''
+  tutorial_tlclocked_string_detail_platforms: Unplugged
+  tutorial_baubles_string_detail_platforms: Unplugged
+  tutorial_bbcart_string_detail_platforms: do-not-show
+  tutorial_tlcknight_string_detail_platforms: Unplugged
+  tutorial_fufafit_string_detail_platforms: Unplugged
+  tutorial_ozodance_string_detail_platforms: Ozobot robot
+  tutorial_codingrobotics_string_detail_platforms: iPad app, Dash robot
+  tutorial_box_string_detail_platforms: do-not-show
+  tutorial_hopgame_string_detail_platforms: iOS app
+  tutorial_icontrol_string_detail_platforms: Sphero robot
+  tutorial_cocomteach_string_detail_platforms: ''
+  tutorial_bbcmathii_string_detail_platforms: do-not-show
+  tutorial_bbcphys_string_detail_platforms: do-not-show
+  tutorial_bitsbox_string_detail_platforms: ''
+  tutorial_tlcemo_string_detail_platforms: Unplugged
+  tutorial_crd_string_detail_platforms: Unplugged
+  tutorial_bbcbio_string_detail_platforms: do-not-show
+  tutorial_ticklebb8_string_detail_platforms: BB-8 robot
+  tutorial_grok_string_detail_platforms: do-not-show
+  tutorial_ijournalist_string_detail_platforms: ''
+  tutorial_bbcmusic_string_detail_platforms: do-not-show
+  tutorial_secretcodes_string_detail_platforms: ''
+  tutorial_tlchex_string_detail_platforms: Unplugged
+  tutorial_tickles_string_detail_platforms: Sphero robot
+  tutorial_ozogame_string_detail_platforms: Ozobot robot
+  tutorial_vidcodeio_string_detail_platforms: Unplugged
+  tutorial_tlcbrain_string_detail_platforms: Unplugged
+  tutorial_hopquiz_string_detail_platforms: iOS app
+  tutorial_unfortunate_string_detail_platforms: Dash and Dot robot
+  tutorial_cha_string_detail_platforms: ''
+  tutorial_elaseq_string_detail_platforms: Unplugged
+  tutorial_bbcmathi_string_detail_platforms: do-not-show
+  tutorial_tlcpixel_string_detail_platforms: Unplugged
+  tutorial_introrobo_string_detail_platforms: Dash and Dot robot
+  tutorial_tlcinvis_string_detail_platforms: Unplugged
+  tutorial_tlcjflap_string_detail_platforms: ''
+  tutorial_procolor_string_detail_platforms: Ozobot robot
+  tutorial_spiralsfinch_string_detail_platforms: Finch robot
+  tutorial_ozoi_string_detail_platforms: Ozobot robot
+  tutorial_ticklel_string_detail_platforms: LEGO WeDo robot
+  tutorial_spiralsdash_string_detail_platforms: Dash robot
+  tutorial_ghdebug_string_detail_platforms: ''
+  tutorial_tlckk_string_detail_platforms: Unplugged
+  tutorial_firstcomp_string_detail_platforms: Unplugged
+  tutorial_mazefinch_string_detail_platforms: Finch robot
+  tutorial_tlccc_string_detail_platforms: Unplugged
+  tutorial_tlcdoodle_string_detail_platforms: Unplugged
+  tutorial_tlcpunch_string_detail_platforms: Unplugged
+  tutorial_finchfract_string_detail_platforms: Finch robot
+  tutorial_tlcmind_string_detail_platforms: Unplugged
+  tutorial_tlctelebot_string_detail_platforms: Unplugged
+  tutorial_tlcaus_string_detail_platforms: Unplugged
+  tutorial_tlcmicro_string_detail_platforms: Unplugged
+  tutorial_imathematician_string_detail_platforms: ''
+  tutorial_tlcmagic_string_detail_platforms: Unplugged
+  tutorial_scratchmus_string_detail_platforms: ''
+  tutorial_scratchanim_string_detail_platforms: ''
+  tutorial_scratchfly_string_detail_platforms: ''
+  tutorial_tynkerarc_string_detail_platforms: ''
+  tutorial_grokffpython_string_detail_platforms: ''
+  tutorial_grokffblock_string_detail_platforms: ''
+  tutorial_grokeliza_string_detail_platforms: ''
+  tutorial_tynkercan_string_detail_platforms: ''
+  tutorial_grokflags_string_detail_platforms: ''
+  tutorial_robomind_string_detail_platforms: ''
+  tutorial_adventureq_string_detail_platforms: ''
+  tutorial_khan-es_string_detail_platforms: ''
+  tutorial_kpt_string_detail_platforms: ''
+  tutorial_kpl_string_detail_platforms: ''
+  tutorial_khe_string_detail_platforms: ''
+  tutorial_kfr_string_detail_platforms: ''
+  tutorial_app-inventor_string_detail_platforms: Android
+  tutorial_blockly_string_detail_platforms: ''
+  tutorial_tynker_string_detail_platforms: do-not-show
+  tutorial_baypt_string_detail_platforms: ''
+  tutorial_code-combat_string_detail_platforms: do-not-show
+  tutorial_mky_string_detail_platforms: ''
+  tutorial_pirates_string_detail_platforms: ''
+  tutorial_csfirst_string_detail_platforms: ''
+  tutorial_loopedy_string_detail_platforms: Dash and Dot robot
+  tutorial_dsw_string_detail_platforms: do-not-show
+  tutorial_dswb_string_detail_platforms: do-not-show
+  tutorial_ssw_string_detail_platforms: do-not-show
+  tutorial_sswb_string_detail_platforms: do-not-show
+  tutorial_kodable-unplugged_string_detail_platforms: Unplugged
+  tutorial_scratch_string_detail_platforms: ''
+  tutorial_bayes_string_detail_platforms: ''
+  tutorial_gumball_string_detail_platforms: do-not-show
+  tutorial_hrm_string_detail_platforms: ''
+  tutorial_ice-age_string_detail_platforms: do-not-show
+  tutorial_koapp_string_detail_platforms: do-not-show
+  tutorial_lightbot-intl_string_detail_platforms: ''
+  tutorial_rmc_string_detail_platforms: do-not-show
+  tutorial_smc_string_detail_platforms: do-not-show
+  tutorial_minecraft-2016_string_detail_platforms: do-not-show
+  tutorial_thinkersmith-es_string_detail_platforms: ''
+  tutorial_pixie_string_detail_platforms: ''
+  tutorial_play_string_detail_platforms: do-not-show
+  tutorial_robomind-nl_string_detail_platforms: ''
+  tutorial_spheroi_string_detail_platforms: Sphero robot
+  tutorial_spherol_string_detail_platforms: Sphero robot
+  tutorial_spherov_string_detail_platforms: Sphero robot
+  tutorial_swb_string_detail_platforms: do-not-show
+  tutorial_build-a-galaxy_string_detail_platforms: do-not-show
+  tutorial_alicesims_string_detail_platforms: ''
+  tutorial_tchr_string_detail_platforms: do-not-show
+  tutorial_robogame_string_detail_platforms: Dash and Dot robot
+  tutorial_tap_string_detail_platforms: ''
+  tutorial_cintl_string_detail_platforms: do-not-show
+  tutorial_itchstop_string_detail_platforms: ''
+  tutorial_tynkerpn_string_detail_platforms: ''
+  tutorial_tynkerpd_string_detail_platforms: ''
+  tutorial_persistence_string_detail_platforms: Unplugged
+  tutorial_getloopy_string_detail_platforms: Unplugged
+  tutorial_createface_string_detail_platforms: Unplugged
+  tutorial_happymaps_string_detail_platforms: Unplugged
+  tutorial_moveit_string_detail_platforms: Unplugged
+  tutorial_bigevent_string_detail_platforms: Unplugged
+  tutorial_gpp_string_detail_platforms: Unplugged
+  tutorial_foosgame_string_detail_platforms: ''
+  tutorial_solopython_string_detail_platforms: ''
+  tutorial_kodableint_string_detail_platforms: Unplugged
+  tutorial_kodableadv_string_detail_platforms: Unplugged
+  tutorial_tynkertj_string_detail_platforms: ''
+  tutorial_wolframa_string_detail_platforms: ''
+  tutorial_wolframm_string_detail_platforms: ''
+  tutorial_wolframspi_string_detail_platforms: ''
+  tutorial_wolframsph_string_detail_platforms: ''
+  tutorial_wolframp_string_detail_platforms: ''
+  tutorial_wolframn_string_detail_platforms: ''
+  tutorial_soloweb_string_detail_platforms: ''
+  tutorial_khanweb_string_detail_platforms: ''
+  tutorial_khandata_string_detail_platforms: ''
+  tutorial_googlelogo_string_detail_platforms: ''
+  tutorial_playtune_string_detail_platforms: ''
+  tutorial_computeit_string_detail_platforms: ''
+  tutorial_codesterssj_string_detail_platforms: ''
+  tutorial_cmchat_string_detail_platforms: ''
+  tutorial_tynkerdb_string_detail_platforms: ''
+  tutorial_cmbuild_string_detail_platforms: ''
+  tutorial_robotrattle_string_detail_platforms: ''
+  tutorial_codestersh_string_detail_platforms: ''
+  tutorial_codehsdigipixel_string_detail_platforms: ''
+  tutorial_ccbinary_string_detail_platforms: ''
+  tutorial_codehsturtle_string_detail_platforms: ''
+  tutorial_grokhd_string_detail_platforms: ''
+  tutorial_grokem_string_detail_platforms: ''
+  tutorial_kodmaze_string_detail_platforms: ''
+  tutorial_codestersa_string_detail_platforms: ''
+  tutorial_cmdodo_string_detail_platforms: ''
+  tutorial_tynkerspace_string_detail_platforms: ''
+  tutorial_gfbloons_string_detail_platforms: ''
+  tutorial_raspipong_string_detail_platforms: ''
+  tutorial_codehsvr_string_detail_platforms: ''
+  tutorial_codesterstp_string_detail_platforms: ''
+  tutorial_codestersbb_string_detail_platforms: ''
+  tutorial_gfcrossyroad_string_detail_platforms: ''
+  tutorial_googleww_string_detail_platforms: ''
+  tutorial_codehsjsapp_string_detail_platforms: ''
+  tutorial_gfmihi_string_detail_platforms: ''
+  tutorial_hopdropphone_string_detail_platforms: ''
+  tutorial_techfaa_string_detail_platforms: ''
+  tutorial_codehsjsgraph_string_detail_platforms: ''
+  tutorial_thunkable_string_detail_platforms: ''
+  tutorial_hopcrossyroad_string_detail_platforms: ''
+  tutorial_switchglitch_string_detail_platforms: ''
+  tutorial_codecar_string_detail_platforms: ''
+  tutorial_codesterscp_string_detail_platforms: ''
+  tutorial_grokpetblock_string_detail_platforms: ''
+  tutorial_techbim_string_detail_platforms: ''
+  tutorial_techfpp_string_detail_platforms: ''
+  tutorial_codesterscr_string_detail_platforms: ''
+  tutorial_grokdisease_string_detail_platforms: ''
+  tutorial_techec_string_detail_platforms: ''
+  tutorial_rgbegin_string_detail_platforms: ''
+  tutorial_myradream_string_detail_platforms: ''
+  tutorial_thinkfun_string_detail_platforms: ''
+  tutorial_hopfireworks_string_detail_platforms: ''
+  tutorial_grokspace_string_detail_platforms: ''
+  tutorial_codehspython_string_detail_platforms: ''
+  tutorial_codehsjava_string_detail_platforms: ''
+  tutorial_techioda_string_detail_platforms: ''
+  tutorial_grokmonster_string_detail_platforms: ''
+  tutorial_techmjs_string_detail_platforms: ''
+  tutorial_techga_string_detail_platforms: ''
+  tutorial_techioan_string_detail_platforms: ''
+  tutorial_techiogsr_string_detail_platforms: ''
+  tutorial_groktunnel_string_detail_platforms: ''
+  tutorial_stemcod_string_detail_platforms: ''
+  tutorial_techikb_string_detail_platforms: ''
+  tutorial_kanostreet_string_detail_platforms: ''
+  tutorial_codemojijs_string_detail_platforms: ''
+  tutorial_techapf_string_detail_platforms: ''
+  tutorial_techfpjs_string_detail_platforms: ''
+  tutorial_techlinq_string_detail_platforms: ''
+  tutorial_gpbcatapult_string_detail_platforms: ''
+  tutorial_quorumastro_string_detail_platforms: ''
+  tutorial_alicewonder_string_detail_platforms: ''
+  tutorial_rginter_string_detail_platforms: ''
+  tutorial_cssgrid_string_detail_platforms: ''
+  tutorial_jshero_string_detail_platforms: ''
+  tutorial_codemojipy_string_detail_platforms: ''
+  tutorial_nclabdrone_string_detail_platforms: ''
+  tutorial_gpbcircle_string_detail_platforms: ''
+  tutorial_gpbpaint_string_detail_platforms: ''
+  tutorial_cocomarcade_string_detail_platforms: ''
+  tutorial_beetik_string_detail_platforms: ''
+  tutorial_codedj_string_detail_platforms: ''
+  tutorial_rgadvan_string_detail_platforms: ''
+  tutorial_codehsrn_string_detail_platforms: ''
+  tutorial_codehswd_string_detail_platforms: ''
+  tutorial_turtlerobot_string_detail_platforms: ''
+  tutorial_ozoevo_string_detail_platforms: Ozobot Evo robot
+  tutorial_ozoexped_string_detail_platforms: Ozobot Bit or Evo robot
+  tutorial_ozojourney_string_detail_platforms: Ozobot Bit or Evo robot
+  tutorial_ozocodes_string_detail_platforms: Ozobot Bit or Evo robot
+  tutorial_ozoeclipse_string_detail_platforms: Ozobot Bit or Evo robot
+  tutorial_ozosimulator_string_detail_platforms: Unplugged
+  tutorial_ozoalgorithm_string_detail_platforms: Ozobot Bit or Evo robot
+  tutorial_ozotimer_string_detail_platforms: Ozobot Bit or Evo robot
+  tutorial_ozohabits_string_detail_platforms: Ozobot Bit or Evo robot
+  tutorial_ozoprogram_string_detail_platforms: ''
+  tutorial_ozopair_string_detail_platforms: Ozobot Bit or Evo robot
+  tutorial_codesnoopy_string_detail_platforms: ''
+  tutorial_applabintro_string_detail_platforms: ''
+  tutorial_cslartist_string_detail_platforms: Unplugged
+  tutorial_cslscratchjr_string_detail_platforms: Unplugged
+  tutorial_floevents_string_detail_platforms: Unplugged
+  tutorial_florobot_string_detail_platforms: Unplugged
+  tutorial_isavesanta_string_detail_platforms: ''
+  tutorial_iorder_string_detail_platforms: ''
+  tutorial_ianimate_string_detail_platforms: ''
+  tutorial_iloveada_string_detail_platforms: ''
+  tutorial_kodflash_string_detail_platforms: Unplugged
+  tutorial_kodchoose_string_detail_platforms: Unplugged
+  tutorial_kodpizzapre_string_detail_platforms: Unplugged
+  tutorial_kodpizza_string_detail_platforms: Unplugged
+  tutorial_kodwomen_string_detail_platforms: Unplugged
+  tutorial_tfunplug_string_detail_platforms: Unplugged
+  tutorial_lbvariables_string_detail_platforms: littleBits Code Kit
+  tutorial_lbfunctions_string_detail_platforms: littleBits Code Kit
+  tutorial_lblogic_string_detail_platforms: littleBits Code Kit
+  tutorial_lbworld_string_detail_platforms: littleBits Code Kit
+  tutorial_lbloops_string_detail_platforms: littleBits Code Kit
+  tutorial_lbtug_string_detail_platforms: littleBits Code Kit
+  tutorial_lbpotato_string_detail_platforms: littleBits Code Kit
+  tutorial_lbguitar_string_detail_platforms: littleBits Code Kit
+  tutorial_lbio_string_detail_platforms: littleBits Code Kit
+  tutorial_wonpuppy_string_detail_platforms: Dash robot
+  tutorial_woncue_string_detail_platforms: Cue robot
+  tutorial_wonzoo_string_detail_platforms: Dot robot
+  tutorial_wontrip_string_detail_platforms: Dash robot
+  tutorial_woncollect_string_detail_platforms: Dash robot
+  tutorial_wonsecret_string_detail_platforms: Cue robot
+  tutorial_hsscience_string_detail_platforms: ''
+  tutorial_popculture_string_detail_platforms: ''
+  tutorial_legorobust_string_detail_platforms: WeDo 2.0
+  tutorial_legoplants_string_detail_platforms: WeDo 2.0
+  tutorial_legopark_string_detail_platforms: MINDSTORMS® EV3
+  tutorial_legodetect_string_detail_platforms: MINDSTORMS® EV3
+  tutorial_legolight_string_detail_platforms: MINDSTORMS® EV3
+  tutorial_alexa_string_detail_platforms: ''
+  tutorial_grokpetmicro_string_detail_platforms: ''
+  tutorial_pirateplunder_string_detail_platforms: ''
+  tutorial_cadj_string_detail_platforms: ''
+  tutorial_cacrazy_string_detail_platforms: ''
+  tutorial_cajump_string_detail_platforms: ''
+  tutorial_carest_string_detail_platforms: ''
+  tutorial_accai_string_detail_platforms: ''
+  tutorial_vceclipse_string_detail_platforms: ''
+  tutorial_pmzero_string_detail_platforms: ''
+  tutorial_hsela_string_detail_platforms: ''
+  tutorial_ticklear_string_detail_platforms: ''
+  tutorial_bcrobot_string_detail_platforms: ''
+  tutorial_bcsnow_string_detail_platforms: ''
+  tutorial_ifly_string_detail_platforms: Parrot Minidrones
+  tutorial_idowedo_string_detail_platforms: WeDo
+  tutorial_diggindwarf_string_detail_platforms: ''
+  tutorial_spheroit_string_detail_platforms: Sphero robot
+  tutorial_gameofcodes_string_detail_platforms: ''
+  tutorial_blocklygames_string_detail_platforms: ''
+  tutorial_spherohello_string_detail_platforms: Sphero robot
+  tutorial_spheroarcade_string_detail_platforms: Sphero robot
+  tutorial_bcpy1_string_detail_platforms: ''
+  tutorial_bcpy2_string_detail_platforms: ''
+  tutorial_bcjs1_string_detail_platforms: ''
+  tutorial_bcjs2_string_detail_platforms: ''
+  tutorial_3dbearmars_string_detail_platforms: 3D printer
+  tutorial_bitsboxyak_string_detail_platforms: ''
+  tutorial_blockscadbargraphs_string_detail_platforms: ''
+  tutorial_blockscadbirdhouses_string_detail_platforms: ''
+  tutorial_blockscadclock_string_detail_platforms: ''
+  tutorial_blockscaddinner_string_detail_platforms: ''
+  tutorial_blockscadicecream_string_detail_platforms: ''
+  tutorial_blockscadpizza_string_detail_platforms: ''
+  tutorial_blockscadsugar_string_detail_platforms: ''
+  tutorial_bsgridlight_string_detail_platforms: ''
+  tutorial_bpartscratch_string_detail_platforms: ''
+  tutorial_bpartvid_string_detail_platforms: ''
+  tutorial_bpenglishscratch_string_detail_platforms: ''
+  tutorial_bpenglishvid_string_detail_platforms: ''
+  tutorial_bphealthscratch_string_detail_platforms: ''
+  tutorial_bphealthvid_string_detail_platforms: ''
+  tutorial_bpmathscratch_string_detail_platforms: ''
+  tutorial_bpmathvid_string_detail_platforms: ''
+  tutorial_bpmlkscratch_string_detail_platforms: ''
+  tutorial_bpmlkvid_string_detail_platforms: ''
+  tutorial_bpsafetyscratch_string_detail_platforms: ''
+  tutorial_bpsafetyvid_string_detail_platforms: ''
+  tutorial_bpsciencescratch_string_detail_platforms: ''
+  tutorial_bpsciencevid_string_detail_platforms: ''
+  tutorial_bptechscratch_string_detail_platforms: ''
+  tutorial_bptechvid_string_detail_platforms: ''
+  tutorial_caflags_string_detail_platforms: ''
+  tutorial_matariki_string_detail_platforms: ''
+  tutorial_carestaurant_string_detail_platforms: ''
+  tutorial_casea_string_detail_platforms: ''
+  tutorial_cashield_string_detail_platforms: ''
+  tutorial_ccwslimer_string_detail_platforms: ''
+  tutorial_codinggalaxy_string_detail_platforms: ''
+  tutorial_boatrace_string_detail_platforms: ''
+  tutorial_ccplay_string_detail_platforms: ''
+  tutorial_grinch_string_detail_platforms: ''
+  tutorial_codehsart_string_detail_platforms: ''
+  tutorial_codehsbitcoin_string_detail_platforms: ''
+  tutorial_codehsblockchain_string_detail_platforms: ''
+  tutorial_codehscipher_string_detail_platforms: ''
+  tutorial_codehscollision_string_detail_platforms: ''
+  tutorial_codehsmath_string_detail_platforms: ''
+  tutorial_codehsmusic_string_detail_platforms: ''
+  tutorial_codehssports_string_detail_platforms: ''
+  tutorial_codemojipizza_string_detail_platforms: ''
+  tutorial_moonlander_string_detail_platforms: ''
+  tutorial_sushicards_string_detail_platforms: ''
+  tutorial_codesparkcreate_string_detail_platforms: ''
+  tutorial_hardvsoft_string_detail_platforms: ''
+  tutorial_codestersecard_string_detail_platforms: ''
+  tutorial_codesterslogo_string_detail_platforms: ''
+  tutorial_codesterstshirt_string_detail_platforms: ''
+  tutorial_codewards_string_detail_platforms: ''
+  tutorial_olympics_string_detail_platforms: ''
+  tutorial_codinismhero_string_detail_platforms: ''
+  tutorial_discovery_string_detail_platforms: ''
+  tutorial_csfirstname_string_detail_platforms: ''
+  tutorial_edisonmove_string_detail_platforms: Edison robot
+  tutorial_edisonspider_string_detail_platforms: Edison robot
+  tutorial_edisonspotlight_string_detail_platforms: Edison robot
+  tutorial_firiapython_string_detail_platforms: BBC micro:bit
+  tutorial_gamefrootsquid_string_detail_platforms: ''
+  tutorial_duckpiano_string_detail_platforms: ''
+  tutorial_gpsound_string_detail_platforms: ''
+  tutorial_groklearningpython_string_detail_platforms: ''
+  tutorial_htmltimetravel_string_detail_platforms: ''
+  tutorial_hp_flappy_string_detail_platforms: iPad app
+  tutorial_appytappin_string_detail_platforms: ''
+  tutorial_icipher_string_detail_platforms: ''
+  tutorial_iguess_string_detail_platforms: ''
+  tutorial_imake_string_detail_platforms: Arduino
+  tutorial_imorse_string_detail_platforms: ''
+  tutorial_kanohp_string_detail_platforms: ''
+  tutorial_khanwebpages_string_detail_platforms: ''
+  tutorial_kibobowl_string_detail_platforms: KIBO Robot Kit
+  tutorial_kibodance_string_detail_platforms: KIBO Robot Kit
+  tutorial_buildcharacters_string_detail_platforms: ''
+  tutorial_designgames_string_detail_platforms: ''
+  tutorial_makelevels_string_detail_platforms: ''
+  tutorial_wizard_string_detail_platforms: ''
+  tutorial_mbscratchcards_string_detail_platforms: micro:bit
+  tutorial_mbswiftplaygrounds_string_detail_platforms: micro:bit
+  tutorial_mbbuttons_string_detail_platforms: BBC micro:bit
+  tutorial_meteor_string_detail_platforms: BBC micro:bit
+  tutorial_ballbounce_string_detail_platforms: ''
+  tutorial_mitcodi_string_detail_platforms: ''
+  tutorial_mitdoodle_string_detail_platforms: ''
+  tutorial_talktome_string_detail_platforms: ''
+  tutorial_mobilecspmap_string_detail_platforms: ''
+  tutorial_ozorandom_string_detail_platforms: Ozobot robot
+  tutorial_ozotroll_string_detail_platforms: Ozobot robot
+  tutorial_peblioart_string_detail_platforms: ''
+  tutorial_astropi_string_detail_platforms: ''
+  tutorial_rgart_string_detail_platforms: ''
+  tutorial_rgengineer_string_detail_platforms: ''
+  tutorial_rgmath_string_detail_platforms: ''
+  tutorial_rgscience_string_detail_platforms: ''
+  tutorial_rgtech_string_detail_platforms: ''
+  tutorial_robotmagic3d_string_detail_platforms: ''
+  tutorial_robotmagicflappy_string_detail_platforms: ''
+  tutorial_scratchadventure_string_detail_platforms: ''
+  tutorial_scratchtalk_string_detail_platforms: ''
+  tutorial_scratchjrstory_string_detail_platforms: ''
+  tutorial_scratchjrtwinkle_string_detail_platforms: ''
+  tutorial_spherocomm_string_detail_platforms: Sphero robot
+  tutorial_spherocommunity_string_detail_platforms: Sphero robot
+  tutorial_spherofunctions_string_detail_platforms: Sphero robot
+  tutorial_spheroinfrared_string_detail_platforms: BOLT robot
+  tutorial_spherolightsensor_string_detail_platforms: BOLT robot
+  tutorial_spheromansion_string_detail_platforms: Sphero robot
+  tutorial_roadblocks_string_detail_platforms: Sphero robot
+  tutorial_spherotext2_string_detail_platforms: Sphero robot
+  tutorial_spherotext3_string_detail_platforms: Sphero robot
+  tutorial_spherotext4_string_detail_platforms: Sphero robot
+  tutorial_spheroraptor_string_detail_platforms: Sphero robot
+  tutorial_stempiday_string_detail_platforms: ''
+  tutorial_stemplanetoids_string_detail_platforms: ''
+  tutorial_stempong_string_detail_platforms: ''
+  tutorial_algobot_string_detail_platforms: ''
+  tutorial_thunkableapps_string_detail_platforms: ''
+  tutorial_toxicodedot_string_detail_platforms: ''
+  tutorial_gcactions_string_detail_platforms: ''
+  tutorial_gccomparators_string_detail_platforms: ''
+  tutorial_gcconditions_string_detail_platforms: ''
+  tutorial_gccreate_string_detail_platforms: ''
+  tutorial_gcevents_string_detail_platforms: ''
+  tutorial_gcloops_string_detail_platforms: ''
+  tutorial_gcvariables_string_detail_platforms: ''
+  tutorial_beanything_string_detail_platforms: ''
+  tutorial_change_string_detail_platforms: ''
+  tutorial_cooking_string_detail_platforms: ''
+  tutorial_crystal_string_detail_platforms: ''
+  tutorial_landscape_string_detail_platforms: ''
+  tutorial_pets_string_detail_platforms: ''
+  tutorial_petvet_string_detail_platforms: ''
+  tutorial_superhero_string_detail_platforms: ''
+  tutorial_vidcodeplastic_string_detail_platforms: ''
+  tutorial_vidcodetypeface_string_detail_platforms: ''
+  tutorial_washustorm_string_detail_platforms: ''
+  tutorial_activitypackets_string_detail_platforms: Dash or Cue robot
+  tutorial_googlerookie_string_detail_platforms: ''
+  tutorial_tommyturtle_string_detail_platforms: ''
+  tutorial_mazyad_string_detail_platforms: ''
+  tutorial_gamemaker_string_detail_platforms: ''
+  tutorial_duckrace_string_detail_platforms: ''
+  tutorial_allcancodeapps_string_detail_platforms: ''
+  tutorial_n2y_string_detail_platforms: ''
+  tutorial_microsoftarcade_string_detail_platforms: ''
+  tutorial_csfirstunplugged_string_detail_platforms: ''
+  tutorial_toxicodepython_string_detail_platforms: ''
+  tutorial_codecombatozaria_string_detail_platforms: ''
+  tutorial_vidcodedate_string_detail_platforms: ''
+  tutorial_codemonkeyspace_string_detail_platforms: ''
+  tutorial_codespeakhappy_string_detail_platforms: ''
+  tutorial_grokimage_string_detail_platforms: ''
+  tutorial_icomputelearn_string_detail_platforms: ''
+  tutorial_rpstress_string_detail_platforms: ''
+  tutorial_bsdcause_string_detail_platforms: ''
+  tutorial_vidcodeanimoji_string_detail_platforms: ''
+  tutorial_vidcodeanimojies_string_detail_platforms: ''
+  tutorial_bsdinspire_string_detail_platforms: ''
+  tutorial_tttractor_string_detail_platforms: ''
+  tutorial_codeillusionmickey_string_detail_platforms: ''
+  tutorial_scigirlsquest_string_detail_platforms: ''
+  tutorial_codespeakbreathe_string_detail_platforms: ''
+  tutorial_vidcodeface_string_detail_platforms: ''
+  tutorial_educodemaze_string_detail_platforms: ''
+  tutorial_educoderace_string_detail_platforms: ''
+  tutorial_codespeakchatbot_string_detail_platforms: ''
+  tutorial_gamefrootgames_string_detail_platforms: ''
+  tutorial_codespeakgrandparent_string_detail_platforms: ''
+  tutorial_educodekingdom_string_detail_platforms: ''
+  tutorial_codehsdata_string_detail_platforms: ''
+  tutorial_educodecake_string_detail_platforms: ''
+  tutorial_ttsecond_string_detail_platforms: ''
+  tutorial_bsdtrivia_string_detail_platforms: ''
+  tutorial_csfirstdialogue_string_detail_platforms: ''
+  tutorial_codemonkeybeaver_string_detail_platforms: ''
+  tutorial_codestersdistance_string_detail_platforms: ''
+  tutorial_itchspace_string_detail_platforms: ''
+  tutorial_vidcodemagic_string_detail_platforms: ''
+  tutorial_vidcodemagices_string_detail_platforms: ''
+  tutorial_codespeakmeal_string_detail_platforms: ''
+  tutorial_itchfish_string_detail_platforms: ''
+  tutorial_bsdwebsite_string_detail_platforms: ''
+  tutorial_codespeaktime_string_detail_platforms: ''
+  tutorial_itchwebcam_string_detail_platforms: ''
+  tutorial_itchball_string_detail_platforms: ''
+  tutorial_ttrace_string_detail_platforms: ''
+  tutorial_plethora_string_detail_platforms: ''
+  tutorial_educodesecret_string_detail_platforms: ''
+  tutorial_itchshapes_string_detail_platforms: ''
+  tutorial_codeguppytext_string_detail_platforms: ''
+  tutorial_vidcodeplastiche_string_detail_platforms: ''
+  tutorial_educativechatbot_string_detail_platforms: ''
+  tutorial_educodebasics_string_detail_platforms: ''
+  tutorial_codehsdesign_string_detail_platforms: ''
+  tutorial_htmlacademyphp_string_detail_platforms: ''
+  tutorial_gamefrootdistance_string_detail_platforms: ''
+  tutorial_codesterscovid_string_detail_platforms: ''
+  tutorial_ttbunker_string_detail_platforms: ''
+  tutorial_cuttle_string_detail_platforms: ''
+  tutorial_bsdjokes_string_detail_platforms: ''
+  tutorial_rptree_string_detail_platforms: ''
+  tutorial_codestersunity_string_detail_platforms: ''
+  tutorial_codesterssoccer_string_detail_platforms: ''
+  tutorial_breakoutlock_string_detail_platforms: ''
+  tutorial_thunkablemask_string_detail_platforms: ''
+  tutorial_cafarming_string_detail_platforms: ''
+  tutorial_blocksmithyeti_string_detail_platforms: ''
+  tutorial_codecapture_string_detail_platforms: ''
+  tutorial_codehslitter_string_detail_platforms: ''
+  tutorial_bsdocean_string_detail_platforms: ''
+  tutorial_itchplatformer_string_detail_platforms: ''
+  tutorial_codejika_string_detail_platforms: ''
+  tutorial_gamefrootclicker_string_detail_platforms: ''
+  tutorial_rmagicequity_string_detail_platforms: ''
+  tutorial_ttfreestyle_string_detail_platforms: ''
+  tutorial_ozobotcolor2_string_detail_platforms: 'Ozobot Evo  '
+  tutorial_ozobotcolor3_string_detail_platforms: 'Ozobot Evo  '
+  tutorial_clcarbon_string_detail_platforms: ''
+  tutorial_kodablebasics_string_detail_platforms: ''
+  tutorial_scigirlscc_string_detail_platforms: ''
+  tutorial_irobotpicture_string_detail_platforms: ''
+  tutorial_kcjmyself_string_detail_platforms: ''
+  tutorial_nearpodalgorithms_string_detail_platforms: ''
+  tutorial_kibodrop_string_detail_platforms: KIBO Robot Kit (optional)
+  tutorial_ozobotcolor1_string_detail_platforms: 'Ozobot Evo  '
+  tutorial_scigirlspixels_string_detail_platforms: ''
+  tutorial_kcjheroines_string_detail_platforms: ''
+  tutorial_ozobotvalue_string_detail_platforms: 'Ozobot Evo  '
+  tutorial_icodebytes_string_detail_platforms: ''
+  tutorial_clfashion2_string_detail_platforms: ''
+  tutorial_ai4all_string_detail_platforms: ''
+  tutorial_cldata_string_detail_platforms: ''
+  tutorial_spheroinputs_string_detail_platforms: ''
+  tutorial_edisoncount_string_detail_platforms: ''
+  tutorial_spheroloops_string_detail_platforms: ''
+  tutorial_kiboprogram_string_detail_platforms: KIBO Robot Kit (optional)
+  tutorial_hellorubycsin60_string_detail_platforms: ''
+  tutorial_clfashion1_string_detail_platforms: ''
+  tutorial_irobottraffic_string_detail_platforms: Root robot
+  tutorial_edisonmystery_string_detail_platforms: ''
+  tutorial_microbitseaturtles_string_detail_platforms: ''
+  tutorial_ozobotknow_string_detail_platforms: Ozobot Evo (optional)
+  tutorial_imagilabs_string_detail_platforms: imagiCharm
+  tutorial_irobotsimulator_string_detail_platforms: ''
+  tutorial_irobotkind_string_detail_platforms: Root robot (optional)
+  tutorial_firiavirtual_string_detail_platforms: ''
+  tutorial_irobotguesscode_string_detail_platforms: Root robot
+  tutorial_ozobotnouns_string_detail_platforms: 'Ozobot Evo  '
+  tutorial_nasa3d_string_detail_platforms: ''
+  tutorial_blupants_string_detail_platforms: Lego Ev3, Alphabot2, DIY Raspberry Pi
+    robot or DIY Beaglebone Blue robot
+  tutorial_legodance_string_detail_platforms: LEGO Education SPIKE Prime
+  tutorial_nearpodcoding_string_detail_platforms: ''
+  tutorial_kcjplastic_string_detail_platforms: ''
+  tutorial_legojourney_string_detail_platforms: ''
+  tutorial_legohopper_string_detail_platforms: LEGO Education SPIKE Prime robot
+  tutorial_catrobatembroidery_string_detail_platforms: Embroidery machine for stitching
+    and USB or network port, plus support of the DST format (standard embroidery file
+    format).
+  tutorial_irobotphone_string_detail_platforms: Root robot (optional)
+  tutorial_codeguppydraw_string_detail_platforms: ''
+  tutorial_codejumper_string_detail_platforms: ''
+  tutorial_meeempathy_string_detail_platforms: ''
+  tutorial_dance2019_string_detail_programming_languages: Blocks
+  tutorial_danceparty_string_detail_programming_languages: Blocks
+  tutorial_chibitronics_string_detail_programming_languages: Blocks
+  tutorial_athlete_string_detail_programming_languages: Blocks
+  tutorial_moana_string_detail_programming_languages: Blocks
+  tutorial_star-wars_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_gumadventure_string_detail_programming_languages: Blocks, Scratch
+  tutorial_mchoc_string_detail_programming_languages: Blocks
+  tutorial_vidnews_string_detail_programming_languages: JavaScript
+  tutorial_kodable-pre_string_detail_programming_languages: Blocks
+  tutorial_highseas_string_detail_programming_languages: Blocks, Scratch
+  tutorial_capython_string_detail_programming_languages: Python
+  tutorial_frzn_string_detail_programming_languages: Blocks
+  tutorial_cocom_string_detail_programming_languages: JavaScript, Python, Lua, CoffeeScript
+  tutorial_play-lab_string_detail_programming_languages: Blocks
+  tutorial_boxisland_string_detail_programming_languages: Blocks
+  tutorial_textcomp_string_detail_programming_languages: Language independent
+  tutorial_encryption_string_detail_programming_languages: Language independent
+  tutorial_kanopixel_string_detail_programming_languages: JavaScript, Coffeescript
+  tutorial_foos_string_detail_programming_languages: Blocks
+  tutorial_tynkerdd_string_detail_programming_languages: Blocks, Tynker, JavaScript,
+    Python
+  tutorial_tynkerana_string_detail_programming_languages: Blocks, Tynker, JavaScript,
+    Python
+  tutorial_vidcard_string_detail_programming_languages: JavaScript
+  tutorial_spritebox_string_detail_programming_languages: Blocks, Java, iOS/Swift
+  tutorial_tynkerch_string_detail_programming_languages: JavaScript
+  tutorial_lightbot_string_detail_programming_languages: Blocks
+  tutorial_hoc_string_detail_programming_languages: do-not-show
+  tutorial_code_string_detail_programming_languages: Blocks
+  tutorial_tinspire_string_detail_programming_languages: TI Basic
+  tutorial_itchbounceball_string_detail_programming_languages: Blocks, Scratch
+  tutorial_vidclim_string_detail_programming_languages: JavaScript
+  tutorial_matlab_string_detail_programming_languages: MATLAB
+  tutorial_flap_string_detail_programming_languages: Blocks
+  tutorial_galaxy_string_detail_programming_languages: Blocks
+  tutorial_inf_string_detail_programming_languages: Blocks
+  tutorial_tynkersol_string_detail_programming_languages: Blocks, Tynker, JavaScript,
+    Python
+  tutorial_itchg_string_detail_programming_languages: Blocks
+  tutorial_como_string_detail_programming_languages: CoffeeScript
+  tutorial_processfound_string_detail_programming_languages: Java
+  tutorial_tynkerhomo_string_detail_programming_languages: Blocks, Tynker, JavaScript,
+    Python
+  tutorial_art_string_detail_programming_languages: Blocks
+  tutorial_tynkerbrick_string_detail_programming_languages: Blocks, Tynker, JavaScript,
+    Python
+  tutorial_itchbio_string_detail_programming_languages: Blocks
+  tutorial_itchj_string_detail_programming_languages: Blocks
+  tutorial_tickleo_string_detail_programming_languages: Blocks
+  tutorial_hopgeo_string_detail_programming_languages: Hopscotch
+  tutorial_tynkermult_string_detail_programming_languages: Blocks, Tynker, JavaScript,
+    Python
+  tutorial_monster_string_detail_programming_languages: Blocks
+  tutorial_tynkerapp_string_detail_programming_languages: do-not-show
+  tutorial_tynkerpup_string_detail_programming_languages: Blocks, Tynker
+  tutorial_livecode_string_detail_programming_languages: Language independent
+  tutorial_cocomgame_string_detail_programming_languages: JavaScript, Python, Lua,
+    CoffeeScript
+  tutorial_tynkerspin_string_detail_programming_languages: Blocks, Tynker, JavaScript,
+    Python
+  tutorial_code-avengers_string_detail_programming_languages: JavaScript
+  tutorial_tynkercq_string_detail_programming_languages: Blocks, Tynker
+  tutorial_cmgame_string_detail_programming_languages: CoffeeScript
+  tutorial_codesters_string_detail_programming_languages: do-not-show
+  tutorial_qrm_string_detail_programming_languages: Quorum
+  tutorial_texas-instruments_string_detail_programming_languages: TI Basic
+  tutorial_cajava_string_detail_programming_languages: JavaScript
+  tutorial_codehs_string_detail_programming_languages: JavaScript
+  tutorial_hopemo_string_detail_programming_languages: Hopscotch
+  tutorial_tynkercm_string_detail_programming_languages: Blocks, Tynker, JavaScript,
+    Python
+  tutorial_codesterswintergreet_string_detail_programming_languages: Python
+  tutorial_codestersc_string_detail_programming_languages: Python
+  tutorial_codestersturtle_string_detail_programming_languages: Python
+  tutorial_penjee_string_detail_programming_languages: Python
+  tutorial_trinket_string_detail_programming_languages: Blocks, Kano Code
+  tutorial_frogger_string_detail_programming_languages: Blocks
+  tutorial_tynkereco_string_detail_programming_languages: Blocks, Tynker, JavaScript,
+    Python
+  tutorial_mitedarc_string_detail_programming_languages: Blocks
+  tutorial_khan_string_detail_programming_languages: JavaScript
+  tutorial_tynkerd_string_detail_programming_languages: Blocks, Tynker, JavaScript,
+    Python
+  tutorial_cdmy_string_detail_programming_languages: JavaScript
+  tutorial_codestersdance_string_detail_programming_languages: Blocks, Python
+  tutorial_codestersbasketball_string_detail_programming_languages: Python
+  tutorial_nclkarel_string_detail_programming_languages: Karel (simplified Python)
+  tutorial_buildpong_string_detail_programming_languages: Blocks, Ready, Unity
+  tutorial_tynkerdrones_string_detail_programming_languages: Blocks
+  tutorial_carla_string_detail_programming_languages: Coffeescript
+  tutorial_zulama_string_detail_programming_languages: JavaScript
+  tutorial_capost_string_detail_programming_languages: HTML, CSS
+  tutorial_marco_string_detail_programming_languages: Blocks
+  tutorial_codestersflappybike_string_detail_programming_languages: Python
+  tutorial_kanopong_string_detail_programming_languages: JavaScript
+  tutorial_tynkerright_string_detail_programming_languages: Blocks
+  tutorial_touchdevelop_string_detail_programming_languages: do-not-show
+  tutorial_tynkercc_string_detail_programming_languages: Blocks, Tynker, JavaScript,
+    Python
+  tutorial_bamboo_string_detail_programming_languages: JavaScript
+  tutorial_robojav_string_detail_programming_languages: Java
+  tutorial_roboba_string_detail_programming_languages: Blocks, Ch/C/C++
+  tutorial_knodsnake_string_detail_programming_languages: JavaScript
+  tutorial_soccharater_string_detail_programming_languages: JavaScript
+  tutorial_silent_string_detail_programming_languages: JavaScript
+  tutorial_robomesh_string_detail_programming_languages: Blocks, Python
+  tutorial_amaze_string_detail_programming_languages: Blocks, Ready, Unity
+  tutorial_codestersds_string_detail_programming_languages: Blocks
+  tutorial_knodtext_string_detail_programming_languages: Python
+  tutorial_alicegar_string_detail_programming_languages: Blocks
+  tutorial_codesterstransform_string_detail_programming_languages: Python
+  tutorial_flexfrog_string_detail_programming_languages: CSS
+  tutorial_codemoji_string_detail_programming_languages: do-not-show
+  tutorial_robobii_string_detail_programming_languages: Blocks, Ch/C/C++
+  tutorial_robobm_string_detail_programming_languages: Blocks, Ch/C/C++
+  tutorial_codingrobots_string_detail_programming_languages: Blocks, Ch/C/C++
+  tutorial_robob_string_detail_programming_languages: Blocks, Ch/C/C++
+  tutorial_coders_string_detail_programming_languages: Language independent
+  tutorial_tynkerhw_string_detail_programming_languages: Blocks, Tynker, JavaScript,
+    Python
+  tutorial_tynkermh_string_detail_programming_languages: Blocks, Tynker, JavaScript,
+    Python
+  tutorial_caphoto_string_detail_programming_languages: JavaScript, HTML, CSS
+  tutorial_mozillahw_string_detail_programming_languages: JavaScript
+  tutorial_ticklep_string_detail_programming_languages: do-not-show
+  tutorial_bbot_string_detail_programming_languages: Visual programming language
+  tutorial_scratchg_string_detail_programming_languages: Language independent
+  tutorial_sjforest_string_detail_programming_languages: Blocks
+  tutorial_sjgreet_string_detail_programming_languages: Blocks
+  tutorial_sjsunset_string_detail_programming_languages: Blocks
+  tutorial_fufafrenz_string_detail_programming_languages: Language independent
+  tutorial_bbcgeo_string_detail_programming_languages: do-not-show
+  tutorial_chspixel_string_detail_programming_languages: JavaScript
+  tutorial_hummingbird_string_detail_programming_languages: Blocks
+  tutorial_recoloring_string_detail_programming_languages: Coffee Script (Pencil Code)
+  tutorial_bbcchem_string_detail_programming_languages: do-not-show
+  tutorial_floalgo_string_detail_programming_languages: Language independent
+  tutorial_flocond_string_detail_programming_languages: Blocks, Language independent
+  tutorial_floloops_string_detail_programming_languages: Blocks, Language independent
+  tutorial_pgts_string_detail_programming_languages: Language independent
+  tutorial_ozo_string_detail_programming_languages: Blocks
+  tutorial_bbcla_string_detail_programming_languages: do-not-show
+  tutorial_bbcsci_string_detail_programming_languages: do-not-show
+  tutorial_tlctour_string_detail_programming_languages: Language independent
+  tutorial_codesterstj_string_detail_programming_languages: Python
+  tutorial_tlclocked_string_detail_programming_languages: Language independent
+  tutorial_baubles_string_detail_programming_languages: Language independent
+  tutorial_bbcart_string_detail_programming_languages: do-not-show
+  tutorial_tlcknight_string_detail_programming_languages: Language independent
+  tutorial_fufafit_string_detail_programming_languages: Language independent
+  tutorial_ozodance_string_detail_programming_languages: Blocks
+  tutorial_codingrobotics_string_detail_programming_languages: Language independent
+  tutorial_box_string_detail_programming_languages: do-not-show
+  tutorial_hopgame_string_detail_programming_languages: Hopscotch
+  tutorial_icontrol_string_detail_programming_languages: Tickle
+  tutorial_cocomteach_string_detail_programming_languages: JavaScript, Python, Lua,
+    CoffeeScript
+  tutorial_bbcmathii_string_detail_programming_languages: do-not-show
+  tutorial_bbcphys_string_detail_programming_languages: do-not-show
+  tutorial_bitsbox_string_detail_programming_languages: JavaScript
+  tutorial_tlcemo_string_detail_programming_languages: Language independent
+  tutorial_crd_string_detail_programming_languages: Language independent
+  tutorial_bbcbio_string_detail_programming_languages: do-not-show
+  tutorial_ticklebb8_string_detail_programming_languages: Blocks
+  tutorial_grok_string_detail_programming_languages: do-not-show
+  tutorial_ijournalist_string_detail_programming_languages: HTML, CSS
+  tutorial_bbcmusic_string_detail_programming_languages: do-not-show
+  tutorial_secretcodes_string_detail_programming_languages: Blocks
+  tutorial_tlchex_string_detail_programming_languages: Language independent
+  tutorial_tickles_string_detail_programming_languages: Blocks
+  tutorial_ozogame_string_detail_programming_languages: Blocks
+  tutorial_vidcodeio_string_detail_programming_languages: Language independent
+  tutorial_tlcbrain_string_detail_programming_languages: Language independent
+  tutorial_hopquiz_string_detail_programming_languages: Hopscotch
+  tutorial_unfortunate_string_detail_programming_languages: Blocks
+  tutorial_cha_string_detail_programming_languages: Language independent
+  tutorial_elaseq_string_detail_programming_languages: Language independent
+  tutorial_bbcmathi_string_detail_programming_languages: do-not-show
+  tutorial_tlcpixel_string_detail_programming_languages: Language independent
+  tutorial_introrobo_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_tlcinvis_string_detail_programming_languages: Language independent
+  tutorial_tlcjflap_string_detail_programming_languages: Language independent
+  tutorial_procolor_string_detail_programming_languages: Language independent
+  tutorial_spiralsfinch_string_detail_programming_languages: Blocks
+  tutorial_ozoi_string_detail_programming_languages: Language independent
+  tutorial_ticklel_string_detail_programming_languages: Blocks
+  tutorial_spiralsdash_string_detail_programming_languages: Blocks
+  tutorial_ghdebug_string_detail_programming_languages: Blocks
+  tutorial_tlckk_string_detail_programming_languages: Language independent
+  tutorial_firstcomp_string_detail_programming_languages: Language independent
+  tutorial_mazefinch_string_detail_programming_languages: Blocks
+  tutorial_tlccc_string_detail_programming_languages: Language independent
+  tutorial_tlcdoodle_string_detail_programming_languages: Language independent
+  tutorial_tlcpunch_string_detail_programming_languages: Language independent
+  tutorial_finchfract_string_detail_programming_languages: Java, Python
+  tutorial_tlcmind_string_detail_programming_languages: Language independent
+  tutorial_tlctelebot_string_detail_programming_languages: Language independent
+  tutorial_tlcaus_string_detail_programming_languages: Language independent
+  tutorial_tlcmicro_string_detail_programming_languages: Language independent
+  tutorial_imathematician_string_detail_programming_languages: Scratch
+  tutorial_tlcmagic_string_detail_programming_languages: Language independent
+  tutorial_scratchmus_string_detail_programming_languages: Blocks, Scratch
+  tutorial_scratchanim_string_detail_programming_languages: Blocks, Scratch
+  tutorial_scratchfly_string_detail_programming_languages: Blocks, Scratch
+  tutorial_tynkerarc_string_detail_programming_languages: Blocks, Tynker, JavaScript,
+    Python
+  tutorial_grokffpython_string_detail_programming_languages: Python
+  tutorial_grokffblock_string_detail_programming_languages: Blocks
+  tutorial_grokeliza_string_detail_programming_languages: Python
+  tutorial_tynkercan_string_detail_programming_languages: Blocks, Tynker, JavaScript,
+    Python
+  tutorial_grokflags_string_detail_programming_languages: Python
+  tutorial_robomind_string_detail_programming_languages: Blocks
+  tutorial_adventureq_string_detail_programming_languages: Blocks
+  tutorial_khan-es_string_detail_programming_languages: JavaScript
+  tutorial_kpt_string_detail_programming_languages: JavaScript
+  tutorial_kpl_string_detail_programming_languages: JavaScript
+  tutorial_khe_string_detail_programming_languages: JavaScript
+  tutorial_kfr_string_detail_programming_languages: JavaScript
+  tutorial_app-inventor_string_detail_programming_languages: Blocks
+  tutorial_blockly_string_detail_programming_languages: Blocks
+  tutorial_tynker_string_detail_programming_languages: do-not-show
+  tutorial_baypt_string_detail_programming_languages: Blocks
+  tutorial_code-combat_string_detail_programming_languages: do-not-show
+  tutorial_mky_string_detail_programming_languages: CoffeeScript
+  tutorial_pirates_string_detail_programming_languages: Blocks, Pirate code
+  tutorial_csfirst_string_detail_programming_languages: Scratch
+  tutorial_loopedy_string_detail_programming_languages: Blocks
+  tutorial_dsw_string_detail_programming_languages: do-not-show
+  tutorial_dswb_string_detail_programming_languages: do-not-show
+  tutorial_ssw_string_detail_programming_languages: do-not-show
+  tutorial_sswb_string_detail_programming_languages: do-not-show
+  tutorial_kodable-unplugged_string_detail_programming_languages: Language independent
+  tutorial_scratch_string_detail_programming_languages: Language independent
+  tutorial_bayes_string_detail_programming_languages: Blocks
+  tutorial_gumball_string_detail_programming_languages: do-not-show
+  tutorial_hrm_string_detail_programming_languages: Assembly
+  tutorial_ice-age_string_detail_programming_languages: do-not-show
+  tutorial_koapp_string_detail_programming_languages: do-not-show
+  tutorial_lightbot-intl_string_detail_programming_languages: Blocks
+  tutorial_rmc_string_detail_programming_languages: do-not-show
+  tutorial_smc_string_detail_programming_languages: do-not-show
+  tutorial_minecraft-2016_string_detail_programming_languages: do-not-show
+  tutorial_thinkersmith-es_string_detail_programming_languages: JavaScript
+  tutorial_pixie_string_detail_programming_languages: Blocks
+  tutorial_play_string_detail_programming_languages: do-not-show
+  tutorial_robomind-nl_string_detail_programming_languages: Blocks
+  tutorial_spheroi_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_spherol_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_spherov_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_swb_string_detail_programming_languages: do-not-show
+  tutorial_build-a-galaxy_string_detail_programming_languages: do-not-show
+  tutorial_alicesims_string_detail_programming_languages: Blocks
+  tutorial_tchr_string_detail_programming_languages: do-not-show
+  tutorial_robogame_string_detail_programming_languages: Blocks
+  tutorial_tap_string_detail_programming_languages: Blocks, Tynker, JavaScript, Python
+  tutorial_cintl_string_detail_programming_languages: do-not-show
+  tutorial_itchstop_string_detail_programming_languages: Blocks
+  tutorial_tynkerpn_string_detail_programming_languages: Blocks, Tynker
+  tutorial_tynkerpd_string_detail_programming_languages: Blocks, Tynker
+  tutorial_persistence_string_detail_programming_languages: Language independent
+  tutorial_getloopy_string_detail_programming_languages: Language independent
+  tutorial_createface_string_detail_programming_languages: Language independent
+  tutorial_happymaps_string_detail_programming_languages: Language independent
+  tutorial_moveit_string_detail_programming_languages: Language independent
+  tutorial_bigevent_string_detail_programming_languages: Language independent
+  tutorial_gpp_string_detail_programming_languages: Language independent
+  tutorial_foosgame_string_detail_programming_languages: Blocks
+  tutorial_solopython_string_detail_programming_languages: Python
+  tutorial_kodableint_string_detail_programming_languages: Language independent, Symbols
+  tutorial_kodableadv_string_detail_programming_languages: Language independent, Javascript
+  tutorial_tynkertj_string_detail_programming_languages: Python
+  tutorial_wolframa_string_detail_programming_languages: Wolfram Language
+  tutorial_wolframm_string_detail_programming_languages: Wolfram Language
+  tutorial_wolframspi_string_detail_programming_languages: Wolfram Language
+  tutorial_wolframsph_string_detail_programming_languages: Wolfram Language
+  tutorial_wolframp_string_detail_programming_languages: Wolfram Language
+  tutorial_wolframn_string_detail_programming_languages: Wolfram Language
+  tutorial_soloweb_string_detail_programming_languages: HTML, CSS
+  tutorial_khanweb_string_detail_programming_languages: HTML & CSS
+  tutorial_khandata_string_detail_programming_languages: SQL
+  tutorial_googlelogo_string_detail_programming_languages: Blocks
+  tutorial_playtune_string_detail_programming_languages: Blocks
+  tutorial_computeit_string_detail_programming_languages: Language independent
+  tutorial_codesterssj_string_detail_programming_languages: Blocks, Python
+  tutorial_cmchat_string_detail_programming_languages: Python
+  tutorial_tynkerdb_string_detail_programming_languages: Blocks, Tynker, JavaScript,
+    Python
+  tutorial_cmbuild_string_detail_programming_languages: CoffeeScript
+  tutorial_robotrattle_string_detail_programming_languages: Blocks
+  tutorial_codestersh_string_detail_programming_languages: Blocks, Python
+  tutorial_codehsdigipixel_string_detail_programming_languages: Language independent
+  tutorial_ccbinary_string_detail_programming_languages: Blocks
+  tutorial_codehsturtle_string_detail_programming_languages: Python
+  tutorial_grokhd_string_detail_programming_languages: Blocks
+  tutorial_grokem_string_detail_programming_languages: Python
+  tutorial_kodmaze_string_detail_programming_languages: Language independent
+  tutorial_codestersa_string_detail_programming_languages: Python
+  tutorial_cmdodo_string_detail_programming_languages: CoffeeScript
+  tutorial_tynkerspace_string_detail_programming_languages: Blocks, Tynker, JavaScript,
+    Python
+  tutorial_gfbloons_string_detail_programming_languages: Blocks
+  tutorial_raspipong_string_detail_programming_languages: Python
+  tutorial_codehsvr_string_detail_programming_languages: JavaScript
+  tutorial_codesterstp_string_detail_programming_languages: Blocks, Python
+  tutorial_codestersbb_string_detail_programming_languages: Blocks, Python
+  tutorial_gfcrossyroad_string_detail_programming_languages: Blocks
+  tutorial_googleww_string_detail_programming_languages: Blocks
+  tutorial_codehsjsapp_string_detail_programming_languages: JavaScript
+  tutorial_gfmihi_string_detail_programming_languages: Blocks
+  tutorial_hopdropphone_string_detail_programming_languages: Hopscotch
+  tutorial_techfaa_string_detail_programming_languages: JavaScript, Language independent
+  tutorial_codehsjsgraph_string_detail_programming_languages: JavaScript
+  tutorial_thunkable_string_detail_programming_languages: Blocks
+  tutorial_hopcrossyroad_string_detail_programming_languages: Hopscotch
+  tutorial_switchglitch_string_detail_programming_languages: Language independent
+  tutorial_codecar_string_detail_programming_languages: C/C++
+  tutorial_codesterscp_string_detail_programming_languages: Blocks, Python
+  tutorial_grokpetblock_string_detail_programming_languages: Blocks
+  tutorial_techbim_string_detail_programming_languages: Language independent
+  tutorial_techfpp_string_detail_programming_languages: Python
+  tutorial_codesterscr_string_detail_programming_languages: Python
+  tutorial_grokdisease_string_detail_programming_languages: Python
+  tutorial_techec_string_detail_programming_languages: JavaScript
+  tutorial_rgbegin_string_detail_programming_languages: Blocks
+  tutorial_myradream_string_detail_programming_languages: Blocks
+  tutorial_thinkfun_string_detail_programming_languages: Language independent
+  tutorial_hopfireworks_string_detail_programming_languages: Hopscotch
+  tutorial_grokspace_string_detail_programming_languages: Blocks
+  tutorial_codehspython_string_detail_programming_languages: Python
+  tutorial_codehsjava_string_detail_programming_languages: Java
+  tutorial_techioda_string_detail_programming_languages: Language independent
+  tutorial_grokmonster_string_detail_programming_languages: Blocks
+  tutorial_techmjs_string_detail_programming_languages: JavaScript
+  tutorial_techga_string_detail_programming_languages: Language independent
+  tutorial_techioan_string_detail_programming_languages: Java
+  tutorial_techiogsr_string_detail_programming_languages: Rust
+  tutorial_groktunnel_string_detail_programming_languages: Python
+  tutorial_stemcod_string_detail_programming_languages: JavaScript
+  tutorial_techikb_string_detail_programming_languages: Kotlin
+  tutorial_kanostreet_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_codemojijs_string_detail_programming_languages: JavaScript
+  tutorial_techapf_string_detail_programming_languages: Python
+  tutorial_techfpjs_string_detail_programming_languages: JavaScript
+  tutorial_techlinq_string_detail_programming_languages: C#
+  tutorial_gpbcatapult_string_detail_programming_languages: Blocks
+  tutorial_quorumastro_string_detail_programming_languages: Quorum
+  tutorial_alicewonder_string_detail_programming_languages: JavaScript
+  tutorial_rginter_string_detail_programming_languages: Blocks
+  tutorial_cssgrid_string_detail_programming_languages: CSS
+  tutorial_jshero_string_detail_programming_languages: JavaScript
+  tutorial_codemojipy_string_detail_programming_languages: iOS/Swift, Python
+  tutorial_nclabdrone_string_detail_programming_languages: Python
+  tutorial_gpbcircle_string_detail_programming_languages: Blocks
+  tutorial_gpbpaint_string_detail_programming_languages: Blocks
+  tutorial_cocomarcade_string_detail_programming_languages: JavaScript, Python
+  tutorial_beetik_string_detail_programming_languages: Blocks
+  tutorial_codedj_string_detail_programming_languages: JavaScript
+  tutorial_rgadvan_string_detail_programming_languages: Blocks, JavaScript, Python
+  tutorial_codehsrn_string_detail_programming_languages: JavaScript
+  tutorial_codehswd_string_detail_programming_languages: HTML
+  tutorial_turtlerobot_string_detail_programming_languages: Language independent
+  tutorial_ozoevo_string_detail_programming_languages: Blocks
+  tutorial_ozoexped_string_detail_programming_languages: OzoCodes
+  tutorial_ozojourney_string_detail_programming_languages: Blocks
+  tutorial_ozocodes_string_detail_programming_languages: OzoCodes
+  tutorial_ozoeclipse_string_detail_programming_languages: Blocks, OzoCodes
+  tutorial_ozosimulator_string_detail_programming_languages: Language independent
+  tutorial_ozoalgorithm_string_detail_programming_languages: Blocks
+  tutorial_ozotimer_string_detail_programming_languages: Blocks
+  tutorial_ozohabits_string_detail_programming_languages: OzoCodes
+  tutorial_ozoprogram_string_detail_programming_languages: Blocks
+  tutorial_ozopair_string_detail_programming_languages: Blocks
+  tutorial_codesnoopy_string_detail_programming_languages: Blocks
+  tutorial_applabintro_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_cslartist_string_detail_programming_languages: Blocks
+  tutorial_cslscratchjr_string_detail_programming_languages: Blocks
+  tutorial_floevents_string_detail_programming_languages: Language independent
+  tutorial_florobot_string_detail_programming_languages: Language independent
+  tutorial_isavesanta_string_detail_programming_languages: Blocks, Scratch
+  tutorial_iorder_string_detail_programming_languages: Blocks, Scratch
+  tutorial_ianimate_string_detail_programming_languages: Language independent
+  tutorial_iloveada_string_detail_programming_languages: ChildScript
+  tutorial_kodflash_string_detail_programming_languages: Language independent
+  tutorial_kodchoose_string_detail_programming_languages: Language independent
+  tutorial_kodpizzapre_string_detail_programming_languages: Language independent
+  tutorial_kodpizza_string_detail_programming_languages: Language independent
+  tutorial_kodwomen_string_detail_programming_languages: Language independent
+  tutorial_tfunplug_string_detail_programming_languages: Language independent
+  tutorial_lbvariables_string_detail_programming_languages: Blocks
+  tutorial_lbfunctions_string_detail_programming_languages: Blocks
+  tutorial_lblogic_string_detail_programming_languages: Blocks
+  tutorial_lbworld_string_detail_programming_languages: Blocks
+  tutorial_lbloops_string_detail_programming_languages: Blocks
+  tutorial_lbtug_string_detail_programming_languages: Blocks
+  tutorial_lbpotato_string_detail_programming_languages: Blocks
+  tutorial_lbguitar_string_detail_programming_languages: Blocks
+  tutorial_lbio_string_detail_programming_languages: Blocks
+  tutorial_wonpuppy_string_detail_programming_languages: Blocks
+  tutorial_woncue_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_wonzoo_string_detail_programming_languages: Blocks
+  tutorial_wontrip_string_detail_programming_languages: Blocks
+  tutorial_woncollect_string_detail_programming_languages: Blocks
+  tutorial_wonsecret_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_hsscience_string_detail_programming_languages: Hopscotch
+  tutorial_popculture_string_detail_programming_languages: Language independent
+  tutorial_legorobust_string_detail_programming_languages: Blocks
+  tutorial_legoplants_string_detail_programming_languages: Blocks
+  tutorial_legopark_string_detail_programming_languages: Blocks
+  tutorial_legodetect_string_detail_programming_languages: Blocks
+  tutorial_legolight_string_detail_programming_languages: Blocks
+  tutorial_alexa_string_detail_programming_languages: JavaScript
+  tutorial_grokpetmicro_string_detail_programming_languages: Python, MicroPython
+  tutorial_pirateplunder_string_detail_programming_languages: Blocks
+  tutorial_cadj_string_detail_programming_languages: Language independent
+  tutorial_cacrazy_string_detail_programming_languages: Blocks
+  tutorial_cajump_string_detail_programming_languages: Language independent
+  tutorial_carest_string_detail_programming_languages: Blocks
+  tutorial_accai_string_detail_programming_languages: Language independent
+  tutorial_vceclipse_string_detail_programming_languages: JavaScript
+  tutorial_pmzero_string_detail_programming_languages: Blocks
+  tutorial_hsela_string_detail_programming_languages: Hopscotch
+  tutorial_ticklear_string_detail_programming_languages: Blocks
+  tutorial_bcrobot_string_detail_programming_languages: Blocks
+  tutorial_bcsnow_string_detail_programming_languages: Blocks
+  tutorial_ifly_string_detail_programming_languages: Tynker
+  tutorial_idowedo_string_detail_programming_languages: Scratch
+  tutorial_diggindwarf_string_detail_programming_languages: JavaScript
+  tutorial_spheroit_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_gameofcodes_string_detail_programming_languages: Blocks, Ready, Unity
+  tutorial_blocklygames_string_detail_programming_languages: Blocks
+  tutorial_spherohello_string_detail_programming_languages: JavaScript
+  tutorial_spheroarcade_string_detail_programming_languages: iOS/Swift
+  tutorial_bcpy1_string_detail_programming_languages: Python
+  tutorial_bcpy2_string_detail_programming_languages: Python
+  tutorial_bcjs1_string_detail_programming_languages: JavaScript
+  tutorial_bcjs2_string_detail_programming_languages: JavaScript
+  tutorial_3dbearmars_string_detail_programming_languages: Language independent (can
+    be taught in multiple languages), Uses 3D modeling in augmented reality
+  tutorial_bitsboxyak_string_detail_programming_languages: JavaScript
+  tutorial_blockscadbargraphs_string_detail_programming_languages: Blocks
+  tutorial_blockscadbirdhouses_string_detail_programming_languages: Blocks
+  tutorial_blockscadclock_string_detail_programming_languages: Blocks
+  tutorial_blockscaddinner_string_detail_programming_languages: Blocks
+  tutorial_blockscadicecream_string_detail_programming_languages: Blocks
+  tutorial_blockscadpizza_string_detail_programming_languages: Blocks
+  tutorial_blockscadsugar_string_detail_programming_languages: Blocks
+  tutorial_bsgridlight_string_detail_programming_languages: Blocks
+  tutorial_bpartscratch_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_bpartvid_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_bpenglishscratch_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_bpenglishvid_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_bphealthscratch_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_bphealthvid_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_bpmathscratch_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_bpmathvid_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_bpmlkscratch_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_bpmlkvid_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_bpsafetyscratch_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_bpsafetyvid_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_bpsciencescratch_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_bpsciencevid_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_bptechscratch_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_bptechvid_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_caflags_string_detail_programming_languages: Blocks
+  tutorial_matariki_string_detail_programming_languages: Blocks
+  tutorial_carestaurant_string_detail_programming_languages: Blocks
+  tutorial_casea_string_detail_programming_languages: Blocks
+  tutorial_cashield_string_detail_programming_languages: Blocks
+  tutorial_ccwslimer_string_detail_programming_languages: Blocks
+  tutorial_codinggalaxy_string_detail_programming_languages: Blocks
+  tutorial_boatrace_string_detail_programming_languages: Blocks
+  tutorial_ccplay_string_detail_programming_languages: JavaScript, Python
+  tutorial_grinch_string_detail_programming_languages: Blocks
+  tutorial_codehsart_string_detail_programming_languages: Blocks
+  tutorial_codehsbitcoin_string_detail_programming_languages: Language independent
+    (can be taught in multiple languages)
+  tutorial_codehsblockchain_string_detail_programming_languages: Language independent
+    (can be taught in multiple languages)
+  tutorial_codehscipher_string_detail_programming_languages: Language independent
+    (can be taught in multiple languages)
+  tutorial_codehscollision_string_detail_programming_languages: JavaScript
+  tutorial_codehsmath_string_detail_programming_languages: Python
+  tutorial_codehsmusic_string_detail_programming_languages: Blocks
+  tutorial_codehssports_string_detail_programming_languages: Blocks
+  tutorial_codemojipizza_string_detail_programming_languages: JavaScript
+  tutorial_moonlander_string_detail_programming_languages: CoffeeScript
+  tutorial_sushicards_string_detail_programming_languages: Blocks
+  tutorial_codesparkcreate_string_detail_programming_languages: Blocks
+  tutorial_hardvsoft_string_detail_programming_languages: ''
+  tutorial_codestersecard_string_detail_programming_languages: Blocks, Python
+  tutorial_codesterslogo_string_detail_programming_languages: Python
+  tutorial_codesterstshirt_string_detail_programming_languages: Blocks, Python
+  tutorial_codewards_string_detail_programming_languages: CoffeeScript
+  tutorial_olympics_string_detail_programming_languages: CoffeeScript
+  tutorial_codinismhero_string_detail_programming_languages: Python
+  tutorial_discovery_string_detail_programming_languages: Blocks, Scratch
+  tutorial_csfirstname_string_detail_programming_languages: Blocks, Scratch
+  tutorial_edisonmove_string_detail_programming_languages: Python, EdPy, a text-based
+    programming language based on Python.
+  tutorial_edisonspider_string_detail_programming_languages: Blocks
+  tutorial_edisonspotlight_string_detail_programming_languages: Blocks
+  tutorial_firiapython_string_detail_programming_languages: Python
+  tutorial_gamefrootsquid_string_detail_programming_languages: Blocks
+  tutorial_duckpiano_string_detail_programming_languages: Blocks
+  tutorial_gpsound_string_detail_programming_languages: Blocks
+  tutorial_groklearningpython_string_detail_programming_languages: Python
+  tutorial_htmltimetravel_string_detail_programming_languages: HTML and CSS
+  tutorial_hp_flappy_string_detail_programming_languages: Blocks, hyperPad Visual
+    Behaviours
+  tutorial_appytappin_string_detail_programming_languages: BitsBox
+  tutorial_icipher_string_detail_programming_languages: ''
+  tutorial_iguess_string_detail_programming_languages: ''
+  tutorial_imake_string_detail_programming_languages: Unplugged
+  tutorial_imorse_string_detail_programming_languages: Blocks
+  tutorial_kanohp_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_khanwebpages_string_detail_programming_languages: HTML/CSS
+  tutorial_kibobowl_string_detail_programming_languages: Blocks
+  tutorial_kibodance_string_detail_programming_languages: Blocks
+  tutorial_buildcharacters_string_detail_programming_languages: JavaScript, Language
+    independent (can be taught in multiple languages)
+  tutorial_designgames_string_detail_programming_languages: JavaScript, Language independent
+    (can be taught in multiple languages)
+  tutorial_makelevels_string_detail_programming_languages: JavaScript, Language independent
+    (can be taught in multiple languages)
+  tutorial_wizard_string_detail_programming_languages: JavaScript
+  tutorial_mbscratchcards_string_detail_programming_languages: Blocks
+  tutorial_mbswiftplaygrounds_string_detail_programming_languages: iOS/Swift
+  tutorial_mbbuttons_string_detail_programming_languages: Blocks
+  tutorial_meteor_string_detail_programming_languages: Blocks
+  tutorial_ballbounce_string_detail_programming_languages: Blocks
+  tutorial_mitcodi_string_detail_programming_languages: Blocks
+  tutorial_mitdoodle_string_detail_programming_languages: Blocks
+  tutorial_talktome_string_detail_programming_languages: Blocks
+  tutorial_mobilecspmap_string_detail_programming_languages: Blocks, App Inventor
+  tutorial_ozorandom_string_detail_programming_languages: Blocks
+  tutorial_ozotroll_string_detail_programming_languages: Blocks
+  tutorial_peblioart_string_detail_programming_languages: JavaScript
+  tutorial_astropi_string_detail_programming_languages: Python
+  tutorial_rgart_string_detail_programming_languages: Blocks
+  tutorial_rgengineer_string_detail_programming_languages: Blocks
+  tutorial_rgmath_string_detail_programming_languages: Blocks
+  tutorial_rgscience_string_detail_programming_languages: Blocks
+  tutorial_rgtech_string_detail_programming_languages: Blocks
+  tutorial_robotmagic3d_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_robotmagicflappy_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_scratchadventure_string_detail_programming_languages: Blocks
+  tutorial_scratchtalk_string_detail_programming_languages: Blocks
+  tutorial_scratchjrstory_string_detail_programming_languages: 'ScratchJr. '
+  tutorial_scratchjrtwinkle_string_detail_programming_languages: ScratchJr.
+  tutorial_spherocomm_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_spherocommunity_string_detail_programming_languages: Blocks, Draw
+  tutorial_spherofunctions_string_detail_programming_languages: JavaScript
+  tutorial_spheroinfrared_string_detail_programming_languages: Blocks
+  tutorial_spherolightsensor_string_detail_programming_languages: Blocks
+  tutorial_spheromansion_string_detail_programming_languages: Blocks
+  tutorial_roadblocks_string_detail_programming_languages: Blocks
+  tutorial_spherotext2_string_detail_programming_languages: JavaScript
+  tutorial_spherotext3_string_detail_programming_languages: JavaScript
+  tutorial_spherotext4_string_detail_programming_languages: JavaScript
+  tutorial_spheroraptor_string_detail_programming_languages: Blocks
+  tutorial_stempiday_string_detail_programming_languages: JavaScript
+  tutorial_stemplanetoids_string_detail_programming_languages: JavaScript
+  tutorial_stempong_string_detail_programming_languages: JavaScript
+  tutorial_algobot_string_detail_programming_languages: Language independent (can
+    be taught in multiple languages)
+  tutorial_thunkableapps_string_detail_programming_languages: Blocks
+  tutorial_toxicodedot_string_detail_programming_languages: Language independent (can
+    be taught in multiple languages)
+  tutorial_gcactions_string_detail_programming_languages: Blocks
+  tutorial_gccomparators_string_detail_programming_languages: Blocks
+  tutorial_gcconditions_string_detail_programming_languages: Blocks
+  tutorial_gccreate_string_detail_programming_languages: Blocks
+  tutorial_gcevents_string_detail_programming_languages: Blocks
+  tutorial_gcloops_string_detail_programming_languages: Blocks
+  tutorial_gcvariables_string_detail_programming_languages: Blocks
+  tutorial_beanything_string_detail_programming_languages: Blocks, Tynker
+  tutorial_change_string_detail_programming_languages: Blocks, Tynker
+  tutorial_cooking_string_detail_programming_languages: Blocks, Tynker
+  tutorial_crystal_string_detail_programming_languages: Blocks, Tynker
+  tutorial_landscape_string_detail_programming_languages: Python
+  tutorial_pets_string_detail_programming_languages: Blocks, Tynker
+  tutorial_petvet_string_detail_programming_languages: Blocks, JavaScript, Python,
+    Tynker
+  tutorial_superhero_string_detail_programming_languages: HTML, CSS
+  tutorial_vidcodeplastic_string_detail_programming_languages: JavaScript
+  tutorial_vidcodetypeface_string_detail_programming_languages: JavaScript
+  tutorial_washustorm_string_detail_programming_languages: Blocks
+  tutorial_activitypackets_string_detail_programming_languages: Blocks, Wonder, Xylo,
+    Blockly
+  tutorial_googlerookie_string_detail_programming_languages: Blocks
+  tutorial_tommyturtle_string_detail_programming_languages: Language independent
+  tutorial_mazyad_string_detail_programming_languages: Blocks
+  tutorial_gamemaker_string_detail_programming_languages: JavaScript
+  tutorial_duckrace_string_detail_programming_languages: Blocks
+  tutorial_allcancodeapps_string_detail_programming_languages: Blocks
+  tutorial_n2y_string_detail_programming_languages: Unplugged
+  tutorial_microsoftarcade_string_detail_programming_languages: Blocks
+  tutorial_csfirstunplugged_string_detail_programming_languages: Blocks, Unplugged,
+    Scratch
+  tutorial_toxicodepython_string_detail_programming_languages: Python
+  tutorial_codecombatozaria_string_detail_programming_languages: JavaScript, Python
+  tutorial_vidcodedate_string_detail_programming_languages: JavaScript
+  tutorial_codemonkeyspace_string_detail_programming_languages: CoffeeScript
+  tutorial_codespeakhappy_string_detail_programming_languages: Blocks
+  tutorial_grokimage_string_detail_programming_languages: Python
+  tutorial_icomputelearn_string_detail_programming_languages: Blocks, JavaScript,
+    Scratch
+  tutorial_rpstress_string_detail_programming_languages: Blocks
+  tutorial_bsdcause_string_detail_programming_languages: JavaScript, HTML, CSS
+  tutorial_vidcodeanimoji_string_detail_programming_languages: JavaScript
+  tutorial_vidcodeanimojies_string_detail_programming_languages: JavaScript
+  tutorial_bsdinspire_string_detail_programming_languages: JavaScript, HTML, CSS
+  tutorial_tttractor_string_detail_programming_languages: JavaScript
+  tutorial_codeillusionmickey_string_detail_programming_languages: JavaScript
+  tutorial_scigirlsquest_string_detail_programming_languages: Blocks
+  tutorial_codespeakbreathe_string_detail_programming_languages: Blocks
+  tutorial_vidcodeface_string_detail_programming_languages: JavaScript
+  tutorial_educodemaze_string_detail_programming_languages: JavaScript
+  tutorial_educoderace_string_detail_programming_languages: JavaScript
+  tutorial_codespeakchatbot_string_detail_programming_languages: Blocks
+  tutorial_gamefrootgames_string_detail_programming_languages: Blocks
+  tutorial_codespeakgrandparent_string_detail_programming_languages: Blocks
+  tutorial_educodekingdom_string_detail_programming_languages: JavaScript
+  tutorial_codehsdata_string_detail_programming_languages: JavaScript
+  tutorial_educodecake_string_detail_programming_languages: HTML + CSS
+  tutorial_ttsecond_string_detail_programming_languages: JavaScript
+  tutorial_bsdtrivia_string_detail_programming_languages: JavaScript, HTML, CSS
+  tutorial_csfirstdialogue_string_detail_programming_languages: Blocks, Scratch
+  tutorial_codemonkeybeaver_string_detail_programming_languages: Blocks
+  tutorial_codestersdistance_string_detail_programming_languages: Python
+  tutorial_itchspace_string_detail_programming_languages: Blocks
+  tutorial_vidcodemagic_string_detail_programming_languages: JavaScript
+  tutorial_vidcodemagices_string_detail_programming_languages: JavaScript
+  tutorial_codespeakmeal_string_detail_programming_languages: JavaScript
+  tutorial_itchfish_string_detail_programming_languages: Blocks
+  tutorial_bsdwebsite_string_detail_programming_languages: JavaScript, HTML, CSS
+  tutorial_codespeaktime_string_detail_programming_languages: Blocks
+  tutorial_itchwebcam_string_detail_programming_languages: Blocks
+  tutorial_itchball_string_detail_programming_languages: Blocks
+  tutorial_ttrace_string_detail_programming_languages: JavaScript, CoffeeScript
+  tutorial_plethora_string_detail_programming_languages: Language independent (can
+    be taught in multiple languages)
+  tutorial_educodesecret_string_detail_programming_languages: Python
+  tutorial_itchshapes_string_detail_programming_languages: Blocks
+  tutorial_codeguppytext_string_detail_programming_languages: JavaScript
+  tutorial_vidcodeplastiche_string_detail_programming_languages: JavaScript
+  tutorial_educativechatbot_string_detail_programming_languages: Python
+  tutorial_educodebasics_string_detail_programming_languages: JavaScript
+  tutorial_codehsdesign_string_detail_programming_languages: HTML
+  tutorial_htmlacademyphp_string_detail_programming_languages: PHP
+  tutorial_gamefrootdistance_string_detail_programming_languages: Blocks
+  tutorial_codesterscovid_string_detail_programming_languages: Python
+  tutorial_ttbunker_string_detail_programming_languages: JavaScript
+  tutorial_cuttle_string_detail_programming_languages: Blocks, Language independent
+    (can be taught in multiple languages)
+  tutorial_bsdjokes_string_detail_programming_languages: JavaScript, HTML, CSS
+  tutorial_rptree_string_detail_programming_languages: Blocks
+  tutorial_codestersunity_string_detail_programming_languages: Python
+  tutorial_codesterssoccer_string_detail_programming_languages: Python
+  tutorial_breakoutlock_string_detail_programming_languages: Blocks, Language independent
+    (can be taught in multiple languages)
+  tutorial_thunkablemask_string_detail_programming_languages: Blocks
+  tutorial_cafarming_string_detail_programming_languages: Theory course on impacts
+    of computing.
+  tutorial_blocksmithyeti_string_detail_programming_languages: JavaScript
+  tutorial_codecapture_string_detail_programming_languages: JavaScript
+  tutorial_codehslitter_string_detail_programming_languages: Python, HTML
+  tutorial_bsdocean_string_detail_programming_languages: JavaScript, HTML, CSS
+  tutorial_itchplatformer_string_detail_programming_languages: Blocks
+  tutorial_codejika_string_detail_programming_languages: JavaScript, HTML, CSS
+  tutorial_gamefrootclicker_string_detail_programming_languages: Blocks
+  tutorial_rmagicequity_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_ttfreestyle_string_detail_programming_languages: JavaScript
+  tutorial_ozobotcolor2_string_detail_programming_languages: Ozobot Color Codes
+  tutorial_ozobotcolor3_string_detail_programming_languages: Ozobot Color Codes
+  tutorial_clcarbon_string_detail_programming_languages: Python
+  tutorial_kodablebasics_string_detail_programming_languages: Blocks, JavaScript,
+    Language independent (can be taught in multiple languages)
+  tutorial_scigirlscc_string_detail_programming_languages: Language independent (can
+    be taught in multiple languages)
+  tutorial_irobotpicture_string_detail_programming_languages: No specific programming
+    languages required; unplugged decoding activity with words/phrases
+  tutorial_kcjmyself_string_detail_programming_languages: Blocks
+  tutorial_nearpodalgorithms_string_detail_programming_languages: Language independent
+    (can be taught in multiple languages)
+  tutorial_kibodrop_string_detail_programming_languages: Blocks
+  tutorial_ozobotcolor1_string_detail_programming_languages: Ozobot Line Following
+    and Color Codes
+  tutorial_scigirlspixels_string_detail_programming_languages: Language independent
+    (can be taught in multiple languages)
+  tutorial_kcjheroines_string_detail_programming_languages: Blocks
+  tutorial_ozobotvalue_string_detail_programming_languages: Ozobot Color Codes
+  tutorial_icodebytes_string_detail_programming_languages: Language independent (can
+    be taught in multiple languages)
+  tutorial_clfashion2_string_detail_programming_languages: SQL
+  tutorial_ai4all_string_detail_programming_languages: Language independent (can be
+    taught in multiple languages)
+  tutorial_cldata_string_detail_programming_languages: Language independent (can be
+    taught in multiple languages)
+  tutorial_spheroinputs_string_detail_programming_languages: Blocks
+  tutorial_edisoncount_string_detail_programming_languages: Blocks
+  tutorial_spheroloops_string_detail_programming_languages: Blocks
+  tutorial_kiboprogram_string_detail_programming_languages: Blocks
+  tutorial_hellorubycsin60_string_detail_programming_languages: Language independent
+    (can be taught in multiple languages)
+  tutorial_clfashion1_string_detail_programming_languages: SQL
+  tutorial_irobottraffic_string_detail_programming_languages: Blocks, iOS/Swift
+  tutorial_edisonmystery_string_detail_programming_languages: Blocks
+  tutorial_microbitseaturtles_string_detail_programming_languages: Blocks, JavaScript,
+    Python
+  tutorial_ozobotknow_string_detail_programming_languages: Language independent (can
+    be taught in multiple languages)
+  tutorial_imagilabs_string_detail_programming_languages: Python
+  tutorial_irobotsimulator_string_detail_programming_languages: Blocks
+  tutorial_irobotkind_string_detail_programming_languages: Blocks
+  tutorial_firiavirtual_string_detail_programming_languages: Python
+  tutorial_irobotguesscode_string_detail_programming_languages: Blocks, iOS/Swift
+  tutorial_ozobotnouns_string_detail_programming_languages: Ozobot Color Codes
+  tutorial_nasa3d_string_detail_programming_languages: Tinkercad Codeblocks
+  tutorial_blupants_string_detail_programming_languages: Blocks, Python
+  tutorial_legodance_string_detail_programming_languages: Blocks
+  tutorial_nearpodcoding_string_detail_programming_languages: Language independent
+    (can be taught in multiple languages)
+  tutorial_kcjplastic_string_detail_programming_languages: Blocks, Also has use of
+    a spreadsheet.
+  tutorial_legojourney_string_detail_programming_languages: Blocks
+  tutorial_legohopper_string_detail_programming_languages: Blocks
+  tutorial_catrobatembroidery_string_detail_programming_languages: Blocks
+  tutorial_irobotphone_string_detail_programming_languages: Blocks, iOS/Swift
+  tutorial_codeguppydraw_string_detail_programming_languages: JavaScript
+  tutorial_codejumper_string_detail_programming_languages: Unplugged
+  tutorial_meeempathy_string_detail_programming_languages: Blocks, Python
+  tutorial_scratchimagine_name: Imagine a World
+  tutorial_codesterspsa_name: 'Codesters: Code Your Own PSA'
+  tutorial_googlehero_name: Code Your Hero
+  tutorial_codestersbball_name: 'Codesters: Basketball'
+  tutorial_scratchcartoon_name: Code a Cartoon
+  tutorial_codemonkeyjr_name: 'CodeMonkey Jr.: Pre-coding for Preschoolers'
+  tutorial_bananatales_name: 'Banana Tales: Python Coding Game'
+  tutorial_scratchtales_name: Talking Tales
+  tutorial_msemoji_name: Quick Draw Emoji with Machine Learning
+  tutorial_cacolor_name: Professor Photon's Color Conundrum
+  tutorial_kodablebeach_name: Beach Cleanup with Kodable
+  tutorial_tynkeren_name: Affordable and Clean Energy
+  tutorial_tynkerjavapro_name: Responsible Consumption and Production (JavaScript)
+  tutorial_grasshopperhack_name: Hack a Game
+  tutorial_pbskids_name: PBS KIDS Scratch Jr
+  tutorial_nclabdata_name: Data Power!
+  tutorial_grasshopperphoto_name: Filter a Photo
+  tutorial_tynkerpyland_name: Life on Land (Python)
+  tutorial_codeitimages_name: Code it! - Images and Animations
+  tutorial_hyperpadenemy_name: Create a Smarter Enemy AI in hyperPad
+  tutorial_tynkerpro_name: Responsible Consumption and Production
+  tutorial_trashtag_name: 'Eco Warriors #Trashtag'
+  tutorial_casiege_name: Security Siege
+  tutorial_thunkableyeet_name: 'Let''s Get This Bread: Learn How to Build Two Apps'
+  tutorial_vidcodedeal_name: 'Vidcode: Deal With It'
+  tutorial_codehsgeno_name: Exploring Genotypes with Code
+  tutorial_hyperpadpong_name: Making a Pong Game in hyperPad
+  tutorial_tynkerland_name: Life on Land
+  tutorial_trinketgirl_name: 'Code Like a Girl: A Storyteller'
+  tutorial_rpimosquito_name: Mosquito patrol
+  tutorial_tynkermars_name: NASA Moon 2 Mars
+  tutorial_cityx_name: 'Coding Galaxy: City X'
+  tutorial_vidcodemap_name: 'Vidcode: Map Your Community'
+  tutorial_robotmagicfarm_name: 'FarmBot: Plant with Code'
+  tutorial_codehstriangle_name: Triangle Computations with CodeHS
+  tutorial_ttwhitehouse_name: White House
+  tutorial_modulo_name: 'Modulo Code: Code E.D.'
+  tutorial_codingtown_name: Coding Town
+  tutorial_kanoart_name: Art Playground
+  tutorial_dragonscript_name: 'DragonScript Arena: a Javascript coding game with Dragons'
+  tutorial_uwcloud_name: Cloud Constructor
+  tutorial_htmlmuffin_name: Master the Web with Muffin the Cat
+  tutorial_microsoftpizza_name: Chase the Pizza!
+  tutorial_stemc_blckhole_name: Escape Velocity and Black Holes!
+  tutorial_careconfigure_name: ReconFigure of Speech
+  tutorial_rpiscratch_name: Scratch 3.0 phrasebook
+  tutorial_ozaria_name: Ozaria by CodeCombat
+  tutorial_ttovum_name: Ovun City
+  tutorial_ttpassage_name: The Passage
+  tutorial_tynkerhtmlen_name: Affordable and Clean Energy (HTML)
+  tutorial_ttfrog_name: Frog Squash
+  tutorial_codemojijava_name: Learn Basic Java
+  tutorial_ccfirewall_name: Firewall
+  tutorial_htmljs_name: 'Intro to JavaScript: from variables to your first program'
+  tutorial_ttaqueducts_name: Aqueducts
+  tutorial_vtgame_name: 'Game Changineer: Create with English'
+  tutorial_baroborav_name: Robot Autonomous Vehicle
+  tutorial_baroboobstacle_name: Linkbot Obstacle Course
+  tutorial_pbstorytelling_name: Interactive Storytelling
+  tutorial_kibosnow_name: KIBO Snowplow - Important Jobs in the Community
+  tutorial_kibohappy_name: Expressing Happiness with KIBO
+  tutorial_rubylove_name: 'Hello Ruby: Love Letters for Computers'
+  tutorial_spherosmiles_name: Super Smiles
+  tutorial_spherobaby_name: Sphero Baby Steps
+  tutorial_toxarchitect_name: Utopian Architect
+  tutorial_idodge_name: Ice Cream Dodge
+  tutorial_firiacodebot_name: Intro to Python with CodeBot
+  tutorial_modlighthouse_name: Lighthouse Design Challenge with Cubelets
+  tutorial_spherogreen_name: Sphero Goes Green
+  tutorial_ozopopstar_name: PopStar|Creating Functions With OzoBlockly
+  tutorial_eddesign_name: Edison the designer
+  tutorial_edshapeup_name: Robot shape-up with Edison
+  tutorial_ozocolor_name: Pop Star|Creating Functions With Ozobot Color Codes
+  tutorial_icomputeeggs_name: iHide Eggs
+  tutorial_rootunplugged_name: iRobot Code Break
+  tutorial_rgtreasure_name: RoboGarden Puzzles - Robo Treasure Chest
+  tutorial_peblioportraits_name: 'Computational Portraiture: Art for Good '
+  tutorial_rootcodebreak_name: iRobot Code Break with Root
+  tutorial_microbit14_name: 'micro:bit: coding towards Global Goal 14, Life Below
+    Water'
+  tutorial_barobomoon_name: Moon Base SOS with Arduino
+  tutorial_eddog_name: Code a guard dog with Edison
+  tutorial_microbit15_name: 'micro:bit: coding towards Global Goal 15, Life on Land'
+  tutorial_unity_name: 'Unity Game Development Creator Kit: Beginner Code'
+  tutorial_blockscadtarget_name: BlocksCAD Transformation Target Practice
+  tutorial_tcadicicles_name: Designing Icicles With Codeblocks in Tinkercad
+  tutorial_blockscadscale_name: BlocksCAD Scale City
+  tutorial_tcadloops_name: Using Loops in Tinkercad to Design a Bursting Star
+  tutorial_phidgets_name: A Phidgets Theremin with Processing
+  tutorial_modvariables_name: Investigating Variables & Block Values using Cubelets
+  tutorial_codestersmicro_name: 'Codesters: Create a Micro Ball Game'
+  tutorial_codestersdata_name: 'Codesters: Code & Graph micro:bit Data'
+  tutorial_ikodexmas_name: iKode Xmas
+  tutorial_rpisensehat_name: Sense HAT data logger
+  tutorial_mee_name: 'Minecraft Hour of Code: AI for Good'
+  tutorial_kuborobo_name: KUBO Robotics Coding Routes
+  tutorial_ai-oceans_name: AI for Oceans
+  tutorial_scratchimagine_longdescription: Imagine a world where anything is possible,
+    then bring it to life with Scratch!
+  tutorial_codesterspsa_longdescription: Learn the basics of coding in Python while
+    creating your own Public Service Announcement. Choose a topic you find important
+    and design you own animated or interactive PSA to share critical information about
+    how to make a positive impact on the world.
+  tutorial_googlehero_longdescription: Turn an everyday hero from your life or community
+    into a superhero by programming them to fly over buildings, spin, work with a
+    sidekick, and score points by touching objects in a game. In Code Your Hero, show
+    off your hero's special powers and your own creativity with CS First and Scratch.
+  tutorial_codestersbball_longdescription: Learn the basics of coding in Python while
+    creating your own Basketball game. You'll learn how to add backgrounds and sprites,
+    and how to use events to control the motion of sprites on the stage.
+  tutorial_scratchcartoon_longdescription: Bring some of your favorite Cartoon Network
+    characters to life by coding your own animation. Add more characters and make
+    them jump, fly, and talk.
+  tutorial_codemonkeyjr_longdescription: In a world filled with captivating creatures
+    and bright colors, 4-6 year olds will join a monkey on a mission to collect bananas
+    and unlock treasure chests. All the while, they will explore and learn the basics
+    of code as they use blocks to program a monkey's journey through the world.
+  tutorial_bananatales_longdescription: Teach Python by helping a baby monkey. Twin
+    baby monkeys were separated by an earthquake - leaving one of the monkeys with
+    no way to get bananas! Now, it is up to your students to use code to rebuild the
+    path and feed the baby monkey.
+  tutorial_scratchtales_longdescription: Take characters on a journey and have them
+    speak aloud using Text-to-Speech blocks powered by Amazon. Choose a voice for
+    each character, then type what you want to say. Make your story interactive by
+    coding your characters to ask questions and travel to different scenes. Experiment
+    with creative new ways of making stories come alive!
+  tutorial_msemoji_longdescription: Build a live interactive website that uses a Machine
+    Learning model to recognize your and your friends' hand-drawn emojis! Along the
+    way you'll get hands-on practice with core concepts of Machine Learning - 1) gathering
+    data, 2) cleaning and formatting the data, 3) training the model, and 4) using
+    the trained model to make predictions.
+  tutorial_cacolor_longdescription: Professor Photon is a highly regarded physicist
+    gone rogue. She has eliminated color from all digital devices! In this Escape
+    Room style project, the learner joins Marlee and Tyrell as they learn about binary
+    numbers, light, color, and more to unravel Professor Photon's Color Conundrum,
+    and restore color to the world's devices.
+  tutorial_kodablebeach_longdescription: Save the beach babies! Learn to program using
+    basic commands and clean up the beach to protect ocean life.
+  tutorial_tynkeren_longdescription: 'Part of the UN Sustainable Development Goals
+    project, this coding prompt shows off projects exploring renewable energy, energy
+    efficiency, and access to energy. Readers can play with working projects and advanced
+    programmers can create their own original projects. '
+  tutorial_tynkerjavapro_longdescription: 'Part of the UN Sustainable Development
+    Goals project, this coding prompt shows off a short project exploring recycling
+    and reuse. Readers can create their own game by expanding the project. '
+  tutorial_grasshopperhack_longdescription: Learn coding skills to hack this game
+    to make it possible to play.
+  tutorial_pbskids_longdescription: With PBS KIDS Scratch Jr, kids can create their
+    own interactive stories and games through programming games and lessons. Learn
+    to code through games and activities featuring characters from Odd Squad, Wild
+    Kratts, Nature Cat, Arthur, WordGirl, Peg + Cat, and Ready Jet Go! The storytelling
+    possibilities are endless with this creative coding app for children ages 5-8.
+  tutorial_nclabdata_longdescription: The world thrives on good data! In this hands-on
+    NCLab tutorial, you will write simple queries, the first step in data analysis.
+    Get acquainted with the power of the PostgreSQL language, used by governments
+    and businesses to manage database systems all over the world. PostgreSQL is written
+    in plain English and is easy to learn. Try it out!
+  tutorial_grasshopperphoto_longdescription: Learn coding skills to create filters
+    to apply to different photos.
+  tutorial_tynkerpyland_longdescription: 'Part of the UN Sustainable Development Goals
+    project, this Python project will have you create your own tree-planting game. '
+  tutorial_codeitimages_longdescription: Learn to program your own amazing images
+    and animations.
+  tutorial_hyperpadenemy_longdescription: 'Learn logical thinking and programming
+    by creating a platformer game enemy AI. '
+  tutorial_tynkerpro_longdescription: 'Part of the UN Sustainable Development Goals
+    project, this coding prompt shows off projects exploring issues surrounding recycling
+    and reuse. Beginners can play with working projects and advanced programmers can
+    create their own projects from scratch. '
+  tutorial_trashtag_longdescription: 'Code your own game and raise awareness for protecting
+    our environment. '
+  tutorial_casiege_longdescription: Join Niko and Sakura on their virtual reality
+    journey to Tubrosos Castle. Learn what it's like to be a gray hat hacker by helping
+    the wizard elf, Cyrena find the Crown of Knowledge. You will expose the poor security
+    systems used at the castle and learn how to avoid becoming the victim of a scam.
+  tutorial_thunkableyeet_longdescription: Learn how to build two apps that will help
+    your city! Yeet!
+  tutorial_vidcodedeal_longdescription: Start coding for good by creating animations
+    featuring notable women leaders and quotes that express their point of view.
+  tutorial_codehsgeno_longdescription: In this hour of code, students will create
+    a program that will solve for allele pairs based on user input. Students will
+    program with Tracy the Turtle in Python to make this happen. Students should have
+    prior knowledge of basic biology concepts and Punnett Squares before beginning
+    this activity.
+  tutorial_hyperpadpong_longdescription: 'Learn to program a pong game with a smart
+    AI opponent. '
+  tutorial_tynkerland_longdescription: 'Part of the UN Sustainable Development Goals
+    project, this coding prompt shows off projects exploring the importance of forests
+    to the world''s ecosystem. Readers can play with working projects and advanced
+    programmers can create their own original projects. '
+  tutorial_trinketgirl_longdescription: Learn to program a big story using Python,
+    and then change it up to create your own story!
+  tutorial_rpimosquito_longdescription: Make a game where you protect people from
+    malaria by making a parrot catch mosquitoes.
+  tutorial_tynkermars_longdescription: Explore NASA's exciting new efforts to reach
+    the Moon and then Mars. Students can design their own animated mission patch,
+    imagine their life as an Artemis astronaut on the Lunar Gateway, and more. Beginners
+    can try step-by-step tutorials, while experienced programmers can create their
+    own original projects with block or text coding.
+  tutorial_cityx_longdescription: Your first quest in City X is to help an old farmer
+    to manage his farm. Let's solve his problem with innovative technology! You will
+    learn the basic concept of watering system and make a gardening robot with incredible
+    fun! Students will apply design thinking concepts to investigate problems while
+    developing their technological awareness, thereby honing their high-level thinking
+    skills.
+  tutorial_vidcodemap_longdescription: Collect and analyze data for community engagement,
+    by coding your own community map!
+  tutorial_robotmagicfarm_longdescription: Code the FarmBot to plant seeds. Start
+    planting simple fields then add complexity.  Finish by growing art of your own
+    design.
+  tutorial_codehstriangle_longdescription: In this hour of code, we'll explore how
+    to create a simulator that will calculate the area of a triangle with dimensions
+    chosen by a user. We'll program with Tracy the Turtle in Python to make this happen.
+    Students should have prior knowledge of basic geometry concepts before beginning
+    this activity.
+  tutorial_ttwhitehouse_longdescription: In this colorful adventure, restore color
+    to a white world through a self-guided first person game. Solve puzzles and complete
+    challenges in order to advance the game and your coding knowledge. After completion,
+    players will be familiarized with color hex values and CSS attributes and comfortable
+    enough to recognize them in real world applications. Don't be afraid to share
+    your creations.
+  tutorial_modulo_longdescription: Out in the deepest of space, the Exploratory Databot,
+    known as E.D. has just discovered a new habitable planet for humankind! Who knows
+    what surprises lay ahead on this remote sandy planet? Unexpectedly while landing,
+    E.D. gets a shock to its motherboard wiping out all its programs. It's up to you
+    to program E.D. to help it through this strange alien's terrain. Are you up for
+    the challenge?
+  tutorial_codingtown_longdescription: Build your own business, code and have fun.
+  tutorial_kanoart_longdescription: Use block code to draw a scene, then bring it
+    to life with animation and mouse interaction. Code your own paintbrushes, add
+    stickers, and get creative!
+  tutorial_dragonscript_longdescription: Welcome to DragonScript Arena – the programming
+    strategy game and coding club. Level up your Javascript & Software Engineering
+    as you play! Build your own Dragon A.I. Imagine Battlebots but with robot Dragons.
+  tutorial_uwcloud_longdescription: Learn the basics of cloud computing by building
+    your own cloud! Build servers, upgrade them, and connect clients to keep up with
+    network demand. Play the role of a Cloud Architect in this interactive game and
+    test your skills in the endless mode.
+  tutorial_htmlmuffin_longdescription: Get ready for a fun and exciting adventure
+    with Muffin the Cat, who will guide you through the basics of HTML and CSS. Together
+    you will make your first landing page and understand the main principles of a
+    website layout.
+  tutorial_microsoftpizza_longdescription: Create a simple Arcade game where your
+    player eats as much pizza as you can before the time runs out!
+  tutorial_stemc_blckhole_longdescription: Did you see the images of the black hole
+    that were released in Spring 2019? Do you want to know more about black holes
+    and how to escape from them? Check out this coding activity on how fast you need
+    to go to escape from a gravitational field and what happens when not even light
+    can escape!
+  tutorial_careconfigure_longdescription: Our story-telling app retells a fairytale,
+    with weird and funny results! But the program is poorly written. Writing good
+    code is vital. Help refine this app into something amazing. Look at word classes
+    in English, and use variables, consonants, lists, and functions to reconfigure
+    this program. If you have written a program before and want some style, this is
+    for you.
+  tutorial_rpiscratch_longdescription: Create an interactive phrasebook that translates
+    useful phrases into different languages.
+  tutorial_ozaria_longdescription: Customize your hero and journey to the Sky Mountain
+    where you learn to type real code, navigate through 15 game levels, and make your
+    own game in order to help save the world of Ozaria.
+  tutorial_ttovum_longdescription: Can you control the chaos? Hack your way into the
+    cyberpunk world of Ovun City. Debug broken code, solve puzzles, and upgrade your
+    hardware as you explore self guided open world. Don't get caught by the drones!
+    It's up to you how Ovun City evolves.
+  tutorial_ttpassage_longdescription: Immerse yourself in an alien world to help Ada
+    escape unknown dangers. Play through this 2D platforming self-guided adventure
+    and learn coding techniques along the way. Players will become familiar with coding
+    techniques and syntax as they solve puzzles, fight monsters and beat the final
+    boss. Some previous familiarity with JavaScript might be useful but isn't required.
+  tutorial_tynkerhtmlen_longdescription: 'Part of the UN Sustainable Development Goals
+    project, this coding project has you create your own webpage exploring renewable
+    energy, energy efficiency, and access to energy. Design your own page showcasing
+    sustainability issues! '
+  tutorial_ttfrog_longdescription: Nostalgia turns educational in this familiar game
+    with a new twist! In an easy-to-understand and self-guided game, you will use
+    codeblocks and programming concepts to help your frog friend safely cross the
+    treacherous lands. Perfect for beginners and experts alike!
+  tutorial_codemojijava_longdescription: This activity introduces students to the
+    basics of Java programming using the Codemoji Terminal. Students learn everything
+    from basic types and variables to functions. Each lesson features an in depth
+    explanation of what each line of code does in order to ensure the students understand
+    what is happening. Each line of code in the lesson is guided for student success.
+  tutorial_ccfirewall_longdescription: Learn how to program your own shareable game!
+    Use code to teach a Hero magic spells to defeat waves and waves of baddies.
+  tutorial_htmljs_longdescription: Meet your new boss, Muffin the Cat, who is getting
+    ready for a CatFashion Expo. He needs a program to track the calories and is asking
+    you to help. In this fun and engaging activity, you will learn the basics of JavaScript
+    by looking at variables, operations, and data types and write MufFit – your first
+    program in JavaScript.
+  tutorial_ttaqueducts_longdescription: In this puzzle game, you're the hero bringing
+    water back to your village! Make your way through the levels in this self-guided
+    isometric experience. Levels will start simple, exposing players to basic coding
+    fundamentals. As you play, you will learn more complex coding techniques. Afterwards,
+    design and build your own levels and puzzles to share.
+  tutorial_vtgame_longdescription: Introduction to computational thinking and programming
+    video games in English. Create your video game in just minutes. Computing concepts
+    of abstraction, object-oriented design, algorithmic thinking, problem solving,
+    debugging, and critical thinking are incorporated. Target students are Grades
+    5 through 12. No prior programming experience necessary.
+  tutorial_baroborav_longdescription: Guide Linkbot as a robotic autonomous vehicle
+    (RAV) through a grid of streets! Students will learn to control a Linkbot robot
+    (virtual or hardware) using a drag-and-drop interface. They will also learn about
+    the important concept of loops and get practice using the Pythagorean theorem
+    to traverse triangular paths.
+  tutorial_baroboobstacle_longdescription: This series of 6 activities will introduce
+    students to basic coding and robotics concepts by using a drag-and-drop interface
+    to maneuver Linkbot robots (virtual and/or hardware) through a variety of obstacle
+    courses.
+  tutorial_pbstorytelling_longdescription: Dive into the world of interactive storytelling.
+    Learn the basics of how to create a story in Twine. Examine different story patterns
+    and structures that are unique to interactive stories. See some ways that interactive
+    storytelling differs from traditional creative writing.
+  tutorial_kibosnow_longdescription: 'The city is covered in snow, and we need to
+    design a KIBO snowplow to help clean up! Students will engage in the engineering
+    design process as they design, test, and improve snowplow robots that can help
+    clean up the cotton-ball snow. Students will also learn more about the many important
+    jobs that make a community function. '
+  tutorial_kibohappy_longdescription: If you're happy and you know it flash your light!
+    In this robotics lesson that also engages with music and social-emotional learning,
+    students collaboratively create a program for KIBO including both input and output
+    that expresses a feeling of happiness. Students learn that robots have output
+    parts that allow them to send information out into the world.
+  tutorial_rubylove_longdescription: 'Love Letters for Computers is a 10 part YouTube
+    series with classroom materials, to help primary school teachers to make computer
+    science more playful, whimsical and gentle for children. '
+  tutorial_spherosmiles_longdescription: Did you know a smile has super powers?! Program
+    your Sphero BOLT to brighten someone's day.
+  tutorial_spherobaby_longdescription: Learn to program "baby steps" to help teach
+    a friend to code.
+  tutorial_toxarchitect_longdescription: Code your builder robot in order to create
+    buildings and landscapes. Utopian Architect is a sandbox designed to facilitate
+    the discovery and the learning of the concept of function. Join us through our
+    activities that quickly raise questions related to the architecture of a program,
+    to the art of organizing thoughts and knowing how to break down big problems into
+    smaller problems.
+  tutorial_idodge_longdescription: This activity, adapted for the Hour of Code, develops
+    children's programming skills by creating apps using text - a simplified JavaScript
+    language. Using the PRIMM approach for teaching programming, the children explore
+    programs and use their computational thinking skills to problem solve, modify
+    and design/develop apps.
+  tutorial_firiacodebot_longdescription: Python fits your brain! Even if you've never
+    used a text-based language before, this activity will teach you everything you
+    need to get your Robot moving, lighting up, and responding to user inputs. CodeBot
+    is a revolutionary platform for authentic real-world coding, combining a real
+    programming language with powerful hardware. Your CODE is in complete control
+    of all the robot's functions!
+  tutorial_modlighthouse_longdescription: 'Students design a lighthouse based on design
+    criteria and constraints.  Then students iterate on that design to make it automatic,
+    and to customize its message. '
+  tutorial_spherogreen_longdescription: 'Learn how to use a counting number variable
+    to keep track of all your classrooms recycling. '
+  tutorial_ozopopstar_longdescription: 'Students will write and call functions, and
+    execute them with the Ozobot. This is the second of two lessons. '
+  tutorial_eddesign_longdescription: Introduce the key computational concepts of loops,
+    nested loops and sequential order using Edison robots and the Scratch-based programming
+    language EdScratch. Students can work through this lesson independently focusing
+    on the idea of patterns, including geometric shapes, and exploring how loops can
+    be used in programs which contain repeating code.
+  tutorial_edshapeup_longdescription: Introduce the key computational concepts of
+    definite loops and variables using Edison robots and EdPy, a text-based programming
+    language based on Python. Students can work through this lesson independently
+    as they practice using definite loops and pattern recognition in order to drive
+    familiar regular polygons before taking on the challenge of less common regular
+    polygons and irregular shapes.
+  tutorial_ozocolor_longdescription: 'Students will be introduced to the concept of
+    functions by using color codes to represent a function. This lesson is an introductory
+    and unplugged lesson to introduce the concept of functions. It is the first lesson
+    of a two lesson series, but either lesson can be taught in isolation. The second
+    lesson utilizes OzoBlockly to build on the concept of functions. '
+  tutorial_icomputeeggs_longdescription: This teacher-led activity, adapted for the
+    Hour of Code, provides pupils with an opportunity to explore physical programming
+    through robotics. Using a drag-and-drop programming environment and a programmable
+    robotic sphere, pupils design algorithms to program a robot to hide Easter eggs.
+    Includes step-by-step lesson plan, teacher/pupil resources and assessment guidance.
+  tutorial_rootunplugged_longdescription: Solve offline printable puzzles using the
+    power of programming, math and more to crack the code to where the Root Robot
+    is hiding!
+  tutorial_rgtreasure_longdescription: Robo Treasure Chest is an unplugged activity
+    that teaches students computational thinking and programming fundamentals in an
+    easy and enjoyable way. Students will learn simple movement commands and new programming
+    expressions like 'Bug' and 'Debug'. This activity also teaches multi-label scenarios
+    concept.
+  tutorial_peblioportraits_longdescription: 'Learn to program animated portraits for
+    a cause you believe in. '
+  tutorial_rootcodebreak_longdescription: Use your Root Robot and the Root Coding
+    app to power through printable puzzles and challenges to crack the code to where
+    Root is hiding.
+  tutorial_microbit14_longdescription: Code your way to preserving the oceans using
+    micro:bit. Find out more about Global Goal 14, Life Below Water and learn to code
+    a sea turtle beach light.
+  tutorial_barobomoon_longdescription: You're one of the pioneer astronauts at the
+    first permanent moon base, and while on an expedition away from base, a malfunction
+    incapacitates your lunar rover and radio. But with a little ingenuity you can
+    create a light-signaling device using an Arduino microcontroller, an LED, and
+    drag-and-drop coding to send an SOS.
+  tutorial_eddog_longdescription: Introduce the key computational concepts of loops
+    and conditionals using Edison robots and the programming language EdBlocks. Students
+    can work through this lesson independently, utilizing the Edison robot's IR light
+    sensors while applying sequential programming and decomposition to a set of progressive
+    programming challenges, exploring how robots can sense and react to the world.
+  tutorial_microbit15_longdescription: Code your way to protecting local wildlife
+    using micro:bit. Find out more about Global Goal 15, Life on Land and learn to
+    code a wildlife species counter.
+  tutorial_unity_longdescription: Create a real video game using C# computer code
+    and Unity, a professional platform for game development! All activity assets and
+    step-by-step tutorials are included. This project can be either teacher-led or
+    student-guided. For efficiency, we recommend that students complete one of the
+    preceding no-code Unity Creator Kits to learn the Unity interface prior to this
+    activity.
+  tutorial_blockscadtarget_longdescription: Test your target-hitting abilities by
+    writing code to move triangles around in three dimensions!
+  tutorial_tcadicicles_longdescription: Combine the power of code and computer-aided
+    design (CAD) to create a 3D icicle design. Then, learn how to print your design
+    if you have access to a 3D printer!
+  tutorial_blockscadscale_longdescription: Write code to create and 3D print scale
+    models of the world's most famous buildings!
+  tutorial_tcadloops_longdescription: Learn how code and computer-aided design (CAD)
+    can be combined to create a 3D model of a bursting star.
+  tutorial_phidgets_longdescription: Create an awesome musical instrument with Phidgets
+    and Processing!
+  tutorial_modvariables_longdescription: 'Students investigate how data flows through
+    a network using Cubelets robot blocks. This lesson assumes students are already
+    familiar with how Cubelets robot blocks work in general.  Visit modrobotics.com/thehub
+    for free "Meet Your Cubelets" lessons to introduce this computational thinking
+    tool to your students. '
+  tutorial_codestersmicro_longdescription: Connect your micro:bit to Codesters and
+    unlock a world of possibilities. Use your micro:bit as a game controller to help
+    your player head a soccer ball. Don't let the ball hit the ground! Micro Ball
+    is a simple, fun game that even a beginning coder can make.
+  tutorial_codestersdata_longdescription: Connect your micro:bit to Codesters and
+    unlock a world of possibilities. Learn how to collect and store data from micro:bit
+    sensors. Then graph the data as a scatter plot in Codesters. Prior knowledge of
+    loops, lists, and events is encouraged.
+  tutorial_ikodexmas_longdescription: This teacher-led activity, adapted for the Hour
+    of Code, introduces children to using a tile-based programming language to develop
+    coding skills. The children use algorithms, programming and computational thinking
+    skills to program Kodu to deliver presents on Christmas Eve. Includes step-by-step
+    lesson plan, pupil tutorial and assessment guidance.
+  tutorial_rpisensehat_longdescription: Learn how use the Sense HAT hardware to build
+    a data-logging device which can capture a range of information about its immediate
+    environment.
+  tutorial_mee_longdescription: Program the Minecraft Agent to collect data about
+    forest fires. Then write code to help prevent the spread of fire, save the village,
+    and bring life back to the forest. Learn coding basics and explore a real-world
+    example of artificial intelligence.
+  tutorial_kuborobo_longdescription: In this activity, students put their logic and
+    sequencing skills to the test as they use the Tagtiles to program their KUBO robot
+    to travel to various locations on a printed map.
+  tutorial_ai-oceans_longdescription: Computer science is about so much more than
+    coding! Learn about AI, machine learning, training data, and bias, while exploring
+    ethical issues and how AI can be used to address world problems.
+  tutorial_scratchimagine_string_detail_grades: Grades 2+
+  tutorial_codesterspsa_string_detail_grades: Grades 6+
+  tutorial_googlehero_string_detail_grades: Grades 2-8
+  tutorial_codestersbball_string_detail_grades: Grades 6+
+  tutorial_scratchcartoon_string_detail_grades: Grades 2+
+  tutorial_codemonkeyjr_string_detail_grades: Pre-reader
+  tutorial_bananatales_string_detail_grades: Grades 2-8
+  tutorial_scratchtales_string_detail_grades: Grades 2-8
+  tutorial_msemoji_string_detail_grades: Grades 6+
+  tutorial_cacolor_string_detail_grades: Grades 6+
+  tutorial_kodablebeach_string_detail_grades: Pre-reader - Grade 5
+  tutorial_tynkeren_string_detail_grades: Grades 2-8
+  tutorial_tynkerjavapro_string_detail_grades: Grades 6+
+  tutorial_grasshopperhack_string_detail_grades: Grades 9+
+  tutorial_pbskids_string_detail_grades: Pre-reader-Grade 5
+  tutorial_nclabdata_string_detail_grades: Grades 9+
+  tutorial_grasshopperphoto_string_detail_grades: Grades 9+
+  tutorial_tynkerpyland_string_detail_grades: Grades 6+
+  tutorial_codeitimages_string_detail_grades: Grades 2+
+  tutorial_hyperpadenemy_string_detail_grades: Grades 9+
+  tutorial_tynkerpro_string_detail_grades: Grades 2-8
+  tutorial_trashtag_string_detail_grades: Grades 6+
+  tutorial_casiege_string_detail_grades: Grades 2-8
+  tutorial_thunkableyeet_string_detail_grades: Grades 6+
+  tutorial_vidcodedeal_string_detail_grades: Grades 6+
+  tutorial_codehsgeno_string_detail_grades: Grades 9+
+  tutorial_hyperpadpong_string_detail_grades: Grades 9+
+  tutorial_tynkerland_string_detail_grades: Grades 2-8
+  tutorial_trinketgirl_string_detail_grades: Grades 6+
+  tutorial_rpimosquito_string_detail_grades: Grades 6-8
+  tutorial_tynkermars_string_detail_grades: Grades 6+
+  tutorial_cityx_string_detail_grades: Grades 6+
+  tutorial_vidcodemap_string_detail_grades: Grades 6+
+  tutorial_robotmagicfarm_string_detail_grades: Grades 2-8
+  tutorial_codehstriangle_string_detail_grades: Grades 6+
+  tutorial_ttwhitehouse_string_detail_grades: Grades 2+
+  tutorial_modulo_string_detail_grades: Grades 6+
+  tutorial_codingtown_string_detail_grades: Grades 2-5
+  tutorial_kanoart_string_detail_grades: Grades 2-5
+  tutorial_dragonscript_string_detail_grades: Grades 9+
+  tutorial_uwcloud_string_detail_grades: Grades 2+
+  tutorial_htmlmuffin_string_detail_grades: Grades 6-8
+  tutorial_microsoftpizza_string_detail_grades: Grades 6-8
+  tutorial_stemc_blckhole_string_detail_grades: Grades 9+
+  tutorial_careconfigure_string_detail_grades: Grades 6+
+  tutorial_rpiscratch_string_detail_grades: Grades 2-5
+  tutorial_ozaria_string_detail_grades: Grades 2+
+  tutorial_ttovum_string_detail_grades: Grades 6+
+  tutorial_ttpassage_string_detail_grades: Grades 2-8
+  tutorial_tynkerhtmlen_string_detail_grades: Grades 2+
+  tutorial_ttfrog_string_detail_grades: Grades 2-8
+  tutorial_codemojijava_string_detail_grades: Grades 6-8
+  tutorial_ccfirewall_string_detail_grades: Grades 6+
+  tutorial_htmljs_string_detail_grades: Grades 6-8
+  tutorial_ttaqueducts_string_detail_grades: Grades 6-8
+  tutorial_vtgame_string_detail_grades: Grades 6+
+  tutorial_baroborav_string_detail_grades: Grades 6+
+  tutorial_baroboobstacle_string_detail_grades: Grades 2+
+  tutorial_pbstorytelling_string_detail_grades: Grades 6+
+  tutorial_kibosnow_string_detail_grades: Pre-reader-Grade 5
+  tutorial_kibohappy_string_detail_grades: Pre-reader-Grade 5
+  tutorial_rubylove_string_detail_grades: Pre-reader-Grade 8
+  tutorial_spherosmiles_string_detail_grades: Grades 2+
+  tutorial_spherobaby_string_detail_grades: Pre-reader - Grade 8
+  tutorial_toxarchitect_string_detail_grades: Grades 6+
+  tutorial_idodge_string_detail_grades: Grades 2-8
+  tutorial_firiacodebot_string_detail_grades: Grades 6+
+  tutorial_modlighthouse_string_detail_grades: Pre-reader+
+  tutorial_spherogreen_string_detail_grades: Grades 2-8
+  tutorial_ozopopstar_string_detail_grades: Grades 2-8
+  tutorial_eddesign_string_detail_grades: Grades 6+
+  tutorial_edshapeup_string_detail_grades: Grades 6+
+  tutorial_ozocolor_string_detail_grades: Grades 2-8
+  tutorial_icomputeeggs_string_detail_grades: Grades 2-8
+  tutorial_rootunplugged_string_detail_grades: Grades 2-8
+  tutorial_rgtreasure_string_detail_grades: Pre-reader - Grade 5
+  tutorial_peblioportraits_string_detail_grades: Grades 9+
+  tutorial_rootcodebreak_string_detail_grades: Grades 2-8
+  tutorial_microbit14_string_detail_grades: Grades 2-8
+  tutorial_barobomoon_string_detail_grades: Grades 6+
+  tutorial_eddog_string_detail_grades: Grades 2-6
+  tutorial_microbit15_string_detail_grades: Grades 2-8
+  tutorial_unity_string_detail_grades: Grades 9+
+  tutorial_blockscadtarget_string_detail_grades: Grades 6+
+  tutorial_tcadicicles_string_detail_grades: Grades 7-8
+  tutorial_blockscadscale_string_detail_grades: Grades 6+
+  tutorial_tcadloops_string_detail_grades: Grades 5-6
+  tutorial_phidgets_string_detail_grades: Grades 9+
+  tutorial_modvariables_string_detail_grades: Grades 6+
+  tutorial_codestersmicro_string_detail_grades: Grades 6-8
+  tutorial_codestersdata_string_detail_grades: Grades 6-8
+  tutorial_ikodexmas_string_detail_grades: Grades 2-5
+  tutorial_rpisensehat_string_detail_grades: Grades 6+
+  tutorial_mee_string_detail_grades: Grades 2+
+  tutorial_kuborobo_string_detail_grades: Pre-reader - Grades 8
+  tutorial_ai-oceans_string_detail_grades: Grades 3+
+  tutorial_scratchimagine_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_codesterspsa_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_googlehero_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_codestersbball_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_scratchcartoon_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_codemonkeyjr_string_platforms: All modern browsers, Android tablet, iPad,
+    Android phone, iPhone
+  tutorial_bananatales_string_platforms: All modern browsers
+  tutorial_scratchtales_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_msemoji_string_platforms: Chrome, Safari
+  tutorial_cacolor_string_platforms: All modern browsers
+  tutorial_kodablebeach_string_platforms: All modern browsers, iPad, iPhone
+  tutorial_tynkeren_string_platforms: All modern browsers, iPad
+  tutorial_tynkerjavapro_string_platforms: 'All modern browsers '
+  tutorial_grasshopperhack_string_platforms: All modern browsers
+  tutorial_pbskids_string_platforms: Android tablet, iPad, Windows phone, Android
+    phone, iPhone, Game console app
+  tutorial_nclabdata_string_platforms: All modern browsers
+  tutorial_grasshopperphoto_string_platforms: All modern browsers
+  tutorial_tynkerpyland_string_platforms: 'All modern browsers '
+  tutorial_codeitimages_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_hyperpadenemy_string_platforms: iPad
+  tutorial_tynkerpro_string_platforms: All modern browsers, iPad
+  tutorial_trashtag_string_platforms: All modern browsers
+  tutorial_casiege_string_platforms: All modern browsers
+  tutorial_thunkableyeet_string_platforms: All modern browsers
+  tutorial_vidcodedeal_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_codehsgeno_string_platforms: All modern browsers
+  tutorial_hyperpadpong_string_platforms: iPad
+  tutorial_tynkerland_string_platforms: All modern browsers, iPad
+  tutorial_trinketgirl_string_platforms: All modern browsers, Android tablet, iPad,
+    Windows phone, Android phone, iPhone, Screen reader
+  tutorial_rpimosquito_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_tynkermars_string_platforms: All modern browsers, iPad
+  tutorial_cityx_string_platforms: Android tablet, iPad, Android phone, iPhone
+  tutorial_vidcodemap_string_platforms: All modern browsers
+  tutorial_robotmagicfarm_string_platforms: All modern browsers, Android tablet, iPad,
+    Windows phone, Android phone, iPhone
+  tutorial_codehstriangle_string_platforms: All modern browsers
+  tutorial_ttwhitehouse_string_platforms: Chrome, Firefox
+  tutorial_modulo_string_platforms: PCs
+  tutorial_codingtown_string_platforms: All modern browsers
+  tutorial_kanoart_string_platforms: Microsoft Edge, Chrome, Android tablet, iPad
+  tutorial_dragonscript_string_platforms: Chrome
+  tutorial_uwcloud_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_htmlmuffin_string_platforms: All modern browsers
+  tutorial_microsoftpizza_string_platforms: All modern browsers, Screen reader
+  tutorial_stemc_blckhole_string_platforms: All modern browsers, iPad
+  tutorial_careconfigure_string_platforms: All modern browsers
+  tutorial_rpiscratch_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_ozaria_string_platforms: All modern browsers
+  tutorial_ttovum_string_platforms: Chrome, Firefox
+  tutorial_ttpassage_string_platforms: Chrome, Firefox
+  tutorial_tynkerhtmlen_string_platforms: 'All modern browsers '
+  tutorial_ttfrog_string_platforms: Chrome, Firefox
+  tutorial_codemojijava_string_platforms: All modern browsers
+  tutorial_ccfirewall_string_platforms: All modern browsers, iPad
+  tutorial_htmljs_string_platforms: All modern browsers, Screen reader
+  tutorial_ttaqueducts_string_platforms: Chrome, Firefox
+  tutorial_vtgame_string_platforms: All modern browsers, iPad
+  tutorial_baroborav_string_platforms: All modern browsers
+  tutorial_baroboobstacle_string_platforms: All modern browsers
+  tutorial_pbstorytelling_string_platforms: All modern browsers
+  tutorial_kibosnow_string_platforms: KIBO Robot Kit
+  tutorial_kibohappy_string_platforms: KIBO Robot Kit
+  tutorial_rubylove_string_platforms: All modern browsers, Unplugged
+  tutorial_spherosmiles_string_platforms: All modern browsers, Android tablet, iPad,
+    Android phone, iPhone
+  tutorial_spherobaby_string_platforms: All modern browsers, Android tablet, iPad,
+    Android phone, iPhone
+  tutorial_toxarchitect_string_platforms: All modern browsers
+  tutorial_idodge_string_platforms: All modern browsers
+  tutorial_firiacodebot_string_platforms: All modern browsers
+  tutorial_modlighthouse_string_platforms: All modern browsers, Android tablet, Android
+    phone, iPad, iPhone
+  tutorial_spherogreen_string_platforms: All modern browsers, Android tablet, iPad,
+    Android phone, iPhone
+  tutorial_ozopopstar_string_platforms: All modern browsers
+  tutorial_eddesign_string_platforms: All modern browsers, iPad, Android tablets
+  tutorial_edshapeup_string_platforms: All modern browsers
+  tutorial_ozocolor_string_platforms: Unplugged
+  tutorial_icomputeeggs_string_platforms: All modern browers, Android phone, Android
+    tablet, iPad, iPhone
+  tutorial_rootunplugged_string_platforms: Unplugged
+  tutorial_rgtreasure_string_platforms: Unplugged
+  tutorial_peblioportraits_string_platforms: Chrome
+  tutorial_rootcodebreak_string_platforms: iPad
+  tutorial_microbit14_string_platforms: All modern browsers
+  tutorial_barobomoon_string_platforms: All modern browsers
+  tutorial_eddog_string_platforms: All modern browsers, iPad, Android tablets
+  tutorial_microbit15_string_platforms: All modern browsers
+  tutorial_unity_string_platforms: All modern browsers
+  tutorial_blockscadtarget_string_platforms: All modern browsers
+  tutorial_tcadicicles_string_platforms: All modern browsers
+  tutorial_blockscadscale_string_platforms: All modern browsers
+  tutorial_tcadloops_string_platforms: All modern browsers
+  tutorial_phidgets_string_platforms: All modern browsers
+  tutorial_modvariables_string_platforms: All modern browsers, Android tablet, Android
+    phone, iPad, iPhone
+  tutorial_codestersmicro_string_platforms: 'All modern browsers '
+  tutorial_codestersdata_string_platforms: 'All modern browsers '
+  tutorial_ikodexmas_string_platforms: All modern browsers
+  tutorial_rpisensehat_string_platforms: All modern browsers
+  tutorial_mee_string_platforms: All modern browsers, Mac, Windows, Chromebook, iPhone,
+    iPad, Android phone, Android tablet
+  tutorial_kuborobo_string_platforms: Unplugged
+  tutorial_ai-oceans_string_platforms: All modern browsers, modern Android tablets,
+    iPads, modern Android phones, iPhones
+  tutorial_scratchimagine_string_detail_platforms: ''
+  tutorial_codesterspsa_string_detail_platforms: ''
+  tutorial_googlehero_string_detail_platforms: ''
+  tutorial_codestersbball_string_detail_platforms: ''
+  tutorial_scratchcartoon_string_detail_platforms: ''
+  tutorial_codemonkeyjr_string_detail_platforms: ''
+  tutorial_bananatales_string_detail_platforms: ''
+  tutorial_scratchtales_string_detail_platforms: ''
+  tutorial_msemoji_string_detail_platforms: ''
+  tutorial_cacolor_string_detail_platforms: ''
+  tutorial_kodablebeach_string_detail_platforms: ''
+  tutorial_tynkeren_string_detail_platforms: ''
+  tutorial_tynkerjavapro_string_detail_platforms: ''
+  tutorial_grasshopperhack_string_detail_platforms: ''
+  tutorial_pbskids_string_detail_platforms: ''
+  tutorial_nclabdata_string_detail_platforms: ''
+  tutorial_grasshopperphoto_string_detail_platforms: ''
+  tutorial_tynkerpyland_string_detail_platforms: ''
+  tutorial_codeitimages_string_detail_platforms: ''
+  tutorial_hyperpadenemy_string_detail_platforms: ''
+  tutorial_tynkerpro_string_detail_platforms: ''
+  tutorial_trashtag_string_detail_platforms: ''
+  tutorial_casiege_string_detail_platforms: ''
+  tutorial_thunkableyeet_string_detail_platforms: ''
+  tutorial_vidcodedeal_string_detail_platforms: ''
+  tutorial_codehsgeno_string_detail_platforms: ''
+  tutorial_hyperpadpong_string_detail_platforms: ''
+  tutorial_tynkerland_string_detail_platforms: ''
+  tutorial_trinketgirl_string_detail_platforms: ''
+  tutorial_rpimosquito_string_detail_platforms: ''
+  tutorial_tynkermars_string_detail_platforms: ''
+  tutorial_cityx_string_detail_platforms: ''
+  tutorial_vidcodemap_string_detail_platforms: ''
+  tutorial_robotmagicfarm_string_detail_platforms: ''
+  tutorial_codehstriangle_string_detail_platforms: ''
+  tutorial_ttwhitehouse_string_detail_platforms: ''
+  tutorial_modulo_string_detail_platforms: ''
+  tutorial_codingtown_string_detail_platforms: ''
+  tutorial_kanoart_string_detail_platforms: ''
+  tutorial_dragonscript_string_detail_platforms: ''
+  tutorial_uwcloud_string_detail_platforms: ''
+  tutorial_htmlmuffin_string_detail_platforms: ''
+  tutorial_microsoftpizza_string_detail_platforms: ''
+  tutorial_stemc_blckhole_string_detail_platforms: ''
+  tutorial_careconfigure_string_detail_platforms: ''
+  tutorial_rpiscratch_string_detail_platforms: ''
+  tutorial_ozaria_string_detail_platforms: ''
+  tutorial_ttovum_string_detail_platforms: ''
+  tutorial_ttpassage_string_detail_platforms: ''
+  tutorial_tynkerhtmlen_string_detail_platforms: ''
+  tutorial_ttfrog_string_detail_platforms: ''
+  tutorial_codemojijava_string_detail_platforms: ''
+  tutorial_ccfirewall_string_detail_platforms: ''
+  tutorial_htmljs_string_detail_platforms: ''
+  tutorial_ttaqueducts_string_detail_platforms: ''
+  tutorial_vtgame_string_detail_platforms: ''
+  tutorial_baroborav_string_detail_platforms: ''
+  tutorial_baroboobstacle_string_detail_platforms: ''
+  tutorial_pbstorytelling_string_detail_platforms: ''
+  tutorial_kibosnow_string_detail_platforms: KIBO Robot Kit
+  tutorial_kibohappy_string_detail_platforms: KIBO Robot Kit
+  tutorial_rubylove_string_detail_platforms: ''
+  tutorial_spherosmiles_string_detail_platforms: Sphero BOLT
+  tutorial_spherobaby_string_detail_platforms: Sphero SPRK+, Sphero Mini, or Sphero
+    BOLT
+  tutorial_toxarchitect_string_detail_platforms: ''
+  tutorial_idodge_string_detail_platforms: ''
+  tutorial_firiacodebot_string_detail_platforms: CodeBot robot
+  tutorial_modlighthouse_string_detail_platforms: Cubelets Robot Blocks
+  tutorial_spherogreen_string_detail_platforms: Sphero BOLT, Sphero SPRK+, or Sphero
+    Mini
+  tutorial_ozopopstar_string_detail_platforms: Ozobot
+  tutorial_eddesign_string_detail_platforms: Edison robot
+  tutorial_edshapeup_string_detail_platforms: Edison robot
+  tutorial_ozocolor_string_detail_platforms: Ozobot
+  tutorial_icomputeeggs_string_detail_platforms: Sphero
+  tutorial_rootunplugged_string_detail_platforms: ''
+  tutorial_rgtreasure_string_detail_platforms: ''
+  tutorial_peblioportraits_string_detail_platforms: ''
+  tutorial_rootcodebreak_string_detail_platforms: Root robot
+  tutorial_microbit14_string_detail_platforms: micro:bit
+  tutorial_barobomoon_string_detail_platforms: Barobo Arduino Starter Kit
+  tutorial_eddog_string_detail_platforms: Edison robot
+  tutorial_microbit15_string_detail_platforms: micro:bit
+  tutorial_unity_string_detail_platforms: Unity software
+  tutorial_blockscadtarget_string_detail_platforms: ''
+  tutorial_tcadicicles_string_detail_platforms: ''
+  tutorial_blockscadscale_string_detail_platforms: ''
+  tutorial_tcadloops_string_detail_platforms: ''
+  tutorial_phidgets_string_detail_platforms: Phidgets Getting Started Kit, Phidgets
+    Distance Sensors.
+  tutorial_modvariables_string_detail_platforms: Cubelets Robot Blocks
+  tutorial_codestersmicro_string_detail_platforms: BBC micro:bit
+  tutorial_codestersdata_string_detail_platforms: BBC micro:bit
+  tutorial_ikodexmas_string_detail_platforms: Microsoft Kodu
+  tutorial_rpisensehat_string_detail_platforms: Raspbian (software), SenseHAT
+  tutorial_mee_string_detail_platforms: ''
+  tutorial_kuborobo_string_detail_platforms: KUBO robot
+  tutorial_ai-oceans_string_detail_platforms: ''
+  tutorial_scratchimagine_string_detail_programming_languages: Blocks
+  tutorial_codesterspsa_string_detail_programming_languages: Python
+  tutorial_googlehero_string_detail_programming_languages: Blocks, Scratch
+  tutorial_codestersbball_string_detail_programming_languages: Python
+  tutorial_scratchcartoon_string_detail_programming_languages: Blocks
+  tutorial_codemonkeyjr_string_detail_programming_languages: Blocks
+  tutorial_bananatales_string_detail_programming_languages: Python
+  tutorial_scratchtales_string_detail_programming_languages: Blocks
+  tutorial_msemoji_string_detail_programming_languages: JavaScript, Python
+  tutorial_cacolor_string_detail_programming_languages: Computational Thinking focused
+    so no language
+  tutorial_kodablebeach_string_detail_programming_languages: Language independent
+    (can be taught in multiple languages)
+  tutorial_tynkeren_string_detail_programming_languages: Blocks
+  tutorial_tynkerjavapro_string_detail_programming_languages: JavaScript, HTML, CSS
+  tutorial_grasshopperhack_string_detail_programming_languages: JavaScript
+  tutorial_pbskids_string_detail_programming_languages: Blocks
+  tutorial_nclabdata_string_detail_programming_languages: Structured Query Language
+    (SQL), specifically PostgreSQL
+  tutorial_grasshopperphoto_string_detail_programming_languages: JavaScript
+  tutorial_tynkerpyland_string_detail_programming_languages: Python
+  tutorial_codeitimages_string_detail_programming_languages: Blocks
+  tutorial_hyperpadenemy_string_detail_programming_languages: hyperPad Visual Programming
+  tutorial_tynkerpro_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_trashtag_string_detail_programming_languages: Blocks
+  tutorial_casiege_string_detail_programming_languages: Security theory based
+  tutorial_thunkableyeet_string_detail_programming_languages: Blocks
+  tutorial_vidcodedeal_string_detail_programming_languages: JavaScript
+  tutorial_codehsgeno_string_detail_programming_languages: Python
+  tutorial_hyperpadpong_string_detail_programming_languages: hyperPad Visual Programming
+  tutorial_tynkerland_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_trinketgirl_string_detail_programming_languages: Python
+  tutorial_rpimosquito_string_detail_programming_languages: Scratch
+  tutorial_tynkermars_string_detail_programming_languages: Blocks, JavaScript, Python,
+    HTML, CSS
+  tutorial_cityx_string_detail_programming_languages: Python
+  tutorial_vidcodemap_string_detail_programming_languages: JavaScript
+  tutorial_robotmagicfarm_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_codehstriangle_string_detail_programming_languages: Python
+  tutorial_ttwhitehouse_string_detail_programming_languages: SCSS, CSS
+  tutorial_modulo_string_detail_programming_languages: Lua
+  tutorial_codingtown_string_detail_programming_languages: JavaScript
+  tutorial_kanoart_string_detail_programming_languages: Blocks
+  tutorial_dragonscript_string_detail_programming_languages: JavaScript, HTML
+  tutorial_uwcloud_string_detail_programming_languages: Language independent (can
+    be taught in multiple languages)
+  tutorial_htmlmuffin_string_detail_programming_languages: HTML and CSS
+  tutorial_microsoftpizza_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_stemc_blckhole_string_detail_programming_languages: JavaScript
+  tutorial_careconfigure_string_detail_programming_languages: Python
+  tutorial_rpiscratch_string_detail_programming_languages: Scratch
+  tutorial_ozaria_string_detail_programming_languages: JavaScript, Python
+  tutorial_ttovum_string_detail_programming_languages: JavaScript
+  tutorial_ttpassage_string_detail_programming_languages: JavaScript
+  tutorial_tynkerhtmlen_string_detail_programming_languages: HTML, CSS
+  tutorial_ttfrog_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_codemojijava_string_detail_programming_languages: Java
+  tutorial_ccfirewall_string_detail_programming_languages: Blocks
+  tutorial_htmljs_string_detail_programming_languages: JavaScript
+  tutorial_ttaqueducts_string_detail_programming_languages: JavaScript, CoffeeScript
+  tutorial_vtgame_string_detail_programming_languages: English
+  tutorial_baroborav_string_detail_programming_languages: Blocks, C/C++
+  tutorial_baroboobstacle_string_detail_programming_languages: Blocks, C/C++
+  tutorial_pbstorytelling_string_detail_programming_languages: Twine (Harlowe variant)
+  tutorial_kibosnow_string_detail_programming_languages: Blocks, Tangible blocks (no
+    screen use)
+  tutorial_kibohappy_string_detail_programming_languages: Blocks, Tangible blocks
+    (no screen use)
+  tutorial_rubylove_string_detail_programming_languages: Blocks, Language independent
+    (can be taught in multiple languages)
+  tutorial_spherosmiles_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_spherobaby_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_toxarchitect_string_detail_programming_languages: JavaScript
+  tutorial_idodge_string_detail_programming_languages: Simplified version of JavaScript
+  tutorial_firiacodebot_string_detail_programming_languages: Python
+  tutorial_modlighthouse_string_detail_programming_languages: Language independent
+    (can be taught in multiple languages)
+  tutorial_spherogreen_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_ozopopstar_string_detail_programming_languages: Blocks
+  tutorial_eddesign_string_detail_programming_languages: Blocks
+  tutorial_edshapeup_string_detail_programming_languages: Python, EdPy, a text-based
+    programming language based on Python.
+  tutorial_ozocolor_string_detail_programming_languages: Blocks
+  tutorial_icomputeeggs_string_detail_programming_languages: Blocks
+  tutorial_rootunplugged_string_detail_programming_languages: Blocks
+  tutorial_rgtreasure_string_detail_programming_languages: Blocks
+  tutorial_peblioportraits_string_detail_programming_languages: JavaScript
+  tutorial_rootcodebreak_string_detail_programming_languages: Blocks
+  tutorial_microbit14_string_detail_programming_languages: Blocks
+  tutorial_barobomoon_string_detail_programming_languages: Blocks, C/C++
+  tutorial_eddog_string_detail_programming_languages: Blocks
+  tutorial_microbit15_string_detail_programming_languages: Blocks
+  tutorial_unity_string_detail_programming_languages: C#
+  tutorial_blockscadtarget_string_detail_programming_languages: Blocks
+  tutorial_tcadicicles_string_detail_programming_languages: Blocks
+  tutorial_blockscadscale_string_detail_programming_languages: Blocks
+  tutorial_tcadloops_string_detail_programming_languages: Blocks
+  tutorial_phidgets_string_detail_programming_languages: Java, Phidgets support ALL
+    major programming languages. Can easily adapt this project to another language/environment.
+  tutorial_modvariables_string_detail_programming_languages: Language independent
+    (can be taught in multiple languages)
+  tutorial_codestersmicro_string_detail_programming_languages: Python
+  tutorial_codestersdata_string_detail_programming_languages: Python
+  tutorial_ikodexmas_string_detail_programming_languages: Microsoft Kodu
+  tutorial_rpisensehat_string_detail_programming_languages: Python
+  tutorial_mee_string_detail_programming_languages: Blocks
+  tutorial_kuborobo_string_detail_programming_languages: Tagtiles that students piece
+    together
+  tutorial_ai-oceans_string_detail_programming_languages: AI and Machine Learning
+  tutorial_hello_name: Hello World
+  tutorial_raspispace_name: 'Space Talk: Launch into Scratch coding'
+  tutorial_codemonkeyjump_name: 'Blocks Jumper: Game Creation'
+  tutorial_poemart_name: Poem Art
+  tutorial_kodablehero_name: Design your Hero
+  tutorial_cacloud_name: Operation Cloud
+  tutorial_blocksmithbot_name: Bot is sus?!
+  tutorial_hatchmario_name: 'Mario''s Secret Adventure: Build Your Own 3D Mario Game'
+  tutorial_microsoftforest_name: Save the Forest!
+  tutorial_blackbirdscreen_name: Screen Saver
+  tutorial_toxicodecompute2_name: Discover Python with Compute it
+  tutorial_minecrafttimecraft_name: Minecraft Timecraft
+  tutorial_blackbirdtether_name: Tetherball
+  tutorial_ob_name: Outbreak Simulator
+  tutorial_codeartportrait_name: Code Your Self-Portrait
+  tutorial_shelly_name: 'Shelly: Learn programming by drawing!'
+  tutorial_weavly_name: 'Weavly: Activities at Home'
+  tutorial_codespeakpassword_name: Program a Strong Password Generator in Python
+  tutorial_kodableshapes_name: Make Shapes with Code
+  tutorial_nasabinary_name: 'Binary Code: How to Talk to a Spacecraft'
+  tutorial_3dmaker_name: 3D Maker
+  tutorial_itchstart_name: 'iTCHcode: Scratch 5 Block Starter'
+  tutorial_hopsub_name: Build Subway Surfers with a Friend
+  tutorial_itchmundos_name: Los mundos en mi mundo_E2
+  tutorial_itchtenacity_name: Tenacity
+  tutorial_kcjskiing_name: 'Sport + Code: Skiing'
+  tutorial_groksecurity_name: 'Cyber Security: Defence Against the Dark Hats'
+  tutorial_creaticode_name: 3D Programming with Scratch Blocks
+  tutorial_kcjhockey_name: 'Sport + Code: Hockey'
+  tutorial_ttdungeon_name: Binary Dungeon
+  tutorial_ccai_name: Road to the AI League
+  tutorial_bsdai_name: AI Webcam Image Classifier
+  tutorial_stemdata_name: 'Data Science: Earth Day'
+  tutorial_thunkableinfo_name: Build an Informational App on Thunkable
+  tutorial_educodespace_name: Space Solo
+  tutorial_kcjtennis_name: 'Sport + Code: Tennis'
+  tutorial_robotmagictower_name: Hanoi Tower Game - recursive functions
+  tutorial_ttdragons_name: Dragon's Apprentice Chapter 1
+  tutorial_kcjarchery_name: 'Sport + Code: Archery'
+  tutorial_ttsprouts_name: Crowded Sprouts
+  tutorial_ttmaze_name: The Maze
+  tutorial_codetribe_name: 'Code Tribe: 10 Minute Program'
+  tutorial_ttcanyon_name: 'The Canyon: Battle Arena'
+  tutorial_kcjxtrail_name: 'Sport + Code: Xtrail'
+  tutorial_codespeakroad_name: Build a Road Game in Scratch
+  tutorial_educodelair_name: Chiroptera's Lair
+  tutorial_ibmhourofz_name: IBM Hour of Z
+  tutorial_gamefrootbacteria_name: Coding Bacteria with Gamefroot
+  tutorial_educodeforest_name: The Frosted Forest
+  tutorial_educodehorus_name: Temple of Horus
+  tutorial_codespeakpokemon_name: Code a Pokemon Evolution Game
+  tutorial_stemholiday_name: Code a Virtual Holiday Card
+  tutorial_codespeakpixel_name: Code a Pixel Art Editor in Bitsbox
+  tutorial_codespellsnexus_name: 'CodeSpells: The Nexus'
+  tutorial_carnegieslime_name: Super Slime Battle
+  tutorial_ozotown_name: 'Ozobot Blockly Challenge: OzoTown'
+  tutorial_milnedash_name: Dash Joins a Dance Circle
+  tutorial_microbitpet_name: micro:bit pet
+  tutorial_spherotriad_name: CIA Triad and Cybersecurity
+  tutorial_spheropassword_name: Password Security and Protection
+  tutorial_codequilt_name: CodeQuilt
+  tutorial_ozoshape1_name: 'Ozobot Blockly Challenge: ShapeTracer 1'
+  tutorial_ozoshape2_name: 'Ozobot Blockly Challenge: ShapeTracer 2'
+  tutorial_hopescape_name: Can You Escape? Build an Escape Room with Hopscotch
+  tutorial_ozorace_name: 50 cm Race
+  tutorial_ozoequestrian_name: Equestrian Event
+  tutorial_irobotpizza_name: Robot Pizza Party
+  tutorial_ai4alldance_name: 'AI4ALL: AI & Dance'
+  tutorial_ai4allneural_name: How Convolutional Neural Networks Work
+  tutorial_spheroinout_name: Inputs and Outputs
+  tutorial_edisonblueprint_name: Edison the Blueprint Designer
+  tutorial_edisonmaze_name: Edison the Maze Racer
+  tutorial_milnefunctions_name: Dash Joins a Dance Circle (with Functions)
+  tutorial_sasmap_name: 'Show With Code: Features on a Map'
+  tutorial_firstrobotics_name: FIRST Tech Challenge Simulator
+  tutorial_sasdata_name: Building Data Fundamentals
+  tutorial_carnegiesensabot_name: Sensabot Challenge
+  tutorial_robotical4_name: Hour of Code Activity 4 - Getting Started with MartyBlocks
+  tutorial_kinderadd_name: Adding and Subtracting with KIBO
+  tutorial_imagipython_name: Creative Coding in Python
+  tutorial_robotical2_name: Hour of Code Activity 2 - the Marty Controller
+  tutorial_robotical3_name: Hour of Code Activity 3 - Getting Started with Marty Blocks
+    Jr
+  tutorial_blockscadvirus_name: BlocksCAD Modeling a Virus with Code
+  tutorial_robotical1_name: Hour of Code Activity 1 - Marty Unplugged
+  tutorial_irobotshapes_name: 'Robotics for K-2: Robot Shapes'
+  tutorial_irobotparts_name: 'Robotics for K-2: Robot Parts'
+  tutorial_irobottools_name: 'Robotics for K-2: Robot Tools'
+  tutorial_kindercar_name: Create Your Dream Car with KIBO
+  tutorial_caavatar_name: 'AVATAR: Big Data & Digital Footprints'
+  tutorial_hello_longdescription: Learn the basics of computer science by programming
+    in Sprite Lab. You will create and animate sprites, and make your own interactive
+    scenes.
+  tutorial_raspispace_longdescription: Create a space scene with characters that 'emote'
+    to share their thoughts or feelings using sounds, colours, and actions. Use Scratch
+    blocks to code your characters with graphic effects, costume animation, speech
+    bubbles and sound effects.
+  tutorial_codemonkeyjump_longdescription: Create games and projects with block coding!
+    In this short course students will learn to create a simple jumper game using
+    basic event and function blocks.
+  tutorial_poemart_longdescription: Illustrate the mood of a poem with code.
+  tutorial_kodablehero_longdescription: Welcome to Bug World! The Kodable fuzzFamily
+    needs your coding help. Use your real-life heroes and your imagination to design
+    a character who will protect the fuzzFamily. You'll choose the properties your
+    hero possesses and put their strength to the test against the buggy slimes of
+    Bug World!
+  tutorial_cacloud_longdescription: Felix posts a seemingly innocent photo of Juno
+    on social media. She desperately wants it removed. Max, her friend, is quick to
+    turn the situation into a secret mission. Join them as they learn about cloud
+    computing and try to track down the photo on a server, stored in an ultra secure
+    data centre. Is there anyway to locate and destroy the photo?
+  tutorial_blocksmithbot_longdescription: Lasers, traps and marvelous mazes! Help
+    Bot0 escape before she gets ejected! Bot0 is a friendly, harmless helper robot.
+    Or is she? Her teammates believe otherwise. Program Bot0 to make her way through
+    the underbelly of the space ship and escape before they find her.
+  tutorial_hatchmario_longdescription: Build your very own 3D Mario game, while learning
+    the basics of programming. Learn about the fundamentals of game development; form
+    an understanding of motion in 3D space; learn to add score, lives and cool sound
+    effects to your game, all in less than an hour. And the best part, you can share
+    your game with your family and friends in just one click and play with them on
+    any device in your home.
+  tutorial_microsoftforest_longdescription: Code a game with Microsoft MakeCode Arcade
+    that recreates the conditions for a forest fire, and then code your fire-fighting
+    airtanker plane to spray water and put out the flames!
+  tutorial_blackbirdscreen_longdescription: Learn how to use conditional statements
+    to create a cool 90s style screen saver.
+  tutorial_toxicodecompute2_longdescription: Let's switch roles. This time YOU are
+    the computer! Read and interpret Python programs to find the right trajectory
+    and win the challenges. You will have to focus and use your intuitive abilities
+    to understand some core concepts of Python.
+  tutorial_minecrafttimecraft_longdescription: 'Travel back in time to save the future
+    in this free Hour of Code lesson in Minecraft: Education Edition. Students will
+    choose their own adventure and learn basic coding concepts to correct mysterious
+    mishaps throughout history. Along the way, they''ll connect with great innovators
+    and inventions in science, architecture, music, engineering, and more.'
+  tutorial_blackbirdtether_longdescription: Learn to use objects to program a fun,
+    physics-based game.
+  tutorial_ob_longdescription: Write code to create and run your own simulation of
+    the virus outbreak at Monster Town. A simulation is a computer model of a process
+    or system. Learn to code and make predictions about what will happen to the neighbors
+    of Monster Town.
+  tutorial_codeartportrait_longdescription: 'Learn to program your portrait using
+    p5.js. Express yourself creatively through code by incorporating your favorite
+    artistic styles and personal touches to create a true masterpiece! You may be
+    eligible to submit your finished project to Code/Art’s CodeYourSelf competition
+    for U.S. girls in grades 3-12. '
+  tutorial_shelly_longdescription: Shelly is a programming language for drawing. Drawing
+    is done by issuing instructions to a turtle. The turtle draws lines and shapes
+    as it moves, using various colors and styles. Challenge and creative modes are
+    available. The challenge mode includes a step-by-step tutorial, which introduces
+    the basics of the Shelly language and of programming in general.
+  tutorial_weavly_longdescription: In these short activities, go on a series of missions,
+    from exploring planets, to visiting animals on a safari, to hunting for sunken
+    treasure!
+  tutorial_codespeakpassword_longdescription: Learn to code a password generator in
+    Python and stay safe against hackers.
+  tutorial_kodableshapes_longdescription: 'Math is a part of our lives everywhere.
+    Use math and coding skills to make your own maze and then try to solve it. Start
+    with a basic square and then see how many different shapes you can include in
+    your maze designs! '
+  tutorial_nasabinary_longdescription: Learn how we use binary code to talk to a spacecraft,
+    and then try it yourself by translating your name into binary code on a name tag,
+    bracelet, pin, or even sound.
+  tutorial_3dmaker_longdescription: Make your own really cool, rotatable, 3D objects
+    fast and easily.
+  tutorial_itchstart_longdescription: This lesson is a good entry point for kids grade
+    2 or 3 that are just trying out Scratch for the very first time. They will get
+    to start with a set of 5 blocks that they need to put together to make their character
+    perform some actions.
+  tutorial_hopsub_longdescription: Learn how to pair program with a friend or classmate,
+    and create your own subway surfer with Hopscotch characters!
+  tutorial_itchmundos_longdescription: Conocerán Scratch, una herramienta para programar.
+    Agregarán objetos y fondos, usarán bloques de eventos y apariencia para dar vida
+    a su programa.
+  tutorial_itchtenacity_longdescription: En este proyecto programan en Scratch el
+    simulador de un robot que limpia las aguas marinas.
+  tutorial_kcjskiing_longdescription: 'It''s all fun and games until someone crashes
+    into a tree… or IS that the fun part? Strap on those skis and bend at the knees
+    as you guide your character down a hill of frozen obstacles using code in this
+    Scratch activity. Design the course, add movement and sensing, plus a bit of collision-interaction
+    and boom - you''ve got yourself a mountain of fun. '
+  tutorial_groksecurity_longdescription: Put your cyber-sleuthing hat on in this short
+    introduction to staying safe online. You'll learn about secure passwords, phishing,
+    security settings, social media and more!
+  tutorial_creaticode_longdescription: Learn to build stunning 3D projects using Scratch
+    blocks!
+  tutorial_kcjhockey_longdescription: You shoot, you SCORE - the crowd goes wild!
+    No need to lace up your skates when building this game, but be ready to sharpen
+    your coding skills! Learn how to code your own hockey game and test our skills
+    against an npc goalie in Scratch. Using movement, sensing, and variables, your
+    digital player can dodge and glide the puck to score the winning goal.
+  tutorial_ttdungeon_longdescription: The evil wizard Nullonor poses a grave threat
+    to the realm, and only you have the power to banish them forever. However, Nullonor
+    is as cunning as he is dangerous. He hides in his magical tower of ever-shifting
+    rooms, and no hero has successfully reached the top floor yet. As the champion
+    of the Index Knights, do you have what it takes to find and defeat Nullonor?
+  tutorial_ccai_longdescription: 'Competitive coding has never been so epic! No coding
+    experience...No problem. Enter the dungeon where you will level up your programming
+    powers by learning the coding strategies and tactics you will need to compete.
+    Once you''ve made it through the dungeon you''ll be ready to take on coders from
+    around the world in the CodeCombat AI League esports arena! '
+  tutorial_bsdai_longdescription: There is a specific set of neural networks and algorithms
+    that we call machine learning. In this project, we will explore an Artificial
+    Intelligence (AI) Image Recognition tool and learn how AI sees images, makes predictions,
+    and how we can make sure that those predictions are accurate and free of bias.
+  tutorial_stemdata_longdescription: Create a simple model for the climate where you
+    live and then use it to understand how a few degrees of increased temperature
+    can have a significant impact on the natural world. Includes an option to download
+    the data to a spreadsheet for further analysis.
+  tutorial_thunkableinfo_longdescription: Learn how to build an informational app
+    with code blocks and a data table
+  tutorial_educodespace_longdescription: The people of planet Allegrus have lost their
+    ancestral songs. Follow this tutorial to build your own musical side-scrolling
+    game and recover the lost melodies. Customize every aspect of the game, while
+    learning the basics of game development, physics and collisions. No coding or
+    musical knowledge required.
+  tutorial_kcjtennis_longdescription: Serve up a challenge and go head-to-head with
+    your own AI opponent in this digital tennis match. Using Scratch, this activity
+    will teach you how to code back-and-forth sprite interactions through broadcasting,
+    variables, and movement. Incorporate win/loss conditionals and kiss your 'love'
+    score good bye. Complete this project by yourself or with support from a grown
+    up.
+  tutorial_robotmagictower_longdescription: Learn about the Hanoi Tower game and how
+    to use recursive functions to solve problems.
+  tutorial_ttdragons_longdescription: 'An evil force has spread its way across the
+    land of Ovun and is threatening to destroy this peaceful city. Explore hidden
+    temples, learn magic runes that let you program and control the elements around
+    you, and battle the shadow fiends. Find all the keys in the Dragon Temples to
+    awaken the dragon. Be the hero that Ovun needs! '
+  tutorial_kcjarchery_longdescription: Stay on target and guide your arrow to the
+    bullseye using code! Learn how to code your own archery game using Scratch and
+    our step-by-step instructions. With the help of colour-sensing sprites, costume
+    changes, and motion sequences, you too can aim for gold and code your way to victory
+    - plus, add a score counter to up the ante. Complete this project by yourself
+    or with support from a grown up.
+  tutorial_ttsprouts_longdescription: Gardening is a full-time job! Start with just
+    a single bench of pots and tend to the plants within a greenhouse by accessing
+    an array. As you seed, water, and harvest each plant, earn money for all your
+    fruits and veggies! Use an increasingly complicated multidimensional array to
+    locate each pot as the greenhouse gets crowded.
+  tutorial_ttmaze_longdescription: You have landed on an alien planet in a pocket
+    universe and must find a way to escape so you can continue on your journey. Explore
+    the ruins of an advanced robotic civilization, navigate your way through mazes
+    and puzzles and fight off enemy robots. With the help of your trusty sidekick
+    F3lix, learn and use new programming concepts to hack your way to victory.
+  tutorial_codetribe_longdescription: A great intro to coding using HTML, CSS and
+    JavaScript. Code a few lines, and create your first application to verify the
+    age of people attending your party.
+  tutorial_ttcanyon_longdescription: You are trapped on an alien planet and must survive
+    the Arena, an endless fight with alien monsters! Use your hacking blaster to change
+    the programming of your sidekick, your opponents, and your environment. Your trusty
+    feline sidekick F3lix can help heal and support you, while you can reprogram enemies
+    and traps to disable them or fight each other.
+  tutorial_kcjxtrail_longdescription: Hit the trails with this cross country biking
+    activity using code and Scratch. Utilizing colour sensing blocks and movement,
+    you will design your course, integrate stops and interactions along the way, and
+    track your progress by coding a score keeper with functions. Don't forget your
+    helmet because we could be in for a wild ride! Complete this project by yourself
+    or with support from a grown up.
+  tutorial_codespeakroad_longdescription: Create a game where the user plays the role
+    of a civil engineer to plan out a road.
+  tutorial_educodelair_longdescription: George is being chased in Chiroptera's Lair
+    and needs your help to escape! Design your own complete 2D puzzle game by following
+    this tutorial and learning the basics of game development. Code your way out of
+    our level, or make your own to challenge your friends!
+  tutorial_ibmhourofz_longdescription: 'Have you ever withdrawn money from an ATM?
+    Used a credit card to pay for something? All these actions have one thing in common:
+    they all start with a simple click. But what''s really happening behind that click?
+    That''s Enterprise Computing. Get started learning more about how enterprise computing
+    works today with IBM Hour of Z.'
+  tutorial_gamefrootbacteria_longdescription: 'Students learn about the conditions
+    in which salmonella bacteria can survive while coding a fun simulation game in
+    Gamefroot! This activity is designed for science teachers AND Digital Technologies
+    teachers looking to engage their students in multiple subject areas. '
+  tutorial_educodeforest_longdescription: Alex has been trapped in the Frosted Forest
+    for a while. Can you help them escape? This easy-to-follow tutorial teaches you
+    how to build and customize a complete puzzle game that runs in any modern browser.
+    Try to beat our level, or create your own to challenge your friends!
+  tutorial_educodehorus_longdescription: Help Lisa solve Horus's enigma and escape
+    his temple. Follow this tutorial to code and customize your very own puzzle game
+    in a few steps. Try to beat our level, or edit it to make it as easy or challenging
+    as you want. Learn the basics of game development while playing!
+  tutorial_codespeakpokemon_longdescription: Code your favorite Pokemon to level up
+    and evolve.
+  tutorial_stemholiday_longdescription: STEMscopes Coding powered by BitsBox allows
+    students to build and share their own virtual holiday card using typed JavaScript
+    code. Our program is easy to use and requires no prior coding experience. We offer
+    embedded support throughout the program, and students can easily figure it out
+    on their own. Get excited to code your own virtual card to share with friends
+    and family this holiday season!
+  tutorial_codespeakpixel_longdescription: Learn to create a pixel art editor to create
+    your own custom character designs and art.
+  tutorial_codespellsnexus_longdescription: Under the mentorship of a mysterious sock
+    puppet, you must infiltrate and reprogram a super-intelligent 'Learn to Code'
+    app that seeks global domination. Solve puzzles. Learn to code. Hack the Nexus.
+  tutorial_carnegieslime_longdescription: Every year the Minions of Scarecorp try
+    to steal your candy crops. Booville High's Baddest Slimeball crew have come together
+    to protect the candy crops with slime weapons. Players play as teen monsters who
+    program their collaborative robot (aka 'cobot') pets to help take down the Minions
+    of Scarecorp who are after their town's candy harvest. Choose between four characters
+    and their cobotic pets.
+  tutorial_ozotown_longdescription: The Ozobot Blockly OzoTown will teach advanced
+    sequencing as students utilize logic, reasoning, and computer science skills to
+    navigate real life scenarios. No bot needed!
+  tutorial_milnedash_longdescription: Dash wants to learn how to dance! Can you help
+    her drive in and out and show her stuff in the middle? This activity is student-directed
+    and will teach the user about sequencing and loops.
+  tutorial_microbitpet_longdescription: 'Code your own electronic pet and customize
+    it to make it your own. '
+  tutorial_spherotriad_longdescription: 'Explore what each of the fundamental principles
+    of cybersecurity mean and learn how to find a balance to achieve a secure system
+    that works for all users. '
+  tutorial_spheropassword_longdescription: Explore how to make strong password combinations
+    using littleBits inventions and coding.
+  tutorial_codequilt_longdescription: Reflect on who gets to code and what can be
+    made with code while becoming familiar with Scratch.
+  tutorial_ozoshape1_longdescription: The Ozobot Blockly ShapeTracer will teach sequencing
+    and debugging skills. Students will utilize logic, reasoning, and computer science
+    skills. No bot needed!
+  tutorial_ozoshape2_longdescription: The Ozobot Blockly ShapeTracer 2 will teach
+    advanced sequencing and looping skills. Students will utilize logic, reasoning,
+    and computer science skills. No bot needed!
+  tutorial_hopescape_longdescription: Code an open-ended logic escape room game, and
+    learn about concepts such as iteration and other important game design elements.
+  tutorial_ozorace_longdescription: Students will plan and execute a program with
+    a variety of parameters, practice measurement, sequencing and debugging as they
+    create a racetrack for Ozobot.
+  tutorial_ozoequestrian_longdescription: Students will use Color Codes to program
+    their mount (Evo) to complete a course.
+  tutorial_irobotpizza_longdescription: Looking to make coding a collaborative, social
+    and super fun experience at your school?  In this out-of-the-box digital event
+    kit, we provide all the tools you'll need to host the perfect family code challenge.
+    At the iRobot Pizza Party, families come together to share a meal and code virtual
+    robots to complete challenges, designed for both beginners and advanced coders.
+  tutorial_ai4alldance_longdescription: In this short, fun byte of AI, students explore
+    how AI tools can help humans innovate, and how human innovators can help improve
+    AI.
+  tutorial_ai4allneural_longdescription: This curriculum is an introductory hands-on
+    deep dive into the technical details about how some AI systems can find objects
+    in images, or other patterns in context. In the end, students will teach others
+    what they have learned. If your students did AI & Dance, they may want to check
+    this out after to learn how that system worked.
+  tutorial_spheroinout_longdescription: indi is ready to learn more about how it and
+    other computers work. In this lesson, discover inputs and outputs through this
+    hands-on exploration.
+  tutorial_edisonblueprint_longdescription: Can you program Edison to drive in different
+    shapes so that the robot can draw different blueprints?
+  tutorial_edisonmaze_longdescription: Let's get the Edison robot to race along a
+    Euler Path shape!
+  tutorial_milnefunctions_longdescription: Dash wants to learn how to dance! Can you
+    help her drive in and out and show her stuff in the middle? This activity is student-directed
+    and will teach the user about sequencing, loops and functions.
+  tutorial_sasmap_longdescription: 'In this lesson, students will use code to demonstrate
+    an understanding of the difference between human and physical features on a map.
+    They will identity a path through a grid of math features such that a robot will
+    land only on human features. Students will then work in teams to write code that
+    will navigate their robot along the correct path. '
+  tutorial_firstrobotics_longdescription: Learn to code with FTC Sim, an online block-based
+    programming language that includes a live simulator so students can instantly
+    see the robot moving based on the code that they have written.
+  tutorial_sasdata_longdescription: Engage students with data through quick polls
+    that generate real-time interactive data visualizations. Students will identify,
+    interpret and communicate about data– important foundational skills for understanding
+    our data-rich world.
+  tutorial_carnegiesensabot_longdescription: Learn how to program a virtual EV3 robot
+    to complete the real-world Sensabot challenge in this activity the Carnegie Mellon
+    Robotics Academy.
+  tutorial_robotical4_longdescription: MartyBlocks is put together in a vertical format,
+    which is more common for writing code. Learners will be presented with a larger
+    workspace and greater functionality for controlling Marty and eventually having
+    them interact with the environment. This lesson will familiarize learners with
+    the sections, layout, comparing this new environment with MartyBlocks Jr.
+  tutorial_kinderadd_longdescription: In this lesson, students will use algorithms
+    and moving robots to model mathematical concepts. KIBO will travel along a physical
+    number line to model counting, addition, and subtraction. Students will create
+    algorithms (optionally including repeat loops) to solve problems, just like programmers
+    do at work!
+  tutorial_imagipython_longdescription: Join the world's first social network for
+    pre-teens who like to code. Design your first colorful project in minutes with
+    the free imagi app.
+  tutorial_robotical2_longdescription: Learners will create a sequence of steps to
+    allow a partner to travel a route to a goal, making use of the Marty Controller.
+    Each of the directional symbols has an attached movement; in this lesson, learners
+    will be encouraged to experiment with the directional arrows but the focus will
+    be on the forward arrow.
+  tutorial_robotical3_longdescription: Learners will explore the new interface for
+    Marty, where their instructions will stay on the device screen. Learners will
+    be estimating how many steps they think Marty will need to reach a goal.
+  tutorial_blockscadvirus_longdescription: 'Use a 3D design platform to model a virus
+    and learn about how our bodies use geometry to fight these invaders. '
+  tutorial_robotical1_longdescription: Learners will see Marty the Robot moving with
+    the Unplugged color cards. Learners will then guide a partner to move forward
+    and stop, making use of colored paper. Each of Robotical's colored cards has an
+    instruction built into it, that Marty understands, without the need to write or
+    arrange any code.
+  tutorial_irobotshapes_longdescription: Learn about different shapes through pattern
+    recognition and sequencing in this unplugged, printable robot-themed workbook!
+  tutorial_irobotparts_longdescription: Learn about the different pieces used to build
+    a robot through exploring your senses and practicing math basics.
+  tutorial_irobottools_longdescription: This workbook explores all of the different
+    kinds of tools used when building a robot through matching, counting, scavenger
+    hunts and measuring activities,
+  tutorial_kindercar_longdescription: Students will become engineers, learning the
+    steps of the Engineering Design Process. Inspired by the book 'If I Built a Car'
+    by Chris Van Dusen, students will follow the engineering design process to create
+    their own dream cars out of craft and recycled materials. They will scan a short
+    programming sequence to get their cars moving!
+  tutorial_caavatar_longdescription: 'AVATAR is the latest interactive attraction
+    at ThrillVille theme park. Sakura and Nikau can''t wait to visit it and experience
+    the world of tomorrow! In this interactive short course, the learner joins Sakura
+    and Nikau to learn about data, digital footprints, the Internet of things, Big
+    Data, and the implications these have for us as people, and our future.   '
+  tutorial_hello_language: Bulgarian, Corsican, Danish, Dutch, English, English (UK),
+    Estonian, French, Georgian, German, Hungarian, Icelandic, Indonesian, Irish, Japanese,
+    Nepali, Norwegian (Bokmål), Norwegian (Nynorsk), Other, Pashto, Portuguese (Portugal),
+    Romanian, Serbian (Cyrillic), Spanish (Spain), Spanish (Mexico), Turkish, Vietnamese
+  tutorial_raspispace_language: Arabic, Dutch, English, English (UK), French, Greek
+  tutorial_codemonkeyjump_language: English
+  tutorial_poemart_language: Bulgarian, Corsican, Danish, Dutch, English, Estonian,
+    French, Georgian, German, Hungarian, Icelandic, Indonesian, Irish, Japanese, Nepali,
+    Norwegian (Bokmål), Norwegian (Nynorsk), Other, Pashto, Portuguese (Brazil), Portuguese
+    (Portugal), Romanian, Serbian (Cyrillic), Spanish (Spain), Spanish (Mexico), Turkish,
+    Vietnamese
+  tutorial_kodablehero_language: English
+  tutorial_cacloud_language: English, English (UK)
+  tutorial_blocksmithbot_language: English
+  tutorial_hatchmario_language: English
+  tutorial_microsoftforest_language: English
+  tutorial_blackbirdscreen_language: English
+  tutorial_toxicodecompute2_language: English
+  tutorial_minecrafttimecraft_language: Bulgarian, Chinese (Simplified), Chinese (Traditional),
+    Czech, Danish, Dutch, English, Finnish, French, German, Greek, Hungarian, Indonesian,
+    Italian, Japanese, Korean, Norwegian (Bokmål), Norwegian (Nynorsk), Polish, Portuguese
+    (Brazil), Portuguese (Portugal), Russian, Slovenian, Spanish (Spain), Spanish
+    (Mexico), Swedish, Turkish, Ukrainian
+  tutorial_blackbirdtether_language: English
+  tutorial_ob_language: Arabic, Chinese (Simplified), Chinese (Traditional), Czech,
+    Danish, Dutch, English, French, German, Greek, Hindi, Indonesian, Italian, Japanese,
+    Korean, Malay, Other, Portuguese (Brazil), Portuguese (Portugal), Romanian, Serbian
+    (Cyrillic), Slovenian, Spanish (Spain), Spanish (Mexico), Swedish, Tamil, Thai,
+    Turkish, Ukrainian, Urdu (Pakistan), Vietnamese
+  tutorial_codeartportrait_language: English
+  tutorial_shelly_language: English, Polish
+  tutorial_weavly_language: English
+  tutorial_codespeakpassword_language: English
+  tutorial_codecombatozaria_language: English, English (UK), Spanish (Spain), Spanish
+    (Mexico)
+  tutorial_kodableshapes_language: English
+  tutorial_nasabinary_language: English
+  tutorial_3dmaker_language: English
+  tutorial_itchstart_language: English
+  tutorial_hopsub_language: Chinese (Simplified), English, Spanish (Spain), Spanish
+    (Mexico)
+  tutorial_itchmundos_language: Spanish (Mexico)
+  tutorial_itchtenacity_language: Spanish (Mexico)
+  tutorial_kcjskiing_language: English, French
+  tutorial_groksecurity_language: English
+  tutorial_creaticode_language: Chinese (Simplified), Chinese (Traditional), English
+  tutorial_kcjhockey_language: English, French
+  tutorial_ttdungeon_language: English
+  tutorial_ccai_language: Arabic, Bulgarian, Catalan, Chinese (Simplified), Chinese
+    (Traditional), Czech, Danish, Dutch, English, English (UK), Finnish, French, Galician,
+    German, Greek, Hebrew, Hungarian, Indonesian, Italian, Japanese, Korean, Lithuanian,
+    Macedonian (FRYOM), Malay, Norwegian (Bokmål), Norwegian (Nynorsk), Polish, Portuguese
+    (Brazil), Portuguese (Portugal), Romanian, Russian, Serbian (Cyrillic), Slovenian,
+    Spanish (Spain), Spanish (Mexico), Swedish, Thai, Turkish, Ukrainian, Vietnamese
+  tutorial_bsdai_language: English, English (UK)
+  tutorial_stemdata_language: English
+  tutorial_thunkableinfo_language: English
+  tutorial_educodespace_language: English
+  tutorial_kcjtennis_language: English, French
+  tutorial_robotmagictower_language: English
+  tutorial_ttdragons_language: English
+  tutorial_kcjarchery_language: English, French
+  tutorial_ttsprouts_language: English
+  tutorial_ttmaze_language: English
+  tutorial_codetribe_language: English, English (UK)
+  tutorial_ttcanyon_language: English
+  tutorial_kcjxtrail_language: English, French
+  tutorial_codespeakroad_language: English
+  tutorial_educodelair_language: English
+  tutorial_ibmhourofz_language: English, English (UK)
+  tutorial_gamefrootbacteria_language: English
+  tutorial_educodeforest_language: English
+  tutorial_educodehorus_language: English
+  tutorial_codespeakpokemon_language: English
+  tutorial_stemholiday_language: English
+  tutorial_codespeakpixel_language: English
+  tutorial_codespellsnexus_language: English
+  tutorial_carnegieslime_language: English
+  tutorial_ozotown_language: English
+  tutorial_milnedash_language: English
+  tutorial_microbitpet_language: English, Spanish (Mexico), French, Croatian, Korean,
+    Portuguese (Brazil), Portuguese (Portugal), Serbian, Chinese (Simplified)
+  tutorial_spherotriad_language: English
+  tutorial_spheropassword_language: English
+  tutorial_codequilt_language: English
+  tutorial_ozoshape1_language: English
+  tutorial_ozoshape2_language: English
+  tutorial_hopescape_language: Chinese (Simplified), English, Spanish (Spain), Spanish
+    (Mexico)
+  tutorial_ozorace_language: English
+  tutorial_ozoequestrian_language: English
+  tutorial_irobotpizza_language: English
+  tutorial_ai4alldance_language: English
+  tutorial_ai4allneural_language: English
+  tutorial_spheroinout_language: English
+  tutorial_edisonblueprint_language: English
+  tutorial_edisonmaze_language: English
+  tutorial_milnefunctions_language: English
+  tutorial_sasmap_language: English
+  tutorial_firstrobotics_language: English
+  tutorial_sasdata_language: English
+  tutorial_carnegiesensabot_language: English
+  tutorial_robotical4_language: English
+  tutorial_kinderadd_language: English, English (UK)
+  tutorial_imagipython_language: English, Swedish
+  tutorial_robotical2_language: English
+  tutorial_robotical3_language: English
+  tutorial_blockscadvirus_language: English
+  tutorial_robotical1_language: English
+  tutorial_irobotshapes_language: English
+  tutorial_irobotparts_language: English
+  tutorial_irobottools_language: English
+  tutorial_kindercar_language: English, English (UK)
+  tutorial_caavatar_language: English, English (UK)
+  tutorial_hello_string_detail_grades: Grades 2+
+  tutorial_raspispace_string_detail_grades: Grades 2-8
+  tutorial_codemonkeyjump_string_detail_grades: Grades 2-8
+  tutorial_poemart_string_detail_grades: Grades 2-8
+  tutorial_kodablehero_string_detail_grades: Pre-reader - Grade 5
+  tutorial_cacloud_string_detail_grades: Grades 6+
+  tutorial_blocksmithbot_string_detail_grades: Grades 2-8
+  tutorial_hatchmario_string_detail_grades: Grades 2+
+  tutorial_microsoftforest_string_detail_grades: Grades 2+
+  tutorial_blackbirdscreen_string_detail_grades: Grades 6+
+  tutorial_toxicodecompute2_string_detail_grades: Grades 2+
+  tutorial_minecrafttimecraft_string_detail_grades: Grades 2+
+  tutorial_blackbirdtether_string_detail_grades: Grades 6+
+  tutorial_ob_string_detail_grades: Grades 2+
+  tutorial_codeartportrait_string_detail_grades: Grades 6+
+  tutorial_shelly_string_detail_grades: Grades 2-8
+  tutorial_weavly_string_detail_grades: Grades 2-8
+  tutorial_codespeakpassword_string_detail_grades: Grades 2+
+  tutorial_kodableshapes_string_detail_grades: Pre-reader - Grade 5
+  tutorial_nasabinary_string_detail_grades: Grades 6+
+  tutorial_3dmaker_string_detail_grades: Grades 2-8
+  tutorial_itchstart_string_detail_grades: Grades 2-8
+  tutorial_hopsub_string_detail_grades: Grades 2-8
+  tutorial_itchmundos_string_detail_grades: Grades 2+
+  tutorial_itchtenacity_string_detail_grades: Grades 2+
+  tutorial_kcjskiing_string_detail_grades: Grades 2+
+  tutorial_groksecurity_string_detail_grades: Grades 6+
+  tutorial_creaticode_string_detail_grades: Grades 6+
+  tutorial_kcjhockey_string_detail_grades: Grades 2+
+  tutorial_ttdungeon_string_detail_grades: Grades 6+
+  tutorial_ccai_string_detail_grades: Grades 6-8
+  tutorial_bsdai_string_detail_grades: Grades 6+
+  tutorial_stemdata_string_detail_grades: Grades 9+
+  tutorial_thunkableinfo_string_detail_grades: Grades 6+
+  tutorial_educodespace_string_detail_grades: Grades 6+
+  tutorial_kcjtennis_string_detail_grades: Grades 2+
+  tutorial_robotmagictower_string_detail_grades: Grades 6+
+  tutorial_ttdragons_string_detail_grades: Grades 6+
+  tutorial_kcjarchery_string_detail_grades: Grades 2+
+  tutorial_ttsprouts_string_detail_grades: Grades 2+
+  tutorial_ttmaze_string_detail_grades: Grades 6+
+  tutorial_codetribe_string_detail_grades: Grades 2-8
+  tutorial_ttcanyon_string_detail_grades: Grades 6-8
+  tutorial_kcjxtrail_string_detail_grades: Grades 2-8
+  tutorial_codespeakroad_string_detail_grades: Grades 2-8
+  tutorial_educodelair_string_detail_grades: Grades 6+
+  tutorial_ibmhourofz_string_detail_grades: Grades 9+
+  tutorial_gamefrootbacteria_string_detail_grades: Grades 6+
+  tutorial_educodeforest_string_detail_grades: Grades 6+
+  tutorial_educodehorus_string_detail_grades: Grades 6+
+  tutorial_codespeakpokemon_string_detail_grades: Grades 6+
+  tutorial_stemholiday_string_detail_grades: Grades 6-8
+  tutorial_codespeakpixel_string_detail_grades: Grades 6+
+  tutorial_codespellsnexus_string_detail_grades: Grades 6+
+  tutorial_carnegieslime_string_detail_grades: Grades 2-8
+  tutorial_ozotown_string_detail_grades: Grades 2+
+  tutorial_milnedash_string_detail_grades: Pre-reader
+  tutorial_microbitpet_string_detail_grades: Grades 2-8
+  tutorial_spherotriad_string_detail_grades: Grades 2+
+  tutorial_spheropassword_string_detail_grades: Grades 2-8
+  tutorial_codequilt_string_detail_grades: Grades 6+
+  tutorial_ozoshape1_string_detail_grades: Grades 2+
+  tutorial_ozoshape2_string_detail_grades: Grades 2+
+  tutorial_hopescape_string_detail_grades: Grades 2+
+  tutorial_ozorace_string_detail_grades: Pre-reader - Grade 5
+  tutorial_ozoequestrian_string_detail_grades: Pre-reader - Grade 5
+  tutorial_irobotpizza_string_detail_grades: Grades 2-8
+  tutorial_ai4alldance_string_detail_grades: Grades 6+
+  tutorial_ai4allneural_string_detail_grades: Grades 6+
+  tutorial_spheroinout_string_detail_grades: Pre-reader - Grade 5
+  tutorial_edisonblueprint_string_detail_grades: Grades 6+
+  tutorial_edisonmaze_string_detail_grades: Grades 2-8
+  tutorial_milnefunctions_string_detail_grades: Grades 6-8
+  tutorial_sasmap_string_detail_grades: Grades 2-5
+  tutorial_firstrobotics_string_detail_grades: Grades 6+
+  tutorial_sasdata_string_detail_grades: Grades 2+
+  tutorial_carnegiesensabot_string_detail_grades: Grades 2-8
+  tutorial_robotical4_string_detail_grades: Grades 2-5
+  tutorial_kinderadd_string_detail_grades: Pre-reader - Grade 5
+  tutorial_imagipython_string_detail_grades: Grades 2-8
+  tutorial_robotical2_string_detail_grades: Pre-reader - Grade 5
+  tutorial_robotical3_string_detail_grades: Grades 2-5
+  tutorial_blockscadvirus_string_detail_grades: Grades 6+
+  tutorial_robotical1_string_detail_grades: Pre-reader - Grade 5
+  tutorial_irobotshapes_string_detail_grades: Pre-reader
+  tutorial_irobotparts_string_detail_grades: Pre-reader
+  tutorial_irobottools_string_detail_grades: Pre-reader
+  tutorial_kindercar_string_detail_grades: Pre-reader
+  tutorial_caavatar_string_detail_grades: Grades 6+
+  tutorial_hello_string_platforms: All modern browsers, Android tablet, iPad, Windows
+    phone, Android phone, iPhone
+  tutorial_raspispace_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_codemonkeyjump_string_platforms: All modern browsers
+  tutorial_poemart_string_platforms: All modern browsers, Android tablet, iPad, Windows
+    phone, Android phone, iPhone, Game console app, Screen reader
+  tutorial_kodablehero_string_platforms: All modern browsers, iPad, iPhone
+  tutorial_cacloud_string_platforms: All modern browsers
+  tutorial_blocksmithbot_string_platforms: All modern browsers
+  tutorial_hatchmario_string_platforms: All modern browsers
+  tutorial_microsoftforest_string_platforms: All modern browsers
+  tutorial_blackbirdscreen_string_platforms: Chrome
+  tutorial_toxicodecompute2_string_platforms: All modern browsers
+  tutorial_minecrafttimecraft_string_platforms: All modern browsers, Mac, Windows,
+    Chromebook, iPhone, iPad, Android phone, Android tablet
+  tutorial_blackbirdtether_string_platforms: Chrome
+  tutorial_ob_string_platforms: All modern browsers, Screen reader
+  tutorial_codeartportrait_string_platforms: All modern browsers, Android tablet,
+    iPad
+  tutorial_shelly_string_platforms: All modern browsers
+  tutorial_weavly_string_platforms: All modern browsers, Screen reader
+  tutorial_codespeakpassword_string_platforms: All modern browsers
+  tutorial_kodableshapes_string_platforms: All modern browsers, iPad, iPhone
+  tutorial_nasabinary_string_platforms: Unplugged, Screen reader
+  tutorial_3dmaker_string_platforms: All modern browsers, Android tablet, iPad, Windows
+    phone, Android phone, iPhone
+  tutorial_itchstart_string_platforms: All modern browsers, iPad
+  tutorial_hopsub_string_platforms: iPad, iPhone
+  tutorial_itchmundos_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_itchtenacity_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_kcjskiing_string_platforms: All modern browsers
+  tutorial_groksecurity_string_platforms: All modern browsers, Android tablet, iPad,
+    Windows phone, Android phone, iPhone
+  tutorial_creaticode_string_platforms: All modern browsers, Android tablet, iPad,
+    Windows phone, Android phone, iPhone
+  tutorial_kcjhockey_string_platforms: All modern browsers
+  tutorial_ttdungeon_string_platforms: Chrome, Firefox
+  tutorial_ccai_string_platforms: All modern browsers
+  tutorial_bsdai_string_platforms: Chrome, Firefox
+  tutorial_stemdata_string_platforms: All modern browsers, iPad
+  tutorial_thunkableinfo_string_platforms: Chrome, Safari
+  tutorial_educodespace_string_platforms: All modern browsers
+  tutorial_kcjtennis_string_platforms: All modern browsers
+  tutorial_robotmagictower_string_platforms: All modern browsers
+  tutorial_ttdragons_string_platforms: Chrome, Firefox
+  tutorial_kcjarchery_string_platforms: All modern browsers
+  tutorial_ttsprouts_string_platforms: Chrome, Firefox
+  tutorial_ttmaze_string_platforms: Chrome, Firefox
+  tutorial_codetribe_string_platforms: All modern browsers, Android tablet, iPad,
+    Windows phone, Android phone, iPhone
+  tutorial_ttcanyon_string_platforms: Chrome, Firefox
+  tutorial_kcjxtrail_string_platforms: All modern browsers
+  tutorial_codespeakroad_string_platforms: Chrome
+  tutorial_educodelair_string_platforms: All modern browsers, iPad
+  tutorial_ibmhourofz_string_platforms: Chrome, Firefox, Android phone, iPhone
+  tutorial_gamefrootbacteria_string_platforms: All modern browsers
+  tutorial_educodeforest_string_platforms: All modern browsers, iPad
+  tutorial_educodehorus_string_platforms: All modern browsers, iPad
+  tutorial_codespeakpokemon_string_platforms: All modern browsers
+  tutorial_stemholiday_string_platforms: Chrome
+  tutorial_codespeakpixel_string_platforms: All modern browsers
+  tutorial_codespellsnexus_string_platforms: Chrome, Firefox
+  tutorial_carnegieslime_string_platforms: All modern browsers
+  tutorial_ozotown_string_platforms: All modern browsers
+  tutorial_milnedash_string_platforms: All modern browsers, Screen reader
+  tutorial_microbitpet_string_platforms: All modern browsers, Screen reader
+  tutorial_spherotriad_string_platforms: Android tablet, iPad, Android phone, iPhone,
+    Windows 10, macOS, ChromeOS
+  tutorial_spheropassword_string_platforms: All modern browsers, Android tablet, iPad,
+    Windows phone, Android phone, iPhone
+  tutorial_codequilt_string_platforms: All modern browsers
+  tutorial_ozoshape1_string_platforms: All modern browsers
+  tutorial_ozoshape2_string_platforms: All modern browsers
+  tutorial_hopescape_string_platforms: iPad, iPhone
+  tutorial_ozorace_string_platforms: All modern browsers
+  tutorial_ozoequestrian_string_platforms: All modern browsers
+  tutorial_irobotpizza_string_platforms: Unplugged
+  tutorial_ai4alldance_string_platforms: All modern browsers
+  tutorial_ai4allneural_string_platforms: All modern browsers
+  tutorial_spheroinout_string_platforms: Unplugged
+  tutorial_edisonblueprint_string_platforms: All modern browsers
+  tutorial_edisonmaze_string_platforms: All modern browsers
+  tutorial_milnefunctions_string_platforms: All modern browsers, Screen reader
+  tutorial_sasmap_string_platforms: All modern browsers, iPad, Screen reader
+  tutorial_firstrobotics_string_platforms: All modern browsers
+  tutorial_sasdata_string_platforms: All modern browsers
+  tutorial_carnegiesensabot_string_platforms: All modern browsers
+  tutorial_robotical4_string_platforms: All modern browsers
+  tutorial_kinderadd_string_platforms: Unplugged
+  tutorial_imagipython_string_platforms: Chrome, Firefox, Android tablet, iPad, Android
+    phone, iPhone
+  tutorial_robotical2_string_platforms: Unplugged
+  tutorial_robotical3_string_platforms: All modern browsers
+  tutorial_blockscadvirus_string_platforms: All modern browsers
+  tutorial_robotical1_string_platforms: Unplugged
+  tutorial_irobotshapes_string_platforms: Unplugged
+  tutorial_irobotparts_string_platforms: Unplugged
+  tutorial_irobottools_string_platforms: Unplugged
+  tutorial_kindercar_string_platforms: Unplugged
+  tutorial_caavatar_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_hello_string_detail_platforms: ''
+  tutorial_raspispace_string_detail_platforms: ''
+  tutorial_codemonkeyjump_string_detail_platforms: ''
+  tutorial_poemart_string_detail_platforms: ''
+  tutorial_kodablehero_string_detail_platforms: ''
+  tutorial_cacloud_string_detail_platforms: ''
+  tutorial_blocksmithbot_string_detail_platforms: Internet Explorer 11, Microsoft
+    Edge, Chrome, Firefox, Safari
+  tutorial_hatchmario_string_detail_platforms: ''
+  tutorial_microsoftforest_string_detail_platforms: ''
+  tutorial_blackbirdscreen_string_detail_platforms: ''
+  tutorial_toxicodecompute2_string_detail_platforms: Microsoft Edge, Chrome, Firefox,
+    Safari
+  tutorial_minecrafttimecraft_string_detail_platforms: ''
+  tutorial_blackbirdtether_string_detail_platforms: ''
+  tutorial_ob_string_detail_platforms: ''
+  tutorial_codeartportrait_string_detail_platforms: ''
+  tutorial_shelly_string_detail_platforms: ''
+  tutorial_weavly_string_detail_platforms: ''
+  tutorial_codespeakpassword_string_detail_platforms: Chrome, Firefox, Safari
+  tutorial_kodableshapes_string_detail_platforms: ''
+  tutorial_nasabinary_string_detail_platforms: ''
+  tutorial_3dmaker_string_detail_platforms: ''
+  tutorial_itchstart_string_detail_platforms: ''
+  tutorial_hopsub_string_detail_platforms: ''
+  tutorial_itchmundos_string_detail_platforms: ''
+  tutorial_itchtenacity_string_detail_platforms: ''
+  tutorial_kcjskiing_string_detail_platforms: ''
+  tutorial_groksecurity_string_detail_platforms: ''
+  tutorial_creaticode_string_detail_platforms: ''
+  tutorial_kcjhockey_string_detail_platforms: ''
+  tutorial_ttdungeon_string_detail_platforms: ''
+  tutorial_ccai_string_detail_platforms: ''
+  tutorial_bsdai_string_detail_platforms: ''
+  tutorial_stemdata_string_detail_platforms: ''
+  tutorial_thunkableinfo_string_detail_platforms: ''
+  tutorial_educodespace_string_detail_platforms: ''
+  tutorial_kcjtennis_string_detail_platforms: ''
+  tutorial_robotmagictower_string_detail_platforms: ''
+  tutorial_ttdragons_string_detail_platforms: ''
+  tutorial_kcjarchery_string_detail_platforms: ''
+  tutorial_ttsprouts_string_detail_platforms: ''
+  tutorial_ttmaze_string_detail_platforms: ''
+  tutorial_codetribe_string_detail_platforms: ''
+  tutorial_ttcanyon_string_detail_platforms: ''
+  tutorial_kcjxtrail_string_detail_platforms: ''
+  tutorial_codespeakroad_string_detail_platforms: ''
+  tutorial_educodelair_string_detail_platforms: ''
+  tutorial_ibmhourofz_string_detail_platforms: ''
+  tutorial_gamefrootbacteria_string_detail_platforms: Microsoft Edge, Chrome, Firefox,
+    Safari
+  tutorial_educodeforest_string_detail_platforms: ''
+  tutorial_educodehorus_string_detail_platforms: ''
+  tutorial_codespeakpokemon_string_detail_platforms: ''
+  tutorial_stemholiday_string_detail_platforms: ''
+  tutorial_codespeakpixel_string_detail_platforms: Chrome, Firefox, Safari
+  tutorial_codespellsnexus_string_detail_platforms: ''
+  tutorial_carnegieslime_string_detail_platforms: ''
+  tutorial_ozotown_string_detail_platforms: Ozobot
+  tutorial_milnedash_string_detail_platforms: Dash robot
+  tutorial_microbitpet_string_detail_platforms: micro:bit
+  tutorial_spherotriad_string_detail_platforms: Sphero Bolt
+  tutorial_spheropassword_string_detail_platforms: littleBits STEAM+ Coding Kit
+  tutorial_codequilt_string_detail_platforms: ''
+  tutorial_ozoshape1_string_detail_platforms: Ozobot
+  tutorial_ozoshape2_string_detail_platforms: Ozobot
+  tutorial_hopescape_string_detail_platforms: ''
+  tutorial_ozorace_string_detail_platforms: Ozobot
+  tutorial_ozoequestrian_string_detail_platforms: Ozobot
+  tutorial_irobotpizza_string_detail_platforms: ''
+  tutorial_ai4alldance_string_detail_platforms: ''
+  tutorial_ai4allneural_string_detail_platforms: ''
+  tutorial_spheroinout_string_detail_platforms: Sphero indi
+  tutorial_edisonblueprint_string_detail_platforms: Edison robot
+  tutorial_edisonmaze_string_detail_platforms: Edison robots
+  tutorial_milnefunctions_string_detail_platforms: Dash robot
+  tutorial_sasmap_string_detail_platforms: iPad, the free app and one robot. Supports
+    BOLT, SPRK+, Sphero Mini, SPRK, Sphero, and Ollie robots.
+  tutorial_firstrobotics_string_detail_platforms: ''
+  tutorial_sasdata_string_detail_platforms: ''
+  tutorial_carnegiesensabot_string_detail_platforms: ''
+  tutorial_robotical4_string_detail_platforms: Marty the Robot
+  tutorial_kinderadd_string_detail_platforms: KIBO Robot Kit
+  tutorial_imagipython_string_detail_platforms: ''
+  tutorial_robotical2_string_detail_platforms: Marty the Robot
+  tutorial_robotical3_string_detail_platforms: Marty the Robot
+  tutorial_blockscadvirus_string_detail_platforms: ''
+  tutorial_robotical1_string_detail_platforms: Marty the Robot
+  tutorial_irobotshapes_string_detail_platforms: ''
+  tutorial_irobotparts_string_detail_platforms: ''
+  tutorial_irobottools_string_detail_platforms: ''
+  tutorial_kindercar_string_detail_platforms: KIBO Robot Kit
+  tutorial_caavatar_string_detail_platforms: ''
+  tutorial_hello_string_detail_programming_languages: Blocks
+  tutorial_raspispace_string_detail_programming_languages: Blocks, Scratch
+  tutorial_codemonkeyjump_string_detail_programming_languages: Blocks
+  tutorial_poemart_string_detail_programming_languages: Blocks
+  tutorial_kodablehero_string_detail_programming_languages: JavaScript, iOS/Swift,
+    Language independent (can be taught in multiple languages)
+  tutorial_cacloud_string_detail_programming_languages: Theory Based
+  tutorial_blocksmithbot_string_detail_programming_languages: JavaScript
+  tutorial_hatchmario_string_detail_programming_languages: Blocks
+  tutorial_microsoftforest_string_detail_programming_languages: Blocks
+  tutorial_blackbirdscreen_string_detail_programming_languages: JavaScript
+  tutorial_toxicodecompute2_string_detail_programming_languages: Python
+  tutorial_minecrafttimecraft_string_detail_programming_languages: Blocks, Python
+  tutorial_blackbirdtether_string_detail_programming_languages: JavaScript
+  tutorial_ob_string_detail_programming_languages: Blocks
+  tutorial_codeartportrait_string_detail_programming_languages: JavaScript, p5.js
+  tutorial_shelly_string_detail_programming_languages: A Logo-like language
+  tutorial_weavly_string_detail_programming_languages: Blocks
+  tutorial_codespeakpassword_string_detail_programming_languages: Python
+  tutorial_kodableshapes_string_detail_programming_languages: JavaScript, Language
+    independent (can be taught in multiple languages)
+  tutorial_nasabinary_string_detail_programming_languages: Binary code
+  tutorial_3dmaker_string_detail_programming_languages: Blocks
+  tutorial_itchstart_string_detail_programming_languages: Blocks
+  tutorial_hopsub_string_detail_programming_languages: Hopscotch
+  tutorial_itchmundos_string_detail_programming_languages: Blocks
+  tutorial_itchtenacity_string_detail_programming_languages: Blocks
+  tutorial_kcjskiing_string_detail_programming_languages: Blocks
+  tutorial_groksecurity_string_detail_programming_languages: None - no programming
+    required
+  tutorial_creaticode_string_detail_programming_languages: Blocks
+  tutorial_kcjhockey_string_detail_programming_languages: Blocks
+  tutorial_ttdungeon_string_detail_programming_languages: Algorithms
+  tutorial_ccai_string_detail_programming_languages: JavaScript, Python
+  tutorial_bsdai_string_detail_programming_languages: HTML, CSS and JavaScript
+  tutorial_stemdata_string_detail_programming_languages: JavaScript, Includes option
+    to download and analyze data in Google Sheets and Excel
+  tutorial_thunkableinfo_string_detail_programming_languages: Blocks
+  tutorial_educodespace_string_detail_programming_languages: JavaScript
+  tutorial_kcjtennis_string_detail_programming_languages: Blocks
+  tutorial_robotmagictower_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_ttdragons_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_kcjarchery_string_detail_programming_languages: Blocks
+  tutorial_ttsprouts_string_detail_programming_languages: JavaScript, C#
+  tutorial_ttmaze_string_detail_programming_languages: JavaScript
+  tutorial_codetribe_string_detail_programming_languages: JavaScript, HTML and CSS.
+  tutorial_ttcanyon_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_kcjxtrail_string_detail_programming_languages: Blocks
+  tutorial_codespeakroad_string_detail_programming_languages: Blocks
+  tutorial_educodelair_string_detail_programming_languages: JavaScript
+  tutorial_ibmhourofz_string_detail_programming_languages: Python, COBOL
+  tutorial_gamefrootbacteria_string_detail_programming_languages: Blocks
+  tutorial_educodeforest_string_detail_programming_languages: JavaScript
+  tutorial_educodehorus_string_detail_programming_languages: JavaScript
+  tutorial_codespeakpokemon_string_detail_programming_languages: Blocks
+  tutorial_stemholiday_string_detail_programming_languages: JavaScript, HTML5
+  tutorial_codespeakpixel_string_detail_programming_languages: JavaScript
+  tutorial_codespellsnexus_string_detail_programming_languages: Blocks, JavaScript,
+    Racket
+  tutorial_carnegieslime_string_detail_programming_languages: Blocks
+  tutorial_ozotown_string_detail_programming_languages: Blocks
+  tutorial_milnedash_string_detail_programming_languages: Blocks
+  tutorial_microbitpet_string_detail_programming_languages: Python, MakeCode
+  tutorial_spherotriad_string_detail_programming_languages: Blocks
+  tutorial_spheropassword_string_detail_programming_languages: Blocks
+  tutorial_codequilt_string_detail_programming_languages: Blocks
+  tutorial_ozoshape1_string_detail_programming_languages: Blocks
+  tutorial_ozoshape2_string_detail_programming_languages: Blocks
+  tutorial_hopescape_string_detail_programming_languages: Blocks, Hopscotch
+  tutorial_ozorace_string_detail_programming_languages: Ozobot Color Codes
+  tutorial_ozoequestrian_string_detail_programming_languages: Color Codes
+  tutorial_irobotpizza_string_detail_programming_languages: Blocks
+  tutorial_ai4alldance_string_detail_programming_languages: No programming required.
+  tutorial_ai4allneural_string_detail_programming_languages: No programming required.
+  tutorial_spheroinout_string_detail_programming_languages: None - color tiles
+  tutorial_edisonblueprint_string_detail_programming_languages: Blocks
+  tutorial_edisonmaze_string_detail_programming_languages: Blocks
+  tutorial_milnefunctions_string_detail_programming_languages: Blocks
+  tutorial_sasmap_string_detail_programming_languages: Blocks
+  tutorial_firstrobotics_string_detail_programming_languages: Blocks, OnbotJava
+  tutorial_sasdata_string_detail_programming_languages: 'No programming languages. '
+  tutorial_carnegiesensabot_string_detail_programming_languages: Blocks
+  tutorial_robotical4_string_detail_programming_languages: Blocks
+  tutorial_kinderadd_string_detail_programming_languages: Tangible KIBO blocks
+  tutorial_imagipython_string_detail_programming_languages: Python
+  tutorial_robotical2_string_detail_programming_languages: This makes use of a paper
+    printout of the Marty Controller
+  tutorial_robotical3_string_detail_programming_languages: Blocks
+  tutorial_blockscadvirus_string_detail_programming_languages: Blocks
+  tutorial_robotical1_string_detail_programming_languages: Language independent (can
+    be taught in multiple languages), Color cards are used to command the device featured
+    in the video and to instruct partners.
+  tutorial_irobotshapes_string_detail_programming_languages: pre-reader computational
+    thinking activity
+  tutorial_irobotparts_string_detail_programming_languages: pre-reader computational
+    thinking activity
+  tutorial_irobottools_string_detail_programming_languages: pre-reader computational
+    thinking activity
+  tutorial_kindercar_string_detail_programming_languages: KIBO tangible blocks
+  tutorial_caavatar_string_detail_programming_languages: CS Conceptual so no language
+    needed
+  tutorial_icomputefireworks_name: 'Fireworks Display: Created with Code'
+  tutorial_icomputefireworks_longdescription: Create your own fireworks display using
+    code.
+  tutorial_icomputefireworks_language: English, English (UK)
+  tutorial_icomputefireworks_string_detail_grades: Grades 2-5
+  tutorial_icomputefireworks_string_platforms: All modern browsers
+  tutorial_icomputefireworks_string_detail_platforms: ''
+  tutorial_icomputefireworks_string_detail_programming_languages: Blocks
+  tutorial_rpccw_name: 'Code Club World: Make cool stuff with free coding games and
+    activities'
+  tutorial_rpledfirefly_name: 'LED firefly: Meet the Raspberry Pi Pico'
+  tutorial_rpcharting_name: 'Charting champions: The power of Python lists'
+  tutorial_rpsolar_name: 'Solar system simulator: Python models and dictionaries'
+  tutorial_rpwebcards_name: 'Flip treat webcards: Create interactive hover cards that
+    flip'
+  tutorial_codeclubhworld_name: 'Hello world: Say hello to Python coding'
+  tutorial_codeclubspells_name: 'Broadcasting spells: Scratch coding beyond the basics'
+  tutorial_coderdojoanime_name: 'Anime expressions: Create and style a webpage for
+    an anime drawing tutorial'
+  tutorial_coderdojotarget_name: 'Target practice: Introduction to Python graphics'
+  tutorial_creaticodescratch_name: Advanced Scratch Coding (2D/3D/AR/AI)
+  tutorial_bbsierpinski_name: 'Sierpinski Triangle: Make Art with Math!'
+  tutorial_bbstopwatch_name: Stopwatch Builder
+  tutorial_idrpatterns_name: Creating patterns with code
+  tutorial_idrshapes_name: Drawing shapes with code
+  tutorial_edisondetect_name: Detect and avoid with Edison
+  tutorial_edisonmusical_name: Edison's musical talents
+  tutorial_codemonkeydiglit_name: Digital Literacy - Mini Course
+  tutorial_bsdrockpaper_name: Rock, Paper, Scissors with Python
+  tutorial_microbitreaction_name: micro:bit reaction game
+  tutorial_kinderanimal_name: KIBO the Playful Animal
+  tutorial_kindersinger_name: KIBO the Singer
+  tutorial_microbitwwn_name: micro:bit which way now? activity
+  tutorial_grokcyberlive_name: Cyber Live
+  tutorial_codemojimaze_name: 'Unplugged: Code A Maze '
+  tutorial_codemojisnake_name: 'Scratch: Create Your Own Snake Game'
+  tutorial_carnegietoxibots_name: 'Zillah City: Fall of the Toxibots'
+  tutorial_carnegieiris_name: Iris Rover Challenge with VICE Virtual Robot
+  tutorial_carnegiespike_name: " Virtual SPIKE Prime Coding - Iris Rover Challenge"
+  tutorial_spheroincolor_name: indi Color Contest
+  tutorial_kcjdominos_name: Simulating Dominos Using JavaScript
+  tutorial_spherocolortheory_name: Additive Color Theory (RGB) with BOLT
+  tutorial_codecombatesports_name: 'Esports Bootcamp: AI League'
+  tutorial_spherodigdisplay_name: The Technology of Digital Displays with littleBits
+  tutorial_spherorvrincolor_name: RVR+ in Color!
+  tutorial_clbinary_name: Learn How Binary Works with Computers using Minecraft
+  tutorial_sascollabcode_name: 'SAS CodeSnaps: Collaborative coding for blind, low
+    vision and sighted students'
+  tutorial_codecombatgoblins_name: 'CodeCombat: Goblins ''n'' Glory'
+  tutorial_scratchstorytelling_name: Anything is Possible! Storytelling with Scratch
+  tutorial_crayolasymbols_name: 'Unplugged Coding from Crayola Education: Visual Symbols
+    Convey Meaning'
+  tutorial_crayoladrawacode_name: 'Unplugged Coding from Crayola Education: Draw A
+    Code'
+  tutorial_crayolafollowmycode_name: 'Unplugged Coding from Crayola Education: Follow
+    My Code'
+  tutorial_madpicturethis_name: Picture This! HTML Decoded
+  tutorial_mindmakersmaps_name: Maps
+  tutorial_mindmakersjorel_name: Jorel's Brother
+  tutorial_mindmakersroboland_name: Roboland
+  tutorial_mindmakersrobolandjr_name: Roboland Jr
+  tutorial_codehsdraw_name: Drawing and Scratch
+  tutorial_codehscamouflage_name: 'Programming an Adaptation: Camouflage'
+  tutorial_firiapythoncodex_name: Python with CodeX
+  tutorial_bekidscoding_name: bekids Coding Challenges
+  tutorial_rodocodehr_name: 'Rodocodo: Code Hour'
+  tutorial_microbitdice_name: micro:bit dice
+  tutorial_madflashcard_name: Deconstructing Code in a Flash(card)
+  tutorial_madappwars_name: App Wars
+  tutorial_kodablepuppies_name: 'Robots and Puppies '
+  tutorial_googlesuperhero_name: Build a Superhero
+  tutorial_googlename _name: Design Your Name
+  tutorial_carnegiezillah_name: Zillah Beats
+  tutorial_nasachspacejam_name: NASA's Space Jam
+  tutorial_hatchxrsolar_name: Build a 3D/AR Solar System
+  tutorial_hatchxrspace_name: Code a 3D Space Invaders Game
+  tutorial_hatchxrtrex_name: Create a 3D T-Rex Game
+  tutorial_blocksmithguinea_name: Guinea Pig Survivors
+  tutorial_pickcodeshapes_name: 'Pickcode: Shapes and Spirals'
+  tutorial_codesterssketch_name: 'Codesters: Etch-a-Sketch'
+  tutorial_pickcodechatbot_name: 'Pickcode: Ad Libs Chatbot'
+  tutorial_codestersfish_name: 'Codesters: Feed the Fish'
+  tutorial_codestershedgehog_name: 'Codesters: Star Hedgehog'
+  tutorial_pickcodeggame_name: 'Pickcode: Guessing Game Chatbot'
+  tutorial_codestersdino_name: 'Codesters: Flappy Dino'
+  tutorial_pickcodemtpaint_name: 'Pickcode: Mobius Triangle Painting'
+  tutorial_microsoftcarnival_name: Code a Carnival
+  tutorial_thunkablescavenger_name: Build a Scavenger Hunt App with Code Blocks
+  tutorial_codeillusionfund_name: 'Disney Codeillusion: Computer Fundamentals'
+  tutorial_codeillusiongoofybeg_name: 'Disney Codeillusion: Game Development Adventure
+    with Goofy for Beginners'
+  tutorial_codeillusiongoofyint_name: 'Disney Codeillusion: Game Development Adventure
+    with Goofy for Intermediates'
+  tutorial_robotmagicescape_name: 'Escape Room: Code with Bots'
+  tutorial_codespeakclimate_name: Create a Website to Spread Awareness About Climate
+    Change
+  tutorial_codespeaktwinkle_name: Coding Twinkle Little Star in ScratchJr
+  tutorial_coinbasecrypto_name: The Crypto Memory Game
+  tutorial_codespeakcomp_name: Build a Composting Game in Scratch
+  tutorial_codespeaksnake_name: 'Coding Snake: Story Time with ScratchJr'
+  tutorial_prstemalexa_name: Alexa in Space
+  tutorial_coderzfarm_name: 'Code Farm: Plant a Garden'
+  tutorial_intelinofield_name: 'intelino Mission: Field Trip'
+  tutorial_cablockchain_name: New Kids on the Blockchain
+  tutorial_nasaparachute_name: 'NASA: Mars Perseverance Parachute Coding Activity'
+  tutorial_nasascratch_name: 'NASA: Explore Mars With Scratch'
+  tutorial_nasaorbit_name: 'NASA: Crew Orbital Docking Simulation'
+  tutorial_nasapackage_name: 'NASA: Package Delivery Drone Simulation Coding Activity '
+  tutorial_nasalunar_name: 'NASA: Lunar Coding Challenge'
+  tutorial_meeestate_name: Escape Estate
+  tutorial_imagipixelart_name: Code your own pixel art!
+  tutorial_kcjhealth_name: The Health & Well-Being Challenge
+  tutorial_msftwakanda_name: Long Live Wakanda
+  tutorial_nafbrand_name: Code your Brand
+  tutorial_rpccw_longdescription: Create your own character, design a T-shirt, and
+    create some music. Earn badges for each completed project.
+  tutorial_rpledfirefly_longdescription: Use a Raspberry Pi Pico microcontroller and
+    basic electronic components to create a blinking LED firefly. Write MicroPython
+    code to light your firefly and create a switch from jumper wires to mimic fireflies
+    in the wild when the switch is closed.
+  tutorial_rpcharting_longdescription: Discover the power of lists in the Python programming
+    language by storing Olympic medal data then use the pygal library to create an
+    interactive chart. Use data analysis skills to uncover patterns and anomalies.
+  tutorial_rpsolar_longdescription: Create an animated, interactive, solar system
+    model using the Python programming language and the p5 graphics library. Use dictionaries
+    to store planet facts that load when an orbiting planet is clicked.
+  tutorial_rpwebcards_longdescription: Create a set of webcards that flip when you
+    hover over them. Use CSS styling and animations then customise with fancy fonts
+    and colour gradients.
+  tutorial_codeclubhworld_longdescription: Write Python text-based code to create
+    an interactive project with user input that prints text and emoji. Use variables
+    to store text and numbers, and functions to organize your code.
+  tutorial_codeclubspells_longdescription: Use Scratch blocks to code a wand that
+    casts spells to turn sprites into toads, grow, and shrink them. Edit and reverse
+    sound to make spell sound effects. Broadcast spell messages so that multiple sprites
+    transform when the message is received.
+  tutorial_coderdojoanime_longdescription: Create a responsive webpage with text and
+    images for an anime drawing tutorial. Use HTML to structure the webpage and CSS
+    styles to apply layout, colour palettes and fonts.
+  tutorial_coderdojotarget_longdescription: Use Python with the p5 graphics library
+    to draw a target and score points by hitting it with arrows. Learn about RGB colours
+    and position your target with x & y coordinates. Use if, elif and else conditions
+    to make scoring decisions.
+  tutorial_creaticodescratch_longdescription: CreatiCode.com offers a wide range of
+    coding activities in many topics, such as 3D games, 3D arts, Augmented Reality
+    games, Artificial Intelligence apps, Youtube video remixing, and UN's sustainable
+    development goals. Scratch-based blocks are used in all activities, so students
+    do not need to learn a different programming language or user interface to code
+    and share their projects.
+  tutorial_bbsierpinski_longdescription: In this short series of lessons, you'll learn
+    to create amazing and colorful math art!
+  tutorial_bbstopwatch_longdescription: In this short series of lessons, you'll learn
+    to create a real, working stopwatch!
+  tutorial_idrpatterns_longdescription: Use the Loop action block in the Weavly coding
+    environment to create geometric patterns like crystals, stars, or other exciting
+    shapes with repeated elements.
+  tutorial_idrshapes_longdescription: 'In this activity, players use the Weavly action
+    blocks to draw simple shapes, such squares, rectangles, triangles, hexagons, and
+    stars. '
+  tutorial_edisondetect_longdescription: Introduce the key computational concepts
+    of loops and an understanding of infrared light using Edison robots and the block
+    based programming language, EdBlocks. This lesson utilizes the Edison robot's
+    drive and obstacle detection functions through a set of progressive programming
+    tasks.
+  tutorial_edisonmusical_longdescription: Simple musical tunes are a great example
+    of sequence in action. Using Edison and the Scratch-based programming language,
+    EdScratch, students can create music and tie together sequence and inputs-outputs
+    into enjoyable programs.
+  tutorial_codemonkeydiglit_longdescription: 'Introduction to some important topics
+    in the digital world: How to use computers, what is software and hardware, possible
+    online threats and protecting your privacy. The course includes 2 lessons - digital
+    use and digital citizenship. Each lesson is made of self guided slides with interactive
+    questions and surveys, 3 mini games and 5 review questions to check the student''s
+    understanding.'
+  tutorial_bsdrockpaper_longdescription: Use the Python programming language to build
+    a 'Rock, Paper, Scissors' game. Don't worry if you have never tried Python, we
+    will walk you through each step.
+  tutorial_microbitreaction_longdescription: Make a micro:bit reaction game with real
+    physical switches made from scrap cardboard and kitchen foil.
+  tutorial_kinderanimal_longdescription: In this lesson, students will turn KIBO into
+    a playful animal that moves in response to a program the children create. Students
+    can also experiment with KIBO's input and output options to take it further.
+  tutorial_kindersinger_longdescription: In this lesson, students will dress KIBO
+    up in a performer's outfit and teach KIBO to sing a favorite song! With KIBO's
+    Sound Record/Playback Module, children will use their sequencing skills to program
+    KIBO to play back their song in the correct order. This lesson is meant for children
+    with prior KIBO experience.
+  tutorial_microbitwwn_longdescription: Shake your micro:bit and be given a random
+    direction to walk.
+  tutorial_grokcyberlive_longdescription: A Navy captain is held captive inside his
+    ship. A major landmark has gone dark. And weapons are pointed at Sydney's busiest
+    sites…It's all connected, and it's up to you to free the captain, track down the
+    culprit, and stop them. Students will need to trace clues, solve puzzles, and
+    figure out how to stop a large-scale simulated cyber attack before it's too late.
+  tutorial_codemojimaze_longdescription: Learn about sequences to help Deeno complete
+    the maze.
+  tutorial_codemojisnake_longdescription: In this unit students will learn how to
+    use coding blocks on Scratch to create a snake game.
+  tutorial_carnegietoxibots_longdescription: No one sleeps on Zillah City. You play
+    as one of the Zeds, a crew dedicated to stamping out the menace of Toxibots, malware-corrupted
+    robots that belong to Toxicorp, a giant corporation. Most of the Toxibots were
+    destroyed, but there are still some around wreaking havoc. Get geared up in the
+    Zed Clubhouse, and program your collaborative robot (aka 'cobot') Beastie to help
+    capture them.
+  tutorial_carnegieiris_longdescription: The Iris Rover Challenge with VICE Virtual
+    Robot provides a structured sequence of programming activities in a real-world
+    project-based context. It is designed to get students thinking about the patterns
+    and structure of not just robotics, but also programming and problem-solving more
+    generally. This lesson includes videos, animations, and a built-in coding environment
+    with the virtual robot.
+  tutorial_carnegiespike_longdescription: The Virtual SPIKE Prime Coding - Iris Rover
+    Challenge provides a structured sequence of programming activities in a real-world
+    project-based context. It is designed to get students thinking about the patterns
+    and structure of not just robotics, but also programming and problem-solving more
+    generally. This lesson includes videos, animations, and a built-in coding environment
+    with virtual robot.
+  tutorial_spheroincolor_longdescription: Sphero indi can see color much like you
+    and me. But who is faster at recognizing colors? Who can recognize the most? In
+    this lesson, discover how we see color and challenge indi to a color contest!
+  tutorial_kcjdominos_longdescription: In this lesson we will simulate falling dominos
+    using JavaScript. Along the way we will learn about variables, functions, loops,
+    mouse events and knocking things over!
+  tutorial_spherocolortheory_longdescription: Mix up your colors by tilting and rotating
+    Sphero BOLT! Explore how additive color theory works by adding different values
+    of red, green, and blue to make many different colors. Learn how you can use your
+    BOLT's sensors to measure its orientation and change colors.
+  tutorial_codecombatesports_longdescription: Competitive coding has never been so
+    epic! Learn the skills you need to play like the pros in our Esports Bootcamp.
+    No coding experience needed. Start by training in the dungeon and discovering
+    the coding strategies and tactics you'll need to compete. After honing your skills,
+    put your code to the test in our esports arena against other players worldwide!
+    Are you our next AI League grand champion?
+  tutorial_spherodigdisplay_longdescription: Digital Displays are all around us, from
+    phones to computer monitors to television to modern billboards. But how do they
+    work? Dig into the graphic technology behind digital displays and get hands-on
+    experience by programming images and animations with the littleBits codeBit and
+    LED matrix.
+  tutorial_spherorvrincolor_longdescription: 'Visible light is made up of waves of
+    varying lengths which the eye detects as color. While RVR+ doesn''t have eyes
+    (well at least ones that can see) it does have a sensor that is able to detect
+    a wide range of colors. Learn the capabilities of RVR+''s color sensor and how
+    to program it. '
+  tutorial_clbinary_longdescription: Using restone components in Minecraft, participants
+    will learn how binary counting works, create AND and OR logic gates, and use binary
+    counting to create a combination lock for opening a locked door.
+  tutorial_sascollabcode_longdescription: It can be challenging to find resources
+    to teach coding to students with visual impairments. SAS believes that every student
+    should have the opportunity to learn to code and aims to accomplish this using
+    braille code blocks with SAS CodeSnaps - a collaborative coding environment that
+    can get an entire classroom coding with just a single iPad and a Sphero robot.
+  tutorial_codecombatgoblins_longdescription: We need your help! Embark on an epic
+    quest where you take control of the game through your powers of programming. Become
+    the hero, unlock loot, and expand your arsenal of code to rescue the town. Then
+    use AI strategies to assemble a party for a final goblin boss battle!
+  tutorial_scratchstorytelling_longdescription: Animate your own story with Scratch!
+    Add sprites, backgrounds, and interactive graphic effects to bring your story
+    to life. Includes an educator facilitation guide, Scratch project tutorial, and
+    coding cards. This activity aligned with Common Core English Language Arts Standards.
+  tutorial_crayolasymbols_longdescription: A picture is worth a thousand words—even
+    small images say a lot! Visual symbols are everywhere, directing us to public
+    restrooms, hospitals, wheelchair ramps, and bus stops. Use shapes and lines to
+    design original symbols that others can count on.
+  tutorial_crayoladrawacode_longdescription: Explore codes from yesterday and today.
+    Ancient people drew symbols on cave walls to tell stories. Ancient Egyptians carved
+    hieroglyphs, a language of visual symbols representing people, objects, and actions,
+    into stone. Create add-on stories with visual codes.
+  tutorial_crayolafollowmycode_longdescription: Create coding dance by sketching visual
+    symbols such as arrows, spirals, and footsteps to create a pattern that you and
+    others will follow. Or make small characters from Model Magic and use them to
+    follow your dance code!
+  tutorial_madpicturethis_longdescription: This lesson will introduce students to
+    HTML language and teach them how to decode it, even if they have never interacted
+    with HTML code before.  By making observations, students will notice patterns
+    and gain a better understanding of how HTML code is written and interpreted.
+  tutorial_mindmakersmaps_longdescription: In this universe, maps of different types
+    serve as a backdrop for fun challenges with autonomous vehicles that obey your
+    programs. To win, you will have to interpret each map and program not only the
+    movements, but adapt to the unexpected using sensors for obstacles and natural
+    events such as weather, temperature, and the passage of time. Have a good trip!
+  tutorial_mindmakersjorel_longdescription: The fun universe of Jorel's Brother is
+    now under your control! But for that, you need to master the fundamentals of programming
+    and develop skills like algorithmic thinking, problem decomposition, pattern identification
+    and abstraction... work hard and maybe you'll find out the name of Jorel's brother!
+  tutorial_mindmakersroboland_longdescription: Program the weird and fun robots Mustachebot
+    and Ladybot! You help them overcome challenges, and they help you develop computational
+    thinking. The more advanced the challenge, the more you learn about algorithms,
+    decomposition, patterns, and abstraction... Work hard and have fun!
+  tutorial_mindmakersrobolandjr_longdescription: Program the weird and funny robots
+    Mustachebot and Ladybot. Whenever you manage to solve a challenge, you get a little
+    green ball and move on to the next one. Capriche!
+  tutorial_codehsdraw_longdescription: Create your own drawing program in Scratch
+    using keyboard and mouse inputs. Anyone will be able to use it make fun and creative
+    digital art!
+  tutorial_codehscamouflage_longdescription: Use ScratchJr to program an animal to
+    show its adaptation of using camouflage in its environment!
+  tutorial_firiapythoncodex_longdescription: Simple step-by-step lessons teach Python
+    coding as you unlock new capabilities, from the beautiful color display to the
+    hi-fi audio system. Use the built-in accelerometer, light sensor, and microphone
+    to code your own unique and interactive projects. And you can directly connect
+    servo motors and external sensors for unlimited expansion possibilities. CodeX
+    = games, music, sensors, art, and more!
+  tutorial_bekidscoding_longdescription: Join Grace, Zak and Dot the Robot on an adventure
+    in the Loop Galaxy! Code with blocks to complete exciting tasks, and learn the
+    basics of algorithms, sequences and loops!
+  tutorial_rodocodehr_longdescription: 'Rodocodo: Code Hour is a self-guided coding
+    game for 4-11 year olds. It teaches the fundamentals of coding such as sequencing,
+    debugging, loops and functions. It also teaches techniques for solving problems
+    so children become more confident, independent learners.'
+  tutorial_microbitdice_longdescription: Shake your micro:bit to make random numbers.
+  tutorial_madflashcard_longdescription: This lesson exposes students to HTML and
+    CSS code and provides them the opportunity to interact with it and see their results
+    in real-time.
+  tutorial_madappwars_longdescription: 'This lesson provides students with the opportunity
+    to explore the business side of app development.  In this activity, students compare
+    two apps that fall under the same umbrella category (example: two travel apps)
+    and evaluate which is better based on specific criteria.'
+  tutorial_kodablepuppies_longdescription: Students will meet Kodable's fluffy friends
+    and learn how to care for them! 'Pets' are in-game puppies that require a lot
+    of love and attention. Students will program Carebots to help with the responsibility
+    of being a new paw-rent using coding concepts such as functions and conditional
+    statements.
+  tutorial_googlesuperhero_longdescription: Turn an everyday hero from your life or
+    community into a superhero by programming them to fly over buildings, spin, work
+    with a sidekick, and score points by touching objects in a game. In Code Your
+    Hero, show off your hero's special powers and your own creativity with CS First
+    and Scratch.
+  tutorial_googlename _longdescription: Pick a name and bring the letters of the word
+    to life using code. Choose a nickname, a pet's name, an animal, a sport, a place
+    or a hobby.
+  tutorial_carnegiezillah_longdescription: Zillah City is thriving, and music is in
+    the air. Rumor has it, the famed Gargantua bot is online and sending the last
+    Toxibots to trash the city block by block…. Grab your cobot hoverboard and get
+    ready to groove, move, and finish off what you started! Players program their
+    cobot hoverbots to change lanes, avoid obstacles, and take out many Toxibots in
+    this rhythm-styled game.
+  tutorial_nasachspacejam_longdescription: Create a solar system that really rocks!
+    Learn about music, astronomy, and coding in this self-guided activity (no coding
+    experience required). Program planets to make music, creating your own musical
+    solar system, complete with spacey melodies.
+  tutorial_hatchxrsolar_longdescription: 'Explore the stars and build your own solar
+    system using concepts of block based programming. Learn about the basics of 3D
+    space, and dive into your imagination to build a universe of your dreams, all
+    in less than an hour. And guess what, you can run your project in AR on any iOS
+    device using the HatchXR app. Don''t forget to share your creations with us using
+    #hatchxr #HourOfCode'
+  tutorial_hatchxrspace_longdescription: 'Code the classic space invaders game in
+    3D, while learning about the basic of game development, motion in 3D space and
+    learn fundamental programming concepts like loops, conditionals, variables, and
+    keyboard events, all in less than an hour. Don''t forget to share your creations
+    with us using #hatchxr #HourOfCode'
+  tutorial_hatchxrtrex_longdescription: 'Build the classic chrome''s T-rex dino game
+    in 3D, while learning about the basic of game development, motion in 3D space
+    and learn fundamental programming concepts like loops, conditionals, variables,
+    and keyboard events, all in less than an hour. Don''t forget to share your creations
+    with us using #hatchxr #HourOfCode'
+  tutorial_blocksmithguinea_longdescription: The guinea pigs are coming and they are
+    hungry. For each round, program Bot to fire carrots, launch lettuce or invoke
+    the mighty Apple shield in this furious, fast-paced coding game. Collect hearts
+    to unlock more tools and contain the feeding frenzy while hoping that your code
+    doesn't break.
+  tutorial_pickcodeshapes_longdescription: Learn to use Pickcode to write code that
+    creates a variety of shapes. Once the course is done, you'll be able to get creative
+    and make whatever design you'd like!
+  tutorial_codesterssketch_longdescription: Learn the basics of coding in Python while
+    creating your own custom Etch-a-Sketch! Learn how to control an onscreen sprite
+    with different key events, accept user input to set the pen width, and use a list
+    to control the pen color.
+  tutorial_pickcodechatbot_longdescription: In this course, you'll learn how to make
+    a simple chatbot that plays a quick ad libs game.
+  tutorial_codestersfish_longdescription: Learn the basics of coding in Python while
+    creating your own falling-object game! You'll learn how to add a background and
+    sprites, and how to use events to create and control sprites on the stage.
+  tutorial_codestershedgehog_longdescription: Learn the basics of coding in Python,
+    then create a game that shoots a sprite to the stars! To shoot your shot you'll
+    first need to learn how to create key, interval, and collision events. BLAST OFF!
+  tutorial_pickcodeggame_longdescription: Learn to make a two player guessing game
+    where one player enters a number into a chatbot, and the chatbot gives hints to
+    the other player as they try to guess.
+  tutorial_codestersdino_longdescription: Learn Python functions and events while
+    creating your own Flappy Dino game. Once the game starts, the dino drops! If you
+    hit a block, you lose.  How many blocks can you navigate the dino through?
+  tutorial_pickcodemtpaint_longdescription: In this course, you'll learn how to use
+    functions to draw a pretty intricate shape (like a mobius strip but in triangle
+    form). After this lesson, you'll have the building blocks for making a ton of
+    different designs.
+  tutorial_microsoftcarnival_longdescription: Code your own classroom carnival with
+    games like Whack-the-Mole, Burstin' Balloons, and Target Practice.
+  tutorial_thunkablescavenger_longdescription: Learn to build your own Scavenger Hunt
+    app in Thunkable, and use your app to hunt for items on your mobile device as
+    soon as your code is complete.
+  tutorial_codeillusionfund_longdescription: Enter into the magical world of coding
+    and computer science as you learn and familiarize yourself with the fundamentals
+    of a computer! This will include practicing clicking and scrolling, dragging and
+    dropping, copy and pasting and typing.
+  tutorial_codeillusiongoofybeg_longdescription: Embark on a magical coding adventure
+    with Goofy! Learn how to draw, color and move shapes, as well as load images and
+    sounds as you master the basics of Game Development using JavaScript.
+  tutorial_codeillusiongoofyint_longdescription: 'Create your very own interactive,
+    digital band with Goofy as you explore the joy of Game Development using JavaScript.
+    This activity will build on what you learned in our introductory activity, Disney
+    Codeillusion: Game Development Adventure with Goofy for Beginners.'
+  tutorial_robotmagicescape_longdescription: Escape from a haunted 3D room with help
+    from programmable bots.
+  tutorial_codespeakclimate_longdescription: Learn how to responsibly build a basic
+    website using HTML and help educate others about climate change.
+  tutorial_codespeaktwinkle_longdescription: Listen to a read aloud of 'Coding Twinkle'
+    and then learn to code it using the ScratchJr app
+  tutorial_coinbasecrypto_longdescription: Test your memory and learn the basics of
+    crypto!
+  tutorial_codespeakcomp_longdescription: Learn about worm composting and build a
+    game in Scratch!
+  tutorial_codespeaksnake_longdescription: Listen to a story about Snake, a classic
+    mobile game star, and code your own game in ScratchJr
+  tutorial_prstemalexa_longdescription: Students will explore voice artificial intelligence
+    - or voice AI - by coding two Alexa skills. Students will start by watching a
+    video covering voice AI basics, and then build a voice AI-powered program in MIT
+    App Inventor that says 'Hello Moon' and a program that can recite random space
+    facts. The lesson ends with a vocabulary review and discussion.
+  tutorial_coderzfarm_longdescription: Program a robot to plant a garden, and learn
+    how robots help farmers in the real world.
+  tutorial_intelinofield_longdescription: Learn to program the intelino smart train
+    unplugged with action snaps and complete the mission of driving students across
+    town on their field trip.
+  tutorial_cablockchain_longdescription: This interactive course explores blockchain
+    technology and cryptocurrencies, the driving force of the next generation web.
+    Follow our characters as they enter the metaverse on a hunt to find a potential
+    scammer. They discover a range of creative applications of blockchain and consider
+    how it could impact society in the future.
+  tutorial_nasaparachute_longdescription: In this activity, you will learn how JPL
+    engineers used a binary code to include a hidden message in the parachute used
+    to help the Mars rover, Perseverance, land successfully on Mars. You will also
+    have the opportunity to create your own hidden message.
+  tutorial_nasascratch_longdescription: Create a Moon or Mars exploration game using
+    Scratch, a visual programming language. Think like NASA space-mission planners
+    to design your game!
+  tutorial_nasaorbit_longdescription: In this activity, students use Scratch, Snap!,
+    or another programming language to create an interactive simulation of a spacecraft
+    docking to the International Space Station. The Crew Orbital Docking Simulation
+    (CODing Sim) engages students in computational thinking, problem-solving, and
+    real-world applications of mathematics.
+  tutorial_nasapackage_longdescription: In this activity, students use Scratch, Snap!,
+    or another programming language to create an interactive simulation of a drone
+    navigating around a geofenced area to deliver a package. The simulation engages
+    students in computational thinking, problem solving, and real-world application
+    of mathematics.
+  tutorial_nasalunar_longdescription: 'Students learn about the Artemis 1 mission
+    and the NASA App Development Challenge (ADC). The goal is for students to follow-along
+    steps we''ve created using Code.org''s App Lab to learn basic programming utilizing
+    block code. '
+  tutorial_meeestate_longdescription: 'Solve puzzles to escape from Dr. Breakowski''s
+    mysterious mansion in the new Minecraft Hour of Code: Escape Estate. Use coding
+    and computational thinking to unlock secrets, open trap doors, and reveal hidden
+    clues. Code your way out by dawn and earn a million emeralds! With coding in blocks
+    or Python, Hour of Code offers a learning pathway for anyone to learn the basics
+    of code.'
+  tutorial_imagipixelart_longdescription: Learn Python and create your own colorful
+    animations in this 1 hour crash course!
+  tutorial_kcjhealth_longdescription: 'Learn about data visualization, algorithmic
+    art and coding, while exploring SDG #3 ''Good Health and Well-Being''.'
+  tutorial_msftwakanda_longdescription: 'Shuri, Okoye, and Riri must band together
+    to help Wakanda. Code your own action-packed activity inspired by Marvel Studios''
+    ''Black Panther: Wakanda Forever''!'
+  tutorial_nafbrand_longdescription: In Code your Brand, you will be creating a virtual
+    contact file to create a personalized QR code with your contact details. After
+    you complete this activity, you will be equipped with a modern business card that
+    you can share while you're networking with people who can help or guide you in
+    your career or college journey.
+  tutorial_rpccw_string_detail_grades: Grades 2-5
+  tutorial_rpledfirefly_string_detail_grades: Grades 6-8
+  tutorial_rpcharting_string_detail_grades: Grades 9+
+  tutorial_rpsolar_string_detail_grades: Grades 9+
+  tutorial_rpwebcards_string_detail_grades: Grades 6-8
+  tutorial_codeclubhworld_string_detail_grades: Grades 6-8
+  tutorial_codeclubspells_string_detail_grades: Grades 2-5
+  tutorial_coderdojoanime_string_detail_grades: Grades 6-8
+  tutorial_coderdojotarget_string_detail_grades: Grades 6-8
+  tutorial_creaticodescratch_string_detail_grades: Grades 6+
+  tutorial_bbsierpinski_string_detail_grades: Grades 6-8
+  tutorial_bbstopwatch_string_detail_grades: Grades 6+
+  tutorial_idrpatterns_string_detail_grades: Pre-reader - Grade 5
+  tutorial_idrshapes_string_detail_grades: Pre-reader - Grade 5
+  tutorial_edisondetect_string_detail_grades: Grades 2-8
+  tutorial_edisonmusical_string_detail_grades: Grades 6+
+  tutorial_codemonkeydiglit_string_detail_grades: Grades 2-8
+  tutorial_bsdrockpaper_string_detail_grades: Grades 6-8
+  tutorial_microbitreaction_string_detail_grades: Grades 2-5
+  tutorial_kinderanimal_string_detail_grades: Pre-reader - Grade 5
+  tutorial_kindersinger_string_detail_grades: Pre-reader - Grade 5
+  tutorial_microbitwwn_string_detail_grades: Grades 2-5
+  tutorial_grokcyberlive_string_detail_grades: Grades 6+
+  tutorial_codemojimaze_string_detail_grades: Pre-reader - Grade 5
+  tutorial_codemojisnake_string_detail_grades: Pre-reader - Grade 5
+  tutorial_carnegietoxibots_string_detail_grades: Grades 2-8
+  tutorial_carnegieiris_string_detail_grades: Grades 2-8
+  tutorial_carnegiespike_string_detail_grades: Grades 2-8
+  tutorial_spheroincolor_string_detail_grades: Pre-reader - Grade 5
+  tutorial_kcjdominos_string_detail_grades: Grades 2-8
+  tutorial_spherocolortheory_string_detail_grades: Grades 6+
+  tutorial_codecombatesports_string_detail_grades: Grades 6-8
+  tutorial_spherodigdisplay_string_detail_grades: Grades 2-8
+  tutorial_spherorvrincolor_string_detail_grades: Grades 6+
+  tutorial_clbinary_string_detail_grades: Grades 2+
+  tutorial_sascollabcode_string_detail_grades: Pre-reader +
+  tutorial_codecombatgoblins_string_detail_grades: Grades 6-8
+  tutorial_scratchstorytelling_string_detail_grades: Grades 2-8
+  tutorial_crayolasymbols_string_detail_grades: Grades 2+
+  tutorial_crayoladrawacode_string_detail_grades: Pre-reader - Grade 8
+  tutorial_crayolafollowmycode_string_detail_grades: Pre-reader - Grade 8
+  tutorial_madpicturethis_string_detail_grades: Grades 6-8
+  tutorial_mindmakersmaps_string_detail_grades: Grades 9+
+  tutorial_mindmakersjorel_string_detail_grades: Grades 6-8
+  tutorial_mindmakersroboland_string_detail_grades: Grades 2-5
+  tutorial_mindmakersrobolandjr_string_detail_grades: Pre-reader - Grade 1
+  tutorial_codehsdraw_string_detail_grades: Grades 2-8
+  tutorial_codehscamouflage_string_detail_grades: Pre-reader - Grade 5
+  tutorial_firiapythoncodex_string_detail_grades: Pre-reader +
+  tutorial_bekidscoding_string_detail_grades: Pre-reader - Grade 5
+  tutorial_rodocodehr_string_detail_grades: Pre-reader - Grade 5
+  tutorial_microbitdice_string_detail_grades: Grades 2-5
+  tutorial_madflashcard_string_detail_grades: Grades 6-8
+  tutorial_madappwars_string_detail_grades: Grades 6+
+  tutorial_kodablepuppies_string_detail_grades: Pre-reader - Grade 5
+  tutorial_googlesuperhero_string_detail_grades: Grades 2-8
+  tutorial_googlename _string_detail_grades: Grades 2-8
+  tutorial_carnegiezillah_string_detail_grades: Grades 2-9
+  tutorial_nasachspacejam_string_detail_grades: Grades 2+
+  tutorial_hatchxrsolar_string_detail_grades: Grades 2+
+  tutorial_hatchxrspace_string_detail_grades: Grades 2+
+  tutorial_hatchxrtrex_string_detail_grades: Grades 2+
+  tutorial_blocksmithguinea_string_detail_grades: Grades 2+
+  tutorial_pickcodeshapes_string_detail_grades: Grades 6+
+  tutorial_codesterssketch_string_detail_grades: Grades 6-8
+  tutorial_pickcodechatbot_string_detail_grades: Grades 6+
+  tutorial_codestersfish_string_detail_grades: Grades 6-8
+  tutorial_codestershedgehog_string_detail_grades: Grades 6-8
+  tutorial_pickcodeggame_string_detail_grades: Grades 9+
+  tutorial_codestersdino_string_detail_grades: Grades 6-8
+  tutorial_pickcodemtpaint_string_detail_grades: Grades 9+
+  tutorial_microsoftcarnival_string_detail_grades: Grades 2+
+  tutorial_thunkablescavenger_string_detail_grades: Grades 6-8
+  tutorial_codeillusionfund_string_detail_grades: Pre-reader - Grade 5
+  tutorial_codeillusiongoofybeg_string_detail_grades: Grades 2+
+  tutorial_codeillusiongoofyint_string_detail_grades: Grades 6+
+  tutorial_robotmagicescape_string_detail_grades: Grades 2+
+  tutorial_codespeakclimate_string_detail_grades: Grades 2+
+  tutorial_codespeaktwinkle_string_detail_grades: Pre-reader - Grade 1
+  tutorial_coinbasecrypto_string_detail_grades: Grades 2-8
+  tutorial_codespeakcomp_string_detail_grades: Grades 2+
+  tutorial_codespeaksnake_string_detail_grades: Pre-reader - Grade 1
+  tutorial_prstemalexa_string_detail_grades: Grades 9+
+  tutorial_coderzfarm_string_detail_grades: Grades 2-8
+  tutorial_intelinofield_string_detail_grades: Pre-reader - Grade 5
+  tutorial_cablockchain_string_detail_grades: Grades 6+
+  tutorial_nasaparachute_string_detail_grades: Grades 2-5
+  tutorial_nasascratch_string_detail_grades: Grades 6-8
+  tutorial_nasaorbit_string_detail_grades: Grades 6-8
+  tutorial_nasapackage_string_detail_grades: Grades 6-8
+  tutorial_nasalunar_string_detail_grades: Grades 6-8
+  tutorial_meeestate_string_detail_grades: Grades 2+
+  tutorial_imagipixelart_string_detail_grades: Grades 2-8
+  tutorial_kcjhealth_string_detail_grades: Grades 6+
+  tutorial_msftwakanda_string_detail_grades: Grades 6+
+  tutorial_nafbrand_string_detail_grades: Grades 9+
+  tutorial_rpccw_string_platforms: All modern browsers, Android tablet, iPad, Windows
+    phone, Android phone, iPhone
+  tutorial_rpledfirefly_string_platforms: All modern browsers
+  tutorial_rpcharting_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_rpsolar_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_rpwebcards_string_platforms: All modern browsers, Android tablet, iPad,
+    Windows phone, Android phone, iPhone
+  tutorial_codeclubhworld_string_platforms: All modern browsers, Android tablet, iPad
+  tutorial_codeclubspells_string_platforms: All modern browsers, Android tablet, iPad,
+    Windows phone, Android phone, iPhone
+  tutorial_coderdojoanime_string_platforms: All modern browsers, Android tablet, iPad,
+    Windows phone, Android phone, iPhone
+  tutorial_coderdojotarget_string_platforms: All modern browsers, Android tablet,
+    iPad, Windows phone, Android phone, iPhone
+  tutorial_creaticodescratch_string_platforms: All modern browsers, Android tablet,
+    iPad, Windows phone, Android phone, iPhone
+  tutorial_bbsierpinski_string_platforms: All modern browsers
+  tutorial_bbstopwatch_string_platforms: All modern browsers
+  tutorial_idrpatterns_string_platforms: All modern browsers
+  tutorial_idrshapes_string_platforms: All modern browsers
+  tutorial_edisondetect_string_platforms: All modern browsers
+  tutorial_edisonmusical_string_platforms: All modern browsers
+  tutorial_codemonkeydiglit_string_platforms: All modern browsers, Android tablet,
+    iPad, Windows phone, Android phone, iPhone
+  tutorial_bsdrockpaper_string_platforms: Chrome, Firefox
+  tutorial_microbitreaction_string_platforms: All modern browsers
+  tutorial_kinderanimal_string_platforms: Unplugged
+  tutorial_kindersinger_string_platforms: Unplugged
+  tutorial_microbitwwn_string_platforms: All modern browsers
+  tutorial_grokcyberlive_string_platforms: All modern browsers
+  tutorial_codemojimaze_string_platforms: Unplugged
+  tutorial_codemojisnake_string_platforms: Chrome
+  tutorial_carnegietoxibots_string_platforms: All modern browsers
+  tutorial_carnegieiris_string_platforms: All modern browsers
+  tutorial_carnegiespike_string_platforms: All modern browsers
+  tutorial_spheroincolor_string_platforms: Unplugged
+  tutorial_kcjdominos_string_platforms: All modern browsers
+  tutorial_spherocolortheory_string_platforms: All modern browsers, Android tablet,
+    iPad, Windows phone, Android phone, iPhone
+  tutorial_codecombatesports_string_platforms: All modern browsers
+  tutorial_spherodigdisplay_string_platforms: All modern browsers, Android tablet,
+    iPad, Windows phone, Android phone, iPhone
+  tutorial_spherorvrincolor_string_platforms: All modern browsers, Android tablet,
+    iPad, Windows phone, Android phone, iPhone
+  tutorial_clbinary_string_platforms: Unplugged
+  tutorial_sascollabcode_string_platforms: iPad
+  tutorial_codecombatgoblins_string_platforms: All modern browsers
+  tutorial_scratchstorytelling_string_platforms: All modern browsers
+  tutorial_crayolasymbols_string_platforms: Unplugged
+  tutorial_crayoladrawacode_string_platforms: Unplugged
+  tutorial_crayolafollowmycode_string_platforms: Unplugged
+  tutorial_madpicturethis_string_platforms: Unplugged
+  tutorial_mindmakersmaps_string_platforms: All modern browsers
+  tutorial_mindmakersjorel_string_platforms: All modern browsers
+  tutorial_mindmakersroboland_string_platforms: All modern browsers
+  tutorial_mindmakersrobolandjr_string_platforms: All modern browsers
+  tutorial_codehsdraw_string_platforms: Unplugged
+  tutorial_codehscamouflage_string_platforms: Unplugged
+  tutorial_firiapythoncodex_string_platforms: Chrome
+  tutorial_bekidscoding_string_platforms: All modern browsers, Android tablet, iPad,
+    Windows phone, Android phone, iPhone
+  tutorial_rodocodehr_string_platforms: All modern browsers, Android tablet, iPad,
+    Windows phone, Android phone, iPhone
+  tutorial_microbitdice_string_platforms: All modern browsers, Android tablet, iPad,
+    Windows phone, Android phone, iPhone
+  tutorial_madflashcard_string_platforms: All modern browsers
+  tutorial_madappwars_string_platforms: All modern browsers
+  tutorial_kodablepuppies_string_platforms: All modern browsers, Android tablet, iPad,
+    Windows phone, Android phone, iPhone
+  tutorial_googlesuperhero_string_platforms: All modern browsers
+  tutorial_googlename _string_platforms: All modern browsers
+  tutorial_carnegiezillah_string_platforms: All modern browsers
+  tutorial_nasachspacejam_string_platforms: All modern browsers
+  tutorial_hatchxrsolar_string_platforms: All modern browsers, Android tablet, iPad,
+    Windows phone, Android phone, iPhone
+  tutorial_hatchxrspace_string_platforms: All modern browsers, Android tablet, iPad,
+    Windows phone, Android phone, iPhone
+  tutorial_hatchxrtrex_string_platforms: All modern browsers, Android tablet, iPad,
+    Windows phone, Android phone, iPhone
+  tutorial_blocksmithguinea_string_platforms: All modern browsers, Android tablet,
+    iPad, Windows phone, Android phone, iPhone
+  tutorial_pickcodeshapes_string_platforms: All modern browsers
+  tutorial_codesterssketch_string_platforms: All modern browsers
+  tutorial_pickcodechatbot_string_platforms: All modern browsers, Android tablet,
+    iPad, Windows phone, Android phone, iPhone
+  tutorial_codestersfish_string_platforms: All modern browsers
+  tutorial_codestershedgehog_string_platforms: All modern browsers
+  tutorial_pickcodeggame_string_platforms: All modern browsers
+  tutorial_codestersdino_string_platforms: All modern browsers
+  tutorial_pickcodemtpaint_string_platforms: All modern browsers
+  tutorial_microsoftcarnival_string_platforms: All modern browsers, Android tablet,
+    iPad, Windows phone, Android phone, iPhone
+  tutorial_thunkablescavenger_string_platforms: All modern browsers
+  tutorial_codeillusionfund_string_platforms: Chrome
+  tutorial_codeillusiongoofybeg_string_platforms: Chrome
+  tutorial_codeillusiongoofyint_string_platforms: Chrome
+  tutorial_robotmagicescape_string_platforms: All modern browsers, Android tablet,
+    iPad, Windows phone, Android phone, iPhone
+  tutorial_codespeakclimate_string_platforms: All modern browsers
+  tutorial_codespeaktwinkle_string_platforms: Android tablet, iPad, Windows phone,
+    Android phone, iPhone
+  tutorial_coinbasecrypto_string_platforms: All modern browsers, Android tablet, iPad,
+    Windows phone, Android phone, iPhone
+  tutorial_codespeakcomp_string_platforms: All modern browsers
+  tutorial_codespeaksnake_string_platforms: Android tablet, iPad, Windows phone, Android
+    phone, iPhone
+  tutorial_prstemalexa_string_platforms: All modern browsers
+  tutorial_coderzfarm_string_platforms: All modern browsers
+  tutorial_intelinofield_string_platforms: Unplugged
+  tutorial_cablockchain_string_platforms: Android tablet, iPad, Windows phone, Android
+    phone, iPhone
+  tutorial_nasaparachute_string_platforms: Unplugged
+  tutorial_nasascratch_string_platforms: Android tablet, iPad, Windows phone, Android
+    phone, iPhone
+  tutorial_nasaorbit_string_platforms: All modern browsers
+  tutorial_nasapackage_string_platforms: All modern browsers
+  tutorial_nasalunar_string_platforms: All modern browsers, iPad, iPhone
+  tutorial_meeestate_string_platforms: All modern browsers, Mac, Windows, Chromebook,
+    iPhone, iPad, Android phone, Android tablet
+  tutorial_imagipixelart_string_platforms: All modern browsers, iPad, Android tablets,
+    Windows phone, Android phone, iPhone
+  tutorial_kcjhealth_string_platforms: All modern browsers
+  tutorial_msftwakanda_string_platforms: All modern browsers
+  tutorial_nafbrand_string_platforms: All modern browsers, Android tablet, iPad, Windows
+    phone, Android phone, iPhone
+  tutorial_rpccw_string_detail_platforms: ''
+  tutorial_rpledfirefly_string_detail_platforms: Raspberry Pi Pico
+  tutorial_rpcharting_string_detail_platforms: ''
+  tutorial_rpsolar_string_detail_platforms: ''
+  tutorial_rpwebcards_string_detail_platforms: ''
+  tutorial_codeclubhworld_string_detail_platforms: ''
+  tutorial_codeclubspells_string_detail_platforms: ''
+  tutorial_coderdojoanime_string_detail_platforms: ''
+  tutorial_coderdojotarget_string_detail_platforms: ''
+  tutorial_creaticodescratch_string_detail_platforms: ''
+  tutorial_bbsierpinski_string_detail_platforms: ''
+  tutorial_bbstopwatch_string_detail_platforms: ''
+  tutorial_idrpatterns_string_detail_platforms: ''
+  tutorial_idrshapes_string_detail_platforms: ''
+  tutorial_edisondetect_string_detail_platforms: Edison Robot
+  tutorial_edisonmusical_string_detail_platforms: Edison Robot
+  tutorial_codemonkeydiglit_string_detail_platforms: ''
+  tutorial_bsdrockpaper_string_detail_platforms: ''
+  tutorial_microbitreaction_string_detail_platforms: BBC micro:bit
+  tutorial_kinderanimal_string_detail_platforms: KIBO 10 Robot Kit
+  tutorial_kindersinger_string_detail_platforms: KIBO 21 Robot Kit
+  tutorial_microbitwwn_string_detail_platforms: BBC micro:bit
+  tutorial_grokcyberlive_string_detail_platforms: ''
+  tutorial_codemojimaze_string_detail_platforms: ''
+  tutorial_codemojisnake_string_detail_platforms: ''
+  tutorial_carnegietoxibots_string_detail_platforms: ''
+  tutorial_carnegieiris_string_detail_platforms: ''
+  tutorial_carnegiespike_string_detail_platforms: ''
+  tutorial_spheroincolor_string_detail_platforms: Sphero Indi Robot
+  tutorial_kcjdominos_string_detail_platforms: ''
+  tutorial_spherocolortheory_string_detail_platforms: Sphero Indi Robot
+  tutorial_codecombatesports_string_detail_platforms: ''
+  tutorial_spherodigdisplay_string_detail_platforms: littleBits STEAM+ Coding Kit
+  tutorial_spherorvrincolor_string_detail_platforms: Sphero
+  tutorial_clbinary_string_detail_platforms: ''
+  tutorial_sascollabcode_string_detail_platforms: iPad, Sphero robot (BOLT, Sphero
+    Mini, or SPRK+)
+  tutorial_codecombatgoblins_string_detail_platforms: ''
+  tutorial_scratchstorytelling_string_detail_platforms: ''
+  tutorial_crayolasymbols_string_detail_platforms: ''
+  tutorial_crayoladrawacode_string_detail_platforms: ''
+  tutorial_crayolafollowmycode_string_detail_platforms: ''
+  tutorial_madpicturethis_string_detail_platforms: ''
+  tutorial_mindmakersmaps_string_detail_platforms: ''
+  tutorial_mindmakersjorel_string_detail_platforms: ''
+  tutorial_mindmakersroboland_string_detail_platforms: ''
+  tutorial_mindmakersrobolandjr_string_detail_platforms: ''
+  tutorial_codehsdraw_string_detail_platforms: ''
+  tutorial_codehscamouflage_string_detail_platforms: ''
+  tutorial_firiapythoncodex_string_detail_platforms: CodeX
+  tutorial_bekidscoding_string_detail_platforms: ''
+  tutorial_rodocodehr_string_detail_platforms: ''
+  tutorial_microbitdice_string_detail_platforms: micro:bit
+  tutorial_madflashcard_string_detail_platforms: ''
+  tutorial_madappwars_string_detail_platforms: ''
+  tutorial_kodablepuppies_string_detail_platforms: ''
+  tutorial_googlesuperhero_string_detail_platforms: ''
+  tutorial_googlename _string_detail_platforms: ''
+  tutorial_carnegiezillah_string_detail_platforms: ''
+  tutorial_nasachspacejam_string_detail_platforms: ''
+  tutorial_hatchxrsolar_string_detail_platforms: ''
+  tutorial_hatchxrspace_string_detail_platforms: ''
+  tutorial_hatchxrtrex_string_detail_platforms: ''
+  tutorial_blocksmithguinea_string_detail_platforms: ''
+  tutorial_pickcodeshapes_string_detail_platforms: ''
+  tutorial_codesterssketch_string_detail_platforms: ''
+  tutorial_pickcodechatbot_string_detail_platforms: ''
+  tutorial_codestersfish_string_detail_platforms: ''
+  tutorial_codestershedgehog_string_detail_platforms: ''
+  tutorial_pickcodeggame_string_detail_platforms: ''
+  tutorial_codestersdino_string_detail_platforms: ''
+  tutorial_pickcodemtpaint_string_detail_platforms: ''
+  tutorial_microsoftcarnival_string_detail_platforms: ''
+  tutorial_thunkablescavenger_string_detail_platforms: ''
+  tutorial_codeillusionfund_string_detail_platforms: ''
+  tutorial_codeillusiongoofybeg_string_detail_platforms: ''
+  tutorial_codeillusiongoofyint_string_detail_platforms: ''
+  tutorial_robotmagicescape_string_detail_platforms: ''
+  tutorial_codespeakclimate_string_detail_platforms: ''
+  tutorial_codespeaktwinkle_string_detail_platforms: ''
+  tutorial_coinbasecrypto_string_detail_platforms: ''
+  tutorial_codespeakcomp_string_detail_platforms: ''
+  tutorial_codespeaksnake_string_detail_platforms: ''
+  tutorial_prstemalexa_string_detail_platforms: ''
+  tutorial_coderzfarm_string_detail_platforms: ''
+  tutorial_intelinofield_string_detail_platforms: intelino J-1 smart train set
+  tutorial_cablockchain_string_detail_platforms: ''
+  tutorial_nasaparachute_string_detail_platforms: ''
+  tutorial_nasascratch_string_detail_platforms: ''
+  tutorial_nasaorbit_string_detail_platforms: ''
+  tutorial_nasapackage_string_detail_platforms: ''
+  tutorial_nasalunar_string_detail_platforms: ''
+  tutorial_meeestate_string_detail_platforms: ''
+  tutorial_imagipixelart_string_detail_platforms: ''
+  tutorial_kcjhealth_string_detail_platforms: ''
+  tutorial_msftwakanda_string_detail_platforms: ''
+  tutorial_nafbrand_string_detail_platforms: ''
+  tutorial_rpccw_string_detail_programming_languages: Blocks
+  tutorial_rpledfirefly_string_detail_programming_languages: Python
+  tutorial_rpcharting_string_detail_programming_languages: Python
+  tutorial_rpsolar_string_detail_programming_languages: Python
+  tutorial_rpwebcards_string_detail_programming_languages: HTML, CSS
+  tutorial_codeclubhworld_string_detail_programming_languages: Python
+  tutorial_codeclubspells_string_detail_programming_languages: Blocks
+  tutorial_coderdojoanime_string_detail_programming_languages: HTML, CSS
+  tutorial_coderdojotarget_string_detail_programming_languages: Python
+  tutorial_creaticodescratch_string_detail_programming_languages: Blocks
+  tutorial_bbsierpinski_string_detail_programming_languages: JavaScript
+  tutorial_bbstopwatch_string_detail_programming_languages: JavaScript
+  tutorial_idrpatterns_string_detail_programming_languages: Blocks
+  tutorial_idrshapes_string_detail_programming_languages: Blocks
+  tutorial_edisondetect_string_detail_programming_languages: Blocks
+  tutorial_edisonmusical_string_detail_programming_languages: Blocks
+  tutorial_codemonkeydiglit_string_detail_programming_languages: Digital Literacy
+  tutorial_bsdrockpaper_string_detail_programming_languages: Python
+  tutorial_microbitreaction_string_detail_programming_languages: Blocks, Python, MakeCode
+  tutorial_kinderanimal_string_detail_programming_languages: Unplugged
+  tutorial_kindersinger_string_detail_programming_languages: Unplugged
+  tutorial_microbitwwn_string_detail_programming_languages: Blocks, Python, MakeCode
+  tutorial_grokcyberlive_string_detail_programming_languages: Cybersecurity concepts
+  tutorial_codemojimaze_string_detail_programming_languages: Unplugged, Sequences
+  tutorial_codemojisnake_string_detail_programming_languages: Blocks
+  tutorial_carnegietoxibots_string_detail_programming_languages: Blocks
+  tutorial_carnegieiris_string_detail_programming_languages: Blocks
+  tutorial_carnegiespike_string_detail_programming_languages: Blocks
+  tutorial_spheroincolor_string_detail_programming_languages: Language independent,
+    Color tiles
+  tutorial_kcjdominos_string_detail_programming_languages: JavaScript
+  tutorial_spherocolortheory_string_detail_programming_languages: Blocks
+  tutorial_codecombatesports_string_detail_programming_languages: JavaScript, Python
+  tutorial_spherodigdisplay_string_detail_programming_languages: Blocks
+  tutorial_spherorvrincolor_string_detail_programming_languages: Blocks
+  tutorial_clbinary_string_detail_programming_languages: Unplugged
+  tutorial_sascollabcode_string_detail_programming_languages: Blocks, Tactile braille
+    blocks
+  tutorial_codecombatgoblins_string_detail_programming_languages: JavaScript, Python
+  tutorial_scratchstorytelling_string_detail_programming_languages: Blocks
+  tutorial_crayolasymbols_string_detail_programming_languages: Unplugged
+  tutorial_crayoladrawacode_string_detail_programming_languages: Unplugged
+  tutorial_crayolafollowmycode_string_detail_programming_languages: Unplugged
+  tutorial_madpicturethis_string_detail_programming_languages: Unplugged, HTML
+  tutorial_mindmakersmaps_string_detail_programming_languages: Blocks
+  tutorial_mindmakersjorel_string_detail_programming_languages: Blocks
+  tutorial_mindmakersroboland_string_detail_programming_languages: Blocks
+  tutorial_mindmakersrobolandjr_string_detail_programming_languages: Blocks
+  tutorial_codehsdraw_string_detail_programming_languages: Blocks
+  tutorial_codehscamouflage_string_detail_programming_languages: Blocks
+  tutorial_firiapythoncodex_string_detail_programming_languages: Python
+  tutorial_bekidscoding_string_detail_programming_languages: Blocks
+  tutorial_rodocodehr_string_detail_programming_languages: Blocks
+  tutorial_microbitdice_string_detail_programming_languages: Blocks, Python, MakeCode
+  tutorial_madflashcard_string_detail_programming_languages: HTML, CSS
+  tutorial_madappwars_string_detail_programming_languages: HTML, CSS
+  tutorial_kodablepuppies_string_detail_programming_languages: C/C++, JavaScript,
+    iOS/Swift
+  tutorial_googlesuperhero_string_detail_programming_languages: Blocks
+  tutorial_googlename _string_detail_programming_languages: Blocks
+  tutorial_carnegiezillah_string_detail_programming_languages: Blocks
+  tutorial_nasachspacejam_string_detail_programming_languages: Blocks
+  tutorial_hatchxrsolar_string_detail_programming_languages: Blocks
+  tutorial_hatchxrspace_string_detail_programming_languages: Blocks
+  tutorial_hatchxrtrex_string_detail_programming_languages: Blocks
+  tutorial_blocksmithguinea_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_pickcodeshapes_string_detail_programming_languages: JavaScript
+  tutorial_codesterssketch_string_detail_programming_languages: Python
+  tutorial_pickcodechatbot_string_detail_programming_languages: JavaScript
+  tutorial_codestersfish_string_detail_programming_languages: Python
+  tutorial_codestershedgehog_string_detail_programming_languages: Python
+  tutorial_pickcodeggame_string_detail_programming_languages: JavaScript
+  tutorial_codestersdino_string_detail_programming_languages: Python
+  tutorial_pickcodemtpaint_string_detail_programming_languages: JavaScript
+  tutorial_microsoftcarnival_string_detail_programming_languages: Blocks
+  tutorial_thunkablescavenger_string_detail_programming_languages: Blocks
+  tutorial_codeillusionfund_string_detail_programming_languages: Computer Basics /
+    Fundamentals of a PC
+  tutorial_codeillusiongoofybeg_string_detail_programming_languages: JavaScript
+  tutorial_codeillusiongoofyint_string_detail_programming_languages: JavaScript
+  tutorial_robotmagicescape_string_detail_programming_languages: Blocks,JavaScript
+  tutorial_codespeakclimate_string_detail_programming_languages: HTML
+  tutorial_codespeaktwinkle_string_detail_programming_languages: Blocks
+  tutorial_coinbasecrypto_string_detail_programming_languages: Cryptocurrency concepts
+  tutorial_codespeakcomp_string_detail_programming_languages: Blocks
+  tutorial_codespeaksnake_string_detail_programming_languages: Blocks
+  tutorial_prstemalexa_string_detail_programming_languages: Blocks
+  tutorial_coderzfarm_string_detail_programming_languages: Blocks
+  tutorial_intelinofield_string_detail_programming_languages: Unplugged
+  tutorial_cablockchain_string_detail_programming_languages: Computational Thinking
+  tutorial_nasaparachute_string_detail_programming_languages: Unplugged, Binary Code
+  tutorial_nasascratch_string_detail_programming_languages: Blocks
+  tutorial_nasaorbit_string_detail_programming_languages: Blocks
+  tutorial_nasapackage_string_detail_programming_languages: Blocks
+  tutorial_nasalunar_string_detail_programming_languages: Blocks, JavaScript
+  tutorial_meeestate_string_detail_programming_languages: Blocks, Python
+  tutorial_imagipixelart_string_detail_programming_languages: Typing
+  tutorial_kcjhealth_string_detail_programming_languages: Blocks
+  tutorial_msftwakanda_string_detail_programming_languages: Blocks
+  tutorial_nafbrand_string_detail_programming_languages: Python
+  school_not_found_heading: We couldn't find your school. Please enter more information.
+  school_name: School name
+  school_name_error: School name is required.
+  school_city: School city
+  school_state: School state
+  school_zip: Postal code
+  school_zip_error: School postal code is required.
+  census_thanks: Thanks for signing up!
+  census_header: Please take a few minutes to tell us about your school (Optional).
+  census_heading: Please share how much coding/computer programming is taught at this
+    school. Assume for the purposes of the following questions that coding/computer
+    programming does not include HTML/CSS, Web design, or how to use apps.
+  census_how_many_hoc: How many students will do an Hour of Code?
+  census_how_many_after_school: How many students do computer programming in an after-school
+    program?
+  census_how_many_ten_hours: How many students take at least 10 hours of computer
+    programming integrated into a non-Computer Science course (such as TechEd, Math,
+    Science, Art, Library or general classroom/homeroom)?
+  census_how_many_twenty_hours: How many students take a semester or year-long computer
+    science course that includes at least 20 hours of coding/computer programming?
+  census_other_cs: This school teaches other computing classes that do not include
+    at least 20 hours of coding/computer programming. (For example, learning to use
+    applications, computer literacy, web design, HTML/CSS, or other)
+  census_connection: What is your connection to this school?
+  census_pledge: I pledge to expand computer science offerings at my school, and to
+    engage a diverse group of students, to bring opportunity to all.
+  census_followup_heading: Your school offers a semester or year-long computer science
+    class! What topics does this course include?
+  census_followup_frequency: How often per week does this class meet?
+  less_than_one: "< 1 hour per week"
+  one_to_three: 1-3 hours per week
+  three_plus: 3+ hours per week
+  census_followup_more: Please tell us more about this course.
+  census_followup_more_placeholder: For example, name of the class, how often it meets,
+    description of what is taught.
+  census_topics_blocks: Block-based programming
+  census_topics_text: "  Text-based programming in a language such as Java, JavaScript,
+    Python, C++, etc. (Excluding HTML or CSS)"
+  census_topics_robots: Robotics / Physical Computing
+  census_topics_internet: Internet and networking
+  census_topics_security: Cybersecurity
+  census_topics_data: Data analysis
+  census_topics_web_design: Web design using HTML and CSS
+  census_topics_game_design: Game design using game layout tools without coding or
+    computer programming
+  teacher: Teacher
+  administrator: Administrator
+  parent: Parent
+  volunteer_or_advocate: Volunteer/Community Advocate
+  other: Other
+  other_describe: Other (please describe below)
+  none: None
+  some: Some
+  all: All
+  dont_know: I don't know
+  language_label: Language
+  team_page_full_team_alt_text: Nearly 100 Code.org employees in matching blue and
+    yellow t-shirts pose in a hotel conference room for the company's summer 2022
+    Codechella event.
+  careers_page_code_pride_alt_text: Two feminine-presenting employees smile while
+    holding the ends of a Code.org-branded rainbow banner. Behind them, several people
+    are wearing Code.org shirts and waving rainbow flags while walking alongside a
+    multi-colored Volkswagen bug.
+  language_code:
+    ar: Arabic
+    az: Azerbaijani
+    bg: Bulgarian
+    bn: Bengali
+    br: Breton
+    bs: Bosnian
+    ca: Catalan
+    co: Corsican
+    cs: Czech
+    da: Danish
+    de: German
+    dv: Dhivehi
+    el: Greek
+    en: English
+    es: Spanish
+    et: Estonian
+    eu: Basque
+    fa: Persian
+    fi: Finnish
+    fil: Filipino
+    fr: French
+    ga: Irish
+    gl: Galician
+    haw: Hawaiian
+    he: Hebrew
+    hi: Hindi
+    hr: Croatian
+    hu: Hungarian
+    hy: Armenian
+    ia: Interlingua (International Auxiliary Language Association)
+    id: Indonesian
+    is: Icelandic
+    it: Italian
+    ja: Japanese
+    ka: Georgian
+    kk: Kazakh
+    km: Khmer
+    kn: Kannada
+    ko: Korean
+    ku: Kurdish
+    ky: Kyrgyz
+    lt: Lithuanian
+    lv: Latvian
+    mi: Maori
+    mk: Macedonian
+    mn: Mongolian
+    mr: Marathi
+    ms: Malay
+    mt: Maltese
+    my: Burmese
+    ne: Nepali
+    nl: Dutch
+    nn: Norwegian (Nynorsk)
+    false: Norwegian (Bokmål)
+    pl: Polish
+    ps: Pashto
+    pt: Portuguese
+    ro: Romanian
+    ru: Russian
+    se: Northern Sami
+    si: Sinhalese
+    sk: Slovak
+    sl: Slovenian
+    sq: Albanian
+    sr: Serbian
+    sv: Swedish
+    sw: Kiswahili
+    ta: Tamil
+    te: Telugu
+    tg: Tajik
+    th: Thai
+    tl: Tagalog
+    tr: Turkish
+    uk: Ukrainian
+    ur: Urdu
+    uz: Uzbek
+    vi: Vietnamese
+    zh: Chinese (Simplified)
+    zu: Zulu
+  locale_code:
+    ar-sa: Arabic
+    az-az: Azerbaijani
+    bg-bg: Bulgarian
+    bn-bd: Bengali
+    bs-ba: Bosnian
+    ca-es: Catalan
+    co-co: Corsican
+    cs-cz: Czech
+    da-dk: Danish
+    de-de: German
+    dv-mv: Dhivehi
+    el-gr: Greek
+    en-gb: English (United Kingdom)
+    en-us: English
+    es-es: Spanish (Spain)
+    es-mx: Spanish (Mexico)
+    et-ee: Estonian
+    eu-es: Basque
+    fa-af: Dari
+    fa-ir: Persian
+    fi-fi: Finnish
+    fil-ph: Filipino
+    fr-fr: French
+    ga-ie: Irish
+    gl-es: Galician
+    haw-hi: Hawaiian
+    he-il: Hebrew
+    hi-in: Hindi
+    hr-hr: Croatian
+    hu-hu: Hungarian
+    hy-am: Armenian
+    id-id: Indonesian
+    is-is: Icelandic
+    it-it: Italian
+    ja-jp: Japanese
+    ka-ge: Georgian
+    kk-kz: Kazakh
+    km-kh: Khmer
+    kn-in: Kannada
+    ko-kr: Korean
+    ku-iq: Kurdish
+    ky-kg: Kyrgyz
+    lt-lt: Lithuanian
+    lv-lv: Latvian
+    mi-nz: Maori
+    mk-mk: Macedonian
+    mn-mn: Mongolian
+    mr-in: Marathi
+    ms-my: Malay
+    mt-mt: Maltese
+    my-mm: Burmese
+    ne-np: Nepali
+    nl-nl: Dutch
+    nn-no: Norwegian (Nynorsk)
+    no-no: Norwegian (Bokmål)
+    pl-pl: Polish
+    ps-af: Pashto
+    pt-br: Portuguese (Brazil)
+    pt-pt: Portuguese (Portugal)
+    ro-ro: Romanian
+    ru-ru: Russian
+    se-fi: Northern Sami
+    si-lk: Sinhalese
+    sk-sk: Slovak
+    sl-si: Slovenian
+    sq-al: Albanian
+    sr-sp: Serbian
+    sv-se: Swedish
+    ta-in: Tamil
+    te-in: Telugu
+    tg-tj: Tajik
+    th-th: Thai
+    tr-tr: Turkish
+    uk-ua: Ukrainian
+    ur-in: Urdu (India)
+    ur-pk: Urdu (Pakistan)
+    uz-uz: Uzbek
+    vi-vn: Vietnamese
+    zh-cn: Chinese (Simplified)
+    zh-hans: Chinese (Simplified)
+    zh-hant: Chinese (Traditional)
+    zh-tw: Chinese (Traditional)
+    zu-za: Zulu


### PR DESCRIPTION
Samoan was recently added to supported languages.
After turning off the supported flags in `cdo-languages` Google sheet, a unit tests began to fail, blocking our deployment pipeline.
The unit tests failing was `test_i18n_hoc_routes.rb`  
the test failed because there wasn't a `pegasus/sites.v3/hourofcode.com/i18n/sm.yml` file
After samoan was added to the sync, _etags_ where correctly created for the new language, but hour of code files were not committed, resulting in an incomplete sync. 

This PR manually adds `sm.yml` to the `pegasus/sites.v3/hourofcode.com/i18n` directory to unblock the failing test.

Additionally, this PR removes the Debug flag for samoan in `locales.yml`

## Links


- jira ticket: [P20-100](https://codedotorg.atlassian.net/browse/P20-100)


## Testing story

Ran a mini sync to test that `hourofcode` files for samoan where synced down and out.
I locally ran the `test_i18n_hoc_routes.rb`  and successfully passed.


