### PR TITLE
[JIMT][SL-566] - calls _onblur when creating p5 obj

### DIFF
--- a/apps/src/p5lab/P5Wrapper.js
+++ b/apps/src/p5lab/P5Wrapper.js
@@ -205,7 +205,7 @@ P5Wrapper.prototype.startExecution = function () {
   new window.p5(
     function (p5obj) {
       this.p5 = p5obj;
-      this.p5._onblur();
+      this.p5._onblur(); // This is to explicitly wipe out the downKeys object over in p5.js so no old keys hang around.
       // Tell p5.play that we don't want it to have Sprite do anything
       // within _syncAnimationSizes()
       this.p5._fixedSpriteAnimationFrameSizes = true;

--- a/apps/src/p5lab/P5Wrapper.js
+++ b/apps/src/p5lab/P5Wrapper.js
@@ -15,9 +15,6 @@ const defaultFrameRate = 30;
  * specific places to enable GameLab functionality
  */
 var P5Wrapper = function () {
-  if (this.p5) {
-    this.p5._onblur();
-  }
   this.p5 = null;
   this.p5decrementPreload = null;
   this.p5eventNames = [
@@ -165,7 +162,6 @@ P5Wrapper.prototype.resetExecution = function () {
 
   if (this.p5) {
     this.p5.remove();
-    this.p5._onblur();
     this.p5 = null;
     this.p5decrementPreload = null;
   }
@@ -209,6 +205,7 @@ P5Wrapper.prototype.startExecution = function () {
   new window.p5(
     function (p5obj) {
       this.p5 = p5obj;
+      this.p5._onblur();
       // Tell p5.play that we don't want it to have Sprite do anything
       // within _syncAnimationSizes()
       this.p5._fixedSpriteAnimationFrameSizes = true;

--- a/apps/src/p5lab/P5Wrapper.js
+++ b/apps/src/p5lab/P5Wrapper.js
@@ -15,6 +15,9 @@ const defaultFrameRate = 30;
  * specific places to enable GameLab functionality
  */
 var P5Wrapper = function () {
+  if (this.p5) {
+    this.p5._onblur();
+  }
   this.p5 = null;
   this.p5decrementPreload = null;
   this.p5eventNames = [
@@ -162,6 +165,7 @@ P5Wrapper.prototype.resetExecution = function () {
 
   if (this.p5) {
     this.p5.remove();
+    this.p5._onblur();
     this.p5 = null;
     this.p5decrementPreload = null;
   }


### PR DESCRIPTION
## Summary

This is a _proposed_ fix, since it'll resolve it, but I'm hoping people more knowledgeable with the system will take a look at it and comment as to whether it's viable or if it points to a deeper issue. It feels like a bandaid.

If you're in sprite lab/p5 lab in the cdc mapping landmarks module, at least, you can make the character fly off the screen.

Repro is just to be holding down an arrow key when the timer resets. When you re-start the app, the character will fly off the edge in whatever direction you had previously pressed. However, if you re-press the same key, then motion will stop.

While investigating, I found additional ways to repro - the simplest one is to put a breakpoint in `p5.prototype._onkeydown`, and run with the debugger. You don't need to do anything, just let the debugger pause and immediately resume and the issue will reproduce.

The root cause is that inside of `p5`, it's storing a _global_ object called `downKeys` keeping track of whatever keys are currently pressed. This is completely decoupled from the `p5` object itself.

When a user presses a key, it fires off `_onkeydown` and sticks the key into that global object. BUT - if the key is still being held down when execution stops, the p5 object is promptly destroyed. That means that when the user finally lets go of the key, the `p5` object no longer exists and cannot fire the `_onkeyup` action that clears out the global object. Hence it sticks around in that global object and re-appears later.

Similar things happen in the debugger - if you hop out via this, you're naturally going to let go of the key. So you resume execution, the `_onkeyup` never fires to clear it, and your character keeps running forever.

So. How to clear it? Fortunately, `p5` provides an `_onblur` event, which clears out the `downKeys` object. The comments claim it fires when the user is no longer focused on the p5 element, but that's not applicable here. Regardless, we can sneak in and call it right after our `p5` object is created to explicitly wipe out any pre-existing `downKeys`.

Also - please note that this fix will _not_ fix the debugger case, and I don't think that one's fixable with the way `p5` is has this implemented. That's a trap where you can hop out of its expected control flow so the keyup doesn't fire (until the user presses a key again), but presumably most of our users won't be adding a breakpoint there so I think we're good.

And that's it.

Alternatives could include:
- the original fix I had did the `_onblur` when the p5 object was destroyed, but I opted to move it to the create case so it resets at the beginning - just in case there are more destroy cases I don't know about.
- I don't think we can directly clear out this object elsewhere, nor have I found another method to try in p5. But this may point to something else we may want to revisit in drawing code on our side? Again, I'm not familiar and am just speculating.
- Maybe we should upgrade p5? The newest versions of it seem to have moved the `downKeys` global into a `_downKeys` attribute, so are presumably unaffected. That'd also allow multiple canvases on screen at once.
- other?

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [Reset P5 state for pressed keys after validation completes](https://codedotorg.atlassian.net/browse/SL-566)


## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
