### PR TITLE
Add default image to curriculum catalog card

### DIFF
--- a/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalog.jsx
@@ -33,8 +33,8 @@ const CurriculumCatalog = ({curriculaData, isEnglish}) => (
             }) => (
               <CurriculumCatalogCard
                 key={key}
-                imageSrc={image}
                 courseDisplayName={display_name}
+                imageSrc={image || undefined}
                 duration={'school_year'} // TODO [MEG] actually pass in this data
                 gradesArray={grade_levels.split(',')}
                 subjects={school_subject?.split(',')}

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
@@ -16,7 +16,7 @@ const CurriculumCatalogCard = ({
   duration,
   gradesArray,
   imageAltText = '', // for decorative images
-  imageSrc,
+  imageSrc = 'https://images.code.org/0a24eb3b51bd86e054362f0760c6e64e-image-1681413990565.png',
   subjects = [],
   topics = [],
   isTranslated = false,
@@ -34,10 +34,7 @@ const CurriculumCatalogCard = ({
       youngestGrade: gradesArray[0],
       oldestGrade: gradesArray[gradesArray.length - 1]
     })}
-    imageSrc={
-      imageSrc ||
-      'https://images.code.org/0a24eb3b51bd86e054362f0760c6e64e-image-1681413990565.png'
-    }
+    imageSrc={imageSrc}
     subjectsAndTopics={[
       ...subjects?.map(
         subject => translatedCourseOfferingSchoolSubjects[subject]

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
@@ -11,18 +11,15 @@ import {
 } from '@cdo/apps/templates/teacherDashboard/CourseOfferingHelpers';
 import style from './curriculum_catalog_card.module.scss';
 
-// TODO [MEG]: remove this placeholder and require() syntax once images are pulled
-const tempImage = require('@cdo/static/resource_cards/anotherhoc.png');
-
 const CurriculumCatalogCard = ({
   courseDisplayName,
   duration,
   gradesArray,
-  imageAltText,
-  imageSrc,
-  subjects,
-  topics,
-  isTranslated,
+  imageAltText = '', // for decorative images
+  imageSrc = 'https://images.code.org/0a24eb3b51bd86e054362f0760c6e64e-image-1681413990565.png',
+  subjects = [],
+  topics = [],
+  isTranslated = false,
   isEnglish
 }) => (
   <CustomizableCurriculumCatalogCard
@@ -61,7 +58,7 @@ CurriculumCatalogCard.propTypes = {
     .isRequired,
   gradesArray: PropTypes.arrayOf(PropTypes.string).isRequired,
   imageAltText: PropTypes.string,
-  imageSrc: PropTypes.string.isRequired,
+  imageSrc: PropTypes.string,
   isTranslated: PropTypes.bool,
   subjects: PropTypes.arrayOf(
     PropTypes.oneOf(Object.keys(translatedCourseOfferingSchoolSubjects))
@@ -70,14 +67,6 @@ CurriculumCatalogCard.propTypes = {
     PropTypes.oneOf(Object.keys(translatedCourseOfferingCsTopics))
   ),
   isEnglish: PropTypes.bool.isRequired
-};
-
-CurriculumCatalogCard.defaultProps = {
-  imageSrc: tempImage, // TODO [MEG]: remove this default once images are pulled
-  imageAltText: '', // for decorative images
-  isTranslated: false,
-  subjects: [],
-  topics: []
 };
 
 const CustomizableCurriculumCatalogCard = ({

--- a/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
@@ -16,7 +16,7 @@ const CurriculumCatalogCard = ({
   duration,
   gradesArray,
   imageAltText = '', // for decorative images
-  imageSrc = 'https://images.code.org/0a24eb3b51bd86e054362f0760c6e64e-image-1681413990565.png',
+  imageSrc,
   subjects = [],
   topics = [],
   isTranslated = false,
@@ -34,7 +34,10 @@ const CurriculumCatalogCard = ({
       youngestGrade: gradesArray[0],
       oldestGrade: gradesArray[gradesArray.length - 1]
     })}
-    imageSrc={imageSrc}
+    imageSrc={
+      imageSrc ||
+      'https://images.code.org/0a24eb3b51bd86e054362f0760c6e64e-image-1681413990565.png'
+    }
     subjectsAndTopics={[
       ...subjects?.map(
         subject => translatedCourseOfferingSchoolSubjects[subject]

--- a/apps/src/templates/curriculumCatalog/curriculumCatalogShapes.jsx
+++ b/apps/src/templates/curriculumCatalog/curriculumCatalogShapes.jsx
@@ -9,7 +9,7 @@ export const curriculumDataShape = PropTypes.shape({
   assignable: PropTypes.bool,
   curriculum_type: PropTypes.string,
   marketing_initiative: PropTypes.string,
-  grade_levels: PropTypes.string.isRequired,
+  grade_levels: PropTypes.string,
   header: PropTypes.string,
   image: PropTypes.string,
   cs_topic: PropTypes.string,

--- a/apps/src/templates/curriculumCatalog/curriculumCatalogShapes.jsx
+++ b/apps/src/templates/curriculumCatalog/curriculumCatalogShapes.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 
 export const curriculumDataShape = PropTypes.shape({
   id: PropTypes.string,
-  key: PropTypes.string,
+  key: PropTypes.string.isRequired,
   display_name: PropTypes.string.isRequired,
   category: PropTypes.string,
   is_featured: PropTypes.bool,

--- a/apps/test/unit/templates/curriculumCatalog/CurriculumCatalogTest.jsx
+++ b/apps/test/unit/templates/curriculumCatalog/CurriculumCatalogTest.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {render, screen} from '@testing-library/react';
 import {Provider} from 'react-redux';
 import {configureStore} from '@reduxjs/toolkit';
+import {expect} from '../../../util/reconfiguredChai';
 import responsive, {
   setResponsiveSize,
   ResponsiveSize
@@ -13,30 +14,30 @@ describe('CurriculumCatalog', () => {
     key: 'devices',
     display_name: 'Creating Apps for Devices',
     grade_levels: '6,7,8,9,10,11,12',
-    image: 'https://images.code.org/name.png',
+    image: 'devices.png',
     cs_topic: 'art_and_design,app_design,physical_computing,programming',
     school_subject: null
   };
 
   const countingCurriculum = {
     key: 'counting-csc',
-    display_name: 'Computer Science Discoveries',
+    display_name: 'Computer Science Connections',
     grade_levels: '3,4,5',
-    image: 'https://images.code.org/name.png',
+    image: 'csc.png',
     cs_topic: 'programming',
     school_subject: 'math'
   };
 
-  const course1Curriculum = {
+  const noImageCurriculum = {
     key: 'course1',
     display_name: 'Course 1',
     grade_levels: 'K,1',
-    image: 'https://images.code.org/name.png',
+    image: null,
     cs_topic: 'programming',
     school_subject: null
   };
 
-  const allCurricula = [makerCurriculum, countingCurriculum, course1Curriculum];
+  const allCurricula = [makerCurriculum, countingCurriculum, noImageCurriculum];
   const defaultProps = {curriculaData: allCurricula, isEnglish: false};
 
   beforeEach(() => {
@@ -61,5 +62,20 @@ describe('CurriculumCatalog', () => {
     allCurricula
       .map(curriculum => curriculum.display_name)
       .forEach(courseName => screen.getByRole('heading', {name: courseName}));
+  });
+
+  it('all curricula show an image, including curricula without a specific image', () => {
+    const images = screen.getAllByRole('img');
+    const imagesStr = images.map(image => image.outerHTML).toString();
+
+    allCurricula.forEach(curriculum => {
+      if (curriculum.image && curriculum.image !== null) {
+        expect(imagesStr).to.match(new RegExp(`src="${curriculum.image}"`));
+      } else {
+        expect(imagesStr).to.match(
+          new RegExp(`src="https:\\/\\/images\\.code\\.org\\/\\S*.png"`)
+        );
+      }
+    });
   });
 });


### PR DESCRIPTION
Adds a default image to the curriculum catalog card:

<img width="785" alt="image" src="https://user-images.githubusercontent.com/9142121/232579923-9e9f6fb5-6927-453f-bc49-ebfadf341211.png">


## Links

When debugging my original approach (which was to add a default prop), I learned two things of note:

1) defaultProps are *not* used when a `null` prop is passed in. According to [the documentation](https://react.dev/learn/passing-props-to-a-component#specifying-a-default-value-for-a-prop),
> The default value is only used if the size prop is missing or if you pass size={undefined}. But if you pass size={null} or size={0}, the default value will not be used.

2) defaultProps for function components are [going to be deprecated](https://twitter.com/AndaristRake/status/1597514454920724480?lang=en) in React 18.3. So instead of continuing to use them, I used [default parameters](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters) instead.


## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
