### PR TITLE
Ensure edited animations are saved correctly in story, science, and poetry labs

### DIFF
--- a/dashboard/app/controllers/projects_controller.rb
+++ b/dashboard/app/controllers/projects_controller.rb
@@ -417,7 +417,9 @@ class ProjectsController < ApplicationController
   end
 
   private def uses_animation_bucket?(project_type)
-    %w(gamelab poetry science spritelab story).include? project_type
+    has_standalone_app_method = defined? (@level.standalone_app_name)
+    is_spritelab = has_standalone_app_method == 'method'
+    return project_type == 'gamelab' || is_spritelab
   end
 
   private def uses_file_bucket?(project_type)

--- a/dashboard/app/controllers/projects_controller.rb
+++ b/dashboard/app/controllers/projects_controller.rb
@@ -422,7 +422,7 @@ class ProjectsController < ApplicationController
     spritelab_subtypes = GamelabJr.standalone_app_names.map {|item| item[1]}
     projects_that_use_animations.concat(poetry_subtypes)
     projects_that_use_animations.concat(spritelab_subtypes)
-    return projects_that_use_animations.include?(project_type)
+    projects_that_use_animations.include?(project_type)
   end
 
   private def uses_file_bucket?(project_type)

--- a/dashboard/app/controllers/projects_controller.rb
+++ b/dashboard/app/controllers/projects_controller.rb
@@ -417,9 +417,12 @@ class ProjectsController < ApplicationController
   end
 
   private def uses_animation_bucket?(project_type)
-    has_standalone_app_method = defined? (@level.standalone_app_name)
-    is_spritelab = has_standalone_app_method == 'method'
-    return project_type == 'gamelab' || is_spritelab
+    available_projects = ['gamelab']
+    poetry_subtypes = Poetry.standalone_app_names.map {|item| item[1]}
+    spritelab_subtypes = GamelabJr.standalone_app_names.map {|item| item[1]}
+    available_projects.concat(poetry_subtypes)
+    available_projects.concat(spritelab_subtypes)
+    return available_projects.include?(project_type)
   end
 
   private def uses_file_bucket?(project_type)

--- a/dashboard/app/controllers/projects_controller.rb
+++ b/dashboard/app/controllers/projects_controller.rb
@@ -417,12 +417,12 @@ class ProjectsController < ApplicationController
   end
 
   private def uses_animation_bucket?(project_type)
-    available_projects = ['gamelab']
+    projects_that_use_animations = ['gamelab']
     poetry_subtypes = Poetry.standalone_app_names.map {|item| item[1]}
     spritelab_subtypes = GamelabJr.standalone_app_names.map {|item| item[1]}
-    available_projects.concat(poetry_subtypes)
-    available_projects.concat(spritelab_subtypes)
-    return available_projects.include?(project_type)
+    projects_that_use_animations.concat(poetry_subtypes)
+    projects_that_use_animations.concat(spritelab_subtypes)
+    return projects_that_use_animations.include?(project_type)
   end
 
   private def uses_file_bucket?(project_type)

--- a/dashboard/app/controllers/projects_controller.rb
+++ b/dashboard/app/controllers/projects_controller.rb
@@ -417,7 +417,7 @@ class ProjectsController < ApplicationController
   end
 
   private def uses_animation_bucket?(project_type)
-    %w(gamelab spritelab).include? project_type
+    %w(gamelab poetry science spritelab story).include? project_type
   end
 
   private def uses_file_bucket?(project_type)


### PR DESCRIPTION
This PR fixes a bug in saving edited animations in poetry, science, and story projects. Reported in [this Slack thread](https://codedotorg.slack.com/archives/C02GRH2PYB1/p1676403880537419), the curriculum writer was on a [csc-bookcovers level](https://studio.code.org/s/csc-bookcover/lessons/2/levels/6) which includes edited animations, and when she attempted to remix the project, she received the error 'Sorry we couldn't load animation...' 

Video before update - 'story' level/project:


https://user-images.githubusercontent.com/107423305/232883692-4eda81af-98af-4018-b641-4730255fdf25.mov


This bug also occurs in science and poetry projects if they contain edited animation.




When an animation is modified by the user, the `sourceURL` is [assigned to `null`](https://github.com/code-dot-org/code-dot-org/blob/54787e2ee9d8c2e930e9f618b8d97b065c82f5c2/apps/src/p5lab/redux/animationList.js#L172) and in [this ticket](https://codedotorg.atlassian.net/browse/SL-574), it was noted that perhaps this may be the reason why the remixed project is unable to find the image. However, in other labs such as 'spritelab' and 'gamelab', the `sourceURL` of an edited animation is assigned to `null`, and these projects can be remixed without missing animation errors. 

In `P5.Lab.js`, the `sourceUrl` of edited animations IS included in the list returned by [`getExportableAnimationList`](https://github.com/code-dot-org/code-dot-org/blob/54787e2ee9d8c2e930e9f618b8d97b065c82f5c2/apps/src/p5lab/P5Lab.js#L1604) and the URL of edited animations [includes](https://github.com/code-dot-org/code-dot-org/blob/54787e2ee9d8c2e930e9f618b8d97b065c82f5c2/apps/src/p5lab/redux/animationList.js#L946) the channel id of the project and the animation key stored in `main.json`.

The reason that 'poetry', 'science', and 'story' projects that contain edited animations currently have errors is due to their omission in the [`uses_animation_bucket` function](https://github.com/code-dot-org/code-dot-org/blob/1441113f4dc2134d6930246c022571feb69d4b8e/dashboard/app/controllers/projects_controller.rb#L419) in `projects_controller.rb`. In [the `remix` function](https://github.com/code-dot-org/code-dot-org/blob/1441113f4dc2134d6930246c022571feb69d4b8e/dashboard/app/controllers/projects_controller.rb#L389), the `project_type` is assigned from `params[:key]`. Then `uses_animation_bucket` is called with this parameter. 

[At first](https://github.com/code-dot-org/code-dot-org/pull/51393/commits/918fecc5893621073cce8b4e9e62659a6fa3cbae), I added the names of the subtypes to the list. However, @molly-moen suggested that I access `standalone_app_names` (the list of subtypes) from `Poetry` and `GamelabJr`. This `standalone_app_names` list is actually an array of arrays. Each subarray's first element is assigned to the subtype name with uppercase characters and whitespace and the second element is assigned the subtype name with lowercase letters and underscores. The second element is the string we need for our list `projects_that_use_animations`. This ensures that if additional subtypes are created, no update will be needed to this function. Also, I had omitted two subtypes initially - `poetry_hoc` and `time_capsule`. This is also a way to ensure the list is complete. 

After this update, these projects were able to be remixed without missing animation errors. Thanks to @molly-moen for helping me with this update!

After update - 'story', 'science', and 'poetry' projects:


https://user-images.githubusercontent.com/107423305/232910166-4faf070d-20e3-4955-97a7-444752ed14e3.mp4




<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links
[jira ticket - Ensure edited animations are saved correctly](https://codedotorg.atlassian.net/browse/SL-574)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
I tested locally in 'story', 'poetry', 'science', 'spritelab', and 'gamelab' projects.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work
1. It still seems somewhat strange that the `sourceUrl` of an edited animation is assigned `null`. As written in [this ticket](https://codedotorg.atlassian.net/browse/SL-574), 'we may want to clean up how we save animations, as we can get into a state due to poor network connection where an updated main.json gets saved but the animation does not, as the two are saved separately.' [jira](https://codedotorg.atlassian.net/browse/SL-797)
2. A small item would be renaming the `poems_for_subtype` method in `poetry.rb` to a clearer name such as `poem_lists_for_standalone_app` and updating references to the method. [jira](https://codedotorg.atlassian.net/browse/SL-796)

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  4.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
