### PR TITLE
Generate Random Rather than Sequential Test Emails

### DIFF
--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -140,7 +140,7 @@ FactoryBot.define do
         end
 
         sequence(:name) {|n| "Facilitator Person #{n}"}
-        email {("Facilitator_#{(User.maximum(:id) || 0) + 1}@code.org")}
+        email {"Facilitator_#{SecureRandom.uuid}@code.org"}
 
         after(:create) do |facilitator, evaluator|
           facilitator.permission = UserPermission::FACILITATOR
@@ -158,7 +158,7 @@ FactoryBot.define do
       end
       factory :workshop_organizer do
         sequence(:name) {|n| "Workshop Organizer Person #{n}"}
-        email {("WorkshopOrganizer_#{(User.maximum(:id) || 0) + 1}@code.org")}
+        email {"WorkshopOrganizer_#{SecureRandom.uuid}@code.org"}
         after(:create) do |workshop_organizer|
           workshop_organizer.permission = UserPermission::WORKSHOP_ORGANIZER
         end


### PR DESCRIPTION
We expect emails to be globally unique, but the method we currently use to generate test emails for facilitators and workshop organizers means that multiple calls to `build :workshop_organizer` will result in the same email being generated for each user, which will cause an error if we attempt to persist both of them.

This isn't a problem right now, because some [unexpected behavior in FactoryBot v4](https://github.com/thoughtbot/factory_bot/blob/main/GETTING_STARTED.md#build-strategies-1) means that records are often automatically persisted upon creation. Starting in v5, we are much more likely to encounter the edge case of multiple records being initially built but not persisted only for a subset of them to be persisted after the fact. In anticipation of updating to that version, we change the generation logic to use unique emails rather than attempting to enforce an arbitrary sequence.

## Links

I did some digging into the history of this email generation logic, and couldn't find any evidence that we cared about the sequential nature of the old approach; it seemed like we were just going with the simplest, cleanest option in the absence of a need for anything this complicated.

- https://github.com/code-dot-org/code-dot-org/pull/16481
- https://github.com/code-dot-org/code-dot-org/pull/23872

## Testing story

Verified on [another branch](https://github.com/code-dot-org/code-dot-org/pull/51328) that this change resolves the issues with FactoryBot v5.

## Follow-up work

Upgrade FactoryBot to v5
