### PR TITLE
[CFU] Add eyes tests for summary view

### DIFF
--- a/apps/src/templates/levelSummary/CheckForUnderstanding.jsx
+++ b/apps/src/templates/levelSummary/CheckForUnderstanding.jsx
@@ -66,7 +66,7 @@ const CheckForUnderstanding = ({
   };
 
   return (
-    <div className={styles.summaryContainer}>
+    <div className={styles.summaryContainer} id="summary-container">
       {/* Top Nav Links */}
       <p className={styles.navLinks}>
         <a

--- a/dashboard/config/scripts_json/allthethings.script_json
+++ b/dashboard/config/scripts_json/allthethings.script_json
@@ -10,7 +10,7 @@
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2023-04-05 09:02:01 UTC",
+    "serialized_at": "2023-04-21 17:06:54 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -754,21 +754,6 @@
         "lesson_group.key": "",
         "script.name": "allthethings"
       }
-    },
-    {
-      "key": "lesson-49",
-      "name": "Music",
-      "absolute_position": 49,
-      "lockable": false,
-      "has_lesson_plan": true,
-      "relative_position": 46,
-      "properties": {
-      },
-      "seeding_key": {
-        "lesson.key": "lesson-49",
-        "lesson_group.key": "",
-        "script.name": "allthethings"
-      }
     }
   ],
   "lesson_activities": [
@@ -1393,18 +1378,6 @@
         "lesson_group.key": "",
         "script.name": "allthethings"
       }
-    },
-    {
-      "key": "e58ff15e-708f-4cd0-97cc-260c9929b0ca",
-      "position": 1,
-      "properties": {
-      },
-      "seeding_key": {
-        "lesson_activity.key": "e58ff15e-708f-4cd0-97cc-260c9929b0ca",
-        "lesson.key": "lesson-49",
-        "lesson_group.key": "",
-        "script.name": "allthethings"
-      }
     }
   ],
   "activity_sections": [
@@ -1886,16 +1859,6 @@
       "seeding_key": {
         "activity_section.key": "b68acb29-b590-46e0-82a1-ade0d51c420f",
         "lesson_activity.key": "bd958217-a2d9-423d-a515-78757692b268"
-      }
-    },
-    {
-      "key": "f9c9c7a9-9f2c-48e1-867b-94d010f2795a",
-      "position": 1,
-      "properties": {
-      },
-      "seeding_key": {
-        "activity_section.key": "f9c9c7a9-9f2c-48e1-867b-94d010f2795a",
-        "lesson_activity.key": "e58ff15e-708f-4cd0-97cc-260c9929b0ca"
       }
     }
   ],
@@ -4423,6 +4386,48 @@
     },
     {
       "chapter": 106,
+      "position": 2,
+      "activity_section_position": 2,
+      "assessment": false,
+      "properties": {
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L5 CSP CFU subgroups2022"
+        ],
+        "lesson.key": "Free Response",
+        "lesson_group.key": "",
+        "script.name": "allthethings",
+        "activity_section.key": "e39b746e-7160-4df7-87c2-c370d042e3da"
+      },
+      "level_keys": [
+        "U2L5 CSP CFU subgroups2022"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 3,
+      "activity_section_position": 3,
+      "assessment": false,
+      "properties": {
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSA U1L4-L1 Contained_2022"
+        ],
+        "lesson.key": "Free Response",
+        "lesson_group.key": "",
+        "script.name": "allthethings",
+        "activity_section.key": "e39b746e-7160-4df7-87c2-c370d042e3da"
+      },
+      "level_keys": [
+        "CSA U1L4-L1 Contained_2022"
+      ]
+    },
+    {
+      "chapter": 108,
       "position": 1,
       "activity_section_position": 1,
       "assessment": true,
@@ -4446,7 +4451,7 @@
       ]
     },
     {
-      "chapter": 107,
+      "chapter": 109,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -4478,7 +4483,7 @@
       ]
     },
     {
-      "chapter": 108,
+      "chapter": 110,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -4510,7 +4515,7 @@
       ]
     },
     {
-      "chapter": 109,
+      "chapter": 111,
       "position": 3,
       "activity_section_position": 3,
       "assessment": false,
@@ -4542,7 +4547,7 @@
       ]
     },
     {
-      "chapter": 110,
+      "chapter": 112,
       "position": 4,
       "activity_section_position": 4,
       "assessment": false,
@@ -4574,7 +4579,7 @@
       ]
     },
     {
-      "chapter": 111,
+      "chapter": 113,
       "position": 5,
       "activity_section_position": 5,
       "assessment": false,
@@ -4606,7 +4611,7 @@
       ]
     },
     {
-      "chapter": 112,
+      "chapter": 114,
       "position": 6,
       "activity_section_position": 6,
       "assessment": false,
@@ -4638,7 +4643,7 @@
       ]
     },
     {
-      "chapter": 113,
+      "chapter": 115,
       "position": 7,
       "activity_section_position": 7,
       "assessment": false,
@@ -4670,7 +4675,7 @@
       ]
     },
     {
-      "chapter": 114,
+      "chapter": 116,
       "position": 8,
       "activity_section_position": 8,
       "assessment": false,
@@ -4702,7 +4707,7 @@
       ]
     },
     {
-      "chapter": 115,
+      "chapter": 117,
       "position": 9,
       "activity_section_position": 9,
       "assessment": false,
@@ -4734,7 +4739,7 @@
       ]
     },
     {
-      "chapter": 116,
+      "chapter": 118,
       "position": 1,
       "activity_section_position": 1,
       "assessment": true,
@@ -4758,7 +4763,7 @@
       ]
     },
     {
-      "chapter": 117,
+      "chapter": 119,
       "position": 1,
       "activity_section_position": 1,
       "assessment": true,
@@ -4782,7 +4787,7 @@
       ]
     },
     {
-      "chapter": 118,
+      "chapter": 120,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -4806,7 +4811,7 @@
       ]
     },
     {
-      "chapter": 119,
+      "chapter": 121,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -4830,7 +4835,7 @@
       ]
     },
     {
-      "chapter": 120,
+      "chapter": 122,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -4854,7 +4859,7 @@
       ]
     },
     {
-      "chapter": 121,
+      "chapter": 123,
       "position": 1,
       "activity_section_position": 1,
       "assessment": true,
@@ -4878,7 +4883,7 @@
       ]
     },
     {
-      "chapter": 122,
+      "chapter": 124,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -4902,7 +4907,7 @@
       ]
     },
     {
-      "chapter": 123,
+      "chapter": 125,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -4926,7 +4931,7 @@
       ]
     },
     {
-      "chapter": 124,
+      "chapter": 126,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -4950,7 +4955,7 @@
       ]
     },
     {
-      "chapter": 125,
+      "chapter": 127,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -4974,7 +4979,7 @@
       ]
     },
     {
-      "chapter": 126,
+      "chapter": 128,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -4998,7 +5003,7 @@
       ]
     },
     {
-      "chapter": 127,
+      "chapter": 129,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -5022,7 +5027,7 @@
       ]
     },
     {
-      "chapter": 128,
+      "chapter": 130,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -5046,7 +5051,7 @@
       ]
     },
     {
-      "chapter": 129,
+      "chapter": 131,
       "position": 1,
       "activity_section_position": 1,
       "assessment": true,
@@ -5070,7 +5075,7 @@
       ]
     },
     {
-      "chapter": 130,
+      "chapter": 132,
       "position": 2,
       "activity_section_position": 2,
       "assessment": true,
@@ -5094,7 +5099,7 @@
       ]
     },
     {
-      "chapter": 131,
+      "chapter": 133,
       "position": 3,
       "activity_section_position": 3,
       "assessment": true,
@@ -5118,7 +5123,7 @@
       ]
     },
     {
-      "chapter": 132,
+      "chapter": 134,
       "position": 1,
       "activity_section_position": 1,
       "assessment": true,
@@ -5142,7 +5147,7 @@
       ]
     },
     {
-      "chapter": 133,
+      "chapter": 135,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -5166,7 +5171,7 @@
       ]
     },
     {
-      "chapter": 134,
+      "chapter": 136,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -5190,7 +5195,7 @@
       ]
     },
     {
-      "chapter": 135,
+      "chapter": 137,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -5214,7 +5219,7 @@
       ]
     },
     {
-      "chapter": 136,
+      "chapter": 138,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -5238,7 +5243,7 @@
       ]
     },
     {
-      "chapter": 137,
+      "chapter": 139,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -5262,7 +5267,7 @@
       ]
     },
     {
-      "chapter": 138,
+      "chapter": 140,
       "position": 3,
       "activity_section_position": 3,
       "assessment": false,
@@ -5286,7 +5291,7 @@
       ]
     },
     {
-      "chapter": 139,
+      "chapter": 141,
       "position": 4,
       "activity_section_position": 4,
       "assessment": false,
@@ -5310,7 +5315,7 @@
       ]
     },
     {
-      "chapter": 140,
+      "chapter": 142,
       "position": 5,
       "activity_section_position": 5,
       "assessment": false,
@@ -5334,7 +5339,7 @@
       ]
     },
     {
-      "chapter": 141,
+      "chapter": 143,
       "position": 6,
       "activity_section_position": 6,
       "assessment": false,
@@ -5358,7 +5363,7 @@
       ]
     },
     {
-      "chapter": 142,
+      "chapter": 144,
       "position": 7,
       "activity_section_position": 7,
       "assessment": false,
@@ -5382,7 +5387,7 @@
       ]
     },
     {
-      "chapter": 143,
+      "chapter": 145,
       "position": 8,
       "activity_section_position": 8,
       "assessment": false,
@@ -5406,7 +5411,7 @@
       ]
     },
     {
-      "chapter": 144,
+      "chapter": 146,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -5430,7 +5435,7 @@
       ]
     },
     {
-      "chapter": 145,
+      "chapter": 147,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -5454,7 +5459,7 @@
       ]
     },
     {
-      "chapter": 146,
+      "chapter": 148,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -5478,7 +5483,7 @@
       ]
     },
     {
-      "chapter": 147,
+      "chapter": 149,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -5502,7 +5507,7 @@
       ]
     },
     {
-      "chapter": 148,
+      "chapter": 150,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -5526,7 +5531,7 @@
       ]
     },
     {
-      "chapter": 149,
+      "chapter": 151,
       "position": 3,
       "activity_section_position": 3,
       "assessment": false,
@@ -5550,7 +5555,7 @@
       ]
     },
     {
-      "chapter": 150,
+      "chapter": 152,
       "position": 4,
       "activity_section_position": 4,
       "assessment": false,
@@ -5574,7 +5579,7 @@
       ]
     },
     {
-      "chapter": 151,
+      "chapter": 153,
       "position": 5,
       "activity_section_position": 5,
       "assessment": false,
@@ -5598,7 +5603,7 @@
       ]
     },
     {
-      "chapter": 152,
+      "chapter": 154,
       "position": 6,
       "activity_section_position": 6,
       "assessment": false,
@@ -5622,7 +5627,7 @@
       ]
     },
     {
-      "chapter": 153,
+      "chapter": 155,
       "position": 7,
       "activity_section_position": 7,
       "assessment": false,
@@ -5646,7 +5651,7 @@
       ]
     },
     {
-      "chapter": 154,
+      "chapter": 156,
       "position": 8,
       "activity_section_position": 8,
       "assessment": false,
@@ -5670,7 +5675,7 @@
       ]
     },
     {
-      "chapter": 155,
+      "chapter": 157,
       "position": 9,
       "activity_section_position": 10,
       "assessment": false,
@@ -5694,7 +5699,7 @@
       ]
     },
     {
-      "chapter": 156,
+      "chapter": 158,
       "position": 10,
       "activity_section_position": 11,
       "assessment": false,
@@ -5718,7 +5723,7 @@
       ]
     },
     {
-      "chapter": 157,
+      "chapter": 159,
       "position": 11,
       "activity_section_position": 12,
       "assessment": false,
@@ -5742,7 +5747,7 @@
       ]
     },
     {
-      "chapter": 158,
+      "chapter": 160,
       "position": 12,
       "activity_section_position": 13,
       "assessment": false,
@@ -5766,7 +5771,7 @@
       ]
     },
     {
-      "chapter": 159,
+      "chapter": 161,
       "position": 1,
       "activity_section_position": 1,
       "assessment": true,
@@ -5790,7 +5795,7 @@
       ]
     },
     {
-      "chapter": 160,
+      "chapter": 162,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -5814,7 +5819,7 @@
       ]
     },
     {
-      "chapter": 161,
+      "chapter": 163,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -5838,7 +5843,7 @@
       ]
     },
     {
-      "chapter": 162,
+      "chapter": 164,
       "position": 3,
       "activity_section_position": 3,
       "assessment": false,
@@ -5862,7 +5867,7 @@
       ]
     },
     {
-      "chapter": 163,
+      "chapter": 165,
       "position": 4,
       "activity_section_position": 4,
       "assessment": false,
@@ -5883,72 +5888,6 @@
       },
       "level_keys": [
         "poetry_modal_function_editor"
-      ]
-    },
-    {
-      "chapter": 164,
-      "position": 1,
-      "activity_section_position": 1,
-      "assessment": false,
-      "properties": {
-        "level_keys": [
-          "Music Level 1"
-        ]
-      },
-      "bonus": false,
-      "seeding_key": {
-        "script_level.level_keys": [
-          "Music Level 1"
-        ],
-        "lesson.key": "lesson-49",
-        "lesson_group.key": "",
-        "script.name": "allthethings",
-        "activity_section.key": "f9c9c7a9-9f2c-48e1-867b-94d010f2795a"
-      },
-      "level_keys": [
-        "Music Level 1"
-      ]
-    },
-    {
-      "chapter": 165,
-      "position": 2,
-      "activity_section_position": 2,
-      "assessment": false,
-      "properties": {
-      },
-      "bonus": false,
-      "seeding_key": {
-        "script_level.level_keys": [
-          "Music Level 2"
-        ],
-        "lesson.key": "lesson-49",
-        "lesson_group.key": "",
-        "script.name": "allthethings",
-        "activity_section.key": "f9c9c7a9-9f2c-48e1-867b-94d010f2795a"
-      },
-      "level_keys": [
-        "Music Level 2"
-      ]
-    },
-    {
-      "chapter": 166,
-      "position": 3,
-      "activity_section_position": 3,
-      "assessment": false,
-      "properties": {
-      },
-      "bonus": false,
-      "seeding_key": {
-        "script_level.level_keys": [
-          "Music Level 3"
-        ],
-        "lesson.key": "lesson-49",
-        "lesson_group.key": "",
-        "script.name": "allthethings",
-        "activity_section.key": "f9c9c7a9-9f2c-48e1-867b-94d010f2795a"
-      },
-      "level_keys": [
-        "Music Level 3"
       ]
     }
   ],
@@ -7215,6 +7154,30 @@
     },
     {
       "seeding_key": {
+        "level.key": "U2L5 CSP CFU subgroups2022",
+        "script_level.level_keys": [
+          "U2L5 CSP CFU subgroups2022"
+        ],
+        "lesson.key": "Free Response",
+        "lesson_group.key": "",
+        "script.name": "allthethings",
+        "activity_section.key": "e39b746e-7160-4df7-87c2-c370d042e3da"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSA U1L4-L1 Contained_2022",
+        "script_level.level_keys": [
+          "CSA U1L4-L1 Contained_2022"
+        ],
+        "lesson.key": "Free Response",
+        "lesson_group.key": "",
+        "script.name": "allthethings",
+        "activity_section.key": "e39b746e-7160-4df7-87c2-c370d042e3da"
+      }
+    },
+    {
+      "seeding_key": {
         "level.key": "Sample CSP Assessment",
         "script_level.level_keys": [
           "Sample CSP Assessment"
@@ -7279,7 +7242,7 @@
     },
     {
       "seeding_key": {
-        "level.key": "2-3 Maze 6",
+        "level.key": "2-3 Maze 3",
         "script_level.level_keys": [
           "2-3 Maze 3",
           "2-3 Maze 6"
@@ -7292,7 +7255,7 @@
     },
     {
       "seeding_key": {
-        "level.key": "2-3 Maze 3",
+        "level.key": "2-3 Maze 6",
         "script_level.level_keys": [
           "2-3 Maze 3",
           "2-3 Maze 6"
@@ -7409,7 +7372,7 @@
     },
     {
       "seeding_key": {
-        "level.key": "4-5 Maze 5",
+        "level.key": "4-5 Maze 2",
         "script_level.level_keys": [
           "4-5 Maze 2",
           "4-5 Maze 5"
@@ -7422,7 +7385,7 @@
     },
     {
       "seeding_key": {
-        "level.key": "4-5 Maze 2",
+        "level.key": "4-5 Maze 5",
         "script_level.level_keys": [
           "4-5 Maze 2",
           "4-5 Maze 5"
@@ -8033,42 +7996,6 @@
         "lesson_group.key": "",
         "script.name": "allthethings",
         "activity_section.key": "b68acb29-b590-46e0-82a1-ade0d51c420f"
-      }
-    },
-    {
-      "seeding_key": {
-        "level.key": "Music Level 1",
-        "script_level.level_keys": [
-          "Music Level 1"
-        ],
-        "lesson.key": "lesson-49",
-        "lesson_group.key": "",
-        "script.name": "allthethings",
-        "activity_section.key": "f9c9c7a9-9f2c-48e1-867b-94d010f2795a"
-      }
-    },
-    {
-      "seeding_key": {
-        "level.key": "Music Level 2",
-        "script_level.level_keys": [
-          "Music Level 2"
-        ],
-        "lesson.key": "lesson-49",
-        "lesson_group.key": "",
-        "script.name": "allthethings",
-        "activity_section.key": "f9c9c7a9-9f2c-48e1-867b-94d010f2795a"
-      }
-    },
-    {
-      "seeding_key": {
-        "level.key": "Music Level 3",
-        "script_level.level_keys": [
-          "Music Level 3"
-        ],
-        "lesson.key": "lesson-49",
-        "lesson_group.key": "",
-        "script.name": "allthethings",
-        "activity_section.key": "f9c9c7a9-9f2c-48e1-867b-94d010f2795a"
       }
     }
   ],

--- a/dashboard/test/ui/features/teacher_tools/level_summary.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_summary.feature
@@ -15,7 +15,7 @@ Scenario: Free Response level 2
   When I open my eyes to test "free response summary 2"
   Given I am a teacher
   And I create a new student section
-  And I am on "http://studio.code.org/s/csp2-2022/lessons/6/levels/3/summary"
+  And I am on "http://studio.code.org/s/allthethings/lessons/27/levels/2/summary"
   And I wait until element "#summary-container" is visible
   And I wait to see ".uitest-sectionselect"
   Then I see no difference for "free response level summary 2"
@@ -25,7 +25,7 @@ Scenario: Free Response level 3
   When I open my eyes to test "free response summary 3"
   Given I am a teacher
   And I create a new student section
-  And I am on "http://studio.code.org/s/csa1-2022/lessons/4/levels/1/summary"
+  And I am on "http://studio.code.org/s/allthethings/lessons/27/levels/3/summary"
   And I wait until element "#summary-container" is visible
   And I wait to see ".uitest-sectionselect"
   Then I see no difference for "free response level summary 3"

--- a/dashboard/test/ui/features/teacher_tools/level_summary.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_summary.feature
@@ -1,0 +1,22 @@
+Feature: Level summary
+
+Scenario: Free Response level 1
+  Given I am a teacher
+  And I create a new student section
+  Given I am on "http://studio.code.org/s/allthethings/lessons/27/levels/1/summary"
+  And I wait until element "#summary-container" is visible
+  And I wait to see ".uitest-sectionselect"
+
+Scenario: Free Response level 2
+  Given I am a teacher
+  And I create a new student section
+  Given I am on "http://studio.code.org/s/csp2-2022/lessons/6/levels/3/summary"
+  And I wait until element "#summary-container" is visible
+  And I wait to see ".uitest-sectionselect"
+
+Scenario: Free Response level 3
+  Given I am a teacher
+  And I create a new student section
+  Given I am on "http://studio.code.org/s/csa1-2022/lessons/4/levels/1/summary"
+  And I wait until element "#summary-container" is visible
+  And I wait to see ".uitest-sectionselect"

--- a/dashboard/test/ui/features/teacher_tools/level_summary.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_summary.feature
@@ -2,28 +2,31 @@
 Feature: Level summary
 
 Scenario: Free Response level 1
+  When I open my eyes to test "free response summary 1"
   Given I am a teacher
   And I create a new student section
-  Given I am on "http://studio.code.org/s/allthethings/lessons/27/levels/1/summary"
+  And I am on "http://studio.code.org/s/allthethings/lessons/27/levels/1/summary"
   And I wait until element "#summary-container" is visible
   And I wait to see ".uitest-sectionselect"
-  And I see no difference for "level summary"
+  Then I see no difference for "free response level summary 1"
   And I close my eyes
 
 Scenario: Free Response level 2
+  When I open my eyes to test "free response summary 2"
   Given I am a teacher
   And I create a new student section
-  Given I am on "http://studio.code.org/s/csp2-2022/lessons/6/levels/3/summary"
+  And I am on "http://studio.code.org/s/csp2-2022/lessons/6/levels/3/summary"
   And I wait until element "#summary-container" is visible
   And I wait to see ".uitest-sectionselect"
-  And I see no difference for "level summary"
+  Then I see no difference for "free response level summary 2"
   And I close my eyes
 
 Scenario: Free Response level 3
+  When I open my eyes to test "free response summary 3"
   Given I am a teacher
   And I create a new student section
-  Given I am on "http://studio.code.org/s/csa1-2022/lessons/4/levels/1/summary"
+  And I am on "http://studio.code.org/s/csa1-2022/lessons/4/levels/1/summary"
   And I wait until element "#summary-container" is visible
   And I wait to see ".uitest-sectionselect"
-  And I see no difference for "level summary"
+  Then I see no difference for "free response level summary 3"
   And I close my eyes

--- a/dashboard/test/ui/features/teacher_tools/level_summary.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_summary.feature
@@ -1,3 +1,4 @@
+@eyes
 Feature: Level summary
 
 Scenario: Free Response level 1
@@ -6,6 +7,8 @@ Scenario: Free Response level 1
   Given I am on "http://studio.code.org/s/allthethings/lessons/27/levels/1/summary"
   And I wait until element "#summary-container" is visible
   And I wait to see ".uitest-sectionselect"
+  And I see no difference for "level summary"
+  And I close my eyes
 
 Scenario: Free Response level 2
   Given I am a teacher
@@ -13,6 +16,8 @@ Scenario: Free Response level 2
   Given I am on "http://studio.code.org/s/csp2-2022/lessons/6/levels/3/summary"
   And I wait until element "#summary-container" is visible
   And I wait to see ".uitest-sectionselect"
+  And I see no difference for "level summary"
+  And I close my eyes
 
 Scenario: Free Response level 3
   Given I am a teacher
@@ -20,3 +25,5 @@ Scenario: Free Response level 3
   Given I am on "http://studio.code.org/s/csa1-2022/lessons/4/levels/1/summary"
   And I wait until element "#summary-container" is visible
   And I wait to see ".uitest-sectionselect"
+  And I see no difference for "level summary"
+  And I close my eyes


### PR DESCRIPTION
Add some feature tests for the summary view on a few Free Response levels, so we can collect visual baselines in advance of refactoring.

Since I just want the visual diffs, I didn't have any specific test cases in mind; open to feedback on whether I should add some `verify` steps or something to these.

Ran locally:
![image](https://user-images.githubusercontent.com/1382374/233161701-a4691584-1f18-491c-b1cb-1a8ef9d9d212.png)


<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
