### PR TITLE
New school and school district data ingestion from NCES for 2021-2022

### DIFF
--- a/dashboard/app/models/school.rb
+++ b/dashboard/app/models/school.rb
@@ -434,6 +434,31 @@ class School < ApplicationRecord
           }
         end
       end
+
+      # Some of this data has #- appended to the front, so we strip that off with .to_s.slice(2) (it's always a single digit)
+      CDO.log.info "Seeding 2021-2022 public school data."
+      AWS::S3.seed_from_file('cdo-nces', "2021-2022/ccd/schools_public.csv") do |filename|
+        merge_from_csv(filename, {headers: true, quote_char: "\x00", encoding: 'bom|utf-8'}, true, is_dry_run: false, ignore_attributes: ['last_known_school_year_open']) do |row|
+          row = row.to_h.map {|k, v| [k, sanitize_string_for_db(v)]}.to_h
+          {
+            id:                           row['School ID - NCES Assigned [Public School] Latest available year'].to_i.to_s,
+            name:                         row['School Name'].upcase,
+            address_line1:                row['Location Address 1 [Public School] 2021-22'].to_s.upcase.truncate(50).presence,
+            address_line2:                row['Location Address 2 [Public School] 2021-22'].to_s.upcase.truncate(30).presence,
+            address_line3:                row['Location Address 3 [Public School] 2021-22'].to_s.upcase.presence,
+            city:                         row['Location City [Public School] 2021-22'].to_s.upcase.presence,
+            state:                        row['Location State Abbr [Public School] 2021-22'].to_s.strip.upcase.presence,
+            zip:                          row['Location ZIP [Public School] 2021-22'],
+            latitude:                     row['Latitude [Public School] 2021-22'].to_f,
+            longitude:                    row['Longitude [Public School] 2021-22'].to_f,
+            school_type:                  CHARTER_SCHOOL_MAP[row['Charter School [Public School] 2021-22'].to_s] || 'public',
+            school_district_id:           row['Agency ID - NCES Assigned [Public School] Latest available year'].to_i,
+            state_school_id:              row['State School ID [Public School] 2021-22'],
+            school_category:              SCHOOL_CATEGORY_MAP[row['School Type [Public School] 2021-22']].presence,
+            last_known_school_year_open:  OPEN_SCHOOL_STATUSES.include?(row['Updated Status [Public School] 2021-22']) ? '2021-2022' : nil
+          }
+        end
+      end
     end
   end
 

--- a/dashboard/app/models/school_district.rb
+++ b/dashboard/app/models/school_district.rb
@@ -199,10 +199,9 @@ class SchoolDistrict < ApplicationRecord
     new_districts = []
     updated_districts = 0
     unchanged_districts = 0
-    CDO.log.info "summary_message: #{is_dry_run ? 'Dry run' : 'Importing'} school districts from #{filename}"
+
     ActiveRecord::Base.transaction do
       districts = CSV.read(filename, **options).each do |row|
-        CDO.log.info "Processing row: #{row.inspect}"
         parsed = block_given? ? yield(row) : row.to_hash.symbolize_keys
         loaded = find_by_id(parsed[:id])
         if loaded.nil?


### PR DESCRIPTION
Seeding script updates to ingestion new school and school district information (through CSV files uploaded to S3) that contain latest NCES data for schools and school districts.

## Links
- jira ticket: https://codedotorg.atlassian.net/browse/ACQ-460?atlOrigin=eyJpIjoiNWU0MWIxMzM5Nzk3NDE5YmFjYzdlZDI5ZTMzY2IyNTciLCJwIjoiaiJ9 

## Testing story
Validated the changes locally by running the import scripts before making changes and bringing the environment to a similar state to production. Then ran the changes in dry run mode and then actually running the script for the seeding. 

## Deployment strategy
The seeding scripts are run as part of all the DTPs, so these changes should apply as part of the next DTP. These also have logs that would go to cloud watch, which has been confirmed for earlier runs and will use that for validation.

## Follow-up work

Once this is done, there will be an additional one off script to use this ingested data and populate the school stats by year table. That will be a separate PR.


## PR Checklist:


- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
