### PR TITLE
Revert "Revert "Enable load balancer slow start""

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -244,6 +244,10 @@ Resources:
           Value: lb_cookie
         - Key: stickiness.lb_cookie.duration_seconds
           Value: 30
+        # Linearly increase the HTTP throughput share to new instances to give them time to initialize and load caches.
+        - Key: slow_start.duration_seconds
+          Value: 120
+
 <%   unless frontends -%>
       Targets:
         - {Id: !Ref <%=daemon%>, Port: 80}

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -247,7 +247,7 @@ Resources:
           Value: 30
         # Linearly increase the HTTP throughput share to new instances to give them time to initialize and load caches.
         - Key: slow_start.duration_seconds
-          Value: 120
+          Value: 300
 
 <%   unless frontends -%>
       Targets:

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -236,8 +236,9 @@ Resources:
       HealthCheckIntervalSeconds: 10
       HealthCheckTimeoutSeconds: 5
       TargetGroupAttributes:
+        # Least Outstanding Requests algorithm precludes usage of Slow Start feature below.
         - Key: load_balancing.algorithm.type
-          Value: least_outstanding_requests
+          Value: round_robin
         - Key: stickiness.enabled
           Value: true
         - Key: stickiness.type


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#51253

Our previous attempt to deploy this change - #51105 - failed because we were using an incompatible load balancing algorithm. Re-attempting this change.

Enable a 300 second slow start (successfully tested via manual configuration change in production) to reduce the likelihood of performance issues when releasing to production during peak usage time periods. Switch load balancing algorithms (something we've tested manually in production during peak usage to ensure no impact on performance) because we were using an algorithm that is incompatible with Slow Start.

https://codedotorg.atlassian.net/browse/INF-864

## Testing story

Our managed test environment provisions a load balancer, but does not have an Auto Scaling Group implemented, so no new "Front End" (web application server) EC2 Instances will be provisioned on our managed test server when this change reaches that environment, so this feature will not be exercised until it reaches production.

We could provision an adhoc with the `Full Stack` (auto scaling, load balancer, RDS database, etc.) enabled, but we have not been successful in getting those to provision lately, and also if we pushed a new commit to this feature branch to simulate a production release, a longstanding limitation in our adhoc provisioning logic, we re-provision the entire stack as a single EC2 Instance environment (no CloudFront, no load balancer, no auto scaling group, no RDS cluster, etc.).

Tested in production via manual configuration change. In one case, 300 second Slow Start period resulted in a release to production during peak usage where there was NO performance degradation. With 120 seconds Slow Start period, there was at least one deploy where performance deteriorated during new application server launch. See [notes in Slack](https://codedotorg.slack.com/archives/C03CK49G9/p1681930084855689).

## Deployment strategy

Possibly release as a 2nd production deploy later in the work day to minimize risk.

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
