### PR TITLE
Remove Unused `signup_error_messages!` Helper

### DIFF
--- a/dashboard/app/helpers/application_helper.rb
+++ b/dashboard/app/helpers/application_helper.rb
@@ -168,29 +168,6 @@ module ApplicationHelper
     end
   end
 
-  def signup_error_messages!
-    # See also https://github.com/plataformatec/devise/blob/master/app/helpers/devise_helper.rb
-    return "" if resource.errors.empty?
-
-    messages = resource.errors.full_messages.map {|msg| content_tag(:li, msg)}.join
-    sentence = resource.oauth? ?
-      I18n.t("signup_form.additional_information") :
-      I18n.t(
-        "errors.messages.not_saved",
-        count: resource.errors.count,
-        resource: resource.class.model_name.human.downcase
-      )
-
-    html = <<-HTML
-    <div id="error_explanation">
-      <h2>#{sentence}</h2>
-      <ul>#{messages}</ul>
-    </div>
-    HTML
-
-    html.html_safe
-  end
-
   # Returns a client state object for the current session and cookies.
   def client_state
     @client_state ||= ClientState.new(session, cookies)

--- a/dashboard/config/locales/devise.en.yml
+++ b/dashboard/config/locales/devise.en.yml
@@ -52,9 +52,6 @@ en:
       expired: "has expired, please request a new one"
       not_found: "not found"
       not_locked: "was not locked"
-      not_saved:
-        one: "1 error prohibited this %{resource} from being saved:"
-        other: "%{count} errors prohibited this %{resource} from being saved:"
     invitations:
       send_instructions: 'An invitation email has been sent to %{email}.'
       invitation_token_invalid: 'The invitation token provided is not valid!'

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -186,7 +186,6 @@ en:
     data_collection_us: "I understand that Code.org is a US-based not-for-profit website and that the laws governing data collection in the U.S. may differ from the laws in my country."
     visit_privacy: 'Visit Code.org’s [Privacy Policy](%{privacy_url}) to learn more.'
     student_terms_markdown: "Email addresses are not stored in a form that allows us to contact students. Students will never receive emails from Code.org except for password recovery. See our [privacy policy](http://code.org/privacy) for more information."
-    additional_information: "We need some additional information to continue signing you up."
     user_type_button: "Update Account Type"
     user_type_label: "Account Type"
     user_type_student: "Student"


### PR DESCRIPTION
This used to be an overridable method in Devise, but has long since been deprecated, first in favor of `devise_error_messages!` and then in favor of the `devise/shared/error_messages` partial. Fortunately, we have also long since stopped using it.

Also remove some associated i18n strings which are similarly unused.

## Links

- https://github.com/heartcombo/devise/blob/v4.7.0/app/helpers/devise_helper.rb

## Testing story

Grepped the codebase for instances of `additional_information` and `not_saved` to verify that we aren't using these strings anywhere else. Tested out a few different ways to generate error messages in the signup workflow locally to verify that everything still works. Otherwise, relying on existing tests to verify that this doesn't represent any change in functionality.