### PR TITLE
Update `cgi` Gem to 0.3.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,10 @@ ruby '2.7.5'
 # see https://www.ruby-lang.org/en/news/2019/12/25/ruby-2-7-0-released/
 gem 'thwait'
 
+# Ruby >= 2.7.7 targets a version of CGI with over-restrictive domain
+# validation; manually target a later version to pick up https://github.com/ruby/cgi/pull/29
+gem 'cgi', '~> 0.3.6'
+
 # Force HTTPS for github-source gems.
 # This is a temporary workaround - remove when bundler version is >=2.0
 # @see https://github.com/bundler/bundler/issues/4978

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -288,6 +288,7 @@ GEM
     cancancan (3.2.2)
     case_transform (0.2)
       activesupport
+    cgi (0.3.6)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
     chronic (0.10.2)
@@ -924,6 +925,7 @@ DEPENDENCIES
   bootstrap-sass (~> 2.3.2.2)
   brakeman
   cancancan (~> 3.2.0)
+  cgi (~> 0.3.6)
   chronic (~> 0.10.2)
   cld
   colorize


### PR DESCRIPTION
In preparation for an update to Ruby 3.0; starting in Ruby 2.7.7, Ruby by default targets version 0.3.5 of the `cgi` gem, which fixed a security issue but also made the domain validation more restrictive than necessary. Version 0.3.6 loosens the restrictions.

## Links

- https://github.com/ruby/cgi/releases/tag/v0.3.6
- https://github.com/ruby/cgi/pull/29
- https://johnathan.org/ruby-2-7-7-invalid-domain/


## Testing story

Without this change, we get several hundred `ArgumentError: invalid domain: ".code.org"` errors in Dashboard tests on Ruby 3. With this change, we do not.