### PR TITLE
[Google Blockly] Stop relying on "strict" connection checks for Sprite Lab with Google Blockly

### DIFF
--- a/apps/src/block_utils.js
+++ b/apps/src/block_utils.js
@@ -645,11 +645,11 @@ const STANDARD_INPUT_TYPES = {
       const inputRow = block
         .appendValueInput(inputConfig.name)
         .setAlign(blockly.ALIGN_RIGHT);
-      if (inputConfig.strict) {
-        inputRow.setStrictCheck(inputConfig.type);
-      } else {
-        inputRow.setCheck(inputConfig.type);
-      }
+      Blockly.cdoUtils.setStrictCheck(
+        inputRow,
+        inputConfig.type,
+        inputConfig.strict
+      );
       return inputRow;
     },
     generateCode(block, inputConfig) {

--- a/apps/src/blockly/addons/cdoUtils.js
+++ b/apps/src/blockly/addons/cdoUtils.js
@@ -1,4 +1,8 @@
-import {ToolboxType, CLAMPED_NUMBER_REGEX} from '../constants';
+import {
+  ToolboxType,
+  CLAMPED_NUMBER_REGEX,
+  DEFAULT_BLOCK_TYPE_CHECKS
+} from '../constants';
 import cdoTheme from '../themes/cdoTheme';
 
 export function setHSV(block, h, s, v) {
@@ -107,4 +111,10 @@ export function getCode(workspace) {
   return Blockly.Xml.domToText(Blockly.Xml.blockSpaceToDom(workspace));
   // After supporting JSON block sources, change to:
   // return JSON.stringify(Blockly.serialization.workspaces.save(workspace));
+}
+
+export function setStrictCheck(inputRow, type) {
+  // If no type check is specified, allow any types from the default set.
+  // The default set does not include Sprite, Behavior, or Location types.
+  inputRow.setCheck(type || DEFAULT_BLOCK_TYPE_CHECKS);
 }

--- a/apps/src/blockly/cdoBlocklyWrapper.js
+++ b/apps/src/blockly/cdoBlocklyWrapper.js
@@ -274,6 +274,9 @@ function initializeBlocklyWrapper(blocklyInstance) {
     },
     getCode: function (workspace) {
       return Blockly.Xml.domToText(Blockly.Xml.blockSpaceToDom(workspace));
+    },
+    setStrictCheck: function (inputRow, type, strict) {
+      strict ? inputRow.setStrictCheck(type) : inputRow.setCheck(type);
     }
   };
   return blocklyWrapper;

--- a/apps/src/blockly/googleBlocklyWrapper.js
+++ b/apps/src/blockly/googleBlocklyWrapper.js
@@ -398,8 +398,8 @@ function initializeBlocklyWrapper(blocklyInstance) {
     return false;
   };
 
-  blocklyWrapper.Input.prototype.setStrictCheck = function (check) {
-    return this.setCheck(check);
+  blocklyWrapper.Block.prototype.setStrictOutput = function (isOutput, check) {
+    return this.setOutput(isOutput, check);
   };
   // We use fieldRow because it is public.
   blocklyWrapper.Input.prototype.getFieldRow = function () {

--- a/apps/src/constants.js
+++ b/apps/src/constants.js
@@ -188,3 +188,10 @@ export const TOOLBOX_EDIT_MODE = 'toolbox_blocks';
 export const NOTIFICATION_ALERT_TYPE = 'notification';
 
 export const START_BLOCKS = 'start_blocks';
+
+export const DEFAULT_BLOCK_TYPE_CHECKS = [
+  'Number',
+  'Boolean',
+  'String',
+  'Colour'
+];


### PR DESCRIPTION
## Context
Blockly provides several connection type strings (`'Number', 'Boolean', 'String', 'Array', 'Colour'`), which all correspond to blocks with the standard "puzzle piece" shapes when using the Thrasos (or Geras) renderer. Code.org also uses some additional type strings (`'Behavior', 'Location', 'Sprite'`), which correspond to specialized Sprite Lab blocks that have their own connection shapes. These custom block types should never be able to connect to the standard Blockly types.

Both versions of Blockly have the ability to prevent blocks with mismatching types from connecting. For a detailed overview of why this is important and how it works (in Google Blockly), see their documentation: https://developers.google.com/blockly/guides/create-custom-blocks/type-checks

Google Blockly allows connections between blocks that have a matching type or any connection where either side's check is set to `null`:

|input| output| allowed?|
|-|-|-|
|number|number|yes|
|number|null|yes|
|null|number|yes|
|null|null|yes|
|sprite|number|no|

In anticipation of Sprite Lab's specialized types (sprites, behaviors, locations), the concept of string connection was added to the CDO Blockly repo. If strict connections are used*, connections are only allowed when both sides match:

|input| output| allowed?|
|-|-|-|
|sprite*|sprite|yes|
|sprite*|null|no|
|null|sprite*|no|
|null|null|yes|
|sprite*|number|no|
|sprite|null|yes|

If a strict connection is not chosen (bottom row, above), then it's still possible for types like sprites to connect to blocks with null connection types. With CDO Blockly, we guarantee that custom types like sprites are always considered strict (https://github.com/code-dot-org/code-dot-org/blob/mike/deprecate-strict-checks/apps/src/block_utils.js#L581).
![image](https://user-images.githubusercontent.com/43474485/233445208-41d96ad5-b3fa-4d01-9fe9-75353ca43ee2.png)


## Migrating Sprite Lab to Google Blockly
Google Blockly does not offer strict connection checks. One possible solution is to re-implement this system in our main repo by writing a custom checker. However, this isn't actually necessary if we adjust our mental model for how/why we might want to reject a connection. 

Before, one might say if we don't specify an input connection type (it's null), then it should accept _any_ output connection type. This forces us to need a strict connection checks for the types that should still be exceptions to the "any type" rule. (To be clear, this is what we do now.)

Alternatively, let's consider a world where no block have a `null` input connection. Instead, these blocks expect just the types that we really want them to (numbers, strings, etc. but not sprites, locations, behaviors):

![image](https://user-images.githubusercontent.com/43474485/233444830-c4ac77fa-2013-4de0-b2a3-b4972db69de7.png)

## Strategy
We can get to the above model quite simply:
1. Define a list of default block type checks (in [constants.js](https://github.com/code-dot-org/code-dot-org/pull/51433/files#diff-f5ea16ab7d155f038ad6e90196513bbc5570c180f110bba3f2f5adf84b82d399))
2. When we set the check type for a block, if there already isn't a type specified use that list instead of `null`. See [cdoUtils.js](https://github.com/code-dot-org/code-dot-org/pull/51433/files#diff-e4f1fff616cfed0528aa90a55e77c636cbf0cdfc823720c482a8ccdc7adc7369)
3. Maintain the existing behavior for CDO Blockly labs by moving it to the CDO blockly wrapper. ([block_utils.js](https://github.com/code-dot-org/code-dot-org/pull/51433/files#diff-4204ee82808ca5d21acf4aef2f991c9674c29b599070f1c7aedc237c3ec3b461), [cdoBlocklyWrapper.js](https://github.com/code-dot-org/code-dot-org/pull/51433/files#diff-cb4f6e24aae251e649f2e5ea3f70aea4784ae4661233892b0b6f4834e1399f1b)) We rely on both wrappers to determine which behavior we want.
4. Because we no longer call `setStrictCheck` outside of the CDO Blockly wrapper, we can remove it from the Google Blockly Wrapper (red portion of [googleBlocklyWrapper.js](https://github.com/code-dot-org/code-dot-org/pull/51433/files#diff-39f0e440025c4f23f4050e7fb36db18df364b1e6d5cf578b326ca71720c8c75b)). 
5. If a lab file would have Google Blockly call `setStrictOutput` we can now just do a standard `setOutput` instead (green portion of [googleBlocklyWrapper.js](https://github.com/code-dot-org/code-dot-org/pull/51433/files#diff-39f0e440025c4f23f4050e7fb36db18df364b1e6d5cf578b326ca71720c8c75b)).


The result of these changes is that we see the same expected behavior when trying to connect blocks of various types, regardless of Blockly version. The difference is the reason why a connection would be rejected. Where previously we would reject based on mismatching types OR the presence of a strict check, now we will reject simply based on types.  The existence of Sprite Lab's specialized block types is sufficient evidence that we would never need (or want) a truly `null` connection type.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  6.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
