### PR TITLE
Create common util for retrieving CSRF token

### DIFF
--- a/apps/src/util/AuthenticityTokenStore.ts
+++ b/apps/src/util/AuthenticityTokenStore.ts
@@ -1,5 +1,5 @@
 /**
- * A utility for retrieving the Rails authentication token, needed for certain
+ * A utility for retrieving the Rails authenticity token, needed for certain
  * requests made to dashboard. On some pages, this is passed down as part of the
  * DOM, but in others, it may need to be retrieved by a separate AJAX request.
  */

--- a/apps/src/util/AuthenticityTokenStore.ts
+++ b/apps/src/util/AuthenticityTokenStore.ts
@@ -1,0 +1,39 @@
+/**
+ * A utility for retrieving the Rails authentication token, needed for certain
+ * requests made to dashboard. On some pages, this is passed down as part of the
+ * DOM, but in others, it may need to be retrieved by a separate AJAX request.
+ */
+
+let authenticityToken: string | null = null;
+
+async function getAuthenticityToken(): Promise<string> {
+  if (authenticityToken !== null) {
+    return authenticityToken;
+  }
+
+  const token = await refreshToken();
+  authenticityToken = token;
+  return authenticityToken;
+}
+
+async function refreshToken(): Promise<string> {
+  // Retrieve token from DOM if present
+  const tokenContainer = document.querySelector<HTMLMetaElement>(
+    'meta[name="csrf-token"]'
+  );
+
+  if (tokenContainer && tokenContainer.content) {
+    return tokenContainer.content;
+  }
+
+  // Request a token from dashboard
+  const response = await fetch('/get_token');
+  const token = response.headers.get('csrf-token');
+  if (token === null) {
+    throw new Error('Could not retrieve CSRF token');
+  }
+  return token;
+}
+
+export {getAuthenticityToken};
+export const AUTHENTICITY_TOKEN_HEADER = 'X-CSRF-TOKEN';

--- a/dashboard/app/controllers/authenticity_token_controller.rb
+++ b/dashboard/app/controllers/authenticity_token_controller.rb
@@ -1,6 +1,7 @@
 class AuthenticityTokenController < ApplicationController
   # GET /get_token
   def get_token
+    return head :forbidden unless Gatekeeper.allows('csrf-token-endpoint', default: true)
     headers['csrf-token'] = form_authenticity_token
     return head :ok
   end

--- a/dashboard/app/controllers/authenticity_token_controller.rb
+++ b/dashboard/app/controllers/authenticity_token_controller.rb
@@ -1,0 +1,7 @@
+class AuthenticityTokenController < ApplicationController
+  # GET /get_token
+  def get_token
+    headers['csrf-token'] = form_authenticity_token
+    return head :ok
+  end
+end

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -1038,5 +1038,7 @@ Dashboard::Application.routes.draw do
     # Adds the experiment cookie in the User's browser which allows them to experience offline features
     get '/offline/join_pilot', action: :set_offline_cookie, controller: :offline
     get '/offline-files.json', action: :offline_files, controller: :offline
+
+    get '/get_token', to: 'authenticity_token#get_token'
   end
 end


### PR DESCRIPTION
Creates a common utility helper to fetch the Rails authenticity (CSRF) token. This is needed for most POST requests made by the browser. See [thread](https://codedotorg.slack.com/archives/C0T0PNR0D/p1681928133278129) for more discussion and reasoning.

As an eventual follow-up, we should replace existing usages of alternate routes to fetch the CSRF token with this method (ex. in Code Review, Teacher Feedback, project_commits#get_token, user_levels#get_token). We can also replace code that accesses the `meta` element directly with this util.

A possible future improvement could be to create a standalone HTTP client, specifically for communicating with dashboard endpoints, that fetches and adds the token to requests as needed. However, a lot of our API calls use fetch or $.ajax directly, so it would require converting all of those.

## Testing story

Tested locally.