### PR TITLE
Replace `URI.encode` in Pegasus Template with `URI::DEFAULT_PARSER.escape`

### DIFF
--- a/pegasus/sites.v3/code.org/views/share_privacy.haml
+++ b/pegasus/sites.v3/code.org/views/share_privacy.haml
@@ -20,9 +20,9 @@
   %label{class:'share-label'}
     Share this notice with parents:
   %a{class:'share-on-remind', href:'https://www.remind.com/v1/share?url=code.org/privacy/student-privacy&referer=code.org&text=' + CGI.escape(remind_subject), target:'_blank', id: 'share_on_remind'}
-  -# using URI.encode here because Windows Outlook client renders + as '+' literally
+  -# using URI::DEFAULT_PARSER.escape here because Windows Outlook client renders + as '+' literally
   %a{class: 'email-button',
-    href: "mailto:?to=&subject=" + URI.encode(email_subject) + "&body=" + URI.encode(email_body), target:'_blank', id: 'email_button'}
+    href: "mailto:?to=&subject=" + URI::DEFAULT_PARSER.escape(email_subject) + "&body=" + URI::DEFAULT_PARSER.escape(email_body), target:'_blank', id: 'email_button'}
     %i.fa.fa-envelope{"aria-hidden": "true"}
     Email
   %a{class: 'print-button', href: "javascript:window.print()", id: 'print_button'}


### PR DESCRIPTION
The former is deprecated as of Ruby 2.7 and removed in Ruby 3, but the latter is a drop-in replacement.

## Links

- https://github.com/code-dot-org/code-dot-org/pull/30570
- https://github.com/code-dot-org/code-dot-org/pull/49848

## Testing story

```ruby
[development] dashboard > URI.encode("Code.org and your child's privacy")
(irb):1: warning: URI.escape is obsolete
=> "Code.org%20and%20your%20child's%20privacy"
[development] dashboard > URI::DEFAULT_PARSER.escape("Code.org and your child's privacy")
=> "Code.org%20and%20your%20child's%20privacy"
```