### PR TITLE
use mocha rather than minitest stubs, since the latter don't work wit…

### DIFF
--- a/dashboard/legacy/test/middleware/test_tables.rb
+++ b/dashboard/legacy/test/middleware/test_tables.rb
@@ -13,6 +13,15 @@ class TablesTest < Minitest::Test
 
   def setup
     @table_name = '_testTable'
+    CDO.stubs(:firebase_name).returns('my-firebase-name')
+    CDO.stubs(:firebase_secret).returns('my-firebase-secret')
+    CDO.stubs(:firebase_channel_id_suffix).returns(TEST_SUFFIX)
+  end
+
+  def teardown
+    CDO.unstub(:firebase_name)
+    CDO.unstub(:firebase_secret)
+    CDO.unstub(:firebase_channel_id_suffix)
   end
 
   # channel id suffix, used by firebase in development and circleci environments
@@ -60,12 +69,6 @@ class TablesTest < Minitest::Test
   end
 
   def export_firebase(table_name = @table_name)
-    CDO.stub(:firebase_name, 'my-firebase-name') do
-      CDO.stub(:firebase_secret, 'my-firebase-secret') do
-        CDO.stub(:firebase_channel_id_suffix, TEST_SUFFIX) do
-          get "/v3/export-firebase-tables/#{@channel_id}/#{table_name}"
-        end
-      end
-    end
+    get "/v3/export-firebase-tables/#{@channel_id}/#{table_name}"
   end
 end


### PR DESCRIPTION
…h the ruby 3.x version of openstruct

## Warning!!

The AP CSP Create Performance Task is in progress from April 1 - May 1 2023. Please
consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org
students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game
Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking
anything in these two labs. Even small changes, such as a different button color, are considered
significant during this time period. Reach out to the Student Learning team or Curriculum team for
more details.

<!-- end warning -->

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
