### PR TITLE
Local testing of homepage behaves like someone in the US

### DIFF
--- a/pegasus/src/homepage.rb
+++ b/pegasus/src/homepage.rb
@@ -33,7 +33,7 @@ class Homepage
 
       # If the banner has a showInternationally flag,
       # only show if exactly one of showInternationally or location_unknown_or_usa are true
-      location_unknown_or_usa = request.country.nil? || request.country.to_s.casecmp?('us')
+      location_unknown_or_usa = request.country.nil? || request.country.to_s.casecmp?('rd') || request.country.to_s.casecmp?('us')
       next if banner.key?("showInternationally") && !(banner["showInternationally"] ^ location_unknown_or_usa)
 
       # We have a banner.  Add the ID to the hash that we return.

--- a/pegasus/test/test_homepage.rb
+++ b/pegasus/test/test_homepage.rb
@@ -57,5 +57,21 @@ class HomepageTest < Minitest::Test
       banner = Homepage.get_announcement_for_page("homepage", @request)
       assert_equal("show-everywhere", banner[:id])
     end
+
+    it 'banners for local testing are shown as if based in the US' do
+      @request.stubs(:country).returns("RD")
+
+      Homepage.class_variable_set(:@@json_path, File.join("#{pegasus_dir}/test/fixtures/homepage", 'show_banner_in_US_and_unknown_location.json'))
+      banner = Homepage.get_announcement_for_page("homepage", @request)
+      assert_equal("show-in-US-and-unknown-location", banner[:id])
+
+      Homepage.class_variable_set(:@@json_path, File.join("#{pegasus_dir}/test/fixtures/homepage", 'show_banner_everywhere.json'))
+      banner = Homepage.get_announcement_for_page("homepage", @request)
+      assert_equal("show-everywhere", banner[:id])
+
+      Homepage.class_variable_set(:@@json_path, File.join("#{pegasus_dir}/test/fixtures/homepage", 'show_banner_outside_US.json'))
+      banner = Homepage.get_announcement_for_page("homepage", @request)
+      refute banner
+    end
   end
 end


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/51356 so that on the homepage, users running the site locally will match behavior with users in the US.

When I navigate to http://localhost.code.org:3000/v2/country, I see
<img width="524" alt="Screenshot 2023-04-24 at 10 08 46 AM" src="https://user-images.githubusercontent.com/9142121/234025257-1dd87ccb-693b-4ddf-82b7-4cc8deee31d2.png">

showing 'RD' as the country code, which is what I configured.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
