### PR TITLE
NCES school data import for 2021 to 2022

### DIFF
--- a/bin/oneoff/nces_data/import_school_stats_by_years_2021_2022_ccd
+++ b/bin/oneoff/nces_data/import_school_stats_by_years_2021_2022_ccd
@@ -6,7 +6,8 @@ CDO.log = Logger.new(STDOUT)
 
 SURVEY_YEAR = '2021-2022'.freeze
 
-DRY_RUN = true
+# Override for the dry run variable using an commandline argument
+DRY_RUN = !((ARGV.find {|arg| arg.casecmp('-dryrun')}).nil?)
 
 VIRTUAL_SCHOOL_MAP = {
   'Full Virtual' => 'Yes',

--- a/bin/oneoff/nces_data/import_school_stats_by_years_2021_2022_ccd
+++ b/bin/oneoff/nces_data/import_school_stats_by_years_2021_2022_ccd
@@ -1,0 +1,126 @@
+#!/usr/bin/env ruby
+
+require_relative '../../../dashboard/config/environment'
+
+CDO.log = Logger.new(STDOUT)
+
+SURVEY_YEAR = '2021-2022'.freeze
+
+DRY_RUN = true
+
+VIRTUAL_SCHOOL_MAP = {
+  'Full Virtual' => 'Yes',
+  'Not Virtual' => 'No',
+  'Supplemental Virtual' => 'No',
+  'Virtual with face to face options' => 'Yes',
+  '–' => nil,
+  '†' => nil
+}.freeze
+
+TITLE_I_MAP = {
+  '1-Title I targeted assistance eligible school-No program' => '1',
+  '2-Title I targeted assistance school' => '2',
+  '3-Title I schoolwide eligible-Title I targeted assistance program' => '3',
+  '4-Title I schoolwide eligible school-No program' => '4',
+  '5-Title I schoolwide school' => '5',
+  '6-Not a Title I school' => '6',
+  '–' => nil,
+  '†' => nil
+}.freeze
+
+COMMUNITY_TYPE_MAP = {
+  '11' => 'city_large',
+  '12' => 'city_midsize',
+  '13' => 'city_small',
+  '21' => 'suburban_large',
+  '22' => 'suburban_midsize',
+  '23' => 'suburban_small',
+  '31' => 'town_fringe',
+  '32' => 'town_distant',
+  '33' => 'town_remote',
+  '41' => 'rural_fringe',
+  '42' => 'rural_distant',
+  '43' => 'rural_remote'
+}.freeze
+
+GRADES_MAP = {
+  'Prekindergarten' => 'PK',
+  'Kindergarten' => 'KG',
+  '1st Grade' => '01',
+  '2nd Grade' => '02',
+  '3rd Grade' => '03',
+  '4th Grade' => '04',
+  '5th Grade' => '05',
+  '6th Grade' => '06',
+  '7th Grade' => '07',
+  '8th Grade' => '08',
+  '9th Grade' => '09',
+  '10th Grade' => '10',
+  '11th Grade' => '11',
+  '12th Grade' => '12',
+  '13th Grade' => '13',
+  'Adult Education' => 'AE',
+  'Ungraded' => 'UG',
+  '–' => 'M',
+  '†' => 'N'
+}
+
+# @param unsanitized [String, nil] the unsanitized string
+# @returns [String, nil] the sanitized version of the string, with equal signs and double
+#   quotations removed. Returns nil on nil input.
+def sanitize_string_for_db(unsanitized)
+  unsanitized&.tr('="', '')
+end
+
+# –, † .to_i will return 0
+
+AWS::S3.process_file('cdo-nces', "#{SURVEY_YEAR}/ccd/schools_public.csv") do |filename|
+  SchoolStatsByYear.merge_from_csv(filename, {col_sep: ",", headers: true, quote_char: "\x00", encoding: 'bom|utf-8'}, dry_run: DRY_RUN) do |row|
+    # remove quote and eq sign from ="12345"
+    row = row.to_h.map {|k, v| [k, sanitize_string_for_db(v)]}.to_h
+
+    {
+      school_id:          row['School ID - NCES Assigned [Public School] Latest available year'].to_i.to_s,
+      school_year:        SURVEY_YEAR,
+      grades_offered_lo:  GRADES_MAP[row['Lowest Grade Offered [Public School] ' + SURVEY_YEAR]],
+      grades_offered_hi:  GRADES_MAP[row['Highest Grade Offered [Public School] ' + SURVEY_YEAR]],
+      grade_pk_offered:   row['Prekindergarten offered [Public School] ' + SURVEY_YEAR] == '1-Yes',
+      grade_kg_offered:   row['Kindergarten offered [Public School] ' + SURVEY_YEAR] == '1-Yes',
+      grade_01_offered:   row['Grade 1 offered [Public School] ' + SURVEY_YEAR] == '1-Yes',
+      grade_02_offered:   row['Grade 2 offered [Public School] ' + SURVEY_YEAR] == '1-Yes',
+      grade_03_offered:   row['Grade 3 offered [Public School] ' + SURVEY_YEAR] == '1-Yes',
+      grade_04_offered:   row['Grade 4 offered [Public School] ' + SURVEY_YEAR] == '1-Yes',
+      grade_05_offered:   row['Grade 5 offered [Public School] ' + SURVEY_YEAR] == '1-Yes',
+      grade_06_offered:   row['Grade 6 offered [Public School] ' + SURVEY_YEAR] == '1-Yes',
+      grade_07_offered:   row['Grade 7 offered [Public School] ' + SURVEY_YEAR] == '1-Yes',
+      grade_08_offered:   row['Grade 8 offered [Public School] ' + SURVEY_YEAR] == '1-Yes',
+      grade_09_offered:   row['Grade 9 offered [Public School] ' + SURVEY_YEAR] == '1-Yes',
+      grade_10_offered:   row['Grade 10 offered [Public School] ' + SURVEY_YEAR] == '1-Yes',
+      grade_11_offered:   row['Grade 11 offered [Public School] ' + SURVEY_YEAR] == '1-Yes',
+      grade_12_offered:   row['Grade 12 offered [Public School] ' + SURVEY_YEAR] == '1-Yes',
+      grade_13_offered:   row['Grade 13 offered [Public School] ' + SURVEY_YEAR] == '1-Yes',
+
+      virtual_status:     VIRTUAL_SCHOOL_MAP[row['Virtual School Status (SY 2016-17 onward) [Public School] ' + SURVEY_YEAR]],
+      students_total:     row['Total Students All Grades (Excludes AE) [Public School] ' + SURVEY_YEAR].presence.try {|v| v.to_i == 0 ? nil : v.to_i},
+      student_am_count:   row['American Indian/Alaska Native Students [Public School] ' + SURVEY_YEAR].to_i,
+      student_as_count:   row['Asian or Asian/Pacific Islander Students [Public School] ' + SURVEY_YEAR].to_i,
+      student_hi_count:   row['Hispanic Students [Public School] ' + SURVEY_YEAR].to_i,
+      student_bl_count:   row['Black or African American Students [Public School] ' + SURVEY_YEAR].to_i,
+      student_wh_count:   row['White Students [Public School] ' + SURVEY_YEAR].to_i,
+      student_hp_count:   row['Nat. Hawaiian or Other Pacific Isl. Students [Public School] ' + SURVEY_YEAR].to_i,
+      student_tr_count:   row['Two or More Races Students [Public School] ' + SURVEY_YEAR].to_i,
+      title_i_status:     TITLE_I_MAP[row['Title I School Status [Public School] ' + SURVEY_YEAR]],
+      frl_eligible_total: row['Free and Reduced Lunch Students [Public School] ' + SURVEY_YEAR].to_i
+    }
+  end
+end
+
+AWS::S3.process_file('cdo-nces', "#{SURVEY_YEAR}/ccd/locale_public.csv") do |filename|
+  SchoolStatsByYear.merge_from_csv(filename, {col_sep: ",", headers: true, quote_char: "\x00", encoding: 'bom|utf-8'}, dry_run: DRY_RUN) do |row|
+    {
+      school_id:      row['NCESSCH'].to_i.to_s,
+      school_year:    SURVEY_YEAR,
+      community_type: COMMUNITY_TYPE_MAP[row['LOCALE']]
+    }
+  end
+end

--- a/dashboard/app/models/school_stats_by_year.rb
+++ b/dashboard/app/models/school_stats_by_year.rb
@@ -79,11 +79,9 @@ class SchoolStatsByYear < ApplicationRecord
         end
       end
 
-      CDO.log.debug("New #{new_schools}, updated #{updated_schools}, unchanged #{unchanged_schools}")
       # Raise an error so that the db transaction rolls back
-      raise "[2:41] This was a dry run. No rows were modified or added. Set dry_run: false to modify db" if dry_run
+      raise "This was a dry run. No rows were modified or added. Set dry_run: false to modify db" if dry_run
     ensure
-      CDO.log.debug "Transaction roll back, getting stats on processing"
       future_tense_dry_run = dry_run ? ' to be' : ''
       summary_message = "School stats seeding: done processing #{filename}.\n"\
         "#{new_schools} new stats#{future_tense_dry_run} added.\n"\

--- a/dashboard/app/models/school_stats_by_year.rb
+++ b/dashboard/app/models/school_stats_by_year.rb
@@ -79,9 +79,11 @@ class SchoolStatsByYear < ApplicationRecord
         end
       end
 
+      CDO.log.debug("New #{new_schools}, updated #{updated_schools}, unchanged #{unchanged_schools}")
       # Raise an error so that the db transaction rolls back
-      raise "This was a dry run. No rows were modified or added. Set dry_run: false to modify db" if dry_run
+      raise "[2:41] This was a dry run. No rows were modified or added. Set dry_run: false to modify db" if dry_run
     ensure
+      CDO.log.debug "Transaction roll back, getting stats on processing"
       future_tense_dry_run = dry_run ? ' to be' : ''
       summary_message = "School stats seeding: done processing #{filename}.\n"\
         "#{new_schools} new stats#{future_tense_dry_run} added.\n"\

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -12,7 +12,7 @@
 
 ActiveRecord::Schema.define(version: 2023_03_23_175726) do
 
-  create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
     t.integer "level_id"
     t.string "action"
@@ -28,7 +28,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id", "level_id"], name: "index_activities_on_user_id_and_level_id"
   end
 
-  create_table "activity_sections", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "activity_sections", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "lesson_activity_id", null: false
     t.string "key", null: false
     t.integer "position", null: false
@@ -39,7 +39,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["lesson_activity_id"], name: "index_activity_sections_on_lesson_activity_id"
   end
 
-  create_table "ap_cs_offerings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "ap_cs_offerings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "school_code", limit: 6, null: false
     t.string "course", limit: 3, null: false
     t.integer "school_year", limit: 2, null: false
@@ -48,7 +48,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["school_code", "school_year", "course"], name: "index_ap_cs_offerings_on_school_code_and_school_year_and_course", unique: true
   end
 
-  create_table "ap_school_codes", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "ap_school_codes", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "school_year"
     t.string "school_code", limit: 6, null: false
     t.string "school_id", limit: 12, null: false
@@ -58,7 +58,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["school_id"], name: "fk_rails_08d2269647"
   end
 
-  create_table "assessment_activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "assessment_activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "level_id", null: false
     t.integer "script_id", null: false
@@ -70,7 +70,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id", "level_id", "script_id"], name: "index_assessment_activities_on_user_and_level_and_script"
   end
 
-  create_table "authentication_options", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "authentication_options", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "hashed_email", default: "", null: false
     t.string "credential_type", null: false
@@ -86,7 +86,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id", "deleted_at"], name: "index_authentication_options_on_user_id_and_deleted_at"
   end
 
-  create_table "authored_hint_view_requests", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "authored_hint_view_requests", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "script_id"
     t.integer "level_id"
@@ -112,7 +112,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id", "script_id", "level_id", "hint_id"], name: "index_authored_hint_view_requests_on_all_related_ids"
   end
 
-  create_table "backpacks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "backpacks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "storage_app_id", null: false
     t.datetime "created_at", null: false
@@ -121,7 +121,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id"], name: "index_backpacks_on_user_id", unique: true
   end
 
-  create_table "blocks", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "blocks", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "pool", default: "", null: false
     t.string "category"
@@ -134,7 +134,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["pool", "name"], name: "index_blocks_on_pool_and_name", unique: true
   end
 
-  create_table "callouts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "callouts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "element_id", limit: 1024, null: false
     t.string "localization_key", limit: 1024, null: false
     t.datetime "created_at"
@@ -145,7 +145,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.string "callout_text"
   end
 
-  create_table "census_state_course_codes", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "census_state_course_codes", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "state"
     t.string "course"
     t.datetime "created_at", null: false
@@ -153,7 +153,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["state", "course"], name: "index_census_state_course_codes_on_state_and_course", unique: true
   end
 
-  create_table "census_submission_form_maps", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "census_submission_form_maps", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "census_submission_id", null: false
     t.integer "form_id", null: false
     t.datetime "created_at", null: false
@@ -162,7 +162,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["form_id"], name: "index_census_submission_form_maps_on_form_id"
   end
 
-  create_table "census_submissions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "census_submissions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "type", null: false
     t.string "submitter_email_address"
     t.string "submitter_name"
@@ -196,7 +196,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["school_year", "id"], name: "index_census_submissions_on_school_year_and_id"
   end
 
-  create_table "census_submissions_school_infos", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "census_submissions_school_infos", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "census_submission_id", null: false
     t.integer "school_info_id", null: false
     t.datetime "created_at", null: false
@@ -205,7 +205,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["school_info_id", "census_submission_id"], name: "school_info_id_census_submission", unique: true
   end
 
-  create_table "census_summaries", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "census_summaries", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "school_id", limit: 12, null: false
     t.integer "school_year", limit: 2, null: false
     t.string "teaches_cs", limit: 2
@@ -215,7 +215,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["school_id", "school_year"], name: "index_census_summaries_on_school_id_and_school_year", unique: true
   end
 
-  create_table "channel_tokens", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "channel_tokens", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "storage_app_id", null: false
     t.integer "level_id", null: false
     t.datetime "created_at"
@@ -228,7 +228,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["storage_id"], name: "index_channel_tokens_on_storage_id"
   end
 
-  create_table "circuit_playground_discount_applications", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "circuit_playground_discount_applications", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "unit_6_intention"
     t.boolean "full_discount"
@@ -244,7 +244,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id"], name: "index_circuit_playground_discount_applications_on_user_id", unique: true
   end
 
-  create_table "circuit_playground_discount_codes", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "circuit_playground_discount_codes", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "code", null: false
     t.boolean "full_discount", null: false
     t.datetime "expiration", null: false
@@ -265,7 +265,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["code_review_id"], name: "index_code_review_comments_on_code_review_id"
   end
 
-  create_table "code_review_group_members", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "code_review_group_members", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.bigint "code_review_group_id", null: false
     t.bigint "follower_id", null: false
     t.datetime "created_at", null: false
@@ -274,7 +274,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["follower_id"], name: "index_code_review_group_members_on_follower_id"
   end
 
-  create_table "code_review_groups", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "code_review_groups", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.bigint "section_id", null: false
     t.string "name"
     t.datetime "created_at", null: false
@@ -282,7 +282,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["section_id"], name: "index_code_review_groups_on_section_id"
   end
 
-  create_table "code_review_requests", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "code_review_requests", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "script_id", null: false
     t.integer "level_id", null: false
@@ -295,7 +295,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id", "script_id", "level_id", "closed_at", "deleted_at"], name: "index_code_review_requests_unique", unique: true
   end
 
-  create_table "code_reviews", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "code_reviews", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "project_id", null: false
     t.integer "script_id", null: false
@@ -307,14 +307,14 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.datetime "deleted_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.virtual "active", type: :boolean, as: "if((`deleted_at` is null),true,NULL)"
-    t.virtual "open", type: :boolean, as: "if((`closed_at` is null),true,NULL)"
+    t.virtual "active", type: :boolean, as: "if(isnull(`deleted_at`),TRUE,NULL)"
+    t.virtual "open", type: :boolean, as: "if(isnull(`closed_at`),TRUE,NULL)"
     t.index ["project_id", "deleted_at"], name: "index_code_reviews_on_project_id_and_deleted_at"
     t.index ["user_id", "project_id", "open", "active"], name: "index_code_reviews_unique", unique: true
     t.index ["user_id", "script_id", "project_level_id", "closed_at", "deleted_at"], name: "index_code_reviews_for_peer_lookup"
   end
 
-  create_table "concepts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "concepts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -322,14 +322,14 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["video_key"], name: "index_concepts_on_video_key"
   end
 
-  create_table "concepts_levels", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "concepts_levels", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "concept_id"
     t.integer "level_id"
     t.index ["concept_id"], name: "index_concepts_levels_on_concept_id"
     t.index ["level_id"], name: "index_concepts_levels_on_level_id"
   end
 
-  create_table "contact_rollups_final", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "contact_rollups_final", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "email", null: false
     t.json "data", null: false
     t.datetime "created_at", null: false
@@ -337,7 +337,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["email"], name: "index_contact_rollups_final_on_email", unique: true
   end
 
-  create_table "contact_rollups_pardot_memory", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "contact_rollups_pardot_memory", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "email", null: false
     t.integer "pardot_id"
     t.datetime "pardot_id_updated_at"
@@ -353,7 +353,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["pardot_id"], name: "index_contact_rollups_pardot_memory_on_pardot_id", unique: true
   end
 
-  create_table "contact_rollups_processed", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "contact_rollups_processed", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "email", null: false
     t.json "data", null: false
     t.datetime "created_at", null: false
@@ -361,7 +361,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["email"], name: "index_contact_rollups_processed_on_email", unique: true
   end
 
-  create_table "contact_rollups_raw", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "contact_rollups_raw", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "email", null: false
     t.string "sources", null: false
     t.json "data"
@@ -370,7 +370,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "contained_level_answers", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "contained_level_answers", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "level_id", null: false
@@ -380,7 +380,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["level_id"], name: "index_contained_level_answers_on_level_id"
   end
 
-  create_table "contained_levels", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "contained_levels", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "level_group_level_id", null: false
@@ -393,7 +393,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["level_group_level_id"], name: "index_contained_levels_on_level_group_level_id"
   end
 
-  create_table "course_offerings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "course_offerings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "key", null: false
     t.string "display_name", null: false
     t.datetime "created_at", null: false
@@ -412,7 +412,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["key"], name: "index_course_offerings_on_key", unique: true
   end
 
-  create_table "course_scripts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "course_scripts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "course_id", null: false
     t.integer "script_id", null: false
     t.integer "position", null: false
@@ -423,7 +423,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["script_id"], name: "index_course_scripts_on_script_id"
   end
 
-  create_table "course_versions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "course_versions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "key", null: false
     t.string "display_name", null: false
     t.text "properties"
@@ -438,7 +438,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["course_offering_id"], name: "index_course_versions_on_course_offering_id"
   end
 
-  create_table "courses", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "courses", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.text "properties"
     t.datetime "created_at", null: false
@@ -446,7 +446,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["name"], name: "index_courses_on_name"
   end
 
-  create_table "data_docs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "data_docs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "key", null: false
     t.string "name"
     t.text "content"
@@ -456,14 +456,14 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["name"], name: "index_data_docs_on_name"
   end
 
-  create_table "donor_schools", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "donor_schools", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.string "nces_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "donors", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "donors", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.string "url"
     t.string "show"
@@ -475,7 +475,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "email_preferences", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "email_preferences", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "email", null: false
     t.boolean "opt_in", null: false
     t.string "ip_address", null: false
@@ -486,7 +486,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["email"], name: "index_email_preferences_on_email", unique: true
   end
 
-  create_table "experiments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "experiments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "name", null: false
@@ -508,7 +508,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["start_at"], name: "index_experiments_on_start_at"
   end
 
-  create_table "featured_projects", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "featured_projects", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "storage_app_id"
     t.datetime "featured_at"
     t.datetime "unfeatured_at"
@@ -517,7 +517,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["topic"], name: "index_featured_projects_on_topic"
   end
 
-  create_table "followers", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "followers", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "student_user_id", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -527,7 +527,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["student_user_id"], name: "index_followers_on_student_user_id"
   end
 
-  create_table "foorm_forms", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "foorm_forms", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.integer "version", null: false
     t.text "questions", null: false
@@ -537,7 +537,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["name", "version"], name: "index_foorm_forms_on_name_and_version", unique: true
   end
 
-  create_table "foorm_libraries", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "foorm_libraries", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.integer "version", null: false
     t.boolean "published", null: false
@@ -546,7 +546,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["name", "version"], name: "index_foorm_libraries_on_multiple_fields", unique: true
   end
 
-  create_table "foorm_library_questions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "foorm_library_questions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "library_name", null: false
     t.integer "library_version", null: false
     t.string "question_name", null: false
@@ -557,7 +557,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["library_name", "library_version", "question_name"], name: "index_foorm_library_questions_on_multiple_fields", unique: true
   end
 
-  create_table "foorm_simple_survey_forms", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "foorm_simple_survey_forms", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "path", null: false
     t.string "kind"
     t.string "form_name", null: false
@@ -568,7 +568,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["path"], name: "index_foorm_simple_survey_forms_on_path"
   end
 
-  create_table "foorm_simple_survey_submissions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "foorm_simple_survey_submissions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "foorm_submission_id", null: false
     t.integer "user_id"
     t.bigint "simple_survey_form_id"
@@ -587,7 +587,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "frameworks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "frameworks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "shortcode", null: false
     t.string "name", null: false
     t.text "properties"
@@ -596,7 +596,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["shortcode"], name: "index_frameworks_on_shortcode", unique: true
   end
 
-  create_table "games", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "games", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -605,7 +605,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["intro_video_id"], name: "index_games_on_intro_video_id"
   end
 
-  create_table "hint_view_requests", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "hint_view_requests", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
     t.integer "script_id"
     t.integer "level_id"
@@ -617,7 +617,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id"], name: "index_hint_view_requests_on_user_id"
   end
 
-  create_table "lesson_activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "lesson_activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "lesson_id", null: false
     t.string "key", null: false
     t.integer "position", null: false
@@ -628,7 +628,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["lesson_id"], name: "index_lesson_activities_on_lesson_id"
   end
 
-  create_table "lesson_groups", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "lesson_groups", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "key", null: false
     t.integer "script_id", null: false
     t.boolean "user_facing", default: true, null: false
@@ -639,35 +639,35 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["script_id", "key"], name: "index_lesson_groups_on_script_id_and_key", unique: true
   end
 
-  create_table "lessons_opportunity_standards", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "lessons_opportunity_standards", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.bigint "lesson_id", null: false
     t.bigint "standard_id", null: false
     t.index ["lesson_id", "standard_id"], name: "index_lessons_opportunity_standards_on_lesson_id_and_standard_id", unique: true
     t.index ["standard_id", "lesson_id"], name: "index_lessons_opportunity_standards_on_standard_id_and_lesson_id"
   end
 
-  create_table "lessons_programming_expressions", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "lessons_programming_expressions", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.bigint "lesson_id", null: false
     t.bigint "programming_expression_id", null: false
     t.index ["lesson_id", "programming_expression_id"], name: "lesson_programming_expression", unique: true
     t.index ["programming_expression_id", "lesson_id"], name: "programming_expression_lesson"
   end
 
-  create_table "lessons_resources", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "lessons_resources", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "lesson_id", null: false
     t.integer "resource_id", null: false
     t.index ["lesson_id", "resource_id"], name: "index_lessons_resources_on_lesson_id_and_resource_id", unique: true
     t.index ["resource_id", "lesson_id"], name: "index_lessons_resources_on_resource_id_and_lesson_id"
   end
 
-  create_table "lessons_vocabularies", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "lessons_vocabularies", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.bigint "lesson_id", null: false
     t.bigint "vocabulary_id", null: false
     t.index ["lesson_id", "vocabulary_id"], name: "index_lessons_vocabularies_on_lesson_id_and_vocabulary_id", unique: true
     t.index ["vocabulary_id", "lesson_id"], name: "index_lessons_vocabularies_on_vocabulary_id_and_lesson_id"
   end
 
-  create_table "level_concept_difficulties", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "level_concept_difficulties", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "level_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -684,7 +684,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["level_id"], name: "index_level_concept_difficulties_on_level_id"
   end
 
-  create_table "level_source_images", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "level_source_images", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.bigint "level_source_id", unsigned: true
     t.binary "image", size: :medium
     t.datetime "created_at"
@@ -692,7 +692,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["level_source_id"], name: "index_level_source_images_on_level_source_id"
   end
 
-  create_table "level_sources", id: :bigint, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "level_sources", id: :bigint, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "level_id"
     t.string "md5", limit: 32, null: false
     t.string "data", limit: 20000, null: false
@@ -702,7 +702,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["level_id", "md5"], name: "index_level_sources_on_level_id_and_md5"
   end
 
-  create_table "level_sources_multi_types", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "level_sources_multi_types", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.bigint "level_source_id", null: false, unsigned: true
     t.integer "level_id", null: false
     t.text "data"
@@ -712,7 +712,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["level_source_id"], name: "index_level_sources_multi_types_on_level_source_id"
   end
 
-  create_table "levels", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "levels", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "game_id"
     t.string "name", null: false
     t.datetime "created_at"
@@ -731,7 +731,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["name"], name: "index_levels_on_name"
   end
 
-  create_table "levels_script_levels", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "levels_script_levels", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "level_id", null: false
     t.integer "script_level_id", null: false
     t.index ["level_id"], name: "index_levels_script_levels_on_level_id"
@@ -739,14 +739,14 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["script_level_id"], name: "index_levels_script_levels_on_script_level_id"
   end
 
-  create_table "libraries", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "libraries", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.text "content"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "metrics", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "metrics", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.date "computed_on", null: false
@@ -759,7 +759,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.float "value", null: false
   end
 
-  create_table "objectives", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "objectives", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.text "properties"
     t.integer "lesson_id"
     t.datetime "created_at", null: false
@@ -769,7 +769,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["lesson_id"], name: "index_objectives_on_lesson_id"
   end
 
-  create_table "paired_user_levels", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "paired_user_levels", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.bigint "driver_user_level_id", unsigned: true
     t.bigint "navigator_user_level_id", unsigned: true
     t.datetime "created_at", null: false
@@ -778,7 +778,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["navigator_user_level_id"], name: "index_paired_user_levels_on_navigator_user_level_id"
   end
 
-  create_table "parent_levels_child_levels", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "parent_levels_child_levels", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "parent_level_id", null: false
     t.integer "child_level_id", null: false
     t.integer "position"
@@ -787,7 +787,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["parent_level_id"], name: "index_parent_levels_child_levels_on_parent_level_id"
   end
 
-  create_table "pd_accepted_programs", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_accepted_programs", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "workshop_name", null: false
@@ -796,7 +796,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.integer "teacher_application_id"
   end
 
-  create_table "pd_application_emails", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_application_emails", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "pd_application_id", null: false
     t.string "application_status", null: false
     t.string "email_type", null: false
@@ -806,14 +806,14 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["pd_application_id"], name: "index_pd_application_emails_on_pd_application_id"
   end
 
-  create_table "pd_application_tags", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_application_tags", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_pd_application_tags_on_name", unique: true
   end
 
-  create_table "pd_application_tags_applications", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_application_tags_applications", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "pd_application_id", null: false
     t.integer "pd_application_tag_id", null: false
     t.datetime "created_at", null: false
@@ -822,7 +822,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["pd_application_tag_id"], name: "index_pd_application_tags_applications_on_pd_application_tag_id"
   end
 
-  create_table "pd_applications", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_applications", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
     t.string "type", null: false
     t.string "application_year", null: false
@@ -852,14 +852,14 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id"], name: "index_pd_applications_on_user_id"
   end
 
-  create_table "pd_applications_status_logs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_applications_status_logs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.bigint "pd_application_id", null: false
     t.string "status", null: false
     t.datetime "timestamp", null: false
     t.integer "position", null: false
   end
 
-  create_table "pd_attendances", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_attendances", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "pd_session_id", null: false
     t.integer "teacher_id"
     t.datetime "created_at"
@@ -873,14 +873,14 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["teacher_id"], name: "index_pd_attendances_on_teacher_id"
   end
 
-  create_table "pd_course_facilitators", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_course_facilitators", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "facilitator_id", null: false
     t.string "course", null: false
     t.index ["course"], name: "index_pd_course_facilitators_on_course"
     t.index ["facilitator_id", "course"], name: "index_pd_course_facilitators_on_facilitator_id_and_course", unique: true
   end
 
-  create_table "pd_district_payment_terms", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_district_payment_terms", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "school_district_id"
     t.string "course", null: false
     t.string "rate_type", null: false
@@ -888,7 +888,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["school_district_id", "course"], name: "index_pd_district_payment_terms_school_district_course"
   end
 
-  create_table "pd_enrollment_notifications", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_enrollment_notifications", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "pd_enrollment_id", null: false
@@ -896,7 +896,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["pd_enrollment_id"], name: "index_pd_enrollment_notifications_on_pd_enrollment_id"
   end
 
-  create_table "pd_enrollments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_enrollments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "pd_workshop_id", null: false
     t.string "name"
     t.string "first_name"
@@ -918,7 +918,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["pd_workshop_id"], name: "index_pd_enrollments_on_pd_workshop_id"
   end
 
-  create_table "pd_facilitator_program_registrations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_facilitator_program_registrations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.text "form_data"
     t.datetime "created_at", null: false
@@ -927,7 +927,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id", "teachercon"], name: "index_pd_fac_prog_reg_on_user_id_and_teachercon", unique: true
   end
 
-  create_table "pd_facilitator_teachercon_attendances", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_facilitator_teachercon_attendances", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.date "tc1_arrive"
     t.date "tc1_depart"
@@ -947,7 +947,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id"], name: "index_pd_facilitator_teachercon_attendances_on_user_id"
   end
 
-  create_table "pd_fit_weekend1819_registrations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_fit_weekend1819_registrations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "pd_application_id"
     t.text "form_data"
     t.datetime "created_at", null: false
@@ -955,7 +955,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["pd_application_id"], name: "index_pd_fit_weekend1819_registrations_on_pd_application_id"
   end
 
-  create_table "pd_fit_weekend_registrations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_fit_weekend_registrations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "pd_application_id"
     t.string "registration_year", null: false
     t.text "form_data"
@@ -965,7 +965,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["registration_year"], name: "index_pd_fit_weekend_registrations_on_registration_year"
   end
 
-  create_table "pd_international_opt_ins", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_international_opt_ins", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.text "form_data", null: false
     t.datetime "created_at", null: false
@@ -973,7 +973,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id"], name: "index_pd_international_opt_ins_on_user_id"
   end
 
-  create_table "pd_legacy_survey_summaries", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_legacy_survey_summaries", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "facilitator_id"
     t.string "course"
     t.string "subject"
@@ -982,7 +982,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "pd_misc_surveys", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_misc_surveys", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.bigint "form_id", null: false
     t.bigint "submission_id", null: false
     t.text "answers"
@@ -994,7 +994,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id"], name: "index_pd_misc_surveys_on_user_id"
   end
 
-  create_table "pd_payment_terms", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_payment_terms", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "regional_partner_id", null: false
     t.date "start_date", null: false
     t.date "end_date"
@@ -1006,7 +1006,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["regional_partner_id"], name: "index_pd_payment_terms_on_regional_partner_id"
   end
 
-  create_table "pd_post_course_surveys", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_post_course_surveys", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.bigint "form_id", null: false
     t.bigint "submission_id", null: false
     t.text "answers"
@@ -1021,7 +1021,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id"], name: "index_pd_post_course_surveys_on_user_id"
   end
 
-  create_table "pd_pre_workshop_surveys", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_pre_workshop_surveys", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "pd_enrollment_id", null: false
     t.text "form_data", null: false
     t.datetime "created_at", null: false
@@ -1029,7 +1029,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["pd_enrollment_id"], name: "index_pd_pre_workshop_surveys_on_pd_enrollment_id", unique: true
   end
 
-  create_table "pd_regional_partner_cohorts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_regional_partner_cohorts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "regional_partner_id"
     t.integer "role", comment: "teacher or facilitator"
     t.string "year", comment: "free-form text year range, YYYY-YYYY, e.g. 2016-2017"
@@ -1043,14 +1043,14 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["summer_workshop_id"], name: "index_pd_regional_partner_cohorts_on_summer_workshop_id"
   end
 
-  create_table "pd_regional_partner_cohorts_users", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_regional_partner_cohorts_users", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "pd_regional_partner_cohort_id", null: false
     t.integer "user_id", null: false
     t.index ["pd_regional_partner_cohort_id"], name: "index_pd_regional_partner_cohorts_users_on_cohort_id"
     t.index ["user_id"], name: "index_pd_regional_partner_cohorts_users_on_user_id"
   end
 
-  create_table "pd_regional_partner_contacts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_regional_partner_contacts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
     t.integer "regional_partner_id"
     t.text "form_data"
@@ -1060,7 +1060,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id"], name: "index_pd_regional_partner_contacts_on_user_id"
   end
 
-  create_table "pd_regional_partner_mappings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_regional_partner_mappings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "regional_partner_id", null: false
     t.string "state"
     t.string "zip_code"
@@ -1071,7 +1071,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["regional_partner_id"], name: "index_pd_regional_partner_mappings_on_regional_partner_id"
   end
 
-  create_table "pd_regional_partner_mini_contacts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_regional_partner_mini_contacts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
     t.integer "regional_partner_id"
     t.text "form_data"
@@ -1081,7 +1081,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id"], name: "index_pd_regional_partner_mini_contacts_on_user_id"
   end
 
-  create_table "pd_regional_partner_program_registrations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_regional_partner_program_registrations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.text "form_data"
     t.integer "teachercon", null: false
@@ -1090,7 +1090,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id", "teachercon"], name: "index_pd_reg_part_prog_reg_on_user_id_and_teachercon"
   end
 
-  create_table "pd_scholarship_infos", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_scholarship_infos", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "application_year", null: false
     t.string "scholarship_status", null: false
@@ -1105,7 +1105,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id"], name: "index_pd_scholarship_infos_on_user_id"
   end
 
-  create_table "pd_sessions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_sessions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "pd_workshop_id"
     t.datetime "start", null: false
     t.datetime "end", null: false
@@ -1117,7 +1117,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["pd_workshop_id"], name: "index_pd_sessions_on_pd_workshop_id"
   end
 
-  create_table "pd_survey_questions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_survey_questions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.bigint "form_id"
     t.text "questions", null: false, comment: "JSON Question data for this JotForm form."
     t.datetime "created_at", null: false
@@ -1126,7 +1126,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["form_id"], name: "index_pd_survey_questions_on_form_id", unique: true
   end
 
-  create_table "pd_teacher_applications", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_teacher_applications", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "user_id", null: false
@@ -1140,7 +1140,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id"], name: "index_pd_teacher_applications_on_user_id", unique: true
   end
 
-  create_table "pd_teachercon1819_registrations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_teachercon1819_registrations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "pd_application_id"
     t.text "form_data"
     t.datetime "created_at", null: false
@@ -1152,7 +1152,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id"], name: "index_pd_teachercon1819_registrations_on_user_id"
   end
 
-  create_table "pd_teachercon_surveys", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_teachercon_surveys", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "pd_enrollment_id", null: false
     t.text "form_data", null: false
     t.datetime "created_at", null: false
@@ -1160,7 +1160,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["pd_enrollment_id"], name: "index_pd_teachercon_surveys_on_pd_enrollment_id", unique: true
   end
 
-  create_table "pd_workshop_daily_surveys", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_workshop_daily_surveys", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.bigint "form_id", null: false
     t.bigint "submission_id", null: false
     t.integer "user_id", null: false
@@ -1178,7 +1178,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id"], name: "index_pd_workshop_daily_surveys_on_user_id"
   end
 
-  create_table "pd_workshop_facilitator_daily_surveys", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_workshop_facilitator_daily_surveys", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.bigint "form_id", null: false
     t.bigint "submission_id", null: false
     t.integer "user_id", null: false
@@ -1198,7 +1198,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id"], name: "index_pd_workshop_facilitator_daily_surveys_on_user_id"
   end
 
-  create_table "pd_workshop_survey_foorm_submissions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_workshop_survey_foorm_submissions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "foorm_submission_id", null: false
     t.integer "user_id", null: false
     t.integer "pd_session_id"
@@ -1214,7 +1214,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id"], name: "index_pd_workshop_survey_foorm_submissions_on_user_id"
   end
 
-  create_table "pd_workshop_surveys", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_workshop_surveys", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "pd_enrollment_id", null: false
     t.text "form_data", null: false
     t.datetime "created_at", null: false
@@ -1223,7 +1223,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["pd_enrollment_id"], name: "index_pd_workshop_surveys_on_pd_enrollment_id", unique: true
   end
 
-  create_table "pd_workshops", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_workshops", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "organizer_id", null: false
     t.string "location_name"
     t.string "location_address"
@@ -1248,14 +1248,14 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["regional_partner_id"], name: "index_pd_workshops_on_regional_partner_id"
   end
 
-  create_table "pd_workshops_facilitators", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pd_workshops_facilitators", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "pd_workshop_id", null: false
     t.integer "user_id", null: false
     t.index ["pd_workshop_id"], name: "index_pd_workshops_facilitators_on_pd_workshop_id"
     t.index ["user_id"], name: "index_pd_workshops_facilitators_on_user_id"
   end
 
-  create_table "peer_reviews", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "peer_reviews", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "submitter_id"
     t.integer "reviewer_id"
     t.boolean "from_instructor", default: false, null: false
@@ -1274,7 +1274,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["submitter_id"], name: "index_peer_reviews_on_submitter_id"
   end
 
-  create_table "pilots", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "pilots", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "display_name", null: false
     t.boolean "allow_joining_via_url", null: false
@@ -1283,7 +1283,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["name"], name: "index_pilots_on_name", unique: true
   end
 
-  create_table "plc_course_units", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "plc_course_units", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "plc_course_id"
     t.string "unit_name"
     t.text "unit_description"
@@ -1296,14 +1296,14 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["script_id"], name: "index_plc_course_units_on_script_id"
   end
 
-  create_table "plc_courses", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "plc_courses", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "course_id"
     t.index ["course_id"], name: "fk_rails_d5fc777f73"
   end
 
-  create_table "plc_enrollment_module_assignments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "plc_enrollment_module_assignments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "plc_enrollment_unit_assignment_id"
     t.integer "plc_learning_module_id"
     t.datetime "created_at", null: false
@@ -1314,7 +1314,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id"], name: "index_plc_enrollment_module_assignments_on_user_id"
   end
 
-  create_table "plc_enrollment_unit_assignments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "plc_enrollment_unit_assignments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "plc_user_course_enrollment_id"
     t.integer "plc_course_unit_id"
     t.string "status"
@@ -1326,7 +1326,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id"], name: "index_plc_enrollment_unit_assignments_on_user_id"
   end
 
-  create_table "plc_learning_modules", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "plc_learning_modules", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -1337,7 +1337,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["stage_id"], name: "index_plc_learning_modules_on_stage_id"
   end
 
-  create_table "plc_user_course_enrollments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "plc_user_course_enrollments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "status"
     t.integer "plc_course_id"
     t.integer "user_id"
@@ -1347,7 +1347,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id", "plc_course_id"], name: "index_plc_user_course_enrollments_on_user_id_and_plc_course_id", unique: true
   end
 
-  create_table "programming_classes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "programming_classes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "programming_environment_id"
     t.integer "programming_environment_category_id"
     t.string "key"
@@ -1364,7 +1364,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["key", "programming_environment_id"], name: "index_programming_classes_on_key_and_programming_environment_id", unique: true
   end
 
-  create_table "programming_environment_categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "programming_environment_categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "programming_environment_id", null: false
     t.string "key", null: false
     t.string "name"
@@ -1376,7 +1376,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["programming_environment_id"], name: "index_programming_environment_categories_on_environment_id"
   end
 
-  create_table "programming_environments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "programming_environments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.text "properties"
     t.datetime "created_at", null: false
@@ -1385,7 +1385,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["name"], name: "index_programming_environments_on_name", unique: true
   end
 
-  create_table "programming_expressions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "programming_expressions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "category"
     t.text "properties"
@@ -1400,7 +1400,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["programming_environment_id"], name: "index_programming_expressions_on_programming_environment_id"
   end
 
-  create_table "programming_methods", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "programming_methods", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "programming_class_id"
     t.string "key"
     t.integer "position"
@@ -1428,7 +1428,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["storage_app_id"], name: "index_project_commits_on_storage_app_id"
   end
 
-  create_table "projects", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "projects", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "storage_id"
     t.text "value", size: :medium
     t.datetime "updated_at", null: false
@@ -1448,7 +1448,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["storage_id"], name: "storage_apps_storage_id_index"
   end
 
-  create_table "puzzle_ratings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "puzzle_ratings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
     t.integer "script_id"
     t.integer "level_id"
@@ -1459,7 +1459,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id", "script_id", "level_id"], name: "index_puzzle_ratings_on_user_id_and_script_id_and_level_id", unique: true
   end
 
-  create_table "queued_account_purges", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "queued_account_purges", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.text "reason_for_review"
     t.datetime "created_at", null: false
@@ -1467,7 +1467,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id"], name: "index_queued_account_purges_on_user_id", unique: true
   end
 
-  create_table "reference_guides", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "reference_guides", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "key", null: false
     t.bigint "course_version_id", null: false
     t.string "parent_reference_guide_key"
@@ -1480,14 +1480,14 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["course_version_id", "parent_reference_guide_key"], name: "index_reference_guides_on_course_version_id_and_parent_key"
   end
 
-  create_table "regional_partner_program_managers", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "regional_partner_program_managers", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "program_manager_id", null: false
     t.integer "regional_partner_id", null: false
     t.index ["program_manager_id"], name: "index_regional_partner_program_managers_on_program_manager_id"
     t.index ["regional_partner_id"], name: "index_regional_partner_program_managers_on_regional_partner_id"
   end
 
-  create_table "regional_partners", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "regional_partners", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.integer "group"
     t.boolean "urban"
@@ -1506,7 +1506,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.boolean "is_active", null: false
   end
 
-  create_table "regional_partners_school_districts", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "regional_partners_school_districts", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "regional_partner_id", null: false
     t.integer "school_district_id", null: false
     t.string "course", comment: "Course for a given workshop"
@@ -1515,7 +1515,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["school_district_id"], name: "index_regional_partners_school_districts_on_school_district_id"
   end
 
-  create_table "resources", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "resources", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.string "url", null: false
     t.string "key", null: false
@@ -1527,7 +1527,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["name", "url"], name: "index_resources_on_name_and_url", type: :fulltext
   end
 
-  create_table "school_districts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "school_districts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "city", null: false
     t.string "state", null: false
@@ -1539,7 +1539,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["state"], name: "index_school_districts_on_state"
   end
 
-  create_table "school_infos", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "school_infos", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "country"
     t.string "school_type"
     t.integer "zip"
@@ -1558,7 +1558,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["school_id"], name: "index_school_infos_on_school_id"
   end
 
-  create_table "school_stats_by_years", primary_key: ["school_id", "school_year"], options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "school_stats_by_years", primary_key: ["school_id", "school_year"], options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "school_id", limit: 12, null: false, comment: "NCES public school ID"
     t.string "school_year", limit: 9, null: false, comment: "School Year"
     t.string "grades_offered_lo", limit: 2, comment: "Grades Offered - Lowest"
@@ -1595,7 +1595,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["school_id"], name: "index_school_stats_by_years_on_school_id"
   end
 
-  create_table "schools", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "schools", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "id", limit: 12, null: false, comment: "NCES public school ID"
     t.integer "school_district_id"
     t.string "name", null: false
@@ -1621,7 +1621,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["zip"], name: "index_schools_on_zip"
   end
 
-  create_table "script_levels", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "script_levels", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "script_id", null: false
     t.integer "chapter"
     t.datetime "created_at"
@@ -1641,7 +1641,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["stage_id"], name: "index_script_levels_on_stage_id"
   end
 
-  create_table "scripts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "scripts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -1665,21 +1665,21 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["wrapup_video_id"], name: "index_scripts_on_wrapup_video_id"
   end
 
-  create_table "scripts_resources", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "scripts_resources", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "script_id"
     t.integer "resource_id"
     t.index ["resource_id", "script_id"], name: "index_scripts_resources_on_resource_id_and_script_id"
     t.index ["script_id", "resource_id"], name: "index_scripts_resources_on_script_id_and_resource_id", unique: true
   end
 
-  create_table "scripts_student_resources", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "scripts_student_resources", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "script_id"
     t.integer "resource_id"
     t.index ["resource_id", "script_id"], name: "index_scripts_student_resources_on_resource_id_and_script_id"
     t.index ["script_id", "resource_id"], name: "index_scripts_student_resources_on_script_id_and_resource_id", unique: true
   end
 
-  create_table "secret_pictures", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "secret_pictures", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "path", null: false
     t.datetime "created_at"
@@ -1688,28 +1688,28 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["path"], name: "index_secret_pictures_on_path", unique: true
   end
 
-  create_table "secret_words", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "secret_words", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "word", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["word"], name: "index_secret_words_on_word", unique: true
   end
 
-  create_table "section_hidden_scripts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "section_hidden_scripts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "section_id", null: false
     t.integer "script_id", null: false
     t.index ["script_id"], name: "index_section_hidden_scripts_on_script_id"
     t.index ["section_id"], name: "index_section_hidden_scripts_on_section_id"
   end
 
-  create_table "section_hidden_stages", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "section_hidden_stages", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "section_id", null: false
     t.integer "stage_id", null: false
     t.index ["section_id"], name: "index_section_hidden_stages_on_section_id"
     t.index ["stage_id"], name: "index_section_hidden_stages_on_stage_id"
   end
 
-  create_table "sections", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "sections", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "name"
     t.datetime "created_at"
@@ -1735,13 +1735,13 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id"], name: "index_sections_on_user_id"
   end
 
-  create_table "seed_info", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "seed_info", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "table", null: false
     t.datetime "mtime"
     t.index ["table"], name: "index_seed_info_on_table"
   end
 
-  create_table "seeded_s3_objects", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "seeded_s3_objects", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "bucket"
     t.string "key"
     t.string "etag"
@@ -1750,7 +1750,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["bucket", "key", "etag"], name: "index_seeded_s3_objects_on_bucket_and_key_and_etag"
   end
 
-  create_table "shared_blockly_functions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "shared_blockly_functions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "level_type"
     t.integer "block_type", default: 0, null: false
@@ -1760,7 +1760,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.text "stack"
   end
 
-  create_table "sign_ins", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "sign_ins", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.datetime "sign_in_at", null: false
     t.integer "sign_in_count", null: false
@@ -1768,7 +1768,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id"], name: "index_sign_ins_on_user_id"
   end
 
-  create_table "stages", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "stages", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.integer "absolute_position"
     t.integer "script_id", null: false
@@ -1784,7 +1784,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["script_id", "key"], name: "index_stages_on_script_id_and_key", unique: true
   end
 
-  create_table "stages_standards", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "stages_standards", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "stage_id", null: false
     t.integer "standard_id", null: false
     t.datetime "created_at", null: false
@@ -1793,7 +1793,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["standard_id"], name: "index_stages_standards_on_standard_id"
   end
 
-  create_table "standard_categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "standard_categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "shortcode", null: false
     t.integer "framework_id", null: false
     t.integer "parent_category_id"
@@ -1805,7 +1805,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["parent_category_id"], name: "index_standard_categories_on_parent_category_id"
   end
 
-  create_table "standards", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "standards", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.text "description"
     t.bigint "category_id"
     t.integer "framework_id"
@@ -1815,13 +1815,13 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["framework_id", "shortcode"], name: "index_standards_on_framework_id_and_shortcode"
   end
 
-  create_table "studio_people", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "studio_people", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "emails"
   end
 
-  create_table "survey_results", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "survey_results", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
     t.string "kind"
     t.text "properties"
@@ -1831,7 +1831,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id"], name: "index_survey_results_on_user_id"
   end
 
-  create_table "teacher_feedbacks", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "teacher_feedbacks", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.text "comment"
     t.integer "student_id"
     t.integer "level_id", null: false
@@ -1851,7 +1851,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["teacher_id"], name: "index_teacher_feedbacks_on_teacher_id"
   end
 
-  create_table "teacher_profiles", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "teacher_profiles", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "studio_person_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -1865,7 +1865,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["studio_person_id"], name: "index_teacher_profiles_on_studio_person_id"
   end
 
-  create_table "teacher_scores", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "teacher_scores", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.bigint "user_level_id", unsigned: true
     t.integer "teacher_id"
     t.integer "score"
@@ -1874,7 +1874,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_level_id"], name: "index_teacher_scores_on_user_level_id"
   end
 
-  create_table "unit_groups", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "unit_groups", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.text "properties"
     t.datetime "created_at", null: false
@@ -1890,21 +1890,21 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["published_state"], name: "index_unit_groups_on_published_state"
   end
 
-  create_table "unit_groups_resources", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "unit_groups_resources", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "unit_group_id"
     t.integer "resource_id"
     t.index ["resource_id", "unit_group_id"], name: "index_unit_groups_resources_on_resource_id_and_unit_group_id"
     t.index ["unit_group_id", "resource_id"], name: "index_unit_groups_resources_on_unit_group_id_and_resource_id", unique: true
   end
 
-  create_table "unit_groups_student_resources", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "unit_groups_student_resources", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "unit_group_id"
     t.integer "resource_id"
     t.index ["resource_id", "unit_group_id"], name: "index_ug_student_resources_on_resource_id_and_unit_group_id"
     t.index ["unit_group_id", "resource_id"], name: "index_ug_student_resources_on_unit_group_id_and_resource_id", unique: true
   end
 
-  create_table "user_geos", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "user_geos", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -1920,7 +1920,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id"], name: "index_user_geos_on_user_id"
   end
 
-  create_table "user_levels", id: :bigint, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "user_levels", id: :bigint, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "level_id", null: false
     t.integer "attempts", default: 0, null: false
@@ -1938,7 +1938,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id", "script_id", "level_id", "deleted_at"], name: "index_user_levels_unique", unique: true
   end
 
-  create_table "user_ml_models", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "user_ml_models", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
     t.string "model_id"
     t.string "name"
@@ -1951,7 +1951,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id"], name: "index_user_ml_models_on_user_id"
   end
 
-  create_table "user_module_task_assignments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "user_module_task_assignments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_enrollment_module_assignment_id"
     t.integer "professional_learning_task_id"
     t.string "status"
@@ -1959,7 +1959,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_enrollment_module_assignment_id"], name: "task_assignment_to_module_assignment_index"
   end
 
-  create_table "user_permissions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "user_permissions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "permission", null: false
     t.datetime "created_at"
@@ -1967,7 +1967,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id", "permission"], name: "index_user_permissions_on_user_id_and_permission", unique: true
   end
 
-  create_table "user_proficiencies", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "user_proficiencies", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -2026,13 +2026,13 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id"], name: "index_user_proficiencies_on_user_id", unique: true
   end
 
-  create_table "user_project_storage_ids", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+  create_table "user_project_storage_ids", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "user_id"
     t.index ["user_id"], name: "user_id", unique: true
     t.index ["user_id"], name: "user_storage_ids_user_id_index"
   end
 
-  create_table "user_school_infos", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "user_school_infos", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.datetime "start_date", null: false
     t.datetime "end_date"
@@ -2043,7 +2043,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id"], name: "index_user_school_infos_on_user_id"
   end
 
-  create_table "user_scripts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "user_scripts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "script_id", null: false
     t.datetime "started_at"
@@ -2058,7 +2058,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id", "script_id", "deleted_at"], name: "index_user_scripts_on_user_id_and_script_id_and_deleted_at", unique: true
   end
 
-  create_table "users", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "users", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "studio_person_id"
     t.string "email", default: "", null: false
     t.string "parent_email"
@@ -2122,7 +2122,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["username", "deleted_at"], name: "index_users_on_username_and_deleted_at", unique: true
   end
 
-  create_table "videos", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "videos", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "key"
     t.string "youtube_code"
     t.datetime "created_at"
@@ -2132,7 +2132,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["key", "locale"], name: "index_videos_on_key_and_locale", unique: true
   end
 
-  create_table "vocabularies", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "vocabularies", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "key", null: false
     t.string "word", null: false
     t.text "definition", null: false

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -12,7 +12,7 @@
 
 ActiveRecord::Schema.define(version: 2023_03_23_175726) do
 
-  create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
     t.integer "level_id"
     t.string "action"
@@ -28,7 +28,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id", "level_id"], name: "index_activities_on_user_id_and_level_id"
   end
 
-  create_table "activity_sections", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "activity_sections", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "lesson_activity_id", null: false
     t.string "key", null: false
     t.integer "position", null: false
@@ -39,7 +39,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["lesson_activity_id"], name: "index_activity_sections_on_lesson_activity_id"
   end
 
-  create_table "ap_cs_offerings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "ap_cs_offerings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "school_code", limit: 6, null: false
     t.string "course", limit: 3, null: false
     t.integer "school_year", limit: 2, null: false
@@ -48,7 +48,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["school_code", "school_year", "course"], name: "index_ap_cs_offerings_on_school_code_and_school_year_and_course", unique: true
   end
 
-  create_table "ap_school_codes", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "ap_school_codes", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "school_year"
     t.string "school_code", limit: 6, null: false
     t.string "school_id", limit: 12, null: false
@@ -58,7 +58,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["school_id"], name: "fk_rails_08d2269647"
   end
 
-  create_table "assessment_activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "assessment_activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "level_id", null: false
     t.integer "script_id", null: false
@@ -70,7 +70,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id", "level_id", "script_id"], name: "index_assessment_activities_on_user_and_level_and_script"
   end
 
-  create_table "authentication_options", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "authentication_options", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "hashed_email", default: "", null: false
     t.string "credential_type", null: false
@@ -86,7 +86,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id", "deleted_at"], name: "index_authentication_options_on_user_id_and_deleted_at"
   end
 
-  create_table "authored_hint_view_requests", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "authored_hint_view_requests", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "script_id"
     t.integer "level_id"
@@ -112,7 +112,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id", "script_id", "level_id", "hint_id"], name: "index_authored_hint_view_requests_on_all_related_ids"
   end
 
-  create_table "backpacks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "backpacks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "storage_app_id", null: false
     t.datetime "created_at", null: false
@@ -121,7 +121,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id"], name: "index_backpacks_on_user_id", unique: true
   end
 
-  create_table "blocks", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "blocks", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "pool", default: "", null: false
     t.string "category"
@@ -134,7 +134,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["pool", "name"], name: "index_blocks_on_pool_and_name", unique: true
   end
 
-  create_table "callouts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "callouts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "element_id", limit: 1024, null: false
     t.string "localization_key", limit: 1024, null: false
     t.datetime "created_at"
@@ -145,7 +145,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.string "callout_text"
   end
 
-  create_table "census_state_course_codes", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "census_state_course_codes", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "state"
     t.string "course"
     t.datetime "created_at", null: false
@@ -153,7 +153,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["state", "course"], name: "index_census_state_course_codes_on_state_and_course", unique: true
   end
 
-  create_table "census_submission_form_maps", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "census_submission_form_maps", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "census_submission_id", null: false
     t.integer "form_id", null: false
     t.datetime "created_at", null: false
@@ -162,7 +162,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["form_id"], name: "index_census_submission_form_maps_on_form_id"
   end
 
-  create_table "census_submissions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "census_submissions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "type", null: false
     t.string "submitter_email_address"
     t.string "submitter_name"
@@ -196,7 +196,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["school_year", "id"], name: "index_census_submissions_on_school_year_and_id"
   end
 
-  create_table "census_submissions_school_infos", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "census_submissions_school_infos", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "census_submission_id", null: false
     t.integer "school_info_id", null: false
     t.datetime "created_at", null: false
@@ -205,7 +205,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["school_info_id", "census_submission_id"], name: "school_info_id_census_submission", unique: true
   end
 
-  create_table "census_summaries", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "census_summaries", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "school_id", limit: 12, null: false
     t.integer "school_year", limit: 2, null: false
     t.string "teaches_cs", limit: 2
@@ -215,7 +215,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["school_id", "school_year"], name: "index_census_summaries_on_school_id_and_school_year", unique: true
   end
 
-  create_table "channel_tokens", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "channel_tokens", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "storage_app_id", null: false
     t.integer "level_id", null: false
     t.datetime "created_at"
@@ -228,7 +228,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["storage_id"], name: "index_channel_tokens_on_storage_id"
   end
 
-  create_table "circuit_playground_discount_applications", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "circuit_playground_discount_applications", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "unit_6_intention"
     t.boolean "full_discount"
@@ -244,7 +244,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id"], name: "index_circuit_playground_discount_applications_on_user_id", unique: true
   end
 
-  create_table "circuit_playground_discount_codes", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "circuit_playground_discount_codes", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "code", null: false
     t.boolean "full_discount", null: false
     t.datetime "expiration", null: false
@@ -265,7 +265,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["code_review_id"], name: "index_code_review_comments_on_code_review_id"
   end
 
-  create_table "code_review_group_members", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "code_review_group_members", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "code_review_group_id", null: false
     t.bigint "follower_id", null: false
     t.datetime "created_at", null: false
@@ -274,7 +274,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["follower_id"], name: "index_code_review_group_members_on_follower_id"
   end
 
-  create_table "code_review_groups", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "code_review_groups", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "section_id", null: false
     t.string "name"
     t.datetime "created_at", null: false
@@ -282,7 +282,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["section_id"], name: "index_code_review_groups_on_section_id"
   end
 
-  create_table "code_review_requests", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "code_review_requests", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "script_id", null: false
     t.integer "level_id", null: false
@@ -295,7 +295,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id", "script_id", "level_id", "closed_at", "deleted_at"], name: "index_code_review_requests_unique", unique: true
   end
 
-  create_table "code_reviews", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "code_reviews", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "project_id", null: false
     t.integer "script_id", null: false
@@ -307,14 +307,14 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.datetime "deleted_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.virtual "active", type: :boolean, as: "if(isnull(`deleted_at`),TRUE,NULL)"
-    t.virtual "open", type: :boolean, as: "if(isnull(`closed_at`),TRUE,NULL)"
+    t.virtual "active", type: :boolean, as: "if((`deleted_at` is null),true,NULL)"
+    t.virtual "open", type: :boolean, as: "if((`closed_at` is null),true,NULL)"
     t.index ["project_id", "deleted_at"], name: "index_code_reviews_on_project_id_and_deleted_at"
     t.index ["user_id", "project_id", "open", "active"], name: "index_code_reviews_unique", unique: true
     t.index ["user_id", "script_id", "project_level_id", "closed_at", "deleted_at"], name: "index_code_reviews_for_peer_lookup"
   end
 
-  create_table "concepts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "concepts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -322,14 +322,14 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["video_key"], name: "index_concepts_on_video_key"
   end
 
-  create_table "concepts_levels", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "concepts_levels", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "concept_id"
     t.integer "level_id"
     t.index ["concept_id"], name: "index_concepts_levels_on_concept_id"
     t.index ["level_id"], name: "index_concepts_levels_on_level_id"
   end
 
-  create_table "contact_rollups_final", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "contact_rollups_final", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "email", null: false
     t.json "data", null: false
     t.datetime "created_at", null: false
@@ -337,7 +337,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["email"], name: "index_contact_rollups_final_on_email", unique: true
   end
 
-  create_table "contact_rollups_pardot_memory", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "contact_rollups_pardot_memory", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "email", null: false
     t.integer "pardot_id"
     t.datetime "pardot_id_updated_at"
@@ -353,7 +353,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["pardot_id"], name: "index_contact_rollups_pardot_memory_on_pardot_id", unique: true
   end
 
-  create_table "contact_rollups_processed", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "contact_rollups_processed", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "email", null: false
     t.json "data", null: false
     t.datetime "created_at", null: false
@@ -361,7 +361,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["email"], name: "index_contact_rollups_processed_on_email", unique: true
   end
 
-  create_table "contact_rollups_raw", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "contact_rollups_raw", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "email", null: false
     t.string "sources", null: false
     t.json "data"
@@ -370,7 +370,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "contained_level_answers", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "contained_level_answers", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "level_id", null: false
@@ -380,7 +380,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["level_id"], name: "index_contained_level_answers_on_level_id"
   end
 
-  create_table "contained_levels", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "contained_levels", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "level_group_level_id", null: false
@@ -393,7 +393,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["level_group_level_id"], name: "index_contained_levels_on_level_group_level_id"
   end
 
-  create_table "course_offerings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "course_offerings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "key", null: false
     t.string "display_name", null: false
     t.datetime "created_at", null: false
@@ -412,7 +412,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["key"], name: "index_course_offerings_on_key", unique: true
   end
 
-  create_table "course_scripts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "course_scripts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "course_id", null: false
     t.integer "script_id", null: false
     t.integer "position", null: false
@@ -423,7 +423,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["script_id"], name: "index_course_scripts_on_script_id"
   end
 
-  create_table "course_versions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "course_versions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "key", null: false
     t.string "display_name", null: false
     t.text "properties"
@@ -438,7 +438,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["course_offering_id"], name: "index_course_versions_on_course_offering_id"
   end
 
-  create_table "courses", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "courses", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.text "properties"
     t.datetime "created_at", null: false
@@ -446,7 +446,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["name"], name: "index_courses_on_name"
   end
 
-  create_table "data_docs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "data_docs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "key", null: false
     t.string "name"
     t.text "content"
@@ -456,14 +456,14 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["name"], name: "index_data_docs_on_name"
   end
 
-  create_table "donor_schools", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "donor_schools", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.string "nces_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "donors", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "donors", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.string "url"
     t.string "show"
@@ -475,7 +475,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "email_preferences", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "email_preferences", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "email", null: false
     t.boolean "opt_in", null: false
     t.string "ip_address", null: false
@@ -486,7 +486,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["email"], name: "index_email_preferences_on_email", unique: true
   end
 
-  create_table "experiments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "experiments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "name", null: false
@@ -508,7 +508,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["start_at"], name: "index_experiments_on_start_at"
   end
 
-  create_table "featured_projects", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "featured_projects", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "storage_app_id"
     t.datetime "featured_at"
     t.datetime "unfeatured_at"
@@ -517,7 +517,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["topic"], name: "index_featured_projects_on_topic"
   end
 
-  create_table "followers", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "followers", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "student_user_id", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -527,7 +527,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["student_user_id"], name: "index_followers_on_student_user_id"
   end
 
-  create_table "foorm_forms", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "foorm_forms", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.integer "version", null: false
     t.text "questions", null: false
@@ -537,7 +537,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["name", "version"], name: "index_foorm_forms_on_name_and_version", unique: true
   end
 
-  create_table "foorm_libraries", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "foorm_libraries", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.integer "version", null: false
     t.boolean "published", null: false
@@ -546,7 +546,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["name", "version"], name: "index_foorm_libraries_on_multiple_fields", unique: true
   end
 
-  create_table "foorm_library_questions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "foorm_library_questions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "library_name", null: false
     t.integer "library_version", null: false
     t.string "question_name", null: false
@@ -557,7 +557,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["library_name", "library_version", "question_name"], name: "index_foorm_library_questions_on_multiple_fields", unique: true
   end
 
-  create_table "foorm_simple_survey_forms", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "foorm_simple_survey_forms", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "path", null: false
     t.string "kind"
     t.string "form_name", null: false
@@ -568,7 +568,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["path"], name: "index_foorm_simple_survey_forms_on_path"
   end
 
-  create_table "foorm_simple_survey_submissions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "foorm_simple_survey_submissions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "foorm_submission_id", null: false
     t.integer "user_id"
     t.bigint "simple_survey_form_id"
@@ -587,7 +587,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "frameworks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "frameworks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "shortcode", null: false
     t.string "name", null: false
     t.text "properties"
@@ -596,7 +596,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["shortcode"], name: "index_frameworks_on_shortcode", unique: true
   end
 
-  create_table "games", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "games", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -605,7 +605,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["intro_video_id"], name: "index_games_on_intro_video_id"
   end
 
-  create_table "hint_view_requests", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "hint_view_requests", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
     t.integer "script_id"
     t.integer "level_id"
@@ -617,7 +617,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id"], name: "index_hint_view_requests_on_user_id"
   end
 
-  create_table "lesson_activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "lesson_activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "lesson_id", null: false
     t.string "key", null: false
     t.integer "position", null: false
@@ -628,7 +628,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["lesson_id"], name: "index_lesson_activities_on_lesson_id"
   end
 
-  create_table "lesson_groups", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "lesson_groups", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "key", null: false
     t.integer "script_id", null: false
     t.boolean "user_facing", default: true, null: false
@@ -639,35 +639,35 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["script_id", "key"], name: "index_lesson_groups_on_script_id_and_key", unique: true
   end
 
-  create_table "lessons_opportunity_standards", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "lessons_opportunity_standards", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "lesson_id", null: false
     t.bigint "standard_id", null: false
     t.index ["lesson_id", "standard_id"], name: "index_lessons_opportunity_standards_on_lesson_id_and_standard_id", unique: true
     t.index ["standard_id", "lesson_id"], name: "index_lessons_opportunity_standards_on_standard_id_and_lesson_id"
   end
 
-  create_table "lessons_programming_expressions", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "lessons_programming_expressions", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "lesson_id", null: false
     t.bigint "programming_expression_id", null: false
     t.index ["lesson_id", "programming_expression_id"], name: "lesson_programming_expression", unique: true
     t.index ["programming_expression_id", "lesson_id"], name: "programming_expression_lesson"
   end
 
-  create_table "lessons_resources", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "lessons_resources", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "lesson_id", null: false
     t.integer "resource_id", null: false
     t.index ["lesson_id", "resource_id"], name: "index_lessons_resources_on_lesson_id_and_resource_id", unique: true
     t.index ["resource_id", "lesson_id"], name: "index_lessons_resources_on_resource_id_and_lesson_id"
   end
 
-  create_table "lessons_vocabularies", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "lessons_vocabularies", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "lesson_id", null: false
     t.bigint "vocabulary_id", null: false
     t.index ["lesson_id", "vocabulary_id"], name: "index_lessons_vocabularies_on_lesson_id_and_vocabulary_id", unique: true
     t.index ["vocabulary_id", "lesson_id"], name: "index_lessons_vocabularies_on_vocabulary_id_and_lesson_id"
   end
 
-  create_table "level_concept_difficulties", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "level_concept_difficulties", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "level_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -684,7 +684,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["level_id"], name: "index_level_concept_difficulties_on_level_id"
   end
 
-  create_table "level_source_images", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "level_source_images", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "level_source_id", unsigned: true
     t.binary "image", size: :medium
     t.datetime "created_at"
@@ -692,7 +692,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["level_source_id"], name: "index_level_source_images_on_level_source_id"
   end
 
-  create_table "level_sources", id: :bigint, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "level_sources", id: :bigint, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "level_id"
     t.string "md5", limit: 32, null: false
     t.string "data", limit: 20000, null: false
@@ -702,7 +702,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["level_id", "md5"], name: "index_level_sources_on_level_id_and_md5"
   end
 
-  create_table "level_sources_multi_types", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "level_sources_multi_types", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "level_source_id", null: false, unsigned: true
     t.integer "level_id", null: false
     t.text "data"
@@ -712,7 +712,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["level_source_id"], name: "index_level_sources_multi_types_on_level_source_id"
   end
 
-  create_table "levels", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "levels", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "game_id"
     t.string "name", null: false
     t.datetime "created_at"
@@ -731,7 +731,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["name"], name: "index_levels_on_name"
   end
 
-  create_table "levels_script_levels", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "levels_script_levels", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "level_id", null: false
     t.integer "script_level_id", null: false
     t.index ["level_id"], name: "index_levels_script_levels_on_level_id"
@@ -739,14 +739,14 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["script_level_id"], name: "index_levels_script_levels_on_script_level_id"
   end
 
-  create_table "libraries", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "libraries", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.text "content"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "metrics", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "metrics", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.date "computed_on", null: false
@@ -759,7 +759,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.float "value", null: false
   end
 
-  create_table "objectives", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "objectives", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.text "properties"
     t.integer "lesson_id"
     t.datetime "created_at", null: false
@@ -769,7 +769,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["lesson_id"], name: "index_objectives_on_lesson_id"
   end
 
-  create_table "paired_user_levels", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "paired_user_levels", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "driver_user_level_id", unsigned: true
     t.bigint "navigator_user_level_id", unsigned: true
     t.datetime "created_at", null: false
@@ -778,7 +778,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["navigator_user_level_id"], name: "index_paired_user_levels_on_navigator_user_level_id"
   end
 
-  create_table "parent_levels_child_levels", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "parent_levels_child_levels", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "parent_level_id", null: false
     t.integer "child_level_id", null: false
     t.integer "position"
@@ -787,7 +787,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["parent_level_id"], name: "index_parent_levels_child_levels_on_parent_level_id"
   end
 
-  create_table "pd_accepted_programs", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_accepted_programs", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "workshop_name", null: false
@@ -796,7 +796,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.integer "teacher_application_id"
   end
 
-  create_table "pd_application_emails", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_application_emails", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "pd_application_id", null: false
     t.string "application_status", null: false
     t.string "email_type", null: false
@@ -806,14 +806,14 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["pd_application_id"], name: "index_pd_application_emails_on_pd_application_id"
   end
 
-  create_table "pd_application_tags", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_application_tags", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_pd_application_tags_on_name", unique: true
   end
 
-  create_table "pd_application_tags_applications", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_application_tags_applications", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "pd_application_id", null: false
     t.integer "pd_application_tag_id", null: false
     t.datetime "created_at", null: false
@@ -822,7 +822,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["pd_application_tag_id"], name: "index_pd_application_tags_applications_on_pd_application_tag_id"
   end
 
-  create_table "pd_applications", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_applications", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
     t.string "type", null: false
     t.string "application_year", null: false
@@ -852,14 +852,14 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id"], name: "index_pd_applications_on_user_id"
   end
 
-  create_table "pd_applications_status_logs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_applications_status_logs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "pd_application_id", null: false
     t.string "status", null: false
     t.datetime "timestamp", null: false
     t.integer "position", null: false
   end
 
-  create_table "pd_attendances", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_attendances", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "pd_session_id", null: false
     t.integer "teacher_id"
     t.datetime "created_at"
@@ -873,14 +873,14 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["teacher_id"], name: "index_pd_attendances_on_teacher_id"
   end
 
-  create_table "pd_course_facilitators", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_course_facilitators", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "facilitator_id", null: false
     t.string "course", null: false
     t.index ["course"], name: "index_pd_course_facilitators_on_course"
     t.index ["facilitator_id", "course"], name: "index_pd_course_facilitators_on_facilitator_id_and_course", unique: true
   end
 
-  create_table "pd_district_payment_terms", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_district_payment_terms", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "school_district_id"
     t.string "course", null: false
     t.string "rate_type", null: false
@@ -888,7 +888,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["school_district_id", "course"], name: "index_pd_district_payment_terms_school_district_course"
   end
 
-  create_table "pd_enrollment_notifications", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_enrollment_notifications", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "pd_enrollment_id", null: false
@@ -896,7 +896,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["pd_enrollment_id"], name: "index_pd_enrollment_notifications_on_pd_enrollment_id"
   end
 
-  create_table "pd_enrollments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_enrollments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "pd_workshop_id", null: false
     t.string "name"
     t.string "first_name"
@@ -918,7 +918,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["pd_workshop_id"], name: "index_pd_enrollments_on_pd_workshop_id"
   end
 
-  create_table "pd_facilitator_program_registrations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_facilitator_program_registrations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.text "form_data"
     t.datetime "created_at", null: false
@@ -927,7 +927,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id", "teachercon"], name: "index_pd_fac_prog_reg_on_user_id_and_teachercon", unique: true
   end
 
-  create_table "pd_facilitator_teachercon_attendances", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_facilitator_teachercon_attendances", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.date "tc1_arrive"
     t.date "tc1_depart"
@@ -947,7 +947,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id"], name: "index_pd_facilitator_teachercon_attendances_on_user_id"
   end
 
-  create_table "pd_fit_weekend1819_registrations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_fit_weekend1819_registrations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "pd_application_id"
     t.text "form_data"
     t.datetime "created_at", null: false
@@ -955,7 +955,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["pd_application_id"], name: "index_pd_fit_weekend1819_registrations_on_pd_application_id"
   end
 
-  create_table "pd_fit_weekend_registrations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_fit_weekend_registrations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "pd_application_id"
     t.string "registration_year", null: false
     t.text "form_data"
@@ -965,7 +965,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["registration_year"], name: "index_pd_fit_weekend_registrations_on_registration_year"
   end
 
-  create_table "pd_international_opt_ins", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_international_opt_ins", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.text "form_data", null: false
     t.datetime "created_at", null: false
@@ -973,7 +973,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id"], name: "index_pd_international_opt_ins_on_user_id"
   end
 
-  create_table "pd_legacy_survey_summaries", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_legacy_survey_summaries", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "facilitator_id"
     t.string "course"
     t.string "subject"
@@ -982,7 +982,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "pd_misc_surveys", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_misc_surveys", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "form_id", null: false
     t.bigint "submission_id", null: false
     t.text "answers"
@@ -994,7 +994,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id"], name: "index_pd_misc_surveys_on_user_id"
   end
 
-  create_table "pd_payment_terms", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_payment_terms", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "regional_partner_id", null: false
     t.date "start_date", null: false
     t.date "end_date"
@@ -1006,7 +1006,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["regional_partner_id"], name: "index_pd_payment_terms_on_regional_partner_id"
   end
 
-  create_table "pd_post_course_surveys", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_post_course_surveys", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "form_id", null: false
     t.bigint "submission_id", null: false
     t.text "answers"
@@ -1021,7 +1021,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id"], name: "index_pd_post_course_surveys_on_user_id"
   end
 
-  create_table "pd_pre_workshop_surveys", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_pre_workshop_surveys", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "pd_enrollment_id", null: false
     t.text "form_data", null: false
     t.datetime "created_at", null: false
@@ -1029,7 +1029,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["pd_enrollment_id"], name: "index_pd_pre_workshop_surveys_on_pd_enrollment_id", unique: true
   end
 
-  create_table "pd_regional_partner_cohorts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_regional_partner_cohorts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "regional_partner_id"
     t.integer "role", comment: "teacher or facilitator"
     t.string "year", comment: "free-form text year range, YYYY-YYYY, e.g. 2016-2017"
@@ -1043,14 +1043,14 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["summer_workshop_id"], name: "index_pd_regional_partner_cohorts_on_summer_workshop_id"
   end
 
-  create_table "pd_regional_partner_cohorts_users", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_regional_partner_cohorts_users", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "pd_regional_partner_cohort_id", null: false
     t.integer "user_id", null: false
     t.index ["pd_regional_partner_cohort_id"], name: "index_pd_regional_partner_cohorts_users_on_cohort_id"
     t.index ["user_id"], name: "index_pd_regional_partner_cohorts_users_on_user_id"
   end
 
-  create_table "pd_regional_partner_contacts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_regional_partner_contacts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
     t.integer "regional_partner_id"
     t.text "form_data"
@@ -1060,7 +1060,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id"], name: "index_pd_regional_partner_contacts_on_user_id"
   end
 
-  create_table "pd_regional_partner_mappings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_regional_partner_mappings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "regional_partner_id", null: false
     t.string "state"
     t.string "zip_code"
@@ -1071,7 +1071,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["regional_partner_id"], name: "index_pd_regional_partner_mappings_on_regional_partner_id"
   end
 
-  create_table "pd_regional_partner_mini_contacts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_regional_partner_mini_contacts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
     t.integer "regional_partner_id"
     t.text "form_data"
@@ -1081,7 +1081,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id"], name: "index_pd_regional_partner_mini_contacts_on_user_id"
   end
 
-  create_table "pd_regional_partner_program_registrations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_regional_partner_program_registrations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.text "form_data"
     t.integer "teachercon", null: false
@@ -1090,7 +1090,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id", "teachercon"], name: "index_pd_reg_part_prog_reg_on_user_id_and_teachercon"
   end
 
-  create_table "pd_scholarship_infos", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_scholarship_infos", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "application_year", null: false
     t.string "scholarship_status", null: false
@@ -1105,7 +1105,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id"], name: "index_pd_scholarship_infos_on_user_id"
   end
 
-  create_table "pd_sessions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_sessions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "pd_workshop_id"
     t.datetime "start", null: false
     t.datetime "end", null: false
@@ -1117,7 +1117,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["pd_workshop_id"], name: "index_pd_sessions_on_pd_workshop_id"
   end
 
-  create_table "pd_survey_questions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_survey_questions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "form_id"
     t.text "questions", null: false, comment: "JSON Question data for this JotForm form."
     t.datetime "created_at", null: false
@@ -1126,7 +1126,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["form_id"], name: "index_pd_survey_questions_on_form_id", unique: true
   end
 
-  create_table "pd_teacher_applications", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_teacher_applications", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "user_id", null: false
@@ -1140,7 +1140,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id"], name: "index_pd_teacher_applications_on_user_id", unique: true
   end
 
-  create_table "pd_teachercon1819_registrations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_teachercon1819_registrations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "pd_application_id"
     t.text "form_data"
     t.datetime "created_at", null: false
@@ -1152,7 +1152,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id"], name: "index_pd_teachercon1819_registrations_on_user_id"
   end
 
-  create_table "pd_teachercon_surveys", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_teachercon_surveys", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "pd_enrollment_id", null: false
     t.text "form_data", null: false
     t.datetime "created_at", null: false
@@ -1160,7 +1160,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["pd_enrollment_id"], name: "index_pd_teachercon_surveys_on_pd_enrollment_id", unique: true
   end
 
-  create_table "pd_workshop_daily_surveys", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_workshop_daily_surveys", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "form_id", null: false
     t.bigint "submission_id", null: false
     t.integer "user_id", null: false
@@ -1178,7 +1178,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id"], name: "index_pd_workshop_daily_surveys_on_user_id"
   end
 
-  create_table "pd_workshop_facilitator_daily_surveys", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_workshop_facilitator_daily_surveys", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "form_id", null: false
     t.bigint "submission_id", null: false
     t.integer "user_id", null: false
@@ -1198,7 +1198,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id"], name: "index_pd_workshop_facilitator_daily_surveys_on_user_id"
   end
 
-  create_table "pd_workshop_survey_foorm_submissions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_workshop_survey_foorm_submissions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "foorm_submission_id", null: false
     t.integer "user_id", null: false
     t.integer "pd_session_id"
@@ -1214,7 +1214,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id"], name: "index_pd_workshop_survey_foorm_submissions_on_user_id"
   end
 
-  create_table "pd_workshop_surveys", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_workshop_surveys", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "pd_enrollment_id", null: false
     t.text "form_data", null: false
     t.datetime "created_at", null: false
@@ -1223,7 +1223,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["pd_enrollment_id"], name: "index_pd_workshop_surveys_on_pd_enrollment_id", unique: true
   end
 
-  create_table "pd_workshops", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_workshops", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "organizer_id", null: false
     t.string "location_name"
     t.string "location_address"
@@ -1248,14 +1248,14 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["regional_partner_id"], name: "index_pd_workshops_on_regional_partner_id"
   end
 
-  create_table "pd_workshops_facilitators", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pd_workshops_facilitators", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "pd_workshop_id", null: false
     t.integer "user_id", null: false
     t.index ["pd_workshop_id"], name: "index_pd_workshops_facilitators_on_pd_workshop_id"
     t.index ["user_id"], name: "index_pd_workshops_facilitators_on_user_id"
   end
 
-  create_table "peer_reviews", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "peer_reviews", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "submitter_id"
     t.integer "reviewer_id"
     t.boolean "from_instructor", default: false, null: false
@@ -1274,7 +1274,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["submitter_id"], name: "index_peer_reviews_on_submitter_id"
   end
 
-  create_table "pilots", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "pilots", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "display_name", null: false
     t.boolean "allow_joining_via_url", null: false
@@ -1283,7 +1283,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["name"], name: "index_pilots_on_name", unique: true
   end
 
-  create_table "plc_course_units", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "plc_course_units", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "plc_course_id"
     t.string "unit_name"
     t.text "unit_description"
@@ -1296,14 +1296,14 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["script_id"], name: "index_plc_course_units_on_script_id"
   end
 
-  create_table "plc_courses", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "plc_courses", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "course_id"
     t.index ["course_id"], name: "fk_rails_d5fc777f73"
   end
 
-  create_table "plc_enrollment_module_assignments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "plc_enrollment_module_assignments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "plc_enrollment_unit_assignment_id"
     t.integer "plc_learning_module_id"
     t.datetime "created_at", null: false
@@ -1314,7 +1314,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id"], name: "index_plc_enrollment_module_assignments_on_user_id"
   end
 
-  create_table "plc_enrollment_unit_assignments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "plc_enrollment_unit_assignments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "plc_user_course_enrollment_id"
     t.integer "plc_course_unit_id"
     t.string "status"
@@ -1326,7 +1326,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id"], name: "index_plc_enrollment_unit_assignments_on_user_id"
   end
 
-  create_table "plc_learning_modules", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "plc_learning_modules", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -1337,7 +1337,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["stage_id"], name: "index_plc_learning_modules_on_stage_id"
   end
 
-  create_table "plc_user_course_enrollments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "plc_user_course_enrollments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "status"
     t.integer "plc_course_id"
     t.integer "user_id"
@@ -1347,7 +1347,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id", "plc_course_id"], name: "index_plc_user_course_enrollments_on_user_id_and_plc_course_id", unique: true
   end
 
-  create_table "programming_classes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "programming_classes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "programming_environment_id"
     t.integer "programming_environment_category_id"
     t.string "key"
@@ -1364,7 +1364,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["key", "programming_environment_id"], name: "index_programming_classes_on_key_and_programming_environment_id", unique: true
   end
 
-  create_table "programming_environment_categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "programming_environment_categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "programming_environment_id", null: false
     t.string "key", null: false
     t.string "name"
@@ -1376,7 +1376,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["programming_environment_id"], name: "index_programming_environment_categories_on_environment_id"
   end
 
-  create_table "programming_environments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "programming_environments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.text "properties"
     t.datetime "created_at", null: false
@@ -1385,7 +1385,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["name"], name: "index_programming_environments_on_name", unique: true
   end
 
-  create_table "programming_expressions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "programming_expressions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "category"
     t.text "properties"
@@ -1400,7 +1400,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["programming_environment_id"], name: "index_programming_expressions_on_programming_environment_id"
   end
 
-  create_table "programming_methods", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "programming_methods", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "programming_class_id"
     t.string "key"
     t.integer "position"
@@ -1428,7 +1428,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["storage_app_id"], name: "index_project_commits_on_storage_app_id"
   end
 
-  create_table "projects", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+  create_table "projects", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "storage_id"
     t.text "value", size: :medium
     t.datetime "updated_at", null: false
@@ -1448,7 +1448,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["storage_id"], name: "storage_apps_storage_id_index"
   end
 
-  create_table "puzzle_ratings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "puzzle_ratings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
     t.integer "script_id"
     t.integer "level_id"
@@ -1459,7 +1459,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id", "script_id", "level_id"], name: "index_puzzle_ratings_on_user_id_and_script_id_and_level_id", unique: true
   end
 
-  create_table "queued_account_purges", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "queued_account_purges", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.text "reason_for_review"
     t.datetime "created_at", null: false
@@ -1467,7 +1467,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id"], name: "index_queued_account_purges_on_user_id", unique: true
   end
 
-  create_table "reference_guides", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "reference_guides", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "key", null: false
     t.bigint "course_version_id", null: false
     t.string "parent_reference_guide_key"
@@ -1480,14 +1480,14 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["course_version_id", "parent_reference_guide_key"], name: "index_reference_guides_on_course_version_id_and_parent_key"
   end
 
-  create_table "regional_partner_program_managers", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "regional_partner_program_managers", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "program_manager_id", null: false
     t.integer "regional_partner_id", null: false
     t.index ["program_manager_id"], name: "index_regional_partner_program_managers_on_program_manager_id"
     t.index ["regional_partner_id"], name: "index_regional_partner_program_managers_on_regional_partner_id"
   end
 
-  create_table "regional_partners", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "regional_partners", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.integer "group"
     t.boolean "urban"
@@ -1506,7 +1506,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.boolean "is_active", null: false
   end
 
-  create_table "regional_partners_school_districts", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "regional_partners_school_districts", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "regional_partner_id", null: false
     t.integer "school_district_id", null: false
     t.string "course", comment: "Course for a given workshop"
@@ -1515,7 +1515,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["school_district_id"], name: "index_regional_partners_school_districts_on_school_district_id"
   end
 
-  create_table "resources", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "resources", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.string "url", null: false
     t.string "key", null: false
@@ -1527,7 +1527,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["name", "url"], name: "index_resources_on_name_and_url", type: :fulltext
   end
 
-  create_table "school_districts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "school_districts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "city", null: false
     t.string "state", null: false
@@ -1539,7 +1539,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["state"], name: "index_school_districts_on_state"
   end
 
-  create_table "school_infos", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "school_infos", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "country"
     t.string "school_type"
     t.integer "zip"
@@ -1558,7 +1558,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["school_id"], name: "index_school_infos_on_school_id"
   end
 
-  create_table "school_stats_by_years", primary_key: ["school_id", "school_year"], options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "school_stats_by_years", primary_key: ["school_id", "school_year"], options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "school_id", limit: 12, null: false, comment: "NCES public school ID"
     t.string "school_year", limit: 9, null: false, comment: "School Year"
     t.string "grades_offered_lo", limit: 2, comment: "Grades Offered - Lowest"
@@ -1595,7 +1595,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["school_id"], name: "index_school_stats_by_years_on_school_id"
   end
 
-  create_table "schools", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "schools", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "id", limit: 12, null: false, comment: "NCES public school ID"
     t.integer "school_district_id"
     t.string "name", null: false
@@ -1621,7 +1621,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["zip"], name: "index_schools_on_zip"
   end
 
-  create_table "script_levels", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "script_levels", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "script_id", null: false
     t.integer "chapter"
     t.datetime "created_at"
@@ -1641,7 +1641,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["stage_id"], name: "index_script_levels_on_stage_id"
   end
 
-  create_table "scripts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "scripts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -1665,21 +1665,21 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["wrapup_video_id"], name: "index_scripts_on_wrapup_video_id"
   end
 
-  create_table "scripts_resources", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "scripts_resources", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "script_id"
     t.integer "resource_id"
     t.index ["resource_id", "script_id"], name: "index_scripts_resources_on_resource_id_and_script_id"
     t.index ["script_id", "resource_id"], name: "index_scripts_resources_on_script_id_and_resource_id", unique: true
   end
 
-  create_table "scripts_student_resources", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "scripts_student_resources", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "script_id"
     t.integer "resource_id"
     t.index ["resource_id", "script_id"], name: "index_scripts_student_resources_on_resource_id_and_script_id"
     t.index ["script_id", "resource_id"], name: "index_scripts_student_resources_on_script_id_and_resource_id", unique: true
   end
 
-  create_table "secret_pictures", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "secret_pictures", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "path", null: false
     t.datetime "created_at"
@@ -1688,28 +1688,28 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["path"], name: "index_secret_pictures_on_path", unique: true
   end
 
-  create_table "secret_words", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "secret_words", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "word", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["word"], name: "index_secret_words_on_word", unique: true
   end
 
-  create_table "section_hidden_scripts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "section_hidden_scripts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "section_id", null: false
     t.integer "script_id", null: false
     t.index ["script_id"], name: "index_section_hidden_scripts_on_script_id"
     t.index ["section_id"], name: "index_section_hidden_scripts_on_section_id"
   end
 
-  create_table "section_hidden_stages", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "section_hidden_stages", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "section_id", null: false
     t.integer "stage_id", null: false
     t.index ["section_id"], name: "index_section_hidden_stages_on_section_id"
     t.index ["stage_id"], name: "index_section_hidden_stages_on_stage_id"
   end
 
-  create_table "sections", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "sections", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "name"
     t.datetime "created_at"
@@ -1735,13 +1735,13 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id"], name: "index_sections_on_user_id"
   end
 
-  create_table "seed_info", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "seed_info", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "table", null: false
     t.datetime "mtime"
     t.index ["table"], name: "index_seed_info_on_table"
   end
 
-  create_table "seeded_s3_objects", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "seeded_s3_objects", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "bucket"
     t.string "key"
     t.string "etag"
@@ -1750,7 +1750,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["bucket", "key", "etag"], name: "index_seeded_s3_objects_on_bucket_and_key_and_etag"
   end
 
-  create_table "shared_blockly_functions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "shared_blockly_functions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "level_type"
     t.integer "block_type", default: 0, null: false
@@ -1760,7 +1760,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.text "stack"
   end
 
-  create_table "sign_ins", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "sign_ins", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.datetime "sign_in_at", null: false
     t.integer "sign_in_count", null: false
@@ -1768,7 +1768,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id"], name: "index_sign_ins_on_user_id"
   end
 
-  create_table "stages", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "stages", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.integer "absolute_position"
     t.integer "script_id", null: false
@@ -1784,7 +1784,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["script_id", "key"], name: "index_stages_on_script_id_and_key", unique: true
   end
 
-  create_table "stages_standards", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "stages_standards", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "stage_id", null: false
     t.integer "standard_id", null: false
     t.datetime "created_at", null: false
@@ -1793,7 +1793,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["standard_id"], name: "index_stages_standards_on_standard_id"
   end
 
-  create_table "standard_categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "standard_categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "shortcode", null: false
     t.integer "framework_id", null: false
     t.integer "parent_category_id"
@@ -1805,7 +1805,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["parent_category_id"], name: "index_standard_categories_on_parent_category_id"
   end
 
-  create_table "standards", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "standards", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.text "description"
     t.bigint "category_id"
     t.integer "framework_id"
@@ -1815,13 +1815,13 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["framework_id", "shortcode"], name: "index_standards_on_framework_id_and_shortcode"
   end
 
-  create_table "studio_people", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "studio_people", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "emails"
   end
 
-  create_table "survey_results", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "survey_results", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
     t.string "kind"
     t.text "properties"
@@ -1831,7 +1831,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id"], name: "index_survey_results_on_user_id"
   end
 
-  create_table "teacher_feedbacks", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "teacher_feedbacks", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.text "comment"
     t.integer "student_id"
     t.integer "level_id", null: false
@@ -1851,7 +1851,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["teacher_id"], name: "index_teacher_feedbacks_on_teacher_id"
   end
 
-  create_table "teacher_profiles", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "teacher_profiles", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "studio_person_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -1865,7 +1865,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["studio_person_id"], name: "index_teacher_profiles_on_studio_person_id"
   end
 
-  create_table "teacher_scores", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "teacher_scores", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.bigint "user_level_id", unsigned: true
     t.integer "teacher_id"
     t.integer "score"
@@ -1874,7 +1874,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_level_id"], name: "index_teacher_scores_on_user_level_id"
   end
 
-  create_table "unit_groups", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "unit_groups", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.text "properties"
     t.datetime "created_at", null: false
@@ -1890,21 +1890,21 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["published_state"], name: "index_unit_groups_on_published_state"
   end
 
-  create_table "unit_groups_resources", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "unit_groups_resources", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "unit_group_id"
     t.integer "resource_id"
     t.index ["resource_id", "unit_group_id"], name: "index_unit_groups_resources_on_resource_id_and_unit_group_id"
     t.index ["unit_group_id", "resource_id"], name: "index_unit_groups_resources_on_unit_group_id_and_resource_id", unique: true
   end
 
-  create_table "unit_groups_student_resources", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "unit_groups_student_resources", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "unit_group_id"
     t.integer "resource_id"
     t.index ["resource_id", "unit_group_id"], name: "index_ug_student_resources_on_resource_id_and_unit_group_id"
     t.index ["unit_group_id", "resource_id"], name: "index_ug_student_resources_on_unit_group_id_and_resource_id", unique: true
   end
 
-  create_table "user_geos", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "user_geos", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -1920,7 +1920,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id"], name: "index_user_geos_on_user_id"
   end
 
-  create_table "user_levels", id: :bigint, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "user_levels", id: :bigint, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "level_id", null: false
     t.integer "attempts", default: 0, null: false
@@ -1938,7 +1938,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id", "script_id", "level_id", "deleted_at"], name: "index_user_levels_unique", unique: true
   end
 
-  create_table "user_ml_models", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "user_ml_models", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
     t.string "model_id"
     t.string "name"
@@ -1951,7 +1951,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id"], name: "index_user_ml_models_on_user_id"
   end
 
-  create_table "user_module_task_assignments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "user_module_task_assignments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_enrollment_module_assignment_id"
     t.integer "professional_learning_task_id"
     t.string "status"
@@ -1959,7 +1959,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_enrollment_module_assignment_id"], name: "task_assignment_to_module_assignment_index"
   end
 
-  create_table "user_permissions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "user_permissions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "permission", null: false
     t.datetime "created_at"
@@ -1967,7 +1967,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id", "permission"], name: "index_user_permissions_on_user_id_and_permission", unique: true
   end
 
-  create_table "user_proficiencies", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "user_proficiencies", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -2026,13 +2026,13 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id"], name: "index_user_proficiencies_on_user_id", unique: true
   end
 
-  create_table "user_project_storage_ids", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "user_project_storage_ids", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
     t.integer "user_id"
     t.index ["user_id"], name: "user_id", unique: true
     t.index ["user_id"], name: "user_storage_ids_user_id_index"
   end
 
-  create_table "user_school_infos", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "user_school_infos", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.datetime "start_date", null: false
     t.datetime "end_date"
@@ -2043,7 +2043,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id"], name: "index_user_school_infos_on_user_id"
   end
 
-  create_table "user_scripts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "user_scripts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "script_id", null: false
     t.datetime "started_at"
@@ -2058,7 +2058,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["user_id", "script_id", "deleted_at"], name: "index_user_scripts_on_user_id_and_script_id_and_deleted_at", unique: true
   end
 
-  create_table "users", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "users", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "studio_person_id"
     t.string "email", default: "", null: false
     t.string "parent_email"
@@ -2122,7 +2122,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["username", "deleted_at"], name: "index_users_on_username_and_deleted_at", unique: true
   end
 
-  create_table "videos", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "videos", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "key"
     t.string "youtube_code"
     t.datetime "created_at"
@@ -2132,7 +2132,7 @@ ActiveRecord::Schema.define(version: 2023_03_23_175726) do
     t.index ["key", "locale"], name: "index_videos_on_key_and_locale", unique: true
   end
 
-  create_table "vocabularies", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "vocabularies", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "key", null: false
     t.string "word", null: false
     t.text "definition", null: false

--- a/dashboard/db/schema_cache.yml
+++ b/dashboard/db/schema_cache.yml
@@ -5,7 +5,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -20,7 +20,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -35,7 +35,7 @@ columns:
     name: level_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -59,7 +59,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &5 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: url
@@ -74,7 +74,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &6 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -110,7 +110,7 @@ columns:
     name: attempt
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -125,7 +125,7 @@ columns:
     name: time
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -140,7 +140,7 @@ columns:
     name: test_result
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -155,7 +155,7 @@ columns:
     name: level_source_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -170,7 +170,7 @@ columns:
     name: lines
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -186,7 +186,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -201,7 +201,7 @@ columns:
     name: lesson_activity_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -225,13 +225,13 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &16 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: position
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -255,7 +255,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &18 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -292,7 +292,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -316,7 +316,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &22 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: course
@@ -331,13 +331,13 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &23 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: school_year
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: smallint
+        sql_type: smallint(6)
         type: :integer
         limit: 2
         precision: 
@@ -383,7 +383,7 @@ columns:
     name: school_year
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -407,7 +407,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &28 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: school_id
@@ -422,7 +422,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &29 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -468,7 +468,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb4_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &32 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: value
@@ -489,10 +489,10 @@ columns:
     name: created_at
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: datetime(6)
+        sql_type: datetime
         type: :datetime
         limit: 
-        precision: 6
+        precision: 0
         scale: 
       extra: ''
     'null': false
@@ -504,10 +504,10 @@ columns:
     name: updated_at
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: datetime(6)
+        sql_type: datetime
         type: :datetime
         limit: 
-        precision: 6
+        precision: 0
         scale: 
       extra: ''
     'null': false
@@ -520,7 +520,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -535,7 +535,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -550,7 +550,7 @@ columns:
     name: level_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -565,7 +565,7 @@ columns:
     name: script_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -580,7 +580,7 @@ columns:
     name: level_source_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint unsigned
+        sql_type: bigint(20) unsigned
         type: :integer
         limit: 8
         precision: 
@@ -595,7 +595,7 @@ columns:
     name: attempt
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -610,7 +610,7 @@ columns:
     name: test_result
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -656,7 +656,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -680,7 +680,7 @@ columns:
     'null': false
     default: ''
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &46 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: hashed_email
@@ -695,7 +695,7 @@ columns:
     'null': false
     default: ''
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &47 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: credential_type
@@ -710,7 +710,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &48 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: authentication_id
@@ -725,7 +725,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &49 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: data
@@ -740,7 +740,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &50 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: deleted_at
@@ -761,7 +761,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -807,7 +807,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -822,7 +822,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -837,7 +837,7 @@ columns:
     name: script_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -852,7 +852,7 @@ columns:
     name: level_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -876,7 +876,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &59 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: hint_class
@@ -891,7 +891,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &60 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: hint_type
@@ -906,13 +906,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &61 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: prev_time
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -927,7 +927,7 @@ columns:
     name: prev_attempt
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -942,7 +942,7 @@ columns:
     name: prev_test_result
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -957,7 +957,7 @@ columns:
     name: prev_level_source_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint unsigned
+        sql_type: bigint(20) unsigned
         type: :integer
         limit: 8
         precision: 
@@ -972,7 +972,7 @@ columns:
     name: next_time
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -987,7 +987,7 @@ columns:
     name: next_attempt
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -1002,7 +1002,7 @@ columns:
     name: next_test_result
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -1017,7 +1017,7 @@ columns:
     name: next_level_source_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint unsigned
+        sql_type: bigint(20) unsigned
         type: :integer
         limit: 8
         precision: 
@@ -1032,7 +1032,7 @@ columns:
     name: final_time
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -1047,7 +1047,7 @@ columns:
     name: final_attempt
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -1062,7 +1062,7 @@ columns:
     name: final_test_result
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -1077,7 +1077,7 @@ columns:
     name: final_level_source_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint unsigned
+        sql_type: bigint(20) unsigned
         type: :integer
         limit: 8
         precision: 
@@ -1123,7 +1123,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint
+        sql_type: bigint(20)
         type: :integer
         limit: 8
         precision: 
@@ -1138,7 +1138,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -1153,7 +1153,7 @@ columns:
     name: storage_app_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -1199,7 +1199,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -1223,7 +1223,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &82 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: pool
@@ -1238,7 +1238,7 @@ columns:
     'null': false
     default: ''
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &83 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: category
@@ -1253,7 +1253,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &84 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: config
@@ -1268,7 +1268,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &85 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: helper_code
@@ -1283,7 +1283,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &86 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -1335,7 +1335,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -1359,7 +1359,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &91 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: localization_key
@@ -1374,7 +1374,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &92 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -1410,7 +1410,7 @@ columns:
     name: script_level_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -1434,7 +1434,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &96 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: 'on'
@@ -1449,7 +1449,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &97 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: callout_text
@@ -1464,14 +1464,14 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   census_state_course_codes:
   - &98 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -1495,7 +1495,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &100 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: course
@@ -1510,7 +1510,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &101 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -1547,7 +1547,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -1562,7 +1562,7 @@ columns:
     name: census_submission_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -1577,7 +1577,7 @@ columns:
     name: form_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -1623,7 +1623,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -1647,7 +1647,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &110 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: submitter_email_address
@@ -1662,7 +1662,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &111 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: submitter_name
@@ -1677,7 +1677,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &112 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: submitter_role
@@ -1692,13 +1692,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &113 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: school_year
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -1722,7 +1722,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &115 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: how_many_after_school
@@ -1737,7 +1737,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &116 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: how_many_10_hours
@@ -1752,7 +1752,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &117 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: how_many_20_hours
@@ -1767,7 +1767,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &118 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: other_classes_under_20_hours
@@ -1932,7 +1932,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &129 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: topic_do_not_know
@@ -1962,7 +1962,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &131 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: tell_us_more
@@ -1977,7 +1977,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &132 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: pledged
@@ -2082,14 +2082,14 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   census_submissions_school_infos:
   - &139 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: census_submission_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -2104,7 +2104,7 @@ columns:
     name: school_info_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -2150,7 +2150,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -2174,13 +2174,13 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &145 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: school_year
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: smallint
+        sql_type: smallint(6)
         type: :integer
         limit: 2
         precision: 
@@ -2204,7 +2204,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &147 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: audit_data
@@ -2219,7 +2219,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &148 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -2256,7 +2256,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -2271,7 +2271,7 @@ columns:
     name: storage_app_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -2286,7 +2286,7 @@ columns:
     name: level_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -2331,7 +2331,7 @@ columns:
     name: storage_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -2346,7 +2346,7 @@ columns:
     name: script_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -2377,7 +2377,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -2392,7 +2392,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -2407,7 +2407,7 @@ columns:
     name: unit_6_intention
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -2461,7 +2461,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &164 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: signed_at
@@ -2482,7 +2482,7 @@ columns:
     name: circuit_playground_discount_code_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -2536,14 +2536,14 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   circuit_playground_discount_codes:
   - &169 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -2567,7 +2567,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &171 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: full_discount
@@ -2664,7 +2664,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint
+        sql_type: bigint(20)
         type: :integer
         limit: 8
         precision: 
@@ -2679,7 +2679,7 @@ columns:
     name: code_review_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -2694,7 +2694,7 @@ columns:
     name: commenter_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -2785,7 +2785,7 @@ columns:
     name: code_review_group_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint
+        sql_type: bigint(20)
         type: :integer
         limit: 8
         precision: 
@@ -2800,7 +2800,7 @@ columns:
     name: follower_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint
+        sql_type: bigint(20)
         type: :integer
         limit: 8
         precision: 
@@ -2846,7 +2846,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint
+        sql_type: bigint(20)
         type: :integer
         limit: 8
         precision: 
@@ -2861,7 +2861,7 @@ columns:
     name: section_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint
+        sql_type: bigint(20)
         type: :integer
         limit: 8
         precision: 
@@ -2885,7 +2885,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &192 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -2922,7 +2922,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint
+        sql_type: bigint(20)
         type: :integer
         limit: 8
         precision: 
@@ -2937,7 +2937,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -2952,7 +2952,7 @@ columns:
     name: script_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -2967,7 +2967,7 @@ columns:
     name: level_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -2982,7 +2982,7 @@ columns:
     name: project_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -3006,7 +3006,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &200 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: closed_at
@@ -3073,7 +3073,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint
+        sql_type: bigint(20)
         type: :integer
         limit: 8
         precision: 
@@ -3088,7 +3088,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -3103,7 +3103,7 @@ columns:
     name: project_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -3118,7 +3118,7 @@ columns:
     name: script_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -3133,7 +3133,7 @@ columns:
     name: level_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -3148,7 +3148,7 @@ columns:
     name: project_level_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -3172,13 +3172,13 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &211 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: storage_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -3284,7 +3284,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -3308,7 +3308,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &220 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -3353,14 +3353,14 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   concepts_levels:
   - &223 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -3375,7 +3375,7 @@ columns:
     name: concept_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -3390,7 +3390,7 @@ columns:
     name: level_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -3406,7 +3406,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -3430,7 +3430,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &228 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: data
@@ -3482,7 +3482,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -3506,13 +3506,13 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &233 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: pardot_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -3596,7 +3596,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &239 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: marked_for_deletion_at
@@ -3648,7 +3648,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -3672,7 +3672,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &244 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: data
@@ -3724,7 +3724,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -3748,7 +3748,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &249 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: sources
@@ -3763,7 +3763,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &250 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: data
@@ -3830,7 +3830,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -3875,7 +3875,7 @@ columns:
     name: level_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -3890,7 +3890,7 @@ columns:
     name: answer_number
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -3914,7 +3914,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &260 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: correct
@@ -3936,7 +3936,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -3981,7 +3981,7 @@ columns:
     name: level_group_level_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -3996,7 +3996,7 @@ columns:
     name: contained_level_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -4020,13 +4020,13 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &267 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: contained_level_page
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -4041,7 +4041,7 @@ columns:
     name: contained_level_position
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -4065,14 +4065,14 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   course_offerings:
   - &270 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -4096,7 +4096,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &272 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: display_name
@@ -4111,7 +4111,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &273 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -4156,7 +4156,7 @@ columns:
     'null': false
     default: other
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &276 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: is_featured
@@ -4201,7 +4201,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &279 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: marketing_initiative
@@ -4216,7 +4216,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &280 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: grade_levels
@@ -4231,7 +4231,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &281 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: header
@@ -4246,7 +4246,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &282 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: image
@@ -4261,7 +4261,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &283 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: cs_topic
@@ -4276,7 +4276,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &284 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: school_subject
@@ -4291,7 +4291,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &285 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: device_compatibility
@@ -4306,14 +4306,14 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   course_scripts:
   - &286 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -4328,7 +4328,7 @@ columns:
     name: course_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -4343,7 +4343,7 @@ columns:
     name: script_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -4358,7 +4358,7 @@ columns:
     name: position
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -4382,14 +4382,14 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: If present, the SingleTeacherExperiment with this name must be enabled
       in order for a teacher or their students to see this script.
   - &291 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: default_script_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -4407,7 +4407,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -4431,7 +4431,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &294 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: display_name
@@ -4446,7 +4446,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &295 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: properties
@@ -4461,7 +4461,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &296 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: content_root_type
@@ -4476,13 +4476,13 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &297 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: content_root_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -4527,7 +4527,7 @@ columns:
     name: course_offering_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -4551,14 +4551,14 @@ columns:
     'null': true
     default: in_development
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   courses:
   - &302 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -4582,7 +4582,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &304 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: properties
@@ -4597,7 +4597,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &305 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -4634,7 +4634,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint
+        sql_type: bigint(20)
         type: :integer
         limit: 8
         precision: 
@@ -4658,7 +4658,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &309 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: name
@@ -4673,7 +4673,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &310 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: content
@@ -4688,7 +4688,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &311 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -4725,7 +4725,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -4749,7 +4749,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &315 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: nces_id
@@ -4764,7 +4764,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &316 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -4801,7 +4801,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -4825,7 +4825,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &320 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: url
@@ -4840,7 +4840,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &321 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: show
@@ -4855,7 +4855,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &322 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: twitter
@@ -4870,7 +4870,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &323 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: level
@@ -4885,7 +4885,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &324 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: weight
@@ -4952,7 +4952,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -4976,7 +4976,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &330 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: opt_in
@@ -5006,7 +5006,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &332 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: source
@@ -5021,7 +5021,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &333 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: form_kind
@@ -5036,7 +5036,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &334 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -5073,7 +5073,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -5127,7 +5127,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &340 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: type
@@ -5142,7 +5142,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &341 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: start_at
@@ -5178,7 +5178,7 @@ columns:
     name: section_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -5193,7 +5193,7 @@ columns:
     name: min_user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -5208,7 +5208,7 @@ columns:
     name: max_user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -5223,7 +5223,7 @@ columns:
     name: overflow_max_user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -5268,7 +5268,7 @@ columns:
     name: script_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -5284,7 +5284,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -5299,7 +5299,7 @@ columns:
     name: storage_app_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -5353,14 +5353,14 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   followers:
   - &355 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -5375,7 +5375,7 @@ columns:
     name: student_user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -5420,7 +5420,7 @@ columns:
     name: section_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -5451,7 +5451,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -5475,13 +5475,13 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &363 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: version
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -5505,7 +5505,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &365 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -5557,7 +5557,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint
+        sql_type: bigint(20)
         type: :integer
         limit: 8
         precision: 
@@ -5581,13 +5581,13 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &370 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: version
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -5648,7 +5648,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -5672,13 +5672,13 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &376 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: library_version
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -5702,7 +5702,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &378 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: question
@@ -5717,7 +5717,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &379 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -5769,7 +5769,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint
+        sql_type: bigint(20)
         type: :integer
         limit: 8
         precision: 
@@ -5793,7 +5793,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &384 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: kind
@@ -5808,7 +5808,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &385 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: form_name
@@ -5823,13 +5823,13 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &386 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: form_version
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -5853,7 +5853,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &388 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -5890,7 +5890,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -5905,7 +5905,7 @@ columns:
     name: foorm_submission_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -5920,7 +5920,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -5935,7 +5935,7 @@ columns:
     name: simple_survey_form_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint
+        sql_type: bigint(20)
         type: :integer
         limit: 8
         precision: 
@@ -5959,7 +5959,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &395 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -5996,7 +5996,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -6026,7 +6026,7 @@ columns:
     name: form_version
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -6087,7 +6087,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint
+        sql_type: bigint(20)
         type: :integer
         limit: 8
         precision: 
@@ -6111,7 +6111,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &405 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: name
@@ -6126,7 +6126,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &406 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: properties
@@ -6141,7 +6141,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &407 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -6178,7 +6178,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -6202,7 +6202,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &411 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -6247,13 +6247,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &414 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: intro_video_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -6269,7 +6269,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -6293,7 +6293,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_general_ci
+    collation: utf8_general_ci
     comment: 
   - &417 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: url_s
@@ -6308,7 +6308,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_general_ci
+    collation: utf8_general_ci
     comment: 
   - &418 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: show_s
@@ -6323,7 +6323,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_general_ci
+    collation: utf8_general_ci
     comment: 
   - &419 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: twitter_s
@@ -6338,7 +6338,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_general_ci
+    collation: utf8_general_ci
     comment: 
   - &420 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: level_s
@@ -6353,7 +6353,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_general_ci
+    collation: utf8_general_ci
     comment: 
   - &421 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: weight_f
@@ -6390,7 +6390,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -6414,7 +6414,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_general_ci
+    collation: utf8_general_ci
     comment: 
   - &425 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: unique_language_s
@@ -6429,7 +6429,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_general_ci
+    collation: utf8_general_ci
     comment: 
   - &426 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: language_s
@@ -6444,7 +6444,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_general_ci
+    collation: utf8_general_ci
     comment: 
   - &427 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: locale_s
@@ -6459,7 +6459,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_general_ci
+    collation: utf8_general_ci
     comment: 
   - &428 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: native_name_s
@@ -6474,7 +6474,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_general_ci
+    collation: utf8_general_ci
     comment: 
   - &429 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: english_name_s
@@ -6489,7 +6489,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_general_ci
+    collation: utf8_general_ci
     comment: 
   - &430 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: supported_codeorg_b
@@ -6534,7 +6534,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_general_ci
+    collation: utf8_general_ci
     comment: 
   - &433 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: crowdin_name_s
@@ -6549,7 +6549,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_general_ci
+    collation: utf8_general_ci
     comment: 
   - &434 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: csf_b
@@ -6631,7 +6631,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -6646,7 +6646,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -6661,7 +6661,7 @@ columns:
     name: script_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -6676,7 +6676,7 @@ columns:
     name: level_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -6691,7 +6691,7 @@ columns:
     name: feedback_type
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -6715,7 +6715,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &445 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -6752,7 +6752,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -6767,7 +6767,7 @@ columns:
     name: lesson_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -6791,13 +6791,13 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &450 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: position
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -6821,7 +6821,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &452 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -6858,7 +6858,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -6882,13 +6882,13 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &456 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: script_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -6948,7 +6948,7 @@ columns:
     name: position
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -6972,29 +6972,29 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   lessons_opportunity_standards:
   - &462 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: id
+    name: lesson_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint
+        sql_type: bigint(20)
         type: :integer
         limit: 8
         precision: 
         scale: 
-      extra: auto_increment
+      extra: ''
     'null': false
     default: 
     default_function: 
     collation: 
     comment: 
   - &463 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: lesson_id
+    name: standard_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint
+        sql_type: bigint(20)
         type: :integer
         limit: 8
         precision: 
@@ -7006,15 +7006,15 @@ columns:
     collation: 
     comment: 
   - &464 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: standard_id
+    name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint
+        sql_type: bigint(20)
         type: :integer
         limit: 8
         precision: 
         scale: 
-      extra: ''
+      extra: auto_increment
     'null': false
     default: 
     default_function: 
@@ -7025,7 +7025,7 @@ columns:
     name: lesson_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint
+        sql_type: bigint(20)
         type: :integer
         limit: 8
         precision: 
@@ -7040,7 +7040,7 @@ columns:
     name: programming_expression_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint
+        sql_type: bigint(20)
         type: :integer
         limit: 8
         precision: 
@@ -7056,7 +7056,7 @@ columns:
     name: lesson_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -7071,7 +7071,7 @@ columns:
     name: resource_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -7087,7 +7087,7 @@ columns:
     name: lesson_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint
+        sql_type: bigint(20)
         type: :integer
         limit: 8
         precision: 
@@ -7102,7 +7102,7 @@ columns:
     name: vocabulary_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint
+        sql_type: bigint(20)
         type: :integer
         limit: 8
         precision: 
@@ -7118,7 +7118,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -7133,7 +7133,7 @@ columns:
     name: level_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -7178,7 +7178,7 @@ columns:
     name: sequencing
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -7193,7 +7193,7 @@ columns:
     name: debugging
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -7208,7 +7208,7 @@ columns:
     name: repeat_loops
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -7223,7 +7223,7 @@ columns:
     name: repeat_until_while
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -7238,7 +7238,7 @@ columns:
     name: for_loops
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -7253,7 +7253,7 @@ columns:
     name: events
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -7268,7 +7268,7 @@ columns:
     name: variables
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -7283,7 +7283,7 @@ columns:
     name: functions
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -7298,7 +7298,7 @@ columns:
     name: functions_with_params
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -7313,7 +7313,7 @@ columns:
     name: conditionals
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -7329,7 +7329,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -7344,7 +7344,7 @@ columns:
     name: level_source_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint unsigned
+        sql_type: bigint(20) unsigned
         type: :integer
         limit: 8
         precision: 
@@ -7405,7 +7405,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint unsigned
+        sql_type: bigint(11) unsigned
         type: :integer
         limit: 8
         precision: 
@@ -7420,7 +7420,7 @@ columns:
     name: level_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -7444,7 +7444,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &493 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: data
@@ -7459,7 +7459,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &494 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -7511,7 +7511,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -7526,7 +7526,7 @@ columns:
     name: level_source_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint unsigned
+        sql_type: bigint(20) unsigned
         type: :integer
         limit: 8
         precision: 
@@ -7541,7 +7541,7 @@ columns:
     name: level_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -7565,7 +7565,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &501 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: md5
@@ -7580,7 +7580,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &502 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: hidden
@@ -7602,7 +7602,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -7617,7 +7617,7 @@ columns:
     name: game_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -7641,7 +7641,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &506 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -7686,13 +7686,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &509 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: ideal_level_source_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint unsigned
+        sql_type: bigint(20) unsigned
         type: :integer
         limit: 8
         precision: 
@@ -7707,7 +7707,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -7746,7 +7746,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &513 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: md5
@@ -7761,7 +7761,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &514 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: published
@@ -7791,7 +7791,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &516 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: audit_log
@@ -7806,14 +7806,14 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   levels_script_levels:
   - &517 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: level_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -7828,7 +7828,7 @@ columns:
     name: script_level_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -7844,7 +7844,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -7868,7 +7868,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &521 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: content
@@ -7883,7 +7883,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &522 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -7920,7 +7920,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -7989,7 +7989,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &529 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: metric_on
@@ -8019,7 +8019,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &531 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: breakdown
@@ -8034,7 +8034,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &532 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: metric
@@ -8049,7 +8049,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &533 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: submetric
@@ -8064,7 +8064,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &534 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: value
@@ -8086,7 +8086,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -8110,13 +8110,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &537 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: lesson_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -8170,14 +8170,14 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   paired_user_levels:
   - &541 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -8192,7 +8192,7 @@ columns:
     name: driver_user_level_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint unsigned
+        sql_type: bigint(20) unsigned
         type: :integer
         limit: 8
         precision: 
@@ -8207,7 +8207,7 @@ columns:
     name: navigator_user_level_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint unsigned
+        sql_type: bigint(20) unsigned
         type: :integer
         limit: 8
         precision: 
@@ -8253,7 +8253,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -8268,7 +8268,7 @@ columns:
     name: parent_level_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -8283,7 +8283,7 @@ columns:
     name: child_level_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -8298,7 +8298,7 @@ columns:
     name: position
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -8322,14 +8322,14 @@ columns:
     'null': false
     default: sublevel
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   pd_accepted_programs:
   - &551 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -8383,7 +8383,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &555 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: course
@@ -8398,13 +8398,13 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &556 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -8419,7 +8419,7 @@ columns:
     name: teacher_application_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -8435,7 +8435,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -8450,7 +8450,7 @@ columns:
     name: pd_application_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -8474,7 +8474,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &561 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: email_type
@@ -8489,7 +8489,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &562 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: to
@@ -8504,7 +8504,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &563 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -8541,7 +8541,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -8565,7 +8565,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &567 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -8602,7 +8602,7 @@ columns:
     name: pd_application_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -8617,7 +8617,7 @@ columns:
     name: pd_application_tag_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -8663,7 +8663,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -8678,7 +8678,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -8702,7 +8702,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &576 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: application_year
@@ -8717,7 +8717,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &577 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: application_type
@@ -8732,13 +8732,13 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &578 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: regional_partner_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -8762,7 +8762,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &580 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: locked_at
@@ -8792,7 +8792,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &582 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: form_data
@@ -8807,7 +8807,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &583 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -8852,7 +8852,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &586 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: response_scores
@@ -8867,7 +8867,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: Scores given to certain responses
   - &587 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: application_guid
@@ -8882,7 +8882,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &588 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: accepted_at
@@ -8912,7 +8912,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &590 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: deleted_at
@@ -8942,7 +8942,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &592 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: applied_at
@@ -8964,7 +8964,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint
+        sql_type: bigint(20)
         type: :integer
         limit: 8
         precision: 
@@ -8979,7 +8979,7 @@ columns:
     name: pd_application_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint
+        sql_type: bigint(20)
         type: :integer
         limit: 8
         precision: 
@@ -9003,7 +9003,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &596 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: timestamp
@@ -9024,7 +9024,7 @@ columns:
     name: position
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -9040,7 +9040,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -9055,7 +9055,7 @@ columns:
     name: pd_session_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -9070,7 +9070,7 @@ columns:
     name: teacher_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -9130,7 +9130,7 @@ columns:
     name: pd_enrollment_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -9145,7 +9145,7 @@ columns:
     name: marked_by_user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -9162,7 +9162,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -9177,7 +9177,7 @@ columns:
     name: facilitator_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -9201,14 +9201,14 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   pd_district_payment_terms:
   - &609 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -9223,7 +9223,7 @@ columns:
     name: school_district_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -9247,7 +9247,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &612 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: rate_type
@@ -9262,7 +9262,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &613 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: rate
@@ -9284,7 +9284,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -9329,7 +9329,7 @@ columns:
     name: pd_enrollment_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -9353,14 +9353,14 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   pd_enrollments:
   - &619 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -9375,7 +9375,7 @@ columns:
     name: pd_workshop_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -9399,7 +9399,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &622 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: first_name
@@ -9414,7 +9414,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &623 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: last_name
@@ -9429,7 +9429,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &624 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: email
@@ -9444,7 +9444,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &625 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -9489,7 +9489,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &628 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: code
@@ -9504,13 +9504,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &629 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -9540,7 +9540,7 @@ columns:
     name: completed_survey_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -9555,7 +9555,7 @@ columns:
     name: school_info_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -9594,13 +9594,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &635 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: application_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -9616,7 +9616,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -9631,7 +9631,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -9655,7 +9655,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &639 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -9691,7 +9691,7 @@ columns:
     name: teachercon
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -9707,7 +9707,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -9722,7 +9722,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -9806,7 +9806,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &649 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: tc2_arrive
@@ -9881,7 +9881,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &654 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: tc3_arrive
@@ -9956,14 +9956,14 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   pd_fit_weekend1819_registrations:
   - &659 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -9978,7 +9978,7 @@ columns:
     name: pd_application_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -10002,7 +10002,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &662 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -10039,7 +10039,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -10054,7 +10054,7 @@ columns:
     name: pd_application_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -10078,7 +10078,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &667 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: form_data
@@ -10093,7 +10093,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &668 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -10130,7 +10130,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -10145,7 +10145,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -10169,7 +10169,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &673 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -10206,7 +10206,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -10221,7 +10221,7 @@ columns:
     name: facilitator_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -10245,7 +10245,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &678 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: subject
@@ -10260,7 +10260,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &679 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: data
@@ -10275,7 +10275,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &680 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -10312,7 +10312,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -10327,7 +10327,7 @@ columns:
     name: form_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint
+        sql_type: bigint(20)
         type: :integer
         limit: 8
         precision: 
@@ -10342,7 +10342,7 @@ columns:
     name: submission_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint
+        sql_type: bigint(20)
         type: :integer
         limit: 8
         precision: 
@@ -10366,13 +10366,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &686 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -10418,7 +10418,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -10433,7 +10433,7 @@ columns:
     name: regional_partner_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -10487,7 +10487,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &694 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: subject
@@ -10502,7 +10502,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &695 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: properties
@@ -10517,7 +10517,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &696 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -10554,7 +10554,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -10569,7 +10569,7 @@ columns:
     name: form_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint
+        sql_type: bigint(20)
         type: :integer
         limit: 8
         precision: 
@@ -10584,7 +10584,7 @@ columns:
     name: submission_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint
+        sql_type: bigint(20)
         type: :integer
         limit: 8
         precision: 
@@ -10608,7 +10608,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &702 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: year
@@ -10623,13 +10623,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &703 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -10653,7 +10653,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: csd or csp
   - &705 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -10690,7 +10690,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -10705,7 +10705,7 @@ columns:
     name: pd_enrollment_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -10729,7 +10729,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &710 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -10766,7 +10766,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -10781,7 +10781,7 @@ columns:
     name: regional_partner_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -10796,7 +10796,7 @@ columns:
     name: role
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -10820,7 +10820,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: free-form text year range, YYYY-YYYY, e.g. 2016-2017
   - &716 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: course
@@ -10835,7 +10835,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &717 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: name
@@ -10850,14 +10850,14 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: Human readable name of cohort (not required, used to support large partners
       with multiple cohorts)
   - &718 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: size
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -10872,7 +10872,7 @@ columns:
     name: summer_workshop_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -10918,7 +10918,7 @@ columns:
     name: pd_regional_partner_cohort_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -10933,7 +10933,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -10949,7 +10949,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -10964,7 +10964,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -10979,7 +10979,7 @@ columns:
     name: regional_partner_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -11003,7 +11003,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &728 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -11040,7 +11040,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -11055,7 +11055,7 @@ columns:
     name: regional_partner_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -11079,7 +11079,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &733 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: zip_code
@@ -11094,7 +11094,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &734 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -11146,7 +11146,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -11161,7 +11161,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -11176,7 +11176,7 @@ columns:
     name: regional_partner_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -11200,7 +11200,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &741 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -11237,7 +11237,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -11252,7 +11252,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -11276,13 +11276,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &746 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: teachercon
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -11328,7 +11328,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -11343,7 +11343,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -11367,7 +11367,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &752 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: scholarship_status
@@ -11382,13 +11382,13 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &753 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: pd_application_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -11403,7 +11403,7 @@ columns:
     name: pd_enrollment_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -11457,14 +11457,14 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   pd_sessions:
   - &758 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -11479,7 +11479,7 @@ columns:
     name: pd_workshop_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -11578,14 +11578,14 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   pd_survey_questions:
   - &766 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -11600,7 +11600,7 @@ columns:
     name: form_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint
+        sql_type: bigint(20)
         type: :integer
         limit: 8
         precision: 
@@ -11624,7 +11624,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: JSON Question data for this JotForm form.
   - &769 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -11660,7 +11660,7 @@ columns:
     name: last_submission_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint
+        sql_type: bigint(20)
         type: :integer
         limit: 8
         precision: 
@@ -11677,7 +11677,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -11722,7 +11722,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -11746,7 +11746,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &777 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: secondary_email
@@ -11761,7 +11761,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &778 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: application
@@ -11776,7 +11776,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &779 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: regional_partner_override
@@ -11791,13 +11791,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &780 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: program_registration_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -11814,7 +11814,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -11829,7 +11829,7 @@ columns:
     name: pd_application_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -11853,7 +11853,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &784 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -11889,7 +11889,7 @@ columns:
     name: regional_partner_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -11904,7 +11904,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -11920,7 +11920,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -11935,7 +11935,7 @@ columns:
     name: pd_enrollment_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -11959,7 +11959,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &791 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -11996,7 +11996,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -12011,7 +12011,7 @@ columns:
     name: form_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint
+        sql_type: bigint(20)
         type: :integer
         limit: 8
         precision: 
@@ -12026,7 +12026,7 @@ columns:
     name: submission_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint
+        sql_type: bigint(20)
         type: :integer
         limit: 8
         precision: 
@@ -12041,7 +12041,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -12056,7 +12056,7 @@ columns:
     name: pd_session_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -12071,7 +12071,7 @@ columns:
     name: pd_workshop_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -12095,13 +12095,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &800 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: day
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -12147,7 +12147,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -12162,7 +12162,7 @@ columns:
     name: form_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint
+        sql_type: bigint(20)
         type: :integer
         limit: 8
         precision: 
@@ -12177,7 +12177,7 @@ columns:
     name: submission_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint
+        sql_type: bigint(20)
         type: :integer
         limit: 8
         precision: 
@@ -12192,7 +12192,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -12207,7 +12207,7 @@ columns:
     name: pd_session_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -12222,7 +12222,7 @@ columns:
     name: pd_workshop_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -12237,7 +12237,7 @@ columns:
     name: facilitator_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -12261,13 +12261,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &811 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: day
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -12313,7 +12313,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -12328,7 +12328,7 @@ columns:
     name: foorm_submission_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -12343,7 +12343,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -12358,7 +12358,7 @@ columns:
     name: pd_session_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -12373,7 +12373,7 @@ columns:
     name: pd_workshop_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -12388,7 +12388,7 @@ columns:
     name: day
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -12433,7 +12433,7 @@ columns:
     name: facilitator_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -12457,14 +12457,14 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   pd_workshop_surveys:
   - &824 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -12479,7 +12479,7 @@ columns:
     name: pd_enrollment_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -12503,7 +12503,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &827 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -12548,14 +12548,14 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   pd_workshops:
   - &830 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -12570,7 +12570,7 @@ columns:
     name: organizer_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -12594,7 +12594,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &833 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: location_address
@@ -12609,7 +12609,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &834 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: processed_location
@@ -12624,7 +12624,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &835 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: course
@@ -12639,7 +12639,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &836 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: subject
@@ -12654,13 +12654,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &837 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: capacity
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -12684,13 +12684,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &839 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: section_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -12795,7 +12795,7 @@ columns:
     name: regional_partner_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -12849,7 +12849,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &850 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: properties
@@ -12864,14 +12864,14 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   pd_workshops_facilitators:
   - &851 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: pd_workshop_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -12886,7 +12886,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -12902,7 +12902,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -12917,7 +12917,7 @@ columns:
     name: submitter_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -12932,7 +12932,7 @@ columns:
     name: reviewer_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -12962,7 +12962,7 @@ columns:
     name: script_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -12977,7 +12977,7 @@ columns:
     name: level_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -12992,7 +12992,7 @@ columns:
     name: level_source_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint unsigned
+        sql_type: bigint(20) unsigned
         type: :integer
         limit: 8
         precision: 
@@ -13016,13 +13016,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &861 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: status
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -13076,7 +13076,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: Human-readable (never machine-parsed) audit trail of assignments and
       status changes with timestamps for the life of the peer review.
   pilots:
@@ -13084,7 +13084,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint
+        sql_type: bigint(20)
         type: :integer
         limit: 8
         precision: 
@@ -13108,7 +13108,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &867 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: display_name
@@ -13123,7 +13123,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &868 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: allow_joining_via_url
@@ -13175,7 +13175,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -13190,7 +13190,7 @@ columns:
     name: plc_course_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -13214,7 +13214,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &874 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: unit_description
@@ -13229,13 +13229,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &875 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: unit_order
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -13280,7 +13280,7 @@ columns:
     name: script_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -13311,7 +13311,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -13356,7 +13356,7 @@ columns:
     name: course_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -13372,7 +13372,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -13387,7 +13387,7 @@ columns:
     name: plc_enrollment_unit_assignment_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -13402,7 +13402,7 @@ columns:
     name: plc_learning_module_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -13447,7 +13447,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -13463,7 +13463,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -13478,7 +13478,7 @@ columns:
     name: plc_user_course_enrollment_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -13493,7 +13493,7 @@ columns:
     name: plc_course_unit_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -13517,7 +13517,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &894 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -13553,7 +13553,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -13569,7 +13569,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -13593,7 +13593,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &899 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -13629,7 +13629,7 @@ columns:
     name: plc_course_unit_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -13653,13 +13653,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &903 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: stage_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -13675,7 +13675,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -13699,13 +13699,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &906 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: plc_course_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -13720,7 +13720,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -13766,7 +13766,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint
+        sql_type: bigint(20)
         type: :integer
         limit: 8
         precision: 
@@ -13781,7 +13781,7 @@ columns:
     name: programming_environment_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -13796,7 +13796,7 @@ columns:
     name: programming_environment_category_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -13820,7 +13820,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &914 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: name
@@ -13835,7 +13835,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &915 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: content
@@ -13850,7 +13850,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &916 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: fields
@@ -13865,7 +13865,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &917 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: examples
@@ -13880,7 +13880,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &918 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: tips
@@ -13895,7 +13895,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &919 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: syntax
@@ -13910,7 +13910,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &920 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: external_documentation
@@ -13925,7 +13925,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &921 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -13962,7 +13962,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint
+        sql_type: bigint(20)
         type: :integer
         limit: 8
         precision: 
@@ -13977,7 +13977,7 @@ columns:
     name: programming_environment_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -14001,7 +14001,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &926 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: name
@@ -14016,7 +14016,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &927 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: color
@@ -14031,7 +14031,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &928 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -14067,7 +14067,7 @@ columns:
     name: position
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -14083,7 +14083,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint
+        sql_type: bigint(20)
         type: :integer
         limit: 8
         precision: 
@@ -14107,7 +14107,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &933 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: properties
@@ -14122,7 +14122,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &934 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -14174,7 +14174,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint
+        sql_type: bigint(20)
         type: :integer
         limit: 8
         precision: 
@@ -14198,7 +14198,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &939 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: category
@@ -14213,7 +14213,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &940 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: properties
@@ -14228,13 +14228,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &941 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: programming_environment_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint
+        sql_type: bigint(20)
         type: :integer
         limit: 8
         precision: 
@@ -14288,13 +14288,13 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &945 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: programming_environment_category_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -14310,7 +14310,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint
+        sql_type: bigint(20)
         type: :integer
         limit: 8
         precision: 
@@ -14325,7 +14325,7 @@ columns:
     name: programming_class_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -14349,13 +14349,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &949 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: position
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -14379,7 +14379,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &951 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: content
@@ -14394,7 +14394,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &952 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: parameters
@@ -14409,7 +14409,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &953 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: examples
@@ -14424,7 +14424,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &954 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: syntax
@@ -14439,7 +14439,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &955 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: external_link
@@ -14454,7 +14454,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &956 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -14499,7 +14499,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &959 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: return_value
@@ -14514,14 +14514,14 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   project_commits:
   - &960 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint
+        sql_type: bigint(20)
         type: :integer
         limit: 8
         precision: 
@@ -14536,7 +14536,7 @@ columns:
     name: storage_app_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -14612,7 +14612,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -14627,7 +14627,7 @@ columns:
     name: storage_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -14651,7 +14651,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb4_0900_ai_ci
+    collation: utf8mb4_general_ci
     comment: 
   - &969 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: updated_at
@@ -14681,7 +14681,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb4_0900_ai_ci
+    collation: utf8mb4_general_ci
     comment: 
   - &971 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: state
@@ -14696,7 +14696,7 @@ columns:
     'null': false
     default: active
     default_function: 
-    collation: utf8mb4_0900_ai_ci
+    collation: utf8mb4_general_ci
     comment: 
   - &972 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -14717,7 +14717,7 @@ columns:
     name: abuse_score
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -14741,7 +14741,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb4_0900_ai_ci
+    collation: utf8mb4_general_ci
     comment: 
   - &975 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: published_at
@@ -14777,7 +14777,7 @@ columns:
     name: remix_parent_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -14808,7 +14808,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -14823,7 +14823,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -14838,7 +14838,7 @@ columns:
     name: script_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -14853,7 +14853,7 @@ columns:
     name: level_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -14868,7 +14868,7 @@ columns:
     name: rating
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -14914,7 +14914,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -14929,7 +14929,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -14953,7 +14953,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &989 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -14990,7 +14990,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint
+        sql_type: bigint(20)
         type: :integer
         limit: 8
         precision: 
@@ -15014,13 +15014,13 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &993 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: course_version_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint
+        sql_type: bigint(20)
         type: :integer
         limit: 8
         precision: 
@@ -15044,7 +15044,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &995 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: display_name
@@ -15059,7 +15059,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &996 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: content
@@ -15074,13 +15074,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &997 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: position
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -15126,7 +15126,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -15141,7 +15141,7 @@ columns:
     name: program_manager_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -15156,7 +15156,7 @@ columns:
     name: regional_partner_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -15172,7 +15172,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -15196,13 +15196,13 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1005 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: group
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -15241,7 +15241,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1008 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: street
@@ -15256,7 +15256,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1009 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: apartment_or_suite
@@ -15271,7 +15271,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1010 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: city
@@ -15286,7 +15286,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1011 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: state
@@ -15301,7 +15301,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1012 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: zip_code
@@ -15316,7 +15316,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1013 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: phone_number
@@ -15331,7 +15331,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1014 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: notes
@@ -15346,7 +15346,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1015 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -15406,7 +15406,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1019 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: is_active
@@ -15428,7 +15428,7 @@ columns:
     name: regional_partner_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -15443,7 +15443,7 @@ columns:
     name: school_district_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -15467,7 +15467,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: Course for a given workshop
   - &1023 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: workshop_days
@@ -15482,14 +15482,14 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: Days that the workshop will take place
   resources:
   - &1024 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -15513,7 +15513,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1026 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: url
@@ -15528,7 +15528,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1027 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: key
@@ -15543,7 +15543,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1028 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: properties
@@ -15558,7 +15558,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1029 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -15594,7 +15594,7 @@ columns:
     name: course_version_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -15619,14 +15619,14 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb4_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   school_districts:
   - &1033 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -15650,7 +15650,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1035 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: city
@@ -15665,7 +15665,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1036 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: state
@@ -15680,7 +15680,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1037 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: zip
@@ -15695,7 +15695,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1038 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: last_known_school_year_open
@@ -15710,7 +15710,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1039 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -15747,7 +15747,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -15771,7 +15771,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1043 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: school_type
@@ -15786,13 +15786,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1044 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: zip
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -15816,13 +15816,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1046 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: school_district_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -15861,7 +15861,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1049 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: school_id
@@ -15876,7 +15876,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1050 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: school_other
@@ -15906,7 +15906,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: This column appears to be redundant with pd_enrollments.school and users.school,
       therefore validation rules must be used to ensure that any user or enrollment
       with a school_info has its school name stored in the correct place.
@@ -15923,7 +15923,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: This column appears to be redundant with users.full_address, therefore
       validation rules must be used to ensure that any user with a school_info has
       its school address stored in the correct place.
@@ -15970,7 +15970,7 @@ columns:
     'null': false
     default: full
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   school_stats_by_years:
   - &1056 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
@@ -15986,7 +15986,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: NCES public school ID
   - &1057 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: school_year
@@ -16001,7 +16001,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: School Year
   - &1058 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: grades_offered_lo
@@ -16016,7 +16016,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: Grades Offered - Lowest
   - &1059 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: grades_offered_hi
@@ -16031,7 +16031,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: Grades Offered - Highest
   - &1060 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: grade_pk_offered
@@ -16271,13 +16271,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: Virtual School Status
   - &1076 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: students_total
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -16292,7 +16292,7 @@ columns:
     name: student_am_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -16307,7 +16307,7 @@ columns:
     name: student_as_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -16322,7 +16322,7 @@ columns:
     name: student_hi_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -16337,7 +16337,7 @@ columns:
     name: student_bl_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -16352,7 +16352,7 @@ columns:
     name: student_wh_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -16367,7 +16367,7 @@ columns:
     name: student_hp_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -16382,7 +16382,7 @@ columns:
     name: student_tr_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -16406,13 +16406,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: TITLE I status (code)
   - &1085 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: frl_eligible_total
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -16466,7 +16466,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: Urban-centric community type
   schools:
   - &1089 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
@@ -16482,13 +16482,13 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: NCES public school ID
   - &1090 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: school_district_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -16512,7 +16512,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1092 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: city
@@ -16527,7 +16527,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1093 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: state
@@ -16542,7 +16542,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1094 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: zip
@@ -16557,7 +16557,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1095 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: school_type
@@ -16572,7 +16572,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1096 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -16617,7 +16617,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: Location address, street 1
   - &1099 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: address_line2
@@ -16632,7 +16632,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: Location address, street 2
   - &1100 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: address_line3
@@ -16647,7 +16647,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: Location address, street 3
   - &1101 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: latitude
@@ -16692,7 +16692,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1104 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: school_category
@@ -16707,7 +16707,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1105 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: last_known_school_year_open
@@ -16722,14 +16722,14 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   script_levels:
   - &1106 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -16744,7 +16744,7 @@ columns:
     name: script_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -16759,7 +16759,7 @@ columns:
     name: chapter
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -16804,7 +16804,7 @@ columns:
     name: stage_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -16819,7 +16819,7 @@ columns:
     name: position
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -16858,7 +16858,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1115 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: named_level
@@ -16894,7 +16894,7 @@ columns:
     name: activity_section_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -16918,13 +16918,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1119 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: activity_section_position
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -16940,7 +16940,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -16964,7 +16964,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1122 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -17000,7 +17000,7 @@ columns:
     name: wrapup_video_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -17015,7 +17015,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -17054,7 +17054,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1128 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: new_name
@@ -17069,7 +17069,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1129 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: family_name
@@ -17084,7 +17084,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1130 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: published_state
@@ -17099,7 +17099,7 @@ columns:
     'null': true
     default: in_development
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1131 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: instruction_type
@@ -17114,7 +17114,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1132 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: instructor_audience
@@ -17129,7 +17129,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1133 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: participant_audience
@@ -17144,14 +17144,14 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   scripts_resources:
   - &1134 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: script_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -17166,7 +17166,7 @@ columns:
     name: resource_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -17182,7 +17182,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint
+        sql_type: bigint(20)
         type: :integer
         limit: 8
         precision: 
@@ -17197,7 +17197,7 @@ columns:
     name: script_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -17212,7 +17212,7 @@ columns:
     name: resource_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -17228,7 +17228,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -17252,7 +17252,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1141 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: path
@@ -17267,7 +17267,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1142 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -17304,7 +17304,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -17328,7 +17328,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1146 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -17365,7 +17365,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -17380,7 +17380,7 @@ columns:
     name: section_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -17395,7 +17395,7 @@ columns:
     name: script_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -17411,7 +17411,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -17426,7 +17426,7 @@ columns:
     name: section_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -17441,7 +17441,7 @@ columns:
     name: stage_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -17457,7 +17457,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -17472,7 +17472,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -17496,7 +17496,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1157 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -17541,13 +17541,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1160 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: script_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -17562,7 +17562,7 @@ columns:
     name: course_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -17586,7 +17586,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1163 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: login_type
@@ -17601,7 +17601,7 @@ columns:
     'null': false
     default: email
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1164 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: deleted_at
@@ -17646,7 +17646,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1167 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: first_activity_at
@@ -17752,7 +17752,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1174 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: participant_type
@@ -17767,14 +17767,14 @@ columns:
     'null': false
     default: student
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   seed_info:
   - &1175 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint
+        sql_type: bigint(20)
         type: :integer
         limit: 8
         precision: 
@@ -17798,7 +17798,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1177 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: mtime
@@ -17820,7 +17820,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -17844,7 +17844,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1180 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: key
@@ -17859,7 +17859,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1181 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: etag
@@ -17874,7 +17874,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1182 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -17911,7 +17911,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -17935,7 +17935,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1186 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: level_type
@@ -17950,13 +17950,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1187 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: block_type
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -17980,7 +17980,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1189 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: description
@@ -17995,7 +17995,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1190 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: arguments
@@ -18010,7 +18010,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1191 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: stack
@@ -18025,14 +18025,14 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   sign_ins:
   - &1192 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -18047,7 +18047,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -18077,7 +18077,7 @@ columns:
     name: sign_in_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -18093,7 +18093,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -18117,13 +18117,13 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1198 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: absolute_position
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -18138,7 +18138,7 @@ columns:
     name: script_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -18198,7 +18198,7 @@ columns:
     name: relative_position
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -18222,13 +18222,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1205 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: lesson_group_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -18252,7 +18252,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1207 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: has_lesson_plan
@@ -18274,7 +18274,7 @@ columns:
     name: stage_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -18289,7 +18289,7 @@ columns:
     name: standard_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -18335,7 +18335,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint
+        sql_type: bigint(20)
         type: :integer
         limit: 8
         precision: 
@@ -18359,13 +18359,13 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1214 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: framework_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -18380,7 +18380,7 @@ columns:
     name: parent_category_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -18404,7 +18404,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1217 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: properties
@@ -18419,7 +18419,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1218 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -18456,7 +18456,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -18480,13 +18480,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1222 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: category_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint
+        sql_type: bigint(20)
         type: :integer
         limit: 8
         precision: 
@@ -18501,7 +18501,7 @@ columns:
     name: framework_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -18525,14 +18525,14 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   studio_people:
   - &1225 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -18586,14 +18586,14 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   survey_results:
   - &1229 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -18608,7 +18608,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -18632,7 +18632,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1232 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: properties
@@ -18647,7 +18647,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1233 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -18684,7 +18684,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -18708,13 +18708,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1237 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: student_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -18729,7 +18729,7 @@ columns:
     name: level_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -18744,7 +18744,7 @@ columns:
     name: teacher_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -18813,13 +18813,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1244 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: student_visit_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -18879,7 +18879,7 @@ columns:
     name: script_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -18894,7 +18894,7 @@ columns:
     name: analytics_section_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -18918,14 +18918,14 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   teacher_profiles:
   - &1251 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -18940,7 +18940,7 @@ columns:
     name: studio_person_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -18994,7 +18994,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1256 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: facilitator
@@ -19039,7 +19039,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1259 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: pd
@@ -19054,7 +19054,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1260 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: other_pd
@@ -19069,7 +19069,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1261 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: properties
@@ -19084,14 +19084,14 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   teacher_scores:
   - &1262 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -19106,7 +19106,7 @@ columns:
     name: user_level_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint unsigned
+        sql_type: bigint(20) unsigned
         type: :integer
         limit: 8
         precision: 
@@ -19121,7 +19121,7 @@ columns:
     name: teacher_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -19136,7 +19136,7 @@ columns:
     name: score
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -19182,7 +19182,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -19206,7 +19206,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1270 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: properties
@@ -19221,7 +19221,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1271 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -19266,7 +19266,7 @@ columns:
     'null': false
     default: in_development
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1274 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: instruction_type
@@ -19281,7 +19281,7 @@ columns:
     'null': false
     default: teacher_led
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1275 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: instructor_audience
@@ -19296,7 +19296,7 @@ columns:
     'null': false
     default: teacher
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1276 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: participant_audience
@@ -19311,14 +19311,14 @@ columns:
     'null': false
     default: student
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   unit_groups_resources:
   - &1277 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: unit_group_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -19333,7 +19333,7 @@ columns:
     name: resource_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -19349,7 +19349,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint
+        sql_type: bigint(20)
         type: :integer
         limit: 8
         precision: 
@@ -19364,7 +19364,7 @@ columns:
     name: unit_group_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -19379,7 +19379,7 @@ columns:
     name: resource_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -19395,7 +19395,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -19410,7 +19410,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -19479,7 +19479,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1288 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: city
@@ -19494,7 +19494,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1289 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: state
@@ -19509,7 +19509,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1290 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: country
@@ -19524,7 +19524,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1291 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: postal_code
@@ -19539,7 +19539,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1292 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: latitude
@@ -19576,7 +19576,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint unsigned
+        sql_type: bigint(20) unsigned
         type: :integer
         limit: 8
         precision: 
@@ -19591,7 +19591,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -19606,7 +19606,7 @@ columns:
     name: level_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -19621,7 +19621,7 @@ columns:
     name: attempts
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -19666,7 +19666,7 @@ columns:
     name: best_result
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -19681,7 +19681,7 @@ columns:
     name: script_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -19696,7 +19696,7 @@ columns:
     name: level_source_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint unsigned
+        sql_type: bigint(20) unsigned
         type: :integer
         limit: 8
         precision: 
@@ -19756,7 +19756,7 @@ columns:
     name: time_spent
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -19795,14 +19795,14 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   user_ml_models:
   - &1309 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint
+        sql_type: bigint(20)
         type: :integer
         limit: 8
         precision: 
@@ -19817,7 +19817,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -19841,7 +19841,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1312 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: name
@@ -19856,7 +19856,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1313 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: deleted_at
@@ -19931,14 +19931,14 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   user_module_task_assignments:
   - &1318 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -19953,7 +19953,7 @@ columns:
     name: user_enrollment_module_assignment_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -19968,7 +19968,7 @@ columns:
     name: professional_learning_task_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -19992,14 +19992,14 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   user_permissions:
   - &1322 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -20014,7 +20014,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -20038,7 +20038,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1325 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -20075,7 +20075,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -20090,7 +20090,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -20150,7 +20150,7 @@ columns:
     name: sequencing_d1_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -20165,7 +20165,7 @@ columns:
     name: sequencing_d2_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -20180,7 +20180,7 @@ columns:
     name: sequencing_d3_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -20195,7 +20195,7 @@ columns:
     name: sequencing_d4_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -20210,7 +20210,7 @@ columns:
     name: sequencing_d5_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -20225,7 +20225,7 @@ columns:
     name: debugging_d1_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -20240,7 +20240,7 @@ columns:
     name: debugging_d2_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -20255,7 +20255,7 @@ columns:
     name: debugging_d3_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -20270,7 +20270,7 @@ columns:
     name: debugging_d4_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -20285,7 +20285,7 @@ columns:
     name: debugging_d5_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -20300,7 +20300,7 @@ columns:
     name: repeat_loops_d1_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -20315,7 +20315,7 @@ columns:
     name: repeat_loops_d2_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -20330,7 +20330,7 @@ columns:
     name: repeat_loops_d3_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -20345,7 +20345,7 @@ columns:
     name: repeat_loops_d4_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -20360,7 +20360,7 @@ columns:
     name: repeat_loops_d5_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -20375,7 +20375,7 @@ columns:
     name: repeat_until_while_d1_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -20390,7 +20390,7 @@ columns:
     name: repeat_until_while_d2_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -20405,7 +20405,7 @@ columns:
     name: repeat_until_while_d3_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -20420,7 +20420,7 @@ columns:
     name: repeat_until_while_d4_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -20435,7 +20435,7 @@ columns:
     name: repeat_until_while_d5_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -20450,7 +20450,7 @@ columns:
     name: for_loops_d1_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -20465,7 +20465,7 @@ columns:
     name: for_loops_d2_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -20480,7 +20480,7 @@ columns:
     name: for_loops_d3_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -20495,7 +20495,7 @@ columns:
     name: for_loops_d4_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -20510,7 +20510,7 @@ columns:
     name: for_loops_d5_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -20525,7 +20525,7 @@ columns:
     name: events_d1_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -20540,7 +20540,7 @@ columns:
     name: events_d2_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -20555,7 +20555,7 @@ columns:
     name: events_d3_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -20570,7 +20570,7 @@ columns:
     name: events_d4_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -20585,7 +20585,7 @@ columns:
     name: events_d5_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -20600,7 +20600,7 @@ columns:
     name: variables_d1_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -20615,7 +20615,7 @@ columns:
     name: variables_d2_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -20630,7 +20630,7 @@ columns:
     name: variables_d3_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -20645,7 +20645,7 @@ columns:
     name: variables_d4_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -20660,7 +20660,7 @@ columns:
     name: variables_d5_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -20675,7 +20675,7 @@ columns:
     name: functions_d1_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -20690,7 +20690,7 @@ columns:
     name: functions_d2_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -20705,7 +20705,7 @@ columns:
     name: functions_d3_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -20720,7 +20720,7 @@ columns:
     name: functions_d4_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -20735,7 +20735,7 @@ columns:
     name: functions_d5_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -20750,7 +20750,7 @@ columns:
     name: functions_with_params_d1_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -20765,7 +20765,7 @@ columns:
     name: functions_with_params_d2_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -20780,7 +20780,7 @@ columns:
     name: functions_with_params_d3_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -20795,7 +20795,7 @@ columns:
     name: functions_with_params_d4_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -20810,7 +20810,7 @@ columns:
     name: functions_with_params_d5_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -20825,7 +20825,7 @@ columns:
     name: conditionals_d1_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -20840,7 +20840,7 @@ columns:
     name: conditionals_d2_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -20855,7 +20855,7 @@ columns:
     name: conditionals_d3_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -20870,7 +20870,7 @@ columns:
     name: conditionals_d4_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -20885,7 +20885,7 @@ columns:
     name: conditionals_d5_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -20916,7 +20916,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -20931,7 +20931,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -20947,7 +20947,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -20962,7 +20962,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -21007,7 +21007,7 @@ columns:
     name: school_info_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -21068,7 +21068,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -21083,7 +21083,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -21098,7 +21098,7 @@ columns:
     name: script_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -21212,7 +21212,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1403 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: deleted_at
@@ -21234,7 +21234,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -21249,7 +21249,7 @@ columns:
     name: studio_person_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -21273,7 +21273,7 @@ columns:
     'null': false
     default: ''
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1407 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: parent_email
@@ -21288,7 +21288,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1408 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: encrypted_password
@@ -21303,7 +21303,7 @@ columns:
     'null': true
     default: ''
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1409 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: reset_password_token
@@ -21318,7 +21318,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1410 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: reset_password_sent_at
@@ -21354,7 +21354,7 @@ columns:
     name: sign_in_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -21408,7 +21408,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1416 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: last_sign_in_ip
@@ -21423,7 +21423,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1417 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -21468,7 +21468,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1420 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: provider
@@ -21483,7 +21483,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1421 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: uid
@@ -21498,7 +21498,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1422 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: admin
@@ -21528,7 +21528,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1424 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: name
@@ -21543,7 +21543,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1425 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: locale
@@ -21558,7 +21558,7 @@ columns:
     'null': false
     default: en-US
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1426 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: birthday
@@ -21588,7 +21588,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1428 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: school
@@ -21603,7 +21603,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1429 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: full_address
@@ -21618,13 +21618,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1430 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: school_info_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -21639,7 +21639,7 @@ columns:
     name: total_lines
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -21654,7 +21654,7 @@ columns:
     name: secret_picture_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -21693,7 +21693,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1435 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: deleted_at
@@ -21738,7 +21738,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1438 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: properties
@@ -21753,7 +21753,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1439 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: invitation_token
@@ -21768,7 +21768,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1440 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: invitation_created_at
@@ -21819,7 +21819,7 @@ columns:
     name: invitation_limit
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -21834,7 +21834,7 @@ columns:
     name: invited_by_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -21858,13 +21858,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1446 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: invitations_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -21879,7 +21879,7 @@ columns:
     name: terms_of_service_version
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -21918,13 +21918,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1450 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: primary_contact_info_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -21940,7 +21940,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -21955,7 +21955,7 @@ columns:
     name: studio_person_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -21979,7 +21979,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1454 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: parent_email
@@ -21994,7 +21994,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1455 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: encrypted_password
@@ -22009,7 +22009,7 @@ columns:
     'null': true
     default: ''
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1456 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: reset_password_token
@@ -22024,7 +22024,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1457 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: reset_password_sent_at
@@ -22060,7 +22060,7 @@ columns:
     name: sign_in_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -22114,7 +22114,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1463 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: last_sign_in_ip
@@ -22129,7 +22129,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1464 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -22174,7 +22174,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1467 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: provider
@@ -22189,7 +22189,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1468 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: UID
@@ -22204,7 +22204,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1469 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: ADMIN
@@ -22234,7 +22234,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1471 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: name
@@ -22249,7 +22249,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1472 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: locale
@@ -22264,7 +22264,7 @@ columns:
     'null': false
     default: en-US
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1473 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: birthday
@@ -22294,7 +22294,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1475 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: school
@@ -22309,7 +22309,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1476 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: full_address
@@ -22324,13 +22324,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1477 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: school_info_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -22345,7 +22345,7 @@ columns:
     name: total_lines
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -22360,7 +22360,7 @@ columns:
     name: secret_picture_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -22399,7 +22399,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1482 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: deleted_at
@@ -22444,7 +22444,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1485 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: properties
@@ -22459,7 +22459,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1486 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: invitation_token
@@ -22474,7 +22474,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1487 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: invitation_created_at
@@ -22525,7 +22525,7 @@ columns:
     name: invitation_limit
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -22540,7 +22540,7 @@ columns:
     name: invited_by_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -22564,13 +22564,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1493 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: invitations_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -22585,7 +22585,7 @@ columns:
     name: terms_of_service_version
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -22624,13 +22624,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1497 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: primary_contact_info_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -22646,7 +22646,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -22670,7 +22670,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1500 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: youtube_code
@@ -22685,7 +22685,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1501 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -22730,7 +22730,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1504 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: locale
@@ -22745,14 +22745,14 @@ columns:
     'null': false
     default: en-US
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   vocabularies:
   - &1505 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint
+        sql_type: bigint(20)
         type: :integer
         limit: 8
         precision: 
@@ -22776,7 +22776,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1507 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: word
@@ -22791,7 +22791,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1508 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: definition
@@ -22806,13 +22806,13 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
   - &1509 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: course_version_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int
+        sql_type: int(11)
         type: :integer
         limit: 4
         precision: 
@@ -22866,7 +22866,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb3_unicode_ci
+    collation: utf8_unicode_ci
     comment: 
 columns_hash:
   activities:
@@ -23387,9 +23387,9 @@ columns_hash:
     position: *460
     properties: *461
   lessons_opportunity_standards:
-    id: *462
-    lesson_id: *463
-    standard_id: *464
+    lesson_id: *462
+    standard_id: *463
+    id: *464
   lessons_programming_expressions:
     lesson_id: *465
     programming_expression_id: *466
@@ -25132,10 +25132,10 @@ indexes:
   backpacks:
   - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
     table: backpacks
-    name: index_backpacks_on_storage_app_id
+    name: index_backpacks_on_user_id
     unique: true
     columns:
-    - storage_app_id
+    - user_id
     lengths: {}
     orders: {}
     opclasses: {}
@@ -25145,10 +25145,10 @@ indexes:
     comment: 
   - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
     table: backpacks
-    name: index_backpacks_on_user_id
+    name: index_backpacks_on_storage_app_id
     unique: true
     columns:
-    - user_id
+    - storage_app_id
     lengths: {}
     orders: {}
     opclasses: {}
@@ -26346,10 +26346,10 @@ indexes:
     comment: 
   - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
     table: levels
-    name: index_levels_on_level_num
+    name: index_levels_on_name
     unique: false
     columns:
-    - level_num
+    - name
     lengths: {}
     orders: {}
     opclasses: {}
@@ -26359,10 +26359,10 @@ indexes:
     comment: 
   - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
     table: levels
-    name: index_levels_on_name
+    name: index_levels_on_level_num
     unique: false
     columns:
-    - name
+    - level_num
     lengths: {}
     orders: {}
     opclasses: {}
@@ -27915,11 +27915,11 @@ indexes:
   programming_classes:
   - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
     table: programming_classes
-    name: index_programming_classes_on_key_and_category_id
+    name: index_programming_classes_on_key_and_programming_environment_id
     unique: true
     columns:
     - key
-    - programming_environment_category_id
+    - programming_environment_id
     lengths: {}
     orders: {}
     opclasses: {}
@@ -27929,11 +27929,11 @@ indexes:
     comment: 
   - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
     table: programming_classes
-    name: index_programming_classes_on_key_and_programming_environment_id
+    name: index_programming_classes_on_key_and_category_id
     unique: true
     columns:
     - key
-    - programming_environment_id
+    - programming_environment_category_id
     lengths: {}
     orders: {}
     opclasses: {}
@@ -28000,10 +28000,10 @@ indexes:
     comment: 
   - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
     table: programming_expressions
-    name: index_programming_expressions_on_environment_category_id
+    name: index_programming_expressions_on_programming_environment_id
     unique: false
     columns:
-    - programming_environment_category_id
+    - programming_environment_id
     lengths: {}
     orders: {}
     opclasses: {}
@@ -28013,10 +28013,10 @@ indexes:
     comment: 
   - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
     table: programming_expressions
-    name: index_programming_expressions_on_programming_environment_id
+    name: index_programming_expressions_on_environment_category_id
     unique: false
     columns:
-    - programming_environment_id
+    - programming_environment_category_id
     lengths: {}
     orders: {}
     opclasses: {}
@@ -28098,11 +28098,11 @@ indexes:
   projects:
   - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
     table: projects
-    name: storage_apps_project_type_index
+    name: storage_apps_storage_id_index
     unique: false
     columns:
-    - project_type
-    lengths: 191
+    - storage_id
+    lengths: {}
     orders: {}
     opclasses: {}
     where: 
@@ -28137,12 +28137,11 @@ indexes:
     comment: 
   - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
     table: projects
-    name: storage_apps_storage_id_state_index
+    name: storage_apps_project_type_index
     unique: false
     columns:
-    - storage_id
-    - state
-    lengths: {}
+    - project_type
+    lengths: 191
     orders: {}
     opclasses: {}
     where: 
@@ -28151,10 +28150,11 @@ indexes:
     comment: 
   - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
     table: projects
-    name: storage_apps_storage_id_index
+    name: storage_apps_storage_id_state_index
     unique: false
     columns:
     - storage_id
+    - state
     lengths: {}
     orders: {}
     opclasses: {}
@@ -28418,19 +28418,6 @@ indexes:
     comment: 
   - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
     table: schools
-    name: index_schools_on_last_known_school_year_open
-    unique: false
-    columns:
-    - last_known_school_year_open
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where: 
-    type: 
-    using: :btree
-    comment: 
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: schools
     name: index_schools_on_school_district_id
     unique: false
     columns:
@@ -28448,6 +28435,19 @@ indexes:
     unique: false
     columns:
     - zip
+    lengths: {}
+    orders: {}
+    opclasses: {}
+    where: 
+    type: 
+    using: :btree
+    comment: 
+  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+    table: schools
+    name: index_schools_on_last_known_school_year_open
+    unique: false
+    columns:
+    - last_known_school_year_open
     lengths: {}
     orders: {}
     opclasses: {}
@@ -28564,6 +28564,32 @@ indexes:
     comment: 
   - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
     table: scripts
+    name: index_scripts_on_wrapup_video_id
+    unique: false
+    columns:
+    - wrapup_video_id
+    lengths: {}
+    orders: {}
+    opclasses: {}
+    where: 
+    type: 
+    using: :btree
+    comment: 
+  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+    table: scripts
+    name: index_scripts_on_published_state
+    unique: false
+    columns:
+    - published_state
+    lengths: {}
+    orders: {}
+    opclasses: {}
+    where: 
+    type: 
+    using: :btree
+    comment: 
+  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+    table: scripts
     name: index_scripts_on_instruction_type
     unique: false
     columns:
@@ -28594,32 +28620,6 @@ indexes:
     unique: false
     columns:
     - participant_audience
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where: 
-    type: 
-    using: :btree
-    comment: 
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: scripts
-    name: index_scripts_on_published_state
-    unique: false
-    columns:
-    - published_state
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where: 
-    type: 
-    using: :btree
-    comment: 
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: scripts
-    name: index_scripts_on_wrapup_video_id
-    unique: false
-    columns:
-    - wrapup_video_id
     lengths: {}
     orders: {}
     opclasses: {}
@@ -29091,6 +29091,32 @@ indexes:
   unit_groups:
   - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
     table: unit_groups
+    name: index_unit_groups_on_name
+    unique: false
+    columns:
+    - name
+    lengths: {}
+    orders: {}
+    opclasses: {}
+    where: 
+    type: 
+    using: :btree
+    comment: 
+  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+    table: unit_groups
+    name: index_unit_groups_on_published_state
+    unique: false
+    columns:
+    - published_state
+    lengths: {}
+    orders: {}
+    opclasses: {}
+    where: 
+    type: 
+    using: :btree
+    comment: 
+  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+    table: unit_groups
     name: index_unit_groups_on_instruction_type
     unique: false
     columns:
@@ -29117,36 +29143,10 @@ indexes:
     comment: 
   - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
     table: unit_groups
-    name: index_unit_groups_on_name
-    unique: false
-    columns:
-    - name
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where: 
-    type: 
-    using: :btree
-    comment: 
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: unit_groups
     name: index_unit_groups_on_participant_audience
     unique: false
     columns:
     - participant_audience
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where: 
-    type: 
-    using: :btree
-    comment: 
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: unit_groups
-    name: index_unit_groups_on_published_state
-    unique: false
-    columns:
-    - published_state
     lengths: {}
     orders: {}
     opclasses: {}
@@ -29259,10 +29259,10 @@ indexes:
   user_ml_models:
   - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
     table: user_ml_models
-    name: index_user_ml_models_on_model_id
+    name: index_user_ml_models_on_user_id
     unique: false
     columns:
-    - model_id
+    - user_id
     lengths: {}
     orders: {}
     opclasses: {}
@@ -29272,10 +29272,10 @@ indexes:
     comment: 
   - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
     table: user_ml_models
-    name: index_user_ml_models_on_user_id
+    name: index_user_ml_models_on_model_id
     unique: false
     columns:
-    - user_id
+    - model_id
     lengths: {}
     orders: {}
     opclasses: {}
@@ -29659,7 +29659,7 @@ indexes:
 version: 20230323175726
 database_version: !ruby/object:ActiveRecord::ConnectionAdapters::AbstractAdapter::Version
   version:
-  - 8
-  - 0
-  - 32
-  full_version_string: 8.0.32-0ubuntu0.20.04.2
+  - 5
+  - 7
+  - 12
+  full_version_string: 5.7.12-log

--- a/dashboard/db/schema_cache.yml
+++ b/dashboard/db/schema_cache.yml
@@ -5,7 +5,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -20,7 +20,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -35,7 +35,7 @@ columns:
     name: level_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -59,7 +59,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &5 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: url
@@ -74,7 +74,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &6 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -110,7 +110,7 @@ columns:
     name: attempt
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -125,7 +125,7 @@ columns:
     name: time
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -140,7 +140,7 @@ columns:
     name: test_result
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -155,7 +155,7 @@ columns:
     name: level_source_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -170,7 +170,7 @@ columns:
     name: lines
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -186,7 +186,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -201,7 +201,7 @@ columns:
     name: lesson_activity_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -225,13 +225,13 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &16 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: position
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -255,7 +255,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &18 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -292,7 +292,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -316,7 +316,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &22 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: course
@@ -331,13 +331,13 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &23 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: school_year
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: smallint(6)
+        sql_type: smallint
         type: :integer
         limit: 2
         precision: 
@@ -383,7 +383,7 @@ columns:
     name: school_year
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -407,7 +407,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &28 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: school_id
@@ -422,7 +422,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &29 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -468,7 +468,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb4_unicode_ci
     comment: 
   - &32 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: value
@@ -489,10 +489,10 @@ columns:
     name: created_at
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: datetime
+        sql_type: datetime(6)
         type: :datetime
         limit: 
-        precision: 0
+        precision: 6
         scale: 
       extra: ''
     'null': false
@@ -504,10 +504,10 @@ columns:
     name: updated_at
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: datetime
+        sql_type: datetime(6)
         type: :datetime
         limit: 
-        precision: 0
+        precision: 6
         scale: 
       extra: ''
     'null': false
@@ -520,7 +520,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -535,7 +535,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -550,7 +550,7 @@ columns:
     name: level_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -565,7 +565,7 @@ columns:
     name: script_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -580,7 +580,7 @@ columns:
     name: level_source_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint(20) unsigned
+        sql_type: bigint unsigned
         type: :integer
         limit: 8
         precision: 
@@ -595,7 +595,7 @@ columns:
     name: attempt
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -610,7 +610,7 @@ columns:
     name: test_result
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -656,7 +656,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -680,7 +680,7 @@ columns:
     'null': false
     default: ''
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &46 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: hashed_email
@@ -695,7 +695,7 @@ columns:
     'null': false
     default: ''
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &47 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: credential_type
@@ -710,7 +710,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &48 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: authentication_id
@@ -725,7 +725,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &49 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: data
@@ -740,7 +740,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &50 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: deleted_at
@@ -761,7 +761,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -807,7 +807,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -822,7 +822,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -837,7 +837,7 @@ columns:
     name: script_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -852,7 +852,7 @@ columns:
     name: level_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -876,7 +876,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &59 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: hint_class
@@ -891,7 +891,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &60 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: hint_type
@@ -906,13 +906,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &61 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: prev_time
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -927,7 +927,7 @@ columns:
     name: prev_attempt
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -942,7 +942,7 @@ columns:
     name: prev_test_result
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -957,7 +957,7 @@ columns:
     name: prev_level_source_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint(20) unsigned
+        sql_type: bigint unsigned
         type: :integer
         limit: 8
         precision: 
@@ -972,7 +972,7 @@ columns:
     name: next_time
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -987,7 +987,7 @@ columns:
     name: next_attempt
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -1002,7 +1002,7 @@ columns:
     name: next_test_result
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -1017,7 +1017,7 @@ columns:
     name: next_level_source_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint(20) unsigned
+        sql_type: bigint unsigned
         type: :integer
         limit: 8
         precision: 
@@ -1032,7 +1032,7 @@ columns:
     name: final_time
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -1047,7 +1047,7 @@ columns:
     name: final_attempt
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -1062,7 +1062,7 @@ columns:
     name: final_test_result
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -1077,7 +1077,7 @@ columns:
     name: final_level_source_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint(20) unsigned
+        sql_type: bigint unsigned
         type: :integer
         limit: 8
         precision: 
@@ -1123,7 +1123,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint(20)
+        sql_type: bigint
         type: :integer
         limit: 8
         precision: 
@@ -1138,7 +1138,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -1153,7 +1153,7 @@ columns:
     name: storage_app_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -1199,7 +1199,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -1223,7 +1223,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &82 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: pool
@@ -1238,7 +1238,7 @@ columns:
     'null': false
     default: ''
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &83 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: category
@@ -1253,7 +1253,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &84 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: config
@@ -1268,7 +1268,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &85 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: helper_code
@@ -1283,7 +1283,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &86 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -1335,7 +1335,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -1359,7 +1359,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &91 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: localization_key
@@ -1374,7 +1374,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &92 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -1410,7 +1410,7 @@ columns:
     name: script_level_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -1434,7 +1434,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &96 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: 'on'
@@ -1449,7 +1449,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &97 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: callout_text
@@ -1464,14 +1464,14 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   census_state_course_codes:
   - &98 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -1495,7 +1495,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &100 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: course
@@ -1510,7 +1510,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &101 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -1547,7 +1547,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -1562,7 +1562,7 @@ columns:
     name: census_submission_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -1577,7 +1577,7 @@ columns:
     name: form_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -1623,7 +1623,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -1647,7 +1647,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &110 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: submitter_email_address
@@ -1662,7 +1662,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &111 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: submitter_name
@@ -1677,7 +1677,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &112 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: submitter_role
@@ -1692,13 +1692,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &113 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: school_year
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -1722,7 +1722,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &115 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: how_many_after_school
@@ -1737,7 +1737,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &116 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: how_many_10_hours
@@ -1752,7 +1752,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &117 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: how_many_20_hours
@@ -1767,7 +1767,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &118 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: other_classes_under_20_hours
@@ -1932,7 +1932,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &129 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: topic_do_not_know
@@ -1962,7 +1962,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &131 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: tell_us_more
@@ -1977,7 +1977,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &132 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: pledged
@@ -2082,14 +2082,14 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   census_submissions_school_infos:
   - &139 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: census_submission_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -2104,7 +2104,7 @@ columns:
     name: school_info_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -2150,7 +2150,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -2174,13 +2174,13 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &145 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: school_year
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: smallint(6)
+        sql_type: smallint
         type: :integer
         limit: 2
         precision: 
@@ -2204,7 +2204,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &147 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: audit_data
@@ -2219,7 +2219,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &148 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -2256,7 +2256,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -2271,7 +2271,7 @@ columns:
     name: storage_app_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -2286,7 +2286,7 @@ columns:
     name: level_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -2331,7 +2331,7 @@ columns:
     name: storage_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -2346,7 +2346,7 @@ columns:
     name: script_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -2377,7 +2377,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -2392,7 +2392,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -2407,7 +2407,7 @@ columns:
     name: unit_6_intention
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -2461,7 +2461,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &164 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: signed_at
@@ -2482,7 +2482,7 @@ columns:
     name: circuit_playground_discount_code_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -2536,14 +2536,14 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   circuit_playground_discount_codes:
   - &169 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -2567,7 +2567,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &171 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: full_discount
@@ -2664,7 +2664,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint(20)
+        sql_type: bigint
         type: :integer
         limit: 8
         precision: 
@@ -2679,7 +2679,7 @@ columns:
     name: code_review_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -2694,7 +2694,7 @@ columns:
     name: commenter_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -2785,7 +2785,7 @@ columns:
     name: code_review_group_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint(20)
+        sql_type: bigint
         type: :integer
         limit: 8
         precision: 
@@ -2800,7 +2800,7 @@ columns:
     name: follower_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint(20)
+        sql_type: bigint
         type: :integer
         limit: 8
         precision: 
@@ -2846,7 +2846,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint(20)
+        sql_type: bigint
         type: :integer
         limit: 8
         precision: 
@@ -2861,7 +2861,7 @@ columns:
     name: section_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint(20)
+        sql_type: bigint
         type: :integer
         limit: 8
         precision: 
@@ -2885,7 +2885,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &192 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -2922,7 +2922,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint(20)
+        sql_type: bigint
         type: :integer
         limit: 8
         precision: 
@@ -2937,7 +2937,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -2952,7 +2952,7 @@ columns:
     name: script_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -2967,7 +2967,7 @@ columns:
     name: level_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -2982,7 +2982,7 @@ columns:
     name: project_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -3006,7 +3006,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &200 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: closed_at
@@ -3073,7 +3073,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint(20)
+        sql_type: bigint
         type: :integer
         limit: 8
         precision: 
@@ -3088,7 +3088,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -3103,7 +3103,7 @@ columns:
     name: project_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -3118,7 +3118,7 @@ columns:
     name: script_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -3133,7 +3133,7 @@ columns:
     name: level_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -3148,7 +3148,7 @@ columns:
     name: project_level_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -3172,13 +3172,13 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &211 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: storage_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -3284,7 +3284,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -3308,7 +3308,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &220 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -3353,14 +3353,14 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   concepts_levels:
   - &223 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -3375,7 +3375,7 @@ columns:
     name: concept_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -3390,7 +3390,7 @@ columns:
     name: level_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -3406,7 +3406,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -3430,7 +3430,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &228 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: data
@@ -3482,7 +3482,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -3506,13 +3506,13 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &233 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: pardot_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -3596,7 +3596,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &239 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: marked_for_deletion_at
@@ -3648,7 +3648,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -3672,7 +3672,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &244 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: data
@@ -3724,7 +3724,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -3748,7 +3748,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &249 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: sources
@@ -3763,7 +3763,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &250 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: data
@@ -3830,7 +3830,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -3875,7 +3875,7 @@ columns:
     name: level_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -3890,7 +3890,7 @@ columns:
     name: answer_number
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -3914,7 +3914,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &260 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: correct
@@ -3936,7 +3936,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -3981,7 +3981,7 @@ columns:
     name: level_group_level_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -3996,7 +3996,7 @@ columns:
     name: contained_level_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -4020,13 +4020,13 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &267 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: contained_level_page
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -4041,7 +4041,7 @@ columns:
     name: contained_level_position
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -4065,14 +4065,14 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   course_offerings:
   - &270 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -4096,7 +4096,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &272 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: display_name
@@ -4111,7 +4111,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &273 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -4156,7 +4156,7 @@ columns:
     'null': false
     default: other
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &276 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: is_featured
@@ -4201,7 +4201,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &279 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: marketing_initiative
@@ -4216,7 +4216,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &280 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: grade_levels
@@ -4231,7 +4231,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &281 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: header
@@ -4246,7 +4246,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &282 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: image
@@ -4261,7 +4261,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &283 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: cs_topic
@@ -4276,7 +4276,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &284 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: school_subject
@@ -4291,7 +4291,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &285 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: device_compatibility
@@ -4306,14 +4306,14 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   course_scripts:
   - &286 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -4328,7 +4328,7 @@ columns:
     name: course_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -4343,7 +4343,7 @@ columns:
     name: script_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -4358,7 +4358,7 @@ columns:
     name: position
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -4382,14 +4382,14 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: If present, the SingleTeacherExperiment with this name must be enabled
       in order for a teacher or their students to see this script.
   - &291 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: default_script_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -4407,7 +4407,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -4431,7 +4431,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &294 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: display_name
@@ -4446,7 +4446,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &295 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: properties
@@ -4461,7 +4461,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &296 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: content_root_type
@@ -4476,13 +4476,13 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &297 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: content_root_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -4527,7 +4527,7 @@ columns:
     name: course_offering_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -4551,14 +4551,14 @@ columns:
     'null': true
     default: in_development
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   courses:
   - &302 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -4582,7 +4582,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &304 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: properties
@@ -4597,7 +4597,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &305 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -4634,7 +4634,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint(20)
+        sql_type: bigint
         type: :integer
         limit: 8
         precision: 
@@ -4658,7 +4658,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &309 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: name
@@ -4673,7 +4673,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &310 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: content
@@ -4688,7 +4688,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &311 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -4725,7 +4725,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -4749,7 +4749,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &315 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: nces_id
@@ -4764,7 +4764,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &316 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -4801,7 +4801,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -4825,7 +4825,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &320 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: url
@@ -4840,7 +4840,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &321 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: show
@@ -4855,7 +4855,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &322 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: twitter
@@ -4870,7 +4870,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &323 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: level
@@ -4885,7 +4885,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &324 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: weight
@@ -4952,7 +4952,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -4976,7 +4976,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &330 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: opt_in
@@ -5006,7 +5006,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &332 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: source
@@ -5021,7 +5021,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &333 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: form_kind
@@ -5036,7 +5036,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &334 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -5073,7 +5073,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -5127,7 +5127,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &340 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: type
@@ -5142,7 +5142,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &341 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: start_at
@@ -5178,7 +5178,7 @@ columns:
     name: section_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -5193,7 +5193,7 @@ columns:
     name: min_user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -5208,7 +5208,7 @@ columns:
     name: max_user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -5223,7 +5223,7 @@ columns:
     name: overflow_max_user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -5268,7 +5268,7 @@ columns:
     name: script_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -5284,7 +5284,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -5299,7 +5299,7 @@ columns:
     name: storage_app_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -5353,14 +5353,14 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   followers:
   - &355 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -5375,7 +5375,7 @@ columns:
     name: student_user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -5420,7 +5420,7 @@ columns:
     name: section_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -5451,7 +5451,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -5475,13 +5475,13 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &363 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: version
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -5505,7 +5505,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &365 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -5557,7 +5557,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint(20)
+        sql_type: bigint
         type: :integer
         limit: 8
         precision: 
@@ -5581,13 +5581,13 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &370 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: version
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -5648,7 +5648,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -5672,13 +5672,13 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &376 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: library_version
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -5702,7 +5702,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &378 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: question
@@ -5717,7 +5717,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &379 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -5769,7 +5769,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint(20)
+        sql_type: bigint
         type: :integer
         limit: 8
         precision: 
@@ -5793,7 +5793,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &384 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: kind
@@ -5808,7 +5808,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &385 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: form_name
@@ -5823,13 +5823,13 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &386 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: form_version
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -5853,7 +5853,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &388 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -5890,7 +5890,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -5905,7 +5905,7 @@ columns:
     name: foorm_submission_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -5920,7 +5920,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -5935,7 +5935,7 @@ columns:
     name: simple_survey_form_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint(20)
+        sql_type: bigint
         type: :integer
         limit: 8
         precision: 
@@ -5959,7 +5959,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &395 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -5996,7 +5996,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -6026,7 +6026,7 @@ columns:
     name: form_version
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -6087,7 +6087,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint(20)
+        sql_type: bigint
         type: :integer
         limit: 8
         precision: 
@@ -6111,7 +6111,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &405 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: name
@@ -6126,7 +6126,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &406 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: properties
@@ -6141,7 +6141,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &407 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -6178,7 +6178,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -6202,7 +6202,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &411 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -6247,13 +6247,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &414 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: intro_video_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -6269,7 +6269,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -6293,7 +6293,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_general_ci
+    collation: utf8mb3_general_ci
     comment: 
   - &417 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: url_s
@@ -6308,7 +6308,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_general_ci
+    collation: utf8mb3_general_ci
     comment: 
   - &418 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: show_s
@@ -6323,7 +6323,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_general_ci
+    collation: utf8mb3_general_ci
     comment: 
   - &419 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: twitter_s
@@ -6338,7 +6338,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_general_ci
+    collation: utf8mb3_general_ci
     comment: 
   - &420 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: level_s
@@ -6353,7 +6353,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_general_ci
+    collation: utf8mb3_general_ci
     comment: 
   - &421 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: weight_f
@@ -6390,7 +6390,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -6414,7 +6414,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_general_ci
+    collation: utf8mb3_general_ci
     comment: 
   - &425 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: unique_language_s
@@ -6429,7 +6429,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_general_ci
+    collation: utf8mb3_general_ci
     comment: 
   - &426 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: language_s
@@ -6444,7 +6444,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_general_ci
+    collation: utf8mb3_general_ci
     comment: 
   - &427 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: locale_s
@@ -6459,7 +6459,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_general_ci
+    collation: utf8mb3_general_ci
     comment: 
   - &428 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: native_name_s
@@ -6474,7 +6474,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_general_ci
+    collation: utf8mb3_general_ci
     comment: 
   - &429 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: english_name_s
@@ -6489,7 +6489,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_general_ci
+    collation: utf8mb3_general_ci
     comment: 
   - &430 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: supported_codeorg_b
@@ -6534,7 +6534,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_general_ci
+    collation: utf8mb3_general_ci
     comment: 
   - &433 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: crowdin_name_s
@@ -6549,7 +6549,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_general_ci
+    collation: utf8mb3_general_ci
     comment: 
   - &434 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: csf_b
@@ -6631,7 +6631,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -6646,7 +6646,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -6661,7 +6661,7 @@ columns:
     name: script_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -6676,7 +6676,7 @@ columns:
     name: level_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -6691,7 +6691,7 @@ columns:
     name: feedback_type
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -6715,7 +6715,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &445 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -6752,7 +6752,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -6767,7 +6767,7 @@ columns:
     name: lesson_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -6791,13 +6791,13 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &450 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: position
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -6821,7 +6821,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &452 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -6858,7 +6858,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -6882,13 +6882,13 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &456 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: script_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -6948,7 +6948,7 @@ columns:
     name: position
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -6972,29 +6972,29 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   lessons_opportunity_standards:
   - &462 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: lesson_id
+    name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint(20)
+        sql_type: bigint
         type: :integer
         limit: 8
         precision: 
         scale: 
-      extra: ''
+      extra: auto_increment
     'null': false
     default: 
     default_function: 
     collation: 
     comment: 
   - &463 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: standard_id
+    name: lesson_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint(20)
+        sql_type: bigint
         type: :integer
         limit: 8
         precision: 
@@ -7006,15 +7006,15 @@ columns:
     collation: 
     comment: 
   - &464 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
-    name: id
+    name: standard_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint(20)
+        sql_type: bigint
         type: :integer
         limit: 8
         precision: 
         scale: 
-      extra: auto_increment
+      extra: ''
     'null': false
     default: 
     default_function: 
@@ -7025,7 +7025,7 @@ columns:
     name: lesson_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint(20)
+        sql_type: bigint
         type: :integer
         limit: 8
         precision: 
@@ -7040,7 +7040,7 @@ columns:
     name: programming_expression_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint(20)
+        sql_type: bigint
         type: :integer
         limit: 8
         precision: 
@@ -7056,7 +7056,7 @@ columns:
     name: lesson_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -7071,7 +7071,7 @@ columns:
     name: resource_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -7087,7 +7087,7 @@ columns:
     name: lesson_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint(20)
+        sql_type: bigint
         type: :integer
         limit: 8
         precision: 
@@ -7102,7 +7102,7 @@ columns:
     name: vocabulary_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint(20)
+        sql_type: bigint
         type: :integer
         limit: 8
         precision: 
@@ -7118,7 +7118,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -7133,7 +7133,7 @@ columns:
     name: level_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -7178,7 +7178,7 @@ columns:
     name: sequencing
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -7193,7 +7193,7 @@ columns:
     name: debugging
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -7208,7 +7208,7 @@ columns:
     name: repeat_loops
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -7223,7 +7223,7 @@ columns:
     name: repeat_until_while
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -7238,7 +7238,7 @@ columns:
     name: for_loops
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -7253,7 +7253,7 @@ columns:
     name: events
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -7268,7 +7268,7 @@ columns:
     name: variables
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -7283,7 +7283,7 @@ columns:
     name: functions
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -7298,7 +7298,7 @@ columns:
     name: functions_with_params
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -7313,7 +7313,7 @@ columns:
     name: conditionals
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -7329,7 +7329,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -7344,7 +7344,7 @@ columns:
     name: level_source_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint(20) unsigned
+        sql_type: bigint unsigned
         type: :integer
         limit: 8
         precision: 
@@ -7405,7 +7405,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint(11) unsigned
+        sql_type: bigint unsigned
         type: :integer
         limit: 8
         precision: 
@@ -7420,7 +7420,7 @@ columns:
     name: level_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -7444,7 +7444,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &493 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: data
@@ -7459,7 +7459,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &494 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -7511,7 +7511,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -7526,7 +7526,7 @@ columns:
     name: level_source_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint(20) unsigned
+        sql_type: bigint unsigned
         type: :integer
         limit: 8
         precision: 
@@ -7541,7 +7541,7 @@ columns:
     name: level_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -7565,7 +7565,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &501 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: md5
@@ -7580,7 +7580,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &502 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: hidden
@@ -7602,7 +7602,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -7617,7 +7617,7 @@ columns:
     name: game_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -7641,7 +7641,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &506 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -7686,13 +7686,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &509 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: ideal_level_source_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint(20) unsigned
+        sql_type: bigint unsigned
         type: :integer
         limit: 8
         precision: 
@@ -7707,7 +7707,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -7746,7 +7746,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &513 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: md5
@@ -7761,7 +7761,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &514 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: published
@@ -7791,7 +7791,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &516 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: audit_log
@@ -7806,14 +7806,14 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   levels_script_levels:
   - &517 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: level_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -7828,7 +7828,7 @@ columns:
     name: script_level_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -7844,7 +7844,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -7868,7 +7868,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &521 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: content
@@ -7883,7 +7883,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &522 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -7920,7 +7920,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -7989,7 +7989,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &529 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: metric_on
@@ -8019,7 +8019,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &531 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: breakdown
@@ -8034,7 +8034,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &532 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: metric
@@ -8049,7 +8049,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &533 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: submetric
@@ -8064,7 +8064,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &534 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: value
@@ -8086,7 +8086,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -8110,13 +8110,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &537 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: lesson_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -8170,14 +8170,14 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   paired_user_levels:
   - &541 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -8192,7 +8192,7 @@ columns:
     name: driver_user_level_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint(20) unsigned
+        sql_type: bigint unsigned
         type: :integer
         limit: 8
         precision: 
@@ -8207,7 +8207,7 @@ columns:
     name: navigator_user_level_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint(20) unsigned
+        sql_type: bigint unsigned
         type: :integer
         limit: 8
         precision: 
@@ -8253,7 +8253,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -8268,7 +8268,7 @@ columns:
     name: parent_level_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -8283,7 +8283,7 @@ columns:
     name: child_level_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -8298,7 +8298,7 @@ columns:
     name: position
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -8322,14 +8322,14 @@ columns:
     'null': false
     default: sublevel
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   pd_accepted_programs:
   - &551 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -8383,7 +8383,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &555 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: course
@@ -8398,13 +8398,13 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &556 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -8419,7 +8419,7 @@ columns:
     name: teacher_application_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -8435,7 +8435,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -8450,7 +8450,7 @@ columns:
     name: pd_application_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -8474,7 +8474,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &561 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: email_type
@@ -8489,7 +8489,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &562 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: to
@@ -8504,7 +8504,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &563 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -8541,7 +8541,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -8565,7 +8565,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &567 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -8602,7 +8602,7 @@ columns:
     name: pd_application_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -8617,7 +8617,7 @@ columns:
     name: pd_application_tag_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -8663,7 +8663,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -8678,7 +8678,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -8702,7 +8702,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &576 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: application_year
@@ -8717,7 +8717,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &577 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: application_type
@@ -8732,13 +8732,13 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &578 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: regional_partner_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -8762,7 +8762,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &580 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: locked_at
@@ -8792,7 +8792,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &582 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: form_data
@@ -8807,7 +8807,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &583 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -8852,7 +8852,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &586 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: response_scores
@@ -8867,7 +8867,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: Scores given to certain responses
   - &587 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: application_guid
@@ -8882,7 +8882,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &588 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: accepted_at
@@ -8912,7 +8912,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &590 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: deleted_at
@@ -8942,7 +8942,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &592 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: applied_at
@@ -8964,7 +8964,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint(20)
+        sql_type: bigint
         type: :integer
         limit: 8
         precision: 
@@ -8979,7 +8979,7 @@ columns:
     name: pd_application_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint(20)
+        sql_type: bigint
         type: :integer
         limit: 8
         precision: 
@@ -9003,7 +9003,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &596 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: timestamp
@@ -9024,7 +9024,7 @@ columns:
     name: position
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -9040,7 +9040,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -9055,7 +9055,7 @@ columns:
     name: pd_session_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -9070,7 +9070,7 @@ columns:
     name: teacher_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -9130,7 +9130,7 @@ columns:
     name: pd_enrollment_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -9145,7 +9145,7 @@ columns:
     name: marked_by_user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -9162,7 +9162,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -9177,7 +9177,7 @@ columns:
     name: facilitator_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -9201,14 +9201,14 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   pd_district_payment_terms:
   - &609 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -9223,7 +9223,7 @@ columns:
     name: school_district_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -9247,7 +9247,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &612 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: rate_type
@@ -9262,7 +9262,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &613 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: rate
@@ -9284,7 +9284,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -9329,7 +9329,7 @@ columns:
     name: pd_enrollment_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -9353,14 +9353,14 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   pd_enrollments:
   - &619 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -9375,7 +9375,7 @@ columns:
     name: pd_workshop_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -9399,7 +9399,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &622 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: first_name
@@ -9414,7 +9414,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &623 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: last_name
@@ -9429,7 +9429,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &624 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: email
@@ -9444,7 +9444,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &625 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -9489,7 +9489,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &628 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: code
@@ -9504,13 +9504,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &629 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -9540,7 +9540,7 @@ columns:
     name: completed_survey_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -9555,7 +9555,7 @@ columns:
     name: school_info_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -9594,13 +9594,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &635 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: application_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -9616,7 +9616,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -9631,7 +9631,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -9655,7 +9655,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &639 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -9691,7 +9691,7 @@ columns:
     name: teachercon
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -9707,7 +9707,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -9722,7 +9722,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -9806,7 +9806,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &649 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: tc2_arrive
@@ -9881,7 +9881,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &654 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: tc3_arrive
@@ -9956,14 +9956,14 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   pd_fit_weekend1819_registrations:
   - &659 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -9978,7 +9978,7 @@ columns:
     name: pd_application_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -10002,7 +10002,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &662 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -10039,7 +10039,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -10054,7 +10054,7 @@ columns:
     name: pd_application_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -10078,7 +10078,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &667 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: form_data
@@ -10093,7 +10093,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &668 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -10130,7 +10130,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -10145,7 +10145,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -10169,7 +10169,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &673 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -10206,7 +10206,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -10221,7 +10221,7 @@ columns:
     name: facilitator_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -10245,7 +10245,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &678 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: subject
@@ -10260,7 +10260,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &679 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: data
@@ -10275,7 +10275,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &680 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -10312,7 +10312,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -10327,7 +10327,7 @@ columns:
     name: form_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint(20)
+        sql_type: bigint
         type: :integer
         limit: 8
         precision: 
@@ -10342,7 +10342,7 @@ columns:
     name: submission_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint(20)
+        sql_type: bigint
         type: :integer
         limit: 8
         precision: 
@@ -10366,13 +10366,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &686 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -10418,7 +10418,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -10433,7 +10433,7 @@ columns:
     name: regional_partner_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -10487,7 +10487,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &694 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: subject
@@ -10502,7 +10502,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &695 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: properties
@@ -10517,7 +10517,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &696 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -10554,7 +10554,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -10569,7 +10569,7 @@ columns:
     name: form_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint(20)
+        sql_type: bigint
         type: :integer
         limit: 8
         precision: 
@@ -10584,7 +10584,7 @@ columns:
     name: submission_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint(20)
+        sql_type: bigint
         type: :integer
         limit: 8
         precision: 
@@ -10608,7 +10608,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &702 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: year
@@ -10623,13 +10623,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &703 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -10653,7 +10653,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: csd or csp
   - &705 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -10690,7 +10690,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -10705,7 +10705,7 @@ columns:
     name: pd_enrollment_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -10729,7 +10729,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &710 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -10766,7 +10766,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -10781,7 +10781,7 @@ columns:
     name: regional_partner_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -10796,7 +10796,7 @@ columns:
     name: role
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -10820,7 +10820,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: free-form text year range, YYYY-YYYY, e.g. 2016-2017
   - &716 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: course
@@ -10835,7 +10835,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &717 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: name
@@ -10850,14 +10850,14 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: Human readable name of cohort (not required, used to support large partners
       with multiple cohorts)
   - &718 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: size
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -10872,7 +10872,7 @@ columns:
     name: summer_workshop_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -10918,7 +10918,7 @@ columns:
     name: pd_regional_partner_cohort_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -10933,7 +10933,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -10949,7 +10949,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -10964,7 +10964,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -10979,7 +10979,7 @@ columns:
     name: regional_partner_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -11003,7 +11003,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &728 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -11040,7 +11040,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -11055,7 +11055,7 @@ columns:
     name: regional_partner_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -11079,7 +11079,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &733 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: zip_code
@@ -11094,7 +11094,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &734 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -11146,7 +11146,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -11161,7 +11161,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -11176,7 +11176,7 @@ columns:
     name: regional_partner_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -11200,7 +11200,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &741 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -11237,7 +11237,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -11252,7 +11252,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -11276,13 +11276,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &746 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: teachercon
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -11328,7 +11328,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -11343,7 +11343,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -11367,7 +11367,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &752 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: scholarship_status
@@ -11382,13 +11382,13 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &753 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: pd_application_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -11403,7 +11403,7 @@ columns:
     name: pd_enrollment_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -11457,14 +11457,14 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   pd_sessions:
   - &758 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -11479,7 +11479,7 @@ columns:
     name: pd_workshop_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -11578,14 +11578,14 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   pd_survey_questions:
   - &766 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -11600,7 +11600,7 @@ columns:
     name: form_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint(20)
+        sql_type: bigint
         type: :integer
         limit: 8
         precision: 
@@ -11624,7 +11624,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: JSON Question data for this JotForm form.
   - &769 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -11660,7 +11660,7 @@ columns:
     name: last_submission_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint(20)
+        sql_type: bigint
         type: :integer
         limit: 8
         precision: 
@@ -11677,7 +11677,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -11722,7 +11722,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -11746,7 +11746,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &777 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: secondary_email
@@ -11761,7 +11761,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &778 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: application
@@ -11776,7 +11776,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &779 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: regional_partner_override
@@ -11791,13 +11791,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &780 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: program_registration_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -11814,7 +11814,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -11829,7 +11829,7 @@ columns:
     name: pd_application_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -11853,7 +11853,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &784 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -11889,7 +11889,7 @@ columns:
     name: regional_partner_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -11904,7 +11904,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -11920,7 +11920,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -11935,7 +11935,7 @@ columns:
     name: pd_enrollment_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -11959,7 +11959,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &791 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -11996,7 +11996,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -12011,7 +12011,7 @@ columns:
     name: form_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint(20)
+        sql_type: bigint
         type: :integer
         limit: 8
         precision: 
@@ -12026,7 +12026,7 @@ columns:
     name: submission_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint(20)
+        sql_type: bigint
         type: :integer
         limit: 8
         precision: 
@@ -12041,7 +12041,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -12056,7 +12056,7 @@ columns:
     name: pd_session_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -12071,7 +12071,7 @@ columns:
     name: pd_workshop_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -12095,13 +12095,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &800 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: day
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -12147,7 +12147,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -12162,7 +12162,7 @@ columns:
     name: form_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint(20)
+        sql_type: bigint
         type: :integer
         limit: 8
         precision: 
@@ -12177,7 +12177,7 @@ columns:
     name: submission_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint(20)
+        sql_type: bigint
         type: :integer
         limit: 8
         precision: 
@@ -12192,7 +12192,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -12207,7 +12207,7 @@ columns:
     name: pd_session_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -12222,7 +12222,7 @@ columns:
     name: pd_workshop_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -12237,7 +12237,7 @@ columns:
     name: facilitator_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -12261,13 +12261,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &811 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: day
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -12313,7 +12313,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -12328,7 +12328,7 @@ columns:
     name: foorm_submission_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -12343,7 +12343,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -12358,7 +12358,7 @@ columns:
     name: pd_session_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -12373,7 +12373,7 @@ columns:
     name: pd_workshop_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -12388,7 +12388,7 @@ columns:
     name: day
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -12433,7 +12433,7 @@ columns:
     name: facilitator_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -12457,14 +12457,14 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   pd_workshop_surveys:
   - &824 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -12479,7 +12479,7 @@ columns:
     name: pd_enrollment_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -12503,7 +12503,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &827 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -12548,14 +12548,14 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   pd_workshops:
   - &830 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -12570,7 +12570,7 @@ columns:
     name: organizer_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -12594,7 +12594,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &833 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: location_address
@@ -12609,7 +12609,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &834 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: processed_location
@@ -12624,7 +12624,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &835 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: course
@@ -12639,7 +12639,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &836 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: subject
@@ -12654,13 +12654,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &837 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: capacity
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -12684,13 +12684,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &839 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: section_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -12795,7 +12795,7 @@ columns:
     name: regional_partner_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -12849,7 +12849,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &850 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: properties
@@ -12864,14 +12864,14 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   pd_workshops_facilitators:
   - &851 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: pd_workshop_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -12886,7 +12886,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -12902,7 +12902,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -12917,7 +12917,7 @@ columns:
     name: submitter_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -12932,7 +12932,7 @@ columns:
     name: reviewer_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -12962,7 +12962,7 @@ columns:
     name: script_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -12977,7 +12977,7 @@ columns:
     name: level_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -12992,7 +12992,7 @@ columns:
     name: level_source_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint(20) unsigned
+        sql_type: bigint unsigned
         type: :integer
         limit: 8
         precision: 
@@ -13016,13 +13016,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &861 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: status
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -13076,7 +13076,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: Human-readable (never machine-parsed) audit trail of assignments and
       status changes with timestamps for the life of the peer review.
   pilots:
@@ -13084,7 +13084,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint(20)
+        sql_type: bigint
         type: :integer
         limit: 8
         precision: 
@@ -13108,7 +13108,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &867 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: display_name
@@ -13123,7 +13123,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &868 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: allow_joining_via_url
@@ -13175,7 +13175,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -13190,7 +13190,7 @@ columns:
     name: plc_course_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -13214,7 +13214,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &874 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: unit_description
@@ -13229,13 +13229,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &875 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: unit_order
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -13280,7 +13280,7 @@ columns:
     name: script_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -13311,7 +13311,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -13356,7 +13356,7 @@ columns:
     name: course_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -13372,7 +13372,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -13387,7 +13387,7 @@ columns:
     name: plc_enrollment_unit_assignment_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -13402,7 +13402,7 @@ columns:
     name: plc_learning_module_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -13447,7 +13447,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -13463,7 +13463,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -13478,7 +13478,7 @@ columns:
     name: plc_user_course_enrollment_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -13493,7 +13493,7 @@ columns:
     name: plc_course_unit_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -13517,7 +13517,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &894 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -13553,7 +13553,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -13569,7 +13569,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -13593,7 +13593,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &899 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -13629,7 +13629,7 @@ columns:
     name: plc_course_unit_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -13653,13 +13653,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &903 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: stage_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -13675,7 +13675,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -13699,13 +13699,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &906 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: plc_course_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -13720,7 +13720,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -13766,7 +13766,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint(20)
+        sql_type: bigint
         type: :integer
         limit: 8
         precision: 
@@ -13781,7 +13781,7 @@ columns:
     name: programming_environment_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -13796,7 +13796,7 @@ columns:
     name: programming_environment_category_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -13820,7 +13820,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &914 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: name
@@ -13835,7 +13835,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &915 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: content
@@ -13850,7 +13850,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &916 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: fields
@@ -13865,7 +13865,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &917 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: examples
@@ -13880,7 +13880,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &918 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: tips
@@ -13895,7 +13895,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &919 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: syntax
@@ -13910,7 +13910,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &920 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: external_documentation
@@ -13925,7 +13925,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &921 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -13962,7 +13962,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint(20)
+        sql_type: bigint
         type: :integer
         limit: 8
         precision: 
@@ -13977,7 +13977,7 @@ columns:
     name: programming_environment_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -14001,7 +14001,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &926 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: name
@@ -14016,7 +14016,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &927 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: color
@@ -14031,7 +14031,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &928 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -14067,7 +14067,7 @@ columns:
     name: position
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -14083,7 +14083,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint(20)
+        sql_type: bigint
         type: :integer
         limit: 8
         precision: 
@@ -14107,7 +14107,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &933 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: properties
@@ -14122,7 +14122,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &934 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -14174,7 +14174,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint(20)
+        sql_type: bigint
         type: :integer
         limit: 8
         precision: 
@@ -14198,7 +14198,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &939 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: category
@@ -14213,7 +14213,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &940 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: properties
@@ -14228,13 +14228,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &941 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: programming_environment_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint(20)
+        sql_type: bigint
         type: :integer
         limit: 8
         precision: 
@@ -14288,13 +14288,13 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &945 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: programming_environment_category_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -14310,7 +14310,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint(20)
+        sql_type: bigint
         type: :integer
         limit: 8
         precision: 
@@ -14325,7 +14325,7 @@ columns:
     name: programming_class_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -14349,13 +14349,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &949 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: position
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -14379,7 +14379,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &951 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: content
@@ -14394,7 +14394,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &952 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: parameters
@@ -14409,7 +14409,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &953 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: examples
@@ -14424,7 +14424,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &954 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: syntax
@@ -14439,7 +14439,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &955 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: external_link
@@ -14454,7 +14454,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &956 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -14499,7 +14499,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &959 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: return_value
@@ -14514,14 +14514,14 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   project_commits:
   - &960 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint(20)
+        sql_type: bigint
         type: :integer
         limit: 8
         precision: 
@@ -14536,7 +14536,7 @@ columns:
     name: storage_app_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -14612,7 +14612,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -14627,7 +14627,7 @@ columns:
     name: storage_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -14651,7 +14651,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb4_general_ci
+    collation: utf8mb4_0900_ai_ci
     comment: 
   - &969 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: updated_at
@@ -14681,7 +14681,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8mb4_general_ci
+    collation: utf8mb4_0900_ai_ci
     comment: 
   - &971 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: state
@@ -14696,7 +14696,7 @@ columns:
     'null': false
     default: active
     default_function: 
-    collation: utf8mb4_general_ci
+    collation: utf8mb4_0900_ai_ci
     comment: 
   - &972 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -14717,7 +14717,7 @@ columns:
     name: abuse_score
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -14741,7 +14741,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8mb4_general_ci
+    collation: utf8mb4_0900_ai_ci
     comment: 
   - &975 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: published_at
@@ -14777,7 +14777,7 @@ columns:
     name: remix_parent_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -14808,7 +14808,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -14823,7 +14823,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -14838,7 +14838,7 @@ columns:
     name: script_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -14853,7 +14853,7 @@ columns:
     name: level_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -14868,7 +14868,7 @@ columns:
     name: rating
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -14914,7 +14914,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -14929,7 +14929,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -14953,7 +14953,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &989 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -14990,7 +14990,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint(20)
+        sql_type: bigint
         type: :integer
         limit: 8
         precision: 
@@ -15014,13 +15014,13 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &993 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: course_version_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint(20)
+        sql_type: bigint
         type: :integer
         limit: 8
         precision: 
@@ -15044,7 +15044,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &995 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: display_name
@@ -15059,7 +15059,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &996 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: content
@@ -15074,13 +15074,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &997 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: position
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -15126,7 +15126,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -15141,7 +15141,7 @@ columns:
     name: program_manager_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -15156,7 +15156,7 @@ columns:
     name: regional_partner_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -15172,7 +15172,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -15196,13 +15196,13 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1005 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: group
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -15241,7 +15241,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1008 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: street
@@ -15256,7 +15256,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1009 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: apartment_or_suite
@@ -15271,7 +15271,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1010 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: city
@@ -15286,7 +15286,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1011 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: state
@@ -15301,7 +15301,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1012 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: zip_code
@@ -15316,7 +15316,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1013 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: phone_number
@@ -15331,7 +15331,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1014 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: notes
@@ -15346,7 +15346,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1015 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -15406,7 +15406,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1019 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: is_active
@@ -15428,7 +15428,7 @@ columns:
     name: regional_partner_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -15443,7 +15443,7 @@ columns:
     name: school_district_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -15467,7 +15467,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: Course for a given workshop
   - &1023 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: workshop_days
@@ -15482,14 +15482,14 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: Days that the workshop will take place
   resources:
   - &1024 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -15513,7 +15513,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1026 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: url
@@ -15528,7 +15528,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1027 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: key
@@ -15543,7 +15543,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1028 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: properties
@@ -15558,7 +15558,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1029 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -15594,7 +15594,7 @@ columns:
     name: course_version_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -15619,14 +15619,14 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb4_unicode_ci
     comment: 
   school_districts:
   - &1033 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -15650,7 +15650,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1035 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: city
@@ -15665,7 +15665,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1036 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: state
@@ -15680,7 +15680,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1037 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: zip
@@ -15695,7 +15695,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1038 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: last_known_school_year_open
@@ -15710,7 +15710,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1039 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -15747,7 +15747,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -15771,7 +15771,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1043 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: school_type
@@ -15786,13 +15786,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1044 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: zip
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -15816,13 +15816,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1046 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: school_district_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -15861,7 +15861,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1049 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: school_id
@@ -15876,7 +15876,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1050 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: school_other
@@ -15906,7 +15906,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: This column appears to be redundant with pd_enrollments.school and users.school,
       therefore validation rules must be used to ensure that any user or enrollment
       with a school_info has its school name stored in the correct place.
@@ -15923,7 +15923,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: This column appears to be redundant with users.full_address, therefore
       validation rules must be used to ensure that any user with a school_info has
       its school address stored in the correct place.
@@ -15970,7 +15970,7 @@ columns:
     'null': false
     default: full
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   school_stats_by_years:
   - &1056 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
@@ -15986,7 +15986,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: NCES public school ID
   - &1057 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: school_year
@@ -16001,7 +16001,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: School Year
   - &1058 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: grades_offered_lo
@@ -16016,7 +16016,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: Grades Offered - Lowest
   - &1059 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: grades_offered_hi
@@ -16031,7 +16031,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: Grades Offered - Highest
   - &1060 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: grade_pk_offered
@@ -16271,13 +16271,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: Virtual School Status
   - &1076 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: students_total
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -16292,7 +16292,7 @@ columns:
     name: student_am_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -16307,7 +16307,7 @@ columns:
     name: student_as_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -16322,7 +16322,7 @@ columns:
     name: student_hi_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -16337,7 +16337,7 @@ columns:
     name: student_bl_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -16352,7 +16352,7 @@ columns:
     name: student_wh_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -16367,7 +16367,7 @@ columns:
     name: student_hp_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -16382,7 +16382,7 @@ columns:
     name: student_tr_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -16406,13 +16406,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: TITLE I status (code)
   - &1085 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: frl_eligible_total
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -16466,7 +16466,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: Urban-centric community type
   schools:
   - &1089 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
@@ -16482,13 +16482,13 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: NCES public school ID
   - &1090 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: school_district_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -16512,7 +16512,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1092 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: city
@@ -16527,7 +16527,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1093 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: state
@@ -16542,7 +16542,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1094 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: zip
@@ -16557,7 +16557,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1095 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: school_type
@@ -16572,7 +16572,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1096 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -16617,7 +16617,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: Location address, street 1
   - &1099 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: address_line2
@@ -16632,7 +16632,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: Location address, street 2
   - &1100 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: address_line3
@@ -16647,7 +16647,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: Location address, street 3
   - &1101 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: latitude
@@ -16692,7 +16692,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1104 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: school_category
@@ -16707,7 +16707,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1105 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: last_known_school_year_open
@@ -16722,14 +16722,14 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   script_levels:
   - &1106 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -16744,7 +16744,7 @@ columns:
     name: script_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -16759,7 +16759,7 @@ columns:
     name: chapter
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -16804,7 +16804,7 @@ columns:
     name: stage_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -16819,7 +16819,7 @@ columns:
     name: position
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -16858,7 +16858,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1115 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: named_level
@@ -16894,7 +16894,7 @@ columns:
     name: activity_section_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -16918,13 +16918,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1119 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: activity_section_position
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -16940,7 +16940,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -16964,7 +16964,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1122 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -17000,7 +17000,7 @@ columns:
     name: wrapup_video_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -17015,7 +17015,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -17054,7 +17054,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1128 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: new_name
@@ -17069,7 +17069,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1129 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: family_name
@@ -17084,7 +17084,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1130 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: published_state
@@ -17099,7 +17099,7 @@ columns:
     'null': true
     default: in_development
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1131 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: instruction_type
@@ -17114,7 +17114,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1132 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: instructor_audience
@@ -17129,7 +17129,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1133 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: participant_audience
@@ -17144,14 +17144,14 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   scripts_resources:
   - &1134 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: script_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -17166,7 +17166,7 @@ columns:
     name: resource_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -17182,7 +17182,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint(20)
+        sql_type: bigint
         type: :integer
         limit: 8
         precision: 
@@ -17197,7 +17197,7 @@ columns:
     name: script_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -17212,7 +17212,7 @@ columns:
     name: resource_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -17228,7 +17228,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -17252,7 +17252,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1141 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: path
@@ -17267,7 +17267,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1142 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -17304,7 +17304,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -17328,7 +17328,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1146 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -17365,7 +17365,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -17380,7 +17380,7 @@ columns:
     name: section_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -17395,7 +17395,7 @@ columns:
     name: script_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -17411,7 +17411,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -17426,7 +17426,7 @@ columns:
     name: section_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -17441,7 +17441,7 @@ columns:
     name: stage_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -17457,7 +17457,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -17472,7 +17472,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -17496,7 +17496,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1157 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -17541,13 +17541,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1160 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: script_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -17562,7 +17562,7 @@ columns:
     name: course_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -17586,7 +17586,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1163 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: login_type
@@ -17601,7 +17601,7 @@ columns:
     'null': false
     default: email
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1164 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: deleted_at
@@ -17646,7 +17646,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1167 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: first_activity_at
@@ -17752,7 +17752,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1174 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: participant_type
@@ -17767,14 +17767,14 @@ columns:
     'null': false
     default: student
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   seed_info:
   - &1175 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint(20)
+        sql_type: bigint
         type: :integer
         limit: 8
         precision: 
@@ -17798,7 +17798,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1177 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: mtime
@@ -17820,7 +17820,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -17844,7 +17844,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1180 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: key
@@ -17859,7 +17859,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1181 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: etag
@@ -17874,7 +17874,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1182 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -17911,7 +17911,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -17935,7 +17935,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1186 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: level_type
@@ -17950,13 +17950,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1187 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: block_type
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -17980,7 +17980,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1189 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: description
@@ -17995,7 +17995,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1190 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: arguments
@@ -18010,7 +18010,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1191 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: stack
@@ -18025,14 +18025,14 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   sign_ins:
   - &1192 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -18047,7 +18047,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -18077,7 +18077,7 @@ columns:
     name: sign_in_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -18093,7 +18093,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -18117,13 +18117,13 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1198 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: absolute_position
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -18138,7 +18138,7 @@ columns:
     name: script_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -18198,7 +18198,7 @@ columns:
     name: relative_position
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -18222,13 +18222,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1205 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: lesson_group_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -18252,7 +18252,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1207 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: has_lesson_plan
@@ -18274,7 +18274,7 @@ columns:
     name: stage_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -18289,7 +18289,7 @@ columns:
     name: standard_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -18335,7 +18335,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint(20)
+        sql_type: bigint
         type: :integer
         limit: 8
         precision: 
@@ -18359,13 +18359,13 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1214 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: framework_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -18380,7 +18380,7 @@ columns:
     name: parent_category_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -18404,7 +18404,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1217 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: properties
@@ -18419,7 +18419,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1218 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -18456,7 +18456,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -18480,13 +18480,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1222 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: category_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint(20)
+        sql_type: bigint
         type: :integer
         limit: 8
         precision: 
@@ -18501,7 +18501,7 @@ columns:
     name: framework_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -18525,14 +18525,14 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   studio_people:
   - &1225 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -18586,14 +18586,14 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   survey_results:
   - &1229 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -18608,7 +18608,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -18632,7 +18632,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1232 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: properties
@@ -18647,7 +18647,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1233 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -18684,7 +18684,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -18708,13 +18708,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1237 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: student_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -18729,7 +18729,7 @@ columns:
     name: level_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -18744,7 +18744,7 @@ columns:
     name: teacher_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -18813,13 +18813,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1244 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: student_visit_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -18879,7 +18879,7 @@ columns:
     name: script_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -18894,7 +18894,7 @@ columns:
     name: analytics_section_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -18918,14 +18918,14 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   teacher_profiles:
   - &1251 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -18940,7 +18940,7 @@ columns:
     name: studio_person_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -18994,7 +18994,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1256 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: facilitator
@@ -19039,7 +19039,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1259 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: pd
@@ -19054,7 +19054,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1260 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: other_pd
@@ -19069,7 +19069,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1261 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: properties
@@ -19084,14 +19084,14 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   teacher_scores:
   - &1262 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -19106,7 +19106,7 @@ columns:
     name: user_level_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint(20) unsigned
+        sql_type: bigint unsigned
         type: :integer
         limit: 8
         precision: 
@@ -19121,7 +19121,7 @@ columns:
     name: teacher_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -19136,7 +19136,7 @@ columns:
     name: score
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -19182,7 +19182,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -19206,7 +19206,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1270 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: properties
@@ -19221,7 +19221,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1271 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -19266,7 +19266,7 @@ columns:
     'null': false
     default: in_development
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1274 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: instruction_type
@@ -19281,7 +19281,7 @@ columns:
     'null': false
     default: teacher_led
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1275 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: instructor_audience
@@ -19296,7 +19296,7 @@ columns:
     'null': false
     default: teacher
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1276 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: participant_audience
@@ -19311,14 +19311,14 @@ columns:
     'null': false
     default: student
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   unit_groups_resources:
   - &1277 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: unit_group_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -19333,7 +19333,7 @@ columns:
     name: resource_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -19349,7 +19349,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint(20)
+        sql_type: bigint
         type: :integer
         limit: 8
         precision: 
@@ -19364,7 +19364,7 @@ columns:
     name: unit_group_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -19379,7 +19379,7 @@ columns:
     name: resource_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -19395,7 +19395,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -19410,7 +19410,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -19479,7 +19479,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1288 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: city
@@ -19494,7 +19494,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1289 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: state
@@ -19509,7 +19509,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1290 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: country
@@ -19524,7 +19524,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1291 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: postal_code
@@ -19539,7 +19539,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1292 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: latitude
@@ -19576,7 +19576,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint(20) unsigned
+        sql_type: bigint unsigned
         type: :integer
         limit: 8
         precision: 
@@ -19591,7 +19591,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -19606,7 +19606,7 @@ columns:
     name: level_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -19621,7 +19621,7 @@ columns:
     name: attempts
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -19666,7 +19666,7 @@ columns:
     name: best_result
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -19681,7 +19681,7 @@ columns:
     name: script_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -19696,7 +19696,7 @@ columns:
     name: level_source_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint(20) unsigned
+        sql_type: bigint unsigned
         type: :integer
         limit: 8
         precision: 
@@ -19756,7 +19756,7 @@ columns:
     name: time_spent
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -19795,14 +19795,14 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   user_ml_models:
   - &1309 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint(20)
+        sql_type: bigint
         type: :integer
         limit: 8
         precision: 
@@ -19817,7 +19817,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -19841,7 +19841,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1312 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: name
@@ -19856,7 +19856,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1313 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: deleted_at
@@ -19931,14 +19931,14 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   user_module_task_assignments:
   - &1318 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -19953,7 +19953,7 @@ columns:
     name: user_enrollment_module_assignment_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -19968,7 +19968,7 @@ columns:
     name: professional_learning_task_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -19992,14 +19992,14 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   user_permissions:
   - &1322 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -20014,7 +20014,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -20038,7 +20038,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1325 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -20075,7 +20075,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -20090,7 +20090,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -20150,7 +20150,7 @@ columns:
     name: sequencing_d1_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -20165,7 +20165,7 @@ columns:
     name: sequencing_d2_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -20180,7 +20180,7 @@ columns:
     name: sequencing_d3_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -20195,7 +20195,7 @@ columns:
     name: sequencing_d4_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -20210,7 +20210,7 @@ columns:
     name: sequencing_d5_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -20225,7 +20225,7 @@ columns:
     name: debugging_d1_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -20240,7 +20240,7 @@ columns:
     name: debugging_d2_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -20255,7 +20255,7 @@ columns:
     name: debugging_d3_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -20270,7 +20270,7 @@ columns:
     name: debugging_d4_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -20285,7 +20285,7 @@ columns:
     name: debugging_d5_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -20300,7 +20300,7 @@ columns:
     name: repeat_loops_d1_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -20315,7 +20315,7 @@ columns:
     name: repeat_loops_d2_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -20330,7 +20330,7 @@ columns:
     name: repeat_loops_d3_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -20345,7 +20345,7 @@ columns:
     name: repeat_loops_d4_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -20360,7 +20360,7 @@ columns:
     name: repeat_loops_d5_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -20375,7 +20375,7 @@ columns:
     name: repeat_until_while_d1_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -20390,7 +20390,7 @@ columns:
     name: repeat_until_while_d2_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -20405,7 +20405,7 @@ columns:
     name: repeat_until_while_d3_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -20420,7 +20420,7 @@ columns:
     name: repeat_until_while_d4_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -20435,7 +20435,7 @@ columns:
     name: repeat_until_while_d5_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -20450,7 +20450,7 @@ columns:
     name: for_loops_d1_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -20465,7 +20465,7 @@ columns:
     name: for_loops_d2_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -20480,7 +20480,7 @@ columns:
     name: for_loops_d3_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -20495,7 +20495,7 @@ columns:
     name: for_loops_d4_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -20510,7 +20510,7 @@ columns:
     name: for_loops_d5_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -20525,7 +20525,7 @@ columns:
     name: events_d1_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -20540,7 +20540,7 @@ columns:
     name: events_d2_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -20555,7 +20555,7 @@ columns:
     name: events_d3_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -20570,7 +20570,7 @@ columns:
     name: events_d4_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -20585,7 +20585,7 @@ columns:
     name: events_d5_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -20600,7 +20600,7 @@ columns:
     name: variables_d1_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -20615,7 +20615,7 @@ columns:
     name: variables_d2_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -20630,7 +20630,7 @@ columns:
     name: variables_d3_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -20645,7 +20645,7 @@ columns:
     name: variables_d4_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -20660,7 +20660,7 @@ columns:
     name: variables_d5_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -20675,7 +20675,7 @@ columns:
     name: functions_d1_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -20690,7 +20690,7 @@ columns:
     name: functions_d2_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -20705,7 +20705,7 @@ columns:
     name: functions_d3_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -20720,7 +20720,7 @@ columns:
     name: functions_d4_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -20735,7 +20735,7 @@ columns:
     name: functions_d5_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -20750,7 +20750,7 @@ columns:
     name: functions_with_params_d1_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -20765,7 +20765,7 @@ columns:
     name: functions_with_params_d2_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -20780,7 +20780,7 @@ columns:
     name: functions_with_params_d3_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -20795,7 +20795,7 @@ columns:
     name: functions_with_params_d4_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -20810,7 +20810,7 @@ columns:
     name: functions_with_params_d5_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -20825,7 +20825,7 @@ columns:
     name: conditionals_d1_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -20840,7 +20840,7 @@ columns:
     name: conditionals_d2_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -20855,7 +20855,7 @@ columns:
     name: conditionals_d3_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -20870,7 +20870,7 @@ columns:
     name: conditionals_d4_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -20885,7 +20885,7 @@ columns:
     name: conditionals_d5_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -20916,7 +20916,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -20931,7 +20931,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -20947,7 +20947,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -20962,7 +20962,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -21007,7 +21007,7 @@ columns:
     name: school_info_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -21068,7 +21068,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -21083,7 +21083,7 @@ columns:
     name: user_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -21098,7 +21098,7 @@ columns:
     name: script_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -21212,7 +21212,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1403 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: deleted_at
@@ -21234,7 +21234,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -21249,7 +21249,7 @@ columns:
     name: studio_person_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -21273,7 +21273,7 @@ columns:
     'null': false
     default: ''
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1407 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: parent_email
@@ -21288,7 +21288,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1408 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: encrypted_password
@@ -21303,7 +21303,7 @@ columns:
     'null': true
     default: ''
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1409 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: reset_password_token
@@ -21318,7 +21318,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1410 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: reset_password_sent_at
@@ -21354,7 +21354,7 @@ columns:
     name: sign_in_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -21408,7 +21408,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1416 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: last_sign_in_ip
@@ -21423,7 +21423,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1417 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -21468,7 +21468,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1420 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: provider
@@ -21483,7 +21483,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1421 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: uid
@@ -21498,7 +21498,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1422 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: admin
@@ -21528,7 +21528,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1424 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: name
@@ -21543,7 +21543,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1425 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: locale
@@ -21558,7 +21558,7 @@ columns:
     'null': false
     default: en-US
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1426 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: birthday
@@ -21588,7 +21588,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1428 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: school
@@ -21603,7 +21603,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1429 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: full_address
@@ -21618,13 +21618,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1430 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: school_info_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -21639,7 +21639,7 @@ columns:
     name: total_lines
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -21654,7 +21654,7 @@ columns:
     name: secret_picture_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -21693,7 +21693,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1435 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: deleted_at
@@ -21738,7 +21738,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1438 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: properties
@@ -21753,7 +21753,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1439 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: invitation_token
@@ -21768,7 +21768,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1440 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: invitation_created_at
@@ -21819,7 +21819,7 @@ columns:
     name: invitation_limit
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -21834,7 +21834,7 @@ columns:
     name: invited_by_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -21858,13 +21858,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1446 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: invitations_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -21879,7 +21879,7 @@ columns:
     name: terms_of_service_version
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -21918,13 +21918,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1450 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: primary_contact_info_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -21940,7 +21940,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -21955,7 +21955,7 @@ columns:
     name: studio_person_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -21979,7 +21979,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1454 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: parent_email
@@ -21994,7 +21994,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1455 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: encrypted_password
@@ -22009,7 +22009,7 @@ columns:
     'null': true
     default: ''
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1456 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: reset_password_token
@@ -22024,7 +22024,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1457 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: reset_password_sent_at
@@ -22060,7 +22060,7 @@ columns:
     name: sign_in_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -22114,7 +22114,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1463 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: last_sign_in_ip
@@ -22129,7 +22129,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1464 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -22174,7 +22174,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1467 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: provider
@@ -22189,7 +22189,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1468 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: UID
@@ -22204,7 +22204,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1469 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: ADMIN
@@ -22234,7 +22234,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1471 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: name
@@ -22249,7 +22249,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1472 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: locale
@@ -22264,7 +22264,7 @@ columns:
     'null': false
     default: en-US
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1473 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: birthday
@@ -22294,7 +22294,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1475 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: school
@@ -22309,7 +22309,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1476 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: full_address
@@ -22324,13 +22324,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1477 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: school_info_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -22345,7 +22345,7 @@ columns:
     name: total_lines
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -22360,7 +22360,7 @@ columns:
     name: secret_picture_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -22399,7 +22399,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1482 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: deleted_at
@@ -22444,7 +22444,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1485 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: properties
@@ -22459,7 +22459,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1486 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: invitation_token
@@ -22474,7 +22474,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1487 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: invitation_created_at
@@ -22525,7 +22525,7 @@ columns:
     name: invitation_limit
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -22540,7 +22540,7 @@ columns:
     name: invited_by_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -22564,13 +22564,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1493 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: invitations_count
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -22585,7 +22585,7 @@ columns:
     name: terms_of_service_version
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -22624,13 +22624,13 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1497 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: primary_contact_info_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -22646,7 +22646,7 @@ columns:
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -22670,7 +22670,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1500 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: youtube_code
@@ -22685,7 +22685,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1501 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: created_at
@@ -22730,7 +22730,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1504 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: locale
@@ -22745,14 +22745,14 @@ columns:
     'null': false
     default: en-US
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   vocabularies:
   - &1505 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: bigint(20)
+        sql_type: bigint
         type: :integer
         limit: 8
         precision: 
@@ -22776,7 +22776,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1507 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: word
@@ -22791,7 +22791,7 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1508 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: definition
@@ -22806,13 +22806,13 @@ columns:
     'null': false
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
   - &1509 !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::Column
     name: course_version_id
     sql_type_metadata: !ruby/object:ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata
       delegate_dc_obj: !ruby/object:ActiveRecord::ConnectionAdapters::SqlTypeMetadata
-        sql_type: int(11)
+        sql_type: int
         type: :integer
         limit: 4
         precision: 
@@ -22866,7 +22866,7 @@ columns:
     'null': true
     default: 
     default_function: 
-    collation: utf8_unicode_ci
+    collation: utf8mb3_unicode_ci
     comment: 
 columns_hash:
   activities:
@@ -23387,9 +23387,9 @@ columns_hash:
     position: *460
     properties: *461
   lessons_opportunity_standards:
-    lesson_id: *462
-    standard_id: *463
-    id: *464
+    id: *462
+    lesson_id: *463
+    standard_id: *464
   lessons_programming_expressions:
     lesson_id: *465
     programming_expression_id: *466
@@ -25132,10 +25132,10 @@ indexes:
   backpacks:
   - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
     table: backpacks
-    name: index_backpacks_on_user_id
+    name: index_backpacks_on_storage_app_id
     unique: true
     columns:
-    - user_id
+    - storage_app_id
     lengths: {}
     orders: {}
     opclasses: {}
@@ -25145,10 +25145,10 @@ indexes:
     comment: 
   - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
     table: backpacks
-    name: index_backpacks_on_storage_app_id
+    name: index_backpacks_on_user_id
     unique: true
     columns:
-    - storage_app_id
+    - user_id
     lengths: {}
     orders: {}
     opclasses: {}
@@ -26346,10 +26346,10 @@ indexes:
     comment: 
   - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
     table: levels
-    name: index_levels_on_name
+    name: index_levels_on_level_num
     unique: false
     columns:
-    - name
+    - level_num
     lengths: {}
     orders: {}
     opclasses: {}
@@ -26359,10 +26359,10 @@ indexes:
     comment: 
   - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
     table: levels
-    name: index_levels_on_level_num
+    name: index_levels_on_name
     unique: false
     columns:
-    - level_num
+    - name
     lengths: {}
     orders: {}
     opclasses: {}
@@ -27915,11 +27915,11 @@ indexes:
   programming_classes:
   - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
     table: programming_classes
-    name: index_programming_classes_on_key_and_programming_environment_id
+    name: index_programming_classes_on_key_and_category_id
     unique: true
     columns:
     - key
-    - programming_environment_id
+    - programming_environment_category_id
     lengths: {}
     orders: {}
     opclasses: {}
@@ -27929,11 +27929,11 @@ indexes:
     comment: 
   - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
     table: programming_classes
-    name: index_programming_classes_on_key_and_category_id
+    name: index_programming_classes_on_key_and_programming_environment_id
     unique: true
     columns:
     - key
-    - programming_environment_category_id
+    - programming_environment_id
     lengths: {}
     orders: {}
     opclasses: {}
@@ -28000,10 +28000,10 @@ indexes:
     comment: 
   - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
     table: programming_expressions
-    name: index_programming_expressions_on_programming_environment_id
+    name: index_programming_expressions_on_environment_category_id
     unique: false
     columns:
-    - programming_environment_id
+    - programming_environment_category_id
     lengths: {}
     orders: {}
     opclasses: {}
@@ -28013,10 +28013,10 @@ indexes:
     comment: 
   - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
     table: programming_expressions
-    name: index_programming_expressions_on_environment_category_id
+    name: index_programming_expressions_on_programming_environment_id
     unique: false
     columns:
-    - programming_environment_category_id
+    - programming_environment_id
     lengths: {}
     orders: {}
     opclasses: {}
@@ -28098,11 +28098,11 @@ indexes:
   projects:
   - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
     table: projects
-    name: storage_apps_storage_id_index
+    name: storage_apps_project_type_index
     unique: false
     columns:
-    - storage_id
-    lengths: {}
+    - project_type
+    lengths: 191
     orders: {}
     opclasses: {}
     where: 
@@ -28137,11 +28137,12 @@ indexes:
     comment: 
   - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
     table: projects
-    name: storage_apps_project_type_index
+    name: storage_apps_storage_id_state_index
     unique: false
     columns:
-    - project_type
-    lengths: 191
+    - storage_id
+    - state
+    lengths: {}
     orders: {}
     opclasses: {}
     where: 
@@ -28150,11 +28151,10 @@ indexes:
     comment: 
   - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
     table: projects
-    name: storage_apps_storage_id_state_index
+    name: storage_apps_storage_id_index
     unique: false
     columns:
     - storage_id
-    - state
     lengths: {}
     orders: {}
     opclasses: {}
@@ -28418,6 +28418,19 @@ indexes:
     comment: 
   - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
     table: schools
+    name: index_schools_on_last_known_school_year_open
+    unique: false
+    columns:
+    - last_known_school_year_open
+    lengths: {}
+    orders: {}
+    opclasses: {}
+    where: 
+    type: 
+    using: :btree
+    comment: 
+  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+    table: schools
     name: index_schools_on_school_district_id
     unique: false
     columns:
@@ -28435,19 +28448,6 @@ indexes:
     unique: false
     columns:
     - zip
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where: 
-    type: 
-    using: :btree
-    comment: 
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: schools
-    name: index_schools_on_last_known_school_year_open
-    unique: false
-    columns:
-    - last_known_school_year_open
     lengths: {}
     orders: {}
     opclasses: {}
@@ -28564,32 +28564,6 @@ indexes:
     comment: 
   - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
     table: scripts
-    name: index_scripts_on_wrapup_video_id
-    unique: false
-    columns:
-    - wrapup_video_id
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where: 
-    type: 
-    using: :btree
-    comment: 
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: scripts
-    name: index_scripts_on_published_state
-    unique: false
-    columns:
-    - published_state
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where: 
-    type: 
-    using: :btree
-    comment: 
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: scripts
     name: index_scripts_on_instruction_type
     unique: false
     columns:
@@ -28620,6 +28594,32 @@ indexes:
     unique: false
     columns:
     - participant_audience
+    lengths: {}
+    orders: {}
+    opclasses: {}
+    where: 
+    type: 
+    using: :btree
+    comment: 
+  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+    table: scripts
+    name: index_scripts_on_published_state
+    unique: false
+    columns:
+    - published_state
+    lengths: {}
+    orders: {}
+    opclasses: {}
+    where: 
+    type: 
+    using: :btree
+    comment: 
+  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+    table: scripts
+    name: index_scripts_on_wrapup_video_id
+    unique: false
+    columns:
+    - wrapup_video_id
     lengths: {}
     orders: {}
     opclasses: {}
@@ -29091,32 +29091,6 @@ indexes:
   unit_groups:
   - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
     table: unit_groups
-    name: index_unit_groups_on_name
-    unique: false
-    columns:
-    - name
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where: 
-    type: 
-    using: :btree
-    comment: 
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: unit_groups
-    name: index_unit_groups_on_published_state
-    unique: false
-    columns:
-    - published_state
-    lengths: {}
-    orders: {}
-    opclasses: {}
-    where: 
-    type: 
-    using: :btree
-    comment: 
-  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
-    table: unit_groups
     name: index_unit_groups_on_instruction_type
     unique: false
     columns:
@@ -29143,10 +29117,36 @@ indexes:
     comment: 
   - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
     table: unit_groups
+    name: index_unit_groups_on_name
+    unique: false
+    columns:
+    - name
+    lengths: {}
+    orders: {}
+    opclasses: {}
+    where: 
+    type: 
+    using: :btree
+    comment: 
+  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+    table: unit_groups
     name: index_unit_groups_on_participant_audience
     unique: false
     columns:
     - participant_audience
+    lengths: {}
+    orders: {}
+    opclasses: {}
+    where: 
+    type: 
+    using: :btree
+    comment: 
+  - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
+    table: unit_groups
+    name: index_unit_groups_on_published_state
+    unique: false
+    columns:
+    - published_state
     lengths: {}
     orders: {}
     opclasses: {}
@@ -29259,10 +29259,10 @@ indexes:
   user_ml_models:
   - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
     table: user_ml_models
-    name: index_user_ml_models_on_user_id
+    name: index_user_ml_models_on_model_id
     unique: false
     columns:
-    - user_id
+    - model_id
     lengths: {}
     orders: {}
     opclasses: {}
@@ -29272,10 +29272,10 @@ indexes:
     comment: 
   - !ruby/object:ActiveRecord::ConnectionAdapters::IndexDefinition
     table: user_ml_models
-    name: index_user_ml_models_on_model_id
+    name: index_user_ml_models_on_user_id
     unique: false
     columns:
-    - model_id
+    - user_id
     lengths: {}
     orders: {}
     opclasses: {}
@@ -29659,7 +29659,7 @@ indexes:
 version: 20230323175726
 database_version: !ruby/object:ActiveRecord::ConnectionAdapters::AbstractAdapter::Version
   version:
-  - 5
-  - 7
-  - 12
-  full_version_string: 5.7.12-log
+  - 8
+  - 0
+  - 32
+  full_version_string: 8.0.32-0ubuntu0.20.04.2


### PR DESCRIPTION
One off scrip to ingest the stats for schools for SY 2021-2022. This would populate the SchoolStatsByYear table using the csv uploaded for the corresponding school year.

## Links
JIRA https://codedotorg.atlassian.net/browse/ACQ-460?atlOrigin=eyJpIjoiZmRmZGRjODIyMzQ1NDIyMzg5YWVhZWZiYjU2NjdjNDQiLCJwIjoiaiJ9

## Testing story

When testing locally, the script failed for 123 schools as they were missing corresponding entries in Schools table. Those schools were skipped as duplicates because there was an existing school entry with the same state school ID. This issue is still unresolved, but it looks like ingestions in the past also hit this issue from cloud watch logs and DB queries. Hence, moving forward with this to unblock ingestion for majority of the schools, while I continue following up on the issue with duplicates due to state school ID.

https://codedotorg.slack.com/archives/C04540KNGDQ/p1682359022125929

## Deployment strategy
Will execute the script on production once rolled out. The script has an override to specify dry run, so will start with dry run and then execute if that looks good.

## Follow-up work
Resolution of the duplicate issue for the 123 schools hit during local run.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
