### PR TITLE
Reimplement `CDO` Configuration Object without OpenStruct

### DIFF
--- a/lib/cdo.rb
+++ b/lib/cdo.rb
@@ -39,7 +39,7 @@ module Cdo
         raise "Unknown property not in defaults: #{key}" unless defaults.key?(key.to_sym)
       end
       raise "'#{rack_env}' is not known environment." unless rack_envs.include?(rack_env)
-      freeze
+      freeze_config
     end
 
     def shared_cache

--- a/lib/cdo/config.rb
+++ b/lib/cdo/config.rb
@@ -33,6 +33,12 @@ module Cdo
       @table.key?(name.to_sym)
     end
 
+    # Implement our own soft-freeze: Don't allow any config items to be
+    # created/modified, but allow stubbing for unit tests.
+    def freeze_config
+      @table.freeze
+    end
+
     #def respond_to_missing?(mid, include_private = false) # :nodoc:
     #  puts "respond_to_missing?(#{mid.inspect}, #{include_private.inspect})"
     #  mname = mid.to_s.chomp("=").to_sym
@@ -56,14 +62,6 @@ module Cdo
           raise!
         end
       end
-    end
-
-    # Soft-freeze: Don't allow any config items to be created/modified,
-    # but allow stubbing for unit tests.
-    def freeze
-      @frozen = true
-      @table.freeze
-      super
     end
 
     # Loads one or several sources into the merged configuration.

--- a/lib/cdo/config.rb
+++ b/lib/cdo/config.rb
@@ -33,7 +33,6 @@ module Cdo
     # Implement our own soft-freeze: Don't allow any config items to be
     # created/modified, but allow stubbing for unit tests.
     def freeze_config
-      @table.freeze
       @frozen = true
     end
 

--- a/lib/cdo/secrets_config.rb
+++ b/lib/cdo/secrets_config.rb
@@ -31,7 +31,7 @@ module Cdo
       results
     end
 
-    def freeze
+    def freeze_config
       lazy_load_secrets!
       super
     end

--- a/lib/cdo/secrets_config.rb
+++ b/lib/cdo/secrets_config.rb
@@ -67,9 +67,9 @@ module Cdo
         Cdo::Secrets.new(logger: log)
       end
 
-      table.select {|_k, v| v.to_s.match(SECRET_REGEX)}.each do |key, value|
+      @table.select {|_k, v| v.to_s.match(SECRET_REGEX)}.each do |key, value|
         cdo_secrets.required(*value.to_s.scan(SECRET_REGEX).flatten)
-        table[key] = Cdo.lazy do
+        @table[key] = Cdo.lazy do
           value.is_a?(Secret) ?
             cdo_secrets.get!(value.key) :
             value.to_s.gsub(SECRET_REGEX) {cdo_secrets.get!($1)}
@@ -89,7 +89,7 @@ module Cdo
     # Any exceptions or defaults can be re-added later in the YAML document, after secrets have been cleared.
     private def clear_secrets
       @secrets ||= []
-      @secrets |= table.select {|_, v| v.is_a?(Secret)}.keys.map(&:to_s)
+      @secrets |= @table.select {|_, v| v.is_a?(Secret)}.keys.map(&:to_s)
       @secrets.product([nil]).to_h.to_yaml.sub(/^---.*\n/, '')
     end
   end

--- a/lib/test/cdo/test_config.rb
+++ b/lib/test/cdo/test_config.rb
@@ -54,13 +54,13 @@ class ConfigTest < Minitest::Test
     end
   end
 
-  def test_freeze
+  def test_freeze_config
     config = Cdo::Config.new
     config.load_configuration(x: 'y')
-    config.x = 'z'
-    config.freeze
-    assert_equal 'z', config.x
-    assert_raises(RuntimeError) {config.x = 'a'}
+    assert_equal 'y', config.x
+    assert_equal nil, config.y
+    config.freeze_config
+    assert_raises(RuntimeError) {config.load_configuration(z: 'a')}
     assert_raises(ArgumentError) {config.y}
   end
 end

--- a/lib/test/cdo/test_secrets_config.rb
+++ b/lib/test/cdo/test_secrets_config.rb
@@ -23,7 +23,7 @@ class SecretsConfigTest < Minitest::Test
     file.write yml_erb
     file.close
     config.load_configuration(file.path)
-    config.freeze
+    config.freeze_config
   end
 
   def stub_secret(str)


### PR DESCRIPTION
OpenStruct [has undergone some changes in Ruby 3.0][Ruby 3 gotchas: OpenStruct does not evaluate fields lazily] which break a few things with our CDO configuration option management object which inherits from it. We could probably patch up those incompatibilities, but [OpenStruct is generally not recommended for use][OpenStruct Caveats], so instead we just reimplement the specific functionality that we want on the class directly, and stop inheriting from it.

The specific OpenStruct functionality that we lose here is mostly a lot of logic to support redefining values that have already been defined (something we explicitly want to avoid anyway), as well as workarounds to prevent accidental overloading of various internal methods (something our specific use case of the structure renders irrelevant), and various miscellaneous YAGNI helpers that we aren't currently taking advantage of. I also chose not to carry over [the manual protected accessor for the internal table object](https://github.com/ruby/ostruct/blob/e61b4464a033c38a65657eaf0467d12e2c7b9ec1/lib/ostruct.rb#L339-L341) in favor of explicit `@table` references, and to define our own `freeze_config` method for applying our custom soft-freeze logic rather than overriding the builtin method just so we can prevent the default functionality.

## Links

[OpenStruct Caveats]: https://ruby-doc.org/stdlib-3.0.2/libdoc/ostruct/rdoc/OpenStruct.html#class-OpenStruct-label-Caveats
[Ruby 3 gotchas: OpenStruct does not evaluate fields lazily]: https://docs.gitlab.com/ee/development/ruby3_gotchas.html#openstruct-does-not-evaluate-fields-lazily

- https://github.com/code-dot-org/code-dot-org/pull/43413#discussion_r748431657
- [Ruby 3.0 OpenStruct](https://github.com/ruby/ostruct/blob/v0.3.1/lib/ostruct.rb)
- [Ruby 2.7 OpenStruct](https://github.com/ruby/ostruct/blob/e61b4464a033c38a65657eaf0467d12e2c7b9ec1/lib/ostruct.rb)
- [Ruby 3 gotchas: OpenStruct does not evaluate fields lazily]
- [OpenStruct Caveats]

## Testing story

Tweaked existing unit tests to reflect new slightly modified edge cases and method names. Otherwise relying on existing test coverage to verify that this does not result in any significant change in functionality.

Also tested [on an adhoc](https://adhoc-reimplement-cdo-config-without-openstruct.cdn-code.org/)