### PR TITLE
Add trailing commas to Typography files

### DIFF
--- a/apps/src/componentLibrary/typography/Typography.story.jsx
+++ b/apps/src/componentLibrary/typography/Typography.story.jsx
@@ -3,7 +3,7 @@ import Typography from './index';
 
 export default {
   title: 'Typography Component',
-  component: Typography
+  component: Typography,
 };
 
 //
@@ -20,95 +20,95 @@ const Template = args => <Typography {...args} />;
 export const Heading1 = Template.bind({});
 Heading1.args = {
   semanticTag: 'h1',
-  children: 'This is a Typography Component. (H1)'
+  children: 'This is a Typography Component. (H1)',
 };
 
 export const Heading1asHeading3 = Template.bind({});
 Heading1asHeading3.args = {
   semanticTag: 'h1',
   visualAppearance: 'heading-lg',
-  children: 'This is a Typography Component. (H1 as H3)'
+  children: 'This is a Typography Component. (H1 as H3)',
 };
 
 export const Heading2 = Template.bind({});
 Heading2.args = {
   semanticTag: 'h2',
-  children: 'This is a Typography Component. (H2)'
+  children: 'This is a Typography Component. (H2)',
 };
 
 export const Heading2asBodyOne = Template.bind({});
 Heading2asBodyOne.args = {
   semanticTag: 'h2',
   visualAppearance: 'body-one',
-  children: 'This is a Typography Component. (H2 as p.body-one)'
+  children: 'This is a Typography Component. (H2 as p.body-one)',
 };
 
 export const Heading3 = Template.bind({});
 Heading3.args = {
   semanticTag: 'h3',
-  children: 'This is a Typography Component. (H3)'
+  children: 'This is a Typography Component. (H3)',
 };
 
 export const Heading3asHeading5 = Template.bind({});
 Heading3asHeading5.args = {
   semanticTag: 'h3',
   visualAppearance: 'heading-sm',
-  children: 'This is a Typography Component. (H3 as H5)'
+  children: 'This is a Typography Component. (H3 as H5)',
 };
 
 export const Heading4 = Template.bind({});
 Heading4.args = {
   semanticTag: 'h4',
-  children: 'This is a Typography Component. (H4)'
+  children: 'This is a Typography Component. (H4)',
 };
 
 export const Heading5 = Template.bind({});
 Heading5.args = {
   semanticTag: 'h5',
-  children: 'This is a Typography Component. (H5)'
+  children: 'This is a Typography Component. (H5)',
 };
 
 export const Heading6 = Template.bind({});
 Heading6.args = {
   semanticTag: 'h6',
-  children: 'This is a Typography Component. (H6)'
+  children: 'This is a Typography Component. (H6)',
 };
 
 export const BodyOne = Template.bind({});
 BodyOne.args = {
   semanticTag: 'p',
   visualAppearance: 'body-one',
-  children: 'This is a Typography Component. (p.body-one)'
+  children: 'This is a Typography Component. (p.body-one)',
 };
 
 export const BodyTwo = Template.bind({});
 BodyTwo.args = {
   semanticTag: 'p',
   visualAppearance: 'body-two',
-  children: 'This is a Typography Component. (p.body-two)'
+  children: 'This is a Typography Component. (p.body-two)',
 };
 
 export const OverlineText = Template.bind({});
 OverlineText.args = {
   semanticTag: 'p',
   visualAppearance: 'overline',
-  children: 'This is a Typography Component. (p.overline)'
+  children: 'This is a Typography Component. (p.overline)',
 };
 
 export const StrongText = Template.bind({});
 StrongText.args = {
   semanticTag: 'strong',
-  children: 'This is a Typography Component. (strong)'
+  children: 'This is a Typography Component. (strong)',
 };
 
 export const EmText = Template.bind({});
 EmText.args = {
   semanticTag: 'em',
-  children: 'This is a Typography Component. (em)'
+  children: 'This is a Typography Component. (em)',
 };
 
 export const FigcaptionText = Template.bind({});
 FigcaptionText.args = {
   semanticTag: 'figcaption',
-  children: 'This is a Typography Component. (figcaption)'
+  children: 'This is a Typography Component. (figcaption)',
 };

--- a/apps/src/componentLibrary/typography/Typography.tsx
+++ b/apps/src/componentLibrary/typography/Typography.tsx
@@ -22,7 +22,7 @@ const Typography: React.FunctionComponent<TypographyProps> = ({
   visualAppearance,
   children,
   className,
-  style
+  style,
 }) => {
   const Tag = semanticTag;
 

--- a/apps/src/componentLibrary/typography/TypographyElements.tsx
+++ b/apps/src/componentLibrary/typography/TypographyElements.tsx
@@ -17,21 +17,21 @@ const typographyElementsToGenerate: TypographyElementToGenerateTemplate[] = [
   {
     displayName: 'BodyOneText',
     semanticTag: 'p',
-    defaultVisualAppearance: 'body-one'
+    defaultVisualAppearance: 'body-one',
   },
   {
     displayName: 'BodyTwoText',
     semanticTag: 'p',
-    defaultVisualAppearance: 'body-two'
+    defaultVisualAppearance: 'body-two',
   },
   {
     displayName: 'OverlineText',
     semanticTag: 'p',
-    defaultVisualAppearance: 'overline'
+    defaultVisualAppearance: 'overline',
   },
   {displayName: 'EmText', semanticTag: 'em'},
   {displayName: 'StrongText', semanticTag: 'strong'},
-  {displayName: 'Figcaption', semanticTag: 'figcaption'}
+  {displayName: 'Figcaption', semanticTag: 'figcaption'},
 ];
 
 // Generates a set of components(Typography Elements) based on the data in typographyElementsToGenerate
@@ -74,5 +74,5 @@ export const {
   OverlineText,
   EmText,
   StrongText,
-  Figcaption
+  Figcaption,
 } = generateComponents(typographyElementsToGenerate);


### PR DESCRIPTION
## Warning!!

The AP CSP Create Performance Task is in progress from April 1 - May 1 2023. Please
consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org
students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game
Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking
anything in these two labs. Even small changes, such as a different button color, are considered
significant during this time period. Reach out to the Student Learning team or Curriculum team for
more details.

<!-- end warning -->

A PR got caught in an in-between state when the trailing comma lint rule was merged. This fixes it!

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
