### PR TITLE
Use `Time#strftime` rather than `RFC2822_DAY_NAME`

### DIFF
--- a/lib/cdo/cron.rb
+++ b/lib/cdo/cron.rb
@@ -15,7 +15,7 @@ module Cdo
           select(&:on_weekday?).
           map {|day| Chronic.parse(time_str, now: day)}.
           map(&:utc)
-        day_names = times.map {|day| Time::RFC2822_DAY_NAME[day.wday].upcase}
+        day_names = times.map {|day| day.strftime('%a').upcase}
         "0 #{times.first.hour} * * #{day_names.first}-#{day_names.last}"
       end
     end
@@ -25,7 +25,7 @@ module Cdo
       Time.use_zone(time_zone) do
         Chronic.time_class = Time.zone
         time = Chronic.parse(time_str).utc
-        day_name = Time::RFC2822_DAY_NAME[time.wday].upcase
+        day_name = time.strftime('%a').upcase
         "#{time.min} #{time.hour} * * #{day_name}"
       end
     end


### PR DESCRIPTION
The constant `Time::RFC2822_DAY_NAME` (also `RFC2822_MONTH_NAME`, which we don't use) has been removed in Ruby 3.0 in favor of the `Time#strftime` method; update our use of it accordingly.

## Links

- https://github.com/ruby/time/pull/2