### PR TITLE
Fix Violations of and Reenable `Style/HashAsLastArrayItem`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -362,13 +362,6 @@ Style/GlobalStdStream:
 Style/GlobalVars:
   Enabled: false
 
-# Offense count: 2
-# This cop supports safe auto-correction (--auto-correct).
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: braces, no_braces
-Style/HashAsLastArrayItem:
-  Enabled: false
-
 # Offense count: 20
 # This cop supports safe auto-correction (--auto-correct).
 # Configuration parameters: AllowSplatArgument.

--- a/dashboard/app/controllers/api/v1/pd/workshops_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshops_controller.rb
@@ -309,7 +309,7 @@ class Api::V1::Pd::WorkshopsController < ::ApplicationController
       :virtual,
       :suppress_email,
       :third_party_provider,
-      sessions_attributes: [:id, :start, :end, :_destroy],
+      {sessions_attributes: [:id, :start, :end, :_destroy]},
     ]
 
     allowed_params.delete :regional_partner_id unless can_update_regional_partner

--- a/dashboard/app/controllers/application_controller.rb
+++ b/dashboard/app/controllers/application_controller.rb
@@ -151,7 +151,7 @@ class ApplicationController < ActionController::Base
     :parent_email_preference_opt_in_required,
     :parent_email_preference_opt_in,
     :parent_email_preference_email,
-    school_info_attributes: SCHOOL_INFO_ATTRIBUTES,
+    {school_info_attributes: SCHOOL_INFO_ATTRIBUTES},
   ]
 
   PERMITTED_USER_FIELDS.concat(UI_TEST_ATTRIBUTES) if rack_env?(:test, :development)


### PR DESCRIPTION
> Checks for presence or absence of braces around hash literal as a last array item depending on configuration.

This feels particularly relevant as we prepare for an update to Ruby 3.0, in which [implicit hashes as the last argument of a method call was deprecated.](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/)

Fix applied automatically with `bundle exec rubocop --auto-correct-all --only Style/HashAsLastArrayItem`

## Links

- https://docs.rubocop.org/rubocop/cops_style.html#stylehashaslastarrayitem
- https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/HashAsLastArrayItem