### PR TITLE
adding url safe base64 encoding

### DIFF
--- a/apps/src/templates/certificates/Certificate.jsx
+++ b/apps/src/templates/certificates/Certificate.jsx
@@ -65,11 +65,15 @@ function Certificate(props) {
       course: props.tutorial,
       donor
     };
-    const encoded = btoa(reEncodeNonLatin1(JSON.stringify(data)));
+    const asciiData = btoa(reEncodeNonLatin1(JSON.stringify(data)));
+    const urlSafeData = asciiData
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=+$/g, '');
     // This method complies with “Base 64 Encoding with URL and Filename
     // Safe Alphabet” in RFC 4648. The alphabet uses ‘-’ instead of ‘+’ and
     // ‘_’ instead of ‘/’.
-    return encoded.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+    return urlSafeData;
   };
 
   const getCertificateImagePath = () => {

--- a/apps/src/templates/certificates/Certificate.jsx
+++ b/apps/src/templates/certificates/Certificate.jsx
@@ -66,6 +66,9 @@ function Certificate(props) {
       donor
     };
     const encoded = btoa(reEncodeNonLatin1(JSON.stringify(data)));
+    // This method complies with “Base 64 Encoding with URL and Filename
+    // Safe Alphabet” in RFC 4648. The alphabet uses ‘-’ instead of ‘+’ and
+    // ‘_’ instead of ‘/’.
     return encoded.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
   };
 

--- a/apps/src/templates/certificates/Certificate.jsx
+++ b/apps/src/templates/certificates/Certificate.jsx
@@ -67,9 +67,9 @@ function Certificate(props) {
     };
     const asciiData = btoa(reEncodeNonLatin1(JSON.stringify(data)));
     const urlSafeData = asciiData
-      .replace(/\+/g, '-')
-      .replace(/\//g, '_')
-      .replace(/=+$/g, '');
+      .replaceAll('+', '-')
+      .replaceAll('/', '_')
+      .replaceAll('=', '');
     // This method complies with “Base 64 Encoding with URL and Filename
     // Safe Alphabet” in RFC 4648. The alphabet uses ‘-’ instead of ‘+’ and
     // ‘_’ instead of ‘/’.

--- a/apps/src/templates/certificates/Certificate.jsx
+++ b/apps/src/templates/certificates/Certificate.jsx
@@ -65,7 +65,8 @@ function Certificate(props) {
       course: props.tutorial,
       donor
     };
-    return btoa(reEncodeNonLatin1(JSON.stringify(data)));
+    const encoded = btoa(reEncodeNonLatin1(JSON.stringify(data)));
+    return encoded.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
   };
 
   const getCertificateImagePath = () => {

--- a/apps/test/unit/templates/certificates/CertificateTest.js
+++ b/apps/test/unit/templates/certificates/CertificateTest.js
@@ -91,7 +91,11 @@ describe('Certificate', () => {
       wrapper.update();
       image = wrapper.find('#uitest-certificate img');
       const expectedData = {name: 'Student', course: 'dance'};
-      const expectedFilename = btoa(JSON.stringify(expectedData));
+      const encodedData = btoa(JSON.stringify(expectedData));
+      const expectedFilename = encodedData
+        .replace(/\+/g, '-')
+        .replace(/\//g, '_')
+        .replace(/=+$/g, '');
       const expectedSrc = `/certificate_images/${expectedFilename}.jpg`;
       expect(image.prop('src')).to.equal(expectedSrc);
     });

--- a/apps/test/unit/templates/certificates/CertificateTest.js
+++ b/apps/test/unit/templates/certificates/CertificateTest.js
@@ -93,9 +93,9 @@ describe('Certificate', () => {
       const expectedData = {name: 'Student', course: 'dance'};
       const encodedData = btoa(JSON.stringify(expectedData));
       const expectedFilename = encodedData
-        .replace(/\+/g, '-')
-        .replace(/\//g, '_')
-        .replace(/=+$/g, '');
+        .replaceAll('+', '-')
+        .replaceAll('/', '_')
+        .replaceAll('=', '');
       const expectedSrc = `/certificate_images/${expectedFilename}.jpg`;
       expect(image.prop('src')).to.equal(expectedSrc);
     });


### PR DESCRIPTION
When writing names for the certificate of completion that contain certain special characters, the certificate of completion doesn't show the image. It shows a “?” and throwing a 404 error.
![Screenshot 2023-04-24 at 19 18 00](https://user-images.githubusercontent.com/66776217/234143289-84c7cb5e-7860-465c-8863-09ff41c94a2b.png)

The root cause is how the javascript side encodes the data used in the ruby side. The javascript [`btoa` (binary to ascii) method](https://developer.mozilla.org/en-US/docs/Web/API/btoa) introduces slashes(`/`) and plus symbols(`+`) in the certificate url preventing the backend from finding the right resource. 
![Screenshot 2023-04-24 at 19 20 04](https://user-images.githubusercontent.com/66776217/234143458-c3eb0d85-ad30-4a95-9edb-717c3c7488d7.png)

In order to solve this issue, it is required to use an adaptation of the Base64 encoding that is url-safe. Modified Base64 for URL variants exist (such as base64url in [RFC 4648](https://datatracker.ietf.org/doc/html/rfc4648)), where the '+' and '/' characters of standard Base64 are respectively replaced by '-' and '_'. 

Thankfully, the [ruby side of the certificates](https://github.com/code-dot-org/code-dot-org/blob/7399beef08a11846c54ce3abd23a95e1eeb6c062/dashboard/app/controllers/certificate_images_controller.rb#L17) already expects an url-safe version of the Base64 encoding.

This PR introduces the symbol substitution required to produce url-safe certificate links, in the `getEncodedParams` method.

## Links

- jira ticket: [P20-110](https://codedotorg.atlassian.net/browse/P20-110)
- testing links: [http://localhost-studio.code.org:3000/congrats](http://localhost-studio.code.org:3000/congrats)
-  More Ruby documentation on Base64 encoding [here](https://ruby-doc.org/stdlib-2.4.0/libdoc/base64/rdoc/Base64.html).

## Testing story

Testing with the name 楊育睿
Production:
![Screenshot 2023-04-24 at 19 39 09](https://user-images.githubusercontent.com/66776217/234147425-ddba55cb-a535-406d-be76-65c36e6ac473.png)

Development:
![image](https://user-images.githubusercontent.com/66776217/234147461-8a631a9f-be66-41d1-b19b-cdda6d9859ee.png)
![image (1)](https://user-images.githubusercontent.com/66776217/234147679-e82b2877-f474-4bb1-bfe5-c0929fec514f.png)

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->


## Follow-up work

- Shoudl we use a different encoding that better supports non latin base characters?
<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Warning!!

The AP CSP Create Performance Task is in progress from April 1 - May 1 2023. Please
consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org
students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game
Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking
anything in these two labs. Even small changes, such as a different button color, are considered
significant during this time period. Reach out to the Student Learning team or Curriculum team for
more details.

<!-- end warning -->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [X] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
- [x] New features are translatable or updates will not break translations
