### PR TITLE
Project Beats: fix chord block infinite callback

### DIFF
--- a/apps/src/music/blockly/FieldChord.ts
+++ b/apps/src/music/blockly/FieldChord.ts
@@ -187,7 +187,7 @@ export default class FieldChord extends Field {
         previewChord: this.options.previewChord,
         previewNote: this.options.previewNote,
         cancelPreviews: this.options.cancelPreviews,
-        onChange: value => this.setValue(value),
+        onChange: this.onValueChange,
       }),
       this.newDiv
     );
@@ -204,4 +204,6 @@ export default class FieldChord extends Field {
       .join(', ');
     return notes.length > MAX_DISPLAY_NOTES ? allNotes + '...' : allNotes;
   }
+
+  private onValueChange = (value: ChordEventValue) => this.setValue(value);
 }


### PR DESCRIPTION
Fixes an infinite callback loop in the ChordPanel view; the `onChange` prop was being used in the dependency array of a `useEffect` hook (recently added to fix react dependency array violations). Since we were passing an anonymous function, it was changing on every render and calling the hook infinitely. The fix here is to assign the function to an instance field and pass that to the view, so the reference is stable and not changing on every render.

## Testing story

Tested locally