### PR TITLE
Fix Violations of and Reenable `Style/RedundantPercentQ`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -494,11 +494,6 @@ Style/RedundantInitialize:
 Style/RedundantParentheses:
   Enabled: false
 
-# Offense count: 23
-# This cop supports safe auto-correction (--auto-correct).
-Style/RedundantPercentQ:
-  Enabled: false
-
 # Offense count: 26
 # This cop supports safe auto-correction (--auto-correct).
 Style/RedundantRegexpCharacterClass:

--- a/bin/oneoff/data_fix/fix_bad_school_info_in_users
+++ b/bin/oneoff/data_fix/fix_bad_school_info_in_users
@@ -47,7 +47,8 @@ CDO.log.info "Called with options: #{options}"
 info_count = 0
 user_count = 0
 
-school_info_ids = ActiveRecord::Base.connection.execute(%Q{
+school_info_ids = ActiveRecord::Base.connection.execute(
+  <<~SQL
     SELECT DISTINCT t.id FROM (
       SELECT MIN(id) AS id FROM school_infos WHERE validation_type = 'none' AND country = 'US'
       AND school_type in ('public','charter')
@@ -62,7 +63,7 @@ school_info_ids = ActiveRecord::Base.connection.execute(%Q{
       GROUP BY school_type, state, school_district_id
     ) t JOIN school_infos si ON si.id = t.id
     WHERE (si.school_id IS NOT NULL OR si.school_name IS NOT NULL)
-  }
+  SQL
 ).pluck(0)
 
 csv_file = "#{Dir.tmpdir}/#{File.basename(__FILE__)}.#{Time.now.strftime('%Y%m%d%H%M')}.csv"

--- a/dashboard/test/ui/features/step_definitions/account_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/account_steps.rb
@@ -29,26 +29,22 @@ Given(/^I sign in as "([^"]*)"( and go home)?$/) do |name, home|
 end
 
 Given(/^I sign out and sign in as "([^"]*)"$/) do |name|
-  steps %Q{
-    And I sign in as "#{name}"
-  }
+  steps "And I sign in as \"#{name}\""
 end
 
 Given(/^I sign in as "([^"]*)" from the sign in page$/) do |name|
-  steps %Q{
+  steps <<~GHERKIN
     And check that the url contains "/users/sign_in"
     And I wait to see "#signin"
     And I fill in username and password for "#{name}"
     And I click "#signin-button"
     And I wait to see ".header_user"
-  }
+  GHERKIN
 end
 
 Given(/^I am a (student|teacher)( and go home)?$/) do |user_type, home|
   random_name = "Test#{user_type.capitalize} " + SecureRandom.base64
-  steps %Q{
-    And I create a #{user_type} named "#{random_name}"#{home}
-  }
+  steps "And I create a #{user_type} named \"#{random_name}\"#{home}"
 end
 
 def generate_user(name)
@@ -75,9 +71,7 @@ def sign_up(name)
     expect(opacity).to eq(0)
   end
   page_load(wait_proc: wait_proc) do
-    steps %Q{
-      And I click selector "#signup-button"
-    }
+    steps 'And I click selector "#signup-button"'
   end
 rescue RSpec::Expectations::ExpectationNotMetError
   tries ||= 0
@@ -85,9 +79,7 @@ rescue RSpec::Expectations::ExpectationNotMetError
   sleep 1
 
   email, _ = generate_user(name)
-  steps %Q{
-    And I type "#{email}" into "#user_email"
-  }
+  steps "And I type \"#{email}\" into \"#user_email\""
   retry
 end
 
@@ -141,28 +133,28 @@ And(/^I fill in the sign up form with (in)?valid values for "([^"]*)"$/) do |inv
   password = invalid ? 'Short' : 'ExtraLong'
   email = "user#{Time.now.to_i}_#{rand(1_000_000)}@test.xx"
   age = "10"
-  steps %Q{
+  steps <<~GHERKIN
     And I type "#{name}" into "#user_name"
     And I type "#{email}" into "#user_email"
     And I type "#{password}" into "#user_password"
     And I type "#{password}" into "#user_password_confirmation"
     And I select the "#{age}" option in dropdown "user_age"
     And I click ".btn.btn-primary" to load a new page
-  }
+  GHERKIN
 end
 
 And(/I fill in username and password for "([^"]*)"$/) do |name|
-  steps %Q{
+  steps <<~GHERKIN
     And I type "#{@users[name][:email]}" into "#user_login"
     And I type "#{@users[name][:password]}" into "#user_password"
-  }
+  GHERKIN
 end
 
 And(/I fill in account email and current password for "([^"]*)"$/) do |name|
-  steps %Q{
+  steps <<~GHERKIN
     And I type "#{@users[name][:email]}" into "#user_email"
     And I type "#{@users[name][:password]}" into "#user_current_password"
-  }
+  GHERKIN
 end
 
 When(/^I sign out$/) do

--- a/dashboard/test/ui/features/step_definitions/applab.rb
+++ b/dashboard/test/ui/features/step_definitions/applab.rb
@@ -20,7 +20,7 @@ And /^Applab HTML has no button$/ do
 end
 
 Given /^I start a new Applab project/ do
-  steps <<-STEPS
+  steps <<-GHERKIN
     And I am on "http://studio.code.org/projects/applab/new"
     And I rotate to landscape
     And I wait for the page to fully load
@@ -28,36 +28,36 @@ Given /^I start a new Applab project/ do
     And element "#codeModeButton" is visible
     And element "#designModeButton" is visible
     And element "#dataModeButton" is visible
-  STEPS
+  GHERKIN
 end
 
 Given /^I am on the (\d+)(?:st|nd|rd|th)? App ?Lab test level$/ do |level_index|
-  steps <<-STEPS
+  steps <<-GHERKIN
     And I am on "http://studio.code.org/s/allthethings/lessons/#{APPLAB_ALLTHETHINGS_LESSON}/levels/#{level_index}"
     And I rotate to landscape
     And I wait for the page to fully load
-  STEPS
+  GHERKIN
 end
 
 When /^I switch to design mode$/ do
-  steps <<-STEPS
+  steps <<-GHERKIN
     When I press "designModeButton"
     And I wait to see Applab design mode
-  STEPS
+  GHERKIN
 end
 
 When /^I switch to data mode$/ do
-  steps <<-STEPS
+  steps <<-GHERKIN
     When I press "dataModeButton"
     And I wait to see Applab data mode
-  STEPS
+  GHERKIN
 end
 
 When /^I switch to code mode$/ do
-  steps <<-STEPS
+  steps <<-GHERKIN
     When I press "codeModeButton"
     And I wait to see Applab code mode
-  STEPS
+  GHERKIN
 end
 
 And /^I wait to see Applab design mode$/ do
@@ -78,7 +78,7 @@ end
 # Step for dragging an Applab design mode element into the applab visualization.
 # Use with element type strings from ElementType (library.js)
 When /^I drag a (\w+) into the app$/ do |element_type|
-  drag_script = %Q{
+  drag_script = <<~JAVASCRIPT
     var element = $("[data-element-type='#{element_type}']");
     var screenOffset = element.offset();
     var mousedown = $.Event("mousedown", {
@@ -97,27 +97,27 @@ When /^I drag a (\w+) into the app$/ do |element_type|
     element.trigger(mousedown);
     $(document).trigger(drag);
     $(document).trigger(mouseup);
-  }
+  JAVASCRIPT
   @browser.execute_script(drag_script)
 end
 
 When /^I navigate to the embedded version of my project$/ do
-  steps <<-STEPS
+  steps <<-GHERKIN
     When I open the share dialog
     And I click selector "#project-share a:contains('Show advanced options')"
     And I click selector "#project-share li:contains('Embed')"
     And I copy the embed code into a new document
-  STEPS
+  GHERKIN
 end
 
 When /^I navigate to the embedded version of my project with source hidden$/ do
-  steps <<-STEPS
+  steps <<-GHERKIN
     When I open the share dialog
     And I click selector "#project-share a:contains('Show advanced options')"
     And I click selector "#project-share li:contains('Embed')"
     And I click selector "#project-share label:contains('Hide ability to view code')"
     And I copy the embed code into a new document
-  STEPS
+  GHERKIN
 end
 
 Then(/^the palette has (\d+) blocks$/) do |num_blocks|
@@ -130,12 +130,12 @@ Then(/^the droplet code is "([^"]*)"$/) do |code|
 end
 
 And /^I append text to droplet "([^"]*)"$/ do |text|
-  script = %Q{
+  script = <<~JAVASCRIPT
     var aceEditor = window.__TestInterface.getDroplet().aceEditor;
     aceEditor.navigateFileEnd();
     aceEditor.textInput.focus();
     aceEditor.onTextInput("#{text}");
-  }
+  JAVASCRIPT
   @browser.execute_script(script)
 end
 
@@ -188,7 +188,7 @@ end
 def drag_grippy(element_js, delta_x, delta_y)
   script = get_mouse_event_creator_script
 
-  script += %Q{
+  script += <<~JAVASCRIPT
     var element = #{element_js};
     var start = {
       x: element.offset().left,
@@ -205,7 +205,7 @@ def drag_grippy(element_js, delta_x, delta_y)
     element[0].dispatchEvent(mousedown);
     element[0].dispatchEvent(drag);
     element[0].dispatchEvent(mouseup);
-  }
+  JAVASCRIPT
   # Run the script and then wait a little bit of time to give the UI a chance to reflow.
   @browser.execute_script(script, 0.5)
 end
@@ -222,7 +222,7 @@ And /^I hover over element with id "([^"]*)"$/ do |element_id|
   script = get_mouse_event_creator_script
   script += get_scale_script
 
-  script += %Q{
+  script += <<~JAVASCRIPT
     var element = $("#" + "#{element_id}");
     var scale = getScale(element[0]);
     var x = element.offset().left + (5 * scale);
@@ -231,7 +231,7 @@ And /^I hover over element with id "([^"]*)"$/ do |element_id|
     var mousemove = createMouseEvent('mousemove', x, y);
 
     element[0].dispatchEvent(mousemove);
-  }
+  JAVASCRIPT
 
   @browser.execute_script(script)
 end
@@ -240,7 +240,7 @@ And /^I hover over the screen at xpos ([\d]+) and ypos ([\d]+)$/ do |xpos, ypos|
   script = get_mouse_event_creator_script
   script += get_scale_script
 
-  script += %Q{
+  script += <<~JAVASCRIPT
     var visualization = $("#visualizationOverlay");
     var transform = window.getComputedStyle(visualization[0]).transform;
     var scale = parseFloat(/matrix\\(([^,]*),/.exec(transform)[1]);
@@ -249,7 +249,7 @@ And /^I hover over the screen at xpos ([\d]+) and ypos ([\d]+)$/ do |xpos, ypos|
     var mousemove = createMouseEvent('mousemove', x, y);
 
     visualization[0].dispatchEvent(mousemove);
-  }
+  JAVASCRIPT
 
   @browser.execute_script(script)
 end
@@ -313,7 +313,7 @@ And /^I drag element "([^"]*)" ([\d]+) horizontally and ([\d]+) vertically$/ do 
   script = get_mouse_event_creator_script
   script += get_scale_script
 
-  script += %Q{
+  script += <<~JAVASCRIPT
     var element = $("#{element_id}");
     var scale = getScale(element[0]);
 
@@ -333,7 +333,7 @@ And /^I drag element "([^"]*)" ([\d]+) horizontally and ([\d]+) vertically$/ do 
     element[0].dispatchEvent(mousedown);
     element[0].dispatchEvent(drag);
     element[0].dispatchEvent(mouseup);
-  }
+  JAVASCRIPT
 
   @browser.execute_script(script)
 end

--- a/dashboard/test/ui/features/step_definitions/pd.rb
+++ b/dashboard/test/ui/features/step_definitions/pd.rb
@@ -1,16 +1,16 @@
 Given(/^I am a workshop administrator with some applications of each type and status$/) do
-  steps %Q{
+  steps <<~GHERKIN
     And I am a workshop administrator
     And I create some fake applications of each type and status
-  }
+  GHERKIN
 end
 
 Given(/^I am a workshop administrator$/) do
   random_name = "TestWorkshopAdmin" + SecureRandom.hex(10)
-  steps %Q{
+  steps <<~GHERKIN
     And I create a teacher named "#{random_name}"
     And I make the teacher a workshop admin
-  }
+  GHERKIN
 end
 
 And(/^I get facilitator access$/) do
@@ -22,10 +22,10 @@ Given /^I am a CSF facilitator named "([^"]*)" for regional partner "([^"]*)"$/ 
 
   RegionalPartner.find_or_create_by(name: partner_name, group: 1, is_active: true)
 
-  steps %Q{
+  steps <<~GHERKIN
     And there is a facilitator named "#{facilitator_name}" for course "#{Pd::Workshop::COURSE_CSF}"
     And I sign in as "#{facilitator_name}"
-  }
+  GHERKIN
 end
 
 Given /^I am a program manager named "([^"]*)" for regional partner "([^"]*)"$/ do |pm_name, partner_name|
@@ -36,9 +36,7 @@ Given /^I am a program manager named "([^"]*)" for regional partner "([^"]*)"$/ 
   email, password = generate_user(pm_name)
   FactoryBot.create(:program_manager, name: pm_name, email: email, password: password, regional_partner: regional_partner)
 
-  steps %Q{
-    And I sign in as "#{pm_name}"
-  }
+  steps "And I sign in as \"#{pm_name}\""
 end
 
 And(/^I get program manager access$/) do
@@ -47,10 +45,10 @@ end
 
 Given(/^I am a program manager$/) do
   @pm_name = "Program Manager#{Time.now.to_i}_#{rand(1_000_000)}"
-  steps %{
+  steps <<~GHERKIN
     Given I create a teacher named "#{@pm_name}"
     And I get program manager access
-  }
+  GHERKIN
 end
 
 Given(/^I have a regional partner with a teacher application$/) do
@@ -83,52 +81,52 @@ Given /^I select the "([^"]*)" facilitator at index (\d+)$/ do |name, index|
   email = @users[name][:email]
   facilitator = "#{name} (#{email})"
 
-  steps %Q{
+  steps <<~GHERKIN
     And I wait until element "#facilitator#{index}" is visible
     And I select the "#{facilitator}" option in dropdown "facilitator#{index}"
-  }
+  GHERKIN
 end
 
 Given /^I open the new workshop form$/ do
-  steps %Q{
+  steps <<~GHERKIN
     And I am on "http://studio.code.org/pd/workshop_dashboard"
     Then I wait until element "button:contains('New Workshop')" is visible
     Then I press "button:contains('New Workshop')" using jQuery
 
     And I wait until element "h2:contains('New Workshop')" is visible
-  }
+  GHERKIN
 end
 
 Given(/^I am a facilitator with started and completed courses$/) do
   random_name = "TestFacilitator" + SecureRandom.hex[0..9]
-  steps %Q{
+  steps <<~GHERKIN
     And I create a teacher named "#{random_name}"
     And I make the teacher named "#{random_name}" a facilitator for course "CS Fundamentals"
     And I create a workshop for course "CS Fundamentals" facilitated by "#{random_name}" with 5 people and start it
     And I create a workshop for course "CS Fundamentals" facilitated by "#{random_name}" with 5 people and end it
     And I create a workshop for course "CS Fundamentals" facilitated by "#{random_name}" with 5 people
-  }
+  GHERKIN
 end
 
 Given(/^I am an organizer with started and completed courses$/) do
   random_name = "TestOrganizer" + SecureRandom.hex[0..9]
-  steps %Q{
+  steps <<~GHERKIN
     And I create a teacher named "#{random_name}"
     And I make the teacher named "#{random_name}" a workshop organizer
     And I create a workshop for course "CS Fundamentals" organized by "#{random_name}" with 5 people and start it
     And I create a workshop for course "CS Fundamentals" organized by "#{random_name}" with 5 people and end it
     And I create a workshop for course "CS Fundamentals" organized by "#{random_name}" with 5 people
-  }
+  GHERKIN
 end
 
 Given(/^I am a teacher who has just followed a workshop certificate link$/) do
   test_teacher_name = "TestTeacher - Certificate Test"
   require_rails_env
 
-  steps %Q{
+  steps <<~GHERKIN
     And I create a teacher named "#{test_teacher_name}"
     And I create a workshop for course "CS Principles" attended by "#{test_teacher_name}" with 3 facilitators and end it
-  }
+  GHERKIN
 
   enrollment = FactoryBot.create(
     :pd_enrollment,
@@ -136,9 +134,7 @@ Given(/^I am a teacher who has just followed a workshop certificate link$/) do
     :from_user,
     user: find_test_user_by_name(test_teacher_name)
   )
-  steps %Q{
-    And I am on "http://studio.code.org/pd/generate_workshop_certificate/#{enrollment.code}"
-  }
+  steps "And I am on \"http://studio.code.org/pd/generate_workshop_certificate/#{enrollment.code}\""
 end
 
 Given(/^I navigate to the principal approval page for "([^"]*)"$/) do |name|
@@ -150,9 +146,7 @@ Given(/^I navigate to the principal approval page for "([^"]*)"$/) do |name|
   # TODO(Andrew) ensure regional partner in the original application, and remove this:
   application.update!(regional_partner: RegionalPartner.first)
 
-  steps %Q{
-    And I am on "http://studio.code.org/pd/application/principal_approval/#{application.application_guid}"
-  }
+  steps "And I am on \"http://studio.code.org/pd/application/principal_approval/#{application.application_guid}\""
 end
 
 And(/^I make the teacher named "([^"]*)" a facilitator for course "([^"]*)"$/) do |name, course|
@@ -175,7 +169,7 @@ And(/^I make the teacher a workshop admin$/) do
 end
 
 And(/^I complete Section 2 of the teacher PD application$/) do
-  steps %Q{
+  steps <<~GHERKIN
     Then I wait until element "h3" contains text "Section 2: Find Your Region"
     And I press the first "input[name='country']" element
     And I press keys "nonexistent" for element "#school input"
@@ -189,11 +183,11 @@ And(/^I complete Section 2 of the teacher PD application$/) do
     And I select the "Washington" option in dropdown "schoolState"
     And I press keys "98101" for element "input#schoolZipCode"
     And I press the first "input[name='schoolType'][value='Other']" element
-  }
+  GHERKIN
 end
 
 And(/^I complete Section 3 of the teacher PD application$/) do
-  steps %Q{
+  steps <<~GHERKIN
     Then I wait until element "h3" contains text "Section 3: About You"
     And I press the first "input[name='completingOnBehalfOfSomeoneElse'][value='No']" element
     And I press keys "Severus" for element "input#firstName"
@@ -204,21 +198,21 @@ And(/^I complete Section 3 of the teacher PD application$/) do
     And I select the "Washington" option in dropdown "state"
     And I press keys "98101" for element "input#zipCode"
     And I press the first "input[name='howHeard']" element
-  }
+  GHERKIN
 end
 
 And(/^I complete Section 4 of the teacher PD application$/) do
-  steps %Q{
+  steps <<~GHERKIN
     Then I wait until element "h3" contains text "Section 4: Additional Demographic Information"
     And I press the first "input[name='currentRole']" element
     And I press the first "input[name='previousYearlongCdoPd']" element
     And I press "input[name='genderIdentity']:first" using jQuery
     And I press the first "input[name='race']" element
-  }
+  GHERKIN
 end
 
 And(/^I complete Section 5 of the teacher PD application$/) do
-  steps %Q{
+  steps <<~GHERKIN
     Then I wait until element "h3" contains text "Section 5: Administrator/School Leader Information"
     And I press keys "Headmaster" for element "input#principalRole"
     And I press keys "Albus" for element "input#principalFirstName"
@@ -226,18 +220,18 @@ And(/^I complete Section 5 of the teacher PD application$/) do
     And I press keys "socks@hogwarts.edu" for element "input#principalEmail"
     And I press keys "socks@hogwarts.edu" for element "input#principalConfirmEmail"
     And I press keys "5555882300" for element "input#principalPhoneNumber"
-  }
+  GHERKIN
 end
 
 And(/^I complete Section 7 of the teacher PD application$/) do
-  steps %Q{
+  steps <<~GHERKIN
     Then I wait until element "h3" contains text "Section 7: Program Requirements and Submission"
     Then I wait until element "input[name='committed']" is visible
     And I press "input[name='committed']:first" using jQuery
     And I press the first "input#understandFee" element
     And I click selector "input[name='payFee']" if I see it
     And I press the first "input#agree" element
-  }
+  GHERKIN
 end
 
 And(/^I create some fake applications of each type and status$/) do
@@ -256,9 +250,7 @@ And(/^I am viewing a workshop with fake survey results$/) do
   create_fake_survey_questions workshop
   create_fake_daily_survey_results workshop
 
-  steps %Q{
-    And I am on "http://studio.code.org/pd/workshop_dashboard/daily_survey_results/#{workshop.id}"
-  }
+  steps "And I am on \"http://studio.code.org/pd/workshop_dashboard/daily_survey_results/#{workshop.id}\""
 end
 
 def create_fake_survey_questions(workshop)

--- a/dashboard/test/ui/features/step_definitions/project_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/project_steps.rb
@@ -8,19 +8,19 @@ And(/^I confirm correct visibility of view more links$/) do
   dcdo_flag = DCDO.get('image_moderation', {})['limited_project_gallery']
   hidden_view_more_links = dcdo_flag.nil? ? true : dcdo_flag
   if hidden_view_more_links
-    steps %Q{
+    steps <<~GHERKIN
       And the project gallery contains 8 view more links
       And element ".ui-project-app-type-area:eq(3)" contains text "App Lab"
       And element ".ui-project-app-type-area:eq(3)" does not contain text "View more"
       And element ".ui-project-app-type-area:eq(2)" contains text "Game Lab"
       And element ".ui-project-app-type-area:eq(2)" does not contain text "View more"
-    }
+    GHERKIN
   else
-    steps %Q{
+    steps <<~GHERKIN
       And the project gallery contains 10 view more links
       And element ".ui-project-app-type-area:eq(3)" contains text "View more App Lab projects"
       And element ".ui-project-app-type-area:eq(2)" contains text "View more Game Lab projects"
-    }
+    GHERKIN
   end
 end
 
@@ -42,7 +42,7 @@ Then(/^I scroll the Play Lab gallery section into view$/) do
 end
 
 Then(/^I make a "([^"]*)" project named "([^"]*)"$/) do |project_type, name|
-  steps %Q{
+  steps <<~GHERKIN
     Then I am on "http://studio.code.org/projects/#{project_type}/new"
     And I get redirected to "/projects/#{project_type}/([^\/]*?)/edit" via "dashboard"
     And I wait for the page to fully load
@@ -55,11 +55,11 @@ Then(/^I make a "([^"]*)" project named "([^"]*)"$/) do |project_type, name|
     And I press "#runButton" using jQuery
     And I wait until element ".project_updated_at" contains text "Saved"
     And I wait until initial thumbnail capture is complete
-  }
+  GHERKIN
 end
 
 Then(/^I report abuse on the project$/) do
-  steps %Q{
+  steps <<~GHERKIN
     Then I switch tabs
     Then I wait until current URL contains "report_abuse"
     And I wait until element "#uitest-abuse-url" is visible
@@ -69,79 +69,79 @@ Then(/^I report abuse on the project$/) do
     Then I click selector "#uitest-submit-report-abuse" once I see it
     Then I wait until current URL contains "support.code.org"
     Then I switch tabs
-  }
+  GHERKIN
 end
 
 Then(/^I publish the project$/) do
-  steps %Q{
+  steps <<~GHERKIN
     Given I open the project share dialog
     And the project is unpublished
     When I publish the project from the share dialog
-  }
+  GHERKIN
 end
 
 Then /^I open the project share dialog$/ do
-  steps <<-STEPS
+  steps <<-GHERKIN
     Then I click selector ".project_share"
     And I wait to see a dialog titled "Share your project"
-  STEPS
+  GHERKIN
 end
 
 Then /^I publish the project from the share dialog$/ do
-  steps <<-STEPS
+  steps <<-GHERKIN
     And I click selector "#share-dialog-publish-button"
     Then I publish the project from the publish to gallery dialog
-  STEPS
+  GHERKIN
 end
 
 Then /^I publish the project from the personal projects table publish button$/ do
-  steps <<-STEPS
+  steps <<-GHERKIN
     And I wait until element ".ui-personal-projects-publish-button" is visible
     Then I click selector ".ui-personal-projects-publish-button"
     Then I publish the project from the publish to gallery dialog
     And I wait until element ".ui-personal-projects-unpublish-button" is visible
-  STEPS
+  GHERKIN
 end
 
 Then /^I publish the project from the publish to gallery dialog$/ do
-  steps <<-STEPS
+  steps <<-GHERKIN
     And I wait to see a publish dialog with title containing "Publish to Public Gallery"
     And element "#publish-dialog-publish-button" is visible
     And I click selector "#publish-dialog-publish-button"
     And I wait for the dialog to close
-  STEPS
+  GHERKIN
 end
 
 Then /^I navigate to the public gallery via the gallery switcher$/ do
-  steps <<-STEPS
+  steps <<-GHERKIN
     Then I click selector "#uitest-gallery-switcher div:contains(Public Projects)"
     Then check that I am on "http://studio.code.org/projects/public"
     And I wait until element "#uitest-public-projects" is visible
     And element "#uitest-personal-projects" is not visible
-  STEPS
+  GHERKIN
 end
 
 Then /^I navigate to the personal gallery via the gallery switcher$/ do
-  steps <<-STEPS
+  steps <<-GHERKIN
     Then I click selector "#uitest-gallery-switcher div:contains(My Projects)"
     Then check that I am on "http://studio.code.org/projects"
     And I wait until element "#uitest-personal-projects" is visible
     And element "#uitest-public-projects" is not visible
-  STEPS
+  GHERKIN
 end
 
 Then /^I wait to see a publish dialog with title containing "((?:[^"\\]|\\.)*)"$/ do |expected_text|
-  steps %{
+  steps <<-GHERKIN
     Then I wait to see ".publish-dialog-title"
     And element ".publish-dialog-title" contains text "#{expected_text}"
-  }
+  GHERKIN
 end
 
 Then /^I unpublish the project from the share dialog$/ do
-  steps <<-STEPS
+  steps <<-GHERKIN
     Then I click selector "#share-dialog-unpublish-button"
     And I wait for the dialog to close
-  STEPS
+  GHERKIN
 end
 
 Then /^the project is (un)?published/ do |negation|
@@ -160,11 +160,11 @@ Then /^the project can be published$/ do
 end
 
 Then /^I reload the project page/ do
-  steps <<-STEPS
+  steps <<-GHERKIN
     And I reload the page
     And I wait for the page to fully load
     And element ".project_updated_at" eventually contains text "Saved"
-  STEPS
+  GHERKIN
 end
 
 Then /^I set the project version interval to (\d+) seconds?$/ do |seconds|
@@ -202,25 +202,25 @@ end
 
 When /^I open the share dialog$/ do
   Retryable.retryable(on: RSpec::Expectations::ExpectationNotMetError, sleep: 10, tries: 3) do
-    steps <<-STEPS
+    steps <<-GHERKIN
       When I click selector ".project_share"
       And I wait to see a dialog titled "Share your project"
-    STEPS
+    GHERKIN
   end
 end
 
 When /^I navigate to the shared version of my project$/ do
-  steps <<-STEPS
+  steps <<-GHERKIN
     When I open the share dialog
     And I navigate to the share URL
-  STEPS
+  GHERKIN
 end
 
 Then /^I navigate to the share URL$/ do
-  steps <<-STEPS
+  steps <<-GHERKIN
     Then I save the share URL
     And I navigate to the last shared URL
-  STEPS
+  GHERKIN
 end
 
 Then /^I navigate to the last shared URL$/ do

--- a/dashboard/test/ui/features/step_definitions/section_management_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/section_management_steps.rb
@@ -9,7 +9,7 @@ And(/^I create a new (student|teacher|facilitator) section( and go home)?$/) do 
 end
 
 And /^I create a new student section named "([^"]*)" assigned to "([^"]*)"(?: version "([^"]*)")?(?: and unit "([^"]*)")?$/ do |section_name, assignment_family, version_year, secondary|
-  individual_steps %Q{
+  individual_steps <<~GHERKIN
     When I see the section set up box
     When I press the new section button
     Then I should see the new section dialog
@@ -18,27 +18,27 @@ And /^I create a new student section named "([^"]*)" assigned to "([^"]*)"(?: ve
     And I press keys "#{section_name}" for element "#uitest-section-name"
     Then I wait to see "#uitest-assignment-family"
     When I select the "#{assignment_family}" option in dropdown "uitest-assignment-family"
-  }
+  GHERKIN
 
   if version_year
-    individual_steps %Q{
+    individual_steps <<~GHERKIN
       And I click selector "#assignment-version-year" once I see it
       And I click selector ".assignment-version-title:contains(#{version_year})" once I see it
-    }
+    GHERKIN
   end
 
   if secondary
-    individual_steps %Q{
+    individual_steps <<~GHERKIN
       And I wait to see "#uitest-secondary-assignment"
       And I select the "#{secondary}" option in dropdown "uitest-secondary-assignment"
-    }
+    GHERKIN
   end
 
-  individual_steps %Q{
+  individual_steps <<~GHERKIN
     And I press the save button to create a new section
     And I wait for the dialog to close
     Then I should see the student section table
-  }
+  GHERKIN
 end
 
 Given(/^I create a new student section assigned to "([^"]*)"$/) do |script_name|
@@ -50,7 +50,7 @@ Given(/^I create a new student section assigned to "([^"]*)"$/) do |script_name|
 end
 
 And /^I create a new student section with course "([^"]*)", version "([^"]*)"(?: and unit "([^"]*)")?$/ do |assignment_family, version_year, secondary|
-  individual_steps %Q{
+  individual_steps <<~GHERKIN
     When I see the section set up box
     When I press the new section button
     Then I should see the new section dialog
@@ -62,20 +62,20 @@ And /^I create a new student section with course "([^"]*)", version "([^"]*)"(?:
 
     And I click selector "#assignment-version-year" once I see it
     And I click selector ".assignment-version-title:contains(#{version_year})" once I see it
-  }
+  GHERKIN
 
   if secondary
-    individual_steps %Q{
+    individual_steps <<~GHERKIN
       And I wait to see "#uitest-secondary-assignment"
       And I select the "#{secondary}" option in dropdown "uitest-secondary-assignment"
-    }
+    GHERKIN
   end
 
-  individual_steps %Q{
+  individual_steps <<~GHERKIN
     And I press the save button to create a new section
     And I wait for the dialog to close using jQuery
     Then I should see the student section table
-  }
+  GHERKIN
 end
 
 And(/^I create a(n authorized)? teacher-associated( under-13)? student named "([^"]*)"$/) do |authorized, under_13, name|
@@ -102,25 +102,21 @@ end
 
 And(/^I join the section$/) do
   page_load(true) do
-    steps %Q{
+    steps <<~GHERKIN
       Given I am on "#{@section_url}"
       And I click selector ".btn.btn-primary" once I see it
-    }
+    GHERKIN
   end
 end
 
 And(/^I attempt to join the section$/) do
-  steps %Q{
-    Given I am on "#{@section_url}"
-  }
+  steps "Given I am on \"#{@section_url}\""
 end
 
 And(/I type the section code into "([^"]*)"$/) do |selector|
   puts @section_url
   section_code = @section_url.split('/').last
-  steps %Q{
-    And I type "#{section_code}" into "#{selector}"
-  }
+  steps "And I type \"#{section_code}\" into \"#{selector}\""
 end
 
 # press keys allows React to pick up on the changes
@@ -135,10 +131,10 @@ When /^I see the section set up box$/ do
 end
 
 When /^I press the new section button$/ do
-  steps <<-STEPS
+  steps <<-GHERKIN
     Given I scroll the ".uitest-newsection" element into view
     When I press the first ".uitest-newsection" element
-  STEPS
+  GHERKIN
 end
 
 Then /^I should see the new section dialog$/ do
@@ -146,11 +142,11 @@ Then /^I should see the new section dialog$/ do
 end
 
 When /^I select (picture|word|email) login$/ do |login_type|
-  steps %Q{When I press the first ".uitest-#{login_type}Login" element}
+  steps "When I press the first \".uitest-#{login_type}Login\" element"
 end
 
 When /^I select (student|teacher|facilitator) participant type$/ do |participant_type|
-  steps %Q{When I press the first ".uitest-#{participant_type}-type" element}
+  steps "When I press the first \".uitest-#{participant_type}-type\" element"
 end
 
 When /^I press the save button to create a new section$/ do
@@ -279,27 +275,27 @@ Then /^I open the section action dropdown$/ do
 end
 
 Then /^I add the first student to the first code review group$/ do
-  steps <<-STEPS
+  steps <<-GHERKIN
     And I focus selector "#uitest-unassign-all-button"
     And I press keys ":tab"
     And I press keys ":space"
     And I press keys ":arrow_right"
     And I press keys ":space"
-  STEPS
+  GHERKIN
 end
 
 Then /^I open the code review groups management dialog$/ do
-  steps <<-STEPS
+  steps <<-GHERKIN
     And I navigate to teacher dashboard for the section I saved
     And I click selector "#uitest-teacher-dashboard-nav a:contains(Manage Students)" once I see it
     And I click selector "#uitest-code-review-groups-button" once I see it
-  STEPS
+  GHERKIN
 end
 
 Then /^I create a new code review group for the section I saved$/ do
-  steps <<-STEPS
+  steps <<-GHERKIN
     And I open the code review groups management dialog
     And I wait for 2 seconds
     And I click selector "#uitest-create-code-review-group" once I see it
-  STEPS
+  GHERKIN
 end

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -140,19 +140,19 @@ When /^I close the instructions overlay if it exists$/ do
 end
 
 When /^I wait for the page to fully load$/ do
-  steps <<-STEPS
+  steps <<-GHERKIN
     When I wait to see "#runButton"
     And I wait to see ".header_user"
     And I close the instructions overlay if it exists
-  STEPS
+  GHERKIN
 end
 
 When /^I close the dialog$/ do
   # Add a wait to closing dialog because it's sometimes animated, now.
-  steps <<-STEPS
+  steps <<-GHERKIN
     When I press "x-close"
     And I wait for 0.75 seconds
-  STEPS
+  GHERKIN
 end
 
 When /^I wait until "([^"]*)" in localStorage equals "([^"]*)"$/ do |key, value|
@@ -160,16 +160,16 @@ When /^I wait until "([^"]*)" in localStorage equals "([^"]*)"$/ do |key, value|
 end
 
 And /^I add another version to the project$/ do
-  steps <<-STEPS
+  steps <<-GHERKIN
     And I add code "// comment A" to ace editor
     And I wait until element "#resetButton" is visible
     And I press "resetButton"
     And I click selector "#runButton" once I see it
-  STEPS
+  GHERKIN
 end
 
 When /^I reset the puzzle to the starting version$/ do
-  steps <<-STEPS
+  steps <<-GHERKIN
     Then I click selector "#versions-header"
     And I wait to see a dialog titled "Version History"
     And I see "#showVersionsModal"
@@ -183,7 +183,7 @@ When /^I reset the puzzle to the starting version$/ do
     And I click selector "#start-over-button"
     And I wait until element "#showVersionsModal" is gone
     And I wait for 3 seconds
-  STEPS
+  GHERKIN
 end
 
 When /^I reset the puzzle$/ do
@@ -787,11 +787,11 @@ Then /^element "([^"]*)" is (not )?displayed$/ do |selector, negation|
 end
 
 And(/^I select age (\d+) in the age dialog/) do |age|
-  steps %Q{
+  steps <<~GHERKIN
     And element ".age-dialog" is visible
     And I select the "#{age}" option in dropdown "uitest-age-selector"
     And I click selector "#uitest-submit-age"
-  }
+  GHERKIN
 end
 
 And(/^I do not see "([^"]*)" option in the dropdown "([^"]*)"/) do |option, selector|
@@ -1014,24 +1014,24 @@ Then /^the overview page contains ([\d]+) assign (?:button|buttons)$/ do |expect
 end
 
 And /^I dismiss the language selector$/ do
-  steps %Q{
+  steps <<~GHERKIN
     And I click selector ".close" if I see it
     And I wait until I don't see selector ".close"
-  }
+  GHERKIN
 end
 
 And /^I dismiss the login reminder$/ do
-  steps %Q{
+  steps <<~GHERKIN
     And I click selector ".modal-backdrop" if I see it
     And I wait until I don't see selector ".uitest-login-callout"
-  }
+  GHERKIN
 end
 
 And /^I dismiss the teacher panel$/ do
-  steps %Q{
+  steps <<~GHERKIN
     And I click selector ".teacher-panel > .hide-handle > .fa-chevron-right"
     And I wait until I see selector ".teacher-panel > .show-handle > .fa-chevron-left"
-  }
+  GHERKIN
 end
 
 # Call `execute_async_script` on the provided `js` code.
@@ -1087,13 +1087,13 @@ def browser_request(url:, method: 'GET', headers: {}, body: nil, code: 200, trie
 end
 
 And(/^I submit this level$/) do
-  steps %Q{
+  steps <<~GHERKIN
     And I press "runButton"
     And I wait to see "#submitButton"
     And I press "submitButton"
     And I wait to see ".modal"
     And I press "confirm-button" to load a new page
-  }
+  GHERKIN
 end
 
 And(/^I wait until I am on the join page$/) do
@@ -1306,10 +1306,10 @@ Then /^"([^"]*)" contains the saved text$/ do |css|
 end
 
 When /^I switch to text mode$/ do
-  steps <<-STEPS
+  steps <<-GHERKIN
     When I press "show-code-header"
     And I wait to see Droplet text mode
-  STEPS
+  GHERKIN
 end
 
 When /^I wait for the dialog to close$/ do
@@ -1344,7 +1344,7 @@ Then /^current URL is different from the last saved URL$/ do
 end
 
 Then /^I navigate to the saved URL$/ do
-  steps %Q{Then I am on "#{saved_url}"}
+  steps "Then I am on \"#{saved_url}\""
 end
 
 channel_id = nil
@@ -1353,9 +1353,7 @@ Then /^I save the channel id$/ do
 end
 
 And /^I type the saved channel id into element "([^"]*)"/ do |selector|
-  individual_steps %Q{
-    And I press keys "#{channel_id}" for element "#{selector}"
-  }
+  individual_steps "And I press keys \"#{channel_id}\" for element \"#{selector}\""
 end
 
 Then /^page text does (not )?contain "([^"]*)"$/ do |negation, text|
@@ -1384,7 +1382,7 @@ When /^I set up code review for teacher "([^"]*)" with (\d+(?:\.\d*)?) students 
     add_students_to_group_step_list.push("And I add the first student to the first code review group")
   end
 
-  steps %Q{
+  steps <<~GHERKIN
     Given I create a teacher named "#{teacher_name}"
     And I give user "#{teacher_name}" authorized teacher permission
     And I create a new student section assigned to "ui-test-csa-family-script"
@@ -1399,11 +1397,11 @@ When /^I set up code review for teacher "([^"]*)" with (\d+(?:\.\d*)?) students 
     #{add_students_to_group_step_list.join("\n")}
     And I click selector ".uitest-base-dialog-confirm"
     And I click selector ".toggle-input"
-  }
+  GHERKIN
 end
 
 When /^I create a student named "([^"]*)" in a CSA section$/ do |student_name|
-  steps %Q{
+  steps <<~GHERKIN
     Given I create a teacher named "Dumbledore"
     And I give user "Dumbledore" authorized teacher permission
     And I create a new student section assigned to "ui-test-csa-family-script"
@@ -1412,7 +1410,7 @@ When /^I create a student named "([^"]*)" in a CSA section$/ do |student_name|
     And I save the section id from row 0 of the section table
     Given I create a student named "#{student_name}"
     And I join the section
-  }
+  GHERKIN
 end
 
 And(/^I navigate to the pegasus certificate share page$/) do


### PR DESCRIPTION
> Checks for usage of the %q/%Q syntax when '' or "" would do.

Updates applied manually. As recommended by the official Ruby styleguide, I replaced all of our `%Q{}` blocks with simple strings where possible. Where not possible, I replaced them with heredocs. I specifically used squiggly heredocs to remove excess indentation, which is slightly different than the original functionality but in each case I think is desirable. I also updated some heredocs which were using generic names to instead specify the syntax being used.

## Links

- https://docs.rubocop.org/rubocop/cops_style.html#styleredundantpercentq
- https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/RedundantPercentQ
- https://en.wikibooks.org/wiki/Ruby_Programming/Syntax/Literals#The_.25_Notation
- https://rubystyle.guide/#percent-q
- https://rubystyle.guide/#heredoc-long-strings

## Testing story

Relying on existing tests to verify that this doesn't represent any change in functionality.