### PR TITLE
[Levelbuilder] add paste blocks button

### DIFF
--- a/apps/src/sites/studio/pages/levelbuilder.js
+++ b/apps/src/sites/studio/pages/levelbuilder.js
@@ -44,6 +44,7 @@ window.levelbuilder.copyWorkspaceToClipboard = function () {
     Blockly.Xml.blockSpaceToDom(Blockly.mainBlockSpace)
   );
   copyToClipboard(str);
+  localStorage.setItem('blockXml', str);
 };
 
 window.levelbuilder.copySelectedBlockToClipboard = function () {
@@ -52,7 +53,28 @@ window.levelbuilder.copySelectedBlockToClipboard = function () {
       Blockly.Xml.blockToDom(Blockly.selected)
     );
     copyToClipboard(str);
+    localStorage.setItem('blockXml', str);
   }
+};
+
+window.levelbuilder.pasteBlocksToWorkspace = function () {
+  let str = localStorage.getItem('blockXml');
+
+  if (str.startsWith('<xml') && str.endsWith('</xml>')) {
+    // If an entire workspace has been copied, clear the current workspace.
+    Blockly.mainBlockSpace.clear();
+  } else if (str.startsWith('<block') && str.endsWith('</block>')) {
+    // If a single block has been copied, wrap it in <xml></xml>
+    str = `<xml>${str}</xml>`;
+  } else {
+    // str is not valid block xml.
+    return;
+  }
+
+  Blockly.Xml.domToBlockSpace(
+    Blockly.mainBlockSpace,
+    Blockly.Xml.textToDom(str)
+  );
 };
 
 // TODO: Remove when global `CodeMirror` is no longer required.

--- a/apps/src/sites/studio/pages/levelbuilder.js
+++ b/apps/src/sites/studio/pages/levelbuilder.js
@@ -57,19 +57,19 @@ window.levelbuilder.copySelectedBlockToClipboard = function () {
   }
 };
 
-window.levelbuilder.pasteBlocksToWorkspace = function () {
+window.levelbuilder.pasteBlocksToWorkspace = function (clearWorkspace) {
   let str = localStorage.getItem('blockXml');
 
-  if (str.startsWith('<xml') && str.endsWith('</xml>')) {
-    // If an entire workspace has been copied, clear the current workspace.
-    Blockly.mainBlockSpace.clear();
-  } else if (str.startsWith('<block') && str.endsWith('</block>')) {
+  if (str.startsWith('<block') && str.endsWith('</block>')) {
     // If a single block has been copied, wrap it in <xml></xml>
     str = `<xml>${str}</xml>`;
-  } else {
+  }
+  if (!(str.startsWith('<xml') && str.endsWith('</xml>'))) {
     // str is not valid block xml.
     return;
   }
+
+  clearWorkspace && Blockly.mainBlockSpace.clear();
 
   Blockly.Xml.domToBlockSpace(
     Blockly.mainBlockSpace,

--- a/apps/src/sites/studio/pages/levelbuilder.js
+++ b/apps/src/sites/studio/pages/levelbuilder.js
@@ -57,7 +57,7 @@ window.levelbuilder.copySelectedBlockToClipboard = function () {
   }
 };
 
-window.levelbuilder.pasteBlocksToWorkspace = function (clearWorkspace) {
+window.levelbuilder.pasteBlocksToWorkspace = function () {
   let str = localStorage.getItem('blockXml');
 
   if (str.startsWith('<block') && str.endsWith('</block>')) {
@@ -68,8 +68,6 @@ window.levelbuilder.pasteBlocksToWorkspace = function (clearWorkspace) {
     // str is not valid block xml.
     return;
   }
-
-  clearWorkspace && Blockly.mainBlockSpace.clear();
 
   Blockly.Xml.domToBlockSpace(
     Blockly.mainBlockSpace,

--- a/dashboard/app/views/levels/_admin.html.haml
+++ b/dashboard/app/views/levels/_admin.html.haml
@@ -70,15 +70,16 @@
       - elsif @script_level
         %li= link_to 'edit on levelbuilder', URI.join("https://levelbuilder-studio.code.org/", build_script_level_path(@script_level, @extra_params)).to_s
     - if (@level.is_a? Blockly) && (!@level.uses_droplet?)
-      %button{type: 'button', onclick: 'window.levelbuilder.copyWorkspaceToClipboard()', class: 'btn btn-default btn-sm'}
-        Copy all blocks
-      %button{type: 'button', onclick: 'window.levelbuilder.pasteBlocksToWorkspace(true)', class: 'btn btn-default btn-sm'}
-        Clear workspace & paste blocks
-      %br
       %button{type: 'button', onclick: 'window.levelbuilder.copySelectedBlockToClipboard()', class: 'btn btn-default btn-sm'}
         Copy selected block
+      %button{type: 'button', onclick: 'window.levelbuilder.copyWorkspaceToClipboard()', class: 'btn btn-default btn-sm'}
+        Copy all blocks
+      %br
       %button{type: 'button', onclick: 'window.levelbuilder.pasteBlocksToWorkspace()', class: 'btn btn-default btn-sm'}
         Paste block(s)
+      %br
+      %button{type: 'button', onclick: 'Blockly.mainBlockSpace.clear()', class: 'btn btn-default btn-sm'}
+        Clear workspace
       - if @level.uses_google_blockly? || (params[:blocklyVersion] == 'google')
         %button{type: 'button', onclick: 'Blockly.getMainWorkspace().undo(false)', class: 'btn btn-default btn-sm'}
           Undo

--- a/dashboard/app/views/levels/_admin.html.haml
+++ b/dashboard/app/views/levels/_admin.html.haml
@@ -23,17 +23,6 @@
                   %li= link_to "initialization (#{Blockly.count_xml_blocks(@level.initialization_blocks)})", edit_blocks_level_path(@level, :initialization_blocks)
                 - if @level.is_a? Artist
                   %li= link_to 'pre-draw', edit_blocks_level_path(@level, :predraw_blocks)
-              - unless @level.uses_droplet?
-                %button{type: 'button', onclick: 'window.levelbuilder.copyWorkspaceToClipboard()', class: 'btn btn-default btn-sm'}
-                  Copy workspace XML to clipboard
-                %br
-                %button{type: 'button', onclick: 'window.levelbuilder.copySelectedBlockToClipboard()', class: 'btn btn-default btn-sm'}
-                  Copy selected block XML to clipboard
-                %br
-                %button{type: 'button', onclick: 'window.levelbuilder.pasteBlocksToWorkspace()', class: 'btn btn-default btn-sm'}
-                  Paste XML block(s)* to workspace
-                %br
-                  Warning: A copied workspace will replace the existing workspace.
             - elsif @level.is_a? Javalab
               %ul
                 %li= link_to "[s]tart", edit_blocks_level_path(@level, :start_sources), { accesskey: 's' }
@@ -80,7 +69,20 @@
 
       - elsif @script_level
         %li= link_to 'edit on levelbuilder', URI.join("https://levelbuilder-studio.code.org/", build_script_level_path(@script_level, @extra_params)).to_s
-
+    - if (@level.is_a? Blockly) && (!@level.uses_droplet?)
+      %button{type: 'button', onclick: 'window.levelbuilder.copyWorkspaceToClipboard()', class: 'btn btn-default btn-sm'}
+        Copy all blocks
+      %button{type: 'button', onclick: 'window.levelbuilder.pasteBlocksToWorkspace(true)', class: 'btn btn-default btn-sm'}
+        Clear workspace & paste blocks
+      %br
+      %button{type: 'button', onclick: 'window.levelbuilder.copySelectedBlockToClipboard()', class: 'btn btn-default btn-sm'}
+        Copy selected block
+      %button{type: 'button', onclick: 'window.levelbuilder.pasteBlocksToWorkspace()', class: 'btn btn-default btn-sm'}
+        Paste block(s)
+      - if @level.uses_google_blockly? || (params[:blocklyVersion] == 'google')
+        %button{type: 'button', onclick: 'Blockly.getMainWorkspace().undo(false)', class: 'btn btn-default btn-sm'}
+          Undo
+      %hr
     This level is in #{@level.script_levels.count} scripts:
     %ul
       - @level.script_levels.each do |script_level|

--- a/dashboard/app/views/levels/_admin.html.haml
+++ b/dashboard/app/views/levels/_admin.html.haml
@@ -25,10 +25,15 @@
                   %li= link_to 'pre-draw', edit_blocks_level_path(@level, :predraw_blocks)
               - unless @level.uses_droplet?
                 %button{type: 'button', onclick: 'window.levelbuilder.copyWorkspaceToClipboard()', class: 'btn btn-default btn-sm'}
-                  Copy workspace to clipboard
+                  Copy workspace XML to clipboard
                 %br
                 %button{type: 'button', onclick: 'window.levelbuilder.copySelectedBlockToClipboard()', class: 'btn btn-default btn-sm'}
-                  Copy selected block to clipboard
+                  Copy selected block XML to clipboard
+                %br
+                %button{type: 'button', onclick: 'window.levelbuilder.pasteBlocksToWorkspace()', class: 'btn btn-default btn-sm'}
+                  Paste XML block(s)* to workspace
+                %br
+                  Warning: A copied workspace will replace the existing workspace.
             - elsif @level.is_a? Javalab
               %ul
                 %li= link_to "[s]tart", edit_blocks_level_path(@level, :start_sources), { accesskey: 's' }


### PR DESCRIPTION
This adds a button to the levelbuilder "Extra Links" that will paste a recently copied block or workspace (XML) to the main workspace. Unlike our existing keyboard shortcuts and context menu options for copy/paste, which copy the actual blocks, this works seamlessly between CDO and Google Blockly workspaces. 

Copying a block from a CDO Blockly workspace to a Google Blockly workspace:

https://user-images.githubusercontent.com/43474485/234299356-2c69e79a-b5a3-4022-9910-2b9867655677.mp4

If the levelbuilder copies the entire workspace, when they choose to paste, we will first clear the workspace. This is to ensure that redundant blocks (e.g. `when run`, behavior definitions) are not added with each click.

This video demonstrates that the workspace is indeed cleared by dragging some blocks around between a first and second paste:

https://user-images.githubusercontent.com/43474485/234299800-3fee2ed8-0fde-42d7-bc83-132f95ec0652.mp4

To accomplish this, we can store the copied block XML in the browser's local storage. This seems preferable to trying to read the user's actual clipboard data as that would require a secure connection, which we don't have for local servers. If an unsupported block is pasted, we will create an unknown block as usual.

It is hoped that this small feature will be useful to curriculum writers and engineers who currently need to use the browser console to accomplish this.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
