### PR TITLE
Laying groundwork for SoundPicker in Google Blockly

### DIFF
--- a/apps/src/blockly/addons/cdoUtils.js
+++ b/apps/src/blockly/addons/cdoUtils.js
@@ -109,7 +109,7 @@ export function getCode(workspace) {
   // return JSON.stringify(Blockly.serialization.workspaces.save(workspace));
 }
 
-// TODO: Re-defined with a new custom field.
+// TODO: Re-define with a new custom field.
 export function playSoundButton(dashboard, onSelect) {
   return new Blockly.FieldDropdown([['Choose', 'Choose']], () => {
     dashboard.assets.showAssetManager(onSelect, 'audio', null, {

--- a/apps/src/blockly/addons/cdoUtils.js
+++ b/apps/src/blockly/addons/cdoUtils.js
@@ -108,3 +108,12 @@ export function getCode(workspace) {
   // After supporting JSON block sources, change to:
   // return JSON.stringify(Blockly.serialization.workspaces.save(workspace));
 }
+
+// TODO: Re-defined with a new custom field.
+export function playSoundButton(dashboard, onSelect) {
+  return new Blockly.FieldDropdown([['Choose', 'Choose']], () => {
+    dashboard.assets.showAssetManager(onSelect, 'audio', null, {
+      libraryOnly: true,
+    });
+  });
+}

--- a/apps/src/blockly/addons/cdoUtils.js
+++ b/apps/src/blockly/addons/cdoUtils.js
@@ -110,10 +110,6 @@ export function getCode(workspace) {
 }
 
 // TODO: Re-define with a new custom field.
-export function playSoundButton(dashboard, onSelect) {
-  return new Blockly.FieldDropdown([['Choose', 'Choose']], () => {
-    dashboard.assets.showAssetManager(onSelect, 'audio', null, {
-      libraryOnly: true,
-    });
-  });
+export function soundField(onChange) {
+  return new Blockly.FieldDropdown([['Choose', 'Choose']], onChange);
 }

--- a/apps/src/blockly/cdoBlocklyWrapper.js
+++ b/apps/src/blockly/cdoBlocklyWrapper.js
@@ -275,12 +275,8 @@ function initializeBlocklyWrapper(blocklyInstance) {
     getCode: function (workspace) {
       return Blockly.Xml.domToText(Blockly.Xml.blockSpaceToDom(workspace));
     },
-    playSoundButton: function (dashboard, onSelect) {
-      return new Blockly.FieldDropdown([['Choose', 'Choose']], () => {
-        dashboard.assets.showAssetManager(onSelect, 'audio', null, {
-          libraryOnly: true,
-        });
-      });
+    soundField: function (onChange) {
+      return new Blockly.FieldDropdown([['Choose', 'Choose']], onChange);
     },
   };
   return blocklyWrapper;

--- a/apps/src/blockly/cdoBlocklyWrapper.js
+++ b/apps/src/blockly/cdoBlocklyWrapper.js
@@ -275,6 +275,13 @@ function initializeBlocklyWrapper(blocklyInstance) {
     getCode: function (workspace) {
       return Blockly.Xml.domToText(Blockly.Xml.blockSpaceToDom(workspace));
     },
+    playSoundButton: function (dashboard, onSelect) {
+      return new Blockly.FieldDropdown([['Choose', 'Choose']], () => {
+        dashboard.assets.showAssetManager(onSelect, 'audio', null, {
+          libraryOnly: true,
+        });
+      });
+    },
   };
   return blocklyWrapper;
 }

--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -189,15 +189,20 @@ const customInputTypes = {
   },
   soundPicker: {
     addInput(blockly, block, inputConfig, currentInputRow) {
-      var onSelect = function (soundValue) {
+      const onSelect = function (soundValue) {
         block.setTitleValue(soundValue, inputConfig.name);
       };
+      const onChange = dashboard.assets.showAssetManager(
+        onSelect,
+        'audio',
+        null,
+        {
+          libraryOnly: true,
+        }
+      );
       currentInputRow
         .appendField(inputConfig.label)
-        .appendField(
-          Blockly.cdoUtils.playSoundButton(dashboard, onSelect),
-          inputConfig.name
-        );
+        .appendField(Blockly.cdoUtils.soundField(onChange), inputConfig.name);
     },
     generateCode(block, arg) {
       return `'${block.getFieldValue(arg.name)}'`;

--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -192,14 +192,11 @@ const customInputTypes = {
       const onSelect = function (soundValue) {
         block.setTitleValue(soundValue, inputConfig.name);
       };
-      const onChange = dashboard.assets.showAssetManager(
-        onSelect,
-        'audio',
-        null,
-        {
+      const onChange = () => {
+        dashboard.assets.showAssetManager(onSelect, 'audio', null, {
           libraryOnly: true,
-        }
-      );
+        });
+      };
       currentInputRow
         .appendField(inputConfig.label)
         .appendField(Blockly.cdoUtils.soundField(onChange), inputConfig.name);

--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -192,14 +192,12 @@ const customInputTypes = {
       var onSelect = function (soundValue) {
         block.setTitleValue(soundValue, inputConfig.name);
       };
-      currentInputRow.appendField(inputConfig.label).appendField(
-        new Blockly.FieldDropdown([['Choose', 'Choose']], () => {
-          dashboard.assets.showAssetManager(onSelect, 'audio', null, {
-            libraryOnly: true,
-          });
-        }),
-        inputConfig.name
-      );
+      currentInputRow
+        .appendField(inputConfig.label)
+        .appendField(
+          Blockly.cdoUtils.playSoundButton(dashboard, onSelect),
+          inputConfig.name
+        );
     },
     generateCode(block, arg) {
       return `'${block.getFieldValue(arg.name)}'`;


### PR DESCRIPTION
This PR lays the groundwork for using a customized field for the `play sound` function in Google Blockly labs. There is **NO** change in functionality that results from this PR.
Currently in both versions of Blockly, the `play sound` functions uses a dropdown field for the sound picker. The user clicks on `Choose` and then a dropdown menu is displayed with only one option 'Choose'. Then in CDO Blockly labs, after the user clicks a second time, the Sound Picker is displayed.

Video of `play sound` in CDO Blockly labs:


https://user-images.githubusercontent.com/107423305/234384746-c87ed300-2336-4bea-85ac-4c84d29000a8.mp4



~~In Google Blockly labs such as Poetry or Dance, the `play sound` is not yet available in the toolbox.~~ 
The sound picker is defined only in 'spritelab/blocks.js'. The `play sound` block is available and works in Poetry because Poetry is an extension of Sprite Lab and has access to the 'GamelabJr' block pool. Our success criteria for supporting this block with Google Blockly is that it renders and functions as expected in Poetry or SpriteLab with Google Blockly. Currently, when the block is copied and pasted into a Google Blockly lab, the Sound Picker is not yet displayed. Implementing the Sound Picker in Google Block labs will be the follow-up to this PR.


After discussion with @mikeharv and @sanchitmalhotra126 , we agree that instead of implementing a field dropdown, it makes more sense to use a customized field, similar to the `FieldSounds` used in Music Lab. Thus, the user will only click on 'Choose' once, and then the Sound Picker will be displayed. Here's the `FieldSounds` in Music Lab:


https://user-images.githubusercontent.com/107423305/234385233-bc6b70f1-c6f5-42ec-84ec-2fb47a50abe5.mp4



This PR does not change any functionality, but does add the `soundField` function which is called in `blocks.js`. 
The next step is to create a customized field similar to `FieldSounds` that will extend the `Field` interface. When the user clicks on the field, the Sound Picker will be displayed from which the user can then pick the sound. Once this field is available, it will be called on in `playSoundButton` in `cdoUtils.js`. Creating this function will allow us to use a more modern approach to `play sound` in Google Blockly labs without impacting the current implementation in CDO Blockly labs.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
I tested locally to make sure this did not cause any regressions in Sprite Lab.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
