### PR TITLE
[CFU] Add eyes tests for summary view, second try

### DIFF
--- a/apps/src/templates/levelSummary/CheckForUnderstanding.jsx
+++ b/apps/src/templates/levelSummary/CheckForUnderstanding.jsx
@@ -67,7 +67,7 @@ const CheckForUnderstanding = ({
   };
 
   return (
-    <div className={styles.summaryContainer}>
+    <div className={styles.summaryContainer} id="summary-container">
       {/* Top Nav Links */}
       <p className={styles.navLinks}>
         <a

--- a/dashboard/config/scripts_json/allthethings.script_json
+++ b/dashboard/config/scripts_json/allthethings.script_json
@@ -10,7 +10,7 @@
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2023-04-05 09:02:01 UTC",
+    "serialized_at": "2023-04-25 18:41:45 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -4423,6 +4423,48 @@
     },
     {
       "chapter": 106,
+      "position": 2,
+      "activity_section_position": 2,
+      "assessment": false,
+      "properties": {
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L5 CSP CFU subgroups2022"
+        ],
+        "lesson.key": "Free Response",
+        "lesson_group.key": "",
+        "script.name": "allthethings",
+        "activity_section.key": "e39b746e-7160-4df7-87c2-c370d042e3da"
+      },
+      "level_keys": [
+        "U2L5 CSP CFU subgroups2022"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 3,
+      "activity_section_position": 3,
+      "assessment": false,
+      "properties": {
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSA U1L4-L1 Contained_2022"
+        ],
+        "lesson.key": "Free Response",
+        "lesson_group.key": "",
+        "script.name": "allthethings",
+        "activity_section.key": "e39b746e-7160-4df7-87c2-c370d042e3da"
+      },
+      "level_keys": [
+        "CSA U1L4-L1 Contained_2022"
+      ]
+    },
+    {
+      "chapter": 108,
       "position": 1,
       "activity_section_position": 1,
       "assessment": true,
@@ -4446,7 +4488,7 @@
       ]
     },
     {
-      "chapter": 107,
+      "chapter": 109,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -4478,7 +4520,7 @@
       ]
     },
     {
-      "chapter": 108,
+      "chapter": 110,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -4510,7 +4552,7 @@
       ]
     },
     {
-      "chapter": 109,
+      "chapter": 111,
       "position": 3,
       "activity_section_position": 3,
       "assessment": false,
@@ -4542,7 +4584,7 @@
       ]
     },
     {
-      "chapter": 110,
+      "chapter": 112,
       "position": 4,
       "activity_section_position": 4,
       "assessment": false,
@@ -4574,7 +4616,7 @@
       ]
     },
     {
-      "chapter": 111,
+      "chapter": 113,
       "position": 5,
       "activity_section_position": 5,
       "assessment": false,
@@ -4606,7 +4648,7 @@
       ]
     },
     {
-      "chapter": 112,
+      "chapter": 114,
       "position": 6,
       "activity_section_position": 6,
       "assessment": false,
@@ -4638,7 +4680,7 @@
       ]
     },
     {
-      "chapter": 113,
+      "chapter": 115,
       "position": 7,
       "activity_section_position": 7,
       "assessment": false,
@@ -4670,7 +4712,7 @@
       ]
     },
     {
-      "chapter": 114,
+      "chapter": 116,
       "position": 8,
       "activity_section_position": 8,
       "assessment": false,
@@ -4702,7 +4744,7 @@
       ]
     },
     {
-      "chapter": 115,
+      "chapter": 117,
       "position": 9,
       "activity_section_position": 9,
       "assessment": false,
@@ -4734,7 +4776,7 @@
       ]
     },
     {
-      "chapter": 116,
+      "chapter": 118,
       "position": 1,
       "activity_section_position": 1,
       "assessment": true,
@@ -4758,7 +4800,7 @@
       ]
     },
     {
-      "chapter": 117,
+      "chapter": 119,
       "position": 1,
       "activity_section_position": 1,
       "assessment": true,
@@ -4782,7 +4824,7 @@
       ]
     },
     {
-      "chapter": 118,
+      "chapter": 120,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -4806,7 +4848,7 @@
       ]
     },
     {
-      "chapter": 119,
+      "chapter": 121,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -4830,7 +4872,7 @@
       ]
     },
     {
-      "chapter": 120,
+      "chapter": 122,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -4854,7 +4896,7 @@
       ]
     },
     {
-      "chapter": 121,
+      "chapter": 123,
       "position": 1,
       "activity_section_position": 1,
       "assessment": true,
@@ -4878,7 +4920,7 @@
       ]
     },
     {
-      "chapter": 122,
+      "chapter": 124,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -4902,7 +4944,7 @@
       ]
     },
     {
-      "chapter": 123,
+      "chapter": 125,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -4926,7 +4968,7 @@
       ]
     },
     {
-      "chapter": 124,
+      "chapter": 126,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -4950,7 +4992,7 @@
       ]
     },
     {
-      "chapter": 125,
+      "chapter": 127,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -4974,7 +5016,7 @@
       ]
     },
     {
-      "chapter": 126,
+      "chapter": 128,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -4998,7 +5040,7 @@
       ]
     },
     {
-      "chapter": 127,
+      "chapter": 129,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -5022,7 +5064,7 @@
       ]
     },
     {
-      "chapter": 128,
+      "chapter": 130,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -5046,7 +5088,7 @@
       ]
     },
     {
-      "chapter": 129,
+      "chapter": 131,
       "position": 1,
       "activity_section_position": 1,
       "assessment": true,
@@ -5070,7 +5112,7 @@
       ]
     },
     {
-      "chapter": 130,
+      "chapter": 132,
       "position": 2,
       "activity_section_position": 2,
       "assessment": true,
@@ -5094,7 +5136,7 @@
       ]
     },
     {
-      "chapter": 131,
+      "chapter": 133,
       "position": 3,
       "activity_section_position": 3,
       "assessment": true,
@@ -5118,7 +5160,7 @@
       ]
     },
     {
-      "chapter": 132,
+      "chapter": 134,
       "position": 1,
       "activity_section_position": 1,
       "assessment": true,
@@ -5142,7 +5184,7 @@
       ]
     },
     {
-      "chapter": 133,
+      "chapter": 135,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -5166,7 +5208,7 @@
       ]
     },
     {
-      "chapter": 134,
+      "chapter": 136,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -5190,7 +5232,7 @@
       ]
     },
     {
-      "chapter": 135,
+      "chapter": 137,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -5214,7 +5256,7 @@
       ]
     },
     {
-      "chapter": 136,
+      "chapter": 138,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -5238,7 +5280,7 @@
       ]
     },
     {
-      "chapter": 137,
+      "chapter": 139,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -5262,7 +5304,7 @@
       ]
     },
     {
-      "chapter": 138,
+      "chapter": 140,
       "position": 3,
       "activity_section_position": 3,
       "assessment": false,
@@ -5286,7 +5328,7 @@
       ]
     },
     {
-      "chapter": 139,
+      "chapter": 141,
       "position": 4,
       "activity_section_position": 4,
       "assessment": false,
@@ -5310,7 +5352,7 @@
       ]
     },
     {
-      "chapter": 140,
+      "chapter": 142,
       "position": 5,
       "activity_section_position": 5,
       "assessment": false,
@@ -5334,7 +5376,7 @@
       ]
     },
     {
-      "chapter": 141,
+      "chapter": 143,
       "position": 6,
       "activity_section_position": 6,
       "assessment": false,
@@ -5358,7 +5400,7 @@
       ]
     },
     {
-      "chapter": 142,
+      "chapter": 144,
       "position": 7,
       "activity_section_position": 7,
       "assessment": false,
@@ -5382,7 +5424,7 @@
       ]
     },
     {
-      "chapter": 143,
+      "chapter": 145,
       "position": 8,
       "activity_section_position": 8,
       "assessment": false,
@@ -5406,7 +5448,7 @@
       ]
     },
     {
-      "chapter": 144,
+      "chapter": 146,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -5430,7 +5472,7 @@
       ]
     },
     {
-      "chapter": 145,
+      "chapter": 147,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -5454,7 +5496,7 @@
       ]
     },
     {
-      "chapter": 146,
+      "chapter": 148,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -5478,7 +5520,7 @@
       ]
     },
     {
-      "chapter": 147,
+      "chapter": 149,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -5502,7 +5544,7 @@
       ]
     },
     {
-      "chapter": 148,
+      "chapter": 150,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -5526,7 +5568,7 @@
       ]
     },
     {
-      "chapter": 149,
+      "chapter": 151,
       "position": 3,
       "activity_section_position": 3,
       "assessment": false,
@@ -5550,7 +5592,7 @@
       ]
     },
     {
-      "chapter": 150,
+      "chapter": 152,
       "position": 4,
       "activity_section_position": 4,
       "assessment": false,
@@ -5574,7 +5616,7 @@
       ]
     },
     {
-      "chapter": 151,
+      "chapter": 153,
       "position": 5,
       "activity_section_position": 5,
       "assessment": false,
@@ -5598,7 +5640,7 @@
       ]
     },
     {
-      "chapter": 152,
+      "chapter": 154,
       "position": 6,
       "activity_section_position": 6,
       "assessment": false,
@@ -5622,7 +5664,7 @@
       ]
     },
     {
-      "chapter": 153,
+      "chapter": 155,
       "position": 7,
       "activity_section_position": 7,
       "assessment": false,
@@ -5646,7 +5688,7 @@
       ]
     },
     {
-      "chapter": 154,
+      "chapter": 156,
       "position": 8,
       "activity_section_position": 8,
       "assessment": false,
@@ -5670,7 +5712,7 @@
       ]
     },
     {
-      "chapter": 155,
+      "chapter": 157,
       "position": 9,
       "activity_section_position": 10,
       "assessment": false,
@@ -5694,7 +5736,7 @@
       ]
     },
     {
-      "chapter": 156,
+      "chapter": 158,
       "position": 10,
       "activity_section_position": 11,
       "assessment": false,
@@ -5718,7 +5760,7 @@
       ]
     },
     {
-      "chapter": 157,
+      "chapter": 159,
       "position": 11,
       "activity_section_position": 12,
       "assessment": false,
@@ -5742,7 +5784,7 @@
       ]
     },
     {
-      "chapter": 158,
+      "chapter": 160,
       "position": 12,
       "activity_section_position": 13,
       "assessment": false,
@@ -5766,7 +5808,7 @@
       ]
     },
     {
-      "chapter": 159,
+      "chapter": 161,
       "position": 1,
       "activity_section_position": 1,
       "assessment": true,
@@ -5790,7 +5832,7 @@
       ]
     },
     {
-      "chapter": 160,
+      "chapter": 162,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -5814,7 +5856,7 @@
       ]
     },
     {
-      "chapter": 161,
+      "chapter": 163,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
@@ -5838,7 +5880,7 @@
       ]
     },
     {
-      "chapter": 162,
+      "chapter": 164,
       "position": 3,
       "activity_section_position": 3,
       "assessment": false,
@@ -5862,7 +5904,7 @@
       ]
     },
     {
-      "chapter": 163,
+      "chapter": 165,
       "position": 4,
       "activity_section_position": 4,
       "assessment": false,
@@ -5886,7 +5928,7 @@
       ]
     },
     {
-      "chapter": 164,
+      "chapter": 166,
       "position": 1,
       "activity_section_position": 1,
       "assessment": false,
@@ -5910,11 +5952,14 @@
       ]
     },
     {
-      "chapter": 165,
+      "chapter": 167,
       "position": 2,
       "activity_section_position": 2,
       "assessment": false,
       "properties": {
+        "level_keys": [
+          "Music Level 2"
+        ]
       },
       "bonus": false,
       "seeding_key": {
@@ -5931,11 +5976,14 @@
       ]
     },
     {
-      "chapter": 166,
+      "chapter": 168,
       "position": 3,
       "activity_section_position": 3,
       "assessment": false,
       "properties": {
+        "level_keys": [
+          "Music Level 3"
+        ]
       },
       "bonus": false,
       "seeding_key": {
@@ -7215,6 +7263,30 @@
     },
     {
       "seeding_key": {
+        "level.key": "U2L5 CSP CFU subgroups2022",
+        "script_level.level_keys": [
+          "U2L5 CSP CFU subgroups2022"
+        ],
+        "lesson.key": "Free Response",
+        "lesson_group.key": "",
+        "script.name": "allthethings",
+        "activity_section.key": "e39b746e-7160-4df7-87c2-c370d042e3da"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSA U1L4-L1 Contained_2022",
+        "script_level.level_keys": [
+          "CSA U1L4-L1 Contained_2022"
+        ],
+        "lesson.key": "Free Response",
+        "lesson_group.key": "",
+        "script.name": "allthethings",
+        "activity_section.key": "e39b746e-7160-4df7-87c2-c370d042e3da"
+      }
+    },
+    {
+      "seeding_key": {
         "level.key": "Sample CSP Assessment",
         "script_level.level_keys": [
           "Sample CSP Assessment"
@@ -7279,7 +7351,7 @@
     },
     {
       "seeding_key": {
-        "level.key": "2-3 Maze 6",
+        "level.key": "2-3 Maze 3",
         "script_level.level_keys": [
           "2-3 Maze 3",
           "2-3 Maze 6"
@@ -7292,7 +7364,7 @@
     },
     {
       "seeding_key": {
-        "level.key": "2-3 Maze 3",
+        "level.key": "2-3 Maze 6",
         "script_level.level_keys": [
           "2-3 Maze 3",
           "2-3 Maze 6"
@@ -7409,7 +7481,7 @@
     },
     {
       "seeding_key": {
-        "level.key": "4-5 Maze 5",
+        "level.key": "4-5 Maze 2",
         "script_level.level_keys": [
           "4-5 Maze 2",
           "4-5 Maze 5"
@@ -7422,7 +7494,7 @@
     },
     {
       "seeding_key": {
-        "level.key": "4-5 Maze 2",
+        "level.key": "4-5 Maze 5",
         "script_level.level_keys": [
           "4-5 Maze 2",
           "4-5 Maze 5"

--- a/dashboard/test/ui/features/teacher_tools/level_summary.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_summary.feature
@@ -15,7 +15,7 @@ Scenario: Free Response level 2
   When I open my eyes to test "free response summary 2"
   Given I am a teacher
   And I create a new student section
-  And I am on "http://studio.code.org/s/csp2-2022/lessons/6/levels/3/summary"
+  And I am on "http://studio.code.org/s/allthethings/lessons/27/levels/2/summary"
   And I wait until element "#summary-container" is visible
   And I wait to see ".uitest-sectionselect"
   Then I see no difference for "free response level summary 2"
@@ -25,7 +25,7 @@ Scenario: Free Response level 3
   When I open my eyes to test "free response summary 3"
   Given I am a teacher
   And I create a new student section
-  And I am on "http://studio.code.org/s/csa1-2022/lessons/4/levels/1/summary"
+  And I am on "http://studio.code.org/s/allthethings/lessons/27/levels/3/summary"
   And I wait until element "#summary-container" is visible
   And I wait to see ".uitest-sectionselect"
   Then I see no difference for "free response level summary 3"

--- a/dashboard/test/ui/features/teacher_tools/level_summary.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_summary.feature
@@ -1,0 +1,22 @@
+Feature: Level summary
+
+Scenario: Free Response level 1
+  Given I am a teacher
+  And I create a new student section
+  Given I am on "http://studio.code.org/s/allthethings/lessons/27/levels/1/summary"
+  And I wait until element "#summary-container" is visible
+  And I wait to see ".uitest-sectionselect"
+
+Scenario: Free Response level 2
+  Given I am a teacher
+  And I create a new student section
+  Given I am on "http://studio.code.org/s/csp2-2022/lessons/6/levels/3/summary"
+  And I wait until element "#summary-container" is visible
+  And I wait to see ".uitest-sectionselect"
+
+Scenario: Free Response level 3
+  Given I am a teacher
+  And I create a new student section
+  Given I am on "http://studio.code.org/s/csa1-2022/lessons/4/levels/1/summary"
+  And I wait until element "#summary-container" is visible
+  And I wait to see ".uitest-sectionselect"

--- a/dashboard/test/ui/features/teacher_tools/level_summary.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_summary.feature
@@ -2,28 +2,31 @@
 Feature: Level summary
 
 Scenario: Free Response level 1
+  When I open my eyes to test "free response summary 1"
   Given I am a teacher
   And I create a new student section
-  Given I am on "http://studio.code.org/s/allthethings/lessons/27/levels/1/summary"
+  And I am on "http://studio.code.org/s/allthethings/lessons/27/levels/1/summary"
   And I wait until element "#summary-container" is visible
   And I wait to see ".uitest-sectionselect"
-  And I see no difference for "level summary"
+  Then I see no difference for "free response level summary 1"
   And I close my eyes
 
 Scenario: Free Response level 2
+  When I open my eyes to test "free response summary 2"
   Given I am a teacher
   And I create a new student section
-  Given I am on "http://studio.code.org/s/csp2-2022/lessons/6/levels/3/summary"
+  And I am on "http://studio.code.org/s/csp2-2022/lessons/6/levels/3/summary"
   And I wait until element "#summary-container" is visible
   And I wait to see ".uitest-sectionselect"
-  And I see no difference for "level summary"
+  Then I see no difference for "free response level summary 2"
   And I close my eyes
 
 Scenario: Free Response level 3
+  When I open my eyes to test "free response summary 3"
   Given I am a teacher
   And I create a new student section
-  Given I am on "http://studio.code.org/s/csa1-2022/lessons/4/levels/1/summary"
+  And I am on "http://studio.code.org/s/csa1-2022/lessons/4/levels/1/summary"
   And I wait until element "#summary-container" is visible
   And I wait to see ".uitest-sectionselect"
-  And I see no difference for "level summary"
+  Then I see no difference for "free response level summary 3"
   And I close my eyes

--- a/dashboard/test/ui/features/teacher_tools/level_summary.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_summary.feature
@@ -1,3 +1,4 @@
+@eyes
 Feature: Level summary
 
 Scenario: Free Response level 1
@@ -6,6 +7,8 @@ Scenario: Free Response level 1
   Given I am on "http://studio.code.org/s/allthethings/lessons/27/levels/1/summary"
   And I wait until element "#summary-container" is visible
   And I wait to see ".uitest-sectionselect"
+  And I see no difference for "level summary"
+  And I close my eyes
 
 Scenario: Free Response level 2
   Given I am a teacher
@@ -13,6 +16,8 @@ Scenario: Free Response level 2
   Given I am on "http://studio.code.org/s/csp2-2022/lessons/6/levels/3/summary"
   And I wait until element "#summary-container" is visible
   And I wait to see ".uitest-sectionselect"
+  And I see no difference for "level summary"
+  And I close my eyes
 
 Scenario: Free Response level 3
   Given I am a teacher
@@ -20,3 +25,5 @@ Scenario: Free Response level 3
   Given I am on "http://studio.code.org/s/csa1-2022/lessons/4/levels/1/summary"
   And I wait until element "#summary-container" is visible
   And I wait to see ".uitest-sectionselect"
+  And I see no difference for "level summary"
+  And I close my eyes


### PR DESCRIPTION
Second try for #51414, reverted in #51470. 

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

-----

Add some feature tests for the summary view on a few Free Response levels, so we can collect visual baselines in advance of refactoring.

Since I just want the visual diffs, I didn't have any specific test cases in mind; open to feedback on whether I should add some `verify` steps or something to these.

Ran locally:
![image](https://user-images.githubusercontent.com/1382374/233161701-a4691584-1f18-491c-b1cb-1a8ef9d9d212.png)

![image](https://user-images.githubusercontent.com/1382374/234377304-fdd7cec3-02e5-437b-8e0f-c924bdcdf9e6.png)



<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

