### PR TITLE
Rename cabal -> team

### DIFF
--- a/aws/ci_build
+++ b/aws/ci_build
@@ -186,7 +186,7 @@ def main
 
       if CDO.test_system?
         DevelopersTopic.set_dtt 'no (robo-DTT failed)'
-        ChatClient.log "*** Before you manually re-run a test, please ensure that the cabal who owns that test is actively tracking de-flaking. ***", color: 'yellow'
+        ChatClient.log "*** Before you manually re-run a test, please ensure that the team who owns that test is actively tracking de-flaking. ***", color: 'yellow'
       end
     end
 

--- a/tools/hooks/scary_changes.rb
+++ b/tools/hooks/scary_changes.rb
@@ -94,7 +94,7 @@ class ScaryChangeDetector
         Looks like you are adding a column, changing a column or adding an index in this migration:
         #{changes.join("\n")}
         Making these types of changes on a large table (>10M rows) needs to be reviewed and
-        tested with the Infrastructure cabal to avoid negatively impacting production database performance.
+        tested with the Infrastructure team to avoid negatively impacting production database performance.
         The may cause MySQL to rebuild the entire table.
         For more information see https://dev.mysql.com/doc/refman/5.7/en/innodb-online-ddl-operations.html#online-ddl-column-operations.
 


### PR DESCRIPTION
Rename "cabal" -> "team"; we don't use the term "cabal" to describe engineering sub-teams anymore.