### PR TITLE
Fix drop-down menu in international PD form

### DIFF
--- a/apps/src/code-studio/pd/international_opt_in/InternationalOptIn.jsx
+++ b/apps/src/code-studio/pd/international_opt_in/InternationalOptIn.jsx
@@ -223,7 +223,7 @@ class InternationalOptInComponent extends FormComponent {
     const names = cities[selectedCity] || [];
     let nameOptions = [i18n.pdNotApplicable()];
     if (selectedCity !== i18n.pdNotApplicable()) {
-      nameOptions = nameOptions.concat(Object.keys(names));
+      nameOptions = nameOptions.concat(names);
     }
     const selectName = this.buildSelectFieldGroup({
       name: 'schoolName',
@@ -306,7 +306,7 @@ class InternationalOptInComponent extends FormComponent {
     const ids = names[selectedName] || [];
     let idOptions = [i18n.pdNotApplicable()];
     if (selectedName !== i18n.pdNotApplicable()) {
-      idOptions = idOptions.concat(Object.keys(ids));
+      idOptions = idOptions.concat(ids);
     }
     const selectId = this.buildSelectFieldGroup({
       name: 'schoolId',
@@ -373,7 +373,7 @@ class InternationalOptInComponent extends FormComponent {
     const schools = districts[selectedDistrict] || [];
     let schoolOptions = [i18n.pdNotApplicable()];
     if (selectDistrict !== i18n.pdNotApplicable()) {
-      schoolOptions = schoolOptions.concat(Object.keys(schools));
+      schoolOptions = schoolOptions.concat(schools);
     }
     const selectSchool = this.buildSelectFieldGroup({
       name: 'schoolName',


### PR DESCRIPTION
The International professional development attendance form is used to track PD data for our international partners.

We handle this form very differently as any other PD and has individual handling for each partner.

In the previous state, the last dropdown in the school selection section was populating incorrectly as it was trying to use key values, when the data contained an array of school name.

This PR replaces the key by an array.

## Links

- jira ticket: [P20-79](https://codedotorg.atlassian.net/browse/P20-79)

## Testing story

<img width="1728" alt="Screenshot 2023-04-25 at 17 16 58" src="https://user-images.githubusercontent.com/66776217/234417042-0d4b41a5-e4d2-4064-a581-06ee4475f41b.png">

https://user-images.githubusercontent.com/66776217/234417063-a3dad377-e1a6-4424-b373-72b68a901a2a.mov

## Warning!!

The AP CSP Create Performance Task is in progress from April 1 - May 1 2023. Please
consider any risk introduced by this PR that could affect our students taking AP CSP. Code.org
students taking AP CSP primarily use App Lab for their Create Task, however a small percent use Game
Lab. Carefully consider whether your change has any risk of alterering, changing, or breaking
anything in these two labs. Even small changes, such as a different button color, are considered
significant during this time period. Reach out to the Student Learning team or Curriculum team for
more details.

<!-- end warning -->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->


- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
