### PR TITLE
Project Beats: sequencer refactor (part 1)

### DIFF
--- a/apps/src/music/player/interfaces/Effects.ts
+++ b/apps/src/music/player/interfaces/Effects.ts
@@ -7,4 +7,4 @@ export interface Effects {
   delay?: EffectValue;
 }
 
-type EffectValue = 'normal' | 'medium' | 'low';
+export type EffectValue = 'normal' | 'medium' | 'low';

--- a/apps/src/music/player/sequencer/MusicPlayerStubSequencer.ts
+++ b/apps/src/music/player/sequencer/MusicPlayerStubSequencer.ts
@@ -1,0 +1,34 @@
+import {PlaybackEvent} from '../interfaces/PlaybackEvent';
+import Sequencer from './Sequencer';
+
+/**
+ * A stubbed out version of {@link Sequencer} meant to be used by block
+ * modes that use the MusicPlayer API. This allows us migrate block modes
+ * over to using the Sequencer model as we like, without completely crashing
+ * if a block mode does not yet have a sequencer implementation.
+ */
+export default class MusicPlayerStubSequencer extends Sequencer {
+  playSoundAtMeasureById() {
+    console.log('Not implemented');
+  }
+
+  createTrack() {
+    console.log('Not implemented');
+  }
+
+  addSoundsToTrack() {
+    console.log('Not implemented');
+  }
+
+  addRestToTrack() {
+    console.log('Not implemented');
+  }
+
+  getPlaybackEvents(): PlaybackEvent[] {
+    return [];
+  }
+
+  clear(): void {
+    // no-op;
+  }
+}

--- a/apps/src/music/player/sequencer/Sequencer.ts
+++ b/apps/src/music/player/sequencer/Sequencer.ts
@@ -1,0 +1,17 @@
+import {PlaybackEvent} from '../interfaces/PlaybackEvent';
+
+/**
+ * Sequences {@link PlaybackEvent}s in the user's project. The
+ * various implementations of this class are used by different
+ * block modes (i.e. programming models) we currently support.
+ */
+export default abstract class Sequencer {
+  /**
+   * Return a list of sequenced {@link PlaybackEvent}s
+   */
+  abstract getPlaybackEvents(): PlaybackEvent[];
+  /**
+   * Clear all sequenced events.
+   */
+  abstract clear(): void;
+}

--- a/apps/src/music/player/sequencer/Simple2Sequencer.ts
+++ b/apps/src/music/player/sequencer/Simple2Sequencer.ts
@@ -1,0 +1,423 @@
+import {DEFAULT_CHORD_LENGTH, DEFAULT_PATTERN_LENGTH} from '../../constants';
+import {ChordEvent, ChordEventValue} from '../interfaces/ChordEvent';
+import {Effects, EffectValue} from '../interfaces/Effects';
+import {PatternEvent, PatternEventValue} from '../interfaces/PatternEvent';
+import {PlaybackEvent} from '../interfaces/PlaybackEvent';
+import {SkipContext} from '../interfaces/SkipContext';
+import {SoundEvent} from '../interfaces/SoundEvent';
+import MusicLibrary from '../MusicLibrary';
+import Sequencer from './Sequencer';
+
+interface SequenceFrame {
+  measure: number;
+  together: boolean;
+  lastMeasures: number[];
+}
+
+/**
+ * This is very similar to {@link FunctionContext}, but also contains
+ * all playback events that occur in the function. This model will be
+ * useful for timeline rendering, but as of now is only used within this
+ * class.
+ */
+interface FunctionEvents {
+  name: string;
+  uniqueInvocationId: number;
+  playbackEvents: PlaybackEvent[];
+  startMeasure: number;
+  endMeasure: number;
+}
+
+interface SkipFrame {
+  skipSound: boolean;
+  currentIndex: number;
+  randomIndex: number;
+}
+
+/**
+ * A {@link Sequencer} used in the Simple2 (functions) block mode.
+ */
+export default class Simple2Sequencer extends Sequencer {
+  private sequenceStack: SequenceFrame[];
+  private functionStack: number[];
+  private effectsStack: Effects[];
+  private randomStack: SkipFrame[];
+
+  private functionMap: {[id: string]: FunctionEvents};
+  private uniqueInvocationIdUpTo: number;
+  private startMeasure: number;
+  private inTrigger: boolean;
+
+  constructor(private readonly library: MusicLibrary) {
+    super();
+    this.sequenceStack = [];
+    this.functionStack = [];
+    this.effectsStack = [];
+    this.randomStack = [];
+
+    this.functionMap = {};
+    this.uniqueInvocationIdUpTo = 0;
+    this.startMeasure = 1;
+    this.inTrigger = false;
+  }
+
+  /**
+   * Resets to the default new sequence and clears all sequenced events
+   */
+  clear() {
+    this.newSequence();
+    this.functionMap = {};
+  }
+
+  /**
+   * Set up for a new sequence with a new set of blocks (e.g. at the start
+   * of a trigger or when_run block)
+   * @param startMeasure measure to start the sequence
+   * @param inTrigger if the sequence is occurring in a trigger block
+   */
+  newSequence(startMeasure = 1, inTrigger = false) {
+    this.resetStacks();
+
+    this.startMeasure = startMeasure;
+    this.inTrigger = inTrigger;
+  }
+
+  // Beginning of a play_sequential block.
+  playSequential() {
+    this.sequenceStack.push({
+      measure: this.getCurrentMeasure(),
+      together: false,
+      lastMeasures: [],
+    });
+  }
+
+  // End of a play_sequential block.
+  endSequential() {
+    this.endBlock(true);
+  }
+
+  // Beginning of a play_together block.
+  playTogether() {
+    const nextMeasure = this.getCurrentMeasure();
+    this.sequenceStack.push({
+      measure: nextMeasure,
+      together: true,
+      lastMeasures: [nextMeasure],
+    });
+  }
+
+  // End of an play_together block.
+  endTogether() {
+    this.endBlock(false);
+  }
+
+  /**
+   * Starts a new function context.
+   */
+  startFunctionContext(functionName: string) {
+    const uniqueId = this.getUniqueInvocationId();
+
+    this.functionMap[uniqueId] = {
+      name: functionName,
+      uniqueInvocationId: uniqueId,
+      startMeasure: this.getCurrentMeasure(),
+      endMeasure: this.getCurrentMeasure(),
+      playbackEvents: [],
+    };
+
+    this.functionStack.push(uniqueId);
+
+    const currentEffects = this.getCurrentEffects();
+    if (currentEffects !== null) {
+      this.effectsStack.push({...currentEffects});
+    }
+  }
+
+  /**
+   * Ends the current function context.
+   */
+  endFunctionContext() {
+    const lastFunctionId = this.functionStack.pop();
+    if (lastFunctionId !== undefined) {
+      this.functionMap[lastFunctionId].endMeasure = this.getCurrentMeasure();
+    }
+
+    this.effectsStack.pop();
+  }
+
+  /**
+   * Start of a random block; the sequencer will randomly choose a sound from
+   * within this block to be played.
+   *
+   * @param length
+   * @param forceRandomIndex
+   */
+  startRandom(length: number, forceRandomIndex?: number) {
+    this.randomStack.push({
+      skipSound: this.getCurrentSkipContext().skipSound,
+      currentIndex: 0,
+      randomIndex:
+        forceRandomIndex !== undefined
+          ? forceRandomIndex
+          : Math.floor(Math.random() * length),
+    });
+  }
+
+  // Move to the next child of a play_random block.
+  nextRandom() {
+    if (this.randomStack.length === 0) {
+      // weird, warn
+      return;
+    }
+    const currentEntry = this.randomStack[this.randomStack.length - 1];
+    currentEntry.currentIndex++;
+  }
+
+  /**
+   * Ends the current random block.
+   */
+  endRandom() {
+    this.randomStack.pop();
+  }
+
+  setEffect(type: keyof Effects, value: EffectValue) {
+    const currentEffects = this.getCurrentEffects();
+    if (currentEffects === null) {
+      this.effectsStack.push({
+        [type]: value,
+      });
+    } else {
+      currentEffects[type] = value;
+    }
+  }
+
+  /**
+   * Play a sound at the current location.
+   * @param id
+   */
+  playSound(id: string) {
+    const currentFunctionId = this.getCurrentFunctionId();
+    if (currentFunctionId === null) {
+      // weird, warn?
+      return;
+    }
+
+    const currentFunction = this.functionMap[currentFunctionId];
+    const soundData = this.library.getSoundForId(id);
+    if (soundData === null) {
+      console.warn('Could not find sound with ID: ' + id);
+      return;
+    }
+
+    const soundEvent: SoundEvent = {
+      id,
+      type: 'sound',
+      triggered: this.inTrigger,
+      when: this.getCurrentMeasure(),
+      effects: {...this.getCurrentEffects()} || undefined,
+      skipContext: this.getCurrentSkipContext(),
+      length: this.getLengthForId(id),
+      soundType: soundData.type,
+    };
+
+    currentFunction.playbackEvents.push(soundEvent);
+
+    this.updateMeasureForPlayByLength(soundEvent.length);
+    currentFunction.endMeasure = this.getCurrentMeasure();
+  }
+
+  /**
+   * Play a pattern event at the current location
+   * @param value
+   */
+  playPattern(value: PatternEventValue) {
+    const currentFunctionId = this.getCurrentFunctionId();
+    if (currentFunctionId === null) {
+      // weird, warn?
+      return;
+    }
+    const currentFunction = this.functionMap[currentFunctionId];
+
+    const patternEvent: PatternEvent = {
+      type: 'pattern',
+      id: JSON.stringify(value),
+      value,
+      triggered: this.inTrigger,
+      when: this.getCurrentMeasure(),
+      effects: {...this.getCurrentEffects()} || undefined,
+      skipContext: this.getCurrentSkipContext(),
+      length: DEFAULT_PATTERN_LENGTH,
+    };
+
+    currentFunction.playbackEvents.push(patternEvent);
+    this.updateMeasureForPlayByLength(DEFAULT_PATTERN_LENGTH);
+    currentFunction.endMeasure = this.getCurrentMeasure();
+  }
+
+  /**
+   * Play a chord event at the current location.
+   * @param
+   * @returns
+   */
+  playChord(value: ChordEventValue) {
+    const currentFunctionId = this.getCurrentFunctionId();
+    if (currentFunctionId === null) {
+      // weird, warn?
+      return;
+    }
+    const currentFunction = this.functionMap[currentFunctionId];
+
+    const chordEvent: ChordEvent = {
+      type: 'chord',
+      id: JSON.stringify(value),
+      value,
+      triggered: this.inTrigger,
+      when: this.getCurrentMeasure(),
+      effects: {...this.getCurrentEffects()} || undefined,
+      skipContext: this.getCurrentSkipContext(),
+      length: DEFAULT_PATTERN_LENGTH,
+    };
+
+    currentFunction.playbackEvents.push(chordEvent);
+    this.updateMeasureForPlayByLength(DEFAULT_CHORD_LENGTH);
+    currentFunction.endMeasure = this.getCurrentMeasure();
+  }
+
+  rest(length: number) {
+    this.updateMeasureForPlayByLength(length);
+  }
+
+  // Can be used to render timeline
+  getOrderedFunctions(): FunctionEvents[] {
+    return Object.keys(this.functionMap)
+      .sort()
+      .map(id => this.functionMap[id]);
+  }
+
+  getPlaybackEvents(): PlaybackEvent[] {
+    // Currently the Timeline still expects a list of PlaybackEvents, each with a reference
+    // to their parent FunctionContext. We are reconstructing that model here.
+    // Going forward, the Timeline could instead render using getOrderedFunctions(), and not have
+    // to reconstruct the function mapping itself.
+
+    const events: PlaybackEvent[] = [];
+    for (const context of this.getOrderedFunctions()) {
+      const functionEvents = [...context.playbackEvents];
+      for (const functionEvent of functionEvents) {
+        functionEvent.functionContext = {
+          name: context.name,
+          uniqueInvocationId: context.uniqueInvocationId,
+        };
+      }
+      events.push(...functionEvents);
+    }
+
+    return events;
+  }
+
+  // Internal helper to get the entry at the top of the stack, or null
+  // if the stack is empty.
+  private getCurrentSequenceFrame(): SequenceFrame | null {
+    if (this.sequenceStack.length > 0) {
+      return this.sequenceStack[this.sequenceStack.length - 1];
+    } else {
+      return null;
+    }
+  }
+
+  private getCurrentMeasure(): number {
+    const currentEntry = this.getCurrentSequenceFrame();
+    if (currentEntry === null) {
+      return this.startMeasure;
+    }
+
+    return currentEntry.measure;
+  }
+
+  private getCurrentFunctionId(): number | null {
+    if (this.functionStack.length > 0) {
+      return this.functionStack[this.functionStack.length - 1];
+    }
+    return null;
+  }
+
+  // Gets the current context for playing a sound, specifically whether
+  // we are somewhere inside any play_random block, and whether we should
+  // play this specific sound.
+  private getCurrentSkipContext(): SkipContext {
+    if (this.randomStack.length > 0) {
+      const currentEntry = this.randomStack[this.randomStack.length - 1];
+      return {
+        insideRandom: true,
+        skipSound:
+          currentEntry.skipSound ||
+          currentEntry.randomIndex !== currentEntry.currentIndex,
+      };
+    } else {
+      return {insideRandom: false, skipSound: false};
+    }
+  }
+
+  private getCurrentEffects(): Effects | null {
+    if (this.effectsStack.length > 0) {
+      return this.effectsStack[this.effectsStack.length - 1];
+    }
+    return null;
+  }
+
+  // Internal function for the end of a play_sequential or play_together block.
+  private endBlock(isSequential: boolean) {
+    const currentStackEntry = this.getCurrentSequenceFrame();
+    if (currentStackEntry === null) {
+      // warning - unexpeected
+      return;
+    }
+
+    const nextMeasure = isSequential
+      ? currentStackEntry.measure
+      : Math.max(...currentStackEntry.lastMeasures);
+
+    // We are returning to the previous stack frame.
+    this.sequenceStack.pop();
+
+    const nextStackEntry = this.getCurrentSequenceFrame();
+
+    if (nextStackEntry) {
+      // Now the frame we are returning to has to absorb this information.
+      if (nextStackEntry.together) {
+        nextStackEntry.lastMeasures.push(nextMeasure);
+      } else {
+        nextStackEntry.measure = nextMeasure;
+      }
+    }
+  }
+
+  private updateMeasureForPlayByLength(length: number) {
+    const currentStackEntry = this.getCurrentSequenceFrame();
+    if (currentStackEntry === null) {
+      return;
+    }
+
+    if (currentStackEntry.together) {
+      currentStackEntry.lastMeasures.push(currentStackEntry.measure + length);
+    } else {
+      currentStackEntry.measure += length;
+    }
+  }
+
+  private getUniqueInvocationId(): number {
+    return this.uniqueInvocationIdUpTo++;
+  }
+
+  private getLengthForId(id: string): number {
+    const soundData = this.library.getSoundForId(id);
+    return soundData ? soundData.length : 0;
+  }
+
+  private resetStacks() {
+    this.sequenceStack = [];
+    this.functionStack = [];
+    this.effectsStack = [];
+    this.randomStack = [];
+  }
+}

--- a/apps/src/music/player/sequencer/Simple2Sequencer.ts
+++ b/apps/src/music/player/sequencer/Simple2Sequencer.ts
@@ -166,7 +166,9 @@ export default class Simple2Sequencer extends Sequencer {
   // Move to the next child of a play_random block.
   nextRandom() {
     if (this.randomStack.length === 0) {
-      // weird, warn
+      console.warn(
+        'Invalid state; tried to call nextRandom() without active random context'
+      );
       return;
     }
     const currentEntry = this.randomStack[this.randomStack.length - 1];
@@ -198,7 +200,7 @@ export default class Simple2Sequencer extends Sequencer {
   playSound(id: string) {
     const currentFunctionId = this.getCurrentFunctionId();
     if (currentFunctionId === null) {
-      // weird, warn?
+      console.warn('Invalid state: no current function ID');
       return;
     }
 
@@ -233,7 +235,7 @@ export default class Simple2Sequencer extends Sequencer {
   playPattern(value: PatternEventValue) {
     const currentFunctionId = this.getCurrentFunctionId();
     if (currentFunctionId === null) {
-      // weird, warn?
+      console.warn('Invalid state: no current function ID');
       return;
     }
     const currentFunction = this.functionMap[currentFunctionId];
@@ -262,7 +264,7 @@ export default class Simple2Sequencer extends Sequencer {
   playChord(value: ChordEventValue) {
     const currentFunctionId = this.getCurrentFunctionId();
     if (currentFunctionId === null) {
-      // weird, warn?
+      console.warn('Invalid state: no current function ID');
       return;
     }
     const currentFunction = this.functionMap[currentFunctionId];


### PR DESCRIPTION
Part 1 of a larger refactor to introduce a "sequencer" model for moving sequencing logic out of blockly code and into our own code. This PR just adds the new sequencer classes, without using them anywhere. I'm breaking this change up into a few pieces for readability and to ensure we don't break anything unintentionally. Explanation of the overall refactor below:

### Background/Context

We expose certain APIs to blockly that it calls when executing the code generated by blocks. Currently, the main music playback API we expose is the whole MusicPlayer class. This worked well for our initial model because the APIs on the MusicPlayer more less matched the block directly (e.g. "play \<sampleId\> at \<measure\>" block calls `MusicPlayer.playSoundAtMeasureById(sampleId, measure)`). However, as we iterated on the model and introduced new functionality, the blocks strayed quite a bit from the MusicPlayer API, and we had to add some complex logic within the generated blockly code to be able to use the same API. For example the signature of `playSoundAtMeasureById` is now
```
  playSoundAtMeasureById(
    id: string,
    measure: number,
    insideWhenRun: boolean,
    trackId?: string,
    functionContext?: FunctionContext,
    skipContext?: SkipContext,
    effects?: Effects,
    blockId?: string
  ) 
```
and we have to keep track of state within the blockly code to compute a lot of these arguments, such as insideWhenRun, functionContext, skipContext, etc.

This isn't ideal because code inside blockly generator functions are written as strings, making it difficult to validate/test, and now that we've more or less settled on a programming model, it would make sense to align with the API of that model rather than the original one we were prototyping with.

We already have some precedent for moving this logic into standalone components we own (such as ProgramSequencer.js and RandomSkipManager.js), so this change takes that idea one step further to move all sequencing logic out of blockly and into a standalone sequencer class. The base Sequencer class is abstract so we can implement sequencing logic differently for each model. Furthermore, this also further decouples the UI/view model (the list of playback events and associated function boundaries that the timeline uses to draw) from the playback model (the list of playback events the player needs to play). We can also take advantage of Redux to move state management out of MusicPlayer, and store the UI/view model events in Redux directly. This further lessens the views' dependency on the MusicPlayer API.

### Planned Changes
1. Add new sequencer classes (this PR)
2. Integrate with existing model
3. Remove unused code from MusicPlayer and other sequencers
4. Add/repurpose unit tests

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  5.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
