### PR TITLE
Music: post milestones without page reloads

### DIFF
--- a/apps/src/code-studio/browserNavigation.js
+++ b/apps/src/code-studio/browserNavigation.js
@@ -60,12 +60,13 @@ export function updateBrowserForLevelNavigation(
 // If we are on a new level without doing a page reload, then we should set the title
 // to match what levels_helper.rb's level_title function would have done.
 export function setWindowTitle(progressStoreState, newLevelId) {
-  const numLessons = progressStoreState.lessons[0].num_script_lessons;
-  const lessonName = progressStoreState.lessons[0].name;
+  const lesson = progressStoreState.lessons.find(
+    lesson => lesson.id === progressStoreState.currentLessonId
+  );
+  const numLessons = lesson.num_script_lessons;
+  const lessonName = lesson.name;
   const lessonIndex =
-    progressStoreState.lessons[0].levels.findIndex(
-      level => level.activeId === newLevelId
-    ) + 1;
+    lesson.levels.findIndex(level => level.activeId === newLevelId) + 1;
   const scriptDisplayName = progressStoreState.scriptDisplayName;
 
   document.title =

--- a/apps/src/code-studio/components/header/HeaderMiddle.jsx
+++ b/apps/src/code-studio/components/header/HeaderMiddle.jsx
@@ -351,4 +351,5 @@ export default connect(state => ({
   isRtl: state.isRtl,
   appLoadStarted: state.header.appLoadStarted,
   appLoaded: state.header.appLoaded,
+  currentLevelId: state.progress.currentLevelId,
 }))(HeaderMiddle);

--- a/apps/src/code-studio/header.js
+++ b/apps/src/code-studio/header.js
@@ -106,6 +106,16 @@ header.build = function (
     currentPageNumber
   );
 
+  // Store the current level ID in the progress redux handler.
+  // This is important for levels which don't require reloads between
+  // other levels, since the initial URL determines where we start
+  // in a progression.
+  setCurrentLevelId(currentLevelId);
+
+  // Set up a navigation handler, in case we contain levels that don't
+  // require a page reload when switching between them.
+  setupNavigationHandler(lessonData);
+
   // Hold off on rendering HeaderMiddle.  This will allow the "app load"
   // to potentially begin before we first render HeaderMiddle, giving HeaderMiddle
   // the opportunity to wait until the app is loaded before rendering.
@@ -117,7 +127,6 @@ header.build = function (
           scriptNameData={scriptNameData}
           lessonData={lessonData}
           scriptData={scriptData}
-          currentLevelId={currentLevelId}
         />
       </Provider>,
       document.querySelector('.header_level')
@@ -130,15 +139,6 @@ header.build = function (
         document.querySelector('.signin_callout_wrapper')
       );
     }
-    // Store the current level ID in the progress redux handler.
-    // This is important for levels which don't require reloads between
-    // other levels, since the initial URL determines where we start
-    // in a progression.
-    setCurrentLevelId(currentLevelId);
-
-    // Set up a navigation handler, in case we contain levels that don't
-    // require a page reload when switching between them.
-    setupNavigationHandler(lessonData);
   });
 };
 

--- a/apps/src/code-studio/progressRedux.js
+++ b/apps/src/code-studio/progressRedux.js
@@ -116,7 +116,8 @@ export function sendSuccessReport(appType) {
     );
     const scriptLevelId = currentLevel.id;
 
-    // The server can determine the user ID.
+    // The server does not appear to use the user ID parameter,
+    // so just pass 0, like some other milestone posts do.
     const userId = 0;
 
     // An ideal score.

--- a/apps/src/code-studio/progressRedux.js
+++ b/apps/src/code-studio/progressRedux.js
@@ -40,8 +40,9 @@ const OVERWRITE_RESULTS = 'progress/OVERWRITE_RESULTS';
 const PEER_REVIEW_ID = -1;
 
 const initialState = {
-  // These first fields never change after initialization
   currentLevelId: null,
+
+  // These first fields never change after initialization
   currentLessonId: null,
   deeperLearningCourse: null,
   // used on multi-page assessments
@@ -93,6 +94,30 @@ export function navigateToLevelId(levelId) {
 
     updateBrowserForLevelNavigation(state, newLevel.url, levelId);
     dispatch(setCurrentLevelId(levelId));
+  };
+}
+
+export function sendSuccessReport() {
+  return (dispatch, getState) => {
+    const state = getState().progress;
+    const currentLevel = state.lessons[0].levels.find(level =>
+      level.ids.find(id => id === state.currentLevelId)
+    );
+    const scriptLevelId = currentLevel.id;
+
+    const data = {
+      app: 'music',
+      result: true,
+      testResult: 100,
+    };
+
+    return $.ajax({
+      type: 'POST',
+      url: `/milestone/0/${scriptLevelId}`,
+      data: data,
+    }).done(data => {
+      console.log('done');
+    });
   };
 }
 

--- a/apps/src/code-studio/progressRedux.js
+++ b/apps/src/code-studio/progressRedux.js
@@ -103,17 +103,17 @@ export function navigateToLevelId(levelId) {
 
 // The user has successfully completed the level and the page
 // will not be reloading.
-export function sendSuccessReport() {
+export function sendSuccessReport(appType) {
   return (dispatch, getState) => {
     const state = getState().progress;
     const levelId = state.currentLevelId;
-    const currentLevel = state.lessons[0].levels.find(level =>
-      level.ids.find(id => id === levelId)
-    );
+    const currentLevel = state.lessons
+      .find(lesson => lesson.id === state.currentLessonId)
+      .levels.find(level => level.ids.find(id => id === levelId));
     const scriptLevelId = currentLevel.id;
 
     const data = {
-      app: 'music',
+      app: appType,
       result: true,
       testResult: 100,
     };

--- a/apps/src/music/progress/ProgressManager.ts
+++ b/apps/src/music/progress/ProgressManager.ts
@@ -103,9 +103,11 @@ export default class ProgressManager {
         // Ask the lab-specific validator if this validation's
         // conditions are met.
         if (this.validator.conditionsMet(validation.conditions)) {
-          this.currentProgressState.satisfied = validation.next;
-          this.currentProgressState.message = validation.message;
-          this.onProgressChange();
+          if (!this.currentProgressState.satisfied) {
+            this.currentProgressState.satisfied = validation.next;
+            this.currentProgressState.message = validation.message;
+            this.onProgressChange();
+          }
           return;
         }
       } else {

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -205,7 +205,8 @@ class UnconnectedMusicView extends React.Component {
     const currentState = this.progressManager.getCurrentState();
     this.props.setCurrentProgressState(currentState);
 
-    if (currentState.satisfied) {
+    // Tell the external system (if there is one) about the success.
+    if (this.props.levels && currentState.satisfied) {
       this.props.sendSuccessReport('music');
     }
   };

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -36,6 +36,7 @@ import KeyHandler from './KeyHandler';
 import {
   levelsForLessonId,
   navigateToLevelId,
+  sendSuccessReport,
 } from '@cdo/apps/code-studio/progressRedux';
 
 const baseUrl = 'https://curriculum.code.org/media/musiclab/';
@@ -52,7 +53,6 @@ class UnconnectedMusicView extends React.Component {
     appConfig: PropTypes.object,
     levels: PropTypes.array,
     currentLevelIndex: PropTypes.number,
-    onChangeLevel: PropTypes.func,
 
     // populated by Redux
     userId: PropTypes.number,
@@ -71,6 +71,7 @@ class UnconnectedMusicView extends React.Component {
     setInstructionsPosition: PropTypes.func,
     setCurrentProgressState: PropTypes.func,
     navigateToLevelId: PropTypes.func,
+    sendSuccessReport: PropTypes.func,
   };
 
   constructor(props) {
@@ -201,7 +202,12 @@ class UnconnectedMusicView extends React.Component {
   };
 
   onProgressChange = () => {
-    this.props.setCurrentProgressState(this.progressManager.getCurrentState());
+    const currentState = this.progressManager.getCurrentState();
+    this.props.setCurrentProgressState(currentState);
+
+    if (currentState.satisfied) {
+      this.props.sendSuccessReport();
+    }
   };
 
   getIsPlaying = () => {
@@ -587,6 +593,7 @@ const MusicView = connect(
     setCurrentProgressState: progressState =>
       dispatch(setCurrentProgressState(progressState)),
     navigateToLevelId: levelId => dispatch(navigateToLevelId(levelId)),
+    sendSuccessReport: () => dispatch(sendSuccessReport()),
   })
 )(UnconnectedMusicView);
 

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -206,7 +206,7 @@ class UnconnectedMusicView extends React.Component {
     this.props.setCurrentProgressState(currentState);
 
     if (currentState.satisfied) {
-      this.props.sendSuccessReport();
+      this.props.sendSuccessReport('music');
     }
   };
 
@@ -593,7 +593,7 @@ const MusicView = connect(
     setCurrentProgressState: progressState =>
       dispatch(setCurrentProgressState(progressState)),
     navigateToLevelId: levelId => dispatch(navigateToLevelId(levelId)),
-    sendSuccessReport: () => dispatch(sendSuccessReport()),
+    sendSuccessReport: appType => dispatch(sendSuccessReport(appType)),
   })
 )(UnconnectedMusicView);
 

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -316,6 +316,7 @@ class ScriptLevel < ApplicationRecord
       end
 
       summary = {
+        id: id,
         ids: ids.map(&:to_s),
         activeId: active_id.to_s,
         inactiveIds: inactive_ids.map(&:to_s),


### PR DESCRIPTION
With this change, passing a Music Lab level triggers a "milestone" post to the server, which marks the level as complete, and turns the bubble in the header to green.  This is a follow-up to https://github.com/code-dot-org/code-dot-org/pull/50923, which added the ability to switch music levels in a script without page reloads.  

It's worth noting that opening the `HeaderPopup` to reveal the full script's lessons triggers a `/api/user_progress` network request, which asynchronously returns the user's progress from the server and is then merged in (even if the popup has been closed by the user before the request completes).  In https://github.com/code-dot-org/code-dot-org/pull/50923, this would lead to some issues in which the active level might change unexpectedly, and the various assumptions that we had a single lesson's worth of progress were no longer correct.  These are now addressed in this change: we now use the `currentLevelId` in the progress store if it's available, and we now search for the appropriate lesson in the local store.

https://user-images.githubusercontent.com/2205926/234437793-7f8adbb8-92fa-454c-9258-2c7055c36402.mov
