### PR TITLE
AI landing page - Make h1 a single string

### DIFF
--- a/pegasus/sites.v3/code.org/public/ai.haml
+++ b/pegasus/sites.v3/code.org/public/ai.haml
@@ -21,8 +21,7 @@ theme: responsive_full_width
 %section.hero-banner-basic.bg-neutral-dark{style: "display: block !important"}
   .wrapper
     .text-wrapper.col-60
-      %h1{style: "color: white; margin-bottom: 0"}=hoc_s(:ai_hero_heading_01)
-      %h2.heading-xxl{style: "color: white"}=hoc_s(:ai_hero_heading_02)
+      %h1{style: "color: white"}=hoc_s(:ai_hero_heading)
       %p{style: "color: white"}=hoc_s(:ai_hero_desc)
       - if !!DCDO.get('teach-ai-launch-2023', false)
         %a.link-button{href: "#teach-ai-callout"}

--- a/pegasus/sites.v3/code.org/public/css/ai-styles.scss
+++ b/pegasus/sites.v3/code.org/public/css/ai-styles.scss
@@ -56,7 +56,7 @@
     }
 
     @media screen and (max-width: $width-sm) {
-      width: 185px;
+      width: 150px;
       float: none;
       margin: 2em auto 0;
     }

--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -158,8 +158,7 @@
   teachai_launch_blog_desc_01: "Education, nonprofit, and tech leaders come together to offer guidance on integrating AI safely into classrooms worldwide"
   teachai_launch_blog_desc_02: "TeachAI aims to integrate AI education into primary and secondary curricula around the world through new reports, policy recommendations, and public engagement opportunities."
 
-  ai_hero_heading_01: "Artificial intelligence isn't magic…"
-  ai_hero_heading_02: "It's just code!"
+  ai_hero_heading: "Artificial intelligence isn't magic… It's just code!"
   ai_hero_desc: "Demystify artificial intelligence (AI) by learning how it's changing the ways we live, work, and learn."
   ai_intro_heading: "Why learn about AI?"
   ai_intro_video_title: "Why AI Matters with Deb Raji"


### PR DESCRIPTION
Make the h1 on https://code.org/ai a single translatable string instead of two strings — it was originally two strings for a visual line break for dramatic effect, but it's better to have it as one string and the line still breaks where we want it to on desktop. 

**Related comment:** https://github.com/code-dot-org/code-dot-org/pull/51191#discussion_r1169253346

----

### Desktop
<img width="1000" alt="Desktop" src="https://user-images.githubusercontent.com/9256643/234655691-f1807e42-2432-4779-8790-016076ac2f11.png">

### Tablet
<img width="500" alt="Tablet" src="https://user-images.githubusercontent.com/9256643/234655684-541b73a1-bfb6-4ef1-8565-0cccb8c5f0a2.png">

### Mobile
<img width="300" alt="Mobile" src="https://user-images.githubusercontent.com/9256643/234655673-477f0de5-a9b3-4bf6-9178-548292122c12.png">
