### PR TITLE
AI Launch 2023 - Update tagline on homepage skinny banner

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -121,7 +121,7 @@
   pl_superhero_desc: "Join our highly supportive Professional Learning Program for middle and high school educators."
 
   teach_ai_homepage_banner_title: "AI education for the world"
-  teach_ai_homepage_banner_desc: "Code.org is part of TeachAI, dedicated to empowering classrooms everywhere to teach with AI and about AI."
+  teach_ai_homepage_banner_desc: "Code.org is part of TeachAI, dedicated to empowering educators everywhere to teach with AI and about AI."
 
   blockchain_hero_heading: 'How Blockchain Works'
   blockchain_hero_desc: 'Dive into the world of blockchain with "How Blockchain Works," our new video series and accompanying lessons!'


### PR DESCRIPTION
Change the tagline on the TeachAI homepage skinny banner to say "empowering educators" instead of "empowering classrooms"

**Jira ticket:** [ACQ-558](https://codedotorg.atlassian.net/browse/ACQ-558)

----

### Before
<img width="1000" alt="Screenshot 2023-04-26 at 1 58 56 PM" src="https://user-images.githubusercontent.com/9256643/234700931-6f99c1da-e542-47f9-9c9f-af82fdad69c3.png">


### After
<img width="1000" alt="Screenshot 2023-04-26 at 1 57 38 PM" src="https://user-images.githubusercontent.com/9256643/234700778-aa834c83-88a1-4e2a-824d-6e31c2daf900.png">


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204482203262361