### PR TITLE
Add 'deliver_now' to teacher application mailer

### DIFF
--- a/dashboard/app/models/pd/application/teacher_application.rb
+++ b/dashboard/app/models/pd/application/teacher_application.rb
@@ -398,7 +398,7 @@ module Pd::Application
       end
 
       # email_type maps to the mailer action
-      TeacherApplicationMailer.send(email.email_type, self)
+      TeacherApplicationMailer.send(email.email_type, self).deliver_now
     end
 
     # Return a string if the principal approval state is complete, in-progress, or not required.

--- a/dashboard/test/controllers/api/v1/pd/applications_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/applications_controller_test.rb
@@ -9,10 +9,6 @@ module Api::V1::Pd
     freeze_time
 
     setup_all do
-      Pd::Application::TeacherApplicationMailer.stubs(:accepted).returns(
-        mock {|mail| mail.stubs(:deliver_now)}
-      )
-
       @workshop_admin = create :workshop_admin
       @workshop_organizer = create :workshop_organizer
       @program_manager = create :teacher
@@ -254,10 +250,7 @@ module Api::V1::Pd
     # TODO: remove this test when workshop_organizer is deprecated
     test 'regional partners can edit their applications as workshop organizers' do
       sign_in @workshop_organizer
-      @csd_teacher_application_with_partner.update(pd_workshop_id: (create :summer_workshop).id)
-      @csd_teacher_application_with_partner.reload
-
-      Pd::Application::TeacherApplicationMailer.stubs(:deliver_email)
+      Pd::Application::TeacherApplication.any_instance.stubs(:deliver_email)
 
       put :update, params: {id: @csd_teacher_application_with_partner, application: {status: 'accepted', notes: 'Notes'}}
       assert_response :success
@@ -272,10 +265,7 @@ module Api::V1::Pd
 
     test 'regional partners can edit their applications' do
       sign_in @program_manager
-      @csd_teacher_application_with_partner.update(pd_workshop_id: (create :summer_workshop).id)
-      @csd_teacher_application_with_partner.reload
-
-      Pd::Application::TeacherApplicationMailer.stubs(:deliver_email)
+      Pd::Application::TeacherApplication.any_instance.stubs(:deliver_email)
 
       put :update, params: {id: @csd_teacher_application_with_partner, application: {status: 'accepted', notes: 'Notes'}}
       assert_response :success
@@ -387,10 +377,6 @@ module Api::V1::Pd
 
     test 'update sends a decision email once if status changed to decision and if associated with an RP' do
       sign_in @program_manager
-      summer_workshop = create :summer_workshop
-      @csd_teacher_application_with_partner.update(pd_workshop_id: summer_workshop.id)
-      @csd_teacher_application_with_partner.reload
-
       Pd::Application::TeacherApplicationMailer.expects(:accepted).
         with(instance_of(TEACHER_APPLICATION_CLASS)).
         returns(mock {|mail| mail.expects(:deliver_now)})

--- a/dashboard/test/lib/services/registration_reminder_test.rb
+++ b/dashboard/test/lib/services/registration_reminder_test.rb
@@ -14,7 +14,7 @@ class Services::RegistrationReminderTest < ActiveSupport::TestCase
     Timecop.freeze do
       # Initial creation: No reminders
       application_hash = build :pd_teacher_application_hash, regional_partner_id: create(:regional_partner).id
-      application = create :pd_teacher_application, form_data_hash: application_hash
+      application = create :pd_teacher_application, form_data_hash: application_hash, pd_workshop_id: (create :summer_workshop).id
       Services::RegistrationReminder.send_registration_reminders!
       assert_empty application.emails.where(email_type: 'registration_reminder')
 

--- a/dashboard/test/lib/services/registration_reminder_test.rb
+++ b/dashboard/test/lib/services/registration_reminder_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class Services::RegistrationReminderTest < ActiveSupport::TestCase
-  setup_all do
+  setup do
     Pd::Application::TeacherApplication.any_instance.stubs(:deliver_email)
   end
 
@@ -14,7 +14,7 @@ class Services::RegistrationReminderTest < ActiveSupport::TestCase
     Timecop.freeze do
       # Initial creation: No reminders
       application_hash = build :pd_teacher_application_hash, regional_partner_id: create(:regional_partner).id
-      application = create :pd_teacher_application, form_data_hash: application_hash, pd_workshop_id: (create :summer_workshop).id
+      application = create :pd_teacher_application, form_data_hash: application_hash
       Services::RegistrationReminder.send_registration_reminders!
       assert_empty application.emails.where(email_type: 'registration_reminder')
 


### PR DESCRIPTION
Previously, our teacher application mailer used a queueing system to send application updates. When their application status changed, the appropriate email was queued and theoretically those queued emails would be sent as a group. However, we ran into issues getting them to send, so we had to manually send the emails in batches (the last of which was on April 11th, which is also the last time we saw these application accepted/declined emails in our PLC email's inbox).

So, [this PR](https://github.com/code-dot-org/code-dot-org/pull/51411) removed the queueing functionality and instead just delivered emails (but removed the `.deliver_now` function since it was thought to be unnecessary). Since that merged two days ago, we stopped seeing non-reminder emails (which are handled separately) so that leads us to believe adding that line back in will actually start sending these out.

In working through this, Dani, Meg, Vijaya, and Turner used the production console to send out the 'declined' and 'accepted' emails that had not been sent since April 11th (after the timestamp of the last batch) using `.deliver_now`. When just using `send`, the emails did not show up in either the user's personal inbox nor the PLC email's inbox, however, using `.deliver_now` resulted in both the user and PLC receiving the email.

It is unclear why exactly this change seems to be working in the way we saw, but it seems like a safe change since we previously had this line and we can also closely monitor it.

## Links
Slack thread: [here](https://codedotorg.slack.com/archives/C03SUS476R3/p1682533287198709?thread_ts=1680897738.125799&cid=C03SUS476R3)

## Testing story
Testing on prod console using `.deliver_now` and seeing the email now show up in user's personal inbox and in the PLC emails inbox (bcc'd).

## Follow-up work
Closely monitor teacher application emails and check if they align with the application logs we're seeing.

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
