### PR TITLE
[Sprite Lab Migration] new field for soundPicker

### DIFF
--- a/apps/src/blockly/addons/cdoFieldSound.js
+++ b/apps/src/blockly/addons/cdoFieldSound.js
@@ -1,0 +1,73 @@
+import GoogleBlockly from 'blockly/core';
+
+export default class CdoFieldSound extends GoogleBlockly.Field {
+  constructor(value, validator, onChange) {
+    super(value);
+
+    this.onChange = onChange;
+    this.SERIALIZABLE = true;
+  }
+  /**
+   * Validate the changes to the field's value before they are set.
+   * @override
+   * @param newValue The value that is being validated
+   * @returns `String`
+   */
+  doClassValidation_(newValue) {
+    // Maintain support for the default value 'Choose', used with CDO Blockly.
+    if (newValue === null || newValue === undefined || newValue === 'Choose') {
+      return 'sound://default.mp3';
+    }
+    return String(newValue);
+  }
+
+  static fromJson(options) {
+    return new CdoFieldSound(options);
+  }
+
+  initView() {
+    super.initView();
+  }
+
+  showEditor_() {
+    this.onChange();
+    super.showEditor_();
+  }
+
+  getText() {
+    let text = this.value_;
+    if (!text) {
+      return text;
+    }
+    return parsePathString(text);
+  }
+}
+
+function capitalizeFirstLetter(string) {
+  return string.charAt(0).toUpperCase() + string.slice(1);
+}
+
+function parsePathString(text) {
+  // Example string paths:
+  // 'sound://category_board_games/card_dealing_multiple.mp3'
+  // 'sound://default.mp3'
+  const pathStringArray = text.split('/');
+  let category = '';
+  // Some sounds do not include a category, such as default.mp3
+  if (pathStringArray[2].includes('category_')) {
+    // Example: 'category_board_games' becomes 'Board games: '
+    category = capitalizeFirstLetter(
+      pathStringArray[2].replace('category_', '').replaceAll('_', ' ') + ': '
+    );
+  }
+  // Example: 'card_dealing_multiple.mp3' becomes 'Card dealing multiple'
+  const soundName = capitalizeFirstLetter(
+    pathStringArray[pathStringArray.length - 1]
+      .replace('.mp3', '')
+      .replaceAll('_', ' ')
+  );
+
+  // Examples: 'Board Games: Card dealing multiple', 'Default'
+  const fieldText = `${category}${soundName}`;
+  return fieldText;
+}

--- a/apps/src/blockly/addons/cdoUtils.js
+++ b/apps/src/blockly/addons/cdoUtils.js
@@ -109,7 +109,7 @@ export function getCode(workspace) {
   // return JSON.stringify(Blockly.serialization.workspaces.save(workspace));
 }
 
-// TODO: Re-define with a new custom field.
 export function soundField(onChange) {
-  return new Blockly.FieldDropdown([['Choose', 'Choose']], onChange);
+  // The second parameter is for a custom validator, which we do not need.
+  return new Blockly.FieldSound('sound://default.mp3', undefined, onChange);
 }

--- a/apps/src/blockly/googleBlocklyWrapper.js
+++ b/apps/src/blockly/googleBlocklyWrapper.js
@@ -52,6 +52,7 @@ import {ToolboxType, Themes, Renderers} from './constants';
 import {FUNCTION_BLOCK} from './addons/functionBlocks.js';
 import {FUNCTION_BLOCK_NO_FRAME} from './addons/functionBlocksNoFrame.js';
 import {flyoutCategory as functionsFlyoutCategory} from './addons/functionEditor.js';
+import CdoFieldSound from './addons/cdoFieldSound';
 
 const options = {
   contextMenu: true,
@@ -234,6 +235,7 @@ function initializeBlocklyWrapper(blocklyInstance) {
     ['field_number', 'FieldNumber', CdoFieldNumber],
     ['field_angle', 'FieldAngle', CdoFieldAngle],
     ['field_multilinetext', 'FieldMultilineInput', CdoFieldMultilineInput],
+    ['field_sound', 'FieldSound', CdoFieldSound],
   ];
   blocklyWrapper.overrideFields(fieldOverrides);
 
@@ -410,6 +412,9 @@ function initializeBlocklyWrapper(blocklyInstance) {
   };
   blocklyWrapper.Block.prototype.setStrictOutput = function (isOutput, check) {
     return this.setOutput(isOutput, check);
+  };
+  blocklyWrapper.Block.prototype.setTitleValue = function (newValue, name) {
+    return this.setFieldValue(newValue, name);
   };
   // We use fieldRow because it is public.
   blocklyWrapper.Input.prototype.getFieldRow = function () {


### PR DESCRIPTION
Builds off of:
- https://github.com/code-dot-org/code-dot-org/pull/51515

Documentation used:
- https://developers.google.com/blockly/guides/create-custom-blocks/fields/customizing-fields/creating


https://user-images.githubusercontent.com/43474485/234895013-56a8c11c-39a0-46f4-9e98-b6eab45b1845.mp4




## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
