### PR TITLE
Fixing NCES data ingestion script which was using the wrong index for most of the headers

### DIFF
--- a/bin/oneoff/nces_data/import_school_stats_by_years_2021_2022_ccd
+++ b/bin/oneoff/nces_data/import_school_stats_by_years_2021_2022_ccd
@@ -5,6 +5,7 @@ require_relative '../../../dashboard/config/environment'
 CDO.log = Logger.new(STDOUT)
 
 SURVEY_YEAR = '2021-2022'.freeze
+SURVEY_YEAR_HEADER = '2021-22'.freeze
 
 # Override for the dry run variable using an commandline argument
 DRY_RUN = !((ARGV.find {|arg| arg.casecmp('-dryrun')}).nil?)
@@ -83,35 +84,35 @@ AWS::S3.process_file('cdo-nces', "#{SURVEY_YEAR}/ccd/schools_public.csv") do |fi
     {
       school_id:          row['School ID - NCES Assigned [Public School] Latest available year'].to_i.to_s,
       school_year:        SURVEY_YEAR,
-      grades_offered_lo:  GRADES_MAP[row['Lowest Grade Offered [Public School] ' + SURVEY_YEAR]],
-      grades_offered_hi:  GRADES_MAP[row['Highest Grade Offered [Public School] ' + SURVEY_YEAR]],
-      grade_pk_offered:   row['Prekindergarten offered [Public School] ' + SURVEY_YEAR] == '1-Yes',
-      grade_kg_offered:   row['Kindergarten offered [Public School] ' + SURVEY_YEAR] == '1-Yes',
-      grade_01_offered:   row['Grade 1 offered [Public School] ' + SURVEY_YEAR] == '1-Yes',
-      grade_02_offered:   row['Grade 2 offered [Public School] ' + SURVEY_YEAR] == '1-Yes',
-      grade_03_offered:   row['Grade 3 offered [Public School] ' + SURVEY_YEAR] == '1-Yes',
-      grade_04_offered:   row['Grade 4 offered [Public School] ' + SURVEY_YEAR] == '1-Yes',
-      grade_05_offered:   row['Grade 5 offered [Public School] ' + SURVEY_YEAR] == '1-Yes',
-      grade_06_offered:   row['Grade 6 offered [Public School] ' + SURVEY_YEAR] == '1-Yes',
-      grade_07_offered:   row['Grade 7 offered [Public School] ' + SURVEY_YEAR] == '1-Yes',
-      grade_08_offered:   row['Grade 8 offered [Public School] ' + SURVEY_YEAR] == '1-Yes',
-      grade_09_offered:   row['Grade 9 offered [Public School] ' + SURVEY_YEAR] == '1-Yes',
-      grade_10_offered:   row['Grade 10 offered [Public School] ' + SURVEY_YEAR] == '1-Yes',
-      grade_11_offered:   row['Grade 11 offered [Public School] ' + SURVEY_YEAR] == '1-Yes',
-      grade_12_offered:   row['Grade 12 offered [Public School] ' + SURVEY_YEAR] == '1-Yes',
-      grade_13_offered:   row['Grade 13 offered [Public School] ' + SURVEY_YEAR] == '1-Yes',
+      grades_offered_lo:  GRADES_MAP[row['Lowest Grade Offered [Public School] ' + SURVEY_YEAR_HEADER]],
+      grades_offered_hi:  GRADES_MAP[row['Highest Grade Offered [Public School] ' + SURVEY_YEAR_HEADER]],
+      grade_pk_offered:   row['Prekindergarten offered [Public School] ' + SURVEY_YEAR_HEADER] == '1-Yes',
+      grade_kg_offered:   row['Kindergarten offered [Public School] ' + SURVEY_YEAR_HEADER] == '1-Yes',
+      grade_01_offered:   row['Grade 1 offered [Public School] ' + SURVEY_YEAR_HEADER] == '1-Yes',
+      grade_02_offered:   row['Grade 2 offered [Public School] ' + SURVEY_YEAR_HEADER] == '1-Yes',
+      grade_03_offered:   row['Grade 3 offered [Public School] ' + SURVEY_YEAR_HEADER] == '1-Yes',
+      grade_04_offered:   row['Grade 4 offered [Public School] ' + SURVEY_YEAR_HEADER] == '1-Yes',
+      grade_05_offered:   row['Grade 5 offered [Public School] ' + SURVEY_YEAR_HEADER] == '1-Yes',
+      grade_06_offered:   row['Grade 6 offered [Public School] ' + SURVEY_YEAR_HEADER] == '1-Yes',
+      grade_07_offered:   row['Grade 7 offered [Public School] ' + SURVEY_YEAR_HEADER] == '1-Yes',
+      grade_08_offered:   row['Grade 8 offered [Public School] ' + SURVEY_YEAR_HEADER] == '1-Yes',
+      grade_09_offered:   row['Grade 9 offered [Public School] ' + SURVEY_YEAR_HEADER] == '1-Yes',
+      grade_10_offered:   row['Grade 10 offered [Public School] ' + SURVEY_YEAR_HEADER] == '1-Yes',
+      grade_11_offered:   row['Grade 11 offered [Public School] ' + SURVEY_YEAR_HEADER] == '1-Yes',
+      grade_12_offered:   row['Grade 12 offered [Public School] ' + SURVEY_YEAR_HEADER] == '1-Yes',
+      grade_13_offered:   row['Grade 13 offered [Public School] ' + SURVEY_YEAR_HEADER] == '1-Yes',
 
-      virtual_status:     VIRTUAL_SCHOOL_MAP[row['Virtual School Status (SY 2016-17 onward) [Public School] ' + SURVEY_YEAR]],
-      students_total:     row['Total Students All Grades (Excludes AE) [Public School] ' + SURVEY_YEAR].presence.try {|v| v.to_i == 0 ? nil : v.to_i},
-      student_am_count:   row['American Indian/Alaska Native Students [Public School] ' + SURVEY_YEAR].to_i,
-      student_as_count:   row['Asian or Asian/Pacific Islander Students [Public School] ' + SURVEY_YEAR].to_i,
-      student_hi_count:   row['Hispanic Students [Public School] ' + SURVEY_YEAR].to_i,
-      student_bl_count:   row['Black or African American Students [Public School] ' + SURVEY_YEAR].to_i,
-      student_wh_count:   row['White Students [Public School] ' + SURVEY_YEAR].to_i,
-      student_hp_count:   row['Nat. Hawaiian or Other Pacific Isl. Students [Public School] ' + SURVEY_YEAR].to_i,
-      student_tr_count:   row['Two or More Races Students [Public School] ' + SURVEY_YEAR].to_i,
-      title_i_status:     TITLE_I_MAP[row['Title I School Status [Public School] ' + SURVEY_YEAR]],
-      frl_eligible_total: row['Free and Reduced Lunch Students [Public School] ' + SURVEY_YEAR].to_i
+      virtual_status:     VIRTUAL_SCHOOL_MAP[row['Virtual School Status (SY 2016-17 onward) [Public School] ' + SURVEY_YEAR_HEADER]],
+      students_total:     row['Total Students All Grades (Excludes AE) [Public School] ' + SURVEY_YEAR_HEADER].presence.try {|v| v.to_i == 0 ? nil : v.to_i},
+      student_am_count:   row['American Indian/Alaska Native Students [Public School] ' + SURVEY_YEAR_HEADER].to_i,
+      student_as_count:   row['Asian or Asian/Pacific Islander Students [Public School] ' + SURVEY_YEAR_HEADER].to_i,
+      student_hi_count:   row['Hispanic Students [Public School] ' + SURVEY_YEAR_HEADER].to_i,
+      student_bl_count:   row['Black or African American Students [Public School] ' + SURVEY_YEAR_HEADER].to_i,
+      student_wh_count:   row['White Students [Public School] ' + SURVEY_YEAR_HEADER].to_i,
+      student_hp_count:   row['Nat. Hawaiian or Other Pacific Isl. Students [Public School] ' + SURVEY_YEAR_HEADER].to_i,
+      student_tr_count:   row['Two or More Races Students [Public School] ' + SURVEY_YEAR_HEADER].to_i,
+      title_i_status:     TITLE_I_MAP[row['Title I School Status [Public School] ' + SURVEY_YEAR_HEADER]],
+      frl_eligible_total: row['Free and Reduced Lunch Students [Public School] ' + SURVEY_YEAR_HEADER].to_i
     }
   end
 end


### PR DESCRIPTION
The indexing into the CSV files were incorrect and hence parsed all the values as nulls. This resulted in incorrect data import for the latest year. The change is to fix the headers to match the CSV.

## Testing story
I tested this locally again with the new change and this time tried to sample some of the data for various different columns to ensure that they are not all either nil or false, which is what happened in production.

Also, for more context, previously, I was expecting the script to fail with errors (like the ones for school did) when a header is incorrect and hence didn't explicitly check for data correctness. This lead to the bug seeping into production which was the first place where an E2E AFE scenario can be tested. In this change, also did backend data validations as mentioned above. As this gets rolled out, I'm planning to do similar data validations in staging and in production after running the script.


