### PR TITLE
Fix Violations of and Reenable `Rails/NegateInclude`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -199,11 +199,6 @@ Rails/FilePath:
 Rails/I18nLocaleTexts:
   Enabled: false
 
-# Offense count: 19
-# This cop supports unsafe auto-correction (--auto-correct-all).
-Rails/NegateInclude:
-  Enabled: false
-
 # Offense count: 41
 # This cop supports safe auto-correction (--auto-correct).
 # Configuration parameters: Include.

--- a/dashboard/app/controllers/activities_controller.rb
+++ b/dashboard/app/controllers/activities_controller.rb
@@ -179,7 +179,7 @@ class ActivitiesController < ApplicationController
         time_spent: time_since_last_milestone
       )
 
-      is_sublevel = !@script_level.levels.include?(@level)
+      is_sublevel = @script_level.levels.exclude?(@level)
 
       # The level might belong to more than one bubble choice parent level.
       # Find the one that's in this script.

--- a/dashboard/app/helpers/proxy_helper.rb
+++ b/dashboard/app/helpers/proxy_helper.rb
@@ -166,7 +166,7 @@ module ProxyHelper
       !ip_address.link_local? &&
       !ip_address.loopback? &&
       !ip_address.private? &&
-      !IPAddr.new('0.0.0.0/8').include?(ip_address)
+      IPAddr.new('0.0.0.0/8').exclude?(ip_address)
     )
   end
 end

--- a/dashboard/app/helpers/proxy_helper.rb
+++ b/dashboard/app/helpers/proxy_helper.rb
@@ -166,7 +166,10 @@ module ProxyHelper
       !ip_address.link_local? &&
       !ip_address.loopback? &&
       !ip_address.private? &&
-      IPAddr.new('0.0.0.0/8').exclude?(ip_address)
+      # IPAddr doesn't have an exclude? method
+      # rubocop:disable Rails/NegateInclude
+      !IPAddr.new('0.0.0.0/8').include?(ip_address)
+      # rubocop:enable Rails/NegateInclude
     )
   end
 end

--- a/dashboard/app/models/block.rb
+++ b/dashboard/app/models/block.rb
@@ -33,7 +33,7 @@ class Block < ApplicationRecord
   end
 
   def self.load_and_cache_by_pool(pool)
-    if Unit.should_cache? && !Block.all_pool_names.include?(pool)
+    if Unit.should_cache? && Block.all_pool_names.exclude?(pool)
       return nil
     end
 

--- a/dashboard/app/models/contact_rollups_processed.rb
+++ b/dashboard/app/models/contact_rollups_processed.rb
@@ -245,9 +245,9 @@ class ContactRollupsProcessed < ApplicationRecord
     # @see Unit model, csf?, csd? and csp? methods
     curricula = extract_field contact_data, 'dashboard.sections', 'curriculum_umbrella'
     roles.add 'CSF Teacher' if curricula.any?('CSF')
-    roles.add 'CSD Teacher' if !roles.include?('CSD Teacher') && curricula.any?('CSD')
-    roles.add 'CSP Teacher' if !roles.include?('CSP Teacher') && curricula.any?('CSP')
-    roles.add 'CSA Teacher' if !roles.include?('CSA Teacher') && curricula.any?('CSA')
+    roles.add 'CSD Teacher' if roles.exclude?('CSD Teacher') && curricula.any?('CSD')
+    roles.add 'CSP Teacher' if roles.exclude?('CSP Teacher') && curricula.any?('CSP')
+    roles.add 'CSA Teacher' if roles.exclude?('CSA Teacher') && curricula.any?('CSA')
 
     roles.add 'Form Submitter' if
       contact_data.key?('pegasus.forms') ||

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -342,7 +342,7 @@ class Lesson < ApplicationRecord
     # a user trying to edit a lesson plan via /s/[script-name]/lessons/1/edit
     # has sufficient permissions or not. therefore, use a different path
     # when editing lesson plans in hoc scripts.
-    has_lesson_plan && !ScriptConfig.hoc_scripts.include?(script.name) ?
+    has_lesson_plan && ScriptConfig.hoc_scripts.exclude?(script.name) ?
       script_lesson_edit_path(script, self) :
       edit_lesson_path(id: id)
   end

--- a/dashboard/app/models/levels/bounce.rb
+++ b/dashboard/app/models/levels/bounce.rb
@@ -52,7 +52,7 @@ class Bounce < Grid
     # the bounce and basketball skins can only have retro or basketball themes
     sport_theme_non_sport_skin = (
       %(bounce basketball).include?(skin) &&
-      !%(retro basketball).include?(theme)
+      %(retro basketball).exclude?(theme)
     )
 
     errors.add(:theme, "#{skin} skin and #{theme} theme are incompatible") if

--- a/dashboard/app/models/levels/poetry.rb
+++ b/dashboard/app/models/levels/poetry.rb
@@ -36,15 +36,15 @@ class Poetry < GamelabJr
   # Set the default poem to nil if the subtype does not have poems, or if the default poem is
   # not in the list of poems for the subtype.
   def sanitize_default_poem
-    self.default_poem = nil if !Poetry.subtypes_with_poems.include?(standalone_app_name) ||
-      !Poetry.poem_keys_for_subtype(standalone_app_name).include?(default_poem)
+    self.default_poem = nil if Poetry.subtypes_with_poems.exclude?(standalone_app_name) ||
+      Poetry.poem_keys_for_subtype(standalone_app_name).exclude?(default_poem)
   end
 
   # Set the available poems to nil if the subtype does not have poems.
   # Also remove any available poems that are not in the list of poems for the subtype.
   def sanitize_available_poems
     self.available_poems = nil unless Poetry.subtypes_with_poems.include?(standalone_app_name)
-    return if !Poetry.subtypes_with_poems.include?(standalone_app_name) || (available_poems && available_poems.empty?)
+    return if Poetry.subtypes_with_poems.exclude?(standalone_app_name) || (available_poems && available_poems.empty?)
     # filter out any invalid poems from available_poems
     self.available_poems = available_poems & Poetry.poem_keys_for_subtype(standalone_app_name)
   end
@@ -55,7 +55,7 @@ class Poetry < GamelabJr
     # If there is a default poem and dropdown poem(s), check that the default poem is
     # in the dropdown poem list.
     if default_poem.present? && Poetry.subtypes_with_poems.include?(standalone_app_name) &&
-      available_poems && !available_poems.empty? && !available_poems.include?(default_poem)
+      available_poems && !available_poems.empty? && available_poems.exclude?(default_poem)
       errors.add(:default_poem, "selected default poem is not in dropdown poem list")
     end
   end

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -670,7 +670,7 @@ class Pd::Workshop < ApplicationRecord
 
   # @return [Boolean] true if a Code Studio account is required for attendance, otherwise false.
   def account_required_for_attendance?
-    ![Pd::Workshop::COURSE_ADMIN_COUNSELOR, Pd::Workshop::COURSE_COUNSELOR, Pd::Workshop::COURSE_ADMIN].include?(course)
+    [Pd::Workshop::COURSE_ADMIN_COUNSELOR, Pd::Workshop::COURSE_COUNSELOR, Pd::Workshop::COURSE_ADMIN].exclude?(course)
   end
 
   def workshop_starting_date

--- a/dashboard/app/models/unit.rb
+++ b/dashboard/app/models/unit.rb
@@ -783,7 +783,7 @@ class Unit < ApplicationRecord
     script_levels.map do |script_level|
       script_level.levels.map do |level|
         next if level.contained_levels.empty? ||
-          !TEXT_RESPONSE_TYPES.include?(level.contained_levels.first.class)
+          TEXT_RESPONSE_TYPES.exclude?(level.contained_levels.first.class)
         text_response_levels << {
           script_level: script_level,
           levels: [level.contained_levels.first]

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1722,7 +1722,7 @@ class User < ApplicationRecord
     unit_group_units_script_ids = courses_as_participant.map(&:default_unit_group_units).flatten.pluck(:script_id).uniq
 
     user_scripts = Queries::ScriptActivity.in_progress_and_completed_scripts(self).
-      select {|user_script| !unit_group_units_script_ids.include?(user_script.script_id)}
+      select {|user_script| unit_group_units_script_ids.exclude?(user_script.script_id)}
 
     pl_user_scripts = user_scripts.select {|us| us.script.pl_course?}
 
@@ -1762,7 +1762,7 @@ class User < ApplicationRecord
     unit_group_units_script_ids = courses_as_participant.map(&:default_unit_group_units).flatten.pluck(:script_id).uniq
 
     user_scripts = Queries::ScriptActivity.in_progress_and_completed_scripts(self).
-      select {|user_script| !unit_group_units_script_ids.include?(user_script.script_id)}
+      select {|user_script| unit_group_units_script_ids.exclude?(user_script.script_id)}
 
     user_student_scripts = user_scripts.select {|us| !us.script.pl_course?}
 

--- a/dashboard/lib/pd/jot_form/select_question.rb
+++ b/dashboard/lib/pd/jot_form/select_question.rb
@@ -40,7 +40,7 @@ module Pd
       def ensure_valid_answer(answer)
         if answer.is_a? Array
           answer.each {|sub_answer| ensure_valid_answer(sub_answer)}
-        elsif !options.include? answer
+        elsif options.exclude?(answer)
           raise "Unrecognized answer '#{answer}' for question #{id} (Options: #{options.join(',')})"
         end
 

--- a/dashboard/lib/pd/survey_pipeline/helper.rb
+++ b/dashboard/lib/pd/survey_pipeline/helper.rb
@@ -158,7 +158,7 @@ module Pd::SurveyPipeline::Helper
     is_single_select_answer =
       lambda {|hash| [ANSWER_SINGLE_SELECT, ANSWER_SCALE].include? hash[:answer_type]}
     not_single_select_answer =
-      lambda {|hash| ![ANSWER_SINGLE_SELECT, ANSWER_SCALE].include?(hash[:answer_type])}
+      lambda {|hash| [ANSWER_SINGLE_SELECT, ANSWER_SCALE].exclude?(hash[:answer_type])}
 
     map_config = [
       {condition: is_single_select_answer, field: :answer, reducers: [Pd::SurveyPipeline::Reducer::Histogram]},

--- a/dashboard/scripts/archive/block_docs_to_i18n
+++ b/dashboard/scripts/archive/block_docs_to_i18n
@@ -34,7 +34,7 @@ def parse_function_doc(doc_path)
       next
     end
 
-    next unless collecting_params && line.match(/^\|[^-]/) && !line.include?('| Name')
+    next unless collecting_params && line.match(/^\|[^-]/) && line.exclude?('| Name')
     param_name = line.split('|')[1].strip
     param_name_no_brackets = param_name.tr('[]', '')
     param_description = line.split('|')[4].strip

--- a/dashboard/scripts/archive/delete_orphaned_scripts
+++ b/dashboard/scripts/archive/delete_orphaned_scripts
@@ -9,7 +9,7 @@ Unit.transaction do # throw this all in a transaction so we roll it back if some
   end.map(&:downcase)
 
   orphans = Unit.all.select do |script|
-    !file_scripts.include?(script.name.downcase)
+    file_scripts.exclude?(script.name.downcase)
   end
 
   puts "deleting scripts: #{orphans.collect(&:name)}"

--- a/dashboard/scripts/smoke
+++ b/dashboard/scripts/smoke
@@ -67,7 +67,7 @@ def run_tests(options = {})
 
       raise "HTTP Status code error. Expecting #{http_status_code}, got #{http_code}" if http_code != http_status_code
       raise "too small!!!" if test[:min_size] && response.body.length < test[:min_size].to_i
-      raise "Should contain #{test[:contains]}, but doesn't -- #{response.body.inspect}" if test[:contains] && !response.body.include?(test[:contains])
+      raise "Should contain #{test[:contains]}, but doesn't -- #{response.body.inspect}" if test[:contains] && response.body.exclude?(test[:contains])
       if test[:redirect]
         location_uri = URI.join(response["Location"])
         raise "Redirect error. Expecting #{test[:redirect]}, got #{location_uri.path}- #{" - #{test[:failure_message]}" if test[:failure_message]}" if location_uri.path != test[:redirect]

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -204,7 +204,7 @@ end
 When /^I wait until (?:element )?"([^"]*)" does not (?:have|contain) text "([^"]*)"$/ do |selector, text|
   wait_short_until do
     element_text = @browser.execute_script("return $(#{selector.dump}).text();")
-    !element_text.include? text
+    element_text.exclude?(text)
   end
 end
 


### PR DESCRIPTION
> Enforces the use of `collection.exclude?(obj)` over `!collection.include?(obj)`.

Fix applied automatically with `bundle exec rubocop --auto-correct-all --only Rails/NegateInclude`; I then manually added a negation for one false positive.

## Links

- https://rails.rubystyle.guide/#exclude
- https://www.rubydoc.info/gems/rubocop-rails/RuboCop/Cop/Rails/NegateInclude
- https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsnegateinclude
 
## Testing story

Note that this a potentially unsafe fix:

> This cop is unsafe because false positive will occur for receiver objects that do not have an `exclude?` method. (e.g. `IPAddr`)

In this case, I've manually inspected each change to add exceptions for all obviously-invalid receivers, and am relying on existing test coverage to catch anything non-obvious.