### PR TITLE
Added PL offerings to the options on the EditSection screen. 

### DIFF
--- a/apps/src/templates/sectionsRefresh/CurriculumQuickAssign.jsx
+++ b/apps/src/templates/sectionsRefresh/CurriculumQuickAssign.jsx
@@ -66,6 +66,7 @@ export default function CurriculumQuickAssign({
         ],
       };
       const hocData = {...courseOfferings[MARKETING_AUDIENCE.HOC]};
+      const plData = {...courseOfferings[MARKETING_AUDIENCE.PL]};
 
       const determineSelectedCourseOffering = (startingData, audience) => {
         const headers = Object.keys(startingData);
@@ -90,6 +91,7 @@ export default function CurriculumQuickAssign({
           MARKETING_AUDIENCE.ELEMENTARY
         );
         determineSelectedCourseOffering(hocData, MARKETING_AUDIENCE.HOC);
+        determineSelectedCourseOffering(plData, MARKETING_AUDIENCE.PL);
       }
     }
     // added all these dependencies given the eslint warning


### PR DESCRIPTION
This adds to the EditSection functionality by including PL options in the data being searched to find the existing section. 

<img width="920" alt="image" src="https://user-images.githubusercontent.com/24883357/234982174-8966d31d-25b3-42c9-8f94-7ac6fc989603.png">


## Testing story

* Unit tests will be created for this in a different ticket focused on testing.
* I visually tested this with teacher-participant sections where self-paced PL (including multiple and no-units) was assigned, 6–12 Virtual Academic Year Workshops, and a regular curriculum. 
* I also tested this with student-facing sections and no PL options were shown. 

To test locally, sign into an admin account and use this URL replacing the number "25" with an existing local section id:

http://localhost-studio.code.org:3000/sections/25/edit?participantType=teacher&loginType=word

## Follow-up work

* Hannah is getting rid of the params on the edit section in a separate PR.  
* All tests will be written for this and other features of the edit section screen.
