### PR TITLE
Fix Violations of and Reenable `Style/YodaCondition`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -541,10 +541,3 @@ Style/TernaryParentheses:
 # Configuration parameters: AllowNamedUnderscoreVariables.
 Style/TrailingUnderscoreVariable:
   Enabled: false
-
-# Offense count: 13
-# This cop supports unsafe auto-correction (--auto-correct-all).
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: forbid_for_all_comparison_operators, forbid_for_equality_operators_only, require_for_all_comparison_operators, require_for_equality_operators_only
-Style/YodaCondition:
-  Enabled: false

--- a/dashboard/app/controllers/activities_controller.rb
+++ b/dashboard/app/controllers/activities_controller.rb
@@ -21,7 +21,7 @@ class ActivitiesController < ApplicationController
 
   def milestone
     # TODO: do we use the :result and :testResult params for the same thing?
-    solved = ('true' == params[:result])
+    solved = (params[:result] == 'true')
     script_name = ''
 
     if params[:script_level_id]
@@ -145,7 +145,7 @@ class ActivitiesController < ApplicationController
     authorize! :create, UserLevel
 
     test_result = params[:testResult].to_i
-    solved = ('true' == params[:result])
+    solved = (params[:result] == 'true')
 
     lines = params[:lines].to_i
 

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -2271,7 +2271,7 @@ class User < ApplicationRecord
   end
 
   def within_united_states?
-    'United States' == user_geos.first&.country
+    user_geos.first&.country == 'United States'
   end
 
   def associate_with_potential_pd_enrollments

--- a/dashboard/legacy/middleware/files_api.rb
+++ b/dashboard/legacy/middleware/files_api.rb
@@ -401,7 +401,7 @@ class FilesApi < Sinatra::Base
 
     # sources only supports one file (main.json) and we checked max_file_size above,
     # so there's no need to check if we've exceeded the max total app size for the sources bucket.
-    unless 'sources' == endpoint
+    unless endpoint == 'sources'
       app_size = buckets.app_size(encrypted_channel_id)
       quota_exceeded(endpoint, encrypted_channel_id) unless app_size + body.length < max_app_size
       quota_crossed_half_used(endpoint, encrypted_channel_id) if quota_crossed_half_used?(app_size, body.length)
@@ -425,7 +425,7 @@ class FilesApi < Sinatra::Base
     end
 
     # Don't allow project to be saved if it contains non-UTF-8 characters (causing error / project to not load when opened).
-    if 'sources' == endpoint
+    if endpoint == 'sources'
       body_json = JSON.parse(body)
       source = body_json["source"]
       html = body_json["html"]

--- a/dashboard/legacy/test/middleware/test_net_sim_api.rb
+++ b/dashboard/legacy/test/middleware/test_net_sim_api.rb
@@ -903,7 +903,7 @@ class NetSimApiTest < Minitest::Test
 
   def record_exists(table_name, record_id)
     @net_sim_api.get "/v3/netsim/#{@shard_id}/#{table_name}/#{record_id}"
-    200 == @net_sim_api.last_response.status
+    @net_sim_api.last_response.status == 200
   end
 
   def create_node(record, node_type = nil)

--- a/dashboard/scripts/smoke
+++ b/dashboard/scripts/smoke
@@ -38,7 +38,7 @@ end
 
 thread_count = [ARGV.shift.to_i, 1].max
 repeat_count = [ARGV.shift.to_i, 1].max
-quiet = 'quiet' == ARGV.shift
+quiet = ARGV.shift == 'quiet'
 
 def run_tests(options = {})
   TESTS.each do |test|

--- a/dashboard/test/lib/image_lib_test.rb
+++ b/dashboard/test/lib/image_lib_test.rb
@@ -98,7 +98,7 @@ class ImageLibTest < ActiveSupport::TestCase
       end
     end
     result.strip!
-    '0' == result
+    result == '0'
   end
 
   # Helper function to evaluate and return output to stderr.

--- a/lib/test/cdo/test_slack.rb
+++ b/lib/test/cdo/test_slack.rb
@@ -64,14 +64,14 @@ class SlackTest < Minitest::Test
 
   def test_message_uses_channel_map
     Net::HTTP.expects(:post_form).with do |_url, params|
-      '#infra-test' == JSON.parse(params[:payload])['channel']
+      JSON.parse(params[:payload])['channel'] == '#infra-test'
     end.returns(stub(code: 200))
     assert Slack.message(FAKE_MESSAGE, channel: 'test')
   end
 
   def test_message_slackifies_bold
     Net::HTTP.expects(:post_form).with do |_url, params|
-      'this should be *bold*' == JSON.parse(params[:payload])['text']
+      JSON.parse(params[:payload])['text'] == 'this should be *bold*'
     end.returns(stub(code: 200))
     message_with_bold = 'this should be <b>bold</b>'
     assert Slack.message(message_with_bold, channel: FAKE_CHANNEL)
@@ -79,7 +79,7 @@ class SlackTest < Minitest::Test
 
   def test_message_slackifies_italic
     Net::HTTP.expects(:post_form).with do |_url, params|
-      'this should be _italic_' == JSON.parse(params[:payload])['text']
+      JSON.parse(params[:payload])['text'] == 'this should be _italic_'
     end.returns(stub(code: 200))
     message_with_italic = 'this should be <i>italic</i>'
     assert Slack.message(message_with_italic, channel: FAKE_CHANNEL)
@@ -87,8 +87,7 @@ class SlackTest < Minitest::Test
 
   def test_message_slackifies_code_block
     Net::HTTP.expects(:post_form).with do |_url, params|
-      "this should be\n```\na block of code\n```" ==
-        JSON.parse(params[:payload])['text']
+      JSON.parse(params[:payload])['text'] == "this should be\n```\na block of code\n```"
     end.returns(stub(code: 200))
     message_with_code_block = "this should be\n<pre>\na block of code\n</pre>"
     assert Slack.message(message_with_code_block, channel: FAKE_CHANNEL)

--- a/pegasus/src/database.rb
+++ b/pegasus/src/database.rb
@@ -85,7 +85,7 @@ class Tutorials
   end
 
   def self.sort_by_popularity?(site, hoc_mode)
-    ("post-hoc" == hoc_mode) || (site == 'code.org' && [false, 'pre-hoc'].include?(hoc_mode))
+    (hoc_mode == "post-hoc") || (site == 'code.org' && [false, 'pre-hoc'].include?(hoc_mode))
   end
 end
 


### PR DESCRIPTION
> Enforces or forbids Yoda conditions, i.e. comparison operations where the order of expression is reversed. eg. `5 == x`

Fix applied automatically with `bundle exec rubocop --auto-correct-all --only Style/YodaCondition`

## Links

- https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/YodaCondition
- https://docs.rubocop.org/rubocop/cops_style.html#styleyodacondition

## Testing story

This cop is potentially unsafe if any of the operators have redefinied the relevant comparison operation in a way that doesn't follow the normal rules of commutativity. I manually inspected each change to confirm that none of them are obviously doing so, and am relying on existing tests to catch any non-obvious violations.