### PR TITLE
Fix verbose Radium warnings filling DroneCI logs

### DIFF
--- a/apps/src/code-studio/components/ShareAllowedDialog.jsx
+++ b/apps/src/code-studio/components/ShareAllowedDialog.jsx
@@ -508,8 +508,10 @@ const styles = {
     paddingBottom: 12.5,
     paddingLeft: 10,
     paddingRight: 10,
-    margin: 0,
+    marginTop: 0,
     marginRight: 8,
+    marginBottom: 0,
+    marginLeft: 0,
     verticalAlign: 'top',
   },
   buttonDisabled: {
@@ -519,8 +521,10 @@ const styles = {
     paddingBottom: 12.5,
     paddingLeft: 10,
     paddingRight: 5,
-    margin: 0,
+    marginTop: 0,
     marginRight: 8,
+    marginBottom: 0,
+    marginLeft: 0,
     verticalAlign: 'top',
   },
   copyButton: {

--- a/apps/src/lib/util/AnalyticsReporter.js
+++ b/apps/src/lib/util/AnalyticsReporter.js
@@ -60,7 +60,7 @@ class AnalyticsReporter {
   }
 
   log(message) {
-    console.log(`[AMPLITUDE ANALYTICS EVENT]: ${message}`);
+    console.debug(`[AMPLITUDE ANALYTICS EVENT]: ${message}`);
   }
 
   formatUserId(userId) {

--- a/apps/src/lib/util/AnalyticsReporter.js
+++ b/apps/src/lib/util/AnalyticsReporter.js
@@ -60,7 +60,7 @@ class AnalyticsReporter {
   }
 
   log(message) {
-    console.debug(`[AMPLITUDE ANALYTICS EVENT]: ${message}`);
+    console.log(`[AMPLITUDE ANALYTICS EVENT]: ${message}`);
   }
 
   formatUserId(userId) {

--- a/apps/src/music/analytics/AnalyticsReporter.ts
+++ b/apps/src/music/analytics/AnalyticsReporter.ts
@@ -246,6 +246,6 @@ export default class AnalyticsReporter {
   }
 
   log(message: string) {
-    console.log(`[AMPLITUDE ANALYTICS EVENT]: ${message}`);
+    console.debug(`[AMPLITUDE ANALYTICS EVENT]: ${message}`);
   }
 }

--- a/apps/src/music/analytics/AnalyticsReporter.ts
+++ b/apps/src/music/analytics/AnalyticsReporter.ts
@@ -246,6 +246,6 @@ export default class AnalyticsReporter {
   }
 
   log(message: string) {
-    console.debug(`[AMPLITUDE ANALYTICS EVENT]: ${message}`);
+    console.log(`[AMPLITUDE ANALYTICS EVENT]: ${message}`);
   }
 }

--- a/apps/src/templates/LegacyButton.jsx
+++ b/apps/src/templates/LegacyButton.jsx
@@ -103,7 +103,9 @@ export const BUTTON_TYPES = {
   cancel: {
     style: {
       backgroundColor: color.neutral_white,
-      border: `2px solid ${color.neutral_dark}`,
+      borderWidth: 2,
+      borderStyle: 'solid',
+      borderColor: color.neutral_dark,
       color: color.neutral_dark,
       ':hover': {
         backgroundColor: color.neutral_dark20,

--- a/docker/dev_setup.sh
+++ b/docker/dev_setup.sh
@@ -9,7 +9,7 @@ set -xe
 eval "$(rbenv init -)"
 curl -fsSL https://github.com/rbenv/rbenv-installer/raw/main/bin/rbenv-doctor | bash
 
-bundle install
+bundle install --verbose
 
 bundle exec rake install --trace
 

--- a/docker/dev_setup.sh
+++ b/docker/dev_setup.sh
@@ -9,7 +9,7 @@ set -xe
 eval "$(rbenv init -)"
 curl -fsSL https://github.com/rbenv/rbenv-installer/raw/main/bin/rbenv-doctor | bash
 
-bundle install --verbose
+bundle install
 
 bundle exec rake install --trace
 

--- a/docker/ui_tests.sh
+++ b/docker/ui_tests.sh
@@ -26,7 +26,7 @@ mkdir $CIRCLE_ARTIFACTS
 # rbenv-doctor https://github.com/rbenv/rbenv-installer#readme
 curl -fsSL https://github.com/rbenv/rbenv-installer/raw/main/bin/rbenv-doctor | bash
 
-bundle install --verbose
+bundle install
 
 # set up locals.yml
 # Need to actually write all the commented out lines also

--- a/docker/ui_tests.sh
+++ b/docker/ui_tests.sh
@@ -26,7 +26,7 @@ mkdir $CIRCLE_ARTIFACTS
 # rbenv-doctor https://github.com/rbenv/rbenv-installer#readme
 curl -fsSL https://github.com/rbenv/rbenv-installer/raw/main/bin/rbenv-doctor | bash
 
-bundle install
+bundle install --verbose
 
 # set up locals.yml
 # Need to actually write all the commented out lines also

--- a/docker/unit_tests.sh
+++ b/docker/unit_tests.sh
@@ -14,7 +14,7 @@ export RACK_ENV=test
 export DISABLE_SPRING=1
 export LD_LIBRARY_PATH=/usr/local/lib
 
-mispipe "bundle install" ts
+mispipe "bundle install --verbose" ts
 
 # set up locals.yml
 set +x

--- a/docker/unit_tests.sh
+++ b/docker/unit_tests.sh
@@ -14,7 +14,7 @@ export RACK_ENV=test
 export DISABLE_SPRING=1
 export LD_LIBRARY_PATH=/usr/local/lib
 
-mispipe "bundle install --verbose" ts
+mispipe "bundle install" ts
 
 # set up locals.yml
 set +x


### PR DESCRIPTION
DroneCI logs are dominated by:
```
WARN: 'Radium: property "border" in style object', Object{borderWidth: 1, borderStyle: 'solid', minWidth: 100, marginTop: 0, marginBottom: 0, marginLeft: 0, marginRight: 0, :hover: Object{boxShadow: 'none', backgroundColor: '#D4D5D7'}, backgroundColor: '#FFFFFF', border: '2px solid #292F36', color: '#292F36'}, ': do not mix longhand and shorthand properties in the same style object. Check the render method of BaseButton.', 'See https://github.com/FormidableLabs/radium/issues/95 for more information.'
```

Reducing log spam by breaking a few shorthand CSS properties (e.g. border) into longhand (borderWidth, borderStyle, borderColor).
