### PR TITLE
[Migrate Sprite Lab] Refactor CdoFieldButton for sound picker and update location picker

### DIFF
--- a/apps/src/block_utils.js
+++ b/apps/src/block_utils.js
@@ -1338,3 +1338,7 @@ const sanitizeOptions = function (dropdownOptions) {
     option.length === 1 ? [option[0], option[0]] : option
   );
 };
+
+export const capitalizeFirstLetter = function (string) {
+  return string.charAt(0).toUpperCase() + string.slice(1);
+};

--- a/apps/src/block_utils.js
+++ b/apps/src/block_utils.js
@@ -1338,7 +1338,3 @@ const sanitizeOptions = function (dropdownOptions) {
     option.length === 1 ? [option[0], option[0]] : option
   );
 };
-
-export const capitalizeFirstLetter = function (string) {
-  return string.charAt(0).toUpperCase() + string.slice(1);
-};

--- a/apps/src/blockly/addons/cdoFieldButton.js
+++ b/apps/src/blockly/addons/cdoFieldButton.js
@@ -11,11 +11,11 @@ import GoogleBlockly from 'blockly/core';
  * @param icon Optional. SVG <tspan> element - if the field displays a button, this is the icon that is displayed on the button.
  */
 export default class CdoFieldButton extends GoogleBlockly.Field {
-  constructor(options) {
-    super(options.value, options.validator);
-    this.onClick = options.onClick;
-    this.transformText = options.transformText;
-    this.icon = options.icon;
+  constructor({value, validator, onClick, transformText, icon}) {
+    super(value, validator);
+    this.onClick = onClick;
+    this.transformText = transformText;
+    this.icon = icon;
     this.SERIALIZABLE = true;
   }
 
@@ -30,7 +30,6 @@ export default class CdoFieldButton extends GoogleBlockly.Field {
   initView() {
     super.initView();
     if (this.icon) {
-      this.icon.textContent = ' ' + this.icon.textContent;
       this.icon.style.fill = this.getSourceBlock().style.colourPrimary;
       this.textElement_.appendChild(this.icon);
     }

--- a/apps/src/blockly/addons/cdoFieldButton.js
+++ b/apps/src/blockly/addons/cdoFieldButton.js
@@ -1,9 +1,5 @@
 import GoogleBlockly from 'blockly/core';
 
-const BUTTON_CORNER_RADIUS = 3;
-const BUTTON_INNER_HEIGHT = 16;
-import {DEFAULT_SOUND} from '@cdo/apps/blockly/constants';
-
 /**
  * This is a customized field which the user clicks to select an option from a customized picker,
  * for example, the location of a sprite from a grid or a sound file from a customized modal.
@@ -13,12 +9,15 @@ import {DEFAULT_SOUND} from '@cdo/apps/blockly/constants';
  * @param buttonIcon SVG <tspan> element - if the field displays a button, this is the icon that is displayed on the button.
  */
 export default class CdoFieldButton extends GoogleBlockly.Field {
-  constructor(value, onChange, onDisplay, buttonIcon) {
-    super(value);
+  constructor(value, validator, onChange, onDisplay, button) {
+    super(value, validator);
     this.onChange = onChange;
     this.onDisplay = onDisplay;
-    this.buttonIcon = buttonIcon;
-
+    if (button) {
+      this.buttonIcon = button.icon;
+      this.buttonCornerRadius = button.cornerRadius;
+      this.buttonInnerHeight = button.innerHeight;
+    }
     this.SERIALIZABLE = true;
   }
 
@@ -32,22 +31,6 @@ export default class CdoFieldButton extends GoogleBlockly.Field {
   }
 
   /**
-   * Validate the changes to a field's value before they are set.
-   * @override
-   */
-  doClassValidation_(newValue) {
-    if (typeof newValue !== 'string') {
-      return null;
-    }
-    // Handle 'play sound' block with default param from CDO blockly.
-    // TODO: Remove when sprite lab is migrated to Google blockly.
-    if (newValue === 'Choose') {
-      return DEFAULT_SOUND;
-    }
-    return newValue;
-  }
-
-  /**
    * Create the block UI for this field.
    * @override
    */
@@ -57,12 +40,12 @@ export default class CdoFieldButton extends GoogleBlockly.Field {
       this.buttonElement_ = Blockly.utils.dom.createSvgElement(
         'rect',
         {
-          rx: BUTTON_CORNER_RADIUS,
-          ry: BUTTON_CORNER_RADIUS,
+          rx: this.buttonCornerRadius,
+          ry: this.buttonCornerRadius,
           x: 1,
           y: 1,
-          height: BUTTON_INNER_HEIGHT,
-          width: BUTTON_INNER_HEIGHT,
+          height: this.buttonInnerHeight,
+          width: this.buttonInnerHeight,
         },
         this.fieldGroup_
       );
@@ -101,7 +84,7 @@ export default class CdoFieldButton extends GoogleBlockly.Field {
     if (this.value_ !== newValue) {
       this.value_ = newValue;
       if (this.buttonIcon) {
-        // For location picker, update coordinates of block when dragged out from toolbox.
+        // Update display on block label when block is dragged out from toolbox.
         this.onDisplay(newValue);
       }
       this.isDirty_ = true; // Block needs to be re-rendered.

--- a/apps/src/blockly/addons/cdoFieldButton.js
+++ b/apps/src/blockly/addons/cdoFieldButton.js
@@ -12,8 +12,8 @@ import GoogleBlockly from 'blockly/core';
  * @param editFieldLabel boolean - true if the label adjacent to this field is updated with change in field value
  */
 export default class CdoFieldButton extends GoogleBlockly.Field {
-  constructor(value, validator, onChange, onDisplay, button, editFieldLabel) {
-    super(value, validator);
+  constructor(value, onChange, onDisplay, button, editFieldLabel) {
+    super(value);
     this.onChange = onChange;
     this.onDisplay = onDisplay;
     if (button) {

--- a/apps/src/blockly/addons/cdoFieldButton.js
+++ b/apps/src/blockly/addons/cdoFieldButton.js
@@ -12,7 +12,7 @@ import {DEFAULT_SOUND} from '@cdo/apps/blockly/constants';
  * @param onDisplay The function tht handles how the field text is displayed.
  * @param buttonIcon SVG <tspan> element - if the field displays a button, this is the icon that is displayed on the button.
  */
-export default class CdoFieldPicker extends GoogleBlockly.Field {
+export default class CdoFieldButton extends GoogleBlockly.Field {
   constructor(value, onChange, onDisplay, buttonIcon) {
     super(value);
     this.onChange = onChange;
@@ -23,7 +23,7 @@ export default class CdoFieldPicker extends GoogleBlockly.Field {
   }
 
   static fromJson(options) {
-    return new CdoFieldPicker(
+    return new CdoFieldButton(
       options.value,
       options.onChange,
       options.onDisplay,

--- a/apps/src/blockly/addons/cdoFieldButton.js
+++ b/apps/src/blockly/addons/cdoFieldButton.js
@@ -3,30 +3,24 @@ import GoogleBlockly from 'blockly/core';
 /**
  * This is a customized field which the user clicks to select an option from a customized picker,
  * for example, the location of a sprite from a grid or a sound file from a customized modal.
- * @param value The initial value of the field.
- * @param validator A function that is called to validate changes to the field's value.
+ * @param value Optional. The initial value of the field.
+ * @param validator Optional. A function that is called to validate changes to the field's value.
  * Takes in a value & returns a validated value, or null to abort a change
- * @param onChange The function that handles the field's editor.
- * @param onDisplay The function tht handles how the field text is displayed.
- * @param icon SVG <tspan> element - if the field displays a button, this is the icon that is displayed on the button.
+ * @param onClick The function that handles the field's editor.
+ * @param transformText Optional. The function that handles how the field text is displayed.
+ * @param icon Optional. SVG <tspan> element - if the field displays a button, this is the icon that is displayed on the button.
  */
 export default class CdoFieldButton extends GoogleBlockly.Field {
-  constructor(value, validator, onChange, onDisplay, icon) {
-    super(value, validator);
-    this.onChange = onChange;
-    this.onDisplay = onDisplay;
-    this.icon = icon;
+  constructor(options) {
+    super(options.value, options.validator);
+    this.onClick = options.onClick;
+    this.transformText = options.transformText;
+    this.icon = options.icon;
     this.SERIALIZABLE = true;
   }
 
   static fromJson(options) {
-    return new CdoFieldButton(
-      options.value,
-      options.validator,
-      options.onChange,
-      options.onDisplay,
-      options.icon
-    );
+    return new CdoFieldButton(options);
   }
 
   /**
@@ -44,7 +38,7 @@ export default class CdoFieldButton extends GoogleBlockly.Field {
 
   /**
    *  Get the text from this field to display on the block. May differ from
-   * `getText` with call to `this.onDisplay` which can change format of text.
+   * `getText` with call to `this.transformText` which can change format of text.
    * @override
    */
   getDisplayText_() {
@@ -52,8 +46,11 @@ export default class CdoFieldButton extends GoogleBlockly.Field {
     if (!text) {
       return GoogleBlockly.Field.NBSP;
     }
-    // The onDisplay function customizes the text for display.
-    return this.onDisplay(text);
+    // The transformText function customizes the text for display.
+    if (this.transformText) {
+      return this.transformText(text);
+    }
+    return text;
   }
 
   /**
@@ -61,7 +58,7 @@ export default class CdoFieldButton extends GoogleBlockly.Field {
    * @override
    */
   showEditor_() {
-    this.onChange();
+    this.onClick();
   }
 
   /**

--- a/apps/src/blockly/addons/cdoFieldButton.js
+++ b/apps/src/blockly/addons/cdoFieldButton.js
@@ -12,8 +12,8 @@ import GoogleBlockly from 'blockly/core';
  * @param editFieldLabel boolean - true if the label adjacent to this field is updated with change in field value
  */
 export default class CdoFieldButton extends GoogleBlockly.Field {
-  constructor(value, onChange, onDisplay, button, editFieldLabel) {
-    super(value);
+  constructor(value, validator, onChange, onDisplay, button, editFieldLabel) {
+    super(value, validator);
     this.onChange = onChange;
     this.onDisplay = onDisplay;
     if (button) {

--- a/apps/src/blockly/addons/cdoFieldButton.js
+++ b/apps/src/blockly/addons/cdoFieldButton.js
@@ -8,27 +8,24 @@ import GoogleBlockly from 'blockly/core';
  * Takes in a value & returns a validated value, or null to abort a change
  * @param onChange The function that handles the field's editor.
  * @param onDisplay The function tht handles how the field text is displayed.
- * @param buttonIcon SVG <tspan> element - if the field displays a button, this is the icon that is displayed on the button.
- * @param editFieldLabel boolean - true if the label adjacent to this field is updated with change in field value
+ * @param icon SVG <tspan> element - if the field displays a button, this is the icon that is displayed on the button.
  */
 export default class CdoFieldButton extends GoogleBlockly.Field {
-  constructor(value, validator, onChange, onDisplay, button, editFieldLabel) {
+  constructor(value, validator, onChange, onDisplay, icon) {
     super(value, validator);
     this.onChange = onChange;
     this.onDisplay = onDisplay;
-    if (button) {
-      this.button = button;
-    }
-    this.editFieldLabel = editFieldLabel;
+    this.icon = icon;
     this.SERIALIZABLE = true;
   }
 
   static fromJson(options) {
     return new CdoFieldButton(
       options.value,
+      options.validator,
       options.onChange,
       options.onDisplay,
-      options.buttonIcon
+      options.icon
     );
   }
 
@@ -38,29 +35,10 @@ export default class CdoFieldButton extends GoogleBlockly.Field {
    */
   initView() {
     super.initView();
-    if (this.button) {
-      this.buttonElement_ = Blockly.utils.dom.createSvgElement(
-        'rect',
-        {
-          rx: this.button.cornerRadius,
-          ry: this.button.cornerRadius,
-          x: 1,
-          y: 1,
-          height: this.button.innerHeight,
-          width: this.button.innerHeight,
-        },
-        this.fieldGroup_
-      );
-      this.buttonElement_.style.fillOpacity = 1;
-      this.buttonElement_.style.fill =
-        this.getSourceBlock().style.colourSecondary;
-
-      this.textElement_.style.fontSize = '11pt';
-      this.textElement_.style.fill = this.getSourceBlock().style.colourPrimary;
-      this.textElement_.textContent = '';
-      this.textElement_.appendChild(this.button.icon);
-
-      this.fieldGroup_.insertBefore(this.buttonElement_, this.textElement_);
+    if (this.icon) {
+      this.icon.textContent = ' ' + this.icon.textContent;
+      this.icon.style.fill = this.getSourceBlock().style.colourPrimary;
+      this.textElement_.appendChild(this.icon);
     }
   }
 
@@ -79,21 +57,6 @@ export default class CdoFieldButton extends GoogleBlockly.Field {
   }
 
   /**
-   * Used to update the value of a field.
-   * @override
-   */
-  doValueUpdate_(newValue) {
-    if (this.value_ !== newValue) {
-      this.value_ = newValue;
-      if (this.editFieldLabel) {
-        // Update display on block label when block is dragged out from toolbox.
-        this.onDisplay(newValue);
-      }
-      this.isDirty_ = true; // Block needs to be re-rendered.
-    }
-  }
-
-  /**
    * Create an editor for the field.
    * @override
    */
@@ -107,8 +70,8 @@ export default class CdoFieldButton extends GoogleBlockly.Field {
    */
   applyColour() {
     const sourceBlock = this.getSourceBlock();
-    if (this.buttonElement_) {
-      this.buttonElement_.style.fill = sourceBlock.style.colourSecondary;
+    if (this.icon) {
+      this.icon.style.fill = sourceBlock.style.colourPrimary;
     }
   }
 }

--- a/apps/src/blockly/addons/cdoFieldButton.js
+++ b/apps/src/blockly/addons/cdoFieldButton.js
@@ -4,6 +4,8 @@ import GoogleBlockly from 'blockly/core';
  * This is a customized field which the user clicks to select an option from a customized picker,
  * for example, the location of a sprite from a grid or a sound file from a customized modal.
  * @param value The initial value of the field.
+ * @param validator A function that is called to validate changes to the field's value.
+ * Takes in a value & returns a validated value, or null to abort a change
  * @param onChange The function that handles the field's editor.
  * @param onDisplay The function tht handles how the field text is displayed.
  * @param buttonIcon SVG <tspan> element - if the field displays a button, this is the icon that is displayed on the button.

--- a/apps/src/blockly/addons/cdoFieldButton.js
+++ b/apps/src/blockly/addons/cdoFieldButton.js
@@ -9,17 +9,17 @@ import GoogleBlockly from 'blockly/core';
  * @param onChange The function that handles the field's editor.
  * @param onDisplay The function tht handles how the field text is displayed.
  * @param buttonIcon SVG <tspan> element - if the field displays a button, this is the icon that is displayed on the button.
+ * @param editFieldLabel boolean - true if the label adjacent to this field is updated with change in field value
  */
 export default class CdoFieldButton extends GoogleBlockly.Field {
-  constructor(value, validator, onChange, onDisplay, button) {
+  constructor(value, validator, onChange, onDisplay, button, editFieldLabel) {
     super(value, validator);
     this.onChange = onChange;
     this.onDisplay = onDisplay;
     if (button) {
-      this.buttonIcon = button.icon;
-      this.buttonCornerRadius = button.cornerRadius;
-      this.buttonInnerHeight = button.innerHeight;
+      this.button = button;
     }
+    this.editFieldLabel = editFieldLabel;
     this.SERIALIZABLE = true;
   }
 
@@ -38,16 +38,16 @@ export default class CdoFieldButton extends GoogleBlockly.Field {
    */
   initView() {
     super.initView();
-    if (this.buttonIcon) {
+    if (this.button) {
       this.buttonElement_ = Blockly.utils.dom.createSvgElement(
         'rect',
         {
-          rx: this.buttonCornerRadius,
-          ry: this.buttonCornerRadius,
+          rx: this.button.cornerRadius,
+          ry: this.button.cornerRadius,
           x: 1,
           y: 1,
-          height: this.buttonInnerHeight,
-          width: this.buttonInnerHeight,
+          height: this.button.innerHeight,
+          width: this.button.innerHeight,
         },
         this.fieldGroup_
       );
@@ -58,7 +58,7 @@ export default class CdoFieldButton extends GoogleBlockly.Field {
       this.textElement_.style.fontSize = '11pt';
       this.textElement_.style.fill = this.getSourceBlock().style.colourPrimary;
       this.textElement_.textContent = '';
-      this.textElement_.appendChild(this.buttonIcon);
+      this.textElement_.appendChild(this.button.icon);
 
       this.fieldGroup_.insertBefore(this.buttonElement_, this.textElement_);
     }
@@ -85,7 +85,7 @@ export default class CdoFieldButton extends GoogleBlockly.Field {
   doValueUpdate_(newValue) {
     if (this.value_ !== newValue) {
       this.value_ = newValue;
-      if (this.buttonIcon) {
+      if (this.editFieldLabel) {
         // Update display on block label when block is dragged out from toolbox.
         this.onDisplay(newValue);
       }

--- a/apps/src/blockly/addons/cdoFieldPicker.js
+++ b/apps/src/blockly/addons/cdoFieldPicker.js
@@ -4,8 +4,14 @@ const BUTTON_CORNER_RADIUS = 3;
 const BUTTON_INNER_HEIGHT = 16;
 import {DEFAULT_SOUND} from '@cdo/apps/blockly/constants';
 
-// This is a customized field which the user clicks to select an option for a customized picker,
-// for example, the location of a sprite or a sound file from a customized modal.
+/**
+ * This is a customized field which the user clicks to select an option from a customized picker,
+ * for example, the location of a sprite from a grid or a sound file from a customized modal.
+ * @param value The initial value of the field.
+ * @param onChange The function that handles the field's editor.
+ * @param onDisplay The function tht handles how the field text is displayed.
+ * @param buttonIcon If the field displyas a button, this is the string that is displayed on the button.
+ */
 export default class CdoFieldPicker extends GoogleBlockly.Field {
   constructor(value, onChange, onDisplay, buttonIcon) {
     super(value);
@@ -103,7 +109,7 @@ export default class CdoFieldPicker extends GoogleBlockly.Field {
   }
 
   /**
-   * Creates an editor for the field.
+   * Create an editor for the field.
    * @override
    */
   showEditor_() {

--- a/apps/src/blockly/addons/cdoFieldPicker.js
+++ b/apps/src/blockly/addons/cdoFieldPicker.js
@@ -4,6 +4,8 @@ const BUTTON_CORNER_RADIUS = 3;
 const BUTTON_INNER_HEIGHT = 16;
 import {DEFAULT_SOUND} from '@cdo/apps/blockly/constants';
 
+// This is a customized field which the user clicks to select an option for a customized picker,
+// for example, the location of a sprite or a sound file from a customized modal.
 export default class CdoFieldPicker extends GoogleBlockly.Field {
   constructor(value, onChange, onDisplay, buttonIcon) {
     super(value);
@@ -23,6 +25,10 @@ export default class CdoFieldPicker extends GoogleBlockly.Field {
     );
   }
 
+  /**
+   * Validate the changes to a field's value before they are set.
+   * @override
+   */
   doClassValidation_(newValue) {
     if (typeof newValue !== 'string') {
       return null;
@@ -35,6 +41,10 @@ export default class CdoFieldPicker extends GoogleBlockly.Field {
     return newValue;
   }
 
+  /**
+   * Create the block UI for this field.
+   * @override
+   */
   initView() {
     super.initView();
     if (this.buttonIcon) {
@@ -63,6 +73,11 @@ export default class CdoFieldPicker extends GoogleBlockly.Field {
     }
   }
 
+  /**
+   *  Get the text from this field to display on the block. May differ from
+   * `getText` with call to `this.onDisplay` which can change format of text.
+   * @override
+   */
   getDisplayText_() {
     let text = this.getText();
     if (!text) {
@@ -73,8 +88,8 @@ export default class CdoFieldPicker extends GoogleBlockly.Field {
   }
 
   /**
-Expand All
-	@@ -51,38 +79,20 @@ export default class CdoFieldButton extends GoogleBlockly.Field {
+   * Used to update the value of a field.
+   * @override
    */
   doValueUpdate_(newValue) {
     if (this.value_ !== newValue) {
@@ -88,15 +103,11 @@ Expand All
   }
 
   /**
+   * Creates an editor for the field.
    * @override
    */
   showEditor_() {
     this.onChange();
-  }
-
-  /**
-Expand All
-	@@ -99,18 +109,13 @@ export default class CdoFieldButton extends GoogleBlockly.Field {
   }
 
   /**

--- a/apps/src/blockly/addons/cdoFieldPicker.js
+++ b/apps/src/blockly/addons/cdoFieldPicker.js
@@ -10,7 +10,7 @@ import {DEFAULT_SOUND} from '@cdo/apps/blockly/constants';
  * @param value The initial value of the field.
  * @param onChange The function that handles the field's editor.
  * @param onDisplay The function tht handles how the field text is displayed.
- * @param buttonIcon If the field displyas a button, this is the string that is displayed on the button.
+ * @param buttonIcon SVG <tspan> element - if the field displays a button, this is the icon that is displayed on the button.
  */
 export default class CdoFieldPicker extends GoogleBlockly.Field {
   constructor(value, onChange, onDisplay, buttonIcon) {

--- a/apps/src/blockly/addons/cdoUtils.js
+++ b/apps/src/blockly/addons/cdoUtils.js
@@ -125,14 +125,7 @@ export function soundField(onChange, onDisplay) {
   return new Blockly.FieldButton(DEFAULT_SOUND, validator, onChange, onDisplay);
 }
 
-export function locationField(button, onChange, onDisplay) {
-  // FieldButton(value, validator, onChange, onDisplay, buttonIcon, editFieldLabel)
-  return new Blockly.FieldButton(
-    {x: 0, y: 0},
-    null,
-    onChange,
-    onDisplay,
-    button,
-    true
-  );
+export function locationField(icon, onChange, _, onDisplaySetField) {
+  // FieldButton(value, validator, onChange, onDisplay, icon)
+  return new Blockly.FieldButton(null, null, onChange, onDisplaySetField, icon);
 }

--- a/apps/src/blockly/addons/cdoUtils.js
+++ b/apps/src/blockly/addons/cdoUtils.js
@@ -1,6 +1,5 @@
 import {ToolboxType, CLAMPED_NUMBER_REGEX} from '../constants';
 import cdoTheme from '../themes/cdoTheme';
-import {capitalizeFirstLetter} from '@cdo/apps/block_utils';
 import {DEFAULT_SOUND} from '@cdo/apps/blockly/constants';
 
 export function setHSV(block, h, s, v) {
@@ -112,6 +111,9 @@ export function getCode(workspace) {
 }
 
 export function soundField(onChange) {
+  const capitalizeFirstLetter = function (string) {
+    return string.charAt(0).toUpperCase() + string.slice(1);
+  };
   const parsePathString = text => {
     // Example string paths:
     // 'sound://category_board_games/card_dealing_multiple.mp3'

--- a/apps/src/blockly/addons/cdoUtils.js
+++ b/apps/src/blockly/addons/cdoUtils.js
@@ -110,26 +110,14 @@ export function getCode(workspace) {
 }
 
 export function soundField(onChange, onDisplay) {
-  // Handle 'play sound' block with default param from CDO blockly.
-  // TODO: Remove when sprite lab is migrated to Google blockly.
-  const validator = newValue => {
-    if (typeof newValue !== 'string') {
-      return null;
-    }
-    if (newValue === 'Choose') {
-      return DEFAULT_SOUND;
-    }
-    return newValue;
-  };
-  // FieldButton(value, validator, onChange, onDisplay)
-  return new Blockly.FieldButton(DEFAULT_SOUND, validator, onChange, onDisplay);
+  // return new Blockly.FieldButton(DEFAULT_SOUND, onChange, onDisplay);
+  return new Blockly.FieldButton(DEFAULT_SOUND, null, onChange, onDisplay);
 }
 
 export function locationField(button, onChange, onDisplay) {
-  // FieldButton(value, validator, onChange, onDisplay, buttonIcon, editFieldLabel)
+  // FieldButton(value, onChange, onDisplay, buttonIcon, editFieldLabel)
   return new Blockly.FieldButton(
     {x: 0, y: 0},
-    null,
     onChange,
     onDisplay,
     button,

--- a/apps/src/blockly/addons/cdoUtils.js
+++ b/apps/src/blockly/addons/cdoUtils.js
@@ -1,6 +1,8 @@
 import {ToolboxType, CLAMPED_NUMBER_REGEX, DEFAULT_SOUND} from '../constants';
 import cdoTheme from '../themes/cdoTheme';
 import {APP_HEIGHT} from '@cdo/apps/p5lab/constants';
+import {SOUND_PREFIX} from '@cdo/apps/assetManagement/assetPrefix';
+
 export function setHSV(block, h, s, v) {
   block.setColour(Blockly.utils.colour.hsvToHex(h, s, v * 255));
 }
@@ -109,30 +111,32 @@ export function getCode(workspace) {
   // return JSON.stringify(Blockly.serialization.workspaces.save(workspace));
 }
 
-export function soundField(onChange, onDisplay, icon) {
+export function soundField(onClick, transformText, icon) {
   // Handle 'play sound' block with default param from CDO blockly.
   // TODO: Remove when sprite lab is migrated to Google blockly.
   const validator = newValue => {
     if (typeof newValue !== 'string') {
       return null;
     }
-    if (newValue === 'Choose') {
+    if (!newValue.startsWith(SOUND_PREFIX) || !newValue.endsWith('.mp3')) {
+      console.error(
+        'An invalid sound value was selected. Therefore, the default sound value will be used.'
+      );
       return DEFAULT_SOUND;
     }
     return newValue;
   };
-  // FieldButton(value, validator, onChange, onDisplay, icon)
-  return new Blockly.FieldButton(
-    DEFAULT_SOUND,
+  return new Blockly.FieldButton({
+    value: DEFAULT_SOUND,
     validator,
-    onChange,
-    onDisplay,
-    icon
-  );
+    onClick,
+    transformText,
+    icon,
+  });
 }
 
-export function locationField(icon, onChange) {
-  const onDisplaySetField = value => {
+export function locationField(icon, onClick) {
+  const transformTextSetField = value => {
     if (value) {
       try {
         const loc = JSON.parse(value);
@@ -142,6 +146,9 @@ export function locationField(icon, onChange) {
       }
     }
   };
-  // FieldButton(value, validator, onChange, onDisplay, icon)
-  return new Blockly.FieldButton(null, null, onChange, onDisplaySetField, icon);
+  return new Blockly.FieldButton({
+    onClick,
+    transformText: transformTextSetField,
+    icon,
+  });
 }

--- a/apps/src/blockly/addons/cdoUtils.js
+++ b/apps/src/blockly/addons/cdoUtils.js
@@ -140,11 +140,11 @@ export function soundField(onChange) {
   const onDisplay = soundPath => {
     return parsePathString(soundPath);
   };
-  return new Blockly.FieldButton('Choose', onChange, onDisplay);
+  return new Blockly.FieldPicker('Choose', onChange, onDisplay);
 }
 
 export function locationField(buttonIcon, onChange, __, onDisplay) {
-  return new Blockly.FieldButton(
+  return new Blockly.FieldPicker(
     DEFAULT_SOUND,
     onChange,
     onDisplay,

--- a/apps/src/blockly/addons/cdoUtils.js
+++ b/apps/src/blockly/addons/cdoUtils.js
@@ -126,12 +126,13 @@ export function soundField(onChange, onDisplay) {
 }
 
 export function locationField(button, onChange, onDisplay) {
-  // FieldButton(value, validator, onChange, onDisplay, buttonIcon)
+  // FieldButton(value, validator, onChange, onDisplay, buttonIcon, editFieldLabel)
   return new Blockly.FieldButton(
     {x: 0, y: 0},
     null,
     onChange,
     onDisplay,
-    button
+    button,
+    true
   );
 }

--- a/apps/src/blockly/addons/cdoUtils.js
+++ b/apps/src/blockly/addons/cdoUtils.js
@@ -110,14 +110,26 @@ export function getCode(workspace) {
 }
 
 export function soundField(onChange, onDisplay) {
-  // return new Blockly.FieldButton(DEFAULT_SOUND, onChange, onDisplay);
-  return new Blockly.FieldButton(DEFAULT_SOUND, null, onChange, onDisplay);
+  // Handle 'play sound' block with default param from CDO blockly.
+  // TODO: Remove when sprite lab is migrated to Google blockly.
+  const validator = newValue => {
+    if (typeof newValue !== 'string') {
+      return null;
+    }
+    if (newValue === 'Choose') {
+      return DEFAULT_SOUND;
+    }
+    return newValue;
+  };
+  // FieldButton(value, validator, onChange, onDisplay)
+  return new Blockly.FieldButton(DEFAULT_SOUND, validator, onChange, onDisplay);
 }
 
 export function locationField(button, onChange, onDisplay) {
-  // FieldButton(value, onChange, onDisplay, buttonIcon, editFieldLabel)
+  // FieldButton(value, validator, onChange, onDisplay, buttonIcon, editFieldLabel)
   return new Blockly.FieldButton(
     {x: 0, y: 0},
+    null,
     onChange,
     onDisplay,
     button,

--- a/apps/src/blockly/addons/cdoUtils.js
+++ b/apps/src/blockly/addons/cdoUtils.js
@@ -1,4 +1,4 @@
-import {ToolboxType, CLAMPED_NUMBER_REGEX} from '../constants';
+import {ToolboxType, CLAMPED_NUMBER_REGEX, DEFAULT_SOUND} from '../constants';
 import cdoTheme from '../themes/cdoTheme';
 
 export function setHSV(block, h, s, v) {
@@ -110,10 +110,28 @@ export function getCode(workspace) {
 }
 
 export function soundField(onChange, onDisplay) {
-  return new Blockly.FieldButton('Choose', onChange, onDisplay);
+  // Handle 'play sound' block with default param from CDO blockly.
+  // TODO: Remove when sprite lab is migrated to Google blockly.
+  const validator = newValue => {
+    if (typeof newValue !== 'string') {
+      return null;
+    }
+    if (newValue === 'Choose') {
+      return DEFAULT_SOUND;
+    }
+    return newValue;
+  };
+  // FieldButton(value, validator, onChange, onDisplay)
+  return new Blockly.FieldButton(DEFAULT_SOUND, validator, onChange, onDisplay);
 }
 
-export function locationField(buttonIcon, onChange, __, onDisplay) {
-  // FieldButton(value, onChange, onDisplay, buttonIcon)
-  return new Blockly.FieldButton({x: 0, y: 0}, onChange, onDisplay, buttonIcon);
+export function locationField(button, onChange, onDisplay) {
+  // FieldButton(value, validator, onChange, onDisplay, buttonIcon)
+  return new Blockly.FieldButton(
+    {x: 0, y: 0},
+    null,
+    onChange,
+    onDisplay,
+    button
+  );
 }

--- a/apps/src/blockly/addons/cdoUtils.js
+++ b/apps/src/blockly/addons/cdoUtils.js
@@ -1,6 +1,6 @@
 import {ToolboxType, CLAMPED_NUMBER_REGEX, DEFAULT_SOUND} from '../constants';
 import cdoTheme from '../themes/cdoTheme';
-
+import {APP_HEIGHT} from '@cdo/apps/p5lab/constants';
 export function setHSV(block, h, s, v) {
   block.setColour(Blockly.utils.colour.hsvToHex(h, s, v * 255));
 }
@@ -109,7 +109,7 @@ export function getCode(workspace) {
   // return JSON.stringify(Blockly.serialization.workspaces.save(workspace));
 }
 
-export function soundField(onChange, onDisplay) {
+export function soundField(onChange, onDisplay, icon) {
   // Handle 'play sound' block with default param from CDO blockly.
   // TODO: Remove when sprite lab is migrated to Google blockly.
   const validator = newValue => {
@@ -121,11 +121,27 @@ export function soundField(onChange, onDisplay) {
     }
     return newValue;
   };
-  // FieldButton(value, validator, onChange, onDisplay)
-  return new Blockly.FieldButton(DEFAULT_SOUND, validator, onChange, onDisplay);
+  // FieldButton(value, validator, onChange, onDisplay, icon)
+  return new Blockly.FieldButton(
+    DEFAULT_SOUND,
+    validator,
+    onChange,
+    onDisplay,
+    icon
+  );
 }
 
-export function locationField(icon, onChange, _, onDisplaySetField) {
+export function locationField(icon, onChange) {
+  const onDisplaySetField = value => {
+    if (value) {
+      try {
+        const loc = JSON.parse(value);
+        return `(${loc.x}, ${APP_HEIGHT - loc.y})`;
+      } catch (e) {
+        // Just ignore bad values
+      }
+    }
+  };
   // FieldButton(value, validator, onChange, onDisplay, icon)
   return new Blockly.FieldButton(null, null, onChange, onDisplaySetField, icon);
 }

--- a/apps/src/blockly/addons/cdoUtils.js
+++ b/apps/src/blockly/addons/cdoUtils.js
@@ -1,5 +1,7 @@
 import {ToolboxType, CLAMPED_NUMBER_REGEX} from '../constants';
 import cdoTheme from '../themes/cdoTheme';
+import {capitalizeFirstLetter} from '@cdo/apps/block_utils';
+import {DEFAULT_SOUND} from '@cdo/apps/blockly/constants';
 
 export function setHSV(block, h, s, v) {
   block.setColour(Blockly.utils.colour.hsvToHex(h, s, v * 255));
@@ -109,7 +111,41 @@ export function getCode(workspace) {
   // return JSON.stringify(Blockly.serialization.workspaces.save(workspace));
 }
 
-// TODO: Re-define with a new custom field.
 export function soundField(onChange) {
-  return new Blockly.FieldDropdown([['Choose', 'Choose']], onChange);
+  const parsePathString = text => {
+    // Example string paths:
+    // 'sound://category_board_games/card_dealing_multiple.mp3'
+    // 'sound://default.mp3'
+    const pathStringArray = text.split('/');
+    let category = '';
+    // Some sounds do not include a category, such as default.mp3
+    if (pathStringArray[2].includes('category_')) {
+      // Example: 'category_board_games' becomes 'Board games: '
+      category = capitalizeFirstLetter(
+        pathStringArray[2].replace('category_', '').replaceAll('_', ' ') + ': '
+      );
+    }
+    // Example: 'card_dealing_multiple.mp3' becomes 'card_dealing_multiple'
+    const soundName = pathStringArray[pathStringArray.length - 1].replace(
+      '.mp3',
+      ''
+    );
+    // Examples: 'Board games: card_dealing_multiple', 'default'
+    const fieldText = `${category}${soundName}`;
+    return fieldText;
+  };
+
+  const onDisplay = soundPath => {
+    return parsePathString(soundPath);
+  };
+  return new Blockly.FieldButton('Choose', onChange, onDisplay);
+}
+
+export function locationField(buttonIcon, onChange, __, onDisplay) {
+  return new Blockly.FieldButton(
+    DEFAULT_SOUND,
+    onChange,
+    onDisplay,
+    buttonIcon
+  );
 }

--- a/apps/src/blockly/addons/cdoUtils.js
+++ b/apps/src/blockly/addons/cdoUtils.js
@@ -109,40 +109,11 @@ export function getCode(workspace) {
   // return JSON.stringify(Blockly.serialization.workspaces.save(workspace));
 }
 
-export function soundField(onChange) {
-  const capitalizeFirstLetter = function (string) {
-    return string.charAt(0).toUpperCase() + string.slice(1);
-  };
-  const parsePathString = text => {
-    // Example string paths:
-    // 'sound://category_board_games/card_dealing_multiple.mp3'
-    // 'sound://default.mp3'
-    const pathStringArray = text.split('/');
-    let category = '';
-    // Some sounds do not include a category, such as default.mp3
-    if (pathStringArray[2].includes('category_')) {
-      // Example: 'category_board_games' becomes 'Board games: '
-      category = capitalizeFirstLetter(
-        pathStringArray[2].replace('category_', '').replaceAll('_', ' ') + ': '
-      );
-    }
-    // Example: 'card_dealing_multiple.mp3' becomes 'card_dealing_multiple'
-    const soundName = pathStringArray[pathStringArray.length - 1].replace(
-      '.mp3',
-      ''
-    );
-    // Examples: 'Board games: card_dealing_multiple', 'default'
-    const fieldText = `${category}${soundName}`;
-    return fieldText;
-  };
-
-  const onDisplay = soundPath => {
-    return parsePathString(soundPath);
-  };
-  return new Blockly.FieldPicker('Choose', onChange, onDisplay);
+export function soundField(onChange, onDisplay) {
+  return new Blockly.FieldButton('Choose', onChange, onDisplay);
 }
 
 export function locationField(buttonIcon, onChange, __, onDisplay) {
-  // FieldPicker(value, onChange, onDisplay, buttonIcon)
-  return new Blockly.FieldPicker({x: 0, y: 0}, onChange, onDisplay, buttonIcon);
+  // FieldButton(value, onChange, onDisplay, buttonIcon)
+  return new Blockly.FieldButton({x: 0, y: 0}, onChange, onDisplay, buttonIcon);
 }

--- a/apps/src/blockly/addons/cdoUtils.js
+++ b/apps/src/blockly/addons/cdoUtils.js
@@ -1,6 +1,5 @@
 import {ToolboxType, CLAMPED_NUMBER_REGEX} from '../constants';
 import cdoTheme from '../themes/cdoTheme';
-import {DEFAULT_SOUND} from '@cdo/apps/blockly/constants';
 
 export function setHSV(block, h, s, v) {
   block.setColour(Blockly.utils.colour.hsvToHex(h, s, v * 255));
@@ -144,10 +143,6 @@ export function soundField(onChange) {
 }
 
 export function locationField(buttonIcon, onChange, __, onDisplay) {
-  return new Blockly.FieldPicker(
-    DEFAULT_SOUND,
-    onChange,
-    onDisplay,
-    buttonIcon
-  );
+  // FieldPicker(value, onChange, onDisplay, buttonIcon)
+  return new Blockly.FieldPicker({x: 0, y: 0}, onChange, onDisplay, buttonIcon);
 }

--- a/apps/src/blockly/cdoBlocklyWrapper.js
+++ b/apps/src/blockly/cdoBlocklyWrapper.js
@@ -1,5 +1,6 @@
 import {BlocklyVersion} from '@cdo/apps/blockly/constants';
 import {CLAMPED_NUMBER_REGEX} from './constants';
+import {APP_HEIGHT} from '@cdo/apps/p5lab/constants';
 
 const INFINITE_LOOP_TRAP =
   '  executionInfo.checkTimeout(); if (executionInfo.isTerminated()){return;}\n';
@@ -278,7 +279,28 @@ function initializeBlocklyWrapper(blocklyInstance) {
     soundField: function (onChange) {
       return new Blockly.FieldDropdown([['Choose', 'Choose']], onChange);
     },
-    locationField: function (icon, onChange, onDisplaySetLabel, _, color) {
+    locationField: function (
+      icon,
+      onChange,
+      block,
+      inputConfig,
+      currentInputRow
+    ) {
+      const fieldRow = currentInputRow.getFieldRow();
+      const fieldLabel = fieldRow[fieldRow.length - 1];
+      const onDisplaySetLabel = value => {
+        if (value) {
+          try {
+            const loc = JSON.parse(value);
+            fieldLabel.setValue(
+              `${inputConfig.label}(${loc.x}, ${APP_HEIGHT - loc.y})`
+            );
+          } catch (e) {
+            // Just ignore bad values
+          }
+        }
+      };
+      const color = block.getHexColour();
       return new Blockly.FieldButton(icon, onChange, color, onDisplaySetLabel);
     },
   };

--- a/apps/src/blockly/cdoBlocklyWrapper.js
+++ b/apps/src/blockly/cdoBlocklyWrapper.js
@@ -278,8 +278,8 @@ function initializeBlocklyWrapper(blocklyInstance) {
     soundField: function (onChange) {
       return new Blockly.FieldDropdown([['Choose', 'Choose']], onChange);
     },
-    locationField: function (button, onChange, color, onDisplay) {
-      return new Blockly.FieldButton(button.icon, onChange, onDisplay, color);
+    locationField: function (icon, onChange, onDisplaySetLabel, _, color) {
+      return new Blockly.FieldButton(icon, onChange, color, onDisplaySetLabel);
     },
   };
   return blocklyWrapper;

--- a/apps/src/blockly/cdoBlocklyWrapper.js
+++ b/apps/src/blockly/cdoBlocklyWrapper.js
@@ -276,19 +276,19 @@ function initializeBlocklyWrapper(blocklyInstance) {
     getCode: function (workspace) {
       return Blockly.Xml.domToText(Blockly.Xml.blockSpaceToDom(workspace));
     },
-    soundField: function (onChange) {
-      return new Blockly.FieldDropdown([['Choose', 'Choose']], onChange);
+    soundField: function (onClick) {
+      return new Blockly.FieldDropdown([['Choose', 'Choose']], onClick);
     },
     locationField: function (
       icon,
-      onChange,
+      onClick,
       block,
       inputConfig,
       currentInputRow
     ) {
       const fieldRow = currentInputRow.getFieldRow();
       const fieldLabel = fieldRow[fieldRow.length - 1];
-      const onDisplaySetLabel = value => {
+      const transformTextSetLabel = value => {
         if (value) {
           try {
             const loc = JSON.parse(value);
@@ -301,7 +301,12 @@ function initializeBlocklyWrapper(blocklyInstance) {
         }
       };
       const color = block.getHexColour();
-      return new Blockly.FieldButton(icon, onChange, color, onDisplaySetLabel);
+      return new Blockly.FieldButton(
+        icon,
+        onClick,
+        color,
+        transformTextSetLabel
+      );
     },
   };
   return blocklyWrapper;

--- a/apps/src/blockly/cdoBlocklyWrapper.js
+++ b/apps/src/blockly/cdoBlocklyWrapper.js
@@ -278,8 +278,8 @@ function initializeBlocklyWrapper(blocklyInstance) {
     soundField: function (onChange) {
       return new Blockly.FieldDropdown([['Choose', 'Choose']], onChange);
     },
-    locationField: function (icon, onChange, color, onDisplay) {
-      return new Blockly.FieldButton(icon, onChange, color, onDisplay);
+    locationField: function (button, onChange, color, onDisplay) {
+      return new Blockly.FieldButton(button.icon, onChange, onDisplay, color);
     },
   };
   return blocklyWrapper;

--- a/apps/src/blockly/cdoBlocklyWrapper.js
+++ b/apps/src/blockly/cdoBlocklyWrapper.js
@@ -278,6 +278,9 @@ function initializeBlocklyWrapper(blocklyInstance) {
     soundField: function (onChange) {
       return new Blockly.FieldDropdown([['Choose', 'Choose']], onChange);
     },
+    locationField: function (icon, onChange, color, onDisplay) {
+      return new Blockly.FieldButton(icon, onChange, color, onDisplay);
+    },
   };
   return blocklyWrapper;
 }

--- a/apps/src/blockly/constants.js
+++ b/apps/src/blockly/constants.js
@@ -43,3 +43,6 @@ export const Renderers = {
 //   ClampedNumber(,)
 export const CLAMPED_NUMBER_REGEX =
   /^ClampedNumber\(\s*([\d.]*)\s*,\s*([\d.]*)\s*\)$/;
+
+// Used for custom field type FieldPicker for 'play sound' block
+export const DEFAULT_SOUND = 'sound://default.mp3';

--- a/apps/src/blockly/constants.js
+++ b/apps/src/blockly/constants.js
@@ -45,4 +45,4 @@ export const CLAMPED_NUMBER_REGEX =
   /^ClampedNumber\(\s*([\d.]*)\s*,\s*([\d.]*)\s*\)$/;
 
 // Used for custom field type FieldButton for 'play sound' block
-export const DEFAULT_SOUND = 'sound://default.mp3';
+export const DEFAULT_SOUND = 'sound://category_digital/ping.mp3';

--- a/apps/src/blockly/constants.js
+++ b/apps/src/blockly/constants.js
@@ -44,5 +44,5 @@ export const Renderers = {
 export const CLAMPED_NUMBER_REGEX =
   /^ClampedNumber\(\s*([\d.]*)\s*,\s*([\d.]*)\s*\)$/;
 
-// Used for custom field type FieldPicker for 'play sound' block
+// Used for custom field type FieldButton for 'play sound' block
 export const DEFAULT_SOUND = 'sound://default.mp3';

--- a/apps/src/blockly/googleBlocklyWrapper.js
+++ b/apps/src/blockly/googleBlocklyWrapper.js
@@ -412,7 +412,7 @@ function initializeBlocklyWrapper(blocklyInstance) {
     return this.setOutput(isOutput, check);
   };
 
-  // A field's 'value' used to be called its 'title' in older versions of Blockly.
+  // Block fields are referred to as titles in CDO Blockly.
   blocklyWrapper.Block.prototype.setTitleValue = function (newValue, name) {
     return this.setFieldValue(newValue, name);
   };

--- a/apps/src/blockly/googleBlocklyWrapper.js
+++ b/apps/src/blockly/googleBlocklyWrapper.js
@@ -10,7 +10,7 @@ import styleConstants from '@cdo/apps/styleConstants';
 import * as utils from '@cdo/apps/utils';
 import initializeCdoConstants from './addons/cdoConstants';
 import CdoFieldAngle from './addons/cdoFieldAngle';
-import CdoFieldPicker from './addons/cdoFieldPicker';
+import CdoFieldButton from './addons/cdoFieldButton';
 import CdoFieldDropdown from './addons/cdoFieldDropdown';
 import {CdoFieldImageDropdown} from './addons/cdoFieldImageDropdown';
 import CdoFieldMultilineInput from './addons/cdoFieldMultilineInput';
@@ -242,7 +242,7 @@ function initializeBlocklyWrapper(blocklyInstance) {
   blocklyWrapper.blockly_.Trashcan = CdoTrashcan;
 
   // Code.org custom fields
-  blocklyWrapper.FieldPicker = CdoFieldPicker;
+  blocklyWrapper.FieldButton = CdoFieldButton;
   blocklyWrapper.FieldImageDropdown = CdoFieldImageDropdown;
 
   blocklyWrapper.blockly_.registry.register(

--- a/apps/src/blockly/googleBlocklyWrapper.js
+++ b/apps/src/blockly/googleBlocklyWrapper.js
@@ -10,7 +10,7 @@ import styleConstants from '@cdo/apps/styleConstants';
 import * as utils from '@cdo/apps/utils';
 import initializeCdoConstants from './addons/cdoConstants';
 import CdoFieldAngle from './addons/cdoFieldAngle';
-import CdoFieldButton from './addons/cdoFieldButton';
+import CdoFieldPicker from './addons/cdoFieldPicker';
 import CdoFieldDropdown from './addons/cdoFieldDropdown';
 import {CdoFieldImageDropdown} from './addons/cdoFieldImageDropdown';
 import CdoFieldMultilineInput from './addons/cdoFieldMultilineInput';
@@ -242,7 +242,7 @@ function initializeBlocklyWrapper(blocklyInstance) {
   blocklyWrapper.blockly_.Trashcan = CdoTrashcan;
 
   // Code.org custom fields
-  blocklyWrapper.FieldButton = CdoFieldButton;
+  blocklyWrapper.FieldPicker = CdoFieldPicker;
   blocklyWrapper.FieldImageDropdown = CdoFieldImageDropdown;
 
   blocklyWrapper.blockly_.registry.register(

--- a/apps/src/blockly/googleBlocklyWrapper.js
+++ b/apps/src/blockly/googleBlocklyWrapper.js
@@ -412,6 +412,7 @@ function initializeBlocklyWrapper(blocklyInstance) {
     return this.setOutput(isOutput, check);
   };
 
+  // A field's 'value' used to be called its 'title' in older versions of Blockly.
   blocklyWrapper.Block.prototype.setTitleValue = function (newValue, name) {
     return this.setFieldValue(newValue, name);
   };

--- a/apps/src/blockly/googleBlocklyWrapper.js
+++ b/apps/src/blockly/googleBlocklyWrapper.js
@@ -411,6 +411,11 @@ function initializeBlocklyWrapper(blocklyInstance) {
   blocklyWrapper.Block.prototype.setStrictOutput = function (isOutput, check) {
     return this.setOutput(isOutput, check);
   };
+
+  blocklyWrapper.Block.prototype.setTitleValue = function (newValue, name) {
+    return this.setFieldValue(newValue, name);
+  };
+
   // We use fieldRow because it is public.
   blocklyWrapper.Input.prototype.getFieldRow = function () {
     return this.fieldRow;

--- a/apps/src/maze/harvesterBlocks.js
+++ b/apps/src/maze/harvesterBlocks.js
@@ -1,3 +1,5 @@
+import {capitalizeFirstLetter} from '@cdo/apps/block_utils';
+
 /**
  * Blocks specific to Harvester
  */
@@ -6,10 +8,6 @@ var msg = require('./locale');
 var blockUtils = require('../block_utils');
 
 const CROPS = ['corn', 'pumpkin', 'lettuce'];
-
-function capitalizeFirstLetter(string) {
-  return string.charAt(0).toUpperCase() + string.slice(1);
-}
 
 function addIfAtSpecificCropBlock(blockly, generator, crop) {
   blockly.Blocks[`harvester_ifAt${capitalizeFirstLetter(crop)}`] = {

--- a/apps/src/maze/harvesterBlocks.js
+++ b/apps/src/maze/harvesterBlocks.js
@@ -1,5 +1,3 @@
-import {capitalizeFirstLetter} from '@cdo/apps/block_utils';
-
 /**
  * Blocks specific to Harvester
  */
@@ -8,6 +6,10 @@ var msg = require('./locale');
 var blockUtils = require('../block_utils');
 
 const CROPS = ['corn', 'pumpkin', 'lettuce'];
+
+function capitalizeFirstLetter(string) {
+  return string.charAt(0).toUpperCase() + string.slice(1);
+}
 
 function addIfAtSpecificCropBlock(blockly, generator, crop) {
   blockly.Blocks[`harvester_ifAt${capitalizeFirstLetter(crop)}`] = {

--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -112,30 +112,35 @@ const customInputTypes = {
       const icon = document.createElementNS(SVG_NS, 'tspan');
       icon.style.fontFamily = 'FontAwesome';
       icon.textContent = '\uf276';
-      const button = new Blockly.FieldButton(
-        icon,
-        updateValue => {
-          getLocation(loc => {
-            if (loc) {
-              button.setValue(JSON.stringify(loc));
-            }
-          });
-        },
-        block.getHexColour(), // Google Blockly includes block.getColour
-        value => {
-          if (value) {
-            try {
-              const loc = JSON.parse(value);
-              label.setValue(
-                `${inputConfig.label}(${loc.x}, ${APP_HEIGHT - loc.y})`
-              );
-            } catch (e) {
-              // Just ignore bad values
-            }
+      const buttonIcon = document.createElementNS(SVG_NS, 'tspan');
+      buttonIcon.style.fontFamily = 'FontAwesome';
+      buttonIcon.textContent = '\uf276';
+      const onChange = () => {
+        getLocation(loc => {
+          if (loc) {
+            fieldButton.setValue(JSON.stringify(loc));
+          }
+        });
+      };
+      const onDisplay = value => {
+        if (value) {
+          try {
+            const loc = JSON.parse(value);
+            label.setValue(
+              `${inputConfig.label}(${loc.x}, ${APP_HEIGHT - loc.y})`
+            );
+          } catch (e) {
+            // Just ignore bad values
           }
         }
+      };
+      const fieldButton = Blockly.cdoUtils.locationField(
+        buttonIcon,
+        onChange,
+        block.getHexColour(), // Google Blockly includes block.getColour
+        onDisplay
       );
-      currentInputRow.appendField(button, inputConfig.name);
+      currentInputRow.appendField(fieldButton, inputConfig.name);
     },
     generateCode(block, arg) {
       return `(${block.getFieldValue(arg.name)})`;

--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -182,18 +182,18 @@ const customInputTypes = {
       const onSelect = function (soundValue) {
         block.setTitleValue(soundValue, inputConfig.name);
       };
-      const onChange = () => {
+      const onClick = () => {
         dashboard.assets.showAssetManager(onSelect, 'audio', null, {
           libraryOnly: true,
         });
       };
-      const onDisplay = soundPath => {
+      const transformText = soundPath => {
         return parsePathString(soundPath);
       };
       currentInputRow
         .appendField(inputConfig.label)
         .appendField(
-          Blockly.cdoUtils.soundField(onChange, onDisplay, icon),
+          Blockly.cdoUtils.soundField(onClick, transformText, icon),
           inputConfig.name
         );
     },

--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -196,9 +196,41 @@ const customInputTypes = {
           libraryOnly: true,
         });
       };
+      const capitalizeFirstLetter = function (string) {
+        return string.charAt(0).toUpperCase() + string.slice(1);
+      };
+      const parsePathString = text => {
+        // Example string paths:
+        // 'sound://category_board_games/card_dealing_multiple.mp3'
+        // 'sound://default.mp3'
+        const pathStringArray = text.split('/');
+        let category = '';
+        // Some sounds do not include a category, such as default.mp3
+        if (pathStringArray[2].includes('category_')) {
+          // Example: 'category_board_games' becomes 'Board games: '
+          category = capitalizeFirstLetter(
+            pathStringArray[2].replace('category_', '').replaceAll('_', ' ') +
+              ': '
+          );
+        }
+        // Example: 'card_dealing_multiple.mp3' becomes 'card_dealing_multiple'
+        const soundName = pathStringArray[pathStringArray.length - 1].replace(
+          '.mp3',
+          ''
+        );
+        // Examples: 'Board games: card_dealing_multiple', 'default'
+        const fieldText = `${category}${soundName}`;
+        return fieldText;
+      };
+      const onDisplay = soundPath => {
+        return parsePathString(soundPath);
+      };
       currentInputRow
         .appendField(inputConfig.label)
-        .appendField(Blockly.cdoUtils.soundField(onChange), inputConfig.name);
+        .appendField(
+          Blockly.cdoUtils.soundField(onChange, onDisplay),
+          inputConfig.name
+        );
     },
     generateCode(block, arg) {
       return `'${block.getFieldValue(arg.name)}'`;

--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -9,6 +9,7 @@ import {Goal, showBackground} from '../redux/animationPicker';
 import i18n from '@cdo/locale';
 import spritelabMsg from '@cdo/spritelab/locale';
 import experiments from '@cdo/apps/util/experiments';
+import {parsePathString} from '@cdo/apps/p5lab/utils';
 
 function animations(includeBackgrounds) {
   const animationList = getStore().getState().animationList;
@@ -200,32 +201,6 @@ const customInputTypes = {
         dashboard.assets.showAssetManager(onSelect, 'audio', null, {
           libraryOnly: true,
         });
-      };
-      const capitalizeFirstLetter = function (string) {
-        return string.charAt(0).toUpperCase() + string.slice(1);
-      };
-      const parsePathString = text => {
-        // Example string paths:
-        // 'sound://category_board_games/card_dealing_multiple.mp3'
-        // 'sound://default.mp3'
-        const pathStringArray = text.split('/');
-        let category = '';
-        // Some sounds do not include a category, such as default.mp3
-        if (pathStringArray[2].includes('category_')) {
-          // Example: 'category_board_games' becomes 'Board games: '
-          category = capitalizeFirstLetter(
-            pathStringArray[2].replace('category_', '').replaceAll('_', ' ') +
-              ': '
-          );
-        }
-        // Example: 'card_dealing_multiple.mp3' becomes 'card_dealing_multiple'
-        const soundName = pathStringArray[pathStringArray.length - 1].replace(
-          '.mp3',
-          ''
-        );
-        // Examples: 'Board games: card_dealing_multiple', 'default'
-        const fieldText = `${category}${soundName}`;
-        return fieldText;
       };
       const onDisplay = soundPath => {
         return parsePathString(soundPath);

--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -112,6 +112,11 @@ const customInputTypes = {
       const buttonIcon = document.createElementNS(SVG_NS, 'tspan');
       buttonIcon.style.fontFamily = 'FontAwesome';
       buttonIcon.textContent = '\uf276';
+      const button = {
+        icon: buttonIcon,
+        cornerRadius: 3,
+        innerHeight: 15,
+      };
       const onChange = () => {
         getLocation(loc => {
           if (loc) {
@@ -132,10 +137,10 @@ const customInputTypes = {
         }
       };
       const fieldButton = Blockly.cdoUtils.locationField(
-        buttonIcon,
+        button,
         onChange,
-        block.getHexColour(), // Google Blockly includes block.getColour
-        onDisplay
+        onDisplay,
+        block.getHexColour() // Google Blockly includes block.getColour
       );
       currentInputRow.appendField(fieldButton, inputConfig.name);
     },

--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -108,7 +108,7 @@ const customInputTypes = {
         `${inputConfig.name}_LABEL`
       );
       const fieldRow = currentInputRow.getFieldRow();
-      const fieldLabel = fieldRow[fieldRow.length - 1];
+      const fieldLabel = fieldRow[fieldRow.length - 1]; // fieldLabel = 'sprite at'
       const buttonIcon = document.createElementNS(SVG_NS, 'tspan');
       buttonIcon.style.fontFamily = 'FontAwesome';
       buttonIcon.textContent = '\uf276';

--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -105,19 +105,14 @@ const customInputTypes = {
   locationPicker: {
     addInput(blockly, block, inputConfig, currentInputRow) {
       currentInputRow.appendField(
-        `${inputConfig.label}(0, 0)`,
+        `${inputConfig.label}`,
         `${inputConfig.name}_LABEL`
       );
       const fieldRow = currentInputRow.getFieldRow();
       const fieldLabel = fieldRow[fieldRow.length - 1]; // fieldLabel = 'sprite at'
-      const buttonIcon = document.createElementNS(SVG_NS, 'tspan');
-      buttonIcon.style.fontFamily = 'FontAwesome';
-      buttonIcon.textContent = '\uf276';
-      const button = {
-        icon: buttonIcon,
-        cornerRadius: 3,
-        innerHeight: 15,
-      };
+      const icon = document.createElementNS(SVG_NS, 'tspan');
+      icon.style.fontFamily = 'FontAwesome';
+      icon.textContent = '\uf276';
       const onChange = () => {
         getLocation(loc => {
           if (loc) {
@@ -125,7 +120,17 @@ const customInputTypes = {
           }
         });
       };
-      const onDisplay = value => {
+      const onDisplaySetField = value => {
+        if (value) {
+          try {
+            const loc = JSON.parse(value);
+            return `(${loc.x}, ${APP_HEIGHT - loc.y})`;
+          } catch (e) {
+            // Just ignore bad values
+          }
+        }
+      };
+      const onDisplaySetLabel = value => {
         if (value) {
           try {
             const loc = JSON.parse(value);
@@ -138,9 +143,10 @@ const customInputTypes = {
         }
       };
       const fieldButton = Blockly.cdoUtils.locationField(
-        button,
+        icon,
         onChange,
-        onDisplay,
+        onDisplaySetLabel,
+        onDisplaySetField,
         block.getHexColour() // Google Blockly includes block.getColour
       );
       currentInputRow.appendField(fieldButton, inputConfig.name);

--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -108,10 +108,7 @@ const customInputTypes = {
         `${inputConfig.name}_LABEL`
       );
       const fieldRow = currentInputRow.getFieldRow();
-      const label = fieldRow[fieldRow.length - 1];
-      const icon = document.createElementNS(SVG_NS, 'tspan');
-      icon.style.fontFamily = 'FontAwesome';
-      icon.textContent = '\uf276';
+      const fieldLabel = fieldRow[fieldRow.length - 1];
       const buttonIcon = document.createElementNS(SVG_NS, 'tspan');
       buttonIcon.style.fontFamily = 'FontAwesome';
       buttonIcon.textContent = '\uf276';
@@ -126,7 +123,7 @@ const customInputTypes = {
         if (value) {
           try {
             const loc = JSON.parse(value);
-            label.setValue(
+            fieldLabel.setValue(
               `${inputConfig.label}(${loc.x}, ${APP_HEIGHT - loc.y})`
             );
           } catch (e) {

--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -130,6 +130,7 @@ const customInputTypes = {
           }
         }
       };
+      // TODO: Remove function below when sprite lab migrates to google blockly.
       const onDisplaySetLabel = value => {
         if (value) {
           try {

--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -1,7 +1,7 @@
 import {SVG_NS} from '@cdo/apps/constants';
 import {getStore} from '@cdo/apps/redux';
 import {getLocation} from '../redux/locationPicker';
-import {APP_HEIGHT, P5LabInterfaceMode} from '../constants';
+import {P5LabInterfaceMode} from '../constants';
 import {TOOLBOX_EDIT_MODE} from '../../constants';
 import {animationSourceUrl} from '../redux/animationList';
 import {changeInterfaceMode} from '../actions';
@@ -108,11 +108,9 @@ const customInputTypes = {
         `${inputConfig.label}`,
         `${inputConfig.name}_LABEL`
       );
-      const fieldRow = currentInputRow.getFieldRow();
-      const fieldLabel = fieldRow[fieldRow.length - 1]; // fieldLabel = 'sprite at'
       const icon = document.createElementNS(SVG_NS, 'tspan');
       icon.style.fontFamily = 'FontAwesome';
-      icon.textContent = '\uf276';
+      icon.textContent = '\uf276'; // map-pin
       const onChange = () => {
         getLocation(loc => {
           if (loc) {
@@ -120,35 +118,12 @@ const customInputTypes = {
           }
         });
       };
-      const onDisplaySetField = value => {
-        if (value) {
-          try {
-            const loc = JSON.parse(value);
-            return `(${loc.x}, ${APP_HEIGHT - loc.y})`;
-          } catch (e) {
-            // Just ignore bad values
-          }
-        }
-      };
-      // TODO: Remove function below when sprite lab migrates to google blockly.
-      const onDisplaySetLabel = value => {
-        if (value) {
-          try {
-            const loc = JSON.parse(value);
-            fieldLabel.setValue(
-              `${inputConfig.label}(${loc.x}, ${APP_HEIGHT - loc.y})`
-            );
-          } catch (e) {
-            // Just ignore bad values
-          }
-        }
-      };
       const fieldButton = Blockly.cdoUtils.locationField(
         icon,
         onChange,
-        onDisplaySetLabel,
-        onDisplaySetField,
-        block.getHexColour() // Google Blockly includes block.getColour
+        block,
+        inputConfig,
+        currentInputRow
       );
       currentInputRow.appendField(fieldButton, inputConfig.name);
     },
@@ -201,6 +176,9 @@ const customInputTypes = {
   },
   soundPicker: {
     addInput(blockly, block, inputConfig, currentInputRow) {
+      const icon = document.createElementNS(SVG_NS, 'tspan');
+      icon.style.fontFamily = 'FontAwesome';
+      icon.textContent = '\uf08e '; // arrow-up-right-from-square
       const onSelect = function (soundValue) {
         block.setTitleValue(soundValue, inputConfig.name);
       };
@@ -215,7 +193,7 @@ const customInputTypes = {
       currentInputRow
         .appendField(inputConfig.label)
         .appendField(
-          Blockly.cdoUtils.soundField(onChange, onDisplay),
+          Blockly.cdoUtils.soundField(onChange, onDisplay, icon),
           inputConfig.name
         );
     },

--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -9,7 +9,7 @@ import {Goal, showBackground} from '../redux/animationPicker';
 import i18n from '@cdo/locale';
 import spritelabMsg from '@cdo/spritelab/locale';
 import experiments from '@cdo/apps/util/experiments';
-import {parsePathString} from '@cdo/apps/p5lab/utils';
+import {parseSoundPathString} from '@cdo/apps/p5lab/utils';
 
 function animations(includeBackgrounds) {
   const animationList = getStore().getState().animationList;
@@ -110,7 +110,7 @@ const customInputTypes = {
       );
       const icon = document.createElementNS(SVG_NS, 'tspan');
       icon.style.fontFamily = 'FontAwesome';
-      icon.textContent = '\uf276'; // map-pin
+      icon.textContent = ' \uf276'; // map-pin
       const onChange = () => {
         getLocation(loc => {
           if (loc) {
@@ -178,7 +178,7 @@ const customInputTypes = {
     addInput(blockly, block, inputConfig, currentInputRow) {
       const icon = document.createElementNS(SVG_NS, 'tspan');
       icon.style.fontFamily = 'FontAwesome';
-      icon.textContent = '\uf08e '; // arrow-up-right-from-square
+      icon.textContent = ' \uf08e '; // arrow-up-right-from-square
       const onSelect = function (soundValue) {
         block.setTitleValue(soundValue, inputConfig.name);
       };
@@ -188,7 +188,7 @@ const customInputTypes = {
         });
       };
       const transformText = soundPath => {
-        return parsePathString(soundPath);
+        return parseSoundPathString(soundPath);
       };
       currentInputRow
         .appendField(inputConfig.label)

--- a/apps/src/p5lab/utils.js
+++ b/apps/src/p5lab/utils.js
@@ -1,3 +1,5 @@
+import {SOUND_PREFIX} from '@cdo/apps/assetManagement/assetPrefix';
+
 // NOTE: min and max are inclusive
 export function randomInt(min, max) {
   return Math.floor(Math.random() * (max - min + 1)) + min;
@@ -26,9 +28,10 @@ export function parsePathString(text) {
   // Example string paths:
   // 'sound://category_board_games/card_dealing_multiple.mp3'
   // 'sound://default.mp3'
-  if (!text.startsWith('sound://') || !text.endsWith('.mp3')) {
+  if (!text.startsWith(SOUND_PREFIX) || !text.endsWith('.mp3')) {
     throw new Error('This is not a valid path to a sound file.');
   }
+  //throw new Error('This is not a valid path to a sound file.');
   const pathStringArray = text.split('/');
   let category = '';
   // Some sounds do not include a category, such as default.mp3

--- a/apps/src/p5lab/utils.js
+++ b/apps/src/p5lab/utils.js
@@ -17,3 +17,30 @@ export function arrayEquals(a, b) {
 
   return true;
 }
+
+export function capitalizeFirstLetter(string) {
+  return string.charAt(0).toUpperCase() + string.slice(1);
+}
+
+export function parsePathString(text) {
+  // Example string paths:
+  // 'sound://category_board_games/card_dealing_multiple.mp3'
+  // 'sound://default.mp3'
+  const pathStringArray = text.split('/');
+  let category = '';
+  // Some sounds do not include a category, such as default.mp3
+  if (pathStringArray[2].includes('category_')) {
+    // Example: 'category_board_games' becomes 'Board games: '
+    category = capitalizeFirstLetter(
+      pathStringArray[2].replace('category_', '').replaceAll('_', ' ') + ': '
+    );
+  }
+  // Example: 'card_dealing_multiple.mp3' becomes 'card_dealing_multiple'
+  const soundName = pathStringArray[pathStringArray.length - 1].replace(
+    '.mp3',
+    ''
+  );
+  // Examples: 'Board games: card_dealing_multiple', 'default'
+  const fieldText = `${category}${soundName}`;
+  return fieldText;
+}

--- a/apps/src/p5lab/utils.js
+++ b/apps/src/p5lab/utils.js
@@ -24,7 +24,7 @@ export function capitalizeFirstLetter(string) {
   return string.charAt(0).toUpperCase() + string.slice(1);
 }
 
-export function parsePathString(text) {
+export function parseSoundPathString(text) {
   // Example string paths:
   // 'sound://category_board_games/card_dealing_multiple.mp3'
   // 'sound://default.mp3'

--- a/apps/src/p5lab/utils.js
+++ b/apps/src/p5lab/utils.js
@@ -26,7 +26,7 @@ export function parsePathString(text) {
   // Example string paths:
   // 'sound://category_board_games/card_dealing_multiple.mp3'
   // 'sound://default.mp3'
-  if (!text.includes('.mp3')) {
+  if (!text.startsWith('sound://') || !text.endsWith('.mp3')) {
     throw new Error('This is not a valid path to a sound file.');
   }
   const pathStringArray = text.split('/');

--- a/apps/src/p5lab/utils.js
+++ b/apps/src/p5lab/utils.js
@@ -1,3 +1,5 @@
+import {DEFAULT_SOUND} from '@cdo/apps/blockly/constants';
+
 // NOTE: min and max are inclusive
 export function randomInt(min, max) {
   return Math.floor(Math.random() * (max - min + 1)) + min;
@@ -26,6 +28,9 @@ export function parsePathString(text) {
   // Example string paths:
   // 'sound://category_board_games/card_dealing_multiple.mp3'
   // 'sound://default.mp3'
+  if (!text.includes('.mp3')) {
+    return DEFAULT_SOUND;
+  }
   const pathStringArray = text.split('/');
   let category = '';
   // Some sounds do not include a category, such as default.mp3

--- a/apps/src/p5lab/utils.js
+++ b/apps/src/p5lab/utils.js
@@ -1,5 +1,3 @@
-import {DEFAULT_SOUND} from '@cdo/apps/blockly/constants';
-
 // NOTE: min and max are inclusive
 export function randomInt(min, max) {
   return Math.floor(Math.random() * (max - min + 1)) + min;
@@ -29,7 +27,7 @@ export function parsePathString(text) {
   // 'sound://category_board_games/card_dealing_multiple.mp3'
   // 'sound://default.mp3'
   if (!text.includes('.mp3')) {
-    return DEFAULT_SOUND;
+    throw new Error('This is not a valid path to a sound file.');
   }
   const pathStringArray = text.split('/');
   let category = '';

--- a/apps/test/unit/p5lab/utilsTest.js
+++ b/apps/test/unit/p5lab/utilsTest.js
@@ -1,16 +1,19 @@
 import {expect} from '../../util/reconfiguredChai';
 import * as utils from '@cdo/apps/p5lab/utils';
 const {parsePathString} = utils;
+import {SOUND_PREFIX} from '@cdo/apps/assetManagement/assetPrefix';
 
 describe('the parsePathString function', () => {
   it('for a valid path to sound file, returns a user-friendly sound name with category', () => {
     expect(
-      parsePathString('sound://category_board_games/card_dealing_multiple.mp3')
+      parsePathString(
+        `${SOUND_PREFIX}category_board_games/card_dealing_multiple.mp3`
+      )
     ).to.equal('Board games: card_dealing_multiple');
   });
 
   it('for a valid path to sound file, returns a user-friendly sound name when no category is included', () => {
-    expect(parsePathString('sound://default.mp3')).to.equal('default');
+    expect(parsePathString(`${SOUND_PREFIX}default.mp3`)).to.equal('default');
   });
 
   it('for an invalid path to sound file, throws an error', () => {
@@ -23,7 +26,7 @@ describe('the parsePathString function', () => {
   it('for an invalid path to sound file (no mp3 file extension), throws an error', () => {
     const errMsg = 'This is not a valid path to a sound file.';
     expect(() => {
-      parsePathString('sound://default');
+      parsePathString(`${SOUND_PREFIX}default`);
     }).to.throw(Error, errMsg);
   });
 

--- a/apps/test/unit/p5lab/utilsTest.js
+++ b/apps/test/unit/p5lab/utilsTest.js
@@ -19,4 +19,18 @@ describe('the parsePathString function', () => {
       parsePathString('sound');
     }).to.throw(Error, errMsg);
   });
+
+  it('for an invalid path to sound file (no mp3 file extension), throws an error', () => {
+    const errMsg = 'This is not a valid path to a sound file.';
+    expect(() => {
+      parsePathString('sound://default');
+    }).to.throw(Error, errMsg);
+  });
+
+  it('for an invalid path to sound file (does not begin with sound://), throws an error', () => {
+    const errMsg = 'This is not a valid path to a sound file.';
+    expect(() => {
+      parsePathString('default.mp3');
+    }).to.throw(Error, errMsg);
+  });
 });

--- a/apps/test/unit/p5lab/utilsTest.js
+++ b/apps/test/unit/p5lab/utilsTest.js
@@ -1,39 +1,41 @@
 import {expect} from '../../util/reconfiguredChai';
 import * as utils from '@cdo/apps/p5lab/utils';
-const {parsePathString} = utils;
+const {parseSoundPathString} = utils;
 import {SOUND_PREFIX} from '@cdo/apps/assetManagement/assetPrefix';
 
-describe('the parsePathString function', () => {
+describe('the parseSoundPathString function', () => {
   it('for a valid path to sound file, returns a user-friendly sound name with category', () => {
     expect(
-      parsePathString(
+      parseSoundPathString(
         `${SOUND_PREFIX}category_board_games/card_dealing_multiple.mp3`
       )
     ).to.equal('Board games: card_dealing_multiple');
   });
 
   it('for a valid path to sound file, returns a user-friendly sound name when no category is included', () => {
-    expect(parsePathString(`${SOUND_PREFIX}default.mp3`)).to.equal('default');
+    expect(parseSoundPathString(`${SOUND_PREFIX}default.mp3`)).to.equal(
+      'default'
+    );
   });
 
   it('for an invalid path to sound file, throws an error', () => {
     const errMsg = 'This is not a valid path to a sound file.';
     expect(() => {
-      parsePathString('sound');
+      parseSoundPathString('sound');
     }).to.throw(Error, errMsg);
   });
 
   it('for an invalid path to sound file (no mp3 file extension), throws an error', () => {
     const errMsg = 'This is not a valid path to a sound file.';
     expect(() => {
-      parsePathString(`${SOUND_PREFIX}default`);
+      parseSoundPathString(`${SOUND_PREFIX}default`);
     }).to.throw(Error, errMsg);
   });
 
   it('for an invalid path to sound file (does not begin with sound://), throws an error', () => {
     const errMsg = 'This is not a valid path to a sound file.';
     expect(() => {
-      parsePathString('default.mp3');
+      parseSoundPathString('default.mp3');
     }).to.throw(Error, errMsg);
   });
 });

--- a/apps/test/unit/p5lab/utilsTest.js
+++ b/apps/test/unit/p5lab/utilsTest.js
@@ -1,0 +1,20 @@
+import {expect} from '../../util/reconfiguredChai';
+import {DEFAULT_SOUND} from '@cdo/apps/blockly/constants';
+import * as utils from '@cdo/apps/p5lab/utils';
+const {parsePathString} = utils;
+
+describe('the parsePathString function', () => {
+  it('returns ', () => {
+    expect(
+      parsePathString('sound://category_board_games/card_dealing_multiple.mp3')
+    ).to.equal('Board games: card_dealing_multiple');
+  });
+
+  it('returns ', () => {
+    expect(parsePathString('sound://default.mp3')).to.equal('default');
+  });
+
+  it('returns DEFAULT_SOUND when not a valid sound file path', () => {
+    expect(parsePathString('Choose')).to.equal(DEFAULT_SOUND);
+  });
+});

--- a/apps/test/unit/p5lab/utilsTest.js
+++ b/apps/test/unit/p5lab/utilsTest.js
@@ -1,20 +1,22 @@
 import {expect} from '../../util/reconfiguredChai';
-import {DEFAULT_SOUND} from '@cdo/apps/blockly/constants';
 import * as utils from '@cdo/apps/p5lab/utils';
 const {parsePathString} = utils;
 
 describe('the parsePathString function', () => {
-  it('returns ', () => {
+  it('for a valid path to sound file, returns a user-friendly sound name with category', () => {
     expect(
       parsePathString('sound://category_board_games/card_dealing_multiple.mp3')
     ).to.equal('Board games: card_dealing_multiple');
   });
 
-  it('returns ', () => {
+  it('for a valid path to sound file, returns a user-friendly sound name when no category is included', () => {
     expect(parsePathString('sound://default.mp3')).to.equal('default');
   });
 
-  it('returns DEFAULT_SOUND when not a valid sound file path', () => {
-    expect(parsePathString('Choose')).to.equal(DEFAULT_SOUND);
+  it('for an invalid path to sound file, throws an error', () => {
+    const errMsg = 'This is not a valid path to a sound file.';
+    expect(() => {
+      parsePathString('sound');
+    }).to.throw(Error, errMsg);
   });
 });


### PR DESCRIPTION
## Summary
This PR refactors the `CdoFieldButton`, a field which is currently used for the location picker but now also works for the sound picker used in the `play sound` block in Google Blockly labs. Because I refactored `cdoFieldButton.js`, I also took this opportunity to update the location picker in Google Blockly labs.

This work is a follow up to [this prior PR](https://github.com/code-dot-org/code-dot-org/pull/51515) which added the `soundField` function that allows Google Blockly and CDO Blockly to execute different implementations of the sound picker field. In CDO Blockly, `FieldDropdown` is still used, but in Google Blockly, `CdoFieldButton` is used instead. The reason is that in the currently implementation of the sound picker, the user clicks on `Choose` and then a dropdown menu is displayed with only one option 'Choose' which the  clicks a second time. Then the sound modal is displayed for which the user needs to click again! 

## Before Update
Video of `play sound` in CDO Blockly labs:

https://user-images.githubusercontent.com/107423305/234384746-c87ed300-2336-4bea-85ac-4c84d29000a8.mp4


Here is a video of the location picker and sound picker in a Poetry lab on production:

https://user-images.githubusercontent.com/107423305/235236594-064919d7-98d1-40da-a9ce-217accef0727.mp4

## Possible Approaches
The path leading to the refactoring of `cdoFieldButton.js` was not a straight one. I was considering the following options:
- Refactor the current `cdoFieldDropdown` so the sound picker behavior would replicate the current sound picker on production,
- Use `cdoFieldButton`,
- Create a new customized field, and
- Refactor `cdoFieldButton` and then use.


I rejected the first option and felt more confidence about this decision after consulting with @mikeharv  and @sanchitmalhotra126 who both agreed that streamlining the process of picking a sound would be an improvement. After this update, the user clicks on the `play sound` field and then the sound modal is immediately displayed.

I tried using `cdoFieldButton` as is, but it did not work with the sound picker. Then I tried creating a new customized field and used the music lab's customized fields as a model: `FieldSounds`, `FieldChord`, and `FieldPattern`. However, those fields are much more complex than what the sound picker requires. 

@mikeharv implemented a much simpler [customized field](https://github.com/code-dot-org/code-dot-org/compare/staging...mike/FieldSound-class) which works with the sound picker! [This resource](https://developers.google.com/blockly/guides/create-custom-blocks/fields/customizing-fields/creating) gives a nice overview for creating custom fields from scratch. However, I decided to not take this approach either. In the next section, I describe the approach I did end up taking for this task - the 4th possible option listed above.

## Change Description of Approach Taken
In [this prior PR](https://github.com/code-dot-org/code-dot-org/pull/51515) I discussed using a customized field for `play sound`. However, I opted to refactor the existing `CdoFieldButton` class to accommodate the sound picker since the two pickers are similar - the user clicks on the field, and then the picker is displayed.

In addition to the `soundField` function, I added the `locationField` function so that the implementations between Google and CDO Blockly could be different. 

In the updated `CdoFieldButton` constructor signature. I removed the unnecessary space-holder for the color parameter and added a parameters for `icon` and `validator`. I renamed `title` as `value`. In the past, field values were called field titles (Thanks to @mikeharv who explained this to me!). Note that `setTitleValue` is also added in `googleBlocklyWrapper.js` since it is referenced in `soundPicker` in `spritelab/blocks.js`. I also renamed `opt_buttonHandler` as `onClick` and `opt_changeHandler` as `transformText` with more detailed descriptions in the constructor comments. 

The location picker is interesting in that the value of the field is actually displayed in the label to the left of the field. The text of the field displayed on the button is a map-pin `icon`. 

Current location picker:
<img width="341" alt="current-location picker" src="https://user-images.githubusercontent.com/107423305/236011479-ec2785a8-66bc-4014-91ff-25d86d708339.png">

This current implementation of the location picker is a bit idiosyncratic, so I updated the location picker field so that the value of the field and the icon are displayed within the field. 

Updated location picker:
<img width="347" alt="refactored-location picker" src="https://user-images.githubusercontent.com/107423305/236013810-5d192398-f83d-4a09-a789-682bae0b81e2.png">


Thus, I could remove the button element and if there is an `icon`, then it can simply be appended to `textElement_` which represents the value of the field. Now whether the user clicks on the map-pin icon or the (x, y) coordinates, the location picker will be displayed.

I added `validation` as a constructor parameter because if the 'play sound' block is passed an input value 'Choose', the default value from the CDO Blockly version of the block, the default sound will be used instead.

The display of the value in the sound picker is also refactored compared to the current implementation on Sprite Lab.  Currently, the displayed sound value is the path to the sound file, e.g. 'sound://category_board_games/card_dealing_multiple.mp3' or  'sound://default.mp3'. All sounds except the default belong to a category. @mikeharv suggested that the selected sound be displayed in a friendlier format such as 'Category: Sound name'. He provided an initial implementation in [his branch](https://github.com/code-dot-org/code-dot-org/compare/staging...mike/FieldSound-class). However, I opted to keep the underscores with the sound name because some of the paths had multiple white spaces, such as 'Accent: Puzzle game accent a 01' and added an error check. 
The display is now: 'Accent: puzzle_game_acccent_a_01'. 

In the current implementation of the 'play sound' block, the default value of the field is 'Choose' and NO sound is emitted until the user chooses a sound. After discussion with both @mikeharv and @sanchitmalhotra126 , we agreed that it makes sense to have an initial sound value, similar to 'play sounds' in music lab. I chose the default value to be 'sound://category_digital/ping.mp3' which would be displayed as 'Digital: ping' and not 'default'. I am concerned that a young student may not understand the meaning of 'default' so the 'ping' sound was chosen because it has a short, simple name. I asked the K5 curriculum team for input in [this Slack thread](https://codedotorg.slack.com/archives/C02GRH2PYB1/p1683133304800379), and this value can be changed easily based on their feedback. 

To be consistent with the location picker, I also added an icon next to the value. This is to indicate to the user that this field is a 'selector', and not a dropdown or open-response text field. 

Updated sound picker with modern theme:

<img width="364" alt="play-sound-modern" src="https://user-images.githubusercontent.com/107423305/236016104-b2237687-6477-4dbc-99ed-eb94eb0137fc.png">

Updated sound picker with high contrast theme:
<img width="506" alt="play-sound-high-contrast" src="https://user-images.githubusercontent.com/107423305/236016117-0f4e7e6d-3ed9-4122-86de-3c82b20c41c9.png">

The conversion of the string is handled by the `transformText` function defined in `blocks.js`. It is then passed to the `FieldButton` constructor. For the location picker, the `transformText` function defined in either `cdoUtils.js` or `cdoBlocklyWrapper` converts the json value of the (x,y) coordinates of the sprite to a user-friendly string such as '(100, 200)' that is displayed on the field alongside the icon.

Another change to note for the location picker is that when a user sets the theme to 'High Contrast`, the icon is increased in size in proportion to the text and block.

Before update in high contrast:

<img width="452" alt="current-high-contrast-location-picker" src="https://user-images.githubusercontent.com/107423305/236015438-4b373bce-f560-4e19-88aa-272e2f99deb8.png">

After update in high contrast:

<img width="455" alt="refactored-high-contrast-location-picker" src="https://user-images.githubusercontent.com/107423305/236015519-853a69a5-100c-4910-a097-eba2ed9ce466.png">


## After Update
Here is a video of the sound picker after the update:


https://user-images.githubusercontent.com/107423305/236046280-f0aa86e0-ae3f-4fd9-9d0d-a41b0bb464f0.mp4



Here is a video of the location picker after the update:


https://user-images.githubusercontent.com/107423305/236046251-74bec702-347b-4f2e-9fac-e2bc01452762.mp4




I confirmed in Sprite lab that the location and sound pickers worked as they did before the update as well.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
I added unit tests to test the `parsePathString` function.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
