### PR TITLE
[Google Blockly] Update unused block frames

### DIFF
--- a/apps/src/blockly/addons/blockSvgUnused.js
+++ b/apps/src/blockly/addons/blockSvgUnused.js
@@ -56,7 +56,7 @@ export default class BlockSvgUnused extends BlockSvgFrame {
       'mousedown',
       this,
       function (e) {
-        if (Blockly.utils.isRightButton(e)) {
+        if (Blockly.browserEvents.isRightButton(e)) {
           // Right-click.
           return;
         }
@@ -71,14 +71,12 @@ export default class BlockSvgUnused extends BlockSvgFrame {
     this.bindClickEvent();
     var groupRect = svgGroup.getBoundingClientRect();
     var minWidthAdjustment = this.frameHelp_.getBoundingClientRect().width;
-    var width =
-      Math.max(groupRect.width, minWidthAdjustment) +
-      2 * frameSizes.MARGIN_SIDE;
+    var width = Math.max(groupRect.width, minWidthAdjustment);
     super.render(svgGroup, isRtl, width);
     this.frameHelp_.setAttribute(
       'transform',
       'translate(' +
-        (width - 2 * frameSizes.MARGIN_SIDE) +
+        width +
         ',' +
         -(frameSizes.MARGIN_TOP + frameSizes.HEADER_HEIGHT / 2) +
         ')'

--- a/apps/src/blockly/addons/blockSvgUnused.js
+++ b/apps/src/blockly/addons/blockSvgUnused.js
@@ -92,3 +92,22 @@ export default class BlockSvgUnused extends BlockSvgFrame {
     this.frameHelp_ = undefined;
   }
 }
+
+// Added as a change listener in the wrapper.
+// When a block is clicked, dragged or deleted, we remove any "Unused clock" frame.
+export function onBlockClickDragDelete(event) {
+  if (
+    event.type === Blockly.Events.BLOCK_CLICK ||
+    event.type === Blockly.Events.BLOCK_DRAG ||
+    event.type === Blockly.Events.BLOCK_DELETE
+  ) {
+    const workspace = Blockly.blockly_.common.getWorkspaceById(
+      event.workspaceId
+    );
+    const block = workspace.getBlockById(event.blockId);
+    if (!block) {
+      return;
+    }
+    block.removeUnusedBlockFrame();
+  }
+}

--- a/apps/src/blockly/addons/blockSvgUnused.js
+++ b/apps/src/blockly/addons/blockSvgUnused.js
@@ -97,13 +97,11 @@ export default class BlockSvgUnused extends BlockSvgFrame {
 // When a block is clicked, dragged or deleted, we remove any "Unused clock" frame.
 export function onBlockClickDragDelete(event) {
   if (
-    event.type === Blockly.Events.BLOCK_CLICK ||
+    event.type === Blockly.Events.CLICK ||
     event.type === Blockly.Events.BLOCK_DRAG ||
     event.type === Blockly.Events.BLOCK_DELETE
   ) {
-    const workspace = Blockly.blockly_.common.getWorkspaceById(
-      event.workspaceId
-    );
+    const workspace = Blockly.common.getWorkspaceById(event.workspaceId);
     const block = workspace.getBlockById(event.blockId);
     if (!block) {
       return;

--- a/apps/src/blockly/googleBlocklyWrapper.js
+++ b/apps/src/blockly/googleBlocklyWrapper.js
@@ -149,6 +149,7 @@ function initializeBlocklyWrapper(blocklyInstance) {
   blocklyWrapper.wrapReadOnlyProperty('BlockSvg');
   blocklyWrapper.wrapReadOnlyProperty('browserEvents');
   blocklyWrapper.wrapReadOnlyProperty('blockRendering.ConstantProvider');
+  blocklyWrapper.wrapReadOnlyProperty('common');
   blocklyWrapper.wrapReadOnlyProperty('common_locale');
   blocklyWrapper.wrapReadOnlyProperty('ComponentManager');
   blocklyWrapper.wrapReadOnlyProperty('Connection');

--- a/apps/src/blockly/googleBlocklyWrapper.js
+++ b/apps/src/blockly/googleBlocklyWrapper.js
@@ -47,7 +47,7 @@ import initializeCss from './addons/cdoCss';
 import CdoConnectionChecker from './addons/cdoConnectionChecker';
 import {UNKNOWN_BLOCK} from './addons/unknownBlock';
 import {registerAllContextMenuItems} from './addons/contextMenu';
-import BlockSvgUnused from './addons/blockSvgUnused';
+import BlockSvgUnused, {onBlockClickDragDelete} from './addons/blockSvgUnused';
 import {ToolboxType, Themes, Renderers} from './constants';
 import {FUNCTION_BLOCK} from './addons/functionBlocks.js';
 import {FUNCTION_BLOCK_NO_FRAME} from './addons/functionBlocksNoFrame.js';
@@ -589,20 +589,6 @@ function initializeBlocklyWrapper(blocklyInstance) {
     blocklyWrapper.isStartMode = !!opt_options.editBlocks;
     const workspace = blocklyWrapper.blockly_.inject(container, options);
 
-    // When a block is clicked, dragged or deleted, we remove any "Unused clock" frame.
-    function onBlockClickDragDelete(event) {
-      if (
-        event.type === blocklyWrapper.blockly_.Events.BLOCK_CLICK ||
-        event.type === blocklyWrapper.blockly_.Events.BLOCK_DRAG ||
-        event.type === blocklyWrapper.blockly_.Events.BLOCK_DELETE
-      ) {
-        const block = workspace.getBlockById(event.blockId);
-        if (!block) {
-          return;
-        }
-        block.removeUnusedBlockFrame();
-      }
-    }
     workspace.addChangeListener(onBlockClickDragDelete);
 
     // Initialize plugin.


### PR DESCRIPTION
## Context
Earlier today, after merging the 9.3.3 bump into another branch, @fisher-alice noticed a regression in our "unused block" SVG frames. Frames were not being removed after blocks were moved:
| | |
|-|-|
|![image](https://user-images.githubusercontent.com/43474485/235236682-6dc244f8-fe27-4e8e-a139-128053a9ab9a.png)|![image](https://user-images.githubusercontent.com/43474485/235236571-d2708e50-ed7f-48e8-8d70-76cf1a519cd5.png)|

As a result, we reverted the bump and investigated the cause of the issue.

Revert: https://github.com/code-dot-org/code-dot-org/pull/51601
Original bump: https://github.com/code-dot-org/code-dot-org/pull/51566

## Cause of Regression
While not considered a breaking change, the 9.3 releases include a reworking of how/when blocks are rendered that is designed to improve performance. We had been overriding `render()` in order to remove unused block frames. The way we were overriding `render` in the wrapper could be thought of as "unsupported but happens to work". It no longer works. For more information, see: 
- https://github.com/google/blockly/releases/tag/blockly-v9.3.0
- https://github.com/google/blockly/issues/6786

## Solution
We can achieve the same desired behavior by using by adding a new event listener. https://developers.google.com/blockly/guides/configure/web/events
This method is supported with older versions of Google Blockly which means we can ship it ahead of the 9.3 bump. It also means that we can attempt the 9.3 bump again soon with greater confidence.

## Changes
This PR updates the way these frames are disposed which should unblock the 9.3 bump.

As part of this work, a few intentional other changes were made to how the frames work:
1. Unused block frame svgs are now disposed when clicked or as soon as a drag begins, instead of only when the move is completed. This is desired because the frame can cover up blocks in a way that makes it hard to see where you are putting it.
2. Unused block frame svgs now correctly calculate their margins and the spacing of the help icon. Because of the way this class BlockSvgUnused extends BlockSvgFrame. Because `render` calls `super.render` we were actually doubling the amount of horizontal margin being added to the svg width, and also had an similar offset in the placement of the help icon.
3. [Bug fix] If you toggled Run/Reset multiple times, the svg would increase in width. This was happening because we were rendering the frame too often. The frame width is based on the width of the current svg, but adding the frame increasing the width of the svg... We can address this by only rendering the frame if we haven't already done so.
4. [Bug fix] Nothing was happening when you clicked the help icon. This was due to `isRightButton` moving from `utils` to `browserEvents` in mainline. The help icon now correctly triggers the callout.

| | Before | After |
|-|-|-|
|**1.**| ![911](https://user-images.githubusercontent.com/43474485/235238574-5aefc50d-fcd6-40a5-bfb4-578e28af2e0e.gif)frames were only disposed after the block is moved| ![after](https://user-images.githubusercontent.com/43474485/235239210-681a2f40-c93d-4354-9c18-39435bbc2e7c.gif)svgs are now disposed as soon as a drag begins|
|**2.**| <img width="287" alt="image" src="https://user-images.githubusercontent.com/43474485/235239631-fb57917d-b497-401d-a4f7-e8ad4dca2b32.png">|<img width="263" alt="image" src="https://user-images.githubusercontent.com/43474485/235239688-599cfcbf-bef3-47f8-80a5-b3e8a265a47f.png"> |

**3. (Before fix)**

https://user-images.githubusercontent.com/43474485/235240770-b1ce5bce-57eb-4838-979d-b0d8e876c486.mp4

**4. (After fix)**
<img width="553" alt="image" src="https://user-images.githubusercontent.com/43474485/235241115-f13bfbc5-91af-4b43-92d9-c927f615f4b7.png">


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

1. Complete the 9.3.3 bump
2. Automated testing of this customization
3. Consider improving or removing the behavior of the help icon and callout.

Note about the callouts: There is still some janky behavior with callouts if a block is moved or deleted. The callout persist on the page. In order to dismiss the callout, the user must either close it or press Run/Reset. 
Here's an example of a callout with a qtip that no longer points to the block after the block was moved:
<img width="364" alt="image" src="https://user-images.githubusercontent.com/43474485/235242253-f1cd4d3f-b592-48c3-b763-b77895febfd2.png">
This feels buggy, but it's also always worked strangely, even in CDO Blockly labs.  In 2022, we discussed removing this help icon and callout entirely. Once the existing behavior is restored we should consider picking up that task once more. Some simple options we could consider are removing the help icon, or removing the entire frame.


## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  6.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
