### PR TITLE
Gives feedback in save state

### DIFF
--- a/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
+++ b/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
@@ -120,6 +120,7 @@ const saveSection = (section, isNewSection) => {
 export default function SectionsSetUpContainer({sectionToBeEdited}) {
   const [sections, updateSection] = useSections(sectionToBeEdited);
   const [advancedSettingsOpen, setAdvancedSettingsOpen] = useState(false);
+  const [isSaveInProgress, setIsSaveInProgress] = useState(false);
 
   const isNewSection = !sectionToBeEdited;
   const initialSectionRef = useRef(sectionToBeEdited);
@@ -277,10 +278,18 @@ export default function SectionsSetUpContainer({sectionToBeEdited}) {
         this might mean creating a different button for the "edit" page
         */}
         <Button
-          text={isNewSection ? i18n.finishCreatingSections() : i18n.save()}
+          text={
+            isSaveInProgress
+              ? i18n.saving()
+              : isNewSection
+              ? i18n.finishCreatingSections()
+              : i18n.save()
+          }
           color={Button.ButtonColor.brandSecondaryDefault}
+          disabled={isSaveInProgress}
           onClick={e => {
             e.preventDefault();
+            setIsSaveInProgress(true);
             recordSectionSetupEvent(sections[0]);
             saveSection(sections[0], isNewSection);
           }}


### PR DESCRIPTION
Before, a user could click the buttons multiple times, creating duplicate sections. There was also no feedback for the user having hit save a first time, so you couldn't tell if it worked or not.

Here is what happens now when a user hits save (text changes, button is disabled)

![Screenshot 2023-04-28 at 2 55 24 PM](https://user-images.githubusercontent.com/37230822/235261272-eb78ecb9-20f1-47e7-b91f-702cf4ac52e4.png)


## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/TEACH-454

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
