### PR TITLE
Update program benefits on admin page to include AFE

### DIFF
--- a/pegasus/sites.v3/code.org/public/administrators.haml
+++ b/pegasus/sites.v3/code.org/public/administrators.haml
@@ -69,8 +69,8 @@ theme: responsive_full_width
         %div
           %i{class: "#{icon_location_dot}"}
         .text-wrapper
-          %h3 Local knowledge and implementation support
-          %p Regional support teams who understand your district's unique needs and provide guidance on implementation, certification and funding.
+          %h3 Local implementation support & resources
+          %p Regional support teams who understand your district's unique needs and provide guidance on implementation, certification and funding. Ready-made resources to engage students, families, and educators.
       %li
         %div
           %i{class: "#{icon_chart_pie}"}
@@ -93,8 +93,8 @@ theme: responsive_full_width
         %div
           %i{class: "#{icon_smile}"}
         .text-wrapper
-          %h3 Communications tools to support students, families, and educators
-          %p Ready-made resource library dedicated to demystifying CS education for each stakeholder in your district.
+          %h3 Amazon Future Engineer Benefits
+          %p Eligible schools can receive paid 1-year CSTA membership for teachers, Amazon classroom resources, first access to career exploration offerings, awards, scholarships, and more. 
       %li
         %div
           %i{class: "#{icon_money_check_dollar_pen}"}


### PR DESCRIPTION
Update 2 of the program benefits on code.org/administrators so that we can include information about AFE as a benefit. 

<img width="1133" alt="Screenshot 2023-05-01 at 11 31 12 AM" src="https://user-images.githubusercontent.com/208083/235477966-d80c5e9b-69bd-4d8a-b44c-80fd21da2edf.png">

