### PR TITLE
Add Summary Entry point to Multi levels

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -659,6 +659,7 @@ describe('entry tests', () => {
     'levels/_match': './src/sites/studio/pages/levels/_match.js',
     'levels/_multi': './src/sites/studio/pages/levels/_multi.js',
     'levels/_pixelation': './src/sites/studio/pages/levels/_pixelation.js',
+    'levels/_single_multi': './src/sites/studio/pages/levels/_single_multi.js',
     'levels/_standalone_video':
       './src/sites/studio/pages/levels/_standalone_video.js',
     'levels/_summary': './src/sites/studio/pages/levels/_summary.js',

--- a/apps/src/sites/studio/pages/levels/_single_multi.js
+++ b/apps/src/sites/studio/pages/levels/_single_multi.js
@@ -1,0 +1,24 @@
+import $ from 'jquery';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import getScriptData from '@cdo/apps/util/getScriptData';
+import {Provider} from 'react-redux';
+import InstructorsOnly from '@cdo/apps/code-studio/components/InstructorsOnly';
+import {getStore} from '@cdo/apps/redux';
+import SummaryEntryPoint from '@cdo/apps/templates/levelSummary/SummaryEntryPoint';
+
+$(document).ready(() => {
+  $('#summaryEntryPoint').each(function () {
+    const container = this;
+    const store = getStore();
+
+    ReactDOM.render(
+      <Provider store={store}>
+        <InstructorsOnly>
+          <SummaryEntryPoint scriptData={getScriptData('summaryinfo')} />
+        </InstructorsOnly>
+      </Provider>,
+      container
+    );
+  });
+});

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -153,7 +153,7 @@ class ScriptLevelsController < ApplicationController
       level = @level.contained_levels.any? ? @level.contained_levels.first : @level
 
       # TODO: Change/remove this check as we add support for more level types.
-      if level.is_a?(FreeResponse)
+      if level.is_a?(FreeResponse) || level.is_a?(Multi)
         @responses = UserLevel.where(level: level, user: @section&.students)
       end
     end

--- a/dashboard/app/views/levels/_single_multi.html.haml
+++ b/dashboard/app/views/levels/_single_multi.html.haml
@@ -3,9 +3,16 @@
 - data['answers'] ||= []
 - localized_answers = level.localized_property(:answers)
 - contained_mode = local_assigns.fetch :contained_mode, false
+- in_level_group = !contained_mode && @level.game&.level_group?
 - app = 'multi'
 - use_tight_layout = data['layout'] == "tight" || tight_layout
 - force_wrap_layout = data['layout'] == "wrap"
+
+:ruby
+  js_data = {
+    response_count: @responses&.count || 0,
+    is_contained_level: contained_mode
+  }
 
 - multi_answer_characters = ("A".."Z").to_a
 
@@ -34,6 +41,8 @@
       = render partial: 'levels/teacher_markdown', locals: {data: level.properties}
 
 .multi{id: "level_#{level.id}", class: layout_class}
+  - if DCDO.get("show_multi_level_summary_entry_point", false) && !in_level_group
+    %div#summaryEntryPoint
   - question_content_blank = data['content1'].blank? && data['content2'].blank? && data['content3'].blank? && data['markdown'].blank?
   - if question_content_blank
     - question_content_class = nil
@@ -116,6 +125,8 @@
       - answers = localized_answers.map {|answer| answer['correct'] || false}
 
     - answers_feedback = localized_answers.map {|answer| answer['feedback']}
+
+  %script{src: webpack_asset_path('js/levels/_single_multi.js'), data: {summaryinfo: js_data.to_json}}
 
   :javascript
     window.dashboard.codeStudioLevels.registerLevel(#{level.id}, new Multi(


### PR DESCRIPTION
Adds the entry point to the summary for Multi levels behind a new DCDO flag `show_multi_level_summary_entry_point`. 

Contained level:
<img width="1400" alt="Screenshot 2023-05-01 at 12 08 11 PM" src="https://user-images.githubusercontent.com/46464143/235662010-d1fb3070-5302-46ad-960e-882b0919a8f2.png">

Standalone level:
<img width="1638" alt="Screenshot 2023-05-01 at 12 08 24 PM" src="https://user-images.githubusercontent.com/46464143/235662017-b7d7592e-bc74-4e69-94e0-595d4a44b9f3.png">
