### PR TITLE
Don't show the summary entry point in level groups

### DIFF
--- a/dashboard/app/views/levels/_free_response.html.haml
+++ b/dashboard/app/views/levels/_free_response.html.haml
@@ -34,7 +34,7 @@
     );
 
 .free-response{:class => ('left-aligned' if left_align)}
-  - if DCDO.get("show_level_summary_entry_point", false)
+  - if DCDO.get("show_level_summary_entry_point", false) && !in_level_group
     %div#summaryEntryPoint
   - title = level.get_property(:title)
   - if title.present? && (!in_level_group || is_contained_level)


### PR DESCRIPTION
Really small fix to prevent the summary page entry point from showing up on level groups.