### PR TITLE
Project Beats: initial localization pass

### DIFF
--- a/apps/i18n/music/en_us.json
+++ b/apps/i18n/music/en_us.json
@@ -1,12 +1,12 @@
 {
-  "arpeggioUp": "Arpeggio Up",
-  "arpeggioDown": "Arpeggio Down",
-  "arpeggioRandom": "Arpeggio Random",
   "control": "Control",
+  "chordArpeggioUp": "Arpeggio Up",
+  "chordArpeggioDown": "Arpeggio Down",
+  "chordArpeggioRandom": "Arpeggio Random",
+  "chordTogether": "Together",
   "feedback": "Feedback",
   "share": "Share",
   "shareComingSoon": "Sharing is under construction. Check back soon.",
   "startOver": "Start Over",
-  "together": "Together",
   "upload": "Upload"
 }

--- a/apps/i18n/music/en_us.json
+++ b/apps/i18n/music/en_us.json
@@ -1,2 +1,12 @@
 {
+  "arpeggioUp": "Arpeggio Up",
+  "arpeggioDown": "Arpeggio Down",
+  "arpeggioRandom": "Arpeggio Random",
+  "control": "Control",
+  "feedback": "Feedback",
+  "share": "Share",
+  "shareComingSoon": "Sharing is under construction. Check back soon.",
+  "startOver": "Start Over",
+  "together": "Together",
+  "upload": "Upload"
 }

--- a/apps/src/music/locale.ts
+++ b/apps/src/music/locale.ts
@@ -1,0 +1,8 @@
+/**
+ * A TypeScript wrapper for the Music Lab locale object which casts
+ * it to the {@link MusicLocale} type.
+ */
+import {MusicLocale} from './types';
+const musicLocale = require('@cdo/music/locale');
+
+export default musicLocale as MusicLocale;

--- a/apps/src/music/types.ts
+++ b/apps/src/music/types.ts
@@ -1,0 +1,9 @@
+// TODO: Ideally this type would only contain keys present in
+// translated string JSON files (ex. apps/i18n/music/en_us.json).
+// However, this requires depending on files outside of apps/src,
+// so this approach is still being investigated. For now, this type
+// is an object whose keys are all functions which return strings,
+// matching what we expect for a locale object.
+export type MusicLocale = {
+  [key: string]: () => string;
+};

--- a/apps/src/music/views/BeatPad.jsx
+++ b/apps/src/music/views/BeatPad.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import classNames from 'classnames';
 import styles from './beatpad.module.scss';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
+import musicLocale from '../locale';
 
 const BUTTONS_PER_ROW = 3;
 const enabledClasses = [
@@ -50,7 +51,7 @@ const BeatPad = ({triggers, playTrigger, onClose, isPlaying}) => {
   return (
     <div className={styles.container}>
       <div className={styles.labelContainer}>
-        <p className={styles.label}>{'Control'}</p>
+        <p className={styles.label}>{musicLocale.control()}</p>
         <FontAwesome
           icon={'times'}
           onClick={onClose}

--- a/apps/src/music/views/ChordPanel.tsx
+++ b/apps/src/music/views/ChordPanel.tsx
@@ -14,10 +14,10 @@ const START_OCTAVE = 4;
 const MAX_NOTES = 16;
 
 const styleDropdownOptions: [PlayStyle, string][] = [
-  ['arpeggio-up', musicLocale.arpeggioUp()],
-  ['arpeggio-down', musicLocale.arpeggioDown()],
-  ['arpeggio-random', musicLocale.arpeggioRandom()],
-  ['together', musicLocale.together()],
+  ['arpeggio-up', musicLocale.chordArpeggioUp()],
+  ['arpeggio-down', musicLocale.chordArpeggioDown()],
+  ['arpeggio-random', musicLocale.chordArpeggioRandom()],
+  ['together', musicLocale.chordTogether()],
 ];
 
 export interface ChordPanelProps {

--- a/apps/src/music/views/ChordPanel.tsx
+++ b/apps/src/music/views/ChordPanel.tsx
@@ -5,6 +5,7 @@ import MusicLibrary from '../player/MusicLibrary';
 import {ChordEventValue, PlayStyle} from '../player/interfaces/ChordEvent';
 import {generateGraphDataFromChord, ChordGraphNote} from '../utils/Chords';
 import PreviewControls from './PreviewControls';
+import musicLocale from '../locale';
 
 const moduleStyles = require('./chordPanel.module.scss').default;
 
@@ -13,10 +14,10 @@ const START_OCTAVE = 4;
 const MAX_NOTES = 16;
 
 const styleDropdownOptions: [PlayStyle, string][] = [
-  ['arpeggio-up', 'Arpeggio Up'],
-  ['arpeggio-down', 'Arpeggio Down'],
-  ['arpeggio-random', 'Arpeggio Random'],
-  ['together', 'Together'],
+  ['arpeggio-up', musicLocale.arpeggioUp()],
+  ['arpeggio-down', musicLocale.arpeggioDown()],
+  ['arpeggio-random', musicLocale.arpeggioRandom()],
+  ['together', musicLocale.together()],
 ];
 
 export interface ChordPanelProps {

--- a/apps/src/music/views/TopButtons.jsx
+++ b/apps/src/music/views/TopButtons.jsx
@@ -5,6 +5,7 @@ import {AnalyticsContext} from '../context';
 import moduleStyles from './topbuttons.module.scss';
 import FontAwesome from '../../templates/FontAwesome';
 import AppConfig from '../appConfig';
+import musicLocale from '../locale';
 
 /**
  * Renders a set of miscellaneous buttons in the top of the Music Lab workspace,
@@ -52,7 +53,7 @@ const TopButtons = ({clearCode, uploadSound}) => {
         onClick={startOverClicked}
       >
         <FontAwesome icon={'refresh'} />
-        &nbsp; Start Over
+        &nbsp; {musicLocale.startOver()}
       </button>
       <button
         type="button"
@@ -60,7 +61,7 @@ const TopButtons = ({clearCode, uploadSound}) => {
         onClick={onShareClicked}
       >
         <FontAwesome icon={'share-square-o'} />
-        &nbsp; Share
+        &nbsp; {musicLocale.share()}
         <div
           className={classNames(
             moduleStyles.shareComingSoon,
@@ -68,7 +69,7 @@ const TopButtons = ({clearCode, uploadSound}) => {
           )}
         >
           <FontAwesome icon={'clock-o'} />
-          &nbsp; Sharing is under construction. Check back soon.
+          &nbsp; {musicLocale.shareComingSoon()}
         </div>
       </button>
       <button
@@ -77,7 +78,7 @@ const TopButtons = ({clearCode, uploadSound}) => {
         onClick={onFeedbackClicked}
       >
         <FontAwesome icon={'commenting'} />
-        &nbsp; Feedback
+        &nbsp; {musicLocale.feedback()}
       </button>
       {showUploadSound && (
         <fieldset>
@@ -94,7 +95,7 @@ const TopButtons = ({clearCode, uploadSound}) => {
             id="compress_btn"
             className={moduleStyles.button}
           >
-            Upload
+            {musicLocale.upload()}
           </button>
         </fieldset>
       )}

--- a/apps/test/util/music/locale-do-not-import.js
+++ b/apps/test/util/music/locale-do-not-import.js
@@ -1,4 +1,11 @@
-// locale for music
+/**
+ * DO NOT IMPORT THIS DIRECTLY. Instead do:
+ *   ```
+ *   import msg from '@cdo/music/locale'.
+ *   ```
+ * This allows the webpack config to determine how locales should be loaded,
+ * which is important for making locale setup work seamlessly in tests.
+ */
 
 import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
 import localeWithI18nStringTracker from '@cdo/apps/util/i18nStringTracker';

--- a/apps/webpack.js
+++ b/apps/webpack.js
@@ -41,7 +41,7 @@ var toTranspileWithinNodeModules = [
   ),
   path.resolve(__dirname, 'node_modules', 'slate'),
   path.resolve(__dirname, 'node_modules', 'react-loading-skeleton'),
-  path.resolve(__dirname, 'node_modules', 'unified')
+  path.resolve(__dirname, 'node_modules', 'unified'),
 ];
 
 const scssIncludePath = path.resolve(__dirname, '..', 'shared', 'css');
@@ -57,8 +57,8 @@ const nodePolyfillConfig = {
       stream: 'stream-browserify',
       path: 'path-browserify',
       process: 'process/browser',
-      timers: 'timers-browserify'
-    })
+      timers: 'timers-browserify',
+    }),
   ],
   resolve: {
     fallback: {
@@ -68,9 +68,9 @@ const nodePolyfillConfig = {
       'process/browser': require.resolve('process/browser'),
       stream: require.resolve('stream-browserify'),
       timers: require.resolve('timers-browserify'),
-      crypto: false
-    }
-  }
+      crypto: false,
+    },
+  },
 };
 
 // Our base config, on which other configs are derived
@@ -109,6 +109,12 @@ var baseConfig = {
         __dirname,
         'src',
         'javalab',
+        'locale-do-not-import.js'
+      ),
+      '@cdo/music/locale': path.resolve(
+        __dirname,
+        'src',
+        'music',
         'locale-do-not-import.js'
       ),
       '@cdo/poetry/locale': path.resolve(
@@ -153,8 +159,8 @@ var baseConfig = {
       '@cdo/static': path.resolve(__dirname, 'static'),
       repl: path.resolve(__dirname, 'src/noop'),
       '@cdo/storybook': path.resolve(__dirname, '.storybook'),
-      serialport: false
-    }
+      serialport: false,
+    },
   },
   module: {
     rules: [
@@ -162,9 +168,9 @@ var baseConfig = {
         test: /\.ejs$/,
         include: [
           path.resolve(__dirname, 'src'),
-          path.resolve(__dirname, 'test')
+          path.resolve(__dirname, 'test'),
         ],
-        loader: 'ejs-webpack-loader'
+        loader: 'ejs-webpack-loader',
       },
       {test: /\.css$/, use: [{loader: 'style-loader'}, {loader: 'css-loader'}]},
 
@@ -179,11 +185,11 @@ var baseConfig = {
               implementation: sass,
               sassOptions: {
                 includePaths: [scssIncludePath],
-                outputStyle: 'compressed'
-              }
-            }
-          }
-        ]
+                outputStyle: 'compressed',
+              },
+            },
+          },
+        ],
       },
 
       {test: /\.interpreted.js$/, type: 'asset/source'},
@@ -193,7 +199,7 @@ var baseConfig = {
           path.resolve(__dirname, 'static'),
           path.resolve(__dirname, 'src'),
           path.resolve(__dirname, 'test'),
-          path.resolve(`${__dirname}/../dashboard/app/assets/`, 'images')
+          path.resolve(`${__dirname}/../dashboard/app/assets/`, 'images'),
         ],
         // note that in the name template given below, a dash prefixing
         // the hash is explicitly avoided. If rails tries to serve
@@ -207,40 +213,40 @@ var baseConfig = {
               limit: 1024,
               // uses the file-loader when file size is over the limit
               name: '[name]wp[contenthash].[ext]',
-              esModule: false
-            }
-          }
-        ]
+              esModule: false,
+            },
+          },
+        ],
       },
       {
         test: /\.jsx?$/,
         enforce: 'pre',
         include: [
           path.resolve(__dirname, 'src'),
-          path.resolve(__dirname, 'test')
+          path.resolve(__dirname, 'test'),
         ].concat(toTranspileWithinNodeModules),
         exclude: [path.resolve(__dirname, 'src', 'lodash.js')],
         loader: 'babel-loader',
         options: {
           cacheDirectory: path.resolve(__dirname, '.babel-cache'),
-          compact: false
-        }
+          compact: false,
+        },
       },
       {
         test: /\.tsx?$/,
         use: 'ts-loader',
-        exclude: /node_modules/
-      }
+        exclude: /node_modules/,
+      },
     ],
-    noParse: [/html2canvas/]
-  }
+    noParse: [/html2canvas/],
+  },
 };
 
 if (envConstants.HOT) {
   baseConfig.module.loaders.push({
     test: /\.jsx?$/,
     loader: 'react-hot-loader',
-    include: [path.resolve(__dirname, 'src')]
+    include: [path.resolve(__dirname, 'src')],
   });
 }
 
@@ -255,13 +261,13 @@ if (envConstants.COVERAGE) {
       // we need to turn off instrumentation for this file
       // because we have tests that actually make assertions
       // about the contents of the compiled version of this file :(
-      path.resolve(__dirname, 'src', 'flappy', 'levels.js')
+      path.resolve(__dirname, 'src', 'flappy', 'levels.js'),
     ],
     options: {
       cacheDirectory: true,
       compact: false,
-      esModules: true
-    }
+      esModules: true,
+    },
   });
 }
 
@@ -290,18 +296,18 @@ function storybookConfig(sbConfig) {
       ...baseConfig.resolve,
       alias: {
         ...baseConfig.resolve.alias,
-        '@cdo/apps/lib/util/firehose': path.resolve(__dirname, 'test', 'util')
-      }
+        '@cdo/apps/lib/util/firehose': path.resolve(__dirname, 'test', 'util'),
+      },
     },
     // Overwrite rules
     module: {
       ...sbConfig.module,
       ...baseConfig.module,
-      rules: baseConfig.module.rules
+      rules: baseConfig.module.rules,
     },
     // Overwrite externals
     externals: {
-      blockly: 'this Blockly'
+      blockly: 'this Blockly',
     },
     // Extend plugins
     plugins: [
@@ -314,9 +320,9 @@ function storybookConfig(sbConfig) {
         'process.env.NODE_ENV': JSON.stringify(
           envConstants.NODE_ENV || 'development'
         ),
-        PISKEL_DEVELOPMENT_MODE: JSON.stringify(false)
-      })
-    ]
+        PISKEL_DEVELOPMENT_MODE: JSON.stringify(false),
+      }),
+    ],
   };
 }
 
@@ -352,6 +358,13 @@ var karmaConfig = _.extend({}, baseConfig, {
         'gamelab',
         'locale-do-not-import.js'
       ),
+      '@cdo/music/locale': path.resolve(
+        __dirname,
+        'test',
+        'util',
+        'music',
+        'locale-do-not-import.js'
+      ),
       '@cdo/javalab/locale': path.resolve(
         __dirname,
         'test',
@@ -384,8 +397,8 @@ var karmaConfig = _.extend({}, baseConfig, {
         'kits',
         'maker',
         'StubChromeSerialPort.js'
-      )
-    })
+      ),
+    }),
   }),
   externals: {
     blockly: 'this Blockly',
@@ -395,13 +408,13 @@ var karmaConfig = _.extend({}, baseConfig, {
     cheerio: 'window',
     'react/addons': true,
     'react/lib/ExecutionEnvironment': true,
-    'react/lib/ReactContext': true
+    'react/lib/ReactContext': true,
   },
   plugins: [
     new webpack.ProvidePlugin({
       React: 'react',
       Buffer: ['buffer', 'Buffer'],
-      process: 'process/browser'
+      process: 'process/browser',
     }),
     new webpack.DefinePlugin({
       IN_UNIT_TEST: JSON.stringify(true),
@@ -411,9 +424,9 @@ var karmaConfig = _.extend({}, baseConfig, {
         envConstants.NODE_ENV || 'development'
       ),
       LEVEL_TYPE: JSON.stringify(envConstants.LEVEL_TYPE),
-      PISKEL_DEVELOPMENT_MODE: JSON.stringify(false)
-    })
-  ]
+      PISKEL_DEVELOPMENT_MODE: JSON.stringify(false),
+    }),
+  ],
 });
 
 /**
@@ -448,7 +461,7 @@ function create(options) {
     output: {
       path: outputDir,
       publicPath: '/assets/js/',
-      filename: `[name]${suffix}`
+      filename: `[name]${suffix}`,
     },
     devtool: devtool(options),
     entry: entries,
@@ -464,19 +477,19 @@ function create(options) {
           envConstants.NODE_ENV || 'development'
         ),
         PISKEL_DEVELOPMENT_MODE: JSON.stringify(piskelDevMode),
-        DEBUG_MINIFIED: envConstants.DEBUG_MINIFIED || 0
+        DEBUG_MINIFIED: envConstants.DEBUG_MINIFIED || 0,
       }),
-      ...plugins
+      ...plugins,
     ],
     watch: watch,
     keepalive: watch,
-    failOnError: !watch
+    failOnError: !watch,
   });
 
   if (watch) {
     config.plugins = config.plugins.concat(
       new LiveReloadPlugin({
-        appendScriptTag: envConstants.AUTO_RELOAD
+        appendScriptTag: envConstants.AUTO_RELOAD,
       })
     );
 
@@ -494,5 +507,5 @@ module.exports = {
   config: baseConfig,
   karmaConfig: karmaConfig,
   storybookConfig: storybookConfig,
-  create: create
+  create: create,
 };

--- a/dashboard/app/views/musiclab/index.html.haml
+++ b/dashboard/app/views/musiclab/index.html.haml
@@ -3,4 +3,5 @@
 
 - content_for(:head) do
   %script{src: webpack_asset_path('js/googleblockly.js')}
+  %script{src: webpack_asset_path("js/#{js_locale}/music_locale.js")}
   %script{src: webpack_asset_path('js/musiclab/index.js'), data: {channelid: @channel_id}}


### PR DESCRIPTION
Initial localization pass for Project Beats (music lab). This adds localized string entries for all non-blockly strings (just UI labels).

I also set up a few small util classes to add some typing to the localization object (see discussion [here](https://codedotorg.slack.com/archives/C044AGTKW3D/p1682969329958779)). We're discussing this approach with the platform team; currently, the type of the object is just an object whose entries are all functions that return strings, so there's not a ton of useful type checking just yet (aside from requiring that you call the function). But hopefully this allows us to add stronger typing down the road without having to update much code.

## Links

https://codedotorg.atlassian.net/browse/SL-630

## Testing story

Tested locally with en_us and another language (with dummy translations) to ensure text is localized.

## Follow-up work

Localizing blockly strings (block names, toolbox, tooltips, etc).