### PR TITLE
Pulling year long header above express

### DIFF
--- a/dashboard/lib/quick_assign_helper.rb
+++ b/dashboard/lib/quick_assign_helper.rb
@@ -48,16 +48,16 @@ module QuickAssignHelper
       data[curriculum_type].keys.each do |header|
         data[curriculum_type][header].sort_by! {|co| co[:display_name]}
       end
-      data[curriculum_type] = data[curriculum_type].sort.to_h
+      data[curriculum_type] = data[curriculum_type].sort {|(h1, _), (h2, _)| compare_headers(h1, h2)}.to_h
     end
 
     data
   end
 
-  # Helper function to compare headers so that "Favorites" is always first in the list
+  # Helper function to compare headers so that "Favorites" (hoc) and "Year Long" are always first
   def self.compare_headers(h1, h2)
-    return -1 if h1 == localized_header('favorites')
-    return 1 if h2 == localized_header('favorites')
+    return -1 if h1 == localized_header('favorites') || h1 == localized_header('year_long')
+    return 1 if h2 == localized_header('favorites') || h2 == localized_header('year_long')
     h1 <=> h2
   end
 


### PR DESCRIPTION
Updates the sorting function so that the 'Course' offerings for year-long courses appear above express. 

Before:
<img width="977" alt="Screenshot 2023-05-01 at 4 43 49 PM" src="https://user-images.githubusercontent.com/37230822/235550251-605f4708-9673-48c6-84b0-44b41a2c3322.png">

After:
<img width="1102" alt="Screenshot 2023-05-01 at 4 39 07 PM" src="https://user-images.githubusercontent.com/37230822/235550267-3a6047f6-7a67-4e9d-86a6-236c9a88c0e8.png">


## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/TEACH-459

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
