### PR TITLE
Update /statistics page

### DIFF
--- a/pegasus/sites.v3/code.org/public/statistics.md.erb
+++ b/pegasus/sites.v3/code.org/public/statistics.md.erb
@@ -16,7 +16,7 @@ Code.org partners with researchers on a variety of studies. Want more? <a href="
 
 ### Teachers are taking on computer science
 Over 1 million teachers have taken steps to bring computer science to their schools.
-<%= view :display_chart, id: "chart1", type: "ColumnChart", query_url: "https://docs.google.com/spreadsheets/d/1zXQWidXlgOB38o5thwtgfiT_JGnhhH9GhHSdlRYfVfo/gviz/tq?gid=0&range=A2:B95&headers=1", width: 1000, height: 500 %>
+<%= view :display_chart, id: "chart1", type: "ColumnChart", query_url: "https://docs.google.com/spreadsheets/d/1zXQWidXlgOB38o5thwtgfiT_JGnhhH9GhHSdlRYfVfo/gviz/tq?gid=0&range=A2:B115&headers=1", width: 1000, height: 500 %>
 Does your local school teach computer science? [Encourage them to start today](/yourschool)!
 
 <br>

--- a/pegasus/sites.v3/code.org/public/statistics.md.erb
+++ b/pegasus/sites.v3/code.org/public/statistics.md.erb
@@ -23,6 +23,7 @@ Does your local school teach computer science? [Encourage them to start today](/
 
 ### The Hour of Code goes global
 With over [200 partners](https://hourofcode.com/partners), since 2013, the [Hour of Code](https://hourofcode.com) has reached 15% of students around the world.
+<%= view :display_chart, id: "chart2", type: "ColumnChart", query_url: "https://docs.google.com/spreadsheets/d/1zXQWidXlgOB38o5thwtgfiT_JGnhhH9GhHSdlRYfVfo/gviz/tq?gid=0&range=D2:E115&headers=1", width: 1000, height: 500 %>
 
 ## What we're doing
 Tracking the work of thousands of teachers and millions of students.
@@ -43,9 +44,6 @@ Tracking the work of thousands of teachers and millions of students.
 <th>End of 2017</th>
 <th>End of 2018</th>
 <th>End of 2019</th>
-<th>End of 2020</th>
-<th>End of 2021</th>
-<th>End of 2022</th>
 </tr>
 </thead>
 <tbody>

--- a/pegasus/sites.v3/code.org/public/statistics.md.erb
+++ b/pegasus/sites.v3/code.org/public/statistics.md.erb
@@ -23,7 +23,6 @@ Does your local school teach computer science? [Encourage them to start today](/
 
 ### The Hour of Code goes global
 With over [200 partners](https://hourofcode.com/partners), since 2013, the [Hour of Code](https://hourofcode.com) has reached 15% of students around the world.
-<%= view :display_chart, id: "chart2", type: "ColumnChart", query_url: "https://docs.google.com/spreadsheets/d/1zXQWidXlgOB38o5thwtgfiT_JGnhhH9GhHSdlRYfVfo/gviz/tq?gid=0&range=D2:E95&headers=1", width: 1000, height: 500 %>
 
 ## What we're doing
 Tracking the work of thousands of teachers and millions of students.
@@ -43,6 +42,10 @@ Tracking the work of thousands of teachers and millions of students.
 <th>End of 2016</th>
 <th>End of 2017</th>
 <th>End of 2018</th>
+<th>End of 2019</th>
+<th>End of 2020</th>
+<th>End of 2021</th>
+<th>End of 2022</th>
 </tr>
 </thead>
 <tbody>
@@ -54,6 +57,7 @@ Tracking the work of thousands of teachers and millions of students.
 <td>344M, <br>49%<br> female</td>
 <td>520M, <br>49%<br> female</td>
 <td>720M, <br>50%<br> female</td>
+<td>910M, <br>49%<br> female</td>
 </tr>
 <tr>
 <td>Engage classrooms and students in our CS courses. (Total # of accounts on Code Studio)</td>
@@ -63,6 +67,7 @@ Tracking the work of thousands of teachers and millions of students.
 <td>495,000 teachers,<br>16M <br>students</td>
 <td>750,000 teachers,<br>25M<br>students</td>
 <td>1M teachers,<br>36M<br>students</td>
+<td>1.3M teachers,<br>46M<br>students</td>
 </tr>
 <tr>
 <td>Enable students to show “basic coding proficiency” with CS Fundamentals.</td>
@@ -72,6 +77,7 @@ Tracking the work of thousands of teachers and millions of students.
 <td>887,840 total,<br>365,842 female</td>
 <td>2,061,449 total,<br>860,361 female</td>
 <td>3,296,655 total,<br>1,394,208 female</td>
+<td>4.4M total,<br>1.8M female</td>
 </tr>
 <tr>
 <td>Code.org students take and pass the AP CS Principles exam</td>
@@ -81,6 +87,7 @@ Tracking the work of thousands of teachers and millions of students.
 <td>N/A</td>
 <td>11,975 total,<br>3,406 female,<br>2,268 URG<a href="#urg">*</a></td>
 <td>19,409 total,<br>5,838 female,<br>4,009 URG<a href="#urg">*</a></td>
+<td>27.7K total,<br>9K female,<br>5.9K URG<a href="#urg">*</a></td>
 </tr>
 <tr>
 <td>Improve diversity in CS (survey of teachers on Code Studio)</td>
@@ -90,6 +97,7 @@ Tracking the work of thousands of teachers and millions of students.
 <td>45% female,<br>48% URG<a href="#urg">*</a>,<br>47% in high needs schools</td>
 <td>45% female,<br>48% URG<a href="#urg">*</a>,<br>47% in high needs schools</td>
 <td>46% female,<br>48% URG<a href="#urg">*</a>,<br>47% in high needs schools</td>
+<td>45% female,<br>50% URG<a href="#urg">*</a>,<br>45% in high needs schools</td>
 </tr>
 <tr>
 <td>Help school districts implement CS curricula</td>
@@ -99,6 +107,7 @@ Tracking the work of thousands of teachers and millions of students.
 <td>41 regional partners<br>(120+ districts)</td>
 <td>56 regional partners<br>(175+ districts)</td>
 <td>64 regional partners</td>
+<td>60 regional partners</td>
 </tr>
 <tr>
 <td>Prepare new CS teachers across grades K-12</td>
@@ -108,6 +117,7 @@ Tracking the work of thousands of teachers and millions of students.
 <td>52,000</td>
 <td>72,000</td>
 <td>86,565</td>
+<td>106,547</td>
 </tr>
 <tr>
 <td>Lead a coalition to set policies supporting CS.<br>Policies changed in:</td>
@@ -116,8 +126,8 @@ Tracking the work of thousands of teachers and millions of students.
 <td>17 states,<br>including $9M<br>in CS funding</td>
 <td>31 states, <br>including $13M <br>in CS funding</td>
 <td>40 states,<br>including $29M<br> in CS funding</td>
-<td>
-<a href="https://docs.google.com/document/d/1J3TbEQt3SmIWuha7ooBPvlWpiK-pNVIV5uuQEzNzdkE/edit">48 states</a>,<br>including $63M<br>in CS funding</td>
+<td><a href="https://docs.google.com/document/d/1J3TbEQt3SmIWuha7ooBPvlWpiK-pNVIV5uuQEzNzdkE/edit">48 states</a>,<br>including $63M<br>in CS funding</td>
+<td>50 states,<br>including $150M<br> in CS funding</td>
 </tr>
 <tr>
 <td>Go global</td>
@@ -127,6 +137,7 @@ Tracking the work of thousands of teachers and millions of students.
 <td>50 langs,<br>70 intl partners</td>
 <td>62 langs,<br>84 intl partners</td>
 <td>63 langs,<br>102 intl partners</td>
+<td>67 langs,<br>102 intl partners</td>
 </tr>
 <tr>
 <td>Team size</td>
@@ -136,6 +147,7 @@ Tracking the work of thousands of teachers and millions of students.
 <td>59</td>
 <td>69</td>
 <td>80</td>
+<td>85</td>
 </tr>
 </tbody>
 </table>


### PR DESCRIPTION
On the code.org/statistics page:

- Extend the graphs to show up through 2023
- Add a column for 2019 (I'm still trying to find the information for 2020, 2021, 2022)

![localhost code org_3000_statistics](https://user-images.githubusercontent.com/208083/236045052-c05f08bd-8fb2-4b31-88ad-fb98b8ae1dce.png)
