### PR TITLE
Version and Unit dropdowns close with table collapse

### DIFF
--- a/apps/src/templates/sectionsRefresh/CurriculumQuickAssign.jsx
+++ b/apps/src/templates/sectionsRefresh/CurriculumQuickAssign.jsx
@@ -233,13 +233,14 @@ export default function CurriculumQuickAssign({
           sectionCourse={sectionCourse}
         />
       )}
-
-      <VersionUnitDropdowns
-        courseOffering={selectedCourseOffering}
-        updateCourse={course => updateSection('course', course)}
-        sectionCourse={sectionCourse}
-        isNewSection={isNewSection}
-      />
+      {marketingAudience && (
+        <VersionUnitDropdowns
+          courseOffering={selectedCourseOffering}
+          updateCourse={course => updateSection('course', course)}
+          sectionCourse={sectionCourse}
+          isNewSection={isNewSection}
+        />
+      )}
     </div>
   );
 }

--- a/apps/test/unit/templates/sectionsRefresh/CurriculumQuickAssignTest.jsx
+++ b/apps/test/unit/templates/sectionsRefresh/CurriculumQuickAssignTest.jsx
@@ -36,6 +36,23 @@ describe('CurriculumQuickAssign', () => {
     expect(wrapper.find('Button').at(0).props().icon).to.equal('caret-down');
   });
 
+  it('opens and closes version dropdowns with table open and collapse', () => {
+    const wrapper = mount(
+      <CurriculumQuickAssign updateSection={() => {}} sectionCourse={{}} />
+    );
+    expect(wrapper.find('VersionUnitDropdowns')).to.have.lengthOf(0);
+    wrapper
+      .find('Button')
+      .at(0)
+      .simulate('click', {preventDefault: () => {}});
+    expect(wrapper.find('VersionUnitDropdowns')).to.have.lengthOf(1);
+    wrapper
+      .find('Button')
+      .at(0)
+      .simulate('click', {preventDefault: () => {}});
+    expect(wrapper.find('VersionUnitDropdowns')).to.have.lengthOf(0);
+  });
+
   it('clears decide later when marketing audience selected', () => {
     const wrapper = mount(
       <CurriculumQuickAssign updateSection={() => {}} sectionCourse={{}} />


### PR DESCRIPTION
This PR is the simple fix (more context in the Jira ticket and the one that is tagged). We want the version and unit dropdowns to disappear when a user collapses the table.

## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/TEACH-457

## Testing story

Added a test that will ensure the version dropdown doesn't get called until the marketing audience is selected

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

As tagged in https://codedotorg.atlassian.net/browse/TEACH-468, make this more specific to the marketing audience of a selected course offering

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
