### PR TITLE
Fix Violations of and Reenable `Style/NegatedIfElseCondition`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -430,11 +430,6 @@ Style/MultilineTernaryOperator:
 Style/MutableConstant:
   Enabled: false
 
-# Offense count: 20
-# This cop supports safe auto-correction (--auto-correct).
-Style/NegatedIfElseCondition:
-  Enabled: false
-
 # Offense count: 80
 Style/OpenStructUse:
   Enabled: false

--- a/bin/i18n-codeorg/lib/merge-all-locales.rb
+++ b/bin/i18n-codeorg/lib/merge-all-locales.rb
@@ -12,14 +12,7 @@ require 'json'
 # previous translation, update the new_translation with the prev_translation.
 
 def merge_translation_tree(en_translation, new_translation, prev_translation)
-  if !new_translation.is_a?(Hash)
-    # Leaf node, a translation.
-    # New translation equals to English, and old translation already exists
-    if !prev_translation.nil? && new_translation == en_translation &&
-       new_translation != prev_translation
-      new_translation = prev_translation
-    end
-  else
+  if new_translation.is_a?(Hash)
     # Recursive merge for subtree.
     new_translation.each_key do |key|
       next unless en_translation.key?(key) && prev_translation.key?(key)
@@ -33,6 +26,13 @@ def merge_translation_tree(en_translation, new_translation, prev_translation)
       unless new_translation.key?(key)
         new_translation[key] = en_translation[key]
       end
+    end
+  else
+    # Leaf node, a translation.
+    # New translation equals to English, and old translation already exists
+    if !prev_translation.nil? && new_translation == en_translation &&
+       new_translation != prev_translation
+      new_translation = prev_translation
     end
   end
   new_translation

--- a/bin/oneoff/backfill_data/storage_apps_project_type_and_standalone
+++ b/bin/oneoff/backfill_data/storage_apps_project_type_and_standalone
@@ -50,7 +50,7 @@ def main
       hidden = value_parsed['hidden']
 
       project_type = storage_app[:project_type] ? storage_app[:project_type] : project_type_from_value(value_parsed)
-      standalone = !storage_app[:standalone] ? false : !hidden
+      standalone = storage_app[:standalone] ? !hidden : false
 
       updates << [storage_app[:id], project_type, standalone]
     rescue

--- a/bin/oneoff/upload_non_en_videos.rb
+++ b/bin/oneoff/upload_non_en_videos.rb
@@ -106,9 +106,7 @@ end
 
 # Returns the YouTube code
 def upload_to_youtube(service, filename, title, upload_files)
-  if !upload_files
-    'youtube_code'
-  else
+  if upload_files
     properties = {
       snippet: {
         category_id: '22',
@@ -122,6 +120,8 @@ def upload_to_youtube(service, filename, title, upload_files)
     part = 'snippet,status'
     response = service.insert_video(part, properties, params)
     response.id
+  else
+    'youtube_code'
   end
 end
 

--- a/dashboard/app/controllers/regional_partners_controller.rb
+++ b/dashboard/app/controllers/regional_partners_controller.rb
@@ -101,10 +101,10 @@ class RegionalPartnersController < ApplicationController
     state = region if region.present? && region.in?(STATE_ABBR_WITH_DC_HASH.keys.map(&:to_s))
     zip_code = region if region.present? && RegexpUtils.us_zip_code?(region)
     result = @regional_partner.mappings.find_or_create_by(state: state, zip_code: zip_code)
-    if !result.errors[:base].nil_or_empty?
-      flash[:alert] = "Failed to add #{region}. #{result.errors[:base].join(',')}."
-    else
+    if result.errors[:base].nil_or_empty?
       flash[:notice] = "Successfully added #{region}."
+    else
+      flash[:alert] = "Failed to add #{region}. #{result.errors[:base].join(',')}."
     end
     redirect_to @regional_partner
   end

--- a/dashboard/app/models/concerns/sti_factory.rb
+++ b/dashboard/app/models/concerns/sti_factory.rb
@@ -11,11 +11,11 @@ module StiFactory
     end
 
     def with_type(type)
-      if self.type != type
+      if self.type == type
+        self
+      else
         self.type = type
         becomes(type.constantize)
-      else
-        self
       end
     end
   end

--- a/dashboard/app/models/lesson_group.rb
+++ b/dashboard/app/models/lesson_group.rb
@@ -60,14 +60,7 @@ class LessonGroup < ApplicationRecord
     counters = Counters.new(0, 0, 0, 0)
 
     raw_lesson_groups&.map(&:deep_symbolize_keys)&.map do |raw_lesson_group|
-      if !raw_lesson_group[:user_facing]
-        lesson_group = LessonGroup.find_or_create_by!(
-          key: '',
-          script: script,
-          user_facing: false,
-          position: 1
-        )
-      else
+      if raw_lesson_group[:user_facing]
         LessonGroup.prevent_changing_plc_display_name(raw_lesson_group)
         LessonGroup.prevent_blank_display_name(raw_lesson_group)
         LessonGroup.prevent_changing_stable_i18n_key(script, raw_lesson_group)
@@ -89,6 +82,13 @@ class LessonGroup < ApplicationRecord
           }
         )
         lesson_group.save! if lesson_group.changed?
+      else
+        lesson_group = LessonGroup.find_or_create_by!(
+          key: '',
+          script: script,
+          user_facing: false,
+          position: 1
+        )
       end
 
       new_lessons =

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1311,14 +1311,14 @@ class User < ApplicationRecord
 
     script_sections = sections.select {|s| s.script.try(:id) == script_level.script.id}
 
-    if !script_sections.empty?
-      # if we have one or more sections matching this script id, we consider a lesson hidden if all of those sections
-      # hides the lesson
-      script_sections.all? {|s| script_level.hidden_for_section?(s.id)}
-    else
+    if script_sections.empty?
       # if we have no sections matching this script id, we consider a lesson hidden if any of the sections we're in
       # hide it
       sections.any? {|s| script_level.hidden_for_section?(s.id)}
+    else
+      # if we have one or more sections matching this script id, we consider a lesson hidden if all of those sections
+      # hides the lesson
+      script_sections.all? {|s| script_level.hidden_for_section?(s.id)}
     end
   end
 

--- a/dashboard/legacy/middleware/channels_api.rb
+++ b/dashboard/legacy/middleware/channels_api.rb
@@ -280,8 +280,8 @@ class ChannelsApi < Sinatra::Base
     language = request.language
 
     value = explain_share_failure(id)
-    intl_value = language != 'en' ?
-      explain_share_failure(id, language) : nil
+    intl_value = language == 'en' ?
+      nil : explain_share_failure(id, language)
     {
       share_failure: value,
       intl_share_failure: intl_value,

--- a/dashboard/legacy/middleware/helpers/animation_bucket.rb
+++ b/dashboard/legacy/middleware/helpers/animation_bucket.rb
@@ -33,7 +33,7 @@ class AnimationBucket < BucketHelper
     if version == 'latestVersion'
       track_list_operation 'AnimationBucket.s3_get_object(A)'
       versions = s3.list_object_versions(bucket: @bucket, prefix: key).versions
-      requested_version = !versions.empty? ? versions.first.version_id : version
+      requested_version = versions.empty? ? version : versions.first.version_id
     end
 
     super(key, if_modified_since, requested_version)

--- a/dashboard/lib/level_loader.rb
+++ b/dashboard/lib/level_loader.rb
@@ -119,13 +119,13 @@ class LevelLoader
     # Only reload level data when file contents change
     level_data = File.read(level_path)
     md5 = Digest::MD5.hexdigest(level_data)
-    if level_md5s_by_name[name] != md5
+    if level_md5s_by_name[name] == md5
+      nil
+    else
       level = Level.find_by_name(name) || Level.new(name: name)
       level.md5 = md5
       level = load_custom_level_xml(level_data, level)
       level
-    else
-      nil
     end
   rescue Exception => exception
     # print filename for better debugging

--- a/lib/cdo.rb
+++ b/lib/cdo.rb
@@ -270,7 +270,7 @@ module Cdo
       @@log ||= Logger.new(STDOUT).tap do |l|
         l.level = Logger::INFO
         l.formatter = proc do |severity, _, _, msg|
-          "#{severity != 'INFO' ? "#{severity}: " : ''}#{msg}\n"
+          "#{severity == 'INFO' ? '' : "#{severity}: "}#{msg}\n"
         end
       end
     end

--- a/lib/cdo/cloud_formation/adhoc.rb
+++ b/lib/cdo/cloud_formation/adhoc.rb
@@ -5,14 +5,14 @@ module Cdo::CloudFormation
   # included AWS::CloudFormation in adhoc environment.
   module Adhoc
     def start_inactive_instance
-      if instance.state.name != 'stopped'
-        log.info "Instance #{instance.id} in Stack #{stack_name} can't be started because it is not" \
-            " currently stopped.  Current state - #{instance.state.name}"
-      else
+      if instance.state.name == 'stopped'
         log.info "Starting Instance #{instance.id} ..."
         options[:quiet] = true
         stack.options[:start_inactive_instance] = true
         create_or_update
+      else
+        log.info "Instance #{instance.id} in Stack #{stack_name} can't be started because it is not" \
+            " currently stopped.  Current state - #{instance.state.name}"
       end
       cfn_stack.outputs.each do |output|
         log.info "#{output.output_key}: #{output.output_value}"

--- a/lib/cdo/parse_email_address_string.rb
+++ b/lib/cdo/parse_email_address_string.rb
@@ -29,9 +29,9 @@ def parse_email_address_string(string)
   # without them being confused with the < > wrapping the email address at the end.
   #
   # Or just treat the entire string as an email address.
-  if !(/(.*)<(.*)>$/ =~ string).nil?
-    {name: $1.strip, email: $2}
-  else
+  if (/(.*)<(.*)>$/ =~ string).nil?
     {name: nil, email: string}
+  else
+    {name: $1.strip, email: $2}
   end
 end

--- a/lib/cdo/poste.rb
+++ b/lib/cdo/poste.rb
@@ -292,10 +292,10 @@ class Deliverer
     message.puts ''
     message.puts "--#{marker}--"
 
-    if !rack_env?(:development)
-      @smtp.send_message message.string, from_address[:email], *to_addresses
-    else
+    if rack_env?(:development)
       puts(message.string)
+    else
+      @smtp.send_message message.string, from_address[:email], *to_addresses
     end
   end
 

--- a/pegasus/helpers/page_helpers.rb
+++ b/pegasus/helpers/page_helpers.rb
@@ -52,7 +52,7 @@ end
 # Setting `is_retina` to `false` matches non-retina displays.
 def css_retina?(is_retina = true)
   css_query_parts = ['-webkit-min-device-pixel-ratio: 2', 'min-resolution: 192dpi']
-  css_query_parts.map {|q| "#{!is_retina ? 'not all and ' : ''}(#{q})"}.join(', ')
+  css_query_parts.map {|q| "#{is_retina ? '' : 'not all and '}(#{q})"}.join(', ')
 end
 
 # Returns a concatenated, minified CSS string from all CSS files in the given paths,

--- a/pegasus/routes/state_sheets.rb
+++ b/pegasus/routes/state_sheets.rb
@@ -1,8 +1,8 @@
 # redirect state fact sheets with lowercase path to uppercase path
 get '/advocacy/state-facts/*.pdf' do |uri|
-  if uri != uri.upcase
-    redirect "/advocacy/state-facts/#{uri.upcase}.pdf"
-  else
+  if uri == uri.upcase
     pass
+  else
+    redirect "/advocacy/state-facts/#{uri.upcase}.pdf"
   end
 end

--- a/pegasus/src/curriculum_course.rb
+++ b/pegasus/src/curriculum_course.rb
@@ -77,7 +77,7 @@ class CurriculumCourse
       lessons.push lesson
     end
     # Just push all the lessons without a number to the end.
-    lessons.sort_by! {|k| k[:number] != "" ? k[:number].to_i : 10000}
+    lessons.sort_by! {|k| k[:number] == "" ? 10000 : k[:number].to_i}
     lessons
   end
 


### PR DESCRIPTION
>  This cop checks for uses of `if-else` and ternary operators with a negated condition which can be simplified by inverting condition and swapping branches.

Fix applied automatically with `bundle exec rubocop --auto-correct-all --only Style/NegatedIfElseCondition`

I'm not entirely convinced that this rule is always desirable; I can imagine there might be some situations in which the code really does read better with a negative condition first, or otherwise in which this rule might get in the way. But the actual changes the rule requires us to make all seem like improvements to me, so I'm less hesitant in practice than in theory.

What do y'all think about this one?

## Links

- https://docs.rubocop.org/rubocop/cops_style.html#stylenegatedifelsecondition
- https://www.rubydoc.info/gems/rubocop/1.12.0/RuboCop/Cop/Style/NegatedIfElseCondition