### PR TITLE
Fix no-prototype-builtins violations and turn eslint rule on

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,8 +28,6 @@ module.exports = {
     "no-extra-boolean-cast": "off",
     "no-implicit-globals": "error",
     "no-new-object": "error",
-    // TODO: Turn back to error once we've fixed all the existing warnings
-    "no-prototype-builtins": "off",
     "no-redeclare": ["error", { builtinGlobals: true }],
     "no-restricted-imports": ["error", "radium"],
     "no-trailing-spaces": "error",

--- a/apps/src/Sound.js
+++ b/apps/src/Sound.js
@@ -324,19 +324,19 @@ Sound.prototype.getPlayableFile = function () {
     var audioTest = new window.Audio();
 
     if (
-      this.config.hasOwnProperty('mp3') &&
+      Object.prototype.hasOwnProperty.call(this.config, 'mp3') &&
       audioTest.canPlayType('audio/mp3')
     ) {
       return this.config.mp3;
     }
     if (
-      this.config.hasOwnProperty('ogg') &&
+      Object.prototype.hasOwnProperty.call(this.config, 'ogg') &&
       audioTest.canPlayType('audio/ogg')
     ) {
       return this.config.ogg;
     }
     if (
-      this.config.hasOwnProperty('wav') &&
+      Object.prototype.hasOwnProperty.call(this.config, 'wav') &&
       audioTest.canPlayType('audio/wav')
     ) {
       return this.config.wav;
@@ -357,7 +357,7 @@ Sound.prototype.getPlayableBytes = function () {
 
     let audioTest = new window.Audio();
     if (
-      this.config.hasOwnProperty('bytes') &&
+      Object.prototype.hasOwnProperty.call(this.config, 'bytes') &&
       audioTest.canPlayType('audio/mp3')
     ) {
       return this.config.bytes;

--- a/apps/src/code-studio/pd/application_dashboard/detail_view_contents.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/detail_view_contents.jsx
@@ -972,7 +972,7 @@ export class DetailViewContents extends React.Component {
   };
 
   render() {
-    if (this.state.hasOwnProperty('deleted')) {
+    if (Object.prototype.hasOwnProperty.call(this.state, 'deleted')) {
       const message = this.state.deleted
         ? 'This application has been deleted.'
         : 'This application could not be deleted.';

--- a/apps/src/code-studio/pd/components/customSchoolInfo.jsx
+++ b/apps/src/code-studio/pd/components/customSchoolInfo.jsx
@@ -63,7 +63,10 @@ export default class CustomSchoolInfo extends React.Component {
           required={true}
           onChange={this.handleSchoolInfoChange}
           validationState={
-            this.props.errors.hasOwnProperty('school_name')
+            Object.prototype.hasOwnProperty.call(
+              this.props.errors,
+              'school_name'
+            )
               ? VALIDATION_STATE_ERROR
               : null
           }
@@ -79,7 +82,10 @@ export default class CustomSchoolInfo extends React.Component {
             this.props.school_info ? this.props.school_info.school_type : null
           }
           validationState={
-            this.props.errors.hasOwnProperty('school_type')
+            Object.prototype.hasOwnProperty.call(
+              this.props.errors,
+              'school_type'
+            )
               ? VALIDATION_STATE_ERROR
               : null
           }
@@ -98,7 +104,10 @@ export default class CustomSchoolInfo extends React.Component {
               required={true}
               onChange={this.handleSchoolDistrictChange}
               validationState={
-                this.props.errors.hasOwnProperty('school_district_name')
+                Object.prototype.hasOwnProperty.call(
+                  this.props.errors,
+                  'school_district_name'
+                )
                   ? VALIDATION_STATE_ERROR
                   : null
               }
@@ -110,7 +119,10 @@ export default class CustomSchoolInfo extends React.Component {
             <FormGroup
               id="school_state"
               validationState={
-                this.props.errors.hasOwnProperty('school_state')
+                Object.prototype.hasOwnProperty.call(
+                  this.props.errors,
+                  'school_state'
+                )
                   ? VALIDATION_STATE_ERROR
                   : null
               }
@@ -137,7 +149,10 @@ export default class CustomSchoolInfo extends React.Component {
               required={true}
               onChange={this.handleSchoolInfoChange}
               validationState={
-                this.props.errors.hasOwnProperty('school_zip')
+                Object.prototype.hasOwnProperty.call(
+                  this.props.errors,
+                  'school_zip'
+                )
                   ? VALIDATION_STATE_ERROR
                   : null
               }

--- a/apps/src/code-studio/pd/components/schoolAutocompleteDropdownWithCustomFields.jsx
+++ b/apps/src/code-studio/pd/components/schoolAutocompleteDropdownWithCustomFields.jsx
@@ -55,7 +55,10 @@ export default class SchoolAutocompleteDropdownWithCustomFields extends React.Co
           <FormGroup
             id="school_id"
             validationState={
-              this.props.errors.hasOwnProperty('school_id')
+              Object.prototype.hasOwnProperty.call(
+                this.props.errors,
+                'school_id'
+              )
                 ? VALIDATION_STATE_ERROR
                 : null
             }

--- a/apps/src/code-studio/pd/workshop_dashboard/reports/report_view.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/reports/report_view.jsx
@@ -111,7 +111,7 @@ export default class ReportView extends React.Component {
       API_DATE_FORMAT
     );
     const queryBy = newState.queryBy || this.state.queryBy;
-    const course = newState.hasOwnProperty('course')
+    const course = Object.prototype.hasOwnProperty.call(newState, 'course')
       ? newState.course
       : this.state.course;
     const report = newState.report || this.state.report;

--- a/apps/src/code-studio/pd/workshop_enrollment/enroll_form.jsx
+++ b/apps/src/code-studio/pd/workshop_enrollment/enroll_form.jsx
@@ -419,7 +419,10 @@ export default class EnrollForm extends React.Component {
             onChange={this.handleChange}
             defaultValue={this.props.first_name}
             validationState={
-              this.state.errors.hasOwnProperty('first_name')
+              Object.prototype.hasOwnProperty.call(
+                this.state.errors,
+                'first_name'
+              )
                 ? VALIDATION_STATE_ERROR
                 : null
             }
@@ -432,7 +435,10 @@ export default class EnrollForm extends React.Component {
             required={true}
             onChange={this.handleChange}
             validationState={
-              this.state.errors.hasOwnProperty('last_name')
+              Object.prototype.hasOwnProperty.call(
+                this.state.errors,
+                'last_name'
+              )
                 ? VALIDATION_STATE_ERROR
                 : null
             }
@@ -450,7 +456,7 @@ export default class EnrollForm extends React.Component {
               this.props.email ? 'Email can be changed in account settings' : ''
             }
             validationState={
-              this.state.errors.hasOwnProperty('email')
+              Object.prototype.hasOwnProperty.call(this.state.errors, 'email')
                 ? VALIDATION_STATE_ERROR
                 : null
             }
@@ -464,7 +470,10 @@ export default class EnrollForm extends React.Component {
               required={true}
               onChange={this.handleChange}
               validationState={
-                this.state.errors.hasOwnProperty('confirm_email')
+                Object.prototype.hasOwnProperty.call(
+                  this.state.errors,
+                  'confirm_email'
+                )
                   ? VALIDATION_STATE_ERROR
                   : null
               }
@@ -482,7 +491,7 @@ export default class EnrollForm extends React.Component {
           <FormGroup>
             <FormGroup
               validationState={
-                this.state.errors.hasOwnProperty('role')
+                Object.prototype.hasOwnProperty.call(this.state.errors, 'role')
                   ? VALIDATION_STATE_ERROR
                   : null
               }
@@ -519,7 +528,10 @@ export default class EnrollForm extends React.Component {
                 onChange={this.handleChange}
                 selectedItems={this.state.grades_teaching}
                 validationState={
-                  this.state.errors.hasOwnProperty('grades_teaching')
+                  Object.prototype.hasOwnProperty.call(
+                    this.state.errors,
+                    'grades_teaching'
+                  )
                     ? VALIDATION_STATE_ERROR
                     : null
                 }
@@ -541,7 +553,10 @@ export default class EnrollForm extends React.Component {
               onChange={this.handleChange}
               selectedItems={this.state.csf_intro_intent}
               validationState={
-                this.state.errors.hasOwnProperty('csf_intro_intent')
+                Object.prototype.hasOwnProperty.call(
+                  this.state.errors,
+                  'csf_intro_intent'
+                )
                   ? VALIDATION_STATE_ERROR
                   : null
               }
@@ -559,7 +574,10 @@ export default class EnrollForm extends React.Component {
               onChange={this.handleChange}
               selectedItems={this.state.csf_intro_other_factors}
               validationState={
-                this.state.errors.hasOwnProperty('csf_intro_other_factors')
+                Object.prototype.hasOwnProperty.call(
+                  this.state.errors,
+                  'csf_intro_other_factors'
+                )
                   ? VALIDATION_STATE_ERROR
                   : null
               }
@@ -595,7 +613,10 @@ export default class EnrollForm extends React.Component {
                 onChange={this.handleChange}
                 selectedItems={this.state.csf_courses_planned}
                 validationState={
-                  this.state.errors.hasOwnProperty('csf_courses_planned')
+                  Object.prototype.hasOwnProperty.call(
+                    this.state.errors,
+                    'csf_courses_planned'
+                  )
                     ? VALIDATION_STATE_ERROR
                     : null
                 }
@@ -611,7 +632,8 @@ export default class EnrollForm extends React.Component {
                 onChange={this.handleChange}
                 selectedItems={this.state.attended_csf_intro_workshop}
                 validationState={
-                  this.state.errors.hasOwnProperty(
+                  Object.prototype.hasOwnProperty.call(
+                    this.state.errors,
                     'attended_csf_intro_workshop'
                   )
                     ? VALIDATION_STATE_ERROR
@@ -630,7 +652,8 @@ export default class EnrollForm extends React.Component {
                 onChange={this.handleChange}
                 selectedItems={this.state.csf_has_physical_curriculum_guide}
                 validationState={
-                  this.state.errors.hasOwnProperty(
+                  Object.prototype.hasOwnProperty.call(
+                    this.state.errors,
                     'csf_has_physical_curriculum_guide'
                   )
                     ? VALIDATION_STATE_ERROR
@@ -654,7 +677,10 @@ export default class EnrollForm extends React.Component {
               onChange={this.handleChange}
               selectedItems={this.state.previous_courses}
               validationState={
-                this.state.errors.hasOwnProperty('previous_courses')
+                Object.prototype.hasOwnProperty.call(
+                  this.state.errors,
+                  'previous_courses'
+                )
                   ? VALIDATION_STATE_ERROR
                   : null
               }
@@ -672,7 +698,10 @@ export default class EnrollForm extends React.Component {
               onChange={this.handleChange}
               selectedItems={this.state.replace_existing}
               validationState={
-                this.state.errors.hasOwnProperty('replace_existing')
+                Object.prototype.hasOwnProperty.call(
+                  this.state.errors,
+                  'replace_existing'
+                )
                   ? VALIDATION_STATE_ERROR
                   : null
               }
@@ -694,7 +723,10 @@ export default class EnrollForm extends React.Component {
                 required={true}
                 onChange={this.handleChange}
                 validationState={
-                  this.state.errors.hasOwnProperty('years_teaching')
+                  Object.prototype.hasOwnProperty.call(
+                    this.state.errors,
+                    'years_teaching'
+                  )
                     ? VALIDATION_STATE_ERROR
                     : null
                 }
@@ -707,7 +739,10 @@ export default class EnrollForm extends React.Component {
                 required={true}
                 onChange={this.handleChange}
                 validationState={
-                  this.state.errors.hasOwnProperty('years_teaching_cs')
+                  Object.prototype.hasOwnProperty.call(
+                    this.state.errors,
+                    'years_teaching_cs'
+                  )
                     ? VALIDATION_STATE_ERROR
                     : null
                 }
@@ -722,7 +757,10 @@ export default class EnrollForm extends React.Component {
                 onChange={this.handleChange}
                 selectedItems={this.state.taught_ap_before}
                 validationState={
-                  this.state.errors.hasOwnProperty('taught_ap_before')
+                  Object.prototype.hasOwnProperty.call(
+                    this.state.errors,
+                    'taught_ap_before'
+                  )
                     ? VALIDATION_STATE_ERROR
                     : null
                 }
@@ -738,7 +776,10 @@ export default class EnrollForm extends React.Component {
                 onChange={this.handleChange}
                 selectedItems={this.state.planning_to_teach_ap}
                 validationState={
-                  this.state.errors.hasOwnProperty('planning_to_teach_ap')
+                  Object.prototype.hasOwnProperty.call(
+                    this.state.errors,
+                    'planning_to_teach_ap'
+                  )
                     ? VALIDATION_STATE_ERROR
                     : null
                 }

--- a/apps/src/code-studio/reporting.js
+++ b/apps/src/code-studio/reporting.js
@@ -48,7 +48,7 @@ function validateType(key, value, type) {
  */
 function validateReport(report) {
   for (var key in report) {
-    if (!report.hasOwnProperty(key)) {
+    if (!Object.prototype.hasOwnProperty.call(report, key)) {
       continue;
     }
 

--- a/apps/src/craft/code-connection/craft.js
+++ b/apps/src/craft/code-connection/craft.js
@@ -43,7 +43,7 @@ const preloadImage = function (url) {
  * @param {any} input
  */
 function getItemName(input) {
-  if (input.hasOwnProperty('name')) {
+  if (Object.prototype.hasOwnProperty.call(input, 'name')) {
     input = input['name'];
   }
   return input;

--- a/apps/src/lib/kits/maker/boards/circuitPlayground/CircuitPlaygroundBoard.js
+++ b/apps/src/lib/kits/maker/boards/circuitPlayground/CircuitPlaygroundBoard.js
@@ -340,7 +340,9 @@ export default class CircuitPlaygroundBoard extends EventEmitter {
   }
 
   mappedPin(pin) {
-    return pinMapping.hasOwnProperty(pin) ? pinMapping[pin] : pin;
+    return Object.prototype.hasOwnProperty.call(pinMapping, pin)
+      ? pinMapping[pin]
+      : pin;
   }
 
   pinMode(pin, modeConstant) {

--- a/apps/src/lib/kits/maker/boards/circuitPlayground/Thermometer.js
+++ b/apps/src/lib/kits/maker/boards/circuitPlayground/Thermometer.js
@@ -16,10 +16,10 @@ const PlaygroundThermometer = {
           return thermometerRawValue;
         },
       };
-      if (!this.hasOwnProperty('raw')) {
+      if (!Object.prototype.hasOwnProperty.call(this, 'raw')) {
         Object.defineProperty(this, 'raw', rawValueDescriptor);
       }
-      if (!this.hasOwnProperty('value')) {
+      if (!Object.prototype.hasOwnProperty.call(this, 'value')) {
         Object.defineProperty(this, 'value', rawValueDescriptor);
       }
     },

--- a/apps/src/lib/tools/jsinterpreter/CustomMarshalingInterpreter.js
+++ b/apps/src/lib/tools/jsinterpreter/CustomMarshalingInterpreter.js
@@ -241,7 +241,7 @@ export default class CustomMarshalingInterpreter extends Interpreter {
     if (obj.isCustomMarshal) {
       if (!this.shouldBlockCustomMarshalling_(name, obj)) {
         if (
-          !obj.data.hasOwnProperty(name) &&
+          !Object.prototype.hasOwnProperty.call(obj.data, name) &&
           value instanceof Interpreter.Object
         ) {
           // When assigning an interpreter object as a property on a

--- a/apps/src/lib/tools/jsinterpreter/JSInterpreter.js
+++ b/apps/src/lib/tools/jsinterpreter/JSInterpreter.js
@@ -737,7 +737,10 @@ export default class JSInterpreter {
         //      in the doneLeft value, because the expression kind of looks like i = i + 1 which
         //      has a left (i = ) and a right (i + 1) side, and the left side is where the assignment
         //      actually takes place.
-        this.atInterstitialNode = INTERSTITIAL_NODES.hasOwnProperty(nodeType);
+        this.atInterstitialNode = Object.prototype.hasOwnProperty.call(
+          INTERSTITIAL_NODES,
+          nodeType
+        );
         if (inUserCode && !doneUserLine) {
           doneUserLine =
             this.atInterstitialNode ||

--- a/apps/src/lib/ui/SyncOmniAuthSectionControl.jsx
+++ b/apps/src/lib/ui/SyncOmniAuthSectionControl.jsx
@@ -115,7 +115,10 @@ class SyncOmniAuthSectionControl extends React.Component {
   render() {
     const {sectionProvider, sectionCode} = this.props;
     const {buttonState} = this.state;
-    const supportedType = PROVIDER_NAME.hasOwnProperty(sectionProvider);
+    const supportedType = Object.prototype.hasOwnProperty.call(
+      PROVIDER_NAME,
+      sectionProvider
+    );
     if (!supportedType || !sectionCode) {
       // Possibly not loaded yet.
       return null;

--- a/apps/src/lib/ui/accounts/AddParentEmailModal.jsx
+++ b/apps/src/lib/ui/accounts/AddParentEmailModal.jsx
@@ -65,7 +65,7 @@ export default class AddParentEmailModal extends React.Component {
   cancel = () => this.props.handleCancel();
 
   onSubmitFailure = error => {
-    if (error && error.hasOwnProperty('serverErrors')) {
+    if (error && Object.prototype.hasOwnProperty.call(error, 'serverErrors')) {
       this.setState(
         {
           saveState: STATE_INITIAL,

--- a/apps/src/lib/ui/accounts/ChangeEmailModal.jsx
+++ b/apps/src/lib/ui/accounts/ChangeEmailModal.jsx
@@ -56,7 +56,7 @@ export default class ChangeEmailModal extends React.Component {
   cancel = () => this.props.handleCancel();
 
   onSubmitFailure = error => {
-    if (error && error.hasOwnProperty('serverErrors')) {
+    if (error && Object.prototype.hasOwnProperty.call(error, 'serverErrors')) {
       this.setState(
         {
           saveState: STATE_INITIAL,

--- a/apps/src/lib/ui/accounts/ChangeUserTypeModal.jsx
+++ b/apps/src/lib/ui/accounts/ChangeUserTypeModal.jsx
@@ -50,7 +50,7 @@ export default class ChangeUserTypeModal extends React.Component {
   cancel = () => this.props.handleCancel();
 
   onSubmitFailure = error => {
-    if (error && error.hasOwnProperty('serverErrors')) {
+    if (error && Object.prototype.hasOwnProperty.call(error, 'serverErrors')) {
       this.setState(
         {
           saveState: STATE_INITIAL,

--- a/apps/src/netsim/ArgumentUtils.js
+++ b/apps/src/netsim/ArgumentUtils.js
@@ -40,7 +40,10 @@ exports.extendOptionsObject = function (optionsObject) {
     throw new TypeError('Options object must be an object.');
   }
 
-  if (optionsObject && optionsObject.hasOwnProperty('get')) {
+  if (
+    optionsObject &&
+    Object.prototype.hasOwnProperty.call(optionsObject, 'get')
+  ) {
     throw new Error(
       'Cannot extend options; property "get" would be overwritten.'
     );

--- a/apps/src/netsim/NetSimEncodingControl.js
+++ b/apps/src/netsim/NetSimEncodingControl.js
@@ -110,7 +110,7 @@ NetSimEncodingControl.hideRowsByEncoding = function (rootElement, encodings) {
   var hiddenEncodings = [];
   for (var key in EncodingType) {
     if (
-      EncodingType.hasOwnProperty(key) &&
+      Object.prototype.hasOwnProperty.call(EncodingType, key) &&
       encodings.indexOf(EncodingType[key]) === -1
     ) {
       hiddenEncodings.push(EncodingType[key]);

--- a/apps/src/netsim/NetSimRouterNode.js
+++ b/apps/src/netsim/NetSimRouterNode.js
@@ -1020,7 +1020,10 @@ NetSimRouterNode.prototype.acceptConnection = function (otherNode, onComplete) {
         addressesSoFar[this.getAddress()] = true;
         addressesSoFar[this.getAutoDnsAddress()] = true;
         var addressCollision = connections.some(function (wire) {
-          var collides = addressesSoFar.hasOwnProperty(wire.localAddress);
+          var collides = Object.prototype.hasOwnProperty.call(
+            addressesSoFar,
+            wire.localAddress
+          );
           addressesSoFar[wire.localAddress] = true;
           return collides;
         });

--- a/apps/src/netsim/NetSimTable.js
+++ b/apps/src/netsim/NetSimTable.js
@@ -537,7 +537,10 @@ NetSimTable.prototype.arrayFromCache_ = function (predicate) {
     };
   var result = [];
   for (var k in this.cache_) {
-    if (this.cache_.hasOwnProperty(k) && predicate(k, this.cache_[k])) {
+    if (
+      Object.prototype.hasOwnProperty.call(this.cache_, k) &&
+      predicate(k, this.cache_[k])
+    ) {
       result.push(this.cache_[k]);
     }
   }

--- a/apps/src/netsim/NetSimUtils.js
+++ b/apps/src/netsim/NetSimUtils.js
@@ -147,7 +147,7 @@ exports.getEncodingLabel = function (encodingType) {
  */
 exports.forEachEnumValue = function (enumObj, func) {
   for (var enumKey in enumObj) {
-    if (enumObj.hasOwnProperty(enumKey)) {
+    if (Object.prototype.hasOwnProperty.call(enumObj, enumKey)) {
       func(enumObj[enumKey]);
     }
   }

--- a/apps/src/netsim/Packet.js
+++ b/apps/src/netsim/Packet.js
@@ -173,7 +173,7 @@ Packet.Encoder.prototype.validateSpec = function () {
       );
     }
 
-    if (keyCache.hasOwnProperty(this.headerSpec_[i])) {
+    if (Object.prototype.hasOwnProperty.call(keyCache, this.headerSpec_[i])) {
       throw new Error('Invalid packet format: Field keys must be unique.');
     } else {
       keyCache[this.headerSpec_[i]] = 'used';
@@ -304,7 +304,7 @@ Packet.Encoder.prototype.getFieldBitWidth = function (headerType) {
 Packet.Encoder.prototype.makeBinaryHeaders = function (headers) {
   var binaryHeaders = {};
   this.headerSpec_.forEach(function (headerField) {
-    if (headers.hasOwnProperty(headerField)) {
+    if (Object.prototype.hasOwnProperty.call(headers, headerField)) {
       // Convert differently for address and packet fields?
       if (Packet.isAddressField(headerField)) {
         binaryHeaders[headerField] = this.addressStringToBinary(
@@ -354,7 +354,10 @@ Packet.Encoder.prototype.concatenateBinary = function (binaryHeaders, body) {
     // Get header value from provided headers, if it exists.
     // If not, we'll start with an empty string and pad it to the correct
     // length, below.
-    var fieldBits = binaryHeaders.hasOwnProperty(fieldSpec)
+    var fieldBits = Object.prototype.hasOwnProperty.call(
+      binaryHeaders,
+      fieldSpec
+    )
       ? binaryHeaders[fieldSpec]
       : '';
 

--- a/apps/src/p5lab/shapes.js
+++ b/apps/src/p5lab/shapes.js
@@ -198,8 +198,8 @@ export function throwIfSerializedAnimationListIsInvalid(
     ['name', 'frameSize', 'frameCount', 'looping', 'frameDelay'].forEach(
       requiredPropName => {
         if (
-          Object.prototype.hasOwnProperty.call(
-            !propsByKey[animationKey],
+          !Object.prototype.hasOwnProperty.call(
+            propsByKey[animationKey],
             requiredPropName
           )
         ) {

--- a/apps/src/p5lab/shapes.js
+++ b/apps/src/p5lab/shapes.js
@@ -197,7 +197,12 @@ export function throwIfSerializedAnimationListIsInvalid(
   for (const animationKey in propsByKey) {
     ['name', 'frameSize', 'frameCount', 'looping', 'frameDelay'].forEach(
       requiredPropName => {
-        if (!propsByKey[animationKey].hasOwnProperty(requiredPropName)) {
+        if (
+          Object.prototype.hasOwnProperty.call(
+            !propsByKey[animationKey],
+            requiredPropName
+          )
+        ) {
           throw new Error(
             `Required prop '${requiredPropName}' is missing from animation with key '${animationKey}'.`
           );
@@ -242,7 +247,7 @@ export function throwIfSerializedAnimationListIsInvalid(
   let knownNames = {};
   for (let key in propsByKey) {
     let name = propsByKey[key].name;
-    if (knownNames.hasOwnProperty(name)) {
+    if (Object.prototype.hasOwnProperty.call(knownNames, name)) {
       throw new Error(`Name "${name}" appears more than once in propsByKey`);
     }
     knownNames[name] = true;

--- a/apps/src/p5lab/spritelab/CoreLibrary.js
+++ b/apps/src/p5lab/spritelab/CoreLibrary.js
@@ -268,7 +268,7 @@ export default class CoreLibrary {
     if (!spriteArg) {
       return [];
     }
-    if (spriteArg.hasOwnProperty('id')) {
+    if (Object.prototype.hasOwnProperty.call(spriteArg, 'id')) {
       let sprite = this.nativeSpriteMap[spriteArg.id];
       if (sprite) {
         return [sprite];

--- a/apps/src/publicKeyCryptography/NumberedSteps.jsx
+++ b/apps/src/publicKeyCryptography/NumberedSteps.jsx
@@ -54,7 +54,7 @@ NumberedSteps.propTypes = {
  * be faded out.
  */
 export function Step(props) {
-  const isStepEnabled = props.hasOwnProperty('requires')
+  const isStepEnabled = Object.prototype.hasOwnProperty.call(props, 'requires')
     ? props.requires
     : true;
   const trStyle = {

--- a/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerEligibility.jsx
+++ b/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerEligibility.jsx
@@ -262,7 +262,10 @@ export default class AmazonFutureEngineerEligibility extends React.Component {
                 required={true}
                 onChange={this.updateFormData}
                 validationState={
-                  this.state.errors.hasOwnProperty('email')
+                  Object.prototype.hasOwnProperty.call(
+                    this.state.errors,
+                    'email'
+                  )
                     ? VALIDATION_STATE_ERROR
                     : null
                 }
@@ -272,7 +275,10 @@ export default class AmazonFutureEngineerEligibility extends React.Component {
                 setField={this.handleSchoolDropdownChange}
                 showRequiredIndicator={true}
                 value={formData.schoolId}
-                showErrorMsg={this.state.errors.hasOwnProperty('schoolId')}
+                showErrorMsg={Object.prototype.hasOwnProperty.call(
+                  this.state.errors,
+                  'schoolId'
+                )}
                 style={styles.schoolInput}
               />
               <Button

--- a/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerEligibilityForm.jsx
+++ b/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerEligibilityForm.jsx
@@ -163,7 +163,7 @@ export default class AmazonFutureEngineerEligibilityForm extends React.Component
   };
 
   checkValidationState = elementId => {
-    return this.state.errors.hasOwnProperty(elementId);
+    return Object.prototype.hasOwnProperty.call(this.state.errors, elementId);
   };
 
   validateRequiredFields = () => {
@@ -232,7 +232,7 @@ export default class AmazonFutureEngineerEligibilityForm extends React.Component
             onChange={this.handleChange}
             defaultValue={this.props.email}
             validationState={
-              this.state.errors.hasOwnProperty('email')
+              Object.prototype.hasOwnProperty.call(this.state.errors, 'email')
                 ? VALIDATION_STATE_ERROR
                 : null
             }
@@ -254,7 +254,10 @@ export default class AmazonFutureEngineerEligibilityForm extends React.Component
             required={true}
             onChange={this.handleChange}
             validationState={
-              this.state.errors.hasOwnProperty('firstName')
+              Object.prototype.hasOwnProperty.call(
+                this.state.errors,
+                'firstName'
+              )
                 ? VALIDATION_STATE_ERROR
                 : null
             }
@@ -266,7 +269,10 @@ export default class AmazonFutureEngineerEligibilityForm extends React.Component
             required={true}
             onChange={this.handleChange}
             validationState={
-              this.state.errors.hasOwnProperty('lastName')
+              Object.prototype.hasOwnProperty.call(
+                this.state.errors,
+                'lastName'
+              )
                 ? VALIDATION_STATE_ERROR
                 : null
             }
@@ -311,7 +317,10 @@ export default class AmazonFutureEngineerEligibilityForm extends React.Component
                 onChange={this.handleChange}
                 value={this.state.consentCSTA}
                 validationState={
-                  this.state.errors.hasOwnProperty('consentCSTA')
+                  Object.prototype.hasOwnProperty.call(
+                    this.state.errors,
+                    'consentCSTA'
+                  )
                     ? VALIDATION_STATE_ERROR
                     : null
                 }
@@ -366,7 +375,10 @@ export default class AmazonFutureEngineerEligibilityForm extends React.Component
             onChange={this.handleChange}
             value={this.state.consentAFE}
             validationState={
-              this.state.errors.hasOwnProperty('consentAFE')
+              Object.prototype.hasOwnProperty.call(
+                this.state.errors,
+                'consentAFE'
+              )
                 ? VALIDATION_STATE_ERROR
                 : null
             }

--- a/apps/src/templates/instructions/InlineAudio.jsx
+++ b/apps/src/templates/instructions/InlineAudio.jsx
@@ -167,7 +167,7 @@ class InlineAudio extends React.Component {
   }
 
   isLocaleSupported() {
-    return VOICES.hasOwnProperty(this.props.locale);
+    return Object.prototype.hasOwnProperty.call(VOICES, this.props.locale);
   }
 
   getAudioSrc() {

--- a/apps/src/templates/sectionAssessments/sectionAssessmentsRedux.js
+++ b/apps/src/templates/sectionAssessments/sectionAssessmentsRedux.js
@@ -1095,7 +1095,8 @@ export const isCurrentScriptCSD = state => {
  *  @returns {boolean} true if current studentId has submitted responses for current script.
  */
 export const currentStudentHasResponses = state => {
-  return !!getAssessmentResponsesForCurrentScript(state).hasOwnProperty(
+  return !!Object.prototype.hasOwnProperty.call(
+    getAssessmentResponsesForCurrentScript(state),
     state.sectionAssessments.studentId
   );
 };

--- a/apps/src/templates/teacherDashboard/EditSectionForm.jsx
+++ b/apps/src/templates/teacherDashboard/EditSectionForm.jsx
@@ -163,7 +163,10 @@ class EditSectionForm extends Component {
           initialCourseVersionId
         ].key
       : null;
-    const course = courseOfferings.hasOwnProperty(section.courseOfferingId)
+    const course = Object.prototype.hasOwnProperty.call(
+      courseOfferings,
+      section.courseOfferingId
+    )
       ? courseOfferings[section.courseOfferingId]
       : null;
     const courseName = course ? course.display_name : null;

--- a/apps/src/weblab/CdoBramble.js
+++ b/apps/src/weblab/CdoBramble.js
@@ -645,7 +645,7 @@ export default class CdoBramble {
       // Regex: Compare without whitespace.
       const projectChanged = Object.keys(startObj).reduce(
         (hasChanged, currentFilename) => {
-          if (!userObj.hasOwnProperty(currentFilename)) {
+          if (!Object.prototype.hasOwnProperty.call(userObj, currentFilename)) {
             hasChanged = true;
           } else {
             const dataChanged =

--- a/apps/test/unit/applab/EventSandboxerTest.js
+++ b/apps/test/unit/applab/EventSandboxerTest.js
@@ -445,8 +445,12 @@ describe('EventSandboxer', function () {
         target: {tagName: 'TEXTAREA', selectionEnd: undefined},
       };
       const newEvent = sandboxer.sandboxEvent(originalEvent);
-      assert.isFalse(newEvent.hasOwnProperty('selectionStart'));
-      assert.isFalse(newEvent.hasOwnProperty('selectionEnd'));
+      assert.isFalse(
+        Object.prototype.hasOwnProperty.call(newEvent, 'selectionStart')
+      );
+      assert.isFalse(
+        Object.prototype.hasOwnProperty.call(newEvent, 'selectionEnd')
+      );
     });
 
     it('does not add selectionStart or selectionEnd to the new event if the target is the range type of INPUT', () => {
@@ -459,8 +463,12 @@ describe('EventSandboxer', function () {
         },
       };
       const newEvent = sandboxer.sandboxEvent(originalEvent);
-      assert.isFalse(newEvent.hasOwnProperty('selectionStart'));
-      assert.isFalse(newEvent.hasOwnProperty('selectionEnd'));
+      assert.isFalse(
+        Object.prototype.hasOwnProperty.call(newEvent, 'selectionStart')
+      );
+      assert.isFalse(
+        Object.prototype.hasOwnProperty.call(newEvent, 'selectionEnd')
+      );
     });
   });
 

--- a/apps/test/unit/lib/tools/jsdebugger/JsDebuggerTest.js
+++ b/apps/test/unit/lib/tools/jsdebugger/JsDebuggerTest.js
@@ -329,7 +329,9 @@ function createOrCaptureSpy(parentObj, methodName) {
   let spyFn, wasCaptured;
 
   beforeEach(() => {
-    if (parentObj[methodName].hasOwnProperty('callCount')) {
+    if (
+      Object.prototype.hasOwnProperty.call(parentObj[methodName], 'callCount')
+    ) {
       // Something is already spying on this method.  Capture the spy for use
       // in our test, and don't clean it up ourselves.
       spyFn = parentObj[methodName];

--- a/apps/test/unit/lib/util/audioApiTest.js
+++ b/apps/test/unit/lib/util/audioApiTest.js
@@ -17,7 +17,7 @@ describe('Audio API', function () {
   // executor because they get aliased.
   it('is internally complete', function () {
     for (let commandName in commands) {
-      if (!commands.hasOwnProperty(commandName)) {
+      if (!Object.prototype.hasOwnProperty.call(commands, commandName)) {
         continue;
       }
       expect(executors).to.have.ownProperty(commandName);
@@ -25,7 +25,7 @@ describe('Audio API', function () {
     }
 
     for (let commandName in executors) {
-      if (!executors.hasOwnProperty(commandName)) {
+      if (!Object.prototype.hasOwnProperty.call(executors, commandName)) {
         continue;
       }
       expect(commands).to.have.ownProperty(commandName);
@@ -33,7 +33,7 @@ describe('Audio API', function () {
     }
 
     for (let commandName in dropletConfig) {
-      if (!dropletConfig.hasOwnProperty(commandName)) {
+      if (!Object.prototype.hasOwnProperty.call(dropletConfig, commandName)) {
         continue;
       }
       expect(dropletConfig[commandName].func).to.equal(commandName);

--- a/apps/test/unit/lib/util/timeoutApiTest.js
+++ b/apps/test/unit/lib/util/timeoutApiTest.js
@@ -34,7 +34,7 @@ describe('Timeout API', () => {
   // executor because they get aliased.
   it('is internally complete', () => {
     for (let commandName in commands) {
-      if (!commands.hasOwnProperty(commandName)) {
+      if (!Object.prototype.hasOwnProperty.call(commands, commandName)) {
         continue;
       }
       expect(executors).to.have.ownProperty(commandName);
@@ -42,7 +42,7 @@ describe('Timeout API', () => {
     }
 
     for (let commandName in executors) {
-      if (!executors.hasOwnProperty(commandName)) {
+      if (!Object.prototype.hasOwnProperty.call(executors, commandName)) {
         continue;
       }
       expect(commands).to.have.ownProperty(commandName);
@@ -50,7 +50,7 @@ describe('Timeout API', () => {
     }
 
     for (let commandName in dropletConfig) {
-      if (!dropletConfig.hasOwnProperty(commandName)) {
+      if (!Object.prototype.hasOwnProperty.call(dropletConfig, commandName)) {
         continue;
       }
       expect(dropletConfig[commandName].func).to.equal(commandName);

--- a/apps/test/unit/netsim/ArgumentUtils.js
+++ b/apps/test/unit/netsim/ArgumentUtils.js
@@ -68,7 +68,7 @@ describe('ArgumentUtils', function () {
       var originalOptions = {a: 1, b: 2, c: 3};
       var options = ArgumentUtils.extendOptionsObject(originalOptions);
       for (var key in originalOptions) {
-        assert(options.hasOwnProperty(key));
+        assert(Object.prototype.hasOwnProperty.call(options, key));
         assert.equal(options[key], originalOptions[key]);
       }
     });

--- a/apps/test/unit/netsim/NetSimLogEntry.js
+++ b/apps/test/unit/netsim/NetSimLogEntry.js
@@ -31,7 +31,7 @@ describe('NetSimLogEntry', function () {
     var logEntry = new NetSimLogEntry(testShard);
     var row = logEntry.buildRow();
 
-    assert(row.hasOwnProperty('nodeID'));
+    assert(Object.prototype.hasOwnProperty.call(row, 'nodeID'));
     assert.isUndefined(row.nodeID);
 
     assert.property(row, 'base64Binary');

--- a/apps/test/util/assertions.js
+++ b/apps/test/util/assertions.js
@@ -35,7 +35,7 @@ export function assertHidden(selector) {
  */
 export function assertOwnProperty(obj, propertyName) {
   assert(
-    obj.hasOwnProperty(propertyName),
+    Object.prototype.hasOwnProperty.call(obj, propertyName),
     'Expected ' +
       obj.constructor.name +
       " to have a property '" +

--- a/apps/test/util/testUtils.js
+++ b/apps/test/util/testUtils.js
@@ -254,7 +254,7 @@ function zeroPadLeft(string, desiredWidth) {
 
 const originalWindowValues = {};
 export function replaceOnWindow(key, newValue) {
-  if (originalWindowValues.hasOwnProperty(key)) {
+  if (Object.prototype.hasOwnProperty.call(originalWindowValues, key)) {
     throw new Error(
       `Can't replace 'window.${key}' - it's already been replaced.`
     );
@@ -264,7 +264,7 @@ export function replaceOnWindow(key, newValue) {
 }
 
 export function restoreOnWindow(key) {
-  if (!originalWindowValues.hasOwnProperty(key)) {
+  if (!Object.prototype.hasOwnProperty.call(originalWindowValues, key)) {
     throw new Error(`Can't restore 'window.${key}' - it wasn't replaced.`);
   }
   window[key] = originalWindowValues[key];


### PR DESCRIPTION
The eslint upgrade added a new rule we were violating, [no-prototype-builtins](https://eslint.org/docs/latest/rules/no-prototype-builtins). The fix is straightforward, it is to move from the syntax `foo.hasOwnProperty("bar");` to `Object.prototype.hasOwnProperty.call(foo, "bar");`. I applied that fix here and enabled the eslint rule again.

Tagging both student learning and teacher tools in this pr as there were files from both teams touched here.
## Links

- jira ticket: [SL-774](https://codedotorg.atlassian.net/browse/SL-774)


## Testing story
Around 75% of the files I touched had corresponding unit test files (and some were themselves unit tests). This gave me enough confidence that this change does work as expected, as I didn't hit any errors beyond finding my own misplacement of a `!`. 


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
