### PR TITLE
Fix Violations of and Reenable `Rails/SquishedSQLHeredocs`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -237,11 +237,6 @@ Rails/RefuteMethods:
 Rails/SkipsModelValidations:
   Enabled: false
 
-# Offense count: 38
-# This cop supports safe auto-correction (--auto-correct).
-Rails/SquishedSQLHeredocs:
-  Enabled: false
-
 # Offense count: 276
 # This cop supports safe auto-correction (--auto-correct).
 # Configuration parameters: EnforcedStyle.

--- a/dashboard/app/models/contact_rollups_final.rb
+++ b/dashboard/app/models/contact_rollups_final.rb
@@ -17,7 +17,7 @@ class ContactRollupsFinal < ApplicationRecord
   self.table_name = 'contact_rollups_final'
 
   def self.insert_from_processed_table
-    insert_sql = <<~SQL
+    insert_sql = <<~SQL.squish
       INSERT INTO #{table_name}
       SELECT *
       FROM contact_rollups_processed;

--- a/dashboard/db/migrate/20130812211107_create_concepts.rb
+++ b/dashboard/db/migrate/20130812211107_create_concepts.rb
@@ -11,7 +11,7 @@ class CreateConcepts < ActiveRecord::Migration[4.2]
       t.references :concept, :level
     end
 
-    execute(<<~SQL)
+    execute(<<~SQL.squish)
       insert into concepts (name, description)
       values
       ('output 1', 'Use functions to trigger actions'),

--- a/dashboard/db/migrate/20150206185854_denormalize_secret_words.rb
+++ b/dashboard/db/migrate/20150206185854_denormalize_secret_words.rb
@@ -1,7 +1,7 @@
 class DenormalizeSecretWords < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :secret_words, :string
-    execute <<~SQL
+    execute <<~SQL.squish
       update users set secret_words =
         (select concat((select word from secret_words where id = secret_word_1_id),
                        ' ',

--- a/dashboard/db/migrate/20160118192602_add_published_column_to_levels.rb
+++ b/dashboard/db/migrate/20160118192602_add_published_column_to_levels.rb
@@ -2,7 +2,7 @@ class AddPublishedColumnToLevels < ActiveRecord::Migration[4.2]
   def up
     add_column :levels, :published, :boolean, default: 0
 
-    execute <<-SQL
+    execute <<-SQL.squish
       update levels set published = 1 where published is NULL
     SQL
 

--- a/dashboard/db/migrate/20160205205103_ensure_cohorts_id_column_is_first.rb
+++ b/dashboard/db/migrate/20160205205103_ensure_cohorts_id_column_is_first.rb
@@ -6,7 +6,7 @@
 # dump consistency logic to throw an exception.
 class EnsureCohortsIdColumnIsFirst < ActiveRecord::Migration[4.2]
   def change
-    execute <<-SQL
+    execute <<-SQL.squish
       ALTER TABLE cohorts_districts CHANGE column id id INT(11) NOT NULL AUTO_INCREMENT FIRST;
     SQL
   end

--- a/dashboard/db/migrate/20220701192307_rename_versions_to_commits.rb
+++ b/dashboard/db/migrate/20220701192307_rename_versions_to_commits.rb
@@ -2,13 +2,13 @@ class RenameVersionsToCommits < ActiveRecord::Migration[6.0]
   def up
     rename_table :project_versions, :project_commits
 
-    execute <<-SQL
+    execute <<-SQL.squish
       CREATE VIEW project_versions AS SELECT * from project_commits;
     SQL
   end
 
   def down
-    execute <<-SQL
+    execute <<-SQL.squish
       DROP VIEW project_versions;
     SQL
 

--- a/dashboard/db/migrate/20220713165055_drop_project_versions_view.rb
+++ b/dashboard/db/migrate/20220713165055_drop_project_versions_view.rb
@@ -1,12 +1,12 @@
 class DropProjectVersionsView < ActiveRecord::Migration[6.0]
   def up
-    execute <<-SQL
+    execute <<-SQL.squish
       DROP VIEW project_versions;
     SQL
   end
 
   def down
-    execute <<-SQL
+    execute <<-SQL.squish
       CREATE VIEW project_versions AS SELECT * from project_commits;
     SQL
   end

--- a/dashboard/db/migrate/20220920231241_rename_code_review_notes_to_comments.rb
+++ b/dashboard/db/migrate/20220920231241_rename_code_review_notes_to_comments.rb
@@ -2,13 +2,13 @@ class RenameCodeReviewNotesToComments < ActiveRecord::Migration[6.0]
   def up
     rename_table :code_review_notes, :code_review_comments
 
-    execute <<-SQL
+    execute <<-SQL.squish
       CREATE VIEW code_review_notes AS SELECT * from code_review_comments;
     SQL
   end
 
   def down
-    execute <<-SQL
+    execute <<-SQL.squish
       DROP VIEW code_review_notes;
     SQL
 

--- a/dashboard/db/migrate/20220927170718_drop_code_review_notes_view.rb
+++ b/dashboard/db/migrate/20220927170718_drop_code_review_notes_view.rb
@@ -1,12 +1,12 @@
 class DropCodeReviewNotesView < ActiveRecord::Migration[6.0]
   def up
-    execute <<-SQL
+    execute <<-SQL.squish
       DROP VIEW code_review_notes;
     SQL
   end
 
   def down
-    execute <<-SQL
+    execute <<-SQL.squish
       CREATE VIEW code_review_notes AS SELECT * from code_review_comments;
     SQL
   end

--- a/dashboard/lib/services/registration_reminder.rb
+++ b/dashboard/lib/services/registration_reminder.rb
@@ -52,17 +52,17 @@ class Services::RegistrationReminder
     # - Exclude applications created prior to the fall 2019 application season, when this feature launched.
     # - SELECT DISTINCT since we never want to list an application more than once.
     Pd::Application::ApplicationBase.
-      joins(<<~SQL).
+      joins(<<~SQL.squish).
         inner join pd_application_emails accepted
         on pd_applications.id = accepted.pd_application_id
         and accepted.email_type = 'accepted'
       SQL
-      joins(<<~SQL).
+      joins(<<~SQL.squish).
         left outer join pd_application_emails registration_reminder
         on pd_applications.id = registration_reminder.pd_application_id
         and registration_reminder.email_type = 'registration_reminder'
       SQL
-      joins(<<~SQL).
+      joins(<<~SQL.squish).
         left outer join pd_enrollments
         on pd_applications.user_id = pd_enrollments.user_id
         and pd_enrollments.created_at >= accepted.sent_at

--- a/dashboard/test/helpers/delete_accounts_helper_test.rb
+++ b/dashboard/test/helpers/delete_accounts_helper_test.rb
@@ -966,7 +966,7 @@ class DeleteAccountsHelperTest < ActionView::TestCase
   test "clears form_data from pd_facilitator_program_registrations" do
     teacher = create :teacher
     ActiveRecord::Base.connection.exec_query(
-      <<-SQL
+      <<-SQL.squish
         INSERT INTO `pd_facilitator_program_registrations` (user_id, form_data, created_at, updated_at)
         VALUES (#{teacher.id}, '{\"country\": \"USA\"}', '#{Time.now.to_s(:db)}', '#{Time.now.to_s(:db)}')
     SQL
@@ -989,7 +989,7 @@ class DeleteAccountsHelperTest < ActionView::TestCase
   test "clears form_data from pd_fit_weekend1819_registrations" do
     application = create :pd_teacher_application
     ActiveRecord::Base.connection.exec_query(
-      <<-SQL
+      <<-SQL.squish
         INSERT INTO `pd_fit_weekend1819_registrations` (pd_application_id, form_data, created_at, updated_at)
         VALUES (#{application.id}, '{\"country\": \"USA\"}', '#{Time.now.to_s(:db)}', '#{Time.now.to_s(:db)}')
     SQL
@@ -1012,7 +1012,7 @@ class DeleteAccountsHelperTest < ActionView::TestCase
   test "clears form_data from pd_fit_weekend_registrations" do
     application = create :pd_teacher_application
     ActiveRecord::Base.connection.exec_query(
-      <<-SQL
+      <<-SQL.squish
         INSERT INTO `pd_fit_weekend_registrations` (pd_application_id, registration_year, form_data, created_at, updated_at)
         VALUES (#{application.id}, '2019-2020', '{\"country\": \"USA\"}', '#{Time.now.to_s(:db)}', '#{Time.now.to_s(:db)}')
     SQL
@@ -1086,7 +1086,7 @@ class DeleteAccountsHelperTest < ActionView::TestCase
   test "clears form_data from pd_regional_partner_program_registrations" do
     teacher = create :teacher
     ActiveRecord::Base.connection.exec_query(
-      <<-SQL
+      <<-SQL.squish
         INSERT INTO `pd_regional_partner_program_registrations` (user_id, form_data, teachercon, created_at, updated_at)
         VALUES (#{teacher.id}, '{\"country\": \"USA\"}', 1, '#{Time.now.to_s(:db)}', '#{Time.now.to_s(:db)}')
     SQL
@@ -1104,7 +1104,7 @@ class DeleteAccountsHelperTest < ActionView::TestCase
   test "sets invalid teachercon from pd_regional_partner_program_registrations" do
     teacher = create :teacher
     ActiveRecord::Base.connection.exec_query(
-      <<-SQL
+      <<-SQL.squish
         INSERT INTO `pd_regional_partner_program_registrations` (user_id, form_data, teachercon, created_at, updated_at)
         VALUES (#{teacher.id}, '{\"country\": \"USA\"}', 1, '#{Time.now.to_s(:db)}', '#{Time.now.to_s(:db)}')
     SQL
@@ -1126,7 +1126,7 @@ class DeleteAccountsHelperTest < ActionView::TestCase
   test "clears form_data from pd_teachercon1819_registrations" do
     teacher = create :teacher
     ActiveRecord::Base.connection.exec_query(
-      <<-SQL
+      <<-SQL.squish
         INSERT INTO `pd_teachercon1819_registrations` (user_id, form_data, created_at, updated_at)
         VALUES (#{teacher.id}, '{\"country\": \"USA\"}', '#{Time.now.to_s(:db)}', '#{Time.now.to_s(:db)}')
     SQL
@@ -1166,7 +1166,7 @@ class DeleteAccountsHelperTest < ActionView::TestCase
     secondary_email = 'secondary@email.com'
 
     ActiveRecord::Base.connection.exec_query(
-      <<-SQL
+      <<-SQL.squish
         INSERT INTO `pd_teacher_applications` (user_id, primary_email, secondary_email, created_at, updated_at, application)
         VALUES (#{user.id}, '#{user.email}', '#{secondary_email}', '#{Time.now.to_s(:db)}', '#{Time.now.to_s(:db)}', '{}')
       SQL
@@ -1186,7 +1186,7 @@ class DeleteAccountsHelperTest < ActionView::TestCase
     secondary_email = 'secondary@email.com'
 
     ActiveRecord::Base.connection.exec_query(
-      <<-SQL
+      <<-SQL.squish
         INSERT INTO `pd_teacher_applications` (user_id, primary_email, secondary_email, created_at, updated_at, application)
         VALUES (#{user.id}, '#{user.email}', '#{secondary_email}', '#{Time.now.to_s(:db)}', '#{Time.now.to_s(:db)}', '{}')
       SQL
@@ -1206,7 +1206,7 @@ class DeleteAccountsHelperTest < ActionView::TestCase
     secondary_email = 'secondary@email.com'
 
     ActiveRecord::Base.connection.exec_query(
-      <<-SQL
+      <<-SQL.squish
         INSERT INTO `pd_teacher_applications` (user_id, primary_email, secondary_email, created_at, updated_at, application)
         VALUES (#{user.id}, '#{user.email}', '#{secondary_email}', '#{Time.now.to_s(:db)}', '#{Time.now.to_s(:db)}', '{\"primaryEmail\": \"#{user.email}\"}')
       SQL

--- a/dashboard/test/models/contact_rollups_raw_test.rb
+++ b/dashboard/test/models/contact_rollups_raw_test.rb
@@ -65,7 +65,7 @@ class ContactRollupsRawTest < ActiveSupport::TestCase
 
     # we're not actually interested in user IDs in contact rollups
     # just a simple example of something we could extract in a subquery
-    subquery = <<~SQL
+    subquery = <<~SQL.squish
       SELECT parent_email AS email, MAX(updated_at) AS updated_at, MAX(id) AS higher_student_id
       FROM users
       GROUP BY parent_email
@@ -85,7 +85,7 @@ class ContactRollupsRawTest < ActiveSupport::TestCase
 
   test 'get_extraction_query looks as expected when called with a single column' do
     select_query = 'SELECT email, opt_in, updated_at FROM email_preferences'
-    expected_sql = <<~SQL
+    expected_sql = <<~SQL.squish
       INSERT INTO #{ContactRollupsRaw.table_name}
         (email, sources, data, data_updated_at, created_at, updated_at)
       SELECT
@@ -104,7 +104,7 @@ class ContactRollupsRawTest < ActiveSupport::TestCase
 
   test 'get_extraction_query looks as expected when called with multiple columns' do
     select_query = 'SELECT email, birthday, gender, updated_at FROM users'
-    expected_sql = <<~SQL
+    expected_sql = <<~SQL.squish
       INSERT INTO #{ContactRollupsRaw.table_name}
         (email, sources, data, data_updated_at, created_at, updated_at)
       SELECT


### PR DESCRIPTION
> Checks SQL heredocs to use ‘.squish`.

Fix applied automatically with `bundle exec rubocop --auto-correct-all --only Rails/SquishedSQLHeredocs`

## Links

- https://apidock.com/rails/String/squish
- https://www.rubydoc.info/gems/rubocop-rails/RuboCop/Cop/Rails/SquishedSQLHeredocs
- https://docs.rubocop.org/rubocop-rails/cops_rails.html#railssquishedsqlheredocs

## Deployment Strategy

Because this makes changes to some old migration files, the DOTD will be warned about this PR before it is deployed to production. The changes are non-breaking and the migrations are old, so it's entirely safe to deploy; we just need to make sure we let the DOTD know in advance to minimize disruption.