### PR TITLE
Switch Music Lab to use remote storage as default

### DIFF
--- a/apps/src/music/blockly/MusicBlocklyWorkspace.js
+++ b/apps/src/music/blockly/MusicBlocklyWorkspace.js
@@ -6,7 +6,7 @@ import {getToolbox} from './toolbox';
 import FieldSounds from './FieldSounds';
 import FieldPattern from './FieldPattern';
 import AppConfig, {getBlockMode} from '../appConfig';
-import {BlockMode, LOCAL_STORAGE, REMOTE_STORAGE} from '../constants';
+import {BlockMode, REMOTE_STORAGE} from '../constants';
 import {
   DEFAULT_TRACK_NAME_EXTENSION,
   DYNAMIC_TRIGGER_EXTENSION,
@@ -398,11 +398,11 @@ export default class MusicBlocklyWorkspace {
   }
 
   // Get the project manager for the current storage type.
-  // If no storage type is specified in AppConfig, use local storage.
+  // If no storage type is specified in AppConfig, use remote storage.
   getProjectManager(appOptions) {
     let storageType = AppConfig.getValue('storage-type');
     if (!storageType) {
-      storageType = LOCAL_STORAGE;
+      storageType = REMOTE_STORAGE;
     }
     storageType = storageType.toLowerCase();
 

--- a/apps/src/musicMenu/MusicMenu.jsx
+++ b/apps/src/musicMenu/MusicMenu.jsx
@@ -89,8 +89,8 @@ const optionsList = [
     name: 'storage-type',
     type: 'radio',
     values: [
-      {value: LOCAL_STORAGE, description: 'Save to local storage (default).'},
-      {value: REMOTE_STORAGE, description: 'Save to remote storage.'},
+      {value: LOCAL_STORAGE, description: 'Save to local storage.'},
+      {value: REMOTE_STORAGE, description: 'Save to remote storage (default).'},
     ],
   },
 ];


### PR DESCRIPTION
The new projects client has been running on local storage in Music Lab since Friday. We can safely switch over to the remote storage version of the client as the default now. This will make upcoming work around the projects client and reloading easier.

## Testing story
Tested the remote storage is now the default. You can still use local storage with the query parameter `?storage-type=local`

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
