### PR TITLE
Revert "Update `annotate` Gem to 3.2.0"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,7 +63,7 @@ gem 'memory_profiler'
 gem 'rack-mini-profiler'
 
 group :development do
-  gem 'annotate', '~> 3.2'
+  gem 'annotate', '~> 3.1.1'
   gem 'aws-google', '~> 0.2.0'
   gem 'web-console', '~> 4.2.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -205,8 +205,8 @@ GEM
       public_suffix (>= 2.0.2, < 6.0)
     aes_key_wrap (1.0.1)
     afm (0.2.2)
-    annotate (3.2.0)
-      activerecord (>= 3.2, < 8.0)
+    annotate (3.1.1)
+      activerecord (>= 3.2, < 7.0)
       rake (>= 10.4, < 14.0)
     ansi (1.5.0)
     ast (2.4.2)
@@ -901,7 +901,7 @@ DEPENDENCIES
   activerecord-import (~> 1.0.3)
   acts_as_list
   addressable
-  annotate (~> 3.2)
+  annotate (~> 3.1.1)
   auto_strip_attributes (~> 2.1)
   aws-google (~> 0.2.0)
   aws-sdk-acm

--- a/dashboard/config/application.rb
+++ b/dashboard/config/application.rb
@@ -156,6 +156,15 @@ module Dashboard
     config.autoload_paths << Rails.root.join('app', 'models', 'sections')
     config.autoload_paths << Rails.root.join('../lib/cdo/shared_constants')
 
+    # Make sure to explicitly cast all autoload paths to strings; the gem we use to
+    # annotate model files with schema descriptions doesn't know how to deal with
+    # Pathnames. See https://github.com/ctran/annotate_models/issues/758
+    #
+    # We have a PR opened with a fix at https://github.com/ctran/annotate_models/pull/848;
+    # once a version of the gem is released which includes that change, we can get rid of
+    # this line.
+    config.autoload_paths.map!(&:to_s)
+
     # Also make sure some of these directories are always loaded up front in production
     # environments.
     #


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#51587; this is still causing problems just like it did last time I tried it :upside_down_face: 

See thread at https://codedotorg.slack.com/archives/C0T0PNTM3/p1683120291202649 for details