### PR TITLE
Add Poem Lab Validation for Text Highlighting

### DIFF
--- a/apps/src/p5lab/poetry/PoetryLibrary.js
+++ b/apps/src/p5lab/poetry/PoetryLibrary.js
@@ -225,6 +225,7 @@ export default class PoetryLibrary extends CoreLibrary {
         this.validationInfo.foregroundEffects = this.foregroundEffects.map(
           effect => effect.name
         );
+        this.validationInfo.highlightColor = this.poemState.text.highlightColor;
         return this.validationInfo;
       },
 

--- a/apps/src/p5lab/poetry/PoetryLibrary.js
+++ b/apps/src/p5lab/poetry/PoetryLibrary.js
@@ -226,6 +226,7 @@ export default class PoetryLibrary extends CoreLibrary {
           effect => effect.name
         );
         this.validationInfo.highlightColor = this.poemState.text.highlightColor;
+        this.validationInfo.frameType = this.poemState.frameType;
         return this.validationInfo;
       },
 


### PR DESCRIPTION
## The Problem:

There currently isn't a way to write validation code to check if a user used a text highlight as one option for "adding colors or effects to your poem"

![image](https://user-images.githubusercontent.com/68714964/236007480-373d502d-d274-424b-8f6d-e5502970a9d0.png)


## The Solution:

Added to the existing `getValidationInfo()` function to include the text highlight color with the validation object that's returned.

## Small update

Needed to make a similar small change to be able to capture `frameType` as well so we can validate things like this:

![image](https://user-images.githubusercontent.com/68714964/236010209-87fd93e8-5289-4415-ae60-10b4bd281800.png)


<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
