### PR TITLE
Add new React Bootstrap version

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -31,7 +31,11 @@ module.exports = {
     // TODO: Turn back to error once we've fixed all the existing warnings
     "no-prototype-builtins": "off",
     "no-redeclare": ["error", { builtinGlobals: true }],
-    "no-restricted-imports": ["error", "radium"],
+
+    // In Feb 2022, we voted to deprecate Radium (proposal at https://docs.google.com/document/d/1Y3uK_iYMhTUaCI6yIDwOAMprIJCuzXSs2fECQggwp60/edit#heading=h.htf3pg55q2kt)
+    // We are now using 'react-bootstrap-2'. See further work at https://github.com/code-dot-org/code-dot-org/pull/51681
+    "no-restricted-imports": ["error", "radium", "react-bootstrap"],
+
     "no-trailing-spaces": "error",
     "no-undef": "error",
     "no-unused-vars": ["error", { args: "none" }],

--- a/apps/package.json
+++ b/apps/package.json
@@ -285,6 +285,7 @@
     "query-string": "4.1.0",
     "react-ace": "^9.2.1",
     "react-beautiful-dnd": "^13.1.0",
+    "react-bootstrap-2": "npm:react-bootstrap@^2.7.4",
     "react-csv": "^2.0.3",
     "react-debounce-input": "^3.2.2",
     "react-dom-confetti": "^0.2.0",

--- a/apps/src/code-studio/pd/application/PrivacyDialog.jsx
+++ b/apps/src/code-studio/pd/application/PrivacyDialog.jsx
@@ -4,7 +4,7 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import {Modal, Button} from 'react-bootstrap';
+import {Modal, Button} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import color from '@cdo/apps/util/color';
 import {PrivacyDialogMode} from '../constants';
 

--- a/apps/src/code-studio/pd/application/principalApproval/PrincipalApprovalComponent.jsx
+++ b/apps/src/code-studio/pd/application/principalApproval/PrincipalApprovalComponent.jsx
@@ -1,6 +1,6 @@
 import React, {useState} from 'react';
 import PropTypes from 'prop-types';
-import {FormGroup, Row, Col, ControlLabel} from 'react-bootstrap';
+import {FormGroup, Row, Col, ControlLabel} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import {
   PageLabels,
   TextFields,

--- a/apps/src/code-studio/pd/application/teacher/AboutYou.jsx
+++ b/apps/src/code-studio/pd/application/teacher/AboutYou.jsx
@@ -7,7 +7,7 @@ import {
   TextFields,
 } from '@cdo/apps/generated/pd/teacherApplicationConstants';
 import {isEmail, isZipCode} from '@cdo/apps/util/formatValidation';
-import {FormGroup, Row, Col} from 'react-bootstrap';
+import {FormGroup, Row, Col} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import {LabelsContext} from '../../form_components_func/LabeledFormComponent';
 import {LabeledRadioButtons} from '../../form_components_func/labeled/LabeledRadioButtons';
 import {LabeledCheckBoxesWithAdditionalTextFields} from '../../form_components_func/labeled/LabeledCheckBoxes';

--- a/apps/src/code-studio/pd/application/teacher/AdditionalDemographicInformation.jsx
+++ b/apps/src/code-studio/pd/application/teacher/AdditionalDemographicInformation.jsx
@@ -7,7 +7,7 @@ import {
   TextFields,
 } from '@cdo/apps/generated/pd/teacherApplicationConstants';
 import {PROGRAM_CSA} from './TeacherApplicationConstants';
-import {FormGroup} from 'react-bootstrap';
+import {FormGroup} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import {LabelsContext} from '../../form_components_func/LabeledFormComponent';
 import {FormContext} from '../../form_components_func/FormComponent';
 import {

--- a/apps/src/code-studio/pd/application/teacher/AdministratorInformation.jsx
+++ b/apps/src/code-studio/pd/application/teacher/AdministratorInformation.jsx
@@ -3,7 +3,7 @@ import {
   PageLabels,
   SectionHeaders,
 } from '@cdo/apps/generated/pd/teacherApplicationConstants';
-import {FormGroup} from 'react-bootstrap';
+import {FormGroup} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import PropTypes from 'prop-types';
 import {LabelsContext} from '../../form_components_func/LabeledFormComponent';
 import {FormContext} from '../../form_components_func/FormComponent';

--- a/apps/src/code-studio/pd/application/teacher/ChooseYourProgram.jsx
+++ b/apps/src/code-studio/pd/application/teacher/ChooseYourProgram.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {FormGroup} from 'react-bootstrap';
+import {FormGroup} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import {
   PageLabels,
   SectionHeaders,

--- a/apps/src/code-studio/pd/application/teacher/FindYourRegion.jsx
+++ b/apps/src/code-studio/pd/application/teacher/FindYourRegion.jsx
@@ -1,5 +1,6 @@
 import React, {useEffect, useState} from 'react';
 import PropTypes from 'prop-types';
+/* eslint-disable no-restricted-imports */
 import {
   FormGroup,
   ControlLabel,
@@ -8,6 +9,7 @@ import {
   Row,
   Col,
 } from 'react-bootstrap';
+/* eslint-enable no-restricted-imports */
 import {styles} from './TeacherApplicationConstants';
 import {
   PageLabels,

--- a/apps/src/code-studio/pd/application/teacher/ImplementationPlan.jsx
+++ b/apps/src/code-studio/pd/application/teacher/ImplementationPlan.jsx
@@ -13,7 +13,7 @@ import {
   TextFields,
   Year,
 } from '@cdo/apps/generated/pd/teacherApplicationConstants';
-import {FormGroup} from 'react-bootstrap';
+import {FormGroup} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import {LabelsContext} from '../../form_components_func/LabeledFormComponent';
 import {FormContext} from '../../form_components_func/FormComponent';
 import {LabeledCheckBoxes} from '../../form_components_func/labeled/LabeledCheckBoxes';

--- a/apps/src/code-studio/pd/application/teacher/ProfessionalLearningProgramRequirements.jsx
+++ b/apps/src/code-studio/pd/application/teacher/ProfessionalLearningProgramRequirements.jsx
@@ -5,7 +5,7 @@ import {
   SectionHeaders,
   TextFields,
 } from '@cdo/apps/generated/pd/teacherApplicationConstants';
-import {FormGroup} from 'react-bootstrap';
+import {FormGroup} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import {
   PROGRAM_CSD,
   PROGRAM_CSP,

--- a/apps/src/code-studio/pd/application_dashboard/admin_navigation_buttons.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/admin_navigation_buttons.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import {Button} from 'react-bootstrap';
+import {Button} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 
 export default class AdminNavigationButtons extends React.Component {
   static contextTypes = {

--- a/apps/src/code-studio/pd/application_dashboard/applicant_search.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/applicant_search.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import color from '@cdo/apps/util/color';
+/* eslint-disable no-restricted-imports */
 import {
   Form,
   FormGroup,
@@ -7,6 +8,7 @@ import {
   FormControl,
   Button,
 } from 'react-bootstrap';
+/* eslint-enable no-restricted-imports */
 import $ from 'jquery';
 import {Link} from 'react-router';
 import {getPathToApplication} from '@cdo/apps/code-studio/pd/application_dashboard/pathToApplicationHelper';

--- a/apps/src/code-studio/pd/application_dashboard/cohort_calculator.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/cohort_calculator.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import {Table} from 'react-bootstrap';
+import {Table} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import {RegionalPartnerValuePropType} from '../components/regional_partner_dropdown';
 import {CohortCalculatorStatuses} from '@cdo/apps/generated/pd/sharedApplicationConstants';
 import $ from 'jquery';

--- a/apps/src/code-studio/pd/application_dashboard/cohort_view.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/cohort_view.jsx
@@ -11,7 +11,7 @@ import CohortCalculator, {countAcceptedApplications} from './cohort_calculator';
 import RegionalPartnerDropdown, {
   RegionalPartnerPropType,
 } from '../components/regional_partner_dropdown';
-import {Button, Col, Row} from 'react-bootstrap';
+import {Button, Col, Row} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 
 class CohortView extends React.Component {
   static propTypes = {

--- a/apps/src/code-studio/pd/application_dashboard/cohort_view_table.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/cohort_view_table.jsx
@@ -5,7 +5,7 @@ import ReactTooltip from 'react-tooltip';
 import * as Table from 'reactabular-table';
 import * as sort from 'sortabular';
 import color from '@cdo/apps/util/color';
-import {Button} from 'react-bootstrap';
+import {Button} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import _, {orderBy} from 'lodash';
 import moment from 'moment';
 import wrappedSortable from '@cdo/apps/templates/tables/wrapped_sortable';

--- a/apps/src/code-studio/pd/application_dashboard/detail_view/change_log.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/detail_view/change_log.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import {Table} from 'react-bootstrap';
+import {Table} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 
 export default class ChangeLog extends React.Component {
   static propTypes = {

--- a/apps/src/code-studio/pd/application_dashboard/detail_view_contents.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/detail_view_contents.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';
+/* eslint-disable no-restricted-imports */
 import {
   Row,
   Col,
@@ -11,6 +12,7 @@ import {
   InputGroup,
   Table,
 } from 'react-bootstrap';
+/* eslint-enable no-restricted-imports */
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
 import $ from 'jquery';
 import {

--- a/apps/src/code-studio/pd/application_dashboard/form_data_edit.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/form_data_edit.jsx
@@ -5,6 +5,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
+/* eslint-disable no-restricted-imports */
 import {
   FormGroup,
   ControlLabel,
@@ -14,6 +15,7 @@ import {
   Panel,
   Table,
 } from 'react-bootstrap';
+/* eslint-enable no-restricted-imports */
 import parseJson from 'json-parse-better-errors';
 import color from '@cdo/apps/util/color';
 

--- a/apps/src/code-studio/pd/application_dashboard/principal_approval_buttons.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/principal_approval_buttons.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import $ from 'jquery';
-import {Button} from 'react-bootstrap';
+import {Button} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import Spinner from '../components/spinner.jsx';
 import ConfirmationDialog from '../components/confirmation_dialog';
 import {SendAdminApprovalEmailStatuses} from '@cdo/apps/generated/pd/teacherApplicationConstants';

--- a/apps/src/code-studio/pd/application_dashboard/quick_view.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/quick_view.jsx
@@ -21,7 +21,7 @@ import QuickViewTable from './quick_view_table';
 import Spinner from '../components/spinner';
 import $ from 'jquery';
 import {getApplicationStatuses} from './constants';
-import {Button, FormGroup, ControlLabel, Row, Col} from 'react-bootstrap';
+import {Button, FormGroup, ControlLabel, Row, Col} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 
 export class QuickView extends React.Component {
   static propTypes = {

--- a/apps/src/code-studio/pd/application_dashboard/quick_view_table.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/quick_view_table.jsx
@@ -5,7 +5,7 @@ import ReactTooltip from 'react-tooltip';
 import * as Table from 'reactabular-table';
 import * as sort from 'sortabular';
 import color from '@cdo/apps/util/color';
-import {Button} from 'react-bootstrap';
+import {Button} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import _, {orderBy} from 'lodash';
 import {StatusColors, getApplicationStatuses} from './constants';
 import wrappedSortable from '@cdo/apps/templates/tables/wrapped_sortable';

--- a/apps/src/code-studio/pd/application_dashboard/summary.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/summary.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';
 import SummaryTable from './summary_table';
-import {Row, Col} from 'react-bootstrap';
+import {Row, Col} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import {mapValues, omit} from 'lodash';
 import RegionalPartnerDropdown, {
   RegionalPartnerPropType,

--- a/apps/src/code-studio/pd/application_dashboard/summary_table.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/summary_table.jsx
@@ -3,7 +3,7 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import {Table, Button} from 'react-bootstrap';
+import {Table, Button} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import {StatusColors, getApplicationStatuses} from './constants';
 import {difference, upperFirst} from 'lodash';
 import color from '@cdo/apps/util/color';

--- a/apps/src/code-studio/pd/components/confirmation_dialog.jsx
+++ b/apps/src/code-studio/pd/components/confirmation_dialog.jsx
@@ -3,7 +3,7 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import {Modal, Button} from 'react-bootstrap';
+import {Modal, Button} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 
 export default class ConfirmationDialog extends React.Component {
   static propTypes = {

--- a/apps/src/code-studio/pd/components/customSchoolInfo.jsx
+++ b/apps/src/code-studio/pd/components/customSchoolInfo.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import {FormGroup, ControlLabel, HelpBlock} from 'react-bootstrap';
+import {FormGroup, ControlLabel, HelpBlock} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import Select from 'react-select';
 import {ButtonList} from '../form_components/ButtonList.jsx';
 import FieldGroup from '../form_components/FieldGroup';

--- a/apps/src/code-studio/pd/components/header.jsx
+++ b/apps/src/code-studio/pd/components/header.jsx
@@ -4,7 +4,7 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import {Breadcrumb} from 'react-bootstrap';
+import {Breadcrumb} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 
 export default class Header extends React.Component {
   static contextTypes = {

--- a/apps/src/code-studio/pd/components/regional_partner_dropdown.jsx
+++ b/apps/src/code-studio/pd/components/regional_partner_dropdown.jsx
@@ -6,7 +6,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';
-import {FormGroup, ControlLabel} from 'react-bootstrap';
+import {FormGroup, ControlLabel} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import Select from 'react-select';
 import {SelectStyleProps} from '../constants';
 import {setRegionalPartnerFilter} from './regional_partners_reducers';

--- a/apps/src/code-studio/pd/components/scholarshipDropdown.jsx
+++ b/apps/src/code-studio/pd/components/scholarshipDropdown.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import {FormGroup} from 'react-bootstrap';
+import {FormGroup} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import Select from 'react-select';
 
 // update this to lock scholarships so that scholarship status can't be updated via the UI.

--- a/apps/src/code-studio/pd/components/schoolAutocompleteDropdownWithCustomFields.jsx
+++ b/apps/src/code-studio/pd/components/schoolAutocompleteDropdownWithCustomFields.jsx
@@ -4,7 +4,7 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import {FormGroup, Row, Col, ControlLabel, HelpBlock} from 'react-bootstrap';
+import {FormGroup, Row, Col, ControlLabel, HelpBlock} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import SchoolAutocompleteDropdown from '@cdo/apps/templates/SchoolAutocompleteDropdown';
 import CustomSchoolInfo from './customSchoolInfo';
 import {SchoolInfoPropType} from './constants';

--- a/apps/src/code-studio/pd/foorm/Foorm.jsx
+++ b/apps/src/code-studio/pd/foorm/Foorm.jsx
@@ -1,7 +1,7 @@
 import * as Survey from 'survey-react';
 import PropTypes from 'prop-types';
 import React from 'react';
-import {Button} from 'react-bootstrap';
+import {Button} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import Spinner from '../components/spinner';
 
 const SPINNER_WAIT_MS = 2000;

--- a/apps/src/code-studio/pd/foorm/editor/components/FoormEntityEditor.jsx
+++ b/apps/src/code-studio/pd/foorm/editor/components/FoormEntityEditor.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {connect} from 'react-redux';
 import PropTypes from 'prop-types';
-import {Tabs, Tab} from 'react-bootstrap';
+import {Tabs, Tab} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import FoormEntityEditorPreview from './FoormEntityEditorPreview';
 import FoormEntityEditorHeader from './FoormEntityEditorHeader';
 import _ from 'lodash';

--- a/apps/src/code-studio/pd/foorm/editor/components/FoormEntityEditorHeader.jsx
+++ b/apps/src/code-studio/pd/foorm/editor/components/FoormEntityEditorHeader.jsx
@@ -1,7 +1,7 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import ToggleGroup from '@cdo/apps/templates/ToggleGroup';
-import {Button} from 'react-bootstrap';
+import {Button} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import Spinner from '../../../components/spinner';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
 import moment from 'moment';

--- a/apps/src/code-studio/pd/foorm/editor/components/FoormEntityLoadButtons.jsx
+++ b/apps/src/code-studio/pd/foorm/editor/components/FoormEntityLoadButtons.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {connect} from 'react-redux';
 import PropTypes from 'prop-types';
-import {Button} from 'react-bootstrap';
+import {Button} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import loadable from '@cdo/apps/util/loadable';
 const VirtualizedSelect = loadable(() =>
   import('@cdo/apps/templates/VirtualizedSelect')

--- a/apps/src/code-studio/pd/foorm/editor/form/FoormFormSaveBar.jsx
+++ b/apps/src/code-studio/pd/foorm/editor/form/FoormFormSaveBar.jsx
@@ -4,6 +4,7 @@ import color from '@cdo/apps/util/color';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
 import ConfirmationDialog from '../../../components/confirmation_dialog';
 import {connect} from 'react-redux';
+/* eslint-disable no-restricted-imports */
 import {
   Modal,
   FormGroup,
@@ -11,6 +12,7 @@ import {
   Button,
   FormControl,
 } from 'react-bootstrap';
+/* eslint-enable no-restricted-imports */
 import Select from 'react-select/lib/Select';
 import {SelectStyleProps} from '../../../constants';
 import 'react-select/dist/react-select.css';

--- a/apps/src/code-studio/pd/foorm/editor/library/FoormLibrarySaveBar.jsx
+++ b/apps/src/code-studio/pd/foorm/editor/library/FoormLibrarySaveBar.jsx
@@ -4,6 +4,7 @@ import color from '@cdo/apps/util/color';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
 import ConfirmationDialog from '../../../components/confirmation_dialog';
 import {connect} from 'react-redux';
+/* eslint-disable no-restricted-imports */
 import {
   Modal,
   FormGroup,
@@ -11,6 +12,7 @@ import {
   Button,
   FormControl,
 } from 'react-bootstrap';
+/* eslint-enable no-restricted-imports */
 import Select from 'react-select/lib/Select';
 import {SelectStyleProps} from '../../../constants';
 import 'react-select/dist/react-select.css';

--- a/apps/src/code-studio/pd/form_components/ButtonList.jsx
+++ b/apps/src/code-studio/pd/form_components/ButtonList.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import _ from 'lodash';
+/* eslint-disable no-restricted-imports */
 import {
   Radio,
   Checkbox,
@@ -8,6 +9,7 @@ import {
   FormGroup,
   HelpBlock,
 } from 'react-bootstrap';
+/* eslint-enable no-restricted-imports */
 
 import utils from './utils';
 

--- a/apps/src/code-studio/pd/form_components/FieldGroup.jsx
+++ b/apps/src/code-studio/pd/form_components/FieldGroup.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+/* eslint-disable no-restricted-imports */
 import {
   ControlLabel,
   FormControl,
@@ -8,6 +9,7 @@ import {
   Row,
   Col,
 } from 'react-bootstrap';
+/* eslint-enable no-restricted-imports */
 
 const REQUIRED = <span style={{color: 'red'}}>&nbsp;*</span>;
 

--- a/apps/src/code-studio/pd/form_components/FormController.jsx
+++ b/apps/src/code-studio/pd/form_components/FormController.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import $ from 'jquery';
-import {Button, Alert, FormGroup} from 'react-bootstrap';
+import {Button, Alert, FormGroup} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import {Pagination} from '@react-bootstrap/pagination';
 import i18n from '@cdo/locale';
 

--- a/apps/src/code-studio/pd/form_components/FormController.story.jsx
+++ b/apps/src/code-studio/pd/form_components/FormController.story.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {FormGroup} from 'react-bootstrap';
+import {FormGroup} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import FormComponent from './FormComponent';
 import FormController from './FormController';
 import reactBootstrapStoryDecorator from '../reactBootstrapStoryDecorator';

--- a/apps/src/code-studio/pd/form_components/QuestionsTable.jsx
+++ b/apps/src/code-studio/pd/form_components/QuestionsTable.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import {Radio, ControlLabel, FormGroup, Table} from 'react-bootstrap';
+import {Radio, ControlLabel, FormGroup, Table} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 
 const questionPropType = PropTypes.shape({
   label: PropTypes.string.isRequired,

--- a/apps/src/code-studio/pd/form_components/SingleCheckbox.jsx
+++ b/apps/src/code-studio/pd/form_components/SingleCheckbox.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import {Checkbox} from 'react-bootstrap';
+import {Checkbox} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 
 const REQUIRED = <span style={{color: 'red'}}>&nbsp;*</span>;
 

--- a/apps/src/code-studio/pd/form_components_func/FormController.jsx
+++ b/apps/src/code-studio/pd/form_components_func/FormController.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React, {useState, useEffect, useCallback, useMemo} from 'react';
 import $ from 'jquery';
-import {Button, Alert, FormGroup} from 'react-bootstrap';
+import {Button, Alert, FormGroup} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import {Pagination} from '@react-bootstrap/pagination';
 import {isEqual, omit} from 'lodash';
 import i18n from '@cdo/locale';

--- a/apps/src/code-studio/pd/international_opt_in/InternationalOptIn.jsx
+++ b/apps/src/code-studio/pd/international_opt_in/InternationalOptIn.jsx
@@ -6,7 +6,7 @@ import formComponentUtils from '../form_components/utils';
 import DatePicker from '../workshop_dashboard/components/date_picker';
 import moment from 'moment';
 import {DATE_FORMAT} from '../workshop_dashboard/workshopConstants';
-import {Row, Col, ControlLabel, FormGroup} from 'react-bootstrap';
+import {Row, Col, ControlLabel, FormGroup} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import i18n from '@cdo/locale';
 import {pegasus} from '@cdo/apps/lib/util/urlHelpers';
 

--- a/apps/src/code-studio/pd/pre_workshop_survey/PreWorkshopQuestions.jsx
+++ b/apps/src/code-studio/pd/pre_workshop_survey/PreWorkshopQuestions.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import {FormGroup} from 'react-bootstrap';
+import {FormGroup} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import FormComponent from '../form_components/FormComponent';
 
 export default class PreWorkshopQuestions extends FormComponent {

--- a/apps/src/code-studio/pd/professional_learning_landing/EnrolledWorkshops.jsx
+++ b/apps/src/code-studio/pd/professional_learning_landing/EnrolledWorkshops.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import * as utils from '../../../utils';
 import WorkshopTableLoader from '../workshop_dashboard/components/workshop_table_loader';
 import {workshopShape} from '../workshop_dashboard/types.js';
-import {Table, Button, Modal} from 'react-bootstrap';
+import {Table, Button, Modal} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import ReactTooltip from 'react-tooltip';
 import moment from 'moment';
 import {

--- a/apps/src/code-studio/pd/regional_partner_mini_contact/RegionalPartnerMiniContact.jsx
+++ b/apps/src/code-studio/pd/regional_partner_mini_contact/RegionalPartnerMiniContact.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import {Modal, FormGroup, Button, ControlLabel} from 'react-bootstrap';
+import {Modal, FormGroup, Button, ControlLabel} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import Select from 'react-select';
 import 'react-select/dist/react-select.css';
 import {SelectStyleProps} from '../constants';

--- a/apps/src/code-studio/pd/teachercon_survey/FridayOnly.jsx
+++ b/apps/src/code-studio/pd/teachercon_survey/FridayOnly.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {FormGroup} from 'react-bootstrap';
+import {FormGroup} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import FormComponent from '../form_components/FormComponent';
 import VariableFormGroup from '../workshop_survey/VariableFormGroup';
 import QuestionsTable from '../form_components/QuestionsTable';

--- a/apps/src/code-studio/pd/teachercon_survey/WholeWeek.jsx
+++ b/apps/src/code-studio/pd/teachercon_survey/WholeWeek.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {FormGroup, Row, Col} from 'react-bootstrap';
+import {FormGroup, Row, Col} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import FormComponent from '../form_components/FormComponent';
 import QuestionsTable from '../form_components/QuestionsTable';
 

--- a/apps/src/code-studio/pd/workshop_dashboard/AttendancePanel.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/AttendancePanel.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
-import {Row, Col, Button} from 'react-bootstrap';
+import {Row, Col, Button} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import WorkshopPanel from './WorkshopPanel';
 import {DATE_FORMAT} from './workshopConstants';
 

--- a/apps/src/code-studio/pd/workshop_dashboard/DetailsPanel.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/DetailsPanel.jsx
@@ -1,7 +1,7 @@
 import $ from 'jquery';
 import React from 'react';
 import PropTypes from 'prop-types';
-import {Row, Col, ButtonToolbar, Button} from 'react-bootstrap';
+import {Row, Col, ButtonToolbar, Button} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import ConfirmationDialog from '../components/confirmation_dialog';
 import WorkshopForm from './components/workshop_form';
 import WorkshopPanel from './WorkshopPanel';

--- a/apps/src/code-studio/pd/workshop_dashboard/EndWorkshopPanel.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/EndWorkshopPanel.jsx
@@ -1,7 +1,7 @@
 import $ from 'jquery';
 import React from 'react';
 import PropTypes from 'prop-types';
-import {Button} from 'react-bootstrap';
+import {Button} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import WorkshopPanel from './WorkshopPanel';
 import ConfirmationDialog from '../components/confirmation_dialog';
 import color from '@cdo/apps/util/color';

--- a/apps/src/code-studio/pd/workshop_dashboard/EnrollmentsPanel.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/EnrollmentsPanel.jsx
@@ -1,7 +1,7 @@
 import $ from 'jquery';
 import React from 'react';
 import PropTypes from 'prop-types';
-import {Button} from 'react-bootstrap';
+import {Button} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import moment from 'moment';
 import MoveEnrollmentsDialog from './components/move_enrollments_dialog';
 import EditEnrollmentNameDialog from './components/edit_enrollment_name_dialog';

--- a/apps/src/code-studio/pd/workshop_dashboard/IntroPanel.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/IntroPanel.jsx
@@ -2,7 +2,7 @@ import $ from 'jquery';
 import React from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
-import {Button} from 'react-bootstrap';
+import {Button} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import ConfirmationDialog from '../components/confirmation_dialog';
 import WorkshopPanel from './WorkshopPanel';
 

--- a/apps/src/code-studio/pd/workshop_dashboard/WorkshopPanel.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/WorkshopPanel.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {Row, Col, Panel} from 'react-bootstrap';
+import {Row, Col, Panel} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 
 /**
  * Simple wrapper component for a chunk of related content when

--- a/apps/src/code-studio/pd/workshop_dashboard/attendance/session_attendance.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/attendance/session_attendance.jsx
@@ -9,7 +9,7 @@ import _ from 'lodash';
 import SessionAttendanceRow from './session_attendance_row';
 import VisibilitySensor from '../components/visibility_sensor';
 import Spinner from '../../components/spinner';
-import {Table} from 'react-bootstrap';
+import {Table} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import IdleTimer from 'react-idle-timer';
 import {COURSE_CSF} from '../workshopConstants';
 import {PermissionPropType, WorkshopAdmin, ProgramManager} from '../permission';

--- a/apps/src/code-studio/pd/workshop_dashboard/attendance/session_attendance_row.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/attendance/session_attendance_row.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 
 import React from 'react';
 import $ from 'jquery';
-import {OverlayTrigger, Tooltip} from 'react-bootstrap';
+import {OverlayTrigger, Tooltip} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 
 export default class SessionAttendanceRow extends React.Component {
   static propTypes = {

--- a/apps/src/code-studio/pd/workshop_dashboard/attendance/workshop_attendance.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/attendance/workshop_attendance.jsx
@@ -12,7 +12,7 @@ import Spinner from '../../components/spinner';
 import SessionAttendance from './session_attendance';
 import {PermissionPropType, WorkshopAdmin, Organizer} from '../permission';
 import color from '@cdo/apps/util/color';
-import {Row, Col, ButtonToolbar, Button, Tabs, Tab} from 'react-bootstrap';
+import {Row, Col, ButtonToolbar, Button, Tabs, Tab} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 
 export class WorkshopAttendance extends React.Component {
   static contextTypes = {

--- a/apps/src/code-studio/pd/workshop_dashboard/components/CourseSelect.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/CourseSelect.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {FormGroup, ControlLabel, FormControl, HelpBlock} from 'react-bootstrap';
+import {FormGroup, ControlLabel, FormControl, HelpBlock} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import {
   Facilitator,
   Organizer,

--- a/apps/src/code-studio/pd/workshop_dashboard/components/SubjectSelect.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/SubjectSelect.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {FormGroup, ControlLabel, FormControl, HelpBlock} from 'react-bootstrap';
+import {FormGroup, ControlLabel, FormControl, HelpBlock} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import {Subjects} from '@cdo/apps/generated/pd/sharedWorkshopConstants';
 
 /**

--- a/apps/src/code-studio/pd/workshop_dashboard/components/date_picker.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/date_picker.jsx
@@ -10,7 +10,7 @@ import Radium from 'radium'; // eslint-disable-line no-restricted-imports
 import ReactDatePicker from 'react-datepicker';
 import {DATE_FORMAT} from '../workshopConstants';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
-import {InputGroup, FormGroup, FormControl} from 'react-bootstrap';
+import {InputGroup, FormGroup, FormControl} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import 'react-datepicker/dist/react-datepicker.css';
 
 class DateInputWithIconUnwrapped extends React.Component {

--- a/apps/src/code-studio/pd/workshop_dashboard/components/edit_enrollment_name_dialog.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/edit_enrollment_name_dialog.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {Modal, Button, Row, Col, FormGroup} from 'react-bootstrap';
+import {Modal, Button, Row, Col, FormGroup} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import _ from 'lodash';
 
 export default class EditEnrollmentNameDialog extends React.Component {

--- a/apps/src/code-studio/pd/workshop_dashboard/components/facilitator_list_form_part.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/facilitator_list_form_part.jsx
@@ -4,7 +4,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import {Row, Col, Button} from 'react-bootstrap';
+import {Row, Col, Button} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 
 const MAX_FACILITATORS = 10;
 

--- a/apps/src/code-studio/pd/workshop_dashboard/components/move_enrollments_dialog.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/move_enrollments_dialog.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {Modal, Button} from 'react-bootstrap';
+import {Modal, Button} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 
 export default class MoveEnrollmentsDialog extends React.Component {
   static propTypes = {

--- a/apps/src/code-studio/pd/workshop_dashboard/components/organizer_form_part.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/organizer_form_part.jsx
@@ -1,7 +1,7 @@
 import $ from 'jquery';
 import PropTypes from 'prop-types';
 import React from 'react';
-import {Row, Col} from 'react-bootstrap';
+import {Row, Col} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 
 export default class OrganizerFormPart extends React.Component {
   static propTypes = {

--- a/apps/src/code-studio/pd/workshop_dashboard/components/session_form_part.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/session_form_part.jsx
@@ -6,7 +6,7 @@ import _ from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
 import moment from 'moment';
-import {Row, Col, Button, FormGroup, HelpBlock} from 'react-bootstrap';
+import {Row, Col, Button, FormGroup, HelpBlock} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import TimeSelect from './time_select';
 import DatePicker from './date_picker';
 import {DATE_FORMAT, TIME_FORMAT} from '../workshopConstants';

--- a/apps/src/code-studio/pd/workshop_dashboard/components/session_list_form_part.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/session_list_form_part.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import moment from 'moment';
-import {Row, Col} from 'react-bootstrap';
+import {Row, Col} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import SessionFormPart from './session_form_part';
 import {DATE_FORMAT, MAX_SESSIONS} from '../workshopConstants';
 

--- a/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/choice_responses.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/choice_responses.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import _ from 'lodash';
-import {Panel} from 'react-bootstrap';
+import {Panel} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 
 // This component renders a survey answer for answer_type of 'scale',
 // 'singleSelect', or 'multiSelect'.

--- a/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/free_response_section.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/free_response_section.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import {Well} from 'react-bootstrap';
+import {Well} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import _ from 'lodash';
 
 export default class FreeResponseSection extends React.Component {

--- a/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/survey_rollup_table.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/survey_rollup_table.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Table} from 'react-bootstrap';
+import {Table} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import PropTypes from 'prop-types';
 import _ from 'lodash';
 import {COURSE_CSF} from '../../workshopConstants';

--- a/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/text_responses.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/text_responses.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import {Well} from 'react-bootstrap';
+import {Well} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import _ from 'lodash';
 import he from 'he';
 

--- a/apps/src/code-studio/pd/workshop_dashboard/components/time_select.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/time_select.jsx
@@ -8,7 +8,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import moment from 'moment';
-import {FormControl, InputGroup, Dropdown, MenuItem} from 'react-bootstrap';
+import {FormControl, InputGroup, Dropdown, MenuItem} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
 import {TIME_FORMAT} from '../workshopConstants';
 

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_enrollment.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_enrollment.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import _ from 'lodash';
-import {Tabs, Tab} from 'react-bootstrap';
+import {Tabs, Tab} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import {enrollmentShape} from '../types';
 import WorkshopEnrollmentSchoolInfo from './workshop_enrollment_school_info';
 import WorkshopEnrollmentPreSurvey from './workshop_enrollment_pre_survey';

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_enrollment_pre_survey.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_enrollment_pre_survey.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import _ from 'lodash';
-import {Table} from 'react-bootstrap';
+import {Table} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import {Chart} from 'react-google-charts';
 import {workshopEnrollmentStyles} from '../workshop_enrollment_styles';
 import {enrollmentShape} from '../types';

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_enrollment_school_info.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_enrollment_school_info.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';
-import {Button, Table} from 'react-bootstrap';
+import {Button, Table} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import ConfirmationDialog from '../../components/confirmation_dialog';
 import {enrollmentShape} from '../types';
 import {workshopEnrollmentStyles as styles} from '../workshop_enrollment_styles';

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
@@ -12,6 +12,7 @@ import Spinner from '../../components/spinner';
 import SessionListFormPart from './session_list_form_part';
 import FacilitatorListFormPart from './facilitator_list_form_part';
 import OrganizerFormPart from './organizer_form_part';
+/* eslint-disable no-restricted-imports */
 import {
   Grid,
   Row,
@@ -26,6 +27,7 @@ import {
   Radio,
   Alert,
 } from 'react-bootstrap';
+/* eslint-enable no-restricted-imports */
 import {TIME_FORMAT, DATE_FORMAT, DATETIME_FORMAT} from '../workshopConstants';
 import {
   PermissionPropType,

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_management.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_management.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';
-import {Button} from 'react-bootstrap';
+import {Button} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import {
   WorkshopTypes,
   SubjectNames,

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_table.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_table.jsx
@@ -12,7 +12,7 @@ import FacilitatorsList from './facilitators_list';
 import WorkshopManagement from './workshop_management';
 import wrappedSortable from '@cdo/apps/templates/tables/wrapped_sortable';
 import {workshopShape} from '../types.js';
-import {Button} from 'react-bootstrap';
+import {Button} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import {shouldShowSurveyResults} from '../workshop_summary_utils';
 
 export default class WorkshopTable extends React.Component {

--- a/apps/src/code-studio/pd/workshop_dashboard/reports/foorm/results.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/reports/foorm/results.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import {Tab, Tabs} from 'react-bootstrap';
+import {Tab, Tabs} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import SectionResults from './section_results';
 import SurveyRollupTableFoorm from '../../components/survey_results/survey_rollup_table_foorm';
 

--- a/apps/src/code-studio/pd/workshop_dashboard/reports/foorm/results_loader.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/reports/foorm/results_loader.jsx
@@ -5,7 +5,7 @@ import Spinner from '../../../components/spinner';
 import Results from './results';
 import color from '@cdo/apps/util/color';
 import SubmissionsDownloadForm from './submissions_download_form';
-import {Button} from 'react-bootstrap';
+import {Button} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import {PermissionPropType, WorkshopAdmin} from '../../permission';
 import {connect} from 'react-redux';
 

--- a/apps/src/code-studio/pd/workshop_dashboard/reports/foorm/submissions_download_form.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/reports/foorm/submissions_download_form.jsx
@@ -1,6 +1,7 @@
 // Pop-up modal for downloading all Foorm submissions for a single form as a csv.
 import React from 'react';
 import PropTypes from 'prop-types';
+/* eslint-disable no-restricted-imports */
 import {
   Modal,
   Button,
@@ -9,6 +10,7 @@ import {
   Col,
   Row,
 } from 'react-bootstrap';
+/* eslint-enable no-restricted-imports */
 import 'react-select/dist/react-select.css';
 import Select from 'react-select/lib/Select';
 import ReactTooltip from 'react-tooltip';

--- a/apps/src/code-studio/pd/workshop_dashboard/reports/local_summer_workshop_daily_survey/results.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/reports/local_summer_workshop_daily_survey/results.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import {Tab, Tabs} from 'react-bootstrap';
+import {Tab, Tabs} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import ChoiceResponses from '../../components/survey_results/choice_responses';
 import SurveyRollupTable from '../../components/survey_results/survey_rollup_table';
 import TextResponses from '../../components/survey_results/text_responses';

--- a/apps/src/code-studio/pd/workshop_dashboard/reports/report_view.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/reports/report_view.jsx
@@ -10,7 +10,7 @@ import moment from 'moment';
 import WorkshopSummaryReport from './workshop_summary_report';
 import TeacherAttendanceReport from './teacher_attendance_report';
 import DatePicker from '../components/date_picker';
-
+/* eslint-disable no-restricted-imports */
 import {
   Grid,
   Row,
@@ -19,6 +19,7 @@ import {
   ControlLabel,
   FormControl,
 } from 'react-bootstrap';
+/* eslint-enable no-restricted-imports */
 import {
   QUERY_BY_OPTIONS,
   QUERY_BY_VALUES,

--- a/apps/src/code-studio/pd/workshop_dashboard/reports/teacher_attendance_report.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/reports/teacher_attendance_report.jsx
@@ -7,7 +7,7 @@ import React from 'react';
 import {connect} from 'react-redux';
 import ReportTable from './report_table';
 import {PermissionPropType} from '../permission';
-import {Button} from 'react-bootstrap';
+import {Button} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import {QUERY_BY_VALUES, COURSE_VALUES} from './report_constants';
 import Spinner from '../../components/spinner';
 

--- a/apps/src/code-studio/pd/workshop_dashboard/reports/workshop_summary_report.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/reports/workshop_summary_report.jsx
@@ -7,7 +7,7 @@ import React from 'react';
 import {connect} from 'react-redux';
 import ReportTable from './report_table';
 import {PermissionPropType, WorkshopAdmin} from '../permission';
-import {Checkbox, Button} from 'react-bootstrap';
+import {Checkbox, Button} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import {QUERY_BY_VALUES, COURSE_VALUES} from './report_constants';
 import Spinner from '../../components/spinner';
 

--- a/apps/src/code-studio/pd/workshop_dashboard/workshop.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshop.jsx
@@ -9,7 +9,7 @@ import _ from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';
-import {Grid, Row, Col} from 'react-bootstrap';
+import {Grid, Row, Col} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import Spinner from '../components/spinner';
 import {PermissionPropType, WorkshopAdmin} from './permission';
 import SignUpPanel from './SignUpPanel';

--- a/apps/src/code-studio/pd/workshop_dashboard/workshop_filter.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshop_filter.jsx
@@ -16,6 +16,7 @@ import DatePicker from './components/date_picker';
 import {DATE_FORMAT} from './workshopConstants';
 import {PermissionPropType, WorkshopAdmin} from './permission';
 import moment from 'moment';
+/* eslint-disable no-restricted-imports */
 import {
   Grid,
   Row,
@@ -29,6 +30,7 @@ import {
   MenuItem,
   Clearfix,
 } from 'react-bootstrap';
+/* eslint-enable no-restricted-imports */
 import {
   Courses,
   Subjects,

--- a/apps/src/code-studio/pd/workshop_dashboard/workshop_index.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshop_index.jsx
@@ -5,7 +5,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';
-import {Button, ButtonToolbar} from 'react-bootstrap';
+import {Button, ButtonToolbar} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import ServerSortWorkshopTable from './components/server_sort_workshop_table';
 import {
   PermissionPropType,

--- a/apps/src/code-studio/pd/workshop_enrollment/enroll_form.jsx
+++ b/apps/src/code-studio/pd/workshop_enrollment/enroll_form.jsx
@@ -4,6 +4,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import $ from 'jquery';
+/* eslint-disable no-restricted-imports */
 import {
   FormGroup,
   Button,
@@ -11,6 +12,7 @@ import {
   HelpBlock,
   Alert,
 } from 'react-bootstrap';
+/* eslint-enable no-restricted-imports */
 import Select from 'react-select';
 import {ButtonList} from '../form_components/ButtonList.jsx';
 import FieldGroup from '../form_components/FieldGroup';

--- a/apps/src/code-studio/pd/workshop_enrollment/enrollmentCancelButton.jsx
+++ b/apps/src/code-studio/pd/workshop_enrollment/enrollmentCancelButton.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import {Button} from 'react-bootstrap';
+import {Button} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import ConfirmationDialog from '../components/confirmation_dialog';
 
 export default class EnrollmentCancelButton extends React.Component {

--- a/apps/src/code-studio/pd/workshop_survey/Demographics.jsx
+++ b/apps/src/code-studio/pd/workshop_survey/Demographics.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {FormGroup} from 'react-bootstrap';
+import {FormGroup} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import FormComponent from '../form_components/FormComponent';
 
 const LABELS = {

--- a/apps/src/code-studio/pd/workshop_survey/Disclaimer.jsx
+++ b/apps/src/code-studio/pd/workshop_survey/Disclaimer.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {FormGroup} from 'react-bootstrap';
+import {FormGroup} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import FormComponent from '../form_components/FormComponent';
 
 export default class Disclaimer extends FormComponent {

--- a/apps/src/code-studio/pd/workshop_survey/Implementation.jsx
+++ b/apps/src/code-studio/pd/workshop_survey/Implementation.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {FormGroup} from 'react-bootstrap';
+import {FormGroup} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import FormComponent from '../form_components/FormComponent';
 
 const LABELS = {

--- a/apps/src/code-studio/pd/workshop_survey/PersonalInvolvement.jsx
+++ b/apps/src/code-studio/pd/workshop_survey/PersonalInvolvement.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {FormGroup} from 'react-bootstrap';
+import {FormGroup} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import FormComponent from '../form_components/FormComponent';
 
 const LABELS = {

--- a/apps/src/code-studio/pd/workshop_survey/VariableFormGroup.jsx
+++ b/apps/src/code-studio/pd/workshop_survey/VariableFormGroup.jsx
@@ -4,7 +4,7 @@ import React from 'react';
 import {ButtonList} from '../form_components/ButtonList';
 import FieldGroup from '../form_components/FieldGroup';
 
-import {FormGroup, FormControl, ControlLabel, Table} from 'react-bootstrap';
+import {FormGroup, FormControl, ControlLabel, Table} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 
 const SINGLE_SELECT = 'single_select';
 const MULTI_SELECT = 'multi_select';

--- a/apps/src/code-studio/pd/workshop_survey/WorkshopQuality.jsx
+++ b/apps/src/code-studio/pd/workshop_survey/WorkshopQuality.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import {FormGroup} from 'react-bootstrap';
+import {FormGroup} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import VariableFormGroup from './VariableFormGroup';
 import FormComponent from '../form_components/FormComponent';
 

--- a/apps/src/code-studio/pd/workshop_survey/WorkshopResults.jsx
+++ b/apps/src/code-studio/pd/workshop_survey/WorkshopResults.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {FormGroup} from 'react-bootstrap';
+import {FormGroup} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import FormComponent from '../form_components/FormComponent';
 
 const BUTTON_LABELS = {

--- a/apps/src/code-studio/peer_reviews/PeerReviewSubmissionData.jsx
+++ b/apps/src/code-studio/peer_reviews/PeerReviewSubmissionData.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {Table} from 'react-bootstrap';
+import {Table} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import PeerReviewLinkSection from './PeerReviewLinkSection';
 
 class PeerReviewSubmissionData extends React.Component {

--- a/apps/src/code-studio/peer_reviews/PeerReviewSubmissions.jsx
+++ b/apps/src/code-studio/peer_reviews/PeerReviewSubmissions.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Button, FormControl} from 'react-bootstrap';
+import {Button, FormControl} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import PropTypes from 'prop-types';
 import _ from 'lodash';
 import Spinner from '../pd/components/spinner';

--- a/apps/src/javalab/JavalabEditor.jsx
+++ b/apps/src/javalab/JavalabEditor.jsx
@@ -28,7 +28,7 @@ import {editorSetup} from './editorSetup';
 import {EditorState, Compartment} from '@codemirror/state';
 import {projectChanged} from '@cdo/apps/code-studio/initApp/project';
 import classNames from 'classnames';
-import {Tab, Nav, NavItem} from 'react-bootstrap';
+import {Tab, Nav, NavItem} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import style from './javalab-editor.module.scss';
 import JavalabEditorTabMenu from './JavalabEditorTabMenu';
 import JavalabFileExplorer from './JavalabFileExplorer';

--- a/apps/src/p5lab/AnimationTab/ItemLoopToggle.jsx
+++ b/apps/src/p5lab/AnimationTab/ItemLoopToggle.jsx
@@ -1,6 +1,6 @@
 /** @file controls below an animation looping toggle */
 import React from 'react';
-import {OverlayTrigger, Tooltip} from 'react-bootstrap';
+import {OverlayTrigger, Tooltip} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import PropTypes from 'prop-types';
 import style from './item-loop-toggle.module.scss';
 

--- a/apps/src/p5lab/AnimationTab/ListItemButtons.jsx
+++ b/apps/src/p5lab/AnimationTab/ListItemButtons.jsx
@@ -1,6 +1,6 @@
 /** @file controls below an animation thumbnail */
 import React from 'react';
-import {OverlayTrigger, Tooltip} from 'react-bootstrap';
+import {OverlayTrigger, Tooltip} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import color from '@cdo/apps/util/color';
 import PropTypes from 'prop-types';
 import SpeedSlider from '@cdo/apps/templates/SpeedSlider';

--- a/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerAccountConfirmation.jsx
+++ b/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerAccountConfirmation.jsx
@@ -1,6 +1,6 @@
 import firehoseClient from '@cdo/apps/lib/util/firehose';
 import React from 'react';
-import {Button} from 'react-bootstrap';
+import {Button} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import {studio, pegasus} from '@cdo/apps/lib/util/urlHelpers';
 import color from '@cdo/apps/util/color';
 

--- a/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerEligibility.jsx
+++ b/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerEligibility.jsx
@@ -1,7 +1,7 @@
 import firehoseClient from '@cdo/apps/lib/util/firehose';
 import React from 'react';
 import PropTypes from 'prop-types';
-import {FormGroup, Button} from 'react-bootstrap';
+import {FormGroup, Button} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import FieldGroup from '../../code-studio/pd/form_components/FieldGroup';
 import color from '@cdo/apps/util/color';
 import SchoolAutocompleteDropdownWithLabel from '@cdo/apps/templates/census2017/SchoolAutocompleteDropdownWithLabel';

--- a/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerEligibilityForm.jsx
+++ b/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerEligibilityForm.jsx
@@ -1,7 +1,7 @@
 import firehoseClient from '@cdo/apps/lib/util/firehose';
 import PropTypes from 'prop-types';
 import React from 'react';
-import {Button, Checkbox} from 'react-bootstrap';
+import {Button, Checkbox} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import _ from 'lodash';
 import ValidationStep, {Status} from '@cdo/apps/lib/ui/ValidationStep';
 import SchoolAutocompleteDropdownWithLabel from '@cdo/apps/templates/census2017/SchoolAutocompleteDropdownWithLabel';

--- a/apps/src/templates/certificates/petition/ControlledFieldGroup.jsx
+++ b/apps/src/templates/certificates/petition/ControlledFieldGroup.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {FormControl, FormGroup, HelpBlock} from 'react-bootstrap';
+import {FormControl, FormGroup, HelpBlock} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 

--- a/apps/src/templates/certificates/petition/PetitionForm.jsx
+++ b/apps/src/templates/certificates/petition/PetitionForm.jsx
@@ -1,5 +1,5 @@
 import React, {useState, useCallback} from 'react';
-import {Button} from 'react-bootstrap';
+import {Button} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import {range, mapValues, without, find} from 'lodash';
 import i18n from '@cdo/locale';
 import $ from 'jquery';

--- a/apps/test/unit/code-studio/pd/application_dashboard/summaryTest.js
+++ b/apps/test/unit/code-studio/pd/application_dashboard/summaryTest.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {shallow} from 'enzyme';
-import {Row} from 'react-bootstrap';
+import {Row} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import {
   Summary,
   removeIncompleteApplications,

--- a/apps/test/unit/code-studio/pd/foorm/FoormEntityLoadButtonsTest.js
+++ b/apps/test/unit/code-studio/pd/foorm/FoormEntityLoadButtonsTest.js
@@ -4,7 +4,7 @@ import {assert} from 'chai';
 
 import {UnconnectedFoormEntityLoadButtons as FoormEntityLoadButtons} from '@cdo/apps/code-studio/pd/foorm/editor/components/FoormEntityLoadButtons';
 import SingleCheckbox from '@cdo/apps/code-studio/pd/form_components/SingleCheckbox';
-import {Button} from 'react-bootstrap';
+import {Button} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import sinon from 'sinon';
 
 describe('FoormEntityLoadButtons', () => {

--- a/apps/test/unit/code-studio/pd/form_components/ButtonListTest.js
+++ b/apps/test/unit/code-studio/pd/form_components/ButtonListTest.js
@@ -3,6 +3,7 @@ import React from 'react';
 import {expect} from '../../../../util/reconfiguredChai';
 import {shallow} from 'enzyme';
 import sinon from 'sinon';
+/* eslint-disable no-restricted-imports */
 import {
   Radio,
   Checkbox,
@@ -10,6 +11,7 @@ import {
   FormGroup,
   HelpBlock,
 } from 'react-bootstrap';
+/* eslint-enable no-restricted-imports */
 
 describe('ButtonList', () => {
   describe('With type: radio', () => {

--- a/apps/test/unit/code-studio/pd/form_components/SingleCheckboxTest.js
+++ b/apps/test/unit/code-studio/pd/form_components/SingleCheckboxTest.js
@@ -1,5 +1,5 @@
 import SingleCheckbox from '@cdo/apps/code-studio/pd/form_components/SingleCheckbox';
-import {Checkbox} from 'react-bootstrap';
+import {Checkbox} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import React from 'react';
 import {expect} from 'chai';
 import {shallow} from 'enzyme';

--- a/apps/test/unit/code-studio/pd/workshop_dashboard/components/workshopFormTest.js
+++ b/apps/test/unit/code-studio/pd/workshop_dashboard/components/workshopFormTest.js
@@ -2,7 +2,7 @@ import React from 'react';
 import {mount} from 'enzyme';
 import {assert} from 'chai';
 import {Factory} from 'rosie';
-import {FormControl} from 'react-bootstrap';
+import {FormControl} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import Permission, {
   WorkshopAdmin,
   ProgramManager,

--- a/apps/test/unit/code-studio/pd/workshop_dashboard/components/workshop_managementTest.js
+++ b/apps/test/unit/code-studio/pd/workshop_dashboard/components/workshop_managementTest.js
@@ -1,7 +1,7 @@
 import {WorkshopManagement} from '@cdo/apps/code-studio/pd/workshop_dashboard/components/workshop_management';
 import {WorkshopTypes} from '@cdo/apps/generated/pd/sharedWorkshopConstants';
 import ConfirmationDialog from '@cdo/apps/code-studio/pd/components/confirmation_dialog';
-import {Button} from 'react-bootstrap';
+import {Button} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import React from 'react';
 import {expect} from 'chai';
 import {shallow} from 'enzyme';

--- a/apps/test/unit/templates/manageStudents/ManageStudentsSharingCellTest.js
+++ b/apps/test/unit/templates/manageStudents/ManageStudentsSharingCellTest.js
@@ -2,7 +2,7 @@ import React from 'react';
 import {shallow} from 'enzyme';
 import {expect} from '../../../util/deprecatedChai';
 import {UnconnectedManageStudentsSharingCell as ManageStudentsSharingCell} from '@cdo/apps/templates/manageStudents/ManageStudentsSharingCell';
-import {Checkbox} from 'react-bootstrap';
+import {Checkbox} from 'react-bootstrap'; // eslint-disable-line no-restricted-imports
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
 
 describe('ManageStudentsSharingCell', () => {

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -1230,6 +1230,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.21.0", "@babel/runtime@^7.8.7":
+  version "7.21.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.21.5.tgz#8492dddda9644ae3bda3b45eabe87382caee7200"
+  integrity sha512-8jI69toZqqcsnqGGqwGS4Qb1VwLOEp4hz+CXPywcvjs60u3B4Pom/U/7rm4W8tMOYEB+E9wgD0mW1l3r8qlI9Q==
+  dependencies:
+    regenerator-runtime "^0.13.11"
+
 "@babel/runtime@^7.4.5":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.8.3.tgz#0811944f73a6c926bb2ad35e918dcc1bfab279f1"
@@ -1941,6 +1948,11 @@
   resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.21.tgz#5de5a2385a35309427f6011992b544514d559aa1"
   integrity sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==
 
+"@popperjs/core@^2.11.6":
+  version "2.11.7"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.7.tgz#ccab5c8f7dc557a52ca3288c10075c9ccd37fff7"
+  integrity sha512-Cr4OjIkipTtcXKjAsm8agyleBuDHvxzeBoa1v543lbv1YaIwQjESsVcmjiWiPEbC1FIeHOG/Op9kdCmAmiS3Kw==
+
 "@reach/router@^1.2.1":
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/@reach/router/-/router-1.3.4.tgz#d2574b19370a70c80480ed91f3da840136d10f8c"
@@ -1950,6 +1962,13 @@
     invariant "^2.2.3"
     prop-types "^15.6.1"
     react-lifecycles-compat "^3.0.4"
+
+"@react-aria/ssr@^3.5.0":
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/@react-aria/ssr/-/ssr-3.6.0.tgz#e5d52bd1686ff229f68f806cf94ee29dd9f54fb7"
+  integrity sha512-OFiYQdv+Yk7AO7IsQu/fAEPijbeTwrrEYvdNoJ3sblBBedD5j5fBTNWrUPNVlwC4XWWnWTCMaRIVsJujsFiWXg==
+  dependencies:
+    "@swc/helpers" "^0.4.14"
 
 "@react-bootstrap/pagination@^1.0.0":
   version "1.0.0"
@@ -1968,6 +1987,28 @@
     redux "^4.2.0"
     redux-thunk "^2.4.2"
     reselect "^4.1.7"
+
+"@restart/hooks@^0.4.9":
+  version "0.4.9"
+  resolved "https://registry.yarnpkg.com/@restart/hooks/-/hooks-0.4.9.tgz#ad858fb39d99e252cccce19416adc18fc3f18fcb"
+  integrity sha512-3BekqcwB6Umeya+16XPooARn4qEPW6vNvwYnlofIYe6h9qG1/VeD7UvShCWx11eFz5ELYmwIEshz+MkPX3wjcQ==
+  dependencies:
+    dequal "^2.0.2"
+
+"@restart/ui@^1.6.3":
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/@restart/ui/-/ui-1.6.3.tgz#8063f5b5e0131d41db2cefe148b20cb08a208e76"
+  integrity sha512-7HM5aiSWvJBWr+FghZj/n3PSuH2kUrOPiu/D92aIv1zTL8IBwFoQ3oz/f76svoN5v2PKaP6pQbg6vTcIiSffzg==
+  dependencies:
+    "@babel/runtime" "^7.21.0"
+    "@popperjs/core" "^2.11.6"
+    "@react-aria/ssr" "^3.5.0"
+    "@restart/hooks" "^0.4.9"
+    "@types/warning" "^3.0.0"
+    dequal "^2.0.3"
+    dom-helpers "^5.2.0"
+    uncontrollable "^7.2.1"
+    warning "^4.0.3"
 
 "@serialport/binding-abstract@^8.0.6":
   version "8.0.6"
@@ -2874,6 +2915,13 @@
     regenerator-runtime "^0.13.7"
     resolve-from "^5.0.0"
 
+"@swc/helpers@^0.4.14":
+  version "0.4.14"
+  resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.4.14.tgz#1352ac6d95e3617ccb7c1498ff019654f1e12a74"
+  integrity sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==
+  dependencies:
+    tslib "^2.4.0"
+
 "@testing-library/dom@^8.0.0":
   version "8.20.0"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.20.0.tgz#914aa862cef0f5e89b98cc48e3445c4c921010f6"
@@ -3095,6 +3143,13 @@
     hoist-non-react-statics "^3.3.0"
     redux "^4.0.0"
 
+"@types/react-transition-group@^4.4.5":
+  version "4.4.5"
+  resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.5.tgz#aae20dcf773c5aa275d5b9f7cdbca638abc5e416"
+  integrity sha512-juKD/eiSM3/xZYzjuzH6ZwpP+/lejltmiS3QEzV/vmb/Q8+HfDmxu+Baga8UEMGBqV88Nbg4l2hY/K2DkyaLLA==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react@*", "@types/react@>=16.9.11", "@types/react@^16.0.7", "@types/react@^18.0.28", "@types/react@^18.0.9":
   version "18.0.28"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.28.tgz#accaeb8b86f4908057ad629a26635fe641480065"
@@ -3156,6 +3211,11 @@
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/@types/w3c-web-usb/-/w3c-web-usb-1.0.6.tgz#5d8560d0d9f585ffc80865bc773db7bc975b680c"
   integrity sha512-cSjhgrr8g4KbPnnijAr/KJDNKa/bBa+ixYkywFRvrhvi9n1WEl7yYbtRyzE6jqNQiSxxJxoAW3STaOQwJHndaw==
+
+"@types/warning@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/warning/-/warning-3.0.0.tgz#0d2501268ad8f9962b740d387c4654f5f8e23e52"
+  integrity sha512-t/Tvs5qR47OLOr+4E9ckN8AmP2Tf16gWq+/qA4iUGS/OOyHVO8wv2vjJuX8SNOUTJyWb+2t7wJm6cXILFnOROA==
 
 "@types/webpack-env@^1.16.0":
   version "1.18.0"
@@ -6619,6 +6679,11 @@ depd@2.0.0:
   resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
   integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
 
+dequal@^2.0.2, dequal@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.3.tgz#2644214f1997d39ed0ee0ece72335490a7ac67be"
+  integrity sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==
+
 des.js@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/des.js/-/des.js-1.0.0.tgz#c074d2e2aa6a8a9a07dbd61f9a15c2cd83ec8ecc"
@@ -6789,6 +6854,14 @@ dom-converter@^0.2, dom-converter@^0.2.0:
   resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.4.0.tgz#e9b369700f959f62ecde5a6babde4bccd9169af8"
   dependencies:
     "@babel/runtime" "^7.1.2"
+
+dom-helpers@^5.0.1, dom-helpers@^5.2.0, dom-helpers@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.2.1.tgz#d9400536b2bf8225ad98fe052e029451ac40e902"
+  integrity sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==
+  dependencies:
+    "@babel/runtime" "^7.8.7"
+    csstype "^3.0.2"
 
 dom-serialize@^2.2.0:
   version "2.2.1"
@@ -14391,6 +14464,14 @@ prop-types-extra@^1.0.1:
     react-is "^16.3.2"
     warning "^3.0.0"
 
+prop-types-extra@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/prop-types-extra/-/prop-types-extra-1.1.1.tgz#58c3b74cbfbb95d304625975aa2f0848329a010b"
+  integrity sha512-59+AHNnHYCdiC+vMwY52WmvP5dM3QLeoumYuEyceQDi9aEhtwN9zIQ2ZNo25sMyXnbh32h+P1ezDsUpUH3JAew==
+  dependencies:
+    react-is "^16.3.2"
+    warning "^4.0.0"
+
 prop-types@^15.0.0, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
@@ -14799,6 +14880,24 @@ react-beautiful-dnd@^13.1.0:
     redux "^4.0.4"
     use-memo-one "^1.1.1"
 
+"react-bootstrap-2@npm:react-bootstrap@^2.7.4":
+  version "2.7.4"
+  resolved "https://registry.yarnpkg.com/react-bootstrap/-/react-bootstrap-2.7.4.tgz#db95ecdcdfae9619de14511b5e9923bf95daf73d"
+  integrity sha512-EPKPwhfbxsKsNBhJBitJwqul9fvmlYWSft6jWE2EpqhEyjhqIqNihvQo2onE5XtS+QHOavUSNmA+8Lnv5YeAyg==
+  dependencies:
+    "@babel/runtime" "^7.21.0"
+    "@restart/hooks" "^0.4.9"
+    "@restart/ui" "^1.6.3"
+    "@types/react-transition-group" "^4.4.5"
+    classnames "^2.3.2"
+    dom-helpers "^5.2.1"
+    invariant "^2.2.4"
+    prop-types "^15.8.1"
+    prop-types-extra "^1.1.0"
+    react-transition-group "^4.4.5"
+    uncontrollable "^7.2.1"
+    warning "^4.0.3"
+
 react-bootstrap@^0.33.1:
   version "0.33.1"
   resolved "https://registry.yarnpkg.com/react-bootstrap/-/react-bootstrap-0.33.1.tgz#e072592aa143b9792526281272eca754bc9a4940"
@@ -15196,6 +15295,16 @@ react-transition-group@^2.0.0:
     prop-types "^15.6.2"
     react-lifecycles-compat "^3.0.4"
 
+react-transition-group@^4.4.5:
+  version "4.4.5"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.5.tgz#e53d4e3f3344da8521489fbef8f2581d42becdd1"
+  integrity sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    dom-helpers "^5.0.1"
+    loose-envify "^1.4.0"
+    prop-types "^15.6.2"
+
 react-typist@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/react-typist/-/react-typist-2.0.5.tgz#9830395a73a03e6368e1392ecb98edaa3a648e44"
@@ -15525,6 +15634,11 @@ regenerator-runtime@^0.11.0:
 regenerator-runtime@^0.12.0:
   version "0.12.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz#fa1a71544764c036f8c49b13a08b2594c9f8a0de"
+
+regenerator-runtime@^0.13.11:
+  version "0.13.11"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
+  integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
 
 regenerator-runtime@^0.13.2:
   version "0.13.2"
@@ -17919,6 +18033,11 @@ tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.3.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
   integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
 
+tslib@^2.4.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.0.tgz#42bfed86f5787aeb41d031866c8f402429e0fddf"
+  integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
+
 tsutils@^3.21.0:
   version "3.21.0"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.21.0.tgz#b48717d394cea6c1e096983eed58e9d61715b623"
@@ -18114,7 +18233,7 @@ unc-path-regex@^0.1.2:
   resolved "https://registry.yarnpkg.com/unc-path-regex/-/unc-path-regex-0.1.2.tgz#e73dd3d7b0d7c5ed86fbac6b0ae7d8c6a69d50fa"
   integrity sha512-eXL4nmJT7oCpkZsHZUOJo8hcX3GbsiDOa0Qu9F646fi8dT3XuSVopVqAcEiVzSKKH7UoDti23wNX3qGFxcW5Qg==
 
-uncontrollable@^7.0.2:
+uncontrollable@^7.0.2, uncontrollable@^7.2.1:
   version "7.2.1"
   resolved "https://registry.yarnpkg.com/uncontrollable/-/uncontrollable-7.2.1.tgz#1fa70ba0c57a14d5f78905d533cf63916dc75738"
   integrity sha512-svtcfoTADIB0nT9nltgjujTi7BzVmwjZClOmskKu/E8FW9BXzg9os8OLr4f8Dlnk0rYWJIWr4wv9eKUXiQvQwQ==
@@ -18653,16 +18772,16 @@ warning@^3.0.0:
   dependencies:
     loose-envify "^1.0.0"
 
-warning@^4.0.1:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.2.tgz#aa6876480872116fa3e11d434b0d0d8d91e44607"
-  dependencies:
-    loose-envify "^1.0.0"
-
-warning@^4.0.3:
+warning@^4.0.0, warning@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
   integrity sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==
+  dependencies:
+    loose-envify "^1.0.0"
+
+warning@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.2.tgz#aa6876480872116fa3e11d434b0d0d8d91e44607"
   dependencies:
     loose-envify "^1.0.0"
 


### PR DESCRIPTION
Adds the current version of React Bootstrap using alias `react-bootstrap-2`, and includes `react-bootstrap` as a restricted import to discourage further use. Documentation for alias packages here https://classic.yarnpkg.com/lang/en/docs/cli/add/.

I originally tried aliasing our current version of `react-bootstrap` as `react-bootstrap-0` and then having our newest version of the package use the standard `react-bootstrap`. That involved replacing all instances of `from 'react-bootstrap'` with `from 'react-bootstrap-0'`. But that produced the following errors upon `yarn build`:
```
ERROR in ./node_modules/@react-bootstrap/pagination/lib/Pagination.js 27:22-73
Module not found: Error: Can't resolve 'react-bootstrap/lib/utils/bootstrapUtils' in '/Users/megcrenshaw/code-dot-org/apps/node_modules/@react-bootstrap/pagination/lib'
 @ ./node_modules/@react-bootstrap/pagination/lib/index.js 6:19-42
 @ ./src/code-studio/pd/form_components/FormController.jsx 16:18-56
 @ ./src/code-studio/pd/pre_workshop_survey/PreWorkshopSurvey.jsx 10:46-90
 @ ./src/sites/studio/pages/pd/pre_workshop_survey/new.js 7:48-121

ERROR in ./node_modules/@react-bootstrap/pagination/lib/PaginationButton.js 23:18-59
Module not found: Error: Can't resolve 'react-bootstrap/lib/SafeAnchor' in '/Users/megcrenshaw/code-dot-org/apps/node_modules/@react-bootstrap/pagination/lib'
 @ ./node_modules/@react-bootstrap/pagination/lib/index.js 10:25-54
 @ ./src/code-studio/pd/form_components/FormController.jsx 16:18-56
 @ ./src/code-studio/pd/pre_workshop_survey/PreWorkshopSurvey.jsx 10:46-90
 @ ./src/sites/studio/pages/pd/pre_workshop_survey/new.js 7:48-121

ERROR in ./node_modules/@react-bootstrap/pagination/lib/PaginationButton.js 27:29-87
Module not found: Error: Can't resolve 'react-bootstrap/lib/utils/createChainedFunction' in '/Users/megcrenshaw/code-dot-org/apps/node_modules/@react-bootstrap/pagination/lib'
 @ ./node_modules/@react-bootstrap/pagination/lib/index.js 10:25-54
 @ ./src/code-studio/pd/form_components/FormController.jsx 16:18-56
 @ ./src/code-studio/pd/pre_workshop_survey/PreWorkshopSurvey.jsx 10:46-90
 @ ./src/sites/studio/pages/pd/pre_workshop_survey/new.js 7:48-121
```

The package `@react-bootstrap/pagination` was created to preserve old functionality of the Pagination component while bootstrap updated (see "Migration Details" in their [documentation from the old version](https://react-bootstrap-v3.netlify.app/components/pagination/#pagination)). But the error messages indicate that it searches `react-bootstrap` library for certain paths that no longer exist in the new version. I briefly tried to update the Pagination component, but it wasn't an easy fix –– the page number links we are used to seeing disappear with the update, as the functionality for the page number links changed in the newer Pagination component. This is the functionality that gets lost:
<img width="488" alt="image" src="https://user-images.githubusercontent.com/9142121/236219720-04004f6c-b0c7-4df6-9ff5-d860664deb04.png">

So instead, I went to keeping `react-bootstrap` as it is and adding a new version `react-bootstrap-2`. See the follow-up work section for tasks needed to get this cleaner.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

I did run lint locally which passed, but Drone passing is the best indicator that lint is passing and that our pages are working as usual.

I did spot-check our workshop form, as that uses a lot of react bootstrap components
https://github.com/code-dot-org/code-dot-org/blob/261353fb88546da4ea8dc16f923c5302effc4aa9/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx#L15-L28
<img width="1031" alt="image" src="https://user-images.githubusercontent.com/9142121/236228332-4e134798-0cee-4958-aa00-c9ce1b11dfd3.png">

Not included in this PR, but I also added a tooltip to the curriculum catalog page via `import {Tooltip} from 'react-bootstrap-2';` and `<Tooltip placement="top-end">Testing tooltip</Tooltip>` to see if the new version is working as expected:
<img width="1106" alt="image" src="https://user-images.githubusercontent.com/9142121/236230784-e3c88ebe-26e6-42c5-a8c0-a0935722ec7c.png">

It's ugly, but it works!

## Deployment strategy

## Follow-up work

1) Remove current Pagination usages to newest react-bootstrap (https://codedotorg.atlassian.net/browse/ACQ-581)
2) Make newest react-bootstrap the default (https://codedotorg.atlassian.net/browse/ACQ-582)

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
