### PR TITLE
Adds flowVersion param to distinguish 'new' flow for a/b testing

### DIFF
--- a/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
+++ b/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
@@ -18,6 +18,7 @@ import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
 
 const FORM_ID = 'sections-set-up-container';
 const SECTIONS_API = '/api/v1/sections';
+const NEW = 'New';
 
 // Custom hook to update the list of sections to create
 // Currently, this hook returns two things:
@@ -154,6 +155,7 @@ export default function SectionsSetUpContainer({sectionToBeEdited}) {
         sectionLockSelection: section.restrictSection,
         sectionName: section.name,
         sectionPairProgramSelection: section.pairingAllowed,
+        flowVersion: NEW,
       });
     }
     /*
@@ -182,6 +184,7 @@ export default function SectionsSetUpContainer({sectionToBeEdited}) {
         newCourseId: section.course?.courseOfferingId,
         newCourseVersionId: section.course?.courseVersionId,
         newVersionYear: null,
+        flowVersion: NEW,
       });
     }
   };


### PR DESCRIPTION
The current amplitude events are logging in the exact same way- this will give us an easy param to filter on the new flow vs old (blank). I could've set up all the other events to log 'old', but then we would be filtering on the old flow = 'old' + null, which seemed like an extra, potentially more confusing, step.

## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/TEACH-470

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
