### PR TITLE
Projects client: optimize save logic

### DIFF
--- a/apps/src/labs/projects/ProjectManager.ts
+++ b/apps/src/labs/projects/ProjectManager.ts
@@ -110,6 +110,7 @@ export default class ProjectManager {
     const channelChanged = this.channelChanged(project);
     // If neither source nor channel has actually changed, no need to save again.
     if (!sourceChanged && !channelChanged) {
+      this.saveInProgress = false;
       return this.getNoopResponse();
     }
     // Only save the source if it has changed.

--- a/apps/src/labs/projects/ProjectManager.ts
+++ b/apps/src/labs/projects/ProjectManager.ts
@@ -34,6 +34,8 @@ export default class ProjectManager {
   private eventListeners: {
     [key in keyof typeof ProjectManagerEvent]?: [(response: Response) => void];
   } = {};
+  private lastSource: string | undefined;
+  private lastChannel: string | undefined;
 
   constructor(
     channelId: string,
@@ -56,6 +58,7 @@ export default class ProjectManager {
     let source = {};
     if (sourceResponse.ok) {
       source = await sourceResponse.json();
+      this.lastSource = JSON.stringify(source);
     }
 
     const channelResponse = await this.channelsStore.load(this.channelId);
@@ -64,6 +67,7 @@ export default class ProjectManager {
     }
 
     const channel = await channelResponse.json();
+    this.lastChannel = JSON.stringify(channel);
     // ensure the project type is set on the channel
     channel.projectType = this.appOptionsStore.getProjectType();
     const project = {source, channel};
@@ -73,8 +77,9 @@ export default class ProjectManager {
     return new Response(blob);
   }
 
-  hasQueuedSave(): boolean {
-    return this.saveQueued;
+  hasUnsavedChanges(): boolean {
+    const project = this.getProject();
+    return this.sourceChanged(project) || this.channelChanged(project);
   }
 
   // TODO: Add functionality to reduce channel updates during
@@ -94,29 +99,39 @@ export default class ProjectManager {
       if (!this.saveQueued) {
         this.enqueueSave();
       }
-      const noopResponse = new Response(null, {status: 304});
-      this.executeListeners(ProjectManagerEvent.SaveNoop, noopResponse);
-      return noopResponse;
+      return this.getNoopResponse();
     }
-
     this.saveInProgress = true;
     this.saveQueued = false;
     this.nextSaveTime = Date.now() + this.saveInterval;
     this.executeListeners(ProjectManagerEvent.SaveStart);
     const project = this.getProject();
-    const sourceResponse = await this.sourcesStore.save(
-      this.channelId,
-      project.source
-    );
-    if (!sourceResponse.ok) {
-      this.saveInProgress = false;
-      this.executeListeners(ProjectManagerEvent.SaveFail, sourceResponse);
+    const sourceChanged = this.sourceChanged(project);
+    const channelChanged = this.channelChanged(project);
+    // If neither source nor channel has actually changed, no need to save again.
+    if (!sourceChanged && !channelChanged) {
+      return this.getNoopResponse();
+    }
+    // Only save the source if it has changed.
+    if (sourceChanged) {
+      const sourceResponse = await this.sourcesStore.save(
+        this.channelId,
+        project.source
+      );
+      if (!sourceResponse.ok) {
+        this.saveInProgress = false;
+        this.executeListeners(ProjectManagerEvent.SaveFail, sourceResponse);
 
-      // TODO: Should we wrap this response in some way?
-      // Maybe add a more specific statusText to the response?
-      return sourceResponse;
+        // TODO: Should we wrap this response in some way?
+        // Maybe add a more specific statusText to the response?
+        return sourceResponse;
+      }
+      this.lastSource = JSON.stringify(project.source);
     }
 
+    // Always save the channel--either the channel has changed and/or the source changed.
+    // Even if only the source changed, we still update the channel to modify the last
+    // updated time.
     const channelResponse = await this.channelsStore.save(project.channel);
     if (!channelResponse.ok) {
       this.saveInProgress = false;
@@ -126,6 +141,7 @@ export default class ProjectManager {
       // Maybe add a more specific statusText to the response?
       return channelResponse;
     }
+    this.lastChannel = JSON.stringify(project.channel);
 
     this.saveInProgress = false;
     this.executeListeners(ProjectManagerEvent.SaveSuccess);
@@ -169,5 +185,19 @@ export default class ProjectManager {
     response: Response = new Response()
   ) {
     this.eventListeners[type]?.forEach(listener => listener(response));
+  }
+
+  private getNoopResponse() {
+    const noopResponse = new Response(null, {status: 304});
+    this.executeListeners(ProjectManagerEvent.SaveNoop, noopResponse);
+    return noopResponse;
+  }
+
+  private sourceChanged(project: Project): boolean {
+    return this.lastSource !== JSON.stringify(project.source);
+  }
+
+  private channelChanged(project: Project): boolean {
+    return this.lastChannel !== JSON.stringify(project.channel);
   }
 }

--- a/apps/src/music/blockly/MusicBlocklyWorkspace.js
+++ b/apps/src/music/blockly/MusicBlocklyWorkspace.js
@@ -371,7 +371,7 @@ export default class MusicBlocklyWorkspace {
   }
 
   hasUnsavedChanges() {
-    return this.projectManager.hasQueuedSave();
+    return this.projectManager.hasUnsavedChanges();
   }
 
   loadDefaultCode() {


### PR DESCRIPTION
We would previously always save (after a throttle period) if `save` had been called. This ended up causing some unnecessary saves, as we were calling save in Music Lab for every Blockly workspace change, which could end up with no code change (for example, clicking on a block counts as a change). We also were forcing a save on close if there was an enqueued save, which could mean the user sees a pop-up warning about unsaved changes even if there weren't any unsaved changes.

Since both the source and channel are just json, it's easy to tell if we actually need to save changes or not. If the source has changed since our last save, we save both the source and channel (so we can update the last saved time on the channel). If only the channel changed, we can just save the channel (this could happen in the future when we allow project renaming).

I also updated our page change logic to check for unsaved changes rather than just and enqueued save, which will mean fewer pop-ups for users.

## Links
- jira ticket: [SL-826](https://codedotorg.atlassian.net/browse/SL-826)


## Testing story
Tested locally on `/projectbeats` and `allthethings` (although `allthethings` is still a bit buggy due to in-progress work on reloading, so saving only works if you don't switch between levels).


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
