### PR TITLE
Make a button class that works w/ icons for ltr and rtl languages

### DIFF
--- a/pegasus/sites.v3/code.org/public/ai.haml
+++ b/pegasus/sites.v3/code.org/public/ai.haml
@@ -21,9 +21,10 @@ theme: responsive_full_width
       %h1{style: "color: white"}=hoc_s(:ai_hero_heading)
       %p{style: "color: white"}=hoc_s(:ai_hero_desc)
       - if !!DCDO.get('teach-ai-launch-2023', false)
-        %a.link-button{href: "#teach-ai-callout"}
-          %i{class: "#{icon_megaphone}", style: "margin-right: 6px"}
-          =hoc_s(:call_to_action_special_announcement)
+        %a.link-button.has-icon{href: "#teach-ai-callout"}
+          %div.flex-wrapper
+            %i{class: "#{icon_megaphone}"}
+            =hoc_s(:call_to_action_special_announcement)
     %figure.col-33{style: "float: right"}
       %img.fade-in-out{src: "/images/banners/ai-bot-wizard.svg", alt: "", style: "z-index: 10"}
       %img{src: "/images/banners/ai-bot-default.svg", alt: "", style: "position: relative;"}

--- a/pegasus/sites.v3/code.org/public/css/design-system-pegasus.scss
+++ b/pegasus/sites.v3/code.org/public/css/design-system-pegasus.scss
@@ -142,8 +142,8 @@ a.link-button {
   &.has-icon {
     .flex-wrapper {
       display: flex;
-      gap: 0 .75em;
       align-items: center;
+      gap: 0 .75em;
     }
   }
 }

--- a/pegasus/sites.v3/code.org/public/css/design-system-pegasus.scss
+++ b/pegasus/sites.v3/code.org/public/css/design-system-pegasus.scss
@@ -138,6 +138,14 @@ a.link-button {
       background: $neutral_dark10;
     }
   }
+
+  &.has-icon {
+    .flex-wrapper {
+      display: flex;
+      gap: 0 .75em;
+      align-items: center;
+    }
+  }
 }
 
 // Basic hero banner


### PR DESCRIPTION
Added a `.has-icon` button class for buttons with icons + text that has even spacing for ltr or rtl languages. 

Example of page w/ an icon button: https://code.org/ai

**Related comment:** https://github.com/code-dot-org/code-dot-org/pull/51448/files#r1176756839

**Jira ticket:** [ACQ-551](https://codedotorg.atlassian.net/browse/ACQ-551?atlOrigin=eyJpIjoiZmY4MjI1MjMxMjZjNGZkNmJjMjRiMTVkNzZlOWJmNWEiLCJwIjoiaiJ9)

----

### LTR
<img width="954" alt="LTR" src="https://user-images.githubusercontent.com/9256643/236287572-593ba226-8eba-44ad-a41d-8d5f19984c99.png">

### RTL
<img width="970" alt="RTL" src="https://user-images.githubusercontent.com/9256643/236287699-e189c6f3-3dff-498e-9d8b-8b1db029feab.png">

