### PR TITLE
Fix `env.colorize` Call After Rails 6.1 Update

### DIFF
--- a/dashboard/.irbrc
+++ b/dashboard/.irbrc
@@ -13,7 +13,7 @@ color = colors[env.to_sym] || :white
 
 IRB.conf[:PROMPT] ||= {}
 IRB.conf[:PROMPT][:RAILS_APP] = {
-  PROMPT_I: "[#{env.colorize(color)}] #{app} > ",
+  PROMPT_I: "[#{env.to_s.colorize(color)}] #{app} > ",
   PROMPT_N: nil,
   PROMPT_S: nil,
   PROMPT_C: nil,


### PR DESCRIPTION
~Not sure why, but we need to explicitly cast the `env` object to a string in Rails 6.1 for the `colorize` gem to be able to treat it as a string; in earlier versions, it got handled correctly automatically.~

In Rails 6.0, `Rails.env` [returns an instance of `ActiveSupport::StringInquirer`](https://github.com/rails/rails/blob/91cf62e7b43c33ae6263adf3d7563da9b68ff21d/railties/lib/rails.rb#L68-L75), a class [which extends `String` to provide some extra functionality](https://github.com/rails/rails/blob/v6.0.6/activesupport/lib/active_support/string_inquirer.rb), which means that this is an entirely valid object to call `colorize` on.

In Rails 6.1, `Rails.env` was updated to internally [return an `ActiveSupport::EnvironmentInquirer`](https://github.com/rails/rails/blob/66073335585f04f2ed0f5ef930eb3c8955d50a6a/railties/lib/rails.rb#L67-L74), a class [which extends `StringInquierer` to add a required initialization argument](https://github.com/rails/rails/blob/v6.1.4.7/activesupport/lib/active_support/environment_inquirer.rb). Ideally since this is still an extension of String it should still be just fine to call `colorize` on this object, but as part of its internal logic, [`colorize` tries to initialize a new blank instance](https://github.com/fazibear/colorize/blob/960378b73c52bd08df5ed647aaf1750f42c22ee0/lib/colorize/instance_methods.rb#L22) of the calling class, which in this case does not support blank initialization.

The simple fix is to explicitly cast `Rails.env` to a String before colorizing.