### PR TITLE
Fix "Update Infrastructure Topics" Scripts after Rails 6.1

### DIFF
--- a/lib/cdo/infra_production_topic.rb
+++ b/lib/cdo/infra_production_topic.rb
@@ -12,7 +12,8 @@ module InfraProductionTopic
     timezone_name = 'US/Pacific'
 
     timezone = TZInfo::Timezone.get(timezone_name)
-    offset_in_hours = timezone.current_period.utc_total_offset_rational.numerator
+    offset_in_seconds = timezone.observed_utc_offset
+    offset_in_hours = offset_in_seconds / 3600
     offset = format '%+.2d:00', offset_in_hours
 
     Time.now.getlocal(offset)

--- a/lib/cdo/infra_test_topic.rb
+++ b/lib/cdo/infra_test_topic.rb
@@ -29,7 +29,8 @@ module InfraTestTopic
     timezone_name = 'US/Pacific'
 
     timezone = TZInfo::Timezone.get(timezone_name)
-    offset_in_hours = timezone.current_period.utc_total_offset_rational.numerator
+    offset_in_seconds = timezone.observed_utc_offset
+    offset_in_hours = offset_in_seconds / 3600
     offset = format '%+.2d:00', offset_in_hours
 
     Time.now.getlocal(offset)


### PR DESCRIPTION
The update to Rails 6.1 also involved updating TZInfo, which unfortunately had a small breaking change which affects some pieces of our deployment pipeline not covered by tests. Specifically:

> The `TZInfo::TimezonePeriod#utc_total_offset_rational` method has been removed. Equivalent information can be obtained using the `TZInfo::TimezonePeriod#observed_utc_offset method`.

## Links

- https://app.honeybadger.io/projects/45435/faults/95709191
- https://github.com/jeremyevans/sequel/issues/1596
- https://github.com/tzinfo/tzinfo/releases/tag/v2.0.0

## Testing story

Tested locally that these two approaches produce the same results on different versions of Rails:

```
$ git switch --detach v2023-05-04.0
[~/code-dot-org ((v2023-05-04.0))]$ bin/dashboard-console
Loading development environment (Rails 6.0.6)
[development] dashboard > timezone = TZInfo::Timezone.get('US/Pacific')
=> #<TZInfo::DataTimezone: US/Pacific>
[development] dashboard > timezone.current_period.utc_total_offset_rational.numerator
=> -7
[development] dashboard >
[~/code-dot-org ((v2023-05-04.0))]$ git switch staging
[~/code-dot-org (staging)]$ bin/dashboard-console
Loading development environment (Rails 6.1.4.7)
irb(main):001:0> timezone = TZInfo::Timezone.get('US/Pacific')
=> #<TZInfo::DataTimezone: US/Pacific>
irb(main):002:0> timezone.observed_utc_offset
=> -25200
irb(main):003:0> timezone.observed_utc_offset / 3600
=> -7
irb(main):004:0>
```

Also verified that with this change, I can successfully use the DOTD script to manually mark the DTT as green.