### PR TITLE
Enforce allow_multiple_attempts on contained levels behind a DCDO flag

### DIFF
--- a/apps/src/code-studio/levels/freeResponse.js
+++ b/apps/src/code-studio/levels/freeResponse.js
@@ -4,10 +4,11 @@ import {onAnswerChanged, resetContainedLevel} from './codeStudioLevels';
 import {sourceForLevel} from '../clientState';
 
 export default class FreeResponse {
-  constructor(levelId, optional) {
+  constructor(levelId, optional, allowMultipleAttempts) {
     this.levelId = levelId;
     // Levelbuilder booleans are undefined, 'true', or 'false'.
     this.optional = [true, 'true'].includes(optional);
+    this.allowMultipleAttempts = [true, 'true'].includes(allowMultipleAttempts);
 
     $(document).ready(function () {
       var textarea = $(`textarea#level_${levelId}.response`);
@@ -53,6 +54,9 @@ export default class FreeResponse {
   }
 
   lockAnswers() {
+    if (this.allowMultipleAttempts) {
+      return;
+    }
     $(`textarea#level_${this.levelId}.response`).prop('disabled', true);
     $('#reset-predict-progress-button')?.prop('disabled', false);
   }

--- a/apps/src/code-studio/levels/multi.js
+++ b/apps/src/code-studio/levels/multi.js
@@ -19,7 +19,8 @@ var Multi = function (
   answers,
   answersFeedback,
   lastAttemptString,
-  containedMode
+  containedMode,
+  allowMultipleAttempts
 ) {
   // The dashboard levelId.
   this.levelId = levelId;
@@ -58,6 +59,8 @@ var Multi = function (
   this.crossedAnswers = [];
 
   this.submitAllowed = true;
+
+  this.allowMultipleAttempts = !!allowMultipleAttempts;
 
   $(document).ready(() => this.ready());
 };
@@ -203,6 +206,9 @@ Multi.prototype.ready = function () {
 };
 
 Multi.prototype.lockAnswers = function () {
+  if (this.allowMultipleAttempts) {
+    return;
+  }
   $('#' + this.id + ' .answerbutton').addClass('lock-answers');
   $('#reset-predict-progress-button')?.prop('disabled', false);
 };

--- a/apps/src/containedLevels.js
+++ b/apps/src/containedLevels.js
@@ -65,8 +65,12 @@ export function postContainedLevelAttempt({
     return;
   }
   const isTeacher = getStore().getState().currentUser?.userType === 'teacher';
+  const levelAllowsMultipleAttempts = !!codeStudioLevels.getLevel(
+    codeStudioLevels.getLevelIds()[0]
+  )?.allowMultipleAttempts;
+  const canRetryLevel = isTeacher || levelAllowsMultipleAttempts;
 
-  if (!isTeacher && attempts !== 1) {
+  if (!canRetryLevel && attempts !== 1) {
     return;
   }
 

--- a/apps/test/unit/code-studio/levels/freeResponse.js
+++ b/apps/test/unit/code-studio/levels/freeResponse.js
@@ -5,6 +5,8 @@ import {writeSourceForLevel} from '@cdo/apps/code-studio/clientState';
 
 describe('Free Response', () => {
   const levelId = 1047;
+  const optional = false;
+  const allowMultipleAttempts = false;
   const scriptName = 'test-script';
   const lastAttemptString = 'This is my final answer';
   const otherLastAttemptString = 'This is some other answer';
@@ -29,7 +31,11 @@ describe('Free Response', () => {
 
   describe('Shows last attempt', () => {
     it('shows nothing if there was no last attempt', () => {
-      const freeResponse = new FreeResponse(levelId);
+      const freeResponse = new FreeResponse(
+        levelId,
+        optional,
+        allowMultipleAttempts
+      );
       expect(freeResponse.getResult().response).to.be.empty;
     });
 
@@ -42,7 +48,11 @@ describe('Free Response', () => {
         lastAttemptString
       );
 
-      const freeResponse = new FreeResponse(levelId);
+      const freeResponse = new FreeResponse(
+        levelId,
+        optional,
+        allowMultipleAttempts
+      );
       expect(freeResponse.getResult().response).to.equal(lastAttemptString);
     });
 
@@ -56,7 +66,11 @@ describe('Free Response', () => {
       );
       textarea.value = otherLastAttemptString;
 
-      const freeResponse = new FreeResponse(levelId);
+      const freeResponse = new FreeResponse(
+        levelId,
+        optional,
+        allowMultipleAttempts
+      );
       expect(freeResponse.getResult().response).to.equal(
         otherLastAttemptString
       );
@@ -72,7 +86,11 @@ describe('Free Response', () => {
       lastAttemptString
     );
 
-    const freeResponse = new FreeResponse(levelId);
+    const freeResponse = new FreeResponse(
+      levelId,
+      optional,
+      allowMultipleAttempts
+    );
     expect(freeResponse.getResult().response).to.equal(lastAttemptString);
 
     freeResponse.resetAnswers();

--- a/apps/test/unit/code-studio/levels/multi.js
+++ b/apps/test/unit/code-studio/levels/multi.js
@@ -17,6 +17,7 @@ describe('multi', () => {
   const otherLastAttemptString = '0';
   const emptyLastAttemptString = '';
   const containedMode = false;
+  const allowMultipleAttempts = false;
 
   before(() => {
     replaceOnWindow('appOptions', {});
@@ -39,7 +40,8 @@ describe('multi', () => {
         answers,
         answersFeedback,
         emptyLastAttemptString,
-        containedMode
+        containedMode,
+        allowMultipleAttempts
       );
       multi.clickItem(1);
       assert.strictEqual(multi.validateAnswers(), true);
@@ -55,7 +57,8 @@ describe('multi', () => {
         answers,
         answersFeedback,
         emptyLastAttemptString,
-        containedMode
+        containedMode,
+        allowMultipleAttempts
       );
       multi.clickItem(0);
       assert.strictEqual(multi.validateAnswers(), false);
@@ -71,7 +74,8 @@ describe('multi', () => {
         answers,
         answersFeedback,
         emptyLastAttemptString,
-        containedMode
+        containedMode,
+        allowMultipleAttempts
       );
       assert.strictEqual(multi.validateAnswers(), false);
     });
@@ -88,7 +92,8 @@ describe('multi', () => {
         noAnswers,
         answersFeedback,
         emptyLastAttemptString,
-        containedMode
+        containedMode,
+        allowMultipleAttempts
       );
 
       multi.clickItem(1);
@@ -109,7 +114,8 @@ describe('multi', () => {
         answers,
         answersFeedback,
         emptyLastAttemptString,
-        containedMode
+        containedMode,
+        allowMultipleAttempts
       );
       expect(multi.selectedAnswers).to.be.empty;
     });
@@ -124,7 +130,8 @@ describe('multi', () => {
         answers,
         answersFeedback,
         lastAttemptString,
-        containedMode
+        containedMode,
+        allowMultipleAttempts
       );
       expect(multi.selectedAnswers).to.include(lastAttemptNum);
     });
@@ -146,7 +153,8 @@ describe('multi', () => {
         answers,
         answersFeedback,
         emptyLastAttemptString,
-        containedMode
+        containedMode,
+        allowMultipleAttempts
       );
 
       expect(multi.selectedAnswers).to.include(lastAttemptNum);
@@ -169,7 +177,8 @@ describe('multi', () => {
         answers,
         answersFeedback,
         lastAttemptString,
-        containedMode
+        containedMode,
+        allowMultipleAttempts
       );
 
       expect(multi.selectedAnswers).to.include(lastAttemptNum);
@@ -192,7 +201,8 @@ describe('multi', () => {
         answers,
         answersFeedback,
         emptyLastAttemptString,
-        containedMode
+        containedMode,
+        allowMultipleAttempts
       );
 
       expect(multi.selectedAnswers).to.include(lastAttemptNum);
@@ -214,7 +224,8 @@ describe('multi', () => {
         answers,
         answersFeedback,
         lastAttemptString,
-        containedMode
+        containedMode,
+        allowMultipleAttempts
       );
       multi.clickItem(1);
       const result = multi.getResult(true);
@@ -239,7 +250,8 @@ describe('multi', () => {
         answers,
         answersFeedback,
         null,
-        containedMode
+        containedMode,
+        allowMultipleAttempts
       );
       const result = multi.getResult(true);
 

--- a/dashboard/app/views/levels/_free_response.html.haml
+++ b/dashboard/app/views/levels/_free_response.html.haml
@@ -16,7 +16,7 @@
 
 - if in_level_group # The LevelGroup will collect results for each level.
   :javascript
-    window.dashboard.codeStudioLevels.registerLevel(#{level.id}, new FreeResponse(#{level.id}, #{!!level.optional}));
+    window.dashboard.codeStudioLevels.registerLevel(#{level.id}, new FreeResponse(#{level.id}, #{!!level.optional}, #{level.allow_multiple_attempts}));
 
 - else # Otherwise we need to provide a `getResult` function.
   :javascript

--- a/dashboard/app/views/levels/_free_response.html.haml
+++ b/dashboard/app/views/levels/_free_response.html.haml
@@ -4,6 +4,8 @@
   in_level_group ||= false
   left_align = local_assigns[:left_align]
   is_contained_level ||= false
+  enforce_allow_multiple_attempts = DCDO.get('enforce_allow_multiple_attempts', false)
+  allow_multiple_attempts = enforce_allow_multiple_attempts ? level.allow_multiple_attempts? : false
   js_data = {
     response_count: @responses&.count || 0,
     is_contained_level: is_contained_level
@@ -16,7 +18,7 @@
 
 - if in_level_group # The LevelGroup will collect results for each level.
   :javascript
-    window.dashboard.codeStudioLevels.registerLevel(#{level.id}, new FreeResponse(#{level.id}, #{!!level.optional}, #{level.allow_multiple_attempts}));
+    window.dashboard.codeStudioLevels.registerLevel(#{level.id}, new FreeResponse(#{level.id}, #{!!level.optional}, #{allow_multiple_attempts}));
 
 - else # Otherwise we need to provide a `getResult` function.
   :javascript

--- a/dashboard/app/views/levels/_single_multi.html.haml
+++ b/dashboard/app/views/levels/_single_multi.html.haml
@@ -138,5 +138,6 @@
       #{answers || "undefined"},
       #{answers_feedback.to_json},
       #{last_attempt.to_json},
-      #{contained_mode}
+      #{contained_mode},
+      #{!!level.allow_multiple_attempts}
     ));

--- a/dashboard/app/views/levels/_single_multi.html.haml
+++ b/dashboard/app/views/levels/_single_multi.html.haml
@@ -7,6 +7,8 @@
 - app = 'multi'
 - use_tight_layout = data['layout'] == "tight" || tight_layout
 - force_wrap_layout = data['layout'] == "wrap"
+- enforce_allow_multiple_attempts = DCDO.get('enforce_allow_multiple_attempts', false)
+- allow_multiple_attempts = enforce_allow_multiple_attempts ? level.allow_multiple_attempts? : false
 
 :ruby
   js_data = {
@@ -139,5 +141,5 @@
       #{answers_feedback.to_json},
       #{last_attempt.to_json},
       #{contained_mode},
-      #{!!level.allow_multiple_attempts}
+      #{allow_multiple_attempts}
     ));


### PR DESCRIPTION
This PR:
- copies the logic over from https://github.com/code-dot-org/code-dot-org/pull/51297 (commit a62f2257813880512c4ff74be23389274dd19906 in this PR)
-  puts that logic behind a DCDO flag (commit f9048aab2780d893354220cd08c67c43151d7dfd in this PR)


The tests will be added as a follow up as they'll fail until the DCDO flag is set correctly.