### PR TITLE
Only send complete application reminders when email present

### DIFF
--- a/dashboard/lib/services/complete_application_reminder.rb
+++ b/dashboard/lib/services/complete_application_reminder.rb
@@ -20,7 +20,7 @@ class Services::CompleteApplicationReminder
     # They should not receive more than one reminder of this type.
     # @return [Enumerable<Pd::Application::ApplicationBase>]
     def applications_needing_initial_reminder
-      incomplete_applications.select do |app|
+      incomplete_applications_with_email.select do |app|
         most_recent_update = most_recently_updated(app)
         most_recent_update.before?(Date.today - 6.days) && most_recent_update.after?(Date.today - 14.days) &&
           app.emails.where(email_type: 'complete_application_initial_reminder').count == 0
@@ -32,7 +32,7 @@ class Services::CompleteApplicationReminder
     # They should not receive more than one reminder of this type.
     # @return [Enumerable<Pd::Application::ApplicationBase>]
     def applications_needing_final_reminder
-      incomplete_applications.select do |app|
+      incomplete_applications_with_email.select do |app|
         most_recently_updated(app).before?(Date.today - 13.days) &&
           app.emails.where(email_type: 'complete_application_final_reminder').count == 0
       end
@@ -42,9 +42,12 @@ class Services::CompleteApplicationReminder
 
     # Locate all incomplete applications for this year
     # @return [ActiveRecord::Relation<Pd::Application::ApplicationBase>]
-    def incomplete_applications
+    def incomplete_applications_with_email
       Pd::Application::TeacherApplication.
-        where(application_year: Pd::Application::ActiveApplicationModels::APPLICATION_CURRENT_YEAR, status: 'incomplete')
+        where(application_year: Pd::Application::ActiveApplicationModels::APPLICATION_CURRENT_YEAR, status: 'incomplete').
+          select do |app|
+            app.email.present?
+          end
     end
 
     def most_recently_updated(application)

--- a/dashboard/test/lib/services/complete_application_reminder_test.rb
+++ b/dashboard/test/lib/services/complete_application_reminder_test.rb
@@ -112,4 +112,35 @@ class Services::CompleteApplicationReminderTest < ActiveSupport::TestCase
       assert_equal 1, application.emails.where.not(sent_at: nil).where(email_type: 'complete_application_final_reminder').count
     end
   end
+
+  test 'both reminders omit applications without an email' do
+    Timecop.freeze do
+      teacher_without_email = create :teacher, :with_school_info, :demigrated
+      teacher_without_email.update_attribute(:email, '')
+      teacher_without_email.update_attribute(:hashed_email, '')
+      application_hash_without_email = build :pd_teacher_application_hash, alternate_email: ''
+      application_without_email = create :pd_teacher_application,
+                                         status: 'incomplete',
+                                         user: teacher_without_email,
+                                         form_data: application_hash_without_email.to_json
+
+      application_with_email = create :pd_teacher_application, status: 'incomplete'
+
+      # two applications were created
+      assert Pd::Application::TeacherApplication.exists?(id: application_without_email.id)
+      assert Pd::Application::TeacherApplication.exists?(id: application_with_email.id)
+
+      # At 7 days, the only application that gets the first reminder is the application with an email
+      Timecop.travel 7.days
+      applications_needing_initial_reminder = Services::CompleteApplicationReminder.applications_needing_initial_reminder
+      assert_equal 1, applications_needing_initial_reminder.count
+      assert_equal application_with_email.id, applications_needing_initial_reminder.first.id
+
+      # At 14 days, the only application that gets the second reminder is the application with an email
+      Timecop.travel 7.days
+      applications_needing_final_reminder = Services::CompleteApplicationReminder.applications_needing_final_reminder
+      assert_equal 1, applications_needing_final_reminder.count
+      assert_equal application_with_email.id, applications_needing_final_reminder.first.id
+    end
+  end
 end

--- a/dashboard/test/lib/services/complete_application_reminder_test.rb
+++ b/dashboard/test/lib/services/complete_application_reminder_test.rb
@@ -133,14 +133,14 @@ class Services::CompleteApplicationReminderTest < ActiveSupport::TestCase
       # At 7 days, the only application that gets the first reminder is the application with an email
       Timecop.travel 7.days
       applications_needing_initial_reminder = Services::CompleteApplicationReminder.applications_needing_initial_reminder
-      assert_equal 1, applications_needing_initial_reminder.count
-      assert_equal application_with_email.id, applications_needing_initial_reminder.first.id
+      assert applications_needing_initial_reminder.include?(application_with_email)
+      refute applications_needing_initial_reminder.include?(teacher_without_email)
 
       # At 14 days, the only application that gets the second reminder is the application with an email
       Timecop.travel 7.days
       applications_needing_final_reminder = Services::CompleteApplicationReminder.applications_needing_final_reminder
-      assert_equal 1, applications_needing_final_reminder.count
-      assert_equal application_with_email.id, applications_needing_final_reminder.first.id
+      assert applications_needing_final_reminder.include?(application_with_email)
+      refute applications_needing_final_reminder.include?(teacher_without_email)
     end
   end
 end


### PR DESCRIPTION
When clearing the queue of unsent mailers, I found some incomplete emails that were trying to send but were unable to do so because no email was present. This PR changes the "complete application reminders" to only select incomplete apps that also have an email. 

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Added unit tests to reflect updates

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
