### PR TITLE
Use new FontAwesome icons on catalog cards

### DIFF
--- a/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
+++ b/apps/src/templates/curriculumCatalog/CurriculumCatalogCard.jsx
@@ -111,7 +111,6 @@ const CustomizableCurriculumCatalogCard = ({
             <div>{`+${subjectsAndTopics.length - 1}`}</div>
           )}
         </div>
-        {/*TODO [MEG]: Ensure this icon matches spec when we update FontAwesome */}
         {isTranslated && (
           <FontAwesome
             icon="language"
@@ -126,8 +125,7 @@ const CustomizableCurriculumCatalogCard = ({
         <p>{gradeRange}</p>
       </div>
       <div className={style.iconWithDescription}>
-        {/*TODO [MEG]: Update this to be clock fa-solid when we update FontAwesome */}
-        <FontAwesome icon="clock-o" />
+        <FontAwesome icon="clock" className="fa-solid" />
         <p>{duration}</p>
       </div>
       <div

--- a/apps/src/templates/curriculumCatalog/curriculum_catalog_card.module.scss
+++ b/apps/src/templates/curriculumCatalog/curriculum_catalog_card.module.scss
@@ -106,6 +106,10 @@ $container-width: 309px;
     margin: 0;
     color: $neutral_dark;
   }
+
+  i {
+    font-size: 0.875em;
+  }
 }
 
 .buttonsContainer {


### PR DESCRIPTION
Updates FontAwesome icons to use the fa-solid classname. Tested manually:

<img width="882" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/9142121/38970fff-3b05-4677-8ddf-040f81c0f81e">


Compare to the [Figma design spec](https://www.figma.com/file/w5R6KSZF01FAysZor6j4sa/Curriculum-Catalog?node-id=101-9)

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
