### PR TITLE
Update projects api to get channel for script and level

### DIFF
--- a/dashboard/app/controllers/projects_controller.rb
+++ b/dashboard/app/controllers/projects_controller.rb
@@ -283,7 +283,7 @@ class ProjectsController < ApplicationController
     )
   end
 
-  # GET /projects/level/:level_id or GET /projects/level/:level_id(/script_id/:script_id)
+  # GET /projects/level/:level_id(/script_id/:script_id)
   # Given a level_id and the current user (or signed out user), get the existing project
   # or create a new project for that level and user. If a script_id is provided, get or
   # create the project for that level, script and user

--- a/dashboard/app/controllers/projects_controller.rb
+++ b/dashboard/app/controllers/projects_controller.rb
@@ -283,7 +283,7 @@ class ProjectsController < ApplicationController
     )
   end
 
-  # GET /projects/level/:level_id(/script_id/:script_id)
+  # GET /projects(/script/:script_id)/level/:level_id
   # Given a level_id and the current user (or signed out user), get the existing project
   # or create a new project for that level and user. If a script_id is provided, get or
   # create the project for that level, script and user

--- a/dashboard/app/controllers/projects_controller.rb
+++ b/dashboard/app/controllers/projects_controller.rb
@@ -2,7 +2,7 @@ require 'active_support/core_ext/hash/indifferent_access'
 require 'cdo/firehose'
 
 class ProjectsController < ApplicationController
-  before_action :authenticate_user!, except: [:load, :create_new, :show, :edit, :readonly, :redirect_legacy, :public, :index, :export_config, :weblab_footer, :get_or_create_for_level, :get_or_create_for_script_level]
+  before_action :authenticate_user!, except: [:load, :create_new, :show, :edit, :readonly, :redirect_legacy, :public, :index, :export_config, :weblab_footer, :get_or_create_for_level]
   before_action :redirect_admin_from_labs, only: [:load, :create_new, :show, :edit, :remix]
   before_action :authorize_load_project!, only: [:load, :create_new, :edit, :remix]
   before_action :set_level, only: [:load, :create_new, :show, :edit, :readonly, :remix, :export_config, :export_create_channel]

--- a/dashboard/app/controllers/projects_controller.rb
+++ b/dashboard/app/controllers/projects_controller.rb
@@ -283,13 +283,13 @@ class ProjectsController < ApplicationController
     )
   end
 
-  # GET /projects/level/:level_id or GET /projects/level/:level_id?script_name=:script_name
+  # GET /projects/level/:level_id or GET /projects/level/:level_id(/script_id/:script_id)
   # Given a level_id and the current user (or signed out user), get the existing project
-  # or create a new project for that level and user. If a script_name is provided, get or
+  # or create a new project for that level and user. If a script_id is provided, get or
   # create the project for that level, script and user
   # Returns json: {channel: <encrypted-channel-token>}
   def get_or_create_for_level
-    script_id = Unit.find_by_name(params[:script_name])&.id
+    script_id = params[:script_id]
     level = Level.find(params[:level_id])
     error_message = under_13_without_tos_teacher?(level)
     return render(status: :forbidden, json: {error: error_message}) if error_message

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -952,6 +952,19 @@ module LevelsHelper
     error_message = under_13_without_tos_teacher?(level)
     return false unless error_message
 
+    if error_message == I18n.t("errors.messages.too_young")
+      FirehoseClient.instance.put_record(
+        :analysis,
+        {
+          study: "redirect_under_13",
+          event: "student_with_no_teacher_redirected",
+          user_id: current_user.id,
+          data_json: {
+            game: level.game.name
+          }.to_json
+        }
+      )
+    end
     redirect_to '/', flash: {alert: error_message}
     return true
   end

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -949,34 +949,28 @@ module LevelsHelper
   # redirect.
   # @return [boolean] whether a (privacy) redirect happens.
   def redirect_under_13_without_tos_teacher(level)
+    error_message = under_13_without_tos_teacher?(level)
+    return false unless error_message
+
+    redirect_to '/', flash: {alert: error_message}
+    return true
+  end
+
+  def under_13_without_tos_teacher?(level)
     # Note that Game.applab includes both App Lab and Maker Toolkit.
     return false unless level.game == Game.applab || level.game == Game.gamelab || level.game == Game.weblab
 
     if current_user&.under_13? && current_user.terms_version.nil?
       if current_user.teachers.any?
-        error_message = I18n.t("errors.messages.teacher_must_accept_terms")
+        return I18n.t("errors.messages.teacher_must_accept_terms")
       else
-        error_message = I18n.t("errors.messages.too_young")
-        FirehoseClient.instance.put_record(
-          :analysis,
-          {
-            study: "redirect_under_13",
-            event: "student_with_no_teacher_redirected",
-            user_id: current_user.id,
-            data_json: {
-              game: level.game.name
-            }.to_json
-          }
-        )
+        return I18n.t("errors.messages.too_young")
       end
-      redirect_to '/', flash: {alert: error_message}
-      return true
     end
 
     pairings.each do |paired_user|
       if paired_user.under_13? && paired_user.terms_version.nil?
-        redirect_to '/', flash: {alert: I18n.t("errors.messages.pair_programmer")}
-        return true
+        return I18n.t("errors.messages.pair_programmer")
       end
     end
 

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -270,7 +270,7 @@ Dashboard::Application.routes.draw do
 
     # Get or create a project for the given level_id. Optionally, the request
     # can include script_id to get or create a project for the level and script.
-    get "projects/level/:level_id(/script/:script_id)", to: 'projects#get_or_create_for_level'
+    get "projects(/script/:script_id)/level/:level_id", to: 'projects#get_or_create_for_level'
 
     post '/locale', to: 'home#set_locale', as: 'locale'
 

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -267,11 +267,10 @@ Dashboard::Application.routes.draw do
         get '/:tab_name', to: 'projects#index', constraints: {tab_name: /(public|libraries)/}
       end
     end
-    # Get or create a project for the given level_id.
+
+    # Get or create a project for the given level_id. Optionally, the request
+    # can include ?script_name as a query parameter to get or create a project for the level and script.
     get "projects/level/:level_id", to: 'projects#get_or_create_for_level'
-    # Get or create a project for the given script and level. script_id should be the name
-    # of the script.
-    get "projects/s/:script_id/level/:level_id", to: 'projects#get_or_create_for_script_level'
 
     post '/locale', to: 'home#set_locale', as: 'locale'
 

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -267,9 +267,11 @@ Dashboard::Application.routes.draw do
         get '/:tab_name', to: 'projects#index', constraints: {tab_name: /(public|libraries)/}
       end
     end
-
-    # Get or create a project for the given level_id
-    get 'projects/for_level/:level_id', to: 'projects#get_or_create_for_level'
+    # Get or create a project for the given level_id.
+    get "projects/level/:level_id", to: 'projects#get_or_create_for_level'
+    # Get or create a project for the given script and level. script_id should be the name
+    # of the script.
+    get "projects/s/:script_id/level/:level_id", to: 'projects#get_or_create_for_script_level'
 
     post '/locale', to: 'home#set_locale', as: 'locale'
 

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -269,8 +269,8 @@ Dashboard::Application.routes.draw do
     end
 
     # Get or create a project for the given level_id. Optionally, the request
-    # can include ?script_name as a query parameter to get or create a project for the level and script.
-    get "projects/level/:level_id", to: 'projects#get_or_create_for_level'
+    # can include script_id to get or create a project for the level and script.
+    get "projects/level/:level_id(/script/:script_id)", to: 'projects#get_or_create_for_level'
 
     post '/locale', to: 'home#set_locale', as: 'locale'
 

--- a/dashboard/test/controllers/projects_controller_test.rb
+++ b/dashboard/test/controllers/projects_controller_test.rb
@@ -379,10 +379,48 @@ class ProjectsControllerTest < ActionController::TestCase
   end
 
   test 'get_or_create_for_level creates new channel if none exists' do
+    level = create(:level, :blockly)
+    get :get_or_create_for_level, params: {level_id: level.id}
+    assert_response :success
+    assert_not_nil @response.body['channel']
+  end
+
+  test 'get_or_create_for_level returns existing channel' do
+    level = create(:level, :blockly)
+    get :get_or_create_for_level, params: {level_id: level.id}
+    assert_response :success
+    channel_id = @response.body['channel']
+    assert_not_nil channel_id
+
+    get :get_or_create_for_level, params: {level_id: level.id}
+    assert_response :success
+    assert_equal channel_id, @response.body['channel']
+  end
+
+  test 'get_or_create_for_script_level creates new channel if none exists' do
     script = create(:script)
     level = create(:level, :blockly)
     create(:script_level, script: script, levels: [level])
-    get :get_or_create_for_level, params: {level_id: level.id}
+    get :get_or_create_for_script_level, params: {script_id: script.name, level_id: level.id}
+    assert_response :success
+    assert_not_nil @response.body['channel']
+  end
+
+  test 'get_or_create_for_script_level restricts usage for young students in app lab' do
+    sign_in_with_request create(:young_student)
+    script = create(:script)
+    level = create(:applab)
+    create(:script_level, script: script, levels: [level])
+    get :get_or_create_for_script_level, params: {script_id: script.name, level_id: level.id}
+    assert_response :forbidden
+  end
+
+  test 'get_or_create_for_script_level allows usage for young students with tos teacher in app lab' do
+    sign_in_with_request create(:young_student_with_tos_teacher)
+    script = create(:script)
+    level = create(:applab)
+    create(:script_level, script: script, levels: [level])
+    get :get_or_create_for_script_level, params: {script_id: script.name, level_id: level.id}
     assert_response :success
     assert_not_nil @response.body['channel']
   end

--- a/dashboard/test/controllers/projects_controller_test.rb
+++ b/dashboard/test/controllers/projects_controller_test.rb
@@ -401,7 +401,7 @@ class ProjectsControllerTest < ActionController::TestCase
     script = create(:script)
     level = create(:level, :blockly)
     create(:script_level, script: script, levels: [level])
-    get :get_or_create_for_level, params: {script_name: script.name, level_id: level.id}
+    get :get_or_create_for_level, params: {script_id: script.id, level_id: level.id}
     assert_response :success
     assert_not_nil @response.body['channel']
   end
@@ -411,7 +411,7 @@ class ProjectsControllerTest < ActionController::TestCase
     script = create(:script)
     level = create(:applab)
     create(:script_level, script: script, levels: [level])
-    get :get_or_create_for_level, params: {script_name: script.name, level_id: level.id}
+    get :get_or_create_for_level, params: {script_id: script.id, level_id: level.id}
     assert_response :forbidden
   end
 
@@ -420,7 +420,7 @@ class ProjectsControllerTest < ActionController::TestCase
     script = create(:script)
     level = create(:applab)
     create(:script_level, script: script, levels: [level])
-    get :get_or_create_for_level, params: {script_name: script.name, level_id: level.id}
+    get :get_or_create_for_level, params: {script_id: script.id, level_id: level.id}
     assert_response :success
     assert_not_nil @response.body['channel']
   end

--- a/dashboard/test/controllers/projects_controller_test.rb
+++ b/dashboard/test/controllers/projects_controller_test.rb
@@ -378,14 +378,14 @@ class ProjectsControllerTest < ActionController::TestCase
     assert @response.headers['Location'].ends_with? '/edit?enableMaker=true'
   end
 
-  test 'get_or_create_for_level creates new channel if none exists' do
+  test 'get_or_create_for_level without script creates new channel if none exists' do
     level = create(:level, :blockly)
     get :get_or_create_for_level, params: {level_id: level.id}
     assert_response :success
     assert_not_nil @response.body['channel']
   end
 
-  test 'get_or_create_for_level returns existing channel' do
+  test 'get_or_create_for_level without script returns existing channel' do
     level = create(:level, :blockly)
     get :get_or_create_for_level, params: {level_id: level.id}
     assert_response :success
@@ -397,30 +397,30 @@ class ProjectsControllerTest < ActionController::TestCase
     assert_equal channel_id, @response.body['channel']
   end
 
-  test 'get_or_create_for_script_level creates new channel if none exists' do
+  test 'get_or_create_for_level with script creates new channel if none exists' do
     script = create(:script)
     level = create(:level, :blockly)
     create(:script_level, script: script, levels: [level])
-    get :get_or_create_for_script_level, params: {script_id: script.name, level_id: level.id}
+    get :get_or_create_for_level, params: {script_name: script.name, level_id: level.id}
     assert_response :success
     assert_not_nil @response.body['channel']
   end
 
-  test 'get_or_create_for_script_level restricts usage for young students in app lab' do
+  test 'get_or_create_for_level with script restricts usage for young students in app lab' do
     sign_in_with_request create(:young_student)
     script = create(:script)
     level = create(:applab)
     create(:script_level, script: script, levels: [level])
-    get :get_or_create_for_script_level, params: {script_id: script.name, level_id: level.id}
+    get :get_or_create_for_level, params: {script_name: script.name, level_id: level.id}
     assert_response :forbidden
   end
 
-  test 'get_or_create_for_script_level allows usage for young students with tos teacher in app lab' do
+  test 'get_or_create_for_level with script allows usage for young students with tos teacher in app lab' do
     sign_in_with_request create(:young_student_with_tos_teacher)
     script = create(:script)
     level = create(:applab)
     create(:script_level, script: script, levels: [level])
-    get :get_or_create_for_script_level, params: {script_id: script.name, level_id: level.id}
+    get :get_or_create_for_level, params: {script_name: script.name, level_id: level.id}
     assert_response :success
     assert_not_nil @response.body['channel']
   end


### PR DESCRIPTION
Follow-up to #51634. That API only got a project for a level, but we do key projects based on script and level. This allows us to reuse levels across scripts and have a different project for the same level in different scripts. 

This renames and updates the api ` GET /projects/level/level_id`. We now allow an optional parameter ` GET /projects/level/:level_id/script_id/:script_id`. When a script_id is provided, we will get the project based off the level and script, not just the level. 

I also updated the authorization a little. We don't need to authenticate the user before getting the project, because we allow projects for signed out users. I also was reusing our redirect method to check if the user could access the level, but I should have been returning forbidden since this is an api that returns a json response. So I updated the `redirect_under_13_without_tos_teacher` to use a helper method I can reuse to determine if the user can access the level. There's pretty little risk with the auth here, since all you get back is a channel id for a project you own.


## Links

- jira ticket: [SL-828](https://codedotorg.atlassian.net/browse/SL-828)

## Testing story
Mostly tested using unit tests. I also verified our existing redirect behavior still works after the refactor.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
