### PR TITLE
Rename CdoPathObject as CdoPathObjectGeras

### DIFF
--- a/apps/src/blockly/addons/cdoPathObjectGeras.js
+++ b/apps/src/blockly/addons/cdoPathObjectGeras.js
@@ -1,6 +1,6 @@
 import GoogleBlockly from 'blockly/core';
 
-export default class CdoPathObject extends GoogleBlockly.geras.PathObject {
+export default class CdoPathObjectGeras extends GoogleBlockly.geras.PathObject {
   // The built-in function also adds a cross-hatch fill pattern to disabled blocks, which we don't want.
   // Overrriding the function here so we can just set the class but not add the fill pattern.
   updateDisabled_(disabled) {
@@ -10,6 +10,7 @@ export default class CdoPathObject extends GoogleBlockly.geras.PathObject {
   // The built-in function adds a light filter over the whole block. We want to match our old
   // behavior where highlighting the block adds the same yellow outline as selecting.
   updateHighlighted(highlighted) {
+    console.log('updateHighlighted - cdoPathObject - geras');
     this.setClass_('blocklySelected', highlighted);
   }
 }

--- a/apps/src/blockly/addons/cdoPathObjectGeras.js
+++ b/apps/src/blockly/addons/cdoPathObjectGeras.js
@@ -10,7 +10,6 @@ export default class CdoPathObjectGeras extends GoogleBlockly.geras.PathObject {
   // The built-in function adds a light filter over the whole block. We want to match our old
   // behavior where highlighting the block adds the same yellow outline as selecting.
   updateHighlighted(highlighted) {
-    console.log('updateHighlighted - cdoPathObject - geras');
     this.setClass_('blocklySelected', highlighted);
   }
 }

--- a/apps/src/blockly/addons/cdoRendererGeras.js
+++ b/apps/src/blockly/addons/cdoRendererGeras.js
@@ -1,5 +1,5 @@
 import GoogleBlockly from 'blockly/core';
-import CdoPathObject from './cdoPathObject';
+import CdoPathObject from './cdoPathObjectGeras';
 
 export default class CdoRendererGeras extends GoogleBlockly.geras.Renderer {
   /**


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This small PR updates the name of `CdoPathObject` to `CdoPathObjectGeras`. `geras` used to be the only renderer for mainline Blockly labs, but now `thrasos` is the default renderer, and the three renderers we maintain in our repo each have a corresponding `pathObject` file.



## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
I tested locally to make sure I could switch renderers successfully using 'enableExperiments=zelos' or 'enableExperiments=geras' and then back to the default of `thrasos`. 
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
