### PR TITLE
Client-side metrics API for communicating with Dashboard

### DIFF
--- a/apps/src/lib/metrics/DashboardMetricsApi.ts
+++ b/apps/src/lib/metrics/DashboardMetricsApi.ts
@@ -1,0 +1,29 @@
+import {
+  getAuthenticityToken,
+  AUTHENTICITY_TOKEN_HEADER,
+} from '../../util/AuthenticityTokenStore';
+import {MetricsApi} from './MetricsApi';
+
+const BASE_URL = '/browser_events/';
+
+/**
+ * A {@link MetricsApi} implementation that forwards metrics to Dashboard.
+ */
+export default class DashboardMetricsApi implements MetricsApi {
+  async sendLogs(logs: object[]): Promise<Response> {
+    let token;
+    try {
+      token = await getAuthenticityToken();
+    } catch (error) {
+      return Response.error();
+    }
+
+    return fetch(BASE_URL + 'put_logs', {
+      method: 'POST',
+      body: JSON.stringify({logs}),
+      headers: {
+        [AUTHENTICITY_TOKEN_HEADER]: token,
+      },
+    });
+  }
+}

--- a/apps/src/lib/metrics/MetricsReporter.ts
+++ b/apps/src/lib/metrics/MetricsReporter.ts
@@ -1,3 +1,4 @@
+import DashboardMetricsApi from './DashboardMetricsApi';
 import {MetricsApi} from './MetricsApi';
 
 const isDevelopmentEnvironment =
@@ -26,8 +27,6 @@ type LogLevel = 'INFO' | 'WARNING' | 'SEVERE';
  * For legacy client-side reporting see {@link firehose} for AWS
  * Firehose reporting and {@link logToCloud} for New Relic reporting.
  */
-// TODO: This class will be used once more functionality is implemented.
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 class MetricsReporter {
   private lastCheckCanReportTime: number;
 
@@ -116,3 +115,5 @@ class MetricsReporter {
     );
   }
 }
+
+export default new MetricsReporter(new DashboardMetricsApi());


### PR DESCRIPTION
This creates a client-side implementation of the generic MetricsApi that hits the dashboard route created in [this PR](https://github.com/code-dot-org/code-dot-org/pull/51174). Since currently only logging is supported (not putting metrics), this just adds the implementation for the putLogs method. We'll add to this when we enable metrics and counters.

Note: before we can start using this logging functionality, we need to update our CloudFormation template to create the right log groups and log streams on deploy (separate change). I'll hold off merging this until the CloudFormation change has been merged and deployed. 

## Links

https://codedotorg.atlassian.net/browse/SL-761

## Testing story

Tested locally. Ensured that logs get forwarded to the right controller and are posted to cloudwatch. Example events:

<img width="2237" alt="Screenshot 2023-05-05 at 4 27 42 PM" src="https://user-images.githubusercontent.com/85528507/236584399-3a9af156-f780-4304-b050-00ba9644245c.png">