### PR TITLE
skip sync for ai markdown files in pegasus

### DIFF
--- a/bin/i18n/codeorg-testing_markdown_crowdin.yml
+++ b/bin/i18n/codeorg-testing_markdown_crowdin.yml
@@ -9,4 +9,7 @@
 files: [{
   "source": "/i18n/locales/source/markdown/**/*.md",
   "translation": "/pegasus/sites.v3/code.org/i18n/**/%file_name%.%locale%.md.partial",
+  "ignore": [
+    "/i18n/locales/source/markdown/public/ai.md",
+    ],
   }]

--- a/bin/i18n/codeorg_markdown_crowdin.yml
+++ b/bin/i18n/codeorg_markdown_crowdin.yml
@@ -9,4 +9,7 @@
 files: [{
   "source": "/i18n/locales/source/markdown/**/*.md",
   "translation": "/pegasus/sites.v3/code.org/i18n/**/%file_name%.%locale%.md.partial",
+  "ignore": [
+    "/i18n/locales/source/markdown/public/ai.md",
+    ],
   }]

--- a/bin/i18n/sync-in.rb
+++ b/bin/i18n/sync-in.rb
@@ -775,7 +775,6 @@ end
 
 def localize_markdown_content
   markdown_files_to_localize = %w[
-    ai.md.partial
     athome.md.partial
     break.md.partial
     coldplay.md.partial

--- a/bin/i18n/sync-out.rb
+++ b/bin/i18n/sync-out.rb
@@ -487,6 +487,8 @@ def distribute_translations(upload_manifests)
       destination_dir << "/.." if relative_path.start_with? "/views"
       relative_dir = File.dirname(relative_path)
       name = File.basename(loc_file, ".*")
+      # TODO: Remove the ai.md exception when ai.md files are deleted from crowdin
+      next if %w[ai].include? name # ai.md file has been substituted by ai.haml
       destination = File.join(destination_dir, relative_dir, "#{name}.#{locale}.md.partial")
       FileUtils.mkdir_p(File.dirname(destination))
       FileUtils.mv(loc_file, destination)
@@ -609,6 +611,9 @@ def restore_markdown_headers
       source_path = File.join(File.dirname(source_path), File.basename(source_path, ".partial"))
     end
     begin
+      # TODO: Remove the ai.md exception when ai.md files are deleted from crowdin
+      # ai.md file has been substituted by ai.haml therefore source_path for ai.md translations does not exist
+      next unless File.exist? source_path # if source path does not exist, the markdown heaader can not be restored
       source_header, _source_content, _source_line = Documents.new.helpers.parse_yaml_header(source_path)
     rescue Exception => exception
       puts "Error parsing yaml header in source_path=#{source_path} for path=#{path}"


### PR DESCRIPTION
The sync has been failing since `pegasus/sites.v3/code.org/public/ai.md` was substituted by `pegasus/sites.v3/code.org/public/ai.haml`.

We don't want to delete the `ai.md` file from Cowdin yet, as it would delete all translations. 
 For that reason, and in order to unblock the sync, 

## Testing story

I successfully ran a mini sync for `Code.org - Markdown - Testing` project without distributing `ai.md` files or restoring markdown headers.

## Follow-up work

Remove the exceptions included in this PR, once it is safe to delete the translations for `ai.md` from Crowdin.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
