### PR TITLE
Improve margins for the SummaryEntryPoint on standalone levels

### DIFF
--- a/apps/src/templates/levelSummary/SummaryEntryPoint.jsx
+++ b/apps/src/templates/levelSummary/SummaryEntryPoint.jsx
@@ -17,14 +17,16 @@ const SummaryEntryPoint = ({scriptData, students, selectedSection}) => {
   );
   const summaryUrl = document.location.pathname + SUMMARY_PATH + params;
 
+  let className = styles.summaryEntryPoint;
+  if (!scriptData.is_contained_level) {
+    className += ' ' + styles.isStandalone;
+    if (scriptData.question_content_blank) {
+      className += ' ' + styles.noQuestionContent;
+    }
+  }
+
   return (
-    <div
-      className={
-        styles.summaryEntryPoint +
-        ' ' +
-        (scriptData.is_contained_level ? '' : styles.isStandalone)
-      }
-    >
+    <div className={className}>
       <Button
         color={Button.ButtonColor.neutralDark}
         text={i18n.viewStudentResponses()}

--- a/apps/src/templates/levelSummary/summary-entry-point.module.scss
+++ b/apps/src/templates/levelSummary/summary-entry-point.module.scss
@@ -17,6 +17,10 @@
   padding-top: 40px;
 }
 
+.summaryEntryPoint.noQuestionContent {
+  margin-left: 50px;
+}
+
 .button {
   float: left;
 }

--- a/dashboard/app/views/levels/_single_multi.html.haml
+++ b/dashboard/app/views/levels/_single_multi.html.haml
@@ -8,11 +8,6 @@
 - use_tight_layout = data['layout'] == "tight" || tight_layout
 - force_wrap_layout = data['layout'] == "wrap"
 
-:ruby
-  js_data = {
-    response_count: @responses&.count || 0,
-    is_contained_level: contained_mode
-  }
 
 - multi_answer_characters = ("A".."Z").to_a
 
@@ -125,6 +120,14 @@
       - answers = localized_answers.map {|answer| answer['correct'] || false}
 
     - answers_feedback = localized_answers.map {|answer| answer['feedback']}
+
+
+  :ruby
+    js_data = {
+      response_count: @responses&.count || 0,
+      is_contained_level: contained_mode,
+      question_content_blank: question_content_blank,
+    }
 
   %script{src: webpack_asset_path('js/levels/_single_multi.js'), data: {summaryinfo: js_data.to_json}}
 


### PR DESCRIPTION
Fixes the margin for `SummaryEntryPoint` on some Multi/standalone levels. I'm not convinced this will fix all ways these fields can render, but all the allthethings levels looked right after this change.

||before|after|
|------|-----|------|
|/s/allthethings/lessons/9/levels/1|![Screenshot 2023-05-08 at 12 18 12 PM](https://user-images.githubusercontent.com/46464143/236876320-86f0aca9-0cc9-4b6f-b22a-71e1d4fe60e1.png)|![Screenshot 2023-05-08 at 12 13 13 PM](https://user-images.githubusercontent.com/46464143/236875376-cf56a20d-f558-47b4-b356-1e56fd67037e.png)|
|/s/allthethings/lessons/9/levels/2|![Screenshot 2023-05-08 at 12 19 28 PM](https://user-images.githubusercontent.com/46464143/236876563-d1443c6d-fac7-4d68-a5ca-001196a1780b.png)|![Screenshot 2023-05-08 at 12 13 24 PM](https://user-images.githubusercontent.com/46464143/236875524-4ed4c5d3-5345-4a42-8c83-817e49d1fe06.png)|
|/s/allthethings/lessons/9/levels/3|![Screenshot 2023-05-08 at 12 19 37 PM](https://user-images.githubusercontent.com/46464143/236876573-56befc2d-79b2-4b4d-b812-02ea8add994f.png)|![Screenshot 2023-05-08 at 12 13 30 PM](https://user-images.githubusercontent.com/46464143/236875528-e0563318-9e0d-4db1-b842-3eab8a5d868c.png)|
|/s/allthethings/lessons/9/levels/4|![Screenshot 2023-05-08 at 12 20 21 PM](https://user-images.githubusercontent.com/46464143/236876808-62a95bf0-fed6-4a95-8436-0ab6ec5e7e4b.png)|![Screenshot 2023-05-08 at 12 13 39 PM](https://user-images.githubusercontent.com/46464143/236875529-84a86f15-2f46-4ae6-ac30-49791a66a5f7.png)|



