### PR TITLE
Fix parseSoundPathString unit test

### DIFF
--- a/apps/src/p5lab/utils.js
+++ b/apps/src/p5lab/utils.js
@@ -38,7 +38,7 @@ export function parseSoundPathString(text) {
     category = pathStringArray[2];
     // Example: 'category_board_games' becomes 'Board games: '
     category = category.replace('category_', '');
-    category = category.replaceAll('_', ' ');
+    category = category.replace(/_/g, ' ');
     category = capitalizeFirstLetter(category) + ': ';
   }
   // Example: 'card_dealing_multiple.mp3' becomes 'card_dealing_multiple'


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR fixes a unit test for the `parseSoundPathString` function and follows up [this investigation PR](https://github.com/code-dot-org/code-dot-org/pull/51760). The `parseSoundPathString` function was added by [this PR](https://github.com/code-dot-org/code-dot-org/pull/51605). 

The first unit test in the `p5lab/utilsTest.js` file was failing inconsistently on the test machine. See [Slack thread](https://codedotorg.slack.com/archives/C03CM903Y/p1683562325265269).
When I ssh'd on to the test machine, the unit test failed every time I ran it using `npm run test:entry...` I saw that the `replaceAll` function was not recognized, so I used `replace` with a global variable instead. This fixed the issue on the test machine and the test passed consistently when run individually.

This presents to us a mystery - why does the unit test sometimes pass on the test machine? The pattern seems to be that when the test build [initially fails](https://codedotorg.slack.com/archives/C03CM903Y/p1683566699703729), if the test build is restarted, the unit test [does not fail](https://codedotorg.slack.com/archives/C03CM903Y/p1683572603364179). This makes me wonder if the unit tests are actually all run again on a rebuild.

I do want to note that I ran this unit test locally several times using `replaceAll` and the test passed each time. The MDN documentation states that [`replace`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#browser_compatibility) is supported for browser compatibility more broadly than [`replaceAll`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replaceAll#browser_compatibility). I wonder if this is impacting unit tests on the test machine?

To summarize, this PR fixes the unit test so it consistently passes locally AND on the test machine. However, I am unsure why the unit test using `replaceAll` sometimes passes during test builds even though the unit test consistently fails when run individually.



## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
