### PR TITLE
Disable lighthouse recipe in chef default.rb

### DIFF
--- a/cookbooks/cdo-apps/recipes/default.rb
+++ b/cookbooks/cdo-apps/recipes/default.rb
@@ -132,8 +132,6 @@ include_recipe 'cdo-analytics' if %w[production-daemon production-console].inclu
 # Daemon-specific configuration for SSH access to frontend instances.
 include_recipe 'cdo-apps::daemon_ssh' if node['cdo-apps']['daemon'] && node['cdo-apps']['frontends']
 
-include_recipe 'cdo-apps::lighthouse' if node.chef_environment == 'test'
-
 include_recipe 'cdo-tippecanoe' if node['cdo-apps']['daemon']
 
 # Patch to fix issue with systemd-resolved: https://bugs.launchpad.net/ubuntu/+source/systemd/+bug/1805183


### PR DESCRIPTION
Encountered during an upgrade of nodejs from 14 to 18 (#51533 ), on testing we're installing the `lighthouse` npm using chef, using a syntax that's outdated, and the only instance of installing an npm using chef.

Use of lighthouse as part of `test.rake` was already disabled in: https://github.com/code-dot-org/code-dot-org/pull/42301 and https://github.com/code-dot-org/code-dot-org/pull/42295

This just disables evoking the recipe that installs lighthouse on the test server.

A followup PR to this (while we're not fixing a live build) is to remove lighthouse entirely, it appears that lighthouse was added pretty much entirely in: https://github.com/code-dot-org/code-dot-org/pull/26853 so its a good place to inspect for what might be removed.