### PR TITLE
Project Beats: fix rest block code

### DIFF
--- a/apps/src/music/blockly/blocks/simple2.js
+++ b/apps/src/music/blockly/blocks/simple2.js
@@ -181,7 +181,7 @@ export const playRestAtCurrentLocationSimple2 = {
     helpUrl: '',
   },
   generator: block =>
-    `Sequencer.rest(${block.getFieldValue(FIELD_REST_DURATION_NAME)})`,
+    `Sequencer.rest(${block.getFieldValue(FIELD_REST_DURATION_NAME)});`,
 };
 
 export const setEffectAtCurrentLocationSimple2 = {


### PR DESCRIPTION
Forgot to include a semicolon when converting the code in the rest block, which caused a compilation error when using the rest block between other blocks.

## Testing story

Tested locally