### PR TITLE
[CFU] Fix an exception with nil responses

### DIFF
--- a/dashboard/app/views/levels/_summary.html.haml
+++ b/dashboard/app/views/levels/_summary.html.haml
@@ -12,7 +12,7 @@
       user_id: response.user_id,
       text: response.level_source&.data,
     }
-  end.filter { |r| !!r[:text] }  # Remove empty responses.
+  end&.filter { |r| !!r[:text] }  # Remove empty responses.
 
   teacher_markdown = if level.respond_to?(:solution) && level.solution.present? && Policies::InlineAnswer.visible_for_script_level?(current_user, @script_level)
     level.solution


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Fix an exception that occurs on the summary view when `@responses` is nil, which is easily reproduced by visiting a CSF summary page while logged out.

After:
![image](https://github.com/code-dot-org/code-dot-org/assets/1382374/4b955ff6-c332-4454-95d1-741e65e97bbc)

Renders a bit strange, since all the react components are behind an `InstructorsOnly` gate, but the question in the HAML is still there. It seems like CSF is unique here because it allows signed-out users to view things that are usually only visible to signed-in users.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->


- jira ticket: [TEACH-481](https://codedotorg.atlassian.net/browse/TEACH-481)

