### PR TITLE
[CFU] Hide correct answer toggle based on policy

### DIFF
--- a/apps/src/templates/levelSummary/SummaryResponses.jsx
+++ b/apps/src/templates/levelSummary/SummaryResponses.jsx
@@ -67,6 +67,11 @@ const SummaryResponses = ({
     }
   }, [showCorrectAnswer]);
 
+  // "Show correct answer" toggle is only shown for some level types, and
+  // only when the policy allows it for that user.
+  const showAnswerToggle =
+    scriptData.answer_is_visible && scriptData.level.type === MULTI;
+
   return (
     <div className={styles.summaryContainer} id="summary-container">
       {/* Student Responses */}
@@ -96,8 +101,8 @@ const SummaryResponses = ({
           <SectionSelector reloadOnChange={true} />
         </label>
 
-        {/* "Show correct answer" toggle is only shown for some level types. */}
-        {scriptData.level.type === MULTI && (
+        {/* Correct answer toggle */}
+        {showAnswerToggle && (
           <div className={styles.toggleContainer}>
             <ToggleSwitch
               isToggledOn={showCorrectAnswer}

--- a/dashboard/app/views/levels/_summary.html.haml
+++ b/dashboard/app/views/levels/_summary.html.haml
@@ -14,7 +14,9 @@
     }
   end.filter { |r| !!r[:text] }  # Remove empty responses.
 
-  teacher_markdown = if level.respond_to?(:solution) && level.solution.present? && Policies::InlineAnswer.visible_for_script_level?(current_user, @script_level)
+  answer_is_visible = Policies::InlineAnswer.visible_for_script_level?(current_user, @script_level)
+
+  teacher_markdown = if level.respond_to?(:solution) && level.solution.present? && answer_is_visible
     level.solution
   end
 
@@ -29,6 +31,7 @@
     last_attempt: last_attempt,
     left_align: left_align,
     responses: responses,
+    answer_is_visible: answer_is_visible,
     teacher_markdown: teacher_markdown,
     reportingData: {
       lessonName: @script_level.lesson.name,
@@ -77,7 +80,7 @@
 
   #summary-responses
 
-  - if Policies::InlineAnswer.visible_for_script_level?(current_user, @script_level)
+  - if answer_is_visible
     - if level.is_a?(Multi)
       #summary-correct-answer.multi.hide
         - correct_answers = data['answers'].each_with_index.map do |answer, index|


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

If the current user doesn't have permission to view the correct answer for a level, don't show the "Show answer" toggle. Note the answer is still technically available in the page source if you dig for it, just as it is on normal levels.

After:
![image](https://github.com/code-dot-org/code-dot-org/assets/1382374/a65374a3-6693-4e9a-834e-63d1e8f75fc1)


(The missing section dropdown is an unrelated consequence of this account not having any sections.)


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
-->
- jira ticket: [TEACH-482](https://codedotorg.atlassian.net/browse/TEACH-482)

