### PR TITLE
[CFU] Hide section dropdown label with no sections

### DIFF
--- a/apps/src/templates/levelSummary/SummaryResponses.jsx
+++ b/apps/src/templates/levelSummary/SummaryResponses.jsx
@@ -19,6 +19,7 @@ const SummaryResponses = ({
   // redux
   isRtl,
   viewAs,
+  hasSections,
   selectedSection,
   students,
   currentLevelId,
@@ -91,10 +92,13 @@ const SummaryResponses = ({
           </div>
         )}
 
-        <label className={styles.sectionSelector}>
-          {i18n.responsesForClassSection()}
-          <SectionSelector reloadOnChange={true} />
-        </label>
+        {/* Section dropdown */}
+        {hasSections && (
+          <label className={styles.sectionSelector}>
+            {i18n.responsesForClassSection()}
+            <SectionSelector reloadOnChange={true} />
+          </label>
+        )}
 
         {/* "Show correct answer" toggle is only shown for some level types. */}
         {scriptData.level.type === MULTI && (
@@ -131,6 +135,7 @@ SummaryResponses.propTypes = {
   scriptData: PropTypes.object,
   isRtl: PropTypes.bool,
   viewAs: PropTypes.oneOf(Object.values(ViewType)).isRequired,
+  hasSections: PropTypes.bool,
   selectedSection: PropTypes.shape({
     id: PropTypes.number.isRequired,
     name: PropTypes.string.isRequired,
@@ -162,6 +167,7 @@ export default connect(
     return {
       isRtl: state.isRtl,
       viewAs: state.viewAs,
+      hasSections: state.teacherSections.sectionIds.length > 0,
       selectedSection:
         state.teacherSections.sections[state.teacherSections.selectedSectionId],
       students: state.teacherSections.selectedStudents,


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Noticed while doing some other work that the section dropdown disappears if the teacher has no sections, but the label for the dropdown is still there:

![image](https://github.com/code-dot-org/code-dot-org/assets/1382374/2e234fd9-5643-4911-b180-0de00e9f1e46)

The dropdown is a reused component from the teacher panel, so we don't have a lot of control over it, and can't easily have it show up when there are no sections.

This PR just hides the label too:

![image](https://github.com/code-dot-org/code-dot-org/assets/1382374/d57c4aff-5513-4d0d-a67b-727fc52e74bc)

It's still there when you do have sections:

![image](https://github.com/code-dot-org/code-dot-org/assets/1382374/28a14ee9-6a71-4875-91f2-8f4e030944d6)

We still have future work scheduled to show a better message when you don't have sections, so you don't just get a confusing empty chart / empty "Student Responses" heading.