### PR TITLE
Customize Amplitude logging to minimize extra output in tests and builds

### DIFF
--- a/apps/src/lib/util/AnalyticsReporter.js
+++ b/apps/src/lib/util/AnalyticsReporter.js
@@ -15,6 +15,8 @@ import {
 
 // A flag that can be toggled to send events regardless of environment
 const ALWAYS_SEND = false;
+// A flag that can be toggled to console log events in development
+const LOG_EVENT_IN_DEV = false;
 
 class AnalyticsReporter {
   constructor() {
@@ -60,11 +62,10 @@ class AnalyticsReporter {
     }
   }
 
-  // Will only log in development into console.debug (viewable by selecting the Verbose debug level in
-  // dev tools).
+  // Will only log in development if LOG_EVENT_IN_DEV is set to true.
   log(message) {
-    if (isDevelopmentEnvironment()) {
-      console.debug(`[AMPLITUDE ANALYTICS EVENT]: ${message}`);
+    if (isDevelopmentEnvironment() && LOG_EVENT_IN_DEV) {
+      console.log(`[AMPLITUDE ANALYTICS EVENT]: ${message}`);
     }
   }
 

--- a/apps/src/lib/util/AnalyticsReporter.js
+++ b/apps/src/lib/util/AnalyticsReporter.js
@@ -60,7 +60,7 @@ class AnalyticsReporter {
     }
   }
 
-  // Will only log in development if LOG_EVENT_IN_DEV is set to true.
+  // Will only log in development.
   log(message) {
     if (isDevelopmentEnvironment()) {
       console.log(`[AMPLITUDE ANALYTICS EVENT]: ${message}`);

--- a/apps/src/lib/util/AnalyticsReporter.js
+++ b/apps/src/lib/util/AnalyticsReporter.js
@@ -61,7 +61,7 @@ class AnalyticsReporter {
   }
 
   log(message) {
-    if (isDevelopmentEnvironment()) {
+    if (isDevelopmentEnvironment() && !IN_UNIT_TEST) {
       console.log(`[AMPLITUDE ANALYTICS EVENT]: ${message}`);
     }
   }

--- a/apps/src/lib/util/AnalyticsReporter.js
+++ b/apps/src/lib/util/AnalyticsReporter.js
@@ -10,6 +10,7 @@ import {
   getEnvironment,
   isProductionEnvironment,
   isStagingEnvironment,
+  isDevelopmentEnvironment,
 } from '../../utils';
 
 // A flag that can be toggled to send events regardless of environment
@@ -59,8 +60,12 @@ class AnalyticsReporter {
     }
   }
 
+  // Will only log in development into console.debug (viewable by selecting the Verbose debug level in
+  // dev tools).
   log(message) {
-    console.log(`[AMPLITUDE ANALYTICS EVENT]: ${message}`);
+    if (isDevelopmentEnvironment()) {
+      console.debug(`[AMPLITUDE ANALYTICS EVENT]: ${message}`);
+    }
   }
 
   formatUserId(userId) {

--- a/apps/src/lib/util/AnalyticsReporter.js
+++ b/apps/src/lib/util/AnalyticsReporter.js
@@ -15,8 +15,6 @@ import {
 
 // A flag that can be toggled to send events regardless of environment
 const ALWAYS_SEND = false;
-// A flag that can be toggled to console log events in development
-const LOG_EVENT_IN_DEV = false;
 
 class AnalyticsReporter {
   constructor() {
@@ -64,7 +62,7 @@ class AnalyticsReporter {
 
   // Will only log in development if LOG_EVENT_IN_DEV is set to true.
   log(message) {
-    if (isDevelopmentEnvironment() && LOG_EVENT_IN_DEV) {
+    if (isDevelopmentEnvironment()) {
       console.log(`[AMPLITUDE ANALYTICS EVENT]: ${message}`);
     }
   }

--- a/apps/src/lib/util/AnalyticsReporter.js
+++ b/apps/src/lib/util/AnalyticsReporter.js
@@ -60,7 +60,6 @@ class AnalyticsReporter {
     }
   }
 
-  // Will only log in development.
   log(message) {
     if (isDevelopmentEnvironment()) {
       console.log(`[AMPLITUDE ANALYTICS EVENT]: ${message}`);


### PR DESCRIPTION
As per [this Slack thread](https://codedotorg.slack.com/archives/C0T0PNTM3/p1682967256364519), it was brought up that our Amplitude events are logging to console even in unit tests (meaning every drone build is printing out a lot of unnecessary information). In addition to this, some developers were finding it cluttering to their browser's console when they weren't specifically working on Amplitude events.

This PR updates our logging behavior so that Amplitude events are only logged to the console if the current environment is `development`.

## Browser console logging
Amplitude now does not print to the console log by default:
![FINAL_with_false](https://github.com/code-dot-org/code-dot-org/assets/56283563/be2b2f8b-1cf8-4263-8c3d-edf37dc65cc3)

Amplitude only logs in development once flag is flipped to 'true' locally:
![FINAL_with_true](https://github.com/code-dot-org/code-dot-org/assets/56283563/d7fac72e-ff07-4901-a571-e976e8ab3a71)

## Testing
Previously, there were lots of Amplitude log events cluttering up the unit tests:
![Sample_testing_amplitude](https://github.com/code-dot-org/code-dot-org/assets/56283563/2ac7de07-f106-450e-832f-e5661326dc34)

Now, they aren't logged in the test environment:
![No_test_amplitude](https://github.com/code-dot-org/code-dot-org/assets/56283563/513a2558-0162-44a5-8802-3198a0e59699)

## Links
Slack thread this was discussed in: [here](https://codedotorg.slack.com/archives/C0T0PNTM3/p1682967256364519)
Jira task: [here](https://codedotorg.atlassian.net/jira/software/c/projects/ACQ/boards/64?modal=detail&selectedIssue=ACQ-568&assignee=60d62161f65054006980bd71)

## Testing story
Local testing and ensuring the drone build is not printing Amplitude logs when running unit tests.

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
