### PR TITLE
Revert "Don't show the summary entry point in level groups"

### DIFF
--- a/dashboard/app/views/levels/_free_response.html.haml
+++ b/dashboard/app/views/levels/_free_response.html.haml
@@ -36,7 +36,7 @@
     );
 
 .free-response{:class => ('left-aligned' if left_align)}
-  - if DCDO.get("show_level_summary_entry_point", false) && !in_level_group
+  - if DCDO.get("show_level_summary_entry_point", false)
     %div#summaryEntryPoint
   - title = level.get_property(:title)
   - if title.present? && (!in_level_group || is_contained_level)


### PR DESCRIPTION
Summary entry point stopped showing up in contained levels as a result of code-dot-org/code-dot-org#51623. Examples  https://studio.code.org/s/coursef-2020/lessons/2/levels/2, https://studio.code.org/s/csd3-2022/lessons/5/levels/1, and https://studio.code.org/s/csa1-2022/lessons/4/levels/1