### PR TITLE
Refactoring version dropdown to match rest of site

### DIFF
--- a/apps/src/templates/sectionsRefresh/VersionUnitDropdowns.jsx
+++ b/apps/src/templates/sectionsRefresh/VersionUnitDropdowns.jsx
@@ -13,7 +13,6 @@ export default function VersionUnitDropdowns({
   const VERSION_ID = 'versionId';
   const UNIT_ID = 'unitId';
   const noAssignment = '__noAssignment__';
-  const preparedCourseVersions = prepareCourseVersions();
 
   // When selecting a new version, remove the outdated assigned unit
   const updateCourseVersion = id => {
@@ -31,7 +30,7 @@ export default function VersionUnitDropdowns({
   };
 
   const selectedCourseVersionObject =
-    preparedCourseVersions[sectionCourse?.versionId];
+    prepareCourseVersions()[sectionCourse?.versionId];
 
   const orderedUnits = _.orderBy(
     selectedCourseVersionObject?.units,
@@ -62,13 +61,14 @@ export default function VersionUnitDropdowns({
   return (
     <div className={moduleStyles.buttonRow}>
       <div className={moduleStyles.buttonsInRow}>
-        {Object.values(preparedCourseVersions).length > 1 && courseOffering && (
-          <AssignmentVersionSelector
-            selectedCourseVersionId={sectionCourse.versionId}
-            courseVersions={preparedCourseVersions}
-            onChangeVersion={id => updateCourseVersion(id)}
-          />
-        )}
+        {Object.values(prepareCourseVersions()).length > 1 &&
+          courseOffering && (
+            <AssignmentVersionSelector
+              selectedCourseVersionId={sectionCourse.versionId}
+              courseVersions={prepareCourseVersions()}
+              onChangeVersion={id => updateCourseVersion(id)}
+            />
+          )}
         {sectionCourse?.versionId &&
           orderedUnits &&
           Object.entries(orderedUnits).length > 1 && (

--- a/apps/src/templates/sectionsRefresh/VersionUnitDropdowns.jsx
+++ b/apps/src/templates/sectionsRefresh/VersionUnitDropdowns.jsx
@@ -13,6 +13,7 @@ export default function VersionUnitDropdowns({
   const VERSION_ID = 'versionId';
   const UNIT_ID = 'unitId';
   const noAssignment = '__noAssignment__';
+  const preparedCourseVersions = prepareCourseVersions();
 
   // When selecting a new version, remove the outdated assigned unit
   const updateCourseVersion = id => {
@@ -30,7 +31,7 @@ export default function VersionUnitDropdowns({
   };
 
   const selectedCourseVersionObject =
-    prepareCourseVersions()[sectionCourse?.versionId];
+    preparedCourseVersions[sectionCourse?.versionId];
 
   const orderedUnits = _.orderBy(
     selectedCourseVersionObject?.units,
@@ -61,10 +62,10 @@ export default function VersionUnitDropdowns({
   return (
     <div className={moduleStyles.buttonRow}>
       <div className={moduleStyles.buttonsInRow}>
-        {courseOffering && (
+        {Object.values(preparedCourseVersions).length > 1 && courseOffering && (
           <AssignmentVersionSelector
             selectedCourseVersionId={sectionCourse.versionId}
-            courseVersions={prepareCourseVersions()}
+            courseVersions={preparedCourseVersions}
             onChangeVersion={id => updateCourseVersion(id)}
           />
         )}


### PR DESCRIPTION
This pr does a small refactor so that we only call prepareCourseVersions() once, and then also verifies there is more than one version before rendering the dropdown. 
Before:
<img width="735" alt="Screenshot 2023-05-10 at 4 32 14 PM" src="https://github.com/code-dot-org/code-dot-org/assets/37230822/93542c75-2151-4d79-b596-2c30d634d68f">

After:
<img width="801" alt="Screenshot 2023-05-10 at 4 31 44 PM" src="https://github.com/code-dot-org/code-dot-org/assets/37230822/8ac79e63-7193-4f21-8270-2744b9b90293">

## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/TEACH-496

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
