### PR TITLE
Project Beats: add help URLs to blocks

### DIFF
--- a/apps/src/music/blockly/MusicBlocklyWorkspace.js
+++ b/apps/src/music/blockly/MusicBlocklyWorkspace.js
@@ -104,6 +104,16 @@ export default class MusicBlocklyWorkspace {
     Blockly.Msg['PROCEDURES_DEFNORETURN_PROCEDURE'] =
       musicI18n.blockly_functionNamePlaceholder();
 
+    // Wrap the create function block's init function in a function that
+    // sets the block's help URL to the appropriate entry in the Music Lab
+    // docs, and calls the original init function if present.
+    const functionBlock = Blockly.Blocks.procedures_defnoreturn;
+    functionBlock.initOriginal = functionBlock.init;
+    functionBlock.init = function () {
+      this.setHelpUrl('/docs/ide/projectbeats/expressions/create_function');
+      this.initOriginal?.();
+    };
+
     Blockly.setInfiniteLoopTrap();
 
     this.resizeBlockly();

--- a/apps/src/music/blockly/MusicBlocklyWorkspace.js
+++ b/apps/src/music/blockly/MusicBlocklyWorkspace.js
@@ -9,6 +9,7 @@ import AppConfig, {getBlockMode} from '../appConfig';
 import {BlockMode, REMOTE_STORAGE} from '../constants';
 import {
   DEFAULT_TRACK_NAME_EXTENSION,
+  DOCS_BASE_URL,
   DYNAMIC_TRIGGER_EXTENSION,
   FIELD_CHORD_TYPE,
   FIELD_PATTERN_TYPE,
@@ -110,7 +111,7 @@ export default class MusicBlocklyWorkspace {
     const functionBlock = Blockly.Blocks.procedures_defnoreturn;
     functionBlock.initOriginal = functionBlock.init;
     functionBlock.init = function () {
-      this.setHelpUrl('/docs/ide/projectbeats/expressions/create_function');
+      this.setHelpUrl(DOCS_BASE_URL + 'create_function');
       this.initOriginal?.();
     };
 

--- a/apps/src/music/blockly/blocks/simple2.js
+++ b/apps/src/music/blockly/blocks/simple2.js
@@ -8,6 +8,7 @@ import {
   FIELD_EFFECTS_NAME,
   FIELD_EFFECTS_VALUE,
   FIELD_CHORD_NAME,
+  DOCS_BASE_URL,
 } from '../constants';
 import {
   fieldSoundsDefinition,
@@ -105,7 +106,7 @@ export const triggeredAtSimple2 = {
     style: 'event_blocks',
     tooltip: musicI18n.blockly_blockTriggeredTooltip(),
     extensions: [DYNAMIC_TRIGGER_EXTENSION],
-    helpUrl: '/docs/ide/projectbeats/expressions/trigger',
+    helpUrl: DOCS_BASE_URL + 'trigger',
   },
   generator: block =>
     `
@@ -125,7 +126,7 @@ export const playSoundAtCurrentLocationSimple2 = {
     nextStatement: null,
     style: 'lab_blocks',
     tooltip: musicI18n.blockly_blockPlaySoundTooltip(),
-    helpUrl: '/docs/ide/projectbeats/expressions/play_sample',
+    helpUrl: DOCS_BASE_URL + 'play_sample',
   },
   generator: block =>
     `Sequencer.playSound("${block.getFieldValue(FIELD_SOUNDS_NAME)}", "${
@@ -143,7 +144,7 @@ export const playPatternAtCurrentLocationSimple2 = {
     nextStatement: null,
     style: 'lab_blocks',
     tooltip: musicI18n.blockly_blockPlayPatternTooltip(),
-    helpUrl: '/docs/ide/projectbeats/expressions/play_pattern',
+    helpUrl: DOCS_BASE_URL + 'play_pattern',
   },
   generator: block =>
     `Sequencer.playPattern(${JSON.stringify(
@@ -161,7 +162,7 @@ export const playChordAtCurrentLocationSimple2 = {
     nextStatement: null,
     style: 'lab_blocks',
     tooltip: musicI18n.blockly_blockPlayChordTooltip(),
-    helpUrl: '',
+    helpUrl: DOCS_BASE_URL + 'play_keys',
   },
   generator: block =>
     `Sequencer.playChord(${JSON.stringify(
@@ -179,7 +180,7 @@ export const playRestAtCurrentLocationSimple2 = {
     nextStatement: null,
     style: 'lab_blocks',
     tooltip: musicI18n.blockly_blockRestTooltip(),
-    helpUrl: '/docs/ide/projectbeats/expressions/rest',
+    helpUrl: DOCS_BASE_URL + 'rest',
   },
   generator: block =>
     `Sequencer.rest(${block.getFieldValue(FIELD_REST_DURATION_NAME)});`,
@@ -214,7 +215,7 @@ export const setEffectAtCurrentLocationSimple2 = {
     nextStatement: null,
     style: 'lab_blocks',
     tooltip: musicI18n.blockly_blockSetEffectTooltip(),
-    helpUrl: '/docs/ide/projectbeats/expressions/set_effect',
+    helpUrl: DOCS_BASE_URL + 'set_effect',
   },
   generator: block => {
     const effectName = block.getFieldValue(FIELD_EFFECTS_NAME);
@@ -240,7 +241,7 @@ export const playSoundsTogether = {
     nextStatement: null,
     style: 'logic_blocks',
     tooltip: musicI18n.blockly_blockPlaySoundsTogether(),
-    helpUrl: '/docs/ide/projectbeats/expressions/play_together',
+    helpUrl: DOCS_BASE_URL + 'play_together',
   },
   generator: block =>
     ` Sequencer.playTogether();
@@ -266,7 +267,7 @@ export const playSoundsSequential = {
     nextStatement: null,
     style: 'logic_blocks',
     tooltip: musicI18n.blockly_blockPlaySoundsSequentialTooltip(),
-    helpUrl: '/docs/ide/projectbeats/expressions/play_sequential',
+    helpUrl: DOCS_BASE_URL + 'play_sequential',
   },
   generator: block =>
     ` Sequencer.playSequential();
@@ -292,7 +293,7 @@ export const playSoundsRandom = {
     nextStatement: null,
     style: 'logic_blocks',
     tooltip: musicI18n.blockly_blockPlaySoundsRandomTooltip(),
-    helpUrl: '/docs/ide/projectbeats/expressions/play_random',
+    helpUrl: DOCS_BASE_URL + 'play_random',
   },
   generator: block => {
     const resultArray = [];
@@ -346,7 +347,7 @@ export const repeatSimple2 = {
     nextStatement: null,
     style: 'loop_blocks',
     tooltip: '%{BKY_CONTROLS_REPEAT_TOOLTIP}',
-    helpUrl: '/docs/ide/projectbeats/expressions/repeat',
+    helpUrl: DOCS_BASE_URL + 'repeat',
   },
   generator: block => {
     const repeats = block.getFieldValue('times');

--- a/apps/src/music/blockly/blocks/simple2.js
+++ b/apps/src/music/blockly/blocks/simple2.js
@@ -105,6 +105,7 @@ export const triggeredAtSimple2 = {
     style: 'event_blocks',
     tooltip: musicI18n.blockly_blockTriggeredTooltip(),
     extensions: [DYNAMIC_TRIGGER_EXTENSION],
+    helpUrl: '/docs/ide/projectbeats/expressions/trigger',
   },
   generator: block =>
     `
@@ -124,7 +125,7 @@ export const playSoundAtCurrentLocationSimple2 = {
     nextStatement: null,
     style: 'lab_blocks',
     tooltip: musicI18n.blockly_blockPlaySoundTooltip(),
-    helpUrl: '',
+    helpUrl: '/docs/ide/projectbeats/expressions/play_sample',
   },
   generator: block =>
     `Sequencer.playSound("${block.getFieldValue(FIELD_SOUNDS_NAME)}", "${
@@ -142,7 +143,7 @@ export const playPatternAtCurrentLocationSimple2 = {
     nextStatement: null,
     style: 'lab_blocks',
     tooltip: musicI18n.blockly_blockPlayPatternTooltip(),
-    helpUrl: '',
+    helpUrl: '/docs/ide/projectbeats/expressions/play_pattern',
   },
   generator: block =>
     `Sequencer.playPattern(${JSON.stringify(
@@ -178,7 +179,7 @@ export const playRestAtCurrentLocationSimple2 = {
     nextStatement: null,
     style: 'lab_blocks',
     tooltip: musicI18n.blockly_blockRestTooltip(),
-    helpUrl: '',
+    helpUrl: '/docs/ide/projectbeats/expressions/rest',
   },
   generator: block =>
     `Sequencer.rest(${block.getFieldValue(FIELD_REST_DURATION_NAME)});`,
@@ -213,7 +214,7 @@ export const setEffectAtCurrentLocationSimple2 = {
     nextStatement: null,
     style: 'lab_blocks',
     tooltip: musicI18n.blockly_blockSetEffectTooltip(),
-    helpUrl: '',
+    helpUrl: '/docs/ide/projectbeats/expressions/set_effect',
   },
   generator: block => {
     const effectName = block.getFieldValue(FIELD_EFFECTS_NAME);
@@ -239,7 +240,7 @@ export const playSoundsTogether = {
     nextStatement: null,
     style: 'logic_blocks',
     tooltip: musicI18n.blockly_blockPlaySoundsTogether(),
-    helpUrl: '',
+    helpUrl: '/docs/ide/projectbeats/expressions/play_together',
   },
   generator: block =>
     ` Sequencer.playTogether();
@@ -265,7 +266,7 @@ export const playSoundsSequential = {
     nextStatement: null,
     style: 'logic_blocks',
     tooltip: musicI18n.blockly_blockPlaySoundsSequentialTooltip(),
-    helpUrl: '',
+    helpUrl: '/docs/ide/projectbeats/expressions/play_sequential',
   },
   generator: block =>
     ` Sequencer.playSequential();
@@ -291,7 +292,7 @@ export const playSoundsRandom = {
     nextStatement: null,
     style: 'logic_blocks',
     tooltip: musicI18n.blockly_blockPlaySoundsRandomTooltip(),
-    helpUrl: '',
+    helpUrl: '/docs/ide/projectbeats/expressions/play_random',
   },
   generator: block => {
     const resultArray = [];
@@ -345,7 +346,7 @@ export const repeatSimple2 = {
     nextStatement: null,
     style: 'loop_blocks',
     tooltip: '%{BKY_CONTROLS_REPEAT_TOOLTIP}',
-    helpUrl: '',
+    helpUrl: '/docs/ide/projectbeats/expressions/repeat',
   },
   generator: block => {
     const repeats = block.getFieldValue('times');

--- a/apps/src/music/blockly/constants.js
+++ b/apps/src/music/blockly/constants.js
@@ -42,3 +42,7 @@ export const MINUS_IMAGE =
   'MC9zdmciIHZlcnNpb249IjEuMSIgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0Ij48cGF0aCBkPS' +
   'JNMTggMTFoLTEyYy0xLjEwNCAwLTIgLjg5Ni0yIDJzLjg5NiAyIDIgMmgxMmMxLjEwNCAw' +
   'IDItLjg5NiAyLTJzLS44OTYtMi0yLTJ6IiBmaWxsPSJ3aGl0ZSIgLz48L3N2Zz4K';
+
+// Other
+
+export const DOCS_BASE_URL = '/docs/ide/projectbeats/expressions/';


### PR DESCRIPTION
Adds links to block documentation to music lab blocks (as block 'help URLs'). Two callouts:
- ~We currently don't have an entry for play chord, so will need to update that when docs have been added~ Edit: play chord has been added, but the page does not yet exist. Will show up once after the next content scoop.
- In order to provide a help URL to the function block, we have to do a little bit of function reassignment so that the URL can be added on init() and we still call the original init() function to set up the block correctly.

https://github.com/code-dot-org/code-dot-org/assets/85528507/452f4cda-f5c2-428e-bd15-0f8a96ba1d84

## Links

https://codedotorg.atlassian.net/browse/SL-548

## Testing story

Tested locally.