### PR TITLE
Music: quick fix for play icon in sounds panel

### DIFF
--- a/apps/src/music/views/soundsPanel.module.scss
+++ b/apps/src/music/views/soundsPanel.module.scss
@@ -47,13 +47,13 @@
 }
 
 .soundRowMiddle {
-  width: calc(100% - 25px - 55px);
+  width: calc(100% - 25px - 58px);
   float: left;
 }
 
 .soundRowRight {
   float: right;
-  width: 40px;
+  width: 43px;
   margin-right: 15px;
 
   .length {


### PR DESCRIPTION
A quick fix for the play icon in the sounds panel.  With the FontAwesome upgrade it's a bit wider than it used to be.

### before

<img width="338" alt="Screenshot 2023-05-11 at 11 01 58 AM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/73bc2e1a-8a90-4d1f-932e-4366e841804f">

### after

<img width="342" alt="Screenshot 2023-05-11 at 11 09 49 AM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/19bedc98-d4b1-41e5-8f48-8e49e470e99c">
