### PR TITLE
Music: handle missing analytics key

### DIFF
--- a/apps/src/music/analytics/AnalyticsReporter.ts
+++ b/apps/src/music/analytics/AnalyticsReporter.ts
@@ -91,11 +91,18 @@ export default class AnalyticsReporter {
     // Capture start time before making init call
     this.sessionStartTime = Date.now();
 
-    await this.initialize();
-    setSessionId(this.sessionStartTime);
+    try {
+      await this.initialize();
+      setSessionId(this.sessionStartTime);
 
-    this.log(`Session start. Session ID: ${this.sessionStartTime}`);
-    this.sessionInProgress = true;
+      this.log(`Session start. Session ID: ${this.sessionStartTime}`);
+      this.sessionInProgress = true;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.log(
+        `[AMPLITUDE ANALYTICS] Did not initialize analytics reporter.  (${message})`
+      );
+    }
   }
 
   async initialize(): Promise<void> {
@@ -103,7 +110,7 @@ export default class AnalyticsReporter {
     const responseJson = await response.json();
 
     if (!responseJson.key) {
-      return;
+      throw new Error('No key for analytics.');
     }
 
     return init(responseJson.key, undefined, {minIdLength: 1}).promise;

--- a/apps/src/music/analytics/AnalyticsReporter.ts
+++ b/apps/src/music/analytics/AnalyticsReporter.ts
@@ -101,6 +101,11 @@ export default class AnalyticsReporter {
   async initialize(): Promise<void> {
     const response = await fetch(API_KEY_ENDPOINT);
     const responseJson = await response.json();
+
+    if (!responseJson.key) {
+      return;
+    }
+
     return init(responseJson.key, undefined, {minIdLength: 1}).promise;
   }
 


### PR DESCRIPTION
I've always had this exception show as a console error when loading Music Lab on localhost, presumably due to not having an analytics key set up:

```
Uncaught (in promise) TypeError: Cannot read properties of null (reading 'substring')
    at getOldCookieName (cookie-name.js:8:1)
```

Is something like this PR a reasonable way to no longer see the exception?
