### PR TITLE
Music: smaller edges in standalone version

### DIFF
--- a/dashboard/app/views/musiclab/index.html.haml
+++ b/dashboard/app/views/musiclab/index.html.haml
@@ -1,4 +1,4 @@
-#codeApp{style: "position: absolute; top: 60px; bottom: 10px; left: 10px; right: 10px"}
+#codeApp{style: "position: absolute; top: 55px; bottom: 5px; left: 0px; right: 0px"}
   #musiclab-container{style: "height: 100%"}
 
 - content_for(:head) do


### PR DESCRIPTION
This specifies smaller edges in the standalone version of Music lab, to match the smaller edges seen when it's hosted by `LabContainer` in a level progression.

### before

<img width="1512" alt="Screenshot 2023-05-11 at 12 21 27 PM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/f70e94cd-6074-4847-949a-d988d62c696e">

### after

<img width="1512" alt="Screenshot 2023-05-11 at 12 18 42 PM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/bcf5c438-c9ac-4c79-ba77-a930f8998df9">

