### PR TITLE
Header: tidy up the project save error message

### DIFF
--- a/apps/src/code-studio/components/header/ProjectUpdatedAt.jsx
+++ b/apps/src/code-studio/components/header/ProjectUpdatedAt.jsx
@@ -35,6 +35,7 @@ class ProjectUpdatedAt extends React.Component {
           title={msg.projectSaveErrorTooltip()}
         >
           <i className="fa fa-exclamation-triangle" />
+          &nbsp;
           {msg.projectSaveError()}
         </span>
       );

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -317,6 +317,7 @@ img.video_thumbnail {
       margin-top: 2px;
       font-size: 12px;
       display: inline-block;
+      border-radius: 4px;
     }
   }
 


### PR DESCRIPTION
Tidy up the project save error message with a couple improvements:
- a space between the icon and the text
- a border radius to make it a bit more consistent with other header elements

### before

<img width="320" alt="Screenshot 2023-05-11 at 12 43 10 PM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/38c96bbf-0c6c-4fc0-9152-67896de3d4cb">

### after

<img width="316" alt="Screenshot 2023-05-11 at 12 54 38 PM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/681f1071-224d-4ca6-9239-8bf2d8fb3c9b">

