### PR TITLE
Music: move controls

### DIFF
--- a/apps/src/music/views/Controls.jsx
+++ b/apps/src/music/views/Controls.jsx
@@ -15,14 +15,7 @@ const documentationUrl = '/docs/ide/projectbeats';
  * Renders the playback controls bar, including the play/pause button, show/hide beat pad button,
  * and show/hide instructions button.
  */
-const Controls = ({
-  setPlaying,
-  playTrigger,
-  top,
-  instructionsAvailable,
-  toggleInstructions,
-  instructionsOnRight,
-}) => {
+const Controls = ({setPlaying, playTrigger, top}) => {
   const isPlaying = useSelector(state => state.music.isPlaying);
   const isBeatPadShowing = useSelector(state => state.music.isBeatPadShowing);
   const dispatch = useDispatch();
@@ -39,9 +32,9 @@ const Controls = ({
     return (
       <div
         style={{
-          position: 'absolute',
-          [top ? 'bottom' : 'top']: -175,
-          [instructionsOnRight ? 'left' : 'right']: 10,
+          position: 'fixed',
+          bottom: top ? 20 : 220,
+          right: 20,
         }}
       >
         <BeatPad
@@ -75,18 +68,10 @@ const Controls = ({
     });
     dispatch(toggleBeatPad());
   });
-  const infoIconSection = instructionsAvailable
-    ? renderIconButton('info-circle', toggleInstructions)
-    : null;
-
-  const [leftIcon, rightIcon] = instructionsOnRight
-    ? [beatPadIconSection, infoIconSection]
-    : [infoIconSection, beatPadIconSection];
 
   return (
     <div id="controls" className={moduleStyles.controlsContainer}>
       {isBeatPadShowing && renderBeatPad()}
-      {leftIcon}
       <div
         className={classNames(moduleStyles.controlButtons, moduleStyles.center)}
       >
@@ -96,6 +81,7 @@ const Controls = ({
           className={moduleStyles.iconButton}
         />
       </div>
+      {beatPadIconSection}
       <div
         className={classNames(moduleStyles.controlButtons, moduleStyles.side)}
       >
@@ -112,7 +98,6 @@ const Controls = ({
           />
         </a>
       </div>
-      {rightIcon}
     </div>
   );
 };
@@ -121,9 +106,6 @@ Controls.propTypes = {
   setPlaying: PropTypes.func.isRequired,
   playTrigger: PropTypes.func.isRequired,
   top: PropTypes.bool.isRequired,
-  instructionsAvailable: PropTypes.bool.isRequired,
-  toggleInstructions: PropTypes.func.isRequired,
-  instructionsOnRight: PropTypes.bool.isRequired,
 };
 
 export default Controls;

--- a/apps/src/music/views/MusicView.jsx
+++ b/apps/src/music/views/MusicView.jsx
@@ -573,9 +573,6 @@ class UnconnectedMusicView extends React.Component {
           setPlaying={this.setPlaying}
           playTrigger={this.playTrigger}
           top={timelineAtTop}
-          instructionsAvailable={!!this.progressManager}
-          toggleInstructions={() => this.toggleInstructions(false)}
-          instructionsOnRight={instructionsOnRight}
         />
         <Timeline />
       </div>

--- a/apps/src/music/views/controls.module.scss
+++ b/apps/src/music/views/controls.module.scss
@@ -4,11 +4,12 @@
 
 .controlsContainer {
   display: flex;
-  justify-content: center;
+  flex-direction: column;
+  justify-content: space-evenly;
   background-color: $neutral_dark80;
   z-index: 70;
   border-radius: $default-border-radius;
-  margin: $default-spacing 0;
+  margin: 0 $default-spacing 0 0;
   position: relative;
 }
 
@@ -18,7 +19,7 @@
   text-align: center;
 
   &.center {
-    flex: 1;
+    flex: 0;
   }
 
   &.side {

--- a/apps/src/music/views/music-view.module.scss
+++ b/apps/src/music/views/music-view.module.scss
@@ -1,5 +1,5 @@
 // Constants
-$timeline-area-height: 200px;
+$timeline-area-height: 180px;
 $default-border-radius: 4px;
 $default-spacing: 5px;
 
@@ -15,6 +15,7 @@ $default-spacing: 5px;
   user-select: none;
   display: flex;
   flex-direction: column;
+  justify-content: space-between;
 }
 
 .instructionsArea {
@@ -57,7 +58,7 @@ $default-spacing: 5px;
   flex: 1;
   display: flex;
   flex-direction: row;
-  max-height: calc(100% - $timeline-area-height);
+  max-height: calc(100% - $timeline-area-height - $default-spacing);
 
   .topButtonsContainer {
     position: absolute;
@@ -81,10 +82,10 @@ $default-spacing: 5px;
   display: flex;
 
   &.timelineBottom {
-    flex-direction: column;
+    flex-direction: row;
   }
 
   &.timelineTop {
-    flex-direction: column-reverse;
+    flex-direction: row;
   }
 }

--- a/apps/src/music/views/timeline.module.scss
+++ b/apps/src/music/views/timeline.module.scss
@@ -3,13 +3,13 @@
 .wrapper {
   background-color: $neutral_dark90;
   width: 100%;
-  height: 100%;
   border-radius: 4px;
   background-size: 100% 200%;
   padding: 10px;
   box-sizing: border-box;
 
   .container {
+    background-color: $neutral_dark90;
     width: 100%;
     overflow-x: auto;
     overflow-y: hidden;


### PR DESCRIPTION
This is a proposal to move the controls to the side of the timeline, reclaiming valuable vertical space.

Screenshots illustrate the change at our single most common resolution, 1366x768:

### after

<img width="1366" alt="Screenshot 2023-05-11 at 2 03 43 PM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/837a2efd-a855-4e2f-9dad-b3c39d97a1be">

### before

<img width="1366" alt="Screenshot 2023-05-11 at 2 07 37 PM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/64494a23-d257-41aa-9630-b2eb1e76efc5">
