### PR TITLE
Header: avoid overlaps

### DIFF
--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -218,19 +218,19 @@ img.video_thumbnail {
     text-overflow: ellipsis;
   }
 
-  @media screen and (min-width: 971px) {
+  @media screen and (min-width: 1011px) {
     .show_on_tablet {
       display: none;
     }
   }
 
-  @media screen and (max-width: 970px) {
+  @media screen and (max-width: 1010px) {
     .hide_on_tablet {
       display: none;
     }
   }
 
-  @media screen and (max-width: 1100px) {
+  @media screen and (max-width: 1120px) {
     .create_menu {
       display: none !important;
     }

--- a/pegasus/sites.v3/code.org/views/header.haml
+++ b/pegasus/sites.v3/code.org/views/header.haml
@@ -45,7 +45,7 @@
             - else
               %a.linktag#logo-signedout{:href=>CDO.code_org_url}
                 %img#logo{:src=>'/images/logo.svg', alt: I18n.t(:code_org_logo_alt)}
-          #headerlinks.desktop-feature
+          #headerlinks.hide_on_tablet
             - Hamburger.get_header_contents(header_contents_options).each do |entry|
               %a.headerlink.linktag{id: entry[:id], href: entry[:url]}= entry[:title]
 

--- a/shared/css/hamburger.scss
+++ b/shared/css/hamburger.scss
@@ -210,7 +210,7 @@
     background: $dark_teal;
   }
 
-  @media(max-width: 970px) {
+  @media(max-width: 1010px) {
     &.show-mobile {
       display: block;
     }

--- a/shared/css/header.scss
+++ b/shared/css/header.scss
@@ -61,6 +61,18 @@
       position: absolute;
     }
 
+    @media screen and (min-width: 1011px) {
+      .show_on_tablet {
+        display: none;
+      }
+    }
+
+    @media screen and (max-width: 1010px) {
+      .hide_on_tablet {
+        display: none;
+      }
+    }
+
     #headerlinks {
       float: left;
       position: relative;
@@ -141,7 +153,7 @@
     }
   }
 
-  @media screen and (max-width: 1100px) {
+  @media screen and (max-width: 1120px) {
     .create_menu {
       display: none !important;
     }


### PR DESCRIPTION
This is a follow-up to https://github.com/code-dot-org/code-dot-org/pull/50036 which added the Incubator link to the header for "en" users on both dashboard and pegasus.

It turned out that with a longer name in the user dropdown (forcing it to its maximum width), it was possible to have a collision between the Incubator link and both the Create button and the dropdown, forcing the Incubator link to wrap to the next line.

I worked on a clipping solution at first, to make the header a bit more robust, and while it worked on dashboard, the pegasus layout was proving tricky.

So this attempt just adjusts the display cutoff values so that we hide the header content (and move it to the hamburger dropdown) at slightly larger widths, and we also hide the Create button at slightly larger widths too.

## Screenshots

All screenshots are with a signed-in teacher, with the user dropdown at full width, in "en".

### Before

#### Dashboard at 971px width
<img width="971" alt="header-teacher-dashboard-971px" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/6c1089af-1724-4737-8817-51343958665e">

#### Pegasus at 971px width

<img width="971" alt="header-teacher-pegasus-971px" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/fee4be83-8121-4139-a475-c8bbe29a2a07">

### After

#### Dashboard at the smallest width showing menu items
<img width="1011" alt="header-teacher-dashboard-after" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/257371b2-e33d-43dd-9555-4f052ce55817">

#### Dashboard at the smallest width showing menu items and the create dropdown
<img width="1120" alt="header-teacher-dashboard-after-wider" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/469a405c-2ef0-477a-8156-5fcf003a4271">

#### Pegasus at the smallest width showing menu items
<img width="1011" alt="header-teacher-pegasus-after" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/a0a605c7-786b-446b-afab-266f5eeac9f9">

#### Pegasus at the smallest width showing menu items and the create dropdown
<img width="1120" alt="header_teacher-pegasus-after-wider" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/599a82d8-2e04-4b4d-9a50-149bb4d1b771">






