### PR TITLE
Fix bug where the FreeResponse haml template has in_level_group true for contained levels 

### DIFF
--- a/dashboard/app/views/levels/_contained_levels.html.haml
+++ b/dashboard/app/views/levels/_contained_levels.html.haml
@@ -14,6 +14,6 @@
       - if level_class == "multi"
         = render partial: 'levels/single_multi', locals: {standalone: false, contained_mode: true, last_attempt: sublevel_last_attempt, level: contained_level, tight_layout: true}
       - elsif level_class == "free_response"
-        = render partial: 'levels/free_response', locals: {in_level_group: true, last_attempt: sublevel_last_attempt, level: contained_level, left_align: true, is_contained_level: true }
+        = render partial: 'levels/free_response', locals: {in_level_group: false, last_attempt: sublevel_last_attempt, level: contained_level, left_align: true, is_contained_level: true }
 
 %div{style: 'clear: both;'}

--- a/dashboard/app/views/levels/_free_response.html.haml
+++ b/dashboard/app/views/levels/_free_response.html.haml
@@ -16,7 +16,7 @@
     .free-response{class: "contained"}
       = render partial: 'levels/teacher_markdown', locals: {data: {'teacher_markdown' => level.solution}}
 
-- if in_level_group # The LevelGroup will collect results for each level.
+- if in_level_group || is_contained_level # The LevelGroup will collect results for each level.
   :javascript
     window.dashboard.codeStudioLevels.registerLevel(#{level.id}, new FreeResponse(#{level.id}, #{!!level.optional}, #{allow_multiple_attempts}));
 
@@ -60,7 +60,7 @@
   %textarea.response{id: "level_#{level.id}", placeholder: placeholder, style: "height: #{height}px;", readonly: @view_options.readonly_workspace}= last_attempt
 
   -# Don't render the dialog partial if we're inside a LevelGroup.
-  = render partial: 'levels/dialog', locals: {app: 'free_response'} unless in_level_group
+  = render partial: 'levels/dialog', locals: {app: 'free_response'} unless (in_level_group || is_contained_level)
   = render partial: 'levels/teacher_markdown', locals: {data: {'teacher_markdown' => level.solution}} unless is_contained_level
 
 - content_for(:head) do


### PR DESCRIPTION
I looked through this file and adjusted anywhere that had `in_level_group` to be `in_level_group || is_contained_level`. Contained levels aren't level groups so this makes the variables more consistent with our terminology.