### PR TITLE
[CFU] Add tests for multiple choice summary

### DIFF
--- a/apps/src/templates/levelSummary/MultiResponses.jsx
+++ b/apps/src/templates/levelSummary/MultiResponses.jsx
@@ -6,32 +6,42 @@ import color from '@cdo/apps/util/color';
 
 const LETTERS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
 
+// Return an object hash, where the keys are letters representing an answer
+// and the values are the count of responses that chose that answer.
+// Example:
+//   {A: 1, B: 9, C: 2}
+const multiAnswerCounts = (responses, answerCount) => ({
+  // Default to a count of 0 for each answer.
+  ...Object.fromEntries([...LETTERS.slice(0, answerCount)].map(l => [l, 0])),
+  // Overwrite the count for any answers that have student responses.
+  ...responses.reduce((acc, curr) => {
+    const letter = LETTERS.at(curr.text);
+    acc[letter] = acc[letter] ? acc[letter] + 1 : 1;
+    return acc;
+  }, {}),
+});
+
+// Return row data in the format expected by Google Charts.
+// Param `data` is the output of `multiAnswerCounts`.
+// Optional param `highlightCorrect` is either false to render without
+// highlighting, or an Array of the letters representing correct
+// answers. Example:
+//   multiChartData({A: 2, B: 0, C: 6}, ['A'])
+const multiChartData = (data, highlightCorrect = false) => [
+  ['Answer', 'Count', {role: 'annotation'}, {role: 'style'}],
+  ...Object.entries(data).map(row => [
+    ...row,
+    row[1] +
+      (highlightCorrect && highlightCorrect.includes(row[0]) ? '✔️' : ''),
+    highlightCorrect
+      ? highlightCorrect.includes(row[0])
+        ? color.brand_primary_default
+        : color.brand_primary_light
+      : null,
+  ]),
+];
+
 const MultiResponses = ({scriptData, showCorrectAnswer = false}) => {
-  const multiAnswerCounts = (responses, answerCount) => ({
-    // Default to a count of 0 for each answer.
-    ...Object.fromEntries([...LETTERS.slice(0, answerCount)].map(l => [l, 0])),
-    // Overwrite the count for any answers that have student responses.
-    ...responses.reduce((acc, curr) => {
-      const letter = LETTERS.at(curr.text);
-      acc[letter] = acc[letter] ? acc[letter] + 1 : 1;
-      return acc;
-    }, {}),
-  });
-
-  const multiChartData = (data, highlightCorrect = false) => [
-    ['Answer', 'Count', {role: 'annotation'}, {role: 'style'}],
-    ...Object.entries(data).map(row => [
-      ...row,
-      row[1] +
-        (highlightCorrect && highlightCorrect.includes(row[0]) ? '✔️' : ''),
-      highlightCorrect
-        ? highlightCorrect.includes(row[0])
-          ? color.brand_primary_default
-          : color.brand_primary_light
-        : null,
-    ]),
-  ];
-
   const answers = scriptData.level.properties.answers;
   const answerData = useMemo(
     () => multiAnswerCounts(scriptData.responses, answers.length),
@@ -114,4 +124,5 @@ MultiResponses.propTypes = {
   showCorrectAnswer: PropTypes.bool,
 };
 
+export const exportedForTesting = {multiAnswerCounts, multiChartData};
 export default MultiResponses;

--- a/apps/test/unit/templates/levelSummary/FreeResponseResponses.jsx
+++ b/apps/test/unit/templates/levelSummary/FreeResponseResponses.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import {expect} from '../../../util/reconfiguredChai';
+import FreeResponseResponses from '@cdo/apps/templates/levelSummary/FreeResponseResponses';
+import styles from '@cdo/apps/templates/levelSummary/summary.module.scss';
+
+describe('FreeResponseResponses', () => {
+  it('renders responses', () => {
+    const responses = [
+      {user_id: 0, text: 'student response 1'},
+      {user_id: 1, text: 'student response 2'},
+      {user_id: 3, text: 'student response 3'},
+      {user_id: 2, text: 'student response 4'},
+      {user_id: 9, text: 'student response 5'},
+    ];
+    const wrapper = shallow(<FreeResponseResponses responses={responses} />);
+
+    expect(wrapper.find(`.${styles.studentAnswer}`).length).to.eq(
+      responses.length
+    );
+    expect(wrapper.find(`.${styles.studentAnswer}`).at(0).text()).to.eq(
+      'student response 1'
+    );
+  });
+});

--- a/apps/test/unit/templates/levelSummary/MultiResponses.jsx
+++ b/apps/test/unit/templates/levelSummary/MultiResponses.jsx
@@ -1,0 +1,122 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import {expect} from '../../../util/reconfiguredChai';
+import MultiResponses, {
+  exportedForTesting,
+} from '@cdo/apps/templates/levelSummary/MultiResponses';
+import color from '@cdo/apps/util/color';
+const {multiAnswerCounts, multiChartData} = exportedForTesting;
+
+const JS_DATA = {
+  level: {
+    properties: {
+      answers: [{}],
+    },
+  },
+  responses: [{user_id: 0, text: '1'}],
+};
+
+describe('MultiResponses', () => {
+  it('renders chart', () => {
+    const wrapper = shallow(<MultiResponses scriptData={JS_DATA} />);
+
+    expect(wrapper.find('Chart').length).to.eq(1);
+    expect(wrapper.find('Chart').prop('data')).to.eql([
+      ['Answer', 'Count', {role: 'annotation'}, {role: 'style'}],
+      ['A', 0, '0', null],
+      ['B', 1, '1', null],
+    ]);
+  });
+});
+
+describe('multiAnswerCounts', () => {
+  it('defaults to zero with 4 answers', () => {
+    const data = multiAnswerCounts([], 4);
+    expect(data).to.eql({
+      A: 0,
+      B: 0,
+      C: 0,
+      D: 0,
+    });
+  });
+
+  it('defaults to zero with more than 4 answers', () => {
+    const data = multiAnswerCounts([], 6);
+    expect(data).to.eql({
+      A: 0,
+      B: 0,
+      C: 0,
+      D: 0,
+      E: 0,
+      F: 0,
+    });
+  });
+
+  it('generates correct counts for each answer', () => {
+    const data = multiAnswerCounts(
+      [
+        {text: '0'},
+        {text: '0'},
+        {text: '0'},
+        {text: '0'},
+        {text: '0'},
+        {text: '2'},
+        {text: '3'},
+        {text: '3'},
+      ],
+      4
+    );
+    expect(data).to.eql({
+      A: 5,
+      B: 0,
+      C: 1,
+      D: 2,
+    });
+  });
+});
+
+describe('multiChartData', () => {
+  it('outputs only heading data when empty', () => {
+    const data = multiChartData({});
+    expect(data).to.eql([
+      ['Answer', 'Count', {role: 'annotation'}, {role: 'style'}],
+    ]);
+  });
+
+  it('outputs correct data with no highlighting', () => {
+    const data = multiChartData({
+      A: 1,
+      B: 60,
+      C: 7,
+      D: 12,
+    });
+    expect(data).to.eql([
+      ['Answer', 'Count', {role: 'annotation'}, {role: 'style'}],
+      ['A', 1, '1', null],
+      ['B', 60, '60', null],
+      ['C', 7, '7', null],
+      ['D', 12, '12', null],
+    ]);
+  });
+
+  it('outputs correct data with highlighting', () => {
+    const data = multiChartData(
+      {
+        A: 101,
+        B: 0,
+        C: 37,
+        D: 8,
+        E: 0,
+      },
+      ['A', 'B']
+    );
+    expect(data).to.eql([
+      ['Answer', 'Count', {role: 'annotation'}, {role: 'style'}],
+      ['A', 101, '101✔️', color.brand_primary_default],
+      ['B', 0, '0✔️', color.brand_primary_default],
+      ['C', 37, '37', color.brand_primary_light],
+      ['D', 8, '8', color.brand_primary_light],
+      ['E', 0, '0', color.brand_primary_light],
+    ]);
+  });
+});

--- a/apps/test/unit/templates/levelSummary/SummaryResponses.jsx
+++ b/apps/test/unit/templates/levelSummary/SummaryResponses.jsx
@@ -108,4 +108,57 @@ describe('SummaryResponses', () => {
     expect(wrapper.find(`.${styles.studentsSubmittedRight}`).length).to.eq(0);
     expect(wrapper.find(`.${styles.studentsSubmittedLeft}`).length).to.eq(0);
   });
+
+  it('renders toggle when appropriate', () => {
+    const wrapper = setUpWrapper(
+      {},
+      {
+        level: {
+          type: 'Multi',
+          id: 0,
+          properties: {
+            answers: [],
+          },
+        },
+        answer_is_visible: true,
+      }
+    );
+
+    expect(wrapper.find('ToggleSwitch').length).to.eq(1);
+  });
+
+  it('does not render toggle for Free Response', () => {
+    const wrapper = setUpWrapper(
+      {},
+      {
+        level: {
+          type: 'FreeResponse',
+          id: 0,
+          properties: {
+            answers: [],
+          },
+        },
+        answer_is_visible: true,
+      }
+    );
+
+    expect(wrapper.find('ToggleSwitch').length).to.eq(0);
+  });
+
+  it('does not render toggle without policy permission', () => {
+    const wrapper = setUpWrapper(
+      {},
+      {
+        level: {
+          type: 'Multi',
+          id: 0,
+          properties: {
+            answers: [],
+          },
+        },
+      }
+    );
+
+    expect(wrapper.find('ToggleSwitch').length).to.eq(0);
+  });
 });

--- a/dashboard/app/views/levels/_summary.html.haml
+++ b/dashboard/app/views/levels/_summary.html.haml
@@ -42,7 +42,7 @@
     }
   }
 
-#summary-container.container
+#summary-content.container
   #summary-top-links
 
   #level-question

--- a/dashboard/test/ui/features/teacher_tools/level_summary.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_summary.feature
@@ -1,3 +1,4 @@
+@dashboard_db_access
 @eyes
 Feature: Level summary
 

--- a/dashboard/test/ui/features/teacher_tools/level_summary.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_summary.feature
@@ -37,7 +37,8 @@ Scenario: Free Response level 3
 Scenario: Multi level 1
   # Multiple content blocks, images in question and answers
   When I open my eyes to test "multi summary 1"
-  Given I am a teacher
+  Given I create a teacher named "Teacher_1"
+  And I give user "Teacher_1" authorized teacher permission
   And I create a new student section
   And I am on "http://studio.code.org/s/allthethings/lessons/9/levels/1/summary"
   And I wait until element "#summary-container" is visible
@@ -50,7 +51,8 @@ Scenario: Multi level 1
 Scenario: Multi level 2
   # Markdown in question, images and text in answers, more than 4 answers
   When I open my eyes to test "multi summary 2"
-  Given I am a teacher
+  Given I create a teacher named "Teacher_1"
+  And I give user "Teacher_1" authorized teacher permission
   And I create a new student section
   And I am on "http://studio.code.org/s/allthethings/lessons/9/levels/4/summary"
   And I wait until element "#summary-container" is visible

--- a/dashboard/test/ui/features/teacher_tools/level_summary.feature
+++ b/dashboard/test/ui/features/teacher_tools/level_summary.feature
@@ -33,3 +33,29 @@ Scenario: Free Response level 3
   And I wait to see ".uitest-sectionselect"
   Then I see no difference for "free response level summary 3"
   And I close my eyes
+
+Scenario: Multi level 1
+  # Multiple content blocks, images in question and answers
+  When I open my eyes to test "multi summary 1"
+  Given I am a teacher
+  And I create a new student section
+  And I am on "http://studio.code.org/s/allthethings/lessons/9/levels/1/summary"
+  And I wait until element "#summary-container" is visible
+  And I wait to see ".uitest-sectionselect"
+  Then I see no difference for "multi level summary 1"
+  And I click selector "button.toggle-input"
+  And I see no difference for "multi level summary 1 show answer"
+  And I close my eyes
+
+Scenario: Multi level 2
+  # Markdown in question, images and text in answers, more than 4 answers
+  When I open my eyes to test "multi summary 2"
+  Given I am a teacher
+  And I create a new student section
+  And I am on "http://studio.code.org/s/allthethings/lessons/9/levels/4/summary"
+  And I wait until element "#summary-container" is visible
+  And I wait to see ".uitest-sectionselect"
+  Then I see no difference for "multi level summary 2"
+  And I click selector "button.toggle-input"
+  And I see no difference for "multi level summary 2 show answer"
+  And I close my eyes


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Followup to #51653: Add eyes and unit tests for new multiple-choice summary features.

Ran the eyes tests locally through sc-tunnel and accepted the baselines, so hopefully it'll pass dtt first-try.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- -->
- jira ticket: [TEACH-469](https://codedotorg.atlassian.net/browse/TEACH-469)


