### PR TITLE
Update weblab model to do I18n.t translations

### DIFF
--- a/dashboard/app/models/levels/weblab.rb
+++ b/dashboard/app/models/levels/weblab.rb
@@ -55,19 +55,17 @@ class Weblab < Level
       level_prop = {}
 
       properties.keys.each do |dashboard|
-        localized_property = I18n.t(
-          name,
-          scope: [:data, dashboard],
-          default: nil,
-        )
-        puts "dashboard: " + dashboard
-        puts "localized_property: " + localized_property.to_s
         # Select value from properties json
-        value = localized_property.nil? ? JSONValue.value(properties[dashboard].presence) : localized_property
-        puts "value: " + value.to_s
+        value = JSONValue.value(properties[dashboard].presence)
         apps_prop_name = dashboard.camelize(:lower)
         # Don't override existing valid (non-nil/empty) values
         level_prop[apps_prop_name] = value unless value.nil? # make sure we convert false
+      end
+
+      # FND-985 Create shared API to get localized level properties.
+      if should_localize?
+        localized_long_instructions = I18n.t(name, scope:[:data, 'long_instructions'], default: nil)
+        level_prop['longInstructions'] = localized_long_instructions unless localized_long_instructions.nil?
       end
 
       level_prop['levelId'] = level_num

--- a/dashboard/app/models/levels/weblab.rb
+++ b/dashboard/app/models/levels/weblab.rb
@@ -64,8 +64,8 @@ class Weblab < Level
 
       # FND-985 Create shared API to get localized level properties.
       if should_localize?
-        localized_long_instructions = I18n.t(name, scope: [:data, 'long_instructions'], default: nil)
-        level_prop['longInstructions'] = localized_long_instructions unless localized_long_instructions.nil?
+        localized_long_instructions = I18n.t(name, scope: [:data, 'long_instructions'], default: level_prop['longInstructions'])
+        level_prop['longInstructions'] = localized_long_instructions
       end
 
       level_prop['levelId'] = level_num

--- a/dashboard/app/models/levels/weblab.rb
+++ b/dashboard/app/models/levels/weblab.rb
@@ -64,7 +64,7 @@ class Weblab < Level
 
       # FND-985 Create shared API to get localized level properties.
       if should_localize?
-        localized_long_instructions = I18n.t(name, scope:[:data, 'long_instructions'], default: nil)
+        localized_long_instructions = I18n.t(name, scope: [:data, 'long_instructions'], default: nil)
         level_prop['longInstructions'] = localized_long_instructions unless localized_long_instructions.nil?
       end
 

--- a/dashboard/app/models/levels/weblab.rb
+++ b/dashboard/app/models/levels/weblab.rb
@@ -55,10 +55,15 @@ class Weblab < Level
       level_prop = {}
 
       properties.keys.each do |dashboard|
-        apps_prop_name = dashboard.camelize(:lower)
+        localized_property = I18n.t(
+          name,
+          scope: [:data, dashboard],
+          default: nil,
+        )
         # Select value from properties json
+        value = localized_property.nil? ? JSONValue.value(properties[dashboard].presence) : localized_property
+        apps_prop_name = dashboard.camelize(:lower)
         # Don't override existing valid (non-nil/empty) values
-        value = JSONValue.value(properties[dashboard].presence)
         level_prop[apps_prop_name] = value unless value.nil? # make sure we convert false
       end
 

--- a/dashboard/app/models/levels/weblab.rb
+++ b/dashboard/app/models/levels/weblab.rb
@@ -60,8 +60,11 @@ class Weblab < Level
           scope: [:data, dashboard],
           default: nil,
         )
+        puts "dashboard: " + dashboard
+        puts "localized_property: " + localized_property.to_s
         # Select value from properties json
         value = localized_property.nil? ? JSONValue.value(properties[dashboard].presence) : localized_property
+        puts "value: " + value.to_s
         apps_prop_name = dashboard.camelize(:lower)
         # Don't override existing valid (non-nil/empty) values
         level_prop[apps_prop_name] = value unless value.nil? # make sure we convert false


### PR DESCRIPTION
omg y'all I've been spelunking.

It all started with [P20-164](https://codedotorg.atlassian.net/browse/P20-164) a totally innocent report that 14 lessons don't have translations showing.

And it was a great way to learn about the i18n pipeline and how the whole system works! So I took a look

Full saga below the fold

- I checked in CrowdIn to see if we were asking for these lessons to be translated, we were. The hierarchical model of the strings in crowdin made it easy to confirm that these lessons have translations in es-ES.
- I checked on the i18n-dev server to confirm that the translations were being copied down from crowdin and merged into the expected spots according to [the diagram of truth](https://github.com/code-dot-org/code-dot-org/blob/staging/i18n/i18n_pipeline.md).
- Ok so the translations exist in the spot we would expect.. is there a pattern for what courses aren't being translated? Yes, yes there is! They all seem to be WebLab labs, not Blocks or App Lab or AI Lab.
- So from the frontend, do WebLab labs not know how to set locale? Maybe. Is that affecting the instructions? No. WebLab.js doesn't use the setLocale Redux store that I just updated but it also doesn't read from that store, so it doesn't matter. P5Lab does setLocale [here](https://github.com/code-dot-org/code-dot-org/blob/6e230218c84378e4430a0f86b6bb5c97a5e4dd23/apps/src/p5lab/P5Lab.js#L336) where it's reading from `appOptions`
- Alright.. so where does `appOptions` come from server-side? For levels that are translated, like [this one](http://localhost-studio.code.org:3000/s/csd3-2022/lessons/3/levels/3?enableExperiments=reduxLogging) the longInstructions in that `appOptions` are already in Spanish so the server is sending in localized input. 
- In [`levels_helper.rb`](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/helpers/levels_helper.rb#L184) you can see a method called `app_options` that puts together all of this configuration data. Within the `app_options`, we only really care about the `level_options` - data specific to the level, not the user or other configuration. This is set down [here](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/helpers/levels_helper.rb#L498) since this is a `non_blockly_puzzle_level`.
- Blockly puzzles go through a lot of massaging to get their i18n set up. But this is a weblab level. So under the hood in the weblab model, we implement [that method](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/models/levels/weblab.rb#L53).
- But how do other levels implement that method?? Well... blockly levels go through a separate translation process with the options being set in [this method](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/models/levels/blockly.rb#L289). And _free_responses does [a cool translation process directly](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/models/levels/free_response.rb#L62)

I copied over the logic from the `free_response.rb` model over into the `weblab.rb` model.

## Testing story
In production: you can tell from the title that the locale is Spanish but that the instructions are still in English
![Screenshot 2023-05-11 at 9 11 06 AM](https://github.com/code-dot-org/code-dot-org/assets/131800576/c15187c1-9dd1-433f-bf72-6565c60f953d)

In development: the instructions are now in Spanish too!
![Screenshot 2023-05-11 at 9 10 27 AM](https://github.com/code-dot-org/code-dot-org/assets/131800576/609a06fa-8343-4de2-a43a-6b8b316b775d)

In development: in English, the instructions are still in English
![Screenshot 2023-05-12 at 8 07 47 AM](https://github.com/code-dot-org/code-dot-org/assets/131800576/86a4942b-63d9-4782-8d6b-0a543fb93214)



## Follow-up work

This only fixes weblab levels, in looking through `s/allthethings/` in Spanish there are a couple other level types that don't have translations visible but I'm not sure how important updating them are (blocks are the bread and butter).
* Clock
* Odometer
* Netsim
* External Markdown
* Blocks to Math (it's hard to tell cause I'm testing in Spanish and I don't actually speak Spanish).

It also seems like [FND=985](https://codedotorg.atlassian.net/browse/FND-985) was created to do this as a platform wide solution but 🤷 it seems to have been de-prioritized.

https://github.com/code-dot-org/code-dot-org/pull/32650

## PR Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
