### PR TITLE
Remove rollup script row limits

### DIFF
--- a/bin/cron/create_rollup_tables
+++ b/bin/cron/create_rollup_tables
@@ -143,11 +143,6 @@ def main
     end
   end
 
-  # Verify that the data size is sensible.
-  raise "contained_levels too big: #{contained_levels.size} rows exceeds limit of 10000" if contained_levels.size > 10_000
-  raise "contained_level_answers too big: #{contained_levels_answers.size} rows exceeds limit of 100000" if contained_level_answers.size > 100_000
-  raise "level_sources too big: #{level_sources_multi_types.size} rows exceeds limit of 100000" if level_sources_multi_types.size > 100_000
-
   # Maximum rows to insert per query
   batch_size = 2000
 


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Remove the limits on row count during insert in the `create_rollup_tables` script. This script runs weekly on Friday mornings, and has been failing since at least 2023-04-07. Since we already batch the inserts, we think it's safe to remove these limits.

I'm adding a few teams to the reviewers on this, mostly just for awareness, but feel free to push back if you think this change is unsafe.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->


- [slack thread on this approach](https://codedotorg.slack.com/archives/C03CK49G9/p1683665914631939)
- jira ticket: [TEACH-392](https://codedotorg.atlassian.net/browse/TEACH-392)

## Followup task

Send some of these queries to a replica database, to reduce the load on production.

jira: [TEACH-501](https://codedotorg.atlassian.net/browse/TEACH-501)
