### PR TITLE
remove note about old node for Apple Silicon

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -181,17 +181,6 @@ Setup steps for macOS:
 
     3. Running `nvm alias default $(cat ./.nvmrc)` will set your default node version for future shells.
 
-    4. For Apple Silicon (M1) systems, Node 14 is not available. We can temporarily switch to an x86_64 shell to install Node 14, which will then be available from our normal arm64 shell.
-
-       ```sh
-       arch -arch x86_64 zsh
-       # You are now in a new shell, run `arch` to confirm
-       nvm install # or `nvm install 18.16.0`
-       exit
-       # You are now back in the original shell, run `arch` to confirm
-       nvm use && nvm alias default $(cat ./.nvmrc)
-       ```
-
 1. Install **yarn** via `npm install -g yarn@1.22.19`
 
 1. Install **OpenSSL**


### PR DESCRIPTION
Tested and confirmed that `nvm use 18` runs without issue on M1.

Other Apple Silicon users should confirm. Tagging some known M1 users.

## Links

Follow up from #51533

<!--
- spec: []()
- jira ticket: []()
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
