### PR TITLE
PL Launch 2023 - Show homepage PL superhero banner to English only

### DIFF
--- a/pegasus/sites.v3/code.org/homepage.json
+++ b/pegasus/sites.v3/code.org/homepage.json
@@ -74,7 +74,7 @@
     },
     "pl-launch-superhero": {
       "dcdo": "pl-launch-hero-banner",
-      "showInternationally": false,
+      "languages": ["en"],
       "class": "pl-banner-superhero homepage",
       "desktopImage": "/images/pl-superhero-banner-yellow-bg.svg",
       "actions": [


### PR DESCRIPTION
Due to the inconsistency of showing banners based on geolocation, and because we don't support non-English PL yet, we've decided to show the homepage PL hero banner to English only. 
- I've opted to replace the `showInternationally` key with the `languages` key since there's not adequate time to test them working together and we know the `languages` key works. 

**Related PR:** 
- https://github.com/code-dot-org/code-dot-org/pull/51356

**Jira ticket:** [ACQ-590](https://codedotorg.atlassian.net/browse/ACQ-590?atlOrigin=eyJpIjoiMDdmYzRkYWU2YWIzNDY5NmJlMDUyNWE2MDg5YjFlYTciLCJwIjoiaiJ9)

----

https://github.com/code-dot-org/code-dot-org/assets/9256643/4f68ec82-94df-452d-a686-330e207f57ec

