### PR TITLE
Refactor .video-series class to use CSS grid

### DIFF
--- a/pegasus/sites.v3/code.org/public/blockchain.haml
+++ b/pegasus/sites.v3/code.org/public/blockchain.haml
@@ -30,25 +30,25 @@ theme: responsive_full_width
       %img{src: "/images/blockchain-works-logo.png", alt: "", style: "width: 100%"}
     .clear
     .video-series
-      %figure.video-responsive{style: "max-width: unset"}
+      %figure.video-responsive
         %div
           %iframe{src: "https://www.youtube-nocookie.com/embed/MjibPL4tGqo", allowFullScreen: "true", frameborder: "0", title: hoc_s(:blockchain_video_title_01)}
-      %figure.video-responsive{style: "max-width: unset"}
+      %figure.video-responsive
         %div
           %iframe{src: "https://www.youtube-nocookie.com/embed/10wYLCnDHao", allowFullScreen: "true", frameborder: "0", title: hoc_s(:blockchain_video_title_02)}
-      %figure.video-responsive{style: "max-width: unset"}
+      %figure.video-responsive
         %div
           %iframe{src: "https://www.youtube-nocookie.com/embed/It_Ivgm5wQA", allowFullScreen: "true", frameborder: "0", title: hoc_s(:blockchain_video_title_03)}
-      %figure.video-responsive{style: "max-width: unset"}
+      %figure.video-responsive
         %div
           %iframe{src: "https://www.youtube-nocookie.com/embed/3EwkfUz_BPs", allowFullScreen: "true", frameborder: "0", title: hoc_s(:blockchain_video_title_04)}
-      %figure.video-responsive{style: "max-width: unset"}
+      %figure.video-responsive
         %div
           %iframe{src: "https://www.youtube-nocookie.com/embed/d9rKkk3oVdY", allowFullScreen: "true", frameborder: "0", title: hoc_s(:blockchain_video_title_05)}
-      %figure.video-responsive{style: "max-width: unset"}
+      %figure.video-responsive
         %div
           %iframe{src: "https://www.youtube-nocookie.com/embed/WzxbwEQRJPo", allowFullScreen: "true", frameborder: "0", title: hoc_s(:blockchain_video_title_06)}
-      %figure.video-responsive{style: "max-width: unset"}
+      %figure.video-responsive
         %div
           %iframe{src: "https://www.youtube-nocookie.com/embed/C3C_JfG8cNg", allowFullScreen: "true", frameborder: "0", title: hoc_s(:blockchain_video_title_07)}
 

--- a/pegasus/sites.v3/code.org/public/css/ai-styles.scss
+++ b/pegasus/sites.v3/code.org/public/css/ai-styles.scss
@@ -70,32 +70,3 @@
     }
   }
 }
-
-.video-series,
-.video {
-
-  & > div.col-50 {
-    padding: 0 !important;
-    margin: 1em 0 0 !important;
-    width: 49%;
-
-    .video_caption_link {
-      @include figcaption;
-    }
-
-    .modal-body {
-
-      figure {
-        width: 100%;
-      }
-    }
-
-    @media screen and (max-width: $width-sm) {
-      width: 100%;
-    }
-  }
-
-  .play {
-    top: 30% !important;
-  }
-}

--- a/pegasus/sites.v3/code.org/public/css/blockchain-styles.scss
+++ b/pegasus/sites.v3/code.org/public/css/blockchain-styles.scss
@@ -44,12 +44,3 @@
     }
   }
 }
-
-.video-series {
-
-  @media screen and (max-width: $width-sm) {
-    figure {
-      width: 100%;
-    }
-  }
-}

--- a/pegasus/sites.v3/code.org/public/css/design-system-pegasus.scss
+++ b/pegasus/sites.v3/code.org/public/css/design-system-pegasus.scss
@@ -768,13 +768,24 @@ form {
 // Video series
 // - see example: code.org/blockchain
 .video-series {
-  display: flex;
-  justify-content: space-between;
-  flex-wrap: wrap;
+  display: grid;
+  grid-gap: 1.25em;
+  margin-top: 2em;
 
-  figure {
-    width: 49%;
-    margin-top: 1.25em;
+  @media screen and (min-width: $width-sm) {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  // Overrides styles on the
+  // display_video_thumbnail partial
+  & > div.col-50 {
+    padding: 0 !important;
+    margin: 0 !important;
+    width: 100%;
+
+    .video_caption_link {
+      @include figcaption;
+    }
   }
 }
 


### PR DESCRIPTION
Use CSS grid instead of flexbox on `.video-series` containers used in the Pegasus rebrand.

Currently used on the following pages:
- https://code.org/ai 
- https://code.org/blockchain

**Jira ticket:** [ACQ-589](https://codedotorg.atlassian.net/browse/ACQ-589?atlOrigin=eyJpIjoiZGQwMjU3NmQwNDkzNDIxZTk2YzEzNTAyZmRiZDVmZGQiLCJwIjoiaiJ9)

----


https://github.com/code-dot-org/code-dot-org/assets/9256643/d3c66300-72bf-4054-8bf8-923344cfb5a4

