### PR TITLE
Music: rename category Play to Sounds

### DIFF
--- a/apps/i18n/music/en_us.json
+++ b/apps/i18n/music/en_us.json
@@ -45,7 +45,7 @@
   "blockly_toolboxCategoryFunctions": "Functions",
   "blockly_toolboxCategoryLogic": "Logic",
   "blockly_toolboxCategoryMath": "Math",
-  "blockly_toolboxCategoryPlay": "Play",
+  "blockly_toolboxCategoryPlay": "Sounds",
   "blockly_toolboxCategorySimple": "Simple",
   "blockly_toolboxCategoryTracks": "Tracks",
   "blockly_toolboxCategoryVariables": "Variables",


### PR DESCRIPTION
To alleviate potential confusion, rename the block category `Play` to `Sounds`.  Playback is achieved by pressing the `Run` button elsewhere.

<img width="326" alt="Screenshot 2023-05-13 at 7 31 54 PM" src="https://github.com/code-dot-org/code-dot-org/assets/2205926/890e8404-ea9b-496c-a742-5729c1422e6d">
