### PR TITLE
Music: initial UI test

### DIFF
--- a/apps/src/music/blockly/toolbox.js
+++ b/apps/src/music/blockly/toolbox.js
@@ -39,6 +39,7 @@ const toolboxBlocks = {
     type: BlockTypes.SET_CURRENT_LOCATION_NEXT_MEASURE,
   },
   [BlockTypes.PLAY_SOUND_AT_CURRENT_LOCATION_SIMPLE2]: {
+    id: 'play-sound-block',
     kind: 'block',
     type: BlockTypes.PLAY_SOUND_AT_CURRENT_LOCATION_SIMPLE2,
   },

--- a/apps/src/music/views/TimelineElement.jsx
+++ b/apps/src/music/views/TimelineElement.jsx
@@ -51,6 +51,7 @@ const TimelineElement = ({
   return (
     <div
       className={classNames(
+        'timeline-element',
         moduleStyles.timelineElement,
         colorClass,
         isCurrentlyPlaying && moduleStyles.timelineElementPlaying,

--- a/apps/static/music/defaultCodeSimple2.json
+++ b/apps/static/music/defaultCodeSimple2.json
@@ -1,7 +1,7 @@
 {
   "blocks": {
     "languageVersion": 0,
-    "blocks": [{"type": "when_run_simple2", "x": 30, "y": 30}]
+    "blocks": [{"id": "when-run-block", "type": "when_run_simple2", "x": 30, "y": 30}]
   },
   "variables": [{"name": "currentTime"}, {"name": "i"}]
 }

--- a/dashboard/test/ui/features/star_labs/musiclab/musiclab_drag_block.feature
+++ b/dashboard/test/ui/features/star_labs/musiclab/musiclab_drag_block.feature
@@ -1,0 +1,24 @@
+Feature: Music Lab block can be dragged
+
+Scenario: Dragging play sound block
+  Given I am on "http://studio.code.org/s/allthethings/lessons/46/levels/1?show-video=false"
+  Then I wait until I am on "http://studio.code.org/s/allthethings/lessons/46/levels/1?show-video=false"
+  And I rotate to landscape
+
+  # Wait until we see the first category.
+  And I wait until element "#blockly-0" is visible
+
+  # Also wait until we see the "when run" block.
+  And I wait until element "[data-id='when-run-block']" is visible
+
+  # There should be no music timeline entry yet.
+  And element ".timeline-element" is not visible
+
+  # Open the first category.
+  And I press "blockly-0"
+
+  # Drag the "play sound" block and attach it to the "when run" block.
+  Then I drag block "play-sound-block" to block "when-run-block"
+
+  # There should now be a music timeline entry.
+  And element ".timeline-element" is visible


### PR DESCRIPTION
This adds an initial UI test for Music Lab.  For now, it simply checks that a toolbox can be opened, a "play sound" block can be dragged and attached to the "when run" block, and a timeline element appears.
