### PR TITLE
Remove double submit buttons on standalone multi levels

### DIFF
--- a/dashboard/app/views/levels/_dialog.html.haml
+++ b/dashboard/app/views/levels/_dialog.html.haml
@@ -9,9 +9,6 @@
     - if local_assigns[:next_button]
       %a.btn.btn-large.btn-primary.nextPageButton
         =t('next_page')
-    - elsif local_assigns[:continue_button]
-      %a.btn.btn-large.btn-primary.next-lesson.submitButton
-        =t('continue')
     - else
       %a.btn.btn-large.btn-primary.next-lesson.submitButton
         =t('submit')

--- a/dashboard/app/views/levels/_single_multi.html.haml
+++ b/dashboard/app/views/levels/_single_multi.html.haml
@@ -66,13 +66,6 @@
     - unless use_tight_layout
       %br/
 
-    - if standalone && !data['options'].try(:[], 'hide_submit')
-      .buttons{class: data['submittable'] == 'true' ? 'submittable' : nil}
-        %a.btn.btn-large.btn-primary.next-lesson.submitButton{id: "submit_level_#{level.id}"}
-          =t('submit')
-        %a.btn.btn-large.btn-primary.unsubmitButton{style: "display: none", id: "unsubmit_level_#{level.id}"}
-          =t('unsubmit')
-
     .mainblock
       %form#voteform{onsubmit: 'return false;'}
         - data['answers'].each_with_index do |answer, i|


### PR DESCRIPTION
Currently, standalone multi levels have "Submit" buttons both above and below the question, like:

![Screenshot 2023-05-16 at 9 04 05 AM](https://github.com/code-dot-org/code-dot-org/assets/46464143/b8329c1c-1881-41d1-95db-45b673823809)

This PR removes the top set of buttons. The other set comes from [_dialog.html.haml](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/views/levels/_dialog.html.haml), which is included [here](https://github.com/code-dot-org/code-dot-org/blob/aea6b18f1f35f6f07469980f7adea831a2891690/dashboard/app/views/levels/_single_multi.html.haml#L93) for multi levels only if it's a standalone level. I'm keeping that set as `_dialog.html.haml`, and its associated js file, do a lot more logic.

I also removed some dead code from `_dialog.html.haml` in this PR. I confirmed it was not used by searching both for `continue_button` and finding nothing relevant and by searching places where this partial is used and not finding any uses of this parameter. Let me know if you want me to split this into a different PR.