### PR TITLE
Rollup script: Log sizes and temporarily disable one exception

### DIFF
--- a/bin/cron/create_rollup_tables
+++ b/bin/cron/create_rollup_tables
@@ -144,8 +144,12 @@ def main
   end
 
   # Verify that the data size is sensible.
-  raise "contained_levels too big: #{contained_levels.size} rows exceeds limit of 10000" if contained_levels.size > 10_000
-  raise "contained_level_answers too big: #{contained_levels_answers.size} rows exceeds limit of 100000" if contained_level_answers.size > 100_000
+  CDO.log.info "contained_levels: #{contained_levels.size}"
+  CDO.log.info "contained_level_answers: #{contained_level_answers.size}"
+  CDO.log.info "level_sources: #{level_sources_multi_types.size}"
+  # TODO: Adjust and re-enable limits below as appropriate once we get the log info from above.
+  #raise "contained_levels too big: #{contained_levels.size} rows exceeds limit of 10000" if contained_levels.size > 10_000
+  raise "contained_level_answers too big: #{contained_level_answers.size} rows exceeds limit of 100000" if contained_level_answers.size > 100_000
   raise "level_sources too big: #{level_sources_multi_types.size} rows exceeds limit of 100000" if level_sources_multi_types.size > 100_000
 
   # Maximum rows to insert per query


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Followup with @pablo-code-org's suggested approach from #51849.

Add logging for all three object sizes, and temporarily comment out the first exception that we know is raising.

Also fixes a typo in the second exception message.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->


- [slack thread on this approach](https://codedotorg.slack.com/archives/C03CK49G9/p1683665914631939)
- jira ticket: [TEACH-392](https://codedotorg.atlassian.net/browse/TEACH-392)

## Followup task

Send some of these queries to a replica database, to reduce the load on production.

jira: [TEACH-501](https://codedotorg.atlassian.net/browse/TEACH-501)
