### PR TITLE
Show duration input on Activities even when no lesson plan

### DIFF
--- a/apps/src/lib/levelbuilder/lesson-editor/ActivityCard.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ActivityCard.jsx
@@ -106,35 +106,38 @@ class ActivityCard extends Component {
             ...(this.props.collapsed && {marginBottom: 10}),
           }}
         >
-          {hasLessonPlan && (
-            <div style={styles.activityHeaderComponents}>
-              <div style={styles.inputsAndIcon}>
-                <FontAwesome
-                  icon={this.props.collapsed ? 'expand' : 'compress'}
-                  onClick={this.props.handleCollapse}
+          <div style={styles.activityHeaderComponents}>
+            <div style={styles.inputsAndIcon}>
+              {hasLessonPlan && (
+                <div>
+                  <FontAwesome
+                    icon={this.props.collapsed ? 'expand' : 'compress'}
+                    onClick={this.props.handleCollapse}
+                  />
+                  <label style={styles.labelAndInput}>
+                    <span style={styles.label}>{`Activity:`}</span>
+                    <input
+                      value={activity.displayName}
+                      style={{width: 200}}
+                      onChange={this.handleChangeDisplayName}
+                      className="uitest-activity-name-input"
+                    />
+                  </label>
+                </div>
+              )}
+              <label style={styles.labelAndInput}>
+                <span style={styles.label}>{`Duration:`}</span>
+                <input
+                  value={activity.duration}
+                  style={{width: 35}}
+                  onChange={this.handleChangeDuration}
+                  className="uitest-activity-duration-input"
                 />
-
-                <label style={styles.labelAndInput}>
-                  <span style={styles.label}>{`Activity:`}</span>
-                  <input
-                    value={activity.displayName}
-                    style={{width: 200}}
-                    onChange={this.handleChangeDisplayName}
-                    className="uitest-activity-name-input"
-                  />
-                </label>
-                <label style={styles.labelAndInput}>
-                  <span style={styles.label}>{`Duration:`}</span>
-                  <input
-                    value={activity.duration}
-                    style={{width: 35}}
-                    onChange={this.handleChangeDuration}
-                    className="uitest-activity-duration-input"
-                  />
-                  <span style={{fontSize: 10}}>{'(mins)'}</span>
-                </label>
-              </div>
-              {(allowMajorCurriculumChanges || levelsInActivity === 0) && (
+                <span style={{fontSize: 10}}>{'(mins)'}</span>
+              </label>
+            </div>
+            {hasLessonPlan &&
+              (allowMajorCurriculumChanges || levelsInActivity === 0) && (
                 <OrderControls
                   name={activity.displayName || 'Unnamed Activity'}
                   move={this.handleMoveActivity}
@@ -143,8 +146,7 @@ class ActivityCard extends Component {
                   itemType={'activity'}
                 />
               )}
-            </div>
-          )}
+          </div>
         </div>
         <div style={styles.activityBody} hidden={this.props.collapsed}>
           {activity.activitySections.map(section => (

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/ActivityCardTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/ActivityCardTest.jsx
@@ -134,7 +134,7 @@ describe('ActivityCard', () => {
       />
     );
     expect(wrapper.contains('Activity:')).to.be.false;
-    expect(wrapper.contains('Duration:')).to.be.false;
+    expect(wrapper.contains('Duration:')).to.be.true;
     expect(wrapper.find('OrderControls').length).to.equal(0);
     expect(wrapper.find('Connect(ActivitySectionCard)').length).to.equal(1);
     expect(wrapper.find('button').length).to.equal(1);

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/LessonEditorTest.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/LessonEditorTest.js
@@ -166,7 +166,7 @@ describe('LessonEditor', () => {
       .be.true;
     expect(wrapper.find('Connect(ActivitiesEditor)').length).to.equal(1);
     expect(wrapper.find('TextareaWithMarkdownPreview').length).to.equal(2);
-    expect(wrapper.find('input').length).to.equal(7);
+    expect(wrapper.find('input').length).to.equal(8);
     expect(wrapper.find('select').length).to.equal(1);
     expect(wrapper.find('AnnouncementsEditor').length).to.equal(0);
     expect(wrapper.find('CollapsibleEditorSection').length).to.equal(3);


### PR DESCRIPTION
Looking at the Curriculum Catalog durations I realized that curriculum without lesson plans were all getting marked as "lesson" length. This is because there was no duration values stored for those lessons. We had been hiding the duration input if the lesson was a lesson with no lesson plan. This PR updates the lesson editor show the duration field on the Activity editor for both lessons with and without lesson plans. 

New look of the Activity Editor for a lesson without a lesson plan: 
<img width="1765" alt="Screenshot 2023-05-15 at 4 52 59 PM" src="https://github.com/code-dot-org/code-dot-org/assets/208083/e4e18fa3-f4bd-44a7-aef7-28a5779555a4">

@dancodedotorg also pointed out this will allow the curriculum team to add duration on post-project tests in CSD and have them show up in the calendar. 

Confirmed that adding the duration for a post-project test makes it show up in the calendar:

![Screenshot 2023-05-15 at 4 40 43 PM](https://github.com/code-dot-org/code-dot-org/assets/208083/b6717e31-8446-4831-9b00-98fd7c9bbe0c)

Confirmed that adding duration for 20-hour course makes it show up with more accurate duration:

<img width="334" alt="Screenshot 2023-05-15 at 4 51 15 PM" src="https://github.com/code-dot-org/code-dot-org/assets/208083/92ee69cd-7fc0-4b09-8903-afe986f58e48">