### PR TITLE
Music: skip UI test on mobile devices

### DIFF
--- a/dashboard/test/ui/features/star_labs/musiclab/musiclab_drag_block.feature
+++ b/dashboard/test/ui/features/star_labs/musiclab/musiclab_drag_block.feature
@@ -1,3 +1,5 @@
+@no_mobile
+
 Feature: Music Lab block can be dragged
 
 Scenario: Dragging play sound block


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/51880.  The UI test fails on iPhone & iPad, so this is a quick update to skip on those devices until a proper fix is implemented.
