### PR TITLE
[Google Blockly] re-enable events after comparing block arrays

### DIFF
--- a/apps/src/blockly/addons/cdoUtils.js
+++ b/apps/src/blockly/addons/cdoUtils.js
@@ -133,15 +133,15 @@ function testJsonSerialization(workspace) {
   Blockly.Events.disable();
 
   // Create an array of blocks based on JSON serialization of the current workspace.
-  const blockJson = Blockly.serialization.workspaces.save(workspace);
+  const jsonSerialization = Blockly.serialization.workspaces.save(workspace);
   const tempJsonWorkspace = new Blockly.Workspace();
-  Blockly.serialization.workspaces.load(blockJson, tempJsonWorkspace);
+  Blockly.serialization.workspaces.load(jsonSerialization, tempJsonWorkspace);
   const jsonBlocks = tempJsonWorkspace.getAllBlocks();
 
   // Create an array of blocks based on the XML encoding of the current workspace.
-  const blockXml = Blockly.Xml.blockSpaceToDom(workspace);
+  const xmlSerialization = Blockly.Xml.blockSpaceToDom(workspace);
   const tempXmlWorkspace = new Blockly.Workspace();
-  Blockly.Xml.domToWorkspace(blockXml, tempXmlWorkspace);
+  Blockly.Xml.domToWorkspace(xmlSerialization, tempXmlWorkspace);
   const xmlBlocks = tempXmlWorkspace.getAllBlocks();
 
   // compareBlockArrays returns an array of differences found.
@@ -167,8 +167,13 @@ function testJsonSerialization(workspace) {
   }
   if (experiments.isEnabled(experiments.BLOCKLY_JSON)) {
     // Avoid logging to the console for typical users.
-    console.log({differences: differences});
+    console.log({
+      differences: differences,
+      jsonSerialization: jsonSerialization,
+      xmlSerialization: xmlSerialization,
+    });
   }
+  Blockly.Events.enable();
 }
 
 // Used to find differences between blocks created from xml and json sources.


### PR DESCRIPTION
This is a quick follow-up to https://github.com/code-dot-org/code-dot-org/pull/51739 which adds logging related to comparing block arrays created from different serialization methods.

Because we use temporary un-rendered workspaces to test the blocks, we need to disable Blockly events that might cause us to try to render different elements (e.g. SVG frames around "unused" blocks). I missed that we would also need to enable the events again after we test the blocks. 

This PR adds the following quick fixes:
- Renames a couple of variables to clarify their meaning*.
- Logs a couple other values to the console to aid in investigating potential issues (only shown to internal users with an enabled experiment flag)
- Adds a call to `Blockly.Events.enable();` at the end of the test function.

* _Note about renaming:_ I've been thinking about serialization about a way to save/load "blocks", but I think it's important that shift that mental model slightly. While it's true that the XML serialization is just a tree of blocks, the JSON serialization will include other data. For example, it will include data data about variables that have been declared for the workspace. Eventually it will include also data about procedures that are not present on the workspace. (This is related to the modal function editor work!)
