### PR TITLE
Kaitie/video pop up for section setup

### DIFF
--- a/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
+++ b/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
@@ -16,7 +16,6 @@ import {
 } from '@cdo/apps/componentLibrary/typography';
 import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
-// import {videoDataShape} from './types';
 import {showVideoDialog} from '@cdo/apps/code-studio/videos';
 
 const FORM_ID = 'sections-set-up-container';
@@ -210,11 +209,6 @@ export default function SectionsSetUpContainer({
   };
 
   const onURLClick = () => {
-    // need to find the video...
-    // const video = this.props.video;
-    // if (this.props.openInNewTab) {
-    //   window.open(video.src, '_blank', 'noopener,noreferrer');
-    // } else {
     showVideoDialog(
       {
         autoplay: true,
@@ -224,13 +218,6 @@ export default function SectionsSetUpContainer({
         key: 'Gettting_Started_ClassSection',
         name: 'Creating a Class Section',
         src: 'https://www.youtube-nocookie.com/embed/4Wugxc80fNU/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=yPWQfa4CHbw&wmode=transparent',
-        // src: video.src,
-        // name: video.name,
-        // key: video.key,
-        // download: video.download,
-        // thumbnail: video.thumbnail,
-        // enable_fallback: video.enable_fallback,
-        // autoplay: video.autoplay,
       },
       true
     );
@@ -250,12 +237,9 @@ export default function SectionsSetUpContainer({
               {i18n.setUpClassSectionsSubheader()}
             </BodyOneText>
             <BodyOneText>
-              <a onClick={onURLClick}>
+              <a onClick={onURLClick} className={moduleStyles.textPopUp}>
                 {i18n.setUpClassSectionsSubheaderLink()}
               </a>
-              {/* <a href="https://www.youtube.com/watch?v=4Wugxc80fNU">
-                {i18n.setUpClassSectionsSubheaderLink()}
-              </a> */}
             </BodyOneText>
           </>
         )}

--- a/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
+++ b/apps/src/templates/sectionsRefresh/SectionsSetUpContainer.jsx
@@ -16,6 +16,8 @@ import {
 } from '@cdo/apps/componentLibrary/typography';
 import {EVENTS} from '@cdo/apps/lib/util/AnalyticsConstants';
 import analyticsReporter from '@cdo/apps/lib/util/AnalyticsReporter';
+// import {videoDataShape} from './types';
+import {showVideoDialog} from '@cdo/apps/code-studio/videos';
 
 const FORM_ID = 'sections-set-up-container';
 const SECTIONS_API = '/api/v1/sections';
@@ -207,6 +209,33 @@ export default function SectionsSetUpContainer({
       });
   };
 
+  const onURLClick = () => {
+    // need to find the video...
+    // const video = this.props.video;
+    // if (this.props.openInNewTab) {
+    //   window.open(video.src, '_blank', 'noopener,noreferrer');
+    // } else {
+    showVideoDialog(
+      {
+        autoplay: true,
+        download:
+          'https://videos.code.org/levelbuilder/gettingstarted-creatingclasssection_sm-mp4.mp4',
+        enable_fallback: true,
+        key: 'Gettting_Started_ClassSection',
+        name: 'Creating a Class Section',
+        src: 'https://www.youtube-nocookie.com/embed/4Wugxc80fNU/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=yPWQfa4CHbw&wmode=transparent',
+        // src: video.src,
+        // name: video.name,
+        // key: video.key,
+        // download: video.download,
+        // thumbnail: video.thumbnail,
+        // enable_fallback: video.enable_fallback,
+        // autoplay: video.autoplay,
+      },
+      true
+    );
+  };
+
   return (
     <form id={FORM_ID}>
       <div className={moduleStyles.containerWithMarginTop}>
@@ -221,9 +250,12 @@ export default function SectionsSetUpContainer({
               {i18n.setUpClassSectionsSubheader()}
             </BodyOneText>
             <BodyOneText>
-              <a href="https://www.youtube.com/watch?v=4Wugxc80fNU">
+              <a onClick={onURLClick}>
                 {i18n.setUpClassSectionsSubheaderLink()}
               </a>
+              {/* <a href="https://www.youtube.com/watch?v=4Wugxc80fNU">
+                {i18n.setUpClassSectionsSubheaderLink()}
+              </a> */}
             </BodyOneText>
           </>
         )}

--- a/apps/src/templates/sectionsRefresh/sections-refresh.module.scss
+++ b/apps/src/templates/sectionsRefresh/sections-refresh.module.scss
@@ -208,3 +208,7 @@ button.advancedSettingsButton {
   display: flex;
   justify-content: flex-end;
 }
+
+.textPopUp {
+  cursor: pointer;
+}


### PR DESCRIPTION
Currently, on the "new section landing page" there is text that links to a video showing users how to set-up a section.  The ask was to create a pop-up that includes this video instead of opening the link in the existing window. 

Here is the text in question:
<img width="945" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/24883357/3a11dcad-aece-4b68-98f6-b53d3d32d7b3">


With this change, clicking on this text will open up this window:
<img width="989" alt="image" src="https://github.com/code-dot-org/code-dot-org/assets/24883357/77e5a63d-a160-4d06-bbf7-806295c029d5">


## Links

To test this, use this URL: http://localhost-studio.code.org:3000/sections/new?participantType=student&loginType=word

[Jira ticket](https://codedotorg.atlassian.net/jira/software/projects/TEACH/boards/65?selectedIssue=TEACH-420)

## Testing story

To test this, use this URL: http://localhost-studio.code.org:3000/sections/new?participantType=student&loginType=word

- Currently no additional tests were created for this. 