### PR TITLE
[CFU] Fix checkbox handling with multiple answers selected

### DIFF
--- a/apps/src/templates/levelSummary/MultiResponses.jsx
+++ b/apps/src/templates/levelSummary/MultiResponses.jsx
@@ -15,8 +15,12 @@ const multiAnswerCounts = (responses, answerCount) => ({
   ...Object.fromEntries([...LETTERS.slice(0, answerCount)].map(l => [l, 0])),
   // Overwrite the count for any answers that have student responses.
   ...responses.reduce((acc, curr) => {
-    const letter = LETTERS.at(curr.text);
-    acc[letter] = acc[letter] ? acc[letter] + 1 : 1;
+    // Each response can be an index or a comma-separated list of indices.
+    const indices = curr.text.split(',');
+    indices.forEach(index => {
+      const letter = LETTERS.at(index);
+      acc[letter] = acc[letter] ? acc[letter] + 1 : 1;
+    });
     return acc;
   }, {}),
 });

--- a/apps/test/unit/templates/levelSummary/MultiResponses.jsx
+++ b/apps/test/unit/templates/levelSummary/MultiResponses.jsx
@@ -79,7 +79,7 @@ describe('multiAnswerCounts', () => {
       [
         {text: '0,2'},
         {text: '0'},
-        {text: '0,3'},
+        {text: '0,3,2'},
         {text: '0,3'},
         {text: '0'},
         {text: '2,3'},
@@ -91,7 +91,7 @@ describe('multiAnswerCounts', () => {
     expect(data).to.eql({
       A: 6,
       B: 0,
-      C: 2,
+      C: 3,
       D: 5,
     });
   });

--- a/apps/test/unit/templates/levelSummary/MultiResponses.jsx
+++ b/apps/test/unit/templates/levelSummary/MultiResponses.jsx
@@ -73,6 +73,28 @@ describe('multiAnswerCounts', () => {
       D: 2,
     });
   });
+
+  it('generates correct counts with multiple answers selected', () => {
+    const data = multiAnswerCounts(
+      [
+        {text: '0,2'},
+        {text: '0'},
+        {text: '0,3'},
+        {text: '0,3'},
+        {text: '0'},
+        {text: '2,3'},
+        {text: '3,0'},
+        {text: '3'},
+      ],
+      4
+    );
+    expect(data).to.eql({
+      A: 6,
+      B: 0,
+      C: 2,
+      D: 5,
+    });
+  });
 });
 
 describe('multiChartData', () => {


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

When students submit a multiple choice checkbox question with more than one checkbox checked, the response data comes through as a comma-separated list of indices into the answer array, instead of a single index. This PR splits those indices apart and counts each of them as separate answers for the purpose of the bar chart, instead of just breaking.

![image](https://github.com/code-dot-org/code-dot-org/assets/1382374/92fef39f-1d3a-4ac8-b484-5bc36e8c8cd8)


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- -->
- jira ticket: [TEACH-505](https://codedotorg.atlassian.net/browse/TEACH-505)



