### PR TITLE
AI Launch 2023 - Remove announcement banner from logged in teacher homepage

### DIFF
--- a/pegasus/sites.v3/code.org/announcements.json
+++ b/pegasus/sites.v3/code.org/announcements.json
@@ -2,7 +2,6 @@
   "pages": {
     "/projects": "coldplay",
     "/certificates": "hoc-more",
-    "/home": "ai-launch-2023",
     "/courses": "ai-launch-2023"
   },
   "banners": {


### PR DESCRIPTION
Remove AI announcement banner from the logged in Teacher homepage: https://studio.code.org/home

**Related PR:**
- https://github.com/code-dot-org/code-dot-org/pull/51564

**Jira ticket:** [ACQ-594](https://codedotorg.atlassian.net/browse/ACQ-594?atlOrigin=eyJpIjoiMjVmZmFkZGVkOTUzNDUyZmE1YzY5YTY2MTcxYzkxYTIiLCJwIjoiaiJ9)

----

## Before
<img width="900" alt="Before" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/7139a5dc-97e6-4539-aa02-e0345cc9aa78">

## After
<img width="900" alt="After" src="https://github.com/code-dot-org/code-dot-org/assets/9256643/bb489126-d0e4-48af-ae40-7a68683f2ae2">
